### PR TITLE
raft: add fast path to raftLog.match()

### DIFF
--- a/pkg/raft/log.go
+++ b/pkg/raft/log.go
@@ -191,7 +191,7 @@ func (l *raftLog) append(a LeadSlice) bool {
 // the s.prev entry doesn't match, or is missing.
 //
 // All the entries up to the returned index are already present in the log, and
-// do not need to be rewritten. The caller can safely fast-forward the appended
+// do not need to be rewritten. The caller can safely fast-forward the appending
 // LeadSlice to this index.
 func (l *raftLog) match(s LeadSlice) (uint64, bool) {
 	if !l.matchTerm(s.prev) {

--- a/pkg/raft/log.go
+++ b/pkg/raft/log.go
@@ -198,12 +198,36 @@ func (l *raftLog) match(s LeadSlice) (uint64, bool) {
 		return 0, false
 	}
 
-	// TODO(pav-kv): add a fast-path here using the Log Matching property of raft.
-	// Check the term match at min(s.lastIndex(), l.lastIndex()) entry, and fall
-	// back to conflict search only if it mismatches.
-	// TODO(pav-kv): also, there should be no mismatch if s.term == l.accTerm, so
-	// the fast-path can avoid this one check too.
+	// At this point, a prefix of entryIDs in s with index in
+	// [s.prev.index ... s.lastIndex()] is guaranteed to match a slice of l.
 	//
+	//
+	// Fast path: if the raft leader's term containing the appending
+	// LeadSlice s is the same as accTerm (the term of the newest leader
+	// whose append was accepted into l), then there is no mismatch
+	// between the two logs.
+	//
+	// See comments on LeadSlice.term, raftLog.accTerm(), and section
+	// 5.3 of the Raft paper for more details.
+	//
+	//
+	// It is possible for s.term == l.accTerm() to evaluate to false
+	// even if there is no mismatch between the two logs, this happens
+	// if we have not yet appended the first log entry from the s.term
+	// leader to l. In this case, we can still use the Raft log matching
+	// property to do a fast path optimization: check the term match at
+	// min(s.lastIndex(), l.lastIndex()) entry of LeadSlice s. If the
+	// term matches, there is no mismatch between the two logs.
+	//
+	// In either case, if there is no mismatch, return
+	// min(s.lastIndex(), l.lastIndex()). All entryIDs in s up to and
+	// including this index are guaranteed to match.
+	minLast := min(s.lastIndex(), l.unstable.lastIndex())
+	if s.term == l.accTerm() ||
+		l.matchTerm(entryID{s.termAt(minLast), minLast}) {
+		return minLast, true
+	}
+
 	// TODO(pav-kv): every matchTerm call in the linear scan below can fall back
 	// to fetching an entry from storage. This is inefficient, we can improve it.
 	// Logs that don't match at one index, don't match at all indices above. So we


### PR DESCRIPTION
This PR addresses the TODO optimizations to add a fast path to [`raftLog.match()`](https://github.com/cockroachdb/cockroach/blob/0864c4ccfd74528f05e5cb745dc065c58b064e5e/pkg/raft/log.go#L196) to avoid doing a linear scan to find a fork point on "our" raftLog against the appending `LeadSlice` in the common-case.

`l` is "our" log, `s` is the log append `LeadSlice` from `MsgApp`.

By raft invariants, we have a guarantee that our (follower) log `l` is a prefix of the `l.accTerm` leader's log. 
So if the `accTerm` leader sends us log appends (indicated by the `LeadSlice s.term` field, and checked by `l.accTerm` == `s.term`),  

we may skip all the `matchTerm` checks for the entries in the appending `LeadSlice s`as they will all succeed meaning there are no log inconsistencies between the log append `LeadSlice s` and our log `l`. 

It is also possible that we have not yet appended the first log entry from the s.term leader so `l.accTerm` == `s.term` would evaluate to `false`. In this case, we can still use the Raft log matching property to do a fast-path check:
Check the term match at `min(s.lastIndex(), l.lastIndex())` entry of `s`. If the term matches, there is no mismatch between the two logs.

In either case, if there is no mismatch, return `min(s.lastIndex(), l.lastIndex())`. All entryIDs up to and including this index are guaranteed to match.

Note that there is still one remaining TODO in  `raftLog.match()` untouched.
However with the `termCache` in place the potential penalty cost of doing a linear scan (`l.matchTerm(id)`) for all `id` within `LeadSlice s.entries.id`)  is no longer substantial, as it is very unlikely that the term check falls back to a storage call. 
Therefore the TODO may be updated to reflect the current state.

Epic: None
Release note: None

