### PR TITLE
release-26.1: bulkutil: add BulkJobCleaner for managing temp file cleanup 

### DIFF
--- a/pkg/sql/bulkutil/BUILD.bazel
+++ b/pkg/sql/bulkutil/BUILD.bazel
@@ -2,12 +2,16 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "bulkutil",
-    srcs = ["external_storage_mux.go"],
+    srcs = [
+        "bulk_job_cleaner.go",
+        "external_storage_mux.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/bulkutil",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/ccl/storageccl",
         "//pkg/cloud",
+        "//pkg/jobs/jobspb",
         "//pkg/security/username",
         "@com_github_cockroachdb_errors//:errors",
     ],
@@ -16,15 +20,23 @@ go_library(
 go_test(
     name = "bulkutil_test",
     srcs = [
+        "bulk_job_cleaner_test.go",
         "external_storage_mux_test.go",
         "main_test.go",
     ],
     embed = [":bulkutil"],
     deps = [
+        "//pkg/base",
+        "//pkg/blobs",
         "//pkg/cloud",
+        "//pkg/cloud/impl:cloudimpl",
+        "//pkg/jobs/jobspb",
         "//pkg/security/username",
+        "//pkg/settings/cluster",
+        "//pkg/testutils",
         "//pkg/util/leaktest",
         "//pkg/util/randutil",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/sql/bulkutil/bulk_job_cleaner.go
+++ b/pkg/sql/bulkutil/bulk_job_cleaner.go
@@ -1,0 +1,138 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package bulkutil
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/cloud"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/errors"
+)
+
+// BulkJobCleaner provides generic cleanup operations for bulk jobs that write
+// temporary files to external storage (e.g., IMPORT, index backfill). It
+// efficiently deletes files and sweeps job directories using cached storage
+// handles.
+//
+// Cleanup operations are best-effort; callers should log returned errors
+// rather than failing the job.
+type BulkJobCleaner struct {
+	mux *ExternalStorageMux
+}
+
+// NewBulkJobCleaner builds a cleaner that reuses external storage handles
+// across delete/list operations.
+func NewBulkJobCleaner(
+	factory cloud.ExternalStorageFromURIFactory, user username.SQLUsername,
+) *BulkJobCleaner {
+	return &BulkJobCleaner{
+		mux: NewExternalStorageMux(factory, user),
+	}
+}
+
+// Close releases any cached external storage handles.
+func (c *BulkJobCleaner) Close() error {
+	if c == nil {
+		return nil
+	}
+	return c.mux.Close()
+}
+
+// CleanupURIs deletes the provided URIs. The operation is best-effort; errors
+// are aggregated and returned.
+func (c *BulkJobCleaner) CleanupURIs(ctx context.Context, uris []string) error {
+	if c == nil {
+		return nil
+	}
+	var errOut error
+	for _, uri := range uris {
+		if uri == "" {
+			continue
+		}
+		if err := c.mux.DeleteFile(ctx, uri); err != nil {
+			errOut = errors.CombineErrors(errOut, err)
+		}
+	}
+	return errOut
+}
+
+// CleanupJobDirectories enumerates all files under the job-scoped directories
+// and removes them. This is intended as a catch-all sweep after targeted
+// cleanup has already run.
+//
+// The storagePrefixes parameter specifies the storage locations (without the
+// job directory path) where temporary files may exist. The function constructs
+// the full cleanup path as "<prefix>/job/<jobID>/" and removes all files under
+// that path.
+//
+// Examples:
+//
+//   - Input: storagePrefixes=["nodelocal://1/", "nodelocal://2/"], jobID=123
+//     Cleans: "nodelocal://1/job/123/*" and "nodelocal://2/job/123/*"
+//
+//   - Input: storagePrefixes=["nodelocal://1/export/"], jobID=456
+//     Cleans: "nodelocal://1/export/job/456/*"
+//
+// These prefixes should be persisted in job state before any files are written
+// to ensure complete cleanup even if the job fails partway through.
+func (c *BulkJobCleaner) CleanupJobDirectories(
+	ctx context.Context, jobID jobspb.JobID, storagePrefixes []string,
+) error {
+	if c == nil {
+		return nil
+	}
+
+	// Construct full job directory paths from storage prefixes.
+	jobDirs := make([]string, 0, len(storagePrefixes))
+	for _, prefix := range storagePrefixes {
+		if prefix == "" {
+			continue
+		}
+		// Ensure prefix ends with / before appending job path.
+		if !strings.HasSuffix(prefix, "/") {
+			prefix += "/"
+		}
+		jobDir := fmt.Sprintf("%sjob/%d/", prefix, jobID)
+		jobDirs = append(jobDirs, jobDir)
+	}
+
+	// Remove duplicates.
+	seen := make(map[string]struct{})
+	var uniqueDirs []string
+	for _, dir := range jobDirs {
+		if _, exists := seen[dir]; !exists {
+			seen[dir] = struct{}{}
+			uniqueDirs = append(uniqueDirs, dir)
+		}
+	}
+
+	var errOut error
+	for _, jobDir := range uniqueDirs {
+		listErr := c.mux.ListFiles(ctx, jobDir, func(name string) error {
+			trimmed := strings.TrimPrefix(name, "/")
+			target := jobDir
+			if !strings.HasSuffix(target, "/") {
+				target += "/"
+			}
+			target += trimmed
+			if err := c.mux.DeleteFile(ctx, target); err != nil {
+				errOut = errors.CombineErrors(errOut, err)
+			}
+			return nil
+		})
+		if errors.Is(listErr, cloud.ErrListingUnsupported) {
+			continue
+		}
+		if listErr != nil {
+			errOut = errors.CombineErrors(errOut, listErr)
+		}
+	}
+	return errOut
+}

--- a/pkg/sql/bulkutil/bulk_job_cleaner_test.go
+++ b/pkg/sql/bulkutil/bulk_job_cleaner_test.go
@@ -1,0 +1,383 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package bulkutil
+
+import (
+	"bytes"
+	"context"
+	"net/url"
+	"sort"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/blobs"
+	"github.com/cockroachdb/cockroach/pkg/cloud"
+	_ "github.com/cockroachdb/cockroach/pkg/cloud/impl" // register cloud storage providers
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+// mockStorageWithTracking tracks all Delete and List operations.
+type mockStorageWithTracking struct {
+	cloud.ExternalStorage
+	uri         string
+	deleted     []string
+	listed      []string
+	files       map[string]struct{} // simulated files in storage
+	deleteError error
+	listError   error
+}
+
+func (m *mockStorageWithTracking) Delete(ctx context.Context, basename string) error {
+	m.deleted = append(m.deleted, basename)
+	if m.deleteError != nil {
+		return m.deleteError
+	}
+	delete(m.files, basename)
+	return nil
+}
+
+func (m *mockStorageWithTracking) List(
+	ctx context.Context, prefix, delimiter string, fn cloud.ListingFn,
+) error {
+	m.listed = append(m.listed, prefix)
+	if m.listError != nil {
+		return m.listError
+	}
+
+	// Return files matching the prefix.
+	var matches []string
+	for file := range m.files {
+		matches = append(matches, file)
+	}
+	sort.Strings(matches) // Ensure deterministic ordering.
+
+	for _, file := range matches {
+		if err := fn(file); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *mockStorageWithTracking) Close() error {
+	return nil
+}
+
+func TestBulkJobCleaner_CleanupURIs(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+
+	t.Run("deletes specific URIs successfully", func(t *testing.T) {
+		mocks := make(map[string]*mockStorageWithTracking)
+		factory := func(ctx context.Context, uri string, user username.SQLUsername, opts ...cloud.ExternalStorageOption) (cloud.ExternalStorage, error) {
+			mock := &mockStorageWithTracking{
+				uri:     uri,
+				deleted: []string{},
+				files:   make(map[string]struct{}),
+			}
+			mocks[uri] = mock
+			return mock, nil
+		}
+
+		cleaner := NewBulkJobCleaner(factory, username.RootUserName())
+		defer func() {
+			_ = cleaner.Close()
+		}()
+
+		uris := []string{
+			"nodelocal://1/job/123/map/file1.sst",
+			"nodelocal://1/job/123/map/file2.sst",
+			"nodelocal://2/job/123/merge/file3.sst",
+		}
+
+		err := cleaner.CleanupURIs(ctx, uris)
+		require.NoError(t, err)
+
+		// Verify deletions on node 1.
+		require.Contains(t, mocks, "nodelocal://1")
+		node1Deleted := mocks["nodelocal://1"].deleted
+		require.ElementsMatch(t, []string{
+			"/job/123/map/file1.sst",
+			"/job/123/map/file2.sst",
+		}, node1Deleted)
+
+		// Verify deletions on node 2.
+		require.Contains(t, mocks, "nodelocal://2")
+		node2Deleted := mocks["nodelocal://2"].deleted
+		require.ElementsMatch(t, []string{
+			"/job/123/merge/file3.sst",
+		}, node2Deleted)
+	})
+
+	t.Run("aggregates errors from multiple deletions", func(t *testing.T) {
+		deleteErr := errors.New("delete failed")
+		factory := func(ctx context.Context, uri string, user username.SQLUsername, opts ...cloud.ExternalStorageOption) (cloud.ExternalStorage, error) {
+			return &mockStorageWithTracking{
+				uri:         uri,
+				deleted:     []string{},
+				files:       make(map[string]struct{}),
+				deleteError: deleteErr,
+			}, nil
+		}
+
+		cleaner := NewBulkJobCleaner(factory, username.RootUserName())
+		defer func() {
+			_ = cleaner.Close()
+		}()
+
+		uris := []string{
+			"nodelocal://1/job/123/file1.sst",
+			"nodelocal://1/job/123/file2.sst",
+		}
+
+		err := cleaner.CleanupURIs(ctx, uris)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "delete failed")
+	})
+}
+
+func TestBulkJobCleaner_CleanupJobDirectories(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	jobID := jobspb.JobID(123)
+
+	t.Run("removes all files under job directories", func(t *testing.T) {
+		mocks := make(map[string]*mockStorageWithTracking)
+		factory := func(ctx context.Context, uri string, user username.SQLUsername, opts ...cloud.ExternalStorageOption) (cloud.ExternalStorage, error) {
+			mock := &mockStorageWithTracking{
+				uri:     uri,
+				deleted: []string{},
+				listed:  []string{},
+				files: map[string]struct{}{
+					"/map/file1.sst":       {},
+					"/map/file2.sst":       {},
+					"/merge/file3.sst":     {},
+					"/merge/sub/file4.sst": {},
+				},
+			}
+			mocks[uri] = mock
+			return mock, nil
+		}
+
+		cleaner := NewBulkJobCleaner(factory, username.RootUserName())
+		defer func() {
+			_ = cleaner.Close()
+		}()
+
+		// Pass storage prefixes (without /job/{jobID}/ path).
+		storagePrefixes := []string{
+			"nodelocal://1/export/",
+			"nodelocal://2/export/",
+		}
+
+		err := cleaner.CleanupJobDirectories(ctx, jobID, storagePrefixes)
+		require.NoError(t, err)
+
+		// Verify node 1 was listed with correct job directory.
+		require.Contains(t, mocks, "nodelocal://1")
+		node1 := mocks["nodelocal://1"]
+		require.Contains(t, node1.listed, "/export/job/123/")
+
+		// Verify all files on node 1 were deleted.
+		require.ElementsMatch(t, []string{
+			"/export/job/123/map/file1.sst",
+			"/export/job/123/map/file2.sst",
+			"/export/job/123/merge/file3.sst",
+			"/export/job/123/merge/sub/file4.sst",
+		}, node1.deleted)
+
+		// Verify node 2 was listed with correct job directory.
+		require.Contains(t, mocks, "nodelocal://2")
+		node2 := mocks["nodelocal://2"]
+		require.Contains(t, node2.listed, "/export/job/123/")
+
+		// Verify all files on node 2 were deleted.
+		require.ElementsMatch(t, []string{
+			"/export/job/123/map/file1.sst",
+			"/export/job/123/map/file2.sst",
+			"/export/job/123/merge/file3.sst",
+			"/export/job/123/merge/sub/file4.sst",
+		}, node2.deleted)
+	})
+
+	t.Run("deduplicates job directory prefixes", func(t *testing.T) {
+		mocks := make(map[string]*mockStorageWithTracking)
+		factory := func(ctx context.Context, uri string, user username.SQLUsername, opts ...cloud.ExternalStorageOption) (cloud.ExternalStorage, error) {
+			mock := &mockStorageWithTracking{
+				uri:     uri,
+				deleted: []string{},
+				listed:  []string{},
+				files:   map[string]struct{}{},
+			}
+			mocks[uri] = mock
+			return mock, nil
+		}
+
+		cleaner := NewBulkJobCleaner(factory, username.RootUserName())
+		defer func() {
+			_ = cleaner.Close()
+		}()
+
+		// Same storage prefix specified multiple times should be deduplicated.
+		storagePrefixes := []string{
+			"nodelocal://1/export/",
+			"nodelocal://1/export/",
+			"nodelocal://1/export/",
+		}
+
+		err := cleaner.CleanupJobDirectories(ctx, jobID, storagePrefixes)
+		require.NoError(t, err)
+
+		// Verify the job directory was only listed once despite duplicate prefixes.
+		require.Contains(t, mocks, "nodelocal://1")
+		require.Len(t, mocks["nodelocal://1"].listed, 1)
+		require.Equal(t, "/export/job/123/", mocks["nodelocal://1"].listed[0])
+	})
+
+	t.Run("aggregates delete errors from multiple files", func(t *testing.T) {
+		deleteErr := errors.New("delete failed")
+
+		factory := func(ctx context.Context, uri string, user username.SQLUsername, opts ...cloud.ExternalStorageOption) (cloud.ExternalStorage, error) {
+			return &mockStorageWithTracking{
+				uri:     uri,
+				deleted: []string{},
+				listed:  []string{},
+				files: map[string]struct{}{
+					"/file1.sst": {},
+					"/file2.sst": {},
+				},
+				deleteError: deleteErr,
+			}, nil
+		}
+
+		cleaner := NewBulkJobCleaner(factory, username.RootUserName())
+		defer func() {
+			_ = cleaner.Close()
+		}()
+
+		storagePrefixes := []string{
+			"nodelocal://1/export/",
+		}
+
+		err := cleaner.CleanupJobDirectories(ctx, jobID, storagePrefixes)
+		require.Error(t, err)
+		// Should see multiple delete errors combined.
+		require.ErrorContains(t, err, "delete failed")
+	})
+}
+
+func TestBulkJobCleaner_WithRealNodelocal(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	jobID := jobspb.JobID(789)
+
+	// Create temp directory for nodelocal storage.
+	tmpDir, cleanupFn := testutils.TempDir(t)
+	defer cleanupFn()
+
+	// Setup factory that creates real nodelocal storage.
+	clientFactory := blobs.TestBlobServiceClient(tmpDir)
+	testSettings := cluster.MakeTestingClusterSettings()
+	ioConf := base.ExternalIODirConfig{}
+
+	factory := func(ctx context.Context, uri string, user username.SQLUsername, opts ...cloud.ExternalStorageOption) (cloud.ExternalStorage, error) {
+		conf, err := cloud.ExternalStorageConfFromURI(uri, user)
+		if err != nil {
+			return nil, err
+		}
+		return cloud.MakeExternalStorage(ctx, conf, ioConf, testSettings, clientFactory, nil, nil, cloud.NilMetrics)
+	}
+
+	// Helper to split URI into storage prefix and file path.
+	getStorageAndPath := func(uri string) (string, string) {
+		parsed, err := url.Parse(uri)
+		require.NoError(t, err)
+		// Storage prefix is scheme + host only.
+		prefix := url.URL{
+			Scheme: parsed.Scheme,
+			Host:   parsed.Host,
+		}
+		return prefix.String(), parsed.Path
+	}
+
+	// Create files in job directory.
+	files := []string{
+		"nodelocal://1/export/job/789/map/file1.sst",
+		"nodelocal://1/export/job/789/map/file2.sst",
+		"nodelocal://1/export/job/789/merge/file3.sst",
+		"nodelocal://1/export/job/789/merge/sub/file4.sst",
+		"nodelocal://1/export/job/789/merge/sub/file5.sst",
+	}
+
+	// Write files.
+	for _, uri := range files {
+		storagePrefix, filePath := getStorageAndPath(uri)
+		store, err := factory(ctx, storagePrefix, username.RootUserName())
+		require.NoError(t, err)
+
+		err = cloud.WriteFile(ctx, store, filePath, bytes.NewReader([]byte("test data")))
+		require.NoError(t, err)
+		require.NoError(t, store.Close())
+	}
+
+	// Verify all files exist.
+	for _, uri := range files {
+		storagePrefix, filePath := getStorageAndPath(uri)
+		store, err := factory(ctx, storagePrefix, username.RootUserName())
+		require.NoError(t, err)
+
+		_, _, err = store.ReadFile(ctx, filePath, cloud.ReadOptions{NoFileSize: true})
+		require.NoError(t, err, "file should exist before cleanup")
+		require.NoError(t, store.Close())
+	}
+
+	cleaner := NewBulkJobCleaner(factory, username.RootUserName())
+	defer func() {
+		_ = cleaner.Close()
+	}()
+
+	// Cleanup one file.
+	err := cleaner.CleanupURIs(ctx, []string{files[4]})
+	require.NoError(t, err)
+
+	// Verify the file is deleted.
+	{
+		storagePrefix, filePath := getStorageAndPath(files[4])
+		store, err := factory(ctx, storagePrefix, username.RootUserName())
+		require.NoError(t, err)
+
+		_, _, err = store.ReadFile(ctx, filePath, cloud.ReadOptions{NoFileSize: true})
+		require.Error(t, err, "file should not exist after cleanup")
+		require.True(t, errors.Is(err, cloud.ErrFileDoesNotExist), "expected file does not exist error")
+		require.NoError(t, store.Close())
+	}
+
+	// Clean up entire job directory using storage prefix.
+	storagePrefixes := []string{"nodelocal://1/export/"}
+	err = cleaner.CleanupJobDirectories(ctx, jobID, storagePrefixes)
+	require.NoError(t, err)
+
+	// Verify all files in job directory are deleted.
+	for _, uri := range files {
+		storagePrefix, filePath := getStorageAndPath(uri)
+		store, err := factory(ctx, storagePrefix, username.RootUserName())
+		require.NoError(t, err)
+
+		_, _, err = store.ReadFile(ctx, filePath, cloud.ReadOptions{NoFileSize: true})
+		require.Error(t, err, "file should not exist after cleanup")
+		require.True(t, errors.Is(err, cloud.ErrFileDoesNotExist), "expected file does not exist error")
+		require.NoError(t, store.Close())
+	}
+}


### PR DESCRIPTION
Backport 1/1 commits from #159835 on behalf of @spilchen.

----

Introduces BulkJobCleaner, a new infrastructure for deleting temporary files from external storage used by bulk operations such as IMPORT and index backfill. The cleaner supports best-effort cleanup of specific URIs or full job directories using a standardized path convention. Subsequent changes will wire this in for index backfill and IMPORT.

Informs #158873
Epic: CRDB-48845
Release note: none

----

Release justification: