### PR TITLE
release-26.1: inspect: use defer to clean up protected timestamp

### DIFF
--- a/pkg/sql/inspect/inspect_resumer.go
+++ b/pkg/sql/inspect/inspect_resumer.go
@@ -58,6 +58,8 @@ func (c *inspectResumer) Resume(ctx context.Context, execCtx interface{}) error 
 		return err
 	}
 
+	defer c.maybeCleanupProtectedTimestamp(ctx, execCfg)
+
 	if err := c.maybeRunAfterProtectedTimestampHook(execCfg); err != nil {
 		return err
 	}
@@ -91,8 +93,6 @@ func (c *inspectResumer) Resume(ctx context.Context, execCtx interface{}) error 
 	if err := c.runInspectPlan(ctx, jobExecCtx, planCtx, plan, progressTracker); err != nil {
 		return err
 	}
-
-	c.maybeCleanupProtectedTimestamp(ctx, execCfg)
 
 	return nil
 }


### PR DESCRIPTION
Backport 1/1 commits from #160227 on behalf of @rafiss.

----

Epic CRDB-55075
Release note: None

----

Release justification: fix for feature that is GA in 26.1