### PR TITLE
release-24.3: sqlstatsccl: ease assertions on TestSQLStatsRegions

### DIFF
--- a/pkg/ccl/testccl/sqlstatsccl/sql_stats_test.go
+++ b/pkg/ccl/testccl/sqlstatsccl/sql_stats_test.go
@@ -10,6 +10,7 @@ import (
 	gosql "database/sql"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -234,7 +235,18 @@ func TestSQLStatsRegions(t *testing.T) {
 				var actual appstatspb.StatementStatistics
 				err = json.Unmarshal([]byte(actualJSON), &actual)
 				require.NoError(t, err)
-				require.Equal(t, expectedRegions, actual.Regions)
+
+				foundRegions := 0
+				for _, r := range expectedRegions {
+					if slices.Contains(actual.Regions, r) {
+						foundRegions += 1
+					}
+				}
+				// As long as we find more than 1 region, we pass the test.
+				// Asserting that all 3 regions are present times out
+				// frequently and makes this test less useful.
+				require.Greater(t, foundRegions, 1, "expect at least 2 regions present in the statement stats, found: %v", actual.Regions)
+
 				return nil
 			}, 3*time.Minute)
 		})


### PR DESCRIPTION
Backport 1/1 commits from #139353.

/cc @cockroachdb/release

---

The goal of this test is to ensure that sql stats infrastructure is region-aware. Previously, we would wait until all 3 regions in the cluster were represented in the stats. This would time out regularly. Instead, we will just wait for 2 regions which reliably show up.

That should provide enough signal in this test to catch regressions where region-awareness is broken.

Resolves: #139283
Resolves: #139218
Fixes: #160148

Release note: None
Release justification: Fixes [test flake](https://github.com/cockroachdb/cockroach/issues/160148) with release blocker.