### PR TITLE
backup: add BEFORE/AFTER syntax to SHOW BACKUPS

### DIFF
--- a/docs/generated/sql/bnf/show_backup.bnf
+++ b/docs/generated/sql/bnf/show_backup.bnf
@@ -1,5 +1,5 @@
 show_backup_stmt ::=
-	'SHOW' 'BACKUPS' 'IN' collectionURI
+	'SHOW' 'BACKUPS' 'IN' collectionURI opt_show_after_before_clause
 	| 'SHOW' 'BACKUP' 'SCHEMAS' 'FROM' subdirectory 'IN' collectionURI 'WITH' show_backup_options ( ( ',' show_backup_options ) )*
 	| 'SHOW' 'BACKUP' 'SCHEMAS' 'FROM' subdirectory 'IN' collectionURI 'WITH' 'OPTIONS' '(' show_backup_options ( ( ',' show_backup_options ) )* ')'
 	| 'SHOW' 'BACKUP' 'SCHEMAS' 'FROM' subdirectory 'IN' collectionURI 

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -864,7 +864,7 @@ use_stmt ::=
 	'USE' var_value
 
 show_backup_stmt ::=
-	'SHOW' 'BACKUPS' 'IN' string_or_placeholder_opt_list
+	'SHOW' 'BACKUPS' 'IN' string_or_placeholder_opt_list opt_show_after_before_clause
 	| 'SHOW' 'BACKUP' show_backup_details 'FROM' string_or_placeholder 'IN' string_or_placeholder_opt_list opt_with_show_backup_options
 	| 'SHOW' 'BACKUP' string_or_placeholder 'IN' string_or_placeholder_opt_list opt_with_show_backup_options
 
@@ -2204,6 +2204,13 @@ to_or_eq ::=
 var_value ::=
 	a_expr
 	| extra_var_value
+
+opt_show_after_before_clause ::=
+	'AFTER' a_expr
+	| 'BEFORE' a_expr
+	| 'AFTER' a_expr 'BEFORE' a_expr
+	| 'BEFORE' a_expr 'AFTER' a_expr
+	| 
 
 show_backup_details ::=
 	'SCHEMAS'

--- a/pkg/sql/parser/testdata/backup_restore
+++ b/pkg/sql/parser/testdata/backup_restore
@@ -150,6 +150,59 @@ SHOW BACKUPS IN $1 -- literals removed
 SHOW BACKUPS IN $1 -- identifiers removed
 
 parse
+SHOW BACKUPS IN 'bar' AFTER '1'
+----
+SHOW BACKUPS IN '*****' AFTER '1' -- normalized!
+SHOW BACKUPS IN ('*****') AFTER ('1') -- fully parenthesized
+SHOW BACKUPS IN '_' AFTER '_' -- literals removed
+SHOW BACKUPS IN '*****' AFTER '1' -- identifiers removed
+SHOW BACKUPS IN 'bar' AFTER '1' -- passwords exposed
+
+parse
+SHOW BACKUPS IN 'bar' BEFORE '1'
+----
+SHOW BACKUPS IN '*****' BEFORE '1' -- normalized!
+SHOW BACKUPS IN ('*****') BEFORE ('1') -- fully parenthesized
+SHOW BACKUPS IN '_' BEFORE '_' -- literals removed
+SHOW BACKUPS IN '*****' BEFORE '1' -- identifiers removed
+SHOW BACKUPS IN 'bar' BEFORE '1' -- passwords exposed
+
+parse
+SHOW BACKUPS IN 'bar' AFTER '1' BEFORE '2'
+----
+SHOW BACKUPS IN '*****' AFTER '1' BEFORE '2' -- normalized!
+SHOW BACKUPS IN ('*****') AFTER ('1') BEFORE ('2') -- fully parenthesized
+SHOW BACKUPS IN '_' AFTER '_' BEFORE '_' -- literals removed
+SHOW BACKUPS IN '*****' AFTER '1' BEFORE '2' -- identifiers removed
+SHOW BACKUPS IN 'bar' AFTER '1' BEFORE '2' -- passwords exposed
+
+parse
+SHOW BACKUPS IN 'bar' BEFORE '2' AFTER '1'
+----
+SHOW BACKUPS IN '*****' AFTER '1' BEFORE '2' -- normalized!
+SHOW BACKUPS IN ('*****') AFTER ('1') BEFORE ('2') -- fully parenthesized
+SHOW BACKUPS IN '_' AFTER '_' BEFORE '_' -- literals removed
+SHOW BACKUPS IN '*****' AFTER '1' BEFORE '2' -- identifiers removed
+SHOW BACKUPS IN 'bar' AFTER '1' BEFORE '2' -- passwords exposed
+
+parse
+SHOW BACKUPS IN $1 AFTER $2 BEFORE $3
+----
+SHOW BACKUPS IN $1 AFTER $2 BEFORE $3
+SHOW BACKUPS IN ($1) AFTER ($2) BEFORE ($3) -- fully parenthesized
+SHOW BACKUPS IN $1 AFTER $1 BEFORE $1 -- literals removed
+SHOW BACKUPS IN $1 AFTER $2 BEFORE $3 -- identifiers removed
+
+parse
+SHOW BACKUPS IN $1 BEFORE $2 AFTER $3
+----
+SHOW BACKUPS IN $1 AFTER $3 BEFORE $2 -- normalized!
+SHOW BACKUPS IN ($1) AFTER ($3) BEFORE ($2) -- fully parenthesized
+SHOW BACKUPS IN $1 AFTER $1 BEFORE $1 -- literals removed
+SHOW BACKUPS IN $1 AFTER $3 BEFORE $2 -- identifiers removed
+
+
+parse
 SHOW BACKUP 'foo' IN 'bar'
 ----
 SHOW BACKUP 'foo' IN '*****' -- normalized!

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -100,6 +100,7 @@ type ShowBackup struct {
 	From         bool
 	Details      ShowBackupDetails
 	Options      ShowBackupOptions
+	TimeRange    ShowAfterBefore
 }
 
 // Format implements the NodeFormatter interface.
@@ -107,6 +108,10 @@ func (node *ShowBackup) Format(ctx *FmtCtx) {
 	if node.Path == nil {
 		ctx.WriteString("SHOW BACKUPS IN ")
 		ctx.FormatURIs(node.InCollection)
+		if !node.TimeRange.IsDefault() {
+			ctx.WriteString(" ")
+			ctx.FormatNode(&node.TimeRange)
+		}
 		return
 	}
 	ctx.WriteString("SHOW BACKUP ")
@@ -133,6 +138,34 @@ func (node *ShowBackup) Format(ctx *FmtCtx) {
 		ctx.FormatNode(&node.Options)
 		ctx.WriteString(")")
 	}
+}
+
+// ShowAfterBefore represents the AFTER <expr> BEFORE <expr> option for
+// SHOW BACKUPS.
+type ShowAfterBefore struct {
+	After  Expr
+	Before Expr
+}
+
+var _ NodeFormatter = &ShowAfterBefore{}
+
+func (s *ShowAfterBefore) Format(ctx *FmtCtx) {
+	if s.After != nil {
+		ctx.WriteString("AFTER ")
+		ctx.FormatNode(s.After)
+	}
+
+	if s.Before != nil {
+		if s.After != nil {
+			ctx.WriteString(" ")
+		}
+		ctx.WriteString("BEFORE ")
+		ctx.FormatNode(s.Before)
+	}
+}
+
+func (s *ShowAfterBefore) IsDefault() bool {
+	return s.After == nil && s.Before == nil
 }
 
 type ShowBackupOptions struct {


### PR DESCRIPTION
This commit adds the `BEFORE <ts> AFTER <ts>` to the `SHOW BACKUPS` syntax.

Epic: CRDB-57536

Informs: #159647

Release note: None