### PR TITLE
rolemembershipcache: remove workaround for historical reads

### DIFF
--- a/pkg/sql/rolemembershipcache/cache.go
+++ b/pkg/sql/rolemembershipcache/cache.go
@@ -143,14 +143,11 @@ func (m *MembershipCache) RunAtCacheReadTS(
 				if roleOptionsDesc.IsUncommittedVersion() {
 					readTS = hlc.Timestamp{}
 				} else if roleOptionsDesc.GetVersion() > m.roleOptionsVersion {
-					// Update versions and moved the read timestamp forward. For the
-					// in-progress read, use the current transaction's timestamp.
+					// Update versions and invalidate the cache. For the in-progress read,
+					// use the current transaction's timestamp.
 					readTS = hlc.Timestamp{}
 					m.roleOptionsVersion = roleOptionsDesc.GetVersion()
-					if m.readTS.Less(roleOptionsDesc.GetModificationTime()) {
-						m.readTS = roleOptionsDesc.GetModificationTime()
-					}
-					return
+					m.roleMembersVersion = 0
 				}
 			}
 		}()
@@ -162,14 +159,11 @@ func (m *MembershipCache) RunAtCacheReadTS(
 				if dbRoleSettingsDesc.IsUncommittedVersion() {
 					readTS = hlc.Timestamp{}
 				} else if dbRoleSettingsDesc.GetVersion() > m.dbRoleSettingsVersion {
-					// Update versions and moved the read timestamp forward. For the
-					// in-progress read, use the current transaction's timestamp.
+					// Update versions and invalidate the cache. For the in-progress read,
+					// use the current transaction's timestamp.
 					readTS = hlc.Timestamp{}
 					m.dbRoleSettingsVersion = dbRoleSettingsDesc.GetVersion()
-					if m.readTS.Less(dbRoleSettingsDesc.GetModificationTime()) {
-						m.readTS = dbRoleSettingsDesc.GetModificationTime()
-					}
-					return
+					m.roleMembersVersion = 0
 				}
 			}
 		}()


### PR DESCRIPTION
71a510e0c7d0e934ae3b5e856d154c0606da8d37 recently was merged to change how the role membership cache is accessed. As part of that work, we worked around a bug with historical reads when locked leasing is enabled.

1750959972ade87d85d749d51f555c3a34a3ab32 fixes that bug, so we can remove the workaround now.

informs https://github.com/cockroachdb/cockroach/issues/152044
Release note: None