### PR TITLE
roachtest: skip distMerge=true import

### DIFF
--- a/pkg/cmd/roachtest/tests/import.go
+++ b/pkg/cmd/roachtest/tests/import.go
@@ -328,7 +328,8 @@ func registerImport(r registry.Registry) {
 			suites = registry.ManualOnly
 		}
 
-		for _, distMerge := range []bool{false, true} {
+		// TODO(#159956): unskip distMerge=true.
+		for _, distMerge := range []bool{false} {
 			for _, numNodes := range testSpec.nodes {
 				ts := testSpec
 				numNodes := numNodes


### PR DESCRIPTION
The import roachtest is failing repeatedly with distMerge=true, let's skip it until the test is stabilized.

Informs: #159956.
Release note: None