### PR TITLE
scripts/gceworker: use dig for update-firewall

### DIFF
--- a/scripts/gceworker.sh
+++ b/scripts/gceworker.sh
@@ -78,7 +78,7 @@ function refresh_ssh_config() {
 }
 
 function update_firewall() {
-	MY_IP="$(curl -4 -s https://icanhazip.com/)"
+	MY_IP="$(dig +short myip.opendns.com @resolver1.opendns.com)"
 	RULE="$(whoami)-home-ssh-rule"
 	gcloud compute firewall-rules delete --quiet "$RULE" || true
 	gcloud compute firewall-rules create --quiet "$RULE" \


### PR DESCRIPTION
Claude suggests that using dig is more reliable since it uses DNS rather than HTTPS, avoiding the TLS handshake issues.

Epic: None
Release note: None