### PR TITLE
util/tracing: add ability to backfill Span

### DIFF
--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -1252,7 +1252,10 @@ child operation: %s, tracer created at:
 		opts.LogTags = opts.Parent.i.crdb.logTags
 	}
 
-	startTime := timeutil.Now()
+	startTime := opts.StartTime
+	if startTime.IsZero() {
+		startTime = timeutil.Now()
+	}
 
 	// First, create any external spans that we may need (OpenTelemetry, net/trace).
 	// We do this early so that they are available when we construct the main Span,


### PR DESCRIPTION
If it is determined that something waited for a span of time only after it waited, it could still be helpful to reflect that it waited for that span in the trace. As such, the ability to add a span to the trace which reflect that it started at some prior time is introduced. For now this is restricted to adding already-finished spans, as this is the only use-case identified so far for a backdated span.

Release note: none.
Epic: none.