### PR TITLE
release-25.4: execbuilder: fix a stats-related flake in a new test

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_scan
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_scan
@@ -31,6 +31,10 @@ start_key           end_key       replicas  lease_holder
 statement ok
 ANALYZE abc
 
+# Clear the stat cache so that the new statistic is guaranteed to be used.
+statement ok
+SELECT crdb_internal.clear_table_stats_cache();
+
 query T
 EXPLAIN ANALYZE (DISTSQL) SELECT a FROM abc WHERE a >= 0 AND a < 100 ORDER BY a LIMIT 10
 ----


### PR DESCRIPTION
Backport 1/1 commits from #160760 on behalf of @yuzefovich.

----

Fixes: #160752.
Fixes: #160753.
Release note: None

----

Release justification: test-only change.