### PR TITLE
catalog/lease: fix historical reads with locked leasing

### DIFF
--- a/pkg/sql/catalog/lease/lease_internal_test.go
+++ b/pkg/sql/catalog/lease/lease_internal_test.go
@@ -1260,7 +1260,7 @@ func TestReadOlderVersionForTimestamp(t *testing.T) {
 			resetDescriptorState(manager, tableID, tc)
 
 			// Retrieve historicalDescriptors modification times.
-			retrieved, err := manager.readOlderVersionForTimestamp(ctx, tableID, tc.ts)
+			retrieved, err := manager.readOlderVersionForTimestamp(ctx, tableID, TimestampToReadTimestamp(tc.ts))
 			require.NoError(t, err)
 
 			// Validate retrieved descriptors match expected versions.


### PR DESCRIPTION
Previously, our last resort logic to read descriptors at the end timestamp for historical descriptors would behave incorrectly for locked descriptor leasing. This would read at the leased timestamp and, for initially created descriptors, incorrectly return "descriptor not found". Even if the descriptor is avaialble at the actual timestamp for the transaction. To address this, this patch surfaces these errors only if the base timestamp is not able to satisfy the request either. The findForTimestamp logic already attempts the base timestamp if the locked timestamp is not viable.

Fixes: #159998

Release note: None