### PR TITLE
roachtest: unskip multitenant/distsql

### DIFF
--- a/pkg/cmd/roachtest/tests/multitenant_distsql.go
+++ b/pkg/cmd/roachtest/tests/multitenant_distsql.go
@@ -32,8 +32,6 @@ func registerMultiTenantDistSQL(r registry.Registry) {
 			b := bundle
 			to := timeout
 			r.Add(registry.TestSpec{
-				Skip:             "https://github.com/cockroachdb/cockroach/issues/128366",
-				SkipDetails:      "test is broken",
 				Name:             fmt.Sprintf("multitenant/distsql/instances=%d/bundle=%s/timeout=%d", numInstances, b, to),
 				Owner:            registry.OwnerSQLQueries,
 				Cluster:          r.MakeClusterSpec(4),


### PR DESCRIPTION
I ran all variants of multitenant/distsql 50 times and hit no failures, so it should be safe to unskip the test. My guess is that we've made some improvements around the sqlliveness (e.g. we've removed the gossip-based planning altogether) that might have helped here.

Fixes: #128366.
Release note: None