### PR TITLE
kvserver: simplify split/replicate trace tests

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -391,6 +391,7 @@ go_test(
         "store_test.go",
         "stores_test.go",
         "testutils_test.go",
+        "trace_collection_test.go",
         "ts_maintenance_queue_test.go",
         "txn_recovery_integration_test.go",
         "txn_wait_queue_test.go",

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -49,9 +49,15 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
+
+// FilterTracingSpans exposes filterTracingSpans for testing.
+func FilterTracingSpans(rec tracingpb.Recording, opNamesToFilter ...string) tracingpb.Recording {
+	return filterTracingSpans(rec, opNamesToFilter...)
+}
 
 func (s *Store) Transport() *RaftTransport {
 	return s.cfg.Transport

--- a/pkg/kv/kvserver/trace_collection_test.go
+++ b/pkg/kv/kvserver/trace_collection_test.go
@@ -1,0 +1,89 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package kvserver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithTraceCollection(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	tr := tracing.NewTracer()
+
+	t.Run("recordVerbose=true returns recording", func(t *testing.T) {
+		result, rec, err := withTraceCollection(ctx, tr, "test-span", true,
+			func(ctx context.Context) (bool, error) {
+				sp := tracing.SpanFromContext(ctx)
+				require.NotNil(t, sp)
+				require.Equal(t, tracingpb.RecordingVerbose, sp.RecordingType())
+				sp.Record("test message")
+				return true, nil
+			},
+		)
+
+		require.NoError(t, err)
+		require.True(t, result)
+		require.NotNil(t, rec)
+		require.GreaterOrEqual(t, rec.Len(), 1)
+		// Verify the recording contains our span and message.
+		found := false
+		for _, span := range rec {
+			if span.Operation == "test-span" {
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "expected to find test-span in recording")
+	})
+
+	t.Run("recordVerbose=false returns nil recording", func(t *testing.T) {
+		result, rec, err := withTraceCollection(ctx, tr, "test-span", false,
+			func(ctx context.Context) (bool, error) {
+				return false, nil
+			},
+		)
+
+		require.NoError(t, err)
+		require.False(t, result)
+		require.Nil(t, rec)
+	})
+
+	t.Run("error passthrough", func(t *testing.T) {
+		testErr := errors.New("test error")
+		result, rec, err := withTraceCollection(ctx, tr, "test-span", true,
+			func(ctx context.Context) (bool, error) {
+				return false, testErr
+			},
+		)
+
+		require.ErrorIs(t, err, testErr)
+		require.False(t, result)
+		require.NotNil(t, rec, "recording should be returned even on error when recordVerbose=true")
+	})
+
+	t.Run("bool result passthrough", func(t *testing.T) {
+		for _, expected := range []bool{true, false} {
+			result, _, err := withTraceCollection(ctx, tr, "test-span", false,
+				func(ctx context.Context) (bool, error) {
+					return expected, nil
+				},
+			)
+			require.NoError(t, err)
+			require.Equal(t, expected, result)
+		}
+	})
+}

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -886,8 +886,17 @@ func (tc *TestCluster) Targets(serverIdxs ...int) []roachpb.ReplicationTarget {
 func (tc *TestCluster) changeReplicas(
 	changeType roachpb.ReplicaChangeType, startKey roachpb.RKey, targets ...roachpb.ReplicationTarget,
 ) (roachpb.RangeDescriptor, error) {
+	return tc.changeReplicasCtx(context.Background(), changeType, startKey, targets...)
+}
+
+// changeReplicasCtx is like changeReplicas but accepts a context.
+func (tc *TestCluster) changeReplicasCtx(
+	ctx context.Context,
+	changeType roachpb.ReplicaChangeType,
+	startKey roachpb.RKey,
+	targets ...roachpb.ReplicationTarget,
+) (roachpb.RangeDescriptor, error) {
 	tc.t.Helper()
-	ctx := context.TODO()
 
 	var returnErr error
 	var desc *roachpb.RangeDescriptor
@@ -932,10 +941,20 @@ func (tc *TestCluster) changeReplicas(
 func (tc *TestCluster) addReplica(
 	startKey roachpb.Key, typ roachpb.ReplicaChangeType, targets ...roachpb.ReplicationTarget,
 ) (roachpb.RangeDescriptor, error) {
+	return tc.addReplicaCtx(context.Background(), startKey, typ, targets...)
+}
+
+// addReplicaCtx is like addReplica but accepts a context.
+func (tc *TestCluster) addReplicaCtx(
+	ctx context.Context,
+	startKey roachpb.Key,
+	typ roachpb.ReplicaChangeType,
+	targets ...roachpb.ReplicationTarget,
+) (roachpb.RangeDescriptor, error) {
 	rKey := keys.MustAddr(startKey)
 
-	rangeDesc, err := tc.changeReplicas(
-		typ, rKey, targets...,
+	rangeDesc, err := tc.changeReplicasCtx(
+		ctx, typ, rKey, targets...,
 	)
 	if err != nil {
 		return roachpb.RangeDescriptor{}, err
@@ -952,7 +971,14 @@ func (tc *TestCluster) addReplica(
 func (tc *TestCluster) AddVoters(
 	startKey roachpb.Key, targets ...roachpb.ReplicationTarget,
 ) (roachpb.RangeDescriptor, error) {
-	return tc.addReplica(startKey, roachpb.ADD_VOTER, targets...)
+	return tc.AddVotersCtx(context.Background(), startKey, targets...)
+}
+
+// AddVotersCtx is like AddVoters but accepts a context.
+func (tc *TestCluster) AddVotersCtx(
+	ctx context.Context, startKey roachpb.Key, targets ...roachpb.ReplicationTarget,
+) (roachpb.RangeDescriptor, error) {
+	return tc.addReplicaCtx(ctx, startKey, roachpb.ADD_VOTER, targets...)
 }
 
 // AddNonVoters is part of TestClusterInterface.
@@ -1075,8 +1101,18 @@ func (tc *TestCluster) waitForNewReplicas(
 func (tc *TestCluster) AddVotersOrFatal(
 	t serverutils.TestFataler, startKey roachpb.Key, targets ...roachpb.ReplicationTarget,
 ) roachpb.RangeDescriptor {
+	return tc.AddVotersOrFatalCtx(context.Background(), t, startKey, targets...)
+}
+
+// AddVotersOrFatalCtx is like AddVotersOrFatal but accepts a context.
+func (tc *TestCluster) AddVotersOrFatalCtx(
+	ctx context.Context,
+	t serverutils.TestFataler,
+	startKey roachpb.Key,
+	targets ...roachpb.ReplicationTarget,
+) roachpb.RangeDescriptor {
 	t.Helper()
-	desc, err := tc.AddVoters(startKey, targets...)
+	desc, err := tc.AddVotersCtx(ctx, startKey, targets...)
 	if err != nil {
 		t.Fatalf(`could not add %v replicas to range containing %s: %+v`,
 			targets, startKey, err)


### PR DESCRIPTION
These tests were comprehensive, but also a nightmare. Settle for something simpler.

Closes #159491.
^-- 25.3, but we're not going to backport. Repeat failures of the old tests should be rare and can simply be closed out with a reference to this PR.
Epic: none