### PR TITLE
kvserver: fixup log-line formatting

### DIFF
--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -783,7 +783,7 @@ func (s handleRaftReadyStats) SafeFormat(p redact.SafePrinter, _ rune) {
 	dUnaccounted := dTotal - dSnap - dAppend - dApply - dPebble
 
 	{
-		p.Printf("raft ready handling: %.2fs [append=%.2fs, apply=%.2fs, ",
+		p.Printf("raft ready handling: %.2fs [append=%.2fs, apply=%.2fs",
 			dTotal.Seconds(), dAppend.Seconds(), dApply.Seconds())
 		if s.append.Sync {
 			var sync redact.SafeString
@@ -792,7 +792,7 @@ func (s handleRaftReadyStats) SafeFormat(p redact.SafePrinter, _ rune) {
 			} else {
 				sync = "sync"
 			}
-			p.Printf("%s=%.2fs", sync, dPebble.Seconds())
+			p.Printf(", %s=%.2fs", sync, dPebble.Seconds())
 		}
 	}
 	if dSnap > 0 {


### PR DESCRIPTION
Before this, you could see log messages like:

    [T1,Vsystem,n1,s1,r5517/3:/Tenant/3/Table/114/1/{‹5›…-‹6›…},raft]
    3000 raft ready handling: 1.14s [append=0.00s, apply=1.14s, ,
    other=0.00s], wrote [apply=39 KiB (4 in 3 batches),
    apply-write-bytes=27 KiB]; node might be overloaded

Epic: none
Release note: None