### PR TITLE
mma: small logging fixes

### DIFF
--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
@@ -443,6 +443,7 @@ func MakeReplicaTypeChange(
 // removing another. If the replica being rebalanced is the current
 // leaseholder, the impact of the rebalance also includes the lease load.
 func makeRebalanceReplicaChanges(
+	ctx context.Context,
 	rangeID roachpb.RangeID,
 	existingReplicas []StoreIDAndReplicaState,
 	rLoad RangeLoad,
@@ -455,7 +456,7 @@ func makeRebalanceReplicaChanges(
 		}
 	}
 	if remove == (StoreIDAndReplicaState{}) {
-		log.KvDistribution.Fatalf(context.Background(), "remove target %s not in existing replicas", removeTarget)
+		log.KvDistribution.Fatalf(ctx, "remove target %s not in existing replicas", removeTarget)
 	}
 
 	addIDAndType := ReplicaIDAndType{
@@ -1311,7 +1312,7 @@ func newClusterState(ts timeutil.TimeSource, interner *stringInterner) *clusterS
 
 func (cs *clusterState) processStoreLoadMsg(ctx context.Context, storeMsg *StoreLoadMsg) {
 	now := cs.ts.Now()
-	cs.gcPendingChanges(now)
+	cs.gcPendingChanges(ctx, now)
 
 	ns := cs.nodes[storeMsg.NodeID]
 	ss := cs.stores[storeMsg.StoreID]
@@ -1487,7 +1488,7 @@ func (cs *clusterState) processRangeMsg(
 	// rs.pendingChanges is the union of remainingChanges and enactedChanges.
 	// These changes are also in cs.pendingChanges.
 	if len(enactedChanges) > 0 {
-		log.KvDistribution.Infof(ctx, "enactedChanges %v", enactedChanges)
+		log.KvDistribution.VEventf(ctx, 2, "enactedChanges %v", enactedChanges)
 	}
 	for _, change := range enactedChanges {
 		// Mark the change as enacted. Enacting a change does not remove the
@@ -1512,7 +1513,7 @@ func (cs *clusterState) processRangeMsg(
 	// effect is also incorporated into the storeStates, but not in the range
 	// membership (since we undid that above).
 	if len(remainingChanges) > 0 {
-		log.KvDistribution.Infof(ctx, "remainingChanges %v", remainingChanges)
+		log.KvDistribution.VEventf(ctx, 2, "remainingChanges %v", remainingChanges)
 		// Temporarily set the rs.pendingChanges to nil, since
 		// preCheckOnApplyReplicaChanges returns false if there are any pending
 		// changes, and these are the changes that are pending. This is hacky
@@ -1536,7 +1537,7 @@ func (cs *clusterState) processRangeMsg(
 			// pendingChanges data-structures, which is what we want here since
 			// these changes are already in those data-structures.
 			for _, change := range remainingChanges {
-				cs.applyReplicaChange(change.ReplicaChange, false)
+				cs.applyReplicaChange(ctx, change.ReplicaChange, false)
 			}
 		} else {
 			reason := redact.Sprint(err)
@@ -1544,7 +1545,7 @@ func (cs *clusterState) processRangeMsg(
 			// changes, so we need to drop them. This should be rare, but can happen
 			// if the leaseholder executed a change that MMA was completely unaware
 			// of.
-			log.KvDistribution.Infof(ctx, "remainingChanges %v are no longer valid due to %v",
+			log.KvDistribution.VEventf(ctx, 2, "remainingChanges %v are no longer valid due to %v",
 				remainingChanges, reason)
 			if metrics != nil {
 				metrics.DroppedDueToStateInconsistency.Inc(1)
@@ -1586,7 +1587,7 @@ func (cs *clusterState) processStoreLeaseholderMsgInternal(
 	metrics *rangeOperationMetrics,
 ) {
 	now := cs.ts.Now()
-	cs.gcPendingChanges(now)
+	cs.gcPendingChanges(ctx, now)
 
 	clear(cs.scratchRangeMap)
 	totalErrorCount := 0
@@ -1830,7 +1831,7 @@ const pendingLeaseTransferGCDuration = 1 * time.Minute
 const partiallyEnactedGCDuration = 30 * time.Second
 
 // Called periodically by allocator.
-func (cs *clusterState) gcPendingChanges(now time.Time) {
+func (cs *clusterState) gcPendingChanges(ctx context.Context, now time.Time) {
 	var rangesWithChanges map[roachpb.RangeID]struct{}
 	for _, pendingChange := range cs.pendingChanges {
 		if rangesWithChanges == nil {
@@ -1863,7 +1864,7 @@ func (cs *clusterState) gcPendingChanges(now time.Time) {
 			changeIDs = append(changeIDs, pendingChange.changeID)
 		}
 		for _, changeID := range changeIDs {
-			cs.undoPendingChange(changeID)
+			cs.undoPendingChange(ctx, changeID)
 		}
 	}
 }
@@ -1884,7 +1885,7 @@ func (cs *clusterState) pendingChangeEnacted(cid changeID, enactedAt time.Time) 
 }
 
 // undoPendingChange reverses the change with ID cid.
-func (cs *clusterState) undoPendingChange(cid changeID) {
+func (cs *clusterState) undoPendingChange(ctx context.Context, cid changeID) {
 	change, ok := cs.pendingChanges[cid]
 	if !ok {
 		panic(errors.AssertionFailedf("change %v not found %v", cid, printMapPendingChanges(cs.pendingChanges)))
@@ -1898,7 +1899,7 @@ func (cs *clusterState) undoPendingChange(cid changeID) {
 	rs.lastFailedChange = cs.ts.Now()
 	// Undo the change delta as well as the replica change and remove the pending
 	// change from all tracking (range, store, cluster).
-	cs.undoReplicaChange(change.ReplicaChange)
+	cs.undoReplicaChange(ctx, change.ReplicaChange)
 	rs.removePendingChangeTracking(cid)
 	delete(cs.stores[change.target.StoreID].adjusted.loadPendingChanges, change.changeID)
 	delete(cs.pendingChanges, change.changeID)
@@ -1927,7 +1928,7 @@ func printMapPendingChanges(changes map[changeID]*pendingReplicaChange) string {
 //
 // REQUIRES: all the replica changes are to the same range, and that the range
 // has no pending changes.
-func (cs *clusterState) addPendingRangeChange(change PendingRangeChange) {
+func (cs *clusterState) addPendingRangeChange(ctx context.Context, change PendingRangeChange) {
 	if len(change.pendingReplicaChanges) == 0 {
 		return
 	}
@@ -1953,7 +1954,7 @@ func (cs *clusterState) addPendingRangeChange(change PendingRangeChange) {
 	}
 	now := cs.ts.Now()
 	for _, pendingChange := range change.pendingReplicaChanges {
-		cs.applyReplicaChange(pendingChange.ReplicaChange, true)
+		cs.applyReplicaChange(ctx, pendingChange.ReplicaChange, true)
 		cs.changeSeqGen++
 		cid := cs.changeSeqGen
 		pendingChange.changeID = cid
@@ -1965,7 +1966,7 @@ func (cs *clusterState) addPendingRangeChange(change PendingRangeChange) {
 		cs.pendingChanges[cid] = pendingChange
 		storeState.adjusted.loadPendingChanges[cid] = pendingChange
 		rangeState.pendingChanges = append(rangeState.pendingChanges, pendingChange)
-		log.KvDistribution.VEventf(context.Background(), 3,
+		log.KvDistribution.VEventf(ctx, 3,
 			"addPendingRangeChange: change_id=%v, range_id=%v, change=%v",
 			cid, rangeID, pendingChange.ReplicaChange)
 	}
@@ -2080,7 +2081,9 @@ func (cs *clusterState) preCheckOnUndoReplicaChanges(rangeChange PendingRangeCha
 }
 
 // REQUIRES: the range and store are known to the allocator.
-func (cs *clusterState) applyReplicaChange(change ReplicaChange, applyLoadChange bool) {
+func (cs *clusterState) applyReplicaChange(
+	ctx context.Context, change ReplicaChange, applyLoadChange bool,
+) {
 	storeState, ok := cs.stores[change.target.StoreID]
 	if !ok {
 		panic(fmt.Sprintf("store %v not found in cluster state", change.target.StoreID))
@@ -2090,7 +2093,7 @@ func (cs *clusterState) applyReplicaChange(change ReplicaChange, applyLoadChange
 		panic(fmt.Sprintf("range %v not found in cluster state", change.rangeID))
 	}
 
-	log.KvDistribution.VEventf(context.Background(), 2, "applying replica change %v to range %d on store %d",
+	log.KvDistribution.VEventf(ctx, 2, "applying replica change %v to range %d on store %d",
 		change, change.rangeID, change.target.StoreID)
 	if change.isRemoval() {
 		delete(storeState.adjusted.replicas, change.rangeID)
@@ -2122,8 +2125,8 @@ func (cs *clusterState) applyReplicaChange(change ReplicaChange, applyLoadChange
 	}
 }
 
-func (cs *clusterState) undoReplicaChange(change ReplicaChange) {
-	log.KvDistribution.Infof(context.Background(), "undoing replica change %v to range %d on store %d",
+func (cs *clusterState) undoReplicaChange(ctx context.Context, change ReplicaChange) {
+	log.KvDistribution.VEventf(ctx, 2, "undoing replica change %v to range %d on store %d",
 		change, change.rangeID, change.target.StoreID)
 	rangeState := cs.ranges[change.rangeID]
 	storeState := cs.stores[change.target.StoreID]
@@ -2422,7 +2425,7 @@ func (cs *clusterState) canShedAndAddLoad(
 			dimFractionIncrease := float64(deltaToAdd[dim]) / float64(targetSS.adjusted.load[dim])
 			// The use of 33% is arbitrary.
 			if dimFractionIncrease > overloadedDimFractionIncrease/3 {
-				log.KvDistribution.Infof(ctx, "%v: %f > %f/3", dim, dimFractionIncrease, overloadedDimFractionIncrease)
+				log.KvDistribution.VEventf(ctx, 2, "%v: %f > %f/3", dim, dimFractionIncrease, overloadedDimFractionIncrease)
 				otherDimensionsBecameWorseInTarget = true
 				break
 			}

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_test.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_test.go
@@ -579,16 +579,17 @@ func TestClusterState(t *testing.T) {
 							add, remove, _ := parseChangeAddRemove(t, parts[1])
 							addTarget := roachpb.ReplicationTarget{NodeID: cs.stores[add].NodeID, StoreID: add}
 							removeTarget := roachpb.ReplicationTarget{NodeID: cs.stores[remove].NodeID, StoreID: remove}
-							rebalanceChanges := makeRebalanceReplicaChanges(rangeID, rState.replicas, rState.load, addTarget, removeTarget)
+							rebalanceChanges := makeRebalanceReplicaChanges(
+								ctx, rangeID, rState.replicas, rState.load, addTarget, removeTarget)
 							changes = append(changes, rebalanceChanges[:]...)
 						}
 					}
 					rangeChange := MakePendingRangeChange(rangeID, changes)
-					cs.addPendingRangeChange(rangeChange)
+					cs.addPendingRangeChange(ctx, rangeChange)
 					return printPendingChangesTest(testingGetPendingChanges(t, cs))
 
 				case "gc-pending-changes":
-					cs.gcPendingChanges(cs.ts.Now())
+					cs.gcPendingChanges(ctx, cs.ts.Now())
 					return printPendingChangesTest(testingGetPendingChanges(t, cs))
 
 				case "reject-pending-changes":
@@ -600,10 +601,10 @@ func TestClusterState(t *testing.T) {
 					for _, id := range changeIDsInt {
 						if expectPanic {
 							require.Panics(t, func() {
-								cs.undoPendingChange(id)
+								cs.undoPendingChange(ctx, id)
 							})
 						} else {
-							cs.undoPendingChange(id)
+							cs.undoPendingChange(ctx, id)
 						}
 					}
 					return printPendingChangesTest(testingGetPendingChanges(t, cs))

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_frac_threshold.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_frac_threshold.txt
@@ -52,6 +52,10 @@ rebalance-stores store-id=1 fraction-pending-decrease-threshold=0.4
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n1): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=770 meanLoad=400 fractionUsed=77.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] can add load to n2s2: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))] srcSLS[(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true))]
+[mmaid=1] applying replica change r4 type: RemoveLease target store n1,s1 (replica-id=1 type=VOTER_FULL leaseholder=true)->(replica-id=1 type=VOTER_FULL) to range 4 on store 1
+[mmaid=1] addPendingRangeChange: change_id=1, range_id=4, change=r4 type: RemoveLease target store n1,s1 (replica-id=1 type=VOTER_FULL leaseholder=true)->(replica-id=1 type=VOTER_FULL)
+[mmaid=1] applying replica change r4 type: AddLease target store n2,s2 (replica-id=2 type=VOTER_FULL)->(replica-id=2 type=VOTER_FULL leaseholder=true) to range 4 on store 2
+[mmaid=1] addPendingRangeChange: change_id=2, range_id=4, change=r4 type: AddLease target store n2,s2 (replica-id=2 type=VOTER_FULL)->(replica-id=2 type=VOTER_FULL leaseholder=true)
 [mmaid=1] result(success): shedding r4 lease from s1 to s2 [change:r4=[transfer_to=2 cids=1,2]] with resulting loads source:[cpu:770ns/s, write-bandwidth:0 B/s, byte-size:0 B] target:[cpu:353ns/s, write-bandwidth:0 B/s, byte-size:0 B] (means: [cpu:400ns/s, write-bandwidth:0 B/s, byte-size:0 B]) (frac_pending: (src:0.00,target:0.23) (src:2.53,target:0.00))
 [mmaid=1] considering lease-transfer r3 from s1: candidates are [2 3]
 [mmaid=1] load summary for dim=CPURate (s1): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=770 meanLoad=400 fractionUsed=77.00% meanUtil=40.00% capacity=1000]
@@ -77,6 +81,10 @@ rebalance-stores store-id=1 fraction-pending-decrease-threshold=0.4
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n1): overloadSlow, reason: fractionUsed < 75% [load=540 meanLoad=400 fractionUsed=54.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] can add load to n3s3: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))] srcSLS[(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow high_disk=false frac_pending=0.00,0.23(false))]
+[mmaid=1] applying replica change r3 type: RemoveLease target store n1,s1 (replica-id=1 type=VOTER_FULL leaseholder=true)->(replica-id=1 type=VOTER_FULL) to range 3 on store 1
+[mmaid=1] addPendingRangeChange: change_id=3, range_id=3, change=r3 type: RemoveLease target store n1,s1 (replica-id=1 type=VOTER_FULL leaseholder=true)->(replica-id=1 type=VOTER_FULL)
+[mmaid=1] applying replica change r3 type: AddLease target store n3,s3 (replica-id=3 type=VOTER_FULL)->(replica-id=3 type=VOTER_FULL leaseholder=true) to range 3 on store 3
+[mmaid=1] addPendingRangeChange: change_id=4, range_id=3, change=r3 type: AddLease target store n3,s3 (replica-id=3 type=VOTER_FULL)->(replica-id=3 type=VOTER_FULL leaseholder=true)
 [mmaid=1] result(success): shedding r3 lease from s1 to s3 [change:r3=[transfer_to=3 cids=3,4]] with resulting loads source:[cpu:540ns/s, write-bandwidth:0 B/s, byte-size:0 B] target:[cpu:353ns/s, write-bandwidth:0 B/s, byte-size:0 B] (means: [cpu:400ns/s, write-bandwidth:0 B/s, byte-size:0 B]) (frac_pending: (src:0.00,target:0.46) (src:2.53,target:0.00))
 [mmaid=1] s1 has reached pending decrease threshold(0.46>=0.40) after 2 lease transfers
 [mmaid=1] skipping replica transfers for s1 to try more leases next time

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_replica_refusing.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_replica_refusing.txt
@@ -97,6 +97,10 @@ rebalance-stores store-id=1
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n1): loadNormal, reason: load is within 5% of mean [load=910 meanLoad=900 fractionUsed=91.00% meanUtil=90.00% capacity=1000]
 [mmaid=1] can add load to n3s3: true targetSLS[(store=loadNormal worst=CPURate cpu=loadNormal writes=loadNormal bytes=loadNormal node=loadNormal high_disk=false frac_pending=0.00,0.00(true))] srcSLS[(store=loadNormal worst=CPURate cpu=loadNormal writes=loadNormal bytes=loadNormal node=loadNormal high_disk=false frac_pending=0.00,0.00(true))]
+[mmaid=1] applying replica change r1 type: RemoveLease target store n1,s1 (replica-id=1 type=VOTER_FULL leaseholder=true)->(replica-id=1 type=VOTER_FULL) to range 1 on store 1
+[mmaid=1] addPendingRangeChange: change_id=1, range_id=1, change=r1 type: RemoveLease target store n1,s1 (replica-id=1 type=VOTER_FULL leaseholder=true)->(replica-id=1 type=VOTER_FULL)
+[mmaid=1] applying replica change r1 type: AddLease target store n3,s3 (replica-id=3 type=VOTER_FULL)->(replica-id=3 type=VOTER_FULL leaseholder=true) to range 1 on store 3
+[mmaid=1] addPendingRangeChange: change_id=2, range_id=1, change=r1 type: AddLease target store n3,s3 (replica-id=3 type=VOTER_FULL)->(replica-id=3 type=VOTER_FULL leaseholder=true)
 [mmaid=1] result(success): shedding r1 lease from s1 to s3 [change:r1=[transfer_to=3 cids=1,2]] with resulting loads source:[cpu:910ns/s, write-bandwidth:0 B/s, byte-size:0 B] target:[cpu:899ns/s, write-bandwidth:0 B/s, byte-size:0 B] (means: [cpu:900ns/s, write-bandwidth:0 B/s, byte-size:0 B]) (frac_pending: (src:0.00,target:0.09) (src:0.12,target:0.00))
 [mmaid=1] skipping replica transfers for s1 to try more leases next time
 [mmaid=1] rebalancing pass shed: {s1}

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_transfer_count.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_transfer_count.txt
@@ -52,6 +52,10 @@ rebalance-stores store-id=1 fraction-pending-decrease-threshold=1.0 max-lease-tr
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n1): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=770 meanLoad=400 fractionUsed=77.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] can add load to n2s2: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))] srcSLS[(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true))]
+[mmaid=1] applying replica change r4 type: RemoveLease target store n1,s1 (replica-id=1 type=VOTER_FULL leaseholder=true)->(replica-id=1 type=VOTER_FULL) to range 4 on store 1
+[mmaid=1] addPendingRangeChange: change_id=1, range_id=4, change=r4 type: RemoveLease target store n1,s1 (replica-id=1 type=VOTER_FULL leaseholder=true)->(replica-id=1 type=VOTER_FULL)
+[mmaid=1] applying replica change r4 type: AddLease target store n2,s2 (replica-id=2 type=VOTER_FULL)->(replica-id=2 type=VOTER_FULL leaseholder=true) to range 4 on store 2
+[mmaid=1] addPendingRangeChange: change_id=2, range_id=4, change=r4 type: AddLease target store n2,s2 (replica-id=2 type=VOTER_FULL)->(replica-id=2 type=VOTER_FULL leaseholder=true)
 [mmaid=1] result(success): shedding r4 lease from s1 to s2 [change:r4=[transfer_to=2 cids=1,2]] with resulting loads source:[cpu:770ns/s, write-bandwidth:0 B/s, byte-size:0 B] target:[cpu:353ns/s, write-bandwidth:0 B/s, byte-size:0 B] (means: [cpu:400ns/s, write-bandwidth:0 B/s, byte-size:0 B]) (frac_pending: (src:0.00,target:0.23) (src:2.53,target:0.00))
 [mmaid=1] considering lease-transfer r3 from s1: candidates are [2 3]
 [mmaid=1] load summary for dim=CPURate (s1): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=770 meanLoad=400 fractionUsed=77.00% meanUtil=40.00% capacity=1000]
@@ -77,6 +81,10 @@ rebalance-stores store-id=1 fraction-pending-decrease-threshold=1.0 max-lease-tr
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n1): overloadSlow, reason: fractionUsed < 75% [load=540 meanLoad=400 fractionUsed=54.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] can add load to n3s3: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))] srcSLS[(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow high_disk=false frac_pending=0.00,0.23(false))]
+[mmaid=1] applying replica change r3 type: RemoveLease target store n1,s1 (replica-id=1 type=VOTER_FULL leaseholder=true)->(replica-id=1 type=VOTER_FULL) to range 3 on store 1
+[mmaid=1] addPendingRangeChange: change_id=3, range_id=3, change=r3 type: RemoveLease target store n1,s1 (replica-id=1 type=VOTER_FULL leaseholder=true)->(replica-id=1 type=VOTER_FULL)
+[mmaid=1] applying replica change r3 type: AddLease target store n3,s3 (replica-id=3 type=VOTER_FULL)->(replica-id=3 type=VOTER_FULL leaseholder=true) to range 3 on store 3
+[mmaid=1] addPendingRangeChange: change_id=4, range_id=3, change=r3 type: AddLease target store n3,s3 (replica-id=3 type=VOTER_FULL)->(replica-id=3 type=VOTER_FULL leaseholder=true)
 [mmaid=1] result(success): shedding r3 lease from s1 to s3 [change:r3=[transfer_to=3 cids=3,4]] with resulting loads source:[cpu:540ns/s, write-bandwidth:0 B/s, byte-size:0 B] target:[cpu:353ns/s, write-bandwidth:0 B/s, byte-size:0 B] (means: [cpu:400ns/s, write-bandwidth:0 B/s, byte-size:0 B]) (frac_pending: (src:0.00,target:0.46) (src:2.53,target:0.00))
 [mmaid=1] reached max lease transfer count 2, returning
 [mmaid=1] skipping replica transfers for s1 to try more leases next time

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_transfer_unbounded.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_transfer_unbounded.txt
@@ -51,6 +51,10 @@ rebalance-stores store-id=1 fraction-pending-decrease-threshold=10.0 max-lease-t
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n1): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=770 meanLoad=400 fractionUsed=77.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] can add load to n2s2: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))] srcSLS[(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true))]
+[mmaid=1] applying replica change r4 type: RemoveLease target store n1,s1 (replica-id=1 type=VOTER_FULL leaseholder=true)->(replica-id=1 type=VOTER_FULL) to range 4 on store 1
+[mmaid=1] addPendingRangeChange: change_id=1, range_id=4, change=r4 type: RemoveLease target store n1,s1 (replica-id=1 type=VOTER_FULL leaseholder=true)->(replica-id=1 type=VOTER_FULL)
+[mmaid=1] applying replica change r4 type: AddLease target store n2,s2 (replica-id=2 type=VOTER_FULL)->(replica-id=2 type=VOTER_FULL leaseholder=true) to range 4 on store 2
+[mmaid=1] addPendingRangeChange: change_id=2, range_id=4, change=r4 type: AddLease target store n2,s2 (replica-id=2 type=VOTER_FULL)->(replica-id=2 type=VOTER_FULL leaseholder=true)
 [mmaid=1] result(success): shedding r4 lease from s1 to s2 [change:r4=[transfer_to=2 cids=1,2]] with resulting loads source:[cpu:770ns/s, write-bandwidth:0 B/s, byte-size:0 B] target:[cpu:353ns/s, write-bandwidth:0 B/s, byte-size:0 B] (means: [cpu:400ns/s, write-bandwidth:0 B/s, byte-size:0 B]) (frac_pending: (src:0.00,target:0.23) (src:2.53,target:0.00))
 [mmaid=1] considering lease-transfer r3 from s1: candidates are [2 3]
 [mmaid=1] load summary for dim=CPURate (s1): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=770 meanLoad=400 fractionUsed=77.00% meanUtil=40.00% capacity=1000]
@@ -100,6 +104,10 @@ rebalance-stores store-id=1 fraction-pending-decrease-threshold=10.0 max-lease-t
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n1): overloadSlow, reason: fractionUsed < 75% [load=540 meanLoad=400 fractionUsed=54.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] can add load to n3s3: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))] srcSLS[(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow high_disk=false frac_pending=0.00,0.23(false))]
+[mmaid=1] applying replica change r2 type: RemoveLease target store n1,s1 (replica-id=1 type=VOTER_FULL leaseholder=true)->(replica-id=1 type=VOTER_FULL) to range 2 on store 1
+[mmaid=1] addPendingRangeChange: change_id=3, range_id=2, change=r2 type: RemoveLease target store n1,s1 (replica-id=1 type=VOTER_FULL leaseholder=true)->(replica-id=1 type=VOTER_FULL)
+[mmaid=1] applying replica change r2 type: AddLease target store n3,s3 (replica-id=3 type=VOTER_FULL)->(replica-id=3 type=VOTER_FULL leaseholder=true) to range 2 on store 3
+[mmaid=1] addPendingRangeChange: change_id=4, range_id=2, change=r2 type: AddLease target store n3,s3 (replica-id=3 type=VOTER_FULL)->(replica-id=3 type=VOTER_FULL leaseholder=true)
 [mmaid=1] result(success): shedding r2 lease from s1 to s3 [change:r2=[transfer_to=3 cids=3,4]] with resulting loads source:[cpu:540ns/s, write-bandwidth:0 B/s, byte-size:0 B] target:[cpu:353ns/s, write-bandwidth:0 B/s, byte-size:0 B] (means: [cpu:400ns/s, write-bandwidth:0 B/s, byte-size:0 B]) (frac_pending: (src:0.00,target:0.46) (src:2.53,target:0.00))
 [mmaid=1] considering lease-transfer r1 from s1: candidates are [2 3]
 [mmaid=1] load summary for dim=CPURate (s1): overloadSlow, reason: fractionUsed < 75% [load=540 meanLoad=400 fractionUsed=54.00% meanUtil=40.00% capacity=1000]

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_count.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_count.txt
@@ -37,6 +37,10 @@ rebalance-stores store-id=1 max-range-move-count=1 fraction-pending-decrease-thr
 [mmaid=2] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=2] load summary for dim=CPURate (n3): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=900 meanLoad=525 fractionUsed=90.00% meanUtil=52.50% capacity=1000]
 [mmaid=2] can add load to n4s4: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))] srcSLS[(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true))]
+[mmaid=2] applying replica change r3 type: AddReplica target store n4,s4 (replica-id=none type=VOTER_FULL)->(replica-id=unknown type=VOTER_FULL) to range 3 on store 4
+[mmaid=2] addPendingRangeChange: change_id=1, range_id=3, change=r3 type: AddReplica target store n4,s4 (replica-id=none type=VOTER_FULL)->(replica-id=unknown type=VOTER_FULL)
+[mmaid=2] applying replica change r3 type: RemoveReplica target store n3,s3 (replica-id=3 type=VOTER_FULL)->(replica-id=none type=VOTER_FULL) to range 3 on store 3
+[mmaid=2] addPendingRangeChange: change_id=2, range_id=3, change=r3 type: RemoveReplica target store n3,s3 (replica-id=3 type=VOTER_FULL)->(replica-id=none type=VOTER_FULL)
 [mmaid=2] result(success): rebalancing r3 from s3 to s4 [change: r3=[change_replicas=[{ADD_VOTER n4,s4} {REMOVE_VOTER n3,s3}] cids=1,2]] with resulting loads source: [cpu:900ns/s, write-bandwidth:0 B/s, byte-size:0 B] target: [cpu:210ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=2] reached max range move count 1; done shedding
 [mmaid=2] rebalancing pass shed: {s3}

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_frac_threshold.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_frac_threshold.txt
@@ -37,6 +37,10 @@ rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-t
 [mmaid=2] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=2] load summary for dim=CPURate (n3): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=900 meanLoad=525 fractionUsed=90.00% meanUtil=52.50% capacity=1000]
 [mmaid=2] can add load to n4s4: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))] srcSLS[(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true))]
+[mmaid=2] applying replica change r3 type: AddReplica target store n4,s4 (replica-id=none type=VOTER_FULL)->(replica-id=unknown type=VOTER_FULL) to range 3 on store 4
+[mmaid=2] addPendingRangeChange: change_id=1, range_id=3, change=r3 type: AddReplica target store n4,s4 (replica-id=none type=VOTER_FULL)->(replica-id=unknown type=VOTER_FULL)
+[mmaid=2] applying replica change r3 type: RemoveReplica target store n3,s3 (replica-id=3 type=VOTER_FULL)->(replica-id=none type=VOTER_FULL) to range 3 on store 3
+[mmaid=2] addPendingRangeChange: change_id=2, range_id=3, change=r3 type: RemoveReplica target store n3,s3 (replica-id=3 type=VOTER_FULL)->(replica-id=none type=VOTER_FULL)
 [mmaid=2] result(success): rebalancing r3 from s3 to s4 [change: r3=[change_replicas=[{ADD_VOTER n4,s4} {REMOVE_VOTER n3,s3}] cids=1,2]] with resulting loads source: [cpu:900ns/s, write-bandwidth:0 B/s, byte-size:0 B] target: [cpu:210ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=2] s3 has reached pending decrease threshold(0.10>=0.01) after rebalancing; done shedding
 [mmaid=2] rebalancing pass shed: {s3}

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_unbounded.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_unbounded.txt
@@ -40,6 +40,10 @@ rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-t
 [mmaid=2] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=2] load summary for dim=CPURate (n3): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=900 meanLoad=525 fractionUsed=90.00% meanUtil=52.50% capacity=1000]
 [mmaid=2] can add load to n4s4: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))] srcSLS[(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true))]
+[mmaid=2] applying replica change r3 type: AddReplica target store n4,s4 (replica-id=none type=VOTER_FULL)->(replica-id=unknown type=VOTER_FULL) to range 3 on store 4
+[mmaid=2] addPendingRangeChange: change_id=1, range_id=3, change=r3 type: AddReplica target store n4,s4 (replica-id=none type=VOTER_FULL)->(replica-id=unknown type=VOTER_FULL)
+[mmaid=2] applying replica change r3 type: RemoveReplica target store n3,s3 (replica-id=3 type=VOTER_FULL)->(replica-id=none type=VOTER_FULL) to range 3 on store 3
+[mmaid=2] addPendingRangeChange: change_id=2, range_id=3, change=r3 type: RemoveReplica target store n3,s3 (replica-id=3 type=VOTER_FULL)->(replica-id=none type=VOTER_FULL)
 [mmaid=2] result(success): rebalancing r3 from s3 to s4 [change: r3=[change_replicas=[{ADD_VOTER n4,s4} {REMOVE_VOTER n3,s3}] cids=1,2]] with resulting loads source: [cpu:900ns/s, write-bandwidth:0 B/s, byte-size:0 B] target: [cpu:210ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=2] load summary for dim=CPURate (s3): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=900 meanLoad=525 fractionUsed=90.00% meanUtil=52.50% capacity=1000]
 [mmaid=2] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
@@ -62,6 +66,10 @@ rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-t
 [mmaid=2] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=2] load summary for dim=CPURate (n3): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=800 meanLoad=525 fractionUsed=80.00% meanUtil=52.50% capacity=1000]
 [mmaid=2] can add load to n4s4: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=1.10,0.00(false))] srcSLS[(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.10(false))]
+[mmaid=2] applying replica change r2 type: AddReplica target store n4,s4 (replica-id=none type=VOTER_FULL)->(replica-id=unknown type=VOTER_FULL) to range 2 on store 4
+[mmaid=2] addPendingRangeChange: change_id=3, range_id=2, change=r2 type: AddReplica target store n4,s4 (replica-id=none type=VOTER_FULL)->(replica-id=unknown type=VOTER_FULL)
+[mmaid=2] applying replica change r2 type: RemoveReplica target store n3,s3 (replica-id=3 type=VOTER_FULL)->(replica-id=none type=VOTER_FULL) to range 2 on store 3
+[mmaid=2] addPendingRangeChange: change_id=4, range_id=2, change=r2 type: RemoveReplica target store n3,s3 (replica-id=3 type=VOTER_FULL)->(replica-id=none type=VOTER_FULL)
 [mmaid=2] result(success): rebalancing r2 from s3 to s4 [change: r2=[change_replicas=[{ADD_VOTER n4,s4} {REMOVE_VOTER n3,s3}] cids=3,4]] with resulting loads source: [cpu:800ns/s, write-bandwidth:0 B/s, byte-size:0 B] target: [cpu:320ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=2] load summary for dim=CPURate (s3): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=800 meanLoad=525 fractionUsed=80.00% meanUtil=52.50% capacity=1000]
 [mmaid=2] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
@@ -84,6 +92,10 @@ rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-t
 [mmaid=2] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=2] load summary for dim=CPURate (n3): overloadSlow, reason: fractionUsed < 75% [load=700 meanLoad=525 fractionUsed=70.00% meanUtil=52.50% capacity=1000]
 [mmaid=2] can add load to n4s4: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=2.20,0.00(false))] srcSLS[(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow high_disk=false frac_pending=0.00,0.20(false))]
+[mmaid=2] applying replica change r1 type: AddReplica target store n4,s4 (replica-id=none type=VOTER_FULL)->(replica-id=unknown type=VOTER_FULL) to range 1 on store 4
+[mmaid=2] addPendingRangeChange: change_id=5, range_id=1, change=r1 type: AddReplica target store n4,s4 (replica-id=none type=VOTER_FULL)->(replica-id=unknown type=VOTER_FULL)
+[mmaid=2] applying replica change r1 type: RemoveReplica target store n3,s3 (replica-id=3 type=VOTER_FULL)->(replica-id=none type=VOTER_FULL) to range 1 on store 3
+[mmaid=2] addPendingRangeChange: change_id=6, range_id=1, change=r1 type: RemoveReplica target store n3,s3 (replica-id=3 type=VOTER_FULL)->(replica-id=none type=VOTER_FULL)
 [mmaid=2] result(success): rebalancing r1 from s3 to s4 [change: r1=[change_replicas=[{ADD_VOTER n4,s4} {REMOVE_VOTER n3,s3}] cids=5,6]] with resulting loads source: [cpu:700ns/s, write-bandwidth:0 B/s, byte-size:0 B] target: [cpu:430ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=2] rebalancing pass shed: {s3}
 pending(6)

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/skip_range_invalid_config.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/skip_range_invalid_config.txt
@@ -70,7 +70,9 @@ rebalance-stores store-id=1
 [mmaid=1] start processing shedding store s1: cpu node load overloadSlow, store load overloadSlow, worst dim CPURate
 [mmaid=1] top-K[CPURate] ranges for s1 with lease on local s1: r1:[cpu:50ns/s, write-bandwidth:50 B/s, byte-size:50 B]
 [mmaid=1] local store s1 is CPU overloaded (overloadSlow >= overloadSlow), attempting lease transfers first
+[mmaid=1] no span config due to normalization error, skipping constraint analysis
 [mmaid=1] skipping r1: no constraints analyzed (conf=<nil> replicas=[s1:replica-id=1 type=VOTER_FULL leaseholder=true lease disposition:ok])
 [mmaid=1] attempting to shed replicas next
+[mmaid=1] no span config due to normalization error, skipping constraint analysis
 [mmaid=1] skipping r1: no constraints analyzed (conf=<nil> replicas=[s1:replica-id=1 type=VOTER_FULL leaseholder=true lease disposition:ok])
 pending(0)

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/store_status_exclusion.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/store_status_exclusion.txt
@@ -196,6 +196,10 @@ rebalance-stores store-id=1
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n1): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=550 fractionUsed=100.00% meanUtil=55.00% capacity=1000]
 [mmaid=1] can add load to n2s2: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))] srcSLS[(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true))]
+[mmaid=1] applying replica change r1 type: RemoveLease target store n1,s1 (replica-id=1 type=VOTER_FULL leaseholder=true)->(replica-id=1 type=VOTER_FULL) to range 1 on store 1
+[mmaid=1] addPendingRangeChange: change_id=1, range_id=1, change=r1 type: RemoveLease target store n1,s1 (replica-id=1 type=VOTER_FULL leaseholder=true)->(replica-id=1 type=VOTER_FULL)
+[mmaid=1] applying replica change r1 type: AddLease target store n2,s2 (replica-id=2 type=VOTER_FULL)->(replica-id=2 type=VOTER_FULL leaseholder=true) to range 1 on store 2
+[mmaid=1] addPendingRangeChange: change_id=2, range_id=1, change=r1 type: AddLease target store n2,s2 (replica-id=2 type=VOTER_FULL)->(replica-id=2 type=VOTER_FULL leaseholder=true)
 [mmaid=1] result(success): shedding r1 lease from s1 to s2 [change:r1=[transfer_to=2 cids=1,2]] with resulting loads source:[cpu:1µs/s, write-bandwidth:0 B/s, byte-size:0 B] target:[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B] (means: [cpu:550ns/s, write-bandwidth:0 B/s, byte-size:0 B]) (frac_pending: (src:0.00,target:0.00) (src:0.00,target:0.00))
 [mmaid=1] skipping replica transfers for s1 to try more leases next time
 [mmaid=1] rebalancing pass shed: {s1}


### PR DESCRIPTION
- A context is plumbed in more places.
- Most logs require verbosity of 2, to avoid log spam.
- Log entries corresponding to state changes produced by MMA use Infof. This was already true for lease transfers, and is now also true for replica moves.

Epic: CRDB-55052

Release note: None