### PR TITLE
restore: remove incremental_location from SQL read syntaxes

### DIFF
--- a/docs/generated/sql/bnf/restore_options.bnf
+++ b/docs/generated/sql/bnf/restore_options.bnf
@@ -10,7 +10,6 @@ restore_options ::=
 	| 'DETACHED'
 	| 'SKIP_LOCALITIES_CHECK'
 	| 'NEW_DB_NAME' '=' string_or_placeholder
-	| 'INCREMENTAL_LOCATION' '=' string_or_placeholder_opt_list
 	| 'VIRTUAL_CLUSTER_NAME' '=' string_or_placeholder
 	| 'VIRTUAL_CLUSTER' '=' string_or_placeholder
 	| 'SCHEMA_ONLY'

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1284,8 +1284,6 @@ unreserved_keyword ::=
 	| 'INCLUDE_ALL_SECONDARY_TENANTS'
 	| 'INCLUDE_ALL_VIRTUAL_CLUSTERS'
 	| 'INCREMENT'
-	| 'INCREMENTAL'
-	| 'INCREMENTAL_LOCATION'
 	| 'INDEX'
 	| 'INDEXES'
 	| 'INHERITS'
@@ -3103,7 +3101,6 @@ restore_options ::=
 	| 'DETACHED'
 	| 'SKIP_LOCALITIES_CHECK'
 	| 'NEW_DB_NAME' '=' string_or_placeholder
-	| 'INCREMENTAL_LOCATION' '=' string_or_placeholder_opt_list
 	| virtual_cluster_name '=' string_or_placeholder
 	| virtual_cluster_opt '=' string_or_placeholder
 	| 'SCHEMA_ONLY'
@@ -3764,7 +3761,6 @@ show_backup_options ::=
 	| 'CHECK_FILES'
 	| 'SKIP' 'SIZE'
 	| 'DEBUG_IDS'
-	| 'INCREMENTAL_LOCATION' '=' string_or_placeholder_opt_list
 	| 'KMS' '=' string_or_placeholder_opt_list
 	| 'ENCRYPTION_PASSPHRASE' '=' string_or_placeholder
 	| 'PRIVILEGES'
@@ -4234,8 +4230,6 @@ bare_label_keywords ::=
 	| 'INCLUDE_ALL_VIRTUAL_CLUSTERS'
 	| 'INCLUDING'
 	| 'INCREMENT'
-	| 'INCREMENTAL'
-	| 'INCREMENTAL_LOCATION'
 	| 'INDEX'
 	| 'INDEXES'
 	| 'INDEX'

--- a/pkg/backup/backupdest/backup_destination_test.go
+++ b/pkg/backup/backupdest/backup_destination_test.go
@@ -359,7 +359,6 @@ func TestResolveBackupManifests(t *testing.T) {
 			username.RootUserName(),
 			false, /* includeSkipped */
 			true,  /* includeCompacted */
-			false, /* isCustomIncLocation */
 		)
 		defer mem.Shrink(ctx, memSize)
 		require.NoError(t, err)
@@ -386,7 +385,6 @@ func TestResolveBackupManifests(t *testing.T) {
 			username.RootUserName(),
 			false, /* includeSkipped */
 			true,  /* includeCompacted */
-			false, /* isCustomIncLocation */
 		)
 		defer mem.Shrink(ctx, memSize)
 		require.NoError(t, err)

--- a/pkg/backup/backupdest/incrementals_test.go
+++ b/pkg/backup/backupdest/incrementals_test.go
@@ -273,9 +273,7 @@ func TestFindAllIncrementalPathsFallbackLogic(t *testing.T) {
 
 	testIdx := 0
 	// getStores returns a set of stores rooted at the root of the collection URI,
-	// the full backup subdir for incrementals, and the full backup subdir for
-	// custom incremental locations. It also returns the collection URI and the
-	// URI specified by `incremental_location`.
+	// the full backup subdir for incrementals.
 	getStores := func(t *testing.T, subdir string) (
 		store struct {
 			cleanup func()

--- a/pkg/backup/backupdest/incrementals_test.go
+++ b/pkg/backup/backupdest/incrementals_test.go
@@ -240,10 +240,7 @@ func TestFindAllIncrementalPaths(t *testing.T) {
 				}
 			}
 
-			incs, err := backupdest.FindAllIncrementalPaths(
-				ctx, &execCfg, incStore, store,
-				targetSubdir, false, /* customIncLocation */
-			)
+			incs, err := backupdest.FindAllIncrementalPaths(ctx, &execCfg, incStore, store, targetSubdir)
 			require.NoError(t, err)
 			require.Len(t, incs, len(targetChain)-1)
 
@@ -324,10 +321,7 @@ func TestFindAllIncrementalPathsFallbackLogic(t *testing.T) {
 			end = end.Add(time.Hour)
 		}
 
-		incs, err := backupdest.FindAllIncrementalPaths(
-			ctx, &execCfg, stores.inc, stores.root,
-			subdir, false, /* customIncLocation */
-		)
+		incs, err := backupdest.FindAllIncrementalPaths(ctx, &execCfg, stores.inc, stores.root, subdir)
 		require.NoError(t, err)
 		require.Len(t, incs, numBackups-1)
 	})

--- a/pkg/backup/compaction_job.go
+++ b/pkg/backup/compaction_job.go
@@ -721,7 +721,7 @@ func resolveBackupDirs(
 		return nil, nil, "", err
 	}
 	resolvedIncDirs, err := backupdest.ResolveIncrementalsBackupLocation(
-		ctx, user, execCfg, nil, collectionURIs, resolvedSubdir,
+		collectionURIs, resolvedSubdir,
 	)
 	if err != nil {
 		return nil, nil, "", err
@@ -790,7 +790,7 @@ func getBackupChain(
 	_, manifests, localityInfo, memReserved, err := backupdest.ResolveBackupManifests(
 		ctx, execCfg, &mem, defaultCollectionURI, dest.To, mkStore, resolvedSubdir,
 		resolvedBaseDirs, resolvedIncDirs, endTime, baseEncryptionInfo, kmsEnv,
-		user, false /*includeSkipped */, true /*includeCompacted */, false, /* isCustomIncLocation */
+		user, false /*includeSkipped */, true, /*includeCompacted */
 	)
 	if err != nil {
 		return nil, nil, nil, nil, err

--- a/pkg/backup/restore_planning_test.go
+++ b/pkg/backup/restore_planning_test.go
@@ -64,7 +64,6 @@ func TestRestoreResolveOptionsForJobDescription(t *testing.T) {
 
 		IntoDB:               tree.NewDString("test expr"),
 		NewDBName:            tree.NewDString("test expr"),
-		IncrementalStorage:   []tree.Expr{tree.NewDString("http://example.com")},
 		DecryptionKMSURI:     []tree.Expr{tree.NewDString("http://example.com")},
 		EncryptionPassphrase: tree.NewDString("test expr"),
 	}
@@ -89,7 +88,7 @@ func TestRestoreResolveOptionsForJobDescription(t *testing.T) {
 		"into_db",
 		"newDBName",
 		[]string{"http://example.com"},
-		[]string{"http://example.com"})
+	)
 	require.NoError(t, err)
 	ensureAllStructFieldsSet(output, "output")
 

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1036,7 +1036,7 @@ func (u *sqlSymUnion) filterType() tree.FilterType {
 
 %token <str> IDENTITY
 %token <str> IF IFERROR IFNULL IGNORE_FOREIGN_KEYS ILIKE IMMEDIATE IMMEDIATELY IMMUTABLE IMPORT IN INCLUDE
-%token <str> INCLUDING INCLUDE_ALL_SECONDARY_TENANTS INCLUDE_ALL_VIRTUAL_CLUSTERS INCREMENT INCREMENTAL INCREMENTAL_LOCATION
+%token <str> INCLUDING INCLUDE_ALL_SECONDARY_TENANTS INCLUDE_ALL_VIRTUAL_CLUSTERS INCREMENT
 %token <str> INET INET_CONTAINED_BY_OR_EQUALS
 %token <str> INET_CONTAINS_OR_EQUALS INDEX INDEXES INHERITS INJECT INITIALLY
 %token <str> INDEX_BEFORE_PAREN INDEX_BEFORE_NAME_THEN_PAREN INDEX_AFTER_ORDER_BY_BEFORE_AT
@@ -4151,10 +4151,6 @@ restore_options:
   {
     $$.val = &tree.RestoreOptions{NewDBName: $3.expr()}
   }
-| INCREMENTAL_LOCATION '=' string_or_placeholder_opt_list
-	{
-		$$.val = &tree.RestoreOptions{IncrementalStorage: $3.stringOrPlaceholderOptList()}
-	}
 | virtual_cluster_name '=' string_or_placeholder
   {
     $$.val = &tree.RestoreOptions{AsTenant: $3.expr()}
@@ -9148,10 +9144,6 @@ show_backup_options:
  | DEBUG_IDS
  {
  $$.val = &tree.ShowBackupOptions{DebugIDs: true}
- }
- | INCREMENTAL_LOCATION '=' string_or_placeholder_opt_list
- {
- $$.val = &tree.ShowBackupOptions{IncrementalStorage: $3.stringOrPlaceholderOptList()}
  }
  | KMS '=' string_or_placeholder_opt_list
  {
@@ -18733,8 +18725,6 @@ unreserved_keyword:
 | INCLUDE_ALL_SECONDARY_TENANTS
 | INCLUDE_ALL_VIRTUAL_CLUSTERS
 | INCREMENT
-| INCREMENTAL
-| INCREMENTAL_LOCATION
 | INDEX
 | INDEXES
 | INHERITS
@@ -19288,8 +19278,6 @@ bare_label_keywords:
 | INCLUDE_ALL_VIRTUAL_CLUSTERS
 | INCLUDING
 | INCREMENT
-| INCREMENTAL
-| INCREMENTAL_LOCATION
 | INDEX
 | INDEXES
 | INDEX_AFTER_ORDER_BY_BEFORE_AT

--- a/pkg/sql/parser/testdata/backup_restore
+++ b/pkg/sql/parser/testdata/backup_restore
@@ -115,24 +115,6 @@ SHOW BACKUP 'latest' IN '*****' WITH OPTIONS (check_files, encryption_passphrase
 SHOW BACKUP 'latest' IN 'bar' WITH OPTIONS (check_files, encryption_passphrase = 'secret') -- passwords exposed
 
 parse
-SHOW BACKUP FROM LATEST IN 'bar' WITH incremental_location = 'baz', skip size
-----
-SHOW BACKUP FROM 'latest' IN '*****' WITH OPTIONS (incremental_location = '*****', skip size) -- normalized!
-SHOW BACKUP FROM ('latest') IN ('*****') WITH OPTIONS (incremental_location = ('*****'), skip size) -- fully parenthesized
-SHOW BACKUP FROM '_' IN '_' WITH OPTIONS (incremental_location = '_', skip size) -- literals removed
-SHOW BACKUP FROM 'latest' IN '*****' WITH OPTIONS (incremental_location = '*****', skip size) -- identifiers removed
-SHOW BACKUP FROM 'latest' IN 'bar' WITH OPTIONS (incremental_location = 'baz', skip size) -- passwords exposed
-
-parse
-SHOW BACKUP FROM LATEST IN ('bar','bar1') WITH KMS = ('foo', 'bar'), incremental_location=('hi','hello')
-----
-SHOW BACKUP FROM 'latest' IN ('*****', '*****') WITH OPTIONS (incremental_location = ('*****', '*****'), kms = ('*****', '*****')) -- normalized!
-SHOW BACKUP FROM ('latest') IN (('*****'), ('*****')) WITH OPTIONS (incremental_location = (('*****'), ('*****')), kms = (('*****'), ('*****'))) -- fully parenthesized
-SHOW BACKUP FROM '_' IN ('_', '_') WITH OPTIONS (incremental_location = ('_', '_'), kms = ('_', '_')) -- literals removed
-SHOW BACKUP FROM 'latest' IN ('*****', '*****') WITH OPTIONS (incremental_location = ('*****', '*****'), kms = ('*****', '*****')) -- identifiers removed
-SHOW BACKUP FROM 'latest' IN ('bar', 'bar1') WITH OPTIONS (incremental_location = ('hi', 'hello'), kms = ('foo', 'bar')) -- passwords exposed
-
-parse
 SHOW BACKUPS IN 'bar'
 ----
 SHOW BACKUPS IN '*****' -- normalized!
@@ -427,24 +409,6 @@ RESTORE TABLE foo FROM $1 IN $1 -- literals removed
 RESTORE TABLE _ FROM $2 IN $1 -- identifiers removed
 
 parse
-RESTORE TABLE foo FROM $1 IN $2 WITH incremental_location = 'bar'
-----
-RESTORE TABLE foo FROM $1 IN $2 WITH OPTIONS (incremental_location = '*****') -- normalized!
-RESTORE TABLE (foo) FROM ($1) IN ($2) WITH OPTIONS (incremental_location = ('*****')) -- fully parenthesized
-RESTORE TABLE foo FROM $1 IN $1 WITH OPTIONS (incremental_location = '_') -- literals removed
-RESTORE TABLE _ FROM $1 IN $2 WITH OPTIONS (incremental_location = '*****') -- identifiers removed
-RESTORE TABLE foo FROM $1 IN $2 WITH OPTIONS (incremental_location = 'bar') -- passwords exposed
-
-parse
-RESTORE foo FROM $1 IN $2 WITH incremental_location = 'bar'
-----
-RESTORE TABLE foo FROM $1 IN $2 WITH OPTIONS (incremental_location = '*****') -- normalized!
-RESTORE TABLE (foo) FROM ($1) IN ($2) WITH OPTIONS (incremental_location = ('*****')) -- fully parenthesized
-RESTORE TABLE foo FROM $1 IN $1 WITH OPTIONS (incremental_location = '_') -- literals removed
-RESTORE TABLE _ FROM $1 IN $2 WITH OPTIONS (incremental_location = '*****') -- identifiers removed
-RESTORE TABLE foo FROM $1 IN $2 WITH OPTIONS (incremental_location = 'bar') -- passwords exposed
-
-parse
 RESTORE TABLE foo FROM 'abc' IN ($1, $2, 'bar')
 ----
 RESTORE TABLE foo FROM 'abc' IN ($1, $2, '*****') -- normalized!
@@ -571,15 +535,6 @@ RESTORE DATABASE foo FROM ('latest') IN ('*****') WITH OPTIONS (experimental cop
 RESTORE DATABASE foo FROM '_' IN '_' WITH OPTIONS (experimental copy) -- literals removed
 RESTORE DATABASE _ FROM 'latest' IN '*****' WITH OPTIONS (experimental copy) -- identifiers removed
 RESTORE DATABASE foo FROM 'latest' IN 'bar' WITH OPTIONS (experimental copy) -- passwords exposed
-
-parse
-RESTORE DATABASE foo FROM LATEST IN 'bar' WITH incremental_location = 'baz'
-----
-RESTORE DATABASE foo FROM 'latest' IN '*****' WITH OPTIONS (incremental_location = '*****') -- normalized!
-RESTORE DATABASE foo FROM ('latest') IN ('*****') WITH OPTIONS (incremental_location = ('*****')) -- fully parenthesized
-RESTORE DATABASE foo FROM '_' IN '_' WITH OPTIONS (incremental_location = '_') -- literals removed
-RESTORE DATABASE _ FROM 'latest' IN '*****' WITH OPTIONS (incremental_location = '*****') -- identifiers removed
-RESTORE DATABASE foo FROM 'latest' IN 'bar' WITH OPTIONS (incremental_location = 'baz') -- passwords exposed
 
 parse
 RESTORE DATABASE foo, baz FROM LATEST IN 'bar' AS OF SYSTEM TIME '1'

--- a/pkg/sql/parser/testdata/show
+++ b/pkg/sql/parser/testdata/show
@@ -2229,15 +2229,6 @@ SHOW VIRTUAL CLUSTER foo WITH REPLICATION STATUS, PRIOR REPLICATION DETAILS, CAP
 SHOW VIRTUAL CLUSTER _ WITH REPLICATION STATUS, PRIOR REPLICATION DETAILS, CAPABILITIES -- identifiers removed
 
 parse
-SHOW BACKUP 'family' IN ('string', 'placeholder', 'placeholder', 'placeholder', 'string', 'placeholder', 'string', 'placeholder') WITH incremental_location = 'nullif', privileges
-----
-SHOW BACKUP 'family' IN ('*****', '*****', '*****', '*****', '*****', '*****', '*****', '*****') WITH OPTIONS (incremental_location = '*****', privileges) -- normalized!
-SHOW BACKUP ('family') IN (('*****'), ('*****'), ('*****'), ('*****'), ('*****'), ('*****'), ('*****'), ('*****')) WITH OPTIONS (incremental_location = ('*****'), privileges) -- fully parenthesized
-SHOW BACKUP '_' IN ('_', '_', '_', '_', '_', '_', '_', '_') WITH OPTIONS (incremental_location = '_', privileges) -- literals removed
-SHOW BACKUP 'family' IN ('*****', '*****', '*****', '*****', '*****', '*****', '*****', '*****') WITH OPTIONS (incremental_location = '*****', privileges) -- identifiers removed
-SHOW BACKUP 'family' IN ('string', 'placeholder', 'placeholder', 'placeholder', 'string', 'placeholder', 'string', 'placeholder') WITH OPTIONS (incremental_location = 'nullif', privileges) -- passwords exposed
-
-parse
 SHOW BACKUP 'abc' IN 'def' WITH SKIP SIZE
 ----
 SHOW BACKUP 'abc' IN '*****' WITH OPTIONS (skip size) -- normalized!

--- a/pkg/sql/sem/tree/backup.go
+++ b/pkg/sql/sem/tree/backup.go
@@ -119,7 +119,6 @@ type RestoreOptions struct {
 	Detached                         bool
 	SkipLocalitiesCheck              bool
 	NewDBName                        Expr
-	IncrementalStorage               StringOrPlaceholderOptList
 	AsTenant                         Expr
 	ForceTenantID                    Expr
 	SchemaOnly                       bool
@@ -449,12 +448,6 @@ func (o *RestoreOptions) Format(ctx *FmtCtx) {
 		ctx.FormatNode(o.NewDBName)
 	}
 
-	if o.IncrementalStorage != nil {
-		maybeAddSep()
-		ctx.WriteString("incremental_location = ")
-		ctx.FormatURIs(o.IncrementalStorage)
-	}
-
 	if o.AsTenant != nil {
 		maybeAddSep()
 		ctx.WriteString("virtual_cluster_name = ")
@@ -587,12 +580,6 @@ func (o *RestoreOptions) CombineWith(other *RestoreOptions) error {
 		return errors.New("new_db_name specified multiple times")
 	}
 
-	if o.IncrementalStorage == nil {
-		o.IncrementalStorage = other.IncrementalStorage
-	} else if other.IncrementalStorage != nil {
-		return errors.New("incremental_location option specified multiple times")
-	}
-
 	if o.AsTenant == nil {
 		o.AsTenant = other.AsTenant
 	} else if other.AsTenant != nil {
@@ -675,7 +662,6 @@ func (o RestoreOptions) IsDefault() bool {
 		o.Detached == options.Detached &&
 		o.SkipLocalitiesCheck == options.SkipLocalitiesCheck &&
 		o.NewDBName == options.NewDBName &&
-		cmp.Equal(o.IncrementalStorage, options.IncrementalStorage) &&
 		o.AsTenant == options.AsTenant &&
 		o.ForceTenantID == options.ForceTenantID &&
 		o.SchemaOnly == options.SchemaOnly &&

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -172,7 +172,6 @@ type ShowBackupOptions struct {
 	AsJson               bool
 	CheckFiles           bool
 	DebugIDs             bool
-	IncrementalStorage   StringOrPlaceholderOptList
 	DecryptionKMSURI     StringOrPlaceholderOptList
 	EncryptionPassphrase Expr
 	Privileges           bool
@@ -225,11 +224,6 @@ func (o *ShowBackupOptions) Format(ctx *FmtCtx) {
 			ctx.WriteString(PasswordSubstitution)
 		}
 	}
-	if o.IncrementalStorage != nil {
-		maybeAddSep()
-		ctx.WriteString("incremental_location = ")
-		ctx.FormatURIs(o.IncrementalStorage)
-	}
 
 	if o.Privileges {
 		maybeAddSep()
@@ -274,7 +268,6 @@ func (o ShowBackupOptions) IsDefault() bool {
 	return o.AsJson == options.AsJson &&
 		o.CheckFiles == options.CheckFiles &&
 		o.DebugIDs == options.DebugIDs &&
-		cmp.Equal(o.IncrementalStorage, options.IncrementalStorage) &&
 		cmp.Equal(o.DecryptionKMSURI, options.DecryptionKMSURI) &&
 		o.EncryptionPassphrase == options.EncryptionPassphrase &&
 		o.Privileges == options.Privileges &&
@@ -330,11 +323,6 @@ func (o *ShowBackupOptions) CombineWith(other *ShowBackupOptions) error {
 	}
 	o.EncryptionPassphrase, err = combineExpr(o.EncryptionPassphrase, other.EncryptionPassphrase,
 		"encryption_passphrase")
-	if err != nil {
-		return err
-	}
-	o.IncrementalStorage, err = combineStringOrPlaceholderOptList(o.IncrementalStorage,
-		other.IncrementalStorage, "incremental_location")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This patch removes support for the `incremental_location` syntax from our read paths.

Resolves: #159172

Release note (backwards-incompatible change): The `incremental_location` option has been removed from `SHOW BACKUP` and `RESTORE`.