### PR TITLE
kvserver: deflake TestSplitWithExternalFilesFastStats

### DIFF
--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -4391,6 +4391,7 @@ func TestSplitWithExternalFilesFastStats(t *testing.T) {
 					Store: &kvserver.StoreTestingKnobs{
 						DisableMergeQueue:              true,
 						DisableSplitQueue:              true,
+						DisableGCQueue:                 true,
 						DisableCanAckBeforeApplication: true,
 					},
 				},


### PR DESCRIPTION
This test expects to find estimated stats but finds accurate stats sometimes.

Our best theory here is that sometimes GC comes around before we check the stats and removes the estimated stats.

Fixes #160687
Release note: None