### PR TITLE
cli: add dashboard generation command

### DIFF
--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -46,6 +46,7 @@ go_library(
         "flags.go",
         "flags_util.go",
         "gen.go",
+        "gen_dashboard.go",
         "gen_encryption.go",
         "haproxy.go",
         "init.go",
@@ -109,6 +110,7 @@ go_library(
     embedsrcs = [
         "files/cockroachdb_metrics_base.yaml",
         "files/cockroachdb_datadog_metrics.yaml",
+        "files/dashboard.yaml",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/cli",
     visibility = ["//visibility:public"],
@@ -372,6 +374,7 @@ go_test(
         "doctor_test.go",
         "ear_test.go",
         "flags_test.go",
+        "gen_dashboard_test.go",
         "gen_encryption_test.go",
         "gen_test.go",
         "haproxy_test.go",

--- a/pkg/cli/files/dashboard.yaml
+++ b/pkg/cli/files/dashboard.yaml
@@ -1,0 +1,1903 @@
+dashboards:
+  - title: "Overview"
+    graphs:
+      - title: "SQL Queries Per Second"
+        tooltip: "A moving average of the number of SELECT, INSERT, UPDATE, and DELETE statements, and the sum of all four, successfully executed per second."
+        axis:
+          label: "queries per second"
+        group_by_storage: false
+        metrics:
+          - name: "cr.node.sql.select.count"
+            title: "Selects"
+          - name: "cr.node.sql.update.count"
+            title: "Updates"
+          - name: "cr.node.sql.insert.count"
+            title: "Inserts"
+          - name: "cr.node.sql.delete.count"
+            title: "Deletes"
+          - name: "cr.node.sql.crud_query.count"
+            title: "Total Queries"
+
+      - title: "Service Latency: SQL Statements, 99th percentile"
+        tooltip: "Over the last minute, this node executed 99% of SQL statements within this time. This time only includes SELECT, INSERT, UPDATE and DELETE statements and does not include network latency between the node and client."
+        axis:
+          label: "latency"
+          units: "Duration"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.sql.service.latency-p99"
+            title: "Service Latency p99"
+
+      - title: "SQL Statement Contention"
+        tooltip: "A moving average of the number of SQL statements executed per second that experienced contention."
+        axis:
+          label: "Average number of queries per second"
+        group_by_storage: false
+        metrics:
+          - name: "cr.node.sql.distsql.contended_queries.count"
+            title: "Contention"
+
+      - title: "Replicas per Node"
+        tooltip: "The number of range replicas stored on this node. Ranges are subsets of your data, which are replicated to ensure survivability."
+        axis:
+          label: "replicas"
+        group_by_storage: true
+        metrics:
+          - name: "cr.store.replicas"
+            title: "Replicas"
+
+      - title: "Capacity"
+        tooltip: "Capacity graph showing storage metrics"
+        axis:
+          label: "capacity"
+          units: "Bytes"
+        group_by_storage: false
+        metrics:
+          - name: "cr.store.capacity"
+            title: "Max"
+          - name: "cr.store.capacity.available"
+            title: "Available"
+          - name: "cr.store.capacity.used"
+            title: "Used"
+
+  - title: "Hardware"
+    graphs:
+      - title: "CPU Percent"
+        tooltip: "CPU usage for the CRDB nodes"
+        axis:
+          label: "CPU"
+          units: "Percentage"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.sys.cpu.combined.percent-normalized"
+            title: "CPU Usage"
+
+      - title: "Host CPU Percent"
+        tooltip: "Machine-wide CPU usage"
+        axis:
+          label: "CPU"
+          units: "Percentage"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.sys.cpu.host.combined.percent-normalized"
+            title: "Host CPU Usage"
+
+      - title: "Memory Usage"
+        tooltip: "Memory in use"
+        axis:
+          label: "memory usage"
+          units: "Bytes"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.sys.rss"
+            title: "Memory"
+
+      - title: "Disk Read Bytes/s"
+        axis:
+          label: "bytes"
+          units: "Bytes"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.sys.host.disk.read.bytes"
+            title: "Disk Read"
+
+      - title: "Disk Write Bytes/s"
+        axis:
+          label: "bytes"
+          units: "Bytes"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.sys.host.disk.write.bytes"
+            title: "Disk Write"
+
+      - title: "Disk Read IOPS"
+        axis:
+          label: "IOPS"
+          units: "Count"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.sys.host.disk.read.count"
+            title: "Read IOPS"
+
+      - title: "Disk Write IOPS"
+        axis:
+          label: "IOPS"
+          units: "Count"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.sys.host.disk.write.count"
+            title: "Write IOPS"
+
+      - title: "Disk Ops In Progress"
+        axis:
+          label: "Ops"
+          units: "Count"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.sys.host.disk.iopsinprogress"
+            title: "Ops In Progress"
+
+      - title: "Available Disk Capacity"
+        axis:
+          label: "capacity"
+          units: "Bytes"
+        group_by_storage: true
+        metrics:
+          - name: "cr.store.capacity.available"
+            title: "Available Capacity"
+
+  - title: "Runtime"
+    graphs:
+      - title: "Live Node Count"
+        tooltip: "The number of live nodes in the cluster."
+        axis:
+          label: "nodes"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.liveness.livenodes"
+            title: "Live Nodes"
+
+      - title: "Memory Usage"
+        tooltip: "Memory in use by CockroachDB"
+        axis:
+          label: "memory usage"
+          units: "Bytes"
+        metrics:
+          - name: "cr.node.sys.rss"
+            title: "Total memory (RSS)"
+          - name: "cr.node.sys.go.allocbytes"
+            title: "Go Allocated"
+          - name: "cr.node.sys.go.totalbytes"
+            title: "Go Total"
+          - name: "cr.node.sys.go.limitbytes"
+            title: "Go Limit"
+          - name: "cr.node.sys.cgo.allocbytes"
+            title: "CGo Allocated"
+          - name: "cr.node.sys.cgo.totalbytes"
+            title: "CGo Total"
+
+      - title: "Goroutine Count"
+        tooltip: "The number of Goroutines. This count should rise and fall based on load."
+        axis:
+          label: "goroutines"
+          units: "Count"
+        metrics:
+          - name: "cr.node.sys.goroutines"
+            title: "Goroutines"
+
+      - title: "Goroutine Scheduling Latency: 99th percentile"
+        tooltip: "P99 scheduling latency for goroutines"
+        axis:
+          label: "latency"
+          units: "Duration"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.go.scheduler_latency-p99"
+            title: "Scheduling Latency p99"
+
+      - title: "Runnable Goroutines per CPU"
+        tooltip: "The number of Goroutines waiting for CPU. This count should rise and fall based on load."
+        axis:
+          label: "goroutines"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.sys.runnable.goroutines.per.cpu"
+            title: "Runnable Goroutines per CPU"
+
+      - title: "GC Runs"
+        tooltip: "The number of times that Go's garbage collector was invoked per second."
+        axis:
+          label: "runs"
+        metrics:
+          - name: "cr.node.sys.gc.count"
+            title: "GC Runs"
+
+      - title: "GC Pause Time"
+        tooltip: "The amount of processor time used by Go's garbage collector per second. During garbage collection, application code execution is paused."
+        axis:
+          label: "pause time"
+          units: "Duration"
+        metrics:
+          - name: "cr.node.sys.gc.pause.ns"
+            title: "GC Pause Time"
+
+      - title: "GC Stopping Time"
+        tooltip: "The time it takes from deciding to stop-the-world (gc related) until all Ps are stopped."
+        axis:
+          label: "pause time"
+          units: "Duration"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.sys.gc.stop.ns"
+            title: "GC Stopping Time"
+
+      - title: "GC Assist Time"
+        tooltip: "Estimated total CPU time user goroutines spent performing GC tasks on processors."
+        axis:
+          label: "gc assist time"
+          units: "Duration"
+        metrics:
+          - name: "cr.node.sys.gc.assist.ns"
+            title: "GC Assist Time"
+
+      - title: "Non-GC Pause Time"
+        tooltip: "The stop-the-world pause time during non-gc process."
+        axis:
+          label: "pause time"
+          units: "Duration"
+        metrics:
+          - name: "cr.node.sys.go.pause.other.ns"
+            title: "Non-GC Pause Time"
+
+      - title: "Non-GC Stopping Time"
+        tooltip: "The time it takes from deciding to stop-the-world (non-gc-related) until all Ps are stopped."
+        axis:
+          label: "pause time"
+          units: "Duration"
+        metrics:
+          - name: "cr.node.sys.go.stop.other.ns"
+            title: "Non-GC Stopping Time"
+
+      - title: "CPU Time"
+        tooltip: "The amount of CPU time used by CockroachDB (User) and system-level operations (Sys)."
+        axis:
+          label: "cpu time"
+          units: "Duration"
+        metrics:
+          - name: "cr.node.sys.cpu.user.ns"
+            title: "User CPU Time"
+          - name: "cr.node.sys.cpu.sys.ns"
+            title: "Sys CPU Time"
+
+      - title: "Clock Offset"
+        tooltip: "Mean clock offset of each node against the rest of the cluster."
+        axis:
+          label: "offset"
+          units: "Duration"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.clock-offset.meannanos"
+            title: "Clock Offset"
+
+  - title: "Networking"
+    graphs:
+      - title: "Network Bytes Sent"
+        axis:
+          label: "bytes"
+          units: "Bytes"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.sys.host.net.send.bytes"
+            title: "Bytes Sent"
+
+      - title: "Network Bytes Received"
+        axis:
+          label: "bytes"
+          units: "Bytes"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.sys.host.net.recv.bytes"
+            title: "Bytes Received"
+
+      - title: "RPC Heartbeat Latency: 50th percentile"
+        tooltip: "Round-trip latency for recent successful outgoing heartbeats."
+        axis:
+          label: "latency"
+          units: "Duration"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.round-trip-latency-p50"
+            title: "Latency p50"
+
+      - title: "RPC Heartbeat Latency: 99th percentile"
+        tooltip: "Round-trip latency for recent successful outgoing heartbeats."
+        axis:
+          label: "latency"
+          units: "Duration"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.round-trip-latency-p99"
+            title: "Latency p99"
+
+      - title: "Unhealthy RPC Connections"
+        tooltip: "The number of outgoing connections on each node that are in an unhealthy state."
+        axis:
+          label: "connections"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.rpc.connection.unhealthy"
+            title: "Unhealthy Connections"
+
+      - title: "Network Packet Errors and Drops"
+        axis:
+          label: "packets"
+          units: "Count"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.sys.host.net.recv.err"
+            title: "Recv Errors"
+          - name: "cr.node.sys.host.net.recv.drop"
+            title: "Recv Drops"
+          - name: "cr.node.sys.host.net.send.err"
+            title: "Send Errors"
+          - name: "cr.node.sys.host.net.send.drop"
+            title: "Send Drops"
+
+      - title: "TCP Retransmits"
+        tooltip: "The number of TCP segments retransmitted. Some retransmissions are benign, but phase changes can be indicative of network congestion or overloaded peers."
+        axis:
+          label: "segments"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.sys.host.net.send.tcp.retrans_segs"
+            title: "Retransmitted Segments"
+
+      - title: "Proxy requests"
+        tooltip: "The number of proxy attempts each gateway node is initiating."
+        axis:
+          label: "requests"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.distsender.rpc.proxy.sent"
+            title: "Proxy Requests"
+
+      - title: "Proxy request errors"
+        tooltip: "The number of proxy attempts which resulted in an error."
+        axis:
+          label: "errors"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.distsender.rpc.proxy.err"
+            title: "Proxy Errors"
+
+      - title: "Proxy forwards"
+        tooltip: "The number of proxy requests each server node is attempting to foward."
+        axis:
+          label: "requests"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.distsender.rpc.proxy.forward.sent"
+            title: "Proxy Forwards"
+
+      - title: "Proxy forward errors"
+        tooltip: "The number of proxy forward attempts which resulted in an error."
+        axis:
+          label: "errors"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.distsender.rpc.proxy.forward.err"
+            title: "Proxy Forward Errors"
+
+  - title: "SQL"
+    graphs:
+      - title: "Open SQL Sessions"
+        tooltip: "The total number of open SQL Sessions."
+        axis:
+          label: "connections"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.sql.conns"
+            title: "Open Sessions"
+
+      - title: "SQL Connection Rate"
+        tooltip: "Rate of SQL connection attempts"
+        axis:
+          label: "connections per second"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.sql.new_conns"
+            title: "Connection Rate"
+
+      - title: "Upgrades of SQL Transaction Isolation Level"
+        tooltip: "The total number of times a SQL transaction was upgraded to a stronger isolation level. If this metric is non-zero, then your application may be affected by the upcoming support of additional isolation levels."
+        axis:
+          label: "transactions"
+        metrics:
+          - name: "cr.node.sql.txn.upgraded_iso_level.count"
+            title: "Upgrades of Transaction Isolation Level"
+
+      - title: "Open SQL Transactions"
+        tooltip: "The total number of open SQL transactions."
+        axis:
+          label: "transactions"
+        metrics:
+          - name: "cr.node.sql.txns.open"
+            title: "Open Transactions"
+
+      - title: "Active SQL Statements"
+        tooltip: "The total number of running SQL statements."
+        axis:
+          label: "queries"
+        metrics:
+          - name: "cr.node.sql.statements.active"
+            title: "Active Statements"
+
+      - title: "SQL Byte Traffic"
+        tooltip: "The total amount of SQL client network traffic in bytes per second."
+        axis:
+          label: "byte traffic"
+          units: "Bytes"
+        metrics:
+          - name: "cr.node.sql.bytesin"
+            title: "Bytes In"
+          - name: "cr.node.sql.bytesout"
+            title: "Bytes Out"
+
+      - title: "SQL Queries Per Second"
+        tooltip: "A ten-second moving average of the # of SELECT, INSERT, UPDATE, and DELETE statements, and the sum of all four, successfully executed per second."
+        axis:
+          label: "queries"
+        metrics:
+          - name: "cr.node.sql.select.count"
+            title: "Selects"
+          - name: "cr.node.sql.update.count"
+            title: "Updates"
+          - name: "cr.node.sql.insert.count"
+            title: "Inserts"
+          - name: "cr.node.sql.delete.count"
+            title: "Deletes"
+          - name: "cr.node.sql.crud_query.count"
+            title: "Total Queries"
+
+      - title: "SQL Queries Within Routines Per Second"
+        tooltip: "A ten-second moving average of the # of SELECT, INSERT, UPDATE, and DELETE statements executed within routines (user-defined functions and stored procedures)."
+        axis:
+          label: "queries within routines"
+        metrics:
+          - name: "cr.node.sql.routine.select.count"
+            title: "Selects"
+          - name: "cr.node.sql.routine.update.count"
+            title: "Updates"
+          - name: "cr.node.sql.routine.insert.count"
+            title: "Inserts"
+          - name: "cr.node.sql.routine.delete.count"
+            title: "Deletes"
+
+      - title: "SQL Statement Errors"
+        tooltip: "The number of statements which returned a planning, runtime, or client-side retry error."
+        axis:
+          label: "errors"
+        metrics:
+          - name: "cr.node.sql.failure.count"
+            title: "Errors"
+
+      - title: "SQL Statement Contention"
+        tooltip: "The total number of SQL statements that experienced contention."
+        axis:
+          label: "queries"
+        metrics:
+          - name: "cr.node.sql.distsql.contended_queries.count"
+            title: "Contention"
+
+      - title: "Full Table/Index Scans"
+        tooltip: "The total number of full table/index scans per second."
+        axis:
+          label: "full scans per second"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.sql.full.scan.count"
+            title: "Full Scans"
+
+      - title: "Transaction Deadlocks"
+        tooltip: "The total number of transaction per second; typically, should be 0."
+        axis:
+          label: "transaction deadlocks per second"
+        group_by_storage: true
+        metrics:
+          - name: "cr.store.txnwaitqueue.deadlocks_total"
+            title: "Deadlocks"
+
+      - title: "Active Flows for Distributed SQL Statements"
+        tooltip: "The number of flows on each node contributing to currently running distributed SQL statements."
+        axis:
+          label: "flows"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.sql.distsql.flows.active"
+            title: "Active Flows"
+
+      - title: "Failed SQL Connections"
+        tooltip: "The total number of failed SQL connection attempts."
+        axis:
+          label: "failed connections"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.sql.conn.failures"
+            title: "Number of Failed SQL Connections"
+
+      - title: "Connection Latency: 99th percentile"
+        tooltip: "Over the last minute, this node established and authenticated 99% of connections within this time."
+        axis:
+          label: "latency"
+          units: "Duration"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.sql.conn.latency-p99"
+            title: "Connection Latency p99"
+
+      - title: "Connection Latency: 90th percentile"
+        tooltip: "Over the last minute, this node established and authenticated 90% of connections within this time."
+        axis:
+          label: "latency"
+          units: "Duration"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.sql.conn.latency-p90"
+            title: "Connection Latency p90"
+
+      - title: "Service Latency: SQL Statements, 99.99th percentile"
+        tooltip: "Over the last minute, this node executed 99.99% of SQL statements within this time. This time only includes SELECT, INSERT, UPDATE and DELETE statements and does not include network latency between the node and client."
+        axis:
+          label: "latency"
+          units: "Duration"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.sql.service.latency-p99.99"
+            title: "Service Latency p99.99"
+
+      - title: "Service Latency: SQL Statements, 99.9th percentile"
+        tooltip: "Over the last minute, this node executed 99.9% of SQL statements within this time. This time only includes SELECT, INSERT, UPDATE and DELETE statements and does not include network latency between the node and client."
+        axis:
+          label: "latency"
+          units: "Duration"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.sql.service.latency-p99.9"
+            title: "Service Latency p99.9"
+
+      - title: "Service Latency: SQL Statements, 99th percentile"
+        tooltip: "Over the last minute, this node executed 99% of SQL statements within this time. This time only includes SELECT, INSERT, UPDATE and DELETE statements and does not include network latency between the node and client."
+        axis:
+          label: "latency"
+          units: "Duration"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.sql.service.latency-p99"
+            title: "Service Latency p99"
+
+      - title: "Service Latency: SQL Statements, 90th percentile"
+        tooltip: "Over the last minute, this node executed 90% of SQL statements within this time. This time only includes SELECT, INSERT, UPDATE and DELETE statements and does not include network latency between the node and client."
+        axis:
+          label: "latency"
+          units: "Duration"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.sql.service.latency-p90"
+            title: "Service Latency p90"
+
+      - title: "KV Execution Latency: 99th percentile"
+        tooltip: "The 99th percentile of latency between query requests and responses over a 1 minute period. Values are displayed individually for each node."
+        axis:
+          label: "latency"
+          units: "Duration"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.exec.latency-p99"
+            title: "KV Execution Latency p99"
+
+      - title: "KV Execution Latency: 90th percentile"
+        tooltip: "The 90th percentile of latency between query requests and responses over a 1 minute period. Values are displayed individually for each node."
+        axis:
+          label: "latency"
+          units: "Duration"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.exec.latency-p90"
+            title: "KV Execution Latency p90"
+
+      - title: "Transactions"
+        tooltip: "The total number of transactions initiated, committed, rolled back, or aborted per second."
+        axis:
+          label: "transactions"
+        metrics:
+          - name: "cr.node.sql.txn.begin.count"
+            title: "Begin"
+          - name: "cr.node.sql.txn.commit.count"
+            title: "Commits"
+          - name: "cr.node.sql.txn.rollback.count"
+            title: "Rollbacks"
+          - name: "cr.node.sql.txn.abort.count"
+            title: "Aborts"
+
+      - title: "Transaction Restarts"
+        tooltip: "Transaction restarts broken down by reason."
+        axis:
+          label: "restarts"
+        metrics:
+          - name: "cr.node.txn.restarts.writetooold"
+            title: "Write Too Old"
+          - name: "cr.node.txn.restarts.serializable"
+            title: "Forwarded Timestamp (iso=serializable)"
+          - name: "cr.node.txn.restarts.asyncwritefailure"
+            title: "Async Consensus Failure"
+          - name: "cr.node.txn.restarts.readwithinuncertainty"
+            title: "Read Within Uncertainty Interval"
+          - name: "cr.node.txn.restarts.txnaborted"
+            title: "Aborted"
+          - name: "cr.node.txn.restarts.txnpush"
+            title: "Pushed"
+          - name: "cr.node.txn.restarts.unknown"
+            title: "Unknown"
+
+      - title: "Transaction Latency: 99th percentile"
+        tooltip: "Over the last minute, this node executed 99% of transactions within this time. This time does not include network latency between the node and client."
+        axis:
+          label: "latency"
+          units: "Duration"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.sql.txn.latency-p99"
+            title: "Transaction Latency p99"
+
+      - title: "Transaction Latency: 90th percentile"
+        tooltip: "Over the last minute, this node executed 90% of transactions within this time. This time does not include network latency between the node and client."
+        axis:
+          label: "latency"
+          units: "Duration"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.sql.txn.latency-p90"
+            title: "Transaction Latency p90"
+
+      - title: "SQL Memory"
+        tooltip: "The current amount of allocated SQL memory. This amount is compared against the node's --max-sql-memory flag."
+        axis:
+          label: "allocated bytes"
+          units: "Bytes"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.sql.mem.root.current"
+            title: "SQL Memory"
+
+      - title: "Schema Changes"
+        tooltip: "The total number of DDL statements per second."
+        axis:
+          label: "statements"
+        metrics:
+          - name: "cr.node.sql.ddl.count"
+            title: "DDL Statements"
+
+      - title: "Table Statistics Collections"
+        tooltip: "Details about table statistics collections."
+        axis:
+          label: "jobs"
+        metrics:
+          - name: "cr.node.jobs.auto_create_stats.currently_running"
+            title: "Auto Running"
+          - name: "cr.node.jobs.auto_create_partial_stats.currently_running"
+            title: "Auto Partial Running"
+          - name: "cr.node.jobs.create_stats.currently_running"
+            title: "Manual Running"
+          - name: "cr.node.jobs.auto_create_stats.currently_paused"
+            title: "Auto Paused"
+          - name: "cr.node.jobs.auto_create_partial_stats.currently_paused"
+            title: "Auto Partial Paused"
+          - name: "cr.node.jobs.auto_create_stats.resume_failed"
+            title: "Auto Failed"
+          - name: "cr.node.jobs.auto_create_partial_stats.resume_failed"
+            title: "Auto Partial Failed"
+
+      - title: "Statement Denials: Cluster Settings"
+        tooltip: "The total number of statements denied."
+        axis:
+          label: "statements"
+        metrics:
+          - name: "cr.node.sql.feature_flag_denial"
+            title: "Statements Denied"
+
+      - title: "Distributed Query Error Reruns"
+        tooltip: "The total number of times the distributed query errors were rerun as local."
+        axis:
+          label: "queries"
+        metrics:
+          - name: "cr.node.sql.distsql.dist_query_rerun_locally.count"
+            title: "Reruns"
+          - name: "cr.node.sql.distsql.dist_query_rerun_locally.failure_count"
+            title: "Failures"
+
+  - title: "Storage"
+    graphs:
+      - title: "Capacity"
+        tooltip: "Disk capacity metrics"
+        axis:
+          label: "capacity"
+          units: "Bytes"
+        metrics:
+          - name: "cr.store.capacity"
+            title: "Max"
+          - name: "cr.store.capacity.available"
+            title: "Available"
+          - name: "cr.store.capacity.used"
+            title: "Used"
+
+      - title: "Live Bytes"
+        tooltip: "Number of bytes of live data"
+        axis:
+          label: "live bytes"
+          units: "Bytes"
+        metrics:
+          - name: "cr.store.livebytes"
+            title: "Live"
+          - name: "cr.store.sysbytes"
+            title: "System"
+
+      - title: "WAL Fsync Latency"
+        tooltip: "The latency for fsyncs to the storage engine's write-ahead log."
+        axis:
+          label: "latency"
+          units: "Duration"
+        group_by_storage: true
+        metrics:
+          - name: "cr.store.storage.wal.fsync.latency-p99.9"
+            title: "p99.9"
+          - name: "cr.store.storage.wal.fsync.latency-p99.99"
+            title: "p99.99"
+          - name: "cr.store.storage.wal.fsync.latency-max"
+            title: "p100"
+
+      - title: "Log Commit Latency"
+        tooltip: "The latency for commits to the Raft Log. This is typically dominated by the latency of an fdatasync to the storage engine's write-ahead log."
+        axis:
+          label: "latency"
+          units: "Duration"
+        group_by_storage: true
+        metrics:
+          - name: "cr.store.raft.process.logcommit.latency-p99.9"
+            title: "p99.9"
+          - name: "cr.store.raft.process.logcommit.latency-p99"
+            title: "p99"
+          - name: "cr.store.raft.process.logcommit.latency-p50"
+            title: "p50"
+
+      - title: "Command Commit Latency"
+        tooltip: "The latency for commits of Raft commands. This measures applying a batch to the storage engine (including writes to the write-ahead log), but no fsync."
+        axis:
+          label: "latency"
+          units: "Duration"
+        group_by_storage: true
+        metrics:
+          - name: "cr.store.raft.process.commandcommit.latency-p99"
+            title: "p99"
+          - name: "cr.store.raft.process.commandcommit.latency-p50"
+            title: "p50"
+
+      - title: "Compaction Duration"
+        tooltip: "The cumulative time spent performing compactions."
+        axis:
+          label: "duration"
+          units: "Duration"
+        group_by_storage: true
+        metrics:
+          - name: "cr.store.storage.compactions.duration"
+            title: "Compaction Duration"
+
+      - title: "Level Compaction Scores"
+        tooltip: "The compaction score for each level of the LSM tree. The storage engine prioritizes compactions out of levels with higher scores."
+        axis:
+          label: "score"
+        group_by_storage: true
+        metrics:
+          - name: "cr.store.storage.l0-level-score"
+            title: "L0"
+          - name: "cr.store.storage.l1-level-score"
+            title: "L1"
+          - name: "cr.store.storage.l2-level-score"
+            title: "L2"
+          - name: "cr.store.storage.l3-level-score"
+            title: "L3"
+          - name: "cr.store.storage.l4-level-score"
+            title: "L4"
+          - name: "cr.store.storage.l5-level-score"
+            title: "L5"
+          - name: "cr.store.storage.l6-level-score"
+            title: "L6"
+
+      - title: "Read Amplification"
+        tooltip: "The average number of real read operations executed per logical read operation."
+        axis:
+          label: "factor"
+        metrics:
+          - name: "cr.store.rocksdb.read-amplification"
+            title: "Read Amplification"
+
+      - title: "File Counts"
+        tooltip: "The number of files in use by type."
+        axis:
+          label: "files"
+        group_by_storage: true
+        metrics:
+          - name: "cr.store.rocksdb.num-sstables"
+            title: "sstables"
+          - name: "cr.store.storage.value_separation.blob_files.count"
+            title: "blob files"
+
+      - title: "L0 SSTable Count"
+        tooltip: "The number of L0 SSTables in use for each store."
+        axis:
+          label: "sstables"
+        group_by_storage: true
+        metrics:
+          - name: "cr.store.storage.l0-num-files"
+            title: "L0 SSTable Count"
+
+      - title: "L0 SSTable Size"
+        tooltip: "The size of all L0 SSTables in use for each store."
+        axis:
+          label: "Size"
+          units: "Bytes"
+        group_by_storage: true
+        metrics:
+          - name: "cr.store.storage.l0-level-size"
+            title: "L0 SSTable Size"
+
+      - title: "Flushes"
+        tooltip: "Bytes written by memtable flushes."
+        axis:
+          label: "written bytes"
+          units: "Bytes"
+        group_by_storage: true
+        metrics:
+          - name: "cr.store.rocksdb.flushed-bytes"
+            title: "Flushes"
+
+      - title: "WAL Bytes Written"
+        tooltip: "Bytes written to WAL files."
+        axis:
+          label: "written bytes"
+          units: "Bytes"
+        group_by_storage: true
+        metrics:
+          - name: "cr.store.storage.wal.bytes_written"
+            title: "WAL Bytes Written"
+
+      - title: "Compactions"
+        tooltip: "Bytes written by compactions."
+        axis:
+          label: "written bytes"
+          units: "Bytes"
+        group_by_storage: true
+        metrics:
+          - name: "cr.store.rocksdb.compacted-bytes-written"
+            title: "Compactions"
+
+      - title: "Ingestions"
+        tooltip: "Bytes written by sstable ingestions."
+        axis:
+          label: "written bytes"
+          units: "Bytes"
+        group_by_storage: true
+        metrics:
+          - name: "cr.store.rocksdb.ingested-bytes"
+            title: "Ingestions"
+
+      - title: "Write Stalls"
+        tooltip: "The number of intentional write stalls per second. Write stalls are used to backpressure incoming writes during periods of heavy write traffic."
+        axis:
+          label: "count"
+        metrics:
+          - name: "cr.store.storage.write-stalls"
+            title: "Write Stalls"
+
+      - title: "Store Disk Write Bytes/s"
+        tooltip: "The number of bytes written to the store's disk per second (as reported by the OS)."
+        axis:
+          label: "bytes"
+          units: "Bytes"
+        group_by_storage: true
+        metrics:
+          - name: "cr.store.storage.disk.write.bytes"
+            title: "Disk Write"
+
+      - title: "Store Disk Read Bytes/s"
+        tooltip: "The number of bytes read from the store's disk per second (as reported by the OS)."
+        axis:
+          label: "bytes"
+          units: "Bytes"
+        group_by_storage: true
+        metrics:
+          - name: "cr.store.storage.disk.read.bytes"
+            title: "Disk Read"
+
+      - title: "File Descriptors"
+        tooltip: "The number of open file descriptors, compared with the file descriptor limit."
+        axis:
+          label: "descriptors"
+        metrics:
+          - name: "cr.node.sys.fd.open"
+            title: "Open"
+          - name: "cr.node.sys.fd.softlimit"
+            title: "Limit"
+
+      - title: "Time Series Writes"
+        tooltip: "The number of successfully written time series samples, and number of errors attempting to write time series, per second."
+        axis:
+          label: "count"
+        metrics:
+          - name: "cr.node.timeseries.write.samples"
+            title: "Samples Written"
+          - name: "cr.node.timeseries.write.errors"
+            title: "Errors"
+
+      - title: "Time Series Bytes Written"
+        tooltip: "The number of bytes written by the time series system per second. Note that this does not reflect the rate at which disk space is consumed by time series; the data is highly compressed on disk."
+        axis:
+          units: "Bytes"
+        metrics:
+          - name: "cr.node.timeseries.write.bytes"
+            title: "Bytes Written"
+
+  - title: "Replication"
+    graphs:
+      - title: "Ranges"
+        tooltip: "Various details about the status of ranges."
+        axis:
+          label: "ranges"
+        metrics:
+          - name: "cr.store.ranges"
+            title: "Ranges"
+          - name: "cr.store.replicas.leaders"
+            title: "Leaders"
+          - name: "cr.store.replicas.leaseholders"
+            title: "Lease Holders"
+          - name: "cr.store.replicas.leaders_not_leaseholders"
+            title: "Leaders w/o Lease"
+          - name: "cr.store.ranges.unavailable"
+            title: "Unavailable"
+          - name: "cr.store.ranges.underreplicated"
+            title: "Under-replicated"
+          - name: "cr.store.ranges.overreplicated"
+            title: "Over-replicated"
+
+      - title: "Replicas per Node"
+        tooltip: "The number of replicas on each node."
+        axis:
+          label: "replicas"
+        metrics:
+          - name: "cr.store.replicas"
+            title: "Replicas"
+
+      - title: "Leaseholders per Node"
+        tooltip: "The number of leaseholder replicas on each node. A leaseholder replica is the one that receives and coordinates all read and write requests for its range."
+        axis:
+          label: "leaseholders"
+        group_by_storage: true
+        metrics:
+          - name: "cr.store.replicas.leaseholders"
+            title: "Leaseholders"
+
+      - title: "Lease Types"
+        tooltip: "Details about the types of leases in use by ranges in the system."
+        axis:
+          label: "leases"
+        metrics:
+          - name: "cr.store.leases.expiration"
+            title: "Expiration Leases"
+          - name: "cr.store.leases.epoch"
+            title: "Epoch Leases"
+          - name: "cr.store.leases.leader"
+            title: "Leader Leases"
+
+      - title: "Lease Preferences"
+        tooltip: "Details about the conformance of range lease preferences."
+        axis:
+          label: "ranges"
+        metrics:
+          - name: "cr.store.leases.preferences.violating"
+            title: "Lease Preferences Violating"
+          - name: "cr.store.leases.preferences.less-preferred"
+            title: "Lease Preferences Less Preferred"
+
+      - title: "Average Replica Queries per Node"
+        tooltip: "Moving average of the number of KV batch requests processed by leaseholder replicas on each node per second. Used for load-based rebalancing decisions."
+        axis:
+          label: "queries"
+        group_by_storage: true
+        metrics:
+          - name: "cr.store.rebalancing.queriespersecond"
+            title: "Queries Per Second"
+
+      - title: "Average Replica CPU per Node"
+        tooltip: "Moving average of all replica CPU usage on each node per second. Used for load-based rebalancing decisions."
+        axis:
+          label: "CPU time"
+          units: "Duration"
+        group_by_storage: true
+        metrics:
+          - name: "cr.store.rebalancing.cpunanospersecond"
+            title: "CPU Time"
+
+      - title: "Logical Bytes per Node"
+        tooltip: "Logical bytes per node"
+        axis:
+          label: "logical store size"
+          units: "Bytes"
+        group_by_storage: true
+        metrics:
+          - name: "cr.store.totalbytes"
+            title: "Logical Bytes"
+
+      - title: "Replica Quiescence"
+        axis:
+          label: "replicas"
+        metrics:
+          - name: "cr.store.replicas"
+            title: "Replicas"
+          - name: "cr.store.replicas.quiescent"
+            title: "Epoch Lease Quiescent"
+          - name: "cr.store.replicas.asleep"
+            title: "Leader Lease Quiescent"
+
+      - title: "Range Operations"
+        axis:
+          label: "ranges"
+        metrics:
+          - name: "cr.store.range.splits"
+            title: "Splits"
+          - name: "cr.store.range.merges"
+            title: "Merges"
+          - name: "cr.store.range.adds"
+            title: "Adds"
+          - name: "cr.store.range.removes"
+            title: "Removes"
+          - name: "cr.store.leases.transfers.success"
+            title: "Lease Transfers"
+          - name: "cr.store.rebalancing.lease.transfers"
+            title: "Load-based Lease Transfers"
+          - name: "cr.store.rebalancing.range.rebalances"
+            title: "Load-based Range Rebalances"
+
+      - title: "Snapshots"
+        axis:
+          label: "snapshots"
+        metrics:
+          - name: "cr.store.range.snapshots.generated"
+            title: "Generated"
+          - name: "cr.store.range.snapshots.applied-voter"
+            title: "Applied (Voters)"
+          - name: "cr.store.range.snapshots.applied-initial"
+            title: "Applied (Initial Upreplication)"
+          - name: "cr.store.range.snapshots.applied-non-voter"
+            title: "Applied (Non-Voters)"
+          - name: "cr.store.replicas.reserved"
+            title: "Reserved"
+
+      - title: "Snapshot Data Received"
+        axis:
+          label: "bytes"
+          units: "Bytes"
+        group_by_storage: true
+        metrics:
+          - name: "cr.store.range.snapshots.rebalancing.rcvd-bytes"
+            title: "Rebalancing"
+          - name: "cr.store.range.snapshots.recovery.rcvd-bytes"
+            title: "Recovery"
+          - name: "cr.store.range.snapshots.upreplication.rcvd-bytes"
+            title: "Upreplication"
+
+      - title: "Receiver Snapshots Queued"
+        axis:
+          label: "snapshots"
+          units: "Count"
+        group_by_storage: true
+        metrics:
+          - name: "cr.store.range.snapshots.recv-queue"
+            title: "Receiver Snapshots Queued"
+
+      - title: "Circuit Breaker Tripped Replicas"
+        axis:
+          label: "replicas"
+        group_by_storage: true
+        metrics:
+          - name: "cr.store.kv.replica_circuit_breaker.num_tripped_replicas"
+            title: "Circuit Breaker Tripped Replicas"
+
+      - title: "Replicate Queue Actions: Successes"
+        axis:
+          label: "replicas"
+          units: "Count"
+        metrics:
+          - name: "cr.store.queue.replicate.addreplica.success"
+            title: "Replicas Added / Sec"
+          - name: "cr.store.queue.replicate.removereplica.success"
+            title: "Replicas Removed / Sec"
+          - name: "cr.store.queue.replicate.replacedeadreplica.success"
+            title: "Dead Replicas Replaced / Sec"
+          - name: "cr.store.queue.replicate.removedeadreplica.success"
+            title: "Dead Replicas Removed / Sec"
+          - name: "cr.store.queue.replicate.replacedecommissioningreplica.success"
+            title: "Decommissioning Replicas Replaced / Sec"
+          - name: "cr.store.queue.replicate.removedecommissioningreplica.success"
+            title: "Decommissioning Replicas Removed / Sec"
+
+      - title: "Replicate Queue Actions: Failures"
+        axis:
+          label: "replicas"
+          units: "Count"
+        metrics:
+          - name: "cr.store.queue.replicate.addreplica.error"
+            title: "Replicas Added Errors / Sec"
+          - name: "cr.store.queue.replicate.removereplica.error"
+            title: "Replicas Removed Errors / Sec"
+          - name: "cr.store.queue.replicate.replacedeadreplica.error"
+            title: "Dead Replicas Replaced Errors / Sec"
+          - name: "cr.store.queue.replicate.removedeadreplica.error"
+            title: "Dead Replicas Removed Errors / Sec"
+          - name: "cr.store.queue.replicate.replacedecommissioningreplica.error"
+            title: "Decommissioning Replicas Replaced Errors / Sec"
+          - name: "cr.store.queue.replicate.removedecommissioningreplica.error"
+            title: "Decommissioning Replicas Removed Errors / Sec"
+
+      - title: "Decommissioning Errors"
+        axis:
+          label: "Replaced Errors / Sec"
+          units: "Count"
+        group_by_storage: true
+        metrics:
+          - name: "cr.store.queue.replicate.replacedecommissioningreplica.error"
+            title: "Replaced Errors / Sec"
+
+  - title: "Distributed"
+    graphs:
+      - title: "Batches"
+        axis:
+          label: "batches"
+        metrics:
+          - name: "cr.node.distsender.batches"
+            title: "Batches"
+          - name: "cr.node.distsender.batches.partial"
+            title: "Partial Batches"
+
+      - title: "RPCs"
+        axis:
+          label: "rpcs"
+        metrics:
+          - name: "cr.node.distsender.rpc.sent"
+            title: "RPCs Sent"
+          - name: "cr.node.distsender.rpc.sent.local"
+            title: "Local Fast-path"
+
+      - title: "RPC Errors"
+        axis:
+          label: "errors"
+        metrics:
+          - name: "cr.node.distsender.rpc.sent.sendnexttimeout"
+            title: "RPC Timeouts"
+          - name: "cr.node.distsender.rpc.sent.nextreplicaerror"
+            title: "Replica Errors"
+          - name: "cr.node.distsender.errors.notleaseholder"
+            title: "Not Leaseholder Errors"
+
+      - title: "KV Transactions"
+        axis:
+          label: "transactions"
+        metrics:
+          - name: "cr.node.txn.commits"
+            title: "Committed"
+          - name: "cr.node.txn.commits1PC"
+            title: "Fast-path Committed"
+          - name: "cr.node.txn.aborts"
+            title: "Aborted"
+
+      - title: "KV Transaction Durations: 99th percentile"
+        tooltip: "The 99th percentile of transaction durations over a 1 minute period."
+        axis:
+          label: "transaction duration"
+          units: "Duration"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.txn.durations-p99"
+            title: "KV Transaction Duration p99"
+
+      - title: "KV Transaction Durations: 90th percentile"
+        tooltip: "The 90th percentile of transaction durations over a 1 minute period."
+        axis:
+          label: "transaction duration"
+          units: "Duration"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.txn.durations-p90"
+            title: "KV Transaction Duration p90"
+
+      - title: "Node Heartbeat Latency: 99th percentile"
+        tooltip: "The 99th percentile of latency to heartbeat a node's internal liveness record over a 1 minute period."
+        axis:
+          label: "heartbeat latency"
+          units: "Duration"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.liveness.heartbeatlatency-p99"
+            title: "Heartbeat Latency p99"
+
+      - title: "Node Heartbeat Latency: 90th percentile"
+        tooltip: "The 90th percentile of latency to heartbeat a node's internal liveness record over a 1 minute period."
+        axis:
+          label: "heartbeat latency"
+          units: "Duration"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.liveness.heartbeatlatency-p90"
+            title: "Heartbeat Latency p90"
+
+  - title: "Queues"
+    graphs:
+      - title: "Queue Processing Failures"
+        axis:
+          label: "failures"
+          units: "Count"
+        metrics:
+          - name: "cr.store.queue.gc.process.failure"
+            title: "GC"
+          - name: "cr.store.queue.replicagc.process.failure"
+            title: "Replica GC"
+          - name: "cr.store.queue.replicate.process.failure"
+            title: "Replication"
+          - name: "cr.store.queue.lease.process.failure"
+            title: "Lease"
+          - name: "cr.store.queue.split.process.failure"
+            title: "Split"
+          - name: "cr.store.queue.merge.process.failure"
+            title: "Merge"
+          - name: "cr.store.queue.consistency.process.failure"
+            title: "Consistency"
+          - name: "cr.store.queue.raftlog.process.failure"
+            title: "Raft Log"
+          - name: "cr.store.queue.raftsnapshot.process.failure"
+            title: "Raft Snapshot"
+          - name: "cr.store.queue.tsmaintenance.process.failure"
+            title: "Time Series Maintenance"
+
+      - title: "Queue Processing Times"
+        axis:
+          label: "processing time"
+          units: "Duration"
+        metrics:
+          - name: "cr.store.queue.gc.processingnanos"
+            title: "GC"
+          - name: "cr.store.queue.replicagc.processingnanos"
+            title: "Replica GC"
+          - name: "cr.store.queue.replicate.processingnanos"
+            title: "Replication"
+          - name: "cr.store.queue.lease.processingnanos"
+            title: "Lease"
+          - name: "cr.store.queue.split.processingnanos"
+            title: "Split"
+          - name: "cr.store.queue.merge.processingnanos"
+            title: "Merge"
+          - name: "cr.store.queue.consistency.processingnanos"
+            title: "Consistency"
+          - name: "cr.store.queue.raftlog.processingnanos"
+            title: "Raft Log"
+          - name: "cr.store.queue.raftsnapshot.processingnanos"
+            title: "Raft Snapshot"
+          - name: "cr.store.queue.tsmaintenance.processingnanos"
+            title: "Time Series Maintenance"
+
+      - title: "Replica GC Queue"
+        axis:
+          label: "actions"
+          units: "Count"
+        metrics:
+          - name: "cr.store.queue.replicagc.process.success"
+            title: "Successful Actions / sec"
+          - name: "cr.store.queue.replicagc.pending"
+            title: "Pending Actions"
+          - name: "cr.store.queue.replicagc.removereplica"
+            title: "Replicas Removed / sec"
+
+      - title: "Replication Queue"
+        axis:
+          label: "actions"
+          units: "Count"
+        metrics:
+          - name: "cr.store.queue.replicate.process.success"
+            title: "Successful Actions / sec"
+          - name: "cr.store.queue.replicate.pending"
+            title: "Pending Actions"
+          - name: "cr.store.queue.replicate.addreplica"
+            title: "Replicas Added / sec"
+          - name: "cr.store.queue.replicate.removereplica"
+            title: "Replicas Removed / sec"
+          - name: "cr.store.queue.replicate.removedeadreplica"
+            title: "Dead Replicas Removed / sec"
+          - name: "cr.store.queue.replicate.removelearnerreplica"
+            title: "Learner Replicas Removed / sec"
+          - name: "cr.store.queue.replicate.rebalancereplica"
+            title: "Replicas Rebalanced / sec"
+          - name: "cr.store.queue.replicate.transferlease"
+            title: "Leases Transferred / sec"
+          - name: "cr.store.queue.replicate.purgatory"
+            title: "Replicas in Purgatory"
+
+      - title: "Lease Queue"
+        axis:
+          label: "actions"
+          units: "Count"
+        metrics:
+          - name: "cr.store.queue.lease.process.success"
+            title: "Successful Actions / sec"
+          - name: "cr.store.queue.lease.pending"
+            title: "Pending Actions"
+          - name: "cr.store.queue.lease.purgatory"
+            title: "Replicas in  Purgatory"
+
+      - title: "Split Queue"
+        axis:
+          label: "actions"
+          units: "Count"
+        metrics:
+          - name: "cr.store.queue.split.process.success"
+            title: "Successful Actions / sec"
+          - name: "cr.store.queue.split.pending"
+            title: "Pending Actions"
+
+      - title: "Merge Queue"
+        axis:
+          label: "actions"
+          units: "Count"
+        metrics:
+          - name: "cr.store.queue.merge.process.success"
+            title: "Successful Actions / sec"
+          - name: "cr.store.queue.merge.pending"
+            title: "Pending Actions"
+
+      - title: "Raft Log Queue"
+        axis:
+          label: "actions"
+          units: "Count"
+        metrics:
+          - name: "cr.store.queue.raftlog.process.success"
+            title: "Successful Actions / sec"
+          - name: "cr.store.queue.raftlog.pending"
+            title: "Pending Actions"
+
+      - title: "Raft Snapshot Queue"
+        axis:
+          label: "actions"
+          units: "Count"
+        metrics:
+          - name: "cr.store.queue.raftsnapshot.process.success"
+            title: "Successful Actions / sec"
+          - name: "cr.store.queue.raftsnapshot.pending"
+            title: "Pending Actions"
+
+      - title: "Consistency Checker Queue"
+        tooltip: "The Consistency Checker Queue periodically checks that all replicas in a given range are consistent. For large clusters, the queue is always expected to have a pending backlog."
+        axis:
+          label: "actions"
+          units: "Count"
+        metrics:
+          - name: "cr.store.queue.consistency.process.success"
+            title: "Successful Actions / sec"
+          - name: "cr.store.queue.consistency.pending"
+            title: "Pending Actions"
+
+      - title: "Time Series Maintenance Queue"
+        axis:
+          label: "actions"
+          units: "Count"
+        metrics:
+          - name: "cr.store.queue.tsmaintenance.process.success"
+            title: "Successful Actions / sec"
+          - name: "cr.store.queue.tsmaintenance.pending"
+            title: "Pending Actions"
+
+      - title: "MVCC GC Queue"
+        axis:
+          label: "actions"
+          units: "Count"
+        metrics:
+          - name: "cr.store.queue.gc.process.success"
+            title: "Successful Actions / sec"
+          - name: "cr.store.queue.gc.pending"
+            title: "Pending Actions"
+
+      - title: "Protected Timestamp Records"
+        tooltip: "Number of protected timestamp records (used by backups, changefeeds, etc. to prevent MVCC GC)"
+        axis:
+          label: "Records"
+          units: "Count"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.spanconfig.kvsubscriber.protected_record_count"
+            title: "Protected Timestamp Records"
+
+  - title: "Slow Requests"
+    graphs:
+      - title: "Slow Raft Proposals"
+        axis:
+          label: "proposals"
+        metrics:
+          - name: "cr.store.requests.slow.raft"
+            title: "Slow Raft Proposals"
+
+      - title: "Slow DistSender RPCs"
+        axis:
+          label: "proposals"
+        metrics:
+          - name: "cr.node.requests.slow.distsender"
+            title: "Slow DistSender RPCs"
+
+      - title: "Slow Lease Acquisitions"
+        axis:
+          label: "lease acquisitions"
+        metrics:
+          - name: "cr.store.requests.slow.lease"
+            title: "Slow Lease Acquisitions"
+
+      - title: "Slow Latch Acquisitions"
+        axis:
+          label: "latch acquisitions"
+        metrics:
+          - name: "cr.store.requests.slow.latch"
+            title: "Slow Latch Acquisitions"
+
+  - title: "Changefeeds"
+    graphs:
+      - title: "Changefeed Status"
+        axis:
+          label: "count"
+          units: "Count"
+        metrics:
+          - name: "cr.node.jobs.changefeed.currently_running"
+            title: "Running"
+          - name: "cr.node.jobs.changefeed.currently_paused"
+            title: "Paused"
+          - name: "cr.node.jobs.changefeed.resume_failed"
+            title: "Failed"
+
+      - title: "Commit Latency"
+        tooltip: "The difference between an event's MVCC timestamp and the time it was acknowledged as received by the downstream sink."
+        axis:
+          label: "latency"
+          units: "Duration"
+        metrics:
+          - name: "cr.node.changefeed.commit_latency-p99"
+            title: "99th Percentile"
+          - name: "cr.node.changefeed.commit_latency-p90"
+            title: "90th Percentile"
+          - name: "cr.node.changefeed.commit_latency-p50"
+            title: "50th Percentile"
+
+      - title: "Emitted Bytes"
+        axis:
+          label: "bytes"
+          units: "Bytes"
+        metrics:
+          - name: "cr.node.changefeed.emitted_bytes"
+            title: "Emitted Bytes"
+
+      - title: "Sink Counts"
+        axis:
+          label: "actions"
+          units: "Count"
+        metrics:
+          - name: "cr.node.changefeed.emitted_messages"
+            title: "Messages"
+          - name: "cr.node.changefeed.flushes"
+            title: "Flushes"
+
+      - title: "Max Checkpoint Lag"
+        tooltip: "The most any changefeed's persisted checkpoint is behind the present. Larger values indicate issues with successfully ingesting or emitting changes."
+        axis:
+          label: "time"
+          units: "Duration"
+        metrics:
+          - name: "cr.node.changefeed.max_behind_nanos"
+            title: "Max Checkpoint Latency"
+
+      - title: "Changefeed Restarts"
+        tooltip: "The rate of transient non-fatal errors, such as temporary connectivity issues or a rolling upgrade."
+        axis:
+          label: "actions"
+          units: "Count"
+        metrics:
+          - name: "cr.node.changefeed.error_retries"
+            title: "Retryable Errors"
+
+      - title: "Oldest Protected Timestamp"
+        tooltip: "The oldest data that any changefeed is protecting from being able to be automatically garbage collected."
+        axis:
+          label: "time"
+          units: "DurationSeconds"
+        metrics:
+          - name: "cr.node.jobs.changefeed.protected_age_sec"
+            title: "Protected Timestamp Age"
+
+      - title: "Backfill Pending Ranges"
+        tooltip: "The number of ranges being backfilled (ex: due to an initial scan or schema change) that are yet to completely enter the Changefeed pipeline."
+        axis:
+          label: "count"
+          units: "Count"
+        metrics:
+          - name: "cr.node.changefeed.backfill_pending_ranges"
+            title: "Backfill Pending Ranges"
+
+      - title: "Schema Registry Registrations"
+        tooltip: "The rate of schema registration requests made by CockroachDB nodes to a configured schema registry endpoint."
+        axis:
+          label: "action"
+          units: "Count"
+        metrics:
+          - name: "cr.node.changefeed.schema_registry.registrations"
+            title: "Schema Registry Registrations"
+
+      - title: "Ranges in catchup mode"
+        tooltip: "Total number of ranges with an active rangefeed that are performing catchup scan"
+        axis:
+          label: "ranges"
+          units: "Count"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.distsender.rangefeed.catchup_ranges"
+            title: "Ranges"
+
+      - title: "RangeFeed catchup scans duration"
+        axis:
+          label: "duration"
+          units: "Duration"
+        group_by_storage: true
+        metrics:
+          - name: "cr.store.kv.rangefeed.catchup_scan_nanos"
+            title: "Catchup Scan Duration"
+
+  - title: "Overload"
+    graphs:
+      - title: "CPU Utilization"
+        tooltip: "CPU utilization of the CockroachDB process as measured by the host, displayed per node."
+        axis:
+          label: "CPU Utilization"
+          units: "Percentage"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.sys.cpu.combined.percent-normalized"
+            title: "CPU Utilization"
+
+      - title: "KV Admission CPU Slots Exhausted Duration Per Second"
+        tooltip: "Relative time the node had exhausted slots for foreground (regular) CPU work per second of wall time, measured in microseconds/second. Increased slot exhausted duration indicates CPU resource exhaustion."
+        axis:
+          label: "Duration (micros/sec)"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.admission.granter.slots_exhausted_duration.kv"
+            title: "KV Admission CPU Slots Exhausted"
+
+      - title: "Admission Foreground IO Tokens Exhausted Duration Per Second"
+        tooltip: "Relative time the store had exhausted foreground (regular) IO tokens for all IO-bound work per second of wall time, measured in microseconds/second."
+        axis:
+          label: "Duration (micros/sec)"
+        group_by_storage: true
+        metrics:
+          - name: "cr.store.admission.granter.io_tokens_exhausted_duration.kv"
+            title: "Foreground IO Tokens Exhausted"
+
+      - title: "Admission Background IO Tokens Exhausted Duration Per Second"
+        tooltip: "Relative time the store had exhausted background (elastic) IO tokens for all IO-bound work per second of wall time, measured in microseconds/second."
+        axis:
+          label: "Duration (micros/sec)"
+        group_by_storage: true
+        metrics:
+          - name: "cr.store.admission.granter.elastic_io_tokens_exhausted_duration.kv"
+            title: "Background IO Tokens Exhausted"
+
+      - title: "IO Overload"
+        tooltip: "A derived score based on Admission Control's view of the store. Admission Control attempts to maintain a score of 0.5."
+        axis:
+          label: "Score"
+        group_by_storage: true
+        metrics:
+          - name: "cr.store.admission.io.overload"
+            title: "IO Overload Score"
+
+      - title: "Elastic CPU Tokens Exhausted Duration Per Second"
+        tooltip: "Relative time the node had exhausted tokens for background (elastic) CPU work per second of wall time, measured in microseconds/second."
+        axis:
+          label: "Duration (micros/sec)"
+          units: "Duration"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.admission.elastic_cpu.nanos_exhausted_duration"
+            title: "Elastic CPU Tokens Exhausted"
+
+      - title: "Admission Queueing Delay p99 – Foreground (Regular) CPU"
+        tooltip: "The 99th percentile latency of requests waiting in the various Admission Control CPU queues."
+        axis:
+          label: "Delay Duration"
+          units: "Duration"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.admission.wait_durations.kv-p99"
+            title: "KV"
+          - name: "cr.node.admission.wait_durations.sql-kv-response-p99"
+            title: "SQL-KV"
+          - name: "cr.node.admission.wait_durations.sql-sql-response-p99"
+            title: "SQL-SQL"
+
+      - title: "Admission Queueing Delay p99 – Foreground (Regular) Store"
+        tooltip: "The 99th percentile latency of requests waiting in the foreground (regular) Admission Control store queue."
+        axis:
+          label: "Write Delay Duration"
+          units: "Duration"
+        group_by_storage: true
+        metrics:
+          - name: "cr.store.admission.wait_durations.kv-stores-p99"
+            title: "KV"
+
+      - title: "Admission Queueing Delay p99 – Background (Elastic) Store"
+        tooltip: "The 99th percentile latency of requests waiting in the background (elastic) Admission Control store queue."
+        axis:
+          label: "Write Delay Duration"
+          units: "Duration"
+        group_by_storage: true
+        metrics:
+          - name: "cr.store.admission.wait_durations.elastic-stores-p99"
+            title: "elastic"
+
+      - title: "Admission Queueing Delay p99 – Background (Elastic) CPU"
+        tooltip: "The 99th percentile latency of requests waiting in the Admission Control elastic CPU queue."
+        axis:
+          label: "Delay Duration"
+          units: "Duration"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.admission.wait_durations.elastic-cpu-p99"
+            title: "Elastic CPU"
+
+      - title: "Admission Queueing Delay p99 – Replication Admission Control"
+        tooltip: "The 99th percentile latency of requests waiting in the Replication Admission Control queue. This metric is indicative of store overload on replicas."
+        axis:
+          label: "Flow Token Wait Duration"
+          units: "Duration"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.kvflowcontrol.eval_wait.regular.duration-p99"
+            title: "Regular"
+          - name: "cr.node.kvflowcontrol.eval_wait.elastic.duration-p99"
+            title: "Elastic"
+
+      - title: "Blocked Replication Streams"
+        tooltip: "Blocked replication streams per node in Replication Admission Control, separated by admission priority."
+        axis:
+          label: "Blocked Stream Count"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.kvflowcontrol.streams.eval.regular.blocked_count"
+            title: "Regular"
+          - name: "cr.node.kvflowcontrol.streams.eval.elastic.blocked_count"
+            title: "Elastic"
+
+      - title: "Replication Stream Send Queue Size"
+        tooltip: "Queued bytes to be sent across all replication streams on a node in Replication Admission Control."
+        axis:
+          label: "Size"
+          units: "Bytes"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.kvflowcontrol.send_queue.bytes"
+            title: "Send Queue Size"
+
+      - title: "Elastic CPU Utilization"
+        tooltip: "CPU utilization by elastic work, compared to the limit set for elastic work."
+        axis:
+          label: "CPU Utilization"
+          units: "Percentage"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.admission.elastic_cpu.utilization"
+            title: "Utilization"
+          - name: "cr.node.admission.elastic_cpu.utilization_limit"
+            title: "Utilization Limit"
+
+      - title: "Goroutine Scheduling Latency: 99th percentile"
+        tooltip: "P99 scheduling latency for goroutines. A value above 1ms here indicates high load that causes background (elastic) CPU work to be throttled."
+        axis:
+          label: "latency"
+          units: "Duration"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.go.scheduler_latency-p99"
+            title: "Scheduling Latency p99"
+
+      - title: "Goroutine Scheduling Latency: 99.9th percentile"
+        tooltip: "P99.9 scheduling latency for goroutines. A high value here can be indicative of high tail latency in various queries."
+        axis:
+          label: "latency"
+          units: "Duration"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.go.scheduler_latency-p99.9"
+            title: "Scheduling Latency p99.9"
+
+      - title: "Runnable Goroutines per CPU"
+        tooltip: "The number of Goroutines waiting per CPU. A value above the value set in admission.kv_slot_adjuster.overload_threshold is used by admission control to throttle regular CPU work."
+        axis:
+          label: "goroutines"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.sys.runnable.goroutines.per.cpu"
+            title: "Runnable Goroutines per CPU"
+
+      - title: "LSM L0 Sublevels"
+        tooltip: "Number of sublevels in L0 of the LSM. A sustained value above 10 typically indicates that the store is overloaded."
+        axis:
+          label: "Count"
+        group_by_storage: true
+        metrics:
+          - name: "cr.store.storage.l0-sublevels"
+            title: "L0 Sublevels"
+
+  - title: "TTL"
+    graphs:
+      - title: "Processing Rate"
+        axis:
+          label: "rows per second"
+          units: "Count"
+        metrics:
+          - name: "cr.node.jobs.row_level_ttl.rows_selected"
+            title: "rows selected"
+          - name: "cr.node.jobs.row_level_ttl.rows_deleted"
+            title: "rows deleted"
+
+      - title: "Estimated Rows"
+        axis:
+          label: "row count"
+          units: "Count"
+        metrics:
+          - name: "cr.node.jobs.row_level_ttl.total_rows"
+            title: "approximate number of rows"
+          - name: "cr.node.jobs.row_level_ttl.total_expired_rows"
+            title: "approximate number of expired rows"
+
+      - title: "Job Latency"
+        tooltip: "Latency of scanning and deleting within the job."
+        axis:
+          label: "latency"
+          units: "Duration"
+        metrics:
+          - name: "cr.node.jobs.row_level_ttl.select_duration-p50"
+            title: "scan latency (p50)"
+          - name: "cr.node.jobs.row_level_ttl.delete_duration-p50"
+            title: "delete latency (p50)"
+          - name: "cr.node.jobs.row_level_ttl.select_duration-p75"
+            title: "scan latency (p75)"
+          - name: "cr.node.jobs.row_level_ttl.delete_duration-p75"
+            title: "delete latency (p75)"
+          - name: "cr.node.jobs.row_level_ttl.select_duration-p90"
+            title: "scan latency (p90)"
+          - name: "cr.node.jobs.row_level_ttl.delete_duration-p90"
+            title: "delete latency (p90)"
+          - name: "cr.node.jobs.row_level_ttl.select_duration-p99"
+            title: "scan latency (p99)"
+          - name: "cr.node.jobs.row_level_ttl.delete_duration-p99"
+            title: "delete latency (p99)"
+
+      - title: "Spans in Progress"
+        tooltip: "Number of active spans being processed by TTL."
+        axis:
+          label: "span count"
+          units: "Count"
+        metrics:
+          - name: "cr.node.jobs.row_level_ttl.num_active_spans"
+            title: "number of spans being processed"
+
+  - title: "Cross Cluster Replication"
+    graphs:
+      - title: "Replication Lag"
+        tooltip: "Replication lag between primary and standby cluster"
+        axis:
+          label: "duration"
+          units: "Duration"
+        metrics:
+          - name: "cr.node.physical_replication.replicated_time_seconds"
+            title: "Replication Lag"
+
+      - title: "Logical Bytes"
+        tooltip: "Rate at which the logical bytes (sum of keys + values) are ingested by all replication jobs"
+        axis:
+          label: "bytes"
+          units: "Bytes"
+        metrics:
+          - name: "cr.node.physical_replication.logical_bytes"
+            title: "Logical Bytes"
+
+  - title: "Logical Data Replication"
+    graphs:
+      - title: "Replication Latency"
+        tooltip: "The difference in commit times between the source cluster and the destination cluster"
+        axis:
+          label: "latency"
+          units: "Duration"
+        metrics:
+          - name: "cr.node.logical_replication.commit_latency-p50"
+            title: "p50"
+          - name: "cr.node.logical_replication.commit_latency-p99"
+            title: "p99"
+
+      - title: "Replication Lag"
+        tooltip: "The age of the oldest row on the source cluster that has yet to replicate to destination cluster"
+        axis:
+          label: "duration"
+          units: "Duration"
+        metrics:
+          - name: "cr.node.logical_replication.replicated_time_seconds"
+            title: "Replication Lag"
+
+      - title: "Row Updates Applied"
+        tooltip: "Rate at which row updates are applied by all logical replication jobs"
+        axis:
+          label: "updates"
+        metrics:
+          - name: "cr.node.logical_replication.events_ingested"
+            title: "Row Updates Applied"
+          - name: "cr.node.logical_replication.events_dlqed"
+            title: "Row Updates sent to DLQ"
+
+      - title: "Logical Bytes Received"
+        tooltip: "Rate at which the logical bytes (sum of keys + values) are received by all logical replication jobs"
+        axis:
+          label: "bytes"
+          units: "Bytes"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.logical_replication.logical_bytes"
+            title: "Logical Bytes"
+
+      - title: "Row Application Processing Time: 50th percentile"
+        tooltip: "The 50th percentile in the time it takes to write a batch of row updates"
+        axis:
+          label: "processing time"
+          units: "Duration"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.logical_replication.batch_hist_nanos-p50"
+            title: "Processing Time p50"
+
+      - title: "Row Application Processing Time: 99th percentile"
+        tooltip: "The 99th percentile in the time it takes to write a batch of row updates"
+        axis:
+          label: "processing time"
+          units: "Duration"
+        group_by_storage: true
+        metrics:
+          - name: "cr.node.logical_replication.batch_hist_nanos-p99"
+            title: "Processing Time p99"
+
+      - title: "DLQ Causes"
+        tooltip: "Reasons events were sent to the DLQ"
+        axis:
+          label: "updates"
+        metrics:
+          - name: "cr.node.logical_replication.events_dlqed_age"
+            title: "Retry Duration Expired"
+          - name: "cr.node.logical_replication.events_dlqed_space"
+            title: "Retry Queue Full"
+          - name: "cr.node.logical_replication.events_dlqed_errtype"
+            title: "Non-retryable"
+
+      - title: "Retry Queue Size"
+        tooltip: "Total size of the retry queues across all processors in all LDR jobs"
+        axis:
+          label: "bytes"
+          units: "Bytes"
+        metrics:
+          - name: "cr.node.logical_replication.retry_queue_bytes"
+            title: "Retry Queue Size"

--- a/pkg/cli/gen_dashboard.go
+++ b/pkg/cli/gen_dashboard.go
@@ -1,0 +1,607 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cli
+
+import (
+	"context"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/cli/clierrorplus"
+	"github.com/cockroachdb/cockroach/pkg/util/yamlutil"
+	"github.com/spf13/cobra"
+)
+
+//go:embed files/dashboard.yaml
+var dashboardYAML []byte
+
+const (
+	Datadog = "datadog"
+	Grafana = "grafana"
+)
+
+var percentileSuffixes = []string{"-p99.999", "-p99.99", "-p99.9", "-p99", "-p90", "-p75", "-p50", "-max"}
+
+// DashboardConfig represents the YAML configuration for a dashboard
+type DashboardConfig struct {
+	Graphs     []GraphConfig `yaml:"graphs,omitempty"`
+	Dashboards []Dashboard   `yaml:"dashboards,omitempty"`
+}
+
+// Dashboard represents a dashboard section containing multiple graphs
+type Dashboard struct {
+	Title  string        `yaml:"title"`
+	Graphs []GraphConfig `yaml:"graphs"`
+}
+
+// GraphConfig represents a single graph/chart in the dashboard
+type GraphConfig struct {
+	Title          string         `yaml:"title"`
+	Tooltip        string         `yaml:"tooltip"`
+	Axis           AxisConfig     `yaml:"axis"`
+	Metrics        []MetricConfig `yaml:"metrics"`
+	GroupByStorage bool           `yaml:"group_by_storage,omitempty"`
+}
+
+// AxisConfig represents the axis configuration for a graph
+type AxisConfig struct {
+	Label string `yaml:"label"`
+	Units string `yaml:"units"`
+}
+
+// MetricConfig represents a single metric in a graph
+type MetricConfig struct {
+	Name  string `yaml:"name"`
+	Title string `yaml:"title"`
+}
+
+// DatadogDashboard represents the top-level Datadog dashboard structure
+type DatadogDashboard struct {
+	Title             string                    `json:"title"`
+	Description       string                    `json:"description"`
+	LayoutType        string                    `json:"layout_type"`
+	Type              string                    `json:"type,omitempty"`
+	Widgets           []DatadogWidget           `json:"widgets"`
+	TemplateVariables []DatadogTemplateVariable `json:"template_variables,omitempty"`
+}
+
+// DatadogTemplateVariable represents a template variable
+type DatadogTemplateVariable struct {
+	Name    string `json:"name"`
+	Prefix  string `json:"prefix,omitempty"`
+	Default string `json:"default"`
+}
+
+// DatadogWidget represents a widget in the dashboard
+type DatadogWidget struct {
+	Definition DatadogWidgetDefinition `json:"definition"`
+	Layout     *DatadogLayout          `json:"layout,omitempty"`
+}
+
+// DatadogLayout represents the layout configuration for a widget
+type DatadogLayout struct {
+	X      int `json:"x"`
+	Y      int `json:"y"`
+	Width  int `json:"width"`
+	Height int `json:"height"`
+}
+
+// DatadogWidgetDefinition represents the definition of a widget
+type DatadogWidgetDefinition struct {
+	Type          string           `json:"type"`
+	Title         string           `json:"title,omitempty"`
+	ShowTitle     bool             `json:"show_title,omitempty"`
+	ShowLegend    bool             `json:"show_legend,omitempty"`
+	LegendLayout  string           `json:"legend_layout,omitempty"`
+	LegendColumns []string         `json:"legend_columns,omitempty"`
+	LayoutType    string           `json:"layout_type,omitempty"`
+	Widgets       []DatadogWidget  `json:"widgets,omitempty"`
+	Requests      []DatadogRequest `json:"requests,omitempty"`
+	YAxis         *DatadogYAxis    `json:"yaxis,omitempty"`
+	// Image widget fields
+	URL           string `json:"url,omitempty"`
+	URLDarkTheme  string `json:"url_dark_theme,omitempty"`
+	Sizing        string `json:"sizing,omitempty"`
+	HasBackground bool   `json:"has_background,omitempty"`
+	HasBorder     bool   `json:"has_border,omitempty"`
+	// Note widget fields
+	Content         string `json:"content,omitempty"`
+	BackgroundColor string `json:"background_color,omitempty"`
+	FontSize        string `json:"font_size,omitempty"`
+	TextAlign       string `json:"text_align,omitempty"`
+	VerticalAlign   string `json:"vertical_align,omitempty"`
+	ShowTick        bool   `json:"show_tick,omitempty"`
+	TickPos         string `json:"tick_pos,omitempty"`
+	TickEdge        string `json:"tick_edge,omitempty"`
+	HasPadding      bool   `json:"has_padding,omitempty"`
+	// Group widget fields
+	BannerImg       string `json:"banner_img,omitempty"`
+	HorizontalAlign string `json:"horizontal_align,omitempty"`
+}
+
+// DatadogRequest represents a request for metrics data
+type DatadogRequest struct {
+	Formulas       []DatadogFormula `json:"formulas,omitempty"`
+	Queries        []DatadogQuery   `json:"queries,omitempty"`
+	ResponseFormat string           `json:"response_format,omitempty"`
+	Style          *DatadogStyle    `json:"style,omitempty"`
+	DisplayType    string           `json:"display_type,omitempty"`
+}
+
+// DatadogFormula represents a formula in a request
+type DatadogFormula struct {
+	Alias        string               `json:"alias,omitempty"`
+	Formula      string               `json:"formula"`
+	NumberFormat *DatadogNumberFormat `json:"number_format,omitempty"`
+}
+
+// DatadogNumberFormat specifies how numbers should be formatted
+type DatadogNumberFormat struct {
+	Unit *DatadogUnit `json:"unit,omitempty"`
+}
+
+// DatadogUnit specifies the unit for a number format
+type DatadogUnit struct {
+	Type        string `json:"type"`
+	UnitName    string `json:"unit_name,omitempty"`
+	PerUnitName string `json:"per_unit_name,omitempty"`
+}
+
+// DatadogQuery represents a metric query
+type DatadogQuery struct {
+	DataSource string `json:"data_source"`
+	Name       string `json:"name"`
+	Query      string `json:"query"`
+}
+
+// DatadogStyle specifies the visual style for a request
+type DatadogStyle struct {
+	Palette   string `json:"palette,omitempty"`
+	LineType  string `json:"line_type,omitempty"`
+	LineWidth string `json:"line_width,omitempty"`
+}
+
+// DatadogYAxis represents the Y-axis configuration
+type DatadogYAxis struct {
+	IncludeZero bool   `json:"include_zero,omitempty"`
+	Scale       string `json:"scale,omitempty"`
+	Min         string `json:"min,omitempty"`
+	Max         string `json:"max,omitempty"`
+}
+
+var rollupInterval int
+var outputFile string
+
+var genDashboardCmd = &cobra.Command{
+	Use:   "dashboard [datadog|grafana]",
+	Short: "generate dashboard from embedded dashboard configuration",
+	Long: `Generate a dashboard JSON file from the embedded CockroachDB dashboard YAML configuration.
+
+This command reads the embedded dashboard.yaml file and generates a dashboard JSON file
+in the format specified (datadog or grafana).
+
+Examples:
+  cockroach gen dashboard datadog
+  cockroach gen dashboard grafana
+  cockroach gen dashboard datadog --rollup-interval=30
+  cockroach gen dashboard datadog --output=my-dashboard.json
+  cockroach gen dashboard datadog --output=/path/to/dashboard.json --rollup-interval=60
+`,
+	Args:      cobra.ExactArgs(1),
+	ValidArgs: []string{"datadog", "grafana"},
+	RunE:      clierrorplus.MaybeDecorateError(runGenDashboardCmd),
+}
+
+func init() {
+	genDashboardCmd.Flags().IntVar(&rollupInterval, "rollup-interval", 10, "interval in seconds for metric rollup (default: 10)")
+	genDashboardCmd.Flags().StringVar(&outputFile, "output", "", "output file path for the generated dashboard (must have .json extension)")
+}
+
+func runGenDashboardCmd(_ *cobra.Command, args []string) error {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	dashboardType := args[0]
+
+	// Validate output file extension if specified
+	if outputFile != "" && !strings.HasSuffix(outputFile, ".json") {
+		return fmt.Errorf("output file must have .json extension: %s", outputFile)
+	}
+
+	// Generate metrics name mapping using the same logic as tsdump_upload
+	metricsNameMap, err := generateMetricsNameMap(ctx)
+	if err != nil {
+		return fmt.Errorf("generating metrics name map: %w", err)
+	}
+
+	// Load metric type map to determine counter vs histogram types
+	metricTypeMap, err := loadMetricTypesMap(ctx)
+	if err != nil {
+		return fmt.Errorf("generating metric type map: %w", err)
+	}
+
+	// Parse the embedded YAML file
+	var dashConfig DashboardConfig
+	if err := yamlutil.UnmarshalStrict(dashboardYAML, &dashConfig); err != nil {
+		return fmt.Errorf("parsing dashboard config: %w", err)
+	}
+
+	fmt.Printf("Processing dashboard configuration for %s...\n", dashboardType)
+
+	switch dashboardType {
+	case Datadog:
+		return generateDatadogDashboard(dashConfig, metricsNameMap, metricTypeMap)
+	case Grafana:
+		return fmt.Errorf("grafana dashboard generation not yet implemented")
+	default:
+		return fmt.Errorf("unsupported dashboard type: %s (must be 'datadog' or 'grafana')", dashboardType)
+	}
+}
+
+func generateDatadogDashboard(
+	dashConfig DashboardConfig, metricsNameMap map[string]string, metricTypeMap map[string]string,
+) error {
+	// Create template variables for filtering
+	templateVars := []DatadogTemplateVariable{
+		{Name: "region", Prefix: "region", Default: "*"},
+		{Name: "cluster", Prefix: "cluster", Default: "*"},
+		{Name: "host", Prefix: "host", Default: "*"},
+		{Name: "node_id", Prefix: "node_id", Default: "*"},
+		{Name: "store", Prefix: "store", Default: "*"},
+	}
+
+	// Create a single combined dashboard
+	dashboard := DatadogDashboard{
+		Title:             "CockroachDB Dashboard",
+		Description:       "CockroachDB metrics dashboard combining all metric categories",
+		TemplateVariables: templateVars,
+		Widgets:           []DatadogWidget{},
+		LayoutType:        "ordered",
+	}
+
+	// Add static header widget at the beginning
+	headerWidget := createStaticHeaderWidget()
+	dashboard.Widgets = append(dashboard.Widgets, headerWidget)
+
+	// Process flat graphs (backward compatible)
+	for _, graph := range dashConfig.Graphs {
+		widget := convertGraphToDatadogWidget(graph, metricsNameMap, metricTypeMap)
+		dashboard.Widgets = append(dashboard.Widgets, widget)
+	}
+
+	// Process dashboard sections (new feature)
+	for _, dashboardSection := range dashConfig.Dashboards {
+		dashboardWidget := convertDashboardToDatadogWidget(dashboardSection, metricsNameMap, metricTypeMap)
+		dashboard.Widgets = append(dashboard.Widgets, dashboardWidget)
+	}
+
+	return writeDashboardToFile(dashboard, Datadog)
+}
+
+// writeDashboardToFile marshals the dashboard to JSON and writes it to a file
+func writeDashboardToFile(dashboard DatadogDashboard, dashboardType string) error {
+	// Marshal to JSON
+	jsonData, err := json.MarshalIndent(dashboard, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling dashboard: %w", err)
+	}
+
+	// Determine output path
+	outputPath := outputFile
+	if outputPath == "" {
+		// Use default filename if no output specified
+		outputPath = fmt.Sprintf("cockroachdb_%s_dashboard.json", dashboardType)
+	}
+
+	// Write to file
+	if err := os.WriteFile(outputPath, jsonData, 0644); err != nil {
+		return fmt.Errorf("writing dashboard file: %w", err)
+	}
+
+	fmt.Printf("Successfully generated %s dashboard: %s\n", dashboardType, outputPath)
+	return nil
+}
+
+// convertDashboardToDatadogWidget converts a Dashboard section to a Datadog group widget
+func convertDashboardToDatadogWidget(
+	dashboardSection Dashboard, metricsNameMap map[string]string, metricTypeMap map[string]string,
+) DatadogWidget {
+	var dashboardWidgets []DatadogWidget
+
+	// Convert each graph in the dashboard section to a widget
+	for _, graph := range dashboardSection.Graphs {
+		widget := convertGraphToDatadogWidget(graph, metricsNameMap, metricTypeMap)
+		dashboardWidgets = append(dashboardWidgets, widget)
+	}
+
+	// Create dashboard group widget definition
+	definition := DatadogWidgetDefinition{
+		Type:       "group",
+		Title:      dashboardSection.Title,
+		ShowTitle:  true,
+		LayoutType: "ordered",
+		Widgets:    dashboardWidgets,
+	}
+
+	return DatadogWidget{
+		Definition: definition,
+	}
+}
+
+// convertGraphToDatadogWidget converts a GraphConfig to a Datadog widget
+func convertGraphToDatadogWidget(
+	graph GraphConfig, metricsNameMap map[string]string, metricTypeMap map[string]string,
+) DatadogWidget {
+	var queries []DatadogQuery
+	var formulas []DatadogFormula
+
+	// Build queries and formulas for each metric
+	for i, metric := range graph.Metrics {
+		queryName := fmt.Sprintf("query%d", i+1)
+
+		// Build Datadog query
+		query := DatadogQuery{
+			DataSource: "metrics",
+			Name:       queryName,
+			Query:      buildDatadogQuery(metric.Name, metricsNameMap, metricTypeMap, graph.GroupByStorage),
+		}
+		queries = append(queries, query)
+
+		// Create formula
+		formulaStr := queryName
+		if graph.Axis.Units == "Percentage" {
+			formulaStr = queryName + " * 100"
+		}
+		formula := DatadogFormula{
+			Alias:   metric.Title,
+			Formula: formulaStr,
+		}
+
+		// Add number format based on units
+		if numberFormat := getDatadogNumberFormat(graph.Axis.Units); numberFormat != nil {
+			formula.NumberFormat = numberFormat
+		}
+
+		formulas = append(formulas, formula)
+	}
+
+	// Create request
+	request := DatadogRequest{
+		Formulas:       formulas,
+		Queries:        queries,
+		ResponseFormat: "timeseries",
+		Style: &DatadogStyle{
+			Palette:   "dog_classic",
+			LineType:  "solid",
+			LineWidth: "normal",
+		},
+		DisplayType: "line",
+	}
+
+	// Create widget definition
+	definition := DatadogWidgetDefinition{
+		Type:          "timeseries",
+		Title:         graph.Title,
+		ShowLegend:    true,
+		LegendLayout:  "auto",
+		LegendColumns: []string{"avg", "min", "max", "value", "sum"},
+		Requests:      []DatadogRequest{request},
+		YAxis: &DatadogYAxis{
+			IncludeZero: true,
+			Scale:       "linear",
+			Min:         "0",
+			Max:         "auto",
+		},
+	}
+
+	return DatadogWidget{
+		Definition: definition,
+	}
+}
+
+// stripPercentileSuffix removes percentile suffixes like -p50, -p75, -p90, -p99, -p99.9, -p99.99, -p99.999 from a metric name.
+func stripPercentileSuffix(name string) string {
+	for _, suffix := range percentileSuffixes {
+		if strings.HasSuffix(name, suffix) {
+			return strings.TrimSuffix(name, suffix)
+		}
+	}
+	return name
+}
+
+// extractPercentileValue extracts the percentile value from a metric name with percentile suffix.
+// For example: "sql.service.latency-p99" returns "99", "sql.service.latency-p99.9" returns "99.9"
+func extractPercentileValue(metricName string) string {
+	for _, suffix := range percentileSuffixes {
+		if strings.HasSuffix(metricName, suffix) {
+			// Extract the percentile value by removing the "-" prefix
+			return strings.TrimPrefix(suffix, "-")
+		}
+	}
+	return ""
+}
+
+// buildDatadogQuery constructs a Datadog query string from a metric name
+func buildDatadogQuery(
+	metricName string,
+	metricsNameMap map[string]string,
+	metricTypeMap map[string]string,
+	groupByStorage bool,
+) string {
+	// Step 1: Extract and strip node/store prefix using reCrStoreNode regex
+	// reCrStoreNode is defined in tsdump.go and matches "cr.(node|store).(.*)"
+	sl := reCrStoreNode.FindStringSubmatch(metricName)
+	var registry string
+	if len(sl) >= 3 {
+		registry = sl[1]   // "node" or "store"
+		metricName = sl[2] // rest of the metric name
+	}
+
+	// Step 2: Strip percentile suffix and extract percentile value
+	// Use stripPercentileSuffix() from gen.go
+	baseMetricName := stripPercentileSuffix(metricName)
+	percentileValue := extractPercentileValue(metricName)
+
+	// Step 3: Convert to Prometheus format
+	// prometheusNameReplaceRE is defined in tsdump_upload.go
+	promName := prometheusNameReplaceRE.ReplaceAllString(baseMetricName, "_")
+
+	// Step 4: Lookup Datadog name in metricsNameMap
+	datadogMetricName := promName
+	if ddName, ok := metricsNameMap[promName]; ok {
+		datadogMetricName = ddName
+	}
+
+	// Ensure cockroachdb prefix
+	if !strings.HasPrefix(datadogMetricName, "cockroachdb.") {
+		datadogMetricName = "cockroachdb." + datadogMetricName
+	}
+
+	// Step 5: Look up metric type
+	metricType := metricTypeMap[baseMetricName]
+
+	// Step 6: Generate query based on metric type
+	// Determine aggregation (default to sum)
+	aggregation := "sum"
+	if metricType == "HISTOGRAM" && percentileValue != "" {
+		aggregation = percentileValue
+	}
+
+	// Build tags - use region, cluster, and host as base tags
+	tags := "$region,$cluster,$host,$store,$node_id"
+	var groupByClause string
+
+	// Add node/store tags based on original metric prefix only if groupByStorage is true
+	if groupByStorage {
+		if registry == "node" {
+			groupByClause = " by {node_id}"
+		} else if registry == "store" {
+			groupByClause = " by {store}"
+		}
+	}
+
+	// Build base query
+	query := fmt.Sprintf("%s:%s{%s}%s", aggregation, datadogMetricName, tags, groupByClause)
+
+	// Apply rate() for COUNTER metrics
+	if metricType == "COUNTER" {
+		query += ".as_rate()"
+	}
+
+	query += fmt.Sprintf(".rollup(sum, %d)", rollupInterval)
+	return query
+}
+
+// getDatadogNumberFormat returns number format configuration for a given unit
+func getDatadogNumberFormat(units string) *DatadogNumberFormat {
+	switch units {
+	case "Duration":
+		return &DatadogNumberFormat{
+			Unit: &DatadogUnit{
+				Type:     "canonical_unit",
+				UnitName: "nanosecond",
+			},
+		}
+	case "DurationSeconds":
+		return &DatadogNumberFormat{
+			Unit: &DatadogUnit{
+				Type:     "canonical_unit",
+				UnitName: "second",
+			},
+		}
+	case "Bytes":
+		return &DatadogNumberFormat{
+			Unit: &DatadogUnit{
+				Type:     "canonical_unit",
+				UnitName: "byte_in_binary_bytes_family",
+			},
+		}
+	case "Percentage":
+		return &DatadogNumberFormat{
+			Unit: &DatadogUnit{
+				Type:     "canonical_unit",
+				UnitName: "percent",
+			},
+		}
+	case "Count":
+		// For counts, return nil to use default formatting
+		// Datadog doesn't require explicit unit configuration for counts
+		return nil
+	default:
+		return nil
+	}
+}
+
+// createStaticHeaderWidget creates the static header group widget containing
+// the CockroachDB logo and description text
+func createStaticHeaderWidget() DatadogWidget {
+	// Create image widget for CockroachDB logo
+	imageWidget := DatadogWidget{
+		Definition: DatadogWidgetDefinition{
+			Type:            "image",
+			URL:             "/static/images/logos/cockroachdb_large.svg",
+			URLDarkTheme:    "/static/images/logos/cockroachdb_reversed_large.svg",
+			Sizing:          "cover",
+			HasBackground:   true,
+			HasBorder:       true,
+			VerticalAlign:   "center",
+			HorizontalAlign: "center",
+		},
+	}
+
+	// Create description note widget
+	descriptionWidget := DatadogWidget{
+		Definition: DatadogWidgetDefinition{
+			Type:            "note",
+			Content:         "This dashboard provides a high-level view of your CockroachDB cluster, including:\n- A high-level view of SQL performance & latency.\n- Information about resource consumption to help aid in capacity planning.",
+			BackgroundColor: "transparent",
+			FontSize:        "14",
+			TextAlign:       "left",
+			VerticalAlign:   "center",
+			ShowTick:        false,
+			TickPos:         "100%",
+			TickEdge:        "left",
+			HasPadding:      false,
+		},
+	}
+
+	// Create configuration instructions note widget
+	configWidget := DatadogWidget{
+		Definition: DatadogWidgetDefinition{
+			Type: "note",
+			Content: "#### Optimize your CockroachDB integration configuration for monitoring\n1. Configure `cluster` and `region` tags in your `cockroachdb.d/conf.yaml`" +
+				" [file](https://github.com/DataDog/integrations-core/blob/7f091cbd40dfa13ec713d00d53caa2273a6cc7f6/cockroachdb/datadog_checks/cockroachdb/data/conf.yaml.example#L583-L591):\n\n " +
+				"   ```\n    instances:\n" +
+				"      - openmetrics_endpoint: http://localhost:8080/_status/vars\n        tags: [\"cluster:prod\", \"region:us-east-1\"]\n" +
+				"      - openmetrics_endpoint: http://localhost:8082/_status/vars\n        tags: [\"cluster:dev\", \"region:us-east-2\"]\n    ```",
+			BackgroundColor: "white",
+			FontSize:        "14",
+			TextAlign:       "left",
+			VerticalAlign:   "center",
+			ShowTick:        false,
+			TickPos:         "100%",
+			TickEdge:        "left",
+			HasPadding:      true,
+		},
+	}
+
+	// Create the group widget containing all three widgets
+	groupWidget := DatadogWidget{
+		Definition: DatadogWidgetDefinition{
+			Type:       "group",
+			Title:      "Description",
+			BannerImg:  "",
+			ShowTitle:  false,
+			LayoutType: "ordered",
+			Widgets:    []DatadogWidget{imageWidget, descriptionWidget, configWidget},
+		},
+	}
+
+	return groupWidget
+}

--- a/pkg/cli/gen_dashboard_test.go
+++ b/pkg/cli/gen_dashboard_test.go
@@ -1,0 +1,337 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildDatadogQuery(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	// Set up the global rollupInterval for testing
+	rollupInterval = 10
+
+	testCases := []struct {
+		name             string
+		metricName       string
+		metricsNameMap   map[string]string
+		metricTypeMap    map[string]string
+		groupByStorage   bool
+		expectedQuery    string
+		expectedContains []string
+	}{
+		{
+			name:           "basic counter metric without prefix",
+			metricName:     "sql.conns",
+			metricsNameMap: map[string]string{},
+			metricTypeMap:  map[string]string{"sql.conns": "COUNTER"},
+			groupByStorage: false,
+			expectedContains: []string{
+				"sum:cockroachdb.sql_conns",
+				"$region,$cluster,$host,$store,$node_id",
+				".as_rate()",
+				".rollup(sum, 10)",
+			},
+		},
+		{
+			name:           "basic gauge metric without prefix",
+			metricName:     "sys.cpu.user.percent",
+			metricsNameMap: map[string]string{},
+			metricTypeMap:  map[string]string{"sys.cpu.user.percent": "GAUGE"},
+			groupByStorage: false,
+			expectedContains: []string{
+				"sum:cockroachdb.sys_cpu_user_percent",
+				"$region,$cluster,$host,$store,$node_id",
+				".rollup(sum, 10)",
+			},
+		},
+		{
+			name:           "node metric with groupByStorage",
+			metricName:     "cr.node.sql.conns",
+			metricsNameMap: map[string]string{},
+			metricTypeMap:  map[string]string{"sql.conns": "COUNTER"},
+			groupByStorage: true,
+			expectedContains: []string{
+				"sum:cockroachdb.sql_conns",
+				"$region,$cluster,$host,$store,$node_id",
+				" by {node_id}",
+				".as_rate()",
+				".rollup(sum, 10)",
+			},
+		},
+		{
+			name:           "store metric with groupByStorage",
+			metricName:     "cr.store.capacity",
+			metricsNameMap: map[string]string{},
+			metricTypeMap:  map[string]string{"capacity": "GAUGE"},
+			groupByStorage: true,
+			expectedContains: []string{
+				"sum:cockroachdb.capacity",
+				"$region,$cluster,$host,$store,$node_id",
+				" by {store}",
+				".rollup(sum, 10)",
+			},
+		},
+		{
+			name:           "node metric without groupByStorage",
+			metricName:     "cr.node.sql.conns",
+			metricsNameMap: map[string]string{},
+			metricTypeMap:  map[string]string{"sql.conns": "COUNTER"},
+			groupByStorage: false,
+			expectedContains: []string{
+				"sum:cockroachdb.sql_conns",
+				"$region,$cluster,$host,$store,$node_id",
+				".as_rate()",
+				".rollup(sum, 10)",
+			},
+		},
+		{
+			name:           "histogram metric with p99 percentile",
+			metricName:     "sql.service.latency-p99",
+			metricsNameMap: map[string]string{},
+			metricTypeMap:  map[string]string{"sql.service.latency": "HISTOGRAM"},
+			groupByStorage: false,
+			expectedContains: []string{
+				"p99:cockroachdb.sql_service_latency",
+				"$region,$cluster,$host,$store,$node_id",
+				".rollup(sum, 10)",
+			},
+		},
+		{
+			name:           "histogram metric with p99.9 percentile",
+			metricName:     "sql.service.latency-p99.9",
+			metricsNameMap: map[string]string{},
+			metricTypeMap:  map[string]string{"sql.service.latency": "HISTOGRAM"},
+			groupByStorage: false,
+			expectedContains: []string{
+				"p99.9:cockroachdb.sql_service_latency",
+				"$region,$cluster,$host,$store,$node_id",
+				".rollup(sum, 10)",
+			},
+		},
+		{
+			name:           "histogram metric with p50 percentile",
+			metricName:     "sql.service.latency-p50",
+			metricsNameMap: map[string]string{},
+			metricTypeMap:  map[string]string{"sql.service.latency": "HISTOGRAM"},
+			groupByStorage: false,
+			expectedContains: []string{
+				"p50:cockroachdb.sql_service_latency",
+				"$region,$cluster,$host,$store,$node_id",
+				".rollup(sum, 10)",
+			},
+		},
+		{
+			name:       "metric with datadog name mapping",
+			metricName: "sql.conns",
+			metricsNameMap: map[string]string{
+				"sql_conns": "sql.connections.total",
+			},
+			metricTypeMap:  map[string]string{"sql.conns": "COUNTER"},
+			groupByStorage: false,
+			expectedContains: []string{
+				"sum:cockroachdb.sql.connections.total",
+				"$region,$cluster,$host,$store,$node_id",
+				".as_rate()",
+				".rollup(sum, 10)",
+			},
+		},
+		{
+			name:       "metric already with cockroachdb prefix in mapping",
+			metricName: "sql.conns",
+			metricsNameMap: map[string]string{
+				"sql_conns": "cockroachdb.sql_conns",
+			},
+			metricTypeMap:  map[string]string{"sql.conns": "COUNTER"},
+			groupByStorage: false,
+			expectedContains: []string{
+				"sum:cockroachdb.sql_conns",
+				"$region,$cluster,$host,$store,$node_id",
+				".as_rate()",
+				".rollup(sum, 10)",
+			},
+		},
+		{
+			name:           "counter metric without rate",
+			metricName:     "txn.commits",
+			metricsNameMap: map[string]string{},
+			metricTypeMap:  map[string]string{"txn.commits": "COUNTER"},
+			groupByStorage: false,
+			expectedContains: []string{
+				"sum:cockroachdb.txn_commits",
+				"$region,$cluster,$host,$store,$node_id",
+				".as_rate()",
+				".rollup(sum, 10)",
+			},
+		},
+		{
+			name:           "node metric with percentile and groupByStorage",
+			metricName:     "cr.node.sql.service.latency-p99",
+			metricsNameMap: map[string]string{},
+			metricTypeMap:  map[string]string{"sql.service.latency": "HISTOGRAM"},
+			groupByStorage: true,
+			expectedContains: []string{
+				"p99:cockroachdb.sql_service_latency",
+				"$region,$cluster,$host,$store,$node_id",
+				" by {node_id}",
+				".rollup(sum, 10)",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			query := buildDatadogQuery(tc.metricName, tc.metricsNameMap, tc.metricTypeMap, tc.groupByStorage)
+
+			// Check that all expected substrings are present
+			for _, expected := range tc.expectedContains {
+				require.Contains(t, query, expected, "query should contain: %s", expected)
+			}
+
+			// Verify gauge metrics don't have .as_rate()
+			if tc.metricTypeMap[stripPercentileSuffix(tc.metricName)] == "GAUGE" {
+				require.NotContains(t, query, ".as_rate()", "gauge metrics should not have .as_rate()")
+			}
+
+			// Verify counter metrics have .as_rate()
+			if tc.metricTypeMap[stripPercentileSuffix(tc.metricName)] == "COUNTER" {
+				require.Contains(t, query, ".as_rate()", "counter metrics should have .as_rate()")
+			}
+
+			// Verify histogram metrics use correct percentile aggregation
+			if tc.metricTypeMap[stripPercentileSuffix(tc.metricName)] == "HISTOGRAM" {
+				percentileValue := extractPercentileValue(tc.metricName)
+				if percentileValue != "" {
+					expectedAgg := percentileValue + ":"
+					require.Contains(t, query, expectedAgg, "histogram with percentile should use correct aggregation")
+				}
+			}
+
+			// Verify groupByStorage behavior
+			if tc.groupByStorage {
+				// Should have either " by {node_id}" or " by {store}"
+				hasNodeGroupBy := Contains(query, " by {node_id}")
+				hasStoreGroupBy := Contains(query, " by {store}")
+				require.True(t, hasNodeGroupBy || hasStoreGroupBy, "groupByStorage=true should add group by clause")
+			}
+		})
+	}
+}
+
+// Contains is a helper function to check if a string contains a substring
+func Contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > len(substr) && containsSubstring(s, substr))
+}
+
+func containsSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
+func TestBuildDatadogQueryWithDifferentRollupIntervals(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCases := []struct {
+		name           string
+		rollupInterval int
+		expectedRollup string
+	}{
+		{
+			name:           "rollup interval 10",
+			rollupInterval: 10,
+			expectedRollup: ".rollup(sum, 10)",
+		},
+		{
+			name:           "rollup interval 30",
+			rollupInterval: 30,
+			expectedRollup: ".rollup(sum, 30)",
+		},
+		{
+			name:           "rollup interval 60",
+			rollupInterval: 60,
+			expectedRollup: ".rollup(sum, 60)",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Set the global rollupInterval
+			rollupInterval = tc.rollupInterval
+
+			query := buildDatadogQuery(
+				"sql.conns",
+				map[string]string{},
+				map[string]string{"sql.conns": "COUNTER"},
+				false,
+			)
+
+			require.Contains(t, query, tc.expectedRollup, "query should contain correct rollup interval")
+		})
+	}
+
+	// Reset to default
+	rollupInterval = 10
+}
+
+func TestExtractPercentileValue(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCases := []struct {
+		name          string
+		metricName    string
+		expectedValue string
+	}{
+		{
+			name:          "p99 percentile",
+			metricName:    "sql.service.latency-p99",
+			expectedValue: "p99",
+		},
+		{
+			name:          "p99.9 percentile",
+			metricName:    "sql.service.latency-p99.9",
+			expectedValue: "p99.9",
+		},
+		{
+			name:          "p50 percentile",
+			metricName:    "sql.service.latency-p50",
+			expectedValue: "p50",
+		},
+		{
+			name:          "p90 percentile",
+			metricName:    "sql.service.latency-p90",
+			expectedValue: "p90",
+		},
+		{
+			name:          "max percentile",
+			metricName:    "sql.service.latency-max",
+			expectedValue: "max",
+		},
+		{
+			name:          "no percentile",
+			metricName:    "sql.conns",
+			expectedValue: "",
+		},
+		{
+			name:          "metric with p in name but not percentile",
+			metricName:    "sql.parsing.count",
+			expectedValue: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := extractPercentileValue(tc.metricName)
+			require.Equal(t, tc.expectedValue, result)
+		})
+	}
+}

--- a/pkg/cli/log_flags.go
+++ b/pkg/cli/log_flags.go
@@ -86,8 +86,8 @@ func setupLogging(ctx context.Context, cmd *cobra.Command, isServerCmd, applyCon
 	// flag) is passed without argument, see below.
 	commandSpecificDefaultLegacyStderrOverride := severity.INFO
 
-	if isDemoCmd(cmd) || cmd == genMetricListCmd || cmd == debugTimeSeriesDumpCmd {
-		// `cockroach demo` and `cockroach gen metric-list` are special:
+	if isDemoCmd(cmd) || cmd == genMetricListCmd || cmd == debugTimeSeriesDumpCmd || cmd == genDashboardCmd {
+		// `cockroach demo`, `cockroach gen metric-list` and `cockroach gen dashboard` are special:
 		// they start a server, but without
 		// disk and interactively. We don't want to litter the console
 		// with warning or error messages unless overridden; however,


### PR DESCRIPTION
Previously, there was no standardized way to generate monitoring
dashboards for CockroachDB clusters across different platforms.
Users had to manually create and configure dashboards, leading
to inconsistent monitoring setups.

This change adds a new `cockroach gen dashboard` command that
generates monitoring dashboard configurations from an embedded
YAML file. The command currently supports Datadog format and
includes comprehensive metrics covering Overview, Hardware,
Runtime, Networking, SQL, and Storage categories.

The embedded dashboard configuration provides a standardized
set of key metrics for monitoring cluster health, helping
operators achieve consistent monitoring across different
platforms and environments.

Flags:
- `--rollup-interval`: Configures the metric rollup interval in
  seconds (default: 10). This allows users to control the data
  granularity in generated dashboards.
- `--output`: Specifies a custom output file path for the
  generated dashboard JSON (must have .json extension). When not
  specified, uses default filename based on dashboard type.

Part of: CRDB-53463
Epic: CRDB-49093

Release note (ops change): A new `cockroach gen dashboard`
command configures dashboards based on key metrics to monitor
health of the CockroachDB cluster. The command supports
`--rollup-interval` to control metric granularity and `--output`
to specify custom output file paths. This helps standardize
monitoring across different platforms.

----
[sample generated dashboard](https://github.com/user-attachments/files/24498827/cockroachdb_datadog_dashboard.json)