### PR TITLE
integration_test: modify insight priority test to avoid unexpected contention

### DIFF
--- a/pkg/sql/sqlstats/insights/integration/insights_test.go
+++ b/pkg/sql/sqlstats/insights/integration/insights_test.go
@@ -667,6 +667,12 @@ func TestInsightsPriorityIntegration(t *testing.T) {
 	_, err := conn.ExecContext(ctx, "SET SESSION application_name=$1", appName)
 	require.NoError(t, err)
 
+	// Enable latch wait contention event registration so that high-contention
+	// insights triggered by latch contention have corresponding events in the
+	// contention registry.
+	_, err = conn.ExecContext(ctx, "SET register_latch_wait_contention_events = true")
+	require.NoError(t, err)
+
 	_, err = conn.Exec("CREATE TABLE t (id string, s string);")
 	require.NoError(t, err)
 


### PR DESCRIPTION
Being blessed with a resource constrained machine made it easy to reproduce the recent test flakes which have been cropping up in `TestInsightsPriorityIntegration`. The test itself does something very simple. It tries to create a slow query insight by sending a moderately slow query to the database. It then looks for that insight in the insights registry.

What can happen though on an overworked machine, is the following. The query is sent, and query execution has to contend with multiple pauses issued by the host machine. These pauses can occur during contention reading, which can cause the system to "observe" contention. This contention is bubbled upward, and when the insight is created, the insight is incorrectly labeled as a contention insight, rather than a slow query insight.

Because we filter contention insights out by only insights which have corresponding contention events, and because the contention events caused are latch events, and are therefore not catalogued by default, the tests fail, for the insight expected cannot be surfaced without its companion contention event.

There are a few ways to fix this, but the least invasive and most obvious was to flip the flag which saves latch events so that even if the insight accidentally becomes related to contention, it will not be filtered out when reading from the registry.

Fixes: #160067
Fixes: #158486
Fixes: #158471
Fixes: #157893
Epic: none

Release note: none