### PR TITLE
sql: deflake grant_in_txn logictest

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/grant_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/grant_in_txn
@@ -191,6 +191,14 @@ GRANT role_bar TO role_foo WITH ADMIN OPTION;
 statement ok
 GRANT role_foo TO testuser WITH ADMIN OPTION;
 
+# GRANTS only wait for the new version to be visible, but future schema changes
+# can retry errors if the old version is in use, due to the two version invariant.
+retry
+query I
+SELECT count(*) FROM system.lease WHERE desc_id = 'system.role_members'::REGCLASS::OID GROUP BY desc_id, version;
+----
+1
+
 # switch to testuser
 
 user testuser


### PR DESCRIPTION
Previously, we would use WaitForOneVersion after grant statements, which would guarantee, and transaction that follows would hit two version invariant errors if the prior version was in use. When we switched these operations to WaitForNewVersion, we can no longer guarantee the next transaction will hit a retry error, if the old version is still in use. This patch, adds logic to wait for a single version in grant_in_txn to avoid the flake.

Fixes: #158417

Release note: None