### PR TITLE
ghweeklysummary: fix PR fetch limit logic

### DIFF
--- a/pkg/cmd/kv/ghweeklysummary/main.go
+++ b/pkg/cmd/kv/ghweeklysummary/main.go
@@ -293,8 +293,11 @@ func stripPrefix(title string) string {
 }
 
 func fetchPRs(repo, author string, after, before time.Time, limit int) ([]PRInfo, error) {
-	// Build search query.
-	query := fmt.Sprintf("repo:%s author:%s is:pr", repo, author)
+	// Build search query with date range to limit results at the API level.
+	// GitHub search uses 'updated' qualifier to filter by last activity date.
+	afterStr := after.Format("2006-01-02")
+	beforeStr := before.Format("2006-01-02")
+	query := fmt.Sprintf("repo:%s author:%s is:pr updated:%s..%s", repo, author, afterStr, beforeStr)
 
 	var allPRs []PRInfo // PRs that matched the query and are within the date range
 	var seenPRCount int // counts all PRs pulled from Github, including those that don't match the date range


### PR DESCRIPTION
The --limit flag was intended to control how many PRs are fetched from GitHub before date filtering, but the implementation incorrectly used the count of PRs that matched the date range. This caused early termination when few PRs matched the filter but many more existed to scan.

Track seen PRs separately from matched PRs to ensure we actually scan up to --limit PRs from GitHub regardless of how many pass the date filter.

Also improve the error message when the GitHub API call fails by including the query and output.

Epic: none