### PR TITLE
release-25.4: unsafesql: introduce cluster setting for unsafe access

### DIFF
--- a/pkg/settings/lint/lint_test.go
+++ b/pkg/settings/lint/lint_test.go
@@ -165,7 +165,13 @@ func TestLintClusterSettingNames(t *testing.T) {
 				}
 			}
 
-			if strings.Contains(settingName, "unsafe") && !setting.IsUnsafe() {
+			// Exception list for settings that contain "unsafe" in the name but should
+			// not require the unsafe interlock. These are legacy settings that cannot
+			// be renamed.
+			unsafeNameExceptions := map[string]bool{
+				"sql.override.allow_unsafe_internals.enabled": true,
+			}
+			if strings.Contains(settingName, "unsafe") && !setting.IsUnsafe() && !unsafeNameExceptions[settingName] {
 				return errors.Errorf("%s: setting name contains \"unsafe\" but is not marked unsafe (hint: use option settings.WithUnsafe)", settingName)
 			}
 			if setting.IsUnsafe() && !strings.Contains(settingName, "unsafe") {

--- a/pkg/sql/unsafesql/BUILD.bazel
+++ b/pkg/sql/unsafesql/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sqlerrors",
+        "//pkg/util/envutil",
         "//pkg/util/log",
         "//pkg/util/log/eventpb",
         "//pkg/util/log/severity",

--- a/pkg/sql/unsafesql/unsafesql.go
+++ b/pkg/sql/unsafesql/unsafesql.go
@@ -13,12 +13,22 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log/severity"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/redact"
 )
+
+var allowUnsafeSetting = settings.RegisterBoolSetting(
+	settings.ApplicationLevel,
+	"sql.override.allow_unsafe_internals.enabled",
+	"overrides the allow_unsafe_internals session variable behavior"+
+		" as a failsafe in case of emergencies. This setting should not be"+
+		" externally visible.",
+	envutil.EnvOrDefaultBool("COCKROACH_OVERRIDE_ALLOW_UNSAFE_INTERNALS", false),
+	settings.Sensitive)
 
 // The accessedLogLimiter is used to limit the rate of logging unsafe internal access
 // events. It is set to allow ten events per second.
@@ -49,6 +59,11 @@ func CheckInternalsAccess(
 	ann *tree.Annotations,
 	sv *settings.Values,
 ) error {
+	// If the cluster setting override is set, allow without logging.
+	if allowUnsafeSetting.Get(sv) {
+		return nil
+	}
+
 	// If the querier is internal, we should allow it.
 	if sd.Internal || sd.IsInternalAppName() {
 		return nil

--- a/pkg/sql/unsafesql/unsafesql_test.go
+++ b/pkg/sql/unsafesql/unsafesql_test.go
@@ -57,7 +57,7 @@ func checkUnsafeErr(t *testing.T, err error) {
 	t.Fatal("expected unsafe access error, got", err)
 }
 
-func TestAccessCheckServer(t *testing.T) {
+func TestIntegration(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
@@ -77,195 +77,234 @@ func TestAccessCheckServer(t *testing.T) {
 	// create a user table to test user table access.
 	runner.Exec(t, "CREATE TABLE foo (id INT PRIMARY KEY)")
 
-	// create and register a log accessedSpy to see the unsafe access logs
-	accessedSpy := logtestutils.NewStructuredLogSpy[eventpb.UnsafeInternalsAccessed](
-		t, []logpb.Channel{logpb.Channel_SENSITIVE_ACCESS}, []string{"unsafe_internals_accessed"}, logtestutils.FromLogEntry,
-	)
-	// create and register a log deniedSpy to see the denied access logs
-	deniedSpy := logtestutils.NewStructuredLogSpy[eventpb.UnsafeInternalsDenied](
-		t, []logpb.Channel{logpb.Channel_SENSITIVE_ACCESS}, []string{"unsafe_internals_denied"}, logtestutils.FromLogEntry,
-	)
-	accessedCleanup := log.InterceptWith(ctx, accessedSpy)
-	deniedCleanup := log.InterceptWith(ctx, deniedSpy)
-	defer accessedCleanup()
-	defer deniedCleanup()
+	t.Run("AccessCheckTable", func(t *testing.T) {
+		// create and register a log accessedSpy to see the unsafe access logs
+		accessedSpy := logtestutils.NewStructuredLogSpy[eventpb.UnsafeInternalsAccessed](
+			t, []logpb.Channel{logpb.Channel_SENSITIVE_ACCESS}, []string{"unsafe_internals_accessed"}, logtestutils.FromLogEntry,
+		)
+		// create and register a log deniedSpy to see the denied access logs
+		deniedSpy := logtestutils.NewStructuredLogSpy[eventpb.UnsafeInternalsDenied](
+			t, []logpb.Channel{logpb.Channel_SENSITIVE_ACCESS}, []string{"unsafe_internals_denied"}, logtestutils.FromLogEntry,
+		)
+		accessedCleanup := log.InterceptWith(ctx, accessedSpy)
+		deniedCleanup := log.InterceptWith(ctx, deniedSpy)
 
-	// helper function for sending queries in different ways.
-	sendQuery := func(allowUnsafe bool, internal bool, query string) error {
-		if internal {
-			idb := s.InternalDB().(isql.DB)
-			err := idb.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-				txn.SessionData().LocalOnlySessionData.AllowUnsafeInternals = allowUnsafe
+		defer accessedCleanup()
+		defer deniedCleanup()
 
-				_, err := txn.QueryBuffered(ctx, "internal-query", txn.KV(), query)
-				return err
-			})
-			if err != nil {
-				return err
+		// helper function for sending queries in different ways.
+		sendQuery := func(allowUnsafe bool, internal bool, query string) error {
+			if internal {
+				idb := s.InternalDB().(isql.DB)
+				err := idb.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+					txn.SessionData().LocalOnlySessionData.AllowUnsafeInternals = allowUnsafe
+
+					_, err := txn.QueryBuffered(ctx, "internal-query", txn.KV(), query)
+					return err
+				})
+				if err != nil {
+					return err
+				}
+			} else {
+				conn, err := pool.Conn(ctx)
+				if err != nil {
+					return err
+				}
+				_, err = conn.ExecContext(ctx, "SET allow_unsafe_internals = $1", allowUnsafe)
+				if err != nil {
+					return err
+				}
+				_, err = conn.QueryContext(ctx, query)
+				if err != nil {
+					return err
+				}
 			}
-		} else {
-			conn, err := pool.Conn(ctx)
-			if err != nil {
-				return err
-			}
-			_, err = conn.ExecContext(ctx, "SET allow_unsafe_internals = $1", allowUnsafe)
-			if err != nil {
-				return err
-			}
-			_, err = conn.QueryContext(ctx, query)
-			if err != nil {
-				return err
-			}
+			return nil
 		}
-		return nil
-	}
 
-	for _, test := range []struct {
-		Query                string
-		AppName              string
-		Internal             bool
-		AllowUnsafeInternals bool
-		Passes               bool
-		LogsAccessed         bool
-		LogsDenied           bool
-	}{
-		// Regular tables aren't considered unsafe.
-		{
-			Query:  "SELECT * FROM foo",
-			Passes: true,
-		},
-		// Tests on the system objects.
-		{
-			Query:                "SELECT * FROM system.namespace",
-			Internal:             true,
-			AllowUnsafeInternals: false,
-			Passes:               true,
-		},
-		{
-			Query:                "SELECT * FROM system.namespace",
-			Internal:             true,
-			AllowUnsafeInternals: true,
-			Passes:               true,
-		},
-		{
-			Query:                "SELECT * FROM system.namespace",
-			Internal:             false,
-			AllowUnsafeInternals: false,
-			Passes:               false,
-			LogsDenied:           true,
-		},
-		{
-			Query:                "SELECT * FROM system.namespace",
-			Internal:             false,
-			AllowUnsafeInternals: true,
-			Passes:               true,
-			LogsAccessed:         true,
-		},
-		{
-			Query:                "SELECT * FROM system.namespace",
-			AppName:              "$ internal app",
-			Internal:             false,
-			AllowUnsafeInternals: false,
-			Passes:               true,
-			LogsAccessed:         false,
-		},
-		// Tests on unsupported crdb_internal objects.
-		{
-			Query:                "SELECT * FROM crdb_internal.gossip_alerts",
-			AllowUnsafeInternals: false,
-			Passes:               false,
-			LogsDenied:           true,
-		},
-		{
-			Query:                "SELECT * FROM crdb_internal.gossip_alerts",
-			AllowUnsafeInternals: true,
-			Passes:               true,
-			LogsAccessed:         true,
-		},
-		// Tests on supported crdb_internal objects.
-		{
-			Query:                "SELECT * FROM crdb_internal.zones",
-			AllowUnsafeInternals: false,
-			Passes:               true,
-		},
-		{
-			Query:                "SELECT * FROM crdb_internal.zones",
-			AllowUnsafeInternals: true,
-			Passes:               true,
-		},
-		// Non-crdb_internal functions pass
-		{
-			Query:  "SELECT * FROM generate_series(1, 5)",
-			Passes: true,
-		},
-		// Crdb_internal functions require the override.
-		{
-			Query:      "SELECT * FROM crdb_internal.tenant_span_stats()",
-			Passes:     false,
-			LogsDenied: true,
-		},
-		{
-			Query:                "SELECT * FROM crdb_internal.tenant_span_stats()",
-			AllowUnsafeInternals: true,
-			Passes:               true,
-			LogsAccessed:         true,
-		},
-		// Tests on delegate behavior.
-		{
-			Query:  "SHOW GRANTS",
-			Passes: true,
-		},
-		{
-			// this query is what show grants is using under the hood.
-			Query:      "SELECT * FROM crdb_internal.privilege_name('SELECT')",
-			Passes:     false,
-			LogsDenied: true,
-		},
-		{
-			Query:  "SHOW DATABASES",
-			Passes: true,
-		},
-		{
-			// this query is what show databases is using under the hood.
-			Query:      "SELECT * FROM crdb_internal.databases",
-			Passes:     false,
-			LogsDenied: true,
-		},
-		{
-			// test nested delegates
-			Query:  "SHOW JOBS WHEN COMPLETE SELECT job_id FROM [SHOW JOBS]",
-			Passes: true,
-		},
-		{
-			// unexpected unsafe builtin access
-			Query:  "SELECT col_description(0, 0)",
-			Passes: true,
-		},
-	} {
-		t.Run(fmt.Sprintf("query=%s,internal=%t,allowUnsafe=%t", test.Query, test.Internal, test.AllowUnsafeInternals), func(t *testing.T) {
-			accessedSpy.Reset()
-			deniedSpy.Reset()
-			runner.Exec(t, "SET application_name = $1", test.AppName)
-			err := sendQuery(test.AllowUnsafeInternals, test.Internal, test.Query)
-			if test.Passes {
-				require.NoError(t, err)
-			} else {
-				checkUnsafeErr(t, err)
-			}
+		for _, test := range []struct {
+			Query                string
+			AppName              string
+			Internal             bool
+			AllowUnsafeInternals bool
+			Passes               bool
+			LogsAccessed         bool
+			LogsDenied           bool
+		}{
+			// Regular tables aren't considered unsafe.
+			{
+				Query:  "SELECT * FROM foo",
+				Passes: true,
+			},
+			// Tests on the system objects.
+			{
+				Query:                "SELECT * FROM system.namespace",
+				Internal:             true,
+				AllowUnsafeInternals: false,
+				Passes:               true,
+			},
+			{
+				Query:                "SELECT * FROM system.namespace",
+				Internal:             true,
+				AllowUnsafeInternals: true,
+				Passes:               true,
+			},
+			{
+				Query:                "SELECT * FROM system.namespace",
+				Internal:             false,
+				AllowUnsafeInternals: false,
+				Passes:               false,
+				LogsDenied:           true,
+			},
+			{
+				Query:                "SELECT * FROM system.namespace",
+				Internal:             false,
+				AllowUnsafeInternals: true,
+				Passes:               true,
+				LogsAccessed:         true,
+			},
+			{
+				Query:                "SELECT * FROM system.namespace",
+				AppName:              "$ internal app",
+				Internal:             false,
+				AllowUnsafeInternals: false,
+				Passes:               true,
+				LogsAccessed:         false,
+			},
+			// Tests on unsupported crdb_internal objects.
+			{
+				Query:                "SELECT * FROM crdb_internal.gossip_alerts",
+				AllowUnsafeInternals: false,
+				Passes:               false,
+				LogsDenied:           true,
+			},
+			{
+				Query:                "SELECT * FROM crdb_internal.gossip_alerts",
+				AllowUnsafeInternals: true,
+				Passes:               true,
+				LogsAccessed:         true,
+			},
+			// Tests on supported crdb_internal objects.
+			{
+				Query:                "SELECT * FROM crdb_internal.zones",
+				AllowUnsafeInternals: false,
+				Passes:               true,
+			},
+			{
+				Query:                "SELECT * FROM crdb_internal.zones",
+				AllowUnsafeInternals: true,
+				Passes:               true,
+			},
+			// Non-crdb_internal functions pass
+			{
+				Query:  "SELECT * FROM generate_series(1, 5)",
+				Passes: true,
+			},
+			// Crdb_internal functions require the override.
+			{
+				Query:      "SELECT * FROM crdb_internal.tenant_span_stats()",
+				Passes:     false,
+				LogsDenied: true,
+			},
+			{
+				Query:                "SELECT * FROM crdb_internal.tenant_span_stats()",
+				AllowUnsafeInternals: true,
+				Passes:               true,
+				LogsAccessed:         true,
+			},
+			// Tests on delegate behavior.
+			{
+				Query:  "SHOW GRANTS",
+				Passes: true,
+			},
+			{
+				// this query is what show grants is using under the hood.
+				Query:      "SELECT * FROM crdb_internal.privilege_name('SELECT')",
+				Passes:     false,
+				LogsDenied: true,
+			},
+			{
+				Query:  "SHOW DATABASES",
+				Passes: true,
+			},
+			{
+				// this query is what show databases is using under the hood.
+				Query:      "SELECT * FROM crdb_internal.databases",
+				Passes:     false,
+				LogsDenied: true,
+			},
+			{
+				// test nested delegates
+				Query:  "SHOW JOBS WHEN COMPLETE SELECT job_id FROM [SHOW JOBS]",
+				Passes: true,
+			},
+			{
+				// unexpected unsafe builtin access
+				Query:  "SELECT col_description(0, 0)",
+				Passes: true,
+			},
+		} {
+			t.Run(fmt.Sprintf("query=%s,internal=%t,allowUnsafe=%t", test.Query, test.Internal, test.AllowUnsafeInternals), func(t *testing.T) {
+				accessedSpy.Reset()
+				deniedSpy.Reset()
+				runner.Exec(t, "SET application_name = $1", test.AppName)
+				err := sendQuery(test.AllowUnsafeInternals, test.Internal, test.Query)
+				if test.Passes {
+					require.NoError(t, err)
+				} else {
+					checkUnsafeErr(t, err)
+				}
 
-			if test.LogsAccessed {
-				require.Equal(t, 1, accessedSpy.Count(), "expected exactly one log entry for unsafe internals access")
-			} else {
-				require.Equal(t, 0, accessedSpy.Count(), "expected no log entries")
-			}
+				if test.LogsAccessed {
+					require.Equal(t, 1, accessedSpy.Count(), "expected exactly one log entry for unsafe internals access")
+				} else {
+					require.Equal(t, 0, accessedSpy.Count(), "expected no log entries")
+				}
 
-			if test.LogsDenied {
-				require.Equal(t, 1, deniedSpy.Count(), "expected exactly one log entry for unsafe internals access")
-			} else {
-				require.Equal(t, 0, deniedSpy.Count(), "expected no log entries")
-			}
-		})
-	}
+				if test.LogsDenied {
+					require.Equal(t, 1, deniedSpy.Count(), "expected exactly one log entry for unsafe internals access")
+				} else {
+					require.Equal(t, 0, deniedSpy.Count(), "expected no log entries")
+				}
+			})
+		}
+	})
+
+	t.Run("ClusterSettingOverride", func(t *testing.T) {
+		conn, err := pool.Conn(ctx)
+		require.NoError(t, err)
+		defer func() { err = conn.Close(); require.NoError(t, err) }()
+
+		// Ensure allow_unsafe_internals session variable is false.
+		_, err = conn.ExecContext(ctx, "SET allow_unsafe_internals = false")
+		require.NoError(t, err)
+
+		// Verify that unsafe access is denied by default.
+		_, err = conn.QueryContext(ctx, "SELECT * FROM system.namespace")
+		checkUnsafeErr(t, err)
+
+		// Enable the cluster setting override.
+		_, err = conn.ExecContext(ctx, "SET CLUSTER SETTING sql.override.allow_unsafe_internals.enabled = true")
+		require.NoError(t, err)
+
+		// Verify that unsafe access is now allowed even without the session variable.
+		rows, err := conn.QueryContext(ctx, "SELECT * FROM system.namespace LIMIT 1")
+		require.NoError(t, err, "expected query to succeed with cluster setting override enabled")
+		require.NoError(t, rows.Close())
+
+		// Verify access to crdb_internal tables is also allowed.
+		rows, err = conn.QueryContext(ctx, "SELECT * FROM crdb_internal.gossip_alerts LIMIT 1")
+		require.NoError(t, err, "expected crdb_internal query to succeed with cluster setting override enabled")
+		require.NoError(t, rows.Close())
+
+		// Disable the cluster setting override.
+		_, err = conn.ExecContext(ctx, "RESET CLUSTER SETTING sql.override.allow_unsafe_internals.enabled")
+		require.NoError(t, err)
+
+		// Verify that unsafe access is denied again.
+		_, err = conn.QueryContext(ctx, "SELECT * FROM system.namespace")
+		checkUnsafeErr(t, err)
+	})
 }
 
 // panickingStatement is a mock Statement that panics during formatting


### PR DESCRIPTION
Backport 1/1 commits from #159726.

/cc @cockroachdb/release

---

For this backport, we introduce the `sql.override.allow_unsafe_internals.enabled`
setting which disables all checks in unsafesql if enabled. This is just
in case we want to prevent these checks from happening on specific
clusters.

Fixes: #159725
Epic: CRDB-55276
Release note: none

Release justification: introduces a cluster setting override for the unsafesql gate.