### PR TITLE
server/status: fix double-counting of storage metrics in UA deployments

### DIFF
--- a/pkg/ts/BUILD.bazel
+++ b/pkg/ts/BUILD.bazel
@@ -89,6 +89,7 @@ go_test(
         "//pkg/testutils/testcluster",
         "//pkg/ts/testmodel",
         "//pkg/ts/tspb",
+        "//pkg/ts/tsutil",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/log",


### PR DESCRIPTION
Previously, in UA (Unified Architecture) deployments, the metrics recorder stored both the aggregate and per-tenant children for TenantsStorageMetricsSet metrics (livebytes, keybytes, etc.). When querying without a specific TenantID, the query logic fetched both the aggregate and scanned for per-tenant children, summing them together.

This was inadequate because TenantsStorageMetricsSet uses AggGauge metrics where the aggregate value already equals the sum of all children. Storing and summing both resulted in double-counting, causing the DB Console to display twice the actual storage usage (e.g., 26TB instead of 13TB).

To address this, this patch modifies the recorder to exclude TenantsStorageMetricsSet from aggregate recording when tenant registries exist (multi-tenant mode). Only per-tenant children are now stored, and the query correctly sums them to produce the total. Single-tenant deployments continue to record all metrics as before.

Fixes: #160479
Epic: none

Release note (bug fix): Fixes an issue where some metrics were being double counted in UA deployments.