### PR TITLE
release-25.2.11-rc: roachtest: update liquibase-test-harness to fix year-end failures

### DIFF
--- a/pkg/cmd/roachtest/tests/liquibase.go
+++ b/pkg/cmd/roachtest/tests/liquibase.go
@@ -16,7 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 )
 
-var supportedLiquibaseHarnessCommit = "f43b967d60aa4ce7056a6d6ee0bc6d9f144c62d5"
+var supportedLiquibaseHarnessCommit = "91c42e7644c9db5cc86f6d013a33c43900646e2f"
 
 // This test runs the Liquibase test harness against a single cockroach node.
 func registerLiquibase(r registry.Registry) {


### PR DESCRIPTION
Backport 1/1 commits from #160323 on behalf of @rafiss.

----

The liquibase roachtest started failing on December 28, 2025 across all branches with "already exists" errors. The root cause was a bug in the upstream liquibase-test-harness where SimpleDateFormat used `YYYY` (ISO week-based year) instead of `yyyy` (calendar year) for the rollbackToDate command.

ISO week 1 of 2026 starts on December 29, 2025, so when tests ran on Dec 28-29, the rollback date was computed as 2026-12-29 instead of 2025-12-29. Since no changesets have DATEEXECUTED in the future, rollbackToDate found "0 changesets to rollback" and left all database objects in place, causing subsequent tests to fail.

This updates the pinned commit to include the upstream fix: https://github.com/liquibase/liquibase-test-harness/commit/91c42e7644c9

Resolves: #160237
Resolves: #160302
Resolves: #160291
Resolves: #160266
Resolves: #160260
Resolves: #160241
Resolves: #160240
Resolves: #160239
Resolves: #160236
Resolves: #160235
Resolves: #160234
Epic: None

Release note: None

----

Release justification: