### PR TITLE
cli: change default tsdump format to raw and add --destination flag

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1602,6 +1602,7 @@ func init() {
 
 	f = debugTimeSeriesDumpCmd.Flags()
 	f.Var(&debugTimeSeriesDumpOpts.format, "format", "output format (text, csv, tsv, raw, openmetrics)")
+	f.StringVarP(&debugTimeSeriesDumpOpts.output, "output", "o", "", "output file path; writes output to file instead of stdout")
 	f.Var(&debugTimeSeriesDumpOpts.from, "from", "oldest timestamp to include (inclusive)")
 	f.Var(&debugTimeSeriesDumpOpts.to, "to", "newest timestamp to include (inclusive)")
 	f.StringVar(&debugTimeSeriesDumpOpts.clusterLabel, "cluster-label",


### PR DESCRIPTION
Previously, the `cockroach debug tsdump` command defaulted to text format output and required shell redirection (>) to write to a file.

This change:
1. Updates the default format from text to raw (gob), which is optimized for Datadog ingestion.

2. Adds a `--output` flag to write output directly to a file. This avoids potential file corruption issues that can occur with shell redirection.

Output defaults to stdout if `--output` is not specified.

Epic: [CRDB-56325](https://cockroachlabs.atlassian.net/browse/CRDB-56325)
Part-of: [CRDB-53706](https://cockroachlabs.atlassian.net/browse/CRDB-53706)
Release note (cli change): The `cockroach debug tsdump` command now defaults to `--format=raw` instead of `--format=text`. A new `--output` flag allows writing output directly to a file.