### PR TITLE
sql: add a couple of metrics about SetupFlowRequest RPCs

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -7615,6 +7615,14 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+    - name: sql.distsql.parallel_runner.count
+      exported_name: sql_distsql_parallel_runner_count
+      description: Number of SetupFlowRequest RPCs executed concurrently via DistSQL runners
+      y_axis_label: Requests
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
     - name: sql.distsql.queries.active
       exported_name: sql_distsql_queries_active
       description: Number of invocations of the execution engine currently active (multiple of which may occur for a single SQL statement)
@@ -7667,6 +7675,14 @@ layers:
       exported_name: sql_distsql_select_distributed_exec_count_internal
       description: Number of SELECT statements that were distributed (internal queries)
       y_axis_label: SQL Internal Statements
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: sql.distsql.sequential_runner.count
+      exported_name: sql_distsql_sequential_runner_count
+      description: Number of SetupFlowRequest RPCs executed sequentially via the main gateway goroutine
+      y_axis_label: Requests
       type: COUNTER
       unit: COUNT
       aggregation: AVG

--- a/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
+++ b/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
@@ -1928,6 +1928,7 @@ sql_distsql_exec_latency_internal_sum: sql.distsql.exec.latency.internal.sum
 sql_distsql_exec_latency_sum: sql.distsql.exec.latency.sum
 sql_distsql_flows_active: sql.distsql.flows.active
 sql_distsql_flows_total: sql.distsql.flows.total
+sql_distsql_parallel_runner_count: sql.distsql.parallel_runner.count
 sql_distsql_queries_active: sql.distsql.queries.active
 sql_distsql_queries_spilled: sql.distsql.queries.spilled
 sql_distsql_queries_total: sql.distsql.queries.total
@@ -1935,6 +1936,7 @@ sql_distsql_select_count: sql.distsql.select.count
 sql_distsql_select_count_internal: sql.distsql.select.internal
 sql_distsql_select_distributed_exec_count: sql.distsql.select.distributed_exec.count
 sql_distsql_select_distributed_exec_count_internal: sql.distsql.select.distributed_exec.count.internal
+sql_distsql_sequential_runner_count: sql.distsql.sequential_runner.count
 sql_distsql_service_latency: sql.distsql.service.latency
 sql_distsql_service_latency_bucket: sql.distsql.service.latency.bucket
 sql_distsql_service_latency_count: sql.distsql.service.latency.count

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -208,7 +208,7 @@ func NewDistSQLPlanner(
 		rpcCtx.Stopper.AddCloser(dsp.parallelLocalScansSem.Closer("stopper"))
 	}
 
-	dsp.runnerCoordinator.init(ctx, stopper, &st.SV)
+	dsp.runnerCoordinator.init(ctx, stopper, &st.SV, distSQLSrv.Metrics.RunnerReqParallelCount)
 	dsp.initCancelingWorkers(ctx)
 	return dsp
 }

--- a/pkg/sql/execinfra/metrics.go
+++ b/pkg/sql/execinfra/metrics.go
@@ -22,6 +22,8 @@ type DistSQLMetrics struct {
 	CumulativeContentionNanos   *aggmetric.SQLCounter
 	FlowsActive                 *metric.Gauge
 	FlowsTotal                  *metric.Counter
+	RunnerReqParallelCount      *metric.Counter
+	RunnerReqSequentialCount    *metric.Counter
 	MaxBytesHist                metric.IHistogram
 	CurBytesCount               *metric.Gauge
 	VecOpenFDs                  *metric.Gauge
@@ -83,6 +85,18 @@ var (
 		Name:        "sql.distsql.flows.total",
 		Help:        "Number of distributed SQL flows executed",
 		Measurement: "Flows",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaRunnerReqParallelCount = metric.Metadata{
+		Name:        "sql.distsql.parallel_runner.count",
+		Help:        "Number of SetupFlowRequest RPCs executed concurrently via DistSQL runners",
+		Measurement: "Requests",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaRunnerReqSequentialCount = metric.Metadata{
+		Name:        "sql.distsql.sequential_runner.count",
+		Help:        "Number of SetupFlowRequest RPCs executed sequentially via the main gateway goroutine",
+		Measurement: "Requests",
 		Unit:        metric.Unit_COUNT,
 	}
 	metaMemMaxBytes = metric.Metadata{
@@ -161,6 +175,8 @@ func MakeDistSQLMetrics(histogramWindow time.Duration) DistSQLMetrics {
 		CumulativeContentionNanos: aggmetric.NewSQLCounter(metaCumulativeContentionNanos),
 		FlowsActive:               metric.NewGauge(metaFlowsActive),
 		FlowsTotal:                metric.NewCounter(metaFlowsTotal),
+		RunnerReqParallelCount:    metric.NewCounter(metaRunnerReqParallelCount),
+		RunnerReqSequentialCount:  metric.NewCounter(metaRunnerReqSequentialCount),
 		MaxBytesHist: metric.NewHistogram(metric.HistogramOptions{
 			Metadata:     metaMemMaxBytes,
 			Duration:     histogramWindow,


### PR DESCRIPTION
We have a pool of distsql runner workers (proportional to vCPUs per node) that execute SetupFlowRequest RPCs in parallel with the main goroutine of the gateway flow. This commit adds two counters to track number of requests done via those parallel workers as well as sequentially via the main goroutine, which should give us signal whether a cluster needs adjustment of `sql.distsql.num_runners` cluster setting.

Epic: None
Release note: None