### PR TITLE
storage: fix microbenchmarks setup

### DIFF
--- a/pkg/storage/bench_test.go
+++ b/pkg/storage/bench_test.go
@@ -1280,7 +1280,8 @@ func runMVCCConditionalPut(
 		expected = value.TagAndDataBytes()
 	}
 
-	for i := 0; b.Loop(); i++ {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
 		key := roachpb.Key(encoding.EncodeUvarintAscending(keyBuf[:4], uint64(i)))
 		ts := hlc.Timestamp{WallTime: timeutil.Now().UnixNano()}
 		batch := eng.NewBatch()
@@ -1999,7 +2000,8 @@ func runMVCCAcquireLockCommon(
 	}
 	ms := &enginepb.MVCCStats{}
 
-	for i := 0; b.Loop(); i++ {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
 		key := makeKey(i)
 		txn := &txn1
 		var err error


### PR DESCRIPTION
Fix microbenchmarks where setup runs b.N times followed by use of b.Loop(), which may run more than b.N times. Both loops now use b.N in these cases.

Fixes: #159988
Fixes: #159989
Fixes: #159990

Epic: none
Release note: None