### PR TITLE
server: propagate DRPC setting to explicitly started external tenants

### DIFF
--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -481,6 +481,7 @@ go_test(
         "distsql_flows_test.go",
         "drain_test.go",
         "drpc_test.go",
+        "external_tenant_drpc_test.go",
         "get_local_files_test.go",
         "graphite_test.go",
         "grpc_gateway_test.go",

--- a/pkg/server/external_tenant_drpc_test.go
+++ b/pkg/server/external_tenant_drpc_test.go
@@ -1,0 +1,53 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package server_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExternalTenantDRPCPropagation verifies that the DRPC setting from the
+// parent server's DefaultDRPCOption is propagated to external tenants started
+// explicitly via StartTenant(). DRPC is a test infrastructure concern that
+// should apply uniformly to all tenants regardless of how they are started.
+func TestExternalTenantDRPCPropagation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testutils.RunTrueAndFalse(t, "drpc-enabled", func(t *testing.T, drpcEnabled bool) {
+		ctx := context.Background()
+
+		opt := base.TestDRPCDisabled
+		if drpcEnabled {
+			opt = base.TestDRPCEnabled
+		}
+
+		s := serverutils.StartServerOnly(t, base.TestServerArgs{
+			DefaultDRPCOption: opt,
+			DefaultTestTenant: base.TestControlsTenantsExplicitly,
+		})
+		defer s.Stopper().Stop(ctx)
+
+		// Start an external tenant explicitly without providing Settings.
+		// The DRPC config should still be propagated from the parent.
+		tenantArgs := base.TestTenantArgs{
+			TenantID: serverutils.TestTenantID(),
+		}
+		tenant, err := s.TenantController().StartTenant(ctx, tenantArgs)
+		require.NoError(t, err)
+
+		require.Equal(t, drpcEnabled, tenant.RPCContext().UseDRPC,
+			"external tenant should have UseDRPC=%v matching parent's DefaultDRPCOption", drpcEnabled)
+	})
+}

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -1768,7 +1768,6 @@ func (ts *testServer) StartTenant(
 	if st == nil {
 		st = cluster.MakeTestingClusterSettings()
 	}
-
 	sqlCfg := makeTestSQLConfig(st, params.TenantID, params.TenantName)
 	sqlCfg.TenantLoopbackAddr = ts.AdvRPCAddr()
 	if params.MemoryPoolSize != 0 {
@@ -1831,6 +1830,7 @@ func (ts *testServer) StartTenant(
 	baseCfg.GoroutineDumpDirName = ts.Cfg.BaseConfig.GoroutineDumpDirName
 	baseCfg.ExternalIODirConfig = params.ExternalIODirConfig
 	baseCfg.ExternalIODir = params.ExternalIODir
+	baseCfg.UseDRPC = ts.Cfg.UseDRPC
 
 	// Grant the tenant the default capabilities.
 	if err := ts.grantDefaultTenantCapabilities(ctx, params.TenantID, params.SkipTenantCheck); err != nil {


### PR DESCRIPTION
Previously, the DRPC setting was not propagated to external tenants 
started explicitly via `StartTenant()`.

The default tenant path (startDefaultTestTenant) already handled this by
copying ApplicationLevel settings from `ts.params.Settings` via
`TestingCopyForVirtualCluster`, but this only worked when the test
explicitly provided a Settings object. When DefaultDRPCOption was used
without explicit Settings, `ts.params.Settings` remained
nil because `makeTestConfigFromParams` receives params by value and its
internal defaulting doesn't propagate back.

Rather than copying all ApplicationLevel settings (which would conflict
with the expectation that explicitly started tenants get a clean slate),
this change specifically propagates the DRPC setting from the parent
server's DefaultDRPCOption to all tenants created via `StartTenant()`.
DRPC is a test infrastructure concern that should apply uniformly
regardless of how tenants are started.

The shared tenant path is unaffected as `makeSharedProcessTenantConfig`
already copies settings via `TestingCopyForVirtualCluster` when
testSettings is non-nil.

Epic: None
Fixes: #164264
Release note: None