### PR TITLE
scheduledlogging: use stopper.WithCancelOnQuiesce for CaptureIndexUsageStats

### DIFF
--- a/pkg/sql/scheduledlogging/captured_index_usage_stats.go
+++ b/pkg/sql/scheduledlogging/captured_index_usage_stats.go
@@ -125,6 +125,9 @@ func Start(
 
 func (s *CaptureIndexUsageStatsLoggingScheduler) start(ctx context.Context, stopper *stop.Stopper) {
 	_ = stopper.RunAsyncTask(ctx, "capture-index-usage-stats", func(ctx context.Context) {
+		ctx, cancel := stopper.WithCancelOnQuiesce(ctx)
+		defer cancel()
+
 		// Start the scheduler immediately.
 		timer := time.NewTimer(0 * time.Second)
 		defer timer.Stop()


### PR DESCRIPTION
This commit ensures that inflight captureIndexUsageStats will not block node shutdown.

Fixes: #160117
Release note: None