### PR TITLE
release-24.1: ci-stress: skip stressing if there are no tests

### DIFF
--- a/pkg/cmd/ci-stress/main.go
+++ b/pkg/cmd/ci-stress/main.go
@@ -152,6 +152,10 @@ func mainImpl(baseRef string, bazelArgs []string) error {
 		return err
 	}
 	pkgToTests := getPkgToTests(diff)
+	if len(pkgToTests) == 0 {
+		fmt.Println("could not find any eligible tests to stress, exiting")
+		return nil
+	}
 	return runTests(ctx, pkgToTests, bazelArgs)
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #160014 on behalf of @rickystewart.

----

Release note: none
Epic: DEVINF-1582

----

Release justification: Non-production code changes