### PR TITLE
release-26.1: sql: optimize pg_catalog.pg_roles population to fix performance regression

### DIFF
--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemadesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/rolemembershipcache"
 	"github.com/cockroachdb/cockroach/pkg/sql/roleoption"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins/builtinsregistry"
@@ -2995,6 +2996,8 @@ GROUP BY
 			}
 			return nil
 		},
+		rolemembershipcache.CheckRoleOptionsVersion(),
+		rolemembershipcache.CheckDatabaseRoleSettingsVersion(),
 	); err != nil {
 		return err
 	}

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -4951,7 +4951,7 @@ WHERE usename IN ('testuser1', 'testuser2')
 ORDER BY usename
 ----
 usename    usecreatedb  useconfig
-testuser1  false        NULL
+testuser1  true         {timezone=America/Los_Angeles,application_name=a}
 testuser2  false        NULL
 
 query TBTBBT colnames
@@ -4960,10 +4960,10 @@ FROM pg_roles
 WHERE rolname IN ('testuser1', 'testuser2', 'testrole1')
 ORDER BY rolname
 ----
-rolname    rolcreatedb  rolconfig  rolinherit  rolcanlogin  rolvaliduntil
-testrole1  false        NULL       true        false        NULL
-testuser1  true         NULL       true        true         NULL
-testuser2  false        NULL       true        true         NULL
+rolname    rolcreatedb  rolconfig                                          rolinherit  rolcanlogin  rolvaliduntil
+testrole1  false        NULL                                               true        false        NULL
+testuser1  true         {timezone=America/Los_Angeles,application_name=a}  true        true         NULL
+testuser2  false        NULL                                               true        true         3022-01-01 00:00:00 +0000 UTC
 
 query TBBBBT colnames
 SELECT rolname, rolcreatedb, rolcreaterole, rolinherit, rolcanlogin, rolvaliduntil
@@ -4975,7 +4975,7 @@ rolname    rolcreatedb  rolcreaterole  rolinherit  rolcanlogin  rolvaliduntil
 root       true         true           true        true         NULL
 testrole1  false        false          true        false        NULL
 testuser1  true         false          true        true         NULL
-testuser2  false        true           true        true         NULL
+testuser2  false        true           true        true         3022-01-01 00:00:00 +0000 UTC
 
 # Testing users that have admin role
 

--- a/pkg/sql/rolemembershipcache/BUILD.bazel
+++ b/pkg/sql/rolemembershipcache/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/kv/kvpb",
         "//pkg/roachpb",
         "//pkg/security/username",
+        "//pkg/sql/catalog",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/descs",
         "//pkg/sql/catalog/lease",


### PR DESCRIPTION
Backport 1/1 commits from #160121 on behalf of @rafiss.

----


Previously, populating `pg_catalog.pg_roles` made separate privilege lookups for each role option (CREATEROLE, CREATEDB, BYPASSRLS, and multiple REPLICATION variants). Each lookup resulted in queries to the role_options table, which is expensive in multi-region clusters.

This commit optimizes the privilege checks by first checking the in-memory roleOptionsJSON that was already fetched, and only falling back to the global privilege lookup if the role option is not present. This changes the check from O(n * privileges) database lookups to using data already available in memory for most cases.

Additionally, the role membership cache is updated to support tracking versions for the system.role_options and system.database_role_settings tables. This is done via a functional options pattern in RunAtCacheReadTS which allows callers to specify which additional table versions should be checked for cache invalidation. The information_schema implementation now passes both CheckRoleOptionsVersion and CheckDatabaseRoleSettingsVersion to ensure proper cache invalidation when those tables are modified. This cache invalidation is necessary because the privilege checks now rely on the roleOptions data fetched by the forEachRoleAtCacheReadTS query, and that data must reflect the current state of the underlying tables.

Fixes #152044

Release note (performance improvement): Fixed a performance regression in pg_catalog.pg_roles and pg_catalog.pg_authid by avoiding privilege lookups for each row in the table.

----

Release justification: fix performance regression