### PR TITLE
kvserver: teach TestReplicaLifecycleDataDriven about separate engines

### DIFF
--- a/pkg/kv/kvserver/kvstorage/storage.go
+++ b/pkg/kv/kvserver/kvstorage/storage.go
@@ -74,6 +74,11 @@ func WrapState(rw StateRW) State {
 	return State{RO: rw, WO: rw}
 }
 
+// WrapRaft interprets the provided storage accessor as the Raft engine.
+func WrapRaft(rw RaftRW) Raft {
+	return Raft{RO: rw, WO: rw}
+}
+
 // TODORaft interprets the provided storage accessor as the Raft engine.
 //
 // TODO(pav-kv): remove when all callers have clarified their access patterns.

--- a/pkg/kv/kvserver/testdata/replica_lifecycle/create_replica.txt
+++ b/pkg/kv/kvserver/testdata/replica_lifecycle/create_replica.txt
@@ -5,6 +5,7 @@ created descriptor: r1:{a-d} [(n1,s1):3, (n2,s2):4, (n3,s3):5, next=6, gen=0]
 create-replica range-id=1
 ----
 created replica: (n1,s1):3
+state engine:
 Put: 0,0 /Local/RangeID/1/u/RaftReplicaID (0x016989757266747200): replica_id:3 
 
 # Make the uninitialized replica vote.
@@ -20,12 +21,14 @@ created descriptor: r2:{d-k} [(n1,s1):1, (n2,s2):2, (n3,s3):3, next=4, gen=0]
 create-replica range-id=2 initialized
 ----
 created replica: (n1,s1):1
+state engine:
 Put: 0,0 /Local/RangeID/2/r/RangeLease (0x01698a72726c6c2d00): <empty>
 Put: 0,0 /Local/RangeID/2/r/RangeGCThreshold (0x01698a726c67632d00): 0,0
 Put: 0,0 /Local/RangeID/2/r/RangeGCHint (0x01698a727267636800): latest_range_delete_timestamp:<> gc_timestamp:<> gc_timestamp_next:<> 
 Put: 0,0 /Local/RangeID/2/r/RangeVersion (0x01698a727276657200): 10.8-upgrading-step-007
 Put: 0,0 /Local/RangeID/2/r/RangeAppliedState (0x01698a727261736b00): raft_applied_index:10 lease_applied_index:10 range_stats:<sys_bytes:142 sys_count:4 > raft_closed_timestamp:<> raft_applied_index_term:5 
 Put: 0,0 /Local/RangeID/2/u/RaftReplicaID (0x01698a757266747200): replica_id:1 
+log engine:
 Put: 0,0 /Local/RangeID/2/u/RaftHardState (0x01698a757266746800): term:5 vote:0 commit:10 lead:0 lead_epoch:0 
 Put: 0,0 /Local/RangeID/2/u/RaftTruncatedState (0x01698a757266747400): index:10 term:5 
 

--- a/pkg/kv/kvserver/testdata/replica_lifecycle/destroy_replica.txt
+++ b/pkg/kv/kvserver/testdata/replica_lifecycle/destroy_replica.txt
@@ -5,25 +5,29 @@ created descriptor: r1:{a-c} [(n1,s1):1, (n2,s2):2, (n3,s3):3, next=4, gen=0]
 create-replica range-id=1 initialized
 ----
 created replica: (n1,s1):1
+state engine:
 Put: 0,0 /Local/RangeID/1/r/RangeLease (0x01698972726c6c2d00): <empty>
 Put: 0,0 /Local/RangeID/1/r/RangeGCThreshold (0x016989726c67632d00): 0,0
 Put: 0,0 /Local/RangeID/1/r/RangeGCHint (0x016989727267636800): latest_range_delete_timestamp:<> gc_timestamp:<> gc_timestamp_next:<> 
 Put: 0,0 /Local/RangeID/1/r/RangeVersion (0x016989727276657200): 10.8-upgrading-step-007
 Put: 0,0 /Local/RangeID/1/r/RangeAppliedState (0x016989727261736b00): raft_applied_index:10 lease_applied_index:10 range_stats:<sys_bytes:142 sys_count:4 > raft_closed_timestamp:<> raft_applied_index_term:5 
 Put: 0,0 /Local/RangeID/1/u/RaftReplicaID (0x016989757266747200): replica_id:1 
+log engine:
 Put: 0,0 /Local/RangeID/1/u/RaftHardState (0x016989757266746800): term:5 vote:0 commit:10 lead:0 lead_epoch:0 
 Put: 0,0 /Local/RangeID/1/u/RaftTruncatedState (0x016989757266747400): index:10 term:5 
 
 destroy-replica range-id=1
 ----
+state engine:
 Delete (Sized at 28): 0,0 /Local/RangeID/1/r/RangeGCThreshold (0x016989726c67632d00): 
 Delete (Sized at 43): 0,0 /Local/RangeID/1/r/RangeAppliedState (0x016989727261736b00): 
 Delete (Sized at 34): 0,0 /Local/RangeID/1/r/RangeGCHint (0x016989727267636800): 
 Delete (Sized at 44): 0,0 /Local/RangeID/1/r/RangeLease (0x01698972726c6c2d00): 
 Delete (Sized at 36): 0,0 /Local/RangeID/1/r/RangeVersion (0x016989727276657200): 
 Put: 0,0 /Local/RangeID/1/u/RangeTombstone (0x016989757266746200): next_replica_id:4 
-Delete (Sized at 38): 0,0 /Local/RangeID/1/u/RaftHardState (0x016989757266746800): 
 Delete: 0,0 /Local/RangeID/1/u/RaftReplicaID (0x016989757266747200): 
+log engine:
+Delete (Sized at 38): 0,0 /Local/RangeID/1/u/RaftHardState (0x016989757266746800): 
 Delete (Sized at 32): 0,0 /Local/RangeID/1/u/RaftTruncatedState (0x016989757266747400): 
 
 create-descriptor start=c end=f replicas=(1,2,3,4,5)
@@ -33,23 +37,27 @@ created descriptor: r2:{c-f} [(n1,s1):1, (n2,s2):2, (n3,s3):3, (n4,s4):4, (n5,s5
 create-replica range-id=2 initialized
 ----
 created replica: (n1,s1):1
+state engine:
 Put: 0,0 /Local/RangeID/2/r/RangeLease (0x01698a72726c6c2d00): <empty>
 Put: 0,0 /Local/RangeID/2/r/RangeGCThreshold (0x01698a726c67632d00): 0,0
 Put: 0,0 /Local/RangeID/2/r/RangeGCHint (0x01698a727267636800): latest_range_delete_timestamp:<> gc_timestamp:<> gc_timestamp_next:<> 
 Put: 0,0 /Local/RangeID/2/r/RangeVersion (0x01698a727276657200): 10.8-upgrading-step-007
 Put: 0,0 /Local/RangeID/2/r/RangeAppliedState (0x01698a727261736b00): raft_applied_index:10 lease_applied_index:10 range_stats:<sys_bytes:142 sys_count:4 > raft_closed_timestamp:<> raft_applied_index_term:5 
 Put: 0,0 /Local/RangeID/2/u/RaftReplicaID (0x01698a757266747200): replica_id:1 
+log engine:
 Put: 0,0 /Local/RangeID/2/u/RaftHardState (0x01698a757266746800): term:5 vote:0 commit:10 lead:0 lead_epoch:0 
 Put: 0,0 /Local/RangeID/2/u/RaftTruncatedState (0x01698a757266747400): index:10 term:5 
 
 append-raft-entries range-id=2 num-entries=3
 ----
+log engine:
 Put: 0,0 /Local/RangeID/2/u/RaftLog/logIndex:11 (0x01698a757266746c000000000000000b00): Term:5 Index:11 Type:EntryNormal : EMPTY
 Put: 0,0 /Local/RangeID/2/u/RaftLog/logIndex:12 (0x01698a757266746c000000000000000c00): Term:5 Index:12 Type:EntryNormal : EMPTY
 Put: 0,0 /Local/RangeID/2/u/RaftLog/logIndex:13 (0x01698a757266746c000000000000000d00): Term:5 Index:13 Type:EntryNormal : EMPTY
 
 create-range-data range-id=2 num-user-keys=2 num-system-keys=3 num-lock-table-keys=4
 ----
+state engine:
 Put: 0.000000001,0 "c0" (0x633000000000000000000109): ""
 Put: 0.000000001,0 "c1" (0x633100000000000000000109): ""
 Put: 0.000000001,0 /Local/Range"c0"/Transaction/"6ba7b810-9dad-11d1-80b4-00c04fd430c8" (0x016b126330000174786e2d6ba7b8109dad11d180b400c04fd430c800000000000000000109): ""
@@ -62,18 +70,14 @@ Put: "c3"/Intent/00000000-0000-0000-0000-000000000000:
 
 destroy-replica range-id=2
 ----
+state engine:
 Delete (Sized at 28): 0,0 /Local/RangeID/2/r/RangeGCThreshold (0x01698a726c67632d00): 
 Delete (Sized at 43): 0,0 /Local/RangeID/2/r/RangeAppliedState (0x01698a727261736b00): 
 Delete (Sized at 34): 0,0 /Local/RangeID/2/r/RangeGCHint (0x01698a727267636800): 
 Delete (Sized at 44): 0,0 /Local/RangeID/2/r/RangeLease (0x01698a72726c6c2d00): 
 Delete (Sized at 36): 0,0 /Local/RangeID/2/r/RangeVersion (0x01698a727276657200): 
 Put: 0,0 /Local/RangeID/2/u/RangeTombstone (0x01698a757266746200): next_replica_id:6 
-Delete (Sized at 38): 0,0 /Local/RangeID/2/u/RaftHardState (0x01698a757266746800): 
-Delete (Sized at 42): 0,0 /Local/RangeID/2/u/RaftLog/logIndex:11 (0x01698a757266746c000000000000000b00): 
-Delete (Sized at 42): 0,0 /Local/RangeID/2/u/RaftLog/logIndex:12 (0x01698a757266746c000000000000000c00): 
-Delete (Sized at 42): 0,0 /Local/RangeID/2/u/RaftLog/logIndex:13 (0x01698a757266746c000000000000000d00): 
 Delete: 0,0 /Local/RangeID/2/u/RaftReplicaID (0x01698a757266747200): 
-Delete (Sized at 32): 0,0 /Local/RangeID/2/u/RaftTruncatedState (0x01698a757266747400): 
 Delete (Sized at 37): 0.000000001,0 /Local/Range"c0"/Transaction/"6ba7b810-9dad-11d1-80b4-00c04fd430c8" (0x016b126330000174786e2d6ba7b8109dad11d180b400c04fd430c800000000000000000109): 
 Delete (Sized at 37): 0.000000001,0 /Local/Range"c1"/Transaction/"6ba7b810-9dad-11d1-80b4-00c04fd430c8" (0x016b126331000174786e2d6ba7b8109dad11d180b400c04fd430c800000000000000000109): 
 Delete (Sized at 37): 0.000000001,0 /Local/Range"c2"/Transaction/"6ba7b810-9dad-11d1-80b4-00c04fd430c8" (0x016b126332000174786e2d6ba7b8109dad11d180b400c04fd430c800000000000000000109): 
@@ -83,3 +87,9 @@ Delete (Sized at 27): /Local/Lock"c2" 0300000000000000000000000000000000 (0x017a
 Delete (Sized at 27): /Local/Lock"c3" 0300000000000000000000000000000000 (0x017a6b126333000100030000000000000000000000000000000012): 
 Delete (Sized at 12): 0.000000001,0 "c0" (0x633000000000000000000109): 
 Delete (Sized at 12): 0.000000001,0 "c1" (0x633100000000000000000109): 
+log engine:
+Delete (Sized at 38): 0,0 /Local/RangeID/2/u/RaftHardState (0x01698a757266746800): 
+Delete (Sized at 42): 0,0 /Local/RangeID/2/u/RaftLog/logIndex:11 (0x01698a757266746c000000000000000b00): 
+Delete (Sized at 42): 0,0 /Local/RangeID/2/u/RaftLog/logIndex:12 (0x01698a757266746c000000000000000c00): 
+Delete (Sized at 42): 0,0 /Local/RangeID/2/u/RaftLog/logIndex:13 (0x01698a757266746c000000000000000d00): 
+Delete (Sized at 32): 0,0 /Local/RangeID/2/u/RaftTruncatedState (0x01698a757266747400): 

--- a/pkg/kv/kvserver/testdata/replica_lifecycle/split_pre_apply.txt
+++ b/pkg/kv/kvserver/testdata/replica_lifecycle/split_pre_apply.txt
@@ -11,18 +11,21 @@ created descriptor: r1:{a-z} [(n1,s1):1, (n2,s2):2, (n3,s3):3, next=4, gen=0]
 create-replica range-id=1 initialized
 ----
 created replica: (n1,s1):1
+state engine:
 Put: 0,0 /Local/RangeID/1/r/RangeLease (0x01698972726c6c2d00): <empty>
 Put: 0,0 /Local/RangeID/1/r/RangeGCThreshold (0x016989726c67632d00): 0,0
 Put: 0,0 /Local/RangeID/1/r/RangeGCHint (0x016989727267636800): latest_range_delete_timestamp:<> gc_timestamp:<> gc_timestamp_next:<> 
 Put: 0,0 /Local/RangeID/1/r/RangeVersion (0x016989727276657200): 10.8-upgrading-step-007
 Put: 0,0 /Local/RangeID/1/r/RangeAppliedState (0x016989727261736b00): raft_applied_index:10 lease_applied_index:10 range_stats:<sys_bytes:142 sys_count:4 > raft_closed_timestamp:<> raft_applied_index_term:5 
 Put: 0,0 /Local/RangeID/1/u/RaftReplicaID (0x016989757266747200): replica_id:1 
+log engine:
 Put: 0,0 /Local/RangeID/1/u/RaftHardState (0x016989757266746800): term:5 vote:0 commit:10 lead:0 lead_epoch:0 
 Put: 0,0 /Local/RangeID/1/u/RaftTruncatedState (0x016989757266747400): index:10 term:5 
 
 # Add some data that will belong to the RHS range after the split.
 create-range-data range-id=1 base-key=m num-user-keys=1
 ----
+state engine:
 Put: 0.000000001,0 "m0" (0x6d3000000000000000000109): ""
 
 set-lease range-id=1 replica=1
@@ -37,12 +40,14 @@ lhs: r1 ["a", "m"), rhs: r2 ["m", "z")
 create-replica range-id=2
 ----
 created replica: (n1,s1):1
+state engine:
 Put: 0,0 /Local/RangeID/2/u/RaftReplicaID (0x01698a757266747200): replica_id:1 
 
 # Destroy the RHS replica before applying the split. This simulates the case
 # where the RHS replica was removed from the store before the split was applied.
 destroy-replica range-id=2
 ----
+state engine:
 Put: 0,0 /Local/RangeID/2/u/RangeTombstone (0x01698a757266746200): next_replica_id:4 
 Delete: 0,0 /Local/RangeID/2/u/RaftReplicaID (0x01698a757266747200): 
 
@@ -50,6 +55,7 @@ Delete: 0,0 /Local/RangeID/2/u/RaftReplicaID (0x01698a757266747200):
 # all. See https://github.com/cockroachdb/cockroach/issues/157897.
 apply-split range-id=1
 ----
+state engine:
 Put: 0,0 /Local/RangeID/2/u/RangeLastReplicaGCTimestamp (0x01698a75726c727400): 0,0
 Put: 0,0 /Local/Range"m"/QueueLastProcessed/"consistencyChecker" (0x016b126d0001716c7074636f6e73697374656e6379436865636b657200): meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0
 Put: 0,0 /Local/RangeID/2/r/RangeLease (0x01698a72726c6c2d00): repl=(n1,s1):1 seq=0 start=0,0 type=LeaseExpiration exp=0.000000109,0 pro=0,0 acq=Unspecified
@@ -81,6 +87,7 @@ range desc: r2:{m-z} [(n1,s1):1, (n2,s2):2, (n3,s3):3, next=4, gen=0]
 # applying the split.
 create-range-data range-id=1 base-key=g num-user-keys=1
 ----
+state engine:
 Put: 0.000000001,0 "g0" (0x673000000000000000000109): ""
 
 eval-split range-id=1 split-key=f
@@ -91,12 +98,14 @@ lhs: r1 ["a", "f"), rhs: r3 ["f", "m")
 create-replica range-id=3 replica-id=5
 ----
 created replica: (n1,s1):5
+state engine:
 Put: 0,0 /Local/RangeID/3/u/RaftReplicaID (0x01698b757266747200): replica_id:5 
 
 # Apply the split. The RHS is detected as destroyed because its ReplicaID (5)
 # is higher than the one in the split trigger (1).
 apply-split range-id=1
 ----
+state engine:
 Put: 0,0 /Local/RangeID/3/u/RangeLastReplicaGCTimestamp (0x01698b75726c727400): 0,0
 Put: 0,0 /Local/Range"f"/QueueLastProcessed/"consistencyChecker" (0x016b12660001716c7074636f6e73697374656e6379436865636b657200): meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0
 Put: 0,0 /Local/RangeID/3/r/RangeLease (0x01698b72726c6c2d00): repl=(n1,s1):1 seq=0 start=0,0 type=LeaseExpiration exp=0.000000109,1 pro=0,0 acq=Unspecified
@@ -119,6 +128,7 @@ Delete (Sized at 12): 0.000000001,0 "g0" (0x673000000000000000000109):
 # it shouldn't be cleared, because the RHS replica hasn't been destroyed.
 create-range-data range-id=1 base-key=d num-user-keys=1
 ----
+state engine:
 Put: 0.000000001,0 "d0" (0x643000000000000000000109): ""
 
 eval-split range-id=1 split-key=c
@@ -129,10 +139,12 @@ lhs: r1 ["a", "c"), rhs: r4 ["c", "f")
 create-replica range-id=4 replica-id=1
 ----
 created replica: (n1,s1):1
+state engine:
 Put: 0,0 /Local/RangeID/4/u/RaftReplicaID (0x01698c757266747200): replica_id:1 
 
 apply-split range-id=1
 ----
+state engine:
 Put: 0,0 /Local/RangeID/4/u/RangeLastReplicaGCTimestamp (0x01698c75726c727400): 0,0
 Put: 0,0 /Local/Range"c"/QueueLastProcessed/"consistencyChecker" (0x016b12630001716c7074636f6e73697374656e6379436865636b657200): meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0
 Put: 0,0 /Local/RangeID/4/r/RangeLease (0x01698c72726c6c2d00): repl=(n1,s1):1 seq=0 start=0,0 type=LeaseExpiration exp=0.000000109,2 pro=0,0 acq=Unspecified
@@ -140,9 +152,10 @@ Put: 0,0 /Local/RangeID/4/r/RangeGCThreshold (0x01698c726c67632d00): 0.000000004
 Put: 0,0 /Local/RangeID/4/r/RangeGCHint (0x01698c727267636800): latest_range_delete_timestamp:<> gc_timestamp:<wall_time:4 > gc_timestamp_next:<> 
 Put: 0,0 /Local/RangeID/4/r/RangeVersion (0x01698c727276657200): 10.8-upgrading-step-007
 Put: 0,0 /Local/RangeID/4/r/RangeAppliedState (0x01698c727261736b00): raft_applied_index:10 lease_applied_index:10 range_stats:<sys_bytes:200 sys_count:5 > raft_closed_timestamp:<> raft_applied_index_term:5 
+Put: 0,0 /Local/RangeID/4/r/RangeAppliedState (0x01698c727261736b00): raft_applied_index:10 lease_applied_index:10 range_stats:<sys_bytes:200 sys_count:5 > raft_closed_timestamp:<wall_time:100 > raft_applied_index_term:5 
+log engine:
 Put: 0,0 /Local/RangeID/4/u/RaftHardState (0x01698c757266746800): term:5 vote:0 commit:10 lead:0 lead_epoch:0 
 Put: 0,0 /Local/RangeID/4/u/RaftTruncatedState (0x01698c757266747400): index:10 term:5 
-Put: 0,0 /Local/RangeID/4/r/RangeAppliedState (0x01698c727261736b00): raft_applied_index:10 lease_applied_index:10 range_stats:<sys_bytes:200 sys_count:5 > raft_closed_timestamp:<wall_time:100 > raft_applied_index_term:5 
 
 print-range-state
 ----

--- a/pkg/kv/kvserver/testdata/replica_lifecycle/split_trigger.txt
+++ b/pkg/kv/kvserver/testdata/replica_lifecycle/split_trigger.txt
@@ -5,12 +5,14 @@ created descriptor: r1:{a-z} [(n1,s1):1, (n2,s2):2, (n3,s3):3, next=4, gen=0]
 create-replica range-id=1 initialized
 ----
 created replica: (n1,s1):1
+state engine:
 Put: 0,0 /Local/RangeID/1/r/RangeLease (0x01698972726c6c2d00): <empty>
 Put: 0,0 /Local/RangeID/1/r/RangeGCThreshold (0x016989726c67632d00): 0,0
 Put: 0,0 /Local/RangeID/1/r/RangeGCHint (0x016989727267636800): latest_range_delete_timestamp:<> gc_timestamp:<> gc_timestamp_next:<> 
 Put: 0,0 /Local/RangeID/1/r/RangeVersion (0x016989727276657200): 10.8-upgrading-step-007
 Put: 0,0 /Local/RangeID/1/r/RangeAppliedState (0x016989727261736b00): raft_applied_index:10 lease_applied_index:10 range_stats:<sys_bytes:142 sys_count:4 > raft_closed_timestamp:<> raft_applied_index_term:5 
 Put: 0,0 /Local/RangeID/1/u/RaftReplicaID (0x016989757266747200): replica_id:1 
+log engine:
 Put: 0,0 /Local/RangeID/1/u/RaftHardState (0x016989757266746800): term:5 vote:0 commit:10 lead:0 lead_epoch:0 
 Put: 0,0 /Local/RangeID/1/u/RaftTruncatedState (0x016989757266747400): index:10 term:5 
 
@@ -37,12 +39,14 @@ Put: 0,0 /Local/RangeID/2/r/RangeAppliedState (0x01698a727261736b00): raft_appli
 create-replica range-id=2
 ----
 created replica: (n1,s1):1
+state engine:
 Put: 0,0 /Local/RangeID/2/u/RaftReplicaID (0x01698a757266747200): replica_id:1 
 
 # apply-split applies the stashed batch and runs splitPreApply. It automatically
 # detects that the RHS replica exists and initializes it.
 apply-split range-id=1
 ----
+state engine:
 Put: 0,0 /Local/RangeID/2/u/RangeLastReplicaGCTimestamp (0x01698a75726c727400): 0,0
 Put: 0,0 /Local/Range"m"/QueueLastProcessed/"consistencyChecker" (0x016b126d0001716c7074636f6e73697374656e6379436865636b657200): meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0
 Put: 0,0 /Local/RangeID/2/r/RangeLease (0x01698a72726c6c2d00): repl=(n2,s2):2 seq=0 start=0,0 type=LeaseExpiration exp=0.000000109,0 pro=0,0 acq=Unspecified
@@ -50,9 +54,10 @@ Put: 0,0 /Local/RangeID/2/r/RangeGCThreshold (0x01698a726c67632d00): 0.000000004
 Put: 0,0 /Local/RangeID/2/r/RangeGCHint (0x01698a727267636800): latest_range_delete_timestamp:<> gc_timestamp:<wall_time:4 > gc_timestamp_next:<> 
 Put: 0,0 /Local/RangeID/2/r/RangeVersion (0x01698a727276657200): 10.8-upgrading-step-007
 Put: 0,0 /Local/RangeID/2/r/RangeAppliedState (0x01698a727261736b00): raft_applied_index:10 lease_applied_index:10 range_stats:<sys_bytes:198 sys_count:5 > raft_closed_timestamp:<> raft_applied_index_term:5 
+Put: 0,0 /Local/RangeID/2/r/RangeAppliedState (0x01698a727261736b00): raft_applied_index:10 lease_applied_index:10 range_stats:<sys_bytes:198 sys_count:5 > raft_closed_timestamp:<wall_time:100 > raft_applied_index_term:5 
+log engine:
 Put: 0,0 /Local/RangeID/2/u/RaftHardState (0x01698a757266746800): term:5 vote:0 commit:10 lead:0 lead_epoch:0 
 Put: 0,0 /Local/RangeID/2/u/RaftTruncatedState (0x01698a757266747400): index:10 term:5 
-Put: 0,0 /Local/RangeID/2/r/RangeAppliedState (0x01698a727261736b00): raft_applied_index:10 lease_applied_index:10 range_stats:<sys_bytes:198 sys_count:5 > raft_closed_timestamp:<wall_time:100 > raft_applied_index_term:5 
 
 # Note the lease types for r1 and r2. r2 gets an expiration based lease.
 print-range-state
@@ -85,10 +90,12 @@ Put: 0,0 /Local/RangeID/3/r/RangeAppliedState (0x01698b727261736b00): raft_appli
 create-replica range-id=3
 ----
 created replica: (n1,s1):1
+state engine:
 Put: 0,0 /Local/RangeID/3/u/RaftReplicaID (0x01698b757266747200): replica_id:1 
 
 apply-split range-id=1
 ----
+state engine:
 Put: 0,0 /Local/RangeID/3/u/RangeLastReplicaGCTimestamp (0x01698b75726c727400): 0,0
 Put: 0,0 /Local/Range"f"/QueueLastProcessed/"consistencyChecker" (0x016b12660001716c7074636f6e73697374656e6379436865636b657200): meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0
 Put: 0,0 /Local/RangeID/3/r/RangeLease (0x01698b72726c6c2d00): repl=(n1,s1):1 seq=0 start=0,0 type=LeaseEpoch epo=20 min-exp=0,0 pro=0,0 acq=Unspecified
@@ -96,9 +103,10 @@ Put: 0,0 /Local/RangeID/3/r/RangeGCThreshold (0x01698b726c67632d00): 0.000000004
 Put: 0,0 /Local/RangeID/3/r/RangeGCHint (0x01698b727267636800): latest_range_delete_timestamp:<> gc_timestamp:<wall_time:4 > gc_timestamp_next:<> 
 Put: 0,0 /Local/RangeID/3/r/RangeVersion (0x01698b727276657200): 10.8-upgrading-step-007
 Put: 0,0 /Local/RangeID/3/r/RangeAppliedState (0x01698b727261736b00): raft_applied_index:10 lease_applied_index:10 range_stats:<sys_bytes:196 sys_count:5 > raft_closed_timestamp:<> raft_applied_index_term:5 
+Put: 0,0 /Local/RangeID/3/r/RangeAppliedState (0x01698b727261736b00): raft_applied_index:10 lease_applied_index:10 range_stats:<sys_bytes:196 sys_count:5 > raft_closed_timestamp:<wall_time:100 > raft_applied_index_term:5 
+log engine:
 Put: 0,0 /Local/RangeID/3/u/RaftHardState (0x01698b757266746800): term:5 vote:0 commit:10 lead:0 lead_epoch:0 
 Put: 0,0 /Local/RangeID/3/u/RaftTruncatedState (0x01698b757266747400): index:10 term:5 
-Put: 0,0 /Local/RangeID/3/r/RangeAppliedState (0x01698b727261736b00): raft_applied_index:10 lease_applied_index:10 range_stats:<sys_bytes:196 sys_count:5 > raft_closed_timestamp:<wall_time:100 > raft_applied_index_term:5 
 
 set-lease range-id=2 replica=3 lease-type=expiration
 ----
@@ -117,10 +125,12 @@ Put: 0,0 /Local/RangeID/4/r/RangeAppliedState (0x01698c727261736b00): raft_appli
 create-replica range-id=4
 ----
 created replica: (n1,s1):1
+state engine:
 Put: 0,0 /Local/RangeID/4/u/RaftReplicaID (0x01698c757266747200): replica_id:1 
 
 apply-split range-id=2
 ----
+state engine:
 Put: 0,0 /Local/RangeID/4/u/RangeLastReplicaGCTimestamp (0x01698c75726c727400): 0,0
 Put: 0,0 /Local/Range"v"/QueueLastProcessed/"consistencyChecker" (0x016b12760001716c7074636f6e73697374656e6379436865636b657200): meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0
 Put: 0,0 /Local/RangeID/4/r/RangeLease (0x01698c72726c6c2d00): repl=(n3,s3):3 seq=0 start=0,0 type=LeaseExpiration exp=0.000000300,0 pro=0,0 acq=Unspecified
@@ -128,9 +138,10 @@ Put: 0,0 /Local/RangeID/4/r/RangeGCThreshold (0x01698c726c67632d00): 0.000000004
 Put: 0,0 /Local/RangeID/4/r/RangeGCHint (0x01698c727267636800): latest_range_delete_timestamp:<> gc_timestamp:<wall_time:4 > gc_timestamp_next:<> 
 Put: 0,0 /Local/RangeID/4/r/RangeVersion (0x01698c727276657200): 10.8-upgrading-step-007
 Put: 0,0 /Local/RangeID/4/r/RangeAppliedState (0x01698c727261736b00): raft_applied_index:10 lease_applied_index:10 range_stats:<sys_bytes:199 sys_count:5 > raft_closed_timestamp:<> raft_applied_index_term:5 
+Put: 0,0 /Local/RangeID/4/r/RangeAppliedState (0x01698c727261736b00): raft_applied_index:10 lease_applied_index:10 range_stats:<sys_bytes:199 sys_count:5 > raft_closed_timestamp:<wall_time:100 > raft_applied_index_term:5 
+log engine:
 Put: 0,0 /Local/RangeID/4/u/RaftHardState (0x01698c757266746800): term:5 vote:0 commit:10 lead:0 lead_epoch:0 
 Put: 0,0 /Local/RangeID/4/u/RaftTruncatedState (0x01698c757266747400): index:10 term:5 
-Put: 0,0 /Local/RangeID/4/r/RangeAppliedState (0x01698c727261736b00): raft_applied_index:10 lease_applied_index:10 range_stats:<sys_bytes:199 sys_count:5 > raft_closed_timestamp:<wall_time:100 > raft_applied_index_term:5 
 
 # Note the lease types for ranges r3 and r4.
 print-range-state sort-keys=true

--- a/pkg/kv/kvserver/testdata/replica_lifecycle/uninitialized_replica_restart.txt
+++ b/pkg/kv/kvserver/testdata/replica_lifecycle/uninitialized_replica_restart.txt
@@ -5,6 +5,7 @@ created descriptor: r1:{a-d} [(n1,s1):5, (n2,s2):6, (n3,s3):7, next=8, gen=0]
 create-replica range-id=1
 ----
 created replica: (n1,s1):5
+state engine:
 Put: 0,0 /Local/RangeID/1/u/RaftReplicaID (0x016989757266747200): replica_id:5 
 
 # Make the uninitialized replica vote.
@@ -45,6 +46,7 @@ ok
 create-replica range-id=1 replica-id=10
 ----
 created replica: (n1,s1):10
+state engine:
 Put: 0,0 /Local/RangeID/1/u/RaftReplicaID (0x016989757266747200): replica_id:10 
 
 # TODO(pav-kv): HardState of the previous replica should not be inherited.


### PR DESCRIPTION
Previously, the test suite acted as if there was only a single storage engine. This patch introduces logical separation in the test suite.

Epic: none

Release note: None