### PR TITLE
release-25.4: logictest: skip distsql_numtables under race

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_numtables
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_numtables
@@ -1,5 +1,8 @@
 # LogicTest: 5node-default-configs
 
+# This test occasionally times out due to overload under race.
+skip under race
+
 # First, we set up two data tables:
 #   - NumToSquare maps integers from 1 to 100 to their squares
 #   - NumToStr maps integers from 1 to 100*100 to strings; this table is


### PR DESCRIPTION
Backport 1/1 commits from #160397 on behalf of @yuzefovich.

----

We've seen a timeout in this test twice under race with no clear signs of things going wrong, other than the cluster being overloaded - it uses 5node config, so let's just skip it under race.

Fixes: #160391.
Release note: None

----

Release justification: test-only change.