### PR TITLE
admission: modify WorkQueue to support CPU token AC 

### DIFF
--- a/pkg/util/admission/BUILD.bazel
+++ b/pkg/util/admission/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "admission",
     srcs = [
         "admission.go",
+        "cpu_time_token_estimation.go",
         "cpu_time_token_filler.go",
         "cpu_time_token_granter.go",
         "disk_bandwidth.go",

--- a/pkg/util/admission/cpu_time_token_estimation.go
+++ b/pkg/util/admission/cpu_time_token_estimation.go
@@ -1,0 +1,80 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package admission
+
+// cpuTimeTokenEstimator estimates the CPU time token cost of future
+// requests based on the observed costs of past requests. See
+// WorkQueueWithCPUTimeTokenEstimators for the broader context.
+//
+// The estimator works by exponentially smoothing the mean token usage
+// of recently completed work:
+//
+//   - workDone(tokens) should be called for every completed request to
+//     record its token cost.
+//
+//   - update() should be called periodically (once per second).
+//     Each call computes the mean token usage of all requests completed
+//     since the last update and folds that mean into the current estimate
+//     using exponential smoothing. The function returns true if no work
+//     was recorded since the last call to update.
+//
+//   - estimateTokensToBeUsed() returns the current smoothed estimate (with
+//     a minimum of 1).
+//
+// Rationale:
+//
+//   - **Mean over recent requests**: Workloads contain both cheap and
+//     expensive requests. Using the mean CPU cost of a batch of completed
+//     requests gives a representative estimate of average cost over short
+//     windows.
+//
+//   - **Exponential smoothing**: A tenant's workload may shift over time.
+//     Using exponential smoothing weights recent behavior more heavily than
+//     older behavior, avoiding a stale lifetime-average estimate while still
+//     filtering noise.
+//
+// The estimator resets its accumulated counts on each call to update.
+//
+// Note that cpuTimeTokenEstimator is NOT thread-safe. It is meant to be used
+// in WorkQueue, which handles locking via a WorkQueue-wide lock. This approach
+// of protecting many resources in WorkQueue via a shared lock reduces the
+// number of Lock calls made in Admit, etc. as compared to if we did locking
+// within cpuTimeTokenEstimator.
+type cpuTimeTokenEstimator struct {
+	// Reset on every call to update.
+	workDoneCount    int64
+	cumulativeTokens int64
+
+	estimate int64
+}
+
+func (e *cpuTimeTokenEstimator) init(initialEstimate int64) {
+	*e = cpuTimeTokenEstimator{estimate: initialEstimate}
+}
+
+func (e *cpuTimeTokenEstimator) update() (noActivity bool) {
+	if e.workDoneCount == 0 {
+		return true
+	}
+
+	const alpha = 0.5
+	mean := e.cumulativeTokens / e.workDoneCount
+	e.estimate = int64(alpha*float64(mean) + (1-alpha)*float64(e.estimate))
+
+	e.workDoneCount = 0
+	e.cumulativeTokens = 0
+
+	return false
+}
+
+func (e *cpuTimeTokenEstimator) estimateTokensToBeUsed() (tokens int64) {
+	return max(1, e.estimate)
+}
+
+func (e *cpuTimeTokenEstimator) workDone(tokens int64) {
+	e.workDoneCount++
+	e.cumulativeTokens += tokens
+}

--- a/pkg/util/admission/elastic_cpu_grant_coordinator.go
+++ b/pkg/util/admission/elastic_cpu_grant_coordinator.go
@@ -32,7 +32,7 @@ func makeElasticCPUGrantCoordinator(
 	elasticCPUInternalWorkQueue := &WorkQueue{}
 	initWorkQueue(elasticCPUInternalWorkQueue, ambientCtx, KVWork, "kv-elastic-cpu-queue", elasticCPUGranter, st,
 		elasticWorkQueueMetrics,
-		workQueueOptions{usesTokens: true}, nil /* knobs */) // will be closed by the embedding *ElasticCPUWorkQueue
+		workQueueOptions{mode: usesTokens}, nil /* knobs */) // will be closed by the embedding *ElasticCPUWorkQueue
 	elasticCPUWorkQueue := makeElasticCPUWorkQueue(st, elasticCPUInternalWorkQueue, elasticCPUGranter, elasticCPUGranterMetrics)
 	elasticCPUGrantCoordinator := newElasticCPUGrantCoordinator(elasticCPUGranter, elasticCPUWorkQueue, schedulerLatencyListener)
 	elasticCPUGranter.setRequester(elasticCPUInternalWorkQueue)

--- a/pkg/util/admission/elastic_cpu_work_queue.go
+++ b/pkg/util/admission/elastic_cpu_work_queue.go
@@ -46,7 +46,7 @@ type ElasticCPUWorkQueue struct {
 // elasticCPUInternalWorkQueue abstracts *WorkQueue for testing.
 type elasticCPUInternalWorkQueue interface {
 	requester
-	Admit(ctx context.Context, info WorkInfo) (enabled bool, err error)
+	Admit(ctx context.Context, info WorkInfo) (AdmitResponse, error)
 	SetTenantWeights(tenantWeights map[uint64]uint32)
 	adjustTenantUsed(tenantID roachpb.TenantID, additionalUsed int64)
 }
@@ -83,11 +83,11 @@ func (e *ElasticCPUWorkQueue) Admit(
 		duration = MaxElasticCPUDuration
 	}
 	info.RequestedCount = duration.Nanoseconds()
-	enabled, err := e.workQueue.Admit(ctx, info)
+	resp, err := e.workQueue.Admit(ctx, info)
 	if err != nil {
 		return nil, err
 	}
-	if !enabled {
+	if !resp.Enabled {
 		return nil, nil
 	}
 	e.metrics.AcquiredNanos.Inc(duration.Nanoseconds())

--- a/pkg/util/admission/elastic_cpu_work_queue_test.go
+++ b/pkg/util/admission/elastic_cpu_work_queue_test.go
@@ -150,13 +150,11 @@ type testElasticCPUInternalWorkQueue struct {
 
 var _ elasticCPUInternalWorkQueue = &testElasticCPUInternalWorkQueue{}
 
-func (t *testElasticCPUInternalWorkQueue) Admit(
-	_ context.Context, info WorkInfo,
-) (enabled bool, err error) {
+func (t *testElasticCPUInternalWorkQueue) Admit(_ context.Context, info WorkInfo) (AdmitResponse, error) {
 	if !t.disabled {
 		t.buf.WriteString(fmt.Sprintf("admitted=%s ", time.Duration(info.RequestedCount)))
 	}
-	return !t.disabled, nil
+	return AdmitResponse{Enabled: !t.disabled}, nil
 }
 
 func (t *testElasticCPUInternalWorkQueue) SetTenantWeights(tenantWeights map[uint64]uint32) {

--- a/pkg/util/admission/elastic_cpu_work_queue_test.go
+++ b/pkg/util/admission/elastic_cpu_work_queue_test.go
@@ -150,7 +150,9 @@ type testElasticCPUInternalWorkQueue struct {
 
 var _ elasticCPUInternalWorkQueue = &testElasticCPUInternalWorkQueue{}
 
-func (t *testElasticCPUInternalWorkQueue) Admit(_ context.Context, info WorkInfo) (AdmitResponse, error) {
+func (t *testElasticCPUInternalWorkQueue) Admit(
+	_ context.Context, info WorkInfo,
+) (AdmitResponse, error) {
 	if !t.disabled {
 		t.buf.WriteString(fmt.Sprintf("admitted=%s ", time.Duration(info.RequestedCount)))
 	}

--- a/pkg/util/admission/granter_test.go
+++ b/pkg/util/admission/granter_test.go
@@ -85,7 +85,7 @@ func TestCPUGranterBasic(t *testing.T) {
 				req := &testRequester{
 					workKind:               workKind,
 					granter:                granter,
-					usesTokens:             opts.usesTokens,
+					usesTokens:             opts.mode == usesTokens,
 					buf:                    &buf,
 					returnValueFromGranted: 1,
 				}
@@ -436,7 +436,7 @@ func TestStoreCoordinators(t *testing.T) {
 		req := &testRequester{
 			workKind:   workKind,
 			granter:    granter,
-			usesTokens: opts.usesTokens,
+			usesTokens: opts.mode == usesTokens,
 			buf:        &buf,
 		}
 		if workKind == KVWork {

--- a/pkg/util/admission/replicated_write_admission_test.go
+++ b/pkg/util/admission/replicated_write_admission_test.go
@@ -90,7 +90,7 @@ func TestReplicatedWriteAdmission(t *testing.T) {
 				elasticMetrics := makeWorkQueueMetrics("elastic", registry)
 				workQueueMetrics := [admissionpb.NumWorkClasses]*WorkQueueMetrics{regMetrics, elasticMetrics}
 				opts := makeWorkQueueOptions(KVWork)
-				opts.usesTokens = true
+				opts.mode = usesTokens
 				opts.timeSource = timeutil.NewManualTime(tzero)
 				opts.disableEpochClosingGoroutine = true
 				knobs := &TestingKnobs{

--- a/pkg/util/admission/snapshot_queue_test.go
+++ b/pkg/util/admission/snapshot_queue_test.go
@@ -77,7 +77,7 @@ func TestSnapshotQueue(t *testing.T) {
 						wrkMap.delete(id)
 					} else {
 						buf.printf("id %d: admit succeeded", id)
-						wrkMap.setAdmitted(id, StoreWorkHandle{})
+						wrkMap.setAdmitted(id, AdmitResponse{}, StoreWorkHandle{})
 					}
 				}(ctx, id, count, minRate)
 				// Need deterministic output, and this is racing with the goroutine

--- a/pkg/util/admission/store_grant_coordinator.go
+++ b/pkg/util/admission/store_grant_coordinator.go
@@ -226,8 +226,8 @@ func (sgc *StoreGrantCoordinators) initGrantCoordinator(
 	kvg.mu.diskTokensAvailable.writeByteTokens = unlimitedTokens / unloadedDuration.ticksInAdjustmentInterval()
 
 	opts := makeWorkQueueOptions(KVWork)
-	// This is IO work, so override the usesTokens value.
-	opts.usesTokens = true
+	// This is IO work, so override the mode value.
+	opts.mode = usesTokens
 	storeGranters := [admissionpb.NumWorkClasses]granterWithStoreReplicatedWorkAdmitted{
 		&kvStoreTokenChildGranter{
 			workType: admissionpb.RegularStoreWorkType,

--- a/pkg/util/admission/testdata/cpu_time_token_work_queue
+++ b/pkg/util/admission/testdata/cpu_time_token_work_queue
@@ -1,0 +1,55 @@
+init
+----
+
+# See comment above TestCPUTimeTokenWorkQueue for background. This is
+# mostly a test of AdmittedWorkDone (work-done). So AC admits requests,
+# one to tenant ID 53 and another to tenant ID 54. The test granter
+# has been set up to allow granting of all requests. This is just test
+# setup.
+admit id=1 tenant=53 requested-count=3
+----
+tryGet: returning true
+id 1: admit succeeded
+
+admit id=2 tenant=54 requested-count=8
+----
+tryGet: returning true
+id 2: admit succeeded
+
+print
+----
+closed epoch: 0 tenantHeap len: 0
+ tenant-id: 53 used: 3, w: 1, fifo: -128
+ tenant-id: 54 used: 8, w: 1, fifo: -128
+
+# requested-count at admit time was 3. cpu-time below is 1. This
+# simulates a situation where at admit time, the predicted CPU usage
+# was 3 ns of CPU time (see cpu_time_token_estimation.go), and then
+# measured CPU usage was 1 ns of CPU time. In this case, we should
+# return 3-1=2 tokens to the granter, which stores the CPU time token
+# buckets (see cpu_time_token_granter.go).
+work-done id=1 cpu-time=1
+----
+returnGrant 2
+
+# Also, used should be adjusted, to reflect actual usage in CPU time,
+# again measured in ns. You can see below that used is now 1 for the
+# tenant with tenant ID 53.
+print
+----
+closed epoch: 0 tenantHeap len: 0
+ tenant-id: 53 used: 1, w: 1, fifo: -128
+ tenant-id: 54 used: 8, w: 1, fifo: -128
+
+# In this case, measured CPU usage was more than predicted CPU usage.
+# So, we should take additional tokens from the granter this time.
+work-done id=2 cpu-time=15
+----
+tookWithoutPermission 7
+
+# Same here. Used is adjusted, to reflect actual usage.
+print
+----
+closed epoch: 0 tenantHeap len: 0
+ tenant-id: 53 used: 1, w: 1, fifo: -128
+ tenant-id: 54 used: 15, w: 1, fifo: -128

--- a/pkg/util/admission/testing_knobs.go
+++ b/pkg/util/admission/testing_knobs.go
@@ -37,6 +37,11 @@ type TestingKnobs struct {
 	// AlwaysTryGrantWhenAdmitted causes the granter to unconditionally try
 	// admitting another request when admitting one.
 	AlwaysTryGrantWhenAdmitted bool
+
+	// If mode == usesCPUTimeTokens, WorkQueue does CPU time token estimation.
+	// This knob allows disabling that, in order to take control over token
+	// count deductions in tests.
+	DisableCPUTimeTokenEstimation bool
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/util/admission/work_queue_test.go
+++ b/pkg/util/admission/work_queue_test.go
@@ -103,9 +103,10 @@ func (tg *testGranter) storeReplicatedWorkAdmittedLocked(
 }
 
 type testWork struct {
-	tenantID roachpb.TenantID
 	cancel   context.CancelFunc
 	admitted bool
+	// For plain WorkQueue testing.
+	resp AdmitResponse
 	// For StoreWorkQueue testing.
 	handle StoreWorkHandle
 }
@@ -133,11 +134,14 @@ func (m *workMap) delete(id int) {
 	delete(m.workMap, id)
 }
 
+// resp can be empty when not testing plain WorkQueue (e.g.
+// TestSnapshotQueue).
 // handle can be empty when not testing StoreWorkQueue.
-func (m *workMap) setAdmitted(id int, handle StoreWorkHandle) {
+func (m *workMap) setAdmitted(id int, resp AdmitResponse, handle StoreWorkHandle) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.workMap[id].admitted = true
+	m.workMap[id].resp = resp
 	m.workMap[id].handle = handle
 }
 
@@ -213,7 +217,7 @@ func TestWorkQueueBasic(t *testing.T) {
 				var bypass bool
 				d.ScanArgs(t, "bypass", &bypass)
 				ctx, cancel := context.WithCancel(context.Background())
-				wrkMap.set(id, &testWork{tenantID: tenant, cancel: cancel})
+				wrkMap.set(id, &testWork{cancel: cancel})
 				workInfo := WorkInfo{
 					TenantID:        tenant,
 					Priority:        admissionpb.WorkPriority(priority),
@@ -221,14 +225,17 @@ func TestWorkQueueBasic(t *testing.T) {
 					BypassAdmission: bypass,
 				}
 				go func(ctx context.Context, info WorkInfo, id int) {
-					enabled, err := q.Admit(ctx, info)
-					require.True(t, enabled)
+					require.Equal(t, int64(0), info.RequestedCount)
+					resp, err := q.Admit(ctx, info)
 					if err != nil {
 						buf.printf("id %d: admit failed", id)
 						wrkMap.delete(id)
 					} else {
+						require.True(t, resp.Enabled)
+						// Since slots, one concurrent slot always requested.
+						require.Equal(t, int64(1), resp.requestedCount)
 						buf.printf("id %d: admit succeeded", id)
-						wrkMap.setAdmitted(id, StoreWorkHandle{})
+						wrkMap.setAdmitted(id, resp, StoreWorkHandle{})
 					}
 				}(ctx, workInfo, id)
 				// Need deterministic output, and this is racing with the goroutine
@@ -284,7 +291,7 @@ func TestWorkQueueBasic(t *testing.T) {
 				if d.HasArg("cpu-time") {
 					d.ScanArgs(t, "cpu-time", &cpuTime)
 				}
-				q.AdmittedWorkDone(work.tenantID, time.Duration(cpuTime))
+				q.AdmittedWorkDone(work.resp, time.Duration(cpuTime))
 				wrkMap.delete(id)
 				return buf.stringAndReset()
 
@@ -390,22 +397,23 @@ func TestWorkQueueTokenResetRace(t *testing.T) {
 			select {
 			case <-ticker.C:
 				ctx, cancel := context.WithCancel(context.Background())
-				work2 := &testWork{tenantID: roachpb.MustMakeTenantID(tenantID), cancel: cancel}
+				work2 := &testWork{cancel: cancel}
 				tenantID++
-				go func(ctx context.Context, w *testWork, createTime int64) {
-					enabled, err := q.Admit(ctx, WorkInfo{
-						TenantID:   w.tenantID,
+				go func(ctx context.Context, tenantID uint64, createTime int64) {
+					resp, err := q.Admit(ctx, WorkInfo{
+						TenantID:   roachpb.MustMakeTenantID(tenantID),
 						CreateTime: createTime,
 					})
 					buf.printf("admit")
-					require.Equal(t, true, enabled)
 					mu.Lock()
 					defer mu.Unlock()
 					totalCount++
 					if err != nil {
 						errCount++
+					} else {
+						require.Equal(t, true, resp.Enabled)
 					}
-				}(ctx, work2, createTime)
+				}(ctx, tenantID, createTime)
 				createTime++
 				if work != nil {
 					rv := tg.r.granted(1)
@@ -564,7 +572,7 @@ func TestStoreWorkQueueBasic(t *testing.T) {
 				tg[admissionpb.RegularWorkClass] = &testGranter{name: " regular", buf: &buf}
 				tg[admissionpb.ElasticWorkClass] = &testGranter{name: " elastic", buf: &buf}
 				opts := makeWorkQueueOptions(KVWork)
-				opts.usesTokens = true
+				opts.mode = usesTokens
 				opts.timeSource = timeutil.NewManualTime(timeutil.FromUnixMicros(0))
 				opts.disableEpochClosingGoroutine = true
 				opts.disableGCTenantsAndResetUsed = true
@@ -594,7 +602,7 @@ func TestStoreWorkQueueBasic(t *testing.T) {
 				var bypass bool
 				d.ScanArgs(t, "bypass", &bypass)
 				ctx, cancel := context.WithCancel(context.Background())
-				wrkMap.set(id, &testWork{tenantID: tenant, cancel: cancel})
+				wrkMap.set(id, &testWork{cancel: cancel})
 				workInfo := StoreWriteWorkInfo{
 					WorkInfo: WorkInfo{
 						TenantID:        tenant,
@@ -610,7 +618,7 @@ func TestStoreWorkQueueBasic(t *testing.T) {
 						wrkMap.delete(id)
 					} else {
 						buf.printf("id %d: admit succeeded with handle %+v", id, handle)
-						wrkMap.setAdmitted(id, handle)
+						wrkMap.setAdmitted(id, AdmitResponse{}, handle)
 					}
 				}(ctx, workInfo, id)
 				// Need deterministic output, and this is racing with the goroutine


### PR DESCRIPTION
**admission: refactor WorkQueue return values**

This commit is a pure refactor of WorkQueue. It is
prep for the next commit, which will make WorkQueue
support CPU time token AC. The change in the next
commit will be to AdmittedWorkDone. This commit adjusts
the return value of Admit, to enable that change.

Release note: None.

Part of: https://github.com/cockroachdb/cockroach/issues/155991

**admission: modify WorkQueue to support CPU tokens**

This commit modifies WorkQueue to support CPU time token AC.
The change is a change to AdmittedWorkDone. With tokens,
we do not return 1 to the granter always, as in slots.
With slots, we have a concurrency limit to manage. With
CPU time tokens, we have a variable rate limit to manage.
These require different logic in WorkQueue.

Release note: None.

Fixes: https://github.com/cockroachdb/cockroach/issues/155991

**admission: add CPU time token estimation to WorkQueue**

This commit adds CPU time token estimation to WorkQueue.
That is, at Admit time, an estimate is made of the CPU time
cost of the to-be-executed request. Then, once the request
is done executing, the estimators receive info on actual
runtime from grunning, which they use to improve future
estimates.

Release note: None.

Part of: https://github.com/cockroachdb/cockroach/issues/155991