### PR TITLE
release-26.1: inspect: add num_active_spans metric

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -4960,6 +4960,14 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+    - name: jobs.inspect.num_active_spans
+      exported_name: jobs_inspect_num_active_spans
+      description: Number of spans currently being processed by INSPECT jobs
+      y_axis_label: Spans
+      type: GAUGE
+      unit: COUNT
+      aggregation: AVG
+      derivative: NONE
     - name: jobs.inspect.protected_age_sec
       exported_name: jobs_inspect_protected_age_sec
       labeled_name: 'jobs.protected_age_sec{type: inspect}'

--- a/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
+++ b/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
@@ -901,6 +901,7 @@ jobs_inspect_expired_pts_records: jobs.inspect.expired_pts_records
 jobs_inspect_fail_or_cancel_completed: jobs.inspect.fail_or_cancel_completed
 jobs_inspect_fail_or_cancel_retry_error: jobs.inspect.fail_or_cancel_retry_error
 jobs_inspect_issues_found: jobs.inspect.issues_found
+jobs_inspect_num_active_spans: jobs.inspect.num_active_spans
 jobs_inspect_protected_age_sec: jobs.inspect.protected_age_sec
 jobs_inspect_protected_record_count: jobs.inspect.protected_record_count
 jobs_inspect_resume_completed: jobs.inspect.resume_completed

--- a/pkg/sql/inspect/inspect_metrics.go
+++ b/pkg/sql/inspect/inspect_metrics.go
@@ -18,6 +18,7 @@ type InspectMetrics struct {
 	RunsWithIssues *metric.Counter
 	IssuesFound    *metric.Counter
 	SpansProcessed *metric.Counter
+	NumActiveSpans *metric.Gauge
 }
 
 var _ metric.Struct = (*InspectMetrics)(nil)
@@ -50,6 +51,12 @@ var (
 		Measurement: "Spans",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaInspectNumActiveSpans = metric.Metadata{
+		Name:        "jobs.inspect.num_active_spans",
+		Help:        "Number of spans currently being processed by INSPECT jobs",
+		Measurement: "Spans",
+		Unit:        metric.Unit_COUNT,
+	}
 )
 
 // MakeInspectMetrics instantiates the metrics for INSPECT jobs.
@@ -59,6 +66,7 @@ func MakeInspectMetrics(histogramWindow time.Duration) metric.Struct {
 		RunsWithIssues: metric.NewCounter(metaInspectRunsWithIssues),
 		IssuesFound:    metric.NewCounter(metaInspectIssuesFound),
 		SpansProcessed: metric.NewCounter(metaInspectSpansProcessed),
+		NumActiveSpans: metric.NewGauge(metaInspectNumActiveSpans),
 	}
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #160296 on behalf of @rafiss.

----

Add a new gauge metric `jobs.inspect.num_active_spans` that tracks
how many spans are currently being processed by INSPECT jobs. This
follows the same pattern as the row-level TTL job's
`jobs.row_level_ttl.num_active_spans` metric.

The gauge is incremented when a span starts processing and decremented
when it finishes, providing real-time visibility into INSPECT job
concurrency and progress.

Epic: CRDB-55075
Release note: None

----

Release justification: metrics added for 26.1 GA feature