### PR TITLE
release-25.2: sql/importer: speed up TestImportCSVStmt

### DIFF
--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -2195,6 +2195,9 @@ func TestImportCSVStmt(t *testing.T) {
 	ctx := context.Background()
 	baseDir := datapathutils.TestDataPath(t, "csv")
 	tc := serverutils.StartCluster(t, nodes, base.TestClusterArgs{ServerArgs: base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+		},
 		// Test fails when run within a test tenant. More
 		// investigation is required. Tracked with #76378.
 		DefaultTestTenant: base.TODOTestTenantDisabled,


### PR DESCRIPTION
Backport 1/1 commits from #160177 on behalf of @yuzefovich.

----

Backport 1/1 commits from #159967.

/cc @cockroachdb/release

---
    
In order to speed up the test we now use short intervals for the jobs subsystem via the testing knob.

Fixes: #160174
Release note: None

Release justification: test-only change.