### PR TITLE
jobs: start phasing out JobUpdater

### DIFF
--- a/pkg/sql/mvcc_backfiller.go
+++ b/pkg/sql/mvcc_backfiller.go
@@ -234,6 +234,7 @@ type IndexMergeTracker struct {
 		job *jobs.Job
 	}
 
+	db             isql.DB
 	rangeCounter   rangeCounter
 	fractionScaler *multiStageFractionScaler
 }
@@ -246,10 +247,12 @@ type rangeCounter func(ctx context.Context, spans []roachpb.Span) (int, error)
 func NewIndexMergeTracker(
 	progress *MergeProgress,
 	job *jobs.Job,
+	db isql.DB,
 	rangeCounter rangeCounter,
 	scaler *multiStageFractionScaler,
 ) *IndexMergeTracker {
 	imt := IndexMergeTracker{
+		db:             db,
 		rangeCounter:   rangeCounter,
 		fractionScaler: scaler,
 	}
@@ -311,11 +314,15 @@ func (imt *IndexMergeTracker) FlushFractionCompleted(ctx context.Context) error 
 			return err
 		}
 
-		imt.jobMu.Lock()
-		defer imt.jobMu.Unlock()
-		if err := imt.jobMu.job.NoTxn().FractionProgressed(
-			ctx, jobs.FractionUpdater(frac),
-		); err != nil {
+		jobID := func() jobspb.JobID {
+			imt.jobMu.Lock()
+			defer imt.jobMu.Unlock()
+			return imt.jobMu.job.ID()
+		}()
+
+		if err := imt.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+			return jobs.ProgressStorage(jobID).SetFraction(ctx, txn, float64(frac))
+		}); err != nil {
 			return jobs.SimplifyInvalidStateError(err)
 		}
 	}

--- a/pkg/sql/rowexec/sample_aggregator.go
+++ b/pkg/sql/rowexec/sample_aggregator.go
@@ -241,7 +241,9 @@ func (s *sampleAggregator) mainLoop(
 			return job.NoTxn().CheckState(ctx)
 		}
 		lastReportedFractionCompleted = fractionCompleted
-		return job.NoTxn().FractionProgressed(ctx, jobs.FractionUpdater(fractionCompleted))
+		return s.FlowCtx.Cfg.DB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+			return jobs.ProgressStorage(jobID).SetFraction(ctx, txn, float64(fractionCompleted))
+		})
 	}
 
 	var rowsProcessed uint64

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1484,7 +1484,7 @@ func (sc *SchemaChanger) stepStateMachineAfterIndexBackfill(ctx context.Context)
 			return err
 		}
 		if sc.job != nil {
-			if err := sc.job.WithTxn(txn).UpdateStatusMessage(ctx, runStatus); err != nil {
+			if err := jobs.StatusStorage(sc.job.ID()).Set(ctx, txn, string(runStatus)); err != nil {
 				return errors.Wrap(err, "failed to update job status")
 			}
 		}

--- a/pkg/sql/schemachanger/scdeps/run_deps.go
+++ b/pkg/sql/schemachanger/scdeps/run_deps.go
@@ -137,6 +137,7 @@ func (d *jobExecutionDeps) WithTxnInJob(ctx context.Context, fn scrun.JobTxnFunc
 				d.codec,
 				d.rangeCounter,
 				d.job,
+				d.db,
 				pl.GetNewSchemaChange().BackfillProgress,
 				pl.GetNewSchemaChange().MergeProgress,
 			),


### PR DESCRIPTION
Add helpers to directly load/store legacy progress, use them in the history retention job.
Update jobs which only used updater to report progress to use ProgressStorage. 