### PR TITLE
release-26.1: lease: Prevent infinite retries when acquiring leases during server quiescing

### DIFF
--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -1171,6 +1171,8 @@ func (m *Manager) completeBulkAcquisition(id descpb.ID) {
 // basis, where missing descriptors, dropped, adding, or validation errors will
 // be ignored.
 func (m *Manager) EnsureBatch(ctx context.Context, ids []descpb.ID) error {
+	ctx, cancel := m.stopper.WithCancelOnQuiesce(ctx)
+	defer cancel()
 	maxBatchSize := MaxBatchLeaseCount.Get(&m.storage.settings.SV)
 	idsToFetch := make([]descpb.ID, 0, min(len(ids), int(maxBatchSize)))
 	lastVersion := make([]descpb.DescriptorVersion, cap(idsToFetch))


### PR DESCRIPTION
Backport 1/1 commits from #160658 on behalf of @alyshanjahani-crl.

----

This commit uses stopper.WithCancelOnQuiesce in EnsureBatch so that if
a node is trying to acquire leases during server shutdown it does not get
stuck in an infinite loop.

See this test failure in which a crdb_internal query was trying to acquire
leases and was indefinitley retrying (and failing).

https://github.com/cockroachdb/cockroach/issues/160117

Fixes: https://github.com/cockroachdb/cockroach/issues/160117
Release note: None

----

Release justification: fix for a new 26.1 feature