### PR TITLE
kvserver: permit yielding for read requests evaluating without latches

### DIFF
--- a/pkg/kv/kvserver/kvadmission/kvadmission.go
+++ b/pkg/kv/kvserver/kvadmission/kvadmission.go
@@ -400,6 +400,10 @@ func (n *controllerImpl) AdmitKVWork(
 			// reads, so in some sense, the integration is incomplete. This is
 			// probably harmless.
 			elasticWorkHandle, err := n.elasticCPUGrantCoordinator.ElasticCPUWorkQueue.Admit(
+				// NB: yieldInHandle is always false at this point, since requests may
+				// subsequently acquire latches, and requests holding latches should
+				// never yield. Later code, that knows about the state of latching,
+				// can revise this decision.
 				ctx, admitDuration, admissionInfo, false,
 			)
 			if err != nil {

--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/admission"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -73,8 +74,9 @@ func (r *Replica) executeReadOnlyBatch(
 	// designed.
 	rw := r.store.StateEngine().NewReadOnly(storage.StandardDurability)
 	if !rw.ConsistentIterators() {
-		// This is not currently needed for correctness, but future optimizations
-		// may start relying on this, so we assert here.
+		// This is needed for correctness, as we will call
+		// PinEngineStateForIterators, and potentially drop latches before
+		// evaluation.
 		panic("expected consistent iterators")
 	}
 	// Pin engine state eagerly so that all iterators created over this Reader are
@@ -470,6 +472,36 @@ func (r *Replica) executeReadOnlyBatchWithServersideRefreshes(
 		rec = evalCtx
 	}
 
+	latchesHeld := g != nil
+	// Decide on yielding for the ElasticCPUWorkHandle, if any. The
+	// ElasticCPUWorkHandle when created is configured to not yield since that
+	// is the safe choice when it was made (see kvadmission.go). However, batch
+	// execution can be retried after the creation of the ElasticCPUWorkHandle
+	// (e.g. the loop in executeBatchWithConcurrencyRetries), so this point in
+	// the code can be reached multiple times, with different decisions made
+	// regarding yielding. Therefore, we always override with what should be the
+	// correct yield behavior.
+	elasticCPUHandle := admission.ElasticCPUWorkHandleFromContext(ctx)
+	if elasticCPUHandle != nil {
+		// If latches are not held, it is safe to yield (which can slow down
+		// individual request evaluation), without any risk of latch priority
+		// inversion.
+		//
+		// Even though an individual elastic request can take longer, the
+		// goroutine scheduling of foreground work improves, which results in a
+		// higher amount of elastic work to be permitted, so overall throughput of
+		// elastic work is expected to improve.
+		//
+		// NB: This only has an effect if the request evaluation calls
+		// elasticCPUHandle.IsOverLimitAndPossiblyYield. Currently only
+		// ExportRequest evaluation does that. ExportRequest should often be
+		// evaluating without holding latches, since it should fit all the
+		// criteria in canReadOnlyRequestDropLatchesBeforeEval, i.e., consistent
+		// read, pessimistic-eval, wait-policy is block or error, and should often
+		// not find intents in canDropLatchesBeforeEval.
+		yield := !latchesHeld && admission.YieldForElasticCPU.Get(&r.store.cfg.Settings.SV)
+		elasticCPUHandle.SetYield(yield)
+	}
 	for retries := 0; ; retries++ {
 		if retries > 0 {
 			if boundAccount != nil {
@@ -493,7 +525,6 @@ func (r *Replica) executeReadOnlyBatchWithServersideRefreshes(
 		// indicated by the latch guard being nil) before this point, then it cannot
 		// retry at a higher timestamp because it is not isolated at higher
 		// timestamps.
-		latchesHeld := g != nil
 		var ok bool
 		if latchesHeld {
 			ba, ok = canDoServersideRetry(ctx, pErr, ba, g, hlc.Timestamp{})


### PR DESCRIPTION

This should often result in ExportRequests yielding, which can be
beneficial for foreground latency since they consume 100ms of tokens.
In the future we may add support for other elastic read requests to
yield, e.g. ScanRequest.

Epic: none

Release note: None