### PR TITLE
roachprod: pyroscope query lookback config

### DIFF
--- a/pkg/roachprod/pyroscope/templates/pyroscope-config.yml
+++ b/pkg/roachprod/pyroscope/templates/pyroscope-config.yml
@@ -5,6 +5,8 @@ pyroscopedb:
   data_path: /var/lib/pyroscope/data
 
 limits:
+  retention_period: 0
+  max_query_lookback: 0
   max_query_length: 2h
   max_query_parallelism: 4
   max_profile_stacktrace_samples: 500000


### PR DESCRIPTION
Previously, Pyroscope was configured with a default limit on the query lookback range. Because we use Pyroscope to analyze historical data, we want this range to be unbounded. This change enables queries over older data, which is particularly useful when copying blocks from cold storage for analysis.

Epic: None
Release note: None