### PR TITLE
backup: support SHOW BACKUPS with backup ids

### DIFF
--- a/docs/generated/sql/bnf/show_backup.bnf
+++ b/docs/generated/sql/bnf/show_backup.bnf
@@ -1,5 +1,5 @@
 show_backup_stmt ::=
-	'SHOW' 'BACKUPS' 'IN' collectionURI opt_show_after_before_clause
+	'SHOW' 'BACKUPS' 'IN' collectionURI opt_show_backup_time_filter_clause
 	| 'SHOW' 'BACKUP' 'SCHEMAS' 'FROM' subdirectory 'IN' collectionURI 'WITH' show_backup_options ( ( ',' show_backup_options ) )*
 	| 'SHOW' 'BACKUP' 'SCHEMAS' 'FROM' subdirectory 'IN' collectionURI 'WITH' 'OPTIONS' '(' show_backup_options ( ( ',' show_backup_options ) )* ')'
 	| 'SHOW' 'BACKUP' 'SCHEMAS' 'FROM' subdirectory 'IN' collectionURI 

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -865,7 +865,7 @@ use_stmt ::=
 	'USE' var_value
 
 show_backup_stmt ::=
-	'SHOW' 'BACKUPS' 'IN' string_or_placeholder_opt_list opt_show_after_before_clause
+	'SHOW' 'BACKUPS' 'IN' string_or_placeholder_opt_list opt_show_backup_time_filter_clause
 	| 'SHOW' 'BACKUP' show_backup_details 'FROM' string_or_placeholder 'IN' string_or_placeholder_opt_list opt_with_show_backup_options
 	| 'SHOW' 'BACKUP' string_or_placeholder 'IN' string_or_placeholder_opt_list opt_with_show_backup_options
 
@@ -1360,6 +1360,7 @@ unreserved_keyword ::=
 	| 'NAN'
 	| 'NEVER'
 	| 'NEW'
+	| 'NEWER'
 	| 'NEW_DB_NAME'
 	| 'NEW_KMS'
 	| 'NEXT'
@@ -1393,6 +1394,7 @@ unreserved_keyword ::=
 	| 'OFF'
 	| 'OIDS'
 	| 'OLD'
+	| 'OLDER'
 	| 'OLD_KMS'
 	| 'OPERATOR'
 	| 'OPT'
@@ -1564,6 +1566,7 @@ unreserved_keyword ::=
 	| 'TENANTS'
 	| 'TESTING_RELOCATE'
 	| 'TEXT'
+	| 'THAN'
 	| 'TIES'
 	| 'TRACE'
 	| 'TRACING'
@@ -2208,11 +2211,11 @@ var_value ::=
 	a_expr
 	| extra_var_value
 
-opt_show_after_before_clause ::=
-	'AFTER' a_expr
-	| 'BEFORE' a_expr
-	| 'AFTER' a_expr 'BEFORE' a_expr
-	| 'BEFORE' a_expr 'AFTER' a_expr
+opt_show_backup_time_filter_clause ::=
+	'NEWER' 'THAN' a_expr
+	| 'OLDER' 'THAN' a_expr
+	| 'NEWER' 'THAN' a_expr 'OLDER' 'THAN' a_expr
+	| 'OLDER' 'THAN' a_expr 'NEWER' 'THAN' a_expr
 	| 
 
 show_backup_details ::=
@@ -4337,6 +4340,7 @@ bare_label_keywords ::=
 	| 'NATURAL'
 	| 'NEVER'
 	| 'NEW'
+	| 'NEWER'
 	| 'NEW_DB_NAME'
 	| 'NEW_KMS'
 	| 'NEXT'
@@ -4374,6 +4378,7 @@ bare_label_keywords ::=
 	| 'OFF'
 	| 'OIDS'
 	| 'OLD'
+	| 'OLDER'
 	| 'OLD_KMS'
 	| 'ONLY'
 	| 'OPERATOR'
@@ -4567,6 +4572,7 @@ bare_label_keywords ::=
 	| 'TENANT_NAME'
 	| 'TESTING_RELOCATE'
 	| 'TEXT'
+	| 'THAN'
 	| 'THEN'
 	| 'THROTTLING'
 	| 'TIES'

--- a/pkg/backup/BUILD.bazel
+++ b/pkg/backup/BUILD.bazel
@@ -133,6 +133,7 @@ go_library(
         "//pkg/util",
         "//pkg/util/admission",
         "//pkg/util/admission/admissionpb",
+        "//pkg/util/besteffort",
         "//pkg/util/bulk",
         "//pkg/util/ctxgroup",
         "//pkg/util/envutil",

--- a/pkg/backup/backupinfo/BUILD.bazel
+++ b/pkg/backup/backupinfo/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
         "//pkg/storage",
         "//pkg/util",
         "//pkg/util/besteffort",
+        "//pkg/util/buildutil",
         "//pkg/util/bulk",
         "//pkg/util/ctxgroup",
         "//pkg/util/encoding",

--- a/pkg/backup/show.go
+++ b/pkg/backup/show.go
@@ -42,6 +42,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/besteffort"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -50,6 +51,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 )
+
+const showBackupsMaxPageSize = 50
 
 type backupInfoReader interface {
 	showBackup(
@@ -1353,6 +1356,59 @@ var showBackupsInCollectionHeader = colinfo.ResultColumns{
 	{Name: "path", Typ: types.String},
 }
 
+var showBackupsWithIDsHeader = colinfo.ResultColumns{
+	{Name: "id", Typ: types.String},
+	{Name: "backup_time", Typ: types.TimestampTZ},
+	{Name: "revision_start_time", Typ: types.TimestampTZ},
+}
+
+// getTimeRangeOrDefaults parses the NEWER THAN and OLDER THAN expressions from
+// the SHOW BACKUPS command. If a NEWER THAN or OLDER THAN is not specified, a
+// zero time or current time is returned, respectively, It also returns the
+// maximum number of results to return, which is non-zero only if the time range
+// is not fully specified.
+func getTimeRangeOrDefaults(
+	ctx context.Context, p sql.PlanHookState, interval tree.ShowBackupTimeFilter,
+) (newerThan time.Time, olderThan time.Time, maxCount uint, err error) {
+	parseTime := func(t tree.Expr) (time.Time, error) {
+		asOf := tree.AsOfClause{Expr: t}
+		asTime, err := p.EvalAsOfTimestamp(ctx, asOf)
+		if err != nil {
+			return time.Time{}, err
+		}
+		return asTime.Timestamp.GoTime(), nil
+	}
+
+	// To avoid issues with certain backups being skipped at the time boundaries
+	// due to precision differences between backup times and the times encoded in
+	// backup filenames, we round to second-level precision. We choose the most
+	// inclusive rounding, meaning we round down for AFTER and up for BEFORE.
+	precision := time.Second
+	if interval.NewerThan != nil {
+		newerThan, err = parseTime(interval.NewerThan)
+		if err != nil {
+			return time.Time{}, time.Time{}, 0, err
+		}
+		newerThan = newerThan.Truncate(precision)
+	}
+
+	if interval.OlderThan != nil {
+		olderThan, err = parseTime(interval.OlderThan)
+		if err != nil {
+			return time.Time{}, time.Time{}, 0, err
+		}
+	} else {
+		olderThan = timeutil.Now()
+	}
+	olderThan = olderThan.Add(precision - time.Nanosecond).Truncate(precision)
+
+	if interval.NewerThan == nil || interval.OlderThan == nil {
+		maxCount = showBackupsMaxPageSize
+	}
+
+	return newerThan, olderThan, maxCount, nil
+}
+
 // showBackupPlanHook implements PlanHookFn.
 func showBackupsInCollectionPlanHook(
 	ctx context.Context, collection []string, showStmt *tree.ShowBackup, p sql.PlanHookState,
@@ -1362,6 +1418,7 @@ func showBackupsInCollectionPlanHook(
 		return nil, nil, false, err
 	}
 
+	useIDs := p.SessionData().UseBackupsWithIDs
 	fn := func(ctx context.Context, resultsCh chan<- tree.Datums) error {
 		ctx, span := tracing.ChildSpan(ctx, showStmt.StatementTag())
 		defer span.Finish()
@@ -1370,17 +1427,70 @@ func showBackupsInCollectionPlanHook(
 		if err != nil {
 			return errors.Wrapf(err, "connect to external storage")
 		}
-		defer store.Close()
-		res, err := backupdest.ListFullBackupsInCollection(ctx, store)
-		if err != nil {
-			return err
-		}
-		for _, i := range res {
-			resultsCh <- tree.Datums{tree.NewDString(i)}
+		defer besteffort.Error(ctx, "show-backups-close-store", func(_ context.Context) error {
+			return store.Close()
+		})
+
+		if useIDs {
+			newerThan, olderThan, maxCount, err := getTimeRangeOrDefaults(ctx, p, showStmt.TimeRange)
+			if err != nil {
+				return err
+			}
+			res, exceededMax, err := backupinfo.ListRestorableBackups(
+				ctx, store, newerThan, olderThan, maxCount,
+			)
+			if err != nil {
+				return err
+			}
+			if exceededMax {
+				p.BufferClientNotice(
+					context.TODO(),
+					pgnotice.Newf(
+						"only showing %d most recent backups. To see more, please run `SHOW BACKUPS IN ... OLDER THAN '%s'` or specify both OLDER THAN and NEWER THAN.",
+						len(res),
+						res[len(res)-1].EndTime.GoTime().UTC().Format(time.DateTime),
+					),
+				)
+			}
+			for _, i := range res {
+				backupTime, err := tree.MakeDTimestampTZ(
+					timeutil.Unix(0, i.EndTime.WallTime), time.Second,
+				)
+				if err != nil {
+					return err
+				}
+				revStartTime := tree.DNull
+				if i.MVCCFilter == backuppb.MVCCFilter_All {
+					revStartTime, err = tree.MakeDTimestampTZ(
+						timeutil.Unix(0, i.RevisionStartTime.WallTime), time.Second,
+					)
+					if err != nil {
+						return err
+					}
+				}
+				resultsCh <- tree.Datums{
+					tree.NewDString(i.ID),
+					backupTime,
+					revStartTime,
+				}
+			}
+		} else {
+			res, err := backupdest.ListFullBackupsInCollection(ctx, store)
+			if err != nil {
+				return err
+			}
+			for _, i := range res {
+				resultsCh <- tree.Datums{tree.NewDString(i)}
+			}
 		}
 		return nil
 	}
-	return fn, showBackupsInCollectionHeader, false, nil
+
+	header := showBackupsInCollectionHeader
+	if useIDs {
+		header = showBackupsWithIDsHeader
+	}
+	return fn, header, false, nil
 }
 
 func init() {

--- a/pkg/backup/show_test.go
+++ b/pkg/backup/show_test.go
@@ -8,21 +8,26 @@ package backup
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -826,4 +831,173 @@ func TestShowBackupCheckFiles(t *testing.T) {
 			fmt.Sprintf(`SELECT sum(file_bytes) FROM [SHOW BACKUP FROM LATEST IN %s with check_files]`, dest),
 			fileSum)
 	}
+}
+
+func TestShowBackupsWithIDs(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	const numAccounts = 11
+	_, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
+	defer cleanupFn()
+	sqlDB.Exec(t, "SET SESSION use_backups_with_ids = true")
+
+	const collectionURI = "nodelocal://1/backup"
+
+	getSystemTime := func() (ts int64) {
+		sqlDB.QueryRow(t, "SELECT cluster_logical_timestamp()::INT").Scan(&ts)
+		return ts
+	}
+
+	times := []int64{getSystemTime()}
+	sqlDB.Exec(t, fmt.Sprintf("BACKUP INTO $1 AS OF SYSTEM TIME %d", times[0]), collectionURI)
+
+	for i := range 2 {
+		times = append(times, getSystemTime())
+		sqlDB.Exec(
+			t,
+			fmt.Sprintf("BACKUP INTO LATEST IN $1 AS OF SYSTEM TIME %d", times[i+1]),
+			collectionURI,
+		)
+	}
+
+	// We pause the second full backup so that we can take incrementals during its
+	// running to give us overlapped chains to test against.
+	sqlDB.Exec(t, `SET CLUSTER SETTING jobs.debug.pausepoints = 'backup.after.write_first_checkpoint'`)
+	times = append(times, getSystemTime())
+	var pausedJobID jobspb.JobID
+	sqlDB.QueryRow(
+		t,
+		fmt.Sprintf("BACKUP INTO $1 AS OF SYSTEM TIME %d WITH detached", times[len(times)-1]),
+		collectionURI,
+	).Scan(&pausedJobID)
+	jobutils.WaitForJobToPause(t, sqlDB, pausedJobID)
+	sqlDB.Exec(t, `SET CLUSTER SETTING jobs.debug.pausepoints = ''`)
+
+	for range 2 {
+		times = append(times, getSystemTime())
+		sqlDB.Exec(
+			t,
+			fmt.Sprintf("BACKUP INTO LATEST IN $1 AS OF SYSTEM TIME %d", times[len(times)-1]),
+			collectionURI,
+		)
+	}
+
+	sqlDB.Exec(t, "RESUME JOB $1", pausedJobID)
+	jobutils.WaitForJobToSucceed(t, sqlDB, pausedJobID)
+	times = append(times, getSystemTime())
+	sqlDB.Exec(
+		t,
+		fmt.Sprintf("BACKUP INTO LATEST IN $1 AS OF SYSTEM TIME %d", times[len(times)-1]),
+		collectionURI,
+	)
+
+	t.Run("backup times are in descending order", func(t *testing.T) {
+		shownTimes := sqlDB.QueryStr(
+			t, fmt.Sprintf(`SELECT backup_time FROM [SHOW BACKUPS IN '%s']`, collectionURI),
+		)
+		require.Equal(t, len(times), len(shownTimes))
+		require.True(
+			t, slices.IsSortedFunc(shownTimes, func(a, b []string) int {
+				if a[0] == b[0] {
+					return 0
+				} else if a[0] > b[0] {
+					return -1
+				} else {
+					return 1
+				}
+			}),
+		)
+	})
+
+	t.Run("time filtering", func(t *testing.T) {
+		// SHOW BACKUPS is only second-precise, so we just pick a second
+		// after the first backup. If the backup times overlap a second boundary,
+		// then our filter partitions the backups. Over the course of multiple
+		// tests, this gives us good coverage of filter points.
+		filterTime := int64(time.Duration(times[0]).Truncate(time.Second) + time.Second)
+
+		t.Run("OLDER THAN", func(t *testing.T) {
+			var count int
+			sqlDB.QueryRow(
+				t,
+				fmt.Sprintf(
+					`SELECT count(*) FROM [SHOW BACKUPS IN '%s' OLDER THAN %d]`,
+					collectionURI, filterTime,
+				),
+			).Scan(&count)
+
+			var expected int
+			for _, ts := range times {
+				// We must truncate times to the same precision as backup collection
+				// blob names since that's what SHOW BACKUPS uses to filter.
+				truncatedTS := int64(time.Duration(ts).Truncate(10 * time.Millisecond))
+				if truncatedTS <= filterTime {
+					expected++
+				}
+			}
+			require.Equal(
+				t, expected, count,
+				"unexpected number of backups before %d", filterTime,
+			)
+		})
+
+		t.Run("NEWER THAN", func(t *testing.T) {
+			var count int
+			sqlDB.QueryRow(
+				t,
+				fmt.Sprintf(
+					`SELECT count(*) FROM [SHOW BACKUPS IN '%s' NEWER THAN %d]`,
+					collectionURI, filterTime,
+				),
+			).Scan(&count)
+
+			var expected int
+			for _, ts := range times {
+				truncatedTS := int64(time.Duration(ts).Truncate(10 * time.Millisecond))
+				if truncatedTS >= filterTime {
+					expected++
+				}
+			}
+			require.Equal(
+				t, expected, count,
+				"unexpected number of backups after %d", filterTime,
+			)
+		})
+
+		t.Run("OLDER THAN and NEWER THAN", func(t *testing.T) {
+			// Pick a random pair of times for the range. Note that in most cases,
+			// this will end up being the same query as the tests above due to the
+			// short window of time the backups span, over the course of multiple
+			// test runs, this results in good coverage.
+			olderIdx := rand.Intn(len(times) - 1)
+			newerIdx := rand.Intn(len(times)-olderIdx-1) + olderIdx + 1
+
+			// Truncate the times to second precision like SHOW BACKUPS.
+			olderTime := int64(time.Duration(times[olderIdx]).Truncate(time.Second))
+			newerTime := int64(time.Duration(times[newerIdx]).Truncate(time.Second))
+
+			var count int
+			sqlDB.QueryRow(
+				t,
+				fmt.Sprintf(
+					`SELECT count(*) FROM [SHOW BACKUPS IN '%s' OLDER THAN %d NEWER THAN %d]`,
+					collectionURI, newerTime, olderTime,
+				),
+			).Scan(&count)
+
+			var expected int
+			for _, ts := range times {
+				truncatedTS := int64(time.Duration(ts).Truncate(10 * time.Millisecond))
+				if truncatedTS <= newerTime && truncatedTS >= olderTime {
+					expected++
+				}
+			}
+			require.Equal(
+				t, expected, count,
+				"unexpected number of backups between %d and %d",
+				olderTime, newerTime,
+			)
+		})
+	})
 }

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -950,8 +950,8 @@ table_columns
 query TTTTT colnames
 SELECT table_catalog, table_schema, table_name, table_type, is_insertable_into
 FROM system.information_schema.tables
-WHERE 
-(table_schema <> 'crdb_internal' OR table_name = 'node_build_info') 
+WHERE
+(table_schema <> 'crdb_internal' OR table_name = 'node_build_info')
 AND NOT (table_schema = 'public' AND table_name <> 'locations')
 ORDER BY table_name, table_schema
 ----
@@ -2356,9 +2356,9 @@ root      other_db       public              ALL             YES
 
 # root can see everything (filtering most of crdb_internal and system to avoid a brittle test)
 query TTTTTTTT colnames,rowsort
-SELECT * FROM system.information_schema.table_privileges 
-WHERE 
-  (table_schema <> 'crdb_internal' OR table_name = 'node_build_info') AND 
+SELECT * FROM system.information_schema.table_privileges
+WHERE
+  (table_schema <> 'crdb_internal' OR table_name = 'node_build_info') AND
   NOT (table_catalog = 'system' AND table_schema = 'public' AND 'table_name' <> 'locations')
 ORDER BY table_schema, table_name, table_schema, grantee, privilege_type
 ----
@@ -2585,9 +2585,9 @@ NULL     public   system         pg_extension        geometry_columns           
 NULL     public   system         pg_extension        spatial_ref_sys                        SELECT          NO            YES
 
 query TTTTTTTT colnames,rowsort
-SELECT * FROM system.information_schema.role_table_grants 
-WHERE 
-(table_schema <> 'crdb_internal' OR table_name = 'node_build_info') 
+SELECT * FROM system.information_schema.role_table_grants
+WHERE
+(table_schema <> 'crdb_internal' OR table_name = 'node_build_info')
 AND NOT (table_schema = 'public' AND table_name <> 'locations');
 ----
 grantor  grantee  table_catalog  table_schema        table_name                             privilege_type  is_grantable  with_hierarchy
@@ -3018,19 +3018,19 @@ statement ok
 CREATE SEQUENCE test_seq_3 AS smallint
 
 statement ok
-CREATE SEQUENCE test_seq_4 AS integer 
+CREATE SEQUENCE test_seq_4 AS integer
 
 statement ok
 CREATE SEQUENCE test_seq_5 AS bigint
 
 statement ok
-CREATE SEQUENCE test_seq_6 AS INT2 
+CREATE SEQUENCE test_seq_6 AS INT2
 
 statement ok
 CREATE SEQUENCE test_seq_7 AS INT4
 
 statement ok
-CREATE SEQUENCE test_seq_8 AS INT8 
+CREATE SEQUENCE test_seq_8 AS INT8
 
 query TTTTIIITTTTT colnames,rowsort
 SELECT * FROM information_schema.sequences
@@ -3970,6 +3970,7 @@ troubleshooting_mode                                             off
 unbounded_parallel_scans                                         off
 unconstrained_non_covering_index_scan_enabled                    off
 unsafe_allow_triggers_modifying_cascades                         off
+use_backups_with_ids                                             off
 use_cputs_on_non_unique_indexes                                  off
 use_improved_routine_dependency_tracking                         on
 use_improved_routine_deps_triggers_and_computed_cols             on

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3240,6 +3240,7 @@ troubleshooting_mode                                             off            
 unbounded_parallel_scans                                         off                 NULL      NULL        NULL        string
 unconstrained_non_covering_index_scan_enabled                    off                 NULL      NULL        NULL        string
 unsafe_allow_triggers_modifying_cascades                         off                 NULL      NULL        NULL        string
+use_backups_with_ids                                             off                 NULL      NULL        NULL        string
 use_cputs_on_non_unique_indexes                                  off                 NULL      NULL        NULL        string
 use_declarative_schema_changer                                   on                  NULL      NULL        NULL        string
 use_improved_routine_dependency_tracking                         on                  NULL      NULL        NULL        string
@@ -3491,6 +3492,7 @@ troubleshooting_mode                                             off            
 unbounded_parallel_scans                                         off                 NULL  user     NULL      off                 off
 unconstrained_non_covering_index_scan_enabled                    off                 NULL  user     NULL      off                 off
 unsafe_allow_triggers_modifying_cascades                         off                 NULL  user     NULL      off                 off
+use_backups_with_ids                                             off                 NULL  user     NULL      off                 off
 use_cputs_on_non_unique_indexes                                  off                 NULL  user     NULL      off                 off
 use_declarative_schema_changer                                   on                  NULL  user     NULL      on                  on
 use_improved_routine_dependency_tracking                         on                  NULL  user     NULL      on                  on
@@ -3734,6 +3736,7 @@ troubleshooting_mode                                             NULL    NULL   
 unbounded_parallel_scans                                         NULL    NULL     NULL     NULL        NULL
 unconstrained_non_covering_index_scan_enabled                    NULL    NULL     NULL     NULL        NULL
 unsafe_allow_triggers_modifying_cascades                         NULL    NULL     NULL     NULL        NULL
+use_backups_with_ids                                             NULL    NULL     NULL     NULL        NULL
 use_cputs_on_non_unique_indexes                                  NULL    NULL     NULL     NULL        NULL
 use_declarative_schema_changer                                   NULL    NULL     NULL     NULL        NULL
 use_improved_routine_dependency_tracking                         NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -254,6 +254,7 @@ troubleshooting_mode                                             off
 unbounded_parallel_scans                                         off
 unconstrained_non_covering_index_scan_enabled                    off
 unsafe_allow_triggers_modifying_cascades                         off
+use_backups_with_ids                                             off
 use_cputs_on_non_unique_indexes                                  off
 use_declarative_schema_changer                                   on
 use_improved_routine_dependency_tracking                         on

--- a/pkg/sql/parser/testdata/backup_restore
+++ b/pkg/sql/parser/testdata/backup_restore
@@ -132,56 +132,56 @@ SHOW BACKUPS IN $1 -- literals removed
 SHOW BACKUPS IN $1 -- identifiers removed
 
 parse
-SHOW BACKUPS IN 'bar' AFTER '1'
+SHOW BACKUPS IN 'bar' NEWER THAN '1'
 ----
-SHOW BACKUPS IN '*****' AFTER '1' -- normalized!
-SHOW BACKUPS IN ('*****') AFTER ('1') -- fully parenthesized
-SHOW BACKUPS IN '_' AFTER '_' -- literals removed
-SHOW BACKUPS IN '*****' AFTER '1' -- identifiers removed
-SHOW BACKUPS IN 'bar' AFTER '1' -- passwords exposed
+SHOW BACKUPS IN '*****' NEWER THAN '1' -- normalized!
+SHOW BACKUPS IN ('*****') NEWER THAN ('1') -- fully parenthesized
+SHOW BACKUPS IN '_' NEWER THAN '_' -- literals removed
+SHOW BACKUPS IN '*****' NEWER THAN '1' -- identifiers removed
+SHOW BACKUPS IN 'bar' NEWER THAN '1' -- passwords exposed
 
 parse
-SHOW BACKUPS IN 'bar' BEFORE '1'
+SHOW BACKUPS IN 'bar' OLDER THAN '1'
 ----
-SHOW BACKUPS IN '*****' BEFORE '1' -- normalized!
-SHOW BACKUPS IN ('*****') BEFORE ('1') -- fully parenthesized
-SHOW BACKUPS IN '_' BEFORE '_' -- literals removed
-SHOW BACKUPS IN '*****' BEFORE '1' -- identifiers removed
-SHOW BACKUPS IN 'bar' BEFORE '1' -- passwords exposed
+SHOW BACKUPS IN '*****' OLDER THAN '1' -- normalized!
+SHOW BACKUPS IN ('*****') OLDER THAN ('1') -- fully parenthesized
+SHOW BACKUPS IN '_' OLDER THAN '_' -- literals removed
+SHOW BACKUPS IN '*****' OLDER THAN '1' -- identifiers removed
+SHOW BACKUPS IN 'bar' OLDER THAN '1' -- passwords exposed
 
 parse
-SHOW BACKUPS IN 'bar' AFTER '1' BEFORE '2'
+SHOW BACKUPS IN 'bar' NEWER THAN '1' OLDER THAN '2'
 ----
-SHOW BACKUPS IN '*****' AFTER '1' BEFORE '2' -- normalized!
-SHOW BACKUPS IN ('*****') AFTER ('1') BEFORE ('2') -- fully parenthesized
-SHOW BACKUPS IN '_' AFTER '_' BEFORE '_' -- literals removed
-SHOW BACKUPS IN '*****' AFTER '1' BEFORE '2' -- identifiers removed
-SHOW BACKUPS IN 'bar' AFTER '1' BEFORE '2' -- passwords exposed
+SHOW BACKUPS IN '*****' NEWER THAN '1' OLDER THAN '2' -- normalized!
+SHOW BACKUPS IN ('*****') NEWER THAN ('1') OLDER THAN ('2') -- fully parenthesized
+SHOW BACKUPS IN '_' NEWER THAN '_' OLDER THAN '_' -- literals removed
+SHOW BACKUPS IN '*****' NEWER THAN '1' OLDER THAN '2' -- identifiers removed
+SHOW BACKUPS IN 'bar' NEWER THAN '1' OLDER THAN '2' -- passwords exposed
 
 parse
-SHOW BACKUPS IN 'bar' BEFORE '2' AFTER '1'
+SHOW BACKUPS IN 'bar' OLDER THAN '2' NEWER THAN '1'
 ----
-SHOW BACKUPS IN '*****' AFTER '1' BEFORE '2' -- normalized!
-SHOW BACKUPS IN ('*****') AFTER ('1') BEFORE ('2') -- fully parenthesized
-SHOW BACKUPS IN '_' AFTER '_' BEFORE '_' -- literals removed
-SHOW BACKUPS IN '*****' AFTER '1' BEFORE '2' -- identifiers removed
-SHOW BACKUPS IN 'bar' AFTER '1' BEFORE '2' -- passwords exposed
+SHOW BACKUPS IN '*****' NEWER THAN '1' OLDER THAN '2' -- normalized!
+SHOW BACKUPS IN ('*****') NEWER THAN ('1') OLDER THAN ('2') -- fully parenthesized
+SHOW BACKUPS IN '_' NEWER THAN '_' OLDER THAN '_' -- literals removed
+SHOW BACKUPS IN '*****' NEWER THAN '1' OLDER THAN '2' -- identifiers removed
+SHOW BACKUPS IN 'bar' NEWER THAN '1' OLDER THAN '2' -- passwords exposed
 
 parse
-SHOW BACKUPS IN $1 AFTER $2 BEFORE $3
+SHOW BACKUPS IN $1 NEWER THAN $2 OLDER THAN $3
 ----
-SHOW BACKUPS IN $1 AFTER $2 BEFORE $3
-SHOW BACKUPS IN ($1) AFTER ($2) BEFORE ($3) -- fully parenthesized
-SHOW BACKUPS IN $1 AFTER $1 BEFORE $1 -- literals removed
-SHOW BACKUPS IN $1 AFTER $2 BEFORE $3 -- identifiers removed
+SHOW BACKUPS IN $1 NEWER THAN $2 OLDER THAN $3
+SHOW BACKUPS IN ($1) NEWER THAN ($2) OLDER THAN ($3) -- fully parenthesized
+SHOW BACKUPS IN $1 NEWER THAN $1 OLDER THAN $1 -- literals removed
+SHOW BACKUPS IN $1 NEWER THAN $2 OLDER THAN $3 -- identifiers removed
 
 parse
-SHOW BACKUPS IN $1 BEFORE $2 AFTER $3
+SHOW BACKUPS IN $1 OLDER THAN $2 NEWER THAN $3
 ----
-SHOW BACKUPS IN $1 AFTER $3 BEFORE $2 -- normalized!
-SHOW BACKUPS IN ($1) AFTER ($3) BEFORE ($2) -- fully parenthesized
-SHOW BACKUPS IN $1 AFTER $1 BEFORE $1 -- literals removed
-SHOW BACKUPS IN $1 AFTER $3 BEFORE $2 -- identifiers removed
+SHOW BACKUPS IN $1 NEWER THAN $3 OLDER THAN $2 -- normalized!
+SHOW BACKUPS IN ($1) NEWER THAN ($3) OLDER THAN ($2) -- fully parenthesized
+SHOW BACKUPS IN $1 NEWER THAN $1 OLDER THAN $1 -- literals removed
+SHOW BACKUPS IN $1 NEWER THAN $3 OLDER THAN $2 -- identifiers removed
 
 
 parse

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -100,7 +100,7 @@ type ShowBackup struct {
 	From         bool
 	Details      ShowBackupDetails
 	Options      ShowBackupOptions
-	TimeRange    ShowAfterBefore
+	TimeRange    ShowBackupTimeFilter
 }
 
 // Format implements the NodeFormatter interface.
@@ -140,32 +140,32 @@ func (node *ShowBackup) Format(ctx *FmtCtx) {
 	}
 }
 
-// ShowAfterBefore represents the AFTER <expr> BEFORE <expr> option for
-// SHOW BACKUPS.
-type ShowAfterBefore struct {
-	After  Expr
-	Before Expr
+// ShowBackupTimeFilter represents the NEWER THAN <expr> OLDER THAN <expr>
+// option for SHOW BACKUPS.
+type ShowBackupTimeFilter struct {
+	NewerThan Expr
+	OlderThan Expr
 }
 
-var _ NodeFormatter = &ShowAfterBefore{}
+var _ NodeFormatter = &ShowBackupTimeFilter{}
 
-func (s *ShowAfterBefore) Format(ctx *FmtCtx) {
-	if s.After != nil {
-		ctx.WriteString("AFTER ")
-		ctx.FormatNode(s.After)
+func (s *ShowBackupTimeFilter) Format(ctx *FmtCtx) {
+	if s.NewerThan != nil {
+		ctx.WriteString("NEWER THAN ")
+		ctx.FormatNode(s.NewerThan)
 	}
 
-	if s.Before != nil {
-		if s.After != nil {
+	if s.OlderThan != nil {
+		if s.NewerThan != nil {
 			ctx.WriteString(" ")
 		}
-		ctx.WriteString("BEFORE ")
-		ctx.FormatNode(s.Before)
+		ctx.WriteString("OLDER THAN ")
+		ctx.FormatNode(s.OlderThan)
 	}
 }
 
-func (s *ShowAfterBefore) IsDefault() bool {
-	return s.After == nil && s.Before == nil
+func (s *ShowBackupTimeFilter) IsDefault() bool {
+	return s.NewerThan == nil && s.OlderThan == nil
 }
 
 type ShowBackupOptions struct {

--- a/pkg/sql/sessiondatapb/session_data.proto
+++ b/pkg/sql/sessiondatapb/session_data.proto
@@ -145,6 +145,11 @@ message SessionData {
   // for deadlock detection.
   google.protobuf.Duration deadlock_timeout = 33 [(gogoproto.nullable) = false,
     (gogoproto.stdduration) = true];
+
+  // UseBackupsWithIDs, when true, enables the use of backup IDs in SHOW BACKUP
+  // and RESTORE. If set, SHOW BACKUPS with display backups with IDs that can
+  // then be used in SHOW BACKUP and RESTORE statements.
+  bool use_backups_with_ids = 34 [(gogoproto.customname) = "UseBackupsWithIDs"];
 }
 
 // DataConversionConfig contains the parameters that influence the output

--- a/pkg/sql/sessionmutator/mutator.go
+++ b/pkg/sql/sessionmutator/mutator.go
@@ -1122,3 +1122,7 @@ func (m *SessionDataMutator) SetUseImprovedRoutineDepsTriggersAndComputedCols(va
 func (m *SessionDataMutator) SetDistSQLPreventPartitioningSoftLimitedScans(val bool) {
 	m.Data.DistSQLPreventPartitioningSoftLimitedScans = val
 }
+
+func (m *SessionDataMutator) SetUseBackupsWithIDs(val bool) {
+	m.Data.UseBackupsWithIDs = val
+}

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -4542,6 +4542,22 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalTrue,
 	},
+
+	`use_backups_with_ids`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`use_backups_with_ids`),
+		Set: func(_ context.Context, m sessionmutator.SessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("use_backups_with_ids", s)
+			if err != nil {
+				return err
+			}
+			m.SetUseBackupsWithIDs(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().UseBackupsWithIDs), nil
+		},
+		GlobalDefault: globalFalse,
+	},
 }
 
 func ReplicationModeFromString(s string) (sessiondatapb.ReplicationMode, error) {


### PR DESCRIPTION
This commit teaches SHOW BACKUPS to display the new UX with backup IDs, along with BEFORE/AFTER filtering.

Epic: [CRDB-57536](https://cockroachlabs.atlassian.net/browse/CRDB-57536)

Resolves: https://github.com/cockroachdb/cockroach/issues/159647

Release note (sql change): Users can now set the `use_backups_with_ids` session setting to enable a new `SHOW BACKUPS IN` experience. When enabled, `SHOW BACKUPS IN <collection>` displays all backups in the collection. Results can be filtered by backup end time using `OLDER THAN <timestamp>` or `NEWER THAN <timestamp>` clauses.

Example usage:

    SET use_backups_with_ids = true;
    SHOW BACKUPS IN '<collection>' OLDER THAN '-1w' NEWER THAN '-2w';