### PR TITLE
storepool: export GetStoreStatuses for mma health signal plumbing

### DIFF
--- a/pkg/kv/kvserver/allocator/storepool/store_pool.go
+++ b/pkg/kv/kvserver/allocator/storepool/store_pool.go
@@ -78,38 +78,38 @@ type StoreDetailMu struct {
 	LastUnavailable hlc.Timestamp
 }
 
-// storeStatus is the current status of a store.
-type storeStatus int
+// StoreStatus is the current status of a store.
+type StoreStatus int
 
-// These are the possible values for a storeStatus.
+// These are the possible values for a StoreStatus.
 const (
-	_ storeStatus = iota
+	_ StoreStatus = iota
 	// The store's node is not live or no gossip has been received from
 	// the store for more than the timeUntilNodeDead threshold.
-	storeStatusDead
+	StoreStatusDead
 	// The store isn't available because it hasn't gossiped yet. This
 	// status lasts until either gossip is received from the store or
 	// the timeUntilNodeDead threshold has passed, at which point its
 	// status will change to dead.
-	storeStatusUnknown
+	StoreStatusUnknown
 	// The store is alive but it is throttled.
-	storeStatusThrottled
+	StoreStatusThrottled
 	// The store is alive and available.
-	storeStatusAvailable
+	StoreStatusAvailable
 	// The store is decommissioning.
-	storeStatusDecommissioning
+	StoreStatusDecommissioning
 	// The store failed it's liveness heartbeat recently and is considered
-	// suspect. Consequently, stores always move from `storeStatusUnknown`
+	// suspect. Consequently, stores always move from `StoreStatusUnknown`
 	// (indicating a node that has a non-live node liveness record) to
-	// `storeStatusSuspect`.
-	storeStatusSuspect
+	// `StoreStatusSuspect`.
+	StoreStatusSuspect
 	// The store is alive but is currently marked as draining, so it is not a
 	// candidate for lease transfers or replica rebalancing.
-	storeStatusDraining
+	StoreStatusDraining
 )
 
-func (ss storeStatus) String() string {
-	if ss < storeStatusDead || ss > storeStatusDraining {
+func (ss StoreStatus) String() string {
+	if ss < StoreStatusDead || ss > StoreStatusDraining {
 		panic(fmt.Sprintf("unknown store status: %d", ss))
 	}
 	return [...]string{"",
@@ -118,7 +118,7 @@ func (ss storeStatus) String() string {
 }
 
 // SafeValue implements the redact.SafeValue interface.
-func (ss storeStatus) SafeValue() {}
+func (ss StoreStatus) SafeValue() {}
 
 // Copy returns a deep copy of the StoreDetailMu.
 func (sd *StoreDetailMu) Copy() *StoreDetailMu {
@@ -146,25 +146,25 @@ func (sd *StoreDetailMu) status(
 	deadThreshold time.Duration,
 	nl NodeLivenessFunc,
 	suspectDuration time.Duration,
-) storeStatus {
+) StoreStatus {
 	sd.RLock() // all exist paths will RUnlock() the lock.
 	// During normal operation, we expect the state transitions for stores to look like the following:
 	//
 	//      +-----------------------+
-	//   +- |  storeStatusUnknown   |
+	//   +- |  StoreStatusUnknown   |
 	//   |  +-----------------------+             Successful heartbeats
 	//   |                                        throughout the suspect
 	//   |      +-----------------------+         duration
-	//   +----->| storeStatusAvailable  |<-+---------------------------+
+	//   +----->| StoreStatusAvailable  |<-+---------------------------+
 	//          +-----------------------+  |                           |
 	//                                     |                   +--------------------+
-	//                                     |                   | storeStatusSuspect |
+	//                                     |                   | StoreStatusSuspect |
 	//      +------------------------------+                   +--------------------+
 	//      |      Failed liveness                                     ^
 	//      |      heartbeat                                           |
 	//      |                                                          |
 	//      |  +-------------------------+                             |
-	//      +->|  storeStatusUnavailable |-----------------------------+
+	//      +->|  StoreStatusUnavailable |-----------------------------+
 	//         +-------------------------+    Successful liveness
 	//                                        heartbeat
 	//
@@ -173,8 +173,8 @@ func (sd *StoreDetailMu) status(
 	// write lock, updates the LastUnavailable timestamp, returns the store
 	// status, and unlocks the write lock.
 	updateLastUnavailableAndReturnStatusRLocked := func(
-		lastUnavailable hlc.Timestamp, returnStatus storeStatus,
-	) storeStatus {
+		lastUnavailable hlc.Timestamp, returnStatus StoreStatus,
+	) StoreStatus {
 		sd.RUnlock()
 		sd.Lock()
 		defer sd.Unlock()
@@ -183,7 +183,7 @@ func (sd *StoreDetailMu) status(
 	}
 
 	// returnStatusRLocked unlocks the read lock and returns the store status.
-	returnStatusRLocked := func(returnStatus storeStatus) storeStatus {
+	returnStatusRLocked := func(returnStatus StoreStatus) StoreStatus {
 		defer sd.RUnlock()
 		return returnStatus
 	}
@@ -194,12 +194,12 @@ func (sd *StoreDetailMu) status(
 	// even before the first gossip arrives for a store.
 	deadAsOf := sd.LastUpdatedTime.AddDuration(deadThreshold)
 	if now.After(deadAsOf) {
-		return updateLastUnavailableAndReturnStatusRLocked(now, storeStatusDead)
+		return updateLastUnavailableAndReturnStatusRLocked(now, StoreStatusDead)
 	}
 	// If there's no descriptor (meaning no gossip ever arrived for this
 	// store), return unavailable.
 	if sd.Desc == nil {
-		return returnStatusRLocked(storeStatusUnknown)
+		return returnStatusRLocked(StoreStatusUnknown)
 	}
 
 	// Even if the store has been updated via gossip, we still rely on
@@ -209,31 +209,31 @@ func (sd *StoreDetailMu) status(
 	// dead -> decommissioning -> unknown -> draining -> suspect -> available.
 	switch nl(sd.Desc.Node.NodeID) {
 	case livenesspb.NodeLivenessStatus_DEAD, livenesspb.NodeLivenessStatus_DECOMMISSIONED:
-		return updateLastUnavailableAndReturnStatusRLocked(now, storeStatusDead)
+		return updateLastUnavailableAndReturnStatusRLocked(now, StoreStatusDead)
 	case livenesspb.NodeLivenessStatus_DECOMMISSIONING:
-		return returnStatusRLocked(storeStatusDecommissioning)
+		return returnStatusRLocked(StoreStatusDecommissioning)
 	case livenesspb.NodeLivenessStatus_UNAVAILABLE:
-		return updateLastUnavailableAndReturnStatusRLocked(now, storeStatusUnknown)
+		return updateLastUnavailableAndReturnStatusRLocked(now, StoreStatusUnknown)
 	case livenesspb.NodeLivenessStatus_UNKNOWN:
-		return returnStatusRLocked(storeStatusUnknown)
+		return returnStatusRLocked(StoreStatusUnknown)
 	case livenesspb.NodeLivenessStatus_DRAINING:
-		return updateLastUnavailableAndReturnStatusRLocked(now, storeStatusDraining)
+		return updateLastUnavailableAndReturnStatusRLocked(now, StoreStatusDraining)
 	}
 
 	// A store is throttled if it has missed receiving snapshots recently.
 	if sd.ThrottledUntil.After(now) {
-		return returnStatusRLocked(storeStatusThrottled)
+		return returnStatusRLocked(StoreStatusThrottled)
 	}
 
 	// Check whether the store is currently suspect. We measure that by
 	// looking at the time it was last unavailable making sure we have not seen any
 	// failures for a period of time defined by StoreSuspectDuration.
 	if sd.LastUnavailable.AddDuration(suspectDuration).After(now) {
-		return returnStatusRLocked(storeStatusSuspect)
+		return returnStatusRLocked(StoreStatusSuspect)
 	}
 
 	// Clear out the LastUnavailable once we return available status.
-	return returnStatusRLocked(storeStatusAvailable)
+	return returnStatusRLocked(StoreStatusAvailable)
 }
 
 // localityWithString maintains a string representation of each locality along
@@ -462,7 +462,7 @@ func (sp *StorePool) statusString(nl NodeLivenessFunc) redact.RedactableString {
 		}
 		buf.Print(id)
 		status := detail.status(now, timeUntilNodeDead, nl, timeAfterNodeSuspect)
-		if status != storeStatusAvailable {
+		if status != StoreStatusAvailable {
 			buf.Printf(" (status=%s)", status)
 		}
 		detail.RLock()
@@ -766,7 +766,7 @@ func (sp *StorePool) decommissioningReplicasWithLiveness(
 	for _, repl := range repls {
 		detail := sp.GetStoreDetail(repl.StoreID)
 		switch detail.status(now, timeUntilNodeDead, nl, timeAfterNodeSuspect) {
-		case storeStatusDecommissioning:
+		case StoreStatusDecommissioning:
 			decommissioningReplicas = append(decommissioningReplicas, repl)
 		}
 	}
@@ -817,7 +817,7 @@ func (sp *StorePool) IsDead(storeID roachpb.StoreID) (bool, time.Duration, error
 	return false, deadAsOf.GoTime().Sub(now.GoTime()), nil
 }
 
-// IsUnknown returns true if the given store's status is `storeStatusUnknown`
+// IsUnknown returns true if the given store's status is `StoreStatusUnknown`
 // (i.e. it just failed a liveness heartbeat and we cannot ascertain its
 // liveness or deadness at the moment) or an error if the store is not found in
 // the pool.
@@ -826,17 +826,17 @@ func (sp *StorePool) IsUnknown(storeID roachpb.StoreID) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return status == storeStatusUnknown, nil
+	return status == StoreStatusUnknown, nil
 }
 
-// IsDraining returns true if the given store's status is `storeStatusDraining`
+// IsDraining returns true if the given store's status is `StoreStatusDraining`
 // or an error if the store is not found in the pool.
 func (sp *StorePool) IsDraining(storeID roachpb.StoreID) (bool, error) {
 	status, err := sp.storeStatus(storeID, sp.NodeLivenessFn)
 	if err != nil {
 		return false, err
 	}
-	return status == storeStatusDraining, nil
+	return status == StoreStatusDraining, nil
 }
 
 // IsLive returns true if the node is considered alive by the store pool or an error
@@ -846,7 +846,7 @@ func (sp *StorePool) IsLive(storeID roachpb.StoreID) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return status == storeStatusAvailable, nil
+	return status == StoreStatusAvailable, nil
 }
 
 // IsStoreHealthy returns whether we believe this store can serve requests
@@ -859,7 +859,7 @@ func (sp *StorePool) IsStoreHealthy(storeID roachpb.StoreID) bool {
 		return false
 	}
 	switch status {
-	case storeStatusAvailable, storeStatusDecommissioning, storeStatusDraining:
+	case StoreStatusAvailable, StoreStatusDecommissioning, StoreStatusDraining:
 		return true
 	default:
 		return false
@@ -868,10 +868,10 @@ func (sp *StorePool) IsStoreHealthy(storeID roachpb.StoreID) bool {
 
 func (sp *StorePool) storeStatus(
 	storeID roachpb.StoreID, nl NodeLivenessFunc,
-) (storeStatus, error) {
+) (StoreStatus, error) {
 	sd, ok := sp.Details.StoreDetails.Load(storeID)
 	if !ok {
-		return storeStatusUnknown, errors.Errorf("store %d was not found", storeID)
+		return StoreStatusUnknown, errors.Errorf("store %d was not found", storeID)
 	}
 	// NB: We use clock.Now() instead of clock.PhysicalTime() is order to
 	// take clock signals from remote nodes into consideration.
@@ -885,7 +885,7 @@ func (sp *StorePool) storeStatus(
 // first for live replicas, and the second for dead replicas.
 //
 // - Replicas for which liveness or deadness cannot be ascertained
-// (storeStatusUnknown) are excluded from the returned slices.
+// (StoreStatusUnknown) are excluded from the returned slices.
 //
 // - Replicas on decommissioning node/store are considered live.
 //
@@ -915,17 +915,17 @@ func (sp *StorePool) liveAndDeadReplicasWithLiveness(
 		// Mark replica as dead if store is dead.
 		status := detail.status(now, timeUntilNodeDead, nl, timeAfterNodeSuspect)
 		switch status {
-		case storeStatusDead:
+		case StoreStatusDead:
 			deadReplicas = append(deadReplicas, repl)
-		case storeStatusAvailable, storeStatusThrottled, storeStatusDecommissioning:
+		case StoreStatusAvailable, StoreStatusThrottled, StoreStatusDecommissioning:
 			// We count both available and throttled stores to be live for the
 			// purpose of computing quorum.
 			// We count decommissioning replicas to be alive because they are readable
 			// and should be used for up-replication if necessary.
 			liveReplicas = append(liveReplicas, repl)
-		case storeStatusUnknown:
+		case StoreStatusUnknown:
 		// No-op.
-		case storeStatusSuspect, storeStatusDraining:
+		case StoreStatusSuspect, StoreStatusDraining:
 			if includeSuspectAndDrainingStores {
 				liveReplicas = append(liveReplicas, repl)
 			}
@@ -1216,7 +1216,7 @@ func (sp *StorePool) getStoreListFromIDs(
 			continue
 		}
 		switch s := detail.status(now, timeUntilNodeDead, nl, timeAfterNodeSuspect); s {
-		case storeStatusThrottled:
+		case StoreStatusThrottled:
 			aliveStoreCount++
 			detail.RLock()
 			throttled = append(throttled, detail.throttledBecause)
@@ -1224,14 +1224,14 @@ func (sp *StorePool) getStoreListFromIDs(
 				storeDescriptors = append(storeDescriptors, *detail.Desc)
 			}
 			detail.RUnlock()
-		case storeStatusAvailable:
+		case StoreStatusAvailable:
 			aliveStoreCount++
 			detail.RLock()
 			storeDescriptors = append(storeDescriptors, *detail.Desc)
 			detail.RUnlock()
-		case storeStatusDraining:
+		case StoreStatusDraining:
 			throttled = append(throttled, fmt.Sprintf("s%d: draining", storeID))
-		case storeStatusSuspect:
+		case StoreStatusSuspect:
 			aliveStoreCount++
 			throttled = append(throttled, fmt.Sprintf("s%d: suspect", storeID))
 			if filter != StoreFilterThrottled && filter != StoreFilterSuspect {
@@ -1239,7 +1239,7 @@ func (sp *StorePool) getStoreListFromIDs(
 				storeDescriptors = append(storeDescriptors, *detail.Desc)
 				detail.RUnlock()
 			}
-		case storeStatusDead, storeStatusUnknown, storeStatusDecommissioning:
+		case StoreStatusDead, StoreStatusUnknown, StoreStatusDecommissioning:
 			// Do nothing; this store cannot be used.
 		default:
 			panic(fmt.Sprintf("unknown store status: %d", s))
@@ -1400,9 +1400,9 @@ func (sp *StorePool) isStoreReadyForRoutineReplicaTransferInternal(
 		return false
 	}
 	switch status {
-	case storeStatusThrottled, storeStatusAvailable:
+	case StoreStatusThrottled, StoreStatusAvailable:
 		return true
-	case storeStatusDead, storeStatusUnknown, storeStatusDecommissioning, storeStatusSuspect, storeStatusDraining:
+	case StoreStatusDead, StoreStatusUnknown, StoreStatusDecommissioning, StoreStatusSuspect, StoreStatusDraining:
 		log.VEventf(ctx, 3,
 			"not considering non-live store s%d (%v)", targetStoreID, status)
 		return false

--- a/pkg/kv/kvserver/allocator/storepool/store_pool_test.go
+++ b/pkg/kv/kvserver/allocator/storepool/store_pool_test.go
@@ -617,7 +617,7 @@ func TestStorePoolSuspected(t *testing.T) {
 	// Verify a store that we haven't seen yet is unknown status.
 	detail := sp.GetStoreDetail(0)
 	s := detail.status(now, timeUntilNodeDead, sp.NodeLivenessFn, timeAfterNodeSuspect)
-	require.Equal(t, s, storeStatusUnknown)
+	require.Equal(t, s, StoreStatusUnknown)
 	require.Equal(t, hlc.Timestamp{}, detail.LastUnavailable)
 
 	// Now start gossiping the stores statuses.
@@ -630,54 +630,54 @@ func TestStorePoolSuspected(t *testing.T) {
 	detail = sp.GetStoreDetail(store.StoreID)
 
 	s = detail.status(now, timeUntilNodeDead, sp.NodeLivenessFn, timeAfterNodeSuspect)
-	require.Equal(t, s, storeStatusAvailable)
+	require.Equal(t, s, StoreStatusAvailable)
 	require.Equal(t, hlc.Timestamp{}, detail.LastUnavailable)
 
 	// When the store transitions to unavailable, its status changes to temporarily unknown.
 	mnl.SetNodeStatus(store.Node.NodeID, livenesspb.NodeLivenessStatus_UNAVAILABLE)
 	s = detail.status(now, timeUntilNodeDead, sp.NodeLivenessFn, timeAfterNodeSuspect)
-	require.Equal(t, s, storeStatusUnknown)
+	require.Equal(t, s, StoreStatusUnknown)
 	require.NotEqual(t, hlc.Timestamp{}, detail.LastUnavailable)
 
 	// When the store transitions back to live, it passes through suspect for a period.
 	mnl.SetNodeStatus(store.Node.NodeID, livenesspb.NodeLivenessStatus_LIVE)
 	s = detail.status(now, timeUntilNodeDead, sp.NodeLivenessFn, timeAfterNodeSuspect)
-	require.Equal(t, s, storeStatusSuspect)
+	require.Equal(t, s, StoreStatusSuspect)
 
 	// Once the window has passed, it will return to available.
 	now = now.AddDuration(timeAfterNodeSuspect).AddDuration(time.Millisecond)
 	s = detail.status(now, timeUntilNodeDead, sp.NodeLivenessFn, timeAfterNodeSuspect)
-	require.Equal(t, s, storeStatusAvailable)
+	require.Equal(t, s, StoreStatusAvailable)
 
 	// Return a liveness of dead.
 	mnl.SetNodeStatus(store.Node.NodeID, livenesspb.NodeLivenessStatus_DEAD)
 	s = detail.status(now, timeUntilNodeDead, sp.NodeLivenessFn, timeAfterNodeSuspect)
-	require.Equal(t, s, storeStatusDead)
+	require.Equal(t, s, StoreStatusDead)
 
 	// When the store transitions back to live, it passes through suspect for a period.
 	mnl.SetNodeStatus(store.Node.NodeID, livenesspb.NodeLivenessStatus_LIVE)
 	s = detail.status(now, timeUntilNodeDead, sp.NodeLivenessFn, timeAfterNodeSuspect)
-	require.Equal(t, s, storeStatusSuspect)
+	require.Equal(t, s, StoreStatusSuspect)
 
 	// Verify it also returns correctly to available after suspect time.
 	now = now.AddDuration(timeAfterNodeSuspect).AddDuration(time.Millisecond)
 	s = detail.status(now, timeUntilNodeDead, sp.NodeLivenessFn, timeAfterNodeSuspect)
-	require.Equal(t, s, storeStatusAvailable)
+	require.Equal(t, s, StoreStatusAvailable)
 
 	// Verify that restart after draining also makes it temporarily suspect.
 	mnl.SetNodeStatus(store.Node.NodeID, livenesspb.NodeLivenessStatus_DRAINING)
 	s = detail.status(now, timeUntilNodeDead, sp.NodeLivenessFn, timeAfterNodeSuspect)
-	require.Equal(t, s, storeStatusDraining)
+	require.Equal(t, s, StoreStatusDraining)
 
 	// Verify suspect when restarting after a drain.
 	mnl.SetNodeStatus(store.Node.NodeID, livenesspb.NodeLivenessStatus_LIVE)
 	s = detail.status(now, timeUntilNodeDead, sp.NodeLivenessFn, timeAfterNodeSuspect)
-	require.Equal(t, s, storeStatusSuspect)
+	require.Equal(t, s, StoreStatusSuspect)
 
 	now = now.AddDuration(timeAfterNodeSuspect).AddDuration(time.Millisecond)
 	mnl.SetNodeStatus(store.Node.NodeID, livenesspb.NodeLivenessStatus_LIVE)
 	s = detail.status(now, timeUntilNodeDead, sp.NodeLivenessFn, timeAfterNodeSuspect)
-	require.Equal(t, s, storeStatusAvailable)
+	require.Equal(t, s, StoreStatusAvailable)
 }
 
 func TestGetLocalities(t *testing.T) {

--- a/pkg/kv/kvserver/mma_store_rebalancer.go
+++ b/pkg/kv/kvserver/mma_store_rebalancer.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/mmaprototype"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/storepool"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/mmaintegration"
@@ -48,18 +47,16 @@ type mmaStoreRebalancer struct {
 	store *mmaStore
 	mma   mmaprototype.Allocator
 	st    *cluster.Settings
-	sp    *storepool.StorePool
 	as    *mmaintegration.AllocatorSync
 }
 
 func newMMAStoreRebalancer(
-	s *Store, mma mmaprototype.Allocator, st *cluster.Settings, sp *storepool.StorePool,
+	s *Store, mma mmaprototype.Allocator, st *cluster.Settings,
 ) *mmaStoreRebalancer {
 	return &mmaStoreRebalancer{
 		store: (*mmaStore)(s),
 		mma:   mma,
 		st:    st,
-		sp:    sp,
 		as:    s.cfg.AllocatorSync,
 	}
 }

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1748,7 +1748,7 @@ func NewStore(
 		s.splitQueue = newSplitQueue(s, s.db)
 		s.replicateQueue = newReplicateQueue(s, s.allocator)
 		s.replicaGCQueue = newReplicaGCQueue(s, s.db)
-		s.mmaStoreRebalancer = newMMAStoreRebalancer(s, s.cfg.MMAllocator, s.cfg.Settings, s.cfg.StorePool)
+		s.mmaStoreRebalancer = newMMAStoreRebalancer(s, s.cfg.MMAllocator, s.cfg.Settings)
 		s.raftLogQueue = newRaftLogQueue(s, s.db)
 		s.raftSnapshotQueue = newRaftSnapshotQueue(s)
 		s.consistencyQueue = newConsistencyQueue(s)

--- a/pkg/testutils/lint/passes/redactcheck/redactcheck.go
+++ b/pkg/testutils/lint/passes/redactcheck/redactcheck.go
@@ -108,7 +108,7 @@ func runAnalyzer(pass *analysis.Pass) (interface{}, error) {
 						"Dimension": {},
 					},
 					"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/storepool": {
-						"storeStatus": {},
+						"StoreStatus": {},
 					},
 					"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/mmaprototype": {
 						"LoadValue": {},


### PR DESCRIPTION
Part of #156776
Epic: CRDB-55052

---

**storepool: export GetStoreStatuses for mma health signal plumbing**

Previously, storepool's StoreStatus was not exported and only used internally by
storepool. This commit exports StoreStatus so that mma integration can consume
the same store-level signals that SMA relies and translate them into mma's
(Health, Disposition) model.

An alternative approach would be to have store pool handle the translation of
the store status to mma's (Health, Disposition) model. But this would couple
storepool to mma and blur ownership; storepool should remain as the source of
truth for store status. MMA owns the interpretation.

---
**kvserver: rm sp from mmaStoreRebalancer**

This commit removes `sp *storepool.StorePool` field in
`mmaStoreRebalancer` given it being unused.



