### PR TITLE
mmaintegration: update Unknown and Decommissioning translation

### DIFF
--- a/pkg/kv/kvserver/mmaintegration/testdata/TestTranslateStorePoolStatusToMMA
+++ b/pkg/kv/kvserver/mmaintegration/testdata/TestTranslateStorePoolStatusToMMA
@@ -3,9 +3,9 @@
 echo
 ----
 dead: health=Dead, lease=Shedding, replica=Shedding
-unknown: health=Unknown, lease=Refusing, replica=Refusing
+unknown: health=Unknown, lease=Shedding, replica=Refusing
 throttled: health=OK, lease=OK, replica=Refusing
 available: health=OK, lease=OK, replica=OK
-decommissioning: health=OK, lease=Shedding, replica=Shedding
+decommissioning: health=OK, lease=Refusing, replica=Shedding
 suspect: health=Unhealthy, lease=Shedding, replica=Refusing
 draining: health=OK, lease=Shedding, replica=Refusing


### PR DESCRIPTION
This commit changes Decommissioning LeaseDispositionShedding to refusing and
Unknown LeaseDispositionRefusing to shedding.

A decommissioning store is healthy and leaving - it shouldn't accept new leases,
but existing leases can remain and relies on replica replacement triggering
lease transfer.

An unknown store may be unreachable, and since the leaseholder is important for
availability and lease transfers are cheap, proactively shedding leases; this
matches SMA behavior.

Part of: https://github.com/cockroachdb/cockroach/issues/156776
Epic: [CRDB-55052](https://cockroachlabs.atlassian.net/browse/CRDB-55052)