### PR TITLE
sql/schemachanger: prevent NOT NULL violations from retrying infinitely

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
@@ -2804,9 +2805,9 @@ func validateCheckInTxn(
 					if err != nil {
 						return err
 					}
-					return newNotNullViolationErr(notNullCol.GetName(), tableDesc.AccessibleColumns(), violatingRow)
+					return scerrors.SchemaChangerUserError(newNotNullViolationErr(notNullCol.GetName(), tableDesc.AccessibleColumns(), violatingRow))
 				} else {
-					return newCheckViolationErr(formattedCkExpr, tableDesc.AccessibleColumns(), violatingRow)
+					return scerrors.SchemaChangerUserError(newCheckViolationErr(formattedCkExpr, tableDesc.AccessibleColumns(), violatingRow))
 				}
 			}
 			return nil

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -5669,3 +5669,41 @@ statement ok
 ALTER TABLE t_alter_pk_with_inverted ALTER PRIMARY KEY USING COLUMNS (a) USING HASH;
 
 subtest end
+
+# Regression test for #160436: NOT NULL validation errors containing strings
+# that match IsClosedConnection patterns (like "EOF", "is closing",
+# "use of closed connection", etc.) should not be incorrectly classified as
+# retriable connection errors.
+subtest regression_160436_not_null_validation_error_patterns
+
+statement ok
+CREATE TABLE t160436_patterns (
+    i INT PRIMARY KEY,
+    j INT,
+    pattern_eof STRING,
+    pattern_is_closing STRING,
+    pattern_tls_closed STRING,
+    pattern_network_closed STRING,
+    pattern_closed_pipe STRING,
+    pattern_node_unavailable STRING
+);
+
+statement ok
+INSERT INTO t160436_patterns VALUES (
+    1,
+    NULL,
+    '{"IYUH31EOF": 0.123}',
+    'the connection is closing now',
+    'error: tls: use of closed connection',
+    'use of closed network connection detected',
+    'io: read/write on closed pipe',
+    'the node unavailable for requests'
+);
+
+statement error validation of column "j" NOT NULL failed on row:
+ALTER TABLE t160436_patterns ALTER COLUMN j SET NOT NULL;
+
+statement ok
+DROP TABLE t160436_patterns;
+
+subtest end

--- a/pkg/sql/schemachanger/scerrors/errors.go
+++ b/pkg/sql/schemachanger/scerrors/errors.go
@@ -192,18 +192,11 @@ func HasSchemaChangerUserError(err error) bool {
 	return errors.HasType(err, (*schemaChangerUserError)(nil))
 }
 
-// UnwrapSchemaChangerUserError returns the cause of a schemaChangerUserError,
-// or nil if the error is not a schemaChangerUserError.
-func UnwrapSchemaChangerUserError(err error) error {
-	if scUserError := (*schemaChangerUserError)(nil); errors.As(err, &scUserError) {
-		return scUserError.err
-	}
-	return nil
-}
-
 // SafeFormatError is part of the errors.SafeFormatter interface.
+// This wrapper is transparent - it doesn't add any message to the error chain.
+// It only serves as a marker to indicate the error should be surfaced directly
+// to the user without additional wrapping.
 func (e *schemaChangerUserError) SafeFormatError(p errors.Printer) (next error) {
-	p.Printf("schema change operation encountered an error")
 	return e.err
 }
 

--- a/pkg/sql/schemachanger/scexec/exec_backfill.go
+++ b/pkg/sql/schemachanger/scexec/exec_backfill.go
@@ -342,11 +342,11 @@ func runBackfiller(
 			pgCode == pgcode.NotNullViolation ||
 			pgCode == pgcode.IntegrityConstraintViolation {
 			deps.Telemetry().IncrementSchemaChangeErrorType("constraint_violation")
-		} else {
-			// We ran into an  uncategorized schema change error.
-			deps.Telemetry().IncrementSchemaChangeErrorType("uncategorized")
+			return scerrors.SchemaChangerUserError(err)
 		}
-		return scerrors.SchemaChangerUserError(err)
+		// We ran into an  uncategorized schema change error.
+		deps.Telemetry().IncrementSchemaChangeErrorType("uncategorized")
+		return err
 	}
 	if err := tracker.FlushFractionCompleted(ctx); err != nil {
 		return err

--- a/pkg/sql/schemachanger/scexec/exec_validation.go
+++ b/pkg/sql/schemachanger/scexec/exec_validation.go
@@ -180,6 +180,9 @@ func (v validationAccumulator) validate(ctx context.Context, deps Dependencies) 
 	for _, tableNotNulls := range v.notNulls {
 		for _, notNull := range tableNotNulls {
 			if err := executeValidateColumnNotNull(ctx, deps, notNull); err != nil {
+				if scerrors.HasSchemaChangerUserError(err) {
+					return err
+				}
 				return errors.Wrapf(err, "%T: %v", notNull, notNull)
 			}
 		}
@@ -187,6 +190,9 @@ func (v validationAccumulator) validate(ctx context.Context, deps Dependencies) 
 	for _, tableConstraints := range v.constraints {
 		for _, constraint := range tableConstraints {
 			if err := executeValidateConstraint(ctx, deps, constraint); err != nil {
+				if scerrors.HasSchemaChangerUserError(err) {
+					return err
+				}
 				return errors.Wrapf(err, "%T: %v", constraint, constraint)
 			}
 		}

--- a/pkg/sql/schemachanger/scrun/scrun.go
+++ b/pkg/sql/schemachanger/scrun/scrun.go
@@ -205,10 +205,11 @@ func executeStage(
 			!pgerror.HasCandidateCode(err) {
 			err = p.DecorateErrorWithPlanDetails(err)
 		}
-		// Certain errors are aimed to be user consumable and should never be
-		// wrapped.
-		if userError := scerrors.UnwrapSchemaChangerUserError(err); userError != nil {
-			return userError
+		// User errors should be returned without additional wrapping to keep
+		// messages clean, but we preserve the SchemaChangerUserError wrapper
+		// so that IsPermanentSchemaChangeError can identify them as permanent.
+		if scerrors.HasSchemaChangerUserError(err) {
+			return err
 		}
 		return errors.Wrapf(err, "error executing %s", stage)
 	}


### PR DESCRIPTION
Previously, when adding a NOT NULL constraint, the schema change process included a validation step to ensure no existing rows violated the constraint. If violations were found, the schema change was expected to fail immediately.

However, due to a bug, such failures could result in an infinite retry loop. The root cause was that the error message for a NOT NULL violation included the actual row data, which could contain strings like "EOF". The retry logic (via `grpcutil.IsClosedConnection`) mistakenly interpreted such content as signaling a transient connection issue, prompting a retry.

These errors are correctly categorized as user errors and wrapped as such (using `schemaChangerUserError`). However, we were unwrapping this error type before determining whether the error was permanent (in `IsPermanentSchemaChangeError`), thereby losing the ability to correctly classify it.

The fix is to not unwrap the `schemaChangerUserError`. This allows permanent errors to be correctly identified, thus avoiding retries.

Closes #160436

Release note (bug fix): Fixed a bug where schema changes adding a NOT NULL constraint could enter an infinite retry loop if a row violated the constraint and contained certain content (e.g., "EOF"). Such errors are now correctly classified and don't cause retries.