### PR TITLE
release-25.4: backup: deflake TestFullClusterRestoreWithUserIDs

### DIFF
--- a/pkg/backup/full_cluster_backup_restore_test.go
+++ b/pkg/backup/full_cluster_backup_restore_test.go
@@ -1189,29 +1189,29 @@ func TestFullClusterRestoreWithUserIDs(t *testing.T) {
 	sqlDB.Exec(t, `CREATE USER test2`)
 	sqlDB.Exec(t, `BACKUP INTO $1`, localFoo)
 
-	sqlDB.CheckQueryResults(t, `SELECT username, "hashedPassword", "isRole", user_id FROM system.users ORDER BY user_id`, [][]string{
-		{"root", "", "false", "1"},
-		{"admin", "", "true", "2"},
-		{"test1", "NULL", "false", "100"},
-		{"test2", "NULL", "false", "101"},
+	sqlDB.CheckQueryResults(t, `SELECT username, "hashedPassword", "isRole" FROM system.users ORDER BY user_id`, [][]string{
+		{"root", "", "false"},
+		{"admin", "", "true"},
+		{"test1", "NULL", "false"},
+		{"test2", "NULL", "false"},
 	})
 	// Ensure that the new backup succeeds.
 	sqlDBRestore.Exec(t, `RESTORE FROM LATEST IN $1`, localFoo)
 
-	sqlDBRestore.CheckQueryResults(t, `SELECT username, "hashedPassword", "isRole", user_id FROM system.users ORDER BY user_id`, [][]string{
-		{"root", "", "false", "1"},
-		{"admin", "", "true", "2"},
-		{"test1", "NULL", "false", "100"},
-		{"test2", "NULL", "false", "101"},
+	sqlDBRestore.CheckQueryResults(t, `SELECT username, "hashedPassword", "isRole" FROM system.users ORDER BY user_id`, [][]string{
+		{"root", "", "false"},
+		{"admin", "", "true"},
+		{"test1", "NULL", "false"},
+		{"test2", "NULL", "false"},
 	})
 
 	sqlDBRestore.Exec(t, `CREATE USER test3`)
 
-	sqlDBRestore.CheckQueryResults(t, `SELECT username, "hashedPassword", "isRole", user_id FROM system.users ORDER BY user_id`, [][]string{
-		{"root", "", "false", "1"},
-		{"admin", "", "true", "2"},
-		{"test1", "NULL", "false", "100"},
-		{"test2", "NULL", "false", "101"},
-		{"test3", "NULL", "false", "102"},
+	sqlDBRestore.CheckQueryResults(t, `SELECT username, "hashedPassword", "isRole" FROM system.users ORDER BY user_id`, [][]string{
+		{"root", "", "false"},
+		{"admin", "", "true"},
+		{"test1", "NULL", "false"},
+		{"test2", "NULL", "false"},
+		{"test3", "NULL", "false"},
 	})
 }


### PR DESCRIPTION
Backport 1/1 commits from #154339.

/cc @cockroachdb/release

---

Fixes #154006

Release note: none
