### PR TITLE
cli: attach postgresql:// scheme if not provided to encode-uri

### DIFF
--- a/pkg/cli/cert.go
+++ b/pkg/cli/cert.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -331,13 +332,14 @@ var encodeURIOpts = struct {
 }{}
 
 func encodeURI(cmd *cobra.Command, args []string) error {
+	schemePrefixPtn := regexp.MustCompile(`^postgres(ql)?://`)
+	if !schemePrefixPtn.MatchString(args[0]) {
+		args[0] = "postgresql://" + args[0]
+	}
+
 	pgURL, err := url.Parse(args[0])
 	if err != nil {
 		return err
-	}
-
-	if pgURL.Scheme == "" {
-		pgURL.Scheme = "postgresql://"
 	}
 
 	if encodeURIOpts.database != "" {


### PR DESCRIPTION
The `encode-uri` command currently does parse the provided URI as a URI if no scheme is provided. As a consequence, if a string `hostname:26257` is passed, it parses it as a path and no prefix/default root user is attached to the output.

If a URL-structure like `hostname.com` is provided, then the scheme is attached with a double ://, resulting in `postgresql://://hostname.com`.

Epic: None

Release note (cli change): Fixes a bug in the `encode-uri` utility that resulted in faulty encoding of URIs without a scheme. The `postgresql://` scheme is now prefixed to any URIs missing a scheme.