### PR TITLE
sql/importer: tighten request filter in TestUDTChangeDuringImport

### DIFF
--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -5480,7 +5480,18 @@ func TestUDTChangeDuringImport(t *testing.T) {
 					Knobs: base.TestingKnobs{
 						JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 						Store: &kvserver.StoreTestingKnobs{
-							TestingResponseFilter: jobutils.BulkOpResponseFilter(&allowResponse),
+							TestingResponseFilter: func(ctx context.Context, ba *kvpb.BatchRequest, br *kvpb.BatchResponse) *kvpb.Error {
+								for _, ru := range br.Responses {
+									switch ru.GetInner().(type) {
+									case *kvpb.AddSSTableResponse:
+										select {
+										case <-allowResponse:
+										case <-ctx.Done():
+										}
+									}
+								}
+								return nil
+							},
 							TestingRequestFilter: func(ctx context.Context, br *kvpb.BatchRequest) *kvpb.Error {
 								for _, ru := range br.Requests {
 									switch ru.GetInner().(type) {


### PR DESCRIPTION
We just saw a test failure in `TestUDTChangeDuringImport` where we had a deadlock due to the TestingResponseFilter that we install. In particular, that filter captures all Export and AddSSTable responses (former needed for backup, but only the latter is needed for import). It turns out that we have a test case where we modify grants which triggers lease acquisition path which itself can use the Export request, so we'd block that query indefinitely which wasn't desired. I don't think we want to block Export requests in this test, so I updated the filter to apply only to AddSSTable requests.

Fixes: #159663.
Release note: None