### PR TITLE
util/hlc: comment BenchmarkTimestampIsEmpty

### DIFF
--- a/pkg/util/hlc/timestamp.go
+++ b/pkg/util/hlc/timestamp.go
@@ -189,7 +189,7 @@ func (t Timestamp) AsOfSystemTime() string {
 func (t Timestamp) IsEmpty() bool {
 	// TODO(radu): consider making timestamps with zero wall time and non-zero
 	// logical time illegal. Then we can check just the wall time.
-	return t == Timestamp{}
+	return t.WallTime == 0 && t.Logical == 0
 }
 
 // IsSet returns true if t is not an empty Timestamp.

--- a/pkg/util/hlc/timestamp_test.go
+++ b/pkg/util/hlc/timestamp_test.go
@@ -354,12 +354,17 @@ func BenchmarkTimestampString(b *testing.B) {
 //
 // Performance regression triage notes:
 //
-// The function under test is a one-line comparison with the empty struct. We
-// have a TODO in which additional invariants may allow us to compare a single
-// struct field with zero.
+// We've changed the function under test between the following two different
+// implementations:
 //
-// However, until then, this benchmark is mostly informing us about changes in
-// the Go compiler and changes are unlikely to be actionable.
+//	t == Timestamp{}
+//
+// and
+//
+//	t.WallTime == 0 && t.Logical == 0
+//
+// a few times based on this benchmark. If we find ourselves changing it again,
+// consider deleting the benchmark instead.
 func BenchmarkTimestampIsEmpty(b *testing.B) {
 	cases := map[string]Timestamp{
 		"empty":    {},

--- a/pkg/util/hlc/timestamp_test.go
+++ b/pkg/util/hlc/timestamp_test.go
@@ -350,6 +350,16 @@ func BenchmarkTimestampString(b *testing.B) {
 	}
 }
 
+// BenchmarkTimestampIsEmpty benchmarks our IsEmpty implementation.
+//
+// Performance regression triage notes:
+//
+// The function under test is a one-line comparison with the empty struct. We
+// have a TODO in which additional invariants may allow us to compare a single
+// struct field with zero.
+//
+// However, until then, this benchmark is mostly informing us about changes in
+// the Go compiler and changes are unlikely to be actionable.
 func BenchmarkTimestampIsEmpty(b *testing.B) {
 	cases := map[string]Timestamp{
 		"empty":    {},


### PR DESCRIPTION
This benchmark regressed after the upgrade from Go 1.23 to 1.25:

    │  before.txt  │               after.txt               │
    │    sec/op    │    sec/op     vs base                 │
    TimestampIsEmpty/empty   0.4366n ± 1%   0.9353n ± 5%  +114.21% (p=0.000 n=32)

I have not looked too deeply here, other to note that this could be the result of a compiler change. According to compiler explorer, we used to get:

```
TESTQ   AX, AX
JNE     command-line-arguments_Timestamp_IsEmpty_pc12
TESTL   BX, BX
SETEQ   CL
JMP     command-line-arguments_Timestamp_IsEmpty_pc14
command-line-arguments_Timestamp_IsEmpty_pc12:
XORL    CX, CX
command-line-arguments_Timestamp_IsEmpty_pc14:
MOVL    CX, AX
RET
```

And now we get:

```
CMPQ    runtime.zeroVal(SB), AX
JNE     command-line-arguments_Timestamp_IsEmpty_pc20
CMPL    runtime.zeroVal+8(SB), BX
SETEQ   CL
JMP     command-line-arguments_Timestamp_IsEmpty_pc22
command-line-arguments_Timestamp_IsEmpty_pc20:
XORL    CX, CX
command-line-arguments_Timestamp_IsEmpty_pc22:
MOVL    CX, AX
RET
```

Note the CMPQ to what looks like some global zero value as opposed to the TEST instruction.

As far as I know we haven't seen an impact of this in any higher-level benchmarks.

Informs #160446

Release note: None