### PR TITLE
backup: still set rev start time for empty incrementals

### DIFF
--- a/pkg/backup/backup_processor.go
+++ b/pkg/backup/backup_processor.go
@@ -666,7 +666,15 @@ func runBackupProcessor(
 						// Even if the ExportRequest did not export any data we want to report
 						// the span as completed for accurate progress tracking.
 						if len(resp.Files) == 0 {
-							sink.WriteWithNoData(backupsink.ExportedSpan{CompletedSpans: completedSpans})
+							var revStart hlc.Timestamp
+							if spec.MVCCFilter == kvpb.MVCCFilter_All {
+								// Even if no data is written, we need to track the revision
+								// start time.
+								revStart = spec.BackupStartTime
+							}
+							sink.WriteWithNoData(
+								backupsink.ExportedSpan{CompletedSpans: completedSpans, RevStart: revStart},
+							)
 						}
 						for i, file := range resp.Files {
 							entryCounts := countRows(file.Exported, spec.PKIDs)

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -11404,3 +11404,43 @@ func TestRestoreConformanceSingleNode(t *testing.T) {
 	query2 := fmt.Sprintf(`SELECT count(*) FROM system.job_message WHERE job_id = %d AND message = 'span config conformance check completed'`, jobId)
 	sqlDB.CheckQueryResults(t, query2, [][]string{{"1"}})
 }
+
+func TestBackupEmptyRevisionHistoryIncs(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	_, sqlDB, cleanupFn := backupRestoreTestSetupEmpty(t, singleNode, "", InitManualReplication, base.TestClusterArgs{})
+	defer cleanupFn()
+
+	const collectionURI = "nodelocal://1/"
+
+	// Queries the revision start time from the first incremental in a given
+	// collection.
+	queryRevStartTime := func(collectionURI string) int64 {
+		var unixTS int64
+		sqlDB.QueryRow(
+			t,
+			`WITH x AS (SHOW BACKUP FROM LATEST IN $1 WITH as_json)
+			SELECT manifest->'revisionStartTime'->>'wallTime' FROM x OFFSET 1 LIMIT 1
+			`,
+			collectionURI,
+		).Scan(&unixTS)
+		return unixTS
+	}
+
+	t.Run("revision history empty incs should still set revision start time", func(t *testing.T) {
+		uri := fmt.Sprintf("%s%s", collectionURI, t.Name())
+		sqlDB.Exec(t, "BACKUP INTO $1 WITH revision_history", uri)
+		sqlDB.Exec(t, "BACKUP INTO LATEST IN $1 WITH revision_history", uri)
+		revStartTime := queryRevStartTime(uri)
+		require.Positive(t, revStartTime)
+	})
+
+	t.Run("non-revision history empty incs should not set revision start time", func(t *testing.T) {
+		uri := fmt.Sprintf("%s%s", collectionURI, t.Name())
+		sqlDB.Exec(t, "BACKUP INTO $1", uri)
+		sqlDB.Exec(t, "BACKUP INTO LATEST IN $1", uri)
+		revStartTime := queryRevStartTime(uri)
+		require.Zero(t, revStartTime)
+	})
+}

--- a/pkg/backup/backupsink/file_sst_sink.go
+++ b/pkg/backup/backupsink/file_sst_sink.go
@@ -220,6 +220,7 @@ func (s *FileSSTSink) Write(ctx context.Context, resp ExportedSpan) (roachpb.Key
 
 func (s *FileSSTSink) WriteWithNoData(resp ExportedSpan) {
 	s.completedSpans += resp.CompletedSpans
+	s.flushedRevStart.Forward(resp.RevStart)
 	s.midRow = false
 }
 
@@ -247,6 +248,7 @@ func (s *FileSSTSink) Flush(ctx context.Context) error {
 		if s.completedSpans != 0 {
 			progDetails := backuppb.BackupManifest_Progress{
 				CompletedSpans: s.completedSpans,
+				RevStartTime:   s.flushedRevStart,
 			}
 			var prog execinfrapb.RemoteProducerMetadata_BulkProcessorProgress
 			details, err := gogotypes.MarshalAny(&progDetails)
@@ -259,6 +261,7 @@ func (s *FileSSTSink) Flush(ctx context.Context) error {
 				return ctx.Err()
 			case s.conf.ProgCh <- prog:
 			}
+			s.flushedRevStart.Reset()
 			s.completedSpans = 0
 		}
 		return nil


### PR DESCRIPTION
Previously, empty incremental backups would not set revision start time in the backup manifest. This commit fixes the backup processor to still set the revision start time when writing no data.

Epic: None

Release note: None