### PR TITLE
sql: handle inconsistencies in span row counts

### DIFF
--- a/pkg/jobs/jobspb/jobs.go
+++ b/pkg/jobs/jobspb/jobs.go
@@ -180,5 +180,6 @@ func (c CreateStatsDetails) IsAuto() bool {
 // UpdateWithSpanProgress updates the InspectProgress with data from the
 // check-specific fields in the span progress update.
 func (p *InspectProgress) UpdateWithSpanProgress(prog *InspectProcessorProgress) {
-	return
+	// Update the row count field.
+	p.RowCount += prog.SpanRowCount
 }

--- a/pkg/jobs/jobspb/jobs.go
+++ b/pkg/jobs/jobspb/jobs.go
@@ -176,3 +176,9 @@ func (r *RowLevelTTLProcessorProgress) SafeFormat(p redact.SafePrinter, _ rune) 
 func (c CreateStatsDetails) IsAuto() bool {
 	return c.Name == AutoStatsName || c.Name == AutoPartialStatsName
 }
+
+// UpdateWithSpanProgress updates the InspectProgress with data from the
+// check-specific fields in the span progress update.
+func (p *InspectProgress) UpdateWithSpanProgress(prog *InspectProcessorProgress) {
+	return
+}

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -1507,6 +1507,9 @@ message InspectDetails {
       // INDEX_CONSISTENCY performs validation between primary and secondary indexes
       // to detect missing or dangling index entries.
       INSPECT_CHECK_INDEX_CONSISTENCY = 1 [(gogoproto.enumvalue_customname) = "InspectCheckIndexConsistency"];
+
+      // INSPECT_CHECK_ROW_COUNT validates a table has the expected number of rows.
+      INSPECT_CHECK_ROW_COUNT = 2 [(gogoproto.enumvalue_customname) = "InspectCheckRowCount"];
     }
 
     // Type is the kind of validation to perform.
@@ -1533,6 +1536,10 @@ message InspectDetails {
       (gogoproto.customname) = "TableVersion",
       (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb.DescriptorVersion"
     ];
+
+    // RowCount indicates the expected number of rows in the table, if applicable. Should be set
+    // for row count checks.
+    uint64 row_count = 5;
   }
 
   // Checks is the list of individual checks this job will perform.
@@ -1608,11 +1615,13 @@ message HotRangesLoggerProgress {
 message InspectProgress {
   int64 job_total_check_count = 1;
   int64 job_completed_check_count = 2;
+  uint64 row_count = 3; // Accumulator of row counts of each index.
 }
 
 message InspectProcessorProgress {
   int64 checks_completed = 1;  // Number of checks completed since last update.
   bool finished = 2;           // Processor finished all checks.
+  uint64 span_row_count = 3;   // Number of rows in the span processed.
 }
 
 message ImportRollbackProgress {}

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -344,7 +344,8 @@ func (r *importResumer) Resume(ctx context.Context, execCtx interface{}) error {
 				return err
 			}
 			tableName = tblDesc.GetName()
-			checks, err = inspect.ChecksForTable(ctx, nil /* p */, tblDesc)
+			expectedRowCount := uint64(r.res.Rows)
+			checks, err = inspect.ChecksForTable(ctx, nil /* p */, tblDesc, &expectedRowCount)
 			return err
 		}); err != nil {
 			return err

--- a/pkg/sql/inspect/BUILD.bazel
+++ b/pkg/sql/inspect/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "issue.go",
         "log_sink.go",
         "progress.go",
+        "row_count_check.go",
         "runner.go",
         "span_source.go",
         "table_sink.go",

--- a/pkg/sql/inspect/BUILD.bazel
+++ b/pkg/sql/inspect/BUILD.bazel
@@ -79,6 +79,7 @@ go_test(
         "issue_test.go",
         "main_test.go",
         "progress_test.go",
+        "row_count_check_test.go",
         "runner_test.go",
         "table_sink_test.go",
     ],

--- a/pkg/sql/inspect/index_consistency_check.go
+++ b/pkg/sql/inspect/index_consistency_check.go
@@ -58,20 +58,9 @@ func (c *indexConsistencyCheckApplicability) AppliesTo(
 	return spanContainsTable(c.tableID, codec, span)
 }
 
-// checkState represents the state of an index consistency check.
-type checkState int
-
-const (
-	// checkNotStarted indicates Start() has not been called yet.
-	checkNotStarted checkState = iota
-	// checkHashMatched indicates the hash precheck passed - no corruption detected,
-	// so the full check can be skipped.
-	checkHashMatched
-	// checkRunning indicates the full check is actively running and may produce more results.
-	checkRunning
-	// checkDone indicates the check has finished (iterator exhausted or error occurred).
-	checkDone
-)
+func (c *indexConsistencyCheckApplicability) IsSpanLevel() bool {
+	return false
+}
 
 // indexConsistencyCheck verifies consistency between a table's primary index
 // and a specified secondary index by streaming rows from both sides of a

--- a/pkg/sql/inspect/index_consistency_check.go
+++ b/pkg/sql/inspect/index_consistency_check.go
@@ -103,10 +103,14 @@ type indexConsistencyCheck struct {
 
 	// lastQueryPlaceholders stores the placeholder values used in lastQuery.
 	lastQueryPlaceholders []interface{}
+
+	// rowCount stores the number of rows processed by the check.
+	rowCount uint64
 }
 
 var _ inspectCheck = (*indexConsistencyCheck)(nil)
 var _ inspectCheckApplicability = (*indexConsistencyCheck)(nil)
+var _ inspectCheckRowCount = (*indexConsistencyCheck)(nil)
 
 // Started implements the inspectCheck interface.
 func (c *indexConsistencyCheck) Started() bool {
@@ -258,7 +262,8 @@ func (c *indexConsistencyCheck) Start(
 			log.Dev.Infof(ctx, "skipping hash precheck for index %s: column type not compatible with datums_to_bytes",
 				c.secIndex.GetName())
 		} else {
-			match, hashErr := c.hashesMatch(ctx, allColNames, predicate, queryArgs)
+			match, rowCount, hashErr := c.hashesMatch(ctx, allColNames, predicate, queryArgs)
+			c.rowCount = uint64(rowCount)
 			if hashErr != nil {
 				if isQueryConstructionError(hashErr) {
 					// If hashing fails and the error stems from query construction,
@@ -431,6 +436,7 @@ func (c *indexConsistencyCheck) Done(context.Context) bool {
 // Close implements the inspectCheck interface.
 func (c *indexConsistencyCheck) Close(context.Context) error {
 	if c.rowIter != nil {
+		c.rowCount = uint64(c.rowIter.RowsAffected())
 		// Clear the iter ahead of close to ensure we only attempt the close once.
 		it := c.rowIter
 		c.rowIter = nil
@@ -439,6 +445,11 @@ func (c *indexConsistencyCheck) Close(context.Context) error {
 		}
 	}
 	return nil
+}
+
+// Rows implements the inspectCheckRowCount interface.
+func (c *indexConsistencyCheck) Rows() uint64 {
+	return c.rowCount
 }
 
 // loadCatalogInfo loads the table descriptor and validates the specified
@@ -773,20 +784,21 @@ type hashResult struct {
 
 // hashesMatch performs a fast comparison of primary and secondary indexes by
 // computing row counts and hash values. Returns true if both indexes have
-// identical row counts and hash values, indicating no corruption.
+// identical row counts and hash values, indicating no corruption. Returns the
+// row count from the primary index.
 func (c *indexConsistencyCheck) hashesMatch(
 	ctx context.Context, columnNames []string, predicate string, queryArgs []interface{},
-) (bool, error) {
+) (match bool, rowCount int64, err error) {
 	primary, err := c.computeHashAndRowCount(ctx, c.priIndex, columnNames, predicate, queryArgs)
 	if err != nil {
-		return false, errors.Wrapf(err, "computing hash for primary index %s", c.priIndex.GetName())
+		return false, 0, errors.Wrapf(err, "computing hash for primary index %s", c.priIndex.GetName())
 	}
 	secondary, err := c.computeHashAndRowCount(ctx, c.secIndex, columnNames, predicate, queryArgs)
 	if err != nil {
-		return false, errors.Wrapf(err, "computing hash for secondary index %s", c.secIndex.GetName())
+		return false, primary.rowCount, errors.Wrapf(err, "computing hash for secondary index %s", c.secIndex.GetName())
 	}
 	// Hashes match only if both row count and hash value are identical.
-	return primary.rowCount == secondary.rowCount && primary.hash == secondary.hash, nil
+	return primary.rowCount == secondary.rowCount && primary.hash == secondary.hash, primary.rowCount, nil
 }
 
 // computeHashAndRowCount executes a hash query for the specified index and

--- a/pkg/sql/inspect/index_consistency_check.go
+++ b/pkg/sql/inspect/index_consistency_check.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
@@ -79,7 +80,7 @@ const (
 type indexConsistencyCheck struct {
 	indexConsistencyCheckApplicability
 
-	flowCtx *execinfra.FlowCtx
+	execCfg *sql.ExecutorConfig
 	indexID descpb.IndexID
 	// tableVersion is the descriptor version recorded when the check was planned.
 	// It is used to detect concurrent schema changes for non-AS OF inspections.
@@ -255,7 +256,7 @@ func (c *indexConsistencyCheck) Start(
 		}
 	}
 
-	if indexConsistencyHashEnabled.Get(&c.flowCtx.Cfg.Settings.SV) && len(allColNames) > 0 {
+	if indexConsistencyHashEnabled.Get(&c.execCfg.Settings.SV) && len(allColNames) > 0 {
 		// The hash precheck uses crdb_internal.datums_to_bytes, which depends on
 		// keyside.Encode. Skip if any column type isn’t encodable (i.e. TSQUERY, etc.).
 		if !allColumnsDatumsToBytesCompatible(c.columns) {
@@ -298,8 +299,8 @@ func (c *indexConsistencyCheck) Start(
 	c.lastQueryPlaceholders = queryArgs
 
 	// Execute the query with AS OF SYSTEM TIME embedded in the SQL
-	qos := getInspectQoS(&c.flowCtx.Cfg.Settings.SV)
-	it, err := c.flowCtx.Cfg.DB.Executor().QueryIteratorEx(
+	qos := getInspectQoS(&c.execCfg.Settings.SV)
+	it, err := c.execCfg.DistSQLSrv.DB.Executor().QueryIteratorEx(
 		ctx, "inspect-index-consistency-check", nil, /* txn */
 		sessiondata.InternalExecutorOverride{
 			User:             username.NodeUserName(),
@@ -457,7 +458,7 @@ func (c *indexConsistencyCheck) Rows() uint64 {
 // eligible for consistency checking. If the index is valid, it stores the
 // descriptor and index metadata in the indexConsistencyCheck struct.
 func (c *indexConsistencyCheck) loadCatalogInfo(ctx context.Context) error {
-	return c.flowCtx.Cfg.DB.DescsTxn(ctx, func(ctx context.Context, txn descs.Txn) error {
+	return c.execCfg.DistSQLSrv.DB.DescsTxn(ctx, func(ctx context.Context, txn descs.Txn) error {
 		if !c.asOf.IsEmpty() {
 			if err := txn.KV().SetFixedTimestamp(ctx, c.asOf); err != nil {
 				return err
@@ -813,8 +814,8 @@ func (c *indexConsistencyCheck) computeHashAndRowCount(
 	query := buildIndexHashQuery(c.tableDesc.GetID(), index, columnNames, predicate)
 	queryWithAsOf := fmt.Sprintf("SELECT * FROM (%s) AS OF SYSTEM TIME %s", query, c.asOf.AsOfSystemTime())
 
-	qos := getInspectQoS(&c.flowCtx.Cfg.Settings.SV)
-	row, err := c.flowCtx.Cfg.DB.Executor().QueryRowEx(
+	qos := getInspectQoS(&c.execCfg.Settings.SV)
+	row, err := c.execCfg.DistSQLSrv.DB.Executor().QueryRowEx(
 		ctx, "inspect-index-consistency-hash", nil, /* txn */
 		sessiondata.InternalExecutorOverride{
 			User:             username.NodeUserName(),

--- a/pkg/sql/inspect/inspect_job_entry.go
+++ b/pkg/sql/inspect/inspect_job_entry.go
@@ -34,7 +34,6 @@ func TriggerJob(
 	checks []*jobspb.InspectDetails_Check,
 	asOf hlc.Timestamp,
 ) (*jobs.StartableJob, error) {
-	// TODO(sql-queries): add row count check when that is implemented.
 	record := jobs.Record{
 		JobID:       execCfg.JobRegistry.MakeJobID(),
 		Description: jobRecordDescription,

--- a/pkg/sql/inspect/inspect_plan.go
+++ b/pkg/sql/inspect/inspect_plan.go
@@ -109,7 +109,7 @@ func newInspectRun(
 		// No INDEX options or INDEX ALL specified - inspect all indexes.
 		switch stmt.Typ {
 		case tree.InspectTable:
-			checks, err := ChecksForTable(ctx, p, run.table)
+			checks, err := ChecksForTable(ctx, p, run.table, nil /* rowCount */)
 			if err != nil {
 				return inspectRun{}, err
 			}

--- a/pkg/sql/inspect/inspect_processor.go
+++ b/pkg/sql/inspect/inspect_processor.go
@@ -236,16 +236,15 @@ func getProcessorConcurrency(flowCtx *execinfra.FlowCtx) int {
 }
 
 // getInspectLogger returns a logger bundle for the inspect processor.
-func getInspectLogger(flowCtx *execinfra.FlowCtx, jobID jobspb.JobID) *inspectLoggerBundle {
-	execCfg := flowCtx.Cfg.ExecutorConfig.(*sql.ExecutorConfig)
+func getInspectLogger(execCfg *sql.ExecutorConfig, jobID jobspb.JobID) *inspectLoggerBundle {
 	metrics := execCfg.JobRegistry.MetricsStruct().Inspect.(*InspectMetrics)
 
 	loggers := []inspectLogger{
 		&logSink{},
 		&tableSink{
-			db:    flowCtx.Cfg.DB,
+			db:    execCfg.DistSQLSrv.DB,
 			jobID: jobID,
-			sv:    &flowCtx.Cfg.Settings.SV,
+			sv:    &execCfg.Settings.SV,
 		},
 		&metricsLogger{
 			issuesFoundCtr: metrics.IssuesFound,
@@ -422,17 +421,15 @@ func (p *inspectProcessor) pushProgressMeta(
 func newInspectProcessor(
 	ctx context.Context, flowCtx *execinfra.FlowCtx, processorID int32, spec execinfrapb.InspectSpec,
 ) (execinfra.Processor, error) {
-	checkFactories, err := buildInspectCheckFactories(flowCtx, spec)
+	execCfg := flowCtx.Cfg.ExecutorConfig.(*sql.ExecutorConfig)
+
+	checkFactories, err := buildInspectCheckFactories(execCfg, spec)
 	if err != nil {
 		return nil, err
 	}
-	var spansProcessedCtr *metric.Counter
-	var numActiveSpansGauge *metric.Gauge
-	if execCfg, ok := flowCtx.Cfg.ExecutorConfig.(*sql.ExecutorConfig); ok {
-		inspectMetrics := execCfg.JobRegistry.MetricsStruct().Inspect.(*InspectMetrics)
-		spansProcessedCtr = inspectMetrics.SpansProcessed
-		numActiveSpansGauge = inspectMetrics.NumActiveSpans
-	}
+	inspectMetrics := execCfg.JobRegistry.MetricsStruct().Inspect.(*InspectMetrics)
+	spansProcessedCtr := inspectMetrics.SpansProcessed
+	numActiveSpansGauge := inspectMetrics.NumActiveSpans
 
 	return &inspectProcessor{
 		spec:                spec,
@@ -441,7 +438,7 @@ func newInspectProcessor(
 		checkFactories:      checkFactories,
 		cfg:                 flowCtx.Cfg,
 		spanSrc:             newSliceSpanSource(spec.Spans),
-		loggerBundle:        getInspectLogger(flowCtx, spec.JobID),
+		loggerBundle:        getInspectLogger(execCfg, spec.JobID),
 		concurrency:         getProcessorConcurrency(flowCtx),
 		clock:               flowCtx.Cfg.DB.KV().Clock(),
 		spansProcessedCtr:   spansProcessedCtr,
@@ -456,7 +453,7 @@ func newInspectProcessor(
 // This indirection ensures that each check instance is freshly created per span,
 // avoiding shared state across concurrent workers.
 func buildInspectCheckFactories(
-	flowCtx *execinfra.FlowCtx, spec execinfrapb.InspectSpec,
+	execCfg *sql.ExecutorConfig, spec execinfrapb.InspectSpec,
 ) ([]inspectCheckFactory, error) {
 	checkFactories := make([]inspectCheckFactory, 0, len(spec.InspectDetails.Checks))
 	for _, specCheck := range spec.InspectDetails.Checks {
@@ -470,7 +467,7 @@ func buildInspectCheckFactories(
 					indexConsistencyCheckApplicability: indexConsistencyCheckApplicability{
 						tableID: tableID,
 					},
-					flowCtx:      flowCtx,
+					execCfg:      execCfg,
 					indexID:      indexID,
 					tableVersion: tableVersion,
 					asOf:         asOf,

--- a/pkg/sql/inspect/inspect_processor.go
+++ b/pkg/sql/inspect/inspect_processor.go
@@ -494,6 +494,19 @@ func buildInspectCheckFactories(
 					asOf:         asOf,
 				}
 			})
+		case jobspb.InspectCheckRowCount:
+			checkFactories = append(checkFactories, func(asOf hlc.Timestamp) inspectCheck {
+				return &rowCountCheck{
+					rowCountCheckApplicability: rowCountCheckApplicability{
+						tableID: tableID,
+					},
+					execCfg:      execCfg,
+					tableVersion: tableVersion,
+					asOf:         asOf,
+
+					expected: specCheck.RowCount,
+				}
+			})
 		default:
 			return nil, errors.AssertionFailedf("unsupported inspect check type: %v", specCheck.Type)
 		}

--- a/pkg/sql/inspect/inspect_processor.go
+++ b/pkg/sql/inspect/inspect_processor.go
@@ -274,7 +274,7 @@ func (p *inspectProcessor) processSpan(
 	asOfToUse := p.getTimestampForSpan()
 
 	// Only create checks that apply to this span.
-	var checks []inspectCheck
+	var checks inspectChecks
 	for _, factory := range p.checkFactories {
 		check := factory(asOfToUse)
 		applies, err := check.AppliesTo(p.cfg.Codec, span)
@@ -283,6 +283,16 @@ func (p *inspectProcessor) processSpan(
 		}
 		if applies {
 			checks = append(checks, check)
+		}
+	}
+	checks.sortStable()
+
+	// Provide the span-level checks with a reference to all the other checks.
+	for _, check := range checks {
+		if check, ok := check.(inspectSpanCheck); ok {
+			if err := check.RegisterChecksForSpan(checks); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -322,8 +332,20 @@ func (p *inspectProcessor) processSpan(
 		}
 	}
 
+	// Process the span-level checks.
+	progressMsg := &jobspb.InspectProcessorProgress{}
+	for _, check := range checks {
+		if check, ok := check.(inspectSpanCheck); ok {
+			progressMsg.ChecksCompleted++
+			err := check.CheckSpan(ctx, p.loggerBundle, progressMsg)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
 	// Report span completion for checkpointing.
-	if err := p.sendSpanCompletionProgress(ctx, output, span, false /* finished */); err != nil {
+	if err := p.sendSpanCompletionProgress(ctx, output, span, progressMsg); err != nil {
 		return err
 	}
 
@@ -371,14 +393,13 @@ func (p *inspectProcessor) getTimestampForSpan() hlc.Timestamp {
 // sendSpanCompletionProgress sends progress indicating a span has been completed.
 // This is used for checkpointing to track which spans are done.
 func (p *inspectProcessor) sendSpanCompletionProgress(
-	ctx context.Context, output execinfra.RowReceiver, completedSpan roachpb.Span, finished bool,
+	ctx context.Context,
+	output execinfra.RowReceiver,
+	completedSpan roachpb.Span,
+	progressMsg *jobspb.InspectProcessorProgress,
 ) error {
 	if p.spansProcessedCtr != nil {
 		p.spansProcessedCtr.Inc(1)
-	}
-	progressMsg := &jobspb.InspectProcessorProgress{
-		ChecksCompleted: 0, // No additional checks completed, just marking span done
-		Finished:        finished,
 	}
 
 	progressAny, err := pbtypes.MarshalAny(progressMsg)
@@ -393,7 +414,7 @@ func (p *inspectProcessor) sendSpanCompletionProgress(
 			NodeID:          p.flowCtx.NodeID.SQLInstanceID(),
 			FlowID:          p.flowCtx.ID,
 			ProcessorID:     p.processorID,
-			Drained:         finished,
+			Drained:         progressMsg.Finished,
 		},
 	}
 
@@ -423,7 +444,7 @@ func newInspectProcessor(
 ) (execinfra.Processor, error) {
 	execCfg := flowCtx.Cfg.ExecutorConfig.(*sql.ExecutorConfig)
 
-	checkFactories, err := buildInspectCheckFactories(execCfg, spec)
+	checkFactories, err := buildInspectCheckFactories(execCfg, spec.InspectDetails)
 	if err != nil {
 		return nil, err
 	}
@@ -438,7 +459,7 @@ func newInspectProcessor(
 		checkFactories:      checkFactories,
 		cfg:                 flowCtx.Cfg,
 		spanSrc:             newSliceSpanSource(spec.Spans),
-		loggerBundle:        getInspectLogger(execCfg, spec.JobID),
+		loggerBundle:        getInspectLogger(flowCtx.Cfg.ExecutorConfig.(*sql.ExecutorConfig), spec.JobID),
 		concurrency:         getProcessorConcurrency(flowCtx),
 		clock:               flowCtx.Cfg.DB.KV().Clock(),
 		spansProcessedCtr:   spansProcessedCtr,
@@ -453,10 +474,10 @@ func newInspectProcessor(
 // This indirection ensures that each check instance is freshly created per span,
 // avoiding shared state across concurrent workers.
 func buildInspectCheckFactories(
-	execCfg *sql.ExecutorConfig, spec execinfrapb.InspectSpec,
+	execCfg *sql.ExecutorConfig, details jobspb.InspectDetails,
 ) ([]inspectCheckFactory, error) {
-	checkFactories := make([]inspectCheckFactory, 0, len(spec.InspectDetails.Checks))
-	for _, specCheck := range spec.InspectDetails.Checks {
+	checkFactories := make([]inspectCheckFactory, 0, len(details.Checks))
+	for _, specCheck := range details.Checks {
 		tableID := specCheck.TableID
 		indexID := specCheck.IndexID
 		tableVersion := specCheck.TableVersion
@@ -473,7 +494,6 @@ func buildInspectCheckFactories(
 					asOf:         asOf,
 				}
 			})
-
 		default:
 			return nil, errors.AssertionFailedf("unsupported inspect check type: %v", specCheck.Type)
 		}

--- a/pkg/sql/inspect/inspect_processor_test.go
+++ b/pkg/sql/inspect/inspect_processor_test.go
@@ -7,7 +7,6 @@ package inspect
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -24,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -126,6 +126,10 @@ func (t *testingInspectCheck) AppliesTo(codec keys.SQLCodec, span roachpb.Span) 
 	return true, nil
 }
 
+func (c *testingInspectCheck) IsSpanLevel() bool {
+	return false
+}
+
 // Started implements the inspectCheck interface.
 func (t *testingInspectCheck) Started() bool {
 	return t.started
@@ -205,6 +209,73 @@ func (t *testingInspectCheck) Close(context.Context) error {
 	return nil
 }
 
+// testingInspectCheckSpan is a test implementation of inspectCheckSpan.
+type testingInspectCheckSpan struct {
+	started bool
+
+	spanIssues int64
+}
+
+var _ inspectCheckApplicability = (*testingInspectCheckSpan)(nil)
+
+var _ inspectSpanCheck = (*testingInspectCheckSpan)(nil)
+
+func (t *testingInspectCheckSpan) AppliesTo(codec keys.SQLCodec, span roachpb.Span) (bool, error) {
+	// For testing, assume all checks apply to all spans
+	return true, nil
+}
+
+func (c *testingInspectCheckSpan) IsSpanLevel() bool {
+	return true
+}
+
+func (t *testingInspectCheckSpan) AppliesToCluster() (bool, error) {
+	// For testing it runs.
+	return true, nil
+}
+
+func (t *testingInspectCheckSpan) Started() bool {
+	return t.started
+}
+
+func (t *testingInspectCheckSpan) Start(
+	ctx context.Context, cfg *execinfra.ServerConfig, span roachpb.Span, workerIndex int,
+) error {
+	t.started = true
+	return nil
+}
+
+func (*testingInspectCheckSpan) Next(
+	ctx context.Context, cfg *execinfra.ServerConfig,
+) (*inspectIssue, error) {
+	return nil, nil
+}
+
+func (*testingInspectCheckSpan) Done(ctx context.Context) bool {
+	return true
+}
+
+func (*testingInspectCheckSpan) Close(ctx context.Context) error {
+	return nil
+}
+
+func (t *testingInspectCheckSpan) RegisterChecksForSpan(checks inspectChecks) error {
+	return nil
+}
+
+func (t *testingInspectCheckSpan) CheckSpan(
+	ctx context.Context, logger *inspectLoggerBundle, msg *jobspb.InspectProcessorProgress,
+) error {
+	for i := t.spanIssues; i > 0; i-- {
+		err := logger.logIssue(ctx, &inspectIssue{})
+		if err != nil {
+			return errors.Wrapf(err, "error logging inspect issue")
+		}
+	}
+
+	return nil
+}
+
 // discardRowReceiver is a minimal RowReceiver that discards all data.
 type discardRowReceiver struct{}
 
@@ -249,7 +320,7 @@ func runProcessorAndWait(t *testing.T, proc *inspectProcessor, expectErr bool) {
 // makeProcessor will create an inspect processor for test.
 func makeProcessor(
 	t *testing.T,
-	checkFactory inspectCheckFactory,
+	checkFactories []inspectCheckFactory,
 	src spanSource,
 	concurrency int,
 	asOf hlc.Timestamp,
@@ -274,7 +345,7 @@ func makeProcessor(
 				AsOf: asOf,
 			},
 		},
-		checkFactories: []inspectCheckFactory{checkFactory},
+		checkFactories: checkFactories,
 		cfg:            flowCtx.Cfg,
 		flowCtx:        flowCtx,
 		spanSrc:        src,
@@ -358,12 +429,14 @@ func TestInspectProcessor_ControlFlow(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
-			factory := func(asOf hlc.Timestamp) inspectCheck {
-				return &testingInspectCheck{
-					configs: tc.configs,
-				}
+			factories := []inspectCheckFactory{
+				func(asOf hlc.Timestamp) inspectCheck {
+					return &testingInspectCheck{
+						configs: tc.configs,
+					}
+				},
 			}
-			proc, _ := makeProcessor(t, factory, tc.spanSrc, len(tc.configs), hlc.Timestamp{})
+			proc, _ := makeProcessor(t, factories, tc.spanSrc, len(tc.configs), hlc.Timestamp{})
 			runProcessorAndWait(t, proc, tc.expectErr)
 		})
 	}
@@ -377,20 +450,22 @@ func TestInspectProcessor_EmitIssues(t *testing.T) {
 		mode:     spanModeNormal,
 		maxSpans: 1,
 	}
-	factory := func(asOf hlc.Timestamp) inspectCheck {
-		return &testingInspectCheck{
-			configs: []testingCheckConfig{
-				{
-					mode: checkModeNone,
-					issues: []*inspectIssue{
-						{ErrorType: "test_error", PrimaryKey: "pk1"},
-						{ErrorType: "test_error", PrimaryKey: "pk2"},
+	factories := []inspectCheckFactory{
+		func(asOf hlc.Timestamp) inspectCheck {
+			return &testingInspectCheck{
+				configs: []testingCheckConfig{
+					{
+						mode: checkModeNone,
+						issues: []*inspectIssue{
+							{ErrorType: "test_error", PrimaryKey: "pk1"},
+							{ErrorType: "test_error", PrimaryKey: "pk2"},
+						},
 					},
 				},
-			},
-		}
+			}
+		},
 	}
-	proc, logger := makeProcessor(t, factory, spanSrc, 1, hlc.Timestamp{})
+	proc, logger := makeProcessor(t, factories, spanSrc, 1, hlc.Timestamp{})
 
 	runProcessorAndWait(t, proc, true /* expectErr */)
 
@@ -439,21 +514,23 @@ func TestInspectProcessor_AsOfTime(t *testing.T) {
 			testStartTime := time.Now()
 
 			var capturedTimestamp hlc.Timestamp
-			factory := func(asOf hlc.Timestamp) inspectCheck {
-				capturedTimestamp = asOf
-				return &testingInspectCheck{
-					configs: []testingCheckConfig{
-						{
-							mode: checkModeNone,
-							issues: []*inspectIssue{
-								{ErrorType: "test_error", PrimaryKey: "pk1", AOST: asOf.GoTime()},
+			factories := []inspectCheckFactory{
+				func(asOf hlc.Timestamp) inspectCheck {
+					capturedTimestamp = asOf
+					return &testingInspectCheck{
+						configs: []testingCheckConfig{
+							{
+								mode: checkModeNone,
+								issues: []*inspectIssue{
+									{ErrorType: "test_error", PrimaryKey: "pk1", AOST: asOf.GoTime()},
+								},
 							},
 						},
-					},
-				}
+					}
+				},
 			}
 
-			proc, logger := makeProcessor(t, factory, spanSrc, 1, tc.asOf)
+			proc, logger := makeProcessor(t, factories, spanSrc, 1, tc.asOf)
 
 			runProcessorAndWait(t, proc, true /* expectErr */)
 
@@ -464,4 +541,26 @@ func TestInspectProcessor_AsOfTime(t *testing.T) {
 			tc.verifyTimestamp(t, actualTime, capturedTimestamp, testStartTime)
 		})
 	}
+}
+
+func TestInspectProcessor_SpanCheck(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	spanSrc := &testingSpanSource{
+		mode:     spanModeNormal,
+		maxSpans: 1,
+	}
+	factories := []inspectCheckFactory{
+		func(asOf hlc.Timestamp) inspectCheck {
+			return &testingInspectCheckSpan{
+				spanIssues: 2,
+			}
+		},
+	}
+	proc, logger := makeProcessor(t, factories, spanSrc, 1, hlc.Timestamp{})
+
+	runProcessorAndWait(t, proc, true /* expectErr */)
+
+	require.Equal(t, 2, logger.numIssuesFound())
 }

--- a/pkg/sql/inspect/inspect_resumer.go
+++ b/pkg/sql/inspect/inspect_resumer.go
@@ -358,6 +358,10 @@ func buildApplicabilityCheckers(
 			checkers = append(checkers, &indexConsistencyCheckApplicability{
 				tableID: specCheck.TableID,
 			})
+		case jobspb.InspectCheckRowCount:
+			checkers = append(checkers, &rowCountCheckApplicability{
+				tableID: specCheck.TableID,
+			})
 		default:
 			return nil, errors.AssertionFailedf("unsupported inspect check type: %v", specCheck.Type)
 		}

--- a/pkg/sql/inspect/issue.go
+++ b/pkg/sql/inspect/issue.go
@@ -102,4 +102,8 @@ const (
 	// issues) prevents the check from completing normally. These errors indicate
 	// potential data corruption or other serious issues that require investigation.
 	InternalError inspectErrorType = "internal_error"
+
+	// RowCountMismatch occurs when a index's row count doesn't match the
+	// expected value.
+	RowCountMismatch inspectErrorType = "row_count_mismatch"
 )

--- a/pkg/sql/inspect/progress.go
+++ b/pkg/sql/inspect/progress.go
@@ -221,6 +221,9 @@ func (t *inspectProgressTracker) updateProgressCache(
 		inspectProgress.JobCompletedCheckCount += incomingProcProgress.ChecksCompleted
 	}
 
+	// Update the check-specific fields (e.g. row counts).
+	inspectProgress.UpdateWithSpanProgress(&incomingProcProgress)
+
 	// Update cached progress - the goroutine will handle actual persistence.
 	t.mu.cachedProgress = &jobspb.Progress{
 		Details: &jobspb.Progress_Inspect{
@@ -233,6 +236,35 @@ func (t *inspectProgressTracker) updateProgressCache(
 	// capture the final state when a processor completes its work, rather than
 	// waiting for the next periodic checkpoint update.
 	return meta.BulkProcessorProgress.Drained, nil
+}
+
+// stepCompletedCheckCount advances the completed check count in the internal
+// cache. This is used for checks run off the processors.
+func (t *inspectProgressTracker) stepCompletedCheckCount(ctx context.Context, count int) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.mu.cachedProgress == nil {
+		return errors.AssertionFailedf("progress not initialized")
+	}
+
+	orig := t.mu.cachedProgress.GetInspect()
+	if orig == nil {
+		return errors.AssertionFailedf("cached progress does not contain Inspect details")
+	}
+	inspectProgress := protoutil.Clone(orig).(*jobspb.InspectProgress)
+
+	// Increment the completed check count
+	inspectProgress.JobCompletedCheckCount += int64(count)
+
+	// Update cached progress - the goroutine will handle actual persistence.
+	t.mu.cachedProgress = &jobspb.Progress{
+		Details: &jobspb.Progress_Inspect{
+			Inspect: inspectProgress,
+		},
+	}
+
+	return nil
 }
 
 // terminateTracker performs any necessary cleanup when the job completes or fails.
@@ -406,24 +438,47 @@ func (t *inspectProgressTracker) hasUncheckpointedSpans() bool {
 	return t.mu.receivedSpanCount > t.mu.lastCheckpointedSpanCount
 }
 
-// countApplicableChecks determines how many checks will actually run across all spans.
+// countApplicableSpanChecks determines how many checks will actually run across all spans.
 // This provides accurate progress calculation by only counting checks that apply to each span.
-func countApplicableChecks(
+func countApplicableSpanChecks(
 	pkSpans []roachpb.Span, checkers []inspectCheckApplicability, codec keys.SQLCodec,
 ) (int64, error) {
 	var totalApplicableChecks int64 = 0
 
 	for _, span := range pkSpans {
 		for _, checker := range checkers {
-			applies, err := checker.AppliesTo(codec, span)
+			isApplicable, err := checker.AppliesTo(codec, span)
 			if err != nil {
 				return 0, err
 			}
-			if applies {
+			if isApplicable {
 				totalApplicableChecks++
+
+				if checker.IsSpanLevel() {
+					totalApplicableChecks++
+				}
 			}
 		}
 	}
 
 	return totalApplicableChecks, nil
+}
+
+// countApplicableSpanChecks determines how many cluster-level checks apply.
+func countApplicableClusterChecks(checkers []inspectCheckApplicability) (int64, error) {
+	var count int64 = 0
+
+	for _, checker := range checkers {
+		if checker, ok := checker.(inspectCheckClusterApplicability); ok {
+			applies, err := checker.AppliesToCluster()
+			if err != nil {
+				return 0, err
+			}
+			if applies {
+				count++
+			}
+		}
+	}
+
+	return count, nil
 }

--- a/pkg/sql/inspect/row_count_check.go
+++ b/pkg/sql/inspect/row_count_check.go
@@ -1,0 +1,15 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package inspect
+
+// inspectCheckRowCount defines an inspectCheck that counts rows in addition to
+// its primary validation.
+type inspectCheckRowCount interface {
+	inspectCheck
+
+	// Rows returns the number of rows counted by the check.
+	Rows() uint64
+}

--- a/pkg/sql/inspect/row_count_check.go
+++ b/pkg/sql/inspect/row_count_check.go
@@ -5,11 +5,219 @@
 
 package inspect
 
-// inspectCheckRowCount defines an inspectCheck that counts rows in addition to
+import (
+	"context"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
+)
+
+// inspectCheckRowCount extends an inspectCheck that counts rows in addition to
 // its primary validation.
 type inspectCheckRowCount interface {
-	inspectCheck
-
 	// Rows returns the number of rows counted by the check.
 	Rows() uint64
+}
+
+// rowCountCheck verifies a table's row count matches the expected count.
+// It relies on other jobs to perform the row count.
+type rowCountCheck struct {
+	rowCountCheckApplicability
+
+	execCfg *sql.ExecutorConfig
+	// tableVersion is the descriptor version recorded when the check was planned.
+	// It is used to detect concurrent schema changes for non-AS OF inspections.
+	tableVersion descpb.DescriptorVersion
+	asOf         hlc.Timestamp
+
+	expected uint64
+
+	state checkState
+
+	checks []inspectCheck // Stores the checks for use in CheckSpan.
+
+	tableDesc catalog.TableDescriptor // Populated from the job progress for the cluster check.
+	rowCount  uint64                  // Populated from the tableID for the cluster check.
+}
+
+// rowCountCheckApplicability is a lightweight version that only implements applicability logic.
+type rowCountCheckApplicability struct {
+	tableID descpb.ID
+}
+
+// AppliesTo implements the inspectCheckApplicability interface.
+func (c *rowCountCheckApplicability) AppliesTo(
+	codec keys.SQLCodec, span roachpb.Span,
+) (bool, error) {
+	return spanContainsTable(c.tableID, codec, span)
+}
+
+func (c *rowCountCheckApplicability) IsSpanLevel() bool {
+	return true
+}
+
+// AppliesToCluster implements the inspectCheckClusterApplicability interface.
+func (c *rowCountCheckApplicability) AppliesToCluster() (bool, error) {
+	return true, nil
+}
+
+var _ inspectCheck = (*rowCountCheck)(nil)
+var _ inspectCheckApplicability = (*rowCountCheckApplicability)(nil)
+var _ inspectCheckClusterApplicability = (*rowCountCheckApplicability)(nil)
+
+var _ inspectSpanCheck = (*rowCountCheck)(nil)
+var _ inspectClusterCheck = (*rowCountCheck)(nil)
+
+// Started implements the inspectCheck interface.
+func (c *rowCountCheck) Started() bool {
+	return c.state != checkNotStarted
+}
+
+// Start implements the inspectCheck interface.
+func (c *rowCountCheck) Start(
+	ctx context.Context, cfg *execinfra.ServerConfig, span roachpb.Span, workerIndex int,
+) error {
+	if err := assertCheckApplies(c, cfg.Codec, span); err != nil {
+		return err
+	}
+
+	c.state = checkRunning
+
+	return nil
+}
+
+func (c *rowCountCheck) Next(
+	ctx context.Context, cfg *execinfra.ServerConfig,
+) (*inspectIssue, error) {
+	c.state = checkDone
+	return nil, nil
+}
+
+// Done implements the inspectCheck interface.
+func (c *rowCountCheck) Done(context.Context) bool {
+	return c.state == checkDone
+}
+
+// Close implements the inspectCheck interface.
+func (c *rowCountCheck) Close(context.Context) error {
+	return nil
+}
+
+// RegisterChecksForSpan implements the inspectSpanCheck interface.
+func (c *rowCountCheck) RegisterChecksForSpan(checks inspectChecks) error {
+	for _, check := range checks {
+		if _, ok := check.(inspectCheckRowCount); ok {
+			c.checks = checks
+			return nil
+		}
+	}
+
+	return errors.New("rowCountCheck requires an inspectCheckRowCount to be registered")
+}
+
+// CheckSpan implements the inspectSpanCheck interface.
+func (c *rowCountCheck) CheckSpan(
+	ctx context.Context, logger *inspectLoggerBundle, msg *jobspb.InspectProcessorProgress,
+) error {
+	// TODO: handle none of the checks return a row count
+	for _, check := range c.checks {
+		// TODO: Handle inconsistency btwn checks on the same span
+		if check, ok := check.(inspectCheckRowCount); ok {
+			msg.SpanRowCount = check.Rows()
+			return nil
+		}
+	}
+
+	return nil
+}
+
+// StartCluster implements the inspectClusterCheck interface.
+func (c *rowCountCheck) StartCluster(ctx context.Context, progress *jobspb.InspectProgress) error {
+	c.state = checkRunning
+
+	if err := c.loadTableDesc(ctx); err != nil {
+		return err
+	}
+	c.rowCount = progress.RowCount
+
+	return nil
+}
+
+func (c *rowCountCheck) loadTableDesc(ctx context.Context) error {
+	return c.execCfg.DistSQLSrv.DB.DescsTxn(ctx, func(ctx context.Context, txn descs.Txn) error {
+		if !c.asOf.IsEmpty() {
+			if err := txn.KV().SetFixedTimestamp(ctx, c.asOf); err != nil {
+				return err
+			}
+		}
+
+		byIDGetter := txn.Descriptors().ByIDWithLeased(txn.KV())
+		if !c.asOf.IsEmpty() {
+			byIDGetter = txn.Descriptors().ByIDWithoutLeased(txn.KV())
+		}
+
+		var err error
+		c.tableDesc, err = byIDGetter.WithoutNonPublic().Get().Table(ctx, c.tableID)
+		if err != nil {
+			return err
+		}
+		if c.tableVersion != 0 && c.tableDesc.GetVersion() != c.tableVersion {
+			return errors.WithHintf(
+				errors.Newf(
+					"table %s [%d] has had a schema change since the job has started at %s",
+					c.tableDesc.GetName(),
+					c.tableDesc.GetID(),
+					c.tableDesc.GetModificationTime().GoTime().Format(time.RFC3339),
+				),
+				"use AS OF SYSTEM TIME to avoid schema changes during inspection",
+			)
+		}
+
+		return nil
+	})
+}
+
+// NextCluster implements the inspectClusterCheck interface.
+func (c *rowCountCheck) NextCluster(ctx context.Context) (*inspectIssue, error) {
+	if c.state != checkRunning {
+		return nil, nil
+	}
+
+	c.state = checkDone
+
+	if c.rowCount != c.expected {
+		return &inspectIssue{
+			ErrorType:  RowCountMismatch,
+			AOST:       c.asOf.GoTime(),
+			DatabaseID: c.tableDesc.GetParentID(),
+			SchemaID:   c.tableDesc.GetParentSchemaID(),
+			ObjectID:   c.tableDesc.GetID(),
+			Details: map[redact.RedactableString]interface{}{
+				"expected": c.expected,
+				"actual":   c.rowCount,
+			},
+		}, nil
+	} else {
+		return nil, nil
+	}
+}
+
+// NextCluster implements the inspectClusterCheck interface.
+func (c *rowCountCheck) DoneCluster(ctx context.Context) bool {
+	return c.state == checkDone
+}
+
+// NextCluster implements the inspectClusterCheck interface.
+func (c *rowCountCheck) CloseCluster(ctx context.Context) error {
+	return nil
 }

--- a/pkg/sql/inspect/row_count_check_test.go
+++ b/pkg/sql/inspect/row_count_check_test.go
@@ -1,0 +1,111 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package inspect
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRowCountCheck(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s, db, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	codec := s.ApplicationLayer().Codec()
+	execCfg := s.ApplicationLayer().ExecutorConfig().(sql.ExecutorConfig)
+	r := sqlutils.MakeSQLRunner(db)
+
+	// Create a table and populate it with data
+	r.ExecMultiple(t,
+		`CREATE DATABASE test`,
+		`CREATE TABLE test.t (id INT PRIMARY KEY, INDEX idx (id))`,
+		`INSERT INTO test.t SELECT * FROM generate_series(1, 100)`,
+	)
+
+	// Get the table descriptor
+	tableDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, codec, "test", "t")
+
+	// Create checks for the table with expected row count of 100
+	expectedRowCount := uint64(105)
+	checks, err := ChecksForTable(ctx, nil /* PlanHookState */, tableDesc, &expectedRowCount)
+	require.NoError(t, err)
+	require.Len(t, checks, 2)
+
+	// Get a timestamp for AS OF SYSTEM TIME
+	var timestampStr string
+	r.QueryRow(t, "SELECT cluster_logical_timestamp()::STRING").Scan(&timestampStr)
+	asOfTimestamp, err := hlc.ParseHLC(timestampStr)
+	require.NoError(t, err)
+
+	// Trigger the inspect job directly
+	job, err := TriggerJob(
+		ctx,
+		"test row count check",
+		&execCfg,
+		checks,
+		asOfTimestamp,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, job)
+
+	// Wait for the job to complete
+	err = job.AwaitCompletion(ctx)
+	require.Error(t, err, "inspect job should error on the row count mismatch")
+
+	// Verify the job succeeded
+	var jobStatus string
+	var fractionCompleted float64
+	r.QueryRow(t,
+		`SELECT status, fraction_completed FROM [SHOW JOBS] WHERE job_type = 'INSPECT' ORDER BY created DESC LIMIT 1`,
+	).Scan(&jobStatus, &fractionCompleted)
+	require.Equal(t, "failed", jobStatus, "inspect job should fail with mismatching row count")
+	require.InEpsilon(t, 1.0, fractionCompleted, 0.01, "progress should reach 100% on successful completion")
+
+	// Query the inspect_errors table to verify a row count mismatch issue was reported
+	// There should be exactly one error (row count checks produce one error per table)
+	var errorType string
+	var databaseName, schemaName, tableName, primaryKey, aost, details string
+	var jobID int64
+	var errorCount int
+	r.QueryRow(t,
+		fmt.Sprintf(`SELECT count(*) FROM [SHOW INSPECT ERRORS FOR JOB %d]`, job.ID()),
+	).Scan(&errorCount)
+	require.Equal(t, 1, errorCount, "should have exactly one row count mismatch error")
+
+	r.QueryRow(t,
+		fmt.Sprintf(`SHOW INSPECT ERRORS FOR JOB %d WITH DETAILS`, job.ID()),
+	).Scan(&errorType, &databaseName, &schemaName, &tableName, &primaryKey, &jobID, &aost, &details)
+
+	require.Equal(t, string(RowCountMismatch), errorType)
+	require.Equal(t, "test", databaseName, "issue should reference the correct database")
+	require.Equal(t, "public", schemaName, "issue should reference the correct schema")
+	require.Equal(t, "t", tableName, "issue should reference the correct table")
+
+	// Parse the details JSON to verify expected and actual counts
+	var detailsMap map[string]interface{}
+	err = json.Unmarshal([]byte(details), &detailsMap)
+	require.NoError(t, err, "details should be valid JSON")
+	require.Contains(t, detailsMap, "expected", "details should contain expected count")
+	require.Contains(t, detailsMap, "actual", "details should contain actual count")
+	require.Equal(t, float64(expectedRowCount), detailsMap["expected"], "expected count should match")
+	require.Equal(t, float64(100), detailsMap["actual"], "actual count should be 100")
+}

--- a/pkg/sql/inspect/runner_test.go
+++ b/pkg/sql/inspect/runner_test.go
@@ -37,6 +37,10 @@ func (m *mockInspectCheck) AppliesTo(codec keys.SQLCodec, span roachpb.Span) (bo
 	return true, nil
 }
 
+func (c *mockInspectCheck) IsSpanLevel() bool {
+	return false
+}
+
 func (m *mockInspectCheck) Started() bool {
 	return m.started
 }


### PR DESCRIPTION
The row-count check used the first count it found among the checks run
on the span. If the checks were inconsistent this could cause issues.
This change validates consistency between checks rather than propagating
the values to the table row count.

Part of:#155472
Epic: CRDB-55075

Release note: None