### PR TITLE
release-26.1: revert "sql: remove gossip-based DistSQL physical planning"

### DIFF
--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -276,7 +276,6 @@ var retiredSettings = map[InternalKey]struct{}{
 	"storage.columnar_blocks.enabled": {},
 
 	// removed as of 26.1
-	"sql.distsql_planning.use_gossip.enabled":             {},
 	"rocksdb.ingest_backpressure.l0_file_count_threshold": {},
 	"rocksdb.ingest_backpressure.max_delay":               {},
 	"pebble.pre_ingest_delay.enabled":                     {},

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangecache"
@@ -1861,6 +1862,112 @@ func TestShouldPickGatewayNode(t *testing.T) {
 			shouldPick := mockDsp.shouldPickGateway(mockPlanCtx, tc.instances)
 			require.Equal(t, tc.shouldPick, shouldPick)
 		})
+	}
+}
+
+// Test that a node whose descriptor info is not accessible through gossip is
+// not used. This is to simulate nodes that have been decomisioned and also
+// nodes that have been "replaced" by another node at the same address (which, I
+// guess, is also a type of decomissioning).
+func TestPartitionSpansSkipsNodesNotInGossip(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// The spans that we're going to plan for.
+	span := roachpb.Span{Key: roachpb.Key("A"), EndKey: roachpb.Key("Z")}
+	gatewayNode := roachpb.NodeID(2)
+	ranges := []testSpanResolverRange{{"A", 1}, {"B", 2}, {"C", 1}}
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.Background())
+	codec := keys.SystemSQLCodec
+
+	mockGossip := gossip.NewTest(roachpb.NodeID(1), stopper, metric.NewRegistry())
+	var nodeDescs []*roachpb.NodeDescriptor
+	for i := 1; i <= 2; i++ {
+		sqlInstanceID := base.SQLInstanceID(i)
+		desc := &roachpb.NodeDescriptor{
+			NodeID:  roachpb.NodeID(sqlInstanceID),
+			Address: util.UnresolvedAddr{AddressField: fmt.Sprintf("addr%d", i)},
+		}
+		if i == 2 {
+			if err := mockGossip.SetNodeDescriptor(desc); err != nil {
+				t.Fatal(err)
+			}
+		}
+		// All the nodes advertise that they are not draining. This is to
+		// simulate the "node overridden by another node at the same address"
+		// case mentioned in the test comment - for such a node, the descriptor
+		// would be taken out of the gossip data, but other datums it advertised
+		// are left in place.
+		if err := mockGossip.AddInfoProto(
+			gossip.MakeDistSQLDrainingKey(sqlInstanceID),
+			&execinfrapb.DistSQLDrainingInfo{
+				Draining: false,
+			},
+			0, // ttl - no expiration
+		); err != nil {
+			t.Fatal(err)
+		}
+
+		nodeDescs = append(nodeDescs, desc)
+	}
+	tsp := &testSpanResolver{
+		nodes:  nodeDescs,
+		ranges: ranges,
+	}
+
+	st := cluster.MakeTestingClusterSettings()
+	gw := gossip.MakeOptionalGossip(mockGossip)
+	dsp := DistSQLPlanner{
+		st:                   st,
+		gatewaySQLInstanceID: base.SQLInstanceID(tsp.nodes[gatewayNode-1].NodeID),
+		stopper:              stopper,
+		spanResolver:         tsp,
+		gossip:               gw,
+		nodeHealth: distSQLNodeHealth{
+			gossip: gw,
+			connHealthSystem: func(node roachpb.NodeID, _ rpcbase.ConnectionClass) error {
+				_, _, err := mockGossip.GetNodeIDAddress(node)
+				return err
+			},
+			isAvailable: func(base.SQLInstanceID) bool {
+				return true
+			},
+		},
+		codec: codec,
+	}
+
+	ctx := context.Background()
+	// This test is specific to gossip-based planning.
+	useGossipPlanning.Override(ctx, &st.SV, true)
+	planCtx := dsp.NewPlanningCtx(
+		ctx, &extendedEvalContext{Context: eval.Context{Codec: codec, Settings: st}},
+		nil /* planner */, nil /* txn */, FullDistribution,
+	)
+	partitions, err := dsp.PartitionSpans(ctx, planCtx, roachpb.Spans{span}, PartitionSpansBoundDefault)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resMap := make(map[base.SQLInstanceID][][2]string)
+	for _, p := range partitions {
+		if _, ok := resMap[p.SQLInstanceID]; ok {
+			t.Fatalf("node %d shows up in multiple partitions", p.SQLInstanceID)
+		}
+		var spans [][2]string
+		for _, s := range p.Spans {
+			spans = append(spans, [2]string{string(s.Key), string(s.EndKey)})
+		}
+		resMap[p.SQLInstanceID] = spans
+	}
+
+	expectedPartitions :=
+		map[base.SQLInstanceID][][2]string{
+			2: {{"A", "Z"}},
+		}
+	if !reflect.DeepEqual(resMap, expectedPartitions) {
+		t.Errorf("expected partitions:\n  %v\ngot:\n  %v", expectedPartitions, resMap)
 	}
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #160765.

/cc @cockroachdb/release

---

This reverts commit fba7dbf04a1a47fcb43b0e61c9d667f3f682ab62.

Currently, using gossip-based planning is the only way of going around #147755. The cost of maintaining this setting is very low, so let's hold off on removal for a little longer.

Epic: None
Release note: None

Release justification: low-risk revert to have an additional flexibility in large clusters.