### PR TITLE
release-25.2: workloadccl: mark tpccmultidb as bigInitialData

### DIFF
--- a/pkg/ccl/workloadccl/allccl/all_test.go
+++ b/pkg/ccl/workloadccl/allccl/all_test.go
@@ -34,7 +34,7 @@ import (
 
 func bigInitialData(meta workload.Meta) bool {
 	switch meta.Name {
-	case `tpcc`, `tpch`, `tpcds`:
+	case `tpcc`, `tpch`, `tpcds`, `tpccmultidb`:
 		return true
 	default:
 		return false


### PR DESCRIPTION
Backport 1/1 commits from #160209 on behalf of @yuzefovich.

----

We already skip `tpcc` in `bigInitialData`, and I think it was a mistake that `tpccmultidb` wasn't marked in the same way. In particular, this will make it so that we don't run some of the test cases.

The reason I was looking into this is that `TestAllRegisteredSetup/tpccmultidb` took 9 minutes on CI with external process mode. I couldn't quickly speed that up (e.g. exempting from rate limiting didn't help), but skipping it will work just fine.

Epic: None
Release note: None

----

Release justification: test-only change.