### PR TITLE
release-26.1: schemachanger: add subcommand-level control for force_declarative_statements

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/new_schema_changer
+++ b/pkg/sql/logictest/testdata/logic_test/new_schema_changer
@@ -1565,6 +1565,59 @@ SET CLUSTER SETTING sql.schema.force_declarative_statements='+CREATE SCHEMA'
 statement ok
 EXPLAIN (DDL) CREATE SCHEMA sc1
 
+# Test ALTER TABLE subcommand-level control.
+# Disable just ADD COLUMN subcommand.
+statement ok
+SET CLUSTER SETTING sql.schema.force_declarative_statements='!ALTER TABLE ADD COLUMN'
+
+statement ok
+CREATE TABLE stmt_ctrl_sub(n int primary key) WITH (schema_locked = false)
+
+# ADD COLUMN should be disabled (fall back to legacy).
+statement error pgcode 0A000 cannot explain a statement which is not supported by the declarative schema changer
+EXPLAIN (DDL) ALTER TABLE stmt_ctrl_sub ADD COLUMN disabled_col BOOL
+
+# DROP COLUMN should still use declarative (not disabled).
+statement ok
+ALTER TABLE stmt_ctrl_sub ADD COLUMN to_drop BOOL
+
+statement ok
+EXPLAIN (DDL) ALTER TABLE stmt_ctrl_sub DROP COLUMN to_drop
+
+# Test that statement-level disable can be overridden by subcommand-level enable.
+statement ok
+SET CLUSTER SETTING sql.schema.force_declarative_statements='!ALTER TABLE, +ALTER TABLE DROP COLUMN'
+
+# ADD COLUMN should be disabled (inherits from !ALTER TABLE).
+statement error pgcode 0A000 cannot explain a statement which is not supported by the declarative schema changer
+EXPLAIN (DDL) ALTER TABLE stmt_ctrl_sub ADD COLUMN still_disabled BOOL
+
+# DROP COLUMN should use declarative (overridden by +ALTER TABLE DROP COLUMN).
+statement ok
+ALTER TABLE stmt_ctrl_sub ADD COLUMN another_to_drop BOOL
+
+statement ok
+EXPLAIN (DDL) ALTER TABLE stmt_ctrl_sub DROP COLUMN another_to_drop
+
+# Test mixed subcommand statement - any disabled subcommand disables the whole statement.
+statement ok
+SET CLUSTER SETTING sql.schema.force_declarative_statements='!ALTER TABLE ADD COLUMN'
+
+# This statement has ADD COLUMN which is disabled, so the whole thing should fall back.
+statement error pgcode 0A000 cannot explain a statement which is not supported by the declarative schema changer
+EXPLAIN (DDL) ALTER TABLE stmt_ctrl_sub ADD COLUMN mixed_col BOOL, DROP COLUMN another_to_drop
+
+# Test invalid subcommand tag validation.
+statement error ALTER TABLE subcommand tag "ALTER TABLE NONEXISTENT CMD" is not controlled
+SET CLUSTER SETTING sql.schema.force_declarative_statements='!ALTER TABLE NONEXISTENT CMD'
+
+# Clean up.
+statement ok
+SET CLUSTER SETTING sql.schema.force_declarative_statements=''
+
+statement ok
+DROP TABLE stmt_ctrl_sub
+
 subtest end
 
 

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/statement_control.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/statement_control.go
@@ -6,6 +6,8 @@
 package scbuildstmt
 
 import (
+	"reflect"
+	"slices"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -14,15 +16,37 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// statementsForceControl track if a statement tag is enabled or disabled
-// forcefully by the user to use declarative schema changer.
-type statementsForceControl map[string]bool
+// statementsForceControl tracks if a statement tag (or ALTER TABLE subcommand)
+// is enabled or disabled forcefully by the user to use declarative schema changer.
+type statementsForceControl struct {
+	// statements maps statement tags (e.g., "ALTER TABLE", "CREATE SCHEMA") to
+	// their force control state (true=enabled, false=disabled).
+	statements map[string]bool
+	// subcommands maps ALTER TABLE subcommand tags (e.g., "ALTER TABLE ADD COLUMN")
+	// to their force control state. Subcommand-level controls take precedence over
+	// statement-level controls.
+	subcommands map[string]bool
+}
+
+// supportedAlterTableSubcommandTags maps ALTER TABLE subcommand tags
+// (e.g., "ALTER TABLE ADD COLUMN") to empty struct for validation.
+var supportedAlterTableSubcommandTags = map[string]struct{}{}
 
 // forceDeclarativeStatements outlines statements which are forcefully enabled
 // and/or disabled with declarative schema changer, separated by comma.
 // Forcefully enabled statements are prefixed with "+";
 // Forcefully disabled statements are prefixed with "!";
-// E.g. `SET CLUSTER SETTING sql.schema.force_declarative_statements = "+ALTER TABLE,!CREATE SEQUENCE";`
+//
+// Statement-level control:
+//
+//	SET CLUSTER SETTING sql.schema.force_declarative_statements = '+ALTER TABLE,!CREATE SEQUENCE';
+//
+// ALTER TABLE subcommand-level control (subcommand names use uppercase with spaces):
+//
+//	SET CLUSTER SETTING sql.schema.force_declarative_statements = '!ALTER TABLE ADD COLUMN';
+//	SET CLUSTER SETTING sql.schema.force_declarative_statements = '!ALTER TABLE, +ALTER TABLE ADD COLUMN';
+//
+// Subcommand-level controls take precedence over statement-level controls.
 //
 // Note: We can only control statements implemented in declarative schema changer.
 var forceDeclarativeStatements = settings.RegisterStringSetting(
@@ -43,8 +67,25 @@ var forceDeclarativeStatements = settings.RegisterStringSetting(
 			} else {
 				return errors.Errorf("tag is not properly formatted, must start with '+' or '!' (%s)", tag)
 			}
-			if _, ok := supportedStatementTags[tag]; !ok {
-				return errors.Errorf("statement tag %q is not controlled by the declarative schema changer", tag)
+			// Check if this is an ALTER TABLE subcommand tag.
+			sortedKeys := func(m map[string]struct{}) []string {
+				keys := make([]string, 0, len(m))
+				for k := range m {
+					keys = append(keys, k)
+				}
+				slices.Sort(keys)
+				return keys
+			}
+			if strings.HasPrefix(tag, "ALTER TABLE ") {
+				if _, ok := supportedAlterTableSubcommandTags[tag]; !ok {
+					return errors.WithDetail(
+						errors.Errorf("ALTER TABLE subcommand tag %q is not controlled by the declarative schema changer", tag),
+						"supported tags: "+strings.Join(sortedKeys(supportedAlterTableSubcommandTags), ", "))
+				}
+			} else if _, ok := supportedStatementTags[tag]; !ok {
+				return errors.WithDetail(
+					errors.Errorf("statement tag %q is not controlled by the declarative schema changer", tag),
+					"supported tags: "+strings.Join(sortedKeys(supportedStatementTags), ", "))
 			}
 		}
 		return nil
@@ -54,11 +95,10 @@ var forceDeclarativeStatements = settings.RegisterStringSetting(
 // `n` is forcefully disabled, then a "NotImplemented" error will be panicked.
 // Otherwise, return whether `n` is forcefully enabled.
 func (c statementsForceControl) CheckControl(n tree.Statement) (forceEnabled bool) {
-	// This map is only created *if* any force flags are set.
-	if c == nil {
+	if c.statements == nil {
 		return false
 	}
-	enabledOrDisabled, found := c[n.StatementTag()]
+	enabledOrDisabled, found := c.statements[n.StatementTag()]
 	if !found {
 		return false
 	}
@@ -69,13 +109,46 @@ func (c statementsForceControl) CheckControl(n tree.Statement) (forceEnabled boo
 	return enabledOrDisabled
 }
 
-// GetSchemaChangerStatementControl returns a map of statements that
-// are explicitly disabled by administrators for the declarative schema
-// changer.
+// CheckAlterTableCmdControl checks if an ALTER TABLE subcommand is forced to
+// be enabled or disabled. Subcommand-level controls take precedence over
+// statement-level controls.
+//
+// Returns:
+//   - (true, true): subcommand is force-enabled
+//   - (false, true): subcommand is force-disabled
+//   - (_, false): no subcommand-level control found
+func (c statementsForceControl) CheckAlterTableCmdControl(
+	cmd tree.AlterTableCmd,
+) (enabled, found bool) {
+	if c.subcommands == nil {
+		return false, false
+	}
+	tag := alterTableCmdToTag(cmd)
+	enabledOrDisabled, ok := c.subcommands[tag]
+	if !ok {
+		return false, false
+	}
+	return enabledOrDisabled, true
+}
+
+// alterTableCmdToTag converts an ALTER TABLE subcommand to its tag format.
+// E.g., an AlterTableAddColumn command becomes "ALTER TABLE ADD COLUMN".
+// Returns empty string if the command type is not in the alterTableSubcommandNames map.
+func alterTableCmdToTag(cmd tree.AlterTableCmd) string {
+	subcommandName, ok := alterTableSubcommandNames[reflect.TypeOf(cmd)]
+	if !ok {
+		return ""
+	}
+	return "ALTER TABLE " + subcommandName
+}
+
+// getStatementsForceControl returns a control structure that tracks statements
+// and ALTER TABLE subcommands that are explicitly enabled or disabled by
+// administrators for the declarative schema changer.
 func getStatementsForceControl(sv *settings.Values) statementsForceControl {
-	statements := forceDeclarativeStatements.Get(sv)
-	var statementMap statementsForceControl
-	for _, tag := range strings.Split(statements, ",") {
+	settingValue := forceDeclarativeStatements.Get(sv)
+	var control statementsForceControl
+	for _, tag := range strings.Split(settingValue, ",") {
 		tag = strings.ToUpper(strings.TrimSpace(tag))
 		if len(tag) == 0 {
 			continue
@@ -87,10 +160,18 @@ func getStatementsForceControl(sv *settings.Values) statementsForceControl {
 		if tagStart == '!' {
 			enabledOrDisabled = false
 		}
-		if statementMap == nil {
-			statementMap = make(statementsForceControl)
+		// Check if this is an ALTER TABLE subcommand tag.
+		if strings.HasPrefix(tag, "ALTER TABLE ") {
+			if control.subcommands == nil {
+				control.subcommands = make(map[string]bool)
+			}
+			control.subcommands[tag] = enabledOrDisabled
+		} else {
+			if control.statements == nil {
+				control.statements = make(map[string]bool)
+			}
+			control.statements[tag] = enabledOrDisabled
 		}
-		statementMap[tag] = enabledOrDisabled
 	}
-	return statementMap
+	return control
 }


### PR DESCRIPTION
Backport 1/1 commits from #160071 on behalf of @rafiss.

----



Previously, the `sql.schema.force_declarative_statements` cluster setting only supported statement-level control (e.g., `!ALTER TABLE` would disable the declarative schema changer for all ALTER TABLE operations). This made it difficult to selectively disable specific ALTER TABLE subcommands while keeping others enabled.

This change extends the setting to support granular control at the ALTER TABLE subcommand level. Users can now specify tags like:

    SET CLUSTER SETTING sql.schema.force_declarative_statements =
      '!ALTER TABLE ADD COLUMN, +ALTER TABLE DROP COLUMN';

Key changes:
- Extended `statementsForceControl` to track both statement-level and subcommand-level controls
- Added `alterTableSubcommandNames` map to provide subcommand tag names
- Added validation in init() to ensure every supported ALTER TABLE command has a corresponding entry in the names map
- Subcommand-level controls take precedence over statement-level controls
- If any subcommand in a multi-command ALTER TABLE is force-disabled, the entire statement falls back to the legacy schema changer
- Error messages now include eligible tags as a detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes: #159756

Release note: None

----

Release justification: pre-mortem item for 26.1