### PR TITLE
release-26.1: roachtest: avoid FIPS for sequelize

### DIFF
--- a/pkg/cmd/roachtest/tests/sequelize.go
+++ b/pkg/cmd/roachtest/tests/sequelize.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 )
@@ -138,7 +139,7 @@ func registerSequelize(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:             "sequelize",
 		Owner:            registry.OwnerSQLFoundations,
-		Cluster:          r.MakeClusterSpec(1),
+		Cluster:          r.MakeClusterSpec(1, spec.Arch(spec.AllExceptFIPS)),
 		Leases:           registry.MetamorphicLeases,
 		NativeLibs:       registry.LibGEOS,
 		CompatibleClouds: registry.AllExceptAWS,


### PR DESCRIPTION
Backport 1/1 commits from #160335 on behalf of @fqazi.

----

Previously, the sequelize test would fail if it ran on the FIPS architecture because node is not available on it. To address this, this patch removes FIPS from the architecture set.

Fixes: #160172

Release note: None

----

Release justification: