### PR TITLE
release-26.1: sql/pgwire: deflake TestPGTest

### DIFF
--- a/pkg/sql/pgwire/testdata/pgtest/portals_crbugs
+++ b/pkg/sql/pgwire/testdata/pgtest/portals_crbugs
@@ -117,6 +117,29 @@ ReadyForQuery
 {"Type":"CommandComplete","CommandTag":"CREATE ROLE"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
+# Explicitly wait for one version, since we don't handle transaction
+# retries in this test.
+# Note: Normally in logictest we could run a query with retry, but that is not an
+# option here.
+send
+Query {"String": "CREATE PROCEDURE wait_for_one_version() AS $$ DECLARE result INT; attempt INT := 0; BEGIN LOOP SELECT count(*) INTO result FROM system.lease WHERE desc_id = (select id from system.namespace where name='users') GROUP BY desc_id, version; EXIT WHEN result = 1; EXIT WHEN attempt > 100; SELECT pg_sleep(0.1); attempt := attempt + 1; COMMIT; END LOOP; END; $$ LANGUAGE PLpgSQL;"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"CREATE PROCEDURE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "CALL wait_for_one_version()"}
+----
+
+receive
+ReadyForQuery
+----
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
 send
 Query {"String": "BEGIN"}
 Query {"String": "SET LOCAL autocommit_before_ddl=off"}


### PR DESCRIPTION
Backport 1/1 commits from #160553 on behalf of @fqazi.

----

Previously, portals_crbugs could flake because it performed back-to-back
schema changes on roles within an explicit transaction. When a privilege
schema change is executed, we only wait for the new version; if another
schema change immediately follows, it runs the risk of hitting a
retryable error. Because this test cannot retry explicit transactions,
it would fail if the "two-version" invariant was violated. This patch
uses a stored procedure to check for this invariant to be satisfied
before starting the next transaction.

Fixes: https://github.com/cockroachdb/cockroach/issues/159784
Fixes: https://github.com/cockroachdb/cockroach/issues/160418

Release note: None

----

Release justification: test only change