### PR TITLE
release-25.2: sql: fix rare flake in TestCancelDistSQLQuery

### DIFF
--- a/pkg/sql/run_control_test.go
+++ b/pkg/sql/run_control_test.go
@@ -125,7 +125,10 @@ func TestCancelDistSQLQuery(t *testing.T) {
 		errChan <- err
 	}()
 	_, err := conn2.Exec(cancelQuery)
-	if err != nil && !testutils.IsError(err, "query ID") {
+	// We might have blocked the cancellation query longer than it took the
+	// target query to execute, in which case the cancel query itself errors out
+	// (and it's ok).
+	if err != nil && !testutils.IsError(err, "could not cancel query") {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Backport 1/1 commits from #159969 on behalf of @yuzefovich.

----

`TestCancelDistSQLQuery` works by canceling the target query at a random point in its execution. This is achieved by first measuring the query execution latency and then running CANCEL QUERIES stmt at a random point in time within the latency interval. However, it might just so happen that the second target query execution is faster, so the cancel stmt might run after the target query completed. To avoid this we simply need to adjust the error pattern.

Fixes: #158241.
Release note: None

----

Release justification: test-only change.