### PR TITLE
kvclient, drpc: randomly enable drpc for tests

### DIFF
--- a/pkg/kv/kvclient/BUILD.bazel
+++ b/pkg/kv/kvclient/BUILD.bazel
@@ -21,6 +21,7 @@ go_test(
     name = "kvclient_test",
     srcs = ["main_test.go"],
     deps = [
+        "//pkg/base",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",

--- a/pkg/kv/kvclient/kvcoord/txncorrectnesstest/BUILD.bazel
+++ b/pkg/kv/kvclient/kvcoord/txncorrectnesstest/BUILD.bazel
@@ -16,6 +16,7 @@ go_test(
         "write_skew_anomaly_test.go",
     ],
     deps = [
+        "//pkg/base",
         "//pkg/kv",
         "//pkg/kv/kvclient/kvcoord",  # keep
         "//pkg/kv/kvserver",

--- a/pkg/kv/kvclient/kvcoord/txncorrectnesstest/main_test.go
+++ b/pkg/kv/kvclient/kvcoord/txncorrectnesstest/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -18,7 +19,8 @@ import (
 
 func TestMain(m *testing.M) {
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
-	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestServerFactory(server.TestServerFactory,
+		serverutils.TestingGlobalDRPCOption(base.TestDRPCEnabledRandomly))
 	randutil.SeedForTests()
 
 	os.Exit(m.Run())

--- a/pkg/kv/kvclient/kvstreamer/main_test.go
+++ b/pkg/kv/kvclient/kvstreamer/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -21,6 +22,7 @@ import (
 func TestMain(m *testing.M) {
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
 	randutil.SeedForTests()
-	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestServerFactory(server.TestServerFactory,
+		serverutils.TestingGlobalDRPCOption(base.TestDRPCEnabledRandomly))
 	os.Exit(m.Run())
 }

--- a/pkg/kv/kvclient/main_test.go
+++ b/pkg/kv/kvclient/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -24,7 +25,8 @@ func init() {
 }
 func TestMain(m *testing.M) {
 	randutil.SeedForTests()
-	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestServerFactory(server.TestServerFactory,
+		serverutils.TestingGlobalDRPCOption(base.TestDRPCEnabledRandomly))
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
 
 	code := m.Run()

--- a/pkg/kv/kvclient/rangefeed/rangefeedcache/main_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeedcache/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvtenant"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
@@ -22,7 +23,8 @@ func init() {
 }
 
 func TestMain(m *testing.M) {
-	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestServerFactory(server.TestServerFactory,
+		serverutils.TestingGlobalDRPCOption(base.TestDRPCEnabledRandomly))
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
 	kvtenant.InitTestConnectorFactory()
 	os.Exit(m.Run())


### PR DESCRIPTION
This change introduces a package-level setting that randomly enables drpc in the kvclient package.

Epic: CRDB-48935
Fixes: #155586
Release note: None