### PR TITLE
sql: step read seq on rollback

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/savepoints
+++ b/pkg/sql/logictest/testdata/logic_test/savepoints
@@ -33,3 +33,22 @@ SELECT * FROM a
 
 statement ok
 COMMIT
+
+# Regression test for https://github.com/cockroachdb/cockroach/issues/135118.
+# Rolling back a savepoint before rolling back the transaction caused the
+# transaction rollback to fail.
+
+statement ok
+BEGIN
+
+statement ok
+SAVEPOINT sp1
+
+statement ok
+INSERT INTO a(id) VALUES (1);
+
+statement ok
+ROLLBACK TO SAVEPOINT sp1
+
+statement ok
+ROLLBACK


### PR DESCRIPTION
The conn executor creates transactions with "stepped" read sequences. The purpose of this behavior is to prevent a statement from reading its own writes, which is required by postgres semantics. When a savepoint is rolled back, it creates a [start_savepoint_seq, end_savepoint_seq) span of reverted sequences. The txn middleware validates the transaction's read sequence number to ensure it's not inside a reverted span. If the read sequence is inside a reverted span, the transaction requests return assertion failures and are not sent to the KV layer.

This validation means that if a transaction has its read timestamp inside a reverted span when it attempts to roll back the transaction, the RPCs to clean up the transaction are never sent. The transaction is orphaned and is cleaned up automatically, but it leaves the locks in place for a few seconds. Since the txn is cleaned up eventually, the conn executor logs an error instead of poisoning the session.

Fixes: #156507
Fixes: #135118
Fixes: #159594
Release note (bug fix): Fixed a bug that caused rolling back a transaction that just rolled back a savepoint to block transactions touching the same rows for five seconds.