### PR TITLE
release-25.4: sql/tests: use longer stmt timeout in TestRandomSyntaxSQLSmith

### DIFF
--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -756,7 +756,7 @@ func TestRandomSyntaxSQLSmith(t *testing.T) {
 		return err
 	}, func(ctx context.Context, db *verifyFormatDB, r *rsg.RSG) error {
 		s := smither.Generate()
-		err := db.exec(t, ctx, s)
+		err := db.execWithTimeout(t, ctx, s, 125*time.Second)
 		if c := (*crasher)(nil); errors.As(err, &c) {
 			if err := db.exec(t, ctx, "USE defaultdb"); err != nil {
 				t.Fatalf("couldn't reconnect to db after crasher: %v", c)


### PR DESCRIPTION
Backport 1/1 commits from #160718 on behalf of @yuzefovich.

----

Currently all RSG tests use 35s timeout. If a stmt isn't canceled before that, we fail the test, but such a timeout doesn't make it easy to understand whether the stmt was stuck or not. To improve the situation a bit we now give 125s timeout, under the assumptions that goroutine dumps will have 1-2 min blockage making investigations easier.

Fixes: #160678.

Release note: None

----

Release justification: