### PR TITLE
crosscluster/physical: slim down TestProtectedTimestampManagement

### DIFF
--- a/pkg/crosscluster/physical/BUILD.bazel
+++ b/pkg/crosscluster/physical/BUILD.bazel
@@ -151,7 +151,6 @@ go_test(
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/protectedts",
-        "//pkg/kv/kvserver/protectedts/ptpb",
         "//pkg/repstream/streampb",
         "//pkg/roachpb",
         "//pkg/security/securityassets",


### PR DESCRIPTION
This test was doing far too much for a unit test, running multiple test clusters and also waiting for multiple systems like PCR, GC, etc to all interact. In particular, verifying GC behaviors whenGC  TTLs have a minimum duration measured in seconds forced this test to have outsized delays in it -- it often took >30s, even when run on its own, let alone in a larger, more contended test run.

This slashes the test's scope to just verify PCR's direct behavior, cutting its runtime substantially. 

Release note: none.
Epic: none.