### PR TITLE
pgwire: fix JDBC compatibility for SP with COMMIT

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -3781,7 +3781,7 @@ func (ex *connExecutor) runObserverStatement(
 func (ex *connExecutor) runShowSyntax(
 	ctx context.Context, stmt string, res RestrictedCommandResult,
 ) error {
-	res.SetColumns(ctx, colinfo.ShowSyntaxColumns)
+	res.SetColumns(ctx, colinfo.ShowSyntaxColumns, false /* skipRowDescription */)
 	var commErr error
 	parser.RunShowSyntax(ctx, stmt,
 		func(ctx context.Context, field, msg string) {
@@ -3800,7 +3800,7 @@ func (ex *connExecutor) runShowSyntax(
 func (ex *connExecutor) runShowTransactionState(
 	ctx context.Context, res RestrictedCommandResult,
 ) error {
-	res.SetColumns(ctx, colinfo.ResultColumns{{Name: "TRANSACTION STATUS", Typ: types.String}})
+	res.SetColumns(ctx, colinfo.ResultColumns{{Name: "TRANSACTION STATUS", Typ: types.String}}, false /* skipRowDescription */)
 
 	state := fmt.Sprintf("%s", ex.machine.CurState())
 	return res.AddRow(ctx, tree.Datums{tree.NewDString(state)})
@@ -3863,7 +3863,7 @@ func (ex *connExecutor) runShowTransferState(
 	for i := 0; i < len(colNames); i++ {
 		cols[i] = colinfo.ResultColumn{Name: colNames[i], Typ: types.String}
 	}
-	res.SetColumns(ctx, cols)
+	res.SetColumns(ctx, cols, false /* skipRowDescription */)
 
 	var sessionState, sessionRevivalToken tree.Datum
 	var row tree.Datums
@@ -3897,7 +3897,7 @@ func (ex *connExecutor) runShowTransferState(
 func (ex *connExecutor) runShowCompletions(
 	ctx context.Context, n *tree.ShowCompletions, res RestrictedCommandResult,
 ) error {
-	res.SetColumns(ctx, colinfo.ShowCompletionsColumns)
+	res.SetColumns(ctx, colinfo.ShowCompletionsColumns, false /* skipRowDescription */)
 	log.Dev.Warningf(ctx, "COMPLETION GENERATOR FOR: %+v", *n)
 	sd := ex.planner.SessionData()
 	override := sessiondata.InternalExecutorOverride{
@@ -3964,7 +3964,7 @@ func (ex *connExecutor) runShowLastQueryStatistics(
 	for i, n := range stmt.Columns {
 		resColumns[i] = colinfo.ResultColumn{Name: string(n), Typ: types.String}
 	}
-	res.SetColumns(ctx, resColumns)
+	res.SetColumns(ctx, resColumns, false /* skipRowDescription */)
 
 	phaseTimes := ex.statsCollector.PreviousPhaseTimes()
 

--- a/pkg/sql/conn_executor_savepoints.go
+++ b/pkg/sql/conn_executor_savepoints.go
@@ -410,7 +410,7 @@ func (ex *connExecutor) runShowSavepointState(
 	res.SetColumns(ctx, colinfo.ResultColumns{
 		{Name: "savepoint_name", Typ: types.String},
 		{Name: "is_initial_savepoint", Typ: types.Bool},
-	})
+	}, false /* skipRowDescription */)
 
 	for _, entry := range ex.extraTxnState.savepoints {
 		if err := res.AddRow(ctx, tree.Datums{

--- a/pkg/sql/conn_executor_show_commit_timestamp.go
+++ b/pkg/sql/conn_executor_show_commit_timestamp.go
@@ -141,6 +141,6 @@ func (ex *connExecutor) execShowCommitTimestampInNoTxnState(
 func writeShowCommitTimestampRow(
 	ctx context.Context, res RestrictedCommandResult, ts hlc.Timestamp,
 ) error {
-	res.SetColumns(ctx, colinfo.ShowCommitTimestampColumns)
+	res.SetColumns(ctx, colinfo.ShowCommitTimestampColumns, false /* skipRowDescription */)
 	return res.AddRow(ctx, tree.Datums{eval.TimestampToDecimalDatum(ts)})
 }

--- a/pkg/sql/conn_io.go
+++ b/pkg/sql/conn_io.go
@@ -867,7 +867,7 @@ type RestrictedCommandResult interface {
 	// can be nil.
 	//
 	// This needs to be called (once) before AddRow.
-	SetColumns(context.Context, colinfo.ResultColumns)
+	SetColumns(ctx context.Context, cols colinfo.ResultColumns, skipRowDescription bool)
 
 	// ResetStmtType allows a client to change the statement type of the current
 	// result, from the original one set when the result was created trough
@@ -948,7 +948,7 @@ type DescribeResult interface {
 	SetPrepStmtOutput(context.Context, colinfo.ResultColumns)
 	// SetPortalOutput tells the client about the results schema and formatting of
 	// a portal.
-	SetPortalOutput(context.Context, colinfo.ResultColumns, []pgwirebase.FormatCode)
+	SetPortalOutput(ctx context.Context, cols colinfo.ResultColumns, fmtCode []pgwirebase.FormatCode)
 }
 
 // ParseResult represents the result of a Parse command.
@@ -1114,7 +1114,9 @@ func (r *streamingCommandResult) RevokePortalPausability() error {
 }
 
 // SetColumns is part of the RestrictedCommandResult interface.
-func (r *streamingCommandResult) SetColumns(ctx context.Context, cols colinfo.ResultColumns) {
+func (r *streamingCommandResult) SetColumns(
+	ctx context.Context, cols colinfo.ResultColumns, skipRowDescription bool,
+) {
 	// The interface allows for cols to be nil, yet the iterator result expects
 	// non-nil value to indicate that it was the column metadata.
 	if cols == nil {

--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -60,7 +60,7 @@ func setExplainBundleResult(
 	warnings []string,
 ) error {
 	res.ResetStmtType(&tree.ExplainAnalyze{})
-	res.SetColumns(ctx, colinfo.ExplainPlanColumns)
+	res.SetColumns(ctx, colinfo.ExplainPlanColumns, false /* skipRowDescription */)
 
 	var text []string
 	if bundle.collectionErr != nil {

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -976,7 +976,7 @@ func (ih *instrumentationHelper) setExplainAnalyzeResult(
 	trace tracingpb.Recording,
 ) (commErr error) {
 	res.ResetStmtType(&tree.ExplainAnalyze{})
-	res.SetColumns(ctx, colinfo.ExplainPlanColumns)
+	res.SetColumns(ctx, colinfo.ExplainPlanColumns, false /* skipRowDescription */)
 
 	if res.Err() != nil {
 		// Can't add rows if there was an error.

--- a/pkg/sql/isession/command_result.go
+++ b/pkg/sql/isession/command_result.go
@@ -73,7 +73,9 @@ func (i *internalCommandResult) SendNotice(
 	return nil
 }
 
-func (i *internalCommandResult) SetColumns(ctx context.Context, cols colinfo.ResultColumns) {
+func (i *internalCommandResult) SetColumns(
+	ctx context.Context, cols colinfo.ResultColumns, skipRowDescription bool,
+) {
 	// We don't need this because the datums include type information.
 }
 
@@ -166,7 +168,7 @@ func (i *internalCommandResult) SendCopyOut(
 }
 
 func (i *internalCommandResult) SetPortalOutput(
-	ctx context.Context, cols colinfo.ResultColumns, formatCodes []pgwirebase.FormatCode,
+	ctx context.Context, cols colinfo.ResultColumns, fmtCode []pgwirebase.FormatCode,
 ) {
 	i.SetError(errors.AssertionFailedf("SetPortalOutput is not supported by the internal session"))
 }

--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -1272,7 +1272,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 					))
 				}
 			}
-			b.checkDuplicateTargets(target, "CALL")
+			b.checkDuplicateTargets(target, tree.CallStmtTag)
 			if len(target) == 0 {
 				// When there is no INTO target, build the nested procedure call into a
 				// body statement that is only executed for its side effects.

--- a/pkg/sql/pgwire/command_result.go
+++ b/pkg/sql/pgwire/command_result.go
@@ -343,10 +343,12 @@ func (r *commandResult) SendNotice(
 }
 
 // SetColumns is part of the sql.RestrictedCommandResult interface.
-func (r *commandResult) SetColumns(ctx context.Context, cols colinfo.ResultColumns) {
+func (r *commandResult) SetColumns(
+	ctx context.Context, cols colinfo.ResultColumns, skipRowDescription bool,
+) {
 	r.assertNotReleased()
 	r.conn.writerState.fi.registerCmd(r.pos)
-	if r.descOpt == sql.NeedRowDesc {
+	if r.descOpt == sql.NeedRowDesc && !skipRowDescription {
 		_ /* err */ = r.conn.writeRowDescription(ctx, cols, r.formatCodes, &r.conn.writerState.buf)
 	}
 	r.types = make([]*types.T, len(cols))

--- a/pkg/sql/pgwire/command_result_test.go
+++ b/pkg/sql/pgwire/command_result_test.go
@@ -63,7 +63,7 @@ func TestTruncateCommandResult(t *testing.T) {
 		sql.PortalPausabilityDisabled,
 	)
 	r := cr.(*commandResult)
-	r.SetColumns(ctx, []colinfo.ResultColumn{{Name: "a", Typ: types.Int}})
+	r.SetColumns(ctx, []colinfo.ResultColumn{{Name: "a", Typ: types.Int}}, false /* skipRowDescription */)
 
 	// Each row has a 4 byte header and 8 byte value.
 	const expectedBytesPerRow = 12

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -863,7 +863,7 @@ func cookTag(
 		tag = strconv.AppendInt(tag, int64(rowsAffected), 10)
 
 	case tree.Rows:
-		if tagStr != "SHOW" && tagStr != "EXPLAIN" && tagStr != "CALL" {
+		if tagStr != "SHOW" && tagStr != "EXPLAIN" && tagStr != tree.CallStmtTag {
 			tag = append(tag, ' ')
 			tag = strconv.AppendUint(tag, uint64(rowsAffected), 10)
 		}

--- a/pkg/sql/pgwire/testdata/pgtest/pgjdbc
+++ b/pkg/sql/pgwire/testdata/pgtest/pgjdbc
@@ -137,3 +137,182 @@ ReadyForQuery
 {"Type":"DataRow","Values":[{"text":"1"}]}
 {"Type":"CommandComplete","CommandTag":"SELECT 1"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Regression test for #158771: JDBC driver throws NoSuchElementException
+# when calling a procedure that contains a COMMIT statement.
+#
+# The issue occurs when using the extended protocol
+# (Parse/Bind/Describe/Execute/Sync) to call a procedure that commits
+# the transaction internally. The JDBC driver expects specific message
+# sequences when calling or describing a portal bound to such
+# procedures:
+# - NoData message if the procedure has no output parameters
+# - Single RowDescription message if the procedure has output parameters
+#
+# Prior to this fix, CockroachDB incorrectly emitted RowDescription
+# messages regardless of output parameters and sent additional
+# RowDescription messages for each COMMIT statement in the procedure
+# body. This behavior differed from PostgreSQL and caused JDBC driver
+# failures. This fix ensures CockroachDB follows the same protocol
+# semantics as PostgreSQL.
+subtest 158771
+
+# Create 2 procedure:
+# proc_commit() is a simple procedure with a COMMIT after the INSERT.
+# proc_commit_output() has 2 output parameters and several COMMITs in the body.
+send
+Query {"String": "DROP TABLE IF EXISTS t_158771"}
+Query {"String": "CREATE TABLE t_158771 (a INT4, b INT4, c INT4)"}
+Query {"String": "CREATE OR REPLACE PROCEDURE proc_commit() LANGUAGE plpgsql AS $$ BEGIN INSERT INTO t_158771 (a, b, c) VALUES (1, NULL, NULL); COMMIT; END; $$"}
+Query {"String": "CREATE OR REPLACE PROCEDURE proc_commit_output(OUT val INT, OUT val1 INT) LANGUAGE plpgsql AS $$ BEGIN INSERT INTO t_158771 (a, b, c) VALUES (1, NULL, NULL); val = 1; val1 = 2; COMMIT; COMMIT; COMMIT; END; $$"}
+----
+
+until ignore=NoticeResponse
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"DROP TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+{"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+{"Type":"CommandComplete","CommandTag":"CREATE PROCEDURE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+{"Type":"CommandComplete","CommandTag":"CREATE PROCEDURE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Test 1: Call procedure using simple protocol.
+send
+Query {"String": "CALL proc_commit()"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"CALL"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "CALL proc_commit_output(NULL, NULL)"}
+----
+
+until ignore_table_oids ignore_type_oids ignore_data_type_sizes
+ReadyForQuery
+----
+{"Type":"RowDescription","Fields":[{"Name":"val","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":0,"DataTypeSize":0,"TypeModifier":-1,"Format":0},{"Name":"val1","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":0,"DataTypeSize":0,"TypeModifier":-1,"Format":0}]}
+{"Type":"DataRow","Values":[{"text":"1"},{"text":"2"}]}
+{"Type":"CommandComplete","CommandTag":"CALL"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Verify the insert worked.
+send
+Query {"String": "SELECT * FROM t_158771"}
+----
+
+until ignore=RowDescription
+ReadyForQuery
+----
+{"Type":"DataRow","Values":[{"text":"1"},null,null]}
+{"Type":"DataRow","Values":[{"text":"1"},null,null]}
+{"Type":"CommandComplete","CommandTag":"SELECT 2"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Test 2: Call procedure using extended protocol with Describe (JDBC pattern)
+send
+Parse {"Name": "s1", "Query": "CALL proc_commit()"}
+Bind {"DestinationPortal": "p1", "PreparedStatement": "s1"}
+Describe {"ObjectType": "P", "Name": "p1"}
+Execute {"Portal": "p1"}
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"NoData"}
+{"Type":"CommandComplete","CommandTag":"CALL"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Parse {"Name": "s2", "Query": "CALL proc_commit_output(NULL, NULL)"}
+Bind {"DestinationPortal": "p2", "PreparedStatement": "s2"}
+Describe {"ObjectType": "P", "Name": "p2"}
+Execute {"Portal": "p2"}
+Sync
+----
+
+until ignore_table_oids ignore_type_oids ignore_data_type_sizes
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"RowDescription","Fields":[{"Name":"val","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":0,"DataTypeSize":0,"TypeModifier":-1,"Format":0},{"Name":"val1","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":0,"DataTypeSize":0,"TypeModifier":-1,"Format":0}]}
+{"Type":"DataRow","Values":[{"text":"1"},{"text":"2"}]}
+{"Type":"CommandComplete","CommandTag":"CALL"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "CREATE OR REPLACE PROCEDURE proc_commit2(OUT val INT, OUT val1 INT) LANGUAGE plpgsql AS $$ BEGIN INSERT INTO t_158771 (a, b, c) VALUES (1, NULL, NULL); COMMIT; END; $$"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"CREATE PROCEDURE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Parse {"Name": "s3", "Query": "CALL proc_commit2(NULL, NULL)"}
+Bind {"DestinationPortal": "p3", "PreparedStatement": "s3"}
+Describe {"ObjectType": "P", "Name": "p3"}
+Execute {"Portal": "p3"}
+Sync
+----
+
+until ignore_table_oids ignore_type_oids ignore_data_type_sizes
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"RowDescription","Fields":[{"Name":"val","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":0,"DataTypeSize":0,"TypeModifier":-1,"Format":0},{"Name":"val1","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":0,"DataTypeSize":0,"TypeModifier":-1,"Format":0}]}
+{"Type":"DataRow","Values":[null,null]}
+{"Type":"CommandComplete","CommandTag":"CALL"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Test 3: Extended protocol without Describe (simpler pattern)
+send
+Parse {"Name": "s4", "Query": "CALL proc_commit()"}
+Bind {"DestinationPortal": "p4", "PreparedStatement": "s4"}
+Execute {"Portal": "p4"}
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"CALL"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Verify final result after the 6 call of SPs, with each inserting one row.
+send
+Query {"String": "SELECT * FROM t_158771"}
+----
+
+until ignore=RowDescription
+ReadyForQuery
+----
+{"Type":"DataRow","Values":[{"text":"1"},null,null]}
+{"Type":"DataRow","Values":[{"text":"1"},null,null]}
+{"Type":"DataRow","Values":[{"text":"1"},null,null]}
+{"Type":"DataRow","Values":[{"text":"1"},null,null]}
+{"Type":"DataRow","Values":[{"text":"1"},null,null]}
+{"Type":"DataRow","Values":[{"text":"1"},null,null]}
+{"Type":"CommandComplete","CommandTag":"SELECT 6"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+subtest end

--- a/pkg/sql/pgwire/testdata/pgtest/procedure
+++ b/pkg/sql/pgwire/testdata/pgtest/procedure
@@ -66,11 +66,8 @@ Query {"String": "CALL p()"}
 until
 ReadyForQuery
 ----
-{"Type":"RowDescription","Fields":null}
 {"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"foo","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func381","UnknownFields":null}
-{"Type":"RowDescription","Fields":null}
 {"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"bar","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func381","UnknownFields":null}
-{"Type":"RowDescription","Fields":null}
 {"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"baz","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func381","UnknownFields":null}
 {"Type":"CommandComplete","CommandTag":"CALL"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
@@ -88,9 +85,7 @@ ReadyForQuery
 {"Type":"ParseComplete"}
 {"Type":"BindComplete"}
 {"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"foo","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func381","UnknownFields":null}
-{"Type":"RowDescription","Fields":null}
 {"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"bar","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func381","UnknownFields":null}
-{"Type":"RowDescription","Fields":null}
 {"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"baz","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func381","UnknownFields":null}
 {"Type":"CommandComplete","CommandTag":"CALL"}
 {"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -737,6 +737,8 @@ func (*BeginTransaction) StatementType() StatementType { return TypeTCL }
 // StatementTag returns a short string identifying the type of statement.
 func (*BeginTransaction) StatementTag() string { return "BEGIN" }
 
+const CallStmtTag = `CALL`
+
 // StatementReturnType implements the Statement interface.
 func (*Call) StatementReturnType() StatementReturnType { return Rows }
 
@@ -744,7 +746,7 @@ func (*Call) StatementReturnType() StatementReturnType { return Rows }
 func (*Call) StatementType() StatementType { return TypeTCL }
 
 // StatementTag returns a short string identifying the type of statement.
-func (*Call) StatementTag() string { return "CALL" }
+func (*Call) StatementTag() string { return CallStmtTag }
 
 // StatementReturnType implements the Statement interface.
 func (*ControlJobs) StatementReturnType() StatementReturnType { return RowsAffected }


### PR DESCRIPTION
Fixes #158771

Previously, when using the extended protocol (Parse/Bind/Describe/Execute/Sync) to call a PL/pgSQL procedure containing COMMIT statements, CockroachDB would send extra RowDescription messages after the COMMIT, causing the JDBC driver to throw NoSuchElementException due to unexpected message sequences.

This change fixes the message flow to match JDBC driver expectations when procedures execute COMMIT statements internally. The fix ensures that the proper sequence of PostgreSQL wire protocol messages is sent, preventing the driver from entering an inconsistent state.

For reference, PG's code for describe portal message: https://github.com/postgres/postgres/blob/451c43974f8e199097d97624a4952ad0973cea61/src/backend/tcop/postgres.c#L2731

Release Notes (Bug Fix): Fixed compatibility issue with JDBC driver when calling PL/pgSQL procedures containing COMMIT statements via prepared statements. The driver would previously throw NoSuchElementException due to unexpected PostgreSQL wire protocol message sequences.