### PR TITLE
coldata: optimize allocations for JSONs

### DIFF
--- a/pkg/col/coldata/json.go
+++ b/pkg/col/coldata/json.go
@@ -15,7 +15,7 @@ import (
 
 // JSONs is a representation of columnar JSON data. It's simply a wrapper around
 // the flat Bytes structure. To pull a JSON out of the structure, we construct
-// a new "encodedJSON" object from scratch on demand.
+// a new JSONEncoded object from scratch on demand.
 type JSONs struct {
 	Bytes
 	// scratch is a scratch space for encoding a JSON object on demand.

--- a/pkg/col/coldata/vec.go
+++ b/pkg/col/coldata/vec.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/json"
 )
 
 // Column is an interface that represents a raw array of a Go native type.
@@ -160,11 +161,14 @@ func (cf *defaultColumnFactory) MakeColumns(columns []Column, t *types.T, length
 		}
 	case types.JsonFamily:
 		alloc := make([]element, allocLength)
+		jsonScratchAlloc := make([]json.JSONEncoded, allocLength)
 		wrapperAlloc := make([]JSONs, len(columns))
 		for i := range columns {
 			wrapperAlloc[i].elements = alloc[:length:length]
+			wrapperAlloc[i].jsonScratch = jsonScratchAlloc[:length:length]
 			columns[i] = &wrapperAlloc[i]
 			alloc = alloc[length:]
+			jsonScratchAlloc = jsonScratchAlloc[length:]
 		}
 	default:
 		panic(fmt.Sprintf("StandardColumnFactory doesn't support %s", t))

--- a/pkg/col/colserde/arrowbatchconverter.go
+++ b/pkg/col/colserde/arrowbatchconverter.go
@@ -424,7 +424,7 @@ func (c *ArrowBatchConverter) ArrowToBatch(
 
 		case types.JsonFamily:
 			valueBytes, offsets := getValueBytesAndOffsets(d, vec.Nulls(), batchLength)
-			vec.JSON().Bytes.Deserialize(valueBytes, offsets)
+			vec.JSON().Deserialize(valueBytes, offsets)
 
 		case types.DecimalFamily:
 			// TODO(yuzefovich): this serialization is quite inefficient - improve

--- a/pkg/sql/colexec/execgen/cmd/execgen/vec_to_datum_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/vec_to_datum_gen.go
@@ -74,14 +74,15 @@ var vecToDatumConversionTmpls = map[types.Family]string{
 						%[1]s := %[3]s.NewDEncodedKey(tree.DEncodedKey(%[2]s))`,
 	types.JsonFamily: `
             // The following operation deliberately copies the input JSON
-            // bytes, since FromEncoding is lazy and keeps a handle on the bytes
-            // it is passed in.
+            // bytes, since FromEncodingInto is lazy and keeps a handle on the
+            // bytes it is passed in.
             _bytes, _err := json.EncodeJSON(nil, %[2]s)
             if _err != nil {
                 colexecerror.ExpectedError(_err)
             }
-            var _j json.JSON
-            _j, _err = json.FromEncoding(_bytes)
+            _j := &jsonScratch[0]
+            jsonScratch = jsonScratch[1:]
+            _err = json.FromEncodingInto(_bytes, _j)
             if _err != nil {
                 colexecerror.ExpectedError(_err)
             }

--- a/pkg/sql/colexec/materializer_test.go
+++ b/pkg/sql/colexec/materializer_test.go
@@ -109,6 +109,7 @@ func BenchmarkMaterializer(b *testing.B) {
 		{"int", []*types.T{types.Int}},
 		{"float", []*types.T{types.Float}},
 		{"bytes", []*types.T{types.Bytes}},
+		{"json", []*types.T{types.Json}},
 		{"int6", []*types.T{types.Int, types.Int, types.Int, types.Int, types.Int, types.Int}},
 		{"string4", []*types.T{types.String, types.String, types.String, types.String}},
 		{"multi80", []*types.T{

--- a/pkg/util/json/contains_testers.go
+++ b/pkg/util/json/contains_testers.go
@@ -94,7 +94,7 @@ func (j jsonObject) slowContains(other JSON) bool {
 	return false
 }
 
-func (j *jsonEncoded) slowContains(other JSON) bool {
+func (j *JSONEncoded) slowContains(other JSON) bool {
 	return j.mustDecode().(containsTester).slowContains(other)
 }
 
@@ -144,6 +144,6 @@ func (j jsonObject) subdocument(_ bool, rng *rand.Rand) JSON {
 	return result
 }
 
-func (j *jsonEncoded) subdocument(isRoot bool, rng *rand.Rand) JSON {
+func (j *JSONEncoded) subdocument(isRoot bool, rng *rand.Rand) JSON {
 	return j.mustDecode().(containsTester).subdocument(isRoot, rng)
 }

--- a/pkg/util/json/encode.go
+++ b/pkg/util/json/encode.go
@@ -205,7 +205,14 @@ func DecodeJSON(b []byte) ([]byte, JSON, error) {
 
 // FromEncoding returns a JSON value which is lazily decoded.
 func FromEncoding(b []byte) (JSON, error) {
-	return newEncodedFromRoot(b)
+	var jsonEncoded JSONEncoded
+	return &jsonEncoded, FromEncodingInto(b, &jsonEncoded)
+}
+
+// FromEncodingInto updates the given JSONEncoded value with lazily-decoded
+// JSON value.
+func FromEncodingInto(b []byte, jsonEncoded *JSONEncoded) error {
+	return jsonEncoded.fromRoot(b)
 }
 
 func decodeJSONArray(containerHeader uint32, b []byte) ([]byte, JSON, error) {

--- a/pkg/util/json/encoded.go
+++ b/pkg/util/json/encoded.go
@@ -18,7 +18,7 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-type jsonEncoded struct {
+type JSONEncoded struct {
 	// containerLength is only set if this is an object or an array.
 	containerLen int
 	typ          Type
@@ -36,12 +36,12 @@ type jsonEncoded struct {
 	}
 }
 
-const jsonEncodedSize = unsafe.Sizeof(jsonEncoded{})
+const jsonEncodedSize = unsafe.Sizeof(JSONEncoded{})
 
-// alreadyDecoded returns a decoded JSON value if this jsonEncoded has already
+// alreadyDecoded returns a decoded JSON value if this JSONEncoded has already
 // been decoded, otherwise it returns nil. This allows us to fast-path certain
 // operations if we've already done the work of decoding an object.
-func (j *jsonEncoded) alreadyDecoded() JSON {
+func (j *JSONEncoded) alreadyDecoded() JSON {
 	j.mu.RLock()
 	defer j.mu.RUnlock()
 	if j.mu.cachedDecoded != nil {
@@ -50,12 +50,12 @@ func (j *jsonEncoded) alreadyDecoded() JSON {
 	return nil
 }
 
-func (j *jsonEncoded) Type() Type {
+func (j *JSONEncoded) Type() Type {
 	return j.typ
 }
 
-// newEncodedFromRoot returns a jsonEncoded from a fully-encoded JSON document.
-func newEncodedFromRoot(v []byte) (*jsonEncoded, error) {
+// newEncodedFromRoot returns a JSONEncoded from a fully-encoded JSON document.
+func newEncodedFromRoot(v []byte) (*JSONEncoded, error) {
 	v, typ, err := jsonTypeFromRootBuffer(v)
 	if err != nil {
 		return nil, err
@@ -70,7 +70,7 @@ func newEncodedFromRoot(v []byte) (*jsonEncoded, error) {
 		containerLen = int(containerHeader & containerHeaderLenMask)
 	}
 
-	return &jsonEncoded{
+	return &JSONEncoded{
 		typ:          typ,
 		containerLen: containerLen,
 		// Manually set the capacity of the new slice to its length, so we properly
@@ -122,7 +122,7 @@ func newEncoded(e jEntry, v []byte) (JSON, error) {
 		typ = StringJSONType
 	case numberTag:
 		typ = NumberJSONType
-	case nullTag: // Don't bother with returning a jsonEncoded for the singleton types.
+	case nullTag: // Don't bother with returning a JSONEncoded for the singleton types.
 		return NullJSONValue, nil
 	case falseTag:
 		return FalseJSONValue, nil
@@ -143,7 +143,7 @@ func newEncoded(e jEntry, v []byte) (JSON, error) {
 		containerLen = int(containerHeader & containerHeaderLenMask)
 	}
 
-	return &jsonEncoded{
+	return &JSONEncoded{
 		typ:          typ,
 		containerLen: containerLen,
 		value:        v,
@@ -190,7 +190,7 @@ func (e *encodedArrayIterator) nextEncoded() (nextJEntry jEntry, next []byte, ok
 
 // iterArrayValues iterates through all the values of an encoded array without
 // requiring decoding of all of them.
-func (j *jsonEncoded) iterArrayValues() encodedArrayIterator {
+func (j *JSONEncoded) iterArrayValues() encodedArrayIterator {
 	if j.typ != ArrayJSONType {
 		panic("can only iterate through the array values of an array")
 	}
@@ -249,7 +249,7 @@ func (e *encodedObjectIterator) nextEncoded() (
 
 // iterObject iterates through all the keys and values of an encoded object
 // without requiring decoding of all of them.
-func (j *jsonEncoded) iterObject() (encodedObjectIterator, error) {
+func (j *JSONEncoded) iterObject() (encodedObjectIterator, error) {
 	if j.typ != ObjectJSONType {
 		panic("can only iterate through the object values of an object")
 	}
@@ -277,7 +277,7 @@ func (j *jsonEncoded) iterObject() (encodedObjectIterator, error) {
 	}, nil
 }
 
-func (j *jsonEncoded) StripNulls() (JSON, bool, error) {
+func (j *JSONEncoded) StripNulls() (JSON, bool, error) {
 	dec, err := j.shallowDecode()
 	if err != nil {
 		return nil, false, err
@@ -285,7 +285,7 @@ func (j *jsonEncoded) StripNulls() (JSON, bool, error) {
 	return dec.StripNulls()
 }
 
-func (j *jsonEncoded) ObjectIter() (*ObjectIterator, error) {
+func (j *JSONEncoded) ObjectIter() (*ObjectIterator, error) {
 	dec, err := j.shallowDecode()
 	if err != nil {
 		return nil, err
@@ -293,12 +293,12 @@ func (j *jsonEncoded) ObjectIter() (*ObjectIterator, error) {
 	return dec.ObjectIter()
 }
 
-func (j *jsonEncoded) nthJEntry(n int, off int) (jEntry, error) {
+func (j *JSONEncoded) nthJEntry(n int, off int) (jEntry, error) {
 	return getJEntryAt(j.value, containerHeaderLen+n*jEntryLen, off)
 }
 
 // objectGetDataRange returns the [begin, end) subslice of the object's data.
-func (j *jsonEncoded) objectGetDataRange(begin, end int) []byte {
+func (j *JSONEncoded) objectGetDataRange(begin, end int) []byte {
 	dataStart := containerHeaderLen + j.containerLen*jEntryLen*2
 	return j.value[dataStart+begin : dataStart+end]
 }
@@ -306,7 +306,7 @@ func (j *jsonEncoded) objectGetDataRange(begin, end int) []byte {
 // getNthEntryBounds returns the beginning, ending, and JEntry of the nth entry
 // in the container. If the container is an object, the i-th entry is the i-th
 // key, and the (i+length)-th entry is the i-th value.
-func (j *jsonEncoded) getNthEntryBounds(n int) (begin, end int, entry jEntry, err error) {
+func (j *JSONEncoded) getNthEntryBounds(n int) (begin, end int, entry jEntry, err error) {
 	// First, we seek for the beginning of the current entry by stepping
 	// backwards via beginningOfIdx.
 	begin, err = j.beginningOfIdx(n)
@@ -326,7 +326,7 @@ func (j *jsonEncoded) getNthEntryBounds(n int) (begin, end int, entry jEntry, er
 // objectGetNthDataRange returns the byte subslice and jEntry of the given nth entry.
 // If the container is an object, the i-th entry is the i-th key, and the
 // (i+length)-th entry is the i-th value.
-func (j *jsonEncoded) objectGetNthDataRange(n int) ([]byte, jEntry, error) {
+func (j *JSONEncoded) objectGetNthDataRange(n int) ([]byte, jEntry, error) {
 	begin, end, entry, err := j.getNthEntryBounds(n)
 	if err != nil {
 		return nil, jEntry{}, err
@@ -336,7 +336,7 @@ func (j *jsonEncoded) objectGetNthDataRange(n int) ([]byte, jEntry, error) {
 
 // objectNthValue returns the nth value in the sorted-by-key representation of
 // the object.
-func (j *jsonEncoded) objectNthValue(n int) (JSON, error) {
+func (j *JSONEncoded) objectNthValue(n int) (JSON, error) {
 	data, entry, err := j.objectGetNthDataRange(j.containerLen + n)
 	if err != nil {
 		return nil, err
@@ -349,7 +349,7 @@ func parseJEntry(jEntry uint32) (isOff bool, offlen int) {
 }
 
 // beginningOfIdx finds the offset to the beginning of the given entry.
-func (j *jsonEncoded) beginningOfIdx(idx int) (int, error) {
+func (j *JSONEncoded) beginningOfIdx(idx int) (int, error) {
 	if idx == 0 {
 		return 0, nil
 	}
@@ -373,12 +373,12 @@ func (j *jsonEncoded) beginningOfIdx(idx int) (int, error) {
 	return offset, nil
 }
 
-func (j *jsonEncoded) arrayGetDataRange(begin, end int) []byte {
+func (j *JSONEncoded) arrayGetDataRange(begin, end int) []byte {
 	dataStart := containerHeaderLen + j.containerLen*jEntryLen
 	return j.value[dataStart+begin : dataStart+end]
 }
 
-func (j *jsonEncoded) FetchValIdx(idx int) (JSON, error) {
+func (j *JSONEncoded) FetchValIdx(idx int) (JSON, error) {
 	if dec := j.alreadyDecoded(); dec != nil {
 		return dec.FetchValIdx(idx)
 	}
@@ -410,7 +410,7 @@ func (j *jsonEncoded) FetchValIdx(idx int) (JSON, error) {
 	}
 }
 
-func (j *jsonEncoded) FetchValKey(key string) (JSON, error) {
+func (j *JSONEncoded) FetchValKey(key string) (JSON, error) {
 	if dec := j.alreadyDecoded(); dec != nil {
 		return dec.FetchValKey(key)
 	}
@@ -456,7 +456,7 @@ func (j *jsonEncoded) FetchValKey(key string) (JSON, error) {
 // shallowDecode decodes only the keys of an object, and doesn't decode any
 // elements of an array. It can be used to save a decode-encode cycle for
 // certain operations (say, key deletion).
-func (j *jsonEncoded) shallowDecode() (JSON, error) {
+func (j *JSONEncoded) shallowDecode() (JSON, error) {
 	if dec := j.alreadyDecoded(); dec != nil {
 		return dec, nil
 	}
@@ -509,7 +509,7 @@ func (j *jsonEncoded) shallowDecode() (JSON, error) {
 	}
 }
 
-func (j *jsonEncoded) mustDecode() JSON {
+func (j *JSONEncoded) mustDecode() JSON {
 	decoded, err := j.shallowDecode()
 	if err != nil {
 		panic(errors.NewAssertionErrorWithWrappedErrf(err, "invalid JSON data: %v", j.value))
@@ -519,7 +519,7 @@ func (j *jsonEncoded) mustDecode() JSON {
 
 // decode should be used in cases where you will definitely have to use the
 // entire decoded JSON structure, like printing it out to a string.
-func (j *jsonEncoded) decode() (JSON, error) {
+func (j *JSONEncoded) decode() (JSON, error) {
 	switch j.typ {
 	case NumberJSONType:
 		_, j, err := decodeJSONNumber(j.value)
@@ -542,7 +542,7 @@ func (j *jsonEncoded) decode() (JSON, error) {
 	return decoded, err
 }
 
-func (j *jsonEncoded) AsText() (*string, error) {
+func (j *JSONEncoded) AsText() (*string, error) {
 	if dec := j.alreadyDecoded(); dec != nil {
 		return dec.AsText()
 	}
@@ -554,7 +554,7 @@ func (j *jsonEncoded) AsText() (*string, error) {
 	return decoded.AsText()
 }
 
-func (j *jsonEncoded) AsDecimal() (*apd.Decimal, bool) {
+func (j *JSONEncoded) AsDecimal() (*apd.Decimal, bool) {
 	if dec := j.alreadyDecoded(); dec != nil {
 		return dec.AsDecimal()
 	}
@@ -566,7 +566,7 @@ func (j *jsonEncoded) AsDecimal() (*apd.Decimal, bool) {
 	return decoded.AsDecimal()
 }
 
-func (j *jsonEncoded) AsBool() (bool, bool) {
+func (j *JSONEncoded) AsBool() (bool, bool) {
 	if dec := j.alreadyDecoded(); dec != nil {
 		return dec.AsBool()
 	}
@@ -578,7 +578,7 @@ func (j *jsonEncoded) AsBool() (bool, bool) {
 	return decoded.AsBool()
 }
 
-func (j *jsonEncoded) AsArray() ([]JSON, bool) {
+func (j *JSONEncoded) AsArray() ([]JSON, bool) {
 	if dec := j.alreadyDecoded(); dec != nil {
 		return dec.AsArray()
 	}
@@ -589,7 +589,7 @@ func (j *jsonEncoded) AsArray() ([]JSON, bool) {
 	return decoded.AsArray()
 }
 
-func (j *jsonEncoded) Compare(other JSON) (_ int, err error) {
+func (j *JSONEncoded) Compare(other JSON) (_ int, err error) {
 	if other == nil {
 		return -1, nil
 	}
@@ -615,7 +615,7 @@ func (j *jsonEncoded) Compare(other JSON) (_ int, err error) {
 	return dec.Compare(other)
 }
 
-func (j *jsonEncoded) Exists(key string) (bool, error) {
+func (j *JSONEncoded) Exists(key string) (bool, error) {
 	if dec := j.alreadyDecoded(); dec != nil {
 		return dec.Exists(key)
 	}
@@ -642,15 +642,15 @@ func (j *jsonEncoded) Exists(key string) (bool, error) {
 				return false, err
 			}
 			// This is a minor optimization - we know that newEncoded always returns a
-			// jsonEncoded if it's decoding a string, and we can save actually
+			// JSONEncoded if it's decoding a string, and we can save actually
 			// allocating that string for this check by not forcing a decode into a
 			// jsonString.  This operates on two major assumptions:
-			// 1. newEncoded returns a jsonEncoded (and not a jsonString) for string
+			// 1. newEncoded returns a JSONEncoded (and not a jsonString) for string
 			// types and
-			// 2. the `value` field on such a jsonEncoded directly corresponds to the string.
+			// 2. the `value` field on such a JSONEncoded directly corresponds to the string.
 			// This is tested sufficiently that if either of those assumptions is
 			// broken it will be caught.
-			if next.Type() == StringJSONType && string(next.(*jsonEncoded).value) == key {
+			if next.Type() == StringJSONType && string(next.(*JSONEncoded).value) == key {
 				return true, nil
 			}
 		}
@@ -663,7 +663,7 @@ func (j *jsonEncoded) Exists(key string) (bool, error) {
 	}
 }
 
-func (j *jsonEncoded) FetchValKeyOrIdx(key string) (JSON, error) {
+func (j *JSONEncoded) FetchValKeyOrIdx(key string) (JSON, error) {
 	switch j.typ {
 	case ObjectJSONType:
 		return j.FetchValKey(key)
@@ -681,7 +681,7 @@ func (j *jsonEncoded) FetchValKeyOrIdx(key string) (JSON, error) {
 }
 
 // RemoveIndex implements the JSON interface.
-func (j *jsonEncoded) RemoveIndex(idx int) (JSON, bool, error) {
+func (j *JSONEncoded) RemoveIndex(idx int) (JSON, bool, error) {
 	decoded, err := j.shallowDecode()
 	if err != nil {
 		return nil, false, err
@@ -690,7 +690,7 @@ func (j *jsonEncoded) RemoveIndex(idx int) (JSON, bool, error) {
 }
 
 // Concat implements the JSON interface.
-func (j *jsonEncoded) Concat(other JSON) (JSON, error) {
+func (j *JSONEncoded) Concat(other JSON) (JSON, error) {
 	decoded, err := j.shallowDecode()
 	if err != nil {
 		return nil, err
@@ -699,7 +699,7 @@ func (j *jsonEncoded) Concat(other JSON) (JSON, error) {
 }
 
 // RemoveString implements the JSON interface.
-func (j *jsonEncoded) RemoveString(s string) (JSON, bool, error) {
+func (j *JSONEncoded) RemoveString(s string) (JSON, bool, error) {
 	decoded, err := j.shallowDecode()
 	if err != nil {
 		return nil, false, err
@@ -707,7 +707,7 @@ func (j *jsonEncoded) RemoveString(s string) (JSON, bool, error) {
 	return decoded.RemoveString(s)
 }
 
-func (j *jsonEncoded) RemovePath(path []string) (JSON, bool, error) {
+func (j *JSONEncoded) RemovePath(path []string) (JSON, bool, error) {
 	decoded, err := j.shallowDecode()
 	if err != nil {
 		return nil, false, err
@@ -715,7 +715,7 @@ func (j *jsonEncoded) RemovePath(path []string) (JSON, bool, error) {
 	return decoded.RemovePath(path)
 }
 
-func (j *jsonEncoded) doRemovePath(path []string) (JSON, bool, error) {
+func (j *JSONEncoded) doRemovePath(path []string) (JSON, bool, error) {
 	decoded, err := j.shallowDecode()
 	if err != nil {
 		return nil, false, err
@@ -724,22 +724,22 @@ func (j *jsonEncoded) doRemovePath(path []string) (JSON, bool, error) {
 }
 
 // Size implements the JSON interface.
-func (j *jsonEncoded) Size() uintptr {
+func (j *JSONEncoded) Size() uintptr {
 	return jsonEncodedSize + uintptr(cap(j.value))
 }
 
-func (j *jsonEncoded) String() string {
+func (j *JSONEncoded) String() string {
 	var buf bytes.Buffer
 	j.Format(&buf)
 	return buf.String()
 }
 
 // isScalar implements the JSON interface.
-func (j *jsonEncoded) isScalar() bool {
+func (j *JSONEncoded) isScalar() bool {
 	return j.typ != ArrayJSONType && j.typ != ObjectJSONType
 }
 
-func (j *jsonEncoded) Len() int {
+func (j *JSONEncoded) Len() int {
 	if j.typ != ArrayJSONType && j.typ != ObjectJSONType {
 		return 0
 	}
@@ -747,7 +747,7 @@ func (j *jsonEncoded) Len() int {
 }
 
 // EncodeForwardIndex implements the JSON interface.
-func (j *jsonEncoded) EncodeForwardIndex(buf []byte, dir encoding.Direction) ([]byte, error) {
+func (j *JSONEncoded) EncodeForwardIndex(buf []byte, dir encoding.Direction) ([]byte, error) {
 	decoded, err := j.decode()
 	if err != nil {
 		return nil, err
@@ -756,7 +756,7 @@ func (j *jsonEncoded) EncodeForwardIndex(buf []byte, dir encoding.Direction) ([]
 }
 
 // EncodeInvertedIndexKeys implements the JSON interface.
-func (j *jsonEncoded) EncodeInvertedIndexKeys(b []byte) ([][]byte, error) {
+func (j *JSONEncoded) EncodeInvertedIndexKeys(b []byte) ([][]byte, error) {
 	// TODO(justin): this could possibly be optimized.
 	decoded, err := j.decode()
 	if err != nil {
@@ -765,7 +765,7 @@ func (j *jsonEncoded) EncodeInvertedIndexKeys(b []byte) ([][]byte, error) {
 	return decoded.EncodeInvertedIndexKeys(b)
 }
 
-func (j *jsonEncoded) encodeContainingInvertedIndexSpans(
+func (j *JSONEncoded) encodeContainingInvertedIndexSpans(
 	b []byte, isRoot, isObjectValue bool,
 ) (inverted.Expression, error) {
 	decoded, err := j.decode()
@@ -775,7 +775,7 @@ func (j *jsonEncoded) encodeContainingInvertedIndexSpans(
 	return decoded.encodeContainingInvertedIndexSpans(b, isRoot, isObjectValue)
 }
 
-func (j *jsonEncoded) encodeContainedInvertedIndexSpans(
+func (j *JSONEncoded) encodeContainedInvertedIndexSpans(
 	b []byte, isRoot, isObjectValue bool,
 ) (inverted.Expression, error) {
 	decoded, err := j.decode()
@@ -786,7 +786,7 @@ func (j *jsonEncoded) encodeContainedInvertedIndexSpans(
 }
 
 // numInvertedIndexEntries implements the JSON interface.
-func (j *jsonEncoded) numInvertedIndexEntries() (int, error) {
+func (j *JSONEncoded) numInvertedIndexEntries() (int, error) {
 	if j.isScalar() || j.containerLen == 0 {
 		return 1, nil
 	}
@@ -797,7 +797,7 @@ func (j *jsonEncoded) numInvertedIndexEntries() (int, error) {
 	return decoded.numInvertedIndexEntries()
 }
 
-func (j *jsonEncoded) allPaths() ([]JSON, error) {
+func (j *JSONEncoded) allPaths() ([]JSON, error) {
 	decoded, err := j.decode()
 	if err != nil {
 		return nil, err
@@ -806,7 +806,7 @@ func (j *jsonEncoded) allPaths() ([]JSON, error) {
 }
 
 // HasContainerLeaf implements the JSON interface.
-func (j *jsonEncoded) HasContainerLeaf() (bool, error) {
+func (j *JSONEncoded) HasContainerLeaf() (bool, error) {
 	decoded, err := j.decode()
 	if err != nil {
 		return false, err
@@ -815,7 +815,7 @@ func (j *jsonEncoded) HasContainerLeaf() (bool, error) {
 }
 
 // preprocessForContains implements the JSON interface.
-func (j *jsonEncoded) preprocessForContains() (containsable, error) {
+func (j *JSONEncoded) preprocessForContains() (containsable, error) {
 	if dec := j.alreadyDecoded(); dec != nil {
 		return dec.preprocessForContains()
 	}
@@ -828,7 +828,7 @@ func (j *jsonEncoded) preprocessForContains() (containsable, error) {
 }
 
 // jEntry implements the JSON interface.
-func (j *jsonEncoded) jEntry() jEntry {
+func (j *JSONEncoded) jEntry() jEntry {
 	var typeTag uint32
 	switch j.typ {
 	case NullJSONType:
@@ -849,17 +849,17 @@ func (j *jsonEncoded) jEntry() jEntry {
 }
 
 // encode implements the JSON interface.
-func (j *jsonEncoded) encode(appendTo []byte) (jEntry jEntry, b []byte, err error) {
+func (j *JSONEncoded) encode(appendTo []byte) (jEntry jEntry, b []byte, err error) {
 	return j.jEntry(), append(appendTo, j.value...), nil
 }
 
 // MaybeDecode implements the JSON interface.
-func (j *jsonEncoded) MaybeDecode() JSON {
+func (j *JSONEncoded) MaybeDecode() JSON {
 	return j.mustDecode()
 }
 
 // toGoRepr implements the JSON interface.
-func (j *jsonEncoded) toGoRepr() (interface{}, error) {
+func (j *JSONEncoded) toGoRepr() (interface{}, error) {
 	decoded, err := j.shallowDecode()
 	if err != nil {
 		return nil, err
@@ -868,6 +868,6 @@ func (j *jsonEncoded) toGoRepr() (interface{}, error) {
 }
 
 // tryDecode implements the JSON interface.
-func (j *jsonEncoded) tryDecode() (JSON, error) {
+func (j *JSONEncoded) tryDecode() (JSON, error) {
 	return j.shallowDecode()
 }

--- a/pkg/util/json/encoded_format.go
+++ b/pkg/util/json/encoded_format.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-func (j *jsonEncoded) Format(buf *bytes.Buffer) {
+func (j *JSONEncoded) Format(buf *bytes.Buffer) {
 	// We don't know exactly how big the JSON string will be when decoded and
 	// formatted, but we can make a reasonable guess based on the size of the
 	// encoded data. This can avoid some buffer reallocations in the common case.
@@ -26,7 +26,7 @@ func (j *jsonEncoded) Format(buf *bytes.Buffer) {
 	}
 }
 
-func (j *jsonEncoded) format(buf *bytes.Buffer) error {
+func (j *JSONEncoded) format(buf *bytes.Buffer) error {
 	switch j.typ {
 	case NumberJSONType:
 		_, d, err := decodeJSONNumber(j.value)

--- a/pkg/util/json/json.go
+++ b/pkg/util/json/json.go
@@ -216,14 +216,14 @@ type JSON interface {
 	// JEntry.
 	encode(appendTo []byte) (jEntry jEntry, b []byte, err error)
 
-	// MaybeDecode returns an equivalent JSON which is not a jsonEncoded.
+	// MaybeDecode returns an equivalent JSON which is not a JSONEncoded.
 	MaybeDecode() JSON
 
 	// toGoRepr returns the Go-style representation of this JSON value
 	// (map[string]interface{} for objects, etc.).
 	toGoRepr() (interface{}, error)
 
-	// tryDecode returns an equivalent JSON which is not a jsonEncoded, returning
+	// tryDecode returns an equivalent JSON which is not a JSONEncoded, returning
 	// an error if the encoded data was corrupt.
 	tryDecode() (JSON, error)
 
@@ -668,7 +668,7 @@ func (j jsonTrue) Compare(other JSON) (int, error) {
 }
 
 func decodeIfNeeded(j JSON) (JSON, error) {
-	if enc, ok := j.(*jsonEncoded); ok {
+	if enc, ok := j.(*JSONEncoded); ok {
 		var err error
 		j, err = enc.decode()
 		if err != nil {
@@ -1524,7 +1524,7 @@ func isEnd(json JSON) bool {
 			end = false
 		}
 
-	case *jsonEncoded:
+	case *JSONEncoded:
 		switch t.typ {
 		case ArrayJSONType, ObjectJSONType:
 			if t.containerLen != 0 {
@@ -1546,7 +1546,7 @@ func emptyJSONForType(json JSON) JSON {
 	case jsonObject:
 		return emptyJSONObject
 
-	case *jsonEncoded:
+	case *JSONEncoded:
 		switch t.typ {
 		case ArrayJSONType:
 			return emptyJSONArray
@@ -2161,7 +2161,7 @@ var errCannotSetPathInScalar = pgerror.WithCandidateCode(errors.New("cannot set 
 // * if the provided index points to after the end of the array, `to` is appended to the array.
 func setValKeyOrIdx(j JSON, key string, to JSON, createMissing bool) (JSON, error) {
 	switch v := j.(type) {
-	case *jsonEncoded:
+	case *JSONEncoded:
 		n, err := v.shallowDecode()
 		if err != nil {
 			return nil, err
@@ -2217,7 +2217,7 @@ func deepSet(j JSON, path []string, to JSON, createMissing bool) (JSON, error) {
 		return setValKeyOrIdx(j, path[0], to, createMissing)
 	default:
 		switch v := j.(type) {
-		case *jsonEncoded:
+		case *JSONEncoded:
 			n, err := v.shallowDecode()
 			if err != nil {
 				return nil, err
@@ -2244,7 +2244,7 @@ var errCannotReplaceExistingKey = pgerror.WithCandidateCode(errors.New("cannot r
 
 func insertValKeyOrIdx(j JSON, key string, newVal JSON, insertAfter bool) (JSON, error) {
 	switch v := j.(type) {
-	case *jsonEncoded:
+	case *JSONEncoded:
 		n, err := v.shallowDecode()
 		if err != nil {
 			return nil, err
@@ -2305,7 +2305,7 @@ func deepInsert(j JSON, path []string, to JSON, insertAfter bool) (JSON, error) 
 		return insertValKeyOrIdx(j, path[0], to, insertAfter)
 	default:
 		switch v := j.(type) {
-		case *jsonEncoded:
+		case *JSONEncoded:
 			n, err := v.shallowDecode()
 			if err != nil {
 				return nil, err
@@ -2591,7 +2591,7 @@ func (j jsonArray) Exists(s string) (bool, error) {
 			if string(elem) == s {
 				return true, nil
 			}
-		case *jsonEncoded:
+		case *JSONEncoded:
 			if elem.typ == StringJSONType && string(elem.value) == s {
 				return true, nil
 			}

--- a/pkg/util/json/json_test.go
+++ b/pkg/util/json/json_test.go
@@ -502,7 +502,7 @@ func TestJSONSize(t *testing.T) {
 					t.Fatal(err)
 				}
 				if encodedFromLargeBuf.Size() != encoded.Size() {
-					t.Errorf("expected jsonEncoded on a large buf for %v to have size %d, found %d", j, encoded.Size(), encodedFromLargeBuf.Size())
+					t.Errorf("expected JSONEncoded on a large buf for %v to have size %d, found %d", j, encoded.Size(), encodedFromLargeBuf.Size())
 				}
 			})
 		})


### PR DESCRIPTION
**util/json: export jsonEncoded implementation**

This will be used in the follow-up commit to reduce the number of allocations.

**coldata: optimize allocations for JSONs**

Previously, every `JSONs.Get` call resulted in a separate allocation of `JSONEncoded` object that was filled in with the encoding. This commit takes advantage of the fact that `JSONEncoded` implementation being exported and now pre-allocates the scratch slice for the whole JSON vector. (This behavior is ok given that we are ok reusing memory at the batch granularity, so if the caller wants to keep the json object they received from `Get`, they must make a copy.) Minor changes were needed to the json library itself to accommodate this. Similarly, we now pre-allocate the json scratch space when converting from columnar format to the Datum format (after possible adjusting for the NULL count).

Epic: None
Release note: None