### PR TITLE
storage: use iter.Seq for iteration over range key stacks

### DIFF
--- a/pkg/crosscluster/physical/stream_ingestion_processor.go
+++ b/pkg/crosscluster/physical/stream_ingestion_processor.go
@@ -1265,7 +1265,7 @@ func splitRangeKeySSTAtKey(
 			// NB: We don't call Next() here because the
 			// split key is exclusive already.
 			last = append(last[:0], rangeKeys.Bounds.EndKey...)
-			for _, rk := range rangeKeys.AsRangeKeys() {
+			for rk := range rangeKeys.All() {
 				if err := writer.PutRawMVCCRangeKey(rk, []byte{}); err != nil {
 					return nil, nil, err
 				}
@@ -1300,7 +1300,7 @@ func splitRangeKeySSTAtKey(
 		}
 		last = append(last[:0], rangeKeys.Bounds.EndKey...)
 		last.Next()
-		for _, rk := range rangeKeys.AsRangeKeys() {
+		for rk := range rangeKeys.All() {
 			if err := writer.PutRawMVCCRangeKey(rk, []byte{}); err != nil {
 				return nil, nil, err
 			}

--- a/pkg/kv/kvnemesis/operations.go
+++ b/pkg/kv/kvnemesis/operations.go
@@ -396,7 +396,7 @@ func (op AddSSTableOperation) format(w *strings.Builder, fctx formatCtx) {
 		if iter.RangeKeyChanged() {
 			hasPoint, hasRange := iter.HasPointAndRange()
 			if hasRange {
-				for _, rkv := range iter.RangeKeys().AsRangeKeyValues() {
+				for rkv := range iter.RangeKeys().AsRangeKeyValues() {
 					mvccValue, err := storage.DecodeMVCCValue(rkv.Value)
 					if err != nil {
 						panic(err)

--- a/pkg/kv/kvserver/gc/gc_random_test.go
+++ b/pkg/kv/kvserver/gc/gc_random_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -481,7 +482,7 @@ func getExpectationsGenerator(
 						// so we will add them to history of current key for analysis.
 						// Bare range tombstones are ignored.
 						if r {
-							for _, r := range it.RangeKeys().AsRangeKeys() {
+							for r := range it.RangeKeys().All() {
 								history = append(history, historyItem{
 									MVCCKeyValue: storage.MVCCKeyValue{
 										Key: storage.MVCCKey{
@@ -621,7 +622,7 @@ func getKeyHistory(t *testing.T, r storage.Reader, key roachpb.Key) string {
 			break
 		}
 		if r && len(result) == 0 {
-			for _, rk := range it.RangeKeys().AsRangeKeyValues() {
+			for rk := range it.RangeKeys().AsRangeKeyValues() {
 				result = append(result, fmt.Sprintf("R:%s", rk.RangeKey.String()))
 			}
 		}
@@ -643,7 +644,7 @@ func rangeFragmentsFromIt(t *testing.T, it storage.MVCCIterator) [][]storage.MVC
 			break
 		}
 		if _, hasRange := it.HasPointAndRange(); hasRange {
-			result = append(result, it.RangeKeys().Clone().AsRangeKeyValues())
+			result = append(result, slices.Collect(it.RangeKeys().Clone().AsRangeKeyValues()))
 		}
 		it.NextKey()
 	}

--- a/pkg/kv/kvserver/gc/gc_test.go
+++ b/pkg/kv/kvserver/gc/gc_test.go
@@ -12,6 +12,7 @@ import (
 	"math"
 	"math/rand"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -1495,7 +1496,7 @@ func engineData(t *testing.T, r storage.Reader, desc roachpb.RangeDescriptor) []
 		_, r := rangeIt.HasPointAndRange()
 		if r {
 			span := rangeIt.RangeBounds()
-			newKeys := rangeIt.RangeKeys().AsRangeKeys()
+			newKeys := slices.Collect(rangeIt.RangeKeys().All())
 			if lastEnd.Equal(span.Key) {
 				// Try merging keys by timestamp.
 				var newPartial []storage.MVCCRangeKey

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -2668,7 +2668,7 @@ func scanRangeKeys(t *testing.T, r Reader) []MVCCRangeKeyValue {
 		if !ok {
 			break
 		}
-		for _, rkv := range iter.RangeKeys().AsRangeKeyValues() {
+		for rkv := range iter.RangeKeys().AsRangeKeyValues() {
 			rangeKeys = append(rangeKeys, rkv.Clone())
 		}
 	}
@@ -2730,7 +2730,7 @@ func scanIter(t *testing.T, iter SimpleMVCCIterator) []interface{} {
 		hasPoint, hasRange := iter.HasPointAndRange()
 		if hasRange {
 			if bounds := iter.RangeBounds(); !bounds.Key.Equal(prevRangeStart) {
-				for _, rkv := range iter.RangeKeys().AsRangeKeyValues() {
+				for rkv := range iter.RangeKeys().AsRangeKeyValues() {
 					keys = append(keys, rkv.Clone())
 				}
 				prevRangeStart = bounds.Key.Clone()

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -5830,7 +5830,7 @@ func TestMVCCGarbageCollectRanges(t *testing.T) {
 				if !ok {
 					break
 				}
-				for _, rk := range it.RangeKeys().AsRangeKeys() {
+				for rk := range it.RangeKeys().All() {
 					require.Less(t, expectIndex, len(d.after), "not enough expectations; at unexpected range: %s", rk)
 					require.EqualValues(t, d.after[expectIndex], rk, "range key is not equal")
 					expectIndex++


### PR DESCRIPTION
Update MVCCRangeKeyStack methods to expose Go iterators rather than construct new slices, and remove unused methods.

Epic: none
Release note: none