### PR TITLE
importer: add temporary SST cleanup for distributed merge

### DIFF
--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -779,6 +779,11 @@ message ImportProgress {
   repeated SequenceDetails sequence_details = 6;
 
   roachpb.BulkOpSummary summary = 7 [(gogoproto.nullable) = false];
+
+  // SSTStoragePrefixes identifies the external storage prefixes used to write
+  // distributed-merge SSTs for this import. These prefixes are used to clean
+  // up job-scoped files on completion or cancellation.
+  repeated string sst_storage_prefixes = 8 [(gogoproto.customname) = "SSTStoragePrefixes"];
 }
 
 // TypeSchemaChangeDetails is the job detail information for a type schema change job.

--- a/pkg/sql/importer/BUILD.bazel
+++ b/pkg/sql/importer/BUILD.bazel
@@ -49,6 +49,7 @@ go_library(
         "//pkg/sql",
         "//pkg/sql/bulkmerge",
         "//pkg/sql/bulksst",
+        "//pkg/sql/bulkutil",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/colinfo",


### PR DESCRIPTION
Previously, import jobs using distributed merge would create temporary SST files in nodelocal storage during both the map stage (unsorted SSTs) and merge stage (merged SSTs), but did not clean up these files on job completion or cancellation. This could lead to orphaned SST files accumulating in nodelocal storage.

This change adds SST cleanup for import using distributed merge, following the same pattern established for backfill. The implementation tracks storage prefixes in the import job progress before any SSTs are written, ensuring cleanup can occur even if the job fails mid-execution. A cleanupTempStorage() method is called on both successful completion (in Resume()) and failure/cancellation (in OnFailOrCancel()), using bulkutil.BulkJobCleaner to delete all job-scoped temporary files.

The cleanup is best-effort: errors are logged as warnings but do not fail the job. Storage prefixes are deduplicated and recorded proactively in both the map stage (import_processor.go) and merge stage (import_processor_planning.go) before any SST writes occur.

Fixes: #159928
Release note: none