### PR TITLE
release-26.1: jobs: time out claim jobs query after 1 minute by default

### DIFF
--- a/pkg/jobs/config.go
+++ b/pkg/jobs/config.go
@@ -24,6 +24,7 @@ const (
 	cancelUpdateLimitKey       = "jobs.cancel_update_limit"
 	debugPausePointsSettingKey = "jobs.debug.pausepoints"
 	metricsPollingIntervalKey  = "jobs.metrics.interval.poll"
+	claimQueryTimeoutKey       = "jobs.registry.claim_query.timeout"
 )
 
 const (
@@ -133,6 +134,14 @@ var (
 		debugPausePointsSettingKey,
 		"the list, comma separated, of named pausepoints currently enabled for debugging",
 		"",
+	)
+
+	claimQueryTimeout = settings.RegisterDurationSetting(
+		settings.ApplicationLevel,
+		claimQueryTimeoutKey,
+		"the timeout for the claim query used when adopting jobs",
+		time.Minute,
+		settings.PositiveDuration,
 	)
 )
 


### PR DESCRIPTION
Backport 1/1 commits from #160084 on behalf of @msbutler.

----

The claim query should take less than a second, but we have seen it hang for
multiple hours because the underlying transaction continuously retries and
deadlocks. To prevent this, this patch causes the claim query to timeout after
a minute by default, set by the private cluster setting
jobs.registry.claim_query.timeout. The per node claim loop will try again in
the next iteration.

Informs #158976

Release note: none

----

Release justification: