### PR TITLE
roachprod: add support for create/list/destroy load balancer (AWS) 

### DIFF
--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -3108,6 +3108,28 @@ func LoadBalancerIP(
 	return addr.IP, nil
 }
 
+// ListLoadBalancers returns all load balancers for the given cluster.
+func ListLoadBalancers(l *logger.Logger, clusterName string) ([]vm.ServiceAddress, error) {
+	c, err := GetClusterFromCache(l, clusterName)
+	if err != nil {
+		return nil, err
+	}
+	return c.ListLoadBalancers(l)
+}
+
+// DeleteLoadBalancer deletes all load balancers for the given cluster.
+func DeleteLoadBalancer(l *logger.Logger, clusterName string) error {
+	c, err := GetClusterFromCache(l, clusterName)
+	if err != nil {
+		return err
+	}
+
+	// Delete all load balancers for the cluster (port=0 means delete all).
+	return vm.FanOut(c.VMs, func(provider vm.Provider, vms vm.List) error {
+		return provider.DeleteLoadBalancer(l, vms, 0)
+	})
+}
+
 // Deploy deploys a new version of cockroach to the given cluster. It currently
 // does not support clusters running external SQL instances.
 // TODO(herko): Add support for virtual clusters (external SQL processes)


### PR DESCRIPTION
This change adds Network Load Balancer (NLB) support for AWS clusters by
  implementing the CreateLoadBalancer, DeleteLoadBalancer, and
  ListLoadBalancers methods on the AWS provider.

  The implementation:
  - Creates a regional NLB with a TCP listener on the specified port
  - Creates a target group with health checks and registers all cluster VMs
  - Uses a naming convention {cluster}-{port}-{type}-roachprod (truncated to
  32 chars due to AWS limits)
  - Handles multi-region clusters by creating an NLB in each region
  - Cleans up all associated resources (listeners, target groups) on deletion
  - Supports deleting all load balancers for a cluster
  
  # Usage
  
  ## Create a load balancer for SQL connections
  roachprod load-balancer create <$cluster> --secure

  ## List load balancers and view connection info
  roachprod load-balancer list <$cluster>
  roachprod load-balancer pgurl <$cluster>
  roachprod load-balancer ip <$cluster>

  ## Get connection URL through load balancer
  roachprod fetch-certs <$cluster>
  
  ## Connect to cluster node via load balancer
  eval ./cockroach sql --url=$(roachprod load-balancer pgurl <$cluster> --secure)

  ## Delete all load balancers
  roachprod load-balancer destroy <$cluster>
  
  
Fixes: [#54176](https://github.com/cockroachdb/cockroach/issues/153072)
Epic: None
Release Note: None