### PR TITLE
release-26.1: sql: alter type hangs on certain conversion errors

### DIFF
--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -1462,7 +1462,8 @@ func (ib *IndexBackfiller) BuildIndexEntriesChunk(
 				// Explicitly mark with user errors for codes that we know
 				// cannot be retried.
 				if code := pgerror.GetPGCode(err); code == pgcode.FeatureNotSupported ||
-					code == pgcode.InvalidParameterValue {
+					code == pgcode.InvalidParameterValue ||
+					code == pgcode.InvalidTextRepresentation {
 					return scerrors.SchemaChangerUserError(err)
 				}
 				return err

--- a/pkg/sql/logictest/testdata/logic_test/alter_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_type
@@ -774,3 +774,20 @@ statement ok
 ALTER TYPE typ_127147 DROP VALUE 'a';
 
 subtest end
+
+# Validate that invalid type conversions will return errors to users.
+subtest invalid_type_conversion
+
+statement ok
+CREATE TABLE invalid_table(id UUID PRIMARY KEY, s STRING);
+INSERT INTO invalid_table SELECT gen_random_uuid(), '{';
+
+skipif config local-legacy-schema-changer
+statement error pgcode 22P02 failed to construct index entries during backfill: could not parse JSON.*
+ALTER TABLE invalid_table ALTER COLUMN s SET DATA TYPE JSONB USING s::JSONB; -- Attempt to convert string to json
+
+skipif config local-legacy-schema-changer
+statement error failed to construct index entries during backfill: could not parse "{" as type int: strconv.ParseInt: parsing "{": invalid syntax
+ALTER TABLE invalid_table ALTER COLUMN s SET DATA TYPE INT USING s::INT; -- Attempt to convert string to int
+
+subtest end


### PR DESCRIPTION
Backport 1/1 commits from #160730 on behalf of @fqazi.

----

Previously, converting invalid text to JSON would lead to the schema changer hanging. This was because the error returned on failed conversion were not marked as user errors. This led to the schema changer retrying them. To address this, this patch labels type conversion errors are user errors.

Fixes: #159958
Release note: None

----

Release justification: bug fix