### PR TITLE
kvserver/tscache: add comment to BenchmarkIntervalSklDecodeValue

### DIFF
--- a/pkg/kv/kvserver/tscache/interval_skl_test.go
+++ b/pkg/kv/kvserver/tscache/interval_skl_test.go
@@ -1426,6 +1426,10 @@ func randRangeOpt(rng *rand.Rand) rangeOptions {
 	return rangeOptions(rng.Intn(int(excludeFrom|excludeTo) + 1))
 }
 
+// NOTE: if this benchmark, specifically the "time" variants (i.e. sec/op) is
+// being flagged in a benchmark GH issue, it can likely be ignored, as the
+// benchmark is sensitive to timings. We care more about the allocation
+// benchmarks.
 func BenchmarkIntervalSklDecodeValue(b *testing.B) {
 	runBenchWithVals(b, func(b *testing.B, val cacheValue) {
 		var arr [encodedValSize]byte


### PR DESCRIPTION
The `BenchmarkIntervalSklDecodeValue` benchmark was previously lacking context about how to interpret its results. This commit adds a comment explaining that the "time" variants (i.e. `sec/op`) of this benchmark can be noisy and may trigger false positives in benchmark CI issues. The allocation benchmarks are the more reliable metrics to monitor.

Touches: #160253

Release note: None

Epic: None