### PR TITLE
pgwire: fix TestPGTest/large_input for shared process tenants

### DIFF
--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -619,7 +619,7 @@ func TestDistSQLReceiverDrainsMeta(t *testing.T) {
 				},
 			},
 			Insecure:          true,
-			DefaultTestTenant: base.TestDoesNotWorkWithSecondaryTenantsButWeDontKnowWhyYet(112960),
+			DefaultTestTenant: base.TestDoesNotWorkWithSecondaryTenantsButWeDontKnowWhyYet(160517),
 		}})
 	defer tc.Stopper().Stop(ctx)
 	s := tc.ApplicationLayer(0)


### PR DESCRIPTION
Previously, the TestPGTest/large_input test failed when running with a shared process virtual cluster because the cluster setting `sql.conn.max_read_buffer_message_size` was only set on the application tenant. In shared process mode, SQL connections come through the system tenant's pgwire listener, and the PreServeConnHandler uses the system tenant's settings to validate message sizes before routing to the appropriate tenant.

This commit fixes the test by also setting the cluster setting on the system tenant, ensuring that the message size limit is enforced correctly in both standalone and shared process modes.

Fixes: #112960
Epic: CRDB-48944

Release note: None