### PR TITLE
security: Add SAN required cluster setting

### DIFF
--- a/pkg/security/cert_settings.go
+++ b/pkg/security/cert_settings.go
@@ -11,6 +11,7 @@ import "github.com/cockroachdb/cockroach/pkg/settings"
 const (
 	baseClientCertSettingName            = "security.client_cert."
 	ClientCertSubjectRequiredSettingName = baseClientCertSettingName + "subject_required.enabled"
+	ClientCertSANRequiredSettingName     = baseClientCertSettingName + "san_required.enabled"
 )
 
 // ClientCertSubjectRequired mandates a requirement for role subject to be set
@@ -24,4 +25,16 @@ var ClientCertSubjectRequired = settings.RegisterBoolSetting(
 	false,
 	settings.WithPublic,
 	settings.WithReportable(true),
+)
+
+// ClientCertSANRequired mandates a requirement for SAN to be set
+// in client certs. It controls both RPC access and login via
+// authCert.
+var ClientCertSANRequired = settings.RegisterBoolSetting(
+	settings.SystemVisible,
+	ClientCertSANRequiredSettingName,
+	"mandates a requirement for client certs to contain SAN",
+	false,
+	settings.WithVisibility(settings.Reserved),
+	settings.WithReportable(false),
 )


### PR DESCRIPTION
* security.client_cert.san_required.enabled new cluster setting for the SAN auth.
* This will be used in future PRs
* Currently the visibility of the cluster setting is set to reserved, will be made public once
the feature is live.

Epic: CRDB-55364

Release note: None