### PR TITLE
release-26.1: kvserver: ignore SysBytes in assertRecomputedStats

### DIFF
--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -1373,8 +1373,8 @@ func TestStoreRangeMergeStats(t *testing.T) {
 	require.NoError(t, err)
 
 	// Stats should agree with recomputation.
-	assertRecomputedStats(t, "range A before split", snap, lhsDesc, msA, store.Clock().PhysicalNow())
-	assertRecomputedStats(t, "range B before split", snap, rhsDesc, msB, store.Clock().PhysicalNow())
+	assertRecomputedStatsExceptSys(t, "range A before split", snap, lhsDesc, msA, store.Clock().PhysicalNow())
+	assertRecomputedStatsExceptSys(t, "range B before split", snap, rhsDesc, msB, store.Clock().PhysicalNow())
 
 	// Merge the b range back into the a range.
 	args := adminMergeArgs(lhsDesc.StartKey.AsRawKey())
@@ -1391,7 +1391,7 @@ func TestStoreRangeMergeStats(t *testing.T) {
 	// Merged stats should agree with recomputation.
 	nowNanos := tc.Servers[0].Clock().Now().WallTime
 	msMerged.AgeTo(nowNanos)
-	assertRecomputedStats(t, "merged range", snap, replMerged.Desc(), msMerged, nowNanos)
+	assertRecomputedStatsExceptSys(t, "merged range", snap, replMerged.Desc(), msMerged, nowNanos)
 }
 
 func TestStoreRangeMergeInFlightTxns(t *testing.T) {

--- a/pkg/kv/kvserver/client_test.go
+++ b/pkg/kv/kvserver/client_test.go
@@ -183,7 +183,7 @@ func assertRangeStats(
 	require.Equal(t, expMS, ms, "%s: stats differ", name)
 }
 
-func assertRecomputedStats(
+func assertRecomputedStatsExceptSys(
 	t *testing.T,
 	name string,
 	r storage.Reader,
@@ -202,6 +202,11 @@ func assertRecomputedStats(
 	// Recomputing stats always has ContainsEstimates = 0, while on-disk stats may
 	// have a non-zero value. ContainsEstimates should be asserted separately.
 	ms.ContainsEstimates = expMS.ContainsEstimates
+	// Ignore SysBytes/SysCount/AbortSpanBytes: these can race with lease updates
+	// since RequestLease doesn't acquire latches. See:
+	// https://github.com/cockroachdb/cockroach/issues/93896.
+	expMS.SysBytes, expMS.SysCount, expMS.AbortSpanBytes = 0, 0, 0
+	ms.SysBytes, ms.SysCount, ms.AbortSpanBytes = 0, 0, 0
 	require.Equal(t, expMS, ms, "%s: recomputed stats diverge", name)
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #159885 on behalf of @tbg.

----

SysBytes can race with lease updates since RequestLease doesn't acquire latches. Rename the helper to make this explicit.

Fixes (with 25.4 backport) #159884.
Informs #93896.

Release note: None

----

Release justification: fixes test flakiness.