### PR TITLE
roachprod-microbench: use markdown checklist for regression issues

### DIFF
--- a/pkg/cmd/roachprod-microbench/github.go
+++ b/pkg/cmd/roachprod-microbench/github.go
@@ -250,10 +250,10 @@ func createRegressionPostRequest(
 		dashboardLink := generateDashboardLink(reg.benchmarkName)
 		if dashboardLink == "" {
 			// If we can't generate a link, skip the link but still show the regression
-			sb.WriteString(fmt.Sprintf("- %s (%s): %s (%.1f%%)\n",
+			sb.WriteString(fmt.Sprintf("- [ ] %s (%s): %s (%.1f%%)\n",
 				reg.benchmarkName, reg.metricUnit, reg.formattedDelta, reg.percentChange))
 		} else {
-			sb.WriteString(fmt.Sprintf("- [%s (%s): %s (%.1f%%)](%s)\n",
+			sb.WriteString(fmt.Sprintf("- [ ] [%s (%s): %s (%.1f%%)](%s)\n",
 				reg.benchmarkName, reg.metricUnit, reg.formattedDelta, reg.percentChange, dashboardLink))
 		}
 	}

--- a/pkg/cmd/roachprod-microbench/github_test.go
+++ b/pkg/cmd/roachprod-microbench/github_test.go
@@ -100,9 +100,9 @@ func TestCreateRegressionPostRequestBasic(t *testing.T) {
 	require.Contains(t, req.Message, "25.5%")
 	require.Contains(t, req.Message, "v24.1.0 -> master")
 
-	// Verify dashboard links are included (entire line is a link)
+	// Verify dashboard links are included (entire line is a link with checkbox)
 	require.Contains(t, req.Message, "https://microbench.testeng.crdb.io/dashboard/?benchmark=BenchmarkScan&package=pkg/sql")
-	require.Contains(t, req.Message, "[pkg/sql→BenchmarkScan (ns/op): +1.2ms (25.5%)](https://microbench.testeng.crdb.io/dashboard/")
+	require.Contains(t, req.Message, "- [ ] [pkg/sql→BenchmarkScan (ns/op): +1.2ms (25.5%)](https://microbench.testeng.crdb.io/dashboard/")
 }
 
 func TestCreateRegressionPostRequestMultiple(t *testing.T) {
@@ -186,9 +186,9 @@ func TestCreateRegressionPostRequestFormat(t *testing.T) {
 		"(ns/op): +1.2ms (25.5%)",
 		"BenchmarkInsert/batch=100",
 		"(B/op): +5.0KB (30.0%)",
-		// Verify entire line is a markdown link
-		"[pkg/sql/exec→BenchmarkScan/rows=1000 (ns/op): +1.2ms (25.5%)](https://microbench.testeng.crdb.io/dashboard/?benchmark=BenchmarkScan/rows=1000&amp;package=pkg/sql/exec)",
-		"[pkg/sql/exec→BenchmarkInsert/batch=100 (B/op): +5.0KB (30.0%)](https://microbench.testeng.crdb.io/dashboard/?benchmark=BenchmarkInsert/batch=100&amp;package=pkg/sql/exec)",
+		// Verify entire line is a markdown checklist item with link
+		"- [ ] [pkg/sql/exec→BenchmarkScan/rows=1000 (ns/op): +1.2ms (25.5%)](https://microbench.testeng.crdb.io/dashboard/?benchmark=BenchmarkScan/rows=1000&amp;package=pkg/sql/exec)",
+		"- [ ] [pkg/sql/exec→BenchmarkInsert/batch=100 (B/op): +5.0KB (30.0%)](https://microbench.testeng.crdb.io/dashboard/?benchmark=BenchmarkInsert/batch=100&amp;package=pkg/sql/exec)",
 	}
 
 	for _, expected := range expectedElements {


### PR DESCRIPTION
Previously, performance regression issues listed benchmarks as plain markdown list items. This made it difficult to track which regressions had been investigated.

This change formats the regression list using markdown checklist syntax (`- [ ]`), allowing users to check off items as they investigate each regression in the GitHub issue.

Epic: none