### PR TITLE
release-25.4: scerrors: always log reason for falling back to legacy schema changer

### DIFF
--- a/pkg/sql/schemachanger/scerrors/errors.go
+++ b/pkg/sql/schemachanger/scerrors/errors.go
@@ -77,7 +77,7 @@ func (el EventLogger) HandlePanicAndLogError(ctx context.Context, err *error) {
 			log.Dev.InfofDepth(ctx, depth, "done %s in %s", el.msg, redact.Safe(timeutil.Since(el.start)))
 		}
 	case HasNotImplemented(*err):
-		log.VEventfDepth(ctx, depth, 1, "declarative schema changer does not support %s: %v", el.msg, *err)
+		log.Dev.InfofDepth(ctx, depth, "declarative schema changer does not support %s: %v", el.msg, *err)
 	case errors.HasAssertionFailure(*err):
 		*err = errors.Wrapf(*err, "%s", el.msg)
 		fallthrough


### PR DESCRIPTION
Backport 1/1 commits from #159916 on behalf of @rafiss.

----

This will help us understand the reasons why schema changes fallback to the legacy behavior.

Epic CRDB-31281
Release note: None

----

Release justification: low risk change to logging