### PR TITLE
spanlatch: remove BenchmarkAtomicLoad benchmark

### DIFF
--- a/pkg/kv/kvserver/spanlatch/signal_test.go
+++ b/pkg/kv/kvserver/spanlatch/signal_test.go
@@ -7,7 +7,6 @@ package spanlatch
 
 import (
 	"sync"
-	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -175,12 +174,5 @@ func BenchmarkMultiSelectClosedChan(b *testing.B) {
 		case <-c:
 		case <-c2:
 		}
-	}
-}
-
-func BenchmarkAtomicLoad(b *testing.B) {
-	a := int32(1)
-	for i := 0; i < b.N; i++ {
-		_ = atomic.LoadInt32(&a)
 	}
 }


### PR DESCRIPTION
This benchmark was a simple wrapper around `atomic.LoadInt32` that was used to demonstrate the performance characteristics of atomic loads compared to channel operations. Since it benchmarks a standard library primitive rather than any CockroachDB code, it is not useful to keep.

Touches: #160253

Release note: None

Epic: None