### PR TITLE
jobs: clear claims when nudged

### DIFF
--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -1125,6 +1125,12 @@ func (r *Registry) Start(ctx context.Context, stopper *stop.Stopper) error {
 			case shouldClaim := <-r.adoptionCh:
 				// Try to adopt the most recently created job.
 				if shouldClaim {
+					// A nudge to claim and adopt suggests someone is waiting for periodic
+					// registry behaviors like claiming to happen; some of those behaviors
+					// are in the cancel loop, like clearing stale claims or detecting a
+					// cancel request, so run that fn as well when nudged in case that is
+					// or is part of what the nudge was sent to hasten.
+					cancelLoopTask(ctx)
 					claimJobs(ctx)
 				}
 				processClaimedJobs(ctx)


### PR DESCRIPTION
When we're nudged to adopt, its a signal there is likely work to adopt. Sometimes that work isn't adoptable though until a stale claim is first cleared. Given the point of an adopt-now nudge is to get it adopted right away, and clearing claims is a pre-req to adtoping, checking for and clearing claims before adopting when nudged can ensure the nudge has the desired effect.

Release note: none.
Epic: none.