### PR TITLE
mmaprototype: remove highDiskSpaceUtilization from storeLoadSummary

### DIFF
--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
@@ -2413,7 +2413,7 @@ func (a *Allocator) LeaseholderShouldMoveDueToPreferences(
 // whether a store has disk capacity for additional replicas; or whether the
 // disk is over capacity and should shed replicas.
 func (a *Allocator) DiskOptions() DiskCapacityOptions {
-	return makeDiskCapacityOptions(&a.st.SV)
+	return MakeDiskCapacityOptions(&a.st.SV)
 }
 
 // IOOverloadOptions returns the store IO overload options. It is used to

--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator_scorer.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator_scorer.go
@@ -756,7 +756,8 @@ type DiskCapacityOptions struct {
 	ShedAndBlockAllThreshold float64
 }
 
-func makeDiskCapacityOptions(sv *settings.Values) DiskCapacityOptions {
+// MakeDiskCapacityOptions creates DiskCapacityOptions from cluster settings.
+func MakeDiskCapacityOptions(sv *settings.Values) DiskCapacityOptions {
 	return DiskCapacityOptions{
 		RebalanceToThreshold:     rebalanceToMaxDiskUtilizationThreshold.Get(sv),
 		ShedAndBlockAllThreshold: maxDiskUtilizationThreshold.Get(sv),

--- a/pkg/kv/kvserver/allocator/mmaprototype/allocator.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/allocator.go
@@ -60,9 +60,14 @@ type Allocator interface {
 	// associated node in the cluster.
 	ProcessStoreLoadMsg(ctx context.Context, msg *StoreLoadMsg)
 
+	// SetDiskUtilThresholds configures the disk utilization thresholds used
+	// to augment store dispositions in UpdateStoresStatuses:
+	// - refuseThreshold: stores above this refuse new replicas
+	// - shedThreshold: stores above this actively shed replicas
+	SetDiskUtilThresholds(refuseThreshold, shedThreshold float64)
+
 	// UpdateStoresStatuses updates the health and disposition for the stores in
 	// storeStatuses. Stores unknown to the allocator are ignored with logging.
-	// to the allocator are ignored with logging.
 	UpdateStoresStatuses(ctx context.Context, storeStatuses map[roachpb.StoreID]Status)
 
 	// Methods related to making changes.

--- a/pkg/kv/kvserver/allocator/mmaprototype/allocator.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/allocator.go
@@ -68,6 +68,9 @@ type Allocator interface {
 
 	// UpdateStoresStatuses updates the health and disposition for the stores in
 	// storeStatuses. Stores unknown to the allocator are ignored with logging.
+	//
+	// The replica disposition is augmented based on disk utilization using
+	// thresholds set via SetDiskUtilThresholds.
 	UpdateStoresStatuses(ctx context.Context, storeStatuses map[roachpb.StoreID]Status)
 
 	// Methods related to making changes.

--- a/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
@@ -542,44 +542,25 @@ func sortTargetCandidateSetAndPick(
 	})
 	bestDiversity := cands.candidates[0].diversityScore
 	j := 0
-	// Iterate over candidates with the same diversity. First such set that is
-	// not disk capacity constrained is where we stop. Even if they can't accept
-	// because they have too many pending changes or can't handle the addition
-	// of the range. That is, we are not willing to reduce diversity when
-	// rebalancing ranges. When rebalancing leases, the diversityScore of all
-	// the candidates will be 0.
+	// Iterate over candidates with the same diversity. We stop at the first set
+	// of candidates with the same diversity. Even if they can't accept because
+	// they have too many pending changes or can't handle the addition of the
+	// range. That is, we are not willing to reduce diversity when rebalancing
+	// ranges. When rebalancing leases, the diversityScore of all the candidates
+	// will be 0.
 	for i, cand := range cands.candidates {
 		if !diversityScoresAlmostEqual(bestDiversity, cand.diversityScore) {
-			if j == 0 {
-				// Don't have any candidates yet.
-				bestDiversity = cand.diversityScore
-			} else {
-				// Have a set of candidates.
-				if s := formatCandidatesLog(&b, cands.candidates[i:]); s != "" {
-					log.KvDistribution.VEventf(ctx, 2, "discarding candidates due to lower diversity score: %s", s)
-				}
-				break
+			// Have a set of candidates with the best diversity.
+			if s := formatCandidatesLog(&b, cands.candidates[i:]); s != "" {
+				log.KvDistribution.VEventf(ctx, 2, "discarding candidates due to lower diversity score: %s", s)
 			}
+			break
 		}
-		// Diversity is the same. Include if not reaching disk capacity.
-		// TODO(tbg): remove highDiskSpaceUtilization check here. These candidates
-		// should instead be filtered out by retainReadyLeaseTargetStoresOnly (which
-		// filters down the initial candidate set before computing the mean).
-		if !cand.highDiskSpaceUtilization {
-			cands.candidates[j] = cand
-			j++
-		} else {
-			log.KvDistribution.VEventf(ctx, 2, "discarding candidate due to high disk space utilization: %v", cand.StoreID)
-		}
+		cands.candidates[j] = cand
+		j++
 	}
-	if j == 0 {
-		log.KvDistribution.VEventf(ctx, 2, "sortTargetCandidateSetAndPick: no candidates due to disk space util")
-		failLogger(noCandidateDiskSpaceUtil)
-		return 0
-	}
-
-	// Every candidate in [0:j] has same diversity and is sorted by increasing
-	// load, and within the same load by increasing leasePreferenceIndex.
+	// Every candidate in [0:j] has the same (best) diversity and is sorted by
+	// increasing load, and within the same load by increasing leasePreferenceIndex.
 	cands.candidates = cands.candidates[:j]
 	j = 0
 	// Filter out the candidates that are overloaded or have too many pending
@@ -982,8 +963,8 @@ func (cs *clusterState) computeCandidatesForReplicaTransfer(
 
 // retainReadyReplicaTargetStoresOnly filters the input set to only those stores
 // that are ready to accept a replica. A store is not ready if it has a non-OK
-// replica disposition. In practice, the input set is already filtered by
-// constraints.
+// replica disposition (which also takes disk utilization into account via
+// updateStoreStatuses).
 //
 // Stores already housing a replica (on top of being in the input storeSet)
 // bypass this disposition check since they already have the replica - its load
@@ -1017,12 +998,6 @@ func retainReadyReplicaTargetStoresOnly(
 		switch {
 		case ss.status.Disposition.Replica != ReplicaDispositionOK:
 			log.KvDistribution.VEventf(ctx, 2, "skipping s%d for replica transfer: replica disposition %v (health %v)", storeID, ss.status.Disposition.Replica, ss.status.Health)
-		case highDiskSpaceUtilization(ss.reportedLoad[ByteSize], ss.capacity[ByteSize]):
-			// TODO(tbg): remove this from mma and just let the caller set this
-			// disposition based on the following cluster settings:
-			// - kv.allocator.max_disk_utilization_threshold
-			// - kv.allocator.rebalance_to_max_disk_utilization_threshold
-			log.KvDistribution.VEventf(ctx, 2, "skipping s%d for replica transfer: high disk utilization (health %v)", storeID, ss.status.Health)
 		default:
 			out = append(out, storeID)
 		}

--- a/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
@@ -204,7 +204,14 @@ func (a *allocatorState) ProcessStoreLoadMsg(ctx context.Context, msg *StoreLoad
 	a.cs.processStoreLoadMsg(ctx, msg)
 }
 
-// UpdateStoresStatus implements the Allocator interface.
+// SetDiskUtilThresholds implements the Allocator interface.
+func (a *allocatorState) SetDiskUtilThresholds(refuseThreshold, shedThreshold float64) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.cs.setDiskUtilThresholds(refuseThreshold, shedThreshold)
+}
+
+// UpdateStoresStatuses implements the Allocator interface.
 func (a *allocatorState) UpdateStoresStatuses(
 	ctx context.Context, storeStatuses map[roachpb.StoreID]Status,
 ) {

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_test.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_test.go
@@ -521,6 +521,7 @@ func TestClusterState(t *testing.T) {
 					// Calls updateStoreStatuses for the specified stores (or all stores
 					// if none specified). This triggers the disk utilization check which
 					// augments the replica disposition based on current adjusted load.
+					// Thresholds must be set via set-disk-thresholds first.
 					storeIDs, _ := dd.ScanArgOpt[[]roachpb.StoreID](t, d, "store-ids")
 					if len(storeIDs) == 0 {
 						// Default to all stores.

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_test.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_test.go
@@ -355,6 +355,9 @@ func TestClusterState(t *testing.T) {
 		func(t *testing.T, path string) {
 			ts := timeutil.NewManualTime(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
 			cs := newClusterState(ts, newStringInterner())
+			// Set default disk utilization thresholds for tests (matches original MMA behavior).
+			cs.diskUtilRefuseThreshold = 0.9
+			cs.diskUtilShedThreshold = 0.9
 			tr := tracing.NewTracer()
 			tr.SetRedactable(true)
 			defer tr.Close()

--- a/pkg/kv/kvserver/allocator/mmaprototype/load.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/load.go
@@ -662,7 +662,7 @@ func loadSummaryForDimension(
 }
 
 func highDiskSpaceUtilization(load LoadValue, capacity LoadValue) bool {
-	if capacity == UnknownCapacity {
+	if capacity == UnknownCapacity || capacity == 0 {
 		log.KvDistribution.Errorf(context.Background(), "disk capacity is unknown")
 		return false
 	}

--- a/pkg/kv/kvserver/allocator/mmaprototype/load.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/load.go
@@ -661,13 +661,16 @@ func loadSummaryForDimension(
 	return min(summaryUpperBound, summ)
 }
 
-func highDiskSpaceUtilization(load LoadValue, capacity LoadValue) bool {
+// highDiskSpaceUtilization checks if disk utilization >= the given threshold.
+// This is called in updateStoreStatuses to augment store dispositions based on
+// disk utilization thresholds (refusing at 0.925, shedding at 0.95 by default).
+func highDiskSpaceUtilization(load LoadValue, capacity LoadValue, threshold float64) bool {
 	if capacity == UnknownCapacity || capacity == 0 {
 		log.KvDistribution.Errorf(context.Background(), "disk capacity is unknown")
 		return false
 	}
 	fractionUsed := float64(load) / float64(capacity)
-	return fractionUsed > 0.9
+	return fractionUsed >= threshold
 }
 
 const loadMultiplierForAddition = 1.1

--- a/pkg/kv/kvserver/allocator/mmaprototype/mma_metrics.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/mma_metrics.go
@@ -491,7 +491,6 @@ const (
 	notOverloaded
 	noCandidate
 	noHealthyCandidate
-	noCandidateDiskSpaceUtil
 	noCandidateDueToLoad
 	noCandidateDueToUnmatchedLeasePreference
 	noCandidateToAcceptLoad
@@ -513,8 +512,6 @@ func (sr shedResult) SafeFormat(w redact.SafePrinter, _ rune) {
 		w.SafeString("no-cand")
 	case noHealthyCandidate:
 		w.SafeString("no-healthy-cand")
-	case noCandidateDiskSpaceUtil:
-		w.SafeString("no-cand-diskspace")
 	case noCandidateDueToLoad:
 		w.SafeString("no-cand-load")
 	case noCandidateDueToUnmatchedLeasePreference:

--- a/pkg/kv/kvserver/allocator/mmaprototype/store_load_summary.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/store_load_summary.go
@@ -16,7 +16,6 @@ type storeLoadSummary struct {
 	sls                                                    loadSummary
 	nls                                                    loadSummary
 	dimSummary                                             [NumLoadDimensions]loadSummary
-	highDiskSpaceUtilization                               bool
 	maxFractionPendingIncrease, maxFractionPendingDecrease float64
 
 	loadSeqNum uint64
@@ -27,9 +26,9 @@ func (sls storeLoadSummary) String() string {
 }
 
 func (sls storeLoadSummary) SafeFormat(w redact.SafePrinter, _ rune) {
-	w.Printf("(store=%v worst=%v cpu=%v writes=%v bytes=%v node=%v high_disk=%v frac_pending=%.2f,%.2f(%t))",
+	w.Printf("(store=%v worst=%v cpu=%v writes=%v bytes=%v node=%v frac_pending=%.2f,%.2f(%t))",
 		sls.sls, sls.worstDim, sls.dimSummary[CPURate], sls.dimSummary[WriteBandwidth], sls.dimSummary[ByteSize],
-		sls.nls, sls.highDiskSpaceUtilization, sls.maxFractionPendingIncrease,
+		sls.nls, sls.maxFractionPendingIncrease,
 		sls.maxFractionPendingDecrease,
 		sls.maxFractionPendingIncrease < epsilon && sls.maxFractionPendingDecrease < epsilon)
 }

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica_local_stores.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica_local_stores.txt
@@ -142,7 +142,7 @@ get-load-info
 ----
 store-id=1 node-id=1 status=ok accepting all reported=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=80 node-adjusted-cpu=88 seq=2
 store-id=2 node-id=1 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:88ns/s, write-bandwidth:88 B/s, byte-size:88 B] node-reported-cpu=80 node-adjusted-cpu=88 seq=1
-  top-k-ranges (local-store-id=2) dim=ByteSize: r1
+  top-k-ranges (local-store-id=2) dim=CPURate: r1
 
 tick seconds=5
 ----
@@ -171,7 +171,7 @@ get-load-info
 ----
 store-id=1 node-id=1 status=ok accepting all reported=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=160 node-adjusted-cpu=168 seq=2
 store-id=2 node-id=1 status=ok accepting all reported=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] adjusted=[cpu:168ns/s, write-bandwidth:168 B/s, byte-size:168 B] node-reported-cpu=160 node-adjusted-cpu=168 seq=3
-  top-k-ranges (local-store-id=2) dim=ByteSize: r1
+  top-k-ranges (local-store-id=2) dim=CPURate: r1
 
 # Store load msg from s2 at time 16s, which is 11s after the enactment of
 # change 1. So the change is no longer needed for load adjustment.
@@ -194,7 +194,7 @@ get-load-info
 ----
 store-id=1 node-id=1 status=ok accepting all reported=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=160 node-adjusted-cpu=80 seq=2
 store-id=2 node-id=1 status=ok accepting all reported=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] adjusted=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] node-reported-cpu=160 node-adjusted-cpu=80 seq=4
-  top-k-ranges (local-store-id=2) dim=ByteSize: r1
+  top-k-ranges (local-store-id=2) dim=CPURate: r1
 
 # Advance time, but not enough to GC change 2.
 tick seconds=10

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica_local_stores_enacted_gc.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica_local_stores_enacted_gc.txt
@@ -119,7 +119,7 @@ get-load-info
 store-id=1 node-id=1 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:-2ns/s, write-bandwidth:-2 B/s, byte-size:-2 B] node-reported-cpu=0 node-adjusted-cpu=0 seq=1
   top-k-ranges (local-store-id=1) dim=CPURate: r1
 store-id=2 node-id=1 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:2ns/s, write-bandwidth:2 B/s, byte-size:2 B] node-reported-cpu=0 node-adjusted-cpu=0 seq=1
-  top-k-ranges (local-store-id=2) dim=ByteSize: r1
+  top-k-ranges (local-store-id=2) dim=CPURate: r1
 store-id=3 node-id=3 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
   top-k-ranges (local-store-id=1) dim=WriteBandwidth: r1
   top-k-ranges (local-store-id=2) dim=WriteBandwidth: r1
@@ -174,7 +174,7 @@ store-id=1 node-id=1 status=ok accepting all reported=[cpu:0s/s, write-bandwidth
   top-k-ranges (local-store-id=1) dim=CPURate: r1
   top-k-ranges (local-store-id=2) dim=WriteBandwidth: r1
 store-id=2 node-id=1 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:2ns/s, write-bandwidth:2 B/s, byte-size:2 B] node-reported-cpu=0 node-adjusted-cpu=2 seq=1
-  top-k-ranges (local-store-id=2) dim=ByteSize: r1
+  top-k-ranges (local-store-id=2) dim=CPURate: r1
 store-id=3 node-id=3 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
   top-k-ranges (local-store-id=1) dim=WriteBandwidth: r1
   top-k-ranges (local-store-id=2) dim=WriteBandwidth: r1
@@ -191,7 +191,7 @@ get-load-info
 store-id=1 node-id=1 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=0 node-adjusted-cpu=2 seq=2
   top-k-ranges (local-store-id=2) dim=WriteBandwidth: r1
 store-id=2 node-id=1 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:2ns/s, write-bandwidth:2 B/s, byte-size:2 B] node-reported-cpu=0 node-adjusted-cpu=2 seq=1
-  top-k-ranges (local-store-id=2) dim=ByteSize: r1
+  top-k-ranges (local-store-id=2) dim=CPURate: r1
 store-id=3 node-id=3 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
   top-k-ranges (local-store-id=2) dim=WriteBandwidth: r1
 store-id=4 node-id=4 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
@@ -220,7 +220,7 @@ get-load-info
 store-id=1 node-id=1 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=0 node-adjusted-cpu=2 seq=2
   top-k-ranges (local-store-id=2) dim=WriteBandwidth: r1
 store-id=2 node-id=1 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:2ns/s, write-bandwidth:2 B/s, byte-size:2 B] node-reported-cpu=0 node-adjusted-cpu=2 seq=1
-  top-k-ranges (local-store-id=2) dim=ByteSize: r1
+  top-k-ranges (local-store-id=2) dim=CPURate: r1
 store-id=3 node-id=3 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:-2ns/s, write-bandwidth:-3 B/s, byte-size:-3 B] node-reported-cpu=0 node-adjusted-cpu=-2 seq=1
   top-k-ranges (local-store-id=2) dim=WriteBandwidth: r1
 store-id=4 node-id=4 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:2ns/s, write-bandwidth:3 B/s, byte-size:3 B] node-reported-cpu=0 node-adjusted-cpu=2 seq=1
@@ -291,7 +291,7 @@ get-load-info
 store-id=1 node-id=1 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=0 node-adjusted-cpu=2 seq=2
   top-k-ranges (local-store-id=2) dim=WriteBandwidth: r1
 store-id=2 node-id=1 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:2ns/s, write-bandwidth:2 B/s, byte-size:2 B] node-reported-cpu=0 node-adjusted-cpu=2 seq=1
-  top-k-ranges (local-store-id=2) dim=ByteSize: r1
+  top-k-ranges (local-store-id=2) dim=CPURate: r1
 store-id=3 node-id=3 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=0 node-adjusted-cpu=0 seq=2
 store-id=4 node-id=4 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:2ns/s, write-bandwidth:3 B/s, byte-size:3 B] node-reported-cpu=0 node-adjusted-cpu=2 seq=1
-  top-k-ranges (local-store-id=2) dim=ByteSize: r1
+  top-k-ranges (local-store-id=2) dim=CPURate: r1

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_capacity_mismatch.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_capacity_mismatch.txt
@@ -142,21 +142,21 @@ rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-t
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n1): overloadSlow, reason: fractionUsed > 75% [load=900 meanLoad=541 fractionUsed=90.00% meanUtil=75.80% capacity=1000]
 [mmaid=1] evaluating s1: node load overloadSlow, store load overloadSlow, worst dim CPURate
-[mmaid=1] overload-continued s1 ((store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow high_disk=false frac_pending=0.00,0.00(true))) - within grace period
+[mmaid=1] overload-continued s1 ((store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow frac_pending=0.00,0.00(true))) - within grace period
 [mmaid=1] store s1 was added to shedding store list
 [mmaid=1] load summary for dim=CPURate (s2): overloadSlow, reason: fractionUsed > 75% [load=900 meanLoad=541 fractionUsed=90.00% meanUtil=75.80% capacity=1000]
 [mmaid=1] load summary for dim=WriteBandwidth (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
 [mmaid=1] load summary for dim=ByteSize (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n2): overloadSlow, reason: fractionUsed > 75% [load=900 meanLoad=541 fractionUsed=90.00% meanUtil=75.80% capacity=1000]
 [mmaid=1] evaluating s2: node load overloadSlow, store load overloadSlow, worst dim CPURate
-[mmaid=1] overload-continued s2 ((store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow high_disk=false frac_pending=0.00,0.00(true))) - within grace period
+[mmaid=1] overload-continued s2 ((store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow frac_pending=0.00,0.00(true))) - within grace period
 [mmaid=1] store s2 was added to shedding store list
 [mmaid=1] load summary for dim=CPURate (s3): overloadSlow, reason: fractionUsed > 75% [load=900 meanLoad=541 fractionUsed=90.00% meanUtil=75.80% capacity=1000]
 [mmaid=1] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
 [mmaid=1] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n3): overloadSlow, reason: fractionUsed > 75% [load=900 meanLoad=541 fractionUsed=90.00% meanUtil=75.80% capacity=1000]
 [mmaid=1] evaluating s3: node load overloadSlow, store load overloadSlow, worst dim CPURate
-[mmaid=1] overload-continued s3 ((store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow high_disk=false frac_pending=0.00,0.00(true))) - within grace period
+[mmaid=1] overload-continued s3 ((store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow frac_pending=0.00,0.00(true))) - within grace period
 [mmaid=1] store s3 was added to shedding store list
 [mmaid=1] load summary for dim=CPURate (s4): loadLow, reason: load is >10% below mean [load=300 meanLoad=541 fractionUsed=60.00% meanUtil=75.80% capacity=500]
 [mmaid=1] load summary for dim=WriteBandwidth (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=500]
@@ -194,7 +194,7 @@ rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-t
 [mmaid=1] load summary for dim=WriteBandwidth (s5): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=500]
 [mmaid=1] load summary for dim=ByteSize (s5): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=500]
 [mmaid=1] load summary for dim=CPURate (n5): loadLow, reason: load is >10% below mean [load=280 meanLoad=693 fractionUsed=56.00% meanUtil=83.20% capacity=500]
-[mmaid=1] candidate store 3 was discarded due to (nls=false overloadDim=true pending_thresh=false): sls=(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow high_disk=false frac_pending=0.00,0.00(true))
+[mmaid=1] candidate store 3 was discarded due to (nls=false overloadDim=true pending_thresh=false): sls=(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow frac_pending=0.00,0.00(true))
 [mmaid=1] sortTargetCandidateSetAndPick: candidates: s5(SLS:loadNormal, overloadedDimLoadSummary:loadLow), overloadedDim:CPURate, picked s5
 [mmaid=1] load summary for dim=CPURate (s5): overloadUrgent, reason: fractionUsed > 90% [load=478 meanLoad=693 fractionUsed=95.60% meanUtil=83.20% capacity=500]
 [mmaid=1] load summary for dim=WriteBandwidth (s5): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=500]
@@ -205,7 +205,7 @@ rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-t
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n1): loadNormal, reason: load is within 5% of mean [load=720 meanLoad=693 fractionUsed=72.00% meanUtil=83.20% capacity=1000]
 [mmaid=1] cannot add load to n5s5: due to overloadUrgent
-[mmaid=1] [target_sls:(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true)),src_sls:(store=loadNormal worst=CPURate cpu=loadNormal writes=loadNormal bytes=loadNormal node=loadNormal high_disk=false frac_pending=0.00,0.00(true))]
+[mmaid=1] [target_sls:(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent frac_pending=0.00,0.00(true)),src_sls:(store=loadNormal worst=CPURate cpu=loadNormal writes=loadNormal bytes=loadNormal node=loadNormal frac_pending=0.00,0.00(true))]
 [mmaid=1] result(failed): cannot shed from s1 to s5 for r3: delta load [cpu:180ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=1] considering lease-transfer r2 from s1: candidates are [2 4]
 [mmaid=1] load summary for dim=CPURate (s1): overloadSlow, reason: load is >10% above mean [load=900 meanLoad=700 fractionUsed=90.00% meanUtil=84.00% capacity=1000]
@@ -220,7 +220,7 @@ rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-t
 [mmaid=1] load summary for dim=WriteBandwidth (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=500]
 [mmaid=1] load summary for dim=ByteSize (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=500]
 [mmaid=1] load summary for dim=CPURate (n4): loadLow, reason: load is >10% below mean [load=300 meanLoad=700 fractionUsed=60.00% meanUtil=84.00% capacity=500]
-[mmaid=1] candidate store 2 was discarded due to (nls=false overloadDim=true pending_thresh=false): sls=(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow high_disk=false frac_pending=0.00,0.00(true))
+[mmaid=1] candidate store 2 was discarded due to (nls=false overloadDim=true pending_thresh=false): sls=(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow frac_pending=0.00,0.00(true))
 [mmaid=1] sortTargetCandidateSetAndPick: candidates: s4(SLS:loadNormal, overloadedDimLoadSummary:loadLow), overloadedDim:CPURate, picked s4
 [mmaid=1] load summary for dim=CPURate (s4): overloadUrgent, reason: fractionUsed > 90% [load=498 meanLoad=700 fractionUsed=99.60% meanUtil=84.00% capacity=500]
 [mmaid=1] load summary for dim=WriteBandwidth (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=500]
@@ -231,7 +231,7 @@ rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-t
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n1): loadNormal, reason: load is within 5% of mean [load=720 meanLoad=700 fractionUsed=72.00% meanUtil=84.00% capacity=1000]
 [mmaid=1] cannot add load to n4s4: due to overloadUrgent
-[mmaid=1] [target_sls:(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true)),src_sls:(store=loadNormal worst=CPURate cpu=loadNormal writes=loadNormal bytes=loadNormal node=loadNormal high_disk=false frac_pending=0.00,0.00(true))]
+[mmaid=1] [target_sls:(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent frac_pending=0.00,0.00(true)),src_sls:(store=loadNormal worst=CPURate cpu=loadNormal writes=loadNormal bytes=loadNormal node=loadNormal frac_pending=0.00,0.00(true))]
 [mmaid=1] result(failed): cannot shed from s1 to s4 for r2: delta load [cpu:180ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=1] considering lease-transfer r1 from s1: candidates are [2 3]
 [mmaid=1] load summary for dim=CPURate (s1): loadNormal, reason: load is within 5% of mean [load=900 meanLoad=900 fractionUsed=90.00% meanUtil=90.00% capacity=1000]
@@ -262,10 +262,10 @@ rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-t
 [mmaid=1] load summary for dim=CPURate (n7): loadLow, reason: load is >10% below mean [load=250 meanLoad=541 fractionUsed=50.00% meanUtil=75.80% capacity=500]
 [mmaid=1] considering replica-transfer r3 from s1: store load [cpu:900ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=1] candidates are:
-[mmaid=1]  s2: (store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow high_disk=false frac_pending=0.00,0.00(true))
-[mmaid=1]  s4: (store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))
-[mmaid=1]  s6: (store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))
-[mmaid=1]  s7: (store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))
+[mmaid=1]  s2: (store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow frac_pending=0.00,0.00(true))
+[mmaid=1]  s4: (store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow frac_pending=0.00,0.00(true))
+[mmaid=1]  s6: (store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow frac_pending=0.00,0.00(true))
+[mmaid=1]  s7: (store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow frac_pending=0.00,0.00(true))
 [mmaid=1] discarding candidates with higher load than lowestLoadSet(loadNormal):  s2(SLS:overloadSlow, overloadedDimLoadSummary:overloadSlow), overloadedDim:CPURate
 [mmaid=1] sortTargetCandidateSetAndPick: candidates: s4(SLS:loadNormal, overloadedDimLoadSummary:loadLow) s6(SLS:loadNormal, overloadedDimLoadSummary:loadLow) s7(SLS:loadNormal, overloadedDimLoadSummary:loadLow), overloadedDim:CPURate, picked s6
 [mmaid=1] load summary for dim=CPURate (s6): overloadUrgent, reason: fractionUsed > 90% [load=480 meanLoad=541 fractionUsed=96.00% meanUtil=75.80% capacity=500]
@@ -277,7 +277,7 @@ rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-t
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n1): overloadSlow, reason: load is >10% above mean [load=700 meanLoad=541 fractionUsed=70.00% meanUtil=75.80% capacity=1000]
 [mmaid=1] cannot add load to n6s6: due to overloadUrgent
-[mmaid=1] [target_sls:(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true)),src_sls:(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow high_disk=false frac_pending=0.00,0.00(true))]
+[mmaid=1] [target_sls:(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent frac_pending=0.00,0.00(true)),src_sls:(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow frac_pending=0.00,0.00(true))]
 [mmaid=1] result(failed): cannot shed from s1 to s6 for r3: delta load [cpu:200ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=1] load summary for dim=CPURate (s1): overloadSlow, reason: fractionUsed > 75% [load=900 meanLoad=541 fractionUsed=90.00% meanUtil=75.80% capacity=1000]
 [mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
@@ -301,10 +301,10 @@ rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-t
 [mmaid=1] load summary for dim=CPURate (n7): loadLow, reason: load is >10% below mean [load=250 meanLoad=541 fractionUsed=50.00% meanUtil=75.80% capacity=500]
 [mmaid=1] considering replica-transfer r2 from s1: store load [cpu:900ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=1] candidates are:
-[mmaid=1]  s3: (store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow high_disk=false frac_pending=0.00,0.00(true))
-[mmaid=1]  s5: (store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))
-[mmaid=1]  s6: (store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))
-[mmaid=1]  s7: (store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))
+[mmaid=1]  s3: (store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow frac_pending=0.00,0.00(true))
+[mmaid=1]  s5: (store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow frac_pending=0.00,0.00(true))
+[mmaid=1]  s6: (store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow frac_pending=0.00,0.00(true))
+[mmaid=1]  s7: (store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow frac_pending=0.00,0.00(true))
 [mmaid=1] discarding candidates with higher load than lowestLoadSet(loadNormal):  s3(SLS:overloadSlow, overloadedDimLoadSummary:overloadSlow), overloadedDim:CPURate
 [mmaid=1] sortTargetCandidateSetAndPick: candidates: s5(SLS:loadNormal, overloadedDimLoadSummary:loadLow) s6(SLS:loadNormal, overloadedDimLoadSummary:loadLow) s7(SLS:loadNormal, overloadedDimLoadSummary:loadLow), overloadedDim:CPURate, picked s6
 [mmaid=1] load summary for dim=CPURate (s6): overloadUrgent, reason: fractionUsed > 90% [load=480 meanLoad=541 fractionUsed=96.00% meanUtil=75.80% capacity=500]
@@ -316,7 +316,7 @@ rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-t
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n1): overloadSlow, reason: load is >10% above mean [load=700 meanLoad=541 fractionUsed=70.00% meanUtil=75.80% capacity=1000]
 [mmaid=1] cannot add load to n6s6: due to overloadUrgent
-[mmaid=1] [target_sls:(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true)),src_sls:(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow high_disk=false frac_pending=0.00,0.00(true))]
+[mmaid=1] [target_sls:(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent frac_pending=0.00,0.00(true)),src_sls:(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow frac_pending=0.00,0.00(true))]
 [mmaid=1] result(failed): cannot shed from s1 to s6 for r2: delta load [cpu:200ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=1] load summary for dim=CPURate (s1): overloadSlow, reason: fractionUsed > 75% [load=900 meanLoad=541 fractionUsed=90.00% meanUtil=75.80% capacity=1000]
 [mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
@@ -340,10 +340,10 @@ rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-t
 [mmaid=1] load summary for dim=CPURate (n7): loadLow, reason: load is >10% below mean [load=250 meanLoad=541 fractionUsed=50.00% meanUtil=75.80% capacity=500]
 [mmaid=1] considering replica-transfer r1 from s1: store load [cpu:900ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=1] candidates are:
-[mmaid=1]  s4: (store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))
-[mmaid=1]  s5: (store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))
-[mmaid=1]  s6: (store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))
-[mmaid=1]  s7: (store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))
+[mmaid=1]  s4: (store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow frac_pending=0.00,0.00(true))
+[mmaid=1]  s5: (store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow frac_pending=0.00,0.00(true))
+[mmaid=1]  s6: (store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow frac_pending=0.00,0.00(true))
+[mmaid=1]  s7: (store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow frac_pending=0.00,0.00(true))
 [mmaid=1] sortTargetCandidateSetAndPick: candidates: s4(SLS:loadNormal, overloadedDimLoadSummary:loadLow) s5(SLS:loadNormal, overloadedDimLoadSummary:loadLow) s6(SLS:loadNormal, overloadedDimLoadSummary:loadLow) s7(SLS:loadNormal, overloadedDimLoadSummary:loadLow), overloadedDim:CPURate, picked s7
 [mmaid=1] load summary for dim=CPURate (s7): overloadUrgent, reason: fractionUsed > 90% [load=470 meanLoad=541 fractionUsed=94.00% meanUtil=75.80% capacity=500]
 [mmaid=1] load summary for dim=WriteBandwidth (s7): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=500]
@@ -354,7 +354,7 @@ rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-t
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n1): overloadSlow, reason: load is >10% above mean [load=700 meanLoad=541 fractionUsed=70.00% meanUtil=75.80% capacity=1000]
 [mmaid=1] cannot add load to n7s7: due to overloadUrgent
-[mmaid=1] [target_sls:(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true)),src_sls:(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow high_disk=false frac_pending=0.00,0.00(true))]
+[mmaid=1] [target_sls:(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent frac_pending=0.00,0.00(true)),src_sls:(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow frac_pending=0.00,0.00(true))]
 [mmaid=1] result(failed): cannot shed from s1 to s7 for r1: delta load [cpu:200ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=1] start processing shedding store s2: cpu node load overloadSlow, store load overloadSlow, worst dim CPURate
 [mmaid=1] top-K[CPURate] ranges for s2 with lease on local s1: r2:[cpu:20ns/s, write-bandwidth:0 B/s, byte-size:0 B] r1:[cpu:20ns/s, write-bandwidth:0 B/s, byte-size:0 B]

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_frac_threshold.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_frac_threshold.txt
@@ -14,7 +14,7 @@ rebalance-stores store-id=1 fraction-pending-decrease-threshold=0.4
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n1): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=400 fractionUsed=100.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] evaluating s1: node load overloadUrgent, store load overloadUrgent, worst dim CPURate
-[mmaid=1] overload-continued s1 ((store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true))) - within grace period
+[mmaid=1] overload-continued s1 ((store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent frac_pending=0.00,0.00(true))) - within grace period
 [mmaid=1] store s1 was added to shedding store list
 [mmaid=1] load summary for dim=CPURate (s2): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] load summary for dim=WriteBandwidth (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
@@ -51,7 +51,7 @@ rebalance-stores store-id=1 fraction-pending-decrease-threshold=0.4
 [mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n1): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=770 meanLoad=400 fractionUsed=77.00% meanUtil=40.00% capacity=1000]
-[mmaid=1] can add load to n2s2: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))] srcSLS[(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true))]
+[mmaid=1] can add load to n2s2: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow frac_pending=0.00,0.00(true))] srcSLS[(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent frac_pending=0.00,0.00(true))]
 [mmaid=1] applying replica change r4 type: RemoveLease target store n1,s1 (replica-id=1 type=VOTER_FULL leaseholder=true)->(replica-id=1 type=VOTER_FULL) to range 4 on store 1
 [mmaid=1] addPendingRangeChange: change_id=1, range_id=4, change=r4 type: RemoveLease target store n1,s1 (replica-id=1 type=VOTER_FULL leaseholder=true)->(replica-id=1 type=VOTER_FULL)
 [mmaid=1] applying replica change r4 type: AddLease target store n2,s2 (replica-id=2 type=VOTER_FULL)->(replica-id=2 type=VOTER_FULL leaseholder=true) to range 4 on store 2
@@ -70,7 +70,7 @@ rebalance-stores store-id=1 fraction-pending-decrease-threshold=0.4
 [mmaid=1] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n3): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
-[mmaid=1] candidate store 2 was discarded due to (nls=false overloadDim=false pending_thresh=true): sls=(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=2.53,0.00(false))
+[mmaid=1] candidate store 2 was discarded due to (nls=false overloadDim=false pending_thresh=true): sls=(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow frac_pending=2.53,0.00(false))
 [mmaid=1] sortTargetCandidateSetAndPick: candidates: s3(SLS:loadNormal, overloadedDimLoadSummary:loadLow), overloadedDim:CPURate, picked s3
 [mmaid=1] load summary for dim=CPURate (s3): loadLow, reason: load is >10% below mean [load=353 meanLoad=400 fractionUsed=35.30% meanUtil=40.00% capacity=1000]
 [mmaid=1] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
@@ -80,7 +80,7 @@ rebalance-stores store-id=1 fraction-pending-decrease-threshold=0.4
 [mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n1): overloadSlow, reason: fractionUsed < 75% [load=540 meanLoad=400 fractionUsed=54.00% meanUtil=40.00% capacity=1000]
-[mmaid=1] can add load to n3s3: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))] srcSLS[(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow high_disk=false frac_pending=0.00,0.23(false))]
+[mmaid=1] can add load to n3s3: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow frac_pending=0.00,0.00(true))] srcSLS[(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow frac_pending=0.00,0.23(false))]
 [mmaid=1] applying replica change r3 type: RemoveLease target store n1,s1 (replica-id=1 type=VOTER_FULL leaseholder=true)->(replica-id=1 type=VOTER_FULL) to range 3 on store 1
 [mmaid=1] addPendingRangeChange: change_id=3, range_id=3, change=r3 type: RemoveLease target store n1,s1 (replica-id=1 type=VOTER_FULL leaseholder=true)->(replica-id=1 type=VOTER_FULL)
 [mmaid=1] applying replica change r3 type: AddLease target store n3,s3 (replica-id=3 type=VOTER_FULL)->(replica-id=3 type=VOTER_FULL leaseholder=true) to range 3 on store 3

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_refusing_target.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_refusing_target.txt
@@ -52,7 +52,7 @@ rebalance-stores store-id=1
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n1): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=700 fractionUsed=100.00% meanUtil=70.00% capacity=1000]
 [mmaid=1] evaluating s1: node load overloadUrgent, store load overloadUrgent, worst dim CPURate
-[mmaid=1] overload-continued s1 ((store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true))) - within grace period
+[mmaid=1] overload-continued s1 ((store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent frac_pending=0.00,0.00(true))) - within grace period
 [mmaid=1] store s1 was added to shedding store list
 [mmaid=1] load summary for dim=CPURate (s2): loadLow, reason: load is >10% below mean [load=100 meanLoad=700 fractionUsed=10.00% meanUtil=70.00% capacity=1000]
 [mmaid=1] load summary for dim=WriteBandwidth (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
@@ -64,7 +64,7 @@ rebalance-stores store-id=1
 [mmaid=1] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n3): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=700 fractionUsed=100.00% meanUtil=70.00% capacity=1000]
 [mmaid=1] evaluating s3: node load overloadUrgent, store load overloadUrgent, worst dim CPURate
-[mmaid=1] overload-continued s3 ((store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true))) - within grace period
+[mmaid=1] overload-continued s3 ((store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent frac_pending=0.00,0.00(true))) - within grace period
 [mmaid=1] store s3 was added to shedding store list
 [mmaid=1] start processing shedding store s1: cpu node load overloadUrgent, store load overloadUrgent, worst dim CPURate
 [mmaid=1] top-K[CPURate] ranges for s1 with lease on local s1: r1:[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B]

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_replica_refusing.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_replica_refusing.txt
@@ -62,7 +62,7 @@ rebalance-stores store-id=1
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n1): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=866 fractionUsed=100.00% meanUtil=86.67% capacity=1000]
 [mmaid=1] evaluating s1: node load overloadUrgent, store load overloadUrgent, worst dim CPURate
-[mmaid=1] overload-continued s1 ((store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true))) - within grace period
+[mmaid=1] overload-continued s1 ((store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent frac_pending=0.00,0.00(true))) - within grace period
 [mmaid=1] store s1 was added to shedding store list
 [mmaid=1] load summary for dim=CPURate (s2): loadNormal, reason: load is within 5% of mean [load=800 meanLoad=866 fractionUsed=80.00% meanUtil=86.67% capacity=1000]
 [mmaid=1] load summary for dim=WriteBandwidth (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
@@ -96,7 +96,7 @@ rebalance-stores store-id=1
 [mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n1): loadNormal, reason: load is within 5% of mean [load=910 meanLoad=900 fractionUsed=91.00% meanUtil=90.00% capacity=1000]
-[mmaid=1] can add load to n3s3: true targetSLS[(store=loadNormal worst=CPURate cpu=loadNormal writes=loadNormal bytes=loadNormal node=loadNormal high_disk=false frac_pending=0.00,0.00(true))] srcSLS[(store=loadNormal worst=CPURate cpu=loadNormal writes=loadNormal bytes=loadNormal node=loadNormal high_disk=false frac_pending=0.00,0.00(true))]
+[mmaid=1] can add load to n3s3: true targetSLS[(store=loadNormal worst=CPURate cpu=loadNormal writes=loadNormal bytes=loadNormal node=loadNormal frac_pending=0.00,0.00(true))] srcSLS[(store=loadNormal worst=CPURate cpu=loadNormal writes=loadNormal bytes=loadNormal node=loadNormal frac_pending=0.00,0.00(true))]
 [mmaid=1] applying replica change r1 type: RemoveLease target store n1,s1 (replica-id=1 type=VOTER_FULL leaseholder=true)->(replica-id=1 type=VOTER_FULL) to range 1 on store 1
 [mmaid=1] addPendingRangeChange: change_id=1, range_id=1, change=r1 type: RemoveLease target store n1,s1 (replica-id=1 type=VOTER_FULL leaseholder=true)->(replica-id=1 type=VOTER_FULL)
 [mmaid=1] applying replica change r1 type: AddLease target store n3,s3 (replica-id=3 type=VOTER_FULL)->(replica-id=3 type=VOTER_FULL leaseholder=true) to range 1 on store 3

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_transfer_count.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_transfer_count.txt
@@ -14,7 +14,7 @@ rebalance-stores store-id=1 fraction-pending-decrease-threshold=1.0 max-lease-tr
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n1): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=400 fractionUsed=100.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] evaluating s1: node load overloadUrgent, store load overloadUrgent, worst dim CPURate
-[mmaid=1] overload-continued s1 ((store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true))) - within grace period
+[mmaid=1] overload-continued s1 ((store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent frac_pending=0.00,0.00(true))) - within grace period
 [mmaid=1] store s1 was added to shedding store list
 [mmaid=1] load summary for dim=CPURate (s2): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] load summary for dim=WriteBandwidth (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
@@ -51,7 +51,7 @@ rebalance-stores store-id=1 fraction-pending-decrease-threshold=1.0 max-lease-tr
 [mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n1): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=770 meanLoad=400 fractionUsed=77.00% meanUtil=40.00% capacity=1000]
-[mmaid=1] can add load to n2s2: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))] srcSLS[(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true))]
+[mmaid=1] can add load to n2s2: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow frac_pending=0.00,0.00(true))] srcSLS[(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent frac_pending=0.00,0.00(true))]
 [mmaid=1] applying replica change r4 type: RemoveLease target store n1,s1 (replica-id=1 type=VOTER_FULL leaseholder=true)->(replica-id=1 type=VOTER_FULL) to range 4 on store 1
 [mmaid=1] addPendingRangeChange: change_id=1, range_id=4, change=r4 type: RemoveLease target store n1,s1 (replica-id=1 type=VOTER_FULL leaseholder=true)->(replica-id=1 type=VOTER_FULL)
 [mmaid=1] applying replica change r4 type: AddLease target store n2,s2 (replica-id=2 type=VOTER_FULL)->(replica-id=2 type=VOTER_FULL leaseholder=true) to range 4 on store 2
@@ -70,7 +70,7 @@ rebalance-stores store-id=1 fraction-pending-decrease-threshold=1.0 max-lease-tr
 [mmaid=1] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n3): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
-[mmaid=1] candidate store 2 was discarded due to (nls=false overloadDim=false pending_thresh=true): sls=(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=2.53,0.00(false))
+[mmaid=1] candidate store 2 was discarded due to (nls=false overloadDim=false pending_thresh=true): sls=(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow frac_pending=2.53,0.00(false))
 [mmaid=1] sortTargetCandidateSetAndPick: candidates: s3(SLS:loadNormal, overloadedDimLoadSummary:loadLow), overloadedDim:CPURate, picked s3
 [mmaid=1] load summary for dim=CPURate (s3): loadLow, reason: load is >10% below mean [load=353 meanLoad=400 fractionUsed=35.30% meanUtil=40.00% capacity=1000]
 [mmaid=1] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
@@ -80,7 +80,7 @@ rebalance-stores store-id=1 fraction-pending-decrease-threshold=1.0 max-lease-tr
 [mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n1): overloadSlow, reason: fractionUsed < 75% [load=540 meanLoad=400 fractionUsed=54.00% meanUtil=40.00% capacity=1000]
-[mmaid=1] can add load to n3s3: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))] srcSLS[(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow high_disk=false frac_pending=0.00,0.23(false))]
+[mmaid=1] can add load to n3s3: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow frac_pending=0.00,0.00(true))] srcSLS[(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow frac_pending=0.00,0.23(false))]
 [mmaid=1] applying replica change r3 type: RemoveLease target store n1,s1 (replica-id=1 type=VOTER_FULL leaseholder=true)->(replica-id=1 type=VOTER_FULL) to range 3 on store 1
 [mmaid=1] addPendingRangeChange: change_id=3, range_id=3, change=r3 type: RemoveLease target store n1,s1 (replica-id=1 type=VOTER_FULL leaseholder=true)->(replica-id=1 type=VOTER_FULL)
 [mmaid=1] applying replica change r3 type: AddLease target store n3,s3 (replica-id=3 type=VOTER_FULL)->(replica-id=3 type=VOTER_FULL leaseholder=true) to range 3 on store 3

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_transfer_unbounded.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_transfer_unbounded.txt
@@ -13,7 +13,7 @@ rebalance-stores store-id=1 fraction-pending-decrease-threshold=10.0 max-lease-t
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n1): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=400 fractionUsed=100.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] evaluating s1: node load overloadUrgent, store load overloadUrgent, worst dim CPURate
-[mmaid=1] overload-continued s1 ((store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true))) - within grace period
+[mmaid=1] overload-continued s1 ((store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent frac_pending=0.00,0.00(true))) - within grace period
 [mmaid=1] store s1 was added to shedding store list
 [mmaid=1] load summary for dim=CPURate (s2): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] load summary for dim=WriteBandwidth (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
@@ -50,7 +50,7 @@ rebalance-stores store-id=1 fraction-pending-decrease-threshold=10.0 max-lease-t
 [mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n1): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=770 meanLoad=400 fractionUsed=77.00% meanUtil=40.00% capacity=1000]
-[mmaid=1] can add load to n2s2: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))] srcSLS[(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true))]
+[mmaid=1] can add load to n2s2: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow frac_pending=0.00,0.00(true))] srcSLS[(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent frac_pending=0.00,0.00(true))]
 [mmaid=1] applying replica change r4 type: RemoveLease target store n1,s1 (replica-id=1 type=VOTER_FULL leaseholder=true)->(replica-id=1 type=VOTER_FULL) to range 4 on store 1
 [mmaid=1] addPendingRangeChange: change_id=1, range_id=4, change=r4 type: RemoveLease target store n1,s1 (replica-id=1 type=VOTER_FULL leaseholder=true)->(replica-id=1 type=VOTER_FULL)
 [mmaid=1] applying replica change r4 type: AddLease target store n2,s2 (replica-id=2 type=VOTER_FULL)->(replica-id=2 type=VOTER_FULL leaseholder=true) to range 4 on store 2
@@ -79,7 +79,7 @@ rebalance-stores store-id=1 fraction-pending-decrease-threshold=10.0 max-lease-t
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n1): overloadSlow, reason: fractionUsed < 75% [load=540 meanLoad=400 fractionUsed=54.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] cannot add load to n2s2: due to target_summary(overloadSlow)>=loadNoChange,targetSLS.frac_pending(2.53or0.00>=epsilon)
-[mmaid=1] [target_sls:(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow high_disk=false frac_pending=2.53,0.00(false)),src_sls:(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow high_disk=false frac_pending=0.00,0.23(false))]
+[mmaid=1] [target_sls:(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow frac_pending=2.53,0.00(false)),src_sls:(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow frac_pending=0.00,0.23(false))]
 [mmaid=1] result(failed): cannot shed from s1 to s2 for r3: delta load [cpu:230ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=1] considering lease-transfer r2 from s1: candidates are [2 3]
 [mmaid=1] load summary for dim=CPURate (s1): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=770 meanLoad=400 fractionUsed=77.00% meanUtil=40.00% capacity=1000]
@@ -103,7 +103,7 @@ rebalance-stores store-id=1 fraction-pending-decrease-threshold=10.0 max-lease-t
 [mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n1): overloadSlow, reason: fractionUsed < 75% [load=540 meanLoad=400 fractionUsed=54.00% meanUtil=40.00% capacity=1000]
-[mmaid=1] can add load to n3s3: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))] srcSLS[(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow high_disk=false frac_pending=0.00,0.23(false))]
+[mmaid=1] can add load to n3s3: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow frac_pending=0.00,0.00(true))] srcSLS[(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow frac_pending=0.00,0.23(false))]
 [mmaid=1] applying replica change r2 type: RemoveLease target store n1,s1 (replica-id=1 type=VOTER_FULL leaseholder=true)->(replica-id=1 type=VOTER_FULL) to range 2 on store 1
 [mmaid=1] addPendingRangeChange: change_id=3, range_id=2, change=r2 type: RemoveLease target store n1,s1 (replica-id=1 type=VOTER_FULL leaseholder=true)->(replica-id=1 type=VOTER_FULL)
 [mmaid=1] applying replica change r2 type: AddLease target store n3,s3 (replica-id=3 type=VOTER_FULL)->(replica-id=3 type=VOTER_FULL leaseholder=true) to range 2 on store 3
@@ -132,7 +132,7 @@ rebalance-stores store-id=1 fraction-pending-decrease-threshold=10.0 max-lease-t
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n1): loadLow, reason: load is >10% below mean [load=310 meanLoad=400 fractionUsed=31.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] cannot add load to n2s2: due to !overloadedDimPermitsChange,target_summary(overloadSlow)>=loadNoChange,targetSLS.frac_pending(2.53or0.00>=epsilon),target-store(overloadSlow)>src-store(loadNormal)
-[mmaid=1] [target_sls:(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow high_disk=false frac_pending=2.53,0.00(false)),src_sls:(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.46(false))]
+[mmaid=1] [target_sls:(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow frac_pending=2.53,0.00(false)),src_sls:(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow frac_pending=0.00,0.46(false))]
 [mmaid=1] result(failed): cannot shed from s1 to s2 for r1: delta load [cpu:230ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=1] skipping replica transfers for s1 to try more leases next time
 [mmaid=1] rebalancing pass shed: {s1}

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_count.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_count.txt
@@ -26,7 +26,7 @@ rebalance-stores store-id=1 max-range-move-count=1 fraction-pending-decrease-thr
 [mmaid=2] load summary for dim=CPURate (n4): loadLow, reason: load is >10% below mean [load=100 meanLoad=525 fractionUsed=10.00% meanUtil=52.50% capacity=1000]
 [mmaid=2] considering replica-transfer r3 from s3: store load [cpu:1µs/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=2] candidates are:
-[mmaid=2]  s4: (store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))
+[mmaid=2]  s4: (store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow frac_pending=0.00,0.00(true))
 [mmaid=2] sortTargetCandidateSetAndPick: candidates: s4(SLS:loadNormal, overloadedDimLoadSummary:loadLow), overloadedDim:CPURate, picked s4
 [mmaid=2] load summary for dim=CPURate (s4): loadLow, reason: load is >10% below mean [load=210 meanLoad=525 fractionUsed=21.00% meanUtil=52.50% capacity=1000]
 [mmaid=2] load summary for dim=WriteBandwidth (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
@@ -36,7 +36,7 @@ rebalance-stores store-id=1 max-range-move-count=1 fraction-pending-decrease-thr
 [mmaid=2] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=2] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=2] load summary for dim=CPURate (n3): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=900 meanLoad=525 fractionUsed=90.00% meanUtil=52.50% capacity=1000]
-[mmaid=2] can add load to n4s4: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))] srcSLS[(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true))]
+[mmaid=2] can add load to n4s4: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow frac_pending=0.00,0.00(true))] srcSLS[(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent frac_pending=0.00,0.00(true))]
 [mmaid=2] applying replica change r3 type: AddReplica target store n4,s4 (replica-id=none type=VOTER_FULL)->(replica-id=unknown type=VOTER_FULL) to range 3 on store 4
 [mmaid=2] addPendingRangeChange: change_id=1, range_id=3, change=r3 type: AddReplica target store n4,s4 (replica-id=none type=VOTER_FULL)->(replica-id=unknown type=VOTER_FULL)
 [mmaid=2] applying replica change r3 type: RemoveReplica target store n3,s3 (replica-id=3 type=VOTER_FULL)->(replica-id=none type=VOTER_FULL) to range 3 on store 3

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_frac_threshold.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_frac_threshold.txt
@@ -26,7 +26,7 @@ rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-t
 [mmaid=2] load summary for dim=CPURate (n4): loadLow, reason: load is >10% below mean [load=100 meanLoad=525 fractionUsed=10.00% meanUtil=52.50% capacity=1000]
 [mmaid=2] considering replica-transfer r3 from s3: store load [cpu:1µs/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=2] candidates are:
-[mmaid=2]  s4: (store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))
+[mmaid=2]  s4: (store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow frac_pending=0.00,0.00(true))
 [mmaid=2] sortTargetCandidateSetAndPick: candidates: s4(SLS:loadNormal, overloadedDimLoadSummary:loadLow), overloadedDim:CPURate, picked s4
 [mmaid=2] load summary for dim=CPURate (s4): loadLow, reason: load is >10% below mean [load=210 meanLoad=525 fractionUsed=21.00% meanUtil=52.50% capacity=1000]
 [mmaid=2] load summary for dim=WriteBandwidth (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
@@ -36,7 +36,7 @@ rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-t
 [mmaid=2] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=2] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=2] load summary for dim=CPURate (n3): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=900 meanLoad=525 fractionUsed=90.00% meanUtil=52.50% capacity=1000]
-[mmaid=2] can add load to n4s4: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))] srcSLS[(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true))]
+[mmaid=2] can add load to n4s4: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow frac_pending=0.00,0.00(true))] srcSLS[(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent frac_pending=0.00,0.00(true))]
 [mmaid=2] applying replica change r3 type: AddReplica target store n4,s4 (replica-id=none type=VOTER_FULL)->(replica-id=unknown type=VOTER_FULL) to range 3 on store 4
 [mmaid=2] addPendingRangeChange: change_id=1, range_id=3, change=r3 type: AddReplica target store n4,s4 (replica-id=none type=VOTER_FULL)->(replica-id=unknown type=VOTER_FULL)
 [mmaid=2] applying replica change r3 type: RemoveReplica target store n3,s3 (replica-id=3 type=VOTER_FULL)->(replica-id=none type=VOTER_FULL) to range 3 on store 3

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_include.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_include.txt
@@ -81,7 +81,7 @@ rebalance-stores store-id=1
 [mmaid=1] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n3): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=525 fractionUsed=100.00% meanUtil=52.50% capacity=1000]
 [mmaid=1] evaluating s3: node load overloadUrgent, store load overloadUrgent, worst dim CPURate
-[mmaid=1] overload-continued s3 ((store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true))) - within grace period
+[mmaid=1] overload-continued s3 ((store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent frac_pending=0.00,0.00(true))) - within grace period
 [mmaid=1] store s3 was added to shedding store list
 [mmaid=1] load summary for dim=CPURate (s4): loadLow, reason: load is >10% below mean [load=100 meanLoad=525 fractionUsed=10.00% meanUtil=52.50% capacity=1000]
 [mmaid=1] load summary for dim=WriteBandwidth (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_lateral.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_lateral.txt
@@ -50,21 +50,21 @@ rebalance-stores store-id=1
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n1): loadNoChange, reason: fractionUsed < 75% [load=100 meanLoad=100 fractionUsed=10.00% meanUtil=7.50% capacity=1000]
 [mmaid=1] evaluating s1: node load loadNoChange, store load overloadSlow, worst dim CPURate
-[mmaid=1] overload-continued s1 ((store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadLow bytes=loadNormal node=loadNoChange high_disk=false frac_pending=0.00,0.00(true))) - within grace period
+[mmaid=1] overload-continued s1 ((store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadLow bytes=loadNormal node=loadNoChange frac_pending=0.00,0.00(true))) - within grace period
 [mmaid=1] store s1 was added to shedding store list
 [mmaid=1] load summary for dim=CPURate (s2): overloadSlow, reason: fractionUsed < 75% [load=100 meanLoad=75 fractionUsed=10.00% meanUtil=7.50% capacity=1000]
 [mmaid=1] load summary for dim=WriteBandwidth (s2): loadLow, reason: load is >10% below mean [load=20000000 meanLoad=32500000 fractionUsed=20.00% meanUtil=32.50% capacity=100000000]
 [mmaid=1] load summary for dim=ByteSize (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n2): loadNoChange, reason: fractionUsed < 75% [load=100 meanLoad=100 fractionUsed=10.00% meanUtil=7.50% capacity=1000]
 [mmaid=1] evaluating s2: node load loadNoChange, store load overloadSlow, worst dim CPURate
-[mmaid=1] overload-continued s2 ((store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadLow bytes=loadNormal node=loadNoChange high_disk=false frac_pending=0.00,0.00(true))) - within grace period
+[mmaid=1] overload-continued s2 ((store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadLow bytes=loadNormal node=loadNoChange frac_pending=0.00,0.00(true))) - within grace period
 [mmaid=1] store s2 was added to shedding store list
 [mmaid=1] load summary for dim=CPURate (s3): loadLow, reason: load is >10% below mean [load=50 meanLoad=75 fractionUsed=5.00% meanUtil=7.50% capacity=1000]
 [mmaid=1] load summary for dim=WriteBandwidth (s3): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=80000000 meanLoad=32500000 fractionUsed=80.00% meanUtil=32.50% capacity=100000000]
 [mmaid=1] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n3): loadNormal, reason: load is within 5% of mean [load=100 meanLoad=100 fractionUsed=5.00% meanUtil=7.50% capacity=2000]
 [mmaid=1] evaluating s3: node load loadNormal, store load overloadUrgent, worst dim WriteBandwidth
-[mmaid=1] overload-continued s3 ((store=overloadUrgent worst=WriteBandwidth cpu=loadLow writes=overloadUrgent bytes=loadNormal node=loadNormal high_disk=false frac_pending=0.00,0.00(true))) - within grace period
+[mmaid=1] overload-continued s3 ((store=overloadUrgent worst=WriteBandwidth cpu=loadLow writes=overloadUrgent bytes=loadNormal node=loadNormal frac_pending=0.00,0.00(true))) - within grace period
 [mmaid=1] store s3 was added to shedding store list
 [mmaid=1] load summary for dim=CPURate (s4): loadLow, reason: load is >10% below mean [load=50 meanLoad=75 fractionUsed=5.00% meanUtil=7.50% capacity=1000]
 [mmaid=1] load summary for dim=WriteBandwidth (s4): loadLow, reason: load is >10% below mean [load=10000000 meanLoad=32500000 fractionUsed=10.00% meanUtil=32.50% capacity=100000000]
@@ -87,7 +87,7 @@ rebalance-stores store-id=1
 [mmaid=1] load summary for dim=WriteBandwidth (s3): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=80000000 meanLoad=40000000 fractionUsed=80.00% meanUtil=40.00% capacity=100000000]
 [mmaid=1] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n3): loadNormal, reason: load is within 5% of mean [load=100 meanLoad=100 fractionUsed=5.00% meanUtil=7.50% capacity=2000]
-[mmaid=1] candidate store 2 was discarded due to (nls=false overloadDim=true pending_thresh=false): sls=(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadLow bytes=loadNormal node=loadNoChange high_disk=false frac_pending=0.00,0.00(true))
+[mmaid=1] candidate store 2 was discarded due to (nls=false overloadDim=true pending_thresh=false): sls=(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadLow bytes=loadNormal node=loadNoChange frac_pending=0.00,0.00(true))
 [mmaid=1] discarding candidates with higher load than loadThreshold(overloadSlow):  s3(SLS:overloadUrgent, overloadedDimLoadSummary:loadLow), overloadedDim:CPURate
 [mmaid=1] sortTargetCandidateSetAndPick: no candidates due to load
 [mmaid=1] result(failed): no candidates to move lease from n1s1 for r1 after sortTargetCandidateSetAndPick
@@ -115,7 +115,7 @@ rebalance-stores store-id=1
 [mmaid=1] load summary for dim=CPURate (n3): loadNormal, reason: load is within 5% of mean [load=100 meanLoad=100 fractionUsed=5.00% meanUtil=7.50% capacity=2000]
 [mmaid=1] considering replica-transfer r1 from s3: store load [cpu:50ns/s, write-bandwidth:80 MB/s, byte-size:0 B]
 [mmaid=1] candidates are:
-[mmaid=1]  s4: (store=loadNormal worst=ByteSize cpu=loadLow writes=loadLow bytes=loadNormal node=loadNormal high_disk=false frac_pending=0.00,0.00(true))
+[mmaid=1]  s4: (store=loadNormal worst=ByteSize cpu=loadLow writes=loadLow bytes=loadNormal node=loadNormal frac_pending=0.00,0.00(true))
 [mmaid=1] sortTargetCandidateSetAndPick: candidates: s4(SLS:loadNormal, overloadedDimLoadSummary:loadLow), overloadedDim:WriteBandwidth, picked s4
 [mmaid=1] load summary for dim=CPURate (s4): loadLow, reason: load is >10% below mean [load=61 meanLoad=75 fractionUsed=6.10% meanUtil=7.50% capacity=1000]
 [mmaid=1] load summary for dim=WriteBandwidth (s4): loadLow, reason: load is >10% below mean [load=21000000 meanLoad=32500000 fractionUsed=21.00% meanUtil=32.50% capacity=100000000]
@@ -126,7 +126,7 @@ rebalance-stores store-id=1
 [mmaid=1] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n3): loadNormal, reason: load is within 5% of mean [load=90 meanLoad=100 fractionUsed=4.50% meanUtil=7.50% capacity=2000]
 [mmaid=1] cannot add load to n3s4: due to target_summary(overloadSlow)>=loadNoChange,target-node(overloadSlow)>target-store(loadNormal)
-[mmaid=1] [target_sls:(store=loadNormal worst=ByteSize cpu=loadLow writes=loadLow bytes=loadNormal node=overloadSlow high_disk=false frac_pending=0.00,0.00(true)),src_sls:(store=overloadSlow worst=WriteBandwidth cpu=loadLow writes=overloadSlow bytes=loadNormal node=loadNormal high_disk=false frac_pending=0.00,0.00(true))]
+[mmaid=1] [target_sls:(store=loadNormal worst=ByteSize cpu=loadLow writes=loadLow bytes=loadNormal node=overloadSlow frac_pending=0.00,0.00(true)),src_sls:(store=overloadSlow worst=WriteBandwidth cpu=loadLow writes=overloadSlow bytes=loadNormal node=loadNormal frac_pending=0.00,0.00(true))]
 [mmaid=1] result(failed): cannot shed from s3 to s4 for r1: delta load [cpu:10ns/s, write-bandwidth:10 MB/s, byte-size:0 B]
 [mmaid=1] rebalancing pass failures (store,reason:count): (s1,no-cand-load:1), (s3,no-cand-to-accept-load:1)
 pending(0)
@@ -170,7 +170,7 @@ rebalance-stores store-id=1
 [mmaid=2] load summary for dim=WriteBandwidth (s3): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=80000000 meanLoad=40000000 fractionUsed=80.00% meanUtil=40.00% capacity=100000000]
 [mmaid=2] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=2] load summary for dim=CPURate (n3): loadNormal, reason: load is within 5% of mean [load=100 meanLoad=100 fractionUsed=5.00% meanUtil=7.50% capacity=2000]
-[mmaid=2] candidate store 2 was discarded due to (nls=false overloadDim=true pending_thresh=false): sls=(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadLow bytes=loadNormal node=loadNoChange high_disk=false frac_pending=0.00,0.00(true))
+[mmaid=2] candidate store 2 was discarded due to (nls=false overloadDim=true pending_thresh=false): sls=(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadLow bytes=loadNormal node=loadNoChange frac_pending=0.00,0.00(true))
 [mmaid=2] discarding candidates with higher load than loadThreshold(overloadSlow):  s3(SLS:overloadUrgent, overloadedDimLoadSummary:loadLow), overloadedDim:CPURate
 [mmaid=2] sortTargetCandidateSetAndPick: no candidates due to load
 [mmaid=2] result(failed): no candidates to move lease from n1s1 for r1 after sortTargetCandidateSetAndPick
@@ -205,7 +205,7 @@ rebalance-stores store-id=1
 [mmaid=2] load summary for dim=CPURate (n3): loadNormal, reason: load is within 5% of mean [load=100 meanLoad=100 fractionUsed=5.00% meanUtil=7.50% capacity=2000]
 [mmaid=2] considering replica-transfer r1 from s3: store load [cpu:50ns/s, write-bandwidth:80 MB/s, byte-size:0 B]
 [mmaid=2] candidates are:
-[mmaid=2]  s4: (store=loadNormal worst=ByteSize cpu=loadLow writes=loadLow bytes=loadNormal node=loadNormal high_disk=false frac_pending=0.00,0.00(true))
+[mmaid=2]  s4: (store=loadNormal worst=ByteSize cpu=loadLow writes=loadLow bytes=loadNormal node=loadNormal frac_pending=0.00,0.00(true))
 [mmaid=2] sortTargetCandidateSetAndPick: candidates: s4(SLS:loadNormal, overloadedDimLoadSummary:loadLow), overloadedDim:WriteBandwidth, picked s4
 [mmaid=2] load summary for dim=CPURate (s4): loadLow, reason: load is >10% below mean [load=61 meanLoad=75 fractionUsed=6.10% meanUtil=7.50% capacity=1000]
 [mmaid=2] load summary for dim=WriteBandwidth (s4): loadLow, reason: load is >10% below mean [load=21000000 meanLoad=32500000 fractionUsed=21.00% meanUtil=32.50% capacity=100000000]
@@ -216,7 +216,7 @@ rebalance-stores store-id=1
 [mmaid=2] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=2] load summary for dim=CPURate (n3): loadNormal, reason: load is within 5% of mean [load=90 meanLoad=100 fractionUsed=4.50% meanUtil=7.50% capacity=2000]
 [mmaid=2] cannot add load to n3s4: due to target_summary(overloadSlow)>=loadNoChange,target-node(overloadSlow)>target-store(loadNormal)
-[mmaid=2] [target_sls:(store=loadNormal worst=ByteSize cpu=loadLow writes=loadLow bytes=loadNormal node=overloadSlow high_disk=false frac_pending=0.00,0.00(true)),src_sls:(store=overloadSlow worst=WriteBandwidth cpu=loadLow writes=overloadSlow bytes=loadNormal node=loadNormal high_disk=false frac_pending=0.00,0.00(true))]
+[mmaid=2] [target_sls:(store=loadNormal worst=ByteSize cpu=loadLow writes=loadLow bytes=loadNormal node=overloadSlow frac_pending=0.00,0.00(true)),src_sls:(store=overloadSlow worst=WriteBandwidth cpu=loadLow writes=overloadSlow bytes=loadNormal node=loadNormal frac_pending=0.00,0.00(true))]
 [mmaid=2] result(failed): cannot shed from s3 to s4 for r1: delta load [cpu:10ns/s, write-bandwidth:10 MB/s, byte-size:0 B]
 [mmaid=2] rebalancing pass failures (store,reason:count): (s1,no-cand-load:1), (s2,no-cand:1), (s3,no-cand-to-accept-load:1)
 pending(0)

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_refusing_target.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_refusing_target.txt
@@ -56,21 +56,21 @@ rebalance-stores store-id=1
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n1): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=775 fractionUsed=100.00% meanUtil=77.50% capacity=1000]
 [mmaid=1] evaluating s1: node load overloadUrgent, store load overloadUrgent, worst dim CPURate
-[mmaid=1] overload-continued s1 ((store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true))) - within grace period
+[mmaid=1] overload-continued s1 ((store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent frac_pending=0.00,0.00(true))) - within grace period
 [mmaid=1] store s1 was added to shedding store list
 [mmaid=1] load summary for dim=CPURate (s2): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=775 fractionUsed=100.00% meanUtil=77.50% capacity=1000]
 [mmaid=1] load summary for dim=WriteBandwidth (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=ByteSize (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n2): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=775 fractionUsed=100.00% meanUtil=77.50% capacity=1000]
 [mmaid=1] evaluating s2: node load overloadUrgent, store load overloadUrgent, worst dim CPURate
-[mmaid=1] overload-continued s2 ((store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true))) - within grace period
+[mmaid=1] overload-continued s2 ((store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent frac_pending=0.00,0.00(true))) - within grace period
 [mmaid=1] store s2 was added to shedding store list
 [mmaid=1] load summary for dim=CPURate (s3): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=775 fractionUsed=100.00% meanUtil=77.50% capacity=1000]
 [mmaid=1] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n3): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=775 fractionUsed=100.00% meanUtil=77.50% capacity=1000]
 [mmaid=1] evaluating s3: node load overloadUrgent, store load overloadUrgent, worst dim CPURate
-[mmaid=1] overload-continued s3 ((store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true))) - within grace period
+[mmaid=1] overload-continued s3 ((store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent frac_pending=0.00,0.00(true))) - within grace period
 [mmaid=1] store s3 was added to shedding store list
 [mmaid=1] load summary for dim=CPURate (s4): loadLow, reason: load is >10% below mean [load=100 meanLoad=775 fractionUsed=10.00% meanUtil=77.50% capacity=1000]
 [mmaid=1] load summary for dim=WriteBandwidth (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_unbounded.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_unbounded.txt
@@ -29,7 +29,7 @@ rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-t
 [mmaid=2] load summary for dim=CPURate (n4): loadLow, reason: load is >10% below mean [load=100 meanLoad=525 fractionUsed=10.00% meanUtil=52.50% capacity=1000]
 [mmaid=2] considering replica-transfer r3 from s3: store load [cpu:1µs/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=2] candidates are:
-[mmaid=2]  s4: (store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))
+[mmaid=2]  s4: (store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow frac_pending=0.00,0.00(true))
 [mmaid=2] sortTargetCandidateSetAndPick: candidates: s4(SLS:loadNormal, overloadedDimLoadSummary:loadLow), overloadedDim:CPURate, picked s4
 [mmaid=2] load summary for dim=CPURate (s4): loadLow, reason: load is >10% below mean [load=210 meanLoad=525 fractionUsed=21.00% meanUtil=52.50% capacity=1000]
 [mmaid=2] load summary for dim=WriteBandwidth (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
@@ -39,7 +39,7 @@ rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-t
 [mmaid=2] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=2] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=2] load summary for dim=CPURate (n3): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=900 meanLoad=525 fractionUsed=90.00% meanUtil=52.50% capacity=1000]
-[mmaid=2] can add load to n4s4: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))] srcSLS[(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true))]
+[mmaid=2] can add load to n4s4: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow frac_pending=0.00,0.00(true))] srcSLS[(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent frac_pending=0.00,0.00(true))]
 [mmaid=2] applying replica change r3 type: AddReplica target store n4,s4 (replica-id=none type=VOTER_FULL)->(replica-id=unknown type=VOTER_FULL) to range 3 on store 4
 [mmaid=2] addPendingRangeChange: change_id=1, range_id=3, change=r3 type: AddReplica target store n4,s4 (replica-id=none type=VOTER_FULL)->(replica-id=unknown type=VOTER_FULL)
 [mmaid=2] applying replica change r3 type: RemoveReplica target store n3,s3 (replica-id=3 type=VOTER_FULL)->(replica-id=none type=VOTER_FULL) to range 3 on store 3
@@ -55,7 +55,7 @@ rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-t
 [mmaid=2] load summary for dim=CPURate (n4): loadLow, reason: load is >10% below mean [load=210 meanLoad=525 fractionUsed=21.00% meanUtil=52.50% capacity=1000]
 [mmaid=2] considering replica-transfer r2 from s3: store load [cpu:900ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=2] candidates are:
-[mmaid=2]  s4: (store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=1.10,0.00(false))
+[mmaid=2]  s4: (store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow frac_pending=1.10,0.00(false))
 [mmaid=2] sortTargetCandidateSetAndPick: candidates: s4(SLS:loadNormal, overloadedDimLoadSummary:loadLow), overloadedDim:CPURate, picked s4
 [mmaid=2] load summary for dim=CPURate (s4): loadLow, reason: load is >10% below mean [load=320 meanLoad=525 fractionUsed=32.00% meanUtil=52.50% capacity=1000]
 [mmaid=2] load summary for dim=WriteBandwidth (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
@@ -65,7 +65,7 @@ rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-t
 [mmaid=2] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=2] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=2] load summary for dim=CPURate (n3): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=800 meanLoad=525 fractionUsed=80.00% meanUtil=52.50% capacity=1000]
-[mmaid=2] can add load to n4s4: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=1.10,0.00(false))] srcSLS[(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.10(false))]
+[mmaid=2] can add load to n4s4: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow frac_pending=1.10,0.00(false))] srcSLS[(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent frac_pending=0.00,0.10(false))]
 [mmaid=2] applying replica change r2 type: AddReplica target store n4,s4 (replica-id=none type=VOTER_FULL)->(replica-id=unknown type=VOTER_FULL) to range 2 on store 4
 [mmaid=2] addPendingRangeChange: change_id=3, range_id=2, change=r2 type: AddReplica target store n4,s4 (replica-id=none type=VOTER_FULL)->(replica-id=unknown type=VOTER_FULL)
 [mmaid=2] applying replica change r2 type: RemoveReplica target store n3,s3 (replica-id=3 type=VOTER_FULL)->(replica-id=none type=VOTER_FULL) to range 2 on store 3
@@ -81,7 +81,7 @@ rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-t
 [mmaid=2] load summary for dim=CPURate (n4): loadLow, reason: load is >10% below mean [load=320 meanLoad=525 fractionUsed=32.00% meanUtil=52.50% capacity=1000]
 [mmaid=2] considering replica-transfer r1 from s3: store load [cpu:800ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=2] candidates are:
-[mmaid=2]  s4: (store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=2.20,0.00(false))
+[mmaid=2]  s4: (store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow frac_pending=2.20,0.00(false))
 [mmaid=2] sortTargetCandidateSetAndPick: candidates: s4(SLS:loadNormal, overloadedDimLoadSummary:loadLow), overloadedDim:CPURate, picked s4
 [mmaid=2] load summary for dim=CPURate (s4): loadLow, reason: load is >10% below mean [load=430 meanLoad=525 fractionUsed=43.00% meanUtil=52.50% capacity=1000]
 [mmaid=2] load summary for dim=WriteBandwidth (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
@@ -91,7 +91,7 @@ rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-t
 [mmaid=2] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=2] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=2] load summary for dim=CPURate (n3): overloadSlow, reason: fractionUsed < 75% [load=700 meanLoad=525 fractionUsed=70.00% meanUtil=52.50% capacity=1000]
-[mmaid=2] can add load to n4s4: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=2.20,0.00(false))] srcSLS[(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow high_disk=false frac_pending=0.00,0.20(false))]
+[mmaid=2] can add load to n4s4: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow frac_pending=2.20,0.00(false))] srcSLS[(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow frac_pending=0.00,0.20(false))]
 [mmaid=2] applying replica change r1 type: AddReplica target store n4,s4 (replica-id=none type=VOTER_FULL)->(replica-id=unknown type=VOTER_FULL) to range 1 on store 4
 [mmaid=2] addPendingRangeChange: change_id=5, range_id=1, change=r1 type: AddReplica target store n4,s4 (replica-id=none type=VOTER_FULL)->(replica-id=unknown type=VOTER_FULL)
 [mmaid=2] applying replica change r1 type: RemoveReplica target store n3,s3 (replica-id=3 type=VOTER_FULL)->(replica-id=none type=VOTER_FULL) to range 1 on store 3

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_nls_sls_mismatch.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_nls_sls_mismatch.txt
@@ -72,21 +72,21 @@ rebalance-stores store-id=1
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000000000]
 [mmaid=1] load summary for dim=CPURate (n1): overloadSlow, reason: fractionUsed < 75% [load=7000000000 meanLoad=4000000000 fractionUsed=43.75% meanUtil=33.33% capacity=16000000000]
 [mmaid=1] evaluating s1: node load overloadSlow, store load overloadSlow, worst dim WriteBandwidth
-[mmaid=1] overload-continued s1 ((store=overloadSlow worst=WriteBandwidth cpu=loadLow writes=overloadSlow bytes=loadNormal node=overloadSlow high_disk=false frac_pending=0.00,0.00(true))) - within grace period
+[mmaid=1] overload-continued s1 ((store=overloadSlow worst=WriteBandwidth cpu=loadLow writes=overloadSlow bytes=loadNormal node=overloadSlow frac_pending=0.00,0.00(true))) - within grace period
 [mmaid=1] store s1 was added to shedding store list
 [mmaid=1] load summary for dim=CPURate (s2): overloadSlow, reason: fractionUsed < 75% and >1.75x meanUtil [load=6000000000 meanLoad=2666666666 fractionUsed=75.00% meanUtil=33.33% capacity=8000000000]
 [mmaid=1] load summary for dim=WriteBandwidth (s2): loadLow, reason: load is >10% below mean [load=10000000 meanLoad=36666666 fractionUsed=10.00% meanUtil=36.67% capacity=100000000]
 [mmaid=1] load summary for dim=ByteSize (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000000000]
 [mmaid=1] load summary for dim=CPURate (n1): overloadSlow, reason: fractionUsed < 75% [load=7000000000 meanLoad=4000000000 fractionUsed=43.75% meanUtil=33.33% capacity=16000000000]
 [mmaid=1] evaluating s2: node load overloadSlow, store load overloadSlow, worst dim CPURate
-[mmaid=1] overload-continued s2 ((store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadLow bytes=loadNormal node=overloadSlow high_disk=false frac_pending=0.00,0.00(true))) - within grace period
+[mmaid=1] overload-continued s2 ((store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadLow bytes=loadNormal node=overloadSlow frac_pending=0.00,0.00(true))) - within grace period
 [mmaid=1] store s2 was added to shedding store list
 [mmaid=1] load summary for dim=CPURate (s3): loadLow, reason: load is >10% below mean [load=1000000000 meanLoad=2666666666 fractionUsed=12.50% meanUtil=33.33% capacity=8000000000]
 [mmaid=1] load summary for dim=WriteBandwidth (s3): overloadSlow, reason: fractionUsed < 75% [load=50000000 meanLoad=36666666 fractionUsed=50.00% meanUtil=36.67% capacity=100000000]
 [mmaid=1] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000000000]
 [mmaid=1] load summary for dim=CPURate (n2): loadLow, reason: load is >10% below mean [load=1000000000 meanLoad=4000000000 fractionUsed=12.50% meanUtil=33.33% capacity=8000000000]
 [mmaid=1] evaluating s3: node load loadLow, store load overloadSlow, worst dim WriteBandwidth
-[mmaid=1] overload-continued s3 ((store=overloadSlow worst=WriteBandwidth cpu=loadLow writes=overloadSlow bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))) - within grace period
+[mmaid=1] overload-continued s3 ((store=overloadSlow worst=WriteBandwidth cpu=loadLow writes=overloadSlow bytes=loadNormal node=loadLow frac_pending=0.00,0.00(true))) - within grace period
 [mmaid=1] store s3 was added to shedding store list
 [mmaid=1] start processing shedding store s1: cpu node load overloadSlow, store load overloadSlow, worst dim WriteBandwidth
 [mmaid=1] top-K[WriteBandwidth] ranges for s1 with lease on local s1: r1:[cpu:100ms/s, write-bandwidth:10 MB/s, byte-size:0 B]

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/replica_disposition.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/replica_disposition.txt
@@ -123,7 +123,7 @@ update-store-statuses
 
 retain-ready-replica-target-stores-only in=(1,2,3)
 ----
-skipping s2 for replica transfer: replica disposition refusing (health ok)
+skipping s2 for replica transfer: replica disposition shedding (health ok)
 [1 3]
 
 # Test combination of filters: s2 still high disk,
@@ -134,7 +134,7 @@ ok refusing=replicas
 
 retain-ready-replica-target-stores-only in=(1,2,3)
 ----
-skipping s2 for replica transfer: replica disposition refusing (health ok)
+skipping s2 for replica transfer: replica disposition shedding (health ok)
 skipping s3 for replica transfer: replica disposition refusing (health ok)
 [1]
 

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/replica_disposition.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/replica_disposition.txt
@@ -1,7 +1,9 @@
 # Test retainReadyReplicaTargetStoresOnly which filters stores based on:
 # 1. Health (must be HealthOK)
 # 2. Store-level replica disposition (must be ReplicaDispositionOK)
-# 3. High disk space utilization (>90%)
+#
+# High disk space utilization (>90%) is handled via updateStoreStatuses which
+# augments the replica disposition to ReplicaDispositionRefusing.
 #
 # Note: constraint-based exclusions (e.g., to avoid multiple replicas per node)
 # are handled post-means at the caller level, not here.
@@ -115,9 +117,13 @@ store-load-msg
   store-id=2 node-id=2 load=[50,0,95] capacity=[200,100,100] load-time=0s
 ----
 
+# Trigger updateStoreStatuses to augment disposition based on disk utilization.
+update-store-statuses
+----
+
 retain-ready-replica-target-stores-only in=(1,2,3)
 ----
-skipping s2 for replica transfer: high disk utilization (health ok)
+skipping s2 for replica transfer: replica disposition refusing (health ok)
 [1 3]
 
 # Test combination of filters: s2 still high disk,
@@ -128,7 +134,7 @@ ok refusing=replicas
 
 retain-ready-replica-target-stores-only in=(1,2,3)
 ----
-skipping s2 for replica transfer: high disk utilization (health ok)
+skipping s2 for replica transfer: replica disposition refusing (health ok)
 skipping s3 for replica transfer: replica disposition refusing (health ok)
 [1]
 
@@ -136,14 +142,21 @@ skipping s3 for replica transfer: replica disposition refusing (health ok)
 # since it already has the replica (their load should be in the mean regardless
 # of whether it's accepting new replicas).
 
-# Reset stores to healthy.
-set-store-status store-id=2 health=ok
+# Reset stores to healthy. Note: we need to explicitly reset replicas=ok
+# because set-store-status doesn't automatically clear dispositions set by
+# update-store-statuses.
+set-store-status store-id=2 health=ok replicas=ok
 ----
 ok accepting all
 
 # Reset high disk on s2.
 store-load-msg
   store-id=2 node-id=2 load=[50,0,0] capacity=[200,100,100] load-time=0s
+----
+
+# Trigger updateStoreStatuses to ensure disposition is recalculated
+# (disk is now low, so disposition stays ok).
+update-store-statuses
 ----
 
 set-store-status store-id=3 replicas=ok

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/skip_range_invalid_config.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/skip_range_invalid_config.txt
@@ -60,7 +60,7 @@ rebalance-stores store-id=1
 [mmaid=1] load summary for dim=ByteSize (s1): overloadSlow, reason: fractionUsed < 75% and >1.75x meanUtil [load=100 meanLoad=55 fractionUsed=50.00% meanUtil=27.50% capacity=200]
 [mmaid=1] load summary for dim=CPURate (n1): overloadSlow, reason: fractionUsed < 75% and >1.75x meanUtil [load=100 meanLoad=55 fractionUsed=50.00% meanUtil=27.50% capacity=200]
 [mmaid=1] evaluating s1: node load overloadSlow, store load overloadSlow, worst dim CPURate
-[mmaid=1] overload-continued s1 ((store=overloadSlow worst=CPURate cpu=overloadSlow writes=overloadSlow bytes=overloadSlow node=overloadSlow high_disk=false frac_pending=0.00,0.00(true))) - within grace period
+[mmaid=1] overload-continued s1 ((store=overloadSlow worst=CPURate cpu=overloadSlow writes=overloadSlow bytes=overloadSlow node=overloadSlow frac_pending=0.00,0.00(true))) - within grace period
 [mmaid=1] store s1 was added to shedding store list
 [mmaid=1] load summary for dim=CPURate (s2): loadLow, reason: load is >10% below mean [load=10 meanLoad=55 fractionUsed=5.00% meanUtil=27.50% capacity=200]
 [mmaid=1] load summary for dim=WriteBandwidth (s2): loadLow, reason: load is >10% below mean [load=10 meanLoad=55 fractionUsed=5.00% meanUtil=27.50% capacity=200]

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/store_status_exclusion.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/store_status_exclusion.txt
@@ -161,7 +161,7 @@ rebalance-stores store-id=1
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n1): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=400 fractionUsed=100.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] evaluating s1: node load overloadUrgent, store load overloadUrgent, worst dim CPURate
-[mmaid=1] overload-continued s1 ((store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true))) - within grace period
+[mmaid=1] overload-continued s1 ((store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent frac_pending=0.00,0.00(true))) - within grace period
 [mmaid=1] store s1 was added to shedding store list
 [mmaid=1] load summary for dim=CPURate (s2): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] load summary for dim=WriteBandwidth (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
@@ -195,7 +195,7 @@ rebalance-stores store-id=1
 [mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n1): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=550 fractionUsed=100.00% meanUtil=55.00% capacity=1000]
-[mmaid=1] can add load to n2s2: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))] srcSLS[(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true))]
+[mmaid=1] can add load to n2s2: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow frac_pending=0.00,0.00(true))] srcSLS[(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent frac_pending=0.00,0.00(true))]
 [mmaid=1] applying replica change r1 type: RemoveLease target store n1,s1 (replica-id=1 type=VOTER_FULL leaseholder=true)->(replica-id=1 type=VOTER_FULL) to range 1 on store 1
 [mmaid=1] addPendingRangeChange: change_id=1, range_id=1, change=r1 type: RemoveLease target store n1,s1 (replica-id=1 type=VOTER_FULL leaseholder=true)->(replica-id=1 type=VOTER_FULL)
 [mmaid=1] applying replica change r1 type: AddLease target store n2,s2 (replica-id=2 type=VOTER_FULL)->(replica-id=2 type=VOTER_FULL leaseholder=true) to range 1 on store 2

--- a/pkg/kv/kvserver/asim/mmaintegration/BUILD.bazel
+++ b/pkg/kv/kvserver/asim/mmaintegration/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/kv/kvserver/allocator",
+        "//pkg/kv/kvserver/allocator/allocatorimpl",
         "//pkg/kv/kvserver/allocator/mmaprototype",
         "//pkg/kv/kvserver/asim/config",
         "//pkg/kv/kvserver/asim/op",

--- a/pkg/kv/kvserver/asim/mmaintegration/mma_store_rebalancer.go
+++ b/pkg/kv/kvserver/asim/mmaintegration/mma_store_rebalancer.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/allocatorimpl"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/mmaprototype"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/config"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/op"
@@ -70,6 +71,9 @@ func NewMMAStoreRebalancer(
 	controller op.Controller,
 	settings *config.SimulationSettings,
 ) *MMAStoreRebalancer {
+	// Initialize disk utilization thresholds from cluster settings.
+	opts := allocatorimpl.MakeDiskCapacityOptions(&settings.ST.SV)
+	allocator.SetDiskUtilThresholds(opts.RebalanceToThreshold, opts.ShedAndBlockAllThreshold)
 	msr := &MMAStoreRebalancer{
 		AmbientContext:       log.MakeTestingAmbientCtxWithNewTracer(),
 		localStoreID:         localStoreID,
@@ -156,6 +160,8 @@ func (msr *MMAStoreRebalancer) Tick(ctx context.Context, tick time.Time, s state
 			// This uses the real production RefreshStoreStatus, which queries
 			// StorePool (backed by StatusTracker via NodeLivenessFn) and
 			// translates to MMA's status model.
+			opts := allocatorimpl.MakeDiskCapacityOptions(&msr.settings.ST.SV)
+			msr.allocator.SetDiskUtilThresholds(opts.RebalanceToThreshold, opts.ShedAndBlockAllThreshold)
 			msr.allocator.UpdateStoresStatuses(ctx, msr.as.GetMMAStoreStatuses())
 			storeLeaseholderMsg := MakeStoreLeaseholderMsgFromState(s, msr.localStoreID)
 			pendingChanges := msr.allocator.ComputeChanges(ctx, &storeLeaseholderMsg, mmaprototype.ChangeOptions{


### PR DESCRIPTION
Resolves: https://github.com/cockroachdb/cockroach/issues/156776
Epic: [CRDB-55052](https://cockroachlabs.atlassian.net/browse/CRDB-55052)

---
**mmaprototype: fixes highDiskSpaceUtilization for cap = 0**

Previously, When capacity is 0 (no store-load msg yet),
highDiskSpaceUtilization would incorrectly flag stores
as high disk utilization. This commit returns false for capacity == 0.

---
**mmaprototype: use disposition for disk utilization filtering**

Previously, disk utilization was checked inline in
retainReadyReplicaTargetStoresOnly and sortTargetCandidateSetAndPick,
duplicating the logic across multiple places.

Now, disk utilization filtering uses store dispositions set by
updateStoreStatuses.

Release note: None

---
**mmaprototype: plumb disk utilization thresholds from cluster settings**

Previously, MMA had no way to receive disk utilization thresholds from
cluster settings.

Now, add SetDiskUtilThresholds to the Allocator interface and plumb
thresholds from kv.allocator.rebalance_to_max_disk_utilization_threshold
(0.925) and kv.allocator.max_disk_utilization_threshold (0.95). The
thresholds are set during MMAStoreRebalancer construction and refreshed
before each rebalance cycle.

---
**mmaprototype: augment disposition based on disk utilization**

Previously, updateStoreStatuses did not consider disk utilization when
setting store dispositions.

Now, stores >= the shed threshold get ReplicaDispositionShedding,
and stores >= the refuse threshold get ReplicaDispositionRefusing.

Release note: None

---
**mmaprototype: remove highDiskSpaceUtilization from storeLoadSummary**

Previously, storeLoadSummary had a highDiskSpaceUtilization field that
was computed inline and used for disk utilization checks.

Now, disk utilization is handled via store dispositions or in-line
directly, so this field is no longer needed.

Release note: None

