### PR TITLE
sql: attach opName string as pprof label for internal queries

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -4456,15 +4456,24 @@ func (ex *connExecutor) execWithProfiling(
 		}
 		// Compute fingerprint ID here since ih.Setup hasn't been called yet.
 		fingerprintID := appstatspb.ConstructStatementFingerprintID(
-			stmtNoConstants, ex.implicitTxn(), ex.sessionData().Database)
-		pprofutil.Do(ctx, func(ctx context.Context) {
-			err = op(ctx)
-		},
+			stmtNoConstants, ex.implicitTxn(), ex.sessionData().Database,
+		)
+		labels := []string{
 			workloadid.ProfileTag, sqlstatsutil.EncodeStmtFingerprintIDToString(fingerprintID),
 			"appname", ex.sessionData().ApplicationName,
 			"addr", remoteAddr,
 			"stmt.tag", ast.StatementTag(),
 			"stmt.no.constants", stmtNoConstants,
+		}
+		if opName, ok := GetInternalOpName(ctx); ok {
+			labels = append(labels, "opname", opName)
+		}
+		pprofutil.Do(
+			ctx,
+			func(ctx context.Context) {
+				err = op(ctx)
+			},
+			labels...,
 		)
 	} else {
 		err = op(ctx)


### PR DESCRIPTION
Every query that we run via the internal executor comes with "opName" string that is a short description of the query. We now will attach that string as a pprof label that can then be propagated into stack traces.

Epic: None
Release note: None