### PR TITLE
claude: add jira-internal-task skill

### DIFF
--- a/.claude/skills/jira-internal-task/SKILL.md
+++ b/.claude/skills/jira-internal-task/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: jira-internal-task
+description: Create Jira Internal tasks for tracking reactive work items. Use when the user asks to create a Jira task, internal task, or add something to Jira.
+---
+
+# Jira Internal Task Creator
+
+Help the user create Jira "Internal tasks" for tracking reactive work items on sprint boards.
+
+## When to Use
+
+This skill activates when the user says:
+- "make an internal task for this"
+- "create an internal task to do X"
+- "add this to my jira"
+- "create this on jira"
+- "make jira task"
+- Any similar phrasing about creating Jira tasks or internal tasks
+
+## What are Internal Tasks?
+
+Internal tasks are brief work items for sprint tracking:
+- **Audience**: Primarily the engineer and their manager
+- **Purpose**: Track "reactive" work items on sprint boards
+- **Scope**: Don't need to be exhaustive or fully self-contained
+- **Detail level**: Less important that someone unfamiliar can fully educate themselves from the issue
+
+## Workflow
+
+1. **Understand the request**: Parse what the user wants to track
+2. **Draft title and description**:
+   - Title should be concise and actionable
+   - Description can be brief but should capture key context
+   - If unclear, ask for clarification or propose a title/description for approval
+3. **Gather metadata**:
+   - Parent issue key (typically CRDB-XXXXX format, optional). When the user mentions an epic by number only (e.g., "epic 12345" or "under 12345"), infer the full format as CRDB-12345.
+   - Sprint assignment (see Sprint Handling below)
+   - If the user mentions a team different from their default (e.g., "for the SQL team"), pass `--eng-team` explicitly
+4. **Get user approval**: Show the proposed title and description before creating
+5. **Create the task**: Use the Go tool with explicit `--sprint` flag
+
+## Content Guidelines
+
+**Title:**
+- Short, actionable statement
+- Start with a verb when possible (e.g., "Investigate", "Fix", "Add", "Update")
+- Keep under 100 characters
+
+**Description:**
+- Brief context about what needs to be done
+- Can reference specific code, issues, or conversations
+- Don't need extensive background - this is for tracking, not documentation
+- 1-3 paragraphs is usually sufficient
+
+**Be lenient about scope** - these are quick tracking items, not full specifications. However:
+- If completely unclear what the user wants, ask for clarification
+- If you can infer a reasonable title/description, propose it for approval
+
+## Script Usage
+
+The skill uses a Go tool at `.claude/skills/jira-internal-task/cmd/jira-task/`:
+
+```bash
+# List sprints (active + future, excluding closed) - safe to run for sanity checks
+cd .claude/skills/jira-internal-task && go run ./cmd/jira-task sprints
+
+# Create an internal task (--sprint and --assignee are REQUIRED)
+cd .claude/skills/jira-internal-task && go run ./cmd/jira-task create \
+  --title "Brief task title" \
+  --description "Task description with context" \
+  --sprint <numeric-id|latest|-1> \
+  --assignee <email|unassigned> \
+  [--parent CRDB-12345]
+```
+
+## Sprint Handling (IMPORTANT)
+
+The `--sprint` flag is **required** and must be passed explicitly. The agent must always ask the user to decide sprint behavior:
+
+1. **Preferred: Use a numeric sprint ID** - Run `jira-task sprints` to list available sprints and pick the appropriate ID
+2. **Use `latest`** - Only if the user explicitly says "current sprint" or "latest sprint"
+3. **Use `-1` (backlog)** - If the user says "backlog", "put it in the backlog", "in the backlog", or otherwise indicates they don't want it in any sprint
+
+**Always ask the user** which sprint to use. Never assume a default. Example prompt:
+> "Which sprint should this go in? I can put it in the current active sprint, a specific sprint (I can list them), or the backlog (no sprint)."
+
+## Task Parameters
+
+- `--title`: Required. The task title
+- `--description`: Required. The task description/body
+- `--sprint`: **Required**. Numeric sprint ID (preferred), `latest`, or `-1` for backlog (no sprint)
+- `--parent`: Optional. Parent issue key (e.g., CRDB-12345)
+- `--assignee`: **Required**. Email address of the assignee, or `"unassigned"` to create without an assignee
+- `--project`: Defaults to `CRDB`
+
+**Auth Parameters (from environment—never pass explicitly):**
+- `--token`: From `$JIRA_TOKEN`
+- `--email`: From `$JIRA_EMAIL`
+
+**Team Parameters (from environment, override if user specifies their team):**
+- `--eng-team`: From `$JIRA_ENG_TEAM`. If the user mentions their team (e.g., "I'm on SQL"), pass it explicitly.
+- `--board-id`: From `$JIRA_<ENG_TEAM>_BOARD_ID` (e.g., `$JIRA_KV_BOARD_ID`)
+
+**IMPORTANT**:
+- This tool ONLY creates "Internal Task" issue types
+- Never send API requests directly—always use the tool
+- **During development/testing, NEVER actually create Jira tickets**
+- You MAY run `jira-task sprints` for sanity checks (it has no side effects)
+
+## Example Interaction
+
+**User:** "Make an internal task to investigate the query optimizer slowdown we saw this morning"
+
+**Assistant:**
+I'll create a Jira internal task for this. Here's what I'm proposing:
+
+**Title:** Investigate query optimizer slowdown
+**Description:**
+Investigate the query optimizer performance degradation observed this morning. Need to identify the cause and potential fixes.
+
+Which sprint should this go in?
+- Current active sprint (`latest`)
+- A specific sprint (I can list available sprints)
+- Backlog (no sprint assignment)
+
+Do you also want to link this to a parent epic? (provide CRDB-XXXXX key if so)
+
+[User specifies sprint preference]
+
+**Assistant:** [Runs the tool with explicit --sprint flag]
+
+## Resolving Assignees
+
+When the user says "for wenyi@", "assigned to wenyi", or similar, **always verify** the email by searching git history (since Jira silently ignores invalid assignees):
+
+```bash
+git log --since="3 months ago" --format='%an <%ae>' | sort -u | grep -i "<name>"
+```
+
+- **Single match**: Use that email
+- **Multiple matches**: Ask the user to clarify (e.g., "Did you mean nick@ or nicholas@?")
+- **No matches**: Ask the user for the full email address
+
+Examples:
+- "for wenyi" → search git log, find `Wenyi Hu <wenyi@cockroachlabs.com>`, use `wenyi@cockroachlabs.com`
+- "assign to nick" → search git log, find `Nick Travers <nick@cockroachlabs.com>`, use `nick@cockroachlabs.com`
+- "for john" → if multiple Johns found, ask: "Did you mean john.smith@ or john.doe@?"
+
+## Error Handling
+
+- If the tool fails, report the error to the user
+- If required parameters are missing, ask the user
+- If the request is ambiguous, propose a draft and get approval
+
+## Notes
+
+- These tasks are meant to be lightweight - don't overthink the content
+- Focus on capturing enough info for the engineer to remember context
+- When in doubt, ask the user rather than creating something unclear

--- a/.claude/skills/jira-internal-task/cmd/jira-task/BUILD.bazel
+++ b/.claude/skills/jira-internal-task/cmd/jira-task/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+go_library(
+    name = "jira-task_lib",
+    srcs = [
+        "config.go",
+        "create.go",
+        "create_cmd.go",
+        "http.go",
+        "main.go",
+        "sprint.go",
+        "sprints_cmd.go",
+    ],
+    importpath = "github.com/cockroachdb/cockroach/.claude/skills/jira-internal-task/cmd/jira-task",
+    visibility = ["//visibility:private"],
+    deps = ["@com_github_spf13_cobra//:cobra"],
+)
+
+go_binary(
+    name = "jira-task",
+    embed = [":jira-task_lib"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "jira-task_test",
+    srcs = [
+        "main_test.go",
+        "sprints_cmd_test.go",
+    ],
+    embed = [":jira-task_lib"],
+)

--- a/.claude/skills/jira-internal-task/cmd/jira-task/config.go
+++ b/.claude/skills/jira-internal-task/cmd/jira-task/config.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+func resolveBoardID(engTeam string, boardID int) (int, error) {
+	if engTeam == "" {
+		return 0, fmt.Errorf("eng-team is required (set --eng-team or $JIRA_ENG_TEAM)")
+	}
+
+	if boardID != 0 {
+		return boardID, nil
+	}
+
+	envVar := "JIRA_" + strings.ToUpper(engTeam) + "_BOARD_ID"
+	if v := os.Getenv(envVar); v != "" {
+		resolvedBoardID, err := strconv.Atoi(v)
+		if err != nil {
+			return 0, fmt.Errorf("invalid %s value %q: %v", envVar, v, err)
+		}
+		return resolvedBoardID, nil
+	}
+
+	return 0, fmt.Errorf("board-id is required (set --board-id or $%s, or -1 to skip)", envVar)
+}

--- a/.claude/skills/jira-internal-task/cmd/jira-task/create.go
+++ b/.claude/skills/jira-internal-task/cmd/jira-task/create.go
@@ -1,0 +1,279 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// TaskParams holds the parameters for creating a Jira internal task.
+type TaskParams struct {
+	Title        string
+	Description  string
+	Parent       string // Epic/parent issue key (e.g., CRDB-12345)
+	Sprint       string // Sprint ID for customfield_10020
+	SprintName   string // Sprint name for display (not sent to API)
+	Assignee     string // Jira account ID for assignee (resolved from email)
+	AssigneeName string // Display name for output
+}
+
+// JiraClient is an interface for Jira API operations.
+// This allows for easy mocking in tests.
+type JiraClient interface {
+	CreateInternalTask(params TaskParams) (string, error)
+}
+
+// UserInfo holds the resolved user information.
+type UserInfo struct {
+	AccountID   string
+	DisplayName string
+}
+
+// resolveUser looks up a user by email via Jira API.
+func (c *RealJiraClient) resolveUser(email string) (UserInfo, error) {
+	body, err := c.doRequest("GET", jiraBaseURL+"/user/search?query="+email, nil)
+	if err != nil {
+		return UserInfo{}, fmt.Errorf("user search failed: %w", err)
+	}
+
+	var users []struct {
+		AccountID    string `json:"accountId"`
+		EmailAddress string `json:"emailAddress"`
+		DisplayName  string `json:"displayName"`
+	}
+	if err := json.Unmarshal(body, &users); err != nil {
+		return UserInfo{}, fmt.Errorf("failed to parse user search response: %w", err)
+	}
+
+	for _, u := range users {
+		if strings.EqualFold(u.EmailAddress, email) {
+			return UserInfo{AccountID: u.AccountID, DisplayName: u.DisplayName}, nil
+		}
+	}
+
+	if len(users) == 0 {
+		return UserInfo{}, fmt.Errorf("no user found for email %q", email)
+	}
+	return UserInfo{}, fmt.Errorf("no exact match for %q; found: %v", email, users)
+}
+
+// CreateInternalTask creates an Internal Task in Jira via the REST API.
+// params.Assignee must already be a resolved account ID.
+func (c *RealJiraClient) CreateInternalTask(params TaskParams) (string, error) {
+	// Build the request body
+	fields := map[string]any{
+		"project": map[string]string{
+			"key": c.Config.Project,
+		},
+		"summary": params.Title,
+		"description": map[string]any{
+			"type":    "doc",
+			"version": 1,
+			"content": []map[string]any{
+				{
+					"type": "paragraph",
+					"content": []map[string]any{
+						{
+							"type": "text",
+							"text": params.Description,
+						},
+					},
+				},
+			},
+		},
+		"issuetype": map[string]string{
+			"name": "Internal Task",
+		},
+		// customfield_10089 is "Engineering team"
+		"customfield_10089": map[string]string{
+			"value": c.Config.EngTeam,
+		},
+	}
+
+	// Add optional assignee (empty means "unassigned")
+	if params.Assignee != "" {
+		fields["assignee"] = map[string]string{
+			"accountId": params.Assignee,
+		}
+	}
+
+	// Add optional parent (epic)
+	if params.Parent != "" {
+		fields["parent"] = map[string]string{
+			"key": params.Parent,
+		}
+	}
+
+	// Add optional sprint
+	if params.Sprint != "" {
+		sprintID, err := strconv.Atoi(params.Sprint)
+		if err != nil {
+			return "", fmt.Errorf("internal error: sprint should be numeric at this point: %w", err)
+		}
+		fields["customfield_10020"] = sprintID
+	}
+
+	requestBody := map[string]any{
+		"fields": fields,
+	}
+
+	body, err := c.doRequest("POST", jiraBaseURL+"/issue", requestBody)
+	if err != nil {
+		return "", err
+	}
+
+	var result struct {
+		Key  string `json:"key"`
+		Self string `json:"self"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return result.Key, nil
+}
+
+// IssueFields represents the fields we care about when verifying an issue.
+type IssueFields struct {
+	Assignee *struct {
+		AccountID string `json:"accountId"`
+	} `json:"assignee"`
+	Parent *struct {
+		Key string `json:"key"`
+	} `json:"parent"`
+	Sprint []struct {
+		ID int `json:"id"`
+	} `json:"customfield_10020"`
+	EngTeam *struct {
+		Value string `json:"value"`
+	} `json:"customfield_10089"`
+}
+
+// FetchIssue retrieves an issue from Jira to verify its fields.
+func (c *RealJiraClient) FetchIssue(issueKey string) (*IssueFields, error) {
+	body, err := c.doRequest("GET", jiraBaseURL+"/issue/"+issueKey, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch issue: %w", err)
+	}
+
+	var result struct {
+		Fields IssueFields `json:"fields"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &result.Fields, nil
+}
+
+// VerifyIssue checks that the issue was created with the expected values.
+// Returns a list of warnings for any mismatches.
+func (c *RealJiraClient) VerifyIssue(issueKey string, params TaskParams) []string {
+	fields, err := c.FetchIssue(issueKey)
+	if err != nil {
+		return []string{fmt.Sprintf("Could not verify issue: %v", err)}
+	}
+
+	var warnings []string
+
+	// Check assignee (only if one was requested)
+	if params.Assignee != "" {
+		if fields.Assignee == nil {
+			warnings = append(warnings, fmt.Sprintf("Assignee was not set (expected %s)", params.Assignee))
+		} else if fields.Assignee.AccountID != params.Assignee {
+			warnings = append(warnings, fmt.Sprintf("Assignee mismatch: got %s, expected %s",
+				fields.Assignee.AccountID, params.Assignee))
+		}
+	}
+
+	// Check parent
+	if params.Parent != "" {
+		if fields.Parent == nil {
+			warnings = append(warnings, fmt.Sprintf("Parent was not set (expected %s)", params.Parent))
+		} else if fields.Parent.Key != params.Parent {
+			warnings = append(warnings, fmt.Sprintf("Parent mismatch: got %s, expected %s",
+				fields.Parent.Key, params.Parent))
+		}
+	}
+
+	// Check sprint
+	if params.Sprint != "" {
+		expectedSprintID, _ := strconv.Atoi(params.Sprint)
+		if len(fields.Sprint) == 0 {
+			warnings = append(warnings, fmt.Sprintf("Sprint was not set (expected %s)", params.Sprint))
+		} else {
+			found := false
+			for _, s := range fields.Sprint {
+				if s.ID == expectedSprintID {
+					found = true
+					break
+				}
+			}
+			if !found {
+				warnings = append(warnings, fmt.Sprintf("Sprint %s not found in issue sprints", params.Sprint))
+			}
+		}
+	}
+
+	// Check engineering team
+	if fields.EngTeam == nil {
+		warnings = append(warnings, fmt.Sprintf("Engineering team was not set (expected %s)", c.Config.EngTeam))
+	} else if fields.EngTeam.Value != c.Config.EngTeam {
+		warnings = append(warnings, fmt.Sprintf("Engineering team mismatch: got %s, expected %s",
+			fields.EngTeam.Value, c.Config.EngTeam))
+	}
+
+	return warnings
+}
+
+// validateConfig validates the Jira configuration.
+func validateConfig(config JiraConfig) error {
+	if config.Token == "" {
+		return fmt.Errorf("token is required (set --token or $JIRA_TOKEN)\n  Get one at: https://id.atlassian.com/manage-profile/security/api-tokens")
+	}
+	if config.Email == "" {
+		return fmt.Errorf("email is required (set --email or $JIRA_EMAIL)")
+	}
+	return nil
+}
+
+// validateParams validates the task parameters.
+func validateParams(params TaskParams) error {
+	if params.Title == "" {
+		return fmt.Errorf("title is required")
+	}
+
+	if params.Description == "" {
+		return fmt.Errorf("description is required")
+	}
+
+	// Note: Assignee can be empty (meaning "unassigned").
+	// The --assignee flag is required at the CLI level, but the special
+	// value "unassigned" results in an empty Assignee here.
+
+	return nil
+}
+
+// run is the main workhorse function that can be easily tested.
+// It takes parsed parameters and a JiraClient interface, making it mockable.
+// Returns the created issue key on success.
+func run(config JiraConfig, params TaskParams, client JiraClient) (string, error) {
+	// Validate config
+	if err := validateConfig(config); err != nil {
+		return "", err
+	}
+
+	// Validate parameters
+	if err := validateParams(params); err != nil {
+		return "", err
+	}
+
+	// Create the task
+	issueKey, err := client.CreateInternalTask(params)
+	if err != nil {
+		return "", fmt.Errorf("failed to create Jira task: %w", err)
+	}
+
+	return issueKey, nil
+}

--- a/.claude/skills/jira-internal-task/cmd/jira-task/create_cmd.go
+++ b/.claude/skills/jira-internal-task/cmd/jira-task/create_cmd.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	createToken       string
+	createEmail       string
+	createProject     string
+	createEngTeam     string
+	createBoardID     int
+	createTitle       string
+	createDescription string
+	createParent      string
+	createSprint      string
+	createAssignee    string
+)
+
+func newCreateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a Jira internal task",
+		RunE:  runCreate,
+	}
+
+	// Auth/config flags
+	cmd.Flags().StringVar(&createToken, "token", os.Getenv("JIRA_TOKEN"), "Jira API token (default: $JIRA_TOKEN)")
+	cmd.Flags().StringVar(&createEmail, "email", os.Getenv("JIRA_EMAIL"), "Jira account email (default: $JIRA_EMAIL)")
+	cmd.Flags().StringVar(&createProject, "project", "CRDB", "Jira project key")
+	cmd.Flags().StringVar(&createEngTeam, "eng-team", os.Getenv("JIRA_ENG_TEAM"), "Engineering team (default: $JIRA_ENG_TEAM)")
+	cmd.Flags().IntVar(&createBoardID, "board-id", 0, "Sprint board ID (default: $JIRA_<ENG_TEAM>_BOARD_ID, -1 to skip)")
+
+	// Task content flags
+	cmd.Flags().StringVar(&createTitle, "title", "", "Task title (required)")
+	cmd.Flags().StringVar(&createDescription, "description", "", "Task description (required)")
+	cmd.Flags().StringVar(&createParent, "parent", "", "Parent issue key, e.g., CRDB-12345 (optional)")
+	cmd.Flags().StringVar(&createSprint, "sprint", "", "Sprint: numeric ID, \"latest\", or -1 to skip (required)")
+	cmd.Flags().StringVar(&createAssignee, "assignee", "", "Assignee email, or \"unassigned\" to skip (required)")
+
+	_ = cmd.MarkFlagRequired("title")
+	_ = cmd.MarkFlagRequired("description")
+	_ = cmd.MarkFlagRequired("sprint")
+	_ = cmd.MarkFlagRequired("assignee")
+
+	return cmd
+}
+
+func runCreate(cmd *cobra.Command, args []string) error {
+	resolvedBoardID, err := resolveBoardID(createEngTeam, createBoardID)
+	if err != nil {
+		return err
+	}
+
+	// Build config and client
+	config := JiraConfig{
+		Token:   createToken,
+		Email:   createEmail,
+		Project: createProject,
+		EngTeam: createEngTeam,
+		BoardID: resolvedBoardID,
+	}
+	client := &RealJiraClient{Config: config}
+
+	// Resolve sprint
+	var sprintID, sprintName string
+	if createSprint != "-1" && createSprint != "" {
+		info, err := client.resolveSprintID(createSprint)
+		if err != nil {
+			return err
+		}
+		sprintID = strconv.Itoa(info.ID)
+		sprintName = info.Name
+	}
+
+	// Resolve assignee email to account ID and display name.
+	// Special value "unassigned" skips setting the assignee.
+	var assigneeID, assigneeName string
+	if createAssignee != "" && createAssignee != "unassigned" {
+		user, err := client.resolveUser(createAssignee)
+		if err != nil {
+			return err
+		}
+		assigneeID = user.AccountID
+		assigneeName = user.DisplayName
+	}
+
+	// Build task parameters
+	params := TaskParams{
+		Title:        createTitle,
+		Description:  createDescription,
+		Parent:       createParent,
+		Sprint:       sprintID,
+		SprintName:   sprintName,
+		Assignee:     assigneeID,
+		AssigneeName: assigneeName,
+	}
+	issueKey, err := run(config, params, client)
+	if err != nil {
+		return err
+	}
+
+	// Print summary
+	fmt.Printf("\nCreated: %s\n", issueKey)
+	fmt.Printf("  URL:      https://cockroachlabs.atlassian.net/browse/%s\n", issueKey)
+	if params.AssigneeName != "" {
+		fmt.Printf("  Assignee: %s\n", params.AssigneeName)
+	} else {
+		fmt.Printf("  Assignee: Unassigned\n")
+	}
+	if params.SprintName != "" {
+		fmt.Printf("  Sprint:   %s\n", params.SprintName)
+	}
+	if params.Parent != "" {
+		fmt.Printf("  Parent:   %s\n", params.Parent)
+	}
+
+	// Verify the issue was created correctly
+	if warnings := client.VerifyIssue(issueKey, params); len(warnings) > 0 {
+		fmt.Println("\n⚠️  Warnings:")
+		for _, w := range warnings {
+			fmt.Printf("  - %s\n", w)
+		}
+	}
+
+	return nil
+}

--- a/.claude/skills/jira-internal-task/cmd/jira-task/http.go
+++ b/.claude/skills/jira-internal-task/cmd/jira-task/http.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+const (
+	jiraBaseURL  = "https://cockroachlabs.atlassian.net/rest/api/3"
+	jiraAgileURL = "https://cockroachlabs.atlassian.net/rest/agile/1.0"
+)
+
+// JiraConfig holds configuration for connecting to Jira.
+type JiraConfig struct {
+	Token   string
+	Email   string
+	Project string
+	EngTeam string
+	BoardID int
+}
+
+// RealJiraClient implements JiraClient with actual Jira API calls.
+type RealJiraClient struct {
+	Config JiraConfig
+}
+
+// doRequest performs an HTTP request with authentication.
+// If body is non-nil, it's marshaled to JSON. Returns the response body.
+func (c *RealJiraClient) doRequest(method, url string, body any) ([]byte, error) {
+	var reqBody io.Reader
+	if body != nil {
+		jsonBody, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal request body: %w", err)
+		}
+		reqBody = bytes.NewReader(jsonBody)
+	}
+
+	req, err := http.NewRequest(method, url, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	auth := base64.StdEncoding.EncodeToString([]byte(c.Config.Email + ":" + c.Config.Token))
+	req.Header.Set("Authorization", "Basic "+auth)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("Jira API error (status %d): %s", resp.StatusCode, string(respBody))
+	}
+
+	return respBody, nil
+}

--- a/.claude/skills/jira-internal-task/cmd/jira-task/main.go
+++ b/.claude/skills/jira-internal-task/cmd/jira-task/main.go
@@ -1,0 +1,26 @@
+// jira-task manages Jira internal tasks and sprints.
+//
+// NOTE FOR AI AGENTS: Never create test issues to verify this tool works.
+// Only create issues when the user explicitly requests a real task.
+// You MAY run the "sprints" subcommand for sanity checks since it has no side effects.
+package main
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func main() {
+	rootCmd := &cobra.Command{
+		Use:   "jira-task",
+		Short: "Manage Jira internal tasks and sprints",
+	}
+
+	rootCmd.AddCommand(newCreateCmd())
+	rootCmd.AddCommand(newSprintsCmd())
+
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/.claude/skills/jira-internal-task/cmd/jira-task/main_test.go
+++ b/.claude/skills/jira-internal-task/cmd/jira-task/main_test.go
@@ -1,0 +1,290 @@
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+// MockJiraClient is a mock implementation of JiraClient for testing.
+type MockJiraClient struct {
+	CreateInternalTaskFunc func(params TaskParams) (string, error)
+}
+
+func (m *MockJiraClient) CreateInternalTask(params TaskParams) (string, error) {
+	if m.CreateInternalTaskFunc != nil {
+		return m.CreateInternalTaskFunc(params)
+	}
+	return "MOCK-123", nil
+}
+
+// validConfig returns a valid JiraConfig for testing.
+func validConfig() JiraConfig {
+	return JiraConfig{
+		Token:   "test-token",
+		Email:   "test@example.com",
+		Project: "CRDB",
+		EngTeam: "KV",
+		BoardID: 400,
+	}
+}
+
+func TestValidateConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  JiraConfig
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "valid config",
+			config:  validConfig(),
+			wantErr: false,
+		},
+		{
+			name: "missing token",
+			config: JiraConfig{
+				Email:   "test@example.com",
+				Project: "CRDB",
+			},
+			wantErr: true,
+			errMsg:  "token is required (set --token or $JIRA_TOKEN)\n  Get one at: https://id.atlassian.com/manage-profile/security/api-tokens",
+		},
+		{
+			name: "missing email",
+			config: JiraConfig{
+				Token:   "test-token",
+				Project: "CRDB",
+			},
+			wantErr: true,
+			errMsg:  "email is required (set --email or $JIRA_EMAIL)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateConfig(tt.config)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("validateConfig() expected error but got nil")
+					return
+				}
+				if err.Error() != tt.errMsg {
+					t.Errorf("validateConfig() error = %v, want %v", err.Error(), tt.errMsg)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("validateConfig() unexpected error = %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateParams(t *testing.T) {
+	tests := []struct {
+		name    string
+		params  TaskParams
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid params with all fields",
+			params: TaskParams{
+				Title:       "Test task",
+				Description: "Test description",
+				Parent:      "CRDB-12345",
+				Sprint:      "123",
+				Assignee:    "user123",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid params without optional fields",
+			params: TaskParams{
+				Title:       "Test task",
+				Description: "Test description",
+				Assignee:    "user123",
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing title",
+			params: TaskParams{
+				Description: "Test description",
+				Assignee:    "user123",
+			},
+			wantErr: true,
+			errMsg:  "title is required",
+		},
+		{
+			name: "missing description",
+			params: TaskParams{
+				Title:    "Test task",
+				Assignee: "user123",
+			},
+			wantErr: true,
+			errMsg:  "description is required",
+		},
+		{
+			name: "empty assignee is valid (unassigned)",
+			params: TaskParams{
+				Title:       "Test task",
+				Description: "Test description",
+				Assignee:    "", // Empty means "unassigned"
+			},
+			wantErr: false,
+		},
+		{
+			name: "parent with any format is accepted",
+			params: TaskParams{
+				Title:       "Test task",
+				Description: "Test description",
+				Parent:      "anything-goes",
+				Assignee:    "user123",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateParams(tt.params)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("validateParams() expected error but got nil")
+					return
+				}
+				if err.Error() != tt.errMsg {
+					t.Errorf("validateParams() error = %v, want %v", err.Error(), tt.errMsg)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("validateParams() unexpected error = %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestRun(t *testing.T) {
+	tests := []struct {
+		name       string
+		config     JiraConfig
+		params     TaskParams
+		mockClient *MockJiraClient
+		wantErr    bool
+		errMsg     string
+	}{
+		{
+			name:   "successful task creation",
+			config: validConfig(),
+			params: TaskParams{
+				Title:       "Test task",
+				Description: "Test description",
+				Parent:      "CRDB-12345",
+				Assignee:    "user123",
+			},
+			mockClient: &MockJiraClient{
+				CreateInternalTaskFunc: func(params TaskParams) (string, error) {
+					return "CRDB-67890", nil
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:   "validation error - missing title",
+			config: validConfig(),
+			params: TaskParams{
+				Description: "Test description",
+				Assignee:    "user123",
+			},
+			mockClient: &MockJiraClient{},
+			wantErr:    true,
+			errMsg:     "title is required",
+		},
+		{
+			name:   "config error - missing token",
+			config: JiraConfig{Email: "test@example.com"},
+			params: TaskParams{
+				Title:       "Test task",
+				Description: "Test description",
+				Assignee:    "user123",
+			},
+			mockClient: &MockJiraClient{},
+			wantErr:    true,
+			errMsg:     "token is required (set --token or $JIRA_TOKEN)\n  Get one at: https://id.atlassian.com/manage-profile/security/api-tokens",
+		},
+		{
+			name:   "API error during task creation",
+			config: validConfig(),
+			params: TaskParams{
+				Title:       "Test task",
+				Description: "Test description",
+				Assignee:    "user123",
+			},
+			mockClient: &MockJiraClient{
+				CreateInternalTaskFunc: func(params TaskParams) (string, error) {
+					return "", errors.New("API connection failed")
+				},
+			},
+			wantErr: true,
+			errMsg:  "failed to create Jira task: API connection failed",
+		},
+		{
+			name:   "valid params with sprint",
+			config: validConfig(),
+			params: TaskParams{
+				Title:       "Test task",
+				Description: "Test description",
+				Sprint:      "456",
+				Assignee:    "user123",
+			},
+			mockClient: &MockJiraClient{
+				CreateInternalTaskFunc: func(params TaskParams) (string, error) {
+					if params.Sprint != "456" {
+						t.Errorf("Expected sprint 456, got %s", params.Sprint)
+					}
+					return "CRDB-11111", nil
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:   "unassigned task (empty assignee)",
+			config: validConfig(),
+			params: TaskParams{
+				Title:       "Test task",
+				Description: "Test description",
+				Assignee:    "", // Empty means "unassigned"
+			},
+			mockClient: &MockJiraClient{
+				CreateInternalTaskFunc: func(params TaskParams) (string, error) {
+					if params.Assignee != "" {
+						t.Errorf("Expected empty assignee for unassigned, got %s", params.Assignee)
+					}
+					return "CRDB-22222", nil
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := run(tt.config, tt.params, tt.mockClient)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("run() expected error but got nil")
+					return
+				}
+				if err.Error() != tt.errMsg {
+					t.Errorf("run() error = %v, want %v", err.Error(), tt.errMsg)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("run() unexpected error = %v", err)
+				}
+			}
+		})
+	}
+}

--- a/.claude/skills/jira-internal-task/cmd/jira-task/sprint.go
+++ b/.claude/skills/jira-internal-task/cmd/jira-task/sprint.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Sprint represents a Jira sprint from the Agile API.
+type Sprint struct {
+	ID            int    `json:"id"`
+	Name          string `json:"name"`
+	State         string `json:"state"`
+	StartDate     string `json:"startDate"`
+	EndDate       string `json:"endDate"`
+	OriginBoardID int    `json:"originBoardId"`
+}
+
+// SprintResponse is the response from the sprint list API.
+type SprintResponse struct {
+	Values []Sprint `json:"values"`
+}
+
+// SprintInfo contains the resolved sprint ID and name.
+type SprintInfo struct {
+	ID   int
+	Name string
+}
+
+// resolveSprintID resolves a sprint flag value to a sprint ID and name.
+// If the value is already numeric, it's returned as-is.
+// If it's "latest", the active sprint with the largest end time is chosen.
+// Otherwise, it's treated as a search string that must match exactly one sprint.
+func (c *RealJiraClient) resolveSprintID(sprintFlag string) (SprintInfo, error) {
+	if sprintFlag == "" {
+		return SprintInfo{}, nil
+	}
+
+	// If it's already numeric, use it directly
+	if id, err := strconv.Atoi(sprintFlag); err == nil {
+		return SprintInfo{ID: id, Name: fmt.Sprintf("(ID %d)", id)}, nil
+	}
+
+	// Fetch non-closed sprints (active + future)
+	sprints, err := c.fetchNonClosedSprints()
+	if err != nil {
+		return SprintInfo{}, err
+	}
+
+	// Filter to only sprints from this board
+	var boardSprints []Sprint
+	for _, s := range sprints {
+		if s.OriginBoardID == c.Config.BoardID {
+			boardSprints = append(boardSprints, s)
+		}
+	}
+
+	if sprintFlag == "latest" {
+		return findLatestActiveSprint(boardSprints)
+	}
+
+	// Search for a sprint matching the string
+	return findSprintByName(boardSprints, sprintFlag)
+}
+
+// fetchNonClosedSprints fetches active and future sprints (excludes closed).
+func (c *RealJiraClient) fetchNonClosedSprints() ([]Sprint, error) {
+	url := fmt.Sprintf("%s/board/%d/sprint?state=active,future", jiraAgileURL, c.Config.BoardID)
+	body, err := c.doRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch sprints: %w", err)
+	}
+
+	var result SprintResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse sprints: %w", err)
+	}
+
+	return result.Values, nil
+}
+
+// findLatestActiveSprint finds the active sprint with the largest end time.
+// It filters the input sprints for state=="active" and returns the one with the latest end date.
+func findLatestActiveSprint(sprints []Sprint) (SprintInfo, error) {
+	var latest Sprint
+	var latestEnd time.Time
+
+	for _, s := range sprints {
+		if s.State != "active" {
+			continue
+		}
+		endTime, err := time.Parse(time.RFC3339, s.EndDate)
+		if err != nil {
+			continue // skip sprints with unparseable dates
+		}
+		if endTime.After(latestEnd) {
+			latestEnd = endTime
+			latest = s
+		}
+	}
+
+	if latest.ID == 0 {
+		return SprintInfo{}, fmt.Errorf("no active sprints found")
+	}
+
+	return SprintInfo{ID: latest.ID, Name: latest.Name}, nil
+}
+
+// findSprintByName finds a sprint whose name contains the search string.
+// Returns an error if zero or multiple sprints match.
+func findSprintByName(sprints []Sprint, search string) (SprintInfo, error) {
+	var matches []Sprint
+	for _, s := range sprints {
+		if strings.Contains(s.Name, search) {
+			matches = append(matches, s)
+		}
+	}
+
+	if len(matches) == 0 {
+		var names []string
+		for _, s := range sprints {
+			names = append(names, s.Name)
+		}
+		return SprintInfo{}, fmt.Errorf("no sprint matching %q found; available: %v", search, names)
+	}
+
+	if len(matches) > 1 {
+		var names []string
+		for _, s := range matches {
+			names = append(names, s.Name)
+		}
+		return SprintInfo{}, fmt.Errorf("multiple sprints match %q: %v", search, names)
+	}
+
+	return SprintInfo{ID: matches[0].ID, Name: matches[0].Name}, nil
+}

--- a/.claude/skills/jira-internal-task/cmd/jira-task/sprints_cmd.go
+++ b/.claude/skills/jira-internal-task/cmd/jira-task/sprints_cmd.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// SprintListItem is the JSON output format for sprint listing.
+type SprintListItem struct {
+	ID        int    `json:"id"`
+	Name      string `json:"name"`
+	State     string `json:"state"`
+	StartDate string `json:"startDate"`
+	EndDate   string `json:"endDate"`
+}
+
+var (
+	sprintsToken   string
+	sprintsEmail   string
+	sprintsEngTeam string
+	sprintsBoardID int
+)
+
+func newSprintsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sprints",
+		Short: "List active and future sprints (JSON output)",
+		RunE:  runSprints,
+	}
+
+	cmd.Flags().StringVar(&sprintsToken, "token", os.Getenv("JIRA_TOKEN"), "Jira API token (default: $JIRA_TOKEN)")
+	cmd.Flags().StringVar(&sprintsEmail, "email", os.Getenv("JIRA_EMAIL"), "Jira account email (default: $JIRA_EMAIL)")
+	cmd.Flags().StringVar(&sprintsEngTeam, "eng-team", os.Getenv("JIRA_ENG_TEAM"), "Engineering team (default: $JIRA_ENG_TEAM)")
+	cmd.Flags().IntVar(&sprintsBoardID, "board-id", 0, "Sprint board ID (default: $JIRA_<ENG_TEAM>_BOARD_ID)")
+
+	return cmd
+}
+
+func runSprints(cmd *cobra.Command, args []string) error {
+	resolvedBoardID, err := resolveBoardID(sprintsEngTeam, sprintsBoardID)
+	if err != nil {
+		return err
+	}
+
+	config := JiraConfig{
+		Token:   sprintsToken,
+		Email:   sprintsEmail,
+		Project: "CRDB",
+		EngTeam: sprintsEngTeam,
+		BoardID: resolvedBoardID,
+	}
+	client := &RealJiraClient{Config: config}
+
+	sprints, err := client.fetchNonClosedSprints()
+	if err != nil {
+		return err
+	}
+
+	items := formatSprintList(sprints, resolvedBoardID)
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(items)
+}
+
+func formatSprintList(sprints []Sprint, boardID int) []SprintListItem {
+	var items []SprintListItem
+	for _, s := range sprints {
+		if s.OriginBoardID != boardID {
+			continue
+		}
+		items = append(items, SprintListItem{
+			ID:        s.ID,
+			Name:      s.Name,
+			State:     s.State,
+			StartDate: s.StartDate,
+			EndDate:   s.EndDate,
+		})
+	}
+	return items
+}

--- a/.claude/skills/jira-internal-task/cmd/jira-task/sprints_cmd_test.go
+++ b/.claude/skills/jira-internal-task/cmd/jira-task/sprints_cmd_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestFormatSprintListJSON(t *testing.T) {
+	sprints := []Sprint{
+		{ID: 10, Name: "KV Sprint A", State: "active", StartDate: "2026-01-01T00:00:00Z", EndDate: "2026-01-15T00:00:00Z", OriginBoardID: 400},
+		{ID: 11, Name: "KV Holding pen", State: "future", StartDate: "2026-01-16T00:00:00Z", EndDate: "2026-01-30T00:00:00Z", OriginBoardID: 400},
+		{ID: 12, Name: "Other team", State: "active", StartDate: "2026-01-01T00:00:00Z", EndDate: "2026-01-15T00:00:00Z", OriginBoardID: 999},
+	}
+
+	items := formatSprintList(sprints, 400)
+	data, err := json.MarshalIndent(items, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	expected := `[
+  {
+    "id": 10,
+    "name": "KV Sprint A",
+    "state": "active",
+    "startDate": "2026-01-01T00:00:00Z",
+    "endDate": "2026-01-15T00:00:00Z"
+  },
+  {
+    "id": 11,
+    "name": "KV Holding pen",
+    "state": "future",
+    "startDate": "2026-01-16T00:00:00Z",
+    "endDate": "2026-01-30T00:00:00Z"
+  }
+]`
+	if string(data) != expected {
+		t.Fatalf("unexpected JSON output:\n%s", string(data))
+	}
+}
+
+func TestFindSprintByNameAcrossStates(t *testing.T) {
+	sprints := []Sprint{
+		{ID: 20, Name: "KV Sprint A", State: "active"},
+		{ID: 21, Name: "KV Holding pen", State: "future"},
+	}
+
+	info, err := findSprintByName(sprints, "Holding pen")
+	if err != nil {
+		t.Fatalf("expected match, got error: %v", err)
+	}
+	if info.ID != 21 {
+		t.Fatalf("expected sprint ID 21, got %d", info.ID)
+	}
+}

--- a/.claude/skills/jira-internal-task/go.mod
+++ b/.claude/skills/jira-internal-task/go.mod
@@ -1,0 +1,9 @@
+module github.com/cockroachdb/cockroach/.claude/skills/jira-internal-task
+
+go 1.25.5
+
+require (
+	github.com/inconshreveable/mousetrap v1.0.1 // indirect
+	github.com/spf13/cobra v1.6.1 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+)

--- a/.claude/skills/jira-internal-task/go.sum
+++ b/.claude/skills/jira-internal-task/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
+github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=
+github.com/spf13/cobra v1.6.1/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Adds a Claude skill for creating Jira "Internal Task" issues—lightweight
sprint-tracking items for reactive or planned work.

Features:
- Creates tasks via Jira REST API with title, description, parent, sprint, assignee
- Auth from environment ($JIRA_TOKEN, $JIRA_EMAIL, $JIRA_ENG_TEAM, $JIRA_<ENG_TEAM>_BOARD_ID)
- Resolves assignee names to emails via git log lookup
- Sprint handling with --sprint (required): numeric ID, "latest" for active sprint, or -1 for backlog
- "sprints" subcommand to list active/future sprints as JSON (read-only, safe for sanity checks)
- Post-creation verification warns if Jira silently dropped fields (assignee, parent, sprint, eng team)

Example invocations:
- "make an internal task to investigate the allocator flakiness"
- "create a jira task for this under epic 25222"
- "add this to my jira, assign to wenyi"
- "jira task: fix the benchmark regression we just discussed"

Includes a Go CLI tool at .claude/skills/jira-internal-task/cmd/jira-task/ with unit tests
for validation and sprint resolution logic.

<img width="1656" height="1762" alt="image" src="https://github.com/user-attachments/assets/1a6b723f-09b2-4c51-8a52-1c092aacd557" />

Epic: none