### PR TITLE
release-25.4: sql/export: skip columns with Bit(0) type in parquet test

### DIFF
--- a/pkg/sql/export/exportparquet_test.go
+++ b/pkg/sql/export/exportparquet_test.go
@@ -229,6 +229,22 @@ func TestRandomParquetExports(t *testing.T) {
 					require.NoError(t, err)
 
 					for _, col := range cols {
+						// Skip tables with BIT(0) columns (or arrays of BIT(0)).
+						// The testutils parquet decoder cannot decode these as
+						// into the expected empty bit array and decodes the as
+						// nil. Ignore these to avoid these flakes.
+						colTyp := col.Typ
+						if colTyp.Family() == types.ArrayFamily {
+							colTyp = colTyp.ArrayContents()
+						}
+						if colTyp.Family() == types.BitFamily && colTyp.Width() == 0 {
+							// We skip these because of the aforementioned
+							// decoder issue.
+							t.Logf("skipping table '%s' because it has BIT(0) column '%s' (type: %s)",
+								tableName, col.Name, colTyp.String())
+							return fmt.Errorf("table has BIT(0) column")
+						}
+
 						// TODO(#104278): don't call this function to check if a type is supported.
 						// We should explicitly use the ones supported by  util/parquet).
 						_, err := parquet.NewSchema([]string{"test"}, []*types.T{col.Typ})


### PR DESCRIPTION
Backport 1/1 commits from #160093 on behalf of @aerfrei.

----

We were seeing failures on this randomized test when these columns were generated. The testutils parquet decoder can't handle this type (added in #132944) so these fail, but it doesn't represent a real issue.

This fix skips these the randomly generated test cases that include this column type.

Fixes: #154011
Epic: none
Release note: None

----

Release Justification: test only