### PR TITLE
release-25.2.11-rc: roachtest: fix liquibase ignorelist test name format

### DIFF
--- a/pkg/cmd/roachtest/tests/liquibase_blocklist.go
+++ b/pkg/cmd/roachtest/tests/liquibase_blocklist.go
@@ -8,7 +8,7 @@ package tests
 var liquibaseBlocklist = blocklist{}
 
 var liquibaseIgnorelist = blocklist{
-	`liquibase.harness.change.ChangeObjectTests.apply addCheckConstraint against cockroachdb 24.1`:  "requires enterprise version of liquibase",
-	`liquibase.harness.change.ChangeObjectTests.apply createPackage against cockroachdb 24.1`:       "requires enterprise version of liquibase",
-	`liquibase.harness.change.ChangeObjectTests.apply dropCheckConstraint against cockroachdb 24.1`: "requires enterprise version of liquibase",
+	`ChangeObjectTests.apply addCheckConstraint against cockroachdb 24.1`:  "requires enterprise version of liquibase",
+	`ChangeObjectTests.apply createPackage against cockroachdb 24.1`:       "requires enterprise version of liquibase",
+	`ChangeObjectTests.apply dropCheckConstraint against cockroachdb 24.1`: "requires enterprise version of liquibase",
 }


### PR DESCRIPTION
Backport 1/1 commits from #160467 on behalf of @rafiss.

----

The liquibase ignorelist entries had the wrong test name format.

The format changed when we upgraded the test harness in ac8cb118943f132393897153c59a4dd7415d53ec.

The new format does not use the fully qualified class name.

Fixes #160364
Fixes #160362
Fixes #160360
Fixes #160358
Fixes #160355
Fixes #160354
Fixes #160376
Fixes #160373
Fixes #160372
Fixes #160371
Fixes #160367

Release note: None
Epic: None

----

Release justification: