### PR TITLE
sctest: unskip multitenant for schema change tests

### DIFF
--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -637,6 +637,14 @@ func (ts *testServer) startDefaultTestTenant(
 ) (serverutils.ApplicationLayerInterface, error) {
 	tenantSettings := cluster.MakeTestingClusterSettings()
 	if st := ts.params.Settings; st != nil {
+		// Use the same version constraints as the parent settings so that
+		// external process tenants can start when the cluster is running at
+		// a version older than Latest.
+		tenantSettings = cluster.MakeTestingClusterSettingsWithVersions(
+			st.Version.LatestVersion(),
+			st.Version.MinSupportedVersion(),
+			false, /* initializeVersion */
+		)
 		// Copy overrides and other test-specific configuration,
 		// as a convenience for test writers that do the following:
 		// - create a new Settings

--- a/pkg/spanconfig/spanconfigmanager/manager_test.go
+++ b/pkg/spanconfig/spanconfigmanager/manager_test.go
@@ -252,8 +252,6 @@ func TestReconciliationJobIsIdle(t *testing.T) {
 	var jobID jobspb.JobID
 	ctx := context.Background()
 	srv := serverutils.StartServerOnly(t, base.TestServerArgs{
-		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(109457),
-
 		Knobs: base.TestingKnobs{
 			SpanConfig: &spanconfig.TestingKnobs{
 				ManagerCreatedJobInterceptor: func(jobI interface{}) {

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/config.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/config.go
@@ -8,6 +8,7 @@ package sctestdeps
 import (
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
@@ -174,6 +175,13 @@ func WithClusterSettings(cs *cluster.Settings) Option {
 		if state.evalCtx != nil {
 			state.evalCtx.Settings = cs
 		}
+	})
+}
+
+// WithCodec sets the TestState codec to the provided value.
+func WithCodec(codec keys.SQLCodec) Option {
+	return optionFunc(func(state *TestState) {
+		state.evalCtx.Codec = codec
 	})
 }
 

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
@@ -77,6 +77,9 @@ func (s *TestState) ClusterID() uuid.UUID {
 
 // Codec implements the scbuild.Dependencies interface.
 func (s *TestState) Codec() keys.SQLCodec {
+	if s.evalCtx.Codec.IsSet() {
+		return s.evalCtx.Codec
+	}
 	return keys.SystemSQLCodec
 }
 

--- a/pkg/sql/schemachanger/sctest/backup.go
+++ b/pkg/sql/schemachanger/sctest/backup.go
@@ -355,6 +355,11 @@ func backupSuccess(t *testing.T, args backupSuccessTestArgs, cs CumulativeTestCa
 	}
 
 	// Upgrade the cluster if applicable.
+	if args.server.Server.StartedDefaultTestTenant() {
+		sysDB := args.server.Server.SystemLayer().SQLConn(t)
+		_, err := sysDB.Exec("SET CLUSTER SETTING VERSION = $1", clusterversion.Latest.String())
+		require.NoError(t, err)
+	}
 	tdb.Exec(t, "SET CLUSTER SETTING VERSION = $1", clusterversion.Latest.String())
 
 	// Restore the backup of the database taken mid-successful-schema-change

--- a/pkg/sql/schemachanger/sctest/end_to_end.go
+++ b/pkg/sql/schemachanger/sctest/end_to_end.go
@@ -105,6 +105,11 @@ func EndToEndSideEffects(t *testing.T, relTestCaseDir string, factory TestServer
 				// for end-to-end side-effect testing, so we ignore them.
 				break
 			case "test":
+				var skipUnderSecondaryTenant bool
+				d.MaybeScanArgs(t, "skip-under-secondary-tenant", &skipUnderSecondaryTenant)
+				if skipUnderSecondaryTenant && !s.Codec().ForSystemTenant() {
+					skip.IgnoreLint(t, "test is skipped under secondary tenant")
+				}
 				stmts, _ := parseStmts()
 				require.Lessf(t, numTestStatementsObserved, 1, "only one test per-file.")
 				numTestStatementsObserved++
@@ -154,6 +159,7 @@ func EndToEndSideEffects(t *testing.T, relTestCaseDir string, factory TestServer
 					sctestdeps.WithIDGenerator(s.ApplicationLayer()),
 					sctestdeps.WithReferenceProviderFactory(refFactory),
 					sctestdeps.WithClusterSettings(s.ClusterSettings()),
+					sctestdeps.WithCodec(s.Codec()),
 				)
 				stmtStates := execStatementWithTestDeps(ctx, t, deps, stmts...)
 				var fileNameSuffix string

--- a/pkg/sql/schemachanger/sctest/test_server_factory.go
+++ b/pkg/sql/schemachanger/sctest/test_server_factory.go
@@ -117,7 +117,6 @@ func (f SingleNodeTestClusterFactory) Start(ctx context.Context, t *testing.T) T
 				UseTransactionalDescIDGenerator: true,
 			},
 		},
-		DefaultTestTenant: base.TestDoesNotWorkWithSecondaryTenantsButWeDontKnowWhyYet(142814),
 	}
 	if f.server != nil {
 		args.Knobs.Server = f.server

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_named_range_configure_zone_discard/alter_named_range_configure_zone_discard.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_named_range_configure_zone_discard/alter_named_range_configure_zone_discard.definition
@@ -1,4 +1,5 @@
-test
+# Secondary tenants cannot modify named ranges, so skip the test in that mode.
+test skip-under-secondary-tenant=true
 ALTER RANGE meta CONFIGURE ZONE USING num_replicas = 7;
 ALTER RANGE meta CONFIGURE ZONE USING gc.ttlseconds = 10000;
 ALTER RANGE meta CONFIGURE ZONE DISCARD;


### PR DESCRIPTION
This fixes external process tenant startup to propagate
version settings from the parent, allowing tenants to start
when the cluster is running at an older version
(e.g., MinSupported).

We also had to pass in the SQLCodec so that the schema TestDeps
accesss the tenant correctly.

Note that MultiRegionTestClusterFactory already allowed
multitenant testing.

fixes #142814
fixes #109457
Release note: None