### PR TITLE
release-25.4: roachtest: set pgwire max repeated error to 256 in c2c mixed version

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_c2c.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_c2c.go
@@ -212,6 +212,9 @@ func (cm *c2cMixed) SetupHook(ctx context.Context) {
 			if err := h.System.Exec(r, "SET CLUSTER SETTING kv.rangefeed.enabled = true"); err != nil {
 				return errors.Wrap(err, "failed to enable rangefeeds")
 			}
+			if err := h.System.Exec(r, "SET CLUSTER SETTING sql.pgwire.max_repeated_error_count = 256"); err != nil {
+				return err
+			}
 			close(cm.sourceStartedChan)
 
 			l.Printf("generating pgurl")
@@ -245,6 +248,10 @@ func (cm *c2cMixed) SetupHook(ctx context.Context) {
 		func(ctx context.Context, l *logger.Logger, r *rand.Rand, h *mixedversion.Helper) error {
 			l.Printf("waiting to hear from source cluster")
 			sourceInfo := chanReadCtx(ctx, sourceInfoChan)
+
+			if err := h.System.Exec(r, "SET CLUSTER SETTING sql.pgwire.max_repeated_error_count = 256"); err != nil {
+				return err
+			}
 
 			if err := h.Exec(r, fmt.Sprintf(
 				"CREATE TENANT %q FROM REPLICATION OF %q ON $1 WITH READ VIRTUAL CLUSTER",


### PR DESCRIPTION
Backport 1/1 commits from #160273 on behalf of @msbutler.

----

On pre 26.1 versions by default, pgwire retries opening a connection tens of thousands of times, which could cause overload in the c2c/mixedversion roachtest. Now that `sql.pgwire.max_repeated_error_count` has been backported to 25.2+, we can deflake the roachtest by setting the max error count to 256.

Informs #150401

Release note: none

----

Release justification: