### PR TITLE
kvserver: add metrics for when precision is lost collecting read summary

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -13197,6 +13197,14 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NONE
+    - name: leases.read_summary.local_compression
+      exported_name: leases_read_summary_local_compression
+      description: Number of times the local segment of a read summary lost precision due to compression
+      y_axis_label: Compressions
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
     - name: leases.requests.latency
       exported_name: leases_requests_latency
       description: Lease request latency (all types and outcomes, coalesced)

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -278,6 +278,12 @@ var (
 		Measurement: "Locks Written",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaReadSummaryLocalCompressionCount = metric.Metadata{
+		Name:        "leases.read_summary.local_compression",
+		Help:        "Number of times the local segment of a read summary lost precision due to compression",
+		Measurement: "Compressions",
+		Unit:        metric.Unit_COUNT,
+	}
 	metaLeaseExpirationCount = metric.Metadata{
 		Name:        "leases.expiration",
 		Help:        "Number of replica leaseholders using expiration-based leases",
@@ -3350,18 +3356,19 @@ type StoreMetrics struct {
 	// Lease request metrics for successful and failed lease requests. These
 	// count proposals (i.e. it does not matter how many replicas apply the
 	// lease).
-	LeaseRequestSuccessCount       *metric.Counter
-	LeaseRequestErrorCount         *metric.Counter
-	LeaseRequestLatency            metric.IHistogram
-	LeaseTransferSuccessCount      *metric.Counter
-	LeaseTransferErrorCount        *metric.Counter
-	LeaseTransferLocksWritten      *metric.Counter
-	LeaseExpirationCount           *metric.Gauge
-	LeaseEpochCount                *metric.Gauge
-	LeaseLeaderCount               *metric.Gauge
-	LeaseLivenessCount             *metric.Gauge
-	LeaseViolatingPreferencesCount *metric.Gauge
-	LeaseLessPreferredCount        *metric.Gauge
+	LeaseRequestSuccessCount         *metric.Counter
+	LeaseRequestErrorCount           *metric.Counter
+	LeaseRequestLatency              metric.IHistogram
+	LeaseTransferSuccessCount        *metric.Counter
+	LeaseTransferErrorCount          *metric.Counter
+	LeaseTransferLocksWritten        *metric.Counter
+	ReadSummaryLocalCompressionCount *metric.Counter
+	LeaseExpirationCount             *metric.Gauge
+	LeaseEpochCount                  *metric.Gauge
+	LeaseLeaderCount                 *metric.Gauge
+	LeaseLivenessCount               *metric.Gauge
+	LeaseViolatingPreferencesCount   *metric.Gauge
+	LeaseLessPreferredCount          *metric.Gauge
 
 	// Storage metrics.
 	ResolveCommitCount *metric.Counter
@@ -4108,15 +4115,16 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 			Duration:     histogramWindow,
 			BucketConfig: metric.IOLatencyBuckets,
 		}),
-		LeaseTransferSuccessCount:      metric.NewCounter(metaLeaseTransferSuccessCount),
-		LeaseTransferErrorCount:        metric.NewCounter(metaLeaseTransferErrorCount),
-		LeaseTransferLocksWritten:      metric.NewCounter(metaLeaseTransferLocksWrittenCount),
-		LeaseExpirationCount:           metric.NewGauge(metaLeaseExpirationCount),
-		LeaseEpochCount:                metric.NewGauge(metaLeaseEpochCount),
-		LeaseLeaderCount:               metric.NewGauge(metaLeaseLeaderCount),
-		LeaseLivenessCount:             metric.NewGauge(metaLeaseLivenessCount),
-		LeaseViolatingPreferencesCount: metric.NewGauge(metaLeaseViolatingPreferencesCount),
-		LeaseLessPreferredCount:        metric.NewGauge(metaLeaseLessPreferredCount),
+		LeaseTransferSuccessCount:        metric.NewCounter(metaLeaseTransferSuccessCount),
+		LeaseTransferErrorCount:          metric.NewCounter(metaLeaseTransferErrorCount),
+		LeaseTransferLocksWritten:        metric.NewCounter(metaLeaseTransferLocksWrittenCount),
+		ReadSummaryLocalCompressionCount: metric.NewCounter(metaReadSummaryLocalCompressionCount),
+		LeaseExpirationCount:             metric.NewGauge(metaLeaseExpirationCount),
+		LeaseEpochCount:                  metric.NewGauge(metaLeaseEpochCount),
+		LeaseLeaderCount:                 metric.NewGauge(metaLeaseLeaderCount),
+		LeaseLivenessCount:               metric.NewGauge(metaLeaseLivenessCount),
+		LeaseViolatingPreferencesCount:   metric.NewGauge(metaLeaseViolatingPreferencesCount),
+		LeaseLessPreferredCount:          metric.NewGauge(metaLeaseLessPreferredCount),
 
 		// Intent resolution metrics.
 		ResolveCommitCount: metric.NewCounter(metaResolveCommit),

--- a/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
+++ b/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
@@ -1335,6 +1335,7 @@ leases_leader: leases.leader
 leases_liveness: leases.liveness
 leases_preferences_less_preferred: leases.preferences.less_preferred
 leases_preferences_violating: leases.preferences.violating
+leases_read_summary_local_compression: leases.read_summary.local_compression
 leases_requests_latency: leases.requests.latency
 leases_requests_latency_bucket: leases.requests.latency.bucket
 leases_requests_latency_count: leases.requests.latency.count


### PR DESCRIPTION
We only do so for the local segment as, by default, we always compress the global segment of the timestamp cache. This should help point to the timestamp cache losing precision upon lease transfers or range merges.

Epic: none

Release note: None