### PR TITLE
sql: support resume during distributed merge index backfill

### DIFF
--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -880,6 +880,15 @@ message BackfillProgress {
   // distributed-merge SSTs for this backfill. These prefixes are used to clean
   // up job-scoped files on completion or cancellation.
   repeated string sst_storage_prefixes = 7 [(gogoproto.customname) = "SSTStoragePrefixes"];
+
+  // DistributedMergePhase tracks backfill progress through the distributed merge
+  // pipeline. This field is only meaningful when the job is using the pipeline,
+  // which is stored separately in DistributedMergeMode.
+  //
+  // Values:
+  //   0: Map phase complete, no merge iterations completed yet.
+  //   N (N >= 1): Merge iteration N completed.
+  int32 distributed_merge_phase = 8;
 }
 
 // IndexBackfillSSTManifest describes an SST produced by the backfill map stage.

--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -247,6 +247,11 @@ type TestingKnobs struct {
 	// progress for a single index backfill.
 	RunBeforeIndexBackfillProgressUpdate func(ctx context.Context, completed []roachpb.Span)
 
+	// AfterDistributedMergeMapPhase is called after the map phase of a distributed
+	// merge index backfill completes, before any merge iterations begin. It receives
+	// the SST manifests produced by the map phase.
+	AfterDistributedMergeMapPhase func(ctx context.Context, manifests []jobspb.IndexBackfillSSTManifest)
+
 	// AfterDistributedMergeIteration is called after each iteration of a
 	// distributed merge during index backfill. It receives the iteration number
 	// and the current SST manifests.

--- a/pkg/sql/schemachanger/scexec/backfiller/progress.go
+++ b/pkg/sql/schemachanger/scexec/backfiller/progress.go
@@ -31,13 +31,14 @@ func convertToJobBackfillProgress(
 			return nil, err
 		}
 		ret = append(ret, jobspb.BackfillProgress{
-			TableID:            bp.TableID,
-			SourceIndexID:      bp.SourceIndexID,
-			DestIndexIDs:       bp.DestIndexIDs,
-			WriteTimestamp:     bp.MinimumWriteTimestamp,
-			CompletedSpans:     strippedSpans,
-			SSTManifests:       manifests,
-			SSTStoragePrefixes: bp.SSTStoragePrefixes,
+			TableID:               bp.TableID,
+			SourceIndexID:         bp.SourceIndexID,
+			DestIndexIDs:          bp.DestIndexIDs,
+			WriteTimestamp:        bp.MinimumWriteTimestamp,
+			CompletedSpans:        strippedSpans,
+			SSTManifests:          manifests,
+			SSTStoragePrefixes:    bp.SSTStoragePrefixes,
+			DistributedMergePhase: bp.DistributedMergePhase,
 		})
 	}
 	return ret, nil
@@ -58,6 +59,7 @@ func convertFromJobBackfillProgress(
 			CompletedSpans:        addTenantPrefixToSpans(codec, bp.CompletedSpans),
 			SSTManifests:          backfill.AddTenantPrefixToSSTManifests(codec, bp.SSTManifests),
 			SSTStoragePrefixes:    bp.SSTStoragePrefixes,
+			DistributedMergePhase: bp.DistributedMergePhase,
 		})
 	}
 	return ret

--- a/pkg/sql/schemachanger/scexec/dependencies.go
+++ b/pkg/sql/schemachanger/scexec/dependencies.go
@@ -285,6 +285,12 @@ type BackfillProgress struct {
 	// distributed-merge SSTs for this backfill. These prefixes are used to clean
 	// up job-scoped files on completion or cancellation.
 	SSTStoragePrefixes []string
+
+	// DistributedMergePhase tracks backfill progress through the distributed
+	// merge pipeline. Values: 0 = map complete/no merge iterations done,
+	// N (N >= 1) = merge iteration N completed.
+	// See jobspb.BackfillProgress.DistributedMergePhase for full semantics.
+	DistributedMergePhase int32
 }
 
 // Backfill corresponds to a definition of a backfill from a source


### PR DESCRIPTION
This commit implements resume support for the distributed merge index backfill pipeline. Previously, if a job was paused during the merge phase, resuming would fail because the system didn't know how to restart the merge process with existing SST manifests.

Added DistributedMergePhase field in BackfillProgress to track whether the job is in the map phase (0) or merge phase (1+). This is persisted to the job payload so we know what to do on resume.

When resuming if we got past the initial map phase, we will simply do one final merge iteration to the KV. I chose this approach to minimize the amount of state needed in the backfill protobuf. Properly restarting multiple merge iterations would require tracking the original maxIterations value and handling edge cases where the cluster setting changes between PAUSE and RESUME. Since we currently use a single merge iteration by default, this complexity isn't warranted yet.

Closes: #158338
Release note: none
Epic: CRDB-48845