### PR TITLE
release-25.4: roachtest: disable mixed version tests on ibm

### DIFF
--- a/pkg/cmd/roachtest/tests/db_console_endpoints.go
+++ b/pkg/cmd/roachtest/tests/db_console_endpoints.go
@@ -99,7 +99,7 @@ func registerDBConsoleEndpointsMixedVersion(r registry.Registry) {
 		Name:             "db-console/mixed-version-endpoints",
 		Owner:            registry.OwnerObservability,
 		Cluster:          r.MakeClusterSpec(5, spec.WorkloadNode()),
-		CompatibleClouds: registry.AllClouds,
+		CompatibleClouds: registry.AllClouds.NoIBM(),
 		Suites:           registry.Suites(registry.MixedVersion, registry.Nightly),
 		Monitor:          true,
 		Randomized:       true,


### PR DESCRIPTION
On release 25.4, the mixed version framework does not support running on s390x and will produce invalid upgrade plans including non supported version.

Fixes: https://github.com/cockroachdb/cockroach/issues/160052
Release note: none
Epic: none

Release Justification: Test only change