### PR TITLE
opt: better optimize ANY/IN subqueries within routines

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/udf
+++ b/pkg/sql/opt/exec/execbuilder/testdata/udf
@@ -381,3 +381,50 @@ vectorized: true
 │
 └── • emptyrow
       columns: ()
+
+# Regression test for #160475. IN-subqueries within UDFs should be
+# index-accelerated in the same way that they are outside of UDFs.
+statement ok
+CREATE TABLE t160475 (
+  a INT,
+  b INT,
+  c INT,
+  INDEX (a, b) STORING (c),
+  FAMILY (a, b, c)
+)
+
+statement ok
+ALTER TABLE t160475 INJECT STATISTICS '[
+  {
+    "avg_size": 4,
+    "columns": ["a"],
+    "distinct_count": 10,
+    "null_count": 0,
+    "row_count": 1000,
+    "created_at": "2025-01-05 21:51:13"
+  },
+  {
+    "avg_size": 4,
+    "columns": ["b"],
+    "distinct_count": 1000,
+    "null_count": 0,
+    "row_count": 1000,
+    "created_at": "2025-01-05 21:51:13"
+  }
+]'
+
+query T kvtrace
+SELECT c FROM t160475 WHERE a = 33 AND b IN (SELECT unnest(ARRAY[44, 55]::INT[]))
+----
+Scan /Table/20/1/12{6-7}
+Scan /Table/126/2/33/4{4-5}, /Table/126/2/33/5{5-6}
+
+statement ok
+CREATE OR REPLACE FUNCTION f160475(x INT, y INT[]) RETURNS INT LANGUAGE SQL AS $$
+  SELECT c FROM t160475 WHERE a = x AND b IN (SELECT UNNEST(y))
+$$
+
+query T kvtrace
+SELECT f160475(33, ARRAY[44, 55]::INT[])
+----
+Scan /Table/126/2/33/4{4-5}, /Table/126/2/33/5{5-6}

--- a/pkg/sql/opt/exec/execbuilder/testdata/udf
+++ b/pkg/sql/opt/exec/execbuilder/testdata/udf
@@ -421,7 +421,7 @@ Scan /Table/126/2/33/4{4-5}, /Table/126/2/33/5{5-6}
 
 statement ok
 CREATE OR REPLACE FUNCTION f160475(x INT, y INT[]) RETURNS INT LANGUAGE SQL AS $$
-  SELECT c FROM t160475 WHERE a = x AND b IN (SELECT UNNEST(y))
+  SELECT c FROM t160475 WHERE a = x AND b IN (SELECT unnest(y))
 $$
 
 query T kvtrace

--- a/pkg/sql/opt/memo/check_expr.go
+++ b/pkg/sql/opt/memo/check_expr.go
@@ -365,6 +365,11 @@ func (m *Memo) CheckExpr(e opt.Expr) {
 			panic(errors.AssertionFailedf("invalid WithScan input columns %v", t.InCols))
 		}
 
+	case *CaseExpr:
+		if len(t.Whens) == 0 {
+			panic(errors.AssertionFailedf("CASE expression must have at least one WHEN branch"))
+		}
+
 	default:
 		if opt.IsJoinOp(e) {
 			left := e.Child(0).(RelExpr)

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -1778,21 +1778,23 @@ ALTER TABLE t0 INJECT STATISTICS '[
 norm
 SELECT * FROM v0 WHERE v0.c0 > 0
 ----
-select
- ├── columns: c0:5(int!null)
- ├── stats: [rows=1, distinct(5)=1, null(5)=0]
- ├── project
- │    ├── columns: rowid:5(int)
- │    ├── stats: [rows=2, distinct(5)=2, null(5)=0]
+project
+ ├── columns: c0:5(int)
+ ├── stats: [rows=1]
+ ├── select
+ │    ├── columns: c0:1(int) t0.rowid:2(int!null)
+ │    ├── stats: [rows=1]
+ │    ├── key: (2)
+ │    ├── fd: (2)-->(1)
  │    ├── scan t0
  │    │    ├── columns: c0:1(int) t0.rowid:2(int!null)
- │    │    ├── stats: [rows=2, distinct(1,2)=2, null(1,2)=0]
+ │    │    ├── stats: [rows=2]
  │    │    ├── key: (2)
  │    │    └── fd: (2)-->(1)
- │    └── projections
- │         └── CASE WHEN c0:1 > 0 THEN 1 ELSE t0.rowid:2 END [as=rowid:5, type=int, outer=(1,2)]
- └── filters
-      └── rowid:5 > 0 [type=bool, outer=(5), constraints=(/5: [/1 - ]; tight)]
+ │    └── filters
+ │         └── CASE WHEN c0:1 > 0 THEN 1 ELSE t0.rowid:2 END > 0 [type=bool, outer=(1,2)]
+ └── projections
+      └── CASE WHEN c0:1 > 0 THEN 1 ELSE t0.rowid:2 END [as=rowid:5, type=int, outer=(1,2)]
 
 exec-ddl
 ALTER TABLE a INJECT STATISTICS '[

--- a/pkg/sql/opt/norm/general_funcs.go
+++ b/pkg/sql/opt/norm/general_funcs.go
@@ -665,6 +665,12 @@ func (c *CustomFuncs) IsLeakproof(expr memo.RelExpr) bool {
 //
 // ----------------------------------------------------------------------
 
+// LenGT returns true if the given scalar expression list has length greater
+// than x.
+func (c *CustomFuncs) LenGT(list memo.ScalarListExpr, x int) bool {
+	return len(list) > x
+}
+
 // ScalarExprAt returns the ScalarExpr in the i-th position in the given list.
 // Returns ok=false if i is out of bounds.
 func (c *CustomFuncs) ScalarExprAt(list memo.ScalarListExpr, i int) (_ opt.ScalarExpr, ok bool) {
@@ -681,6 +687,10 @@ func (c *CustomFuncs) ScalarPair(list memo.ScalarListExpr) (_, _ opt.ScalarExpr,
 		return nil, nil, false
 	}
 	return list[0], list[1], true
+}
+
+func (c *CustomFuncs) DropLast(list memo.ScalarListExpr) memo.ScalarListExpr {
+	return list[:len(list)-1]
 }
 
 // ----------------------------------------------------------------------

--- a/pkg/sql/opt/norm/inline_funcs.go
+++ b/pkg/sql/opt/norm/inline_funcs.go
@@ -162,7 +162,8 @@ func (c *CustomFuncs) CanInline(scalar opt.ScalarExpr) bool {
 		opt.EqOp, opt.NeOp, opt.LeOp, opt.LtOp, opt.GeOp, opt.GtOp,
 		opt.IsOp, opt.IsNotOp, opt.InOp, opt.NotInOp,
 		opt.VariableOp, opt.ConstOp, opt.NullOp,
-		opt.PlusOp, opt.MinusOp, opt.MultOp:
+		opt.PlusOp, opt.MinusOp, opt.MultOp,
+		opt.CaseOp, opt.WhenOp, opt.ScalarListOp:
 
 		// Recursively verify that children are also inlinable.
 		for i, n := 0, scalar.ChildCount(); i < n; i++ {

--- a/pkg/sql/opt/norm/rules/select.opt
+++ b/pkg/sql/opt/norm/rules/select.opt
@@ -440,6 +440,40 @@ $input
     )
 )
 
+# SimplifyCaseSingleFalsyBranch replaces a CASE expression in a filter with a
+# falsy ELSE branch when it has a single WHEN branch that evaluates to False or
+# Null.
+#
+# For example:
+#
+#  SELECT * FROM abc WHERE CASE WHEN a > 1 THEN false ELSE false END
+#  =>
+#  SELECT * FROM abc WHERE false
+#
+# NOTE: The optimizer guarantees that CASE branches with side-effects will only
+# be evaluated if their conditions are true and the ELSE branch with
+# side-effects will only be evaluated if non of the branch conditions are true
+# (see props.VolatilitySet). Therefore, this rule is only valid when the ELSE
+# branch is leakproof. We currently only match constant False and Null values,
+# which are guaranteed to be leakproof.
+[SimplifyCaseSingleFalsyBranch, Normalize]
+(Select
+    $input:*
+    $filters:[
+        ...
+        $item:(FiltersItem
+            (Case
+                (True)
+                $whens:[ (When * (False | Null)) ]
+                $orElse:(False | Null)
+            )
+        )
+        ...
+    ]
+)
+=>
+(Select $input (ReplaceFiltersItem $filters $item $orElse))
+
 # SimplifyCaseSingleTruthyBranch replaces a CASE expression in a filter with its
 # condition when it has a single WHEN branch that evaluates to True, and an ELSE
 # branch that evaluates to False or Null.

--- a/pkg/sql/opt/norm/rules/select.opt
+++ b/pkg/sql/opt/norm/rules/select.opt
@@ -396,6 +396,78 @@ $input
     (ReplaceFiltersItem $filters $item (Eq $left $right))
 )
 
+# EliminateCaseTrailingFalsyBranch removes a trailing WHEN branch that results
+# in False or Null from a CASE expression in a filter when the ELSE branch also
+# results in False or Null. This is valid because the trailing WHEN branch
+# cannot change the result of the CASE expression, regardless of the results of
+# its condition.
+#
+# For example:
+#
+#  SELECT * FROM abc WHERE CASE WHEN a > 1 THEN true WHEN b > 2 THEN false ELSE false END
+#  =>
+#  SELECT * FROM abc WHERE CASE WHEN a > 1 THEN true ELSE false END
+#
+# NOTE: The optimizer guarantees that CASE branches with side-effects will only
+# be evaluated if their conditions are true and the ELSE branch with
+# side-effects will only be evaluated if non of the branch conditions are true
+# (see props.VolatilitySet). Therefore, this rule is only valid when the ELSE
+# branch is leakproof. We currently only match constant False and Null values,
+# which are guaranteed to be leakproof.
+[EliminateCaseTrailingFalsyBranch, Normalize]
+(Select
+    $input:*
+    $filters:[
+        ...
+        $item:(FiltersItem
+            (Case
+                (True)
+                $whens:[ ... (When * (False | Null)) ] &
+                    (LenGT $whens 1)
+                $orElse:(False | Null)
+            )
+        )
+        ...
+    ]
+)
+=>
+(Select
+    $input
+    (ReplaceFiltersItem
+        $filters
+        $item
+        (Case (True) (DropLast $whens) $orElse)
+    )
+)
+
+# SimplifyCaseSingleTruthyBranch replaces a CASE expression in a filter with its
+# condition when it has a single WHEN branch that evaluates to True, and an ELSE
+# branch that evaluates to False or Null.
+#
+# For example:
+#
+#  SELECT * FROM abc WHERE CASE WHEN a > 5 THEN true ELSE false END
+#  =>
+#  SELECT * FROM abc WHERE a > 5
+#
+[SimplifyCaseSingleTruthyBranch, Normalize]
+(Select
+    $input:*
+    $filters:[
+        ...
+        $item:(FiltersItem
+            (Case
+                (True)
+                $whens:[ (When $cond:* (True)) ]
+                (False | Null)
+            )
+        )
+        ...
+    ]
+)
+=>
+(Select $input (ReplaceFiltersItem $filters $item $cond))
+
 # PushSelectIntoProjectSet pushes filters into a ProjectSet. In particular,
 # the filters that are bound to the input columns of the ProjectSet are
 # pushed down into it, in hopes of being pushed down further into joins

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -2511,44 +2511,38 @@ project
  ├── key: (1)
  ├── fd: (1)-->(2)
  └── select
-      ├── columns: c:1!null d:2!null array_agg:9!null
+      ├── columns: c:1!null d:2!null x:5 array_agg:10
       ├── key: (1)
-      ├── fd: ()-->(9), (1)-->(2)
-      ├── project
-      │    ├── columns: array_agg:9 c:1!null d:2!null
+      ├── fd: (1)-->(2,5,10)
+      ├── group-by (hash)
+      │    ├── columns: c:1!null d:2!null x:5 array_agg:10
+      │    ├── grouping columns: c:1!null
       │    ├── key: (1)
-      │    ├── fd: (1)-->(2,9)
-      │    ├── group-by (hash)
-      │    │    ├── columns: c:1!null d:2!null x:5 array_agg:10
-      │    │    ├── grouping columns: c:1!null
+      │    ├── fd: (1)-->(2,5,10)
+      │    ├── left-join (hash)
+      │    │    ├── columns: c:1!null d:2!null x:5 y:6
+      │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
       │    │    ├── key: (1)
-      │    │    ├── fd: (1)-->(2,5,10)
-      │    │    ├── left-join (hash)
-      │    │    │    ├── columns: c:1!null d:2!null x:5 y:6
-      │    │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+      │    │    ├── fd: (1)-->(2,5,6), (5)-->(6)
+      │    │    ├── scan cd
+      │    │    │    ├── columns: c:1!null d:2!null
       │    │    │    ├── key: (1)
-      │    │    │    ├── fd: (1)-->(2,5,6), (5)-->(6)
-      │    │    │    ├── scan cd
-      │    │    │    │    ├── columns: c:1!null d:2!null
-      │    │    │    │    ├── key: (1)
-      │    │    │    │    └── fd: (1)-->(2)
-      │    │    │    ├── scan xy
-      │    │    │    │    ├── columns: x:5!null y:6
-      │    │    │    │    ├── key: (5)
-      │    │    │    │    └── fd: (5)-->(6)
-      │    │    │    └── filters
-      │    │    │         └── c:1 = x:5 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
-      │    │    └── aggregations
-      │    │         ├── array-agg [as=array_agg:10, outer=(6)]
-      │    │         │    └── y:6
-      │    │         ├── const-agg [as=d:2, outer=(2)]
-      │    │         │    └── d:2
-      │    │         └── any-not-null-agg [as=x:5, outer=(5)]
-      │    │              └── x:5
-      │    └── projections
-      │         └── CASE WHEN x:5 IS NOT NULL THEN array_agg:10 ELSE CAST(NULL AS INT8[]) END [as=array_agg:9, outer=(5,10)]
+      │    │    │    └── fd: (1)-->(2)
+      │    │    ├── scan xy
+      │    │    │    ├── columns: x:5!null y:6
+      │    │    │    ├── key: (5)
+      │    │    │    └── fd: (5)-->(6)
+      │    │    └── filters
+      │    │         └── c:1 = x:5 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+      │    └── aggregations
+      │         ├── array-agg [as=array_agg:10, outer=(6)]
+      │         │    └── y:6
+      │         ├── const-agg [as=d:2, outer=(2)]
+      │         │    └── d:2
+      │         └── any-not-null-agg [as=x:5, outer=(5)]
+      │              └── x:5
       └── filters
-           └── array_agg:9 = ARRAY[] [outer=(9), constraints=(/9: [/ARRAY[] - /ARRAY[]]; tight), fd=()-->(9)]
+           └── CASE WHEN x:5 IS NOT NULL THEN array_agg:10 ELSE CAST(NULL AS INT8[]) END = ARRAY[] [outer=(5,10)]
 
 norm expect=TryDecorrelateScalarGroupBy
 SELECT * FROM a WHERE 'foo'=(SELECT concat_agg(y::string) FROM xy WHERE x=k)
@@ -2559,62 +2553,55 @@ project
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  └── select
-      ├── columns: k:1!null i:2 f:3 s:4 j:5 concat_agg:13!null
+      ├── columns: k:1!null i:2 f:3 s:4 j:5 canary:14 concat_agg:15
       ├── immutable
       ├── key: (1)
-      ├── fd: ()-->(13), (1)-->(2-5)
-      ├── project
-      │    ├── columns: concat_agg:13 k:1!null i:2 f:3 s:4 j:5
+      ├── fd: (1)-->(2-5,14,15)
+      ├── group-by (hash)
+      │    ├── columns: k:1!null i:2 f:3 s:4 j:5 canary:14 concat_agg:15
+      │    ├── grouping columns: k:1!null
       │    ├── immutable
       │    ├── key: (1)
-      │    ├── fd: (1)-->(2-5,13)
-      │    ├── group-by (hash)
-      │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 canary:14 concat_agg:15
-      │    │    ├── grouping columns: k:1!null
+      │    ├── fd: (1)-->(2-5,14,15)
+      │    ├── left-join (hash)
+      │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 x:8 column12:12 canary:14
+      │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
       │    │    ├── immutable
       │    │    ├── key: (1)
-      │    │    ├── fd: (1)-->(2-5,14,15)
-      │    │    ├── left-join (hash)
-      │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 x:8 column12:12 canary:14
-      │    │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
-      │    │    │    ├── immutable
+      │    │    ├── fd: (1)-->(2-5,8,12,14), (8)-->(12)
+      │    │    ├── scan a
+      │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
       │    │    │    ├── key: (1)
-      │    │    │    ├── fd: (1)-->(2-5,8,12,14), (8)-->(12)
-      │    │    │    ├── scan a
-      │    │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
-      │    │    │    │    ├── key: (1)
-      │    │    │    │    └── fd: (1)-->(2-5)
-      │    │    │    ├── project
-      │    │    │    │    ├── columns: canary:14!null column12:12 x:8!null
-      │    │    │    │    ├── immutable
+      │    │    │    └── fd: (1)-->(2-5)
+      │    │    ├── project
+      │    │    │    ├── columns: canary:14!null column12:12 x:8!null
+      │    │    │    ├── immutable
+      │    │    │    ├── key: (8)
+      │    │    │    ├── fd: ()-->(14), (8)-->(12)
+      │    │    │    ├── scan xy
+      │    │    │    │    ├── columns: x:8!null y:9
       │    │    │    │    ├── key: (8)
-      │    │    │    │    ├── fd: ()-->(14), (8)-->(12)
-      │    │    │    │    ├── scan xy
-      │    │    │    │    │    ├── columns: x:8!null y:9
-      │    │    │    │    │    ├── key: (8)
-      │    │    │    │    │    └── fd: (8)-->(9)
-      │    │    │    │    └── projections
-      │    │    │    │         ├── true [as=canary:14]
-      │    │    │    │         └── y:9::STRING [as=column12:12, outer=(9), immutable]
-      │    │    │    └── filters
-      │    │    │         └── x:8 = k:1 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
-      │    │    └── aggregations
-      │    │         ├── concat-agg [as=concat_agg:15, outer=(12)]
-      │    │         │    └── column12:12
-      │    │         ├── const-agg [as=i:2, outer=(2)]
-      │    │         │    └── i:2
-      │    │         ├── const-agg [as=f:3, outer=(3)]
-      │    │         │    └── f:3
-      │    │         ├── const-agg [as=s:4, outer=(4)]
-      │    │         │    └── s:4
-      │    │         ├── const-agg [as=j:5, outer=(5)]
-      │    │         │    └── j:5
-      │    │         └── any-not-null-agg [as=canary:14, outer=(14)]
-      │    │              └── canary:14
-      │    └── projections
-      │         └── CASE WHEN canary:14 IS NOT NULL THEN concat_agg:15 ELSE CAST(NULL AS STRING) END [as=concat_agg:13, outer=(14,15)]
+      │    │    │    │    └── fd: (8)-->(9)
+      │    │    │    └── projections
+      │    │    │         ├── true [as=canary:14]
+      │    │    │         └── y:9::STRING [as=column12:12, outer=(9), immutable]
+      │    │    └── filters
+      │    │         └── x:8 = k:1 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
+      │    └── aggregations
+      │         ├── concat-agg [as=concat_agg:15, outer=(12)]
+      │         │    └── column12:12
+      │         ├── const-agg [as=i:2, outer=(2)]
+      │         │    └── i:2
+      │         ├── const-agg [as=f:3, outer=(3)]
+      │         │    └── f:3
+      │         ├── const-agg [as=s:4, outer=(4)]
+      │         │    └── s:4
+      │         ├── const-agg [as=j:5, outer=(5)]
+      │         │    └── j:5
+      │         └── any-not-null-agg [as=canary:14, outer=(14)]
+      │              └── canary:14
       └── filters
-           └── concat_agg:13 = 'foo' [outer=(13), constraints=(/13: [/'foo' - /'foo']; tight), fd=()-->(13)]
+           └── CASE WHEN canary:14 IS NOT NULL THEN concat_agg:15 ELSE CAST(NULL AS STRING) END = 'foo' [outer=(14,15)]
 
 # With a multi-argument aggregate.
 norm expect=TryDecorrelateScalarGroupBy
@@ -4489,55 +4476,49 @@ project
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  └── select
-      ├── columns: k:1!null i:2 f:3 s:4 j:5 case:14
+      ├── columns: k:1!null i:2 f:3 s:4 j:5 bool_or:13
       ├── key: (1)
-      ├── fd: ()-->(14), (1)-->(2-5)
-      ├── project
-      │    ├── columns: case:14 k:1!null i:2 f:3 s:4 j:5
+      ├── fd: (1)-->(2-5,13)
+      ├── group-by (hash)
+      │    ├── columns: k:1!null i:2 f:3 s:4 j:5 bool_or:13
+      │    ├── grouping columns: k:1!null
       │    ├── key: (1)
-      │    ├── fd: (1)-->(2-5,14)
-      │    ├── group-by (hash)
-      │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 bool_or:13
-      │    │    ├── grouping columns: k:1!null
+      │    ├── fd: (1)-->(2-5,13)
+      │    ├── left-join (hash)
+      │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 x:8 y:9 notnull:12
+      │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
       │    │    ├── key: (1)
-      │    │    ├── fd: (1)-->(2-5,13)
-      │    │    ├── left-join (hash)
-      │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 x:8 y:9 notnull:12
-      │    │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+      │    │    ├── fd: (1)-->(2-5,8,9,12), (8)-->(9), (9)~~>(12)
+      │    │    ├── scan a
+      │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
       │    │    │    ├── key: (1)
-      │    │    │    ├── fd: (1)-->(2-5,8,9,12), (8)-->(9), (9)~~>(12)
-      │    │    │    ├── scan a
-      │    │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
-      │    │    │    │    ├── key: (1)
-      │    │    │    │    └── fd: (1)-->(2-5)
-      │    │    │    ├── project
-      │    │    │    │    ├── columns: notnull:12!null x:8!null y:9
+      │    │    │    └── fd: (1)-->(2-5)
+      │    │    ├── project
+      │    │    │    ├── columns: notnull:12!null x:8!null y:9
+      │    │    │    ├── key: (8)
+      │    │    │    ├── fd: (8)-->(9), (9)-->(12)
+      │    │    │    ├── scan xy
+      │    │    │    │    ├── columns: x:8!null y:9
       │    │    │    │    ├── key: (8)
-      │    │    │    │    ├── fd: (8)-->(9), (9)-->(12)
-      │    │    │    │    ├── scan xy
-      │    │    │    │    │    ├── columns: x:8!null y:9
-      │    │    │    │    │    ├── key: (8)
-      │    │    │    │    │    └── fd: (8)-->(9)
-      │    │    │    │    └── projections
-      │    │    │    │         └── y:9 IS NOT NULL [as=notnull:12, outer=(9)]
-      │    │    │    └── filters
-      │    │    │         ├── x:8 = k:1 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
-      │    │    │         └── (i:2 = y:9) IS NOT false [outer=(2,9)]
-      │    │    └── aggregations
-      │    │         ├── bool-or [as=bool_or:13, outer=(12)]
-      │    │         │    └── notnull:12
-      │    │         ├── const-agg [as=i:2, outer=(2)]
-      │    │         │    └── i:2
-      │    │         ├── const-agg [as=f:3, outer=(3)]
-      │    │         │    └── f:3
-      │    │         ├── const-agg [as=s:4, outer=(4)]
-      │    │         │    └── s:4
-      │    │         └── const-agg [as=j:5, outer=(5)]
-      │    │              └── j:5
-      │    └── projections
-      │         └── CASE WHEN bool_or:13 AND (i:2 IS NOT NULL) THEN true WHEN bool_or:13 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=case:14, outer=(2,13)]
+      │    │    │    │    └── fd: (8)-->(9)
+      │    │    │    └── projections
+      │    │    │         └── y:9 IS NOT NULL [as=notnull:12, outer=(9)]
+      │    │    └── filters
+      │    │         ├── x:8 = k:1 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
+      │    │         └── (i:2 = y:9) IS NOT false [outer=(2,9)]
+      │    └── aggregations
+      │         ├── bool-or [as=bool_or:13, outer=(12)]
+      │         │    └── notnull:12
+      │         ├── const-agg [as=i:2, outer=(2)]
+      │         │    └── i:2
+      │         ├── const-agg [as=f:3, outer=(3)]
+      │         │    └── f:3
+      │         ├── const-agg [as=s:4, outer=(4)]
+      │         │    └── s:4
+      │         └── const-agg [as=j:5, outer=(5)]
+      │              └── j:5
       └── filters
-           └── case:14 IS NULL [outer=(14), constraints=(/14: [/NULL - /NULL]; tight), fd=()-->(14)]
+           └── CASE WHEN bool_or:13 AND (i:2 IS NOT NULL) THEN true WHEN bool_or:13 IS NULL THEN false ELSE CAST(NULL AS BOOL) END IS NULL [outer=(2,13)]
 
 # Any with tuple comparison should use IS NOT NULL (i.e., IsTupleNotNull
 # expression) instead of IS DISTINCT FROM NULL.
@@ -5689,59 +5670,55 @@ SELECT j, y FROM a INNER JOIN xy ON x IN (SELECT v FROM uv WHERE u=y AND v=i) OR
 project
  ├── columns: j:5 y:9
  └── select
-      ├── columns: j:5 x:8!null y:9 case:18
-      ├── fd: (8)-->(9)
-      ├── project
-      │    ├── columns: case:18 j:5 x:8!null y:9
-      │    ├── fd: (8)-->(9)
-      │    ├── group-by (hash)
-      │    │    ├── columns: k:1!null j:5 x:8!null y:9 bool_or:17
-      │    │    ├── grouping columns: k:1!null x:8!null
+      ├── columns: k:1!null j:5 x:8!null y:9 bool_or:17
+      ├── key: (1,8)
+      ├── fd: (1)-->(5), (8)-->(9), (1,8)-->(5,9,17)
+      ├── group-by (hash)
+      │    ├── columns: k:1!null j:5 x:8!null y:9 bool_or:17
+      │    ├── grouping columns: k:1!null x:8!null
+      │    ├── key: (1,8)
+      │    ├── fd: (1)-->(5), (8)-->(9), (1,8)-->(5,9,17)
+      │    ├── left-join (hash)
+      │    │    ├── columns: k:1!null i:2 j:5 x:8!null y:9 u:12 v:13 notnull:16
+      │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
       │    │    ├── key: (1,8)
-      │    │    ├── fd: (1)-->(5), (8)-->(9), (1,8)-->(5,9,17)
-      │    │    ├── left-join (hash)
-      │    │    │    ├── columns: k:1!null i:2 j:5 x:8!null y:9 u:12 v:13 notnull:16
-      │    │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+      │    │    ├── fd: (1)-->(2,5), (8)-->(9), (12)-->(13), (13)~~>(16), (1,8)-->(12,13,16)
+      │    │    ├── inner-join (cross)
+      │    │    │    ├── columns: k:1!null i:2 j:5 x:8!null y:9
       │    │    │    ├── key: (1,8)
-      │    │    │    ├── fd: (1)-->(2,5), (8)-->(9), (12)-->(13), (13)~~>(16), (1,8)-->(12,13,16)
-      │    │    │    ├── inner-join (cross)
-      │    │    │    │    ├── columns: k:1!null i:2 j:5 x:8!null y:9
-      │    │    │    │    ├── key: (1,8)
-      │    │    │    │    ├── fd: (1)-->(2,5), (8)-->(9)
-      │    │    │    │    ├── scan a
-      │    │    │    │    │    ├── columns: k:1!null i:2 j:5
-      │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │    └── fd: (1)-->(2,5)
-      │    │    │    │    ├── scan xy
-      │    │    │    │    │    ├── columns: x:8!null y:9
-      │    │    │    │    │    ├── key: (8)
-      │    │    │    │    │    └── fd: (8)-->(9)
-      │    │    │    │    └── filters (true)
-      │    │    │    ├── project
-      │    │    │    │    ├── columns: notnull:16!null u:12!null v:13
+      │    │    │    ├── fd: (1)-->(2,5), (8)-->(9)
+      │    │    │    ├── scan a
+      │    │    │    │    ├── columns: k:1!null i:2 j:5
+      │    │    │    │    ├── key: (1)
+      │    │    │    │    └── fd: (1)-->(2,5)
+      │    │    │    ├── scan xy
+      │    │    │    │    ├── columns: x:8!null y:9
+      │    │    │    │    ├── key: (8)
+      │    │    │    │    └── fd: (8)-->(9)
+      │    │    │    └── filters (true)
+      │    │    ├── project
+      │    │    │    ├── columns: notnull:16!null u:12!null v:13
+      │    │    │    ├── key: (12)
+      │    │    │    ├── fd: (12)-->(13), (13)-->(16)
+      │    │    │    ├── scan uv
+      │    │    │    │    ├── columns: u:12!null v:13
       │    │    │    │    ├── key: (12)
-      │    │    │    │    ├── fd: (12)-->(13), (13)-->(16)
-      │    │    │    │    ├── scan uv
-      │    │    │    │    │    ├── columns: u:12!null v:13
-      │    │    │    │    │    ├── key: (12)
-      │    │    │    │    │    └── fd: (12)-->(13)
-      │    │    │    │    └── projections
-      │    │    │    │         └── v:13 IS NOT NULL [as=notnull:16, outer=(13)]
-      │    │    │    └── filters
-      │    │    │         ├── u:12 = y:9 [outer=(9,12), constraints=(/9: (/NULL - ]; /12: (/NULL - ]), fd=(9)==(12), (12)==(9)]
-      │    │    │         ├── v:13 = i:2 [outer=(2,13), constraints=(/2: (/NULL - ]; /13: (/NULL - ]), fd=(2)==(13), (13)==(2)]
-      │    │    │         └── (x:8 = v:13) IS NOT false [outer=(8,13)]
-      │    │    └── aggregations
-      │    │         ├── bool-or [as=bool_or:17, outer=(16)]
-      │    │         │    └── notnull:16
-      │    │         ├── const-agg [as=y:9, outer=(9)]
-      │    │         │    └── y:9
-      │    │         └── const-agg [as=j:5, outer=(5)]
-      │    │              └── j:5
-      │    └── projections
-      │         └── CASE WHEN bool_or:17 AND (x:8 IS NOT NULL) THEN true WHEN bool_or:17 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=case:18, outer=(8,17)]
+      │    │    │    │    └── fd: (12)-->(13)
+      │    │    │    └── projections
+      │    │    │         └── v:13 IS NOT NULL [as=notnull:16, outer=(13)]
+      │    │    └── filters
+      │    │         ├── u:12 = y:9 [outer=(9,12), constraints=(/9: (/NULL - ]; /12: (/NULL - ]), fd=(9)==(12), (12)==(9)]
+      │    │         ├── v:13 = i:2 [outer=(2,13), constraints=(/2: (/NULL - ]; /13: (/NULL - ]), fd=(2)==(13), (13)==(2)]
+      │    │         └── (x:8 = v:13) IS NOT false [outer=(8,13)]
+      │    └── aggregations
+      │         ├── bool-or [as=bool_or:17, outer=(16)]
+      │         │    └── notnull:16
+      │         ├── const-agg [as=y:9, outer=(9)]
+      │         │    └── y:9
+      │         └── const-agg [as=j:5, outer=(5)]
+      │              └── j:5
       └── filters
-           └── case:18 OR (x:8 IS NULL) [outer=(8,18)]
+           └── CASE WHEN bool_or:17 AND (x:8 IS NOT NULL) THEN true WHEN bool_or:17 IS NULL THEN false ELSE CAST(NULL AS BOOL) END OR (x:8 IS NULL) [outer=(8,17)]
 
 # Regression test for #130398. Do not include columns from the RHS of the
 # semi-join when constructin the Project expression. The opt directive is used

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -581,6 +581,25 @@ project
  └── projections
       └── (k:1 <= 1) OR (k:1 > 5) [as=expr:8, outer=(1)]
 
+# Inline case expressions.
+norm expect=PushSelectIntoInlinableProject
+SELECT * FROM (SELECT CASE WHEN k>0 THEN f>0 WHEN k<0 THEN f<0 ELSE false END AS expr FROM a) a WHERE expr
+----
+project
+ ├── columns: expr:8
+ ├── select
+ │    ├── columns: k:1!null f:3
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(3)
+ │    ├── scan a
+ │    │    ├── columns: k:1!null f:3
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(3)
+ │    └── filters
+ │         └── CASE WHEN k:1 > 0 THEN f:3 > 0.0 WHEN k:1 < 0 THEN f:3 < 0.0 ELSE false END [outer=(1,3)]
+ └── projections
+      └── CASE WHEN k:1 > 0 THEN f:3 > 0.0 WHEN k:1 < 0 THEN f:3 < 0.0 ELSE false END [as=expr:8, outer=(1,3)]
+
 # Inline constants.
 norm expect=PushSelectIntoInlinableProject
 SELECT * FROM (SELECT (f IS NULL OR f != 10.5) AS expr FROM a) a WHERE expr

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -1780,6 +1780,272 @@ select
  └── filters
       └── a:2 IS NOT DISTINCT FROM d:5 [outer=(2,5)]
 
+
+# --------------------------------------------------
+# EliminateCaseTrailingFalsyBranch
+# --------------------------------------------------
+
+norm expect=EliminateCaseTrailingFalsyBranch
+SELECT k FROM a WHERE CASE WHEN i > 0 THEN f > 0 WHEN s = 'foo' THEN false END
+----
+project
+ ├── columns: k:1!null
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null i:2 f:3
+      ├── key: (1)
+      ├── fd: (1)-->(2,3)
+      ├── scan a
+      │    ├── columns: k:1!null i:2 f:3
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2,3)
+      └── filters
+           └── CASE WHEN i:2 > 0 THEN f:3 > 0.0 ELSE CAST(NULL AS BOOL) END [outer=(2,3)]
+
+norm expect=EliminateCaseTrailingFalsyBranch
+SELECT k FROM a WHERE CASE WHEN i > 0 THEN f > 0 WHEN s = 'foo' THEN false ELSE false END
+----
+project
+ ├── columns: k:1!null
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null i:2 f:3
+      ├── key: (1)
+      ├── fd: (1)-->(2,3)
+      ├── scan a
+      │    ├── columns: k:1!null i:2 f:3
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2,3)
+      └── filters
+           └── CASE WHEN i:2 > 0 THEN f:3 > 0.0 ELSE false END [outer=(2,3)]
+
+norm expect=EliminateCaseTrailingFalsyBranch
+SELECT k FROM a WHERE CASE WHEN i > 0 THEN f > 0 WHEN s = 'foo' THEN NULL ELSE NULL END
+----
+project
+ ├── columns: k:1!null
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null i:2 f:3
+      ├── key: (1)
+      ├── fd: (1)-->(2,3)
+      ├── scan a
+      │    ├── columns: k:1!null i:2 f:3
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2,3)
+      └── filters
+           └── CASE WHEN i:2 > 0 THEN f:3 > 0.0 ELSE CAST(NULL AS BOOL) END [outer=(2,3)]
+
+norm expect-not=EliminateCaseTrailingFalsyBranch
+SELECT k FROM a WHERE CASE WHEN s = 'foo' THEN false ELSE false END
+----
+project
+ ├── columns: k:1!null
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null s:4
+      ├── key: (1)
+      ├── fd: (1)-->(4)
+      ├── scan a
+      │    ├── columns: k:1!null s:4
+      │    ├── key: (1)
+      │    └── fd: (1)-->(4)
+      └── filters
+           └── CASE WHEN s:4 = 'foo' THEN false ELSE false END [outer=(4)]
+
+norm expect-not=EliminateCaseTrailingFalsyBranch
+SELECT k FROM a WHERE CASE WHEN i > 0 THEN f > 0 WHEN s = 'foo' THEN false ELSE true END
+----
+project
+ ├── columns: k:1!null
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null i:2 f:3 s:4
+      ├── key: (1)
+      ├── fd: (1)-->(2-4)
+      ├── scan a
+      │    ├── columns: k:1!null i:2 f:3 s:4
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2-4)
+      └── filters
+           └── CASE WHEN i:2 > 0 THEN f:3 > 0.0 WHEN s:4 = 'foo' THEN false ELSE true END [outer=(2-4)]
+
+norm expect-not=EliminateCaseTrailingFalsyBranch
+SELECT k FROM a WHERE CASE WHEN i > 0 THEN f > 0 WHEN s = 'foo' THEN false ELSE s = 'bar' END
+----
+project
+ ├── columns: k:1!null
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null i:2 f:3 s:4
+      ├── key: (1)
+      ├── fd: (1)-->(2-4)
+      ├── scan a
+      │    ├── columns: k:1!null i:2 f:3 s:4
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2-4)
+      └── filters
+           └── CASE WHEN i:2 > 0 THEN f:3 > 0.0 WHEN s:4 = 'foo' THEN false ELSE s:4 = 'bar' END [outer=(2-4)]
+
+norm expect-not=EliminateCaseTrailingFalsyBranch
+SELECT k FROM a WHERE CASE WHEN i > 0 THEN f > 0 WHEN s = 'foo' THEN false WHEN s = 'bar' THEN true END
+----
+project
+ ├── columns: k:1!null
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null i:2 f:3 s:4
+      ├── key: (1)
+      ├── fd: (1)-->(2-4)
+      ├── scan a
+      │    ├── columns: k:1!null i:2 f:3 s:4
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2-4)
+      └── filters
+           └── CASE WHEN i:2 > 0 THEN f:3 > 0.0 WHEN s:4 = 'foo' THEN false WHEN s:4 = 'bar' THEN true ELSE CAST(NULL AS BOOL) END [outer=(2-4)]
+
+norm expect-not=EliminateCaseTrailingFalsyBranch
+SELECT k FROM a WHERE CASE s = 'baz' WHEN i > 0 THEN f > 0 WHEN s = 'foo' THEN false END
+----
+project
+ ├── columns: k:1!null
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null i:2 f:3 s:4
+      ├── key: (1)
+      ├── fd: (1)-->(2-4)
+      ├── scan a
+      │    ├── columns: k:1!null i:2 f:3 s:4
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2-4)
+      └── filters
+           └── CASE s:4 = 'baz' WHEN i:2 > 0 THEN f:3 > 0.0 WHEN s:4 = 'foo' THEN false ELSE CAST(NULL AS BOOL) END [outer=(2-4)]
+
+
+# --------------------------------------------------
+# SimplifyCaseSingleTruthyBranch
+# --------------------------------------------------
+
+norm expect=SimplifyCaseSingleTruthyBranch
+SELECT k FROM a WHERE CASE WHEN i > 0 THEN true END
+----
+project
+ ├── columns: k:1!null
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null i:2!null
+      ├── key: (1)
+      ├── fd: (1)-->(2)
+      ├── scan a
+      │    ├── columns: k:1!null i:2
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2)
+      └── filters
+           └── i:2 > 0 [outer=(2), constraints=(/2: [/1 - ]; tight)]
+
+norm expect=SimplifyCaseSingleTruthyBranch
+SELECT k FROM a WHERE CASE WHEN i > 0 THEN true ELSE false END
+----
+project
+ ├── columns: k:1!null
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null i:2!null
+      ├── key: (1)
+      ├── fd: (1)-->(2)
+      ├── scan a
+      │    ├── columns: k:1!null i:2
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2)
+      └── filters
+           └── i:2 > 0 [outer=(2), constraints=(/2: [/1 - ]; tight)]
+
+norm expect=SimplifyCaseSingleTruthyBranch
+SELECT k FROM a WHERE CASE WHEN i > 0 THEN true ELSE NULL END
+----
+project
+ ├── columns: k:1!null
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null i:2!null
+      ├── key: (1)
+      ├── fd: (1)-->(2)
+      ├── scan a
+      │    ├── columns: k:1!null i:2
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2)
+      └── filters
+           └── i:2 > 0 [outer=(2), constraints=(/2: [/1 - ]; tight)]
+
+norm expect-not=SimplifyCaseSingleTruthyBranch
+SELECT k FROM a WHERE CASE WHEN i > 0 THEN true ELSE true END
+----
+project
+ ├── columns: k:1!null
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null i:2
+      ├── key: (1)
+      ├── fd: (1)-->(2)
+      ├── scan a
+      │    ├── columns: k:1!null i:2
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2)
+      └── filters
+           └── CASE WHEN i:2 > 0 THEN true ELSE true END [outer=(2)]
+
+norm expect-not=SimplifyCaseSingleTruthyBranch
+SELECT k FROM a WHERE CASE WHEN i > 0 THEN true ELSE f > 0 END
+----
+project
+ ├── columns: k:1!null
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null i:2 f:3
+      ├── key: (1)
+      ├── fd: (1)-->(2,3)
+      ├── scan a
+      │    ├── columns: k:1!null i:2 f:3
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2,3)
+      └── filters
+           └── CASE WHEN i:2 > 0 THEN true ELSE f:3 > 0.0 END [outer=(2,3)]
+
+norm expect-not=SimplifyCaseSingleTruthyBranch
+SELECT k FROM a WHERE CASE WHEN i > 0 THEN true WHEN f > 0 THEN true END
+----
+project
+ ├── columns: k:1!null
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null i:2 f:3
+      ├── key: (1)
+      ├── fd: (1)-->(2,3)
+      ├── scan a
+      │    ├── columns: k:1!null i:2 f:3
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2,3)
+      └── filters
+           └── CASE WHEN i:2 > 0 THEN true WHEN f:3 > 0.0 THEN true ELSE CAST(NULL AS BOOL) END [outer=(2,3)]
+
+norm expect-not=SimplifyCaseSingleTruthyBranch
+SELECT k FROM a WHERE CASE s = 'baz' WHEN i > 0 THEN true END
+----
+project
+ ├── columns: k:1!null
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null i:2 s:4
+      ├── key: (1)
+      ├── fd: (1)-->(2,4)
+      ├── scan a
+      │    ├── columns: k:1!null i:2 s:4
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2,4)
+      └── filters
+           └── CASE s:4 = 'baz' WHEN i:2 > 0 THEN true ELSE CAST(NULL AS BOOL) END [outer=(2,4)]
+
+
 # --------------------------------------------------
 # PushSelectIntoProjectSet
 # --------------------------------------------------

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -1839,19 +1839,11 @@ project
 norm expect-not=EliminateCaseTrailingFalsyBranch
 SELECT k FROM a WHERE CASE WHEN s = 'foo' THEN false ELSE false END
 ----
-project
+values
  ├── columns: k:1!null
- ├── key: (1)
- └── select
-      ├── columns: k:1!null s:4
-      ├── key: (1)
-      ├── fd: (1)-->(4)
-      ├── scan a
-      │    ├── columns: k:1!null s:4
-      │    ├── key: (1)
-      │    └── fd: (1)-->(4)
-      └── filters
-           └── CASE WHEN s:4 = 'foo' THEN false ELSE false END [outer=(4)]
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1)
 
 norm expect-not=EliminateCaseTrailingFalsyBranch
 SELECT k FROM a WHERE CASE WHEN i > 0 THEN f > 0 WHEN s = 'foo' THEN false ELSE true END
@@ -1920,6 +1912,106 @@ project
       │    └── fd: (1)-->(2-4)
       └── filters
            └── CASE s:4 = 'baz' WHEN i:2 > 0 THEN f:3 > 0.0 WHEN s:4 = 'foo' THEN false ELSE CAST(NULL AS BOOL) END [outer=(2-4)]
+
+
+# --------------------------------------------------
+# SimplifyCaseSingleFalsyBranch
+# --------------------------------------------------
+
+norm expect=SimplifyCaseSingleFalsyBranch
+SELECT k FROM a WHERE CASE WHEN i > 0 THEN false END
+----
+values
+ ├── columns: k:1!null
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1)
+
+norm expect=SimplifyCaseSingleFalsyBranch
+SELECT k FROM a WHERE CASE WHEN i > 0 THEN false ELSE false END
+----
+values
+ ├── columns: k:1!null
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1)
+
+norm expect=SimplifyCaseSingleFalsyBranch
+SELECT k FROM a WHERE CASE WHEN i > 0 THEN NULL ELSE NULL END
+----
+values
+ ├── columns: k:1!null
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1)
+
+norm expect-not=SimplifyCaseSingleFalsyBranch
+SELECT k FROM a WHERE CASE WHEN i > 0 THEN NULL ELSE true END
+----
+project
+ ├── columns: k:1!null
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null i:2
+      ├── key: (1)
+      ├── fd: (1)-->(2)
+      ├── scan a
+      │    ├── columns: k:1!null i:2
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2)
+      └── filters
+           └── CASE WHEN i:2 > 0 THEN CAST(NULL AS BOOL) ELSE true END [outer=(2)]
+
+norm expect-not=SimplifyCaseSingleFalsyBranch
+SELECT k FROM a WHERE CASE WHEN i > 0 THEN NULL ELSE f > 0 END
+----
+project
+ ├── columns: k:1!null
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null i:2 f:3
+      ├── key: (1)
+      ├── fd: (1)-->(2,3)
+      ├── scan a
+      │    ├── columns: k:1!null i:2 f:3
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2,3)
+      └── filters
+           └── CASE WHEN i:2 > 0 THEN CAST(NULL AS BOOL) ELSE f:3 > 0.0 END [outer=(2,3)]
+
+norm expect-not=SimplifyCaseSingleFalsyBranch
+SELECT k FROM a WHERE CASE WHEN i > 0 THEN false WHEN f > 0 THEN true END
+----
+project
+ ├── columns: k:1!null
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null i:2 f:3
+      ├── key: (1)
+      ├── fd: (1)-->(2,3)
+      ├── scan a
+      │    ├── columns: k:1!null i:2 f:3
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2,3)
+      └── filters
+           └── CASE WHEN i:2 > 0 THEN false WHEN f:3 > 0.0 THEN true ELSE CAST(NULL AS BOOL) END [outer=(2,3)]
+
+norm expect-not=SimplifyCaseSingleFalsyBranch
+SELECT k FROM a WHERE CASE s = 'baz' WHEN i > 0 THEN false END
+----
+project
+ ├── columns: k:1!null
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null i:2 s:4
+      ├── key: (1)
+      ├── fd: (1)-->(2,4)
+      ├── scan a
+      │    ├── columns: k:1!null i:2 s:4
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2,4)
+      └── filters
+           └── CASE s:4 = 'baz' WHEN i:2 > 0 THEN false ELSE CAST(NULL AS BOOL) END [outer=(2,4)]
 
 
 # --------------------------------------------------

--- a/pkg/sql/opt/norm/testdata/rules/udf
+++ b/pkg/sql/opt/norm/testdata/rules/udf
@@ -52,3 +52,122 @@ values
  ├── fd: ()-->(5)
  └── tuple
       └── const: 1
+
+# Regression test for #160475. An IN-subquery built as a complicated expression
+# with a group-by and left-join should be simplifiable into a group-by with an
+# inner-join.
+exec-ddl
+CREATE TABLE t160475 (
+  a INT,
+  b INT,
+  c INT,
+  INDEX (a, b),
+  FAMILY (a, b, c)
+)
+----
+
+exec-ddl
+CREATE OR REPLACE FUNCTION f160475(x INT, y INT[]) RETURNS INT LANGUAGE SQL AS $$
+  SELECT c FROM t160475 WHERE a = x AND b IN (SELECT unnest(y))
+$$
+----
+
+norm format=show-scalars
+SELECT f160475(33, ARRAY[44, 55]::INT[])
+----
+values
+ ├── columns: f160475:13
+ ├── cardinality: [1 - 1]
+ ├── volatile
+ ├── key: ()
+ ├── fd: ()-->(13)
+ └── tuple
+      └── udf: f160475
+           ├── args
+           │    ├── const: 33
+           │    └── const: ARRAY[44,55]
+           ├── params: x:1 y:2
+           └── body
+                └── project
+                     ├── columns: c:5
+                     ├── outer: (1,2)
+                     ├── cardinality: [0 - 1]
+                     ├── immutable
+                     ├── key: ()
+                     ├── fd: ()-->(5)
+                     └── limit
+                          ├── columns: a:3!null c:5 rowid:6!null bool_or:11!null
+                          ├── outer: (1,2)
+                          ├── cardinality: [0 - 1]
+                          ├── immutable
+                          ├── key: ()
+                          ├── fd: ()-->(3,5,6,11)
+                          ├── select
+                          │    ├── columns: a:3!null c:5 rowid:6!null bool_or:11!null
+                          │    ├── outer: (1,2)
+                          │    ├── immutable
+                          │    ├── key: (6)
+                          │    ├── fd: ()-->(3,11), (6)-->(5)
+                          │    ├── group-by (hash)
+                          │    │    ├── columns: a:3 c:5 rowid:6!null bool_or:11!null
+                          │    │    ├── grouping columns: rowid:6!null
+                          │    │    ├── outer: (2)
+                          │    │    ├── immutable
+                          │    │    ├── key: (6)
+                          │    │    ├── fd: (6)-->(3,5,11)
+                          │    │    ├── project
+                          │    │    │    ├── columns: notnull:10!null a:3 c:5 rowid:6!null
+                          │    │    │    ├── outer: (2)
+                          │    │    │    ├── immutable
+                          │    │    │    ├── fd: (6)-->(3,5)
+                          │    │    │    ├── inner-join (cross)
+                          │    │    │    │    ├── columns: a:3 b:4!null c:5 rowid:6!null unnest:9
+                          │    │    │    │    ├── outer: (2)
+                          │    │    │    │    ├── immutable
+                          │    │    │    │    ├── fd: (6)-->(3-5)
+                          │    │    │    │    ├── select
+                          │    │    │    │    │    ├── columns: a:3 b:4!null c:5 rowid:6!null
+                          │    │    │    │    │    ├── key: (6)
+                          │    │    │    │    │    ├── fd: (6)-->(3-5)
+                          │    │    │    │    │    ├── scan t160475
+                          │    │    │    │    │    │    ├── columns: a:3 b:4 c:5 rowid:6!null
+                          │    │    │    │    │    │    ├── key: (6)
+                          │    │    │    │    │    │    └── fd: (6)-->(3-5)
+                          │    │    │    │    │    └── filters
+                          │    │    │    │    │         └── is-not [outer=(4), constraints=(/4: (/NULL - ]; tight)]
+                          │    │    │    │    │              ├── variable: b:4
+                          │    │    │    │    │              └── null
+                          │    │    │    │    ├── project-set
+                          │    │    │    │    │    ├── columns: unnest:9
+                          │    │    │    │    │    ├── outer: (2)
+                          │    │    │    │    │    ├── immutable
+                          │    │    │    │    │    ├── values
+                          │    │    │    │    │    │    ├── cardinality: [1 - 1]
+                          │    │    │    │    │    │    ├── key: ()
+                          │    │    │    │    │    │    └── tuple
+                          │    │    │    │    │    └── zip
+                          │    │    │    │    │         └── function: unnest [outer=(2), immutable]
+                          │    │    │    │    │              └── variable: y:2
+                          │    │    │    │    └── filters
+                          │    │    │    │         └── is-not [outer=(4,9)]
+                          │    │    │    │              ├── eq
+                          │    │    │    │              │    ├── variable: b:4
+                          │    │    │    │              │    └── variable: unnest:9
+                          │    │    │    │              └── false
+                          │    │    │    └── projections
+                          │    │    │         └── is-not [as=notnull:10, outer=(9)]
+                          │    │    │              ├── variable: unnest:9
+                          │    │    │              └── null
+                          │    │    └── aggregations
+                          │    │         ├── bool-or [as=bool_or:11, outer=(10)]
+                          │    │         │    └── variable: notnull:10
+                          │    │         ├── const-agg [as=a:3, outer=(3)]
+                          │    │         │    └── variable: a:3
+                          │    │         └── const-agg [as=c:5, outer=(5)]
+                          │    │              └── variable: c:5
+                          │    └── filters
+                          │         ├── eq [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+                          │         │    ├── variable: a:3
+                          │         │    └── variable: x:1
+                          │         └── variable: bool_or:11 [outer=(11), constraints=(/11: [/true - /true]; tight), fd=()-->(11)]
+                          └── const: 1


### PR DESCRIPTION
#### opt: better optimize ANY/IN subqueries within routines

An ANY/IN subquery within a routine is built into a complicated
expression with a group-by and left-join (see `ConstructGroupByAny`).
Prior to this commit, the left-join could not be planned as a lookup
join because the lookup table is on the LHS of the left-join and the
left-join could not be reordered.

This commit adds and updates normalization rules so that null-rejecting
filters can convert the left-join into an inner-join, allowing a
lookup-join to be built after the join is reordered.

Fixes #160475

Release note (performance improvement): The optimizer now better
optimizes query plans of statements within UDFs and stored procedures
that have IN subqueries.

#### opt: add SimplifyCaseSingleFalsyBranch normalization rule

`SimplifyCaseSingleFalsyBranch` replaces a CASE expression in a filter
with a falsy ELSE branch when it has a single WHEN branch that evaluates
to False or Null. For example:

    SELECT * FROM abc WHERE CASE WHEN a > 1 THEN false ELSE false END
    =>
    SELECT * FROM abc WHERE false

Release note: None
