### PR TITLE
release-25.4: inspect: speed up tests via faster job adoption

### DIFF
--- a/pkg/sql/inspect/index_consistency_check_test.go
+++ b/pkg/sql/inspect/index_consistency_check_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -127,6 +128,7 @@ func TestDetectIndexConsistencyErrors(t *testing.T) {
 				GCJob: &sql.GCJobTestingKnobs{
 					SkipWaitingForMVCCGC: true,
 				},
+				JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 			},
 		},
 	})
@@ -556,7 +558,11 @@ func TestIndexConsistencyWithReservedWordColumns(t *testing.T) {
 
 	issueLogger := &testIssueCollector{}
 	ctx := context.Background()
-	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+		},
+	})
 	defer s.Stopper().Stop(ctx)
 	r := sqlutils.MakeSQLRunner(db)
 

--- a/pkg/sql/inspect/inspect_job_test.go
+++ b/pkg/sql/inspect/inspect_job_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -64,6 +65,7 @@ func TestInspectJobImplicitTxnSemantics(t *testing.T) {
 					return nil
 				},
 			},
+			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 		},
 	})
 	defer s.Stopper().Stop(context.Background())
@@ -319,7 +321,13 @@ func TestInspectProgressWithMultiRangeTable(t *testing.T) {
 
 	ctx := context.Background()
 	const numNodes = 3
-	tc := serverutils.StartCluster(t, numNodes, base.TestClusterArgs{})
+	tc := serverutils.StartCluster(t, numNodes, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+			},
+		},
+	})
 	defer tc.Stopper().Stop(ctx)
 
 	db := tc.ServerConn(0)

--- a/pkg/sql/inspect/inspect_metrics_test.go
+++ b/pkg/sql/inspect/inspect_metrics_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -29,6 +30,9 @@ func TestInspectMetrics(t *testing.T) {
 	ctx := context.Background()
 	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
 		DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
+		Knobs: base.TestingKnobs{
+			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+		},
 	})
 	defer s.Stopper().Stop(ctx)
 

--- a/pkg/sql/inspect/table_sink_test.go
+++ b/pkg/sql/inspect/table_sink_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -26,7 +27,11 @@ func TestTableSink(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+		},
+	})
 	defer s.Stopper().Stop(context.Background())
 	runner := sqlutils.MakeSQLRunner(db)
 


### PR DESCRIPTION
Backport 1/1 commits from #160588.

/cc @cockroachdb/release

---

I noticed that inspect tests were quite slow, so I added `jobs.NewTestingKnobsWithShortIntervals()` to all that start a server or a cluster, which significantly sped up things (from multiple minutes to under a minute when run sequentially).

Epic: None
Release note: None

Release justification: test-only change.