### PR TITLE
sql: row count from index check

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -2228,6 +2228,9 @@ type InspectTestingKnobs struct {
 	OnInspectAfterProtectedTimestamp func() error
 	// InspectIssueLogger is an override to the default issue logger.
 	InspectIssueLogger interface{}
+	// OnCheckComplete is called after a check completes. The check interface
+	// is passed to allow the callback to extract metadata (e.g., row counts).
+	OnCheckComplete func(check interface{}) error
 }
 
 // ModuleTestingKnobs implements the base.ModuleTestingKnobs interface.

--- a/pkg/sql/inspect/BUILD.bazel
+++ b/pkg/sql/inspect/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "issue.go",
         "log_sink.go",
         "progress.go",
+        "row_count_check.go",
         "runner.go",
         "span_source.go",
         "table_sink.go",

--- a/pkg/sql/inspect/row_count_check.go
+++ b/pkg/sql/inspect/row_count_check.go
@@ -1,0 +1,15 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package inspect
+
+// inspectCheckRowCount defines an inspectCheck that counts rows in addition to
+// its primary validation.
+type inspectCheckRowCount interface {
+	inspectCheck
+
+	// Rows returns the number of rows counted by the check.
+	RowCount() uint64
+}

--- a/pkg/sql/inspect/runner.go
+++ b/pkg/sql/inspect/runner.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/errors"
@@ -126,6 +127,17 @@ func (c *inspectRunner) Step(
 		if err := check.Close(ctx); err != nil {
 			return false, err
 		}
+
+		if cfg != nil && cfg.ExecutorConfig != nil {
+			inspectTestingKnobs := cfg.ExecutorConfig.(*sql.ExecutorConfig).InspectTestingKnobs
+			if inspectTestingKnobs != nil && inspectTestingKnobs.OnCheckComplete != nil {
+				err := inspectTestingKnobs.OnCheckComplete(check)
+				if err != nil {
+					return false, err
+				}
+			}
+		}
+
 		c.checks = c.checks[1:]
 	}
 	return false, nil

--- a/pkg/sql/inspect/runner_test.go
+++ b/pkg/sql/inspect/runner_test.go
@@ -84,6 +84,7 @@ type testIssueCollector struct {
 		syncutil.Mutex
 
 		issuesFound []inspectIssue
+		rowCount    *uint64
 	}
 }
 
@@ -121,6 +122,24 @@ func (m *testIssueCollector) reset() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.mu.issuesFound = nil
+	m.mu.rowCount = nil
+}
+
+// recordRowCount stores the row count for a check.
+func (m *testIssueCollector) recordRowCount(rowCount uint64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.mu.rowCount = &rowCount
+}
+
+// getRowCount retrieves the row count.
+func (m *testIssueCollector) getRowCount() (uint64, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.mu.rowCount == nil {
+		return 0, false
+	}
+	return *m.mu.rowCount, true
 }
 
 // findIssue searches for a given issue type on the given primary key string.


### PR DESCRIPTION
This change exposes the row counts computed already computed during
the index consistency check.

Part of: #155472
Epic: CRDB-55075

Release note: None