### PR TITLE
release-26.1: sql: tolerate serialization errors for gist decoding

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -3300,6 +3300,11 @@ func (ex *connExecutor) makeExecPlan(
 		}
 		_, err := explain.DecodePlanGistToRows(ctx, &planner.extendedEvalCtx.Context, ih.planGist.String(), catalog)
 		if err != nil {
+			// Serialization failures can occur from the lease manager if a
+			// consistent view of descriptors was not observed.
+			if pgerror.GetPGCode(err) == pgcode.SerializationFailure {
+				return ctx, err
+			}
 			return ctx, errors.NewAssertionErrorWithWrappedErrf(err, "failed to decode plan gist: %q", ih.planGist.String())
 		}
 	}


### PR DESCRIPTION
Backport 1/1 commits from #160009 on behalf of @fqazi.

----

Previously, when locked leasing was disabled, decoding plans was guaranteed never to hit serialization errors. With locked leasing enabled, mixing leased descriptors with those from KV required them both to have the same version. These errors can occur when executing tests like TestExplainGist, which involves concurrent schema changes. To address this, this patch ignores serialization failure errors during gist decoding.

Fixes: #159714

Release note: None

----

Release justification: bug in logic that is only used in crdb_test builds