### PR TITLE
cli: SAN based startup flag for root and node user

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -982,6 +982,28 @@ debuguser should only be enabled when necessary and disabled when not in use.
 `,
 	}
 
+	RootCertSAN = FlagInfo{
+		Name: "root-cert-san",
+		Description: `
+A string of comma separated list of subject-alternate-name
+<attribute-type>=<attribute-value> mappings for the root
+user. This strictly needs to match the SAN in the client certificate
+provided for root user if this flag is set. Attribute type can be DNS, IP or URI.
+The entire list mentioned here is matched against the SANs in the certificate.
+`,
+	}
+
+	NodeCertSAN = FlagInfo{
+		Name: "node-cert-san",
+		Description: `
+A string of comma separated list of subject-alternate-name
+<attribute-type>=<attribute-value> mappings for the node
+user. This strictly needs to match the SAN in the client certificate
+provided for node user if this flag is set. Attribute type can be DNS, IP or URI.
+The entire list mentioned here is matched against the SANs in the certificate.
+`,
+	}
+
 	TLSCipherSuites = FlagInfo{
 		Name: "tls-cipher-suites",
 		Description: `

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -489,6 +489,8 @@ var startCtx struct {
 	serverTLSCipherSuites  []string
 	disallowRootLogin      bool
 	allowDebugUser         bool
+	serverRootCertSAN      string
+	serverNodeCertSAN      string
 
 	// The TLS auto-handshake parameters.
 	initToken             string
@@ -546,6 +548,8 @@ func setStartContextDefaults() {
 	startCtx.serverNodeCertDN = ""
 	startCtx.disallowRootLogin = false
 	startCtx.allowDebugUser = false
+	startCtx.serverRootCertSAN = ""
+	startCtx.serverNodeCertSAN = ""
 	startCtx.serverListenAddr = ""
 	startCtx.unencryptedLocalhostHTTP = false
 	startCtx.tempDir = ""

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -581,6 +581,12 @@ func init() {
 		// TLS Cipher Suites configured
 		cliflagcfg.StringSliceFlag(f, &startCtx.serverTLSCipherSuites, cliflags.TLSCipherSuites)
 
+		// Root cert subject alternate name (SAN)
+		cliflagcfg.StringFlag(f, &startCtx.serverRootCertSAN, cliflags.RootCertSAN)
+
+		// Node cert subject alternate name (SAN)
+		cliflagcfg.StringFlag(f, &startCtx.serverNodeCertSAN, cliflags.NodeCertSAN)
+
 		// Cluster name verification.
 		cliflagcfg.VarFlag(f, clusterNameSetter{&baseCfg.ClusterName}, cliflags.ClusterName)
 		cliflagcfg.BoolFlag(f, &baseCfg.DisableClusterNameVerification, cliflags.DisableClusterNameVerification)
@@ -666,6 +672,12 @@ func init() {
 
 		// Node cert distinguished name
 		cliflagcfg.StringFlag(f, &startCtx.serverNodeCertDN, cliflags.NodeCertDistinguishedName)
+
+		// Root cert subject alternate name (SAN)
+		cliflagcfg.StringFlag(f, &startCtx.serverRootCertSAN, cliflags.RootCertSAN)
+
+		// Node cert subject alternate name (SAN)
+		cliflagcfg.StringFlag(f, &startCtx.serverNodeCertSAN, cliflags.NodeCertSAN)
 
 		if cmd == listCertsCmd {
 			// The 'list' subcommand does not write to files and thus does
@@ -1169,6 +1181,12 @@ func extraServerFlagInit(cmd *cobra.Command) error {
 	}
 	security.SetDisallowRootLogin(startCtx.disallowRootLogin)
 	security.SetAllowDebugUser(startCtx.allowDebugUser)
+	if err := security.SetRootSAN(startCtx.serverRootCertSAN); err != nil {
+		return err
+	}
+	if err := security.SetNodeSAN(startCtx.serverNodeCertSAN); err != nil {
+		return err
+	}
 	// Currently we don't handle the case where we are setting the --insecure flag
 	// as well as providing the --tls-cipher-suites, we should probably error out
 	// if both are set, issue: #144935.


### PR DESCRIPTION
* Add server startup flags --root-cert-san and --node-cert-san.
* These flags will be used to set the SAN attr. values for root and node users to authenticate,
since identity map doesn't support mapping to
reserved users.
* Added validation and setter functions for appropriate SAN values, storing them in
SAN:<attr-name>:<attr-value> format.
* SAN based startup flags will be used when the customer mandates the use of SAN across all users, since identity mapping doesn't allow mapping to root/node/reserved users.

Epic: CRDB-58371

Release note: None