### PR TITLE
storage: export OptionalValue

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction_test.go
@@ -1732,10 +1732,10 @@ func TestPartialRollbackOnEndTransaction(t *testing.T) {
 		if res.Intent != nil {
 			t.Errorf("found intent, expected none: %+v", res.Intent)
 		}
-		if res.Value == nil {
+		if !res.Value.Exists() {
 			t.Errorf("no value found, expected one")
 		} else {
-			s, err := res.Value.GetBytes()
+			s, err := res.Value.Value.GetBytes()
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/kv/kvserver/batcheval/cmd_get.go
+++ b/pkg/kv/kvserver/batcheval/cmd_get.go
@@ -98,7 +98,7 @@ func Get(
 		intents = append(intents, *getRes.Intent)
 	}
 
-	reply.Value = getRes.Value
+	reply.Value = getRes.Value.ToPointer()
 	if h.ReadConsistency == kvpb.READ_UNCOMMITTED {
 		var intentVals []roachpb.KeyValue
 		// NOTE: MVCCGet uses a Prefix iterator, so we want to use one in
@@ -117,7 +117,7 @@ func Get(
 		}
 	}
 
-	shouldLockKey := getRes.Value != nil || args.LockNonExisting
+	shouldLockKey := getRes.Value.Exists() || args.LockNonExisting
 	var res result.Result
 	if args.KeyLockingStrength != lock.None && shouldLockKey {
 		// ExpectExclusionSince is used by callers (namely, txnWriteBuffers) that

--- a/pkg/kv/kvserver/batcheval/cmd_refresh.go
+++ b/pkg/kv/kvserver/batcheval/cmd_refresh.go
@@ -62,8 +62,8 @@ func Refresh(
 
 	if err != nil {
 		return result.Result{}, err
-	} else if res.Value != nil {
-		if ts := res.Value.Timestamp; refreshFrom.Less(ts) {
+	} else if res.Value.Exists() {
+		if ts := res.Value.Value.Timestamp; refreshFrom.Less(ts) {
 			return result.Result{},
 				kvpb.NewRefreshFailedError(ctx, kvpb.RefreshFailedError_REASON_COMMITTED_VALUE, args.Key, ts)
 		}

--- a/pkg/kv/kvserver/batcheval/cmd_refresh_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_refresh_range_test.go
@@ -199,8 +199,8 @@ func TestRefreshRangeTimeBoundIterator(t *testing.T) {
 		t.Fatal(err)
 	} else if res.Intent != nil {
 		t.Fatalf("got unexpected intent: %v", intent)
-	} else if !res.Value.EqualTagAndData(v) {
-		t.Fatalf("expected %v, got %v", v, res.Value)
+	} else if !res.Value.Value.EqualTagAndData(v) {
+		t.Fatalf("expected %v, got %v", v, res.Value.Value)
 	}
 
 	// Now the real test: a transaction at ts2 has been pushed to ts3

--- a/pkg/kv/kvserver/batcheval/cmd_resolve_intent_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_resolve_intent_test.go
@@ -259,10 +259,10 @@ func TestResolveIntentAfterPartialRollback(t *testing.T) {
 		if res.Intent != nil {
 			t.Errorf("%s: found intent, expected none: %+v", k, res.Intent)
 		}
-		if res.Value == nil {
+		if !res.Value.Exists() {
 			t.Errorf("%s: no value found, expected one", k)
 		} else {
-			s, err := res.Value.GetBytes()
+			s, err := res.Value.Value.GetBytes()
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -366,8 +366,8 @@ func TestResolveIntentWithTargetBytes(t *testing.T) {
 
 				valueRes, err := storage.MVCCGet(ctx, batch, testKeys[0], ts, storage.MVCCGetOptions{})
 				require.NoError(t, err)
-				require.Equal(t, values[0].RawBytes, valueRes.Value.RawBytes,
-					"the value %s in get result does not match the value %s in request", values[0].RawBytes, valueRes.Value.RawBytes)
+				require.Equal(t, values[0].RawBytes, valueRes.Value.Value.RawBytes,
+					"the value %s in get result does not match the value %s in request", values[0].RawBytes, valueRes.Value.Value.RawBytes)
 			}
 		} else {
 			// Resolve an intent range for testKeys[0], testKeys[1], ...,
@@ -435,8 +435,8 @@ func TestResolveIntentWithTargetBytes(t *testing.T) {
 
 				valueRes, err := storage.MVCCGet(ctx, batch, testKeys[2], ts, storage.MVCCGetOptions{})
 				require.NoError(t, err)
-				require.Equal(t, values[2].RawBytes, valueRes.Value.RawBytes,
-					"the value %s in get result does not match the value %s in request", values[2].RawBytes, valueRes.Value.RawBytes)
+				require.Equal(t, values[2].RawBytes, valueRes.Value.Value.RawBytes,
+					"the value %s in get result does not match the value %s in request", values[2].RawBytes, valueRes.Value.Value.RawBytes)
 				_, err = storage.MVCCGet(ctx, batch, testKeys[3], ts, storage.MVCCGetOptions{})
 				require.Error(t, err)
 			}
@@ -469,8 +469,8 @@ func TestResolveIntentWithTargetBytes(t *testing.T) {
 
 				valueRes, err := storage.MVCCGet(ctx, batch, testKeys[nKeys-1], ts, storage.MVCCGetOptions{})
 				require.NoError(t, err)
-				require.Equal(t, values[nKeys-1].RawBytes, valueRes.Value.RawBytes,
-					"the value %s in get result does not match the value %s in request", values[nKeys-1].RawBytes, valueRes.Value.RawBytes)
+				require.Equal(t, values[nKeys-1].RawBytes, valueRes.Value.Value.RawBytes,
+					"the value %s in get result does not match the value %s in request", values[nKeys-1].RawBytes, valueRes.Value.Value.RawBytes)
 			}
 		}
 	})

--- a/pkg/kv/kvserver/batcheval/cmd_subsume.go
+++ b/pkg/kv/kvserver/batcheval/cmd_subsume.go
@@ -160,7 +160,7 @@ func Subsume(
 	valRes, err := storage.MVCCGetAsTxn(ctx, readWriter, descKey, intentRes.Intent.Txn.WriteTimestamp, intentRes.Intent.Txn)
 	if err != nil {
 		return result.Result{}, errors.Wrap(err, "fetching local range descriptor as txn")
-	} else if valRes.Value != nil {
+	} else if valRes.Value.IsPresent() {
 		return result.Result{}, errors.Errorf("non-deletion intent on local range descriptor")
 	}
 

--- a/pkg/kv/kvserver/batcheval/lock.go
+++ b/pkg/kv/kvserver/batcheval/lock.go
@@ -79,11 +79,11 @@ func readProvisionalVal(
 		if err != nil {
 			return roachpb.KeyValue{}, err
 		}
-		if valRes.Value == nil {
+		if !valRes.Value.IsPresent() {
 			// Intent is a deletion.
 			return roachpb.KeyValue{}, nil
 		}
-		return roachpb.KeyValue{Key: intent.Key, Value: *valRes.Value}, nil
+		return roachpb.KeyValue{Key: intent.Key, Value: valRes.Value.Value}, nil
 	}
 	res, err := storage.MVCCScanAsTxn(
 		ctx, reader, intent.Key, intent.Key.Next(), intent.Txn.WriteTimestamp, intent.Txn,

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -216,7 +216,7 @@ func TestLeaseholdersRejectClockUpdateWithJump(t *testing.T) {
 	valRes, err := storage.MVCCGet(context.Background(), store.StateEngine(), key, ts3,
 		storage.MVCCGetOptions{})
 	require.NoError(t, err)
-	require.Equal(t, incArgs.Increment*numCmds, mustGetInt(valRes.Value))
+	require.Equal(t, incArgs.Increment*numCmds, mustGetInt(valRes.Value.ToPointer()))
 }
 
 // TestTxnPutOutOfOrder tests a case where a put operation of an older

--- a/pkg/kv/kvserver/loqrecovery/apply.go
+++ b/pkg/kv/kvserver/loqrecovery/apply.go
@@ -178,7 +178,7 @@ func applyReplicaUpdate(
 	key := keys.RangeDescriptorKey(update.StartKey.AsRKey())
 	res, err := storage.MVCCGet(
 		ctx, readWriter, key, clock.Now(), storage.MVCCGetOptions{Inconsistent: true})
-	if res.Value == nil {
+	if !res.Value.Exists() {
 		return PrepareReplicaReport{}, errors.Errorf(
 			"failed to find a range descriptor for range %v", key)
 	}
@@ -186,7 +186,7 @@ func applyReplicaUpdate(
 		return PrepareReplicaReport{}, err
 	}
 	var localDesc roachpb.RangeDescriptor
-	if err := res.Value.GetProto(&localDesc); err != nil {
+	if err := res.Value.Value.GetProto(&localDesc); err != nil {
 		return PrepareReplicaReport{}, err
 	}
 	// Sanity check that this is indeed the right range.

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -2527,7 +2527,7 @@ func (r *Replica) maybeWatchForMergeLocked(ctx context.Context) (bool, error) {
 		ctx, r.store.StateEngine(), descKey, intentRes.Intent.Txn.WriteTimestamp, intentRes.Intent.Txn)
 	if err != nil {
 		return false, err
-	} else if valRes.Value != nil {
+	} else if valRes.Value.IsPresent() {
 		return false, nil
 	}
 

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -659,8 +659,8 @@ func populatePrevValsInLogicalOpLog(
 		if err != nil {
 			return errors.Wrapf(err, "consuming %T for key %v @ ts %v", op, key, ts)
 		}
-		if prevValRes.Value != nil {
-			*prevValPtr = prevValRes.Value.RawBytes
+		if prevValRes.Value.Exists() {
+			*prevValPtr = prevValRes.Value.Value.RawBytes
 		} else {
 			*prevValPtr = nil
 		}

--- a/pkg/server/node_tombstone_storage.go
+++ b/pkg/server/node_tombstone_storage.go
@@ -58,12 +58,12 @@ func (s *nodeTombstoneStorage) IsDecommissioned(
 		if err != nil {
 			return time.Time{}, err
 		}
-		if valRes.Value == nil {
+		if !valRes.Value.Exists() {
 			// Not found.
 			continue
 		}
 		var tsp hlc.Timestamp
-		if err := valRes.Value.GetProto(&tsp); err != nil {
+		if err := valRes.Value.Value.GetProto(&tsp); err != nil {
 			return time.Time{}, err
 		}
 		// Found, offer to cache and return.

--- a/pkg/storage/bench_test.go
+++ b/pkg/storage/bench_test.go
@@ -1216,9 +1216,9 @@ func runMVCCGet(ctx context.Context, b *testing.B, opts mvccBenchData, useBatch 
 			ReadCategory: fs.BatchEvalReadCategory,
 		}); err != nil {
 			b.Fatalf("failed get: %+v", err)
-		} else if valRes.Value == nil {
+		} else if !valRes.Value.Exists() {
 			b.Fatalf("failed get (key not found): %d@%d", keyIdx, walltime)
-		} else if valueBytes, err := valRes.Value.GetBytes(); err != nil {
+		} else if valueBytes, err := valRes.Value.Value.GetBytes(); err != nil {
 			b.Fatal(err)
 		} else if len(valueBytes) != opts.valueBytes {
 			b.Fatalf("unexpected value size: %d", len(valueBytes))

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -203,8 +203,8 @@ func TestEngineBatchStaleCachedIterator(t *testing.T) {
 		if valRes, err := MVCCGet(context.Background(), batch, key,
 			hlc.Timestamp{}, MVCCGetOptions{}); err != nil {
 			t.Fatal(err)
-		} else if valRes.Value != nil {
-			t.Fatalf("expected no value, got %+v", valRes.Value)
+		} else if valRes.Value.Exists() {
+			t.Fatalf("expected no value, got %+v", valRes.Value.Value)
 		}
 	}
 }

--- a/pkg/storage/metamorphic/operations.go
+++ b/pkg/storage/metamorphic/operations.go
@@ -190,7 +190,7 @@ func (m mvccGetOp) run(ctx context.Context) string {
 	if err != nil {
 		return fmt.Sprintf("error: %s", err)
 	}
-	return fmt.Sprintf("val = %v, intent = %v", res.Value, res.Intent)
+	return fmt.Sprintf("val = %v, intent = %v", res.Value.ToPointer(), res.Intent)
 }
 
 type mvccPutOp struct {

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -1475,8 +1475,8 @@ func cmdGet(e *evalCtx) error {
 		if res.Intent != nil {
 			e.results.buf.Printf("get: %v -> intent {%s}\n", key, res.Intent.Txn)
 		}
-		if res.Value != nil {
-			e.results.buf.Printf("get: %v -> %v @%v\n", key, res.Value.PrettyPrint(), res.Value.Timestamp)
+		if res.Value.Exists() {
+			e.results.buf.Printf("get: %v -> %v @%v\n", key, res.Value.Value.PrettyPrint(), res.Value.Value.Timestamp)
 		} else {
 			e.results.buf.Printf("get: %v -> <no data>\n", key)
 		}

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -1869,12 +1869,12 @@ func (tc *TestCluster) ReadIntFromStores(key roachpb.Key) []int64 {
 				clock.Now(), storage.MVCCGetOptions{})
 			if err != nil {
 				log.VEventf(context.Background(), 1, "store %d: error reading from key %s: %s", s.StoreID(), key, err)
-			} else if valRes.Value == nil {
+			} else if !valRes.Value.Exists() {
 				log.VEventf(context.Background(), 1, "store %d: missing key %s", s.StoreID(), key)
 			} else {
-				results[i], err = valRes.Value.GetInt()
+				results[i], err = valRes.Value.Value.GetInt()
 				if err != nil {
-					log.Dev.Errorf(context.Background(), "store %d: error decoding %s from key %s: %+v", s.StoreID(), valRes.Value, key, err)
+					log.Dev.Errorf(context.Background(), "store %d: error decoding %s from key %s: %+v", s.StoreID(), valRes.Value.Value, key, err)
 				}
 			}
 			return nil


### PR DESCRIPTION
This commit exports the OptionalValue type used for representing a MVCCValue that may not exist. Parts of the storage package interface are updated to prefer the OptionalValue over returning a pointer.

Callers that only check presence via Exists() or IsPresent(), or read the value inline, avoid the heap allocation entirely. Callers that need a pointer (e.g., for proto response fields) can call ToPointer() explicitly, deferring the allocation to the specific call sites that require it.

```
goos: darwin
goarch: arm64
cpu: Apple M1 Pro
                                                          │   old.txt   │              new.txt               │
                                                          │   sec/op    │   sec/op     vs base               │
MVCCGet/batch=false/versions=1/valueSize=8/numRangeKeys=0   2.783µ ± 6%   2.534µ ± 4%  -8.95% (p=0.000 n=10)

                                                          │   old.txt    │               new.txt               │
                                                          │     B/s      │     B/s       vs base               │
MVCCGet/batch=false/versions=1/valueSize=8/numRangeKeys=0   2.742Mi ± 6%   3.009Mi ± 4%  +9.74% (p=0.000 n=10)

                                                          │   old.txt   │              new.txt               │
                                                          │    B/op     │    B/op     vs base                │
MVCCGet/batch=false/versions=1/valueSize=8/numRangeKeys=0   114.00 ± 1%   66.00 ± 2%  -42.11% (p=0.000 n=10)

                                                          │  old.txt   │              new.txt               │
                                                          │ allocs/op  │ allocs/op   vs base                │
MVCCGet/batch=false/versions=1/valueSize=8/numRangeKeys=0   2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
```

Epic: None
Release note: None