### PR TITLE
release-26.1: catalog/lease: handle boundary cases for historical descriptors

### DIFF
--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -932,26 +932,41 @@ func (m *Manager) readOlderVersionForTimestamp(
 		// We permit gaps in historical versions. We want to find the timestamp
 		// that represents the start of the validity interval for the known version
 		// which immediately follows the timestamps we're searching for.
-		i := sort.Search(len(t.mu.active.data), func(i int) bool {
+		tsForComparison := timestamp.GetTimestamp()
+		indexAfterTS := sort.Search(len(t.mu.active.data), func(i int) bool {
 			return timestamp.GetTimestamp().Less(t.mu.active.data[i].GetModificationTime())
 		})
+
+		// If the read timestamp and base timestamp are different, additionally,
+		// check if we need a slightly later end timestamp. This guarantees we will
+		// populate every possible descriptor needed for this request.
+		if timestamp.GetTimestamp() != timestamp.GetBaseTimestamp() {
+			baseTimeStampIndex := sort.Search(len(t.mu.active.data), func(i int) bool {
+				return timestamp.GetBaseTimestamp().Less(t.mu.active.data[i].GetModificationTime())
+			})
+			if baseTimeStampIndex != len(t.mu.active.data) {
+				indexAfterTS = baseTimeStampIndex
+				tsForComparison = timestamp.GetBaseTimestamp()
+			}
+		}
 
 		// If the timestamp we're searching for is somehow after the last descriptor
 		// we have in play, then either we have the right descriptor, or some other
 		// shenanigans where we've evicted the descriptor has occurred.
-		//
-		// TODO(ajwerner): When we come to modify this code to allow us to find
-		// historical descriptors which have been dropped, we'll need to rework
-		// this case and support providing no upperBound to
-		// getDescriptorFromStoreForInterval.
-		if i == len(t.mu.active.data) ||
+		if indexAfterTS == len(t.mu.active.data) ||
 			// If we found a descriptor that isn't the first descriptor, go and check
 			// whether the descriptor for which we're searching actually exists. This
 			// will deal with cases where a concurrent fetch filled it in for us.
-			i > 0 && timestamp.GetTimestamp().Less(t.mu.active.data[i-1].getExpiration(ctx)) {
-			return hlc.Timestamp{}, false, true
+			indexAfterTS > 0 && tsForComparison.Less(t.mu.active.data[indexAfterTS-1].getExpiration(ctx)) {
+			// If the descriptor is offline, then nothing newer can exist.
+			if !t.mu.takenOffline {
+				return hlc.Timestamp{}, false, true
+			}
+			// Otherwise, the table is offline, so there may be newer descriptor
+			// versions before the offline timestamp.
+			return t.mu.takenOfflineAt, true, false
 		}
-		return t.mu.active.data[i].GetModificationTime(), false, false
+		return t.mu.active.data[indexAfterTS].GetModificationTime(), false, false
 	}()
 	if done {
 		return nil, nil


### PR DESCRIPTION
Backport 1/1 commits from #160280 on behalf of @fqazi.

----

Previously, our handling for offline descriptors did not correctly
attempt to reacquire them when they came back online. While in the real
world this is only possible, after recovering a dropped descriptor, we
still need to handle this. We also did not account for locked timestamps
properly for historical queries, so all required descriptors would not
be fetched in certain scenarios. This patch, will correctly attempt to
renew offline descriptors that are accessed after their offline
timestamps (i.e. after we detect they have been removed). It also fixes
historical descriptor reading logic to adjust boundaries to take into
account offline timestamps. We also adjust the boundaries to take into
account the base and read timestamps, since otherwise insufficient data
can be populated in stress scenarios.

Fixes: #159897
Fixes: #160045
Fixes: #160288

Release note: None

----

Release justification: fix for a GA blocker