### PR TITLE
workload/sqlstats: Make sql stats workload more configurable

### DIFF
--- a/pkg/ccl/workloadccl/allccl/BUILD.bazel
+++ b/pkg/ccl/workloadccl/allccl/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//pkg/workload/rand",
         "//pkg/workload/schemachange",
         "//pkg/workload/sqlsmith",
+        "//pkg/workload/sqlstats",
         "//pkg/workload/tpcc",
         "//pkg/workload/tpccchecks",
         "//pkg/workload/tpcds",

--- a/pkg/ccl/workloadccl/allccl/all.go
+++ b/pkg/ccl/workloadccl/allccl/all.go
@@ -30,6 +30,7 @@ import (
 	_ "github.com/cockroachdb/cockroach/pkg/workload/rand"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/schemachange"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/sqlsmith"
+	_ "github.com/cockroachdb/cockroach/pkg/workload/sqlstats"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/tpcc"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/tpccchecks"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/tpcds"

--- a/pkg/workload/sqlstats/BUILD.bazel
+++ b/pkg/workload/sqlstats/BUILD.bazel
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/workload/sqlstats",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/workload",
         "//pkg/workload/histogram",


### PR DESCRIPTION
This workload is intended to generate a large amount of queries to populate
the sql stats subsystem. Previously this workload had such a high cardinality
workload (10! fingerprints) that it would cause memory issues in the cluster
running the workload.

To fix this, the following flags have been added to make the workload more
confiurable:

  * cardinality - configures how many columns are used to generate the
                  randomized workload. Default is 6 which is 720 unique
                  read and write fingerprints (1440 total).
  * fingerprint-size - configures the size of the query used for the read
                       queries. This allows for bigger queries, which impacts
                       the storage space used by sql stats.
  * read-percent - configures the % of read queries executed by the workload

Epic: None
Release note: None