### PR TITLE
release-25.2: jobs: time out claim jobs query after 1 minute by default

### DIFF
--- a/pkg/jobs/adopt.go
+++ b/pkg/jobs/adopt.go
@@ -88,6 +88,11 @@ func (r *Registry) maybeDumpTrace(resumerCtx context.Context, resumer Resumer, j
 // claimJobs places a claim with the given SessionID to job rows that are
 // available.
 func (r *Registry) claimJobs(ctx context.Context, s sqlliveness.Session) error {
+
+	timeout := claimQueryTimeout.Get(&r.settings.SV)
+	ctx, cancel := context.WithDeadlineCause(ctx, timeutil.Now().Add(timeout), errors.New("claim jobs transaction took too long"))
+	defer cancel()
+
 	return r.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 		// Run the claim transaction at low priority to ensure that it does not
 		// contend with foreground reads.

--- a/pkg/jobs/config.go
+++ b/pkg/jobs/config.go
@@ -24,6 +24,7 @@ const (
 	cancelUpdateLimitKey       = "jobs.cancel_update_limit"
 	debugPausePointsSettingKey = "jobs.debug.pausepoints"
 	metricsPollingIntervalKey  = "jobs.metrics.interval.poll"
+	claimQueryTimeoutKey       = "jobs.registry.claim_query.timeout"
 )
 
 const (
@@ -121,6 +122,14 @@ var (
 		debugPausePointsSettingKey,
 		"the list, comma separated, of named pausepoints currently enabled for debugging",
 		"",
+	)
+
+	claimQueryTimeout = settings.RegisterDurationSetting(
+		settings.ApplicationLevel,
+		claimQueryTimeoutKey,
+		"the timeout for the claim query used when adopting jobs",
+		time.Minute,
+		settings.PositiveDuration,
 	)
 )
 


### PR DESCRIPTION
Backport 1/1 commits from #160084 on behalf of @msbutler.

----

The claim query should take less than a second, but we have seen it hang for
multiple hours because the underlying transaction continuously retries and
deadlocks. To prevent this, this patch causes the claim query to timeout after
a minute by default, set by the private cluster setting
jobs.registry.claim_query.timeout. The per node claim loop will try again in
the next iteration.

Informs #158976

Release note: none

----

Release justification: