### PR TITLE
sql: add row count interface for inspect checks

### DIFF
--- a/pkg/sql/inspect/BUILD.bazel
+++ b/pkg/sql/inspect/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "issue.go",
         "log_sink.go",
         "progress.go",
+        "row_count_check.go",
         "runner.go",
         "span_source.go",
         "table_sink.go",

--- a/pkg/sql/inspect/row_count_check.go
+++ b/pkg/sql/inspect/row_count_check.go
@@ -1,0 +1,15 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package inspect
+
+// inspectCheckRowCount defines an inspectCheck that counts rows in addition to
+// its primary validation.
+type inspectCheckRowCount interface {
+	inspectCheck
+
+	// Rows returns the number of rows counted by the check.
+	Rows() uint64
+}


### PR DESCRIPTION
The interface allows checks to expose row counts of a span to other
checks.

Part of: #155472
Epic: CRDB-55075

Release note: None
