### PR TITLE
release-26.1: cli: include two new system tables into zip registry

### DIFF
--- a/pkg/cli/testdata/zip/file-filters/testzip_file_filters
+++ b/pkg/cli/testdata/zip/file-filters/testzip_file_filters
@@ -113,8 +113,10 @@ debug/system.sql_stats_cardinality.txt
 debug/system.sqlliveness.txt
 debug/system.statement_diagnostics.txt
 debug/system.statement_diagnostics_requests.txt
+debug/system.statement_hints.txt
 debug/system.statement_statistics_limit_5000.txt
 debug/system.table_statistics.txt
+debug/system.table_statistics_locks.txt
 debug/system.task_payloads.txt
 debug/system.tenant_settings.txt
 debug/system.tenant_tasks.txt
@@ -246,8 +248,10 @@ debug/system.sql_stats_cardinality.txt
 debug/system.sqlliveness.txt
 debug/system.statement_diagnostics.txt
 debug/system.statement_diagnostics_requests.txt
+debug/system.statement_hints.txt
 debug/system.statement_statistics_limit_5000.txt
 debug/system.table_statistics.txt
+debug/system.table_statistics_locks.txt
 debug/system.task_payloads.txt
 debug/system.tenant_settings.txt
 debug/system.tenant_tasks.txt
@@ -410,8 +414,10 @@ debug/system.sql_stats_cardinality.txt
 debug/system.sqlliveness.txt
 debug/system.statement_diagnostics.txt
 debug/system.statement_diagnostics_requests.txt
+debug/system.statement_hints.txt
 debug/system.statement_statistics_limit_5000.txt
 debug/system.table_statistics.txt
+debug/system.table_statistics_locks.txt
 debug/system.task_payloads.txt
 debug/system.tenant_settings.txt
 debug/system.tenant_tasks.txt
@@ -549,8 +555,10 @@ debug/system.sql_stats_cardinality.txt
 debug/system.sqlliveness.txt
 debug/system.statement_diagnostics.txt
 debug/system.statement_diagnostics_requests.txt
+debug/system.statement_hints.txt
 debug/system.statement_statistics_limit_5000.txt
 debug/system.table_statistics.txt
+debug/system.table_statistics_locks.txt
 debug/system.task_payloads.txt
 debug/system.tenant_settings.txt
 debug/system.tenant_tasks.txt

--- a/pkg/cli/zip_table_registry.go
+++ b/pkg/cli/zip_table_registry.go
@@ -1585,6 +1585,14 @@ JOIN crdb_internal.cluster_settings cs ON cs.variable = s.name`,
 			"username",
 		},
 	},
+	"system.statement_hints": {
+		nonSensitiveCols: NonSensitiveColumns{
+			"row_id",
+			"fingerprint",
+			"hint",
+			"created_at",
+		},
+	},
 	// statement_statistics can have over 100k rows in just the last hour.
 	// Select all the statements that are part of a transaction where one of
 	// the statements is in the 100 by cpu usage, and all the transaction
@@ -1670,6 +1678,15 @@ limit 5000;`,
 			`"distinctCount"`,
 			`"nullCount"`,
 			`"avgSize"`,
+			`"partialPredicate"`,
+			`"fullStatisticID"`,
+		},
+	},
+	"system.table_statistics_locks": {
+		nonSensitiveCols: NonSensitiveColumns{
+			"table_id",
+			"kind",
+			"job_ids",
 		},
 	},
 	"system.task_payloads": {


### PR DESCRIPTION
Backport 1/1 commits from #159781 on behalf of @yuzefovich.

----

This commit includes `system.statement_hints` and `system.table_statistics_locks` tables into the zip registry. Additionally, it includes two more columns for `system.table_statistics`.

Epic: None
Release note: None

----

Release justification: low-risk supportability improvement.