### PR TITLE
builtins: rename inject_hint and move to information_schema

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -3369,6 +3369,15 @@ may increase either contention or retry errors, or both.</p>
 </span></td><td>Volatile</td></tr></tbody>
 </table>
 
+### System repair functions
+
+<table>
+<thead><tr><th>Function &rarr; Returns</th><th>Description</th><th>Volatility</th></tr></thead>
+<tbody>
+<tr><td><a name="information_schema.crdb_rewrite_inline_hints"></a><code>information_schema.crdb_rewrite_inline_hints(statement_fingerprint: <a href="string.html">string</a>, donor_sql: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function adds an inline-hints rewrite rule for a statement fingerprint. It returns the hint ID of the newly created rewrite rule. The rewrite rule only applies to matching statement fingerprints. It first removes all inline hints from the target statement, and then copies inline hints from the donor statement.</p>
+</span></td><td>Volatile</td></tr></tbody>
+</table>
+
 ### TIMETZ functions
 
 <table>

--- a/pkg/sql/logictest/testdata/logic_test/statement_hint_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/statement_hint_builtins
@@ -953,3 +953,22 @@ SELECT information_schema.crdb_rewrite_inline_hints('', '')
 
 statement error pq: could not parse hint donor statement as a single SQL statement
 SELECT information_schema.crdb_rewrite_inline_hints('SELECT 1', 'SELECT 2; SELECT 3')
+
+# Test privilege checks for information_schema.crdb_rewrite_inline_hints.
+
+user testuser
+
+statement error user testuser does not have REPAIRCLUSTER system privilege
+SELECT information_schema.crdb_rewrite_inline_hints('SELECT _', 'SELECT _')
+
+user root
+
+statement ok
+GRANT SYSTEM REPAIRCLUSTER TO testuser
+
+user testuser
+
+statement ok
+SELECT information_schema.crdb_rewrite_inline_hints('SELECT _', 'SELECT _')
+
+user root

--- a/pkg/sql/logictest/testdata/logic_test/statement_hint_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/statement_hint_builtins
@@ -27,7 +27,7 @@ SELECT count(*) FROM system.statement_hints;
 0
 
 let $hint1
-SELECT crdb_internal.inject_hint(
+SELECT information_schema.crdb_rewrite_inline_hints(
   'SELECT * FROM xy WHERE y = 10',
   'SELECT * FROM xy@primary WHERE y = 10'
 );
@@ -39,7 +39,7 @@ SELECT fingerprint FROM system.statement_hints WHERE row_id = $hint1;
 SELECT * FROM xy WHERE y = 10
 
 let $hint2
-SELECT crdb_internal.inject_hint(
+SELECT information_schema.crdb_rewrite_inline_hints(
   'SELECT * FROM xy WHERE y = 10',
   'SELECT * FROM xy@xy_y_idx WHERE y = 10'
 );
@@ -51,7 +51,7 @@ SELECT fingerprint FROM system.statement_hints WHERE row_id = $hint2;
 SELECT * FROM xy WHERE y = 10
 
 let $hint3
-SELECT crdb_internal.inject_hint(
+SELECT information_schema.crdb_rewrite_inline_hints(
   'SELECT * FROM xy INNER JOIN ab ON xy.x = ab.b',
   'SELECT * FROM xy INNER JOIN ab ON xy.x = ab.b'
 );
@@ -90,7 +90,7 @@ statement ok
 BEGIN;
 
 let $hint4
-SELECT crdb_internal.inject_hint(
+SELECT information_schema.crdb_rewrite_inline_hints(
   'SELECT * FROM xy WHERE y = 10',
   'SELECT * FROM xy@{NO_FULL_SCAN} WHERE y = 10'
 );
@@ -111,7 +111,7 @@ SELECT count(*) FROM system.statement_hints;
 # Test that hints are loaded for matching statements.
 
 statement ok
-SELECT crdb_internal.inject_hint(
+SELECT information_schema.crdb_rewrite_inline_hints(
   'SELECT * FROM xy WHERE x > y',
   'SELECT * FROM xy WHERE x > y'
 )
@@ -197,12 +197,12 @@ WHERE feature_name = 'sql.session.statement-hints'
 statement ok
 DEALLOCATE ALL
 
-# Testcases for hint injection.
+# Testcases for inline hint rewriting.
 
 statement ok
 CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT, INDEX (b))
 
-# Try some simple hint injections. First, an index hint.
+# Try some simple hint rewrites. First, add an index hint.
 
 onlyif config local
 query T
@@ -216,7 +216,7 @@ distribution: local
   spans: [/10 - /10]
 
 statement ok
-SELECT crdb_internal.inject_hint(
+SELECT information_schema.crdb_rewrite_inline_hints(
   'SELECT a FROM abc WHERE a = _',
   'SELECT a FROM abc@abc_b_idx WHERE a = _'
 )
@@ -274,7 +274,7 @@ distribution: local
       spans: [/10 - /10]
 
 statement ok
-SELECT crdb_internal.inject_hint(
+SELECT information_schema.crdb_rewrite_inline_hints(
   'SELECT a, x FROM abc JOIN xy ON y = b WHERE a = _',
   'SELECT a, x FROM abc INNER HASH JOIN xy ON y = b WHERE a = _'
 )
@@ -323,7 +323,7 @@ statement hints count: 1
 # Try removing a hint.
 
 statement ok
-SELECT crdb_internal.inject_hint(
+SELECT information_schema.crdb_rewrite_inline_hints(
   'SELECT a FROM abc@abc_pkey WHERE b = _',
   'SELECT a FROM abc WHERE b = _'
 )
@@ -363,7 +363,7 @@ statement hints count: 1
 # Check that we do not use an invalid injected index hint.
 
 statement ok
-SELECT crdb_internal.inject_hint(
+SELECT information_schema.crdb_rewrite_inline_hints(
   'SELECT a + _ FROM abc WHERE a = _',
   'SELECT a + _ FROM abc@foo WHERE a = _'
 )
@@ -407,7 +407,7 @@ statement hints count: 1
 # Check that we do not use an unsatisfiable injected hint.
 
 statement ok
-SELECT crdb_internal.inject_hint(
+SELECT information_schema.crdb_rewrite_inline_hints(
   'SELECT c FROM xy JOIN abc ON c = y WHERE x = _',
   'SELECT c FROM xy INNER LOOKUP JOIN abc ON c = y WHERE x = _'
 )
@@ -458,7 +458,7 @@ statement hints count: 1
 # Try a prepared statement with an injected hint.
 
 let $hint_p1
-SELECT crdb_internal.inject_hint(
+SELECT information_schema.crdb_rewrite_inline_hints(
   'SELECT c FROM abc WHERE b > _',
   'SELECT c FROM abc@{NO_INDEX_JOIN} WHERE b > _'
 )
@@ -505,7 +505,7 @@ FROM [SHOW TRACE FOR SESSION]
 WHERE message LIKE '%injected hints%'
 
 statement ok
-SELECT crdb_internal.inject_hint(
+SELECT information_schema.crdb_rewrite_inline_hints(
   'SELECT c + _ FROM abc WHERE b > _',
   'SELECT c + _ FROM abc@{FORCE_INDEX=abc_pkey,DESC} WHERE b > _'
 )
@@ -557,7 +557,7 @@ WHERE message LIKE '%injected hints%'
 # statement.
 
 statement ok
-SELECT crdb_internal.inject_hint(
+SELECT information_schema.crdb_rewrite_inline_hints(
   'SELECT sum(a) FROM abc WHERE c = _',
   'SELECT sum(a) FROM abc@abc_foo WHERE c = _'
 )
@@ -595,7 +595,7 @@ falling back to planning without injected hints
 # statement.
 
 statement ok
-SELECT crdb_internal.inject_hint(
+SELECT information_schema.crdb_rewrite_inline_hints(
   'SELECT max(a) FROM abc WHERE (b = _) AND (c = _)',
   'SELECT max(a) FROM abc@{FORCE_ZIGZAG} WHERE (b = _) AND (c = _)'
 )
@@ -633,7 +633,7 @@ statement ok
 SET plan_cache_mode = force_generic_plan
 
 statement ok
-SELECT crdb_internal.inject_hint(
+SELECT information_schema.crdb_rewrite_inline_hints(
   'SELECT a * _ FROM abc WHERE b > _',
   'SELECT a * _ FROM abc@abc_pkey WHERE b > _'
 )
@@ -674,7 +674,7 @@ statement ok
 SET plan_cache_mode = auto
 
 statement ok
-SELECT crdb_internal.inject_hint(
+SELECT information_schema.crdb_rewrite_inline_hints(
   'SELECT a - b FROM abc WHERE b = _',
   'SELECT a - b FROM abc@abc_pkey WHERE b = _'
 )
@@ -735,40 +735,40 @@ RESET plan_cache_mode
 statement ok
 DEALLOCATE ALL
 
-# Test basic validation when calling crdb_internal.inject_hint.
+# Test basic validation when calling information_schema.crdb_rewrite_inline_hints.
 
 statement error could not parse statement fingerprint: at or near "foo": syntax error
-SELECT crdb_internal.inject_hint(
+SELECT information_schema.crdb_rewrite_inline_hints(
   'foo',
   'SELECT a FROM ab'
 )
 
 statement error could not parse hint donor statement: at or near "foo": syntax error
-SELECT crdb_internal.inject_hint(
+SELECT information_schema.crdb_rewrite_inline_hints(
   'SELECT a FROM ab',
   'foo'
 )
 
 statement error statement does not match hint donor statement: SELECT a FROM ab vs SELECT b FROM ab
-SELECT crdb_internal.inject_hint(
+SELECT information_schema.crdb_rewrite_inline_hints(
   'SELECT a FROM ab',
   'SELECT b FROM ab'
 )
 
 statement error hint injection donor statement AST node \$1 did not match AST node 5
-SELECT crdb_internal.inject_hint(
+SELECT information_schema.crdb_rewrite_inline_hints(
   'SELECT a FROM ab WHERE b = 5',
   'SELECT a FROM ab WHERE b = $1'
 )
 
 statement ok
-SELECT crdb_internal.inject_hint(
+SELECT information_schema.crdb_rewrite_inline_hints(
   'SELECT a FROM ab WHERE b = 5',
   'SELECT a FROM ab WHERE b = _'
 )
 
 statement ok
-SELECT crdb_internal.inject_hint(
+SELECT information_schema.crdb_rewrite_inline_hints(
   'SELECT b FROM ab WHERE a = $1',
   'SELECT b FROM ab WHERE a = _'
 )
@@ -793,7 +793,7 @@ distribution: local
       spans: [/10 - /10]
 
 statement ok
-SELECT crdb_internal.inject_hint(
+SELECT information_schema.crdb_rewrite_inline_hints(
   'SELECT y FROM abc JOIN xy ON x = b WHERE a = _',
   'SELECT y FROM abc INNER HASH JOIN xy ON x = b WHERE a = _'
 )
@@ -824,7 +824,7 @@ statement hints count: 1
       spans: FULL SCAN
 
 statement ok
-SELECT crdb_internal.inject_hint(
+SELECT information_schema.crdb_rewrite_inline_hints(
   'SELECT y FROM abc JOIN xy ON x = b WHERE a = _',
   'SELECT y FROM abc@abc_b_idx JOIN xy ON x = b WHERE a = _'
 )
@@ -852,11 +852,11 @@ statement hints count: 1
           table: abc@abc_b_idx
           spans: FULL SCAN
 
-# Even if the newest hint injection doesn't work for some reason, we should
-# still only consider that newest hint injection.
+# Even if the newest hint rewrite doesn't work for some reason, we should
+# still only consider that newest hint rewrite.
 
 statement ok
-SELECT crdb_internal.inject_hint(
+SELECT information_schema.crdb_rewrite_inline_hints(
   'SELECT y FROM abc JOIN xy ON x = b WHERE a = _',
   'SELECT y FROM abc JOIN xy@xy_z_idx ON x = b WHERE a = _'
 )
@@ -900,20 +900,20 @@ statement hints count: 1
       table: abc@abc_pkey
       spans: [/10 - /10]
 
-# If there are multiple hint injections for the same fingerprint added in the
+# If there are multiple hint rewrites for the same fingerprint added in the
 # same transaction, we should pick the last one added.
 
 statement ok
 BEGIN
 
 statement ok
-SELECT crdb_internal.inject_hint(
+SELECT information_schema.crdb_rewrite_inline_hints(
   'SELECT y FROM abc JOIN xy ON x = b WHERE a = _',
   'SELECT y FROM abc JOIN xy@xy_y_idx ON x = b WHERE a = _'
 )
 
 statement ok
-SELECT crdb_internal.inject_hint(
+SELECT information_schema.crdb_rewrite_inline_hints(
   'SELECT y FROM abc JOIN xy ON x = b WHERE a = _',
   'SELECT y FROM abc INNER MERGE JOIN xy ON x = b WHERE a = _'
 )
@@ -946,10 +946,10 @@ statement hints count: 1
       table: xy@xy_pkey
       spans: FULL SCAN
 
-# Test error handling for crdb_internal.inject_hint.
+# Test error handling for information_schema.crdb_rewrite_inline_hints.
 
 statement error pq: could not parse statement fingerprint as a single SQL statement
-SELECT crdb_internal.inject_hint('', '')
+SELECT information_schema.crdb_rewrite_inline_hints('', '')
 
 statement error pq: could not parse hint donor statement as a single SQL statement
-SELECT crdb_internal.inject_hint('SELECT 1', 'SELECT 2; SELECT 3')
+SELECT information_schema.crdb_rewrite_inline_hints('SELECT 1', 'SELECT 2; SELECT 3')

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -2518,7 +2518,7 @@ statement ok
 CREATE TABLE t_hints (k INT PRIMARY KEY, v INT, INDEX (v))
 
 statement ok
-SELECT crdb_internal.inject_hint(
+SELECT information_schema.crdb_rewrite_inline_hints(
   'SELECT k FROM t_hints WHERE k >= _',
   'SELECT k FROM t_hints@t_hints_v_idx WHERE k >= _'
 )

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze
@@ -220,7 +220,7 @@ regions: <hidden>
 
 # Verify that the number of applied statement hints is displayed.
 statement ok
-SELECT crdb_internal.inject_hint(
+SELECT information_schema.crdb_rewrite_inline_hints(
   'SELECT k FROM kv WHERE k >= _',
   'SELECT k FROM kv@kv_v_idx WHERE k >= _'
 )

--- a/pkg/sql/pgwire/testdata/pgtest/procedure
+++ b/pkg/sql/pgwire/testdata/pgtest/procedure
@@ -66,9 +66,9 @@ Query {"String": "CALL p()"}
 until
 ReadyForQuery
 ----
-{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"foo","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func381","UnknownFields":null}
-{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"bar","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func381","UnknownFields":null}
-{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"baz","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func381","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"foo","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func382","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"bar","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func382","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"baz","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func382","UnknownFields":null}
 {"Type":"CommandComplete","CommandTag":"CALL"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
@@ -84,8 +84,8 @@ ReadyForQuery
 ----
 {"Type":"ParseComplete"}
 {"Type":"BindComplete"}
-{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"foo","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func381","UnknownFields":null}
-{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"bar","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func381","UnknownFields":null}
-{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"baz","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func381","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"foo","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func382","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"bar","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func382","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"baz","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func382","UnknownFields":null}
 {"Type":"CommandComplete","CommandTag":"CALL"}
 {"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -12836,6 +12836,13 @@ var rewriteInlineHintsOverload = tree.Overload{
 	},
 	ReturnType: tree.FixedReturnType(types.Int),
 	Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+		// The user must have REPAIRCLUSTER to use this builtin.
+		if err := evalCtx.SessionAccessor.CheckPrivilege(
+			ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.REPAIRCLUSTER,
+		); err != nil {
+			return nil, err
+		}
+
 		stmtFingerprint := string(tree.MustBeDString(args[0]))
 		donorSQL := string(tree.MustBeDString(args[1]))
 

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -9676,90 +9676,17 @@ WHERE object_id = table_descriptor_id
 
 	"crdb_internal.inject_hint": makeBuiltin(
 		tree.FunctionProperties{
-			Category:         builtinconstants.CategorySystemInfo,
+			Category:         builtinconstants.CategorySystemRepair,
 			DistsqlBlocklist: true,
 		},
-		tree.Overload{
-			Types: tree.ParamTypes{
-				{Name: "statement_fingerprint", Typ: types.String},
-				{Name: "donor_sql", Typ: types.String},
-			},
-			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				stmtFingerprint := string(tree.MustBeDString(args[0]))
-				donorSQL := string(tree.MustBeDString(args[1]))
-
-				// Validate that the donor statement matches the target statement
-				// without hints.
-				fingerprintFlags := tree.FmtFlags(tree.QueryFormattingForFingerprintsMask.Get(
-					&evalCtx.Settings.SV,
-				))
-				stmts, err := parserutils.Parse(stmtFingerprint)
-				if err != nil {
-					return nil, pgerror.Wrap(
-						err, pgcode.InvalidParameterValue, "could not parse statement fingerprint",
-					)
-				}
-				if len(stmts) != 1 {
-					return nil, pgerror.New(
-						pgcode.InvalidParameterValue,
-						"could not parse statement fingerprint as a single SQL statement",
-					)
-				}
-				targetStmt := stmts[0]
-				stmts, err = parserutils.Parse(donorSQL)
-				if err != nil {
-					return nil, pgerror.Wrap(
-						err, pgcode.InvalidParameterValue, "could not parse hint donor statement",
-					)
-				}
-				if len(stmts) != 1 {
-					return nil, pgerror.New(
-						pgcode.InvalidParameterValue,
-						"could not parse hint donor statement as a single SQL statement",
-					)
-				}
-				donorStmt := stmts[0]
-				donor, err := tree.NewHintInjectionDonor(donorStmt.AST, fingerprintFlags)
-				if err != nil {
-					return nil, errors.NewAssertionErrorWithWrappedErrf(err, "error while creating donor")
-				}
-				if err := donor.Validate(targetStmt.AST, fingerprintFlags); err != nil {
-					return nil, pgerror.WithCandidateCode(err, pgcode.InvalidParameterValue)
-				}
-
-				// Do a trial hint injection to validate that the target statement gets
-				// rewritten into the donor statement.
-				result, _, err := donor.InjectHints(targetStmt.AST)
-				if err != nil {
-					return nil, pgerror.WithCandidateCode(err, pgcode.InvalidParameterValue)
-				}
-				// Either the target statement or the donor statement could be
-				// non-fingerprint or fingerprint, so for an apples-to-apples comparison
-				// we need to convert both to fingerprints.
-				resultFingerprint := tree.FormatStatementHideConstants(result, fingerprintFlags)
-				donorFingerprint := tree.FormatStatementHideConstants(donorStmt.AST, fingerprintFlags)
-				if resultFingerprint != donorFingerprint {
-					return nil, pgerror.Newf(
-						pgcode.InvalidParameterValue,
-						"could not validate that target statement is rewritten as donor statement (%s): %s",
-						donorFingerprint, resultFingerprint,
-					)
-				}
-
-				// Insert into statement_hints.
-				var hint hintpb.StatementHintUnion
-				hint.SetValue(&hintpb.InjectHints{DonorSQL: donorSQL})
-				hintID, err := evalCtx.Planner.InsertStatementHint(ctx, stmtFingerprint, hint)
-				if err != nil {
-					return nil, err
-				}
-				return tree.NewDInt(tree.DInt(hintID)), nil
-			},
-			Info: "This function is used to build a serialized statement hint to be inserted into" +
-				" the system.statement_hints table. It returns the hint ID of the newly created hint.",
-			Volatility: volatility.Volatile,
+		rewriteInlineHintsOverload,
+	),
+	"information_schema.crdb_rewrite_inline_hints": makeBuiltin(
+		tree.FunctionProperties{
+			Category:         builtinconstants.CategorySystemRepair,
+			DistsqlBlocklist: true,
 		},
+		rewriteInlineHintsOverload,
 	),
 	"crdb_internal.clear_statement_hints_cache": makeBuiltin(
 		tree.FunctionProperties{
@@ -12901,3 +12828,88 @@ var datumsToBytesOverload = tree.Overload{
 }
 
 var nilRegionsError = errors.AssertionFailedf("evalCtx.Regions is nil")
+
+var rewriteInlineHintsOverload = tree.Overload{
+	Types: tree.ParamTypes{
+		{Name: "statement_fingerprint", Typ: types.String},
+		{Name: "donor_sql", Typ: types.String},
+	},
+	ReturnType: tree.FixedReturnType(types.Int),
+	Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+		stmtFingerprint := string(tree.MustBeDString(args[0]))
+		donorSQL := string(tree.MustBeDString(args[1]))
+
+		// Validate that the donor statement matches the target statement
+		// without hints.
+		fingerprintFlags := tree.FmtFlags(tree.QueryFormattingForFingerprintsMask.Get(
+			&evalCtx.Settings.SV,
+		))
+		stmts, err := parserutils.Parse(stmtFingerprint)
+		if err != nil {
+			return nil, pgerror.Wrap(
+				err, pgcode.InvalidParameterValue, "could not parse statement fingerprint",
+			)
+		}
+		if len(stmts) != 1 {
+			return nil, pgerror.New(
+				pgcode.InvalidParameterValue,
+				"could not parse statement fingerprint as a single SQL statement",
+			)
+		}
+		targetStmt := stmts[0]
+		stmts, err = parserutils.Parse(donorSQL)
+		if err != nil {
+			return nil, pgerror.Wrap(
+				err, pgcode.InvalidParameterValue, "could not parse hint donor statement",
+			)
+		}
+		if len(stmts) != 1 {
+			return nil, pgerror.New(
+				pgcode.InvalidParameterValue,
+				"could not parse hint donor statement as a single SQL statement",
+			)
+		}
+		donorStmt := stmts[0]
+		donor, err := tree.NewHintInjectionDonor(donorStmt.AST, fingerprintFlags)
+		if err != nil {
+			return nil, errors.NewAssertionErrorWithWrappedErrf(err, "error while creating donor")
+		}
+		if err := donor.Validate(targetStmt.AST, fingerprintFlags); err != nil {
+			return nil, pgerror.WithCandidateCode(err, pgcode.InvalidParameterValue)
+		}
+
+		// Do a trial hint injection to validate that the target statement gets
+		// rewritten into the donor statement.
+		result, _, err := donor.InjectHints(targetStmt.AST)
+		if err != nil {
+			return nil, pgerror.WithCandidateCode(err, pgcode.InvalidParameterValue)
+		}
+		// Either the target statement or the donor statement could be
+		// non-fingerprint or fingerprint, so for an apples-to-apples comparison
+		// we need to convert both to fingerprints.
+		resultFingerprint := tree.FormatStatementHideConstants(result, fingerprintFlags)
+		donorFingerprint := tree.FormatStatementHideConstants(donorStmt.AST, fingerprintFlags)
+		if resultFingerprint != donorFingerprint {
+			return nil, pgerror.Newf(
+				pgcode.InvalidParameterValue,
+				"could not validate that target statement is rewritten as donor statement (%s): %s",
+				donorFingerprint, resultFingerprint,
+			)
+		}
+
+		// Insert into statement_hints.
+		var hint hintpb.StatementHintUnion
+		hint.SetValue(&hintpb.InjectHints{DonorSQL: donorSQL})
+		hintID, err := evalCtx.Planner.InsertStatementHint(ctx, stmtFingerprint, hint)
+		if err != nil {
+			return nil, err
+		}
+
+		return tree.NewDInt(tree.DInt(hintID)), nil
+	},
+	Info: `This function adds an inline-hints rewrite rule for a statement fingerprint. It ` +
+		`returns the hint ID of the newly created rewrite rule. The rewrite rule only applies to ` +
+		`matching statement fingerprints. It first removes all inline hints from the target ` +
+		`statement, and then copies inline hints from the donor statement.`,
+	Volatility: volatility.Volatile,
+}

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2864,6 +2864,7 @@ var builtinOidsArray = []string{
 	2909: `crdb_internal.clear_statement_hints_cache() -> void`,
 	2910: `crdb_internal.await_statement_hints_cache() -> void`,
 	2911: `information_schema.crdb_datums_to_bytes(any...) -> bytes`,
+	2912: `information_schema.crdb_rewrite_inline_hints(statement_fingerprint: string, donor_sql: string) -> int`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid


### PR DESCRIPTION
**builtins: rename inject_hint and move to information_schema**

Fixes: #160577
Fixes: #160712

Release note (sql change): In v26.1.0-alpha.2 the new builtin function `crdb_internal.inject_hint` was introduced. This function is now renamed `information_schema.crdb_rewrite_inline_hints` to better reflect its intention.

---

**builtins: add privilege check to information_schema.crdb_rewrite_inline_hints**

Release note (sql change): Calling `information_schema.crdb_rewrite_inline_hints` now requires the REPAIRCLUSTER privilege.