### PR TITLE
kv: acquire latches during READ_UNCOMMITTED scans

### DIFF
--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -35,18 +35,14 @@ enum ReadConsistencyType {
   // mechanism relies on clocks to determine lease expirations.
   CONSISTENT = 0;
   // READ_UNCOMMITTED reads return both committed and uncommitted data.
-  // The consistency type is similar to INCONSISTENT in that using it
-  // can result in dirty reads. However, like the CONSISTENT type, it
-  // requires the replica performing the read to hold a valid read lease,
-  // meaning that it can't return arbitrarily stale data. Note that
-  // read-committed does not imply any real-time constraints. If process A
-  // completes write w, then process B begins a read r, r is not necessarily
-  // guaranteed to observe w even if they are from the same client. This can
-  // occur due to the unbounded time delay between Raft appends and state
-  // machine application.
-  // TODO(baptist): Should we remove this level as it is virtually identical to
-  // INCONSISTENT. See #98862 as we may change the behavior to give stronger
-  // guarantees.
+  // Like INCONSISTENT, this can result in dirty reads. However, unlike
+  // INCONSISTENT, READ_UNCOMMITTED acquires latches and requires the replica
+  // performing the read to hold a valid read lease. Latches ensure that if
+  // process A completes a write and then process B begins a READ_UNCOMMITTED
+  // read on the same leaseholder, B will observe A's write. Without latches
+  // (as with INCONSISTENT), B might miss A's write due to concurrent execution.
+  // Note that delays between Raft appends and state machine application can
+  // still affect visibility across different replicas.
   READ_UNCOMMITTED = 1;
   // INCONSISTENT reads return the latest available, committed values.
   // They are more efficient, but may read stale values as pending

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -464,8 +464,10 @@ func (m *managerImpl) maybeInterceptReq(ctx context.Context, req Request) (Respo
 // they could wait on them, even if they don't acquire latches.
 func shouldIgnoreLatches(req Request) bool {
 	switch {
-	case req.ReadConsistency != kvpb.CONSISTENT:
-		// Only acquire latches for consistent operations.
+	case req.ReadConsistency == kvpb.INCONSISTENT:
+		// INCONSISTENT reads skip latches as they don't need real-time ordering.
+		// READ_UNCOMMITTED reads acquire latches to provide real-time ordering
+		// guarantees, even though they may read uncommitted data.
 		return true
 	case req.isSingle(kvpb.RequestLease):
 		// Ignore latches for lease requests. These requests are run on replicas

--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -59,7 +59,7 @@ import (
 // The input files use the following DSL:
 //
 // new-txn      name=<txn-name> ts=<int>[,<int>] [epoch=<int>] [iso=<level>] [priority=<priority>] [uncertainty-limit=<int>[,<int>]]
-// new-request name=<req-name> txn=<txn-name>|none ts=<int>[,<int>] [priority=<priority>] [inconsistent] [wait-policy=<policy>] [lock-timeout]
+// new-request name=<req-name> txn=<txn-name>|none ts=<int>[,<int>] [priority=<priority>] [inconsistent] [read-uncommitted] [wait-policy=<policy>] [lock-timeout]
 // [deadlock-timeout] [max-lock-wait-queue-length=<int>] [poison-policy=[err|wait]]
 //
 //	<proto-name> [<field-name>=<field-value>...] (hint: see scanSingleRequest)
@@ -161,6 +161,9 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 				readConsistency := kvpb.CONSISTENT
 				if d.HasArg("inconsistent") {
 					readConsistency = kvpb.INCONSISTENT
+				}
+				if d.HasArg("read-uncommitted") {
+					readConsistency = kvpb.READ_UNCOMMITTED
 				}
 
 				priority := scanUserPriority(t, d)

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/no_latches
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/no_latches
@@ -25,6 +25,33 @@ reset
 ----
 
 # -------------------------------------------------------------
+# READ_UNCOMMITTED reads DO acquire latches (unlike INCONSISTENT)
+# -------------------------------------------------------------
+
+new-request name=readUncommittedReq txn=none ts=10,1 read-uncommitted
+  get key=k
+----
+
+sequence req=readUncommittedReq
+----
+[1] sequence readUncommittedReq: sequencing request
+[1] sequence readUncommittedReq: acquiring latches
+[1] sequence readUncommittedReq: scanning lock table for conflicting locks
+[1] sequence readUncommittedReq: sequencing complete, returned guard
+
+debug-latch-manager
+----
+write count: 0
+ read count: 1
+
+finish req=readUncommittedReq
+----
+[-] finish readUncommittedReq: finishing request
+
+reset
+----
+
+# -------------------------------------------------------------
 # Lease requests do not acquire latches
 # -------------------------------------------------------------
 


### PR DESCRIPTION
# kv: acquire latches during READ_UNCOMMITTED scans

Fixes #98862

## Summary

This PR modifies READ_UNCOMMITTED requests to acquire latches, providing real-time ordering guarantees while still allowing dirty reads. Previously, READ_UNCOMMITTED requests skipped latches (behaving identically to INCONSISTENT), which sacrificed real-time ordering guarantees.

## Problem

READ_UNCOMMITTED scans could violate real-time ordering by missing recently written data. Consider this scenario:

### Before this change (buggy behavior):

```
Time 1: Process A writes key 'x' = 100
        └─> Acquires write latch
        └─> Write completes, releases latch
        └─> Returns success to client

Time 2: Process B reads key 'x' with READ_UNCOMMITTED
        └─> Skips latches (no synchronization!)
        └─> Runs in parallel with write being applied
        └─> Gets old value or nothing! ❌
```

**The issue:** Process B's read happened AFTER Process A's write completed, but Process B didn't see the write because READ_UNCOMMITTED skipped latches. The read could execute in parallel with the write being applied to storage, leading to stale data being returned.

### After this change (correct behavior):

```
Time 1: Process A writes key 'x' = 100
        └─> Acquires write latch on 'x'
        └─> Write completes, releases latch
        └─> Returns success to client

Time 2: Process B reads key 'x' with READ_UNCOMMITTED
        └─> Acquires read latch on 'x' ✓
        └─> WAITS for any conflicting write latches
        └─> Sees the updated value: 100 ✓
```

**Real-time ordering guaranteed:** Reads that start after a write completes will see that write's data.

### Real-world example:

In an e-commerce system using READ_UNCOMMITTED for performance:

```sql
-- Process 1: Update inventory
UPDATE products SET stock = stock - 1 WHERE id = 'widget-123';
-- Returns success ✓

-- Process 2: Check stock (uses READ_UNCOMMITTED)
SELECT stock FROM products WHERE id = 'widget-123';
-- Without latches: might see the old stock value!
-- This violates real-time ordering
```

Two customers could both see "1 in stock" simultaneously and both successfully order, even though one update completed before the other's read started.

## Solution

This PR makes READ_UNCOMMITTED acquire latches (as shown in the "After" section above), ensuring real-time ordering guarantees while still differing from CONSISTENT reads in that it can see uncommitted/in-flight data (dirty reads).

## Changes

1. **`pkg/kv/kvserver/concurrency/concurrency_manager.go`**: Modified `shouldIgnoreLatches()` to check specifically for `INCONSISTENT` rather than `!= CONSISTENT`, allowing READ_UNCOMMITTED to acquire latches.

2. **`pkg/kv/kvpb/api.proto`**: Updated documentation to clarify that READ_UNCOMMITTED now acquires latches for real-time ordering, distinguishing it from INCONSISTENT reads.

3. **`pkg/kv/kvserver/concurrency/concurrency_manager_test.go`**: Added support for `read-uncommitted` flag in the test DSL.

4. **`pkg/kv/kvserver/concurrency/testdata/concurrency_manager/no_latches`**: Added test case verifying READ_UNCOMMITTED acquires latches while INCONSISTENT does not.

## Background: Latches vs Locks

CockroachDB uses two synchronization mechanisms:

| Feature | **Latches** | **Locks** |
|---------|-------------|-----------|
| **Duration** | Microseconds (during operation) | Milliseconds to seconds (transaction lifetime) |
| **Scope** | Single command execution | Entire transaction |
| **Purpose** | Prevent concurrent I/O on same keys | Prevent conflicting transactions |
| **Released** | Immediately after operation completes | When transaction commits/aborts |

**This PR is about latches**, which provide ordering for individual operations. Without latches, READ_UNCOMMITTED operations could run in parallel with writes on the same keys, breaking real-time ordering guarantees.

## Behavior Comparison

| Behavior | CONSISTENT | READ_UNCOMMITTED (after fix) | INCONSISTENT |
|----------|------------|------------------------------|--------------|
| Acquires latches? | ✓ Yes | ✓ Yes | ✗ No |
| Sees uncommitted data? | ✗ No | ✓ Yes (dirty reads) | ✗ No |
| Requires valid lease? | ✓ Yes | ✓ Yes | ✗ No |
| Real-time ordering? | ✓ Yes | ✓ Yes | ✗ No |

## Testing

- Updated `TestConcurrencyManagerBasic/no_latches` to verify READ_UNCOMMITTED acquires latches
- Test confirms INCONSISTENT reads still skip latches (existing behavior preserved)
- Test confirms READ_UNCOMMITTED reads now acquire latches and scan the lock table

Release Notes: None
Epic: None
