### PR TITLE
log: fix race condition when reconfiguring logging in tests

### DIFF
--- a/pkg/ccl/testccl/authccl/auth_test.go
+++ b/pkg/ccl/testccl/authccl/auth_test.go
@@ -163,7 +163,6 @@ func authCCLRunTest(t *testing.T, insecure bool) {
 		defer sc.Close(t)
 
 		// Enable logging channels.
-		log.TestingResetActive()
 		cfg := logconfig.DefaultConfig()
 		// Make a sink for just the session log.
 		bt := true
@@ -178,7 +177,7 @@ func authCCLRunTest(t *testing.T, insecure bool) {
 		if err := cfg.Validate(&dir); err != nil {
 			t.Fatal(err)
 		}
-		cleanup, err := log.ApplyConfig(cfg, nil /* fileSinkMetricsForDir */, nil /* fatalOnLogStall */)
+		cleanup, err := log.ApplyConfigForReconfig(cfg, nil /* fileSinkMetricsForDir */, nil /* fatalOnLogStall */)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/sql/admin_audit_log_test.go
+++ b/pkg/sql/admin_audit_log_test.go
@@ -24,7 +24,6 @@ import (
 
 func installSensitiveAccessLogFileSink(sc *log.TestLogScope, t *testing.T) func() {
 	// Enable logging channels.
-	log.TestingResetActive()
 	cfg := logconfig.DefaultConfig()
 	// Make a sink for just the session log.
 	bt := true
@@ -39,7 +38,7 @@ func installSensitiveAccessLogFileSink(sc *log.TestLogScope, t *testing.T) func(
 	if err := cfg.Validate(&dir); err != nil {
 		t.Fatal(err)
 	}
-	cleanup, err := log.ApplyConfig(cfg, nil /* fileSinkMetricsForDir */, nil /* fatalOnLogStall */)
+	cleanup, err := log.ApplyConfigForReconfig(cfg, nil /* fileSinkMetricsForDir */, nil /* fatalOnLogStall */)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/pgwire/auth_test.go
+++ b/pkg/sql/pgwire/auth_test.go
@@ -184,7 +184,6 @@ func hbaRunTest(t *testing.T, insecure bool) {
 		defer sc.Close(t)
 
 		// Enable logging channels.
-		log.TestingResetActive()
 		cfg := logconfig.DefaultConfig()
 		// Make a sink for just the session log.
 		bt := true
@@ -206,7 +205,7 @@ func hbaRunTest(t *testing.T, insecure bool) {
 		if err := cfg.Validate(&dir); err != nil {
 			t.Fatal(err)
 		}
-		cleanup, err := log.ApplyConfig(cfg, nil /* fileSinkMetricsForDir */, nil /* fatalOnLogStall */)
+		cleanup, err := log.ApplyConfigForReconfig(cfg, nil /* fileSinkMetricsForDir */, nil /* fatalOnLogStall */)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/util/log/clog_test.go
+++ b/pkg/util/log/clog_test.go
@@ -404,8 +404,7 @@ func TestGetLogReader(t *testing.T) {
 
 	// Validate and apply the config.
 	require.NoError(t, config.Validate(&sc.logDir))
-	TestingResetActive()
-	cleanupFn, err := ApplyConfig(config, nil /* fileSinkMetricsForDir */, nil /* fatalOnLogStall */)
+	cleanupFn, err := ApplyConfigForReconfig(config, nil /* fileSinkMetricsForDir */, nil /* fatalOnLogStall */)
 	require.NoError(t, err)
 	defer cleanupFn()
 
@@ -616,8 +615,7 @@ func TestFd2Capture(t *testing.T) {
 	if err := cfg.Validate(&s.logDir); err != nil {
 		t.Fatal(err)
 	}
-	TestingResetActive()
-	cleanupFn, err := ApplyConfig(cfg, nil /* fileSinkMetricsForDir */, nil /* fatalOnLogStall */)
+	cleanupFn, err := ApplyConfigForReconfig(cfg, nil /* fileSinkMetricsForDir */, nil /* fatalOnLogStall */)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/util/log/file_log_gc_test.go
+++ b/pkg/util/log/file_log_gc_test.go
@@ -60,8 +60,7 @@ func TestSecondaryGC(t *testing.T) {
 
 	// Validate and apply the config.
 	require.NoError(t, config.Validate(&s.logDir))
-	TestingResetActive()
-	cleanupFn, err := ApplyConfig(config, nil /* fileSinkMetricsForDir */, nil /* fatalOnLogStall */)
+	cleanupFn, err := ApplyConfigForReconfig(config, nil /* fileSinkMetricsForDir */, nil /* fatalOnLogStall */)
 	require.NoError(t, err)
 	defer cleanupFn()
 

--- a/pkg/util/log/fluent_client_test.go
+++ b/pkg/util/log/fluent_client_test.go
@@ -63,8 +63,7 @@ func TestFluentClient(t *testing.T) {
 	require.NoError(t, cfg.Validate(&sc.logDir))
 
 	// Apply the configuration.
-	TestingResetActive()
-	cleanup, err := ApplyConfig(cfg, nil /* fileSinkMetricsForDir */, nil /* fatalOnLogStall */)
+	cleanup, err := ApplyConfigForReconfig(cfg, nil /* fileSinkMetricsForDir */, nil /* fatalOnLogStall */)
 	require.NoError(t, err)
 	defer cleanup()
 
@@ -89,7 +88,7 @@ func TestFluentClient(t *testing.T) {
 	msg, err := json.Marshal(info)
 	require.NoError(t, err)
 
-	const expected = `{"c":1,"f":"util/log/fluent_client_test.go","g":222,"l":72,"message":"hello world","n":1,"r":1,"s":1,"sev":"I","t":"XXX","tag":"logtest.ops","v":"v999.0.0"}`
+	const expected = `{"c":1,"f":"util/log/fluent_client_test.go","g":222,"l":71,"message":"hello world","n":1,"r":1,"s":1,"sev":"I","t":"XXX","tag":"logtest.ops","v":"v999.0.0"}`
 	require.Equal(t, expected, string(msg))
 }
 

--- a/pkg/util/log/formats_test.go
+++ b/pkg/util/log/formats_test.go
@@ -60,8 +60,7 @@ func TestFormatRedaction(t *testing.T) {
 							config.CaptureFd2.Enable = false
 							// Validate and apply the config.
 							require.NoError(t, config.Validate(&sc.logDir))
-							TestingResetActive()
-							cleanupFn, err := ApplyConfig(config, nil /* fileSinkMetricsForDir */, nil /* fatalOnLogStall */)
+							cleanupFn, err := ApplyConfigForReconfig(config, nil /* fileSinkMetricsForDir */, nil /* fatalOnLogStall */)
 							require.NoError(t, err)
 							defer cleanupFn()
 

--- a/pkg/util/log/http_sink_test.go
+++ b/pkg/util/log/http_sink_test.go
@@ -106,8 +106,7 @@ func testBase(
 	require.NoError(t, cfg.Validate(&sc.logDir))
 
 	// Apply the configuration.
-	TestingResetActive()
-	cleanup, err := ApplyConfig(cfg, nil /* fileSinkMetricsForDir */, nil /* fatalOnLogStall */)
+	cleanup, err := ApplyConfigForReconfig(cfg, nil /* fileSinkMetricsForDir */, nil /* fatalOnLogStall */)
 	require.NoError(t, err)
 	defer cleanup()
 

--- a/pkg/util/log/logtestutils/log_test_utils.go
+++ b/pkg/util/log/logtestutils/log_test_utils.go
@@ -17,7 +17,6 @@ import (
 // InstallLogFileSink installs a file sink for logging tests.
 func InstallLogFileSink(sc *log.TestLogScope, t *testing.T, channel logpb.Channel) func() {
 	// Enable logging channels.
-	log.TestingResetActive()
 	cfg := logconfig.DefaultConfig()
 	// Make a sink for just the session log.
 	cfg.Sinks.FileGroups = make(map[string]*logconfig.FileSinkConfig)
@@ -36,7 +35,7 @@ func InstallLogFileSink(sc *log.TestLogScope, t *testing.T, channel logpb.Channe
 	if err := cfg.Validate(&dir); err != nil {
 		t.Fatal(err)
 	}
-	cleanup, err := log.ApplyConfig(cfg, nil /* fileSinkMetricsForDir */, nil /* fatalOnLogStall */)
+	cleanup, err := log.ApplyConfigForReconfig(cfg, nil /* fileSinkMetricsForDir */, nil /* fatalOnLogStall */)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/util/log/otlp_client_test.go
+++ b/pkg/util/log/otlp_client_test.go
@@ -209,8 +209,7 @@ func TestOTLPSink(t *testing.T) {
 		require.NoError(t, cfg.Validate(&sc.logDir))
 
 		// Apply the configuration.
-		TestingResetActive()
-		cleanup, err := ApplyConfig(cfg, nil /* fileSinkMetricsForDir */, nil /* fatalOnLogStall */)
+		cleanup, err := ApplyConfigForReconfig(cfg, nil /* fileSinkMetricsForDir */, nil /* fatalOnLogStall */)
 		require.NoError(t, err)
 
 		for name, test := range tests {
@@ -283,8 +282,7 @@ func TestOTLPSinkHeaders(t *testing.T) {
 		require.NoError(t, cfg.Validate(&sc.logDir))
 
 		// Apply the configuration.
-		TestingResetActive()
-		cleanup, err := ApplyConfig(cfg, nil /* fileSinkMetricsForDir */, nil /* fatalOnLogStall */)
+		cleanup, err := ApplyConfigForReconfig(cfg, nil /* fileSinkMetricsForDir */, nil /* fatalOnLogStall */)
 		require.NoError(t, err)
 
 		go func() {

--- a/pkg/util/log/redact_test.go
+++ b/pkg/util/log/redact_test.go
@@ -127,12 +127,11 @@ func TestSafeManaged(t *testing.T) {
 				RedactionPolicyManaged = initRedactionPolicyManaged
 			}()
 
-			TestingResetActive()
 			cfg := logconfig.DefaultConfig()
 			if err := cfg.Validate(&s.logDir); err != nil {
 				t.Fatal(err)
 			}
-			cleanupFn, err := ApplyConfig(cfg, nil /* fileSinkMetricsForDir */, nil /* fatalOnLogStall */)
+			cleanupFn, err := ApplyConfigForReconfig(cfg, nil /* fileSinkMetricsForDir */, nil /* fatalOnLogStall */)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/util/log/registry_test.go
+++ b/pkg/util/log/registry_test.go
@@ -76,8 +76,7 @@ func TestIterFileSinks(t *testing.T) {
 	require.NoError(t, cfg.Validate(&sc.logDir))
 
 	// Apply the configuration
-	TestingResetActive()
-	cleanup, err := ApplyConfig(cfg, nil /* fileSinkMetricsForDir */, nil /* fatalOnLogStall */)
+	cleanup, err := ApplyConfigForReconfig(cfg, nil /* fileSinkMetricsForDir */, nil /* fatalOnLogStall */)
 	require.NoError(t, err)
 	defer cleanup()
 
@@ -147,8 +146,7 @@ func TestIterHTTPSinks(t *testing.T) {
 	require.NoError(t, cfg.Validate(&sc.logDir))
 
 	// Apply the configuration
-	TestingResetActive()
-	cleanup, err := ApplyConfig(cfg, nil /* fileSinkMetricsForDir */, nil /* fatalOnLogStall */)
+	cleanup, err := ApplyConfigForReconfig(cfg, nil /* fileSinkMetricsForDir */, nil /* fatalOnLogStall */)
 	require.NoError(t, err)
 	defer cleanup()
 

--- a/pkg/util/log/secondary_log_test.go
+++ b/pkg/util/log/secondary_log_test.go
@@ -42,8 +42,7 @@ func installSessionsFileSink(sc *TestLogScope, t *testing.T) func() {
 	}
 
 	// Apply the configuration.
-	TestingResetActive()
-	cleanup, err := ApplyConfig(cfg, nil /* fileSinkMetricsForDir */, nil /* fatalOnLogStall */)
+	cleanup, err := ApplyConfigForReconfig(cfg, nil /* fileSinkMetricsForDir */, nil /* fatalOnLogStall */)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Previously, test code that needed to reconfigure logging would call TestingResetActive() followed by ApplyConfig(). These were two separate operations with a race window between them where a background goroutine could log a message, calling setActive() and setting the active flag back to true.

This was inadequate because when ApplyConfig() subsequently checked IsActive(), it would find active=true and panic with "logging already active". This caused flaky test failures like #114642 and #160154, particularly when tests created log scopes while servers with background logging goroutines were running.

To address this, this patch introduces ApplyConfigForReconfig() which atomically resets the active flag and applies the new configuration under a single lock acquisition, eliminating the race window. All instances of the TestingResetActive() + ApplyConfig() pattern have been replaced with calls to ApplyConfigForReconfig().

Fixes: #160154
Informs: #110028
Epic: none
Release note: none