### PR TITLE
kvserver: add ability to lazily initialize Raft engine batches

### DIFF
--- a/pkg/kv/kvserver/kvstorage/storage.go
+++ b/pkg/kv/kvserver/kvstorage/storage.go
@@ -120,8 +120,8 @@ type Engines struct {
 	//   particular write, or there is a candidate, but it needs to be verified.
 	todoEngine storage.Engine
 	// logEngine is the engine holding mainly the raft state, such as HardState
-	// and logs, and the Store-local keys. This engine provides timely durability,
-	// by frequent and on-demand syncing.
+	// and logs, and the Store-local keys. This engine provides timely
+	// durability, by frequent and on-demand syncing.
 	logEngine storage.Engine
 	// separated is true iff the engines are logically or physically separated.
 	// Can be true only in tests.


### PR DESCRIPTION
Previously, we were not distinguishing between the State engine and Raft engine when preparing a split. This patch fixes that, by adding the ability to lazily initialize a Raft batch, which will be written to the Raft engine, and passing it to splitPreApply.

Epic: none

Release note: None