### PR TITLE
spanconfigsqlwatcherccl: enable multitenant testing

### DIFF
--- a/pkg/ccl/spanconfigccl/spanconfigsqlwatcherccl/BUILD.bazel
+++ b/pkg/ccl/spanconfigccl/spanconfigsqlwatcherccl/BUILD.bazel
@@ -31,6 +31,7 @@ go_test(
         "//pkg/testutils/testcluster",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",
+        "//pkg/util/log",
         "//pkg/util/randutil",
         "//pkg/util/syncutil",
         "@com_github_cockroachdb_errors//:errors",


### PR DESCRIPTION
This required changing the test to use the system tenant to configure rangefeed settings.

fixes #106821
Release note: None