### PR TITLE
backup: support backup IDs in SHOW BACKUP

### DIFF
--- a/pkg/backup/backupinfo/backup_index.go
+++ b/pkg/backup/backupinfo/backup_index.go
@@ -333,6 +333,9 @@ type parsedIndex struct {
 //
 // NB: Filtering is applied to backup end times truncated to tens of
 // milliseconds.
+//
+// NB: The returned index times are only as precise as the timestamps encoded in
+// the index filenames.
 func listIndexesWithinRange(
 	ctx context.Context,
 	store cloud.ExternalStorage,
@@ -441,22 +444,10 @@ func GetBackupTreeIndexMetadata(
 			if err != nil {
 				return err
 			}
-			reader, _, err := store.ReadFile(
-				ctx, path.Join(indexDir, basename), cloud.ReadOptions{},
-			)
+			indexFilePath := path.Join(indexDir, basename)
+			index, err := readIndexFile(ctx, store, indexFilePath)
 			if err != nil {
-				return errors.Wrapf(err, "reading index file %s", basename)
-			}
-			defer reader.Close(ctx)
-
-			bytes, err := ioctx.ReadAll(ctx, reader)
-			if err != nil {
-				return errors.Wrapf(err, "reading index file %s", basename)
-			}
-
-			index := backuppb.BackupIndexMetadata{}
-			if err := protoutil.Unmarshal(bytes, &index); err != nil {
-				return errors.Wrapf(err, "unmarshalling index file %s", basename)
+				return err
 			}
 			indexes[i] = index
 			return nil
@@ -468,6 +459,67 @@ func GetBackupTreeIndexMetadata(
 	}
 
 	return indexes, nil
+}
+
+// FindLatestBackup finds the index of the latest backup taken in the
+// collection. This backup does not necessarily belong to the latest chain
+// (incrementals from an older chain may be taken during a full backup).
+// The provided store must be rooted at the default collection URI (the one that
+// contains the `metadata/` directory). The ID of the discovered backup is also
+// returned.
+//
+// NB: If a full and incremental have the same end time, the latest chain (i.e.
+// the full) is chosen. If there are multiple incrementals within the same chain
+// that share the same end time, the incremental with the latest start time is
+// chosen. This ensures that the latest backup we pick is always the same backup
+// as what would be shown by ListRestorableBackups.
+func FindLatestBackup(
+	ctx context.Context, store cloud.ExternalStorage,
+) (backuppb.BackupIndexMetadata, string, error) {
+	var latestIdxFilepath string
+	var latestEnd time.Time
+	var lastSeenFullEnd time.Time
+	if err := store.List(
+		ctx,
+		backupbase.BackupIndexDirectoryPath,
+		cloud.ListOptions{},
+		func(file string) error {
+			fullEnd, _, endTime, err := parseTimesFromIndexFilepath(file)
+			if err != nil {
+				return err
+			}
+			if endTime.Before(latestEnd) {
+				// The moment we see an end time before the latest we've seen, we know
+				// that we found the latest backup in the previous iteration.
+				return cloud.ErrListingDone
+			} else if endTime.Equal(latestEnd) && !fullEnd.Equal(lastSeenFullEnd) {
+				// If the end time is equal, but the full end time has changed, we know
+				// that we have found the latest end time, and we should pick the newer
+				// chain.
+				return cloud.ErrListingDone
+			}
+			// Otherwise, we have either found a new latest end time, or we have
+			// found an incremental backup with the same end time as the latest and
+			// we always choose the latest start time to break ties, so we update.
+			latestEnd = endTime
+			latestIdxFilepath = path.Join(
+				backupbase.BackupIndexDirectoryPath, file,
+			)
+			lastSeenFullEnd = fullEnd
+			return nil
+		},
+	); err != nil && !errors.Is(err, cloud.ErrListingDone) {
+		return backuppb.BackupIndexMetadata{}, "", err
+	}
+	if latestIdxFilepath == "" {
+		return backuppb.BackupIndexMetadata{}, "", errors.Newf("no backups found in collection")
+	}
+
+	index, err := readIndexFile(ctx, store, latestIdxFilepath)
+	if err != nil {
+		return backuppb.BackupIndexMetadata{}, "", err
+	}
+	return index, encodeBackupID(lastSeenFullEnd, latestEnd), nil
 }
 
 // ParseBackupFilePathFromIndexFileName parses the path to a backup given the
@@ -766,6 +818,9 @@ func readIndexFile(
 
 // encodeBackupID generates a backup ID for a backup identified by its parent
 // full end time and its own end time.
+//
+// NB: The times passed to this function are expected to be as precise as the
+// timestamps encoded in the index file names, no more or less.
 func encodeBackupID(fullEnd time.Time, backupEnd time.Time) string {
 	var buf []byte
 	buf = encoding.EncodeUint64Ascending(buf, uint64(fullEnd.UnixMilli()))
@@ -782,4 +837,42 @@ func encodeBackupID(fullEnd time.Time, backupEnd time.Time) string {
 	// in the encoding and re-add them during decoding.
 	buf = bytes.TrimRight(buf, "\x00")
 	return base64.URLEncoding.EncodeToString(buf)
+}
+
+// DecodeBackupID decodes a backup ID into its corresponding full end time and
+// backup end time.
+//
+// NB: Because the backup IDs are encodings of timestamps that are as precise as
+// the timestamps encoded in the index file names, the returned times are only
+// as precise as that.
+func DecodeBackupID(backupID string) (fullEnd time.Time, backupEnd time.Time, err error) {
+	if backupID == "" {
+		return time.Time{}, time.Time{}, errors.Newf("failed decoding backup ID: cannot be empty")
+	}
+
+	decoded, err := base64.URLEncoding.DecodeString(backupID)
+	if err != nil {
+		return time.Time{}, time.Time{}, errors.Wrapf(err, "failed decoding backup ID %s", backupID)
+	} else if len(decoded) > 16 {
+		return time.Time{}, time.Time{}, errors.Newf("failed decoding backup ID %s: invalid encoding", backupID)
+	}
+	// Re-add trailing zeroes that may have been trimmed during encoding.
+	padded := make([]byte, 16)
+	copy(padded[:len(decoded)], decoded)
+	slices.Reverse(padded)
+	// Reverse the XOR obfuscation.
+	for i := range 8 {
+		padded[i] = padded[i] ^ padded[i+8]
+	}
+
+	_, fullEndMillis, err := encoding.DecodeUint64Ascending(padded)
+	if err != nil {
+		return time.Time{}, time.Time{}, errors.Wrapf(err, "failed decoding full end time from backup ID %s", backupID)
+	}
+	_, backupEndMillis, err := encoding.DecodeUint64Ascending(padded[8:])
+	if err != nil {
+		return time.Time{}, time.Time{}, errors.Wrapf(err, "failed decoding backup end time from backup ID %s", backupID)
+	}
+
+	return time.UnixMilli(int64(fullEndMillis)).UTC(), time.UnixMilli(int64(backupEndMillis)).UTC(), nil
 }

--- a/pkg/backup/backupinfo/backup_index.go
+++ b/pkg/backup/backupinfo/backup_index.go
@@ -522,6 +522,61 @@ func FindLatestBackup(
 	return index, encodeBackupID(lastSeenFullEnd, latestEnd), nil
 }
 
+// ResolveBackupIDtoIndex takes a backup ID and resolves it to the corresponding
+// backup index. The store should be rooted at the default collection URI
+// (the one that contains the `metadata/` directory).
+//
+// NB: If there are multiple backups with the same end time (i.e. compacted
+// backups), the backup with the *latest* start time is chosen. This ensures
+// that the backup we choose is the same one we encoded in ListRestorableBackups.
+func ResolveBackupIDtoIndex(
+	ctx context.Context, store cloud.ExternalStorage, backupID string,
+) (backuppb.BackupIndexMetadata, error) {
+	fullEnd, backupEnd, err := DecodeBackupID(backupID)
+	if err != nil {
+		return backuppb.BackupIndexMetadata{}, err
+	}
+	indexSubdir, err := endTimeToIndexSubdir(fullEnd)
+	if err != nil {
+		return backuppb.BackupIndexMetadata{}, err
+	}
+
+	var matchingIdxFile string
+	if err := store.List(
+		ctx,
+		indexSubdir+"/",
+		cloud.ListOptions{},
+		func(file string) error {
+			_, end, err := parseIndexBasename(file)
+			if err != nil {
+				return err
+			}
+			if end.Equal(backupEnd) {
+				matchingIdxFile = path.Join(indexSubdir, file)
+			} else if end.Before(backupEnd) {
+				// By choosing to only stop listing after we see a backup OLDER than the
+				// end time encoded in the ID, we ensure that if there are multiple
+				// backups with the same end time, we pick the one with the latest start
+				// time as indexes are sorted with ascending start time breaking ties.
+				return cloud.ErrListingDone
+			}
+			return nil
+		},
+	); err != nil && !errors.Is(err, cloud.ErrListingDone) {
+		return backuppb.BackupIndexMetadata{}, errors.Wrapf(err, "listing index subdir %s", indexSubdir)
+	}
+	if matchingIdxFile == "" {
+		return backuppb.BackupIndexMetadata{}, errors.Newf(
+			"backup with ID %s not found", backupID,
+		)
+	}
+	index, err := readIndexFile(ctx, store, matchingIdxFile)
+	if err != nil {
+		return backuppb.BackupIndexMetadata{}, err
+	}
+	return index, nil
+}
+
 // ParseBackupFilePathFromIndexFileName parses the path to a backup given the
 // basename of its index file and its subdirectory. For full backups, the
 // returned path is relative to the root of the backup. For incremental

--- a/pkg/backup/backupinfo/backup_index.go
+++ b/pkg/backup/backupinfo/backup_index.go
@@ -931,3 +931,13 @@ func DecodeBackupID(backupID string) (fullEnd time.Time, backupEnd time.Time, er
 
 	return time.UnixMilli(int64(fullEndMillis)).UTC(), time.UnixMilli(int64(backupEndMillis)).UTC(), nil
 }
+
+// BackupIDToFullSubdir converts a backup ID to its corresponding full backup
+// subdirectory.
+func BackupIDToFullSubdir(backupID string) (string, error) {
+	fullEnd, _, err := DecodeBackupID(backupID)
+	if err != nil {
+		return "", err
+	}
+	return fullEnd.Format(backupbase.DateBasedIntoFolderName), nil
+}

--- a/pkg/backup/backupinfo/backup_index_test.go
+++ b/pkg/backup/backupinfo/backup_index_test.go
@@ -1114,6 +1114,138 @@ func TestEncodeDecodeBackupID(t *testing.T) {
 	})
 }
 
+func TestResolveBackupIDtoIndex(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	execCfg := &sql.ExecutorConfig{Settings: st}
+	const collectionURI = "nodelocal://1/backup"
+	dir, dirCleanupFn := testutils.TempDir(t)
+	defer dirCleanupFn()
+	externalStorage, err := cloud.ExternalStorageFromURI(
+		ctx,
+		collectionURI,
+		base.ExternalIODirConfig{},
+		st,
+		blobs.TestBlobServiceClient(dir),
+		username.RootUserName(),
+		nil, /* db */
+		nil, /* limiters */
+		cloud.NilMetrics,
+	)
+	require.NoError(t, err)
+	makeExternalStorage := func(
+		_ context.Context, _ string, _ username.SQLUsername, _ ...cloud.ExternalStorageOption,
+	) (cloud.ExternalStorage, error) {
+		return externalStorage, nil
+	}
+
+	fakeBackupCollection{
+		{
+			// Simple chain.
+			b(0, 2), b(2, 4), b(4, 6),
+		},
+		{
+			// Single compacted backup.
+			b(0, 8), b(8, 10), b(10, 12), b(8, 14), b(12, 14),
+		},
+		{
+			// Double compacted backup, same end time.
+			b(0, 16), b(16, 18), b(18, 20), b(20, 22), b(18, 26), b(20, 26), b(22, 26), b(26, 28),
+		},
+		{
+			// Duplicate end time from previous chain.
+			b(0, 28),
+		},
+	}.writeIndexes(t, ctx, execCfg, makeExternalStorage, collectionURI)
+
+	testcases := []struct {
+		name string
+		// endTimesToID is a tuple of [fullEnd, end] times to construct the ID from.
+		endTimesToID [2]int
+		// expectedTimes is the tuple of [start, end] times expected in the resolved
+		// index.
+		expectedTimes [2]int
+	}{
+		{
+			name:          "simple chain/full backup",
+			endTimesToID:  [2]int{2, 2},
+			expectedTimes: [2]int{0, 2},
+		},
+		{
+			name:          "simple chain/incremental backup",
+			endTimesToID:  [2]int{2, 4},
+			expectedTimes: [2]int{2, 4},
+		},
+		{
+			name:          "single compacted backup",
+			endTimesToID:  [2]int{8, 14},
+			expectedTimes: [2]int{12, 14},
+		},
+		{
+			name:          "doubly compacted backup",
+			endTimesToID:  [2]int{16, 26},
+			expectedTimes: [2]int{22, 26},
+		},
+		{
+			name:          "incremental covered by compacted backup",
+			endTimesToID:  [2]int{8, 12},
+			expectedTimes: [2]int{10, 12},
+		},
+		{
+			name:          "duplicate end time from prev chain chain (choose prev)",
+			endTimesToID:  [2]int{16, 28},
+			expectedTimes: [2]int{26, 28},
+		},
+		{
+			name:          "duplicate end time from prev chain chain (choose new)",
+			endTimesToID:  [2]int{28, 28},
+			expectedTimes: [2]int{0, 28},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			fullEnd := intToTime(tc.endTimesToID[0]).GoTime()
+			endTime := intToTime(tc.endTimesToID[1]).GoTime()
+			id := encodeBackupID(fullEnd, endTime)
+
+			index, err := ResolveBackupIDtoIndex(ctx, externalStorage, id)
+			require.NoError(t, err)
+
+			expectedTS := [2]hlc.Timestamp{
+				intToTimeWithNano(tc.expectedTimes[0]),
+				intToTimeWithNano(tc.expectedTimes[1]),
+			}
+			actualTS := [2]hlc.Timestamp{index.StartTime, index.EndTime}
+			require.Equal(t, expectedTS, actualTS)
+		})
+	}
+
+	t.Run("bad IDs", func(t *testing.T) {
+		t.Run("no matching full subdir", func(t *testing.T) {
+			fullEnd := intToTime(100).GoTime()
+			endTime := intToTime(200).GoTime()
+			id := encodeBackupID(fullEnd, endTime)
+
+			_, err := ResolveBackupIDtoIndex(ctx, externalStorage, id)
+			require.ErrorContains(t, err, fmt.Sprintf("backup with ID %s not found", id))
+		})
+
+		t.Run("no matching backup end time", func(t *testing.T) {
+			fullEnd := intToTime(28).GoTime()
+			endTime := intToTime(30).GoTime()
+			id := encodeBackupID(fullEnd, endTime)
+
+			_, err := ResolveBackupIDtoIndex(ctx, externalStorage, id)
+			require.ErrorContains(t, err, fmt.Sprintf("backup with ID %s not found", id))
+		})
+	})
+}
+
+
 // intToTime converts the integer time to an easy-to-read hlc.Timestamp
 // (i.e. XX000000000). We use ints to more easily write times for test cases.
 func intToTime(t int) hlc.Timestamp {

--- a/pkg/backup/backupinfo/backup_index_test.go
+++ b/pkg/backup/backupinfo/backup_index_test.go
@@ -1245,7 +1245,6 @@ func TestResolveBackupIDtoIndex(t *testing.T) {
 	})
 }
 
-
 // intToTime converts the integer time to an easy-to-read hlc.Timestamp
 // (i.e. XX000000000). We use ints to more easily write times for test cases.
 func intToTime(t int) hlc.Timestamp {

--- a/pkg/backup/backupinfo/backup_index_test.go
+++ b/pkg/backup/backupinfo/backup_index_test.go
@@ -8,6 +8,7 @@ package backupinfo
 import (
 	"context"
 	"fmt"
+	"math"
 	"math/rand"
 	"net/url"
 	"os"
@@ -937,7 +938,194 @@ func TestConvertIndexSubdirToSubdir(t *testing.T) {
 	}
 }
 
-// intToTimeWithNano converts the integer time an easy to read hlc.Timestamp
+func TestFindLatestBackup(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	execCfg := &sql.ExecutorConfig{Settings: st}
+	const collectionURI = "nodelocal://1/backup"
+	dir, dirCleanupFn := testutils.TempDir(t)
+	defer dirCleanupFn()
+
+	testcases := []struct {
+		name       string
+		collection fakeBackupCollection
+		// expectedFullEnd is the end time of the full backup of the chain the latest
+		// backup is from.
+		expectedFullEnd int
+		expectedTimes   [2]int
+	}{
+		{
+			name: "single chain/full backup only",
+			collection: fakeBackupCollection{
+				chain(b(0, 2)),
+			},
+			expectedFullEnd: 2,
+			expectedTimes:   [2]int{0, 2},
+		},
+		{
+			name: "single chain/multiple backups",
+			collection: fakeBackupCollection{
+				chain(b(0, 2), b(2, 4), b(4, 6)),
+			},
+			expectedFullEnd: 2,
+			expectedTimes:   [2]int{4, 6},
+		},
+		{
+			name: "single chain/choose non-compacted-backup",
+			collection: fakeBackupCollection{
+				chain(b(0, 2), b(2, 4), b(4, 6), b(2, 8), b(6, 8)),
+			},
+			expectedFullEnd: 2,
+			expectedTimes:   [2]int{6, 8},
+		},
+		{
+			name: "multiple chains/latest is latest full",
+			collection: fakeBackupCollection{
+				chain(b(0, 2), b(2, 4)),
+				chain(b(0, 6)),
+			},
+			expectedFullEnd: 6,
+			expectedTimes:   [2]int{0, 6},
+		},
+		{
+			name: "multiple chains/latest is latest incremental",
+			collection: fakeBackupCollection{
+				chain(b(0, 2), b(2, 4), b(4, 8)),
+				chain(b(0, 6), b(6, 10)),
+			},
+			expectedFullEnd: 6,
+			expectedTimes:   [2]int{6, 10},
+		},
+		{
+			name: "multiple chains/latest in previous chain",
+			collection: fakeBackupCollection{
+				chain(b(0, 2), b(2, 4), b(4, 8), b(8, 10)),
+				chain(b(0, 6)),
+			},
+			expectedFullEnd: 2,
+			expectedTimes:   [2]int{8, 10},
+		},
+		{
+			name: "multiple chains/full and inc+compacted tie",
+			collection: fakeBackupCollection{
+				chain(b(0, 2), b(2, 4), b(2, 8), b(4, 8)),
+				chain(b(0, 8)),
+			},
+			expectedFullEnd: 8,
+			expectedTimes:   [2]int{0, 8},
+		},
+		{
+			name: "multiple chains/choose non-compacted-backup in older chain",
+			collection: fakeBackupCollection{
+				chain(b(0, 2), b(2, 4), b(4, 6), b(2, 10), b(6, 10)),
+				chain(b(0, 8)),
+			},
+			expectedFullEnd: 2,
+			expectedTimes:   [2]int{6, 10},
+		},
+	}
+
+	for idx, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			collectionURI := fmt.Sprintf("%s/%d", collectionURI, idx)
+			externalStorage, err := cloud.ExternalStorageFromURI(
+				ctx,
+				collectionURI,
+				base.ExternalIODirConfig{},
+				st,
+				blobs.TestBlobServiceClient(dir),
+				username.RootUserName(),
+				nil, /* db */
+				nil, /* limiters */
+				cloud.NilMetrics,
+			)
+			require.NoError(t, err)
+			makeExternalStorage := func(
+				_ context.Context, _ string, _ username.SQLUsername, _ ...cloud.ExternalStorageOption,
+			) (cloud.ExternalStorage, error) {
+				return externalStorage, nil
+			}
+
+			tc.collection.writeIndexes(t, ctx, execCfg, makeExternalStorage, collectionURI)
+			latest, id, err := FindLatestBackup(ctx, externalStorage)
+			require.NoError(t, err)
+			expectedStart := intToTimeWithNano(tc.expectedTimes[0])
+			expectedEnd := intToTimeWithNano(tc.expectedTimes[1])
+			require.Equal(t, expectedStart, latest.StartTime, "start time mismatch")
+			require.Equal(t, expectedEnd, latest.EndTime, "end time mismatch")
+			fullEnd, _, err := DecodeBackupID(id)
+			require.NoError(t, err)
+			expectedFullEnd := intToTime(tc.expectedFullEnd).GoTime()
+			require.Equal(t, expectedFullEnd, fullEnd, "full backup end time mismatch")
+		})
+	}
+}
+
+func TestEncodeDecodeBackupID(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// We truncate to 10ms precision since that's the precision we use in the ID.
+	precision := 10 * time.Millisecond
+	fullEnd := time.Now().UTC().Truncate(precision)
+
+	t.Run("full backup ID", func(t *testing.T) {
+		endTime := fullEnd
+		id := encodeBackupID(fullEnd, endTime)
+		decodedFullEnd, decodedEnd, err := DecodeBackupID(id)
+		require.NoError(t, err)
+		require.Equal(t, fullEnd, decodedFullEnd)
+		require.Equal(t, endTime, decodedEnd)
+	})
+
+	t.Run("incremental backup ID", func(t *testing.T) {
+		// We test in increasing differences up to one week to stress test the
+		// XOR encoding.
+		var delta time.Duration
+		for i := 0; i < 8; i++ {
+			// This effectively adds one more random digit to the delta starting at
+			// the minimum precision.
+			delta += time.Duration(int(math.Pow10(i))*rand.Intn(10)) * precision
+			t.Run(fmt.Sprintf("delta=%s", delta), func(t *testing.T) {
+				endTime := fullEnd.Add(delta)
+				id := encodeBackupID(fullEnd, endTime)
+				decodedFullEnd, decodedEnd, err := DecodeBackupID(id)
+				require.NoError(t, err)
+				require.Equal(t, fullEnd, decodedFullEnd)
+				require.Equal(t, endTime, decodedEnd)
+			})
+		}
+	})
+
+	t.Run("invalid ID", func(t *testing.T) {
+		invalidIDs := map[string]string{
+			"empty":          "",
+			"invalid base64": "#!@($*%!)",
+			"too long":       "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+		}
+		for name, id := range invalidIDs {
+			t.Run(name, func(t *testing.T) {
+				_, _, err := DecodeBackupID(id)
+				require.Error(t, err)
+			})
+		}
+	})
+}
+
+// intToTime converts the integer time to an easy-to-read hlc.Timestamp
+// (i.e. XX000000000). We use ints to more easily write times for test cases.
+func intToTime(t int) hlc.Timestamp {
+	if t == 0 {
+		return hlc.Timestamp{}
+	}
+	// Value needs to be large enough to be represented in milliseconds and be
+	// larger than GoTime zero.
+	return hlc.Timestamp{WallTime: int64(t) * 1e9}
+}
+
+// intToTimeWithNano converts the integer time to an easy-to-read hlc.Timestamp
 // (i.e. XX000000000XX). Note that the int is also added as nanoseconds to
 // stress backup's handling of nanosecond precision timestamps. We use ints to
 // more easily write times for test cases.
@@ -945,9 +1133,9 @@ func intToTimeWithNano(t int) hlc.Timestamp {
 	if t == 0 {
 		return hlc.Timestamp{}
 	}
-	// Value needs to be large enough to be represented in milliseconds and be
-	// larger than GoTime zero.
-	return hlc.Timestamp{WallTime: int64(t)*1e9 + int64(t)}
+	ts := intToTime(t)
+	ts.WallTime += int64(t)
+	return ts
 }
 
 // chain is a helper to concisely create a fakeBackupChain.

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -88,13 +88,13 @@ const (
 	BackupValidateDetails
 )
 
-// TODO (msbutler): 22.2 after removing old style show backup syntax, rename
-// Path to Subdir and InCollection to Dest.
-
 // ShowBackup represents a SHOW BACKUP statement.
 //
 // TODO(msbutler): implement a walkableStmt for ShowBackup.
+// TODO(kev-cao): After we deprecate non-ID'd `SHOW BACKUP` statements, we can
+// rename Path to ID.
 type ShowBackup struct {
+	// Path can be either a subdirectory path or a backup ID.
 	Path         Expr
 	InCollection StringOrPlaceholderOptList
 	From         bool


### PR DESCRIPTION
This commit teaches `SHOW BACKUP` to parse backup IDs. If the `use_backups_with_ids` session variable is set to `true`, `SHOW BACKUP` will use the new logic if either a backup ID or `LATEST` is specified.

Epic: CRDB-57536

Resolves: #159648

Release note (sql change): If the `use_backups_with_ids` session variable is set, the new `SHOW BACKUP` experience will be enabled. `SHOW BACKUP` will be able to parse the IDs provided by `SHOW BACKUP` and will display contents for single backups.