### PR TITLE
Revert "spanlatch: add cluster setting for slow latch request threshold"

### DIFF
--- a/pkg/kv/kvserver/spanlatch/BUILD.bazel
+++ b/pkg/kv/kvserver/spanlatch/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanlatch",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/base",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver/concurrency/poison",
         "//pkg/kv/kvserver/spanset",

--- a/pkg/kv/kvserver/spanlatch/settings.go
+++ b/pkg/kv/kvserver/spanlatch/settings.go
@@ -22,14 +22,3 @@ var LongLatchHoldThreshold = settings.RegisterDurationSetting(
 	"the threshold for logging long latch holds",
 	3*time.Second,
 )
-
-// SlowLatchRequestThreshold controls when we will log slow latch acquisition
-// attempts. When a latch acquisition has been waiting for this duration, a
-// warning is logged and the slow request metric is incremented.
-var SlowLatchRequestThreshold = settings.RegisterDurationSettingWithExplicitUnit(
-	settings.SystemOnly,
-	"kv.concurrency.slow_latch_request_duration",
-	"the threshold for logging slow latch acquisition attempts",
-	5*time.Second,
-	settings.DurationWithMinimum(10*time.Millisecond),
-)


### PR DESCRIPTION
This reverts commit 0d90aae8a32bbd2975c353e85bc65cd5fb2a8dca. This was a backported commit, but it was later decided that it should be backported to this release branch since it isn't necessary.