### PR TITLE
pkg/kv/kvserver/protectedts: delete ptcache

### DIFF
--- a/pkg/spanconfig/spanconfigptsreader/adapter.go
+++ b/pkg/spanconfig/spanconfigptsreader/adapter.go
@@ -18,23 +18,12 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// adapter implements the spanconfig.ProtectedTSReader interface and is intended
-// as a bridge between the old and new protected timestamp subsystems in KV.
+// adapter implements the spanconfig.ProtectedTSReader interface by delegating
+// to the KVSubscriber.
 //
-// V1 of the protected timestamp subsystem only allowed protections to be set
-// over spans belonging to the system tenant. These protections were cached by
-// each node in the cluster by ptcache.Cache. V2 of the subsystem allows
-// protections to be set on all spans (including secondary tenant spans) and are
-// cached in the spanconfig.Store maintained by the spanconfig.KVSubscriber. In
-// release 22.1 both the old and new subsystem co-exist, and as such,
-// protections that apply to system tenant spans may be present in either the
-// ptcache.Cache or spanconfig.KVSubscriber. This adapter struct encapsulates
-// protected timestamp information from both these sources behind a single
-// interface.
-//
-// TODO(arul): In 22.2, we would have completely migrated away from the old
-//
-//	subsystem, and we'd be able to get rid of this interface.
+// TODO(david): This adapter is now just a passthrough to the KVSubscriber,
+// which already implements ProtectedTSReader. We should remove this adapter
+// and use KVSubscriber directly.
 type adapter struct {
 	kvSubscriber spanconfig.KVSubscriber
 	s            *cluster.Settings


### PR DESCRIPTION
According to the TODOs and context on #118772, this cache has been broken for years but wasn't fully removed as planned in 24.x.

Release note: none.
Epic: none.