### PR TITLE
sql: unskip TestWriteResumeSpan, TestDropDatabaseDeleteData, TestAbortedTxnLocks, and TestBackfillQueryWithProtectedTS for mulitenant

### DIFF
--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -1749,9 +1749,7 @@ func TestAbortedTxnLocks(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
-	srv := serverutils.StartServerOnly(t, base.TestServerArgs{
-		DefaultTestTenant: base.TestDoesNotWorkWithSecondaryTenantsButWeDontKnowWhyYet(156127),
-	})
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer srv.Stopper().Stop(ctx)
 	s := srv.ApplicationLayer()
 


### PR DESCRIPTION
###  rowexec: fix TestWriteResumeSpan to work with external test tenants #160528 

Previously, TestWriteResumeSpan used raw key literals like roachpb.Key("a") without tenant prefixes.

This commit adds a makeKey helper function that prepends the tenant prefix to keys, following the same pattern already used in TestResumeSpanSSTManifestRoundTrip.

###  sql: fix TestDropDatabaseDeleteData to work with external test tenants

The test was failing with a "sync: negative WaitGroup counter" panic
when running with COCKROACH_TEST_TENANT=true. This happened because the
OnWatchForZoneConfigUpdatesEstablished callback was being invoked
multiple times (once for the system tenant and once for the test
tenant), causing zoneCfgRangeFeedStarted.Done() to be called more than
once on a WaitGroup that only had Add(1).

The fix uses sync.Once to ensure Done() is only called once, regardless
of how many times the callback is invoked.

### sql: unskip TestAbortedTxnLocks for tenants

This passed without any other changes.

### sql: fix TestBackfillQueryWithProtectedTS to work with external test tenants

The test was failing with tenants because `crdb_internal.kv_enqueue_replica`
is not supported in virtual clusters. The fix queries range IDs from the
tenant connection (since the table is in the tenant), then executes
`kv_enqueue_replica` through the system layer connection, matching the
pattern already used in `TestValidationWithProtectedTS` in the same file.

fixes #156127
Release note: None