### PR TITLE
roachtest: add 1M table introspection benchmark variant

### DIFF
--- a/pkg/ccl/workloadccl/fixture.go
+++ b/pkg/ccl/workloadccl/fixture.go
@@ -402,7 +402,8 @@ func ImportFixture(
 		}); err != nil {
 			return 0, err
 		}
-		currentTable += maxTableBatchSize
+		currentTable = batchEnd
+		log.Dev.Infof(ctx, "created %d/%d tables", currentTable, len(tables))
 	}
 
 	pathPrefix := csvServer

--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -267,6 +267,7 @@ go_library(
         "//pkg/workload/insights",
         "//pkg/workload/kv",
         "//pkg/workload/movr",
+        "//pkg/workload/querybench",
         "//pkg/workload/sqlstats",
         "//pkg/workload/tpcc",
         "//pkg/workload/tpch",

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -35,6 +35,7 @@ import (
 	_ "github.com/cockroachdb/cockroach/pkg/workload/insights"           // registers workloads
 	_ "github.com/cockroachdb/cockroach/pkg/workload/kv"                 // registers workloads
 	_ "github.com/cockroachdb/cockroach/pkg/workload/movr"               // registers workloads
+	_ "github.com/cockroachdb/cockroach/pkg/workload/querybench"         // registers workloads
 	_ "github.com/cockroachdb/cockroach/pkg/workload/sqlstats"           // registers workloads
 	_ "github.com/cockroachdb/cockroach/pkg/workload/tpcc"               // registers workloads
 	_ "github.com/cockroachdb/cockroach/pkg/workload/tpch"               // registers workloads

--- a/pkg/cmd/roachtest/tests/large_schema_benchmark.go
+++ b/pkg/cmd/roachtest/tests/large_schema_benchmark.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
@@ -74,6 +75,9 @@ func registerLargeSchemaBenchmark(r registry.Registry, numTables int, isMultiReg
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Weekly),
 		Timeout:          testTimeout,
+		// Skip INSPECT and descriptor post-validation because this benchmark
+		// creates many databases and tables, and running them would take too long.
+		SkipPostValidations: registry.PostValidationInspect | registry.PostValidationInvalidDescriptors,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			// Cap the total number of workers based on the number of
 			// nodes and CPUs on them.
@@ -300,20 +304,196 @@ func registerLargeSchemaBenchmark(r registry.Registry, numTables int, isMultiReg
 	})
 }
 
+// registerLargeSchemaIntrospectionBenchmark registers tests that create
+// empty tables and benchmark introspection queries without any data import
+// or TPCC workload. This measures how introspection performs with large
+// numbers of tables.
+func registerLargeSchemaIntrospectionBenchmark(r registry.Registry) {
+	for _, numTables := range []int{10_000, 100_000, 1_000_000} {
+		numTables := numTables // capture loop variable
+		clusterSpec := []spec.Option{
+			spec.CPU(16),
+			spec.WorkloadNode(),
+			spec.WorkloadNodeCPU(8),
+			spec.VolumeSize(500),
+			spec.VolumeType("pd-ssd"),
+			// Use highmem variant for more memory per node (128 GB vs 64 GB for
+			// n2-standard-16). Large schema operations require significant memory
+			// for the descriptor lease manager and span config subscriber.
+			spec.GCEMachineType("n2-highmem-16"),
+		}
+
+		// Adjust timeout based on number of tables. Larger table counts take
+		// longer to create.
+		timeout := 4 * time.Hour
+		if numTables >= 1_000_000 {
+			timeout = 48 * time.Hour
+		} else if numTables >= 100_000 {
+			timeout = 12 * time.Hour
+		}
+
+		r.Add(registry.TestSpec{
+			Name:             fmt.Sprintf("large-schema-benchmark/multiregion=false/tables=%d", numTables),
+			Owner:            registry.OwnerSQLFoundations,
+			Benchmark:        true,
+			Cluster:          r.MakeClusterSpec(10, clusterSpec...),
+			CompatibleClouds: registry.OnlyGCE,
+			Suites:           registry.Suites(registry.Weekly),
+			Timeout:          timeout,
+			// Skip INSPECT and descriptor post-validation because this benchmark
+			// creates many databases and tables, and running them would take too long.
+			SkipPostValidations: registry.PostValidationInspect | registry.PostValidationInvalidDescriptors,
+			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+				runLargeSchemaIntrospectionBenchmark(ctx, t, c, numTables)
+			},
+		})
+	}
+}
+
+func runLargeSchemaIntrospectionBenchmark(
+	ctx context.Context, t test.Test, c cluster.Cluster, numTables int,
+) {
+	// Number of tables per-database from the TPCC template.
+	const numTablesForTPCC = 9
+	const maxSchemasForDatabase = 72
+
+	// Build the list of databases and schemas needed to create numTables.
+	var dbList []string
+	numTablesRemaining := numTables
+	databaseIdx := 0
+	numSchemasForDatabase := 1
+	for numTablesRemaining > 0 {
+		databaseName := fmt.Sprintf("warehouse_%d", databaseIdx)
+		for schemaIdx := 0; schemaIdx < numSchemasForDatabase && numTablesRemaining > 0; schemaIdx++ {
+			schemaName := fmt.Sprintf("schema_%d", schemaIdx)
+			if schemaIdx == 0 {
+				schemaName = "public"
+			}
+			dbList = append(dbList, fmt.Sprintf("%s.%s", databaseName, schemaName))
+			numTablesRemaining -= numTablesForTPCC
+		}
+		numSchemasForDatabase++
+		numSchemasForDatabase = min(numSchemasForDatabase, maxSchemasForDatabase)
+		databaseIdx++
+	}
+
+	t.L().Printf("Creating %d tables across %d database.schema entries", numTables, len(dbList))
+
+	// Start the cluster and configure settings for large schema.
+	settings := install.MakeClusterSettings()
+	startOpts := option.DefaultStartOpts()
+	startOpts.RoachprodOpts.ScheduleBackups = false
+	c.Start(ctx, t.L(), startOpts, settings, c.CRDBNodes())
+
+	conn := c.Conn(ctx, t.L(), 1)
+	defer conn.Close()
+
+	// Configure cluster settings for large schema operations.
+	clusterSettings := []string{
+		"SET CLUSTER SETTING sql.defaults.autocommit_before_ddl.enabled = 'false'",
+		"SET CLUSTER SETTING sql.catalog.allow_leased_descriptors.enabled = 'true'",
+		"SET CLUSTER SETTING sql.catalog.descriptor_lease.use_locked_timestamps.enabled = 'true'",
+		"SET CLUSTER SETTING jobs.retention_time='2h'",
+		"SET CLUSTER SETTING kv.transaction.internal.max_auto_retries=1000",
+		"SET CLUSTER SETTING sql.schema.approx_max_object_count = 0",
+		// Auto stats job can starve out other jobs when there are many tables.
+		// See https://github.com/cockroachdb/cockroach/issues/149475.
+		"SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false",
+		// Increase the lease refresh limit to handle the large number of
+		// descriptors being created. The default (500) is too low for 1M tables.
+		"SET CLUSTER SETTING sql.tablecache.lease.refresh_limit = 50000",
+		// Increase the intent tracking limit for bulk DDL transactions. The
+		// default is too low for creating 1M tables, causing long waits when
+		// transactions block on system.descriptor intents.
+		"SET CLUSTER SETTING kv.transaction.max_intents_bytes = 16777216",
+		// Increase the refresh span tracking limit for serializable transactions.
+		// When creating many tables per transaction, the read spans on
+		// system.descriptor and system.namespace accumulate beyond the default
+		// 4MB limit. Once exceeded, the transaction loses its ability to refresh
+		// and must fully restart on any timestamp push, causing
+		// RETRY_SERIALIZABLE errors with "can't refresh txn spans; not valid".
+		"SET CLUSTER SETTING kv.transaction.max_refresh_spans_bytes = 67108864",
+	}
+	for _, stmt := range clusterSettings {
+		_, err := conn.Exec(stmt)
+		require.NoError(t, err)
+	}
+
+	// Upload the database list file to the workload node.
+	const populateFileName = "populate_introspection"
+	err := c.PutString(ctx, strings.Join(dbList, "\n"), populateFileName, 0755, c.WorkloadNode())
+	require.NoError(t, err)
+
+	// Create the schema using tpccmultidb with --data-loader=none to create
+	// only the table schema without loading any data. This significantly
+	// speeds up the setup phase since we don't need data for introspection
+	// benchmarks.
+	t.L().Printf("Starting schema creation with tpccmultidb (schema only, no data)")
+	options := tpccOptions{
+		WorkloadCmd: "tpccmultidb",
+		DB:          strings.Split(dbList[0], ".")[0],
+		SetupType:   usingInit,
+		Warehouses:  1, // Required for schema generation but no data will be loaded
+		ExtraSetupArgs: fmt.Sprintf("--db-list-file=%s --data-loader=none --fks=false",
+			populateFileName,
+		),
+		// Use all CRDB nodes for init to distribute table creation load.
+		InitNodes: c.CRDBNodes(),
+		Start: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			// Cluster is already started, this is a no-op.
+		},
+	}
+	setupTPCC(ctx, t, t.L(), c, options)
+
+	t.L().Printf("Schema creation complete, starting introspection benchmark")
+
+	// Write query file in querybench's named-query format (name: query).
+	// querybench expects the entire query to be on a single line.
+	flatQuery := "orm_queries: " + strings.ReplaceAll(strings.TrimSpace(LargeSchemaOrmQueries), "\n", " ")
+	require.NoError(t, c.PutString(ctx, flatQuery, "ormQueries.sql", 0755, c.WorkloadNode()))
+
+	const benchmarkDuration = 20 * time.Minute
+	numWorkers := (len(c.All()) - 1) * 10
+	dbName := strings.Split(dbList[0], ".")[0]
+
+	t.L().Printf("Running introspection benchmark for %v with %d workers on db %s",
+		benchmarkDuration, numWorkers, dbName)
+
+	cmd := fmt.Sprintf(
+		"%s workload run querybench --db=%s --concurrency=%d --query-file=%s "+
+			"--duration=%s --tolerate-errors {pgurl%s} %s",
+		test.DefaultCockroachPath,
+		dbName,
+		numWorkers,
+		"ormQueries.sql",
+		benchmarkDuration,
+		c.CRDBNodes(),
+		roachtestutil.GetWorkloadHistogramArgs(t, c, map[string]string{
+			"concurrency": fmt.Sprintf("%d", numWorkers),
+			"num_tables":  fmt.Sprintf("%d", numTables),
+		}),
+	)
+	if err := c.RunE(ctx, option.WithNodes(c.WorkloadNode()), cmd); err != nil {
+		t.Fatal(err)
+	}
+
+	t.L().Printf("Introspection benchmark complete")
+}
+
 // LargeSchemaOrmQueries is extracted from the round trip analysis tests for
 // ORM queries.
 const LargeSchemaOrmQueries = `
--- JDBC ORM query for types
-    SELECT typinput='pg_catalog.array_in'::regproc as is_array, typtype, typname, pg_type.oid 
-      FROM pg_catalog.pg_type 
-      LEFT JOIN (select ns.oid as nspoid, ns.nspname, r.r 
-              from pg_namespace as ns 
-     -- go with older way of unnesting array to be compatible with 8.0
-              join ( select s.r, (current_schemas(false))[s.r] as nspname 
-                       from generate_series(1, array_upper(current_schemas(false), 1)) as s(r) ) as r 
-             using ( nspname ) 
+/* JDBC ORM query for types */
+    SELECT typinput='pg_catalog.array_in'::regproc as is_array, typtype, typname, pg_type.oid
+      FROM pg_catalog.pg_type
+      LEFT JOIN (select ns.oid as nspoid, ns.nspname, r.r
+              from pg_namespace as ns
+     /* go with older way of unnesting array to be compatible with 8.0 */
+              join ( select s.r, (current_schemas(false))[s.r] as nspname
+                       from generate_series(1, array_upper(current_schemas(false), 1)) as s(r) ) as r
+             using ( nspname )
            ) as sp
-        ON sp.nspoid = typnamespace 
+        ON sp.nspoid = typnamespace
      ORDER BY sp.r, pg_type.oid DESC;
 `
 

--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -158,6 +158,7 @@ func RegisterTests(r registry.Registry) {
 	registerSchemaChangeRandomLoad(r)
 	registerLargeSchemaBackupRestores(r)
 	registerLargeSchemaBenchmarks(r)
+	registerLargeSchemaIntrospectionBenchmark(r)
 	registerSecondaryIndexesMultiVersionCluster(r)
 	registerSequelize(r)
 	registerSlowDrain(r)

--- a/pkg/workload/tpcc/BUILD.bazel
+++ b/pkg/workload/tpcc/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
         "//pkg/workload/histogram/exporter",
         "//pkg/workload/workloadimpl",
         "@com_github_cockroachdb_apd_v3//:apd",
+        "@com_github_cockroachdb_cockroach_go_v2//crdb",
         "@com_github_cockroachdb_cockroach_go_v2//crdb/crdbpgxv5",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_codahale_hdrhistogram//:hdrhistogram",

--- a/pkg/workload/tpcc/tpcc_multi_db.go
+++ b/pkg/workload/tpcc/tpcc_multi_db.go
@@ -20,9 +20,10 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cockroachdb/cockroach-go/v2/crdb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
-	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -63,6 +64,8 @@ type tpccMultiDB struct {
 
 	// initLogic executes the init logic one time.
 	initLogic sync.Once
+	// precreateLogic ensures database/schema creation only runs once.
+	precreateLogic sync.Once
 }
 
 var tpccMultiDBMeta = workload.Meta{
@@ -409,64 +412,81 @@ func (t *tpccMultiDB) Hooks() workload.Hooks {
 			return err
 		}
 		ctx := context.Background()
-		// First create all require databases in a single txn, on multi-region
-		// this will reduce round trips and speed things up.
-		tx, err := db.BeginTx(ctx, &gosql.TxOptions{})
-		if err != nil {
-			return err
-		}
-		// Run the operations in a single txn so they complete more quickly.
-		_, err = tx.Exec("SET LOCAL autocommit_before_ddl = false")
-		if err != nil {
-			return err
-		}
-		// Create all of the databases that was specified in the list.
-		for _, dbName := range t.dbList {
-			if _, err := tx.Exec(fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", dbName.Catalog())); err != nil {
-				return err
+		// Use sync.Once to ensure database/schema creation only runs once,
+		// even if PreCreate is called multiple times.
+		var precreateErr error
+		t.precreateLogic.Do(func() {
+			// Create databases and schemas in batches to avoid waiting for too many
+			// schema change jobs at once. Each batch commits and waits for its jobs
+			// before starting the next batch.
+			const batchSize = 5000
+			batchNum := 0
+			currentEntry := 0
+			for i := 0; i < len(t.dbList); i += batchSize {
+				batchStart := timeutil.Now()
+				batchNum++
+				end := min(i+batchSize, len(t.dbList))
+				batch := t.dbList[i:end]
+
+				if err := crdb.ExecuteTx(ctx, db, &gosql.TxOptions{}, func(tx *gosql.Tx) error {
+					// Disable autocommit before DDL to batch statements in a single
+					// transaction, reducing round trips on multi-region.
+					if _, err := tx.Exec("SET LOCAL autocommit_before_ddl = false"); err != nil {
+						return err
+					}
+					for _, dbName := range batch {
+						if _, err := tx.Exec(fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", dbName.Catalog())); err != nil {
+							return err
+						}
+						if _, err := tx.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s.%s", dbName.Catalog(), dbName.Schema())); err != nil {
+							return err
+						}
+					}
+					return nil
+				}); err != nil {
+					precreateErr = err
+					return
+				}
+				currentEntry = end
+				log.Dev.Infof(ctx, "created %d/%d databases/schemas (batch %d, %d entries in %s)",
+					currentEntry, len(t.dbList), batchNum, len(batch), timeutil.Since(batchStart).Round(time.Millisecond))
 			}
-			if _, err := tx.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s.%s", dbName.Catalog(), dbName.Schema())); err != nil {
-				return err
+
+			// Next configure all the databases as multi-region.
+			// Note: Precreates are run once per database since TPCC usess them to setup
+			// multiregion.
+			for dbName := range t.dbNames {
+				if _, err := db.Exec("USE $1", dbName); err != nil {
+					precreateErr = err
+					return
+				}
+				if _, err := db.Exec("SET search_path = public"); err != nil {
+					precreateErr = err
+					return
+				}
+				// Run the usual TPCC pre-create logic after.
+				if oldPrecreate == nil {
+					continue
+				}
+				if err := oldPrecreate(db); err != nil {
+					precreateErr = err
+					return
+				}
 			}
-		}
-		if err := tx.Commit(); err != nil {
-			return err
-		}
-		// Next configure all the databases as multi-region.
-		// Note: Precreates are run once per database since TPCC usess them to setup
-		// multiregion.
-		for dbName := range t.dbNames {
-			if _, err := db.Exec("USE $1", dbName); err != nil {
-				return err
+			if _, err := db.Exec("RESET search_path"); err != nil {
+				precreateErr = err
+				return
 			}
-			if _, err := db.Exec("SET search_path = public"); err != nil {
-				return err
-			}
-			// Run the usual TPCC pre-create logic after.
-			if oldPrecreate == nil {
-				continue
-			}
-			if err := oldPrecreate(db); err != nil {
-				return err
-			}
-		}
-		if _, err := db.Exec("RESET search_path"); err != nil {
-			return err
-		}
-		return nil
+		})
+		return precreateErr
 	}
 
 	// Execute the original post-load logic across all the databases.
 	hooks.PostLoad = func(ctx context.Context, db *gosql.DB) error {
 		grp := ctxgroup.WithContext(ctx)
-		postLoadConcurrency := quotapool.NewIntPool("post-load-pool", 8)
+		grp.SetLimit(8)
 		for _, dbName := range t.dbList {
-			alloc, err := postLoadConcurrency.Acquire(ctx, 1)
-			if err != nil {
-				return err
-			}
 			grp.GoCtx(func(ctx context.Context) (err error) {
-				defer alloc.Release()
 				conn, err := db.Conn(ctx)
 				if err != nil {
 					return err

--- a/pkg/workload/workloadsql/workloadsql.go
+++ b/pkg/workload/workloadsql/workloadsql.go
@@ -49,17 +49,22 @@ func Setup(
 		return 0, err
 	}
 
+	tables := gen.Tables()
+	log.Dev.Infof(ctx, "starting split operations for %d tables", len(tables))
 	const splitConcurrency = 384 // TODO(dan): Don't hardcode this.
-	for _, table := range gen.Tables() {
+	for _, table := range tables {
 		if err := Split(ctx, db, table, splitConcurrency); err != nil {
 			return 0, err
 		}
 	}
+	log.Dev.Infof(ctx, "finished split operations for %d tables", len(tables))
 
 	if hooks.PostLoad != nil {
+		log.Dev.Infof(ctx, "starting PostLoad hook")
 		if err := hooks.PostLoad(ctx, db); err != nil {
 			return 0, errors.Wrapf(err, "Could not postload")
 		}
+		log.Dev.Infof(ctx, "finished PostLoad hook")
 	}
 
 	return bytes, nil


### PR DESCRIPTION
Add a new variant of the large-schema-benchmark roachtest that creates 1 million tables and benchmarks introspection query performance. Unlike the existing benchmark variants, this test:

- Uses minimal data import (warehouses=1) instead of full TPCC data
- Skips the TPCC workload and runs only ORM introspection queries
- Tests at a much larger scale (1M tables vs max 40K)
- Single-region only configuration
- 48-hour timeout to accommodate the larger scale

This serves as a smoke test to determine how introspection queries perform with 1 million tables, as part of our efforts to improve introspection query performance.

Run with:
```
# Also pass in --debug-always if you want the cluster to remain alive afterwards for testing.
roachtest run '^large-schema-benchmark/multiregion=false/tables=100000$' --cloud gce --parallelism=1
```

Resolves: #159557
Epic: CRDB-54999

Release note: None