### PR TITLE
kvcoord: deflake BenchmarkTxnWriteBuffer

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
@@ -2873,9 +2873,7 @@ func BenchmarkTxnWriteBuffer(b *testing.B) {
 
 							b.ResetTimer()
 							for i := 0; i < b.N; i++ {
-								b.StopTimer()
 								twb := makeBuffer(kvSize, &txn, readsFromPrevBatch)
-								b.StartTimer()
 								_, pErr := twb.SendLocked(ctx, ba)
 								if pErr != nil {
 									b.Fatal(pErr)


### PR DESCRIPTION
The `SendLocked` subtest has been consistently flaky since the test was introduced. The suspicion is that the ratio of time spent between stop/start is extremely small compared to outside the timed section. This tends to cause the benchmark not to be able to reach the 1s target, as 1s of the timed part could equal 20 minutes in total outside of the timed section.

This commit removes the starting and stopping of the timer. The downside is that the benchmark now also measures the allocations as part of `makeBuffer`. But it also makes this subtest consistent with the second subtest (`flushBufferAndSendBatch`) in that respect.

Fixes: #151650

Release note: None