### PR TITLE
sqlccl: lock old descriptor versions in TestExplainGist

### DIFF
--- a/pkg/ccl/testccl/sqlccl/explain_test.go
+++ b/pkg/ccl/testccl/sqlccl/explain_test.go
@@ -152,6 +152,9 @@ func TestExplainGist(t *testing.T) {
 		// Set up some initial state.
 		setup := sqlsmith.Setups["seed"](rng)
 		setup = append(setup, "SET CLUSTER SETTING sql.stats.automatic_collection.enabled = off;")
+		// Avoid retry errors when decoding gists due to locked lease timestamps
+		// around schema changes.
+		setup = append(setup, "SET CLUSTER SETTING sql.catalog.descriptor_lease.lock_old_versions.enabled = true;")
 		if rng.Float64() < 0.5 {
 			// In some cases have stats on the seed table.
 			setup = append(setup, "ANALYZE seed;")


### PR DESCRIPTION
We've seen a couple of failures in `TestExplainGist` where decoding a plan gist encountered a retry error like "the descriptor seed(106) has been modified at timestamp". Prevent such errors by tweaking the cluster setting to lock old descriptor versions.

Fixes: #159714.
Release note: None