### PR TITLE
storage: fix algorithm label for 256-bit V2 encryption keys

### DIFF
--- a/pkg/storage/enginepb/BUILD.bazel
+++ b/pkg/storage/enginepb/BUILD.bazel
@@ -61,6 +61,7 @@ go_test(
     size = "small",
     srcs = [
         "decode_test.go",
+        "key_registry_test.go",
         "mvcc3_test.go",
         "mvcc_test.go",
     ],

--- a/pkg/storage/enginepb/key_registry.go
+++ b/pkg/storage/enginepb/key_registry.go
@@ -22,7 +22,7 @@ func (e EncryptionType) JWKAlgorithm() (string, error) {
 	case EncryptionType_AES_192_CTR_V2:
 		return "cockroach-aes-192-ctr-v2", nil
 	case EncryptionType_AES_256_CTR_V2:
-		return "cockroach-aes-192-ctr-v2", nil
+		return "cockroach-aes-256-ctr-v2", nil
 	}
 	return "", fmt.Errorf("unknown EncryptionType %d", e)
 }

--- a/pkg/storage/enginepb/key_registry_test.go
+++ b/pkg/storage/enginepb/key_registry_test.go
@@ -1,0 +1,34 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package enginepb
+
+import (
+	"testing"
+)
+
+func TestEncryptionTypeJWKAlgorithmRoundTrip(t *testing.T) {
+	for key := range EncryptionType_name {
+		et := EncryptionType(key)
+		// Plaintext doesn't have a JWK algorithm.
+		if et == EncryptionType_Plaintext {
+			continue
+		}
+		t.Run(et.String(), func(t *testing.T) {
+			alg, err := et.JWKAlgorithm()
+			if err != nil {
+				t.Fatalf("JWKAlgorithm() failed: %v", err)
+			}
+			roundTripped, err := EncryptionTypeFromJWKAlgorithm(alg)
+			if err != nil {
+				t.Fatalf("EncryptionTypeFromJWKAlgorithm(%q) failed: %v", alg, err)
+			}
+			if roundTripped != et {
+				t.Errorf("round-trip failed: started with %v, got JWK algorithm %q, converted back to %v",
+					et, alg, roundTripped)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When generating 256-bit encryption keys in the version 2 (JWK) format,
the algorithm was incorrectly labeled as 192-bit in the output JSON.
This change ensures the label correctly reflects the 256-bit size.

Resolves: #160004

Release note (bug fix): Fixed a bug where 256-bit encryption keys
generated in the V2 (JWK) format were incorrectly labeled as 192-bit.

Epic: None