### PR TITLE
release-25.4: kvserver: fix flaky TestReplicaCircuitBreaker_ResolveIntent_QuorumLoss

### DIFF
--- a/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
+++ b/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
@@ -8,6 +8,7 @@ package kvserver_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1347,10 +1348,30 @@ func (*circuitBreakerTest) IsBreakerOpen(err error) bool {
 	// NB: we will see AmbiguousResultError here when proposals are inflight while
 	// the breaker trips. These are wrapping errors, so the assertions below will
 	// look through them.
-	if !errors.Is(err, circuit.ErrBreakerOpen) {
-		return false
+	if errors.Is(err, circuit.ErrBreakerOpen) &&
+		errors.HasType(err, (*kvpb.ReplicaUnavailableError)(nil)) {
+		return true
 	}
-	return errors.HasType(err, (*kvpb.ReplicaUnavailableError)(nil))
+	// Unfortunately, selectBestError in dist_sender.go can "flatten" an
+	// AmbiguousResultError by formatting it as a string via NewAmbiguousResultErrorf,
+	// which loses the error markers. In that case, the ReplicaUnavailableError and
+	// ErrBreakerOpen are only present as stringified text, not as proper error types.
+	// See: https://github.com/cockroachdb/cockroach/issues/159582
+	//
+	// TODO(kvserver): Consider fixing selectBestError to properly wrap errors instead
+	// of formatting them as strings, e.g.:
+	//   return kvpb.NewAmbiguousResultError(errors.WithSecondaryError(ambiguousErr, lastAttemptErr))
+	//
+	// For now, we fall back to string matching for this edge case. The "replica
+	// unavailable" text comes from the stringified ReplicaUnavailableError which
+	// is only produced by the circuit breaker code path.
+	if errors.HasType(err, (*kvpb.AmbiguousResultError)(nil)) {
+		errStr := err.Error()
+		if strings.Contains(errStr, "replica unavailable") {
+			return true
+		}
+	}
+	return false
 }
 
 func (cbt *circuitBreakerTest) RequireIsBreakerOpen(t *testing.T, err error) {


### PR DESCRIPTION
Backport 1/1 commits from #159888 on behalf of @tbg.

----

The test was failing because `selectBestError` in dist_sender.go can "flatten" an `AmbiguousResultError` by formatting it as a string via `NewAmbiguousResultErrorf`, which loses the error markers (`ErrBreakerOpen` and `ReplicaUnavailableError` types).

This change makes `IsBreakerOpen` fall back to string matching when the error is an `AmbiguousResultError` containing "replica unavailable" text, which is the distinctive marker from the stringified `ReplicaUnavailableError`.

A TODO comment is added suggesting the proper production fix would be to change `selectBestError` to wrap errors properly instead of formatting them as strings.

Fixes #159582

Release note: None

----

Release justification: flake fix