### PR TITLE
sql: harden a few processors

### DIFF
--- a/pkg/sql/bulkingest/ingest_file_processor.go
+++ b/pkg/sql/bulkingest/ingest_file_processor.go
@@ -89,12 +89,12 @@ func (p *ingestFileProcessor) Run(ctx context.Context, output execinfra.RowRecei
 		ctx, span = execinfra.ProcessorSpan(ctx, p.flowCtx, "ingestFile", p.processorID)
 		defer span.Finish()
 	}
+	defer output.ProducerDone()
+	defer execinfra.SendTraceData(ctx, p.flowCtx, output)
 	err := p.runIngest(ctx)
 	if err != nil {
 		output.Push(nil, &execinfrapb.ProducerMetadata{Err: err})
 	}
-	execinfra.SendTraceData(ctx, p.flowCtx, output)
-	output.ProducerDone()
 }
 
 // runIngest starts a set of worker goroutines to process SST files concurrently.

--- a/pkg/sql/inspect/inspect_processor.go
+++ b/pkg/sql/inspect/inspect_processor.go
@@ -133,12 +133,12 @@ func (p *inspectProcessor) Run(ctx context.Context, output execinfra.RowReceiver
 		ctx, span = execinfra.ProcessorSpan(ctx, p.flowCtx, "inspect", p.processorID)
 		defer span.Finish()
 	}
+	defer output.ProducerDone()
+	defer execinfra.SendTraceData(ctx, p.flowCtx, output)
 	err := p.runInspect(ctx, output)
 	if err != nil {
 		output.Push(nil, &execinfrapb.ProducerMetadata{Err: err})
 	}
-	execinfra.SendTraceData(ctx, p.flowCtx, output)
-	output.ProducerDone()
 }
 
 // runInspect starts a set of worker goroutines to process spans concurrently.

--- a/pkg/sql/rowexec/columnbackfiller.go
+++ b/pkg/sql/rowexec/columnbackfiller.go
@@ -95,10 +95,10 @@ func (cb *columnBackfiller) Run(ctx context.Context, output execinfra.RowReceive
 	ctx = logtags.AddTag(ctx, opName, int(cb.spec.Table.ID))
 	ctx, span := execinfra.ProcessorSpan(ctx, cb.flowCtx, opName, cb.processorID)
 	defer span.Finish()
+	defer output.ProducerDone()
+	defer execinfra.SendTraceData(ctx, cb.flowCtx, output)
 	meta := cb.doRun(ctx)
-	execinfra.SendTraceData(ctx, cb.flowCtx, output)
 	output.Push(nil /* row */, meta)
-	output.ProducerDone()
 }
 
 // Resume is part of the execinfra.Processor interface.

--- a/pkg/sql/ttl/ttljob/ttljob_processor.go
+++ b/pkg/sql/ttl/ttljob/ttljob_processor.go
@@ -117,12 +117,12 @@ func (t *ttlProcessor) Start(context.Context) {}
 // Run implements the execinfra.Processor interface.
 func (t *ttlProcessor) Run(ctx context.Context, output execinfra.RowReceiver) {
 	ctx = t.StartInternal(ctx, "ttl")
+	defer output.ProducerDone()
+	defer execinfra.SendTraceData(ctx, t.FlowCtx, output)
 	err := t.work(ctx, output)
 	if err != nil {
 		output.Push(nil, &execinfrapb.ProducerMetadata{Err: err})
 	}
-	execinfra.SendTraceData(ctx, t.FlowCtx, output)
-	output.ProducerDone()
 }
 
 func getTableInfo(


### PR DESCRIPTION
This commit ensures that send trace data as well as call ProducerDone on the output in a handful of processors (in case the main work function panics). This is a nice to have that unifies how things are done.

Epic: None
Release note: None