### PR TITLE
release-24.3: kvserver: fail helpfully in and deflake TestOptimisticEvalNoContention

### DIFF
--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -66,6 +66,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/kr/pretty"
@@ -4930,7 +4932,9 @@ func setupDBAndWriteAAndB(t *testing.T) (serverutils.TestServerInterface, *kv.DB
 
 	require.NoError(t, db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) (err error) {
 		defer func() {
-			t.Log(err)
+			if err != nil {
+				t.Log(err)
+			}
 		}()
 		if err := txn.Put(ctx, "a", "a"); err != nil {
 			return err
@@ -5293,7 +5297,8 @@ func TestOptimisticEvalNoContention(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
 	s, db := setupDBAndWriteAAndB(t)
 	defer s.Stopper().Stop(ctx)
 
@@ -5304,8 +5309,14 @@ func TestOptimisticEvalNoContention(t *testing.T) {
 	readDone := make(chan error)
 	go func() {
 		readDone <- db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) (err error) {
+			ctx, sp := tracing.EnsureChildSpan(ctx, s.Tracer(), "limited-scan", tracing.WithForceRealSpan())
+			sp.SetRecordingType(tracingpb.RecordingVerbose)
 			defer func() {
-				t.Log(err)
+				rec := sp.FinishAndGetConfiguredRecording()
+				if err != nil {
+					t.Log(err)
+					t.Log(rec)
+				}
 			}()
 			// There is no contention when doing optimistic evaluation, since it can read a
 			// which is not locked.


### PR DESCRIPTION
Backport 2/2 commits from #131071 on behalf of @tbg.

----

We've seen[^1] that in rare cases, the limited scan in that test does
not successfully evaluate optimistically, and ends up blocking on an
intent indefinitely.

This commit adds a timeout to the scan as well as wraps it in a verbose
trace so that we can understand this problem better the next time we
see it.

I looked at the optimistic read path and see no obvious way this can
be turned off (short of randomizing the cluster setting[^2], which we
don't seem to be doing). So perhaps the read hits a retry or the like,
but either way it will be less poking around in the dark once we get
a repro after this commit.

[^1]: https://github.com/cockroachdb/cockroach/issues/123986#issuecomment-2107606634
[^2]: https://github.com/cockroachdb/cockroach/issues/123986#issuecomment-2107606634

Closes #130973.

Epic: none
Release note: None


----

Release justification: Testing only.