### PR TITLE
sql: add cancel checking to routine exec stats collection

### DIFF
--- a/pkg/cmd/roachtest/tests/query_comparison_util.go
+++ b/pkg/cmd/roachtest/tests/query_comparison_util.go
@@ -354,7 +354,6 @@ func runOneRoundQueryComparison(
 			sqlsmith.SetComplexity(.3),
 			sqlsmith.SetScalarComplexity(.1),
 			sqlsmith.SimpleNames(),
-			sqlsmith.DisableDoBlocks(), // TODO(#158667): unskip this.
 		)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -346,6 +346,10 @@ func runPlanInsidePlan(
 		planCtx.collectExecStats = true
 		planCtx.saveFlows = getDefaultSaveFlowsFunc(ctx, &plannerCopy, planComponentTypeInner)
 		defer func() {
+			if ctx.Err() != nil {
+				// Skip populating ExecStats if we've been canceled.
+				return
+			}
 			sp := tracing.SpanFromContext(ctx)
 			recording := sp.GetRecording(tracingpb.RecordingStructured)
 			if recording.Len() == 0 {


### PR DESCRIPTION
We recently added the sql execution statistics collection for routines and started seeing DO blocks not respecting the statement timeout. This is the case since some routines will have huge traces to process and we didn't have any cancel checking in there - this is now fixed.

Fixes: #158667.
Release note: None