### PR TITLE
jobs: use SELECT FOR UPDATE in claim loop to prevent deadlock

### DIFF
--- a/pkg/jobs/config.go
+++ b/pkg/jobs/config.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/util/metamorphic"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
@@ -25,6 +26,7 @@ const (
 	debugPausePointsSettingKey = "jobs.debug.pausepoints"
 	metricsPollingIntervalKey  = "jobs.metrics.interval.poll"
 	claimQueryTimeoutKey       = "jobs.registry.claim_query.timeout"
+	useSelectForUpdateKey      = "jobs.registry.claim_query.select_for_update.enabled"
 )
 
 const (
@@ -142,6 +144,14 @@ var (
 		"the timeout for the claim query used when adopting jobs",
 		time.Minute,
 		settings.PositiveDuration,
+	)
+
+	UseSelectForUpdate = settings.RegisterBoolSetting(
+		settings.ApplicationLevel,
+		useSelectForUpdateKey,
+		"when true, uses SELECT FOR UPDATE in the claim loop to prevent deadlock; "+
+			"when false, uses the legacy single-query UPDATE RETURNING approach",
+		metamorphic.ConstantWithTestBool("jobs-claim-use-sfu", true),
 	)
 )
 

--- a/pkg/jobs/helpers_test.go
+++ b/pkg/jobs/helpers_test.go
@@ -83,7 +83,7 @@ func (j *Job) TestingCurrentState(ctx context.Context) (State, error) {
 }
 
 const (
-	AdoptQuery               = claimQuery
+	GetAdoptableQuery        = GetClaimableJobsQuery
 	CancelQuery              = pauseAndCancelUpdate
 	RemoveClaimsQuery        = removeClaimsForDeadSessionsQuery
 	ProcessJobsQuery         = processQuery

--- a/pkg/jobs/registry_external_test.go
+++ b/pkg/jobs/registry_external_test.go
@@ -211,7 +211,7 @@ func TestRegistrySettingUpdate(t *testing.T) {
 			name:       "adopt setting",
 			setting:    jobs.AdoptIntervalSettingKey,
 			value:      shortDuration,
-			matchStmt:  jobs.AdoptQuery,
+			matchStmt:  jobs.GetAdoptableQuery,
 			initCount:  0,
 			toOverride: jobs.AdoptIntervalSetting,
 		},
@@ -219,7 +219,7 @@ func TestRegistrySettingUpdate(t *testing.T) {
 			name:       "adopt setting with base",
 			setting:    jobs.IntervalBaseSettingKey,
 			value:      shortDurationBase,
-			matchStmt:  jobs.AdoptQuery,
+			matchStmt:  jobs.GetAdoptableQuery,
 			initCount:  0,
 			toOverride: jobs.AdoptIntervalSetting,
 		},
@@ -293,6 +293,9 @@ func TestRegistrySettingUpdate(t *testing.T) {
 			s, sdb, _ := serverutils.StartServer(t, args)
 			defer s.Stopper().Stop(ctx)
 			tdb := sqlutils.MakeSQLRunner(sdb)
+
+			// Enable SELECT FOR UPDATE in claim query.
+			tdb.Exec(t, "SET CLUSTER SETTING jobs.registry.claim_query.select_for_update.enabled = true")
 
 			// Wait for the initial job runs to finish.
 			testutils.SucceedsSoon(t, func() error {

--- a/pkg/jobs/registry_test.go
+++ b/pkg/jobs/registry_test.go
@@ -648,7 +648,8 @@ func TestRegistryUsePartialIndex(t *testing.T) {
 		queryArgs []interface{}
 	}{
 		{"remove claims", RemoveClaimsQuery, []interface{}{sid, lim}},
-		{"claim jobs", AdoptQuery, []interface{}{sid, iid, lim}},
+		{"get claimable jobs", GetClaimableJobsQuery, []interface{}{lim}},
+		{"claim jobs legacy", legacyClaimQuery, []interface{}{sid, iid, lim}},
 		{"process claimed jobs", ProcessJobsQuery, []interface{}{sid, iid}},
 		{"serve cancel and pause", CancelQuery, []interface{}{sid, iid}},
 	} {


### PR DESCRIPTION
Previously, the claim query run on a node could deadlock with another claim
query run on a different node, as the query would acquire row locks across
ranges in parallel.  For example, node 1's query could acquire locks on r1 then
wait for r2, and node 2 could aquire r2, then wait for r1. This refactor
prevents this deadlock, since SELECT FOR UPDATE queries don't parallelize lock
acquisition across ranges.

To further reduce contention, we could add a SKIP LOCK clause to the query, but
it cannot be used on tables with multiple column families, like system.jobs
(known limitation tracked in https://github.com/cockroachdb/cockroach/issues/160961).

This patch also adds a cluster setting,
jobs.registry.claim_query.select_for_update.enabled, in case the user needs to
fall back to the old claim query.

Informs https://github.com/cockroachdb/cockroach/issues/158976

Release note: none