### PR TITLE
roachtest: disable all jepsen tests in IBM

### DIFF
--- a/pkg/cmd/roachtest/tests/jepsen.go
+++ b/pkg/cmd/roachtest/tests/jepsen.go
@@ -499,7 +499,7 @@ func registerJepsen(r registry.Registry) {
 				// if they detect that the machines have already been properly
 				// initialized.
 				Cluster:          r.MakeClusterSpec(6, spec.ReuseTagged("jepsen")),
-				CompatibleClouds: registry.AllExceptAWS,
+				CompatibleClouds: registry.AllClouds.NoAWS().NoIBM(),
 				Suites:           registry.Suites(registry.Nightly),
 				Leases:           registry.MetamorphicLeases,
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {


### PR DESCRIPTION
Due to high rate of infra flake in IBM cloud due to jepsen, disabling them for now.

Epic: none
Fixes: #160500

Release note: None