### PR TITLE
opt: optimize levenshtein comparisons

### DIFF
--- a/pkg/sql/opt/norm/comp_funcs.go
+++ b/pkg/sql/opt/norm/comp_funcs.go
@@ -173,3 +173,32 @@ func (c *CustomFuncs) CollapseRepeatedLikePatternWildcards(
 	}
 	return nil, false
 }
+
+// MakeLevenshteinLessEqualFunction constructs a new levenshtein_less_equal()
+// function with the three given arguments.
+func (c *CustomFuncs) MakeLevenshteinLessEqualFunction(
+	arg1, arg2, maxD opt.ScalarExpr,
+) opt.ScalarExpr {
+	args := memo.ScalarListExpr{arg1, arg2, maxD}
+	props, overload := findLevenshteinLessEqualFunction()
+	return c.f.ConstructFunction(args, &memo.FunctionPrivate{
+		Name:       "levenshtein_less_equal",
+		Typ:        types.Int,
+		Properties: props,
+		Overload:   overload,
+	})
+}
+
+// findLevenshteinLessEqualFunction returns the function properties and overload
+// of the levenshtein_less_equal function with the signature (string, string,
+// int).
+func findLevenshteinLessEqualFunction() (*tree.FunctionProperties, *tree.Overload) {
+	props, overloads := builtinsregistry.GetBuiltinProperties("levenshtein_less_equal")
+	for o := range overloads {
+		overload := &overloads[o]
+		if overload.Types.Match([]*types.T{types.String, types.String, types.Int}) {
+			return props, overload
+		}
+	}
+	panic(errors.AssertionFailedf("could not find overload for levenshtein_less_equal"))
+}

--- a/pkg/sql/opt/norm/general_funcs.go
+++ b/pkg/sql/opt/norm/general_funcs.go
@@ -674,6 +674,15 @@ func (c *CustomFuncs) ScalarExprAt(list memo.ScalarListExpr, i int) (_ opt.Scala
 	return nil, false
 }
 
+// ScalarPair returns the two expressions in the given list. Returns ok=false if
+// the length of the list is not two.
+func (c *CustomFuncs) ScalarPair(list memo.ScalarListExpr) (_, _ opt.ScalarExpr, ok bool) {
+	if len(list) != 2 {
+		return nil, nil, false
+	}
+	return list[0], list[1], true
+}
+
 // ----------------------------------------------------------------------
 //
 // Ordering functions

--- a/pkg/sql/opt/norm/rules/comp.opt
+++ b/pkg/sql/opt/norm/rules/comp.opt
@@ -296,3 +296,41 @@ $left
 )
 =>
 ((OpName) $input $collapsed)
+
+# ConvertLevenshteinToLevenshteinLessEqualLeft converts a comparison of an
+# integer and the result of a levenshtein function into a comparison with a
+# levenshtein_less_equal function.
+#
+#   levenshtein('foo', 'bar') < 5
+#   =>
+#   levenshtein_less_equal('foo', 'bar', 5) < 5
+#
+# levenshtein_less_equal is more efficient than levenshtein because it returns
+# early once the distance exceeds the given max distance.
+[ConvertLevenshteinToLevenshteinLessEqualLeft, Normalize]
+(Eq | Ge | Gt | Le | Lt
+    (Function $args:* $private:(FunctionPrivate "levenshtein"))
+    $right:* &
+        (IsInt $right) &
+        (Let ($arg1 $arg2 $ok):(ScalarPair $args) $ok)
+)
+=>
+((OpName)
+    (MakeLevenshteinLessEqualFunction $arg1 $arg2 $right)
+    $right
+)
+
+# ConvertLevenshteinToLevenshteinLessEqualRight is the same as
+# ConvertLevenshteinToLevenshteinLessEqualLeft but matches comparisons with the
+# levenshtein function on the RHS.
+[ConvertLevenshteinToLevenshteinLessEqualRight, Normalize]
+(Eq | Ge | Gt | Le | Lt
+    $left:* & (IsInt $left)
+    (Function $args:* $private:(FunctionPrivate "levenshtein")) &
+        (Let ($arg1 $arg2 $ok):(ScalarPair $args) $ok)
+)
+=>
+((OpName)
+    $left
+    (MakeLevenshteinLessEqualFunction $arg1 $arg2 $left)
+)

--- a/pkg/sql/opt/norm/rules/comp.opt
+++ b/pkg/sql/opt/norm/rules/comp.opt
@@ -220,10 +220,8 @@
     (Function $args:* $private:(FunctionPrivate "timezone"))
     $right:(ConstValue) &
         (IsTimestampTZ $right) &
-        (Let ($ts $tsOk):(ScalarExprAt $args 1) $tsOk) &
-        (IsTimestamp $ts) &
-        ^(IsConstValueOrGroupOfConstValues $ts) &
-        (Let ($zone $zoneOk):(ScalarExprAt $args 0) $zoneOk)
+        (Let ($zone $ts $ok):(ScalarPair $args) $ok) &
+        (IsTimestamp $ts)
 )
 =>
 ((OpName) $ts (MakeTimeZoneFunction $zone $right))
@@ -248,10 +246,9 @@
     (Function $args:* $private:(FunctionPrivate "timezone"))
     $right:(ConstValue) &
         (IsTimestamp $right) &
-        (Let ($tz $tzOk):(ScalarExprAt $args 1) $tzOk) &
+        (Let ($zone $tz $ok):(ScalarPair $args) $ok) &
         (IsTimestampTZ $tz) &
-        ^(IsConstValueOrGroupOfConstValues $tz) &
-        (Let ($zone $zoneOk):(ScalarExprAt $args 0) $zoneOk)
+        ^(IsConstValueOrGroupOfConstValues $tz)
 )
 =>
 ((OpName) $tz (MakeTimeZoneFunction $zone $right))

--- a/pkg/sql/opt/norm/testdata/rules/comp
+++ b/pkg/sql/opt/norm/testdata/rules/comp
@@ -1196,3 +1196,71 @@ project
  │    └── columns: s:4
  └── projections
       └── s:4 LIKE s:4 [as="?column?":12, outer=(4)]
+
+# --------------------------------------------------
+# ConvertLevenshteinToLevenshteinLessEqual
+# --------------------------------------------------
+
+norm expect=ConvertLevenshteinToLevenshteinLessEqualLeft
+SELECT
+  levenshtein(s, j::STRING) = 5,
+  levenshtein(s, j::STRING) < 5,
+  levenshtein(s, j::STRING) > 5,
+  levenshtein(s, j::STRING) <= 5,
+  levenshtein(s, j::STRING) >= 5
+FROM a
+----
+project
+ ├── columns: "?column?":12 "?column?":13 "?column?":14 "?column?":15 "?column?":16
+ ├── immutable
+ ├── scan a
+ │    └── columns: s:4 j:5
+ └── projections
+      ├── levenshtein_less_equal(s:4, j:5::STRING, 5) = 5 [as="?column?":12, outer=(4,5), immutable]
+      ├── levenshtein_less_equal(s:4, j:5::STRING, 5) < 5 [as="?column?":13, outer=(4,5), immutable]
+      ├── levenshtein_less_equal(s:4, j:5::STRING, 5) > 5 [as="?column?":14, outer=(4,5), immutable]
+      ├── levenshtein_less_equal(s:4, j:5::STRING, 5) <= 5 [as="?column?":15, outer=(4,5), immutable]
+      └── levenshtein_less_equal(s:4, j:5::STRING, 5) >= 5 [as="?column?":16, outer=(4,5), immutable]
+
+norm expect=ConvertLevenshteinToLevenshteinLessEqualRight
+SELECT
+  levenshtein(s, j::STRING) = i,
+  levenshtein(s, j::STRING) < i,
+  levenshtein(s, j::STRING) > i,
+  levenshtein(s, j::STRING) <= i,
+  levenshtein(s, j::STRING) >= i
+FROM a
+----
+project
+ ├── columns: "?column?":12 "?column?":13 "?column?":14 "?column?":15 "?column?":16
+ ├── immutable
+ ├── scan a
+ │    └── columns: i:2 s:4 j:5
+ └── projections
+      ├── i:2 = levenshtein_less_equal(s:4, j:5::STRING, i:2) [as="?column?":12, outer=(2,4,5), immutable]
+      ├── i:2 > levenshtein_less_equal(s:4, j:5::STRING, i:2) [as="?column?":13, outer=(2,4,5), immutable]
+      ├── i:2 < levenshtein_less_equal(s:4, j:5::STRING, i:2) [as="?column?":14, outer=(2,4,5), immutable]
+      ├── i:2 >= levenshtein_less_equal(s:4, j:5::STRING, i:2) [as="?column?":15, outer=(2,4,5), immutable]
+      └── i:2 <= levenshtein_less_equal(s:4, j:5::STRING, i:2) [as="?column?":16, outer=(2,4,5), immutable]
+
+norm expect-not=(ConvertLevenshteinToLevenshteinLessEqualLeft,ConvertLevenshteinToLevenshteinLessEqualRight)
+SELECT levenshtein(s, j::STRING) < 5.1 FROM a
+----
+project
+ ├── columns: "?column?":12
+ ├── immutable
+ ├── scan a
+ │    └── columns: s:4 j:5
+ └── projections
+      └── levenshtein(s:4, j:5::STRING) < 5.1 [as="?column?":12, outer=(4,5), immutable]
+
+norm expect-not=(ConvertLevenshteinToLevenshteinLessEqualLeft,ConvertLevenshteinToLevenshteinLessEqualRight)
+SELECT levenshtein(s, j::STRING, 1, 2, 3) < 5 FROM a
+----
+project
+ ├── columns: "?column?":12
+ ├── immutable
+ ├── scan a
+ │    └── columns: s:4 j:5
+ └── projections
+      └── levenshtein(s:4, j:5::STRING, 1, 2, 3) < 5 [as="?column?":12, outer=(4,5), immutable]


### PR DESCRIPTION
#### opt: optimize levenshtein comparisons

New rules have been added to convert comparison expressions with the
`levenshtein` built-ins in comparison expressions to
`levenshtein_less_equal`. The latter is more efficient than
`levenshtein` because it returns early once the distance exceeds the
given max distance. In a contrived benchmark this yielded a ~30%
speed-up.

Release note (performance improvement): Queries that have comparison
expressions with the `levenshtein` built-in are now up to 30% faster.

#### opt: refactor NormalizeCmpTimeZoneFunction[TZ]

The `NormalizeCmpTimeZoneFunction` and `NormalizeCmpTimeZoneFunctionTZ`
rules have been refactored for simplicity using the `ScalarPair` custom
function.

Release note: None
