### PR TITLE
schemachanger: allow DROP/ADD primary key in the same statement

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -869,6 +869,8 @@ ALTER TABLE t DROP CONSTRAINT "t_pkey", ADD CONSTRAINT "t_pkey" PRIMARY KEY (y)
 statement ok
 ALTER TABLE t DROP CONSTRAINT "t_pkey", ADD CONSTRAINT "t_pkey_v2" PRIMARY KEY (y)
 
+# The legacy schema changer does not leave behind an index on the old primary key column.
+onlyif config local-legacy-schema-changer
 query TT
 SHOW CREATE t
 ----
@@ -876,6 +878,20 @@ t  CREATE TABLE public.t (
      x INT8 NOT NULL,
      y INT8 NOT NULL,
      CONSTRAINT t_pkey_v2 PRIMARY KEY (y ASC),
+     FAMILY fam_0_x (x),
+     FAMILY fam_1_y (y)
+   );
+
+# The declarative schema changer leaves behind an index on the old primary key column.
+skipif config local-legacy-schema-changer
+query TT
+SHOW CREATE t
+----
+t  CREATE TABLE public.t (
+     x INT8 NOT NULL,
+     y INT8 NOT NULL,
+     CONSTRAINT t_pkey PRIMARY KEY (y ASC),
+     UNIQUE INDEX t_x_key (x ASC),
      FAMILY fam_0_x (x),
      FAMILY fam_1_y (y)
    );
@@ -1067,12 +1083,30 @@ SELECT * FROM t2
 statement ok
 DROP TABLE IF EXISTS t;
 
-statement ok
+statement disable-cf-mutator ok
 CREATE TABLE t (x INT PRIMARY KEY, y INT NOT NULL) WITH (schema_locked = false)
 
+onlyif config local-legacy-schema-changer
 statement error pq: table "t" does not have a primary key, cannot perform ADD COLUMN z INT8 AS \(x \+ 1\) STORED
 ALTER TABLE t DROP CONSTRAINT t_pkey, ADD COLUMN z INT AS (x + 1) STORED, ADD PRIMARY KEY (y)
 
+# The declarative schema changer supports this, since it defers the primary key
+# swap until it sees the new PK being added.
+skipif config local-legacy-schema-changer
+statement ok
+ALTER TABLE t DROP CONSTRAINT t_pkey, ADD COLUMN z INT AS (x + 1) STORED, ADD PRIMARY KEY (y)
+
+skipif config local-legacy-schema-changer
+query TT
+SHOW CREATE t
+----
+t  CREATE TABLE public.t (
+     x INT8 NOT NULL,
+     y INT8 NOT NULL,
+     z INT8 NULL AS (x + 1:::INT8) STORED,
+     CONSTRAINT t_pkey PRIMARY KEY (y ASC),
+     UNIQUE INDEX t_x_key (x ASC)
+   );
 
 subtest create_table_change_pk
 
@@ -2083,7 +2117,7 @@ statement ok
 CREATE TABLE t_name_check (a INT NOT NULL, CONSTRAINT ctcheck CHECK (a > 0))
 
 skipif config local-legacy-schema-changer
-statement error pgcode 42710 constraint with name "ctcheck" already exists
+statement error pgcode 42P07 constraint with name "ctcheck" already exists
 ALTER TABLE t_name_check ADD CONSTRAINT ctcheck PRIMARY KEY (a)
 
 statement ok
@@ -2096,7 +2130,7 @@ statement ok
 CREATE TABLE t_name_check (a INT NOT NULL, CONSTRAINT ctuniq UNIQUE (a))
 
 skipif config local-legacy-schema-changer
-statement error pgcode 42710 constraint with name "ctuniq" already exists
+statement error pgcode 42P07 constraint with name "ctuniq" already exists
 ALTER TABLE t_name_check ADD CONSTRAINT ctuniq PRIMARY KEY (a)
 
 statement ok
@@ -2106,7 +2140,7 @@ statement ok
 CREATE TABLE t_name_check (a INT NOT NULL, INDEX idx (a))
 
 skipif config local-legacy-schema-changer
-statement error pgcode 42710 constraint with name "idx" already exists
+statement error pgcode 42P07 constraint with name "idx" already exists
 ALTER TABLE t_name_check ADD CONSTRAINT idx PRIMARY KEY (a)
 
 # The following subtest tests the case when the new primary key

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_drop_constraint.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_drop_constraint.go
@@ -38,12 +38,13 @@ func alterTableDropConstraint(
 		return
 	}
 
-	// Dropping PK constraint: Fall back to legacy schema changer.
-	// CRDB only allows dropping PK constraint if it's immediately followed by a
-	// add PK constraint command in the same transaction. Declarative schema changer
-	// is not mature enough to deal with DDLs in transaction; we will fall back
-	// until it is.
-	fallBackIfDroppingPrimaryKey(constraintElems, t)
+	// Dropping PK constraint: Fall back to legacy schema changer unless a new
+	// primary key is being added in the same statement. If there is an ADD
+	// PRIMARY KEY, we proceed with dropping the old PK elements here, and the
+	// ADD PRIMARY KEY command will detect this and handle the full PK swap.
+	if dropPrimaryKeyConstraint(b, constraintElems, stmt, t) {
+		return
+	}
 	// Dropping UNIQUE constraint: error out as not implemented.
 	droppingUniqueConstraintNotImplemented(constraintElems, t)
 
@@ -82,13 +83,54 @@ func maybeDropAdditionallyForUniqueWithoutIndexConstraint(
 		})
 }
 
-func fallBackIfDroppingPrimaryKey(
-	constraintElems ElementResultSet, t *tree.AlterTableDropConstraint,
-) {
-	_, _, pie := scpb.FindPrimaryIndex(constraintElems)
-	if pie != nil {
-		panic(scerrors.NotImplementedError(t))
+// dropPrimaryKeyConstraint handles dropping a primary key constraint. If the
+// constraint is not a PK, it returns false and the caller continues with other
+// constraint types. If it is a PK:
+//   - If there's an ADD PRIMARY KEY in the same statement (a PK swap), it marks
+//     the old PK's IndexName element as ToAbsent and returns true. The ADD
+//     PRIMARY KEY (or ADD CONSTRAINT) command will appear later and cause the
+//     schema changer to do the full PK swap.
+//   - If there's no ADD PRIMARY KEY, it panics with NotImplementedError to fall
+//     back to the legacy schema changer.
+func dropPrimaryKeyConstraint(
+	b BuildCtx,
+	constraintElems ElementResultSet,
+	stmt tree.Statement,
+	t *tree.AlterTableDropConstraint,
+) bool {
+	if constraintElems.FilterPrimaryIndex().IsEmpty() {
+		// We are not dropping a primary key constraint.
+		return false
 	}
+	// Check if there's an ADD PRIMARY KEY command in the same ALTER TABLE
+	// statement. If so, the declarative schema changer can handle this case
+	// as a PK swap. We mark the old PK's IndexName as ToAbsent here, and the
+	// ADD PRIMARY KEY command will detect this and handle the full swap.
+	if alterTable, ok := stmt.(*tree.AlterTable); ok {
+		for _, cmd := range alterTable.Cmds {
+			if addConstraint, ok := cmd.(*tree.AlterTableAddConstraint); ok {
+				if uniqueDef, ok := addConstraint.ConstraintDef.(*tree.UniqueConstraintTableDef); ok {
+					if uniqueDef.PrimaryKey {
+						// This is a PK swap. Mark the old PK's IndexName as ToAbsent.
+						// The PrimaryIndex and other elements are handled by the
+						// ADD PRIMARY KEY command via alterPrimaryKey, which
+						// performs the full PK swap including creating the new
+						// primary index and converting the old one appropriately.
+						constraintElems.FilterIndexName().ForEach(
+							func(_ scpb.Status, _ scpb.TargetStatus, e *scpb.IndexName) {
+								b.Drop(e)
+							})
+						return true
+					}
+				}
+			}
+		}
+	}
+	// Dropping a primary key constraint without adding a new one is not
+	// implemented in the declarative schema changer yet. The legacy schema
+	// changer will handle this since it allows the PK to be re-added by a
+	// subsequent statement in the same transaction.
+	panic(scerrors.NotImplementedError(t))
 }
 
 func droppingUniqueConstraintNotImplemented(

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_drop_add_primary_key
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_drop_add_primary_key
@@ -1,0 +1,449 @@
+setup
+CREATE TABLE t (i INT NOT NULL, j INT NOT NULL, CONSTRAINT t_pkey PRIMARY KEY (i));
+INSERT INTO t values (1, 1);
+----
+
+ops
+ALTER TABLE t DROP CONSTRAINT t_pkey, ADD PRIMARY KEY (j, i);
+----
+StatementPhase stage 1 of 1 with 6 MutationType ops
+  transitions:
+    [[PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], ABSENT] -> BACKFILL_ONLY
+    [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}, PUBLIC], ABSENT] -> PUBLIC
+    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}, PUBLIC], ABSENT] -> PUBLIC
+    [[IndexData:{DescID: 104, IndexID: 4}, PUBLIC], ABSENT] -> PUBLIC
+    [[TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
+    [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
+    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
+  ops:
+    *scop.MakeAbsentIndexBackfilling
+      Index:
+        ConstraintID: 4
+        IndexID: 4
+        IsUnique: true
+        SourceIndexID: 1
+        TableID: 104
+        TemporaryIndexID: 5
+    *scop.AddColumnToIndex
+      ColumnID: 2
+      IndexID: 4
+      TableID: 104
+    *scop.MakeAbsentTempIndexDeleteOnly
+      Index:
+        ConstraintID: 5
+        IndexID: 5
+        IsUnique: true
+        SourceIndexID: 1
+        TableID: 104
+    *scop.AddColumnToIndex
+      ColumnID: 2
+      IndexID: 5
+      TableID: 104
+    *scop.AddColumnToIndex
+      ColumnID: 1
+      IndexID: 4
+      Ordinal: 1
+      TableID: 104
+    *scop.AddColumnToIndex
+      ColumnID: 1
+      IndexID: 5
+      Ordinal: 1
+      TableID: 104
+PreCommitPhase stage 1 of 2 with 1 MutationType op
+  transitions:
+    [[PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], BACKFILL_ONLY] -> ABSENT
+    [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}, PUBLIC], PUBLIC] -> ABSENT
+    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}, PUBLIC], PUBLIC] -> ABSENT
+    [[IndexData:{DescID: 104, IndexID: 4}, PUBLIC], PUBLIC] -> ABSENT
+    [[TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], DELETE_ONLY] -> ABSENT
+    [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}, TRANSIENT_ABSENT], PUBLIC] -> ABSENT
+    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}, TRANSIENT_ABSENT], PUBLIC] -> ABSENT
+  ops:
+    *scop.UndoAllInTxnImmediateMutationOpSideEffects
+      {}
+PreCommitPhase stage 2 of 2 with 10 MutationType ops
+  transitions:
+    [[PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], ABSENT] -> BACKFILL_ONLY
+    [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}, PUBLIC], ABSENT] -> PUBLIC
+    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}, PUBLIC], ABSENT] -> PUBLIC
+    [[IndexData:{DescID: 104, IndexID: 4}, PUBLIC], ABSENT] -> PUBLIC
+    [[TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
+    [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
+    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
+  ops:
+    *scop.MakeAbsentIndexBackfilling
+      Index:
+        ConstraintID: 4
+        IndexID: 4
+        IsUnique: true
+        SourceIndexID: 1
+        TableID: 104
+        TemporaryIndexID: 5
+    *scop.MaybeAddSplitForIndex
+      IndexID: 4
+      TableID: 104
+    *scop.AddColumnToIndex
+      ColumnID: 2
+      IndexID: 4
+      TableID: 104
+    *scop.MakeAbsentTempIndexDeleteOnly
+      Index:
+        ConstraintID: 5
+        IndexID: 5
+        IsUnique: true
+        SourceIndexID: 1
+        TableID: 104
+    *scop.MaybeAddSplitForIndex
+      IndexID: 5
+      TableID: 104
+    *scop.AddColumnToIndex
+      ColumnID: 2
+      IndexID: 5
+      TableID: 104
+    *scop.AddColumnToIndex
+      ColumnID: 1
+      IndexID: 4
+      Ordinal: 1
+      TableID: 104
+    *scop.AddColumnToIndex
+      ColumnID: 1
+      IndexID: 5
+      Ordinal: 1
+      TableID: 104
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 104
+      Initialize: true
+    *scop.CreateSchemaChangerJob
+      Authorization:
+        AppName: $ internal-test
+        UserName: root
+      DescriptorIDs:
+      - 104
+      JobID: 1
+      RunningStatus: 'Pending: Updating schema metadata (1 operation) — PostCommit phase (stage 1 of 15).'
+      Statements:
+      - statement: ALTER TABLE t DROP CONSTRAINT t_pkey, ADD PRIMARY KEY (j, i)
+        redactedstatement: ALTER TABLE defaultdb.public.t DROP CONSTRAINT t_pkey, ADD PRIMARY KEY (j, i)
+        statementtag: ALTER TABLE
+PostCommitPhase stage 1 of 15 with 3 MutationType ops
+  transitions:
+    [[TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], DELETE_ONLY] -> WRITE_ONLY
+    [[IndexData:{DescID: 104, IndexID: 5}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
+  ops:
+    *scop.MakeDeleteOnlyIndexWriteOnly
+      IndexID: 5
+      TableID: 104
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 104
+    *scop.UpdateSchemaChangerJob
+      JobID: 1
+PostCommitPhase stage 2 of 15 with 1 BackfillType op
+  transitions:
+    [[PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], BACKFILL_ONLY] -> BACKFILLED
+  ops:
+    *scop.BackfillIndex
+      IndexID: 4
+      SourceIndexID: 1
+      TableID: 104
+PostCommitPhase stage 3 of 15 with 3 MutationType ops
+  transitions:
+    [[PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], BACKFILLED] -> DELETE_ONLY
+  ops:
+    *scop.MakeBackfillingIndexDeleteOnly
+      IndexID: 4
+      TableID: 104
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 104
+    *scop.UpdateSchemaChangerJob
+      JobID: 1
+PostCommitPhase stage 4 of 15 with 3 MutationType ops
+  transitions:
+    [[PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], DELETE_ONLY] -> MERGE_ONLY
+  ops:
+    *scop.MakeBackfilledIndexMerging
+      IndexID: 4
+      TableID: 104
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 104
+    *scop.UpdateSchemaChangerJob
+      JobID: 1
+PostCommitPhase stage 5 of 15 with 1 BackfillType op
+  transitions:
+    [[PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], MERGE_ONLY] -> MERGED
+  ops:
+    *scop.MergeIndex
+      BackfilledIndexID: 4
+      TableID: 104
+      TemporaryIndexID: 5
+PostCommitPhase stage 6 of 15 with 4 MutationType ops
+  transitions:
+    [[PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], MERGED] -> WRITE_ONLY
+    [[TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], WRITE_ONLY] -> TRANSIENT_DELETE_ONLY
+  ops:
+    *scop.MakeWriteOnlyIndexDeleteOnly
+      IndexID: 5
+      TableID: 104
+    *scop.MakeMergedIndexWriteOnly
+      IndexID: 4
+      TableID: 104
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 104
+    *scop.UpdateSchemaChangerJob
+      JobID: 1
+PostCommitPhase stage 7 of 15 with 1 ValidationType op
+  transitions:
+    [[PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], WRITE_ONLY] -> VALIDATED
+  ops:
+    *scop.ValidateIndex
+      IndexID: 4
+      TableID: 104
+PostCommitPhase stage 8 of 15 with 11 MutationType ops
+  transitions:
+    [[SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, PUBLIC], ABSENT] -> BACKFILL_ONLY
+    [[IndexData:{DescID: 104, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
+    [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 4}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
+    [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
+    [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
+    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
+    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
+    [[IndexName:{DescID: 104, Name: t_i_key, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
+  ops:
+    *scop.MakeAbsentIndexBackfilling
+      Index:
+        ConstraintID: 2
+        IndexID: 2
+        IsUnique: true
+        SourceIndexID: 4
+        TableID: 104
+        TemporaryIndexID: 3
+      IsSecondaryIndex: true
+    *scop.MaybeAddSplitForIndex
+      IndexID: 2
+      TableID: 104
+    *scop.MakeAbsentTempIndexDeleteOnly
+      Index:
+        ConstraintID: 3
+        IndexID: 3
+        IsUnique: true
+        SourceIndexID: 4
+        TableID: 104
+      IsSecondaryIndex: true
+    *scop.MaybeAddSplitForIndex
+      IndexID: 3
+      TableID: 104
+    *scop.AddColumnToIndex
+      ColumnID: 1
+      IndexID: 2
+      TableID: 104
+    *scop.AddColumnToIndex
+      ColumnID: 1
+      IndexID: 3
+      TableID: 104
+    *scop.AddColumnToIndex
+      ColumnID: 2
+      IndexID: 2
+      Kind: 1
+      TableID: 104
+    *scop.AddColumnToIndex
+      ColumnID: 2
+      IndexID: 3
+      Kind: 1
+      TableID: 104
+    *scop.SetIndexName
+      IndexID: 2
+      Name: t_i_key
+      TableID: 104
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 104
+    *scop.UpdateSchemaChangerJob
+      JobID: 1
+PostCommitPhase stage 9 of 15 with 3 MutationType ops
+  transitions:
+    [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 4}, TRANSIENT_ABSENT], DELETE_ONLY] -> WRITE_ONLY
+    [[IndexData:{DescID: 104, IndexID: 3}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
+  ops:
+    *scop.MakeDeleteOnlyIndexWriteOnly
+      IndexID: 3
+      TableID: 104
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 104
+    *scop.UpdateSchemaChangerJob
+      JobID: 1
+PostCommitPhase stage 10 of 15 with 1 BackfillType op
+  transitions:
+    [[SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, PUBLIC], BACKFILL_ONLY] -> BACKFILLED
+  ops:
+    *scop.BackfillIndex
+      IndexID: 2
+      SourceIndexID: 4
+      TableID: 104
+PostCommitPhase stage 11 of 15 with 3 MutationType ops
+  transitions:
+    [[SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, PUBLIC], BACKFILLED] -> DELETE_ONLY
+  ops:
+    *scop.MakeBackfillingIndexDeleteOnly
+      IndexID: 2
+      TableID: 104
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 104
+    *scop.UpdateSchemaChangerJob
+      JobID: 1
+PostCommitPhase stage 12 of 15 with 3 MutationType ops
+  transitions:
+    [[SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, PUBLIC], DELETE_ONLY] -> MERGE_ONLY
+  ops:
+    *scop.MakeBackfilledIndexMerging
+      IndexID: 2
+      TableID: 104
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 104
+    *scop.UpdateSchemaChangerJob
+      JobID: 1
+PostCommitPhase stage 13 of 15 with 1 BackfillType op
+  transitions:
+    [[SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, PUBLIC], MERGE_ONLY] -> MERGED
+  ops:
+    *scop.MergeIndex
+      BackfilledIndexID: 2
+      TableID: 104
+      TemporaryIndexID: 3
+PostCommitPhase stage 14 of 15 with 4 MutationType ops
+  transitions:
+    [[SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, PUBLIC], MERGED] -> WRITE_ONLY
+    [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 4}, TRANSIENT_ABSENT], WRITE_ONLY] -> TRANSIENT_DELETE_ONLY
+  ops:
+    *scop.MakeWriteOnlyIndexDeleteOnly
+      IndexID: 3
+      TableID: 104
+    *scop.MakeMergedIndexWriteOnly
+      IndexID: 2
+      TableID: 104
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 104
+    *scop.UpdateSchemaChangerJob
+      JobID: 1
+PostCommitPhase stage 15 of 15 with 1 ValidationType op
+  transitions:
+    [[SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, PUBLIC], WRITE_ONLY] -> VALIDATED
+  ops:
+    *scop.ValidateIndex
+      IndexID: 2
+      TableID: 104
+PostCommitNonRevertiblePhase stage 1 of 3 with 14 MutationType ops
+  transitions:
+    [[PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}, ABSENT], PUBLIC] -> VALIDATED
+    [[IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], VALIDATED] -> PUBLIC
+    [[IndexName:{DescID: 104, Name: t_pkey, IndexID: 4}, PUBLIC], ABSENT] -> PUBLIC
+    [[TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
+    [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
+    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
+    [[SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, PUBLIC], VALIDATED] -> PUBLIC
+    [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 4}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
+    [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
+    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
+  ops:
+    *scop.MakePublicPrimaryIndexWriteOnly
+      IndexID: 1
+      TableID: 104
+    *scop.SetIndexName
+      IndexID: 1
+      Name: crdb_internal_index_1_name_placeholder
+      TableID: 104
+    *scop.SetIndexName
+      IndexID: 4
+      Name: t_pkey
+      TableID: 104
+    *scop.RemoveColumnFromIndex
+      ColumnID: 1
+      IndexID: 5
+      Ordinal: 1
+      TableID: 104
+    *scop.RemoveColumnFromIndex
+      ColumnID: 2
+      IndexID: 5
+      TableID: 104
+    *scop.MakeValidatedSecondaryIndexPublic
+      IndexID: 2
+      TableID: 104
+    *scop.RefreshStats
+      TableID: 104
+    *scop.RemoveColumnFromIndex
+      ColumnID: 1
+      IndexID: 3
+      TableID: 104
+    *scop.RemoveColumnFromIndex
+      ColumnID: 2
+      IndexID: 3
+      Kind: 1
+      TableID: 104
+    *scop.MakeValidatedPrimaryIndexPublic
+      IndexID: 4
+      TableID: 104
+    *scop.MakeIndexAbsent
+      IndexID: 5
+      TableID: 104
+    *scop.MakeIndexAbsent
+      IndexID: 3
+      TableID: 104
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 104
+    *scop.UpdateSchemaChangerJob
+      IsNonCancelable: true
+      JobID: 1
+PostCommitNonRevertiblePhase stage 2 of 3 with 5 MutationType ops
+  transitions:
+    [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}, ABSENT], VALIDATED] -> DELETE_ONLY
+  ops:
+    *scop.MakeWriteOnlyIndexDeleteOnly
+      IndexID: 1
+      TableID: 104
+    *scop.RemoveColumnFromIndex
+      ColumnID: 1
+      IndexID: 1
+      TableID: 104
+    *scop.RemoveColumnFromIndex
+      ColumnID: 2
+      IndexID: 1
+      Kind: 2
+      TableID: 104
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 104
+    *scop.UpdateSchemaChangerJob
+      IsNonCancelable: true
+      JobID: 1
+PostCommitNonRevertiblePhase stage 3 of 3 with 6 MutationType ops
+  transitions:
+    [[PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}, ABSENT], DELETE_ONLY] -> ABSENT
+    [[IndexData:{DescID: 104, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[IndexData:{DescID: 104, IndexID: 5}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
+    [[IndexData:{DescID: 104, IndexID: 3}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
+  ops:
+    *scop.MakeIndexAbsent
+      IndexID: 1
+      TableID: 104
+    *scop.CreateGCJobForIndex
+      IndexID: 1
+      StatementForDropJob:
+        Statement: ALTER TABLE defaultdb.public.t DROP CONSTRAINT t_pkey, ADD PRIMARY KEY (j, i)
+      TableID: 104
+    *scop.CreateGCJobForIndex
+      IndexID: 3
+      StatementForDropJob:
+        Statement: ALTER TABLE defaultdb.public.t DROP CONSTRAINT t_pkey, ADD PRIMARY KEY (j, i)
+      TableID: 104
+    *scop.CreateGCJobForIndex
+      IndexID: 5
+      StatementForDropJob:
+        Statement: ALTER TABLE defaultdb.public.t DROP CONSTRAINT t_pkey, ADD PRIMARY KEY (j, i)
+      TableID: 104
+    *scop.RemoveJobStateFromDescriptor
+      DescriptorID: 104
+      JobID: 1
+    *scop.UpdateSchemaChangerJob
+      DescriptorIDsToRemove:
+      - 104
+      IsNonCancelable: true
+      JobID: 1


### PR DESCRIPTION
Previously, the declarative schema changer would not support statements that dropped and re-added a primary key in the same statement. We actually already could support this though, since declarative schema changer has support for ALTER PRIMARY KEY.

We only need to fallback to legacy if the PK constraint is re-added by a different statement. This is because the declarative schema changer does not yet handle multiple DDL statements in a single transaction.

Epic CRDB-31281
Release note: None