### PR TITLE
settings: put removal of one setting in the correct spot

### DIFF
--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -276,12 +276,12 @@ var retiredSettings = map[InternalKey]struct{}{
 	"storage.columnar_blocks.enabled": {},
 
 	// removed as of 26.1
-	"bulkio.import.write_import_epoch.enabled":            {},
 	"rocksdb.ingest_backpressure.l0_file_count_threshold": {},
 	"rocksdb.ingest_backpressure.max_delay":               {},
 	"pebble.pre_ingest_delay.enabled":                     {},
 
 	// removed as of 26.2
+	"bulkio.import.write_import_epoch.enabled":                 {},
 	"physical_replication.consumer.stream_compression.enabled": {},
 }
 


### PR DESCRIPTION
`bulkio.import.write_import_epoch.enabled` was removed in 26.2.

Touches: #159645.
Epic: None
Release note: None