### PR TITLE
roachprod: `updatePrometheusTargets` should skip node with missing ip

### DIFF
--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -843,6 +843,11 @@ func updatePrometheusTargets(
 			if reachability == promhelperclient.Public {
 				nodeIP = v.PublicIP
 			}
+			// N.B. nodeIP can be missing, e.g., if the VM is stopped.
+			if nodeIP == "" {
+				l.Errorf("no reachable IP found for node %d (is the VM running?)", nodeID)
+				return
+			}
 
 			// ensure atomicity in map update
 			nodeIPPortsMutex.Lock()


### PR DESCRIPTION
`UpdateTargets` is used to update prometheus targets. When a VM is stopped, its public ip is empty. A target without an ip clashes with a local one.
E.g., `:9100` is equivalent to `localhost:9100`,
which is typically `node_exporter` for the prometheus itself. Thus, a node with a missing ip would mysteriously show up as having the _same_ system metrics as prometheus.

When a VM is missing a "reachable" ip (as specified by provider), its prometheus targets are skipped.

Epic: none
Release note: None