### PR TITLE
pgwire: handle negative scale

### DIFF
--- a/pkg/sql/pgwire/pgwirebase/encoding.go
+++ b/pkg/sql/pgwire/pgwirebase/encoding.go
@@ -587,6 +587,10 @@ func DecodeDatum(
 				}
 			}
 
+			if alloc.pgNum.Dscale < 0 {
+				return nil, pgerror.Newf(pgcode.InvalidBinaryRepresentation, "invalid decimal scale: %d", alloc.pgNum.Dscale)
+			}
+
 			if alloc.pgNum.Ndigits > 0 {
 				decDigits := make([]byte, 0, int(alloc.pgNum.Ndigits)*PGDecDigits)
 				for i := int16(0); i < alloc.pgNum.Ndigits; i++ {

--- a/pkg/sql/pgwire/testdata/pgtest/decimal
+++ b/pkg/sql/pgwire/testdata/pgtest/decimal
@@ -108,3 +108,20 @@ ReadyForQuery
 {"Type":"DataRow","Values":[{"text":"10000.000"},{"text":"100000000.000"}]}
 {"Type":"CommandComplete","CommandTag":"SELECT 1"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Regression for #158884.
+# Use a decimal with negative scale (FFF0, which is -16).
+send
+Parse {"Name": "s5", "Query": "SELECT $1::decimal"}
+Bind {"DestinationPortal": "p5", "PreparedStatement": "s5", "ParameterFormatCodes": [1], "Parameters": [{"binary":"000100010000FFF00001"}]}
+Execute {"Portal": "p5"}
+Sync
+----
+
+until
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ErrorResponse","Code":"22P03"}
+{"Type":"ReadyForQuery","TxStatus":"I"}


### PR DESCRIPTION
The node could crash if it received a decimal with a negative scale value. This commit adds a check and returns an error instead.

Epic: CRDB-57539
Fixes: #158884

Release note (bug fix): CockroachDB could previously crash when handling decimals with negative scales via extended PGWire protocol and this has been fixed (an error is returned, similar to PG).