### PR TITLE
release-26.1: physical: deflake TestAlterTenantAddReader

### DIFF
--- a/pkg/crosscluster/physical/alter_replication_job_test.go
+++ b/pkg/crosscluster/physical/alter_replication_job_test.go
@@ -137,6 +137,15 @@ func TestAlterTenantAddReader(t *testing.T) {
 	c.DestSysSQL.CheckQueryResults(t, "SELECT name, data_state FROM [SHOW TENANTS] ORDER BY name",
 		[][]string{{"destination", "replicating"}, {"destination-readonly", "ready"}, {"system", "ready"}},
 	)
+
+	testutils.SucceedsSoon(t, func() error {
+		readonlyConn, err := c.DestSysServer.SQLConnE(serverutils.DBName("cluster:destination-readonly"))
+		if err != nil {
+			return err
+		}
+		defer readonlyConn.Close()
+		return readonlyConn.PingContext(ctx)
+	})
 }
 
 func TestAlterTenantPauseResume(t *testing.T) {


### PR DESCRIPTION
Backport 1/1 commits from #160345 on behalf of @kev-cao.

----

This updates the `TestAlterTenantAddReader` test to wait for the readonly standby tenant to start up its SQL server before shutting down.

Fixes: #160217

Release note: None

----

Release justification: Test-only change