### PR TITLE
goroutinedumper: adopt debug=3 instead of debug=2

### DIFF
--- a/pkg/server/goroutinedumper/BUILD.bazel
+++ b/pkg/server/goroutinedumper/BUILD.bazel
@@ -9,7 +9,6 @@ go_library(
         "//pkg/server/dumpstore",
         "//pkg/settings",
         "//pkg/settings/cluster",
-        "//pkg/util/allstacks",
         "//pkg/util/log",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/server/goroutinedumper/goroutinedumper_test.go
+++ b/pkg/server/goroutinedumper/goroutinedumper_test.go
@@ -182,7 +182,7 @@ func TestTakeGoroutineDump(t *testing.T) {
 	t.Run("fails because dump already exists as a directory", func(t *testing.T) {
 		tempDir, dirCleanupFn := testutils.TempDir(t)
 		defer dirCleanupFn()
-		path := filepath.Join(tempDir, "goroutine_dump.txt.gz")
+		path := filepath.Join(tempDir, "goroutine_dump.pb.gz")
 		err := os.Mkdir(path, 0755)
 		assert.NoError(t, err, "failed to make dump directory %s", path)
 
@@ -204,7 +204,7 @@ func TestTakeGoroutineDump(t *testing.T) {
 		err := takeGoroutineDump(path)
 		assert.NoError(t, err, "unexpected error when dumping goroutines")
 
-		expectedFile := filepath.Join(tempDir, "goroutine_dump.txt.gz")
+		expectedFile := filepath.Join(tempDir, "goroutine_dump.pb.gz")
 		f, err := os.Open(expectedFile)
 		if err != nil {
 			t.Fatalf("could not open goroutine dump file %s: %s", expectedFile, err)


### PR DESCRIPTION
Previously, allstacks.Get() was used to get all goroutines which involved a
disruptive stop-the-world event. By using debug=3 when fetching the goroutine
profile, stop-the-world penalties are minimized, improving the performance
impact of dumping goroutines. Note that debug=3 was introduced recently in
https://github.com/cockroachdb/go/pull/12.

The debug=3 mode emits the goroutine profile in the same binary protocol output
format as debug=0, with the only difference being that it does not aggregate
matching stack/label combinations into a single count, and instead emits a
sample per goroutine with additional synthesized labels to communicate some of
the details of each goroutine.

Fixes: https://github.com/cockroachdb/cockroach/issues/159343 
Fixes: https://github.com/cockroachdb/cockroach/issues/160743

Release note (ops change): goroutine profile dumps are now captured as binary
proto .pb.gz files instead of human readable .txt.gz files. This change
improves the performance of the goroutine dumper by eliminating stop-the-world
events caused by grabbing stacks during goroutine dumps.