### PR TITLE
roachtest: deflake online-restore recovery

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
@@ -568,7 +568,7 @@ func testOnlineRestoreRecovery(ctx context.Context, t test.Test, c cluster.Clust
 			return errors.Wrap(err, "failed to remove pausepoint for online restore")
 		}
 
-		if err := d.deleteUserTableSST(ctx, t.L(), dbConn, collection); err != nil {
+		if err := d.deleteSSTFromBackupLayers(ctx, t.L(), dbConn, collection); err != nil {
 			return err
 		}
 		if _, err := dbConn.ExecContext(ctx, "RESUME JOB $1", downloadJobID); err != nil {


### PR DESCRIPTION
The OR recovery roachtest was failing due to the schemachange workload truncating a table and the roachtest only deleting from the full backup. In certain scenarios, the SST deleted from the full backup would end up being skipped in the restore due to the span it covered never being covered after truncation.

This commit teaches OR to instead delete an SST from every layer of the backup collection, which should make the test resilient to truncation.

Fixes: #159503

Release note: None