### PR TITLE
release-24.1: workflows: add `maybe_stressrace` to GHA Extended CI

### DIFF
--- a/.github/workflows/github-actions-extended-ci.yml
+++ b/.github/workflows/github-actions-extended-ci.yml
@@ -1,7 +1,7 @@
 name: GitHub Actions Extended CI
 on:
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, ready_for_review, reopened, synchronize]
     branches:
       - "master"
       - "release-*"
@@ -46,6 +46,33 @@ jobs:
       - run: ./build/github/prepare-summarize-build.sh
       - name: run tests
         run: ./build/github/maybe-stress.sh ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }}
+      - name: upload build results
+        run: ./build/github/summarize-build.sh bes.bin
+        if: always()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: clean up
+        run: ./build/github/cleanup-engflow-keys.sh
+        if: always()
+  maybe_stressrace:
+    if: github.event.pull_request.draft == false
+    runs-on: [self-hosted, ubuntu_2004]
+    timeout-minutes: 180
+    steps:
+      - name: calculate commit depth
+        run: echo COMMIT_DEPTH=$(echo '${{ github.event.pull_request.commits }} + 1' | bc) >> "$GITHUB_ENV"
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          fetch-depth: ${{ env.COMMIT_DEPTH }}
+      - name: Fetch the base commit
+        run: git fetch origin ${{ github.event.pull_request.base.sha }} --depth 100
+      - name: compute metadata
+        run: echo GITHUB_ACTIONS_BRANCH=${{ github.event.pull_request.number || github.ref_name}} >> "$GITHUB_ENV"
+      - run: ./build/github/get-engflow-keys.sh
+      - run: ./build/github/prepare-summarize-build.sh
+      - name: run tests
+        run: ./build/github/maybe-stressrace.sh ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }}
       - name: upload build results
         run: ./build/github/summarize-build.sh bes.bin
         if: always()

--- a/build/github/maybe-stress-impl.sh
+++ b/build/github/maybe-stress-impl.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+set -euxo pipefail
+
+usage() {
+    echo 'Usage: maybe-stress-impl.sh BASESHA HEADSHA [stress|race]'
+}
+
+if [ -z "$1" ]
+then
+    usage
+    exit 1
+fi
+
+if [ -z "$2" ]
+then
+    usage
+    exit 1
+fi
+
+case "$3" in
+    stress)
+        ;;
+    race)
+        ;;
+    *)
+	usage
+	exit 1
+	;;
+esac
+
+bazel build --config crosslinux //pkg/cmd/ci-stress \
+      --jobs 50 $(./build/github/engflow-args.sh)
+
+BASESHA="$1"
+HEADSHA="$2"
+
+EXTRA_ARGS=
+
+if [ "$3" = race ]
+then
+    EXTRA_ARGS="--config race"
+fi
+
+set +e
+MERGEBASE=$(git merge-base $BASESHA $HEADSHA)
+set -e
+if [ -z "$MERGEBASE" ]
+then
+    echo 'Could not calculate merge base. You may have to rebase your in-progress PR.'
+    exit 1
+fi
+
+# NB: These jobs will run at a lower priority to ensure that the Essential CI
+# jobs (required to merge) will be minimally impacted.
+$(bazel info bazel-bin --config=crosslinux)/pkg/cmd/ci-stress/ci-stress_/ci-stress \
+    $MERGEBASE --config crosslinux --jobs 100 $EXTRA_ARGS \
+    --remote_execution_priority=-1 \
+    --remote_download_minimal \
+    --bes_keywords ci-stress --config=use_ci_timeouts \
+    --build_event_binary_file=bes.bin \
+    $(./build/github/engflow-args.sh)

--- a/build/github/maybe-stressrace.sh
+++ b/build/github/maybe-stressrace.sh
@@ -11,14 +11,14 @@ set -euxo pipefail
 
 if [ -z "$1" ]
 then
-    echo 'Usage: maybe-stress.sh BASESHA HEADSHA'
+    echo 'Usage: maybe-stressrace.sh BASESHA HEADSHA'
     exit 1
 fi
 
 if [ -z "$2" ]
 then
-    echo 'Usage: maybe-stress.sh BASESHA HEADSHA'
+    echo 'Usage: maybe-stressrace.sh BASESHA HEADSHA'
     exit 1
 fi
 
-./build/github/maybe-stress-impl.sh $1 $2 stress
+./build/github/maybe-stress-impl.sh $1 $2 race


### PR DESCRIPTION
Backport 1/1 commits from #160501 on behalf of @rickystewart.

----

This is meant to (eventually) replace `maybe_stressrace` in Bazel Extended CI in TeamCity.

Part of: DEVINF-1640
Release note: none
Epic: DEVINF-1582

----

Release justification: Non-production code changes