### PR TITLE
roachtest: add regex to list operations

### DIFF
--- a/pkg/cmd/roachtest/registry/filter.go
+++ b/pkg/cmd/roachtest/registry/filter.go
@@ -57,22 +57,8 @@ func OnlyBenchmarks() TestFilterOption {
 // NewTestFilter initializes a new filter. The strings are interpreted as
 // regular expressions (which are joined with |).
 func NewTestFilter(regexps []string, options ...TestFilterOption) (*TestFilter, error) {
-	makeRE := func(strs []string) *regexp.Regexp {
-		switch len(strs) {
-		case 0:
-			return regexp.MustCompile(`.`)
-		case 1:
-			return regexp.MustCompile(strs[0])
-		default:
-			for i := range strs {
-				strs[i] = "(" + strs[i] + ")"
-			}
-			return regexp.MustCompile(strings.Join(strs, "|"))
-		}
-	}
-
 	tf := &TestFilter{
-		Name: makeRE(regexps),
+		Name: MergeRegEx(regexps),
 	}
 	for _, o := range options {
 		o(tf)
@@ -87,6 +73,21 @@ func NewTestFilter(regexps []string, options ...TestFilterOption) (*TestFilter, 
 	}
 
 	return tf, nil
+}
+
+// MergeRegEx merges the given strings into a single regexp.
+func MergeRegEx(strs []string) *regexp.Regexp {
+	switch len(strs) {
+	case 0:
+		return regexp.MustCompile(`.`)
+	case 1:
+		return regexp.MustCompile(strs[0])
+	default:
+		for i := range strs {
+			strs[i] = "(" + strs[i] + ")"
+		}
+		return regexp.MustCompile(strings.Join(strs, "|"))
+	}
 }
 
 // MatchFailReason describes the reason(s) a filter did not match the test.

--- a/pkg/cmd/roachtest/test_registry.go
+++ b/pkg/cmd/roachtest/test_registry.go
@@ -180,3 +180,14 @@ func (r testRegistryImpl) AllOperations() []registry.OperationSpec {
 	})
 	return ops
 }
+
+// FilteredOperations returns operations filtered by the given regex.
+func (r testRegistryImpl) FilteredOperations(regex *regexp.Regexp) []registry.OperationSpec {
+	var filteredOps []registry.OperationSpec
+	for _, opSpec := range r.AllOperations() {
+		if regex.MatchString(opSpec.Name) {
+			filteredOps = append(filteredOps, opSpec)
+		}
+	}
+	return filteredOps
+}


### PR DESCRIPTION
Previously, listing operation(s) would always list all operations. This change allows passing regex to the command to get an idea of what would execute if you were to pass the same regex to the run command.

Epic: None
Release note: None