### PR TITLE
release-26.1: colfetcher: emit periodic query progress update metadata

### DIFF
--- a/pkg/col/coldatatestutils/BUILD.bazel
+++ b/pkg/col/coldatatestutils/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/sql/colexecop",
         "//pkg/sql/colmem",
         "//pkg/sql/execinfra/execopnode",
+        "//pkg/sql/execinfrapb",
         "//pkg/sql/randgen",
         "//pkg/sql/types",
         "//pkg/util/duration",

--- a/pkg/col/coldatatestutils/random_testutils.go
+++ b/pkg/col/coldatatestutils/random_testutils.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra/execopnode"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/randgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
@@ -383,14 +384,14 @@ func (o *randomDataOp) Init(ctx context.Context) {
 }
 
 // Next is part of the colexecop.Operator interface.
-func (o *randomDataOp) Next() coldata.Batch {
+func (o *randomDataOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	if o.numReturned == o.numBatches {
 		// Done.
 		b := coldata.ZeroBatch
 		if o.batchAccumulator != nil {
 			o.batchAccumulator(o.ctx, b, o.typs)
 		}
-		return b
+		return b, nil
 	}
 
 	var (
@@ -422,7 +423,7 @@ func (o *randomDataOp) Next() coldata.Batch {
 		if o.batchAccumulator != nil {
 			o.batchAccumulator(o.ctx, b, o.typs)
 		}
-		return b
+		return b, nil
 	}
 }
 

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -863,6 +863,7 @@ go_test(
         "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/catalog/typedesc",
         "//pkg/sql/clusterunique",
+        "//pkg/sql/colfetcher",
         "//pkg/sql/contentionpb",
         "//pkg/sql/distsql",
         "//pkg/sql/execinfra",

--- a/pkg/sql/colcontainer/diskqueue_test.go
+++ b/pkg/sql/colcontainer/diskqueue_test.go
@@ -104,7 +104,7 @@ func TestDiskQueue(t *testing.T) {
 					// since that is the common pattern.
 					dest := coldata.NewMemBatch(typs, testColumnFactory)
 					for {
-						src := op.Next()
+						src := colexecop.NextNoMeta(op)
 						require.NoError(t, q.Enqueue(ctx, src))
 						if src.Length() == 0 {
 							break
@@ -259,7 +259,7 @@ func BenchmarkDiskQueue(b *testing.B) {
 		q, err := colcontainer.NewDiskQueue(ctx, typs, queueCfg, testDiskAcc, testMemAcc)
 		require.NoError(b, err)
 		for {
-			batchToEnqueue := op.Next()
+			batchToEnqueue := colexecop.NextNoMeta(op)
 			if err := q.Enqueue(ctx, batchToEnqueue); err != nil {
 				b.Fatal(err)
 			}

--- a/pkg/sql/colexec/BUILD.bazel
+++ b/pkg/sql/colexec/BUILD.bazel
@@ -87,6 +87,7 @@ go_library(
         "//pkg/util/log",
         "//pkg/util/metamorphic",
         "//pkg/util/mon",
+        "//pkg/util/randutil",
         "//pkg/util/stringarena",
         "//pkg/util/tracing",
         "@com_github_cockroachdb_apd_v3//:apd",  # keep

--- a/pkg/sql/colexec/aggregators_test.go
+++ b/pkg/sql/colexec/aggregators_test.go
@@ -1192,7 +1192,7 @@ func benchmarkAggregateFunction(
 				// Exhaust aggregator until all batches have been read or limit, if
 				// non-zero, is reached.
 				tupleCount := 0
-				for b := a.Next(); b.Length() != 0; b = a.Next() {
+				for b := colexecop.NextNoMeta(a); b.Length() != 0; b = colexecop.NextNoMeta(a) {
 					tupleCount += b.Length()
 					if limit > 0 && tupleCount >= limit {
 						break

--- a/pkg/sql/colexec/aggregators_util.go
+++ b/pkg/sql/colexec/aggregators_util.go
@@ -184,7 +184,7 @@ func (h *filteringSingleFunctionHashHelper) applyFilter(
 	// Note that it is ok that we call Init on every iteration - it is a noop
 	// every time except for the first one.
 	h.filter.Init(ctx)
-	newBatch := h.filter.Next()
+	newBatch := colexecop.NextNoMeta(h.filter)
 	return newBatch.ColVecs(), newBatch.Length(), newBatch.Selection(), true
 }
 
@@ -511,12 +511,12 @@ func newSingleBatchOperator(
 
 func (o *singleBatchOperator) Init(context.Context) {}
 
-func (o *singleBatchOperator) Next() coldata.Batch {
+func (o *singleBatchOperator) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	if o.nexted {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	o.nexted = true
-	return o.batch
+	return o.batch, nil
 }
 
 func (o *singleBatchOperator) reset(vecs []*coldata.Vec, inputLen int, sel []int) {

--- a/pkg/sql/colexec/buffer_test.go
+++ b/pkg/sql/colexec/buffer_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexectestutils"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -28,7 +29,7 @@ func TestBufferOp(t *testing.T) {
 
 	t.Run("TestBufferReturnsInputCorrectly", func(t *testing.T) {
 		buffer.advance()
-		b := buffer.Next()
+		b := colexecop.NextNoMeta(buffer)
 		require.Nil(t, b.Selection())
 		require.Equal(t, len(inputTuples), b.Length())
 		for i, val := range inputTuples {
@@ -36,7 +37,7 @@ func TestBufferOp(t *testing.T) {
 		}
 
 		// We've read over the batch, so we now should get a zero-length batch.
-		b = buffer.Next()
+		b = colexecop.NextNoMeta(buffer)
 		require.Nil(t, b.Selection())
 		require.Equal(t, 0, b.Length())
 	})

--- a/pkg/sql/colexec/builtin_funcs_test.go
+++ b/pkg/sql/colexec/builtin_funcs_test.go
@@ -172,7 +172,7 @@ func benchmarkBuiltinFunctions(b *testing.B, useSelectionVector bool, hasNulls b
 	b.SetBytes(int64(8 * coldata.BatchSize()))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		op.Next()
+		colexecop.NextNoMeta(op)
 	}
 }
 
@@ -249,7 +249,7 @@ func BenchmarkCompareSpecializedOperators(b *testing.B) {
 		b.SetBytes(int64(len("hello there") * coldata.BatchSize()))
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			b := defaultOp.Next()
+			b := colexecop.NextNoMeta(defaultOp)
 			// Due to the flat byte updates, we have to reset the output
 			// bytes col after each next call.
 			b.ColVec(outputIdx).Bytes().Reset()
@@ -260,7 +260,7 @@ func BenchmarkCompareSpecializedOperators(b *testing.B) {
 		b.SetBytes(int64(len("hello there") * coldata.BatchSize()))
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			b := specOp.Next()
+			b := colexecop.NextNoMeta(specOp)
 			// Due to the flat byte updates, we have to reset the output
 			// bytes col after each next call.
 			b.ColVec(outputIdx).Bytes().Reset()

--- a/pkg/sql/colexec/colbuilder/execplan_test.go
+++ b/pkg/sql/colexec/colbuilder/execplan_test.go
@@ -144,7 +144,10 @@ func TestNewColOperatorExpectedTypeSchema(t *testing.T) {
 	var rowIdx int
 	for {
 		row, meta := m.Next()
-		require.Nil(t, meta)
+		if meta != nil {
+			require.NotNil(t, meta.RowNum)
+			continue
+		}
 		if row == nil {
 			break
 		}

--- a/pkg/sql/colexec/colexecbase/BUILD.bazel
+++ b/pkg/sql/colexec/colexecbase/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/sql/colexecerror",
         "//pkg/sql/colexecop",
         "//pkg/sql/colmem",  # keep
+        "//pkg/sql/execinfrapb",
         "//pkg/sql/lex",  # keep
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",

--- a/pkg/sql/colexec/colexecbase/cast.eg.go
+++ b/pkg/sql/colexec/colexecbase/cast.eg.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -1206,11 +1207,14 @@ type castOpNullAny struct {
 
 var _ colexecop.ClosableOperator = &castOpNullAny{}
 
-func (c *castOpNullAny) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castOpNullAny) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(c.colIdx)
 	projVec := batch.ColVec(c.outputIdx)
@@ -1234,7 +1238,7 @@ func (c *castOpNullAny) Next() coldata.Batch {
 			}
 		}
 	}
-	return batch
+	return batch, nil
 }
 
 // castIdentityOp is a special cast operator for the case when "from" and "to"
@@ -1267,11 +1271,14 @@ func init() {
 	}
 }
 
-func (c *castIdentityOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castIdentityOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(c.outputIdx)
 	c.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -1289,7 +1296,7 @@ func (c *castIdentityOp) Next() coldata.Batch {
 			})
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 // castBPCharIdentityOp is a specialization of castIdentityOp which handles
@@ -1300,11 +1307,14 @@ type castBPCharIdentityOp struct {
 
 var _ colexecop.ClosableOperator = &castBPCharIdentityOp{}
 
-func (c *castBPCharIdentityOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castBPCharIdentityOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, meta
 	}
 	inputVec := batch.ColVec(c.colIdx)
 	inputCol := inputVec.Bytes()
@@ -1333,7 +1343,7 @@ func (c *castBPCharIdentityOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type castNativeToDatumOp struct {
@@ -1345,11 +1355,14 @@ type castNativeToDatumOp struct {
 
 var _ colexecop.ClosableOperator = &castNativeToDatumOp{}
 
-func (c *castNativeToDatumOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castNativeToDatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, meta
 	}
 	inputVec := batch.ColVec(c.colIdx)
 	outputVec := batch.ColVec(c.outputIdx)
@@ -1457,7 +1470,7 @@ func (c *castNativeToDatumOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 // setNativeToDatumCast performs the cast of the converted datum in
@@ -1473,11 +1486,14 @@ type castBoolFloatOp struct {
 var _ colexecop.ResettableOperator = &castBoolFloatOp{}
 var _ colexecop.ClosableOperator = &castBoolFloatOp{}
 
-func (c *castBoolFloatOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castBoolFloatOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -1611,7 +1627,7 @@ func (c *castBoolFloatOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castBoolInt2Op struct {
@@ -1621,11 +1637,14 @@ type castBoolInt2Op struct {
 var _ colexecop.ResettableOperator = &castBoolInt2Op{}
 var _ colexecop.ClosableOperator = &castBoolInt2Op{}
 
-func (c *castBoolInt2Op) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castBoolInt2Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -1759,7 +1778,7 @@ func (c *castBoolInt2Op) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castBoolInt4Op struct {
@@ -1769,11 +1788,14 @@ type castBoolInt4Op struct {
 var _ colexecop.ResettableOperator = &castBoolInt4Op{}
 var _ colexecop.ClosableOperator = &castBoolInt4Op{}
 
-func (c *castBoolInt4Op) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castBoolInt4Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -1907,7 +1929,7 @@ func (c *castBoolInt4Op) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castBoolIntOp struct {
@@ -1917,11 +1939,14 @@ type castBoolIntOp struct {
 var _ colexecop.ResettableOperator = &castBoolIntOp{}
 var _ colexecop.ClosableOperator = &castBoolIntOp{}
 
-func (c *castBoolIntOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castBoolIntOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -2055,7 +2080,7 @@ func (c *castBoolIntOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castBoolStringOp struct {
@@ -2065,11 +2090,14 @@ type castBoolStringOp struct {
 var _ colexecop.ResettableOperator = &castBoolStringOp{}
 var _ colexecop.ClosableOperator = &castBoolStringOp{}
 
-func (c *castBoolStringOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castBoolStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -2271,7 +2299,7 @@ func (c *castBoolStringOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castBytesStringOp struct {
@@ -2281,11 +2309,14 @@ type castBytesStringOp struct {
 var _ colexecop.ResettableOperator = &castBytesStringOp{}
 var _ colexecop.ClosableOperator = &castBytesStringOp{}
 
-func (c *castBytesStringOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castBytesStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -2491,7 +2522,7 @@ func (c *castBytesStringOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castBytesUuidOp struct {
@@ -2501,11 +2532,14 @@ type castBytesUuidOp struct {
 var _ colexecop.ResettableOperator = &castBytesUuidOp{}
 var _ colexecop.ClosableOperator = &castBytesUuidOp{}
 
-func (c *castBytesUuidOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castBytesUuidOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -2635,7 +2669,7 @@ func (c *castBytesUuidOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castDateDecimalOp struct {
@@ -2645,11 +2679,14 @@ type castDateDecimalOp struct {
 var _ colexecop.ResettableOperator = &castDateDecimalOp{}
 var _ colexecop.ClosableOperator = &castDateDecimalOp{}
 
-func (c *castDateDecimalOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castDateDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -2787,7 +2824,7 @@ func (c *castDateDecimalOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castDateFloatOp struct {
@@ -2797,11 +2834,14 @@ type castDateFloatOp struct {
 var _ colexecop.ResettableOperator = &castDateFloatOp{}
 var _ colexecop.ClosableOperator = &castDateFloatOp{}
 
-func (c *castDateFloatOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castDateFloatOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -2923,7 +2963,7 @@ func (c *castDateFloatOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castDateInt2Op struct {
@@ -2933,11 +2973,14 @@ type castDateInt2Op struct {
 var _ colexecop.ResettableOperator = &castDateInt2Op{}
 var _ colexecop.ClosableOperator = &castDateInt2Op{}
 
-func (c *castDateInt2Op) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castDateInt2Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -3075,7 +3118,7 @@ func (c *castDateInt2Op) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castDateInt4Op struct {
@@ -3085,11 +3128,14 @@ type castDateInt4Op struct {
 var _ colexecop.ResettableOperator = &castDateInt4Op{}
 var _ colexecop.ClosableOperator = &castDateInt4Op{}
 
-func (c *castDateInt4Op) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castDateInt4Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -3227,7 +3273,7 @@ func (c *castDateInt4Op) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castDateIntOp struct {
@@ -3237,11 +3283,14 @@ type castDateIntOp struct {
 var _ colexecop.ResettableOperator = &castDateIntOp{}
 var _ colexecop.ClosableOperator = &castDateIntOp{}
 
-func (c *castDateIntOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castDateIntOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -3355,7 +3404,7 @@ func (c *castDateIntOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castDateStringOp struct {
@@ -3365,11 +3414,14 @@ type castDateStringOp struct {
 var _ colexecop.ResettableOperator = &castDateStringOp{}
 var _ colexecop.ClosableOperator = &castDateStringOp{}
 
-func (c *castDateStringOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castDateStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -3587,7 +3639,7 @@ func (c *castDateStringOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castDecimalBoolOp struct {
@@ -3597,11 +3649,14 @@ type castDecimalBoolOp struct {
 var _ colexecop.ResettableOperator = &castDecimalBoolOp{}
 var _ colexecop.ClosableOperator = &castDecimalBoolOp{}
 
-func (c *castDecimalBoolOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castDecimalBoolOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -3715,7 +3770,7 @@ func (c *castDecimalBoolOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castDecimalDecimalOp struct {
@@ -3725,11 +3780,14 @@ type castDecimalDecimalOp struct {
 var _ colexecop.ResettableOperator = &castDecimalDecimalOp{}
 var _ colexecop.ClosableOperator = &castDecimalDecimalOp{}
 
-func (c *castDecimalDecimalOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castDecimalDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -3863,7 +3921,7 @@ func (c *castDecimalDecimalOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castDecimalFloatOp struct {
@@ -3873,11 +3931,14 @@ type castDecimalFloatOp struct {
 var _ colexecop.ResettableOperator = &castDecimalFloatOp{}
 var _ colexecop.ClosableOperator = &castDecimalFloatOp{}
 
-func (c *castDecimalFloatOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castDecimalFloatOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -4023,7 +4084,7 @@ func (c *castDecimalFloatOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castDecimalInt2Op struct {
@@ -4033,11 +4094,14 @@ type castDecimalInt2Op struct {
 var _ colexecop.ResettableOperator = &castDecimalInt2Op{}
 var _ colexecop.ClosableOperator = &castDecimalInt2Op{}
 
-func (c *castDecimalInt2Op) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castDecimalInt2Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -4227,7 +4291,7 @@ func (c *castDecimalInt2Op) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castDecimalInt4Op struct {
@@ -4237,11 +4301,14 @@ type castDecimalInt4Op struct {
 var _ colexecop.ResettableOperator = &castDecimalInt4Op{}
 var _ colexecop.ClosableOperator = &castDecimalInt4Op{}
 
-func (c *castDecimalInt4Op) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castDecimalInt4Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -4431,7 +4498,7 @@ func (c *castDecimalInt4Op) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castDecimalIntOp struct {
@@ -4441,11 +4508,14 @@ type castDecimalIntOp struct {
 var _ colexecop.ResettableOperator = &castDecimalIntOp{}
 var _ colexecop.ClosableOperator = &castDecimalIntOp{}
 
-func (c *castDecimalIntOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castDecimalIntOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -4611,7 +4681,7 @@ func (c *castDecimalIntOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castDecimalStringOp struct {
@@ -4621,11 +4691,14 @@ type castDecimalStringOp struct {
 var _ colexecop.ResettableOperator = &castDecimalStringOp{}
 var _ colexecop.ClosableOperator = &castDecimalStringOp{}
 
-func (c *castDecimalStringOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castDecimalStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -4827,7 +4900,7 @@ func (c *castDecimalStringOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castEnumStringOp struct {
@@ -4837,11 +4910,14 @@ type castEnumStringOp struct {
 var _ colexecop.ResettableOperator = &castEnumStringOp{}
 var _ colexecop.ClosableOperator = &castEnumStringOp{}
 
-func (c *castEnumStringOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castEnumStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -5060,7 +5136,7 @@ func (c *castEnumStringOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castFloatBoolOp struct {
@@ -5070,11 +5146,14 @@ type castFloatBoolOp struct {
 var _ colexecop.ResettableOperator = &castFloatBoolOp{}
 var _ colexecop.ClosableOperator = &castFloatBoolOp{}
 
-func (c *castFloatBoolOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castFloatBoolOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -5196,7 +5275,7 @@ func (c *castFloatBoolOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castFloatDecimalOp struct {
@@ -5206,11 +5285,14 @@ type castFloatDecimalOp struct {
 var _ colexecop.ResettableOperator = &castFloatDecimalOp{}
 var _ colexecop.ClosableOperator = &castFloatDecimalOp{}
 
-func (c *castFloatDecimalOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castFloatDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -5356,7 +5438,7 @@ func (c *castFloatDecimalOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castFloatInt2Op struct {
@@ -5366,11 +5448,14 @@ type castFloatInt2Op struct {
 var _ colexecop.ResettableOperator = &castFloatInt2Op{}
 var _ colexecop.ClosableOperator = &castFloatInt2Op{}
 
-func (c *castFloatInt2Op) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castFloatInt2Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -5504,7 +5589,7 @@ func (c *castFloatInt2Op) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castFloatInt4Op struct {
@@ -5514,11 +5599,14 @@ type castFloatInt4Op struct {
 var _ colexecop.ResettableOperator = &castFloatInt4Op{}
 var _ colexecop.ClosableOperator = &castFloatInt4Op{}
 
-func (c *castFloatInt4Op) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castFloatInt4Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -5652,7 +5740,7 @@ func (c *castFloatInt4Op) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castFloatIntOp struct {
@@ -5662,11 +5750,14 @@ type castFloatIntOp struct {
 var _ colexecop.ResettableOperator = &castFloatIntOp{}
 var _ colexecop.ClosableOperator = &castFloatIntOp{}
 
-func (c *castFloatIntOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castFloatIntOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -5800,7 +5891,7 @@ func (c *castFloatIntOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castFloatStringOp struct {
@@ -5810,11 +5901,14 @@ type castFloatStringOp struct {
 var _ colexecop.ResettableOperator = &castFloatStringOp{}
 var _ colexecop.ClosableOperator = &castFloatStringOp{}
 
-func (c *castFloatStringOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castFloatStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -6024,7 +6118,7 @@ func (c *castFloatStringOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castInt2BoolOp struct {
@@ -6034,11 +6128,14 @@ type castInt2BoolOp struct {
 var _ colexecop.ResettableOperator = &castInt2BoolOp{}
 var _ colexecop.ClosableOperator = &castInt2BoolOp{}
 
-func (c *castInt2BoolOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castInt2BoolOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -6160,7 +6257,7 @@ func (c *castInt2BoolOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castInt2DecimalOp struct {
@@ -6170,11 +6267,14 @@ type castInt2DecimalOp struct {
 var _ colexecop.ResettableOperator = &castInt2DecimalOp{}
 var _ colexecop.ClosableOperator = &castInt2DecimalOp{}
 
-func (c *castInt2DecimalOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castInt2DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -6312,7 +6412,7 @@ func (c *castInt2DecimalOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castInt2FloatOp struct {
@@ -6322,11 +6422,14 @@ type castInt2FloatOp struct {
 var _ colexecop.ResettableOperator = &castInt2FloatOp{}
 var _ colexecop.ClosableOperator = &castInt2FloatOp{}
 
-func (c *castInt2FloatOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castInt2FloatOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -6448,7 +6551,7 @@ func (c *castInt2FloatOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castInt2Int4Op struct {
@@ -6458,11 +6561,14 @@ type castInt2Int4Op struct {
 var _ colexecop.ResettableOperator = &castInt2Int4Op{}
 var _ colexecop.ClosableOperator = &castInt2Int4Op{}
 
-func (c *castInt2Int4Op) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castInt2Int4Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -6576,7 +6682,7 @@ func (c *castInt2Int4Op) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castInt2IntOp struct {
@@ -6586,11 +6692,14 @@ type castInt2IntOp struct {
 var _ colexecop.ResettableOperator = &castInt2IntOp{}
 var _ colexecop.ClosableOperator = &castInt2IntOp{}
 
-func (c *castInt2IntOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castInt2IntOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -6704,7 +6813,7 @@ func (c *castInt2IntOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castInt2StringOp struct {
@@ -6714,11 +6823,14 @@ type castInt2StringOp struct {
 var _ colexecop.ResettableOperator = &castInt2StringOp{}
 var _ colexecop.ClosableOperator = &castInt2StringOp{}
 
-func (c *castInt2StringOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castInt2StringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -6972,7 +7084,7 @@ func (c *castInt2StringOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castInt4BoolOp struct {
@@ -6982,11 +7094,14 @@ type castInt4BoolOp struct {
 var _ colexecop.ResettableOperator = &castInt4BoolOp{}
 var _ colexecop.ClosableOperator = &castInt4BoolOp{}
 
-func (c *castInt4BoolOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castInt4BoolOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -7108,7 +7223,7 @@ func (c *castInt4BoolOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castInt4DecimalOp struct {
@@ -7118,11 +7233,14 @@ type castInt4DecimalOp struct {
 var _ colexecop.ResettableOperator = &castInt4DecimalOp{}
 var _ colexecop.ClosableOperator = &castInt4DecimalOp{}
 
-func (c *castInt4DecimalOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castInt4DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -7260,7 +7378,7 @@ func (c *castInt4DecimalOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castInt4FloatOp struct {
@@ -7270,11 +7388,14 @@ type castInt4FloatOp struct {
 var _ colexecop.ResettableOperator = &castInt4FloatOp{}
 var _ colexecop.ClosableOperator = &castInt4FloatOp{}
 
-func (c *castInt4FloatOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castInt4FloatOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -7396,7 +7517,7 @@ func (c *castInt4FloatOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castInt4Int2Op struct {
@@ -7406,11 +7527,14 @@ type castInt4Int2Op struct {
 var _ colexecop.ResettableOperator = &castInt4Int2Op{}
 var _ colexecop.ClosableOperator = &castInt4Int2Op{}
 
-func (c *castInt4Int2Op) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castInt4Int2Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -7548,7 +7672,7 @@ func (c *castInt4Int2Op) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castInt4IntOp struct {
@@ -7558,11 +7682,14 @@ type castInt4IntOp struct {
 var _ colexecop.ResettableOperator = &castInt4IntOp{}
 var _ colexecop.ClosableOperator = &castInt4IntOp{}
 
-func (c *castInt4IntOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castInt4IntOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -7676,7 +7803,7 @@ func (c *castInt4IntOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castInt4StringOp struct {
@@ -7686,11 +7813,14 @@ type castInt4StringOp struct {
 var _ colexecop.ResettableOperator = &castInt4StringOp{}
 var _ colexecop.ClosableOperator = &castInt4StringOp{}
 
-func (c *castInt4StringOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castInt4StringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -7944,7 +8074,7 @@ func (c *castInt4StringOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castIntBoolOp struct {
@@ -7954,11 +8084,14 @@ type castIntBoolOp struct {
 var _ colexecop.ResettableOperator = &castIntBoolOp{}
 var _ colexecop.ClosableOperator = &castIntBoolOp{}
 
-func (c *castIntBoolOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castIntBoolOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -8080,7 +8213,7 @@ func (c *castIntBoolOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castIntDecimalOp struct {
@@ -8090,11 +8223,14 @@ type castIntDecimalOp struct {
 var _ colexecop.ResettableOperator = &castIntDecimalOp{}
 var _ colexecop.ClosableOperator = &castIntDecimalOp{}
 
-func (c *castIntDecimalOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castIntDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -8232,7 +8368,7 @@ func (c *castIntDecimalOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castIntFloatOp struct {
@@ -8242,11 +8378,14 @@ type castIntFloatOp struct {
 var _ colexecop.ResettableOperator = &castIntFloatOp{}
 var _ colexecop.ClosableOperator = &castIntFloatOp{}
 
-func (c *castIntFloatOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castIntFloatOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -8368,7 +8507,7 @@ func (c *castIntFloatOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castIntInt2Op struct {
@@ -8378,11 +8517,14 @@ type castIntInt2Op struct {
 var _ colexecop.ResettableOperator = &castIntInt2Op{}
 var _ colexecop.ClosableOperator = &castIntInt2Op{}
 
-func (c *castIntInt2Op) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castIntInt2Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -8520,7 +8662,7 @@ func (c *castIntInt2Op) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castIntInt4Op struct {
@@ -8530,11 +8672,14 @@ type castIntInt4Op struct {
 var _ colexecop.ResettableOperator = &castIntInt4Op{}
 var _ colexecop.ClosableOperator = &castIntInt4Op{}
 
-func (c *castIntInt4Op) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castIntInt4Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -8672,7 +8817,7 @@ func (c *castIntInt4Op) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castIntStringOp struct {
@@ -8682,11 +8827,14 @@ type castIntStringOp struct {
 var _ colexecop.ResettableOperator = &castIntStringOp{}
 var _ colexecop.ClosableOperator = &castIntStringOp{}
 
-func (c *castIntStringOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castIntStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -8940,7 +9088,7 @@ func (c *castIntStringOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castIntervalStringOp struct {
@@ -8950,11 +9098,14 @@ type castIntervalStringOp struct {
 var _ colexecop.ResettableOperator = &castIntervalStringOp{}
 var _ colexecop.ClosableOperator = &castIntervalStringOp{}
 
-func (c *castIntervalStringOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castIntervalStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -9172,7 +9323,7 @@ func (c *castIntervalStringOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castJsonbStringOp struct {
@@ -9182,11 +9333,14 @@ type castJsonbStringOp struct {
 var _ colexecop.ResettableOperator = &castJsonbStringOp{}
 var _ colexecop.ClosableOperator = &castJsonbStringOp{}
 
-func (c *castJsonbStringOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castJsonbStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -9384,7 +9538,7 @@ func (c *castJsonbStringOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castStringBoolOp struct {
@@ -9394,11 +9548,14 @@ type castStringBoolOp struct {
 var _ colexecop.ResettableOperator = &castStringBoolOp{}
 var _ colexecop.ClosableOperator = &castStringBoolOp{}
 
-func (c *castStringBoolOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castStringBoolOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -9532,7 +9689,7 @@ func (c *castStringBoolOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castStringBytesOp struct {
@@ -9542,11 +9699,14 @@ type castStringBytesOp struct {
 var _ colexecop.ResettableOperator = &castStringBytesOp{}
 var _ colexecop.ClosableOperator = &castStringBytesOp{}
 
-func (c *castStringBytesOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castStringBytesOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -9676,7 +9836,7 @@ func (c *castStringBytesOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castStringDateOp struct {
@@ -9686,11 +9846,14 @@ type castStringDateOp struct {
 var _ colexecop.ResettableOperator = &castStringDateOp{}
 var _ colexecop.ClosableOperator = &castStringDateOp{}
 
-func (c *castStringDateOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castStringDateOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -9836,7 +9999,7 @@ func (c *castStringDateOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castStringDecimalOp struct {
@@ -9846,11 +10009,14 @@ type castStringDecimalOp struct {
 var _ colexecop.ResettableOperator = &castStringDecimalOp{}
 var _ colexecop.ClosableOperator = &castStringDecimalOp{}
 
-func (c *castStringDecimalOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castStringDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -10044,7 +10210,7 @@ func (c *castStringDecimalOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castStringEnumOp struct {
@@ -10054,11 +10220,14 @@ type castStringEnumOp struct {
 var _ colexecop.ResettableOperator = &castStringEnumOp{}
 var _ colexecop.ClosableOperator = &castStringEnumOp{}
 
-func (c *castStringEnumOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castStringEnumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -10192,7 +10361,7 @@ func (c *castStringEnumOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castStringFloatOp struct {
@@ -10202,11 +10371,14 @@ type castStringFloatOp struct {
 var _ colexecop.ResettableOperator = &castStringFloatOp{}
 var _ colexecop.ClosableOperator = &castStringFloatOp{}
 
-func (c *castStringFloatOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castStringFloatOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -10344,7 +10516,7 @@ func (c *castStringFloatOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castStringInt2Op struct {
@@ -10354,11 +10526,14 @@ type castStringInt2Op struct {
 var _ colexecop.ResettableOperator = &castStringInt2Op{}
 var _ colexecop.ClosableOperator = &castStringInt2Op{}
 
-func (c *castStringInt2Op) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castStringInt2Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -10528,7 +10703,7 @@ func (c *castStringInt2Op) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castStringInt4Op struct {
@@ -10538,11 +10713,14 @@ type castStringInt4Op struct {
 var _ colexecop.ResettableOperator = &castStringInt4Op{}
 var _ colexecop.ClosableOperator = &castStringInt4Op{}
 
-func (c *castStringInt4Op) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castStringInt4Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -10712,7 +10890,7 @@ func (c *castStringInt4Op) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castStringIntOp struct {
@@ -10722,11 +10900,14 @@ type castStringIntOp struct {
 var _ colexecop.ResettableOperator = &castStringIntOp{}
 var _ colexecop.ClosableOperator = &castStringIntOp{}
 
-func (c *castStringIntOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castStringIntOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -10872,7 +11053,7 @@ func (c *castStringIntOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castStringIntervalOp struct {
@@ -10882,11 +11063,14 @@ type castStringIntervalOp struct {
 var _ colexecop.ResettableOperator = &castStringIntervalOp{}
 var _ colexecop.ClosableOperator = &castStringIntervalOp{}
 
-func (c *castStringIntervalOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castStringIntervalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -11036,7 +11220,7 @@ func (c *castStringIntervalOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castStringJsonbOp struct {
@@ -11046,11 +11230,14 @@ type castStringJsonbOp struct {
 var _ colexecop.ResettableOperator = &castStringJsonbOp{}
 var _ colexecop.ClosableOperator = &castStringJsonbOp{}
 
-func (c *castStringJsonbOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castStringJsonbOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -11180,7 +11367,7 @@ func (c *castStringJsonbOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castStringStringOp struct {
@@ -11190,11 +11377,14 @@ type castStringStringOp struct {
 var _ colexecop.ResettableOperator = &castStringStringOp{}
 var _ colexecop.ClosableOperator = &castStringStringOp{}
 
-func (c *castStringStringOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castStringStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -11392,7 +11582,7 @@ func (c *castStringStringOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castStringTimestampOp struct {
@@ -11402,11 +11592,14 @@ type castStringTimestampOp struct {
 var _ colexecop.ResettableOperator = &castStringTimestampOp{}
 var _ colexecop.ClosableOperator = &castStringTimestampOp{}
 
-func (c *castStringTimestampOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castStringTimestampOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -11572,7 +11765,7 @@ func (c *castStringTimestampOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castStringTimestamptzOp struct {
@@ -11582,11 +11775,14 @@ type castStringTimestamptzOp struct {
 var _ colexecop.ResettableOperator = &castStringTimestamptzOp{}
 var _ colexecop.ClosableOperator = &castStringTimestamptzOp{}
 
-func (c *castStringTimestamptzOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castStringTimestamptzOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -11752,7 +11948,7 @@ func (c *castStringTimestamptzOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castStringUuidOp struct {
@@ -11762,11 +11958,14 @@ type castStringUuidOp struct {
 var _ colexecop.ResettableOperator = &castStringUuidOp{}
 var _ colexecop.ClosableOperator = &castStringUuidOp{}
 
-func (c *castStringUuidOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castStringUuidOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -11896,7 +12095,7 @@ func (c *castStringUuidOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castTimestampStringOp struct {
@@ -11906,11 +12105,14 @@ type castTimestampStringOp struct {
 var _ colexecop.ResettableOperator = &castTimestampStringOp{}
 var _ colexecop.ClosableOperator = &castTimestampStringOp{}
 
-func (c *castTimestampStringOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castTimestampStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -12112,7 +12314,7 @@ func (c *castTimestampStringOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castTimestamptzStringOp struct {
@@ -12122,11 +12324,14 @@ type castTimestamptzStringOp struct {
 var _ colexecop.ResettableOperator = &castTimestamptzStringOp{}
 var _ colexecop.ClosableOperator = &castTimestamptzStringOp{}
 
-func (c *castTimestamptzStringOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castTimestamptzStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -12364,7 +12569,7 @@ func (c *castTimestamptzStringOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castUuidStringOp struct {
@@ -12374,11 +12579,14 @@ type castUuidStringOp struct {
 var _ colexecop.ResettableOperator = &castUuidStringOp{}
 var _ colexecop.ClosableOperator = &castUuidStringOp{}
 
-func (c *castUuidStringOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castUuidStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -12596,7 +12804,7 @@ func (c *castUuidStringOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castDatumBoolOp struct {
@@ -12606,11 +12814,14 @@ type castDatumBoolOp struct {
 var _ colexecop.ResettableOperator = &castDatumBoolOp{}
 var _ colexecop.ClosableOperator = &castDatumBoolOp{}
 
-func (c *castDatumBoolOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castDatumBoolOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -12753,7 +12964,7 @@ func (c *castDatumBoolOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castDatumInt2Op struct {
@@ -12763,11 +12974,14 @@ type castDatumInt2Op struct {
 var _ colexecop.ResettableOperator = &castDatumInt2Op{}
 var _ colexecop.ClosableOperator = &castDatumInt2Op{}
 
-func (c *castDatumInt2Op) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castDatumInt2Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -12910,7 +13124,7 @@ func (c *castDatumInt2Op) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castDatumInt4Op struct {
@@ -12920,11 +13134,14 @@ type castDatumInt4Op struct {
 var _ colexecop.ResettableOperator = &castDatumInt4Op{}
 var _ colexecop.ClosableOperator = &castDatumInt4Op{}
 
-func (c *castDatumInt4Op) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castDatumInt4Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -13067,7 +13284,7 @@ func (c *castDatumInt4Op) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castDatumIntOp struct {
@@ -13077,11 +13294,14 @@ type castDatumIntOp struct {
 var _ colexecop.ResettableOperator = &castDatumIntOp{}
 var _ colexecop.ClosableOperator = &castDatumIntOp{}
 
-func (c *castDatumIntOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castDatumIntOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -13224,7 +13444,7 @@ func (c *castDatumIntOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castDatumFloatOp struct {
@@ -13234,11 +13454,14 @@ type castDatumFloatOp struct {
 var _ colexecop.ResettableOperator = &castDatumFloatOp{}
 var _ colexecop.ClosableOperator = &castDatumFloatOp{}
 
-func (c *castDatumFloatOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castDatumFloatOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -13381,7 +13604,7 @@ func (c *castDatumFloatOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castDatumDecimalOp struct {
@@ -13391,11 +13614,14 @@ type castDatumDecimalOp struct {
 var _ colexecop.ResettableOperator = &castDatumDecimalOp{}
 var _ colexecop.ClosableOperator = &castDatumDecimalOp{}
 
-func (c *castDatumDecimalOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castDatumDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -13538,7 +13764,7 @@ func (c *castDatumDecimalOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castDatumDateOp struct {
@@ -13548,11 +13774,14 @@ type castDatumDateOp struct {
 var _ colexecop.ResettableOperator = &castDatumDateOp{}
 var _ colexecop.ClosableOperator = &castDatumDateOp{}
 
-func (c *castDatumDateOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castDatumDateOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -13695,7 +13924,7 @@ func (c *castDatumDateOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castDatumTimestampOp struct {
@@ -13705,11 +13934,14 @@ type castDatumTimestampOp struct {
 var _ colexecop.ResettableOperator = &castDatumTimestampOp{}
 var _ colexecop.ClosableOperator = &castDatumTimestampOp{}
 
-func (c *castDatumTimestampOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castDatumTimestampOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -13852,7 +14084,7 @@ func (c *castDatumTimestampOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castDatumIntervalOp struct {
@@ -13862,11 +14094,14 @@ type castDatumIntervalOp struct {
 var _ colexecop.ResettableOperator = &castDatumIntervalOp{}
 var _ colexecop.ClosableOperator = &castDatumIntervalOp{}
 
-func (c *castDatumIntervalOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castDatumIntervalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -14009,7 +14244,7 @@ func (c *castDatumIntervalOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castDatumStringOp struct {
@@ -14019,11 +14254,14 @@ type castDatumStringOp struct {
 var _ colexecop.ResettableOperator = &castDatumStringOp{}
 var _ colexecop.ClosableOperator = &castDatumStringOp{}
 
-func (c *castDatumStringOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castDatumStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -14162,7 +14400,7 @@ func (c *castDatumStringOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castDatumBytesOp struct {
@@ -14172,11 +14410,14 @@ type castDatumBytesOp struct {
 var _ colexecop.ResettableOperator = &castDatumBytesOp{}
 var _ colexecop.ClosableOperator = &castDatumBytesOp{}
 
-func (c *castDatumBytesOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castDatumBytesOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -14315,7 +14556,7 @@ func (c *castDatumBytesOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castDatumTimestamptzOp struct {
@@ -14325,11 +14566,14 @@ type castDatumTimestamptzOp struct {
 var _ colexecop.ResettableOperator = &castDatumTimestamptzOp{}
 var _ colexecop.ClosableOperator = &castDatumTimestamptzOp{}
 
-func (c *castDatumTimestamptzOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castDatumTimestamptzOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -14472,7 +14716,7 @@ func (c *castDatumTimestamptzOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castDatumUuidOp struct {
@@ -14482,11 +14726,14 @@ type castDatumUuidOp struct {
 var _ colexecop.ResettableOperator = &castDatumUuidOp{}
 var _ colexecop.ClosableOperator = &castDatumUuidOp{}
 
-func (c *castDatumUuidOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castDatumUuidOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -14625,7 +14872,7 @@ func (c *castDatumUuidOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castDatumJsonbOp struct {
@@ -14635,11 +14882,14 @@ type castDatumJsonbOp struct {
 var _ colexecop.ResettableOperator = &castDatumJsonbOp{}
 var _ colexecop.ClosableOperator = &castDatumJsonbOp{}
 
-func (c *castDatumJsonbOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castDatumJsonbOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -14778,7 +15028,7 @@ func (c *castDatumJsonbOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type castDatumDatumOp struct {
@@ -14788,11 +15038,14 @@ type castDatumDatumOp struct {
 var _ colexecop.ResettableOperator = &castDatumDatumOp{}
 var _ colexecop.ClosableOperator = &castDatumDatumOp{}
 
-func (c *castDatumDatumOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c *castDatumDatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
@@ -14954,7 +15207,7 @@ func (c *castDatumDatumOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 // castTuples casts all non-null tuples from the vector named 'inputCol' to the

--- a/pkg/sql/colexec/colexecbase/cast_test.go
+++ b/pkg/sql/colexec/colexecbase/cast_test.go
@@ -124,7 +124,7 @@ func BenchmarkCastOp(b *testing.B) {
 						b.ResetTimer()
 						op.Init(ctx)
 						for i := 0; i < b.N; i++ {
-							op.Next()
+							colexecop.NextNoMeta(op)
 						}
 					})
 			}

--- a/pkg/sql/colexec/colexecbase/const.eg.go
+++ b/pkg/sql/colexec/colexecbase/const.eg.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
@@ -165,11 +166,14 @@ type constBoolOp struct {
 	constVal  bool
 }
 
-func (c constBoolOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c constBoolOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(c.outputIdx)
 	col := vec.Bool()
@@ -193,7 +197,7 @@ func (c constBoolOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type constBytesOp struct {
@@ -204,11 +208,14 @@ type constBytesOp struct {
 	constVal  []byte
 }
 
-func (c constBytesOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c constBytesOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(c.outputIdx)
 	col := vec.Bytes()
@@ -231,7 +238,7 @@ func (c constBytesOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type constDecimalOp struct {
@@ -242,11 +249,14 @@ type constDecimalOp struct {
 	constVal  apd.Decimal
 }
 
-func (c constDecimalOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c constDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(c.outputIdx)
 	col := vec.Decimal()
@@ -270,7 +280,7 @@ func (c constDecimalOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type constInt16Op struct {
@@ -281,11 +291,14 @@ type constInt16Op struct {
 	constVal  int16
 }
 
-func (c constInt16Op) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c constInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(c.outputIdx)
 	col := vec.Int16()
@@ -309,7 +322,7 @@ func (c constInt16Op) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type constInt32Op struct {
@@ -320,11 +333,14 @@ type constInt32Op struct {
 	constVal  int32
 }
 
-func (c constInt32Op) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c constInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(c.outputIdx)
 	col := vec.Int32()
@@ -348,7 +364,7 @@ func (c constInt32Op) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type constInt64Op struct {
@@ -359,11 +375,14 @@ type constInt64Op struct {
 	constVal  int64
 }
 
-func (c constInt64Op) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c constInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(c.outputIdx)
 	col := vec.Int64()
@@ -387,7 +406,7 @@ func (c constInt64Op) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type constFloat64Op struct {
@@ -398,11 +417,14 @@ type constFloat64Op struct {
 	constVal  float64
 }
 
-func (c constFloat64Op) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c constFloat64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(c.outputIdx)
 	col := vec.Float64()
@@ -426,7 +448,7 @@ func (c constFloat64Op) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type constTimestampOp struct {
@@ -437,11 +459,14 @@ type constTimestampOp struct {
 	constVal  time.Time
 }
 
-func (c constTimestampOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c constTimestampOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(c.outputIdx)
 	col := vec.Timestamp()
@@ -465,7 +490,7 @@ func (c constTimestampOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type constIntervalOp struct {
@@ -476,11 +501,14 @@ type constIntervalOp struct {
 	constVal  duration.Duration
 }
 
-func (c constIntervalOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c constIntervalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(c.outputIdx)
 	col := vec.Interval()
@@ -504,7 +532,7 @@ func (c constIntervalOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type constJSONOp struct {
@@ -515,11 +543,14 @@ type constJSONOp struct {
 	constVal  json.JSON
 }
 
-func (c constJSONOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c constJSONOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(c.outputIdx)
 	col := vec.JSON()
@@ -542,7 +573,7 @@ func (c constJSONOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type constDatumOp struct {
@@ -553,11 +584,14 @@ type constDatumOp struct {
 	constVal  interface{}
 }
 
-func (c constDatumOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c constDatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(c.outputIdx)
 	col := vec.Datum()
@@ -580,7 +614,7 @@ func (c constDatumOp) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 // NewConstNullOp creates a new operator that produces a constant NULL value at
@@ -602,13 +636,16 @@ type constNullOp struct {
 
 var _ colexecop.Operator = &constNullOp{}
 
-func (c constNullOp) Next() coldata.Batch {
-	batch := c.Input.Next()
+func (c constNullOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 
 	batch.ColVec(c.outputIdx).Nulls().SetNulls()
-	return batch
+	return batch, nil
 }

--- a/pkg/sql/colexec/colexecbase/distinct.eg.go
+++ b/pkg/sql/colexec/colexecbase/distinct.eg.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
@@ -185,10 +186,13 @@ func (p *distinctBoolOp) Reset(ctx context.Context) {
 	}
 }
 
-func (p *distinctBoolOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p *distinctBoolOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	if batch.Length() == 0 {
-		return batch
+		return batch, nil
 	}
 	outputCol := p.outputCol
 	vec := batch.ColVec(p.distinctColIdx)
@@ -425,7 +429,7 @@ func (p *distinctBoolOp) Next() coldata.Batch {
 	}
 	p.lastValNull = lastValNull
 
-	return batch
+	return batch, nil
 }
 
 // distinctBytesOp runs a distinct on the column in distinctColIdx, writing
@@ -464,10 +468,13 @@ func (p *distinctBytesOp) Reset(ctx context.Context) {
 	}
 }
 
-func (p *distinctBytesOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p *distinctBytesOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	if batch.Length() == 0 {
-		return batch
+		return batch, nil
 	}
 	outputCol := p.outputCol
 	vec := batch.ColVec(p.distinctColIdx)
@@ -668,7 +675,7 @@ func (p *distinctBytesOp) Next() coldata.Batch {
 	}
 	p.lastValNull = lastValNull
 
-	return batch
+	return batch, nil
 }
 
 // distinctDecimalOp runs a distinct on the column in distinctColIdx, writing
@@ -707,10 +714,13 @@ func (p *distinctDecimalOp) Reset(ctx context.Context) {
 	}
 }
 
-func (p *distinctDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p *distinctDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	if batch.Length() == 0 {
-		return batch
+		return batch, nil
 	}
 	outputCol := p.outputCol
 	vec := batch.ColVec(p.distinctColIdx)
@@ -915,7 +925,7 @@ func (p *distinctDecimalOp) Next() coldata.Batch {
 	}
 	p.lastValNull = lastValNull
 
-	return batch
+	return batch, nil
 }
 
 // distinctInt16Op runs a distinct on the column in distinctColIdx, writing
@@ -954,10 +964,13 @@ func (p *distinctInt16Op) Reset(ctx context.Context) {
 	}
 }
 
-func (p *distinctInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p *distinctInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	if batch.Length() == 0 {
-		return batch
+		return batch, nil
 	}
 	outputCol := p.outputCol
 	vec := batch.ColVec(p.distinctColIdx)
@@ -1206,7 +1219,7 @@ func (p *distinctInt16Op) Next() coldata.Batch {
 	}
 	p.lastValNull = lastValNull
 
-	return batch
+	return batch, nil
 }
 
 // distinctInt32Op runs a distinct on the column in distinctColIdx, writing
@@ -1245,10 +1258,13 @@ func (p *distinctInt32Op) Reset(ctx context.Context) {
 	}
 }
 
-func (p *distinctInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p *distinctInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	if batch.Length() == 0 {
-		return batch
+		return batch, nil
 	}
 	outputCol := p.outputCol
 	vec := batch.ColVec(p.distinctColIdx)
@@ -1497,7 +1513,7 @@ func (p *distinctInt32Op) Next() coldata.Batch {
 	}
 	p.lastValNull = lastValNull
 
-	return batch
+	return batch, nil
 }
 
 // distinctInt64Op runs a distinct on the column in distinctColIdx, writing
@@ -1536,10 +1552,13 @@ func (p *distinctInt64Op) Reset(ctx context.Context) {
 	}
 }
 
-func (p *distinctInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p *distinctInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	if batch.Length() == 0 {
-		return batch
+		return batch, nil
 	}
 	outputCol := p.outputCol
 	vec := batch.ColVec(p.distinctColIdx)
@@ -1788,7 +1807,7 @@ func (p *distinctInt64Op) Next() coldata.Batch {
 	}
 	p.lastValNull = lastValNull
 
-	return batch
+	return batch, nil
 }
 
 // distinctFloat64Op runs a distinct on the column in distinctColIdx, writing
@@ -1827,10 +1846,13 @@ func (p *distinctFloat64Op) Reset(ctx context.Context) {
 	}
 }
 
-func (p *distinctFloat64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p *distinctFloat64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	if batch.Length() == 0 {
-		return batch
+		return batch, nil
 	}
 	outputCol := p.outputCol
 	vec := batch.ColVec(p.distinctColIdx)
@@ -2111,7 +2133,7 @@ func (p *distinctFloat64Op) Next() coldata.Batch {
 	}
 	p.lastValNull = lastValNull
 
-	return batch
+	return batch, nil
 }
 
 // distinctTimestampOp runs a distinct on the column in distinctColIdx, writing
@@ -2150,10 +2172,13 @@ func (p *distinctTimestampOp) Reset(ctx context.Context) {
 	}
 }
 
-func (p *distinctTimestampOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p *distinctTimestampOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	if batch.Length() == 0 {
-		return batch
+		return batch, nil
 	}
 	outputCol := p.outputCol
 	vec := batch.ColVec(p.distinctColIdx)
@@ -2386,7 +2411,7 @@ func (p *distinctTimestampOp) Next() coldata.Batch {
 	}
 	p.lastValNull = lastValNull
 
-	return batch
+	return batch, nil
 }
 
 // distinctIntervalOp runs a distinct on the column in distinctColIdx, writing
@@ -2425,10 +2450,13 @@ func (p *distinctIntervalOp) Reset(ctx context.Context) {
 	}
 }
 
-func (p *distinctIntervalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p *distinctIntervalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	if batch.Length() == 0 {
-		return batch
+		return batch, nil
 	}
 	outputCol := p.outputCol
 	vec := batch.ColVec(p.distinctColIdx)
@@ -2633,7 +2661,7 @@ func (p *distinctIntervalOp) Next() coldata.Batch {
 	}
 	p.lastValNull = lastValNull
 
-	return batch
+	return batch, nil
 }
 
 // distinctJSONOp runs a distinct on the column in distinctColIdx, writing
@@ -2672,10 +2700,13 @@ func (p *distinctJSONOp) Reset(ctx context.Context) {
 	}
 }
 
-func (p *distinctJSONOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p *distinctJSONOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	if batch.Length() == 0 {
-		return batch
+		return batch, nil
 	}
 	outputCol := p.outputCol
 	vec := batch.ColVec(p.distinctColIdx)
@@ -2911,7 +2942,7 @@ func (p *distinctJSONOp) Next() coldata.Batch {
 	}
 	p.lastValNull = lastValNull
 
-	return batch
+	return batch, nil
 }
 
 // distinctDatumOp runs a distinct on the column in distinctColIdx, writing
@@ -2950,10 +2981,13 @@ func (p *distinctDatumOp) Reset(ctx context.Context) {
 	}
 }
 
-func (p *distinctDatumOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p *distinctDatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	if batch.Length() == 0 {
-		return batch
+		return batch, nil
 	}
 	outputCol := p.outputCol
 	vec := batch.ColVec(p.distinctColIdx)
@@ -3162,5 +3196,5 @@ func (p *distinctDatumOp) Next() coldata.Batch {
 	}
 	p.lastValNull = lastValNull
 
-	return batch
+	return batch, nil
 }

--- a/pkg/sql/colexec/colexecbase/distinct_tmpl.go
+++ b/pkg/sql/colexec/colexecbase/distinct_tmpl.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/errors"
 )
@@ -165,10 +166,13 @@ func (p *distinct_TYPEOp) Reset(ctx context.Context) {
 	}
 }
 
-func (p *distinct_TYPEOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p *distinct_TYPEOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	if batch.Length() == 0 {
-		return batch
+		return batch, nil
 	}
 	outputCol := p.outputCol
 	vec := batch.ColVec(p.distinctColIdx)
@@ -233,7 +237,7 @@ func (p *distinct_TYPEOp) Next() coldata.Batch {
 	}
 	p.lastValNull = lastValNull
 
-	return batch
+	return batch, nil
 }
 
 // {{end}}

--- a/pkg/sql/colexec/colexecbase/fn_op.go
+++ b/pkg/sql/colexec/colexecbase/fn_op.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 )
 
 // fnOp is an operator that executes an arbitrary function for its side-effects,
@@ -23,10 +24,13 @@ type fnOp struct {
 
 var _ colexecop.ResettableOperator = &fnOp{}
 
-func (f *fnOp) Next() coldata.Batch {
-	batch := f.Input.Next()
+func (f *fnOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := f.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	f.fn()
-	return batch
+	return batch, nil
 }
 
 func (f *fnOp) Reset(ctx context.Context) {

--- a/pkg/sql/colexec/colexecbase/ordinality.go
+++ b/pkg/sql/colexec/colexecbase/ordinality.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 )
 
@@ -42,10 +43,13 @@ func NewOrdinalityOp(
 	return c
 }
 
-func (c *ordinalityOp) Next() coldata.Batch {
-	bat := c.Input.Next()
+func (c *ordinalityOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	bat, meta := c.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	if bat.Length() == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 
 	outputVec := bat.ColVec(c.outputIdx)
@@ -67,5 +71,5 @@ func (c *ordinalityOp) Next() coldata.Batch {
 		}
 	}
 
-	return bat
+	return bat, nil
 }

--- a/pkg/sql/colexec/colexecbase/ordinality_test.go
+++ b/pkg/sql/colexec/colexecbase/ordinality_test.go
@@ -95,7 +95,7 @@ func BenchmarkOrdinality(b *testing.B) {
 
 	b.SetBytes(int64(8 * coldata.BatchSize()))
 	for i := 0; i < b.N; i++ {
-		ordinality.Next()
+		colexecop.NextNoMeta(ordinality)
 	}
 }
 

--- a/pkg/sql/colexec/colexecdisk/external_sort_test.go
+++ b/pkg/sql/colexec/colexecdisk/external_sort_test.go
@@ -124,7 +124,7 @@ func TestExternalSortMemoryAccounting(t *testing.T) {
 	require.NoError(t, err)
 
 	sorter.Init(ctx)
-	for b := sorter.Next(); b.Length() > 0; b = sorter.Next() {
+	for b := colexecop.NextNoMeta(sorter); b.Length() > 0; b = colexecop.NextNoMeta(sorter) {
 	}
 
 	require.True(t, spilled)

--- a/pkg/sql/colexec/colexecdisk/hash_based_partitioner.go
+++ b/pkg/sql/colexec/colexecdisk/hash_based_partitioner.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra/execopnode"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -131,6 +132,11 @@ type hashBasedPartitioner struct {
 		acquiredFDs int
 	}
 	cancelChecker colexecutils.CancelChecker
+
+	// storedLeftBatch is the batch we read from the left input before
+	// encountering the metadata from the right input. It'll always remain nil
+	// if we only have one input.
+	storedLeftBatch coldata.Batch
 
 	partitioners      []*colcontainer.PartitionedDiskQueue
 	partitionedInputs []*partitionerToOperator
@@ -412,7 +418,7 @@ func (op *hashBasedPartitioner) partitionBatch(
 	}
 }
 
-func (op *hashBasedPartitioner) Next() coldata.Batch {
+func (op *hashBasedPartitioner) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	var batches [2]coldata.Batch
 StateChanged:
 	for {
@@ -421,7 +427,25 @@ StateChanged:
 		case hbpInitialPartitioning:
 			allZero := true
 			for i := range op.inputs {
-				batches[i] = op.inputs[i].Next()
+				if op.storedLeftBatch != nil {
+					if buildutil.CrdbTestBuild && i != 0 {
+						colexecerror.InternalError(errors.AssertionFailedf("storedLeftBatch must correspond to 0th input"))
+					}
+					batches[i] = op.storedLeftBatch
+					op.storedLeftBatch = nil
+				} else {
+					var meta *execinfrapb.ProducerMetadata
+					batches[i], meta = op.inputs[i].Next()
+					if meta != nil {
+						if i == 1 {
+							// Since we've already fetched a batch from the left
+							// input, we need to make sure to use it on the next
+							// iteration.
+							op.storedLeftBatch = batches[0]
+						}
+						return nil, meta
+					}
+				}
 				allZero = allZero && batches[i].Length() == 0
 			}
 			if allZero {
@@ -588,7 +612,10 @@ StateChanged:
 			continue
 
 		case hbpProcessingUsingMain:
-			b := op.inMemMainOp.Next()
+			b, meta := op.inMemMainOp.Next()
+			if meta != nil {
+				return nil, meta
+			}
 			if b.Length() == 0 {
 				// We're done processing these partitions, so we close them and
 				// transition to processing new ones.
@@ -600,7 +627,7 @@ StateChanged:
 				op.state = hbpProcessNewPartitionUsingMain
 				continue
 			}
-			return b
+			return b, nil
 
 		case hbpProcessNewPartitionUsingFallback:
 			if len(op.partitionsToProcessUsingFallback) == 0 {
@@ -619,7 +646,10 @@ StateChanged:
 			continue
 
 		case hbpProcessingUsingFallback:
-			b := op.diskBackedFallbackOp.Next()
+			b, meta := op.diskBackedFallbackOp.Next()
+			if meta != nil {
+				return nil, meta
+			}
 			if b.Length() == 0 {
 				// We're done processing these partitions, so we close them and
 				// transition to processing new ones.
@@ -631,13 +661,13 @@ StateChanged:
 				op.state = hbpProcessNewPartitionUsingFallback
 				continue
 			}
-			return b
+			return b, nil
 
 		case hbpFinished:
 			if err := op.Close(op.Ctx); err != nil {
 				colexecerror.InternalError(err)
 			}
-			return coldata.ZeroBatch
+			return coldata.ZeroBatch, nil
 
 		default:
 			colexecerror.InternalError(errors.AssertionFailedf("unexpected hashBasedPartitionerState %d", op.state))

--- a/pkg/sql/colexec/colexecdisk/utils.go
+++ b/pkg/sql/colexec/colexecdisk/utils.go
@@ -62,7 +62,7 @@ func (p *partitionerToOperator) Init(ctx context.Context) {
 	p.batch = p.allocator.NewMemBatchWithFixedCapacity(p.types, coldata.BatchSize())
 }
 
-func (p *partitionerToOperator) Next() coldata.Batch {
+func (p *partitionerToOperator) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	var err error
 	// We need to perform the memory accounting on the dequeued batch. Note that
 	// such setup allows us to release the memory under the old p.batch (which
@@ -73,7 +73,7 @@ func (p *partitionerToOperator) Next() coldata.Batch {
 	if err != nil {
 		colexecutils.HandleErrorFromDiskQueue(err)
 	}
-	return p.batch
+	return p.batch, nil
 }
 
 func makeOrdering(cols []uint32) []execinfrapb.Ordering_Column {

--- a/pkg/sql/colexec/colexechash/BUILD.bazel
+++ b/pkg/sql/colexec/colexechash/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/sql/colexecerror",
         "//pkg/sql/colexecop",
         "//pkg/sql/colmem",
+        "//pkg/sql/execinfrapb",
         "//pkg/sql/memsize",
         "//pkg/sql/sem/tree",  # keep
         "//pkg/sql/types",

--- a/pkg/sql/colexec/colexecjoin/BUILD.bazel
+++ b/pkg/sql/colexec/colexecjoin/BUILD.bazel
@@ -7,8 +7,8 @@ go_library(
     srcs = [
         "crossjoiner.go",
         "hashjoiner.go",
+        "joiner_util.go",
         "mergejoiner.go",
-        "mergejoiner_util.go",
         ":gen-exec",  # keep
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecjoin",

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_exceptall.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_exceptall.eg.go
@@ -14225,24 +14225,36 @@ func (o *mergeJoinExceptAllOp) buildFromBufferedGroup() (bufferedGroupComplete b
 	}
 }
 
-func (o *mergeJoinExceptAllOp) Next() coldata.Batch {
-	o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
-	o.outputCapacity = o.output.Capacity()
-	o.bufferedGroup.helper.output = o.output
-	o.builderState.outCount = 0
+func (o *mergeJoinExceptAllOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	if !o.continueBatch {
+		o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
+		o.outputCapacity = o.output.Capacity()
+		o.bufferedGroup.helper.output = o.output
+		o.builderState.outCount = 0
+	}
+	o.continueBatch = false
 	for {
+		// We read from the inputs in multiple states, so checking whether any
+		// metadata was buffered between state transitions is good.
+		if meta := o.maybeEmitMeta(); meta != nil {
+			// If we've built some output tuples but haven't reached the output
+			// batch capacity, ensure that we continue building the output batch
+			// instead of resetting it.
+			o.continueBatch = true
+			return nil, meta
+		}
 		switch o.state {
 		case mjEntry:
 			// If this is the first batch or we're done with the current batch,
 			// get the next batch.
 			if o.proberState.lBatch == nil || (o.proberState.lLength != 0 && o.proberState.lIdx == o.proberState.lLength) {
 				o.cancelChecker.CheckEveryCall()
-				o.proberState.lIdx, o.proberState.lBatch = 0, o.InputOne.Next()
+				o.proberState.lIdx, o.proberState.lBatch = 0, o.inputOneNext()
 				o.proberState.lLength = o.proberState.lBatch.Length()
 			}
 			if o.proberState.rBatch == nil || (o.proberState.rLength != 0 && o.proberState.rIdx == o.proberState.rLength) {
 				o.cancelChecker.CheckEveryCall()
-				o.proberState.rIdx, o.proberState.rBatch = 0, o.InputTwo.Next()
+				o.proberState.rIdx, o.proberState.rBatch = 0, o.inputTwoNext()
 				o.proberState.rLength = o.proberState.rBatch.Length()
 			}
 			if o.sourceFinished() {
@@ -14264,7 +14276,7 @@ func (o *mergeJoinExceptAllOp) Next() coldata.Batch {
 			if len(o.builderState.lGroups) == 0 && len(o.builderState.rGroups) == 0 {
 				o.state = mjDone
 				o.output.SetLength(o.builderState.outCount)
-				return o.output
+				return o.output, nil
 			}
 			o.state = mjBuildFromBatch
 
@@ -14283,7 +14295,7 @@ func (o *mergeJoinExceptAllOp) Next() coldata.Batch {
 			o.buildFromBatch()
 			if o.builderState.outCount == o.outputCapacity {
 				o.output.SetLength(o.builderState.outCount)
-				return o.output
+				return o.output, nil
 			}
 			if o.bufferedGroup.helper.numRightTuples != 0 {
 				o.transitionIntoBuildingFromBufferedGroup()
@@ -14299,11 +14311,11 @@ func (o *mergeJoinExceptAllOp) Next() coldata.Batch {
 			}
 			if o.builderState.outCount == o.outputCapacity {
 				o.output.SetLength(o.builderState.outCount)
-				return o.output
+				return o.output, nil
 			}
 
 		case mjDone:
-			return coldata.ZeroBatch
+			return coldata.ZeroBatch, nil
 
 		default:
 			colexecerror.InternalError(errors.AssertionFailedf("unexpected merge joiner state in Next: %v", o.state))

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_fullouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_fullouter.eg.go
@@ -15372,24 +15372,36 @@ func (o *mergeJoinFullOuterOp) buildFromBufferedGroup() (bufferedGroupComplete b
 	}
 }
 
-func (o *mergeJoinFullOuterOp) Next() coldata.Batch {
-	o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
-	o.outputCapacity = o.output.Capacity()
-	o.bufferedGroup.helper.output = o.output
-	o.builderState.outCount = 0
+func (o *mergeJoinFullOuterOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	if !o.continueBatch {
+		o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
+		o.outputCapacity = o.output.Capacity()
+		o.bufferedGroup.helper.output = o.output
+		o.builderState.outCount = 0
+	}
+	o.continueBatch = false
 	for {
+		// We read from the inputs in multiple states, so checking whether any
+		// metadata was buffered between state transitions is good.
+		if meta := o.maybeEmitMeta(); meta != nil {
+			// If we've built some output tuples but haven't reached the output
+			// batch capacity, ensure that we continue building the output batch
+			// instead of resetting it.
+			o.continueBatch = true
+			return nil, meta
+		}
 		switch o.state {
 		case mjEntry:
 			// If this is the first batch or we're done with the current batch,
 			// get the next batch.
 			if o.proberState.lBatch == nil || (o.proberState.lLength != 0 && o.proberState.lIdx == o.proberState.lLength) {
 				o.cancelChecker.CheckEveryCall()
-				o.proberState.lIdx, o.proberState.lBatch = 0, o.InputOne.Next()
+				o.proberState.lIdx, o.proberState.lBatch = 0, o.inputOneNext()
 				o.proberState.lLength = o.proberState.lBatch.Length()
 			}
 			if o.proberState.rBatch == nil || (o.proberState.rLength != 0 && o.proberState.rIdx == o.proberState.rLength) {
 				o.cancelChecker.CheckEveryCall()
-				o.proberState.rIdx, o.proberState.rBatch = 0, o.InputTwo.Next()
+				o.proberState.rIdx, o.proberState.rBatch = 0, o.inputTwoNext()
 				o.proberState.rLength = o.proberState.rBatch.Length()
 			}
 			if o.sourceFinished() {
@@ -15418,7 +15430,7 @@ func (o *mergeJoinFullOuterOp) Next() coldata.Batch {
 			if len(o.builderState.lGroups) == 0 && len(o.builderState.rGroups) == 0 {
 				o.state = mjDone
 				o.output.SetLength(o.builderState.outCount)
-				return o.output
+				return o.output, nil
 			}
 			o.state = mjBuildFromBatch
 
@@ -15437,7 +15449,7 @@ func (o *mergeJoinFullOuterOp) Next() coldata.Batch {
 			o.buildFromBatch()
 			if o.builderState.outCount == o.outputCapacity {
 				o.output.SetLength(o.builderState.outCount)
-				return o.output
+				return o.output, nil
 			}
 			if o.bufferedGroup.helper.numRightTuples != 0 {
 				o.transitionIntoBuildingFromBufferedGroup()
@@ -15453,11 +15465,11 @@ func (o *mergeJoinFullOuterOp) Next() coldata.Batch {
 			}
 			if o.builderState.outCount == o.outputCapacity {
 				o.output.SetLength(o.builderState.outCount)
-				return o.output
+				return o.output, nil
 			}
 
 		case mjDone:
-			return coldata.ZeroBatch
+			return coldata.ZeroBatch, nil
 
 		default:
 			colexecerror.InternalError(errors.AssertionFailedf("unexpected merge joiner state in Next: %v", o.state))

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_inner.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_inner.eg.go
@@ -10906,24 +10906,36 @@ func (o *mergeJoinInnerOp) buildFromBufferedGroup() (bufferedGroupComplete bool)
 	}
 }
 
-func (o *mergeJoinInnerOp) Next() coldata.Batch {
-	o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
-	o.outputCapacity = o.output.Capacity()
-	o.bufferedGroup.helper.output = o.output
-	o.builderState.outCount = 0
+func (o *mergeJoinInnerOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	if !o.continueBatch {
+		o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
+		o.outputCapacity = o.output.Capacity()
+		o.bufferedGroup.helper.output = o.output
+		o.builderState.outCount = 0
+	}
+	o.continueBatch = false
 	for {
+		// We read from the inputs in multiple states, so checking whether any
+		// metadata was buffered between state transitions is good.
+		if meta := o.maybeEmitMeta(); meta != nil {
+			// If we've built some output tuples but haven't reached the output
+			// batch capacity, ensure that we continue building the output batch
+			// instead of resetting it.
+			o.continueBatch = true
+			return nil, meta
+		}
 		switch o.state {
 		case mjEntry:
 			// If this is the first batch or we're done with the current batch,
 			// get the next batch.
 			if o.proberState.lBatch == nil || (o.proberState.lLength != 0 && o.proberState.lIdx == o.proberState.lLength) {
 				o.cancelChecker.CheckEveryCall()
-				o.proberState.lIdx, o.proberState.lBatch = 0, o.InputOne.Next()
+				o.proberState.lIdx, o.proberState.lBatch = 0, o.inputOneNext()
 				o.proberState.lLength = o.proberState.lBatch.Length()
 			}
 			if o.proberState.rBatch == nil || (o.proberState.rLength != 0 && o.proberState.rIdx == o.proberState.rLength) {
 				o.cancelChecker.CheckEveryCall()
-				o.proberState.rIdx, o.proberState.rBatch = 0, o.InputTwo.Next()
+				o.proberState.rIdx, o.proberState.rBatch = 0, o.inputTwoNext()
 				o.proberState.rLength = o.proberState.rBatch.Length()
 			}
 			if o.sourceFinished() {
@@ -10938,7 +10950,7 @@ func (o *mergeJoinInnerOp) Next() coldata.Batch {
 			if len(o.builderState.lGroups) == 0 && len(o.builderState.rGroups) == 0 {
 				o.state = mjDone
 				o.output.SetLength(o.builderState.outCount)
-				return o.output
+				return o.output, nil
 			}
 			o.state = mjBuildFromBatch
 
@@ -10957,7 +10969,7 @@ func (o *mergeJoinInnerOp) Next() coldata.Batch {
 			o.buildFromBatch()
 			if o.builderState.outCount == o.outputCapacity {
 				o.output.SetLength(o.builderState.outCount)
-				return o.output
+				return o.output, nil
 			}
 			if o.bufferedGroup.helper.numRightTuples != 0 {
 				o.transitionIntoBuildingFromBufferedGroup()
@@ -10973,11 +10985,11 @@ func (o *mergeJoinInnerOp) Next() coldata.Batch {
 			}
 			if o.builderState.outCount == o.outputCapacity {
 				o.output.SetLength(o.builderState.outCount)
-				return o.output
+				return o.output, nil
 			}
 
 		case mjDone:
-			return coldata.ZeroBatch
+			return coldata.ZeroBatch, nil
 
 		default:
 			colexecerror.InternalError(errors.AssertionFailedf("unexpected merge joiner state in Next: %v", o.state))

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_intersectall.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_intersectall.eg.go
@@ -11616,24 +11616,36 @@ func (o *mergeJoinIntersectAllOp) buildFromBufferedGroup() (bufferedGroupComplet
 	}
 }
 
-func (o *mergeJoinIntersectAllOp) Next() coldata.Batch {
-	o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
-	o.outputCapacity = o.output.Capacity()
-	o.bufferedGroup.helper.output = o.output
-	o.builderState.outCount = 0
+func (o *mergeJoinIntersectAllOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	if !o.continueBatch {
+		o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
+		o.outputCapacity = o.output.Capacity()
+		o.bufferedGroup.helper.output = o.output
+		o.builderState.outCount = 0
+	}
+	o.continueBatch = false
 	for {
+		// We read from the inputs in multiple states, so checking whether any
+		// metadata was buffered between state transitions is good.
+		if meta := o.maybeEmitMeta(); meta != nil {
+			// If we've built some output tuples but haven't reached the output
+			// batch capacity, ensure that we continue building the output batch
+			// instead of resetting it.
+			o.continueBatch = true
+			return nil, meta
+		}
 		switch o.state {
 		case mjEntry:
 			// If this is the first batch or we're done with the current batch,
 			// get the next batch.
 			if o.proberState.lBatch == nil || (o.proberState.lLength != 0 && o.proberState.lIdx == o.proberState.lLength) {
 				o.cancelChecker.CheckEveryCall()
-				o.proberState.lIdx, o.proberState.lBatch = 0, o.InputOne.Next()
+				o.proberState.lIdx, o.proberState.lBatch = 0, o.inputOneNext()
 				o.proberState.lLength = o.proberState.lBatch.Length()
 			}
 			if o.proberState.rBatch == nil || (o.proberState.rLength != 0 && o.proberState.rIdx == o.proberState.rLength) {
 				o.cancelChecker.CheckEveryCall()
-				o.proberState.rIdx, o.proberState.rBatch = 0, o.InputTwo.Next()
+				o.proberState.rIdx, o.proberState.rBatch = 0, o.inputTwoNext()
 				o.proberState.rLength = o.proberState.rBatch.Length()
 			}
 			if o.sourceFinished() {
@@ -11648,7 +11660,7 @@ func (o *mergeJoinIntersectAllOp) Next() coldata.Batch {
 			if len(o.builderState.lGroups) == 0 && len(o.builderState.rGroups) == 0 {
 				o.state = mjDone
 				o.output.SetLength(o.builderState.outCount)
-				return o.output
+				return o.output, nil
 			}
 			o.state = mjBuildFromBatch
 
@@ -11667,7 +11679,7 @@ func (o *mergeJoinIntersectAllOp) Next() coldata.Batch {
 			o.buildFromBatch()
 			if o.builderState.outCount == o.outputCapacity {
 				o.output.SetLength(o.builderState.outCount)
-				return o.output
+				return o.output, nil
 			}
 			if o.bufferedGroup.helper.numRightTuples != 0 {
 				o.transitionIntoBuildingFromBufferedGroup()
@@ -11683,11 +11695,11 @@ func (o *mergeJoinIntersectAllOp) Next() coldata.Batch {
 			}
 			if o.builderState.outCount == o.outputCapacity {
 				o.output.SetLength(o.builderState.outCount)
-				return o.output
+				return o.output, nil
 			}
 
 		case mjDone:
-			return coldata.ZeroBatch
+			return coldata.ZeroBatch, nil
 
 		default:
 			colexecerror.InternalError(errors.AssertionFailedf("unexpected merge joiner state in Next: %v", o.state))

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftouter.eg.go
@@ -13162,24 +13162,36 @@ func (o *mergeJoinLeftOuterOp) buildFromBufferedGroup() (bufferedGroupComplete b
 	}
 }
 
-func (o *mergeJoinLeftOuterOp) Next() coldata.Batch {
-	o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
-	o.outputCapacity = o.output.Capacity()
-	o.bufferedGroup.helper.output = o.output
-	o.builderState.outCount = 0
+func (o *mergeJoinLeftOuterOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	if !o.continueBatch {
+		o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
+		o.outputCapacity = o.output.Capacity()
+		o.bufferedGroup.helper.output = o.output
+		o.builderState.outCount = 0
+	}
+	o.continueBatch = false
 	for {
+		// We read from the inputs in multiple states, so checking whether any
+		// metadata was buffered between state transitions is good.
+		if meta := o.maybeEmitMeta(); meta != nil {
+			// If we've built some output tuples but haven't reached the output
+			// batch capacity, ensure that we continue building the output batch
+			// instead of resetting it.
+			o.continueBatch = true
+			return nil, meta
+		}
 		switch o.state {
 		case mjEntry:
 			// If this is the first batch or we're done with the current batch,
 			// get the next batch.
 			if o.proberState.lBatch == nil || (o.proberState.lLength != 0 && o.proberState.lIdx == o.proberState.lLength) {
 				o.cancelChecker.CheckEveryCall()
-				o.proberState.lIdx, o.proberState.lBatch = 0, o.InputOne.Next()
+				o.proberState.lIdx, o.proberState.lBatch = 0, o.inputOneNext()
 				o.proberState.lLength = o.proberState.lBatch.Length()
 			}
 			if o.proberState.rBatch == nil || (o.proberState.rLength != 0 && o.proberState.rIdx == o.proberState.rLength) {
 				o.cancelChecker.CheckEveryCall()
-				o.proberState.rIdx, o.proberState.rBatch = 0, o.InputTwo.Next()
+				o.proberState.rIdx, o.proberState.rBatch = 0, o.inputTwoNext()
 				o.proberState.rLength = o.proberState.rBatch.Length()
 			}
 			if o.sourceFinished() {
@@ -13201,7 +13213,7 @@ func (o *mergeJoinLeftOuterOp) Next() coldata.Batch {
 			if len(o.builderState.lGroups) == 0 && len(o.builderState.rGroups) == 0 {
 				o.state = mjDone
 				o.output.SetLength(o.builderState.outCount)
-				return o.output
+				return o.output, nil
 			}
 			o.state = mjBuildFromBatch
 
@@ -13220,7 +13232,7 @@ func (o *mergeJoinLeftOuterOp) Next() coldata.Batch {
 			o.buildFromBatch()
 			if o.builderState.outCount == o.outputCapacity {
 				o.output.SetLength(o.builderState.outCount)
-				return o.output
+				return o.output, nil
 			}
 			if o.bufferedGroup.helper.numRightTuples != 0 {
 				o.transitionIntoBuildingFromBufferedGroup()
@@ -13236,11 +13248,11 @@ func (o *mergeJoinLeftOuterOp) Next() coldata.Batch {
 			}
 			if o.builderState.outCount == o.outputCapacity {
 				o.output.SetLength(o.builderState.outCount)
-				return o.output
+				return o.output, nil
 			}
 
 		case mjDone:
-			return coldata.ZeroBatch
+			return coldata.ZeroBatch, nil
 
 		default:
 			colexecerror.InternalError(errors.AssertionFailedf("unexpected merge joiner state in Next: %v", o.state))

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftsemi.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftsemi.eg.go
@@ -10859,24 +10859,36 @@ func (o *mergeJoinLeftSemiOp) buildFromBufferedGroup() (bufferedGroupComplete bo
 	}
 }
 
-func (o *mergeJoinLeftSemiOp) Next() coldata.Batch {
-	o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
-	o.outputCapacity = o.output.Capacity()
-	o.bufferedGroup.helper.output = o.output
-	o.builderState.outCount = 0
+func (o *mergeJoinLeftSemiOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	if !o.continueBatch {
+		o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
+		o.outputCapacity = o.output.Capacity()
+		o.bufferedGroup.helper.output = o.output
+		o.builderState.outCount = 0
+	}
+	o.continueBatch = false
 	for {
+		// We read from the inputs in multiple states, so checking whether any
+		// metadata was buffered between state transitions is good.
+		if meta := o.maybeEmitMeta(); meta != nil {
+			// If we've built some output tuples but haven't reached the output
+			// batch capacity, ensure that we continue building the output batch
+			// instead of resetting it.
+			o.continueBatch = true
+			return nil, meta
+		}
 		switch o.state {
 		case mjEntry:
 			// If this is the first batch or we're done with the current batch,
 			// get the next batch.
 			if o.proberState.lBatch == nil || (o.proberState.lLength != 0 && o.proberState.lIdx == o.proberState.lLength) {
 				o.cancelChecker.CheckEveryCall()
-				o.proberState.lIdx, o.proberState.lBatch = 0, o.InputOne.Next()
+				o.proberState.lIdx, o.proberState.lBatch = 0, o.inputOneNext()
 				o.proberState.lLength = o.proberState.lBatch.Length()
 			}
 			if o.proberState.rBatch == nil || (o.proberState.rLength != 0 && o.proberState.rIdx == o.proberState.rLength) {
 				o.cancelChecker.CheckEveryCall()
-				o.proberState.rIdx, o.proberState.rBatch = 0, o.InputTwo.Next()
+				o.proberState.rIdx, o.proberState.rBatch = 0, o.inputTwoNext()
 				o.proberState.rLength = o.proberState.rBatch.Length()
 			}
 			if o.sourceFinished() {
@@ -10891,7 +10903,7 @@ func (o *mergeJoinLeftSemiOp) Next() coldata.Batch {
 			if len(o.builderState.lGroups) == 0 && len(o.builderState.rGroups) == 0 {
 				o.state = mjDone
 				o.output.SetLength(o.builderState.outCount)
-				return o.output
+				return o.output, nil
 			}
 			o.state = mjBuildFromBatch
 
@@ -10910,7 +10922,7 @@ func (o *mergeJoinLeftSemiOp) Next() coldata.Batch {
 			o.buildFromBatch()
 			if o.builderState.outCount == o.outputCapacity {
 				o.output.SetLength(o.builderState.outCount)
-				return o.output
+				return o.output, nil
 			}
 			if o.bufferedGroup.helper.numRightTuples != 0 {
 				o.transitionIntoBuildingFromBufferedGroup()
@@ -10926,11 +10938,11 @@ func (o *mergeJoinLeftSemiOp) Next() coldata.Batch {
 			}
 			if o.builderState.outCount == o.outputCapacity {
 				o.output.SetLength(o.builderState.outCount)
-				return o.output
+				return o.output, nil
 			}
 
 		case mjDone:
-			return coldata.ZeroBatch
+			return coldata.ZeroBatch, nil
 
 		default:
 			colexecerror.InternalError(errors.AssertionFailedf("unexpected merge joiner state in Next: %v", o.state))

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightanti.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightanti.eg.go
@@ -13066,24 +13066,36 @@ func (o *mergeJoinRightAntiOp) buildFromBufferedGroup() (bufferedGroupComplete b
 	}
 }
 
-func (o *mergeJoinRightAntiOp) Next() coldata.Batch {
-	o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
-	o.outputCapacity = o.output.Capacity()
-	o.bufferedGroup.helper.output = o.output
-	o.builderState.outCount = 0
+func (o *mergeJoinRightAntiOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	if !o.continueBatch {
+		o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
+		o.outputCapacity = o.output.Capacity()
+		o.bufferedGroup.helper.output = o.output
+		o.builderState.outCount = 0
+	}
+	o.continueBatch = false
 	for {
+		// We read from the inputs in multiple states, so checking whether any
+		// metadata was buffered between state transitions is good.
+		if meta := o.maybeEmitMeta(); meta != nil {
+			// If we've built some output tuples but haven't reached the output
+			// batch capacity, ensure that we continue building the output batch
+			// instead of resetting it.
+			o.continueBatch = true
+			return nil, meta
+		}
 		switch o.state {
 		case mjEntry:
 			// If this is the first batch or we're done with the current batch,
 			// get the next batch.
 			if o.proberState.lBatch == nil || (o.proberState.lLength != 0 && o.proberState.lIdx == o.proberState.lLength) {
 				o.cancelChecker.CheckEveryCall()
-				o.proberState.lIdx, o.proberState.lBatch = 0, o.InputOne.Next()
+				o.proberState.lIdx, o.proberState.lBatch = 0, o.inputOneNext()
 				o.proberState.lLength = o.proberState.lBatch.Length()
 			}
 			if o.proberState.rBatch == nil || (o.proberState.rLength != 0 && o.proberState.rIdx == o.proberState.rLength) {
 				o.cancelChecker.CheckEveryCall()
-				o.proberState.rIdx, o.proberState.rBatch = 0, o.InputTwo.Next()
+				o.proberState.rIdx, o.proberState.rBatch = 0, o.inputTwoNext()
 				o.proberState.rLength = o.proberState.rBatch.Length()
 			}
 			if o.sourceFinished() {
@@ -13105,7 +13117,7 @@ func (o *mergeJoinRightAntiOp) Next() coldata.Batch {
 			if len(o.builderState.lGroups) == 0 && len(o.builderState.rGroups) == 0 {
 				o.state = mjDone
 				o.output.SetLength(o.builderState.outCount)
-				return o.output
+				return o.output, nil
 			}
 			o.state = mjBuildFromBatch
 
@@ -13124,7 +13136,7 @@ func (o *mergeJoinRightAntiOp) Next() coldata.Batch {
 			o.buildFromBatch()
 			if o.builderState.outCount == o.outputCapacity {
 				o.output.SetLength(o.builderState.outCount)
-				return o.output
+				return o.output, nil
 			}
 			if o.bufferedGroup.helper.numRightTuples != 0 {
 				o.transitionIntoBuildingFromBufferedGroup()
@@ -13140,11 +13152,11 @@ func (o *mergeJoinRightAntiOp) Next() coldata.Batch {
 			}
 			if o.builderState.outCount == o.outputCapacity {
 				o.output.SetLength(o.builderState.outCount)
-				return o.output
+				return o.output, nil
 			}
 
 		case mjDone:
-			return coldata.ZeroBatch
+			return coldata.ZeroBatch, nil
 
 		default:
 			colexecerror.InternalError(errors.AssertionFailedf("unexpected merge joiner state in Next: %v", o.state))

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightouter.eg.go
@@ -13116,24 +13116,36 @@ func (o *mergeJoinRightOuterOp) buildFromBufferedGroup() (bufferedGroupComplete 
 	}
 }
 
-func (o *mergeJoinRightOuterOp) Next() coldata.Batch {
-	o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
-	o.outputCapacity = o.output.Capacity()
-	o.bufferedGroup.helper.output = o.output
-	o.builderState.outCount = 0
+func (o *mergeJoinRightOuterOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	if !o.continueBatch {
+		o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
+		o.outputCapacity = o.output.Capacity()
+		o.bufferedGroup.helper.output = o.output
+		o.builderState.outCount = 0
+	}
+	o.continueBatch = false
 	for {
+		// We read from the inputs in multiple states, so checking whether any
+		// metadata was buffered between state transitions is good.
+		if meta := o.maybeEmitMeta(); meta != nil {
+			// If we've built some output tuples but haven't reached the output
+			// batch capacity, ensure that we continue building the output batch
+			// instead of resetting it.
+			o.continueBatch = true
+			return nil, meta
+		}
 		switch o.state {
 		case mjEntry:
 			// If this is the first batch or we're done with the current batch,
 			// get the next batch.
 			if o.proberState.lBatch == nil || (o.proberState.lLength != 0 && o.proberState.lIdx == o.proberState.lLength) {
 				o.cancelChecker.CheckEveryCall()
-				o.proberState.lIdx, o.proberState.lBatch = 0, o.InputOne.Next()
+				o.proberState.lIdx, o.proberState.lBatch = 0, o.inputOneNext()
 				o.proberState.lLength = o.proberState.lBatch.Length()
 			}
 			if o.proberState.rBatch == nil || (o.proberState.rLength != 0 && o.proberState.rIdx == o.proberState.rLength) {
 				o.cancelChecker.CheckEveryCall()
-				o.proberState.rIdx, o.proberState.rBatch = 0, o.InputTwo.Next()
+				o.proberState.rIdx, o.proberState.rBatch = 0, o.inputTwoNext()
 				o.proberState.rLength = o.proberState.rBatch.Length()
 			}
 			if o.sourceFinished() {
@@ -13155,7 +13167,7 @@ func (o *mergeJoinRightOuterOp) Next() coldata.Batch {
 			if len(o.builderState.lGroups) == 0 && len(o.builderState.rGroups) == 0 {
 				o.state = mjDone
 				o.output.SetLength(o.builderState.outCount)
-				return o.output
+				return o.output, nil
 			}
 			o.state = mjBuildFromBatch
 
@@ -13174,7 +13186,7 @@ func (o *mergeJoinRightOuterOp) Next() coldata.Batch {
 			o.buildFromBatch()
 			if o.builderState.outCount == o.outputCapacity {
 				o.output.SetLength(o.builderState.outCount)
-				return o.output
+				return o.output, nil
 			}
 			if o.bufferedGroup.helper.numRightTuples != 0 {
 				o.transitionIntoBuildingFromBufferedGroup()
@@ -13190,11 +13202,11 @@ func (o *mergeJoinRightOuterOp) Next() coldata.Batch {
 			}
 			if o.builderState.outCount == o.outputCapacity {
 				o.output.SetLength(o.builderState.outCount)
-				return o.output
+				return o.output, nil
 			}
 
 		case mjDone:
-			return coldata.ZeroBatch
+			return coldata.ZeroBatch, nil
 
 		default:
 			colexecerror.InternalError(errors.AssertionFailedf("unexpected merge joiner state in Next: %v", o.state))

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightsemi.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightsemi.eg.go
@@ -10819,24 +10819,36 @@ func (o *mergeJoinRightSemiOp) buildFromBufferedGroup() (bufferedGroupComplete b
 	}
 }
 
-func (o *mergeJoinRightSemiOp) Next() coldata.Batch {
-	o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
-	o.outputCapacity = o.output.Capacity()
-	o.bufferedGroup.helper.output = o.output
-	o.builderState.outCount = 0
+func (o *mergeJoinRightSemiOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	if !o.continueBatch {
+		o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
+		o.outputCapacity = o.output.Capacity()
+		o.bufferedGroup.helper.output = o.output
+		o.builderState.outCount = 0
+	}
+	o.continueBatch = false
 	for {
+		// We read from the inputs in multiple states, so checking whether any
+		// metadata was buffered between state transitions is good.
+		if meta := o.maybeEmitMeta(); meta != nil {
+			// If we've built some output tuples but haven't reached the output
+			// batch capacity, ensure that we continue building the output batch
+			// instead of resetting it.
+			o.continueBatch = true
+			return nil, meta
+		}
 		switch o.state {
 		case mjEntry:
 			// If this is the first batch or we're done with the current batch,
 			// get the next batch.
 			if o.proberState.lBatch == nil || (o.proberState.lLength != 0 && o.proberState.lIdx == o.proberState.lLength) {
 				o.cancelChecker.CheckEveryCall()
-				o.proberState.lIdx, o.proberState.lBatch = 0, o.InputOne.Next()
+				o.proberState.lIdx, o.proberState.lBatch = 0, o.inputOneNext()
 				o.proberState.lLength = o.proberState.lBatch.Length()
 			}
 			if o.proberState.rBatch == nil || (o.proberState.rLength != 0 && o.proberState.rIdx == o.proberState.rLength) {
 				o.cancelChecker.CheckEveryCall()
-				o.proberState.rIdx, o.proberState.rBatch = 0, o.InputTwo.Next()
+				o.proberState.rIdx, o.proberState.rBatch = 0, o.inputTwoNext()
 				o.proberState.rLength = o.proberState.rBatch.Length()
 			}
 			if o.sourceFinished() {
@@ -10851,7 +10863,7 @@ func (o *mergeJoinRightSemiOp) Next() coldata.Batch {
 			if len(o.builderState.lGroups) == 0 && len(o.builderState.rGroups) == 0 {
 				o.state = mjDone
 				o.output.SetLength(o.builderState.outCount)
-				return o.output
+				return o.output, nil
 			}
 			o.state = mjBuildFromBatch
 
@@ -10870,7 +10882,7 @@ func (o *mergeJoinRightSemiOp) Next() coldata.Batch {
 			o.buildFromBatch()
 			if o.builderState.outCount == o.outputCapacity {
 				o.output.SetLength(o.builderState.outCount)
-				return o.output
+				return o.output, nil
 			}
 			if o.bufferedGroup.helper.numRightTuples != 0 {
 				o.transitionIntoBuildingFromBufferedGroup()
@@ -10886,11 +10898,11 @@ func (o *mergeJoinRightSemiOp) Next() coldata.Batch {
 			}
 			if o.builderState.outCount == o.outputCapacity {
 				o.output.SetLength(o.builderState.outCount)
-				return o.output
+				return o.output, nil
 			}
 
 		case mjDone:
-			return coldata.ZeroBatch
+			return coldata.ZeroBatch, nil
 
 		default:
 			colexecerror.InternalError(errors.AssertionFailedf("unexpected merge joiner state in Next: %v", o.state))

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_test.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_test.go
@@ -92,7 +92,7 @@ func TestMergeJoinCrossProduct(t *testing.T) {
 	rightMJSource := colexectestutils.NewChunkingBatchSource(testAllocator, typs, colsRight, nTuples)
 	leftHJSource := colexectestutils.NewChunkingBatchSource(testAllocator, typs, colsLeft, nTuples)
 	rightHJSource := colexectestutils.NewChunkingBatchSource(testAllocator, typs, colsRight, nTuples)
-	mj := NewMergeJoinOp(
+	mj, _ := NewMergeJoinOp(
 		ctx, testAllocator, execinfra.DefaultMemoryLimit, queueCfg,
 		colexecop.NewTestingSemaphore(mjFDLimit), descpb.InnerJoin,
 		leftMJSource, rightMJSource, typs, typs,
@@ -120,12 +120,12 @@ func TestMergeJoinCrossProduct(t *testing.T) {
 	hj.Init(ctx)
 
 	var mjOutputTuples, hjOutputTuples colexectestutils.Tuples
-	for b := mj.Next(); b.Length() != 0; b = mj.Next() {
+	for b := colexecop.NextNoMeta(mj); b.Length() != 0; b = colexecop.NextNoMeta(mj) {
 		for i := 0; i < b.Length(); i++ {
 			mjOutputTuples = append(mjOutputTuples, colexectestutils.GetTupleFromBatch(b, i))
 		}
 	}
-	for b := hj.Next(); b.Length() != 0; b = hj.Next() {
+	for b := colexecop.NextNoMeta(hj); b.Length() != 0; b = colexecop.NextNoMeta(hj) {
 		for i := 0; i < b.Length(); i++ {
 			hjOutputTuples = append(hjOutputTuples, colexectestutils.GetTupleFromBatch(b, i))
 		}
@@ -264,7 +264,7 @@ func BenchmarkMergeJoiner(b *testing.B) {
 					s.Init(ctx)
 
 					b.StartTimer()
-					for b := s.Next(); b.Length() != 0; b = s.Next() {
+					for b := colexecop.NextNoMeta(s); b.Length() != 0; b = colexecop.NextNoMeta(s) {
 					}
 					b.StopTimer()
 				}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_tmpl.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_tmpl.go
@@ -1354,24 +1354,36 @@ func _SOURCE_FINISHED_SWITCH(_JOIN_TYPE joinTypeInfo) { // */}}
 
 // */}}
 
-func (o *mergeJoin_JOIN_TYPE_STRINGOp) Next() coldata.Batch {
-	o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
-	o.outputCapacity = o.output.Capacity()
-	o.bufferedGroup.helper.output = o.output
-	o.builderState.outCount = 0
+func (o *mergeJoin_JOIN_TYPE_STRINGOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	if !o.continueBatch {
+		o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
+		o.outputCapacity = o.output.Capacity()
+		o.bufferedGroup.helper.output = o.output
+		o.builderState.outCount = 0
+	}
+	o.continueBatch = false
 	for {
+		// We read from the inputs in multiple states, so checking whether any
+		// metadata was buffered between state transitions is good.
+		if meta := o.maybeEmitMeta(); meta != nil {
+			// If we've built some output tuples but haven't reached the output
+			// batch capacity, ensure that we continue building the output batch
+			// instead of resetting it.
+			o.continueBatch = true
+			return nil, meta
+		}
 		switch o.state {
 		case mjEntry:
 			// If this is the first batch or we're done with the current batch,
 			// get the next batch.
 			if o.proberState.lBatch == nil || (o.proberState.lLength != 0 && o.proberState.lIdx == o.proberState.lLength) {
 				o.cancelChecker.CheckEveryCall()
-				o.proberState.lIdx, o.proberState.lBatch = 0, o.InputOne.Next()
+				o.proberState.lIdx, o.proberState.lBatch = 0, o.inputOneNext()
 				o.proberState.lLength = o.proberState.lBatch.Length()
 			}
 			if o.proberState.rBatch == nil || (o.proberState.rLength != 0 && o.proberState.rIdx == o.proberState.rLength) {
 				o.cancelChecker.CheckEveryCall()
-				o.proberState.rIdx, o.proberState.rBatch = 0, o.InputTwo.Next()
+				o.proberState.rIdx, o.proberState.rBatch = 0, o.inputTwoNext()
 				o.proberState.rLength = o.proberState.rBatch.Length()
 			}
 			if o.sourceFinished() {
@@ -1385,7 +1397,7 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) Next() coldata.Batch {
 			if len(o.builderState.lGroups) == 0 && len(o.builderState.rGroups) == 0 {
 				o.state = mjDone
 				o.output.SetLength(o.builderState.outCount)
-				return o.output
+				return o.output, nil
 			}
 			o.state = mjBuildFromBatch
 
@@ -1404,7 +1416,7 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) Next() coldata.Batch {
 			o.buildFromBatch()
 			if o.builderState.outCount == o.outputCapacity {
 				o.output.SetLength(o.builderState.outCount)
-				return o.output
+				return o.output, nil
 			}
 			if o.bufferedGroup.helper.numRightTuples != 0 {
 				o.transitionIntoBuildingFromBufferedGroup()
@@ -1420,11 +1432,11 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) Next() coldata.Batch {
 			}
 			if o.builderState.outCount == o.outputCapacity {
 				o.output.SetLength(o.builderState.outCount)
-				return o.output
+				return o.output, nil
 			}
 
 		case mjDone:
-			return coldata.ZeroBatch
+			return coldata.ZeroBatch, nil
 
 		default:
 			colexecerror.InternalError(errors.AssertionFailedf("unexpected merge joiner state in Next: %v", o.state))

--- a/pkg/sql/colexec/colexecproj/BUILD.bazel
+++ b/pkg/sql/colexec/colexecproj/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/sql/colexecop",  # keep
         "//pkg/sql/colmem",  # keep
         "//pkg/sql/execinfra/execreleasable",  # keep
+        "//pkg/sql/execinfrapb",  # keep
         "//pkg/sql/sem/eval",  # keep
         "//pkg/sql/sem/tree",  # keep
         "//pkg/sql/sem/tree/treebin",  # keep

--- a/pkg/sql/colexec/colexecproj/default_cmp_proj_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecproj/default_cmp_proj_ops_tmpl.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra/execreleasable"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
@@ -44,11 +45,14 @@ type defaultCmp_KINDProjOp struct {
 var _ colexecop.Operator = &defaultCmp_KINDProjOp{}
 var _ execreleasable.Releasable = &defaultCmp_KINDProjOp{}
 
-func (d *defaultCmp_KINDProjOp) Next() coldata.Batch {
-	batch := d.Input.Next()
+func (d *defaultCmp_KINDProjOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := d.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	sel := batch.Selection()
 	output := batch.ColVec(d.outputIdx)
@@ -94,7 +98,7 @@ func (d *defaultCmp_KINDProjOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 func (d *defaultCmp_KINDProjOp) Release() {

--- a/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree/treebin"
@@ -59,11 +60,14 @@ type projBitandInt16Int16Op struct {
 	projOpBase
 }
 
-func (p projBitandInt16Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitandInt16Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -134,18 +138,21 @@ func (p projBitandInt16Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitandInt16Int32Op struct {
 	projOpBase
 }
 
-func (p projBitandInt16Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitandInt16Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -216,18 +223,21 @@ func (p projBitandInt16Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitandInt16Int64Op struct {
 	projOpBase
 }
 
-func (p projBitandInt16Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitandInt16Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -298,18 +308,21 @@ func (p projBitandInt16Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitandInt32Int16Op struct {
 	projOpBase
 }
 
-func (p projBitandInt32Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitandInt32Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -380,18 +393,21 @@ func (p projBitandInt32Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitandInt32Int32Op struct {
 	projOpBase
 }
 
-func (p projBitandInt32Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitandInt32Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -462,18 +478,21 @@ func (p projBitandInt32Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitandInt32Int64Op struct {
 	projOpBase
 }
 
-func (p projBitandInt32Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitandInt32Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -544,18 +563,21 @@ func (p projBitandInt32Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitandInt64Int16Op struct {
 	projOpBase
 }
 
-func (p projBitandInt64Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitandInt64Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -626,18 +648,21 @@ func (p projBitandInt64Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitandInt64Int32Op struct {
 	projOpBase
 }
 
-func (p projBitandInt64Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitandInt64Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -708,18 +733,21 @@ func (p projBitandInt64Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitandInt64Int64Op struct {
 	projOpBase
 }
 
-func (p projBitandInt64Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitandInt64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -790,7 +818,7 @@ func (p projBitandInt64Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitandDatumDatumOp struct {
@@ -798,13 +826,16 @@ type projBitandDatumDatumOp struct {
 	projOpBase
 }
 
-func (p projBitandDatumDatumOp) Next() coldata.Batch {
+func (p projBitandDatumDatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -913,18 +944,21 @@ func (p projBitandDatumDatumOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitorInt16Int16Op struct {
 	projOpBase
 }
 
-func (p projBitorInt16Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitorInt16Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -995,18 +1029,21 @@ func (p projBitorInt16Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitorInt16Int32Op struct {
 	projOpBase
 }
 
-func (p projBitorInt16Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitorInt16Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -1077,18 +1114,21 @@ func (p projBitorInt16Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitorInt16Int64Op struct {
 	projOpBase
 }
 
-func (p projBitorInt16Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitorInt16Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -1159,18 +1199,21 @@ func (p projBitorInt16Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitorInt32Int16Op struct {
 	projOpBase
 }
 
-func (p projBitorInt32Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitorInt32Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -1241,18 +1284,21 @@ func (p projBitorInt32Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitorInt32Int32Op struct {
 	projOpBase
 }
 
-func (p projBitorInt32Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitorInt32Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -1323,18 +1369,21 @@ func (p projBitorInt32Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitorInt32Int64Op struct {
 	projOpBase
 }
 
-func (p projBitorInt32Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitorInt32Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -1405,18 +1454,21 @@ func (p projBitorInt32Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitorInt64Int16Op struct {
 	projOpBase
 }
 
-func (p projBitorInt64Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitorInt64Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -1487,18 +1539,21 @@ func (p projBitorInt64Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitorInt64Int32Op struct {
 	projOpBase
 }
 
-func (p projBitorInt64Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitorInt64Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -1569,18 +1624,21 @@ func (p projBitorInt64Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitorInt64Int64Op struct {
 	projOpBase
 }
 
-func (p projBitorInt64Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitorInt64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -1651,7 +1709,7 @@ func (p projBitorInt64Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitorDatumDatumOp struct {
@@ -1659,13 +1717,16 @@ type projBitorDatumDatumOp struct {
 	projOpBase
 }
 
-func (p projBitorDatumDatumOp) Next() coldata.Batch {
+func (p projBitorDatumDatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -1774,18 +1835,21 @@ func (p projBitorDatumDatumOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitxorInt16Int16Op struct {
 	projOpBase
 }
 
-func (p projBitxorInt16Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitxorInt16Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -1856,18 +1920,21 @@ func (p projBitxorInt16Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitxorInt16Int32Op struct {
 	projOpBase
 }
 
-func (p projBitxorInt16Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitxorInt16Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -1938,18 +2005,21 @@ func (p projBitxorInt16Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitxorInt16Int64Op struct {
 	projOpBase
 }
 
-func (p projBitxorInt16Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitxorInt16Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -2020,18 +2090,21 @@ func (p projBitxorInt16Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitxorInt32Int16Op struct {
 	projOpBase
 }
 
-func (p projBitxorInt32Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitxorInt32Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -2102,18 +2175,21 @@ func (p projBitxorInt32Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitxorInt32Int32Op struct {
 	projOpBase
 }
 
-func (p projBitxorInt32Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitxorInt32Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -2184,18 +2260,21 @@ func (p projBitxorInt32Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitxorInt32Int64Op struct {
 	projOpBase
 }
 
-func (p projBitxorInt32Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitxorInt32Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -2266,18 +2345,21 @@ func (p projBitxorInt32Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitxorInt64Int16Op struct {
 	projOpBase
 }
 
-func (p projBitxorInt64Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitxorInt64Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -2348,18 +2430,21 @@ func (p projBitxorInt64Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitxorInt64Int32Op struct {
 	projOpBase
 }
 
-func (p projBitxorInt64Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitxorInt64Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -2430,18 +2515,21 @@ func (p projBitxorInt64Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitxorInt64Int64Op struct {
 	projOpBase
 }
 
-func (p projBitxorInt64Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitxorInt64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -2512,7 +2600,7 @@ func (p projBitxorInt64Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitxorDatumDatumOp struct {
@@ -2520,13 +2608,16 @@ type projBitxorDatumDatumOp struct {
 	projOpBase
 }
 
-func (p projBitxorDatumDatumOp) Next() coldata.Batch {
+func (p projBitxorDatumDatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -2635,18 +2726,21 @@ func (p projBitxorDatumDatumOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusDecimalInt16Op struct {
 	projOpBase
 }
 
-func (p projPlusDecimalInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusDecimalInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -2745,18 +2839,21 @@ func (p projPlusDecimalInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusDecimalInt32Op struct {
 	projOpBase
 }
 
-func (p projPlusDecimalInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusDecimalInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -2855,18 +2952,21 @@ func (p projPlusDecimalInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusDecimalInt64Op struct {
 	projOpBase
 }
 
-func (p projPlusDecimalInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusDecimalInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -2965,18 +3065,21 @@ func (p projPlusDecimalInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusDecimalDecimalOp struct {
 	projOpBase
 }
 
-func (p projPlusDecimalDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusDecimalDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -3075,18 +3178,21 @@ func (p projPlusDecimalDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt16Int16Op struct {
 	projOpBase
 }
 
-func (p projPlusInt16Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusInt16Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -3181,18 +3287,21 @@ func (p projPlusInt16Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt16Int32Op struct {
 	projOpBase
 }
 
-func (p projPlusInt16Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusInt16Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -3287,18 +3396,21 @@ func (p projPlusInt16Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt16Int64Op struct {
 	projOpBase
 }
 
-func (p projPlusInt16Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusInt16Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -3393,18 +3505,21 @@ func (p projPlusInt16Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt16DecimalOp struct {
 	projOpBase
 }
 
-func (p projPlusInt16DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusInt16DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -3511,7 +3626,7 @@ func (p projPlusInt16DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt16DatumOp struct {
@@ -3519,13 +3634,16 @@ type projPlusInt16DatumOp struct {
 	projOpBase
 }
 
-func (p projPlusInt16DatumOp) Next() coldata.Batch {
+func (p projPlusInt16DatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -3638,18 +3756,21 @@ func (p projPlusInt16DatumOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt32Int16Op struct {
 	projOpBase
 }
 
-func (p projPlusInt32Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusInt32Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -3744,18 +3865,21 @@ func (p projPlusInt32Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt32Int32Op struct {
 	projOpBase
 }
 
-func (p projPlusInt32Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusInt32Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -3850,18 +3974,21 @@ func (p projPlusInt32Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt32Int64Op struct {
 	projOpBase
 }
 
-func (p projPlusInt32Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusInt32Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -3956,18 +4083,21 @@ func (p projPlusInt32Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt32DecimalOp struct {
 	projOpBase
 }
 
-func (p projPlusInt32DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusInt32DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -4074,7 +4204,7 @@ func (p projPlusInt32DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt32DatumOp struct {
@@ -4082,13 +4212,16 @@ type projPlusInt32DatumOp struct {
 	projOpBase
 }
 
-func (p projPlusInt32DatumOp) Next() coldata.Batch {
+func (p projPlusInt32DatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -4201,18 +4334,21 @@ func (p projPlusInt32DatumOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt64Int16Op struct {
 	projOpBase
 }
 
-func (p projPlusInt64Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusInt64Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -4307,18 +4443,21 @@ func (p projPlusInt64Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt64Int32Op struct {
 	projOpBase
 }
 
-func (p projPlusInt64Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusInt64Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -4413,18 +4552,21 @@ func (p projPlusInt64Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt64Int64Op struct {
 	projOpBase
 }
 
-func (p projPlusInt64Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusInt64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -4519,18 +4661,21 @@ func (p projPlusInt64Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt64DecimalOp struct {
 	projOpBase
 }
 
-func (p projPlusInt64DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusInt64DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -4637,7 +4782,7 @@ func (p projPlusInt64DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt64DatumOp struct {
@@ -4645,13 +4790,16 @@ type projPlusInt64DatumOp struct {
 	projOpBase
 }
 
-func (p projPlusInt64DatumOp) Next() coldata.Batch {
+func (p projPlusInt64DatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -4764,18 +4912,21 @@ func (p projPlusInt64DatumOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusFloat64Float64Op struct {
 	projOpBase
 }
 
-func (p projPlusFloat64Float64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusFloat64Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -4858,18 +5009,21 @@ func (p projPlusFloat64Float64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusTimestampIntervalOp struct {
 	projOpBase
 }
 
-func (p projPlusTimestampIntervalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusTimestampIntervalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -4952,18 +5106,21 @@ func (p projPlusTimestampIntervalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusIntervalTimestampOp struct {
 	projOpBase
 }
 
-func (p projPlusIntervalTimestampOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusIntervalTimestampOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -5046,18 +5203,21 @@ func (p projPlusIntervalTimestampOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusIntervalIntervalOp struct {
 	projOpBase
 }
 
-func (p projPlusIntervalIntervalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusIntervalIntervalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -5120,7 +5280,7 @@ func (p projPlusIntervalIntervalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusIntervalDatumOp struct {
@@ -5128,13 +5288,16 @@ type projPlusIntervalDatumOp struct {
 	projOpBase
 }
 
-func (p projPlusIntervalDatumOp) Next() coldata.Batch {
+func (p projPlusIntervalDatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -5247,7 +5410,7 @@ func (p projPlusIntervalDatumOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusDatumIntervalOp struct {
@@ -5255,13 +5418,16 @@ type projPlusDatumIntervalOp struct {
 	projOpBase
 }
 
-func (p projPlusDatumIntervalOp) Next() coldata.Batch {
+func (p projPlusDatumIntervalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -5374,7 +5540,7 @@ func (p projPlusDatumIntervalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusDatumInt16Op struct {
@@ -5382,13 +5548,16 @@ type projPlusDatumInt16Op struct {
 	projOpBase
 }
 
-func (p projPlusDatumInt16Op) Next() coldata.Batch {
+func (p projPlusDatumInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -5501,7 +5670,7 @@ func (p projPlusDatumInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusDatumInt32Op struct {
@@ -5509,13 +5678,16 @@ type projPlusDatumInt32Op struct {
 	projOpBase
 }
 
-func (p projPlusDatumInt32Op) Next() coldata.Batch {
+func (p projPlusDatumInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -5628,7 +5800,7 @@ func (p projPlusDatumInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusDatumInt64Op struct {
@@ -5636,13 +5808,16 @@ type projPlusDatumInt64Op struct {
 	projOpBase
 }
 
-func (p projPlusDatumInt64Op) Next() coldata.Batch {
+func (p projPlusDatumInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -5755,18 +5930,21 @@ func (p projPlusDatumInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusDecimalInt16Op struct {
 	projOpBase
 }
 
-func (p projMinusDecimalInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusDecimalInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -5865,18 +6043,21 @@ func (p projMinusDecimalInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusDecimalInt32Op struct {
 	projOpBase
 }
 
-func (p projMinusDecimalInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusDecimalInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -5975,18 +6156,21 @@ func (p projMinusDecimalInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusDecimalInt64Op struct {
 	projOpBase
 }
 
-func (p projMinusDecimalInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusDecimalInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -6085,18 +6269,21 @@ func (p projMinusDecimalInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusDecimalDecimalOp struct {
 	projOpBase
 }
 
-func (p projMinusDecimalDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusDecimalDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -6195,18 +6382,21 @@ func (p projMinusDecimalDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt16Int16Op struct {
 	projOpBase
 }
 
-func (p projMinusInt16Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusInt16Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -6301,18 +6491,21 @@ func (p projMinusInt16Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt16Int32Op struct {
 	projOpBase
 }
 
-func (p projMinusInt16Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusInt16Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -6407,18 +6600,21 @@ func (p projMinusInt16Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt16Int64Op struct {
 	projOpBase
 }
 
-func (p projMinusInt16Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusInt16Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -6513,18 +6709,21 @@ func (p projMinusInt16Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt16DecimalOp struct {
 	projOpBase
 }
 
-func (p projMinusInt16DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusInt16DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -6631,7 +6830,7 @@ func (p projMinusInt16DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt16DatumOp struct {
@@ -6639,13 +6838,16 @@ type projMinusInt16DatumOp struct {
 	projOpBase
 }
 
-func (p projMinusInt16DatumOp) Next() coldata.Batch {
+func (p projMinusInt16DatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -6758,18 +6960,21 @@ func (p projMinusInt16DatumOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt32Int16Op struct {
 	projOpBase
 }
 
-func (p projMinusInt32Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusInt32Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -6864,18 +7069,21 @@ func (p projMinusInt32Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt32Int32Op struct {
 	projOpBase
 }
 
-func (p projMinusInt32Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusInt32Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -6970,18 +7178,21 @@ func (p projMinusInt32Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt32Int64Op struct {
 	projOpBase
 }
 
-func (p projMinusInt32Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusInt32Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -7076,18 +7287,21 @@ func (p projMinusInt32Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt32DecimalOp struct {
 	projOpBase
 }
 
-func (p projMinusInt32DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusInt32DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -7194,7 +7408,7 @@ func (p projMinusInt32DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt32DatumOp struct {
@@ -7202,13 +7416,16 @@ type projMinusInt32DatumOp struct {
 	projOpBase
 }
 
-func (p projMinusInt32DatumOp) Next() coldata.Batch {
+func (p projMinusInt32DatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -7321,18 +7538,21 @@ func (p projMinusInt32DatumOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt64Int16Op struct {
 	projOpBase
 }
 
-func (p projMinusInt64Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusInt64Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -7427,18 +7647,21 @@ func (p projMinusInt64Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt64Int32Op struct {
 	projOpBase
 }
 
-func (p projMinusInt64Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusInt64Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -7533,18 +7756,21 @@ func (p projMinusInt64Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt64Int64Op struct {
 	projOpBase
 }
 
-func (p projMinusInt64Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusInt64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -7639,18 +7865,21 @@ func (p projMinusInt64Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt64DecimalOp struct {
 	projOpBase
 }
 
-func (p projMinusInt64DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusInt64DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -7757,7 +7986,7 @@ func (p projMinusInt64DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt64DatumOp struct {
@@ -7765,13 +7994,16 @@ type projMinusInt64DatumOp struct {
 	projOpBase
 }
 
-func (p projMinusInt64DatumOp) Next() coldata.Batch {
+func (p projMinusInt64DatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -7884,18 +8116,21 @@ func (p projMinusInt64DatumOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusFloat64Float64Op struct {
 	projOpBase
 }
 
-func (p projMinusFloat64Float64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusFloat64Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -7978,18 +8213,21 @@ func (p projMinusFloat64Float64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusTimestampTimestampOp struct {
 	projOpBase
 }
 
-func (p projMinusTimestampTimestampOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusTimestampTimestampOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -8064,18 +8302,21 @@ func (p projMinusTimestampTimestampOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusTimestampIntervalOp struct {
 	projOpBase
 }
 
-func (p projMinusTimestampIntervalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusTimestampIntervalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -8158,18 +8399,21 @@ func (p projMinusTimestampIntervalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusIntervalIntervalOp struct {
 	projOpBase
 }
 
-func (p projMinusIntervalIntervalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusIntervalIntervalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -8232,7 +8476,7 @@ func (p projMinusIntervalIntervalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusIntervalDatumOp struct {
@@ -8240,13 +8484,16 @@ type projMinusIntervalDatumOp struct {
 	projOpBase
 }
 
-func (p projMinusIntervalDatumOp) Next() coldata.Batch {
+func (p projMinusIntervalDatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -8359,18 +8606,21 @@ func (p projMinusIntervalDatumOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusJSONBytesOp struct {
 	projOpBase
 }
 
-func (p projMinusJSONBytesOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusJSONBytesOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -8465,18 +8715,21 @@ func (p projMinusJSONBytesOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusJSONInt16Op struct {
 	projOpBase
 }
 
-func (p projMinusJSONInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusJSONInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -8557,18 +8810,21 @@ func (p projMinusJSONInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusJSONInt32Op struct {
 	projOpBase
 }
 
-func (p projMinusJSONInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusJSONInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -8649,18 +8905,21 @@ func (p projMinusJSONInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusJSONInt64Op struct {
 	projOpBase
 }
 
-func (p projMinusJSONInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusJSONInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -8741,7 +9000,7 @@ func (p projMinusJSONInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusDatumDatumOp struct {
@@ -8749,13 +9008,16 @@ type projMinusDatumDatumOp struct {
 	projOpBase
 }
 
-func (p projMinusDatumDatumOp) Next() coldata.Batch {
+func (p projMinusDatumDatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -8864,7 +9126,7 @@ func (p projMinusDatumDatumOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusDatumIntervalOp struct {
@@ -8872,13 +9134,16 @@ type projMinusDatumIntervalOp struct {
 	projOpBase
 }
 
-func (p projMinusDatumIntervalOp) Next() coldata.Batch {
+func (p projMinusDatumIntervalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -8991,7 +9256,7 @@ func (p projMinusDatumIntervalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusDatumBytesOp struct {
@@ -8999,13 +9264,16 @@ type projMinusDatumBytesOp struct {
 	projOpBase
 }
 
-func (p projMinusDatumBytesOp) Next() coldata.Batch {
+func (p projMinusDatumBytesOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -9116,7 +9384,7 @@ func (p projMinusDatumBytesOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusDatumInt16Op struct {
@@ -9124,13 +9392,16 @@ type projMinusDatumInt16Op struct {
 	projOpBase
 }
 
-func (p projMinusDatumInt16Op) Next() coldata.Batch {
+func (p projMinusDatumInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -9243,7 +9514,7 @@ func (p projMinusDatumInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusDatumInt32Op struct {
@@ -9251,13 +9522,16 @@ type projMinusDatumInt32Op struct {
 	projOpBase
 }
 
-func (p projMinusDatumInt32Op) Next() coldata.Batch {
+func (p projMinusDatumInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -9370,7 +9644,7 @@ func (p projMinusDatumInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusDatumInt64Op struct {
@@ -9378,13 +9652,16 @@ type projMinusDatumInt64Op struct {
 	projOpBase
 }
 
-func (p projMinusDatumInt64Op) Next() coldata.Batch {
+func (p projMinusDatumInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -9497,18 +9774,21 @@ func (p projMinusDatumInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultDecimalInt16Op struct {
 	projOpBase
 }
 
-func (p projMultDecimalInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultDecimalInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -9607,18 +9887,21 @@ func (p projMultDecimalInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultDecimalInt32Op struct {
 	projOpBase
 }
 
-func (p projMultDecimalInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultDecimalInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -9717,18 +10000,21 @@ func (p projMultDecimalInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultDecimalInt64Op struct {
 	projOpBase
 }
 
-func (p projMultDecimalInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultDecimalInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -9827,18 +10113,21 @@ func (p projMultDecimalInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultDecimalDecimalOp struct {
 	projOpBase
 }
 
-func (p projMultDecimalDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultDecimalDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -9937,18 +10226,21 @@ func (p projMultDecimalDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultDecimalIntervalOp struct {
 	projOpBase
 }
 
-func (p projMultDecimalIntervalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultDecimalIntervalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -10031,18 +10323,21 @@ func (p projMultDecimalIntervalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt16Int16Op struct {
 	projOpBase
 }
 
-func (p projMultInt16Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt16Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -10169,18 +10464,21 @@ func (p projMultInt16Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt16Int32Op struct {
 	projOpBase
 }
 
-func (p projMultInt16Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt16Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -10307,18 +10605,21 @@ func (p projMultInt16Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt16Int64Op struct {
 	projOpBase
 }
 
-func (p projMultInt16Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt16Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -10445,18 +10746,21 @@ func (p projMultInt16Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt16DecimalOp struct {
 	projOpBase
 }
 
-func (p projMultInt16DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt16DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -10563,18 +10867,21 @@ func (p projMultInt16DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt16IntervalOp struct {
 	projOpBase
 }
 
-func (p projMultInt16IntervalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt16IntervalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -10637,18 +10944,21 @@ func (p projMultInt16IntervalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt32Int16Op struct {
 	projOpBase
 }
 
-func (p projMultInt32Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt32Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -10775,18 +11085,21 @@ func (p projMultInt32Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt32Int32Op struct {
 	projOpBase
 }
 
-func (p projMultInt32Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt32Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -10913,18 +11226,21 @@ func (p projMultInt32Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt32Int64Op struct {
 	projOpBase
 }
 
-func (p projMultInt32Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt32Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -11051,18 +11367,21 @@ func (p projMultInt32Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt32DecimalOp struct {
 	projOpBase
 }
 
-func (p projMultInt32DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt32DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -11169,18 +11488,21 @@ func (p projMultInt32DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt32IntervalOp struct {
 	projOpBase
 }
 
-func (p projMultInt32IntervalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt32IntervalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -11243,18 +11565,21 @@ func (p projMultInt32IntervalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt64Int16Op struct {
 	projOpBase
 }
 
-func (p projMultInt64Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt64Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -11381,18 +11706,21 @@ func (p projMultInt64Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt64Int32Op struct {
 	projOpBase
 }
 
-func (p projMultInt64Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt64Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -11519,18 +11847,21 @@ func (p projMultInt64Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt64Int64Op struct {
 	projOpBase
 }
 
-func (p projMultInt64Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -11657,18 +11988,21 @@ func (p projMultInt64Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt64DecimalOp struct {
 	projOpBase
 }
 
-func (p projMultInt64DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt64DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -11775,18 +12109,21 @@ func (p projMultInt64DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt64IntervalOp struct {
 	projOpBase
 }
 
-func (p projMultInt64IntervalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt64IntervalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -11849,18 +12186,21 @@ func (p projMultInt64IntervalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultFloat64Float64Op struct {
 	projOpBase
 }
 
-func (p projMultFloat64Float64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultFloat64Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -11943,18 +12283,21 @@ func (p projMultFloat64Float64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultFloat64IntervalOp struct {
 	projOpBase
 }
 
-func (p projMultFloat64IntervalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultFloat64IntervalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -12017,18 +12360,21 @@ func (p projMultFloat64IntervalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultIntervalInt16Op struct {
 	projOpBase
 }
 
-func (p projMultIntervalInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultIntervalInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -12091,18 +12437,21 @@ func (p projMultIntervalInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultIntervalInt32Op struct {
 	projOpBase
 }
 
-func (p projMultIntervalInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultIntervalInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -12165,18 +12514,21 @@ func (p projMultIntervalInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultIntervalInt64Op struct {
 	projOpBase
 }
 
-func (p projMultIntervalInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultIntervalInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -12239,18 +12591,21 @@ func (p projMultIntervalInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultIntervalFloat64Op struct {
 	projOpBase
 }
 
-func (p projMultIntervalFloat64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultIntervalFloat64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -12313,18 +12668,21 @@ func (p projMultIntervalFloat64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultIntervalDecimalOp struct {
 	projOpBase
 }
 
-func (p projMultIntervalDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultIntervalDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -12407,18 +12765,21 @@ func (p projMultIntervalDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivDecimalInt16Op struct {
 	projOpBase
 }
 
-func (p projDivDecimalInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivDecimalInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -12533,18 +12894,21 @@ func (p projDivDecimalInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivDecimalInt32Op struct {
 	projOpBase
 }
 
-func (p projDivDecimalInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivDecimalInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -12659,18 +13023,21 @@ func (p projDivDecimalInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivDecimalInt64Op struct {
 	projOpBase
 }
 
-func (p projDivDecimalInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivDecimalInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -12785,18 +13152,21 @@ func (p projDivDecimalInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivDecimalDecimalOp struct {
 	projOpBase
 }
 
-func (p projDivDecimalDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivDecimalDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -12927,18 +13297,21 @@ func (p projDivDecimalDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivInt16Int16Op struct {
 	projOpBase
 }
 
-func (p projDivInt16Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivInt16Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -13049,18 +13422,21 @@ func (p projDivInt16Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivInt16Int32Op struct {
 	projOpBase
 }
 
-func (p projDivInt16Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivInt16Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -13171,18 +13547,21 @@ func (p projDivInt16Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivInt16Int64Op struct {
 	projOpBase
 }
 
-func (p projDivInt16Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivInt16Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -13293,18 +13672,21 @@ func (p projDivInt16Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivInt16DecimalOp struct {
 	projOpBase
 }
 
-func (p projDivInt16DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivInt16DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -13443,18 +13825,21 @@ func (p projDivInt16DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivInt32Int16Op struct {
 	projOpBase
 }
 
-func (p projDivInt32Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivInt32Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -13565,18 +13950,21 @@ func (p projDivInt32Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivInt32Int32Op struct {
 	projOpBase
 }
 
-func (p projDivInt32Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivInt32Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -13687,18 +14075,21 @@ func (p projDivInt32Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivInt32Int64Op struct {
 	projOpBase
 }
 
-func (p projDivInt32Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivInt32Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -13809,18 +14200,21 @@ func (p projDivInt32Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivInt32DecimalOp struct {
 	projOpBase
 }
 
-func (p projDivInt32DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivInt32DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -13959,18 +14353,21 @@ func (p projDivInt32DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivInt64Int16Op struct {
 	projOpBase
 }
 
-func (p projDivInt64Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivInt64Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -14081,18 +14478,21 @@ func (p projDivInt64Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivInt64Int32Op struct {
 	projOpBase
 }
 
-func (p projDivInt64Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivInt64Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -14203,18 +14603,21 @@ func (p projDivInt64Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivInt64Int64Op struct {
 	projOpBase
 }
 
-func (p projDivInt64Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivInt64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -14325,18 +14728,21 @@ func (p projDivInt64Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivInt64DecimalOp struct {
 	projOpBase
 }
 
-func (p projDivInt64DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivInt64DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -14475,18 +14881,21 @@ func (p projDivInt64DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivFloat64Float64Op struct {
 	projOpBase
 }
 
-func (p projDivFloat64Float64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivFloat64Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -14585,18 +14994,21 @@ func (p projDivFloat64Float64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivIntervalInt16Op struct {
 	projOpBase
 }
 
-func (p projDivIntervalInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivIntervalInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -14675,18 +15087,21 @@ func (p projDivIntervalInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivIntervalInt32Op struct {
 	projOpBase
 }
 
-func (p projDivIntervalInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivIntervalInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -14765,18 +15180,21 @@ func (p projDivIntervalInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivIntervalInt64Op struct {
 	projOpBase
 }
 
-func (p projDivIntervalInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivIntervalInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -14855,18 +15273,21 @@ func (p projDivIntervalInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivIntervalFloat64Op struct {
 	projOpBase
 }
 
-func (p projDivIntervalFloat64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivIntervalFloat64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -14945,18 +15366,21 @@ func (p projDivIntervalFloat64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivDecimalInt16Op struct {
 	projOpBase
 }
 
-func (p projFloorDivDecimalInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivDecimalInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -15071,18 +15495,21 @@ func (p projFloorDivDecimalInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivDecimalInt32Op struct {
 	projOpBase
 }
 
-func (p projFloorDivDecimalInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivDecimalInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -15197,18 +15624,21 @@ func (p projFloorDivDecimalInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivDecimalInt64Op struct {
 	projOpBase
 }
 
-func (p projFloorDivDecimalInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivDecimalInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -15323,18 +15753,21 @@ func (p projFloorDivDecimalInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivDecimalDecimalOp struct {
 	projOpBase
 }
 
-func (p projFloorDivDecimalDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivDecimalDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -15465,18 +15898,21 @@ func (p projFloorDivDecimalDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivInt16Int16Op struct {
 	projOpBase
 }
 
-func (p projFloorDivInt16Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivInt16Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -15567,18 +16003,21 @@ func (p projFloorDivInt16Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivInt16Int32Op struct {
 	projOpBase
 }
 
-func (p projFloorDivInt16Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivInt16Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -15669,18 +16108,21 @@ func (p projFloorDivInt16Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivInt16Int64Op struct {
 	projOpBase
 }
 
-func (p projFloorDivInt16Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivInt16Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -15771,18 +16213,21 @@ func (p projFloorDivInt16Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivInt16DecimalOp struct {
 	projOpBase
 }
 
-func (p projFloorDivInt16DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivInt16DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -15921,18 +16366,21 @@ func (p projFloorDivInt16DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivInt32Int16Op struct {
 	projOpBase
 }
 
-func (p projFloorDivInt32Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivInt32Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -16023,18 +16471,21 @@ func (p projFloorDivInt32Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivInt32Int32Op struct {
 	projOpBase
 }
 
-func (p projFloorDivInt32Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivInt32Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -16125,18 +16576,21 @@ func (p projFloorDivInt32Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivInt32Int64Op struct {
 	projOpBase
 }
 
-func (p projFloorDivInt32Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivInt32Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -16227,18 +16681,21 @@ func (p projFloorDivInt32Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivInt32DecimalOp struct {
 	projOpBase
 }
 
-func (p projFloorDivInt32DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivInt32DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -16377,18 +16834,21 @@ func (p projFloorDivInt32DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivInt64Int16Op struct {
 	projOpBase
 }
 
-func (p projFloorDivInt64Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivInt64Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -16479,18 +16939,21 @@ func (p projFloorDivInt64Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivInt64Int32Op struct {
 	projOpBase
 }
 
-func (p projFloorDivInt64Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivInt64Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -16581,18 +17044,21 @@ func (p projFloorDivInt64Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivInt64Int64Op struct {
 	projOpBase
 }
 
-func (p projFloorDivInt64Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivInt64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -16683,18 +17149,21 @@ func (p projFloorDivInt64Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivInt64DecimalOp struct {
 	projOpBase
 }
 
-func (p projFloorDivInt64DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivInt64DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -16833,18 +17302,21 @@ func (p projFloorDivInt64DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivFloat64Float64Op struct {
 	projOpBase
 }
 
-func (p projFloorDivFloat64Float64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivFloat64Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -16943,18 +17415,21 @@ func (p projFloorDivFloat64Float64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModDecimalInt16Op struct {
 	projOpBase
 }
 
-func (p projModDecimalInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModDecimalInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -17069,18 +17544,21 @@ func (p projModDecimalInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModDecimalInt32Op struct {
 	projOpBase
 }
 
-func (p projModDecimalInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModDecimalInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -17195,18 +17673,21 @@ func (p projModDecimalInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModDecimalInt64Op struct {
 	projOpBase
 }
 
-func (p projModDecimalInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModDecimalInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -17321,18 +17802,21 @@ func (p projModDecimalInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModDecimalDecimalOp struct {
 	projOpBase
 }
 
-func (p projModDecimalDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModDecimalDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -17447,18 +17931,21 @@ func (p projModDecimalDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModInt16Int16Op struct {
 	projOpBase
 }
 
-func (p projModInt16Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModInt16Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -17549,18 +18036,21 @@ func (p projModInt16Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModInt16Int32Op struct {
 	projOpBase
 }
 
-func (p projModInt16Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModInt16Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -17651,18 +18141,21 @@ func (p projModInt16Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModInt16Int64Op struct {
 	projOpBase
 }
 
-func (p projModInt16Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModInt16Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -17753,18 +18246,21 @@ func (p projModInt16Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModInt16DecimalOp struct {
 	projOpBase
 }
 
-func (p projModInt16DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModInt16DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -17887,18 +18383,21 @@ func (p projModInt16DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModInt32Int16Op struct {
 	projOpBase
 }
 
-func (p projModInt32Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModInt32Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -17989,18 +18488,21 @@ func (p projModInt32Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModInt32Int32Op struct {
 	projOpBase
 }
 
-func (p projModInt32Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModInt32Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -18091,18 +18593,21 @@ func (p projModInt32Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModInt32Int64Op struct {
 	projOpBase
 }
 
-func (p projModInt32Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModInt32Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -18193,18 +18698,21 @@ func (p projModInt32Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModInt32DecimalOp struct {
 	projOpBase
 }
 
-func (p projModInt32DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModInt32DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -18327,18 +18835,21 @@ func (p projModInt32DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModInt64Int16Op struct {
 	projOpBase
 }
 
-func (p projModInt64Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModInt64Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -18429,18 +18940,21 @@ func (p projModInt64Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModInt64Int32Op struct {
 	projOpBase
 }
 
-func (p projModInt64Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModInt64Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -18531,18 +19045,21 @@ func (p projModInt64Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModInt64Int64Op struct {
 	projOpBase
 }
 
-func (p projModInt64Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModInt64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -18633,18 +19150,21 @@ func (p projModInt64Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModInt64DecimalOp struct {
 	projOpBase
 }
 
-func (p projModInt64DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModInt64DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -18767,18 +19287,21 @@ func (p projModInt64DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModFloat64Float64Op struct {
 	projOpBase
 }
 
-func (p projModFloat64Float64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModFloat64Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -18877,18 +19400,21 @@ func (p projModFloat64Float64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowDecimalInt16Op struct {
 	projOpBase
 }
 
-func (p projPowDecimalInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowDecimalInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -18987,18 +19513,21 @@ func (p projPowDecimalInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowDecimalInt32Op struct {
 	projOpBase
 }
 
-func (p projPowDecimalInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowDecimalInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -19097,18 +19626,21 @@ func (p projPowDecimalInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowDecimalInt64Op struct {
 	projOpBase
 }
 
-func (p projPowDecimalInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowDecimalInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -19207,18 +19739,21 @@ func (p projPowDecimalInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowDecimalDecimalOp struct {
 	projOpBase
 }
 
-func (p projPowDecimalDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowDecimalDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -19317,18 +19852,21 @@ func (p projPowDecimalDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowInt16Int16Op struct {
 	projOpBase
 }
 
-func (p projPowInt16Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowInt16Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -19447,18 +19985,21 @@ func (p projPowInt16Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowInt16Int32Op struct {
 	projOpBase
 }
 
-func (p projPowInt16Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowInt16Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -19577,18 +20118,21 @@ func (p projPowInt16Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowInt16Int64Op struct {
 	projOpBase
 }
 
-func (p projPowInt16Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowInt16Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -19707,18 +20251,21 @@ func (p projPowInt16Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowInt16DecimalOp struct {
 	projOpBase
 }
 
-func (p projPowInt16DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowInt16DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -19825,18 +20372,21 @@ func (p projPowInt16DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowInt32Int16Op struct {
 	projOpBase
 }
 
-func (p projPowInt32Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowInt32Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -19955,18 +20505,21 @@ func (p projPowInt32Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowInt32Int32Op struct {
 	projOpBase
 }
 
-func (p projPowInt32Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowInt32Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -20085,18 +20638,21 @@ func (p projPowInt32Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowInt32Int64Op struct {
 	projOpBase
 }
 
-func (p projPowInt32Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowInt32Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -20215,18 +20771,21 @@ func (p projPowInt32Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowInt32DecimalOp struct {
 	projOpBase
 }
 
-func (p projPowInt32DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowInt32DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -20333,18 +20892,21 @@ func (p projPowInt32DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowInt64Int16Op struct {
 	projOpBase
 }
 
-func (p projPowInt64Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowInt64Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -20463,18 +21025,21 @@ func (p projPowInt64Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowInt64Int32Op struct {
 	projOpBase
 }
 
-func (p projPowInt64Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowInt64Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -20593,18 +21158,21 @@ func (p projPowInt64Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowInt64Int64Op struct {
 	projOpBase
 }
 
-func (p projPowInt64Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowInt64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -20723,18 +21291,21 @@ func (p projPowInt64Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowInt64DecimalOp struct {
 	projOpBase
 }
 
-func (p projPowInt64DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowInt64DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -20841,18 +21412,21 @@ func (p projPowInt64DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowFloat64Float64Op struct {
 	projOpBase
 }
 
-func (p projPowFloat64Float64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowFloat64Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -20935,18 +21509,21 @@ func (p projPowFloat64Float64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projConcatBytesBytesOp struct {
 	projOpBase
 }
 
-func (p projConcatBytesBytesOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projConcatBytesBytesOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -21033,18 +21610,21 @@ func (p projConcatBytesBytesOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projConcatJSONJSONOp struct {
 	projOpBase
 }
 
-func (p projConcatJSONJSONOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projConcatJSONJSONOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -21127,7 +21707,7 @@ func (p projConcatJSONJSONOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projConcatDatumDatumOp struct {
@@ -21135,13 +21715,16 @@ type projConcatDatumDatumOp struct {
 	projOpBase
 }
 
-func (p projConcatDatumDatumOp) Next() coldata.Batch {
+func (p projConcatDatumDatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -21250,18 +21833,21 @@ func (p projConcatDatumDatumOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLShiftInt16Int16Op struct {
 	projOpBase
 }
 
-func (p projLShiftInt16Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLShiftInt16Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -21356,18 +21942,21 @@ func (p projLShiftInt16Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLShiftInt16Int32Op struct {
 	projOpBase
 }
 
-func (p projLShiftInt16Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLShiftInt16Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -21462,18 +22051,21 @@ func (p projLShiftInt16Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLShiftInt16Int64Op struct {
 	projOpBase
 }
 
-func (p projLShiftInt16Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLShiftInt16Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -21568,18 +22160,21 @@ func (p projLShiftInt16Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLShiftInt32Int16Op struct {
 	projOpBase
 }
 
-func (p projLShiftInt32Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLShiftInt32Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -21674,18 +22269,21 @@ func (p projLShiftInt32Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLShiftInt32Int32Op struct {
 	projOpBase
 }
 
-func (p projLShiftInt32Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLShiftInt32Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -21780,18 +22378,21 @@ func (p projLShiftInt32Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLShiftInt32Int64Op struct {
 	projOpBase
 }
 
-func (p projLShiftInt32Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLShiftInt32Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -21886,18 +22487,21 @@ func (p projLShiftInt32Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLShiftInt64Int16Op struct {
 	projOpBase
 }
 
-func (p projLShiftInt64Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLShiftInt64Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -21992,18 +22596,21 @@ func (p projLShiftInt64Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLShiftInt64Int32Op struct {
 	projOpBase
 }
 
-func (p projLShiftInt64Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLShiftInt64Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -22098,18 +22705,21 @@ func (p projLShiftInt64Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLShiftInt64Int64Op struct {
 	projOpBase
 }
 
-func (p projLShiftInt64Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLShiftInt64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -22204,7 +22814,7 @@ func (p projLShiftInt64Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLShiftDatumInt16Op struct {
@@ -22212,13 +22822,16 @@ type projLShiftDatumInt16Op struct {
 	projOpBase
 }
 
-func (p projLShiftDatumInt16Op) Next() coldata.Batch {
+func (p projLShiftDatumInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -22331,7 +22944,7 @@ func (p projLShiftDatumInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLShiftDatumInt32Op struct {
@@ -22339,13 +22952,16 @@ type projLShiftDatumInt32Op struct {
 	projOpBase
 }
 
-func (p projLShiftDatumInt32Op) Next() coldata.Batch {
+func (p projLShiftDatumInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -22458,7 +23074,7 @@ func (p projLShiftDatumInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLShiftDatumInt64Op struct {
@@ -22466,13 +23082,16 @@ type projLShiftDatumInt64Op struct {
 	projOpBase
 }
 
-func (p projLShiftDatumInt64Op) Next() coldata.Batch {
+func (p projLShiftDatumInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -22585,18 +23204,21 @@ func (p projLShiftDatumInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projRShiftInt16Int16Op struct {
 	projOpBase
 }
 
-func (p projRShiftInt16Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projRShiftInt16Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -22691,18 +23313,21 @@ func (p projRShiftInt16Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projRShiftInt16Int32Op struct {
 	projOpBase
 }
 
-func (p projRShiftInt16Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projRShiftInt16Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -22797,18 +23422,21 @@ func (p projRShiftInt16Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projRShiftInt16Int64Op struct {
 	projOpBase
 }
 
-func (p projRShiftInt16Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projRShiftInt16Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -22903,18 +23531,21 @@ func (p projRShiftInt16Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projRShiftInt32Int16Op struct {
 	projOpBase
 }
 
-func (p projRShiftInt32Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projRShiftInt32Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -23009,18 +23640,21 @@ func (p projRShiftInt32Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projRShiftInt32Int32Op struct {
 	projOpBase
 }
 
-func (p projRShiftInt32Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projRShiftInt32Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -23115,18 +23749,21 @@ func (p projRShiftInt32Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projRShiftInt32Int64Op struct {
 	projOpBase
 }
 
-func (p projRShiftInt32Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projRShiftInt32Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -23221,18 +23858,21 @@ func (p projRShiftInt32Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projRShiftInt64Int16Op struct {
 	projOpBase
 }
 
-func (p projRShiftInt64Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projRShiftInt64Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -23327,18 +23967,21 @@ func (p projRShiftInt64Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projRShiftInt64Int32Op struct {
 	projOpBase
 }
 
-func (p projRShiftInt64Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projRShiftInt64Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -23433,18 +24076,21 @@ func (p projRShiftInt64Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projRShiftInt64Int64Op struct {
 	projOpBase
 }
 
-func (p projRShiftInt64Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projRShiftInt64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -23539,7 +24185,7 @@ func (p projRShiftInt64Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projRShiftDatumInt16Op struct {
@@ -23547,13 +24193,16 @@ type projRShiftDatumInt16Op struct {
 	projOpBase
 }
 
-func (p projRShiftDatumInt16Op) Next() coldata.Batch {
+func (p projRShiftDatumInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -23666,7 +24315,7 @@ func (p projRShiftDatumInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projRShiftDatumInt32Op struct {
@@ -23674,13 +24323,16 @@ type projRShiftDatumInt32Op struct {
 	projOpBase
 }
 
-func (p projRShiftDatumInt32Op) Next() coldata.Batch {
+func (p projRShiftDatumInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -23793,7 +24445,7 @@ func (p projRShiftDatumInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projRShiftDatumInt64Op struct {
@@ -23801,13 +24453,16 @@ type projRShiftDatumInt64Op struct {
 	projOpBase
 }
 
-func (p projRShiftDatumInt64Op) Next() coldata.Batch {
+func (p projRShiftDatumInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -23920,18 +24575,21 @@ func (p projRShiftDatumInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projJSONFetchValJSONBytesOp struct {
 	projOpBase
 }
 
-func (p projJSONFetchValJSONBytesOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projJSONFetchValJSONBytesOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -24038,18 +24696,21 @@ func (p projJSONFetchValJSONBytesOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projJSONFetchValJSONInt16Op struct {
 	projOpBase
 }
 
-func (p projJSONFetchValJSONInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projJSONFetchValJSONInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -24146,18 +24807,21 @@ func (p projJSONFetchValJSONInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projJSONFetchValJSONInt32Op struct {
 	projOpBase
 }
 
-func (p projJSONFetchValJSONInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projJSONFetchValJSONInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -24254,18 +24918,21 @@ func (p projJSONFetchValJSONInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projJSONFetchValJSONInt64Op struct {
 	projOpBase
 }
 
-func (p projJSONFetchValJSONInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projJSONFetchValJSONInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -24362,18 +25029,21 @@ func (p projJSONFetchValJSONInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projJSONFetchTextJSONBytesOp struct {
 	projOpBase
 }
 
-func (p projJSONFetchTextJSONBytesOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projJSONFetchTextJSONBytesOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -24516,18 +25186,21 @@ func (p projJSONFetchTextJSONBytesOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projJSONFetchTextJSONInt16Op struct {
 	projOpBase
 }
 
-func (p projJSONFetchTextJSONInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projJSONFetchTextJSONInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -24660,18 +25333,21 @@ func (p projJSONFetchTextJSONInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projJSONFetchTextJSONInt32Op struct {
 	projOpBase
 }
 
-func (p projJSONFetchTextJSONInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projJSONFetchTextJSONInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -24804,18 +25480,21 @@ func (p projJSONFetchTextJSONInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projJSONFetchTextJSONInt64Op struct {
 	projOpBase
 }
 
-func (p projJSONFetchTextJSONInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projJSONFetchTextJSONInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -24948,18 +25627,21 @@ func (p projJSONFetchTextJSONInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projJSONFetchValPathJSONDatumOp struct {
 	projOpBase
 }
 
-func (p projJSONFetchValPathJSONDatumOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projJSONFetchValPathJSONDatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -25054,18 +25736,21 @@ func (p projJSONFetchValPathJSONDatumOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projJSONFetchTextPathJSONDatumOp struct {
 	projOpBase
 }
 
-func (p projJSONFetchTextPathJSONDatumOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projJSONFetchTextPathJSONDatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -25200,18 +25885,21 @@ func (p projJSONFetchTextPathJSONDatumOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQBoolBoolOp struct {
 	projOpBase
 }
 
-func (p projEQBoolBoolOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQBoolBoolOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -25330,18 +26018,21 @@ func (p projEQBoolBoolOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQBytesBytesOp struct {
 	projOpBase
 }
 
-func (p projEQBytesBytesOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQBytesBytesOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -25424,18 +26115,21 @@ func (p projEQBytesBytesOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQDecimalInt16Op struct {
 	projOpBase
 }
 
-func (p projEQDecimalInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQDecimalInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -25546,18 +26240,21 @@ func (p projEQDecimalInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQDecimalInt32Op struct {
 	projOpBase
 }
 
-func (p projEQDecimalInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQDecimalInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -25668,18 +26365,21 @@ func (p projEQDecimalInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQDecimalInt64Op struct {
 	projOpBase
 }
 
-func (p projEQDecimalInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQDecimalInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -25790,18 +26490,21 @@ func (p projEQDecimalInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQDecimalFloat64Op struct {
 	projOpBase
 }
 
-func (p projEQDecimalFloat64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQDecimalFloat64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -25920,18 +26623,21 @@ func (p projEQDecimalFloat64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQDecimalDecimalOp struct {
 	projOpBase
 }
 
-func (p projEQDecimalDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQDecimalDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -26018,18 +26724,21 @@ func (p projEQDecimalDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQInt16Int16Op struct {
 	projOpBase
 }
 
-func (p projEQInt16Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQInt16Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -26160,18 +26869,21 @@ func (p projEQInt16Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQInt16Int32Op struct {
 	projOpBase
 }
 
-func (p projEQInt16Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQInt16Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -26302,18 +27014,21 @@ func (p projEQInt16Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQInt16Int64Op struct {
 	projOpBase
 }
 
-func (p projEQInt16Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQInt16Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -26444,18 +27159,21 @@ func (p projEQInt16Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQInt16Float64Op struct {
 	projOpBase
 }
 
-func (p projEQInt16Float64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQInt16Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -26618,18 +27336,21 @@ func (p projEQInt16Float64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQInt16DecimalOp struct {
 	projOpBase
 }
 
-func (p projEQInt16DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQInt16DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -26740,18 +27461,21 @@ func (p projEQInt16DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQInt32Int16Op struct {
 	projOpBase
 }
 
-func (p projEQInt32Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQInt32Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -26882,18 +27606,21 @@ func (p projEQInt32Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQInt32Int32Op struct {
 	projOpBase
 }
 
-func (p projEQInt32Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQInt32Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -27024,18 +27751,21 @@ func (p projEQInt32Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQInt32Int64Op struct {
 	projOpBase
 }
 
-func (p projEQInt32Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQInt32Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -27166,18 +27896,21 @@ func (p projEQInt32Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQInt32Float64Op struct {
 	projOpBase
 }
 
-func (p projEQInt32Float64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQInt32Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -27340,18 +28073,21 @@ func (p projEQInt32Float64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQInt32DecimalOp struct {
 	projOpBase
 }
 
-func (p projEQInt32DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQInt32DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -27462,18 +28198,21 @@ func (p projEQInt32DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQInt64Int16Op struct {
 	projOpBase
 }
 
-func (p projEQInt64Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQInt64Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -27604,18 +28343,21 @@ func (p projEQInt64Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQInt64Int32Op struct {
 	projOpBase
 }
 
-func (p projEQInt64Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQInt64Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -27746,18 +28488,21 @@ func (p projEQInt64Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQInt64Int64Op struct {
 	projOpBase
 }
 
-func (p projEQInt64Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQInt64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -27888,18 +28633,21 @@ func (p projEQInt64Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQInt64Float64Op struct {
 	projOpBase
 }
 
-func (p projEQInt64Float64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQInt64Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -28062,18 +28810,21 @@ func (p projEQInt64Float64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQInt64DecimalOp struct {
 	projOpBase
 }
 
-func (p projEQInt64DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQInt64DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -28184,18 +28935,21 @@ func (p projEQInt64DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQFloat64Int16Op struct {
 	projOpBase
 }
 
-func (p projEQFloat64Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQFloat64Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -28358,18 +29112,21 @@ func (p projEQFloat64Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQFloat64Int32Op struct {
 	projOpBase
 }
 
-func (p projEQFloat64Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQFloat64Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -28532,18 +29289,21 @@ func (p projEQFloat64Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQFloat64Int64Op struct {
 	projOpBase
 }
 
-func (p projEQFloat64Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQFloat64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -28706,18 +29466,21 @@ func (p projEQFloat64Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQFloat64Float64Op struct {
 	projOpBase
 }
 
-func (p projEQFloat64Float64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQFloat64Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -28880,18 +29643,21 @@ func (p projEQFloat64Float64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQFloat64DecimalOp struct {
 	projOpBase
 }
 
-func (p projEQFloat64DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQFloat64DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -29010,18 +29776,21 @@ func (p projEQFloat64DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQTimestampTimestampOp struct {
 	projOpBase
 }
 
-func (p projEQTimestampTimestampOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQTimestampTimestampOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -29136,18 +29905,21 @@ func (p projEQTimestampTimestampOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQIntervalIntervalOp struct {
 	projOpBase
 }
 
-func (p projEQIntervalIntervalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQIntervalIntervalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -29234,18 +30006,21 @@ func (p projEQIntervalIntervalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQJSONJSONOp struct {
 	projOpBase
 }
 
-func (p projEQJSONJSONOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQJSONJSONOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -29352,18 +30127,21 @@ func (p projEQJSONJSONOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQDatumDatumOp struct {
 	projOpBase
 }
 
-func (p projEQDatumDatumOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQDatumDatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -29468,18 +30246,21 @@ func (p projEQDatumDatumOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEBoolBoolOp struct {
 	projOpBase
 }
 
-func (p projNEBoolBoolOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEBoolBoolOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -29598,18 +30379,21 @@ func (p projNEBoolBoolOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEBytesBytesOp struct {
 	projOpBase
 }
 
-func (p projNEBytesBytesOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEBytesBytesOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -29692,18 +30476,21 @@ func (p projNEBytesBytesOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEDecimalInt16Op struct {
 	projOpBase
 }
 
-func (p projNEDecimalInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEDecimalInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -29814,18 +30601,21 @@ func (p projNEDecimalInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEDecimalInt32Op struct {
 	projOpBase
 }
 
-func (p projNEDecimalInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEDecimalInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -29936,18 +30726,21 @@ func (p projNEDecimalInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEDecimalInt64Op struct {
 	projOpBase
 }
 
-func (p projNEDecimalInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEDecimalInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -30058,18 +30851,21 @@ func (p projNEDecimalInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEDecimalFloat64Op struct {
 	projOpBase
 }
 
-func (p projNEDecimalFloat64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEDecimalFloat64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -30188,18 +30984,21 @@ func (p projNEDecimalFloat64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEDecimalDecimalOp struct {
 	projOpBase
 }
 
-func (p projNEDecimalDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEDecimalDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -30286,18 +31085,21 @@ func (p projNEDecimalDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEInt16Int16Op struct {
 	projOpBase
 }
 
-func (p projNEInt16Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEInt16Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -30428,18 +31230,21 @@ func (p projNEInt16Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEInt16Int32Op struct {
 	projOpBase
 }
 
-func (p projNEInt16Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEInt16Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -30570,18 +31375,21 @@ func (p projNEInt16Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEInt16Int64Op struct {
 	projOpBase
 }
 
-func (p projNEInt16Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEInt16Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -30712,18 +31520,21 @@ func (p projNEInt16Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEInt16Float64Op struct {
 	projOpBase
 }
 
-func (p projNEInt16Float64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEInt16Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -30886,18 +31697,21 @@ func (p projNEInt16Float64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEInt16DecimalOp struct {
 	projOpBase
 }
 
-func (p projNEInt16DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEInt16DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -31008,18 +31822,21 @@ func (p projNEInt16DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEInt32Int16Op struct {
 	projOpBase
 }
 
-func (p projNEInt32Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEInt32Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -31150,18 +31967,21 @@ func (p projNEInt32Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEInt32Int32Op struct {
 	projOpBase
 }
 
-func (p projNEInt32Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEInt32Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -31292,18 +32112,21 @@ func (p projNEInt32Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEInt32Int64Op struct {
 	projOpBase
 }
 
-func (p projNEInt32Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEInt32Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -31434,18 +32257,21 @@ func (p projNEInt32Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEInt32Float64Op struct {
 	projOpBase
 }
 
-func (p projNEInt32Float64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEInt32Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -31608,18 +32434,21 @@ func (p projNEInt32Float64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEInt32DecimalOp struct {
 	projOpBase
 }
 
-func (p projNEInt32DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEInt32DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -31730,18 +32559,21 @@ func (p projNEInt32DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEInt64Int16Op struct {
 	projOpBase
 }
 
-func (p projNEInt64Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEInt64Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -31872,18 +32704,21 @@ func (p projNEInt64Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEInt64Int32Op struct {
 	projOpBase
 }
 
-func (p projNEInt64Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEInt64Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -32014,18 +32849,21 @@ func (p projNEInt64Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEInt64Int64Op struct {
 	projOpBase
 }
 
-func (p projNEInt64Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEInt64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -32156,18 +32994,21 @@ func (p projNEInt64Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEInt64Float64Op struct {
 	projOpBase
 }
 
-func (p projNEInt64Float64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEInt64Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -32330,18 +33171,21 @@ func (p projNEInt64Float64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEInt64DecimalOp struct {
 	projOpBase
 }
 
-func (p projNEInt64DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEInt64DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -32452,18 +33296,21 @@ func (p projNEInt64DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEFloat64Int16Op struct {
 	projOpBase
 }
 
-func (p projNEFloat64Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEFloat64Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -32626,18 +33473,21 @@ func (p projNEFloat64Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEFloat64Int32Op struct {
 	projOpBase
 }
 
-func (p projNEFloat64Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEFloat64Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -32800,18 +33650,21 @@ func (p projNEFloat64Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEFloat64Int64Op struct {
 	projOpBase
 }
 
-func (p projNEFloat64Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEFloat64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -32974,18 +33827,21 @@ func (p projNEFloat64Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEFloat64Float64Op struct {
 	projOpBase
 }
 
-func (p projNEFloat64Float64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEFloat64Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -33148,18 +34004,21 @@ func (p projNEFloat64Float64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEFloat64DecimalOp struct {
 	projOpBase
 }
 
-func (p projNEFloat64DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEFloat64DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -33278,18 +34137,21 @@ func (p projNEFloat64DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNETimestampTimestampOp struct {
 	projOpBase
 }
 
-func (p projNETimestampTimestampOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNETimestampTimestampOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -33404,18 +34266,21 @@ func (p projNETimestampTimestampOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEIntervalIntervalOp struct {
 	projOpBase
 }
 
-func (p projNEIntervalIntervalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEIntervalIntervalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -33502,18 +34367,21 @@ func (p projNEIntervalIntervalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEJSONJSONOp struct {
 	projOpBase
 }
 
-func (p projNEJSONJSONOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEJSONJSONOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -33620,18 +34488,21 @@ func (p projNEJSONJSONOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEDatumDatumOp struct {
 	projOpBase
 }
 
-func (p projNEDatumDatumOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEDatumDatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -33736,18 +34607,21 @@ func (p projNEDatumDatumOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTBoolBoolOp struct {
 	projOpBase
 }
 
-func (p projLTBoolBoolOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTBoolBoolOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -33866,18 +34740,21 @@ func (p projLTBoolBoolOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTBytesBytesOp struct {
 	projOpBase
 }
 
-func (p projLTBytesBytesOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTBytesBytesOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -33960,18 +34837,21 @@ func (p projLTBytesBytesOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTDecimalInt16Op struct {
 	projOpBase
 }
 
-func (p projLTDecimalInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTDecimalInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -34082,18 +34962,21 @@ func (p projLTDecimalInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTDecimalInt32Op struct {
 	projOpBase
 }
 
-func (p projLTDecimalInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTDecimalInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -34204,18 +35087,21 @@ func (p projLTDecimalInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTDecimalInt64Op struct {
 	projOpBase
 }
 
-func (p projLTDecimalInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTDecimalInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -34326,18 +35212,21 @@ func (p projLTDecimalInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTDecimalFloat64Op struct {
 	projOpBase
 }
 
-func (p projLTDecimalFloat64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTDecimalFloat64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -34456,18 +35345,21 @@ func (p projLTDecimalFloat64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTDecimalDecimalOp struct {
 	projOpBase
 }
 
-func (p projLTDecimalDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTDecimalDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -34554,18 +35446,21 @@ func (p projLTDecimalDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTInt16Int16Op struct {
 	projOpBase
 }
 
-func (p projLTInt16Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTInt16Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -34696,18 +35591,21 @@ func (p projLTInt16Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTInt16Int32Op struct {
 	projOpBase
 }
 
-func (p projLTInt16Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTInt16Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -34838,18 +35736,21 @@ func (p projLTInt16Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTInt16Int64Op struct {
 	projOpBase
 }
 
-func (p projLTInt16Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTInt16Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -34980,18 +35881,21 @@ func (p projLTInt16Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTInt16Float64Op struct {
 	projOpBase
 }
 
-func (p projLTInt16Float64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTInt16Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -35154,18 +36058,21 @@ func (p projLTInt16Float64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTInt16DecimalOp struct {
 	projOpBase
 }
 
-func (p projLTInt16DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTInt16DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -35276,18 +36183,21 @@ func (p projLTInt16DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTInt32Int16Op struct {
 	projOpBase
 }
 
-func (p projLTInt32Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTInt32Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -35418,18 +36328,21 @@ func (p projLTInt32Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTInt32Int32Op struct {
 	projOpBase
 }
 
-func (p projLTInt32Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTInt32Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -35560,18 +36473,21 @@ func (p projLTInt32Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTInt32Int64Op struct {
 	projOpBase
 }
 
-func (p projLTInt32Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTInt32Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -35702,18 +36618,21 @@ func (p projLTInt32Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTInt32Float64Op struct {
 	projOpBase
 }
 
-func (p projLTInt32Float64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTInt32Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -35876,18 +36795,21 @@ func (p projLTInt32Float64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTInt32DecimalOp struct {
 	projOpBase
 }
 
-func (p projLTInt32DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTInt32DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -35998,18 +36920,21 @@ func (p projLTInt32DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTInt64Int16Op struct {
 	projOpBase
 }
 
-func (p projLTInt64Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTInt64Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -36140,18 +37065,21 @@ func (p projLTInt64Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTInt64Int32Op struct {
 	projOpBase
 }
 
-func (p projLTInt64Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTInt64Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -36282,18 +37210,21 @@ func (p projLTInt64Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTInt64Int64Op struct {
 	projOpBase
 }
 
-func (p projLTInt64Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTInt64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -36424,18 +37355,21 @@ func (p projLTInt64Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTInt64Float64Op struct {
 	projOpBase
 }
 
-func (p projLTInt64Float64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTInt64Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -36598,18 +37532,21 @@ func (p projLTInt64Float64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTInt64DecimalOp struct {
 	projOpBase
 }
 
-func (p projLTInt64DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTInt64DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -36720,18 +37657,21 @@ func (p projLTInt64DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTFloat64Int16Op struct {
 	projOpBase
 }
 
-func (p projLTFloat64Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTFloat64Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -36894,18 +37834,21 @@ func (p projLTFloat64Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTFloat64Int32Op struct {
 	projOpBase
 }
 
-func (p projLTFloat64Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTFloat64Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -37068,18 +38011,21 @@ func (p projLTFloat64Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTFloat64Int64Op struct {
 	projOpBase
 }
 
-func (p projLTFloat64Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTFloat64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -37242,18 +38188,21 @@ func (p projLTFloat64Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTFloat64Float64Op struct {
 	projOpBase
 }
 
-func (p projLTFloat64Float64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTFloat64Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -37416,18 +38365,21 @@ func (p projLTFloat64Float64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTFloat64DecimalOp struct {
 	projOpBase
 }
 
-func (p projLTFloat64DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTFloat64DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -37546,18 +38498,21 @@ func (p projLTFloat64DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTTimestampTimestampOp struct {
 	projOpBase
 }
 
-func (p projLTTimestampTimestampOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTTimestampTimestampOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -37672,18 +38627,21 @@ func (p projLTTimestampTimestampOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTIntervalIntervalOp struct {
 	projOpBase
 }
 
-func (p projLTIntervalIntervalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTIntervalIntervalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -37770,18 +38728,21 @@ func (p projLTIntervalIntervalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTJSONJSONOp struct {
 	projOpBase
 }
 
-func (p projLTJSONJSONOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTJSONJSONOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -37888,18 +38849,21 @@ func (p projLTJSONJSONOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTDatumDatumOp struct {
 	projOpBase
 }
 
-func (p projLTDatumDatumOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTDatumDatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -38004,18 +38968,21 @@ func (p projLTDatumDatumOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEBoolBoolOp struct {
 	projOpBase
 }
 
-func (p projLEBoolBoolOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEBoolBoolOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -38134,18 +39101,21 @@ func (p projLEBoolBoolOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEBytesBytesOp struct {
 	projOpBase
 }
 
-func (p projLEBytesBytesOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEBytesBytesOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -38228,18 +39198,21 @@ func (p projLEBytesBytesOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEDecimalInt16Op struct {
 	projOpBase
 }
 
-func (p projLEDecimalInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEDecimalInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -38350,18 +39323,21 @@ func (p projLEDecimalInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEDecimalInt32Op struct {
 	projOpBase
 }
 
-func (p projLEDecimalInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEDecimalInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -38472,18 +39448,21 @@ func (p projLEDecimalInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEDecimalInt64Op struct {
 	projOpBase
 }
 
-func (p projLEDecimalInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEDecimalInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -38594,18 +39573,21 @@ func (p projLEDecimalInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEDecimalFloat64Op struct {
 	projOpBase
 }
 
-func (p projLEDecimalFloat64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEDecimalFloat64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -38724,18 +39706,21 @@ func (p projLEDecimalFloat64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEDecimalDecimalOp struct {
 	projOpBase
 }
 
-func (p projLEDecimalDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEDecimalDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -38822,18 +39807,21 @@ func (p projLEDecimalDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEInt16Int16Op struct {
 	projOpBase
 }
 
-func (p projLEInt16Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEInt16Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -38964,18 +39952,21 @@ func (p projLEInt16Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEInt16Int32Op struct {
 	projOpBase
 }
 
-func (p projLEInt16Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEInt16Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -39106,18 +40097,21 @@ func (p projLEInt16Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEInt16Int64Op struct {
 	projOpBase
 }
 
-func (p projLEInt16Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEInt16Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -39248,18 +40242,21 @@ func (p projLEInt16Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEInt16Float64Op struct {
 	projOpBase
 }
 
-func (p projLEInt16Float64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEInt16Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -39422,18 +40419,21 @@ func (p projLEInt16Float64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEInt16DecimalOp struct {
 	projOpBase
 }
 
-func (p projLEInt16DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEInt16DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -39544,18 +40544,21 @@ func (p projLEInt16DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEInt32Int16Op struct {
 	projOpBase
 }
 
-func (p projLEInt32Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEInt32Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -39686,18 +40689,21 @@ func (p projLEInt32Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEInt32Int32Op struct {
 	projOpBase
 }
 
-func (p projLEInt32Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEInt32Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -39828,18 +40834,21 @@ func (p projLEInt32Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEInt32Int64Op struct {
 	projOpBase
 }
 
-func (p projLEInt32Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEInt32Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -39970,18 +40979,21 @@ func (p projLEInt32Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEInt32Float64Op struct {
 	projOpBase
 }
 
-func (p projLEInt32Float64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEInt32Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -40144,18 +41156,21 @@ func (p projLEInt32Float64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEInt32DecimalOp struct {
 	projOpBase
 }
 
-func (p projLEInt32DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEInt32DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -40266,18 +41281,21 @@ func (p projLEInt32DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEInt64Int16Op struct {
 	projOpBase
 }
 
-func (p projLEInt64Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEInt64Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -40408,18 +41426,21 @@ func (p projLEInt64Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEInt64Int32Op struct {
 	projOpBase
 }
 
-func (p projLEInt64Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEInt64Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -40550,18 +41571,21 @@ func (p projLEInt64Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEInt64Int64Op struct {
 	projOpBase
 }
 
-func (p projLEInt64Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEInt64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -40692,18 +41716,21 @@ func (p projLEInt64Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEInt64Float64Op struct {
 	projOpBase
 }
 
-func (p projLEInt64Float64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEInt64Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -40866,18 +41893,21 @@ func (p projLEInt64Float64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEInt64DecimalOp struct {
 	projOpBase
 }
 
-func (p projLEInt64DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEInt64DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -40988,18 +42018,21 @@ func (p projLEInt64DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEFloat64Int16Op struct {
 	projOpBase
 }
 
-func (p projLEFloat64Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEFloat64Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -41162,18 +42195,21 @@ func (p projLEFloat64Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEFloat64Int32Op struct {
 	projOpBase
 }
 
-func (p projLEFloat64Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEFloat64Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -41336,18 +42372,21 @@ func (p projLEFloat64Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEFloat64Int64Op struct {
 	projOpBase
 }
 
-func (p projLEFloat64Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEFloat64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -41510,18 +42549,21 @@ func (p projLEFloat64Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEFloat64Float64Op struct {
 	projOpBase
 }
 
-func (p projLEFloat64Float64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEFloat64Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -41684,18 +42726,21 @@ func (p projLEFloat64Float64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEFloat64DecimalOp struct {
 	projOpBase
 }
 
-func (p projLEFloat64DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEFloat64DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -41814,18 +42859,21 @@ func (p projLEFloat64DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLETimestampTimestampOp struct {
 	projOpBase
 }
 
-func (p projLETimestampTimestampOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLETimestampTimestampOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -41940,18 +42988,21 @@ func (p projLETimestampTimestampOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEIntervalIntervalOp struct {
 	projOpBase
 }
 
-func (p projLEIntervalIntervalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEIntervalIntervalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -42038,18 +43089,21 @@ func (p projLEIntervalIntervalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEJSONJSONOp struct {
 	projOpBase
 }
 
-func (p projLEJSONJSONOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEJSONJSONOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -42156,18 +43210,21 @@ func (p projLEJSONJSONOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEDatumDatumOp struct {
 	projOpBase
 }
 
-func (p projLEDatumDatumOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEDatumDatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -42272,18 +43329,21 @@ func (p projLEDatumDatumOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTBoolBoolOp struct {
 	projOpBase
 }
 
-func (p projGTBoolBoolOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTBoolBoolOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -42402,18 +43462,21 @@ func (p projGTBoolBoolOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTBytesBytesOp struct {
 	projOpBase
 }
 
-func (p projGTBytesBytesOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTBytesBytesOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -42496,18 +43559,21 @@ func (p projGTBytesBytesOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTDecimalInt16Op struct {
 	projOpBase
 }
 
-func (p projGTDecimalInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTDecimalInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -42618,18 +43684,21 @@ func (p projGTDecimalInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTDecimalInt32Op struct {
 	projOpBase
 }
 
-func (p projGTDecimalInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTDecimalInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -42740,18 +43809,21 @@ func (p projGTDecimalInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTDecimalInt64Op struct {
 	projOpBase
 }
 
-func (p projGTDecimalInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTDecimalInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -42862,18 +43934,21 @@ func (p projGTDecimalInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTDecimalFloat64Op struct {
 	projOpBase
 }
 
-func (p projGTDecimalFloat64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTDecimalFloat64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -42992,18 +44067,21 @@ func (p projGTDecimalFloat64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTDecimalDecimalOp struct {
 	projOpBase
 }
 
-func (p projGTDecimalDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTDecimalDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -43090,18 +44168,21 @@ func (p projGTDecimalDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTInt16Int16Op struct {
 	projOpBase
 }
 
-func (p projGTInt16Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTInt16Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -43232,18 +44313,21 @@ func (p projGTInt16Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTInt16Int32Op struct {
 	projOpBase
 }
 
-func (p projGTInt16Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTInt16Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -43374,18 +44458,21 @@ func (p projGTInt16Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTInt16Int64Op struct {
 	projOpBase
 }
 
-func (p projGTInt16Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTInt16Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -43516,18 +44603,21 @@ func (p projGTInt16Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTInt16Float64Op struct {
 	projOpBase
 }
 
-func (p projGTInt16Float64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTInt16Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -43690,18 +44780,21 @@ func (p projGTInt16Float64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTInt16DecimalOp struct {
 	projOpBase
 }
 
-func (p projGTInt16DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTInt16DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -43812,18 +44905,21 @@ func (p projGTInt16DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTInt32Int16Op struct {
 	projOpBase
 }
 
-func (p projGTInt32Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTInt32Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -43954,18 +45050,21 @@ func (p projGTInt32Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTInt32Int32Op struct {
 	projOpBase
 }
 
-func (p projGTInt32Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTInt32Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -44096,18 +45195,21 @@ func (p projGTInt32Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTInt32Int64Op struct {
 	projOpBase
 }
 
-func (p projGTInt32Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTInt32Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -44238,18 +45340,21 @@ func (p projGTInt32Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTInt32Float64Op struct {
 	projOpBase
 }
 
-func (p projGTInt32Float64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTInt32Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -44412,18 +45517,21 @@ func (p projGTInt32Float64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTInt32DecimalOp struct {
 	projOpBase
 }
 
-func (p projGTInt32DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTInt32DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -44534,18 +45642,21 @@ func (p projGTInt32DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTInt64Int16Op struct {
 	projOpBase
 }
 
-func (p projGTInt64Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTInt64Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -44676,18 +45787,21 @@ func (p projGTInt64Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTInt64Int32Op struct {
 	projOpBase
 }
 
-func (p projGTInt64Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTInt64Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -44818,18 +45932,21 @@ func (p projGTInt64Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTInt64Int64Op struct {
 	projOpBase
 }
 
-func (p projGTInt64Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTInt64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -44960,18 +46077,21 @@ func (p projGTInt64Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTInt64Float64Op struct {
 	projOpBase
 }
 
-func (p projGTInt64Float64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTInt64Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -45134,18 +46254,21 @@ func (p projGTInt64Float64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTInt64DecimalOp struct {
 	projOpBase
 }
 
-func (p projGTInt64DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTInt64DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -45256,18 +46379,21 @@ func (p projGTInt64DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTFloat64Int16Op struct {
 	projOpBase
 }
 
-func (p projGTFloat64Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTFloat64Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -45430,18 +46556,21 @@ func (p projGTFloat64Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTFloat64Int32Op struct {
 	projOpBase
 }
 
-func (p projGTFloat64Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTFloat64Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -45604,18 +46733,21 @@ func (p projGTFloat64Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTFloat64Int64Op struct {
 	projOpBase
 }
 
-func (p projGTFloat64Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTFloat64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -45778,18 +46910,21 @@ func (p projGTFloat64Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTFloat64Float64Op struct {
 	projOpBase
 }
 
-func (p projGTFloat64Float64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTFloat64Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -45952,18 +47087,21 @@ func (p projGTFloat64Float64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTFloat64DecimalOp struct {
 	projOpBase
 }
 
-func (p projGTFloat64DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTFloat64DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -46082,18 +47220,21 @@ func (p projGTFloat64DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTTimestampTimestampOp struct {
 	projOpBase
 }
 
-func (p projGTTimestampTimestampOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTTimestampTimestampOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -46208,18 +47349,21 @@ func (p projGTTimestampTimestampOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTIntervalIntervalOp struct {
 	projOpBase
 }
 
-func (p projGTIntervalIntervalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTIntervalIntervalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -46306,18 +47450,21 @@ func (p projGTIntervalIntervalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTJSONJSONOp struct {
 	projOpBase
 }
 
-func (p projGTJSONJSONOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTJSONJSONOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -46424,18 +47571,21 @@ func (p projGTJSONJSONOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTDatumDatumOp struct {
 	projOpBase
 }
 
-func (p projGTDatumDatumOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTDatumDatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -46540,18 +47690,21 @@ func (p projGTDatumDatumOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEBoolBoolOp struct {
 	projOpBase
 }
 
-func (p projGEBoolBoolOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEBoolBoolOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -46670,18 +47823,21 @@ func (p projGEBoolBoolOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEBytesBytesOp struct {
 	projOpBase
 }
 
-func (p projGEBytesBytesOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEBytesBytesOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -46764,18 +47920,21 @@ func (p projGEBytesBytesOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEDecimalInt16Op struct {
 	projOpBase
 }
 
-func (p projGEDecimalInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEDecimalInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -46886,18 +48045,21 @@ func (p projGEDecimalInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEDecimalInt32Op struct {
 	projOpBase
 }
 
-func (p projGEDecimalInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEDecimalInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -47008,18 +48170,21 @@ func (p projGEDecimalInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEDecimalInt64Op struct {
 	projOpBase
 }
 
-func (p projGEDecimalInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEDecimalInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -47130,18 +48295,21 @@ func (p projGEDecimalInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEDecimalFloat64Op struct {
 	projOpBase
 }
 
-func (p projGEDecimalFloat64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEDecimalFloat64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -47260,18 +48428,21 @@ func (p projGEDecimalFloat64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEDecimalDecimalOp struct {
 	projOpBase
 }
 
-func (p projGEDecimalDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEDecimalDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -47358,18 +48529,21 @@ func (p projGEDecimalDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEInt16Int16Op struct {
 	projOpBase
 }
 
-func (p projGEInt16Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEInt16Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -47500,18 +48674,21 @@ func (p projGEInt16Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEInt16Int32Op struct {
 	projOpBase
 }
 
-func (p projGEInt16Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEInt16Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -47642,18 +48819,21 @@ func (p projGEInt16Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEInt16Int64Op struct {
 	projOpBase
 }
 
-func (p projGEInt16Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEInt16Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -47784,18 +48964,21 @@ func (p projGEInt16Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEInt16Float64Op struct {
 	projOpBase
 }
 
-func (p projGEInt16Float64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEInt16Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -47958,18 +49141,21 @@ func (p projGEInt16Float64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEInt16DecimalOp struct {
 	projOpBase
 }
 
-func (p projGEInt16DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEInt16DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -48080,18 +49266,21 @@ func (p projGEInt16DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEInt32Int16Op struct {
 	projOpBase
 }
 
-func (p projGEInt32Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEInt32Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -48222,18 +49411,21 @@ func (p projGEInt32Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEInt32Int32Op struct {
 	projOpBase
 }
 
-func (p projGEInt32Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEInt32Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -48364,18 +49556,21 @@ func (p projGEInt32Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEInt32Int64Op struct {
 	projOpBase
 }
 
-func (p projGEInt32Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEInt32Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -48506,18 +49701,21 @@ func (p projGEInt32Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEInt32Float64Op struct {
 	projOpBase
 }
 
-func (p projGEInt32Float64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEInt32Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -48680,18 +49878,21 @@ func (p projGEInt32Float64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEInt32DecimalOp struct {
 	projOpBase
 }
 
-func (p projGEInt32DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEInt32DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -48802,18 +50003,21 @@ func (p projGEInt32DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEInt64Int16Op struct {
 	projOpBase
 }
 
-func (p projGEInt64Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEInt64Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -48944,18 +50148,21 @@ func (p projGEInt64Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEInt64Int32Op struct {
 	projOpBase
 }
 
-func (p projGEInt64Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEInt64Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -49086,18 +50293,21 @@ func (p projGEInt64Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEInt64Int64Op struct {
 	projOpBase
 }
 
-func (p projGEInt64Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEInt64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -49228,18 +50438,21 @@ func (p projGEInt64Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEInt64Float64Op struct {
 	projOpBase
 }
 
-func (p projGEInt64Float64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEInt64Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -49402,18 +50615,21 @@ func (p projGEInt64Float64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEInt64DecimalOp struct {
 	projOpBase
 }
 
-func (p projGEInt64DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEInt64DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -49524,18 +50740,21 @@ func (p projGEInt64DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEFloat64Int16Op struct {
 	projOpBase
 }
 
-func (p projGEFloat64Int16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEFloat64Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -49698,18 +50917,21 @@ func (p projGEFloat64Int16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEFloat64Int32Op struct {
 	projOpBase
 }
 
-func (p projGEFloat64Int32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEFloat64Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -49872,18 +51094,21 @@ func (p projGEFloat64Int32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEFloat64Int64Op struct {
 	projOpBase
 }
 
-func (p projGEFloat64Int64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEFloat64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -50046,18 +51271,21 @@ func (p projGEFloat64Int64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEFloat64Float64Op struct {
 	projOpBase
 }
 
-func (p projGEFloat64Float64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEFloat64Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -50220,18 +51448,21 @@ func (p projGEFloat64Float64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEFloat64DecimalOp struct {
 	projOpBase
 }
 
-func (p projGEFloat64DecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEFloat64DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -50350,18 +51581,21 @@ func (p projGEFloat64DecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGETimestampTimestampOp struct {
 	projOpBase
 }
 
-func (p projGETimestampTimestampOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGETimestampTimestampOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -50476,18 +51710,21 @@ func (p projGETimestampTimestampOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEIntervalIntervalOp struct {
 	projOpBase
 }
 
-func (p projGEIntervalIntervalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEIntervalIntervalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -50574,18 +51811,21 @@ func (p projGEIntervalIntervalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEJSONJSONOp struct {
 	projOpBase
 }
 
-func (p projGEJSONJSONOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEJSONJSONOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -50692,18 +51932,21 @@ func (p projGEJSONJSONOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEDatumDatumOp struct {
 	projOpBase
 }
 
-func (p projGEDatumDatumOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEDatumDatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
@@ -50808,7 +52051,7 @@ func (p projGEDatumDatumOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 // GetProjectionOperator returns the appropriate projection operator for the

--- a/pkg/sql/colexec/colexecproj/projection_ops_test.go
+++ b/pkg/sql/colexec/colexecproj/projection_ops_test.go
@@ -190,7 +190,7 @@ func TestRandomComparisons(t *testing.T) {
 			require.NoError(t, err)
 			op.Init(ctx)
 			var idx int
-			for batch := op.Next(); batch.Length() > 0; batch = op.Next() {
+			for batch := colexecop.NextNoMeta(op); batch.Length() > 0; batch = colexecop.NextNoMeta(op) {
 				for i := 0; i < batch.Length(); i++ {
 					absIdx := idx + i
 					assert.Equal(t, expected[absIdx], batch.ColVec(2).Bool()[i],
@@ -282,7 +282,7 @@ func benchmarkProjOp(
 	b.Run(name, func(b *testing.B) {
 		b.SetBytes(int64(len(inputTypes) * 8 * coldata.BatchSize()))
 		for i := 0; i < b.N; i++ {
-			op.Next()
+			colexecop.NextNoMeta(op)
 		}
 	})
 }

--- a/pkg/sql/colexec/colexecprojconst/BUILD.bazel
+++ b/pkg/sql/colexec/colexecprojconst/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//pkg/sql/colexecop",
         "//pkg/sql/colmem",
         "//pkg/sql/execinfra/execreleasable",  # keep
+        "//pkg/sql/execinfrapb",  # keep
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",  # keep
         "//pkg/sql/sem/tree/treebin",  # keep

--- a/pkg/sql/colexec/colexecprojconst/proj_const_left_ops.eg.go
+++ b/pkg/sql/colexec/colexecprojconst/proj_const_left_ops.eg.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree/treebin"
@@ -42,6 +43,7 @@ var (
 	_ json.JSON
 	_ = coldataext.CompareDatum
 	_ = encoding.UnsafeConvertStringToBytes
+	_ *execinfrapb.ProducerMetadata
 )
 
 type projBitandInt16ConstInt16Op struct {
@@ -49,11 +51,14 @@ type projBitandInt16ConstInt16Op struct {
 	constArg int16
 }
 
-func (p projBitandInt16ConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitandInt16ConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -115,7 +120,7 @@ func (p projBitandInt16ConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitandInt16ConstInt32Op struct {
@@ -123,11 +128,14 @@ type projBitandInt16ConstInt32Op struct {
 	constArg int16
 }
 
-func (p projBitandInt16ConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitandInt16ConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -189,7 +197,7 @@ func (p projBitandInt16ConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitandInt16ConstInt64Op struct {
@@ -197,11 +205,14 @@ type projBitandInt16ConstInt64Op struct {
 	constArg int16
 }
 
-func (p projBitandInt16ConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitandInt16ConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -263,7 +274,7 @@ func (p projBitandInt16ConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitandInt32ConstInt16Op struct {
@@ -271,11 +282,14 @@ type projBitandInt32ConstInt16Op struct {
 	constArg int32
 }
 
-func (p projBitandInt32ConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitandInt32ConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -337,7 +351,7 @@ func (p projBitandInt32ConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitandInt32ConstInt32Op struct {
@@ -345,11 +359,14 @@ type projBitandInt32ConstInt32Op struct {
 	constArg int32
 }
 
-func (p projBitandInt32ConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitandInt32ConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -411,7 +428,7 @@ func (p projBitandInt32ConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitandInt32ConstInt64Op struct {
@@ -419,11 +436,14 @@ type projBitandInt32ConstInt64Op struct {
 	constArg int32
 }
 
-func (p projBitandInt32ConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitandInt32ConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -485,7 +505,7 @@ func (p projBitandInt32ConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitandInt64ConstInt16Op struct {
@@ -493,11 +513,14 @@ type projBitandInt64ConstInt16Op struct {
 	constArg int64
 }
 
-func (p projBitandInt64ConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitandInt64ConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -559,7 +582,7 @@ func (p projBitandInt64ConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitandInt64ConstInt32Op struct {
@@ -567,11 +590,14 @@ type projBitandInt64ConstInt32Op struct {
 	constArg int64
 }
 
-func (p projBitandInt64ConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitandInt64ConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -633,7 +659,7 @@ func (p projBitandInt64ConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitandInt64ConstInt64Op struct {
@@ -641,11 +667,14 @@ type projBitandInt64ConstInt64Op struct {
 	constArg int64
 }
 
-func (p projBitandInt64ConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitandInt64ConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -707,7 +736,7 @@ func (p projBitandInt64ConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitandDatumConstDatumOp struct {
@@ -716,13 +745,16 @@ type projBitandDatumConstDatumOp struct {
 	constArg interface{}
 }
 
-func (p projBitandDatumConstDatumOp) Next() coldata.Batch {
+func (p projBitandDatumConstDatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.DatumVec
@@ -818,7 +850,7 @@ func (p projBitandDatumConstDatumOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitorInt16ConstInt16Op struct {
@@ -826,11 +858,14 @@ type projBitorInt16ConstInt16Op struct {
 	constArg int16
 }
 
-func (p projBitorInt16ConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitorInt16ConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -892,7 +927,7 @@ func (p projBitorInt16ConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitorInt16ConstInt32Op struct {
@@ -900,11 +935,14 @@ type projBitorInt16ConstInt32Op struct {
 	constArg int16
 }
 
-func (p projBitorInt16ConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitorInt16ConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -966,7 +1004,7 @@ func (p projBitorInt16ConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitorInt16ConstInt64Op struct {
@@ -974,11 +1012,14 @@ type projBitorInt16ConstInt64Op struct {
 	constArg int16
 }
 
-func (p projBitorInt16ConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitorInt16ConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -1040,7 +1081,7 @@ func (p projBitorInt16ConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitorInt32ConstInt16Op struct {
@@ -1048,11 +1089,14 @@ type projBitorInt32ConstInt16Op struct {
 	constArg int32
 }
 
-func (p projBitorInt32ConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitorInt32ConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -1114,7 +1158,7 @@ func (p projBitorInt32ConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitorInt32ConstInt32Op struct {
@@ -1122,11 +1166,14 @@ type projBitorInt32ConstInt32Op struct {
 	constArg int32
 }
 
-func (p projBitorInt32ConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitorInt32ConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -1188,7 +1235,7 @@ func (p projBitorInt32ConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitorInt32ConstInt64Op struct {
@@ -1196,11 +1243,14 @@ type projBitorInt32ConstInt64Op struct {
 	constArg int32
 }
 
-func (p projBitorInt32ConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitorInt32ConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -1262,7 +1312,7 @@ func (p projBitorInt32ConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitorInt64ConstInt16Op struct {
@@ -1270,11 +1320,14 @@ type projBitorInt64ConstInt16Op struct {
 	constArg int64
 }
 
-func (p projBitorInt64ConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitorInt64ConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -1336,7 +1389,7 @@ func (p projBitorInt64ConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitorInt64ConstInt32Op struct {
@@ -1344,11 +1397,14 @@ type projBitorInt64ConstInt32Op struct {
 	constArg int64
 }
 
-func (p projBitorInt64ConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitorInt64ConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -1410,7 +1466,7 @@ func (p projBitorInt64ConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitorInt64ConstInt64Op struct {
@@ -1418,11 +1474,14 @@ type projBitorInt64ConstInt64Op struct {
 	constArg int64
 }
 
-func (p projBitorInt64ConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitorInt64ConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -1484,7 +1543,7 @@ func (p projBitorInt64ConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitorDatumConstDatumOp struct {
@@ -1493,13 +1552,16 @@ type projBitorDatumConstDatumOp struct {
 	constArg interface{}
 }
 
-func (p projBitorDatumConstDatumOp) Next() coldata.Batch {
+func (p projBitorDatumConstDatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.DatumVec
@@ -1595,7 +1657,7 @@ func (p projBitorDatumConstDatumOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitxorInt16ConstInt16Op struct {
@@ -1603,11 +1665,14 @@ type projBitxorInt16ConstInt16Op struct {
 	constArg int16
 }
 
-func (p projBitxorInt16ConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitxorInt16ConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -1669,7 +1734,7 @@ func (p projBitxorInt16ConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitxorInt16ConstInt32Op struct {
@@ -1677,11 +1742,14 @@ type projBitxorInt16ConstInt32Op struct {
 	constArg int16
 }
 
-func (p projBitxorInt16ConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitxorInt16ConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -1743,7 +1811,7 @@ func (p projBitxorInt16ConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitxorInt16ConstInt64Op struct {
@@ -1751,11 +1819,14 @@ type projBitxorInt16ConstInt64Op struct {
 	constArg int16
 }
 
-func (p projBitxorInt16ConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitxorInt16ConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -1817,7 +1888,7 @@ func (p projBitxorInt16ConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitxorInt32ConstInt16Op struct {
@@ -1825,11 +1896,14 @@ type projBitxorInt32ConstInt16Op struct {
 	constArg int32
 }
 
-func (p projBitxorInt32ConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitxorInt32ConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -1891,7 +1965,7 @@ func (p projBitxorInt32ConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitxorInt32ConstInt32Op struct {
@@ -1899,11 +1973,14 @@ type projBitxorInt32ConstInt32Op struct {
 	constArg int32
 }
 
-func (p projBitxorInt32ConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitxorInt32ConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -1965,7 +2042,7 @@ func (p projBitxorInt32ConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitxorInt32ConstInt64Op struct {
@@ -1973,11 +2050,14 @@ type projBitxorInt32ConstInt64Op struct {
 	constArg int32
 }
 
-func (p projBitxorInt32ConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitxorInt32ConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -2039,7 +2119,7 @@ func (p projBitxorInt32ConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitxorInt64ConstInt16Op struct {
@@ -2047,11 +2127,14 @@ type projBitxorInt64ConstInt16Op struct {
 	constArg int64
 }
 
-func (p projBitxorInt64ConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitxorInt64ConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -2113,7 +2196,7 @@ func (p projBitxorInt64ConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitxorInt64ConstInt32Op struct {
@@ -2121,11 +2204,14 @@ type projBitxorInt64ConstInt32Op struct {
 	constArg int64
 }
 
-func (p projBitxorInt64ConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitxorInt64ConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -2187,7 +2273,7 @@ func (p projBitxorInt64ConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitxorInt64ConstInt64Op struct {
@@ -2195,11 +2281,14 @@ type projBitxorInt64ConstInt64Op struct {
 	constArg int64
 }
 
-func (p projBitxorInt64ConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitxorInt64ConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -2261,7 +2350,7 @@ func (p projBitxorInt64ConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitxorDatumConstDatumOp struct {
@@ -2270,13 +2359,16 @@ type projBitxorDatumConstDatumOp struct {
 	constArg interface{}
 }
 
-func (p projBitxorDatumConstDatumOp) Next() coldata.Batch {
+func (p projBitxorDatumConstDatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.DatumVec
@@ -2372,7 +2464,7 @@ func (p projBitxorDatumConstDatumOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusDecimalConstInt16Op struct {
@@ -2380,11 +2472,14 @@ type projPlusDecimalConstInt16Op struct {
 	constArg apd.Decimal
 }
 
-func (p projPlusDecimalConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusDecimalConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -2474,7 +2569,7 @@ func (p projPlusDecimalConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusDecimalConstInt32Op struct {
@@ -2482,11 +2577,14 @@ type projPlusDecimalConstInt32Op struct {
 	constArg apd.Decimal
 }
 
-func (p projPlusDecimalConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusDecimalConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -2576,7 +2674,7 @@ func (p projPlusDecimalConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusDecimalConstInt64Op struct {
@@ -2584,11 +2682,14 @@ type projPlusDecimalConstInt64Op struct {
 	constArg apd.Decimal
 }
 
-func (p projPlusDecimalConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusDecimalConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -2678,7 +2779,7 @@ func (p projPlusDecimalConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusDecimalConstDecimalOp struct {
@@ -2686,11 +2787,14 @@ type projPlusDecimalConstDecimalOp struct {
 	constArg apd.Decimal
 }
 
-func (p projPlusDecimalConstDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusDecimalConstDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -2780,7 +2884,7 @@ func (p projPlusDecimalConstDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt16ConstInt16Op struct {
@@ -2788,11 +2892,14 @@ type projPlusInt16ConstInt16Op struct {
 	constArg int16
 }
 
-func (p projPlusInt16ConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusInt16ConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -2878,7 +2985,7 @@ func (p projPlusInt16ConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt16ConstInt32Op struct {
@@ -2886,11 +2993,14 @@ type projPlusInt16ConstInt32Op struct {
 	constArg int16
 }
 
-func (p projPlusInt16ConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusInt16ConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -2976,7 +3086,7 @@ func (p projPlusInt16ConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt16ConstInt64Op struct {
@@ -2984,11 +3094,14 @@ type projPlusInt16ConstInt64Op struct {
 	constArg int16
 }
 
-func (p projPlusInt16ConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusInt16ConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -3074,7 +3187,7 @@ func (p projPlusInt16ConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt16ConstDecimalOp struct {
@@ -3082,11 +3195,14 @@ type projPlusInt16ConstDecimalOp struct {
 	constArg int16
 }
 
-func (p projPlusInt16ConstDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusInt16ConstDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -3184,7 +3300,7 @@ func (p projPlusInt16ConstDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt16ConstDatumOp struct {
@@ -3193,13 +3309,16 @@ type projPlusInt16ConstDatumOp struct {
 	constArg int16
 }
 
-func (p projPlusInt16ConstDatumOp) Next() coldata.Batch {
+func (p projPlusInt16ConstDatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.DatumVec
@@ -3305,7 +3424,7 @@ func (p projPlusInt16ConstDatumOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt32ConstInt16Op struct {
@@ -3313,11 +3432,14 @@ type projPlusInt32ConstInt16Op struct {
 	constArg int32
 }
 
-func (p projPlusInt32ConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusInt32ConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -3403,7 +3525,7 @@ func (p projPlusInt32ConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt32ConstInt32Op struct {
@@ -3411,11 +3533,14 @@ type projPlusInt32ConstInt32Op struct {
 	constArg int32
 }
 
-func (p projPlusInt32ConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusInt32ConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -3501,7 +3626,7 @@ func (p projPlusInt32ConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt32ConstInt64Op struct {
@@ -3509,11 +3634,14 @@ type projPlusInt32ConstInt64Op struct {
 	constArg int32
 }
 
-func (p projPlusInt32ConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusInt32ConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -3599,7 +3727,7 @@ func (p projPlusInt32ConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt32ConstDecimalOp struct {
@@ -3607,11 +3735,14 @@ type projPlusInt32ConstDecimalOp struct {
 	constArg int32
 }
 
-func (p projPlusInt32ConstDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusInt32ConstDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -3709,7 +3840,7 @@ func (p projPlusInt32ConstDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt32ConstDatumOp struct {
@@ -3718,13 +3849,16 @@ type projPlusInt32ConstDatumOp struct {
 	constArg int32
 }
 
-func (p projPlusInt32ConstDatumOp) Next() coldata.Batch {
+func (p projPlusInt32ConstDatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.DatumVec
@@ -3830,7 +3964,7 @@ func (p projPlusInt32ConstDatumOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt64ConstInt16Op struct {
@@ -3838,11 +3972,14 @@ type projPlusInt64ConstInt16Op struct {
 	constArg int64
 }
 
-func (p projPlusInt64ConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusInt64ConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -3928,7 +4065,7 @@ func (p projPlusInt64ConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt64ConstInt32Op struct {
@@ -3936,11 +4073,14 @@ type projPlusInt64ConstInt32Op struct {
 	constArg int64
 }
 
-func (p projPlusInt64ConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusInt64ConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -4026,7 +4166,7 @@ func (p projPlusInt64ConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt64ConstInt64Op struct {
@@ -4034,11 +4174,14 @@ type projPlusInt64ConstInt64Op struct {
 	constArg int64
 }
 
-func (p projPlusInt64ConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusInt64ConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -4124,7 +4267,7 @@ func (p projPlusInt64ConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt64ConstDecimalOp struct {
@@ -4132,11 +4275,14 @@ type projPlusInt64ConstDecimalOp struct {
 	constArg int64
 }
 
-func (p projPlusInt64ConstDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusInt64ConstDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -4234,7 +4380,7 @@ func (p projPlusInt64ConstDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt64ConstDatumOp struct {
@@ -4243,13 +4389,16 @@ type projPlusInt64ConstDatumOp struct {
 	constArg int64
 }
 
-func (p projPlusInt64ConstDatumOp) Next() coldata.Batch {
+func (p projPlusInt64ConstDatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.DatumVec
@@ -4355,7 +4504,7 @@ func (p projPlusInt64ConstDatumOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusFloat64ConstFloat64Op struct {
@@ -4363,11 +4512,14 @@ type projPlusFloat64ConstFloat64Op struct {
 	constArg float64
 }
 
-func (p projPlusFloat64ConstFloat64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusFloat64ConstFloat64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -4441,7 +4593,7 @@ func (p projPlusFloat64ConstFloat64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusTimestampConstIntervalOp struct {
@@ -4449,11 +4601,14 @@ type projPlusTimestampConstIntervalOp struct {
 	constArg time.Time
 }
 
-func (p projPlusTimestampConstIntervalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusTimestampConstIntervalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Durations
@@ -4527,7 +4682,7 @@ func (p projPlusTimestampConstIntervalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusIntervalConstTimestampOp struct {
@@ -4535,11 +4690,14 @@ type projPlusIntervalConstTimestampOp struct {
 	constArg duration.Duration
 }
 
-func (p projPlusIntervalConstTimestampOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusIntervalConstTimestampOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Times
@@ -4613,7 +4771,7 @@ func (p projPlusIntervalConstTimestampOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusIntervalConstIntervalOp struct {
@@ -4621,11 +4779,14 @@ type projPlusIntervalConstIntervalOp struct {
 	constArg duration.Duration
 }
 
-func (p projPlusIntervalConstIntervalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusIntervalConstIntervalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Durations
@@ -4679,7 +4840,7 @@ func (p projPlusIntervalConstIntervalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusIntervalConstDatumOp struct {
@@ -4688,13 +4849,16 @@ type projPlusIntervalConstDatumOp struct {
 	constArg duration.Duration
 }
 
-func (p projPlusIntervalConstDatumOp) Next() coldata.Batch {
+func (p projPlusIntervalConstDatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.DatumVec
@@ -4800,7 +4964,7 @@ func (p projPlusIntervalConstDatumOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusDatumConstIntervalOp struct {
@@ -4809,13 +4973,16 @@ type projPlusDatumConstIntervalOp struct {
 	constArg interface{}
 }
 
-func (p projPlusDatumConstIntervalOp) Next() coldata.Batch {
+func (p projPlusDatumConstIntervalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Durations
@@ -4919,7 +5086,7 @@ func (p projPlusDatumConstIntervalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusDatumConstInt16Op struct {
@@ -4928,13 +5095,16 @@ type projPlusDatumConstInt16Op struct {
 	constArg interface{}
 }
 
-func (p projPlusDatumConstInt16Op) Next() coldata.Batch {
+func (p projPlusDatumConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -5038,7 +5208,7 @@ func (p projPlusDatumConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusDatumConstInt32Op struct {
@@ -5047,13 +5217,16 @@ type projPlusDatumConstInt32Op struct {
 	constArg interface{}
 }
 
-func (p projPlusDatumConstInt32Op) Next() coldata.Batch {
+func (p projPlusDatumConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -5157,7 +5330,7 @@ func (p projPlusDatumConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusDatumConstInt64Op struct {
@@ -5166,13 +5339,16 @@ type projPlusDatumConstInt64Op struct {
 	constArg interface{}
 }
 
-func (p projPlusDatumConstInt64Op) Next() coldata.Batch {
+func (p projPlusDatumConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -5276,7 +5452,7 @@ func (p projPlusDatumConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusDecimalConstInt16Op struct {
@@ -5284,11 +5460,14 @@ type projMinusDecimalConstInt16Op struct {
 	constArg apd.Decimal
 }
 
-func (p projMinusDecimalConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusDecimalConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -5378,7 +5557,7 @@ func (p projMinusDecimalConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusDecimalConstInt32Op struct {
@@ -5386,11 +5565,14 @@ type projMinusDecimalConstInt32Op struct {
 	constArg apd.Decimal
 }
 
-func (p projMinusDecimalConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusDecimalConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -5480,7 +5662,7 @@ func (p projMinusDecimalConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusDecimalConstInt64Op struct {
@@ -5488,11 +5670,14 @@ type projMinusDecimalConstInt64Op struct {
 	constArg apd.Decimal
 }
 
-func (p projMinusDecimalConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusDecimalConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -5582,7 +5767,7 @@ func (p projMinusDecimalConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusDecimalConstDecimalOp struct {
@@ -5590,11 +5775,14 @@ type projMinusDecimalConstDecimalOp struct {
 	constArg apd.Decimal
 }
 
-func (p projMinusDecimalConstDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusDecimalConstDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -5684,7 +5872,7 @@ func (p projMinusDecimalConstDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt16ConstInt16Op struct {
@@ -5692,11 +5880,14 @@ type projMinusInt16ConstInt16Op struct {
 	constArg int16
 }
 
-func (p projMinusInt16ConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusInt16ConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -5782,7 +5973,7 @@ func (p projMinusInt16ConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt16ConstInt32Op struct {
@@ -5790,11 +5981,14 @@ type projMinusInt16ConstInt32Op struct {
 	constArg int16
 }
 
-func (p projMinusInt16ConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusInt16ConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -5880,7 +6074,7 @@ func (p projMinusInt16ConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt16ConstInt64Op struct {
@@ -5888,11 +6082,14 @@ type projMinusInt16ConstInt64Op struct {
 	constArg int16
 }
 
-func (p projMinusInt16ConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusInt16ConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -5978,7 +6175,7 @@ func (p projMinusInt16ConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt16ConstDecimalOp struct {
@@ -5986,11 +6183,14 @@ type projMinusInt16ConstDecimalOp struct {
 	constArg int16
 }
 
-func (p projMinusInt16ConstDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusInt16ConstDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -6088,7 +6288,7 @@ func (p projMinusInt16ConstDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt16ConstDatumOp struct {
@@ -6097,13 +6297,16 @@ type projMinusInt16ConstDatumOp struct {
 	constArg int16
 }
 
-func (p projMinusInt16ConstDatumOp) Next() coldata.Batch {
+func (p projMinusInt16ConstDatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.DatumVec
@@ -6209,7 +6412,7 @@ func (p projMinusInt16ConstDatumOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt32ConstInt16Op struct {
@@ -6217,11 +6420,14 @@ type projMinusInt32ConstInt16Op struct {
 	constArg int32
 }
 
-func (p projMinusInt32ConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusInt32ConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -6307,7 +6513,7 @@ func (p projMinusInt32ConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt32ConstInt32Op struct {
@@ -6315,11 +6521,14 @@ type projMinusInt32ConstInt32Op struct {
 	constArg int32
 }
 
-func (p projMinusInt32ConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusInt32ConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -6405,7 +6614,7 @@ func (p projMinusInt32ConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt32ConstInt64Op struct {
@@ -6413,11 +6622,14 @@ type projMinusInt32ConstInt64Op struct {
 	constArg int32
 }
 
-func (p projMinusInt32ConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusInt32ConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -6503,7 +6715,7 @@ func (p projMinusInt32ConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt32ConstDecimalOp struct {
@@ -6511,11 +6723,14 @@ type projMinusInt32ConstDecimalOp struct {
 	constArg int32
 }
 
-func (p projMinusInt32ConstDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusInt32ConstDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -6613,7 +6828,7 @@ func (p projMinusInt32ConstDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt32ConstDatumOp struct {
@@ -6622,13 +6837,16 @@ type projMinusInt32ConstDatumOp struct {
 	constArg int32
 }
 
-func (p projMinusInt32ConstDatumOp) Next() coldata.Batch {
+func (p projMinusInt32ConstDatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.DatumVec
@@ -6734,7 +6952,7 @@ func (p projMinusInt32ConstDatumOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt64ConstInt16Op struct {
@@ -6742,11 +6960,14 @@ type projMinusInt64ConstInt16Op struct {
 	constArg int64
 }
 
-func (p projMinusInt64ConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusInt64ConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -6832,7 +7053,7 @@ func (p projMinusInt64ConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt64ConstInt32Op struct {
@@ -6840,11 +7061,14 @@ type projMinusInt64ConstInt32Op struct {
 	constArg int64
 }
 
-func (p projMinusInt64ConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusInt64ConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -6930,7 +7154,7 @@ func (p projMinusInt64ConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt64ConstInt64Op struct {
@@ -6938,11 +7162,14 @@ type projMinusInt64ConstInt64Op struct {
 	constArg int64
 }
 
-func (p projMinusInt64ConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusInt64ConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -7028,7 +7255,7 @@ func (p projMinusInt64ConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt64ConstDecimalOp struct {
@@ -7036,11 +7263,14 @@ type projMinusInt64ConstDecimalOp struct {
 	constArg int64
 }
 
-func (p projMinusInt64ConstDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusInt64ConstDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -7138,7 +7368,7 @@ func (p projMinusInt64ConstDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt64ConstDatumOp struct {
@@ -7147,13 +7377,16 @@ type projMinusInt64ConstDatumOp struct {
 	constArg int64
 }
 
-func (p projMinusInt64ConstDatumOp) Next() coldata.Batch {
+func (p projMinusInt64ConstDatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.DatumVec
@@ -7259,7 +7492,7 @@ func (p projMinusInt64ConstDatumOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusFloat64ConstFloat64Op struct {
@@ -7267,11 +7500,14 @@ type projMinusFloat64ConstFloat64Op struct {
 	constArg float64
 }
 
-func (p projMinusFloat64ConstFloat64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusFloat64ConstFloat64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -7345,7 +7581,7 @@ func (p projMinusFloat64ConstFloat64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusTimestampConstTimestampOp struct {
@@ -7353,11 +7589,14 @@ type projMinusTimestampConstTimestampOp struct {
 	constArg time.Time
 }
 
-func (p projMinusTimestampConstTimestampOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusTimestampConstTimestampOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Times
@@ -7423,7 +7662,7 @@ func (p projMinusTimestampConstTimestampOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusTimestampConstIntervalOp struct {
@@ -7431,11 +7670,14 @@ type projMinusTimestampConstIntervalOp struct {
 	constArg time.Time
 }
 
-func (p projMinusTimestampConstIntervalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusTimestampConstIntervalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Durations
@@ -7509,7 +7751,7 @@ func (p projMinusTimestampConstIntervalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusIntervalConstIntervalOp struct {
@@ -7517,11 +7759,14 @@ type projMinusIntervalConstIntervalOp struct {
 	constArg duration.Duration
 }
 
-func (p projMinusIntervalConstIntervalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusIntervalConstIntervalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Durations
@@ -7575,7 +7820,7 @@ func (p projMinusIntervalConstIntervalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusIntervalConstDatumOp struct {
@@ -7584,13 +7829,16 @@ type projMinusIntervalConstDatumOp struct {
 	constArg duration.Duration
 }
 
-func (p projMinusIntervalConstDatumOp) Next() coldata.Batch {
+func (p projMinusIntervalConstDatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.DatumVec
@@ -7696,7 +7944,7 @@ func (p projMinusIntervalConstDatumOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusJSONConstBytesOp struct {
@@ -7704,11 +7952,14 @@ type projMinusJSONConstBytesOp struct {
 	constArg json.JSON
 }
 
-func (p projMinusJSONConstBytesOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusJSONConstBytesOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col *coldata.Bytes
@@ -7796,7 +8047,7 @@ func (p projMinusJSONConstBytesOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusJSONConstInt16Op struct {
@@ -7804,11 +8055,14 @@ type projMinusJSONConstInt16Op struct {
 	constArg json.JSON
 }
 
-func (p projMinusJSONConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusJSONConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -7880,7 +8134,7 @@ func (p projMinusJSONConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusJSONConstInt32Op struct {
@@ -7888,11 +8142,14 @@ type projMinusJSONConstInt32Op struct {
 	constArg json.JSON
 }
 
-func (p projMinusJSONConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusJSONConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -7964,7 +8221,7 @@ func (p projMinusJSONConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusJSONConstInt64Op struct {
@@ -7972,11 +8229,14 @@ type projMinusJSONConstInt64Op struct {
 	constArg json.JSON
 }
 
-func (p projMinusJSONConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusJSONConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -8048,7 +8308,7 @@ func (p projMinusJSONConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusDatumConstDatumOp struct {
@@ -8057,13 +8317,16 @@ type projMinusDatumConstDatumOp struct {
 	constArg interface{}
 }
 
-func (p projMinusDatumConstDatumOp) Next() coldata.Batch {
+func (p projMinusDatumConstDatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.DatumVec
@@ -8159,7 +8422,7 @@ func (p projMinusDatumConstDatumOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusDatumConstIntervalOp struct {
@@ -8168,13 +8431,16 @@ type projMinusDatumConstIntervalOp struct {
 	constArg interface{}
 }
 
-func (p projMinusDatumConstIntervalOp) Next() coldata.Batch {
+func (p projMinusDatumConstIntervalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Durations
@@ -8278,7 +8544,7 @@ func (p projMinusDatumConstIntervalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusDatumConstBytesOp struct {
@@ -8287,13 +8553,16 @@ type projMinusDatumConstBytesOp struct {
 	constArg interface{}
 }
 
-func (p projMinusDatumConstBytesOp) Next() coldata.Batch {
+func (p projMinusDatumConstBytesOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col *coldata.Bytes
@@ -8397,7 +8666,7 @@ func (p projMinusDatumConstBytesOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusDatumConstInt16Op struct {
@@ -8406,13 +8675,16 @@ type projMinusDatumConstInt16Op struct {
 	constArg interface{}
 }
 
-func (p projMinusDatumConstInt16Op) Next() coldata.Batch {
+func (p projMinusDatumConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -8516,7 +8788,7 @@ func (p projMinusDatumConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusDatumConstInt32Op struct {
@@ -8525,13 +8797,16 @@ type projMinusDatumConstInt32Op struct {
 	constArg interface{}
 }
 
-func (p projMinusDatumConstInt32Op) Next() coldata.Batch {
+func (p projMinusDatumConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -8635,7 +8910,7 @@ func (p projMinusDatumConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusDatumConstInt64Op struct {
@@ -8644,13 +8919,16 @@ type projMinusDatumConstInt64Op struct {
 	constArg interface{}
 }
 
-func (p projMinusDatumConstInt64Op) Next() coldata.Batch {
+func (p projMinusDatumConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -8754,7 +9032,7 @@ func (p projMinusDatumConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultDecimalConstInt16Op struct {
@@ -8762,11 +9040,14 @@ type projMultDecimalConstInt16Op struct {
 	constArg apd.Decimal
 }
 
-func (p projMultDecimalConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultDecimalConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -8856,7 +9137,7 @@ func (p projMultDecimalConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultDecimalConstInt32Op struct {
@@ -8864,11 +9145,14 @@ type projMultDecimalConstInt32Op struct {
 	constArg apd.Decimal
 }
 
-func (p projMultDecimalConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultDecimalConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -8958,7 +9242,7 @@ func (p projMultDecimalConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultDecimalConstInt64Op struct {
@@ -8966,11 +9250,14 @@ type projMultDecimalConstInt64Op struct {
 	constArg apd.Decimal
 }
 
-func (p projMultDecimalConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultDecimalConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -9060,7 +9347,7 @@ func (p projMultDecimalConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultDecimalConstDecimalOp struct {
@@ -9068,11 +9355,14 @@ type projMultDecimalConstDecimalOp struct {
 	constArg apd.Decimal
 }
 
-func (p projMultDecimalConstDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultDecimalConstDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -9162,7 +9452,7 @@ func (p projMultDecimalConstDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultDecimalConstIntervalOp struct {
@@ -9170,11 +9460,14 @@ type projMultDecimalConstIntervalOp struct {
 	constArg apd.Decimal
 }
 
-func (p projMultDecimalConstIntervalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultDecimalConstIntervalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Durations
@@ -9248,7 +9541,7 @@ func (p projMultDecimalConstIntervalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt16ConstInt16Op struct {
@@ -9256,11 +9549,14 @@ type projMultInt16ConstInt16Op struct {
 	constArg int16
 }
 
-func (p projMultInt16ConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt16ConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -9378,7 +9674,7 @@ func (p projMultInt16ConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt16ConstInt32Op struct {
@@ -9386,11 +9682,14 @@ type projMultInt16ConstInt32Op struct {
 	constArg int16
 }
 
-func (p projMultInt16ConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt16ConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -9508,7 +9807,7 @@ func (p projMultInt16ConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt16ConstInt64Op struct {
@@ -9516,11 +9815,14 @@ type projMultInt16ConstInt64Op struct {
 	constArg int16
 }
 
-func (p projMultInt16ConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt16ConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -9638,7 +9940,7 @@ func (p projMultInt16ConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt16ConstDecimalOp struct {
@@ -9646,11 +9948,14 @@ type projMultInt16ConstDecimalOp struct {
 	constArg int16
 }
 
-func (p projMultInt16ConstDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt16ConstDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -9748,7 +10053,7 @@ func (p projMultInt16ConstDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt16ConstIntervalOp struct {
@@ -9756,11 +10061,14 @@ type projMultInt16ConstIntervalOp struct {
 	constArg int16
 }
 
-func (p projMultInt16ConstIntervalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt16ConstIntervalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Durations
@@ -9814,7 +10122,7 @@ func (p projMultInt16ConstIntervalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt32ConstInt16Op struct {
@@ -9822,11 +10130,14 @@ type projMultInt32ConstInt16Op struct {
 	constArg int32
 }
 
-func (p projMultInt32ConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt32ConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -9944,7 +10255,7 @@ func (p projMultInt32ConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt32ConstInt32Op struct {
@@ -9952,11 +10263,14 @@ type projMultInt32ConstInt32Op struct {
 	constArg int32
 }
 
-func (p projMultInt32ConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt32ConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -10074,7 +10388,7 @@ func (p projMultInt32ConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt32ConstInt64Op struct {
@@ -10082,11 +10396,14 @@ type projMultInt32ConstInt64Op struct {
 	constArg int32
 }
 
-func (p projMultInt32ConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt32ConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -10204,7 +10521,7 @@ func (p projMultInt32ConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt32ConstDecimalOp struct {
@@ -10212,11 +10529,14 @@ type projMultInt32ConstDecimalOp struct {
 	constArg int32
 }
 
-func (p projMultInt32ConstDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt32ConstDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -10314,7 +10634,7 @@ func (p projMultInt32ConstDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt32ConstIntervalOp struct {
@@ -10322,11 +10642,14 @@ type projMultInt32ConstIntervalOp struct {
 	constArg int32
 }
 
-func (p projMultInt32ConstIntervalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt32ConstIntervalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Durations
@@ -10380,7 +10703,7 @@ func (p projMultInt32ConstIntervalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt64ConstInt16Op struct {
@@ -10388,11 +10711,14 @@ type projMultInt64ConstInt16Op struct {
 	constArg int64
 }
 
-func (p projMultInt64ConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt64ConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -10510,7 +10836,7 @@ func (p projMultInt64ConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt64ConstInt32Op struct {
@@ -10518,11 +10844,14 @@ type projMultInt64ConstInt32Op struct {
 	constArg int64
 }
 
-func (p projMultInt64ConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt64ConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -10640,7 +10969,7 @@ func (p projMultInt64ConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt64ConstInt64Op struct {
@@ -10648,11 +10977,14 @@ type projMultInt64ConstInt64Op struct {
 	constArg int64
 }
 
-func (p projMultInt64ConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt64ConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -10770,7 +11102,7 @@ func (p projMultInt64ConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt64ConstDecimalOp struct {
@@ -10778,11 +11110,14 @@ type projMultInt64ConstDecimalOp struct {
 	constArg int64
 }
 
-func (p projMultInt64ConstDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt64ConstDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -10880,7 +11215,7 @@ func (p projMultInt64ConstDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt64ConstIntervalOp struct {
@@ -10888,11 +11223,14 @@ type projMultInt64ConstIntervalOp struct {
 	constArg int64
 }
 
-func (p projMultInt64ConstIntervalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt64ConstIntervalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Durations
@@ -10946,7 +11284,7 @@ func (p projMultInt64ConstIntervalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultFloat64ConstFloat64Op struct {
@@ -10954,11 +11292,14 @@ type projMultFloat64ConstFloat64Op struct {
 	constArg float64
 }
 
-func (p projMultFloat64ConstFloat64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultFloat64ConstFloat64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -11032,7 +11373,7 @@ func (p projMultFloat64ConstFloat64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultFloat64ConstIntervalOp struct {
@@ -11040,11 +11381,14 @@ type projMultFloat64ConstIntervalOp struct {
 	constArg float64
 }
 
-func (p projMultFloat64ConstIntervalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultFloat64ConstIntervalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Durations
@@ -11098,7 +11442,7 @@ func (p projMultFloat64ConstIntervalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultIntervalConstInt16Op struct {
@@ -11106,11 +11450,14 @@ type projMultIntervalConstInt16Op struct {
 	constArg duration.Duration
 }
 
-func (p projMultIntervalConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultIntervalConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -11164,7 +11511,7 @@ func (p projMultIntervalConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultIntervalConstInt32Op struct {
@@ -11172,11 +11519,14 @@ type projMultIntervalConstInt32Op struct {
 	constArg duration.Duration
 }
 
-func (p projMultIntervalConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultIntervalConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -11230,7 +11580,7 @@ func (p projMultIntervalConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultIntervalConstInt64Op struct {
@@ -11238,11 +11588,14 @@ type projMultIntervalConstInt64Op struct {
 	constArg duration.Duration
 }
 
-func (p projMultIntervalConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultIntervalConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -11296,7 +11649,7 @@ func (p projMultIntervalConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultIntervalConstFloat64Op struct {
@@ -11304,11 +11657,14 @@ type projMultIntervalConstFloat64Op struct {
 	constArg duration.Duration
 }
 
-func (p projMultIntervalConstFloat64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultIntervalConstFloat64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -11362,7 +11718,7 @@ func (p projMultIntervalConstFloat64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultIntervalConstDecimalOp struct {
@@ -11370,11 +11726,14 @@ type projMultIntervalConstDecimalOp struct {
 	constArg duration.Duration
 }
 
-func (p projMultIntervalConstDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultIntervalConstDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -11448,7 +11807,7 @@ func (p projMultIntervalConstDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivDecimalConstInt16Op struct {
@@ -11456,11 +11815,14 @@ type projDivDecimalConstInt16Op struct {
 	constArg apd.Decimal
 }
 
-func (p projDivDecimalConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivDecimalConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -11566,7 +11928,7 @@ func (p projDivDecimalConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivDecimalConstInt32Op struct {
@@ -11574,11 +11936,14 @@ type projDivDecimalConstInt32Op struct {
 	constArg apd.Decimal
 }
 
-func (p projDivDecimalConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivDecimalConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -11684,7 +12049,7 @@ func (p projDivDecimalConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivDecimalConstInt64Op struct {
@@ -11692,11 +12057,14 @@ type projDivDecimalConstInt64Op struct {
 	constArg apd.Decimal
 }
 
-func (p projDivDecimalConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivDecimalConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -11802,7 +12170,7 @@ func (p projDivDecimalConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivDecimalConstDecimalOp struct {
@@ -11810,11 +12178,14 @@ type projDivDecimalConstDecimalOp struct {
 	constArg apd.Decimal
 }
 
-func (p projDivDecimalConstDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivDecimalConstDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -11936,7 +12307,7 @@ func (p projDivDecimalConstDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivInt16ConstInt16Op struct {
@@ -11944,11 +12315,14 @@ type projDivInt16ConstInt16Op struct {
 	constArg int16
 }
 
-func (p projDivInt16ConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivInt16ConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -12050,7 +12424,7 @@ func (p projDivInt16ConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivInt16ConstInt32Op struct {
@@ -12058,11 +12432,14 @@ type projDivInt16ConstInt32Op struct {
 	constArg int16
 }
 
-func (p projDivInt16ConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivInt16ConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -12164,7 +12541,7 @@ func (p projDivInt16ConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivInt16ConstInt64Op struct {
@@ -12172,11 +12549,14 @@ type projDivInt16ConstInt64Op struct {
 	constArg int16
 }
 
-func (p projDivInt16ConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivInt16ConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -12278,7 +12658,7 @@ func (p projDivInt16ConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivInt16ConstDecimalOp struct {
@@ -12286,11 +12666,14 @@ type projDivInt16ConstDecimalOp struct {
 	constArg int16
 }
 
-func (p projDivInt16ConstDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivInt16ConstDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -12420,7 +12803,7 @@ func (p projDivInt16ConstDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivInt32ConstInt16Op struct {
@@ -12428,11 +12811,14 @@ type projDivInt32ConstInt16Op struct {
 	constArg int32
 }
 
-func (p projDivInt32ConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivInt32ConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -12534,7 +12920,7 @@ func (p projDivInt32ConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivInt32ConstInt32Op struct {
@@ -12542,11 +12928,14 @@ type projDivInt32ConstInt32Op struct {
 	constArg int32
 }
 
-func (p projDivInt32ConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivInt32ConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -12648,7 +13037,7 @@ func (p projDivInt32ConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivInt32ConstInt64Op struct {
@@ -12656,11 +13045,14 @@ type projDivInt32ConstInt64Op struct {
 	constArg int32
 }
 
-func (p projDivInt32ConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivInt32ConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -12762,7 +13154,7 @@ func (p projDivInt32ConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivInt32ConstDecimalOp struct {
@@ -12770,11 +13162,14 @@ type projDivInt32ConstDecimalOp struct {
 	constArg int32
 }
 
-func (p projDivInt32ConstDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivInt32ConstDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -12904,7 +13299,7 @@ func (p projDivInt32ConstDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivInt64ConstInt16Op struct {
@@ -12912,11 +13307,14 @@ type projDivInt64ConstInt16Op struct {
 	constArg int64
 }
 
-func (p projDivInt64ConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivInt64ConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -13018,7 +13416,7 @@ func (p projDivInt64ConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivInt64ConstInt32Op struct {
@@ -13026,11 +13424,14 @@ type projDivInt64ConstInt32Op struct {
 	constArg int64
 }
 
-func (p projDivInt64ConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivInt64ConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -13132,7 +13533,7 @@ func (p projDivInt64ConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivInt64ConstInt64Op struct {
@@ -13140,11 +13541,14 @@ type projDivInt64ConstInt64Op struct {
 	constArg int64
 }
 
-func (p projDivInt64ConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivInt64ConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -13246,7 +13650,7 @@ func (p projDivInt64ConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivInt64ConstDecimalOp struct {
@@ -13254,11 +13658,14 @@ type projDivInt64ConstDecimalOp struct {
 	constArg int64
 }
 
-func (p projDivInt64ConstDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivInt64ConstDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -13388,7 +13795,7 @@ func (p projDivInt64ConstDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivFloat64ConstFloat64Op struct {
@@ -13396,11 +13803,14 @@ type projDivFloat64ConstFloat64Op struct {
 	constArg float64
 }
 
-func (p projDivFloat64ConstFloat64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivFloat64ConstFloat64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -13490,7 +13900,7 @@ func (p projDivFloat64ConstFloat64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivIntervalConstInt16Op struct {
@@ -13498,11 +13908,14 @@ type projDivIntervalConstInt16Op struct {
 	constArg duration.Duration
 }
 
-func (p projDivIntervalConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivIntervalConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -13572,7 +13985,7 @@ func (p projDivIntervalConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivIntervalConstInt32Op struct {
@@ -13580,11 +13993,14 @@ type projDivIntervalConstInt32Op struct {
 	constArg duration.Duration
 }
 
-func (p projDivIntervalConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivIntervalConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -13654,7 +14070,7 @@ func (p projDivIntervalConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivIntervalConstInt64Op struct {
@@ -13662,11 +14078,14 @@ type projDivIntervalConstInt64Op struct {
 	constArg duration.Duration
 }
 
-func (p projDivIntervalConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivIntervalConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -13736,7 +14155,7 @@ func (p projDivIntervalConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivIntervalConstFloat64Op struct {
@@ -13744,11 +14163,14 @@ type projDivIntervalConstFloat64Op struct {
 	constArg duration.Duration
 }
 
-func (p projDivIntervalConstFloat64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivIntervalConstFloat64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -13818,7 +14240,7 @@ func (p projDivIntervalConstFloat64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivDecimalConstInt16Op struct {
@@ -13826,11 +14248,14 @@ type projFloorDivDecimalConstInt16Op struct {
 	constArg apd.Decimal
 }
 
-func (p projFloorDivDecimalConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivDecimalConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -13936,7 +14361,7 @@ func (p projFloorDivDecimalConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivDecimalConstInt32Op struct {
@@ -13944,11 +14369,14 @@ type projFloorDivDecimalConstInt32Op struct {
 	constArg apd.Decimal
 }
 
-func (p projFloorDivDecimalConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivDecimalConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -14054,7 +14482,7 @@ func (p projFloorDivDecimalConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivDecimalConstInt64Op struct {
@@ -14062,11 +14490,14 @@ type projFloorDivDecimalConstInt64Op struct {
 	constArg apd.Decimal
 }
 
-func (p projFloorDivDecimalConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivDecimalConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -14172,7 +14603,7 @@ func (p projFloorDivDecimalConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivDecimalConstDecimalOp struct {
@@ -14180,11 +14611,14 @@ type projFloorDivDecimalConstDecimalOp struct {
 	constArg apd.Decimal
 }
 
-func (p projFloorDivDecimalConstDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivDecimalConstDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -14306,7 +14740,7 @@ func (p projFloorDivDecimalConstDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivInt16ConstInt16Op struct {
@@ -14314,11 +14748,14 @@ type projFloorDivInt16ConstInt16Op struct {
 	constArg int16
 }
 
-func (p projFloorDivInt16ConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivInt16ConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -14400,7 +14837,7 @@ func (p projFloorDivInt16ConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivInt16ConstInt32Op struct {
@@ -14408,11 +14845,14 @@ type projFloorDivInt16ConstInt32Op struct {
 	constArg int16
 }
 
-func (p projFloorDivInt16ConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivInt16ConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -14494,7 +14934,7 @@ func (p projFloorDivInt16ConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivInt16ConstInt64Op struct {
@@ -14502,11 +14942,14 @@ type projFloorDivInt16ConstInt64Op struct {
 	constArg int16
 }
 
-func (p projFloorDivInt16ConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivInt16ConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -14588,7 +15031,7 @@ func (p projFloorDivInt16ConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivInt16ConstDecimalOp struct {
@@ -14596,11 +15039,14 @@ type projFloorDivInt16ConstDecimalOp struct {
 	constArg int16
 }
 
-func (p projFloorDivInt16ConstDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivInt16ConstDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -14730,7 +15176,7 @@ func (p projFloorDivInt16ConstDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivInt32ConstInt16Op struct {
@@ -14738,11 +15184,14 @@ type projFloorDivInt32ConstInt16Op struct {
 	constArg int32
 }
 
-func (p projFloorDivInt32ConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivInt32ConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -14824,7 +15273,7 @@ func (p projFloorDivInt32ConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivInt32ConstInt32Op struct {
@@ -14832,11 +15281,14 @@ type projFloorDivInt32ConstInt32Op struct {
 	constArg int32
 }
 
-func (p projFloorDivInt32ConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivInt32ConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -14918,7 +15370,7 @@ func (p projFloorDivInt32ConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivInt32ConstInt64Op struct {
@@ -14926,11 +15378,14 @@ type projFloorDivInt32ConstInt64Op struct {
 	constArg int32
 }
 
-func (p projFloorDivInt32ConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivInt32ConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -15012,7 +15467,7 @@ func (p projFloorDivInt32ConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivInt32ConstDecimalOp struct {
@@ -15020,11 +15475,14 @@ type projFloorDivInt32ConstDecimalOp struct {
 	constArg int32
 }
 
-func (p projFloorDivInt32ConstDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivInt32ConstDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -15154,7 +15612,7 @@ func (p projFloorDivInt32ConstDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivInt64ConstInt16Op struct {
@@ -15162,11 +15620,14 @@ type projFloorDivInt64ConstInt16Op struct {
 	constArg int64
 }
 
-func (p projFloorDivInt64ConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivInt64ConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -15248,7 +15709,7 @@ func (p projFloorDivInt64ConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivInt64ConstInt32Op struct {
@@ -15256,11 +15717,14 @@ type projFloorDivInt64ConstInt32Op struct {
 	constArg int64
 }
 
-func (p projFloorDivInt64ConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivInt64ConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -15342,7 +15806,7 @@ func (p projFloorDivInt64ConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivInt64ConstInt64Op struct {
@@ -15350,11 +15814,14 @@ type projFloorDivInt64ConstInt64Op struct {
 	constArg int64
 }
 
-func (p projFloorDivInt64ConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivInt64ConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -15436,7 +15903,7 @@ func (p projFloorDivInt64ConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivInt64ConstDecimalOp struct {
@@ -15444,11 +15911,14 @@ type projFloorDivInt64ConstDecimalOp struct {
 	constArg int64
 }
 
-func (p projFloorDivInt64ConstDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivInt64ConstDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -15578,7 +16048,7 @@ func (p projFloorDivInt64ConstDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivFloat64ConstFloat64Op struct {
@@ -15586,11 +16056,14 @@ type projFloorDivFloat64ConstFloat64Op struct {
 	constArg float64
 }
 
-func (p projFloorDivFloat64ConstFloat64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivFloat64ConstFloat64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -15680,7 +16153,7 @@ func (p projFloorDivFloat64ConstFloat64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModDecimalConstInt16Op struct {
@@ -15688,11 +16161,14 @@ type projModDecimalConstInt16Op struct {
 	constArg apd.Decimal
 }
 
-func (p projModDecimalConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModDecimalConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -15798,7 +16274,7 @@ func (p projModDecimalConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModDecimalConstInt32Op struct {
@@ -15806,11 +16282,14 @@ type projModDecimalConstInt32Op struct {
 	constArg apd.Decimal
 }
 
-func (p projModDecimalConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModDecimalConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -15916,7 +16395,7 @@ func (p projModDecimalConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModDecimalConstInt64Op struct {
@@ -15924,11 +16403,14 @@ type projModDecimalConstInt64Op struct {
 	constArg apd.Decimal
 }
 
-func (p projModDecimalConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModDecimalConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -16034,7 +16516,7 @@ func (p projModDecimalConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModDecimalConstDecimalOp struct {
@@ -16042,11 +16524,14 @@ type projModDecimalConstDecimalOp struct {
 	constArg apd.Decimal
 }
 
-func (p projModDecimalConstDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModDecimalConstDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -16152,7 +16637,7 @@ func (p projModDecimalConstDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModInt16ConstInt16Op struct {
@@ -16160,11 +16645,14 @@ type projModInt16ConstInt16Op struct {
 	constArg int16
 }
 
-func (p projModInt16ConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModInt16ConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -16246,7 +16734,7 @@ func (p projModInt16ConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModInt16ConstInt32Op struct {
@@ -16254,11 +16742,14 @@ type projModInt16ConstInt32Op struct {
 	constArg int16
 }
 
-func (p projModInt16ConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModInt16ConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -16340,7 +16831,7 @@ func (p projModInt16ConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModInt16ConstInt64Op struct {
@@ -16348,11 +16839,14 @@ type projModInt16ConstInt64Op struct {
 	constArg int16
 }
 
-func (p projModInt16ConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModInt16ConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -16434,7 +16928,7 @@ func (p projModInt16ConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModInt16ConstDecimalOp struct {
@@ -16442,11 +16936,14 @@ type projModInt16ConstDecimalOp struct {
 	constArg int16
 }
 
-func (p projModInt16ConstDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModInt16ConstDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -16560,7 +17057,7 @@ func (p projModInt16ConstDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModInt32ConstInt16Op struct {
@@ -16568,11 +17065,14 @@ type projModInt32ConstInt16Op struct {
 	constArg int32
 }
 
-func (p projModInt32ConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModInt32ConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -16654,7 +17154,7 @@ func (p projModInt32ConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModInt32ConstInt32Op struct {
@@ -16662,11 +17162,14 @@ type projModInt32ConstInt32Op struct {
 	constArg int32
 }
 
-func (p projModInt32ConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModInt32ConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -16748,7 +17251,7 @@ func (p projModInt32ConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModInt32ConstInt64Op struct {
@@ -16756,11 +17259,14 @@ type projModInt32ConstInt64Op struct {
 	constArg int32
 }
 
-func (p projModInt32ConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModInt32ConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -16842,7 +17348,7 @@ func (p projModInt32ConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModInt32ConstDecimalOp struct {
@@ -16850,11 +17356,14 @@ type projModInt32ConstDecimalOp struct {
 	constArg int32
 }
 
-func (p projModInt32ConstDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModInt32ConstDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -16968,7 +17477,7 @@ func (p projModInt32ConstDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModInt64ConstInt16Op struct {
@@ -16976,11 +17485,14 @@ type projModInt64ConstInt16Op struct {
 	constArg int64
 }
 
-func (p projModInt64ConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModInt64ConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -17062,7 +17574,7 @@ func (p projModInt64ConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModInt64ConstInt32Op struct {
@@ -17070,11 +17582,14 @@ type projModInt64ConstInt32Op struct {
 	constArg int64
 }
 
-func (p projModInt64ConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModInt64ConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -17156,7 +17671,7 @@ func (p projModInt64ConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModInt64ConstInt64Op struct {
@@ -17164,11 +17679,14 @@ type projModInt64ConstInt64Op struct {
 	constArg int64
 }
 
-func (p projModInt64ConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModInt64ConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -17250,7 +17768,7 @@ func (p projModInt64ConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModInt64ConstDecimalOp struct {
@@ -17258,11 +17776,14 @@ type projModInt64ConstDecimalOp struct {
 	constArg int64
 }
 
-func (p projModInt64ConstDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModInt64ConstDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -17376,7 +17897,7 @@ func (p projModInt64ConstDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModFloat64ConstFloat64Op struct {
@@ -17384,11 +17905,14 @@ type projModFloat64ConstFloat64Op struct {
 	constArg float64
 }
 
-func (p projModFloat64ConstFloat64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModFloat64ConstFloat64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -17478,7 +18002,7 @@ func (p projModFloat64ConstFloat64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowDecimalConstInt16Op struct {
@@ -17486,11 +18010,14 @@ type projPowDecimalConstInt16Op struct {
 	constArg apd.Decimal
 }
 
-func (p projPowDecimalConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowDecimalConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -17580,7 +18107,7 @@ func (p projPowDecimalConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowDecimalConstInt32Op struct {
@@ -17588,11 +18115,14 @@ type projPowDecimalConstInt32Op struct {
 	constArg apd.Decimal
 }
 
-func (p projPowDecimalConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowDecimalConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -17682,7 +18212,7 @@ func (p projPowDecimalConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowDecimalConstInt64Op struct {
@@ -17690,11 +18220,14 @@ type projPowDecimalConstInt64Op struct {
 	constArg apd.Decimal
 }
 
-func (p projPowDecimalConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowDecimalConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -17784,7 +18317,7 @@ func (p projPowDecimalConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowDecimalConstDecimalOp struct {
@@ -17792,11 +18325,14 @@ type projPowDecimalConstDecimalOp struct {
 	constArg apd.Decimal
 }
 
-func (p projPowDecimalConstDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowDecimalConstDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -17886,7 +18422,7 @@ func (p projPowDecimalConstDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowInt16ConstInt16Op struct {
@@ -17894,11 +18430,14 @@ type projPowInt16ConstInt16Op struct {
 	constArg int16
 }
 
-func (p projPowInt16ConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowInt16ConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -18008,7 +18547,7 @@ func (p projPowInt16ConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowInt16ConstInt32Op struct {
@@ -18016,11 +18555,14 @@ type projPowInt16ConstInt32Op struct {
 	constArg int16
 }
 
-func (p projPowInt16ConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowInt16ConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -18130,7 +18672,7 @@ func (p projPowInt16ConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowInt16ConstInt64Op struct {
@@ -18138,11 +18680,14 @@ type projPowInt16ConstInt64Op struct {
 	constArg int16
 }
 
-func (p projPowInt16ConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowInt16ConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -18252,7 +18797,7 @@ func (p projPowInt16ConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowInt16ConstDecimalOp struct {
@@ -18260,11 +18805,14 @@ type projPowInt16ConstDecimalOp struct {
 	constArg int16
 }
 
-func (p projPowInt16ConstDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowInt16ConstDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -18362,7 +18910,7 @@ func (p projPowInt16ConstDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowInt32ConstInt16Op struct {
@@ -18370,11 +18918,14 @@ type projPowInt32ConstInt16Op struct {
 	constArg int32
 }
 
-func (p projPowInt32ConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowInt32ConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -18484,7 +19035,7 @@ func (p projPowInt32ConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowInt32ConstInt32Op struct {
@@ -18492,11 +19043,14 @@ type projPowInt32ConstInt32Op struct {
 	constArg int32
 }
 
-func (p projPowInt32ConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowInt32ConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -18606,7 +19160,7 @@ func (p projPowInt32ConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowInt32ConstInt64Op struct {
@@ -18614,11 +19168,14 @@ type projPowInt32ConstInt64Op struct {
 	constArg int32
 }
 
-func (p projPowInt32ConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowInt32ConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -18728,7 +19285,7 @@ func (p projPowInt32ConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowInt32ConstDecimalOp struct {
@@ -18736,11 +19293,14 @@ type projPowInt32ConstDecimalOp struct {
 	constArg int32
 }
 
-func (p projPowInt32ConstDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowInt32ConstDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -18838,7 +19398,7 @@ func (p projPowInt32ConstDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowInt64ConstInt16Op struct {
@@ -18846,11 +19406,14 @@ type projPowInt64ConstInt16Op struct {
 	constArg int64
 }
 
-func (p projPowInt64ConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowInt64ConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -18960,7 +19523,7 @@ func (p projPowInt64ConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowInt64ConstInt32Op struct {
@@ -18968,11 +19531,14 @@ type projPowInt64ConstInt32Op struct {
 	constArg int64
 }
 
-func (p projPowInt64ConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowInt64ConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -19082,7 +19648,7 @@ func (p projPowInt64ConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowInt64ConstInt64Op struct {
@@ -19090,11 +19656,14 @@ type projPowInt64ConstInt64Op struct {
 	constArg int64
 }
 
-func (p projPowInt64ConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowInt64ConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -19204,7 +19773,7 @@ func (p projPowInt64ConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowInt64ConstDecimalOp struct {
@@ -19212,11 +19781,14 @@ type projPowInt64ConstDecimalOp struct {
 	constArg int64
 }
 
-func (p projPowInt64ConstDecimalOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowInt64ConstDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -19314,7 +19886,7 @@ func (p projPowInt64ConstDecimalOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowFloat64ConstFloat64Op struct {
@@ -19322,11 +19894,14 @@ type projPowFloat64ConstFloat64Op struct {
 	constArg float64
 }
 
-func (p projPowFloat64ConstFloat64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowFloat64ConstFloat64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -19400,7 +19975,7 @@ func (p projPowFloat64ConstFloat64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projConcatBytesConstBytesOp struct {
@@ -19408,11 +19983,14 @@ type projConcatBytesConstBytesOp struct {
 	constArg []byte
 }
 
-func (p projConcatBytesConstBytesOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projConcatBytesConstBytesOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col *coldata.Bytes
@@ -19492,7 +20070,7 @@ func (p projConcatBytesConstBytesOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projConcatJSONConstJSONOp struct {
@@ -19500,11 +20078,14 @@ type projConcatJSONConstJSONOp struct {
 	constArg json.JSON
 }
 
-func (p projConcatJSONConstJSONOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projConcatJSONConstJSONOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col *coldata.JSONs
@@ -19580,7 +20161,7 @@ func (p projConcatJSONConstJSONOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projConcatDatumConstDatumOp struct {
@@ -19589,13 +20170,16 @@ type projConcatDatumConstDatumOp struct {
 	constArg interface{}
 }
 
-func (p projConcatDatumConstDatumOp) Next() coldata.Batch {
+func (p projConcatDatumConstDatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.DatumVec
@@ -19691,7 +20275,7 @@ func (p projConcatDatumConstDatumOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLShiftInt16ConstInt16Op struct {
@@ -19699,11 +20283,14 @@ type projLShiftInt16ConstInt16Op struct {
 	constArg int16
 }
 
-func (p projLShiftInt16ConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLShiftInt16ConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -19789,7 +20376,7 @@ func (p projLShiftInt16ConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLShiftInt16ConstInt32Op struct {
@@ -19797,11 +20384,14 @@ type projLShiftInt16ConstInt32Op struct {
 	constArg int16
 }
 
-func (p projLShiftInt16ConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLShiftInt16ConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -19887,7 +20477,7 @@ func (p projLShiftInt16ConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLShiftInt16ConstInt64Op struct {
@@ -19895,11 +20485,14 @@ type projLShiftInt16ConstInt64Op struct {
 	constArg int16
 }
 
-func (p projLShiftInt16ConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLShiftInt16ConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -19985,7 +20578,7 @@ func (p projLShiftInt16ConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLShiftInt32ConstInt16Op struct {
@@ -19993,11 +20586,14 @@ type projLShiftInt32ConstInt16Op struct {
 	constArg int32
 }
 
-func (p projLShiftInt32ConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLShiftInt32ConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -20083,7 +20679,7 @@ func (p projLShiftInt32ConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLShiftInt32ConstInt32Op struct {
@@ -20091,11 +20687,14 @@ type projLShiftInt32ConstInt32Op struct {
 	constArg int32
 }
 
-func (p projLShiftInt32ConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLShiftInt32ConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -20181,7 +20780,7 @@ func (p projLShiftInt32ConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLShiftInt32ConstInt64Op struct {
@@ -20189,11 +20788,14 @@ type projLShiftInt32ConstInt64Op struct {
 	constArg int32
 }
 
-func (p projLShiftInt32ConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLShiftInt32ConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -20279,7 +20881,7 @@ func (p projLShiftInt32ConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLShiftInt64ConstInt16Op struct {
@@ -20287,11 +20889,14 @@ type projLShiftInt64ConstInt16Op struct {
 	constArg int64
 }
 
-func (p projLShiftInt64ConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLShiftInt64ConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -20377,7 +20982,7 @@ func (p projLShiftInt64ConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLShiftInt64ConstInt32Op struct {
@@ -20385,11 +20990,14 @@ type projLShiftInt64ConstInt32Op struct {
 	constArg int64
 }
 
-func (p projLShiftInt64ConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLShiftInt64ConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -20475,7 +21083,7 @@ func (p projLShiftInt64ConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLShiftInt64ConstInt64Op struct {
@@ -20483,11 +21091,14 @@ type projLShiftInt64ConstInt64Op struct {
 	constArg int64
 }
 
-func (p projLShiftInt64ConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLShiftInt64ConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -20573,7 +21184,7 @@ func (p projLShiftInt64ConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLShiftDatumConstInt16Op struct {
@@ -20582,13 +21193,16 @@ type projLShiftDatumConstInt16Op struct {
 	constArg interface{}
 }
 
-func (p projLShiftDatumConstInt16Op) Next() coldata.Batch {
+func (p projLShiftDatumConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -20692,7 +21306,7 @@ func (p projLShiftDatumConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLShiftDatumConstInt32Op struct {
@@ -20701,13 +21315,16 @@ type projLShiftDatumConstInt32Op struct {
 	constArg interface{}
 }
 
-func (p projLShiftDatumConstInt32Op) Next() coldata.Batch {
+func (p projLShiftDatumConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -20811,7 +21428,7 @@ func (p projLShiftDatumConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLShiftDatumConstInt64Op struct {
@@ -20820,13 +21437,16 @@ type projLShiftDatumConstInt64Op struct {
 	constArg interface{}
 }
 
-func (p projLShiftDatumConstInt64Op) Next() coldata.Batch {
+func (p projLShiftDatumConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -20930,7 +21550,7 @@ func (p projLShiftDatumConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projRShiftInt16ConstInt16Op struct {
@@ -20938,11 +21558,14 @@ type projRShiftInt16ConstInt16Op struct {
 	constArg int16
 }
 
-func (p projRShiftInt16ConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projRShiftInt16ConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -21028,7 +21651,7 @@ func (p projRShiftInt16ConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projRShiftInt16ConstInt32Op struct {
@@ -21036,11 +21659,14 @@ type projRShiftInt16ConstInt32Op struct {
 	constArg int16
 }
 
-func (p projRShiftInt16ConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projRShiftInt16ConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -21126,7 +21752,7 @@ func (p projRShiftInt16ConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projRShiftInt16ConstInt64Op struct {
@@ -21134,11 +21760,14 @@ type projRShiftInt16ConstInt64Op struct {
 	constArg int16
 }
 
-func (p projRShiftInt16ConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projRShiftInt16ConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -21224,7 +21853,7 @@ func (p projRShiftInt16ConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projRShiftInt32ConstInt16Op struct {
@@ -21232,11 +21861,14 @@ type projRShiftInt32ConstInt16Op struct {
 	constArg int32
 }
 
-func (p projRShiftInt32ConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projRShiftInt32ConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -21322,7 +21954,7 @@ func (p projRShiftInt32ConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projRShiftInt32ConstInt32Op struct {
@@ -21330,11 +21962,14 @@ type projRShiftInt32ConstInt32Op struct {
 	constArg int32
 }
 
-func (p projRShiftInt32ConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projRShiftInt32ConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -21420,7 +22055,7 @@ func (p projRShiftInt32ConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projRShiftInt32ConstInt64Op struct {
@@ -21428,11 +22063,14 @@ type projRShiftInt32ConstInt64Op struct {
 	constArg int32
 }
 
-func (p projRShiftInt32ConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projRShiftInt32ConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -21518,7 +22156,7 @@ func (p projRShiftInt32ConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projRShiftInt64ConstInt16Op struct {
@@ -21526,11 +22164,14 @@ type projRShiftInt64ConstInt16Op struct {
 	constArg int64
 }
 
-func (p projRShiftInt64ConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projRShiftInt64ConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -21616,7 +22257,7 @@ func (p projRShiftInt64ConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projRShiftInt64ConstInt32Op struct {
@@ -21624,11 +22265,14 @@ type projRShiftInt64ConstInt32Op struct {
 	constArg int64
 }
 
-func (p projRShiftInt64ConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projRShiftInt64ConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -21714,7 +22358,7 @@ func (p projRShiftInt64ConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projRShiftInt64ConstInt64Op struct {
@@ -21722,11 +22366,14 @@ type projRShiftInt64ConstInt64Op struct {
 	constArg int64
 }
 
-func (p projRShiftInt64ConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projRShiftInt64ConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -21812,7 +22459,7 @@ func (p projRShiftInt64ConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projRShiftDatumConstInt16Op struct {
@@ -21821,13 +22468,16 @@ type projRShiftDatumConstInt16Op struct {
 	constArg interface{}
 }
 
-func (p projRShiftDatumConstInt16Op) Next() coldata.Batch {
+func (p projRShiftDatumConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -21931,7 +22581,7 @@ func (p projRShiftDatumConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projRShiftDatumConstInt32Op struct {
@@ -21940,13 +22590,16 @@ type projRShiftDatumConstInt32Op struct {
 	constArg interface{}
 }
 
-func (p projRShiftDatumConstInt32Op) Next() coldata.Batch {
+func (p projRShiftDatumConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -22050,7 +22703,7 @@ func (p projRShiftDatumConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projRShiftDatumConstInt64Op struct {
@@ -22059,13 +22712,16 @@ type projRShiftDatumConstInt64Op struct {
 	constArg interface{}
 }
 
-func (p projRShiftDatumConstInt64Op) Next() coldata.Batch {
+func (p projRShiftDatumConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -22169,7 +22825,7 @@ func (p projRShiftDatumConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projJSONFetchValJSONConstBytesOp struct {
@@ -22177,11 +22833,14 @@ type projJSONFetchValJSONConstBytesOp struct {
 	constArg json.JSON
 }
 
-func (p projJSONFetchValJSONConstBytesOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projJSONFetchValJSONConstBytesOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col *coldata.Bytes
@@ -22281,7 +22940,7 @@ func (p projJSONFetchValJSONConstBytesOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projJSONFetchValJSONConstInt16Op struct {
@@ -22289,11 +22948,14 @@ type projJSONFetchValJSONConstInt16Op struct {
 	constArg json.JSON
 }
 
-func (p projJSONFetchValJSONConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projJSONFetchValJSONConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -22381,7 +23043,7 @@ func (p projJSONFetchValJSONConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projJSONFetchValJSONConstInt32Op struct {
@@ -22389,11 +23051,14 @@ type projJSONFetchValJSONConstInt32Op struct {
 	constArg json.JSON
 }
 
-func (p projJSONFetchValJSONConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projJSONFetchValJSONConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -22481,7 +23146,7 @@ func (p projJSONFetchValJSONConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projJSONFetchValJSONConstInt64Op struct {
@@ -22489,11 +23154,14 @@ type projJSONFetchValJSONConstInt64Op struct {
 	constArg json.JSON
 }
 
-func (p projJSONFetchValJSONConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projJSONFetchValJSONConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -22581,7 +23249,7 @@ func (p projJSONFetchValJSONConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projJSONFetchTextJSONConstBytesOp struct {
@@ -22589,11 +23257,14 @@ type projJSONFetchTextJSONConstBytesOp struct {
 	constArg json.JSON
 }
 
-func (p projJSONFetchTextJSONConstBytesOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projJSONFetchTextJSONConstBytesOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col *coldata.Bytes
@@ -22729,7 +23400,7 @@ func (p projJSONFetchTextJSONConstBytesOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projJSONFetchTextJSONConstInt16Op struct {
@@ -22737,11 +23408,14 @@ type projJSONFetchTextJSONConstInt16Op struct {
 	constArg json.JSON
 }
 
-func (p projJSONFetchTextJSONConstInt16Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projJSONFetchTextJSONConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -22865,7 +23539,7 @@ func (p projJSONFetchTextJSONConstInt16Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projJSONFetchTextJSONConstInt32Op struct {
@@ -22873,11 +23547,14 @@ type projJSONFetchTextJSONConstInt32Op struct {
 	constArg json.JSON
 }
 
-func (p projJSONFetchTextJSONConstInt32Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projJSONFetchTextJSONConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -23001,7 +23678,7 @@ func (p projJSONFetchTextJSONConstInt32Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projJSONFetchTextJSONConstInt64Op struct {
@@ -23009,11 +23686,14 @@ type projJSONFetchTextJSONConstInt64Op struct {
 	constArg json.JSON
 }
 
-func (p projJSONFetchTextJSONConstInt64Op) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projJSONFetchTextJSONConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -23137,7 +23817,7 @@ func (p projJSONFetchTextJSONConstInt64Op) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projJSONFetchValPathJSONConstDatumOp struct {
@@ -23145,11 +23825,14 @@ type projJSONFetchValPathJSONConstDatumOp struct {
 	constArg json.JSON
 }
 
-func (p projJSONFetchValPathJSONConstDatumOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projJSONFetchValPathJSONConstDatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.DatumVec
@@ -23237,7 +23920,7 @@ func (p projJSONFetchValPathJSONConstDatumOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projJSONFetchTextPathJSONConstDatumOp struct {
@@ -23245,11 +23928,14 @@ type projJSONFetchTextPathJSONConstDatumOp struct {
 	constArg json.JSON
 }
 
-func (p projJSONFetchTextPathJSONConstDatumOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projJSONFetchTextPathJSONConstDatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.DatumVec
@@ -23377,7 +24063,7 @@ func (p projJSONFetchTextPathJSONConstDatumOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 // GetProjectionLConstOperator returns the appropriate constant

--- a/pkg/sql/colexec/colexecprojconst/proj_const_right_ops.eg.go
+++ b/pkg/sql/colexec/colexecprojconst/proj_const_right_ops.eg.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree/treebin"
@@ -45,6 +46,7 @@ var (
 	_ json.JSON
 	_ = coldataext.CompareDatum
 	_ = encoding.UnsafeConvertStringToBytes
+	_ *execinfrapb.ProducerMetadata
 )
 
 type projBitandInt16Int16ConstOp struct {
@@ -52,11 +54,14 @@ type projBitandInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projBitandInt16Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitandInt16Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -118,7 +123,7 @@ func (p projBitandInt16Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitandInt16Int32ConstOp struct {
@@ -126,11 +131,14 @@ type projBitandInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projBitandInt16Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitandInt16Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -192,7 +200,7 @@ func (p projBitandInt16Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitandInt16Int64ConstOp struct {
@@ -200,11 +208,14 @@ type projBitandInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projBitandInt16Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitandInt16Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -266,7 +277,7 @@ func (p projBitandInt16Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitandInt32Int16ConstOp struct {
@@ -274,11 +285,14 @@ type projBitandInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projBitandInt32Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitandInt32Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -340,7 +354,7 @@ func (p projBitandInt32Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitandInt32Int32ConstOp struct {
@@ -348,11 +362,14 @@ type projBitandInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projBitandInt32Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitandInt32Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -414,7 +431,7 @@ func (p projBitandInt32Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitandInt32Int64ConstOp struct {
@@ -422,11 +439,14 @@ type projBitandInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projBitandInt32Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitandInt32Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -488,7 +508,7 @@ func (p projBitandInt32Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitandInt64Int16ConstOp struct {
@@ -496,11 +516,14 @@ type projBitandInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projBitandInt64Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitandInt64Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -562,7 +585,7 @@ func (p projBitandInt64Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitandInt64Int32ConstOp struct {
@@ -570,11 +593,14 @@ type projBitandInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projBitandInt64Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitandInt64Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -636,7 +662,7 @@ func (p projBitandInt64Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitandInt64Int64ConstOp struct {
@@ -644,11 +670,14 @@ type projBitandInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projBitandInt64Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitandInt64Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -710,7 +739,7 @@ func (p projBitandInt64Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitandDatumDatumConstOp struct {
@@ -719,13 +748,16 @@ type projBitandDatumDatumConstOp struct {
 	constArg interface{}
 }
 
-func (p projBitandDatumDatumConstOp) Next() coldata.Batch {
+func (p projBitandDatumDatumConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.DatumVec
@@ -821,7 +853,7 @@ func (p projBitandDatumDatumConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitorInt16Int16ConstOp struct {
@@ -829,11 +861,14 @@ type projBitorInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projBitorInt16Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitorInt16Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -895,7 +930,7 @@ func (p projBitorInt16Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitorInt16Int32ConstOp struct {
@@ -903,11 +938,14 @@ type projBitorInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projBitorInt16Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitorInt16Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -969,7 +1007,7 @@ func (p projBitorInt16Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitorInt16Int64ConstOp struct {
@@ -977,11 +1015,14 @@ type projBitorInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projBitorInt16Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitorInt16Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -1043,7 +1084,7 @@ func (p projBitorInt16Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitorInt32Int16ConstOp struct {
@@ -1051,11 +1092,14 @@ type projBitorInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projBitorInt32Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitorInt32Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -1117,7 +1161,7 @@ func (p projBitorInt32Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitorInt32Int32ConstOp struct {
@@ -1125,11 +1169,14 @@ type projBitorInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projBitorInt32Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitorInt32Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -1191,7 +1238,7 @@ func (p projBitorInt32Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitorInt32Int64ConstOp struct {
@@ -1199,11 +1246,14 @@ type projBitorInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projBitorInt32Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitorInt32Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -1265,7 +1315,7 @@ func (p projBitorInt32Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitorInt64Int16ConstOp struct {
@@ -1273,11 +1323,14 @@ type projBitorInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projBitorInt64Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitorInt64Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -1339,7 +1392,7 @@ func (p projBitorInt64Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitorInt64Int32ConstOp struct {
@@ -1347,11 +1400,14 @@ type projBitorInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projBitorInt64Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitorInt64Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -1413,7 +1469,7 @@ func (p projBitorInt64Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitorInt64Int64ConstOp struct {
@@ -1421,11 +1477,14 @@ type projBitorInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projBitorInt64Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitorInt64Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -1487,7 +1546,7 @@ func (p projBitorInt64Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitorDatumDatumConstOp struct {
@@ -1496,13 +1555,16 @@ type projBitorDatumDatumConstOp struct {
 	constArg interface{}
 }
 
-func (p projBitorDatumDatumConstOp) Next() coldata.Batch {
+func (p projBitorDatumDatumConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.DatumVec
@@ -1598,7 +1660,7 @@ func (p projBitorDatumDatumConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitxorInt16Int16ConstOp struct {
@@ -1606,11 +1668,14 @@ type projBitxorInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projBitxorInt16Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitxorInt16Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -1672,7 +1737,7 @@ func (p projBitxorInt16Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitxorInt16Int32ConstOp struct {
@@ -1680,11 +1745,14 @@ type projBitxorInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projBitxorInt16Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitxorInt16Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -1746,7 +1814,7 @@ func (p projBitxorInt16Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitxorInt16Int64ConstOp struct {
@@ -1754,11 +1822,14 @@ type projBitxorInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projBitxorInt16Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitxorInt16Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -1820,7 +1891,7 @@ func (p projBitxorInt16Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitxorInt32Int16ConstOp struct {
@@ -1828,11 +1899,14 @@ type projBitxorInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projBitxorInt32Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitxorInt32Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -1894,7 +1968,7 @@ func (p projBitxorInt32Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitxorInt32Int32ConstOp struct {
@@ -1902,11 +1976,14 @@ type projBitxorInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projBitxorInt32Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitxorInt32Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -1968,7 +2045,7 @@ func (p projBitxorInt32Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitxorInt32Int64ConstOp struct {
@@ -1976,11 +2053,14 @@ type projBitxorInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projBitxorInt32Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitxorInt32Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -2042,7 +2122,7 @@ func (p projBitxorInt32Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitxorInt64Int16ConstOp struct {
@@ -2050,11 +2130,14 @@ type projBitxorInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projBitxorInt64Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitxorInt64Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -2116,7 +2199,7 @@ func (p projBitxorInt64Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitxorInt64Int32ConstOp struct {
@@ -2124,11 +2207,14 @@ type projBitxorInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projBitxorInt64Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitxorInt64Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -2190,7 +2276,7 @@ func (p projBitxorInt64Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitxorInt64Int64ConstOp struct {
@@ -2198,11 +2284,14 @@ type projBitxorInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projBitxorInt64Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projBitxorInt64Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -2264,7 +2353,7 @@ func (p projBitxorInt64Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projBitxorDatumDatumConstOp struct {
@@ -2273,13 +2362,16 @@ type projBitxorDatumDatumConstOp struct {
 	constArg interface{}
 }
 
-func (p projBitxorDatumDatumConstOp) Next() coldata.Batch {
+func (p projBitxorDatumDatumConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.DatumVec
@@ -2375,7 +2467,7 @@ func (p projBitxorDatumDatumConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusDecimalInt16ConstOp struct {
@@ -2383,11 +2475,14 @@ type projPlusDecimalInt16ConstOp struct {
 	constArg int16
 }
 
-func (p projPlusDecimalInt16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusDecimalInt16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -2477,7 +2572,7 @@ func (p projPlusDecimalInt16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusDecimalInt32ConstOp struct {
@@ -2485,11 +2580,14 @@ type projPlusDecimalInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projPlusDecimalInt32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusDecimalInt32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -2579,7 +2677,7 @@ func (p projPlusDecimalInt32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusDecimalInt64ConstOp struct {
@@ -2587,11 +2685,14 @@ type projPlusDecimalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projPlusDecimalInt64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusDecimalInt64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -2681,7 +2782,7 @@ func (p projPlusDecimalInt64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusDecimalDecimalConstOp struct {
@@ -2689,11 +2790,14 @@ type projPlusDecimalDecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projPlusDecimalDecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusDecimalDecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -2783,7 +2887,7 @@ func (p projPlusDecimalDecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt16Int16ConstOp struct {
@@ -2791,11 +2895,14 @@ type projPlusInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projPlusInt16Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusInt16Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -2881,7 +2988,7 @@ func (p projPlusInt16Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt16Int32ConstOp struct {
@@ -2889,11 +2996,14 @@ type projPlusInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projPlusInt16Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusInt16Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -2979,7 +3089,7 @@ func (p projPlusInt16Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt16Int64ConstOp struct {
@@ -2987,11 +3097,14 @@ type projPlusInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projPlusInt16Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusInt16Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -3077,7 +3190,7 @@ func (p projPlusInt16Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt16DecimalConstOp struct {
@@ -3085,11 +3198,14 @@ type projPlusInt16DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projPlusInt16DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusInt16DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -3187,7 +3303,7 @@ func (p projPlusInt16DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt16DatumConstOp struct {
@@ -3196,13 +3312,16 @@ type projPlusInt16DatumConstOp struct {
 	constArg interface{}
 }
 
-func (p projPlusInt16DatumConstOp) Next() coldata.Batch {
+func (p projPlusInt16DatumConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -3306,7 +3425,7 @@ func (p projPlusInt16DatumConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt32Int16ConstOp struct {
@@ -3314,11 +3433,14 @@ type projPlusInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projPlusInt32Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusInt32Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -3404,7 +3526,7 @@ func (p projPlusInt32Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt32Int32ConstOp struct {
@@ -3412,11 +3534,14 @@ type projPlusInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projPlusInt32Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusInt32Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -3502,7 +3627,7 @@ func (p projPlusInt32Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt32Int64ConstOp struct {
@@ -3510,11 +3635,14 @@ type projPlusInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projPlusInt32Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusInt32Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -3600,7 +3728,7 @@ func (p projPlusInt32Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt32DecimalConstOp struct {
@@ -3608,11 +3736,14 @@ type projPlusInt32DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projPlusInt32DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusInt32DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -3710,7 +3841,7 @@ func (p projPlusInt32DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt32DatumConstOp struct {
@@ -3719,13 +3850,16 @@ type projPlusInt32DatumConstOp struct {
 	constArg interface{}
 }
 
-func (p projPlusInt32DatumConstOp) Next() coldata.Batch {
+func (p projPlusInt32DatumConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -3829,7 +3963,7 @@ func (p projPlusInt32DatumConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt64Int16ConstOp struct {
@@ -3837,11 +3971,14 @@ type projPlusInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projPlusInt64Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusInt64Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -3927,7 +4064,7 @@ func (p projPlusInt64Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt64Int32ConstOp struct {
@@ -3935,11 +4072,14 @@ type projPlusInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projPlusInt64Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusInt64Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -4025,7 +4165,7 @@ func (p projPlusInt64Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt64Int64ConstOp struct {
@@ -4033,11 +4173,14 @@ type projPlusInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projPlusInt64Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusInt64Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -4123,7 +4266,7 @@ func (p projPlusInt64Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt64DecimalConstOp struct {
@@ -4131,11 +4274,14 @@ type projPlusInt64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projPlusInt64DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusInt64DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -4233,7 +4379,7 @@ func (p projPlusInt64DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusInt64DatumConstOp struct {
@@ -4242,13 +4388,16 @@ type projPlusInt64DatumConstOp struct {
 	constArg interface{}
 }
 
-func (p projPlusInt64DatumConstOp) Next() coldata.Batch {
+func (p projPlusInt64DatumConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -4352,7 +4501,7 @@ func (p projPlusInt64DatumConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusFloat64Float64ConstOp struct {
@@ -4360,11 +4509,14 @@ type projPlusFloat64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projPlusFloat64Float64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusFloat64Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -4438,7 +4590,7 @@ func (p projPlusFloat64Float64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusTimestampIntervalConstOp struct {
@@ -4446,11 +4598,14 @@ type projPlusTimestampIntervalConstOp struct {
 	constArg duration.Duration
 }
 
-func (p projPlusTimestampIntervalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusTimestampIntervalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Times
@@ -4524,7 +4679,7 @@ func (p projPlusTimestampIntervalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusIntervalTimestampConstOp struct {
@@ -4532,11 +4687,14 @@ type projPlusIntervalTimestampConstOp struct {
 	constArg time.Time
 }
 
-func (p projPlusIntervalTimestampConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusIntervalTimestampConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Durations
@@ -4610,7 +4768,7 @@ func (p projPlusIntervalTimestampConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusIntervalIntervalConstOp struct {
@@ -4618,11 +4776,14 @@ type projPlusIntervalIntervalConstOp struct {
 	constArg duration.Duration
 }
 
-func (p projPlusIntervalIntervalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPlusIntervalIntervalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Durations
@@ -4676,7 +4837,7 @@ func (p projPlusIntervalIntervalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusIntervalDatumConstOp struct {
@@ -4685,13 +4846,16 @@ type projPlusIntervalDatumConstOp struct {
 	constArg interface{}
 }
 
-func (p projPlusIntervalDatumConstOp) Next() coldata.Batch {
+func (p projPlusIntervalDatumConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Durations
@@ -4795,7 +4959,7 @@ func (p projPlusIntervalDatumConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusDatumIntervalConstOp struct {
@@ -4804,13 +4968,16 @@ type projPlusDatumIntervalConstOp struct {
 	constArg duration.Duration
 }
 
-func (p projPlusDatumIntervalConstOp) Next() coldata.Batch {
+func (p projPlusDatumIntervalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.DatumVec
@@ -4916,7 +5083,7 @@ func (p projPlusDatumIntervalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusDatumInt16ConstOp struct {
@@ -4925,13 +5092,16 @@ type projPlusDatumInt16ConstOp struct {
 	constArg int16
 }
 
-func (p projPlusDatumInt16ConstOp) Next() coldata.Batch {
+func (p projPlusDatumInt16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.DatumVec
@@ -5037,7 +5207,7 @@ func (p projPlusDatumInt16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusDatumInt32ConstOp struct {
@@ -5046,13 +5216,16 @@ type projPlusDatumInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projPlusDatumInt32ConstOp) Next() coldata.Batch {
+func (p projPlusDatumInt32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.DatumVec
@@ -5158,7 +5331,7 @@ func (p projPlusDatumInt32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPlusDatumInt64ConstOp struct {
@@ -5167,13 +5340,16 @@ type projPlusDatumInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projPlusDatumInt64ConstOp) Next() coldata.Batch {
+func (p projPlusDatumInt64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.DatumVec
@@ -5279,7 +5455,7 @@ func (p projPlusDatumInt64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusDecimalInt16ConstOp struct {
@@ -5287,11 +5463,14 @@ type projMinusDecimalInt16ConstOp struct {
 	constArg int16
 }
 
-func (p projMinusDecimalInt16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusDecimalInt16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -5381,7 +5560,7 @@ func (p projMinusDecimalInt16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusDecimalInt32ConstOp struct {
@@ -5389,11 +5568,14 @@ type projMinusDecimalInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projMinusDecimalInt32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusDecimalInt32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -5483,7 +5665,7 @@ func (p projMinusDecimalInt32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusDecimalInt64ConstOp struct {
@@ -5491,11 +5673,14 @@ type projMinusDecimalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projMinusDecimalInt64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusDecimalInt64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -5585,7 +5770,7 @@ func (p projMinusDecimalInt64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusDecimalDecimalConstOp struct {
@@ -5593,11 +5778,14 @@ type projMinusDecimalDecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projMinusDecimalDecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusDecimalDecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -5687,7 +5875,7 @@ func (p projMinusDecimalDecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt16Int16ConstOp struct {
@@ -5695,11 +5883,14 @@ type projMinusInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projMinusInt16Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusInt16Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -5785,7 +5976,7 @@ func (p projMinusInt16Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt16Int32ConstOp struct {
@@ -5793,11 +5984,14 @@ type projMinusInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projMinusInt16Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusInt16Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -5883,7 +6077,7 @@ func (p projMinusInt16Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt16Int64ConstOp struct {
@@ -5891,11 +6085,14 @@ type projMinusInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projMinusInt16Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusInt16Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -5981,7 +6178,7 @@ func (p projMinusInt16Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt16DecimalConstOp struct {
@@ -5989,11 +6186,14 @@ type projMinusInt16DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projMinusInt16DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusInt16DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -6091,7 +6291,7 @@ func (p projMinusInt16DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt16DatumConstOp struct {
@@ -6100,13 +6300,16 @@ type projMinusInt16DatumConstOp struct {
 	constArg interface{}
 }
 
-func (p projMinusInt16DatumConstOp) Next() coldata.Batch {
+func (p projMinusInt16DatumConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -6210,7 +6413,7 @@ func (p projMinusInt16DatumConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt32Int16ConstOp struct {
@@ -6218,11 +6421,14 @@ type projMinusInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projMinusInt32Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusInt32Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -6308,7 +6514,7 @@ func (p projMinusInt32Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt32Int32ConstOp struct {
@@ -6316,11 +6522,14 @@ type projMinusInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projMinusInt32Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusInt32Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -6406,7 +6615,7 @@ func (p projMinusInt32Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt32Int64ConstOp struct {
@@ -6414,11 +6623,14 @@ type projMinusInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projMinusInt32Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusInt32Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -6504,7 +6716,7 @@ func (p projMinusInt32Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt32DecimalConstOp struct {
@@ -6512,11 +6724,14 @@ type projMinusInt32DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projMinusInt32DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusInt32DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -6614,7 +6829,7 @@ func (p projMinusInt32DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt32DatumConstOp struct {
@@ -6623,13 +6838,16 @@ type projMinusInt32DatumConstOp struct {
 	constArg interface{}
 }
 
-func (p projMinusInt32DatumConstOp) Next() coldata.Batch {
+func (p projMinusInt32DatumConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -6733,7 +6951,7 @@ func (p projMinusInt32DatumConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt64Int16ConstOp struct {
@@ -6741,11 +6959,14 @@ type projMinusInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projMinusInt64Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusInt64Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -6831,7 +7052,7 @@ func (p projMinusInt64Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt64Int32ConstOp struct {
@@ -6839,11 +7060,14 @@ type projMinusInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projMinusInt64Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusInt64Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -6929,7 +7153,7 @@ func (p projMinusInt64Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt64Int64ConstOp struct {
@@ -6937,11 +7161,14 @@ type projMinusInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projMinusInt64Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusInt64Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -7027,7 +7254,7 @@ func (p projMinusInt64Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt64DecimalConstOp struct {
@@ -7035,11 +7262,14 @@ type projMinusInt64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projMinusInt64DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusInt64DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -7137,7 +7367,7 @@ func (p projMinusInt64DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusInt64DatumConstOp struct {
@@ -7146,13 +7376,16 @@ type projMinusInt64DatumConstOp struct {
 	constArg interface{}
 }
 
-func (p projMinusInt64DatumConstOp) Next() coldata.Batch {
+func (p projMinusInt64DatumConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -7256,7 +7489,7 @@ func (p projMinusInt64DatumConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusFloat64Float64ConstOp struct {
@@ -7264,11 +7497,14 @@ type projMinusFloat64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projMinusFloat64Float64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusFloat64Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -7342,7 +7578,7 @@ func (p projMinusFloat64Float64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusTimestampTimestampConstOp struct {
@@ -7350,11 +7586,14 @@ type projMinusTimestampTimestampConstOp struct {
 	constArg time.Time
 }
 
-func (p projMinusTimestampTimestampConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusTimestampTimestampConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Times
@@ -7420,7 +7659,7 @@ func (p projMinusTimestampTimestampConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusTimestampIntervalConstOp struct {
@@ -7428,11 +7667,14 @@ type projMinusTimestampIntervalConstOp struct {
 	constArg duration.Duration
 }
 
-func (p projMinusTimestampIntervalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusTimestampIntervalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Times
@@ -7506,7 +7748,7 @@ func (p projMinusTimestampIntervalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusIntervalIntervalConstOp struct {
@@ -7514,11 +7756,14 @@ type projMinusIntervalIntervalConstOp struct {
 	constArg duration.Duration
 }
 
-func (p projMinusIntervalIntervalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusIntervalIntervalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Durations
@@ -7572,7 +7817,7 @@ func (p projMinusIntervalIntervalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusIntervalDatumConstOp struct {
@@ -7581,13 +7826,16 @@ type projMinusIntervalDatumConstOp struct {
 	constArg interface{}
 }
 
-func (p projMinusIntervalDatumConstOp) Next() coldata.Batch {
+func (p projMinusIntervalDatumConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Durations
@@ -7691,7 +7939,7 @@ func (p projMinusIntervalDatumConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusJSONBytesConstOp struct {
@@ -7699,11 +7947,14 @@ type projMinusJSONBytesConstOp struct {
 	constArg []byte
 }
 
-func (p projMinusJSONBytesConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusJSONBytesConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col *coldata.JSONs
@@ -7791,7 +8042,7 @@ func (p projMinusJSONBytesConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusJSONInt16ConstOp struct {
@@ -7799,11 +8050,14 @@ type projMinusJSONInt16ConstOp struct {
 	constArg int16
 }
 
-func (p projMinusJSONInt16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusJSONInt16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col *coldata.JSONs
@@ -7877,7 +8131,7 @@ func (p projMinusJSONInt16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusJSONInt32ConstOp struct {
@@ -7885,11 +8139,14 @@ type projMinusJSONInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projMinusJSONInt32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusJSONInt32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col *coldata.JSONs
@@ -7963,7 +8220,7 @@ func (p projMinusJSONInt32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusJSONInt64ConstOp struct {
@@ -7971,11 +8228,14 @@ type projMinusJSONInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projMinusJSONInt64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMinusJSONInt64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col *coldata.JSONs
@@ -8049,7 +8309,7 @@ func (p projMinusJSONInt64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusDatumDatumConstOp struct {
@@ -8058,13 +8318,16 @@ type projMinusDatumDatumConstOp struct {
 	constArg interface{}
 }
 
-func (p projMinusDatumDatumConstOp) Next() coldata.Batch {
+func (p projMinusDatumDatumConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.DatumVec
@@ -8160,7 +8423,7 @@ func (p projMinusDatumDatumConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusDatumIntervalConstOp struct {
@@ -8169,13 +8432,16 @@ type projMinusDatumIntervalConstOp struct {
 	constArg duration.Duration
 }
 
-func (p projMinusDatumIntervalConstOp) Next() coldata.Batch {
+func (p projMinusDatumIntervalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.DatumVec
@@ -8281,7 +8547,7 @@ func (p projMinusDatumIntervalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusDatumBytesConstOp struct {
@@ -8290,13 +8556,16 @@ type projMinusDatumBytesConstOp struct {
 	constArg []byte
 }
 
-func (p projMinusDatumBytesConstOp) Next() coldata.Batch {
+func (p projMinusDatumBytesConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.DatumVec
@@ -8400,7 +8669,7 @@ func (p projMinusDatumBytesConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusDatumInt16ConstOp struct {
@@ -8409,13 +8678,16 @@ type projMinusDatumInt16ConstOp struct {
 	constArg int16
 }
 
-func (p projMinusDatumInt16ConstOp) Next() coldata.Batch {
+func (p projMinusDatumInt16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.DatumVec
@@ -8521,7 +8793,7 @@ func (p projMinusDatumInt16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusDatumInt32ConstOp struct {
@@ -8530,13 +8802,16 @@ type projMinusDatumInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projMinusDatumInt32ConstOp) Next() coldata.Batch {
+func (p projMinusDatumInt32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.DatumVec
@@ -8642,7 +8917,7 @@ func (p projMinusDatumInt32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMinusDatumInt64ConstOp struct {
@@ -8651,13 +8926,16 @@ type projMinusDatumInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projMinusDatumInt64ConstOp) Next() coldata.Batch {
+func (p projMinusDatumInt64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.DatumVec
@@ -8763,7 +9041,7 @@ func (p projMinusDatumInt64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultDecimalInt16ConstOp struct {
@@ -8771,11 +9049,14 @@ type projMultDecimalInt16ConstOp struct {
 	constArg int16
 }
 
-func (p projMultDecimalInt16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultDecimalInt16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -8865,7 +9146,7 @@ func (p projMultDecimalInt16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultDecimalInt32ConstOp struct {
@@ -8873,11 +9154,14 @@ type projMultDecimalInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projMultDecimalInt32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultDecimalInt32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -8967,7 +9251,7 @@ func (p projMultDecimalInt32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultDecimalInt64ConstOp struct {
@@ -8975,11 +9259,14 @@ type projMultDecimalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projMultDecimalInt64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultDecimalInt64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -9069,7 +9356,7 @@ func (p projMultDecimalInt64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultDecimalDecimalConstOp struct {
@@ -9077,11 +9364,14 @@ type projMultDecimalDecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projMultDecimalDecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultDecimalDecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -9171,7 +9461,7 @@ func (p projMultDecimalDecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultDecimalIntervalConstOp struct {
@@ -9179,11 +9469,14 @@ type projMultDecimalIntervalConstOp struct {
 	constArg duration.Duration
 }
 
-func (p projMultDecimalIntervalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultDecimalIntervalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -9257,7 +9550,7 @@ func (p projMultDecimalIntervalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt16Int16ConstOp struct {
@@ -9265,11 +9558,14 @@ type projMultInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projMultInt16Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt16Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -9387,7 +9683,7 @@ func (p projMultInt16Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt16Int32ConstOp struct {
@@ -9395,11 +9691,14 @@ type projMultInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projMultInt16Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt16Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -9517,7 +9816,7 @@ func (p projMultInt16Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt16Int64ConstOp struct {
@@ -9525,11 +9824,14 @@ type projMultInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projMultInt16Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt16Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -9647,7 +9949,7 @@ func (p projMultInt16Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt16DecimalConstOp struct {
@@ -9655,11 +9957,14 @@ type projMultInt16DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projMultInt16DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt16DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -9757,7 +10062,7 @@ func (p projMultInt16DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt16IntervalConstOp struct {
@@ -9765,11 +10070,14 @@ type projMultInt16IntervalConstOp struct {
 	constArg duration.Duration
 }
 
-func (p projMultInt16IntervalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt16IntervalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -9823,7 +10131,7 @@ func (p projMultInt16IntervalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt32Int16ConstOp struct {
@@ -9831,11 +10139,14 @@ type projMultInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projMultInt32Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt32Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -9953,7 +10264,7 @@ func (p projMultInt32Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt32Int32ConstOp struct {
@@ -9961,11 +10272,14 @@ type projMultInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projMultInt32Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt32Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -10083,7 +10397,7 @@ func (p projMultInt32Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt32Int64ConstOp struct {
@@ -10091,11 +10405,14 @@ type projMultInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projMultInt32Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt32Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -10213,7 +10530,7 @@ func (p projMultInt32Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt32DecimalConstOp struct {
@@ -10221,11 +10538,14 @@ type projMultInt32DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projMultInt32DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt32DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -10323,7 +10643,7 @@ func (p projMultInt32DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt32IntervalConstOp struct {
@@ -10331,11 +10651,14 @@ type projMultInt32IntervalConstOp struct {
 	constArg duration.Duration
 }
 
-func (p projMultInt32IntervalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt32IntervalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -10389,7 +10712,7 @@ func (p projMultInt32IntervalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt64Int16ConstOp struct {
@@ -10397,11 +10720,14 @@ type projMultInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projMultInt64Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt64Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -10519,7 +10845,7 @@ func (p projMultInt64Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt64Int32ConstOp struct {
@@ -10527,11 +10853,14 @@ type projMultInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projMultInt64Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt64Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -10649,7 +10978,7 @@ func (p projMultInt64Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt64Int64ConstOp struct {
@@ -10657,11 +10986,14 @@ type projMultInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projMultInt64Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt64Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -10779,7 +11111,7 @@ func (p projMultInt64Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt64DecimalConstOp struct {
@@ -10787,11 +11119,14 @@ type projMultInt64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projMultInt64DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt64DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -10889,7 +11224,7 @@ func (p projMultInt64DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultInt64IntervalConstOp struct {
@@ -10897,11 +11232,14 @@ type projMultInt64IntervalConstOp struct {
 	constArg duration.Duration
 }
 
-func (p projMultInt64IntervalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultInt64IntervalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -10955,7 +11293,7 @@ func (p projMultInt64IntervalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultFloat64Float64ConstOp struct {
@@ -10963,11 +11301,14 @@ type projMultFloat64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projMultFloat64Float64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultFloat64Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -11041,7 +11382,7 @@ func (p projMultFloat64Float64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultFloat64IntervalConstOp struct {
@@ -11049,11 +11390,14 @@ type projMultFloat64IntervalConstOp struct {
 	constArg duration.Duration
 }
 
-func (p projMultFloat64IntervalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultFloat64IntervalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -11107,7 +11451,7 @@ func (p projMultFloat64IntervalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultIntervalInt16ConstOp struct {
@@ -11115,11 +11459,14 @@ type projMultIntervalInt16ConstOp struct {
 	constArg int16
 }
 
-func (p projMultIntervalInt16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultIntervalInt16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Durations
@@ -11173,7 +11520,7 @@ func (p projMultIntervalInt16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultIntervalInt32ConstOp struct {
@@ -11181,11 +11528,14 @@ type projMultIntervalInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projMultIntervalInt32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultIntervalInt32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Durations
@@ -11239,7 +11589,7 @@ func (p projMultIntervalInt32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultIntervalInt64ConstOp struct {
@@ -11247,11 +11597,14 @@ type projMultIntervalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projMultIntervalInt64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultIntervalInt64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Durations
@@ -11305,7 +11658,7 @@ func (p projMultIntervalInt64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultIntervalFloat64ConstOp struct {
@@ -11313,11 +11666,14 @@ type projMultIntervalFloat64ConstOp struct {
 	constArg float64
 }
 
-func (p projMultIntervalFloat64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultIntervalFloat64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Durations
@@ -11371,7 +11727,7 @@ func (p projMultIntervalFloat64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projMultIntervalDecimalConstOp struct {
@@ -11379,11 +11735,14 @@ type projMultIntervalDecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projMultIntervalDecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projMultIntervalDecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Durations
@@ -11457,7 +11816,7 @@ func (p projMultIntervalDecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivDecimalInt16ConstOp struct {
@@ -11465,11 +11824,14 @@ type projDivDecimalInt16ConstOp struct {
 	constArg int16
 }
 
-func (p projDivDecimalInt16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivDecimalInt16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -11575,7 +11937,7 @@ func (p projDivDecimalInt16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivDecimalInt32ConstOp struct {
@@ -11583,11 +11945,14 @@ type projDivDecimalInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projDivDecimalInt32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivDecimalInt32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -11693,7 +12058,7 @@ func (p projDivDecimalInt32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivDecimalInt64ConstOp struct {
@@ -11701,11 +12066,14 @@ type projDivDecimalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projDivDecimalInt64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivDecimalInt64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -11811,7 +12179,7 @@ func (p projDivDecimalInt64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivDecimalDecimalConstOp struct {
@@ -11819,11 +12187,14 @@ type projDivDecimalDecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projDivDecimalDecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivDecimalDecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -11945,7 +12316,7 @@ func (p projDivDecimalDecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivInt16Int16ConstOp struct {
@@ -11953,11 +12324,14 @@ type projDivInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projDivInt16Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivInt16Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -12059,7 +12433,7 @@ func (p projDivInt16Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivInt16Int32ConstOp struct {
@@ -12067,11 +12441,14 @@ type projDivInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projDivInt16Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivInt16Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -12173,7 +12550,7 @@ func (p projDivInt16Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivInt16Int64ConstOp struct {
@@ -12181,11 +12558,14 @@ type projDivInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projDivInt16Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivInt16Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -12287,7 +12667,7 @@ func (p projDivInt16Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivInt16DecimalConstOp struct {
@@ -12295,11 +12675,14 @@ type projDivInt16DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projDivInt16DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivInt16DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -12429,7 +12812,7 @@ func (p projDivInt16DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivInt32Int16ConstOp struct {
@@ -12437,11 +12820,14 @@ type projDivInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projDivInt32Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivInt32Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -12543,7 +12929,7 @@ func (p projDivInt32Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivInt32Int32ConstOp struct {
@@ -12551,11 +12937,14 @@ type projDivInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projDivInt32Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivInt32Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -12657,7 +13046,7 @@ func (p projDivInt32Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivInt32Int64ConstOp struct {
@@ -12665,11 +13054,14 @@ type projDivInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projDivInt32Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivInt32Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -12771,7 +13163,7 @@ func (p projDivInt32Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivInt32DecimalConstOp struct {
@@ -12779,11 +13171,14 @@ type projDivInt32DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projDivInt32DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivInt32DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -12913,7 +13308,7 @@ func (p projDivInt32DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivInt64Int16ConstOp struct {
@@ -12921,11 +13316,14 @@ type projDivInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projDivInt64Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivInt64Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -13027,7 +13425,7 @@ func (p projDivInt64Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivInt64Int32ConstOp struct {
@@ -13035,11 +13433,14 @@ type projDivInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projDivInt64Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivInt64Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -13141,7 +13542,7 @@ func (p projDivInt64Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivInt64Int64ConstOp struct {
@@ -13149,11 +13550,14 @@ type projDivInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projDivInt64Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivInt64Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -13255,7 +13659,7 @@ func (p projDivInt64Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivInt64DecimalConstOp struct {
@@ -13263,11 +13667,14 @@ type projDivInt64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projDivInt64DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivInt64DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -13397,7 +13804,7 @@ func (p projDivInt64DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivFloat64Float64ConstOp struct {
@@ -13405,11 +13812,14 @@ type projDivFloat64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projDivFloat64Float64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivFloat64Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -13499,7 +13909,7 @@ func (p projDivFloat64Float64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivIntervalInt16ConstOp struct {
@@ -13507,11 +13917,14 @@ type projDivIntervalInt16ConstOp struct {
 	constArg int16
 }
 
-func (p projDivIntervalInt16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivIntervalInt16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Durations
@@ -13581,7 +13994,7 @@ func (p projDivIntervalInt16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivIntervalInt32ConstOp struct {
@@ -13589,11 +14002,14 @@ type projDivIntervalInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projDivIntervalInt32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivIntervalInt32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Durations
@@ -13663,7 +14079,7 @@ func (p projDivIntervalInt32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivIntervalInt64ConstOp struct {
@@ -13671,11 +14087,14 @@ type projDivIntervalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projDivIntervalInt64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivIntervalInt64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Durations
@@ -13745,7 +14164,7 @@ func (p projDivIntervalInt64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projDivIntervalFloat64ConstOp struct {
@@ -13753,11 +14172,14 @@ type projDivIntervalFloat64ConstOp struct {
 	constArg float64
 }
 
-func (p projDivIntervalFloat64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projDivIntervalFloat64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Durations
@@ -13827,7 +14249,7 @@ func (p projDivIntervalFloat64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivDecimalInt16ConstOp struct {
@@ -13835,11 +14257,14 @@ type projFloorDivDecimalInt16ConstOp struct {
 	constArg int16
 }
 
-func (p projFloorDivDecimalInt16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivDecimalInt16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -13945,7 +14370,7 @@ func (p projFloorDivDecimalInt16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivDecimalInt32ConstOp struct {
@@ -13953,11 +14378,14 @@ type projFloorDivDecimalInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projFloorDivDecimalInt32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivDecimalInt32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -14063,7 +14491,7 @@ func (p projFloorDivDecimalInt32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivDecimalInt64ConstOp struct {
@@ -14071,11 +14499,14 @@ type projFloorDivDecimalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projFloorDivDecimalInt64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivDecimalInt64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -14181,7 +14612,7 @@ func (p projFloorDivDecimalInt64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivDecimalDecimalConstOp struct {
@@ -14189,11 +14620,14 @@ type projFloorDivDecimalDecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projFloorDivDecimalDecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivDecimalDecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -14315,7 +14749,7 @@ func (p projFloorDivDecimalDecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivInt16Int16ConstOp struct {
@@ -14323,11 +14757,14 @@ type projFloorDivInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projFloorDivInt16Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivInt16Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -14409,7 +14846,7 @@ func (p projFloorDivInt16Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivInt16Int32ConstOp struct {
@@ -14417,11 +14854,14 @@ type projFloorDivInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projFloorDivInt16Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivInt16Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -14503,7 +14943,7 @@ func (p projFloorDivInt16Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivInt16Int64ConstOp struct {
@@ -14511,11 +14951,14 @@ type projFloorDivInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projFloorDivInt16Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivInt16Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -14597,7 +15040,7 @@ func (p projFloorDivInt16Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivInt16DecimalConstOp struct {
@@ -14605,11 +15048,14 @@ type projFloorDivInt16DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projFloorDivInt16DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivInt16DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -14739,7 +15185,7 @@ func (p projFloorDivInt16DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivInt32Int16ConstOp struct {
@@ -14747,11 +15193,14 @@ type projFloorDivInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projFloorDivInt32Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivInt32Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -14833,7 +15282,7 @@ func (p projFloorDivInt32Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivInt32Int32ConstOp struct {
@@ -14841,11 +15290,14 @@ type projFloorDivInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projFloorDivInt32Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivInt32Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -14927,7 +15379,7 @@ func (p projFloorDivInt32Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivInt32Int64ConstOp struct {
@@ -14935,11 +15387,14 @@ type projFloorDivInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projFloorDivInt32Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivInt32Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -15021,7 +15476,7 @@ func (p projFloorDivInt32Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivInt32DecimalConstOp struct {
@@ -15029,11 +15484,14 @@ type projFloorDivInt32DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projFloorDivInt32DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivInt32DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -15163,7 +15621,7 @@ func (p projFloorDivInt32DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivInt64Int16ConstOp struct {
@@ -15171,11 +15629,14 @@ type projFloorDivInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projFloorDivInt64Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivInt64Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -15257,7 +15718,7 @@ func (p projFloorDivInt64Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivInt64Int32ConstOp struct {
@@ -15265,11 +15726,14 @@ type projFloorDivInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projFloorDivInt64Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivInt64Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -15351,7 +15815,7 @@ func (p projFloorDivInt64Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivInt64Int64ConstOp struct {
@@ -15359,11 +15823,14 @@ type projFloorDivInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projFloorDivInt64Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivInt64Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -15445,7 +15912,7 @@ func (p projFloorDivInt64Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivInt64DecimalConstOp struct {
@@ -15453,11 +15920,14 @@ type projFloorDivInt64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projFloorDivInt64DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivInt64DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -15587,7 +16057,7 @@ func (p projFloorDivInt64DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projFloorDivFloat64Float64ConstOp struct {
@@ -15595,11 +16065,14 @@ type projFloorDivFloat64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projFloorDivFloat64Float64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projFloorDivFloat64Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -15689,7 +16162,7 @@ func (p projFloorDivFloat64Float64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModDecimalInt16ConstOp struct {
@@ -15697,11 +16170,14 @@ type projModDecimalInt16ConstOp struct {
 	constArg int16
 }
 
-func (p projModDecimalInt16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModDecimalInt16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -15807,7 +16283,7 @@ func (p projModDecimalInt16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModDecimalInt32ConstOp struct {
@@ -15815,11 +16291,14 @@ type projModDecimalInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projModDecimalInt32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModDecimalInt32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -15925,7 +16404,7 @@ func (p projModDecimalInt32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModDecimalInt64ConstOp struct {
@@ -15933,11 +16412,14 @@ type projModDecimalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projModDecimalInt64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModDecimalInt64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -16043,7 +16525,7 @@ func (p projModDecimalInt64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModDecimalDecimalConstOp struct {
@@ -16051,11 +16533,14 @@ type projModDecimalDecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projModDecimalDecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModDecimalDecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -16161,7 +16646,7 @@ func (p projModDecimalDecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModInt16Int16ConstOp struct {
@@ -16169,11 +16654,14 @@ type projModInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projModInt16Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModInt16Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -16255,7 +16743,7 @@ func (p projModInt16Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModInt16Int32ConstOp struct {
@@ -16263,11 +16751,14 @@ type projModInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projModInt16Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModInt16Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -16349,7 +16840,7 @@ func (p projModInt16Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModInt16Int64ConstOp struct {
@@ -16357,11 +16848,14 @@ type projModInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projModInt16Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModInt16Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -16443,7 +16937,7 @@ func (p projModInt16Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModInt16DecimalConstOp struct {
@@ -16451,11 +16945,14 @@ type projModInt16DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projModInt16DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModInt16DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -16569,7 +17066,7 @@ func (p projModInt16DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModInt32Int16ConstOp struct {
@@ -16577,11 +17074,14 @@ type projModInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projModInt32Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModInt32Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -16663,7 +17163,7 @@ func (p projModInt32Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModInt32Int32ConstOp struct {
@@ -16671,11 +17171,14 @@ type projModInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projModInt32Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModInt32Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -16757,7 +17260,7 @@ func (p projModInt32Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModInt32Int64ConstOp struct {
@@ -16765,11 +17268,14 @@ type projModInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projModInt32Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModInt32Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -16851,7 +17357,7 @@ func (p projModInt32Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModInt32DecimalConstOp struct {
@@ -16859,11 +17365,14 @@ type projModInt32DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projModInt32DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModInt32DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -16977,7 +17486,7 @@ func (p projModInt32DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModInt64Int16ConstOp struct {
@@ -16985,11 +17494,14 @@ type projModInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projModInt64Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModInt64Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -17071,7 +17583,7 @@ func (p projModInt64Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModInt64Int32ConstOp struct {
@@ -17079,11 +17591,14 @@ type projModInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projModInt64Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModInt64Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -17165,7 +17680,7 @@ func (p projModInt64Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModInt64Int64ConstOp struct {
@@ -17173,11 +17688,14 @@ type projModInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projModInt64Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModInt64Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -17259,7 +17777,7 @@ func (p projModInt64Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModInt64DecimalConstOp struct {
@@ -17267,11 +17785,14 @@ type projModInt64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projModInt64DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModInt64DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -17385,7 +17906,7 @@ func (p projModInt64DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projModFloat64Float64ConstOp struct {
@@ -17393,11 +17914,14 @@ type projModFloat64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projModFloat64Float64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projModFloat64Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -17487,7 +18011,7 @@ func (p projModFloat64Float64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowDecimalInt16ConstOp struct {
@@ -17495,11 +18019,14 @@ type projPowDecimalInt16ConstOp struct {
 	constArg int16
 }
 
-func (p projPowDecimalInt16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowDecimalInt16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -17589,7 +18116,7 @@ func (p projPowDecimalInt16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowDecimalInt32ConstOp struct {
@@ -17597,11 +18124,14 @@ type projPowDecimalInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projPowDecimalInt32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowDecimalInt32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -17691,7 +18221,7 @@ func (p projPowDecimalInt32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowDecimalInt64ConstOp struct {
@@ -17699,11 +18229,14 @@ type projPowDecimalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projPowDecimalInt64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowDecimalInt64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -17793,7 +18326,7 @@ func (p projPowDecimalInt64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowDecimalDecimalConstOp struct {
@@ -17801,11 +18334,14 @@ type projPowDecimalDecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projPowDecimalDecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowDecimalDecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -17895,7 +18431,7 @@ func (p projPowDecimalDecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowInt16Int16ConstOp struct {
@@ -17903,11 +18439,14 @@ type projPowInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projPowInt16Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowInt16Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -18017,7 +18556,7 @@ func (p projPowInt16Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowInt16Int32ConstOp struct {
@@ -18025,11 +18564,14 @@ type projPowInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projPowInt16Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowInt16Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -18139,7 +18681,7 @@ func (p projPowInt16Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowInt16Int64ConstOp struct {
@@ -18147,11 +18689,14 @@ type projPowInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projPowInt16Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowInt16Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -18261,7 +18806,7 @@ func (p projPowInt16Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowInt16DecimalConstOp struct {
@@ -18269,11 +18814,14 @@ type projPowInt16DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projPowInt16DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowInt16DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -18371,7 +18919,7 @@ func (p projPowInt16DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowInt32Int16ConstOp struct {
@@ -18379,11 +18927,14 @@ type projPowInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projPowInt32Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowInt32Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -18493,7 +19044,7 @@ func (p projPowInt32Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowInt32Int32ConstOp struct {
@@ -18501,11 +19052,14 @@ type projPowInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projPowInt32Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowInt32Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -18615,7 +19169,7 @@ func (p projPowInt32Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowInt32Int64ConstOp struct {
@@ -18623,11 +19177,14 @@ type projPowInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projPowInt32Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowInt32Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -18737,7 +19294,7 @@ func (p projPowInt32Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowInt32DecimalConstOp struct {
@@ -18745,11 +19302,14 @@ type projPowInt32DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projPowInt32DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowInt32DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -18847,7 +19407,7 @@ func (p projPowInt32DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowInt64Int16ConstOp struct {
@@ -18855,11 +19415,14 @@ type projPowInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projPowInt64Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowInt64Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -18969,7 +19532,7 @@ func (p projPowInt64Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowInt64Int32ConstOp struct {
@@ -18977,11 +19540,14 @@ type projPowInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projPowInt64Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowInt64Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -19091,7 +19657,7 @@ func (p projPowInt64Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowInt64Int64ConstOp struct {
@@ -19099,11 +19665,14 @@ type projPowInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projPowInt64Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowInt64Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -19213,7 +19782,7 @@ func (p projPowInt64Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowInt64DecimalConstOp struct {
@@ -19221,11 +19790,14 @@ type projPowInt64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projPowInt64DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowInt64DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -19323,7 +19895,7 @@ func (p projPowInt64DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projPowFloat64Float64ConstOp struct {
@@ -19331,11 +19903,14 @@ type projPowFloat64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projPowFloat64Float64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projPowFloat64Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -19409,7 +19984,7 @@ func (p projPowFloat64Float64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projConcatBytesBytesConstOp struct {
@@ -19417,11 +19992,14 @@ type projConcatBytesBytesConstOp struct {
 	constArg []byte
 }
 
-func (p projConcatBytesBytesConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projConcatBytesBytesConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col *coldata.Bytes
@@ -19501,7 +20079,7 @@ func (p projConcatBytesBytesConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projConcatJSONJSONConstOp struct {
@@ -19509,11 +20087,14 @@ type projConcatJSONJSONConstOp struct {
 	constArg json.JSON
 }
 
-func (p projConcatJSONJSONConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projConcatJSONJSONConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col *coldata.JSONs
@@ -19589,7 +20170,7 @@ func (p projConcatJSONJSONConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projConcatDatumDatumConstOp struct {
@@ -19598,13 +20179,16 @@ type projConcatDatumDatumConstOp struct {
 	constArg interface{}
 }
 
-func (p projConcatDatumDatumConstOp) Next() coldata.Batch {
+func (p projConcatDatumDatumConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.DatumVec
@@ -19700,7 +20284,7 @@ func (p projConcatDatumDatumConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLShiftInt16Int16ConstOp struct {
@@ -19708,11 +20292,14 @@ type projLShiftInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projLShiftInt16Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLShiftInt16Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -19798,7 +20385,7 @@ func (p projLShiftInt16Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLShiftInt16Int32ConstOp struct {
@@ -19806,11 +20393,14 @@ type projLShiftInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projLShiftInt16Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLShiftInt16Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -19896,7 +20486,7 @@ func (p projLShiftInt16Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLShiftInt16Int64ConstOp struct {
@@ -19904,11 +20494,14 @@ type projLShiftInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projLShiftInt16Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLShiftInt16Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -19994,7 +20587,7 @@ func (p projLShiftInt16Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLShiftInt32Int16ConstOp struct {
@@ -20002,11 +20595,14 @@ type projLShiftInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projLShiftInt32Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLShiftInt32Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -20092,7 +20688,7 @@ func (p projLShiftInt32Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLShiftInt32Int32ConstOp struct {
@@ -20100,11 +20696,14 @@ type projLShiftInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projLShiftInt32Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLShiftInt32Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -20190,7 +20789,7 @@ func (p projLShiftInt32Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLShiftInt32Int64ConstOp struct {
@@ -20198,11 +20797,14 @@ type projLShiftInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projLShiftInt32Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLShiftInt32Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -20288,7 +20890,7 @@ func (p projLShiftInt32Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLShiftInt64Int16ConstOp struct {
@@ -20296,11 +20898,14 @@ type projLShiftInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projLShiftInt64Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLShiftInt64Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -20386,7 +20991,7 @@ func (p projLShiftInt64Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLShiftInt64Int32ConstOp struct {
@@ -20394,11 +20999,14 @@ type projLShiftInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projLShiftInt64Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLShiftInt64Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -20484,7 +21092,7 @@ func (p projLShiftInt64Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLShiftInt64Int64ConstOp struct {
@@ -20492,11 +21100,14 @@ type projLShiftInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projLShiftInt64Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLShiftInt64Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -20582,7 +21193,7 @@ func (p projLShiftInt64Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLShiftDatumInt16ConstOp struct {
@@ -20591,13 +21202,16 @@ type projLShiftDatumInt16ConstOp struct {
 	constArg int16
 }
 
-func (p projLShiftDatumInt16ConstOp) Next() coldata.Batch {
+func (p projLShiftDatumInt16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.DatumVec
@@ -20703,7 +21317,7 @@ func (p projLShiftDatumInt16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLShiftDatumInt32ConstOp struct {
@@ -20712,13 +21326,16 @@ type projLShiftDatumInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projLShiftDatumInt32ConstOp) Next() coldata.Batch {
+func (p projLShiftDatumInt32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.DatumVec
@@ -20824,7 +21441,7 @@ func (p projLShiftDatumInt32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLShiftDatumInt64ConstOp struct {
@@ -20833,13 +21450,16 @@ type projLShiftDatumInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projLShiftDatumInt64ConstOp) Next() coldata.Batch {
+func (p projLShiftDatumInt64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.DatumVec
@@ -20945,7 +21565,7 @@ func (p projLShiftDatumInt64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projRShiftInt16Int16ConstOp struct {
@@ -20953,11 +21573,14 @@ type projRShiftInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projRShiftInt16Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projRShiftInt16Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -21043,7 +21666,7 @@ func (p projRShiftInt16Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projRShiftInt16Int32ConstOp struct {
@@ -21051,11 +21674,14 @@ type projRShiftInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projRShiftInt16Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projRShiftInt16Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -21141,7 +21767,7 @@ func (p projRShiftInt16Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projRShiftInt16Int64ConstOp struct {
@@ -21149,11 +21775,14 @@ type projRShiftInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projRShiftInt16Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projRShiftInt16Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -21239,7 +21868,7 @@ func (p projRShiftInt16Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projRShiftInt32Int16ConstOp struct {
@@ -21247,11 +21876,14 @@ type projRShiftInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projRShiftInt32Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projRShiftInt32Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -21337,7 +21969,7 @@ func (p projRShiftInt32Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projRShiftInt32Int32ConstOp struct {
@@ -21345,11 +21977,14 @@ type projRShiftInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projRShiftInt32Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projRShiftInt32Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -21435,7 +22070,7 @@ func (p projRShiftInt32Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projRShiftInt32Int64ConstOp struct {
@@ -21443,11 +22078,14 @@ type projRShiftInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projRShiftInt32Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projRShiftInt32Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -21533,7 +22171,7 @@ func (p projRShiftInt32Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projRShiftInt64Int16ConstOp struct {
@@ -21541,11 +22179,14 @@ type projRShiftInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projRShiftInt64Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projRShiftInt64Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -21631,7 +22272,7 @@ func (p projRShiftInt64Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projRShiftInt64Int32ConstOp struct {
@@ -21639,11 +22280,14 @@ type projRShiftInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projRShiftInt64Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projRShiftInt64Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -21729,7 +22373,7 @@ func (p projRShiftInt64Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projRShiftInt64Int64ConstOp struct {
@@ -21737,11 +22381,14 @@ type projRShiftInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projRShiftInt64Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projRShiftInt64Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -21827,7 +22474,7 @@ func (p projRShiftInt64Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projRShiftDatumInt16ConstOp struct {
@@ -21836,13 +22483,16 @@ type projRShiftDatumInt16ConstOp struct {
 	constArg int16
 }
 
-func (p projRShiftDatumInt16ConstOp) Next() coldata.Batch {
+func (p projRShiftDatumInt16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.DatumVec
@@ -21948,7 +22598,7 @@ func (p projRShiftDatumInt16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projRShiftDatumInt32ConstOp struct {
@@ -21957,13 +22607,16 @@ type projRShiftDatumInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projRShiftDatumInt32ConstOp) Next() coldata.Batch {
+func (p projRShiftDatumInt32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.DatumVec
@@ -22069,7 +22722,7 @@ func (p projRShiftDatumInt32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projRShiftDatumInt64ConstOp struct {
@@ -22078,13 +22731,16 @@ type projRShiftDatumInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projRShiftDatumInt64ConstOp) Next() coldata.Batch {
+func (p projRShiftDatumInt64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_overloadHelper := p.BinaryOverloadHelper
 	_ctx := p.Ctx
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.DatumVec
@@ -22190,7 +22846,7 @@ func (p projRShiftDatumInt64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projJSONFetchValJSONBytesConstOp struct {
@@ -22198,11 +22854,14 @@ type projJSONFetchValJSONBytesConstOp struct {
 	constArg []byte
 }
 
-func (p projJSONFetchValJSONBytesConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projJSONFetchValJSONBytesConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col *coldata.JSONs
@@ -22302,7 +22961,7 @@ func (p projJSONFetchValJSONBytesConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projJSONFetchValJSONInt16ConstOp struct {
@@ -22310,11 +22969,14 @@ type projJSONFetchValJSONInt16ConstOp struct {
 	constArg int16
 }
 
-func (p projJSONFetchValJSONInt16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projJSONFetchValJSONInt16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col *coldata.JSONs
@@ -22404,7 +23066,7 @@ func (p projJSONFetchValJSONInt16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projJSONFetchValJSONInt32ConstOp struct {
@@ -22412,11 +23074,14 @@ type projJSONFetchValJSONInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projJSONFetchValJSONInt32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projJSONFetchValJSONInt32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col *coldata.JSONs
@@ -22506,7 +23171,7 @@ func (p projJSONFetchValJSONInt32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projJSONFetchValJSONInt64ConstOp struct {
@@ -22514,11 +23179,14 @@ type projJSONFetchValJSONInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projJSONFetchValJSONInt64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projJSONFetchValJSONInt64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col *coldata.JSONs
@@ -22608,7 +23276,7 @@ func (p projJSONFetchValJSONInt64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projJSONFetchTextJSONBytesConstOp struct {
@@ -22616,11 +23284,14 @@ type projJSONFetchTextJSONBytesConstOp struct {
 	constArg []byte
 }
 
-func (p projJSONFetchTextJSONBytesConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projJSONFetchTextJSONBytesConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col *coldata.JSONs
@@ -22756,7 +23427,7 @@ func (p projJSONFetchTextJSONBytesConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projJSONFetchTextJSONInt16ConstOp struct {
@@ -22764,11 +23435,14 @@ type projJSONFetchTextJSONInt16ConstOp struct {
 	constArg int16
 }
 
-func (p projJSONFetchTextJSONInt16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projJSONFetchTextJSONInt16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col *coldata.JSONs
@@ -22894,7 +23568,7 @@ func (p projJSONFetchTextJSONInt16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projJSONFetchTextJSONInt32ConstOp struct {
@@ -22902,11 +23576,14 @@ type projJSONFetchTextJSONInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projJSONFetchTextJSONInt32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projJSONFetchTextJSONInt32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col *coldata.JSONs
@@ -23032,7 +23709,7 @@ func (p projJSONFetchTextJSONInt32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projJSONFetchTextJSONInt64ConstOp struct {
@@ -23040,11 +23717,14 @@ type projJSONFetchTextJSONInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projJSONFetchTextJSONInt64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projJSONFetchTextJSONInt64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col *coldata.JSONs
@@ -23170,7 +23850,7 @@ func (p projJSONFetchTextJSONInt64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projJSONFetchValPathJSONDatumConstOp struct {
@@ -23178,11 +23858,14 @@ type projJSONFetchValPathJSONDatumConstOp struct {
 	constArg interface{}
 }
 
-func (p projJSONFetchValPathJSONDatumConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projJSONFetchValPathJSONDatumConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col *coldata.JSONs
@@ -23270,7 +23953,7 @@ func (p projJSONFetchValPathJSONDatumConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projJSONFetchTextPathJSONDatumConstOp struct {
@@ -23278,11 +23961,14 @@ type projJSONFetchTextPathJSONDatumConstOp struct {
 	constArg interface{}
 }
 
-func (p projJSONFetchTextPathJSONDatumConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projJSONFetchTextPathJSONDatumConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col *coldata.JSONs
@@ -23410,7 +24096,7 @@ func (p projJSONFetchTextPathJSONDatumConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQBoolBoolConstOp struct {
@@ -23418,11 +24104,14 @@ type projEQBoolBoolConstOp struct {
 	constArg bool
 }
 
-func (p projEQBoolBoolConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQBoolBoolConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Bools
@@ -23532,7 +24221,7 @@ func (p projEQBoolBoolConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQBytesBytesConstOp struct {
@@ -23540,11 +24229,14 @@ type projEQBytesBytesConstOp struct {
 	constArg []byte
 }
 
-func (p projEQBytesBytesConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQBytesBytesConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col *coldata.Bytes
@@ -23620,7 +24312,7 @@ func (p projEQBytesBytesConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQDecimalInt16ConstOp struct {
@@ -23628,11 +24320,14 @@ type projEQDecimalInt16ConstOp struct {
 	constArg int16
 }
 
-func (p projEQDecimalInt16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQDecimalInt16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -23734,7 +24429,7 @@ func (p projEQDecimalInt16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQDecimalInt32ConstOp struct {
@@ -23742,11 +24437,14 @@ type projEQDecimalInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projEQDecimalInt32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQDecimalInt32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -23848,7 +24546,7 @@ func (p projEQDecimalInt32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQDecimalInt64ConstOp struct {
@@ -23856,11 +24554,14 @@ type projEQDecimalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projEQDecimalInt64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQDecimalInt64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -23962,7 +24663,7 @@ func (p projEQDecimalInt64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQDecimalFloat64ConstOp struct {
@@ -23970,11 +24671,14 @@ type projEQDecimalFloat64ConstOp struct {
 	constArg float64
 }
 
-func (p projEQDecimalFloat64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQDecimalFloat64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -24084,7 +24788,7 @@ func (p projEQDecimalFloat64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQDecimalDecimalConstOp struct {
@@ -24092,11 +24796,14 @@ type projEQDecimalDecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projEQDecimalDecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQDecimalDecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -24174,7 +24881,7 @@ func (p projEQDecimalDecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQInt16Int16ConstOp struct {
@@ -24182,11 +24889,14 @@ type projEQInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projEQInt16Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQInt16Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -24308,7 +25018,7 @@ func (p projEQInt16Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQInt16Int32ConstOp struct {
@@ -24316,11 +25026,14 @@ type projEQInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projEQInt16Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQInt16Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -24442,7 +25155,7 @@ func (p projEQInt16Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQInt16Int64ConstOp struct {
@@ -24450,11 +25163,14 @@ type projEQInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projEQInt16Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQInt16Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -24576,7 +25292,7 @@ func (p projEQInt16Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQInt16Float64ConstOp struct {
@@ -24584,11 +25300,14 @@ type projEQInt16Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projEQInt16Float64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQInt16Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -24742,7 +25461,7 @@ func (p projEQInt16Float64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQInt16DecimalConstOp struct {
@@ -24750,11 +25469,14 @@ type projEQInt16DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projEQInt16DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQInt16DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -24856,7 +25578,7 @@ func (p projEQInt16DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQInt32Int16ConstOp struct {
@@ -24864,11 +25586,14 @@ type projEQInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projEQInt32Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQInt32Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -24990,7 +25715,7 @@ func (p projEQInt32Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQInt32Int32ConstOp struct {
@@ -24998,11 +25723,14 @@ type projEQInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projEQInt32Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQInt32Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -25124,7 +25852,7 @@ func (p projEQInt32Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQInt32Int64ConstOp struct {
@@ -25132,11 +25860,14 @@ type projEQInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projEQInt32Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQInt32Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -25258,7 +25989,7 @@ func (p projEQInt32Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQInt32Float64ConstOp struct {
@@ -25266,11 +25997,14 @@ type projEQInt32Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projEQInt32Float64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQInt32Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -25424,7 +26158,7 @@ func (p projEQInt32Float64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQInt32DecimalConstOp struct {
@@ -25432,11 +26166,14 @@ type projEQInt32DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projEQInt32DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQInt32DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -25538,7 +26275,7 @@ func (p projEQInt32DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQInt64Int16ConstOp struct {
@@ -25546,11 +26283,14 @@ type projEQInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projEQInt64Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQInt64Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -25672,7 +26412,7 @@ func (p projEQInt64Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQInt64Int32ConstOp struct {
@@ -25680,11 +26420,14 @@ type projEQInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projEQInt64Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQInt64Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -25806,7 +26549,7 @@ func (p projEQInt64Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQInt64Int64ConstOp struct {
@@ -25814,11 +26557,14 @@ type projEQInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projEQInt64Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQInt64Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -25940,7 +26686,7 @@ func (p projEQInt64Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQInt64Float64ConstOp struct {
@@ -25948,11 +26694,14 @@ type projEQInt64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projEQInt64Float64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQInt64Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -26106,7 +26855,7 @@ func (p projEQInt64Float64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQInt64DecimalConstOp struct {
@@ -26114,11 +26863,14 @@ type projEQInt64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projEQInt64DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQInt64DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -26220,7 +26972,7 @@ func (p projEQInt64DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQFloat64Int16ConstOp struct {
@@ -26228,11 +26980,14 @@ type projEQFloat64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projEQFloat64Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQFloat64Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -26386,7 +27141,7 @@ func (p projEQFloat64Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQFloat64Int32ConstOp struct {
@@ -26394,11 +27149,14 @@ type projEQFloat64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projEQFloat64Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQFloat64Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -26552,7 +27310,7 @@ func (p projEQFloat64Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQFloat64Int64ConstOp struct {
@@ -26560,11 +27318,14 @@ type projEQFloat64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projEQFloat64Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQFloat64Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -26718,7 +27479,7 @@ func (p projEQFloat64Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQFloat64Float64ConstOp struct {
@@ -26726,11 +27487,14 @@ type projEQFloat64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projEQFloat64Float64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQFloat64Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -26884,7 +27648,7 @@ func (p projEQFloat64Float64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQFloat64DecimalConstOp struct {
@@ -26892,11 +27656,14 @@ type projEQFloat64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projEQFloat64DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQFloat64DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -27006,7 +27773,7 @@ func (p projEQFloat64DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQTimestampTimestampConstOp struct {
@@ -27014,11 +27781,14 @@ type projEQTimestampTimestampConstOp struct {
 	constArg time.Time
 }
 
-func (p projEQTimestampTimestampConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQTimestampTimestampConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Times
@@ -27124,7 +27894,7 @@ func (p projEQTimestampTimestampConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQIntervalIntervalConstOp struct {
@@ -27132,11 +27902,14 @@ type projEQIntervalIntervalConstOp struct {
 	constArg duration.Duration
 }
 
-func (p projEQIntervalIntervalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQIntervalIntervalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Durations
@@ -27214,7 +27987,7 @@ func (p projEQIntervalIntervalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQJSONJSONConstOp struct {
@@ -27222,11 +27995,14 @@ type projEQJSONJSONConstOp struct {
 	constArg json.JSON
 }
 
-func (p projEQJSONJSONConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQJSONJSONConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col *coldata.JSONs
@@ -27326,7 +28102,7 @@ func (p projEQJSONJSONConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projEQDatumDatumConstOp struct {
@@ -27334,11 +28110,14 @@ type projEQDatumDatumConstOp struct {
 	constArg interface{}
 }
 
-func (p projEQDatumDatumConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projEQDatumDatumConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.DatumVec
@@ -27430,7 +28209,7 @@ func (p projEQDatumDatumConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEBoolBoolConstOp struct {
@@ -27438,11 +28217,14 @@ type projNEBoolBoolConstOp struct {
 	constArg bool
 }
 
-func (p projNEBoolBoolConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEBoolBoolConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Bools
@@ -27552,7 +28334,7 @@ func (p projNEBoolBoolConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEBytesBytesConstOp struct {
@@ -27560,11 +28342,14 @@ type projNEBytesBytesConstOp struct {
 	constArg []byte
 }
 
-func (p projNEBytesBytesConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEBytesBytesConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col *coldata.Bytes
@@ -27640,7 +28425,7 @@ func (p projNEBytesBytesConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEDecimalInt16ConstOp struct {
@@ -27648,11 +28433,14 @@ type projNEDecimalInt16ConstOp struct {
 	constArg int16
 }
 
-func (p projNEDecimalInt16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEDecimalInt16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -27754,7 +28542,7 @@ func (p projNEDecimalInt16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEDecimalInt32ConstOp struct {
@@ -27762,11 +28550,14 @@ type projNEDecimalInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projNEDecimalInt32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEDecimalInt32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -27868,7 +28659,7 @@ func (p projNEDecimalInt32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEDecimalInt64ConstOp struct {
@@ -27876,11 +28667,14 @@ type projNEDecimalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projNEDecimalInt64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEDecimalInt64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -27982,7 +28776,7 @@ func (p projNEDecimalInt64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEDecimalFloat64ConstOp struct {
@@ -27990,11 +28784,14 @@ type projNEDecimalFloat64ConstOp struct {
 	constArg float64
 }
 
-func (p projNEDecimalFloat64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEDecimalFloat64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -28104,7 +28901,7 @@ func (p projNEDecimalFloat64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEDecimalDecimalConstOp struct {
@@ -28112,11 +28909,14 @@ type projNEDecimalDecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projNEDecimalDecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEDecimalDecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -28194,7 +28994,7 @@ func (p projNEDecimalDecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEInt16Int16ConstOp struct {
@@ -28202,11 +29002,14 @@ type projNEInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projNEInt16Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEInt16Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -28328,7 +29131,7 @@ func (p projNEInt16Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEInt16Int32ConstOp struct {
@@ -28336,11 +29139,14 @@ type projNEInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projNEInt16Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEInt16Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -28462,7 +29268,7 @@ func (p projNEInt16Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEInt16Int64ConstOp struct {
@@ -28470,11 +29276,14 @@ type projNEInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projNEInt16Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEInt16Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -28596,7 +29405,7 @@ func (p projNEInt16Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEInt16Float64ConstOp struct {
@@ -28604,11 +29413,14 @@ type projNEInt16Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projNEInt16Float64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEInt16Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -28762,7 +29574,7 @@ func (p projNEInt16Float64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEInt16DecimalConstOp struct {
@@ -28770,11 +29582,14 @@ type projNEInt16DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projNEInt16DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEInt16DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -28876,7 +29691,7 @@ func (p projNEInt16DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEInt32Int16ConstOp struct {
@@ -28884,11 +29699,14 @@ type projNEInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projNEInt32Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEInt32Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -29010,7 +29828,7 @@ func (p projNEInt32Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEInt32Int32ConstOp struct {
@@ -29018,11 +29836,14 @@ type projNEInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projNEInt32Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEInt32Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -29144,7 +29965,7 @@ func (p projNEInt32Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEInt32Int64ConstOp struct {
@@ -29152,11 +29973,14 @@ type projNEInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projNEInt32Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEInt32Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -29278,7 +30102,7 @@ func (p projNEInt32Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEInt32Float64ConstOp struct {
@@ -29286,11 +30110,14 @@ type projNEInt32Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projNEInt32Float64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEInt32Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -29444,7 +30271,7 @@ func (p projNEInt32Float64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEInt32DecimalConstOp struct {
@@ -29452,11 +30279,14 @@ type projNEInt32DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projNEInt32DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEInt32DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -29558,7 +30388,7 @@ func (p projNEInt32DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEInt64Int16ConstOp struct {
@@ -29566,11 +30396,14 @@ type projNEInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projNEInt64Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEInt64Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -29692,7 +30525,7 @@ func (p projNEInt64Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEInt64Int32ConstOp struct {
@@ -29700,11 +30533,14 @@ type projNEInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projNEInt64Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEInt64Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -29826,7 +30662,7 @@ func (p projNEInt64Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEInt64Int64ConstOp struct {
@@ -29834,11 +30670,14 @@ type projNEInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projNEInt64Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEInt64Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -29960,7 +30799,7 @@ func (p projNEInt64Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEInt64Float64ConstOp struct {
@@ -29968,11 +30807,14 @@ type projNEInt64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projNEInt64Float64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEInt64Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -30126,7 +30968,7 @@ func (p projNEInt64Float64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEInt64DecimalConstOp struct {
@@ -30134,11 +30976,14 @@ type projNEInt64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projNEInt64DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEInt64DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -30240,7 +31085,7 @@ func (p projNEInt64DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEFloat64Int16ConstOp struct {
@@ -30248,11 +31093,14 @@ type projNEFloat64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projNEFloat64Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEFloat64Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -30406,7 +31254,7 @@ func (p projNEFloat64Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEFloat64Int32ConstOp struct {
@@ -30414,11 +31262,14 @@ type projNEFloat64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projNEFloat64Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEFloat64Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -30572,7 +31423,7 @@ func (p projNEFloat64Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEFloat64Int64ConstOp struct {
@@ -30580,11 +31431,14 @@ type projNEFloat64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projNEFloat64Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEFloat64Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -30738,7 +31592,7 @@ func (p projNEFloat64Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEFloat64Float64ConstOp struct {
@@ -30746,11 +31600,14 @@ type projNEFloat64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projNEFloat64Float64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEFloat64Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -30904,7 +31761,7 @@ func (p projNEFloat64Float64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEFloat64DecimalConstOp struct {
@@ -30912,11 +31769,14 @@ type projNEFloat64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projNEFloat64DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEFloat64DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -31026,7 +31886,7 @@ func (p projNEFloat64DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNETimestampTimestampConstOp struct {
@@ -31034,11 +31894,14 @@ type projNETimestampTimestampConstOp struct {
 	constArg time.Time
 }
 
-func (p projNETimestampTimestampConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNETimestampTimestampConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Times
@@ -31144,7 +32007,7 @@ func (p projNETimestampTimestampConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEIntervalIntervalConstOp struct {
@@ -31152,11 +32015,14 @@ type projNEIntervalIntervalConstOp struct {
 	constArg duration.Duration
 }
 
-func (p projNEIntervalIntervalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEIntervalIntervalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Durations
@@ -31234,7 +32100,7 @@ func (p projNEIntervalIntervalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEJSONJSONConstOp struct {
@@ -31242,11 +32108,14 @@ type projNEJSONJSONConstOp struct {
 	constArg json.JSON
 }
 
-func (p projNEJSONJSONConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEJSONJSONConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col *coldata.JSONs
@@ -31346,7 +32215,7 @@ func (p projNEJSONJSONConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projNEDatumDatumConstOp struct {
@@ -31354,11 +32223,14 @@ type projNEDatumDatumConstOp struct {
 	constArg interface{}
 }
 
-func (p projNEDatumDatumConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projNEDatumDatumConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.DatumVec
@@ -31450,7 +32322,7 @@ func (p projNEDatumDatumConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTBoolBoolConstOp struct {
@@ -31458,11 +32330,14 @@ type projLTBoolBoolConstOp struct {
 	constArg bool
 }
 
-func (p projLTBoolBoolConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTBoolBoolConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Bools
@@ -31572,7 +32447,7 @@ func (p projLTBoolBoolConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTBytesBytesConstOp struct {
@@ -31580,11 +32455,14 @@ type projLTBytesBytesConstOp struct {
 	constArg []byte
 }
 
-func (p projLTBytesBytesConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTBytesBytesConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col *coldata.Bytes
@@ -31660,7 +32538,7 @@ func (p projLTBytesBytesConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTDecimalInt16ConstOp struct {
@@ -31668,11 +32546,14 @@ type projLTDecimalInt16ConstOp struct {
 	constArg int16
 }
 
-func (p projLTDecimalInt16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTDecimalInt16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -31774,7 +32655,7 @@ func (p projLTDecimalInt16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTDecimalInt32ConstOp struct {
@@ -31782,11 +32663,14 @@ type projLTDecimalInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projLTDecimalInt32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTDecimalInt32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -31888,7 +32772,7 @@ func (p projLTDecimalInt32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTDecimalInt64ConstOp struct {
@@ -31896,11 +32780,14 @@ type projLTDecimalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projLTDecimalInt64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTDecimalInt64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -32002,7 +32889,7 @@ func (p projLTDecimalInt64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTDecimalFloat64ConstOp struct {
@@ -32010,11 +32897,14 @@ type projLTDecimalFloat64ConstOp struct {
 	constArg float64
 }
 
-func (p projLTDecimalFloat64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTDecimalFloat64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -32124,7 +33014,7 @@ func (p projLTDecimalFloat64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTDecimalDecimalConstOp struct {
@@ -32132,11 +33022,14 @@ type projLTDecimalDecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projLTDecimalDecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTDecimalDecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -32214,7 +33107,7 @@ func (p projLTDecimalDecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTInt16Int16ConstOp struct {
@@ -32222,11 +33115,14 @@ type projLTInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projLTInt16Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTInt16Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -32348,7 +33244,7 @@ func (p projLTInt16Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTInt16Int32ConstOp struct {
@@ -32356,11 +33252,14 @@ type projLTInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projLTInt16Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTInt16Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -32482,7 +33381,7 @@ func (p projLTInt16Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTInt16Int64ConstOp struct {
@@ -32490,11 +33389,14 @@ type projLTInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projLTInt16Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTInt16Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -32616,7 +33518,7 @@ func (p projLTInt16Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTInt16Float64ConstOp struct {
@@ -32624,11 +33526,14 @@ type projLTInt16Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projLTInt16Float64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTInt16Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -32782,7 +33687,7 @@ func (p projLTInt16Float64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTInt16DecimalConstOp struct {
@@ -32790,11 +33695,14 @@ type projLTInt16DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projLTInt16DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTInt16DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -32896,7 +33804,7 @@ func (p projLTInt16DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTInt32Int16ConstOp struct {
@@ -32904,11 +33812,14 @@ type projLTInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projLTInt32Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTInt32Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -33030,7 +33941,7 @@ func (p projLTInt32Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTInt32Int32ConstOp struct {
@@ -33038,11 +33949,14 @@ type projLTInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projLTInt32Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTInt32Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -33164,7 +34078,7 @@ func (p projLTInt32Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTInt32Int64ConstOp struct {
@@ -33172,11 +34086,14 @@ type projLTInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projLTInt32Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTInt32Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -33298,7 +34215,7 @@ func (p projLTInt32Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTInt32Float64ConstOp struct {
@@ -33306,11 +34223,14 @@ type projLTInt32Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projLTInt32Float64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTInt32Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -33464,7 +34384,7 @@ func (p projLTInt32Float64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTInt32DecimalConstOp struct {
@@ -33472,11 +34392,14 @@ type projLTInt32DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projLTInt32DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTInt32DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -33578,7 +34501,7 @@ func (p projLTInt32DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTInt64Int16ConstOp struct {
@@ -33586,11 +34509,14 @@ type projLTInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projLTInt64Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTInt64Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -33712,7 +34638,7 @@ func (p projLTInt64Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTInt64Int32ConstOp struct {
@@ -33720,11 +34646,14 @@ type projLTInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projLTInt64Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTInt64Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -33846,7 +34775,7 @@ func (p projLTInt64Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTInt64Int64ConstOp struct {
@@ -33854,11 +34783,14 @@ type projLTInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projLTInt64Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTInt64Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -33980,7 +34912,7 @@ func (p projLTInt64Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTInt64Float64ConstOp struct {
@@ -33988,11 +34920,14 @@ type projLTInt64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projLTInt64Float64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTInt64Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -34146,7 +35081,7 @@ func (p projLTInt64Float64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTInt64DecimalConstOp struct {
@@ -34154,11 +35089,14 @@ type projLTInt64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projLTInt64DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTInt64DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -34260,7 +35198,7 @@ func (p projLTInt64DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTFloat64Int16ConstOp struct {
@@ -34268,11 +35206,14 @@ type projLTFloat64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projLTFloat64Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTFloat64Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -34426,7 +35367,7 @@ func (p projLTFloat64Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTFloat64Int32ConstOp struct {
@@ -34434,11 +35375,14 @@ type projLTFloat64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projLTFloat64Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTFloat64Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -34592,7 +35536,7 @@ func (p projLTFloat64Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTFloat64Int64ConstOp struct {
@@ -34600,11 +35544,14 @@ type projLTFloat64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projLTFloat64Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTFloat64Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -34758,7 +35705,7 @@ func (p projLTFloat64Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTFloat64Float64ConstOp struct {
@@ -34766,11 +35713,14 @@ type projLTFloat64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projLTFloat64Float64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTFloat64Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -34924,7 +35874,7 @@ func (p projLTFloat64Float64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTFloat64DecimalConstOp struct {
@@ -34932,11 +35882,14 @@ type projLTFloat64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projLTFloat64DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTFloat64DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -35046,7 +35999,7 @@ func (p projLTFloat64DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTTimestampTimestampConstOp struct {
@@ -35054,11 +36007,14 @@ type projLTTimestampTimestampConstOp struct {
 	constArg time.Time
 }
 
-func (p projLTTimestampTimestampConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTTimestampTimestampConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Times
@@ -35164,7 +36120,7 @@ func (p projLTTimestampTimestampConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTIntervalIntervalConstOp struct {
@@ -35172,11 +36128,14 @@ type projLTIntervalIntervalConstOp struct {
 	constArg duration.Duration
 }
 
-func (p projLTIntervalIntervalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTIntervalIntervalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Durations
@@ -35254,7 +36213,7 @@ func (p projLTIntervalIntervalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTJSONJSONConstOp struct {
@@ -35262,11 +36221,14 @@ type projLTJSONJSONConstOp struct {
 	constArg json.JSON
 }
 
-func (p projLTJSONJSONConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTJSONJSONConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col *coldata.JSONs
@@ -35366,7 +36328,7 @@ func (p projLTJSONJSONConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLTDatumDatumConstOp struct {
@@ -35374,11 +36336,14 @@ type projLTDatumDatumConstOp struct {
 	constArg interface{}
 }
 
-func (p projLTDatumDatumConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLTDatumDatumConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.DatumVec
@@ -35470,7 +36435,7 @@ func (p projLTDatumDatumConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEBoolBoolConstOp struct {
@@ -35478,11 +36443,14 @@ type projLEBoolBoolConstOp struct {
 	constArg bool
 }
 
-func (p projLEBoolBoolConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEBoolBoolConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Bools
@@ -35592,7 +36560,7 @@ func (p projLEBoolBoolConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEBytesBytesConstOp struct {
@@ -35600,11 +36568,14 @@ type projLEBytesBytesConstOp struct {
 	constArg []byte
 }
 
-func (p projLEBytesBytesConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEBytesBytesConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col *coldata.Bytes
@@ -35680,7 +36651,7 @@ func (p projLEBytesBytesConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEDecimalInt16ConstOp struct {
@@ -35688,11 +36659,14 @@ type projLEDecimalInt16ConstOp struct {
 	constArg int16
 }
 
-func (p projLEDecimalInt16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEDecimalInt16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -35794,7 +36768,7 @@ func (p projLEDecimalInt16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEDecimalInt32ConstOp struct {
@@ -35802,11 +36776,14 @@ type projLEDecimalInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projLEDecimalInt32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEDecimalInt32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -35908,7 +36885,7 @@ func (p projLEDecimalInt32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEDecimalInt64ConstOp struct {
@@ -35916,11 +36893,14 @@ type projLEDecimalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projLEDecimalInt64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEDecimalInt64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -36022,7 +37002,7 @@ func (p projLEDecimalInt64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEDecimalFloat64ConstOp struct {
@@ -36030,11 +37010,14 @@ type projLEDecimalFloat64ConstOp struct {
 	constArg float64
 }
 
-func (p projLEDecimalFloat64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEDecimalFloat64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -36144,7 +37127,7 @@ func (p projLEDecimalFloat64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEDecimalDecimalConstOp struct {
@@ -36152,11 +37135,14 @@ type projLEDecimalDecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projLEDecimalDecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEDecimalDecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -36234,7 +37220,7 @@ func (p projLEDecimalDecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEInt16Int16ConstOp struct {
@@ -36242,11 +37228,14 @@ type projLEInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projLEInt16Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEInt16Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -36368,7 +37357,7 @@ func (p projLEInt16Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEInt16Int32ConstOp struct {
@@ -36376,11 +37365,14 @@ type projLEInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projLEInt16Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEInt16Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -36502,7 +37494,7 @@ func (p projLEInt16Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEInt16Int64ConstOp struct {
@@ -36510,11 +37502,14 @@ type projLEInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projLEInt16Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEInt16Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -36636,7 +37631,7 @@ func (p projLEInt16Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEInt16Float64ConstOp struct {
@@ -36644,11 +37639,14 @@ type projLEInt16Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projLEInt16Float64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEInt16Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -36802,7 +37800,7 @@ func (p projLEInt16Float64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEInt16DecimalConstOp struct {
@@ -36810,11 +37808,14 @@ type projLEInt16DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projLEInt16DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEInt16DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -36916,7 +37917,7 @@ func (p projLEInt16DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEInt32Int16ConstOp struct {
@@ -36924,11 +37925,14 @@ type projLEInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projLEInt32Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEInt32Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -37050,7 +38054,7 @@ func (p projLEInt32Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEInt32Int32ConstOp struct {
@@ -37058,11 +38062,14 @@ type projLEInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projLEInt32Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEInt32Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -37184,7 +38191,7 @@ func (p projLEInt32Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEInt32Int64ConstOp struct {
@@ -37192,11 +38199,14 @@ type projLEInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projLEInt32Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEInt32Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -37318,7 +38328,7 @@ func (p projLEInt32Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEInt32Float64ConstOp struct {
@@ -37326,11 +38336,14 @@ type projLEInt32Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projLEInt32Float64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEInt32Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -37484,7 +38497,7 @@ func (p projLEInt32Float64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEInt32DecimalConstOp struct {
@@ -37492,11 +38505,14 @@ type projLEInt32DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projLEInt32DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEInt32DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -37598,7 +38614,7 @@ func (p projLEInt32DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEInt64Int16ConstOp struct {
@@ -37606,11 +38622,14 @@ type projLEInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projLEInt64Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEInt64Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -37732,7 +38751,7 @@ func (p projLEInt64Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEInt64Int32ConstOp struct {
@@ -37740,11 +38759,14 @@ type projLEInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projLEInt64Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEInt64Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -37866,7 +38888,7 @@ func (p projLEInt64Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEInt64Int64ConstOp struct {
@@ -37874,11 +38896,14 @@ type projLEInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projLEInt64Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEInt64Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -38000,7 +39025,7 @@ func (p projLEInt64Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEInt64Float64ConstOp struct {
@@ -38008,11 +39033,14 @@ type projLEInt64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projLEInt64Float64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEInt64Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -38166,7 +39194,7 @@ func (p projLEInt64Float64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEInt64DecimalConstOp struct {
@@ -38174,11 +39202,14 @@ type projLEInt64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projLEInt64DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEInt64DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -38280,7 +39311,7 @@ func (p projLEInt64DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEFloat64Int16ConstOp struct {
@@ -38288,11 +39319,14 @@ type projLEFloat64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projLEFloat64Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEFloat64Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -38446,7 +39480,7 @@ func (p projLEFloat64Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEFloat64Int32ConstOp struct {
@@ -38454,11 +39488,14 @@ type projLEFloat64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projLEFloat64Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEFloat64Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -38612,7 +39649,7 @@ func (p projLEFloat64Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEFloat64Int64ConstOp struct {
@@ -38620,11 +39657,14 @@ type projLEFloat64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projLEFloat64Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEFloat64Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -38778,7 +39818,7 @@ func (p projLEFloat64Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEFloat64Float64ConstOp struct {
@@ -38786,11 +39826,14 @@ type projLEFloat64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projLEFloat64Float64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEFloat64Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -38944,7 +39987,7 @@ func (p projLEFloat64Float64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEFloat64DecimalConstOp struct {
@@ -38952,11 +39995,14 @@ type projLEFloat64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projLEFloat64DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEFloat64DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -39066,7 +40112,7 @@ func (p projLEFloat64DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLETimestampTimestampConstOp struct {
@@ -39074,11 +40120,14 @@ type projLETimestampTimestampConstOp struct {
 	constArg time.Time
 }
 
-func (p projLETimestampTimestampConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLETimestampTimestampConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Times
@@ -39184,7 +40233,7 @@ func (p projLETimestampTimestampConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEIntervalIntervalConstOp struct {
@@ -39192,11 +40241,14 @@ type projLEIntervalIntervalConstOp struct {
 	constArg duration.Duration
 }
 
-func (p projLEIntervalIntervalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEIntervalIntervalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Durations
@@ -39274,7 +40326,7 @@ func (p projLEIntervalIntervalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEJSONJSONConstOp struct {
@@ -39282,11 +40334,14 @@ type projLEJSONJSONConstOp struct {
 	constArg json.JSON
 }
 
-func (p projLEJSONJSONConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEJSONJSONConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col *coldata.JSONs
@@ -39386,7 +40441,7 @@ func (p projLEJSONJSONConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projLEDatumDatumConstOp struct {
@@ -39394,11 +40449,14 @@ type projLEDatumDatumConstOp struct {
 	constArg interface{}
 }
 
-func (p projLEDatumDatumConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projLEDatumDatumConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.DatumVec
@@ -39490,7 +40548,7 @@ func (p projLEDatumDatumConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTBoolBoolConstOp struct {
@@ -39498,11 +40556,14 @@ type projGTBoolBoolConstOp struct {
 	constArg bool
 }
 
-func (p projGTBoolBoolConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTBoolBoolConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Bools
@@ -39612,7 +40673,7 @@ func (p projGTBoolBoolConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTBytesBytesConstOp struct {
@@ -39620,11 +40681,14 @@ type projGTBytesBytesConstOp struct {
 	constArg []byte
 }
 
-func (p projGTBytesBytesConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTBytesBytesConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col *coldata.Bytes
@@ -39700,7 +40764,7 @@ func (p projGTBytesBytesConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTDecimalInt16ConstOp struct {
@@ -39708,11 +40772,14 @@ type projGTDecimalInt16ConstOp struct {
 	constArg int16
 }
 
-func (p projGTDecimalInt16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTDecimalInt16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -39814,7 +40881,7 @@ func (p projGTDecimalInt16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTDecimalInt32ConstOp struct {
@@ -39822,11 +40889,14 @@ type projGTDecimalInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projGTDecimalInt32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTDecimalInt32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -39928,7 +40998,7 @@ func (p projGTDecimalInt32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTDecimalInt64ConstOp struct {
@@ -39936,11 +41006,14 @@ type projGTDecimalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projGTDecimalInt64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTDecimalInt64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -40042,7 +41115,7 @@ func (p projGTDecimalInt64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTDecimalFloat64ConstOp struct {
@@ -40050,11 +41123,14 @@ type projGTDecimalFloat64ConstOp struct {
 	constArg float64
 }
 
-func (p projGTDecimalFloat64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTDecimalFloat64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -40164,7 +41240,7 @@ func (p projGTDecimalFloat64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTDecimalDecimalConstOp struct {
@@ -40172,11 +41248,14 @@ type projGTDecimalDecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projGTDecimalDecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTDecimalDecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -40254,7 +41333,7 @@ func (p projGTDecimalDecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTInt16Int16ConstOp struct {
@@ -40262,11 +41341,14 @@ type projGTInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projGTInt16Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTInt16Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -40388,7 +41470,7 @@ func (p projGTInt16Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTInt16Int32ConstOp struct {
@@ -40396,11 +41478,14 @@ type projGTInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projGTInt16Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTInt16Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -40522,7 +41607,7 @@ func (p projGTInt16Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTInt16Int64ConstOp struct {
@@ -40530,11 +41615,14 @@ type projGTInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projGTInt16Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTInt16Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -40656,7 +41744,7 @@ func (p projGTInt16Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTInt16Float64ConstOp struct {
@@ -40664,11 +41752,14 @@ type projGTInt16Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projGTInt16Float64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTInt16Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -40822,7 +41913,7 @@ func (p projGTInt16Float64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTInt16DecimalConstOp struct {
@@ -40830,11 +41921,14 @@ type projGTInt16DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projGTInt16DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTInt16DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -40936,7 +42030,7 @@ func (p projGTInt16DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTInt32Int16ConstOp struct {
@@ -40944,11 +42038,14 @@ type projGTInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projGTInt32Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTInt32Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -41070,7 +42167,7 @@ func (p projGTInt32Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTInt32Int32ConstOp struct {
@@ -41078,11 +42175,14 @@ type projGTInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projGTInt32Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTInt32Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -41204,7 +42304,7 @@ func (p projGTInt32Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTInt32Int64ConstOp struct {
@@ -41212,11 +42312,14 @@ type projGTInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projGTInt32Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTInt32Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -41338,7 +42441,7 @@ func (p projGTInt32Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTInt32Float64ConstOp struct {
@@ -41346,11 +42449,14 @@ type projGTInt32Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projGTInt32Float64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTInt32Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -41504,7 +42610,7 @@ func (p projGTInt32Float64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTInt32DecimalConstOp struct {
@@ -41512,11 +42618,14 @@ type projGTInt32DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projGTInt32DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTInt32DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -41618,7 +42727,7 @@ func (p projGTInt32DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTInt64Int16ConstOp struct {
@@ -41626,11 +42735,14 @@ type projGTInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projGTInt64Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTInt64Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -41752,7 +42864,7 @@ func (p projGTInt64Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTInt64Int32ConstOp struct {
@@ -41760,11 +42872,14 @@ type projGTInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projGTInt64Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTInt64Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -41886,7 +43001,7 @@ func (p projGTInt64Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTInt64Int64ConstOp struct {
@@ -41894,11 +43009,14 @@ type projGTInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projGTInt64Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTInt64Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -42020,7 +43138,7 @@ func (p projGTInt64Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTInt64Float64ConstOp struct {
@@ -42028,11 +43146,14 @@ type projGTInt64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projGTInt64Float64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTInt64Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -42186,7 +43307,7 @@ func (p projGTInt64Float64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTInt64DecimalConstOp struct {
@@ -42194,11 +43315,14 @@ type projGTInt64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projGTInt64DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTInt64DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -42300,7 +43424,7 @@ func (p projGTInt64DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTFloat64Int16ConstOp struct {
@@ -42308,11 +43432,14 @@ type projGTFloat64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projGTFloat64Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTFloat64Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -42466,7 +43593,7 @@ func (p projGTFloat64Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTFloat64Int32ConstOp struct {
@@ -42474,11 +43601,14 @@ type projGTFloat64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projGTFloat64Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTFloat64Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -42632,7 +43762,7 @@ func (p projGTFloat64Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTFloat64Int64ConstOp struct {
@@ -42640,11 +43770,14 @@ type projGTFloat64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projGTFloat64Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTFloat64Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -42798,7 +43931,7 @@ func (p projGTFloat64Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTFloat64Float64ConstOp struct {
@@ -42806,11 +43939,14 @@ type projGTFloat64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projGTFloat64Float64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTFloat64Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -42964,7 +44100,7 @@ func (p projGTFloat64Float64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTFloat64DecimalConstOp struct {
@@ -42972,11 +44108,14 @@ type projGTFloat64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projGTFloat64DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTFloat64DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -43086,7 +44225,7 @@ func (p projGTFloat64DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTTimestampTimestampConstOp struct {
@@ -43094,11 +44233,14 @@ type projGTTimestampTimestampConstOp struct {
 	constArg time.Time
 }
 
-func (p projGTTimestampTimestampConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTTimestampTimestampConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Times
@@ -43204,7 +44346,7 @@ func (p projGTTimestampTimestampConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTIntervalIntervalConstOp struct {
@@ -43212,11 +44354,14 @@ type projGTIntervalIntervalConstOp struct {
 	constArg duration.Duration
 }
 
-func (p projGTIntervalIntervalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTIntervalIntervalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Durations
@@ -43294,7 +44439,7 @@ func (p projGTIntervalIntervalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTJSONJSONConstOp struct {
@@ -43302,11 +44447,14 @@ type projGTJSONJSONConstOp struct {
 	constArg json.JSON
 }
 
-func (p projGTJSONJSONConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTJSONJSONConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col *coldata.JSONs
@@ -43406,7 +44554,7 @@ func (p projGTJSONJSONConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGTDatumDatumConstOp struct {
@@ -43414,11 +44562,14 @@ type projGTDatumDatumConstOp struct {
 	constArg interface{}
 }
 
-func (p projGTDatumDatumConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGTDatumDatumConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.DatumVec
@@ -43510,7 +44661,7 @@ func (p projGTDatumDatumConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEBoolBoolConstOp struct {
@@ -43518,11 +44669,14 @@ type projGEBoolBoolConstOp struct {
 	constArg bool
 }
 
-func (p projGEBoolBoolConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEBoolBoolConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Bools
@@ -43632,7 +44786,7 @@ func (p projGEBoolBoolConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEBytesBytesConstOp struct {
@@ -43640,11 +44794,14 @@ type projGEBytesBytesConstOp struct {
 	constArg []byte
 }
 
-func (p projGEBytesBytesConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEBytesBytesConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col *coldata.Bytes
@@ -43720,7 +44877,7 @@ func (p projGEBytesBytesConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEDecimalInt16ConstOp struct {
@@ -43728,11 +44885,14 @@ type projGEDecimalInt16ConstOp struct {
 	constArg int16
 }
 
-func (p projGEDecimalInt16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEDecimalInt16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -43834,7 +44994,7 @@ func (p projGEDecimalInt16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEDecimalInt32ConstOp struct {
@@ -43842,11 +45002,14 @@ type projGEDecimalInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projGEDecimalInt32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEDecimalInt32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -43948,7 +45111,7 @@ func (p projGEDecimalInt32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEDecimalInt64ConstOp struct {
@@ -43956,11 +45119,14 @@ type projGEDecimalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projGEDecimalInt64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEDecimalInt64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -44062,7 +45228,7 @@ func (p projGEDecimalInt64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEDecimalFloat64ConstOp struct {
@@ -44070,11 +45236,14 @@ type projGEDecimalFloat64ConstOp struct {
 	constArg float64
 }
 
-func (p projGEDecimalFloat64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEDecimalFloat64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -44184,7 +45353,7 @@ func (p projGEDecimalFloat64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEDecimalDecimalConstOp struct {
@@ -44192,11 +45361,14 @@ type projGEDecimalDecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projGEDecimalDecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEDecimalDecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Decimals
@@ -44274,7 +45446,7 @@ func (p projGEDecimalDecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEInt16Int16ConstOp struct {
@@ -44282,11 +45454,14 @@ type projGEInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projGEInt16Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEInt16Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -44408,7 +45583,7 @@ func (p projGEInt16Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEInt16Int32ConstOp struct {
@@ -44416,11 +45591,14 @@ type projGEInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projGEInt16Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEInt16Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -44542,7 +45720,7 @@ func (p projGEInt16Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEInt16Int64ConstOp struct {
@@ -44550,11 +45728,14 @@ type projGEInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projGEInt16Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEInt16Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -44676,7 +45857,7 @@ func (p projGEInt16Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEInt16Float64ConstOp struct {
@@ -44684,11 +45865,14 @@ type projGEInt16Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projGEInt16Float64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEInt16Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -44842,7 +46026,7 @@ func (p projGEInt16Float64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEInt16DecimalConstOp struct {
@@ -44850,11 +46034,14 @@ type projGEInt16DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projGEInt16DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEInt16DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int16s
@@ -44956,7 +46143,7 @@ func (p projGEInt16DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEInt32Int16ConstOp struct {
@@ -44964,11 +46151,14 @@ type projGEInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projGEInt32Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEInt32Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -45090,7 +46280,7 @@ func (p projGEInt32Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEInt32Int32ConstOp struct {
@@ -45098,11 +46288,14 @@ type projGEInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projGEInt32Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEInt32Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -45224,7 +46417,7 @@ func (p projGEInt32Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEInt32Int64ConstOp struct {
@@ -45232,11 +46425,14 @@ type projGEInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projGEInt32Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEInt32Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -45358,7 +46554,7 @@ func (p projGEInt32Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEInt32Float64ConstOp struct {
@@ -45366,11 +46562,14 @@ type projGEInt32Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projGEInt32Float64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEInt32Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -45524,7 +46723,7 @@ func (p projGEInt32Float64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEInt32DecimalConstOp struct {
@@ -45532,11 +46731,14 @@ type projGEInt32DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projGEInt32DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEInt32DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int32s
@@ -45638,7 +46840,7 @@ func (p projGEInt32DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEInt64Int16ConstOp struct {
@@ -45646,11 +46848,14 @@ type projGEInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projGEInt64Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEInt64Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -45772,7 +46977,7 @@ func (p projGEInt64Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEInt64Int32ConstOp struct {
@@ -45780,11 +46985,14 @@ type projGEInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projGEInt64Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEInt64Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -45906,7 +47114,7 @@ func (p projGEInt64Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEInt64Int64ConstOp struct {
@@ -45914,11 +47122,14 @@ type projGEInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projGEInt64Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEInt64Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -46040,7 +47251,7 @@ func (p projGEInt64Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEInt64Float64ConstOp struct {
@@ -46048,11 +47259,14 @@ type projGEInt64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projGEInt64Float64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEInt64Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -46206,7 +47420,7 @@ func (p projGEInt64Float64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEInt64DecimalConstOp struct {
@@ -46214,11 +47428,14 @@ type projGEInt64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projGEInt64DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEInt64DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Int64s
@@ -46320,7 +47537,7 @@ func (p projGEInt64DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEFloat64Int16ConstOp struct {
@@ -46328,11 +47545,14 @@ type projGEFloat64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projGEFloat64Int16ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEFloat64Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -46486,7 +47706,7 @@ func (p projGEFloat64Int16ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEFloat64Int32ConstOp struct {
@@ -46494,11 +47714,14 @@ type projGEFloat64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projGEFloat64Int32ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEFloat64Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -46652,7 +47875,7 @@ func (p projGEFloat64Int32ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEFloat64Int64ConstOp struct {
@@ -46660,11 +47883,14 @@ type projGEFloat64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projGEFloat64Int64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEFloat64Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -46818,7 +48044,7 @@ func (p projGEFloat64Int64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEFloat64Float64ConstOp struct {
@@ -46826,11 +48052,14 @@ type projGEFloat64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projGEFloat64Float64ConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEFloat64Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -46984,7 +48213,7 @@ func (p projGEFloat64Float64ConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEFloat64DecimalConstOp struct {
@@ -46992,11 +48221,14 @@ type projGEFloat64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projGEFloat64DecimalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEFloat64DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Float64s
@@ -47106,7 +48338,7 @@ func (p projGEFloat64DecimalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGETimestampTimestampConstOp struct {
@@ -47114,11 +48346,14 @@ type projGETimestampTimestampConstOp struct {
 	constArg time.Time
 }
 
-func (p projGETimestampTimestampConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGETimestampTimestampConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Times
@@ -47224,7 +48459,7 @@ func (p projGETimestampTimestampConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEIntervalIntervalConstOp struct {
@@ -47232,11 +48467,14 @@ type projGEIntervalIntervalConstOp struct {
 	constArg duration.Duration
 }
 
-func (p projGEIntervalIntervalConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEIntervalIntervalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.Durations
@@ -47314,7 +48552,7 @@ func (p projGEIntervalIntervalConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEJSONJSONConstOp struct {
@@ -47322,11 +48560,14 @@ type projGEJSONJSONConstOp struct {
 	constArg json.JSON
 }
 
-func (p projGEJSONJSONConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEJSONJSONConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col *coldata.JSONs
@@ -47426,7 +48667,7 @@ func (p projGEJSONJSONConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projGEDatumDatumConstOp struct {
@@ -47434,11 +48675,14 @@ type projGEDatumDatumConstOp struct {
 	constArg interface{}
 }
 
-func (p projGEDatumDatumConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
+func (p projGEDatumDatumConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col coldata.DatumVec
@@ -47530,7 +48774,7 @@ func (p projGEDatumDatumConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 // GetProjectionRConstOperator returns the appropriate constant

--- a/pkg/sql/colexec/colexecprojconst/proj_like_ops.eg.go
+++ b/pkg/sql/colexec/colexecprojconst/proj_like_ops.eg.go
@@ -12,6 +12,7 @@ import (
 	"regexp"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 )
 
 type projPrefixBytesBytesConstOp struct {
@@ -21,13 +22,16 @@ type projPrefixBytesBytesConstOp struct {
 	caseInsensitive bool
 }
 
-func (p projPrefixBytesBytesConstOp) Next() coldata.Batch {
+func (p projPrefixBytesBytesConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_negate := p.negate
 	_caseInsensitive := p.caseInsensitive
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col *coldata.Bytes
@@ -91,7 +95,7 @@ func (p projPrefixBytesBytesConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projSuffixBytesBytesConstOp struct {
@@ -101,13 +105,16 @@ type projSuffixBytesBytesConstOp struct {
 	caseInsensitive bool
 }
 
-func (p projSuffixBytesBytesConstOp) Next() coldata.Batch {
+func (p projSuffixBytesBytesConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_negate := p.negate
 	_caseInsensitive := p.caseInsensitive
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col *coldata.Bytes
@@ -171,7 +178,7 @@ func (p projSuffixBytesBytesConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projContainsBytesBytesConstOp struct {
@@ -181,13 +188,16 @@ type projContainsBytesBytesConstOp struct {
 	caseInsensitive bool
 }
 
-func (p projContainsBytesBytesConstOp) Next() coldata.Batch {
+func (p projContainsBytesBytesConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_negate := p.negate
 	_caseInsensitive := p.caseInsensitive
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col *coldata.Bytes
@@ -251,7 +261,7 @@ func (p projContainsBytesBytesConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projSkeletonBytesBytesConstOp struct {
@@ -261,13 +271,16 @@ type projSkeletonBytesBytesConstOp struct {
 	caseInsensitive bool
 }
 
-func (p projSkeletonBytesBytesConstOp) Next() coldata.Batch {
+func (p projSkeletonBytesBytesConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_negate := p.negate
 	_caseInsensitive := p.caseInsensitive
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col *coldata.Bytes
@@ -379,7 +392,7 @@ func (p projSkeletonBytesBytesConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }
 
 type projRegexpBytesBytesConstOp struct {
@@ -388,12 +401,15 @@ type projRegexpBytesBytesConstOp struct {
 	negate   bool
 }
 
-func (p projRegexpBytesBytesConstOp) Next() coldata.Batch {
+func (p projRegexpBytesBytesConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_negate := p.negate
-	batch := p.Input.Next()
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	vec := batch.ColVec(p.colIdx)
 	var col *coldata.Bytes
@@ -445,5 +461,5 @@ func (p projRegexpBytesBytesConstOp) Next() coldata.Batch {
 			}
 		}
 	})
-	return batch
+	return batch, nil
 }

--- a/pkg/sql/colexec/colexecsel/BUILD.bazel
+++ b/pkg/sql/colexec/colexecsel/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/sql/colexecerror",  # keep
         "//pkg/sql/colexecop",
         "//pkg/sql/execinfra/execreleasable",  # keep
+        "//pkg/sql/execinfrapb",  # keep
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",  # keep
         "//pkg/sql/sem/tree/treecmp",  # keep

--- a/pkg/sql/colexec/colexecsel/like_ops_test.go
+++ b/pkg/sql/colexec/colexecsel/like_ops_test.go
@@ -252,7 +252,7 @@ func BenchmarkLikeOps(b *testing.B) {
 			tc.op.Init(ctx)
 			b.SetBytes(int64(width * coldata.BatchSize()))
 			for i := 0; i < b.N; i++ {
-				tc.op.Next()
+				colexecop.NextNoMeta(tc.op)
 			}
 		})
 	}

--- a/pkg/sql/colexec/colexecsel/sel_like_ops.eg.go
+++ b/pkg/sql/colexec/colexecsel/sel_like_ops.eg.go
@@ -12,6 +12,7 @@ import (
 	"regexp"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 )
 
 type selPrefixBytesBytesConstOp struct {
@@ -21,13 +22,16 @@ type selPrefixBytesBytesConstOp struct {
 	caseInsensitive bool
 }
 
-func (p *selPrefixBytesBytesConstOp) Next() coldata.Batch {
+func (p *selPrefixBytesBytesConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_negate := p.negate
 	_caseInsensitive := p.caseInsensitive
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -108,7 +112,7 @@ func (p *selPrefixBytesBytesConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -120,13 +124,16 @@ type selSuffixBytesBytesConstOp struct {
 	caseInsensitive bool
 }
 
-func (p *selSuffixBytesBytesConstOp) Next() coldata.Batch {
+func (p *selSuffixBytesBytesConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_negate := p.negate
 	_caseInsensitive := p.caseInsensitive
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -207,7 +214,7 @@ func (p *selSuffixBytesBytesConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -219,13 +226,16 @@ type selContainsBytesBytesConstOp struct {
 	caseInsensitive bool
 }
 
-func (p *selContainsBytesBytesConstOp) Next() coldata.Batch {
+func (p *selContainsBytesBytesConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_negate := p.negate
 	_caseInsensitive := p.caseInsensitive
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -306,7 +316,7 @@ func (p *selContainsBytesBytesConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -318,13 +328,16 @@ type selSkeletonBytesBytesConstOp struct {
 	caseInsensitive bool
 }
 
-func (p *selSkeletonBytesBytesConstOp) Next() coldata.Batch {
+func (p *selSkeletonBytesBytesConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_negate := p.negate
 	_caseInsensitive := p.caseInsensitive
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -453,7 +466,7 @@ func (p *selSkeletonBytesBytesConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -464,12 +477,15 @@ type selRegexpBytesBytesConstOp struct {
 	negate   bool
 }
 
-func (p *selRegexpBytesBytesConstOp) Next() coldata.Batch {
+func (p *selRegexpBytesBytesConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	_negate := p.negate
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -538,7 +554,7 @@ func (p *selRegexpBytesBytesConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }

--- a/pkg/sql/colexec/colexecsel/selection_ops.eg.go
+++ b/pkg/sql/colexec/colexecsel/selection_ops.eg.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexeccmp"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree/treecmp"
@@ -34,6 +35,7 @@ var (
 	_ duration.Duration
 	_ = coldataext.CompareDatum
 	_ json.JSON
+	_ *execinfrapb.ProducerMetadata
 )
 
 // selConstOpBase contains all of the fields for binary selections with a
@@ -55,11 +57,14 @@ type selEQBoolBoolConstOp struct {
 	constArg bool
 }
 
-func (p *selEQBoolBoolConstOp) Next() coldata.Batch {
+func (p *selEQBoolBoolConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -186,7 +191,7 @@ func (p *selEQBoolBoolConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -195,11 +200,14 @@ type selEQBoolBoolOp struct {
 	selOpBase
 }
 
-func (p *selEQBoolBoolOp) Next() coldata.Batch {
+func (p *selEQBoolBoolOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -337,7 +345,7 @@ func (p *selEQBoolBoolOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -347,11 +355,14 @@ type selEQBytesBytesConstOp struct {
 	constArg []byte
 }
 
-func (p *selEQBytesBytesConstOp) Next() coldata.Batch {
+func (p *selEQBytesBytesConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -444,7 +455,7 @@ func (p *selEQBytesBytesConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -453,11 +464,14 @@ type selEQBytesBytesOp struct {
 	selOpBase
 }
 
-func (p *selEQBytesBytesOp) Next() coldata.Batch {
+func (p *selEQBytesBytesOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -559,7 +573,7 @@ func (p *selEQBytesBytesOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -569,11 +583,14 @@ type selEQDecimalInt16ConstOp struct {
 	constArg int16
 }
 
-func (p *selEQDecimalInt16ConstOp) Next() coldata.Batch {
+func (p *selEQDecimalInt16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -692,7 +709,7 @@ func (p *selEQDecimalInt16ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -701,11 +718,14 @@ type selEQDecimalInt16Op struct {
 	selOpBase
 }
 
-func (p *selEQDecimalInt16Op) Next() coldata.Batch {
+func (p *selEQDecimalInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -835,7 +855,7 @@ func (p *selEQDecimalInt16Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -845,11 +865,14 @@ type selEQDecimalInt32ConstOp struct {
 	constArg int32
 }
 
-func (p *selEQDecimalInt32ConstOp) Next() coldata.Batch {
+func (p *selEQDecimalInt32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -968,7 +991,7 @@ func (p *selEQDecimalInt32ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -977,11 +1000,14 @@ type selEQDecimalInt32Op struct {
 	selOpBase
 }
 
-func (p *selEQDecimalInt32Op) Next() coldata.Batch {
+func (p *selEQDecimalInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -1111,7 +1137,7 @@ func (p *selEQDecimalInt32Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -1121,11 +1147,14 @@ type selEQDecimalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p *selEQDecimalInt64ConstOp) Next() coldata.Batch {
+func (p *selEQDecimalInt64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -1244,7 +1273,7 @@ func (p *selEQDecimalInt64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -1253,11 +1282,14 @@ type selEQDecimalInt64Op struct {
 	selOpBase
 }
 
-func (p *selEQDecimalInt64Op) Next() coldata.Batch {
+func (p *selEQDecimalInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -1387,7 +1419,7 @@ func (p *selEQDecimalInt64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -1397,11 +1429,14 @@ type selEQDecimalFloat64ConstOp struct {
 	constArg float64
 }
 
-func (p *selEQDecimalFloat64ConstOp) Next() coldata.Batch {
+func (p *selEQDecimalFloat64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -1528,7 +1563,7 @@ func (p *selEQDecimalFloat64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -1537,11 +1572,14 @@ type selEQDecimalFloat64Op struct {
 	selOpBase
 }
 
-func (p *selEQDecimalFloat64Op) Next() coldata.Batch {
+func (p *selEQDecimalFloat64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -1679,7 +1717,7 @@ func (p *selEQDecimalFloat64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -1689,11 +1727,14 @@ type selEQDecimalDecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selEQDecimalDecimalConstOp) Next() coldata.Batch {
+func (p *selEQDecimalDecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -1788,7 +1829,7 @@ func (p *selEQDecimalDecimalConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -1797,11 +1838,14 @@ type selEQDecimalDecimalOp struct {
 	selOpBase
 }
 
-func (p *selEQDecimalDecimalOp) Next() coldata.Batch {
+func (p *selEQDecimalDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -1907,7 +1951,7 @@ func (p *selEQDecimalDecimalOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -1917,11 +1961,14 @@ type selEQInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p *selEQInt16Int16ConstOp) Next() coldata.Batch {
+func (p *selEQInt16Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -2060,7 +2107,7 @@ func (p *selEQInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -2069,11 +2116,14 @@ type selEQInt16Int16Op struct {
 	selOpBase
 }
 
-func (p *selEQInt16Int16Op) Next() coldata.Batch {
+func (p *selEQInt16Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -2223,7 +2273,7 @@ func (p *selEQInt16Int16Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -2233,11 +2283,14 @@ type selEQInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selEQInt16Int32ConstOp) Next() coldata.Batch {
+func (p *selEQInt16Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -2376,7 +2429,7 @@ func (p *selEQInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -2385,11 +2438,14 @@ type selEQInt16Int32Op struct {
 	selOpBase
 }
 
-func (p *selEQInt16Int32Op) Next() coldata.Batch {
+func (p *selEQInt16Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -2539,7 +2595,7 @@ func (p *selEQInt16Int32Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -2549,11 +2605,14 @@ type selEQInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selEQInt16Int64ConstOp) Next() coldata.Batch {
+func (p *selEQInt16Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -2692,7 +2751,7 @@ func (p *selEQInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -2701,11 +2760,14 @@ type selEQInt16Int64Op struct {
 	selOpBase
 }
 
-func (p *selEQInt16Int64Op) Next() coldata.Batch {
+func (p *selEQInt16Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -2855,7 +2917,7 @@ func (p *selEQInt16Int64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -2865,11 +2927,14 @@ type selEQInt16Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selEQInt16Float64ConstOp) Next() coldata.Batch {
+func (p *selEQInt16Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -3040,7 +3105,7 @@ func (p *selEQInt16Float64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -3049,11 +3114,14 @@ type selEQInt16Float64Op struct {
 	selOpBase
 }
 
-func (p *selEQInt16Float64Op) Next() coldata.Batch {
+func (p *selEQInt16Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -3235,7 +3303,7 @@ func (p *selEQInt16Float64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -3245,11 +3313,14 @@ type selEQInt16DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selEQInt16DecimalConstOp) Next() coldata.Batch {
+func (p *selEQInt16DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -3368,7 +3439,7 @@ func (p *selEQInt16DecimalConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -3377,11 +3448,14 @@ type selEQInt16DecimalOp struct {
 	selOpBase
 }
 
-func (p *selEQInt16DecimalOp) Next() coldata.Batch {
+func (p *selEQInt16DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -3511,7 +3585,7 @@ func (p *selEQInt16DecimalOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -3521,11 +3595,14 @@ type selEQInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p *selEQInt32Int16ConstOp) Next() coldata.Batch {
+func (p *selEQInt32Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -3664,7 +3741,7 @@ func (p *selEQInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -3673,11 +3750,14 @@ type selEQInt32Int16Op struct {
 	selOpBase
 }
 
-func (p *selEQInt32Int16Op) Next() coldata.Batch {
+func (p *selEQInt32Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -3827,7 +3907,7 @@ func (p *selEQInt32Int16Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -3837,11 +3917,14 @@ type selEQInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selEQInt32Int32ConstOp) Next() coldata.Batch {
+func (p *selEQInt32Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -3980,7 +4063,7 @@ func (p *selEQInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -3989,11 +4072,14 @@ type selEQInt32Int32Op struct {
 	selOpBase
 }
 
-func (p *selEQInt32Int32Op) Next() coldata.Batch {
+func (p *selEQInt32Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -4143,7 +4229,7 @@ func (p *selEQInt32Int32Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -4153,11 +4239,14 @@ type selEQInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selEQInt32Int64ConstOp) Next() coldata.Batch {
+func (p *selEQInt32Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -4296,7 +4385,7 @@ func (p *selEQInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -4305,11 +4394,14 @@ type selEQInt32Int64Op struct {
 	selOpBase
 }
 
-func (p *selEQInt32Int64Op) Next() coldata.Batch {
+func (p *selEQInt32Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -4459,7 +4551,7 @@ func (p *selEQInt32Int64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -4469,11 +4561,14 @@ type selEQInt32Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selEQInt32Float64ConstOp) Next() coldata.Batch {
+func (p *selEQInt32Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -4644,7 +4739,7 @@ func (p *selEQInt32Float64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -4653,11 +4748,14 @@ type selEQInt32Float64Op struct {
 	selOpBase
 }
 
-func (p *selEQInt32Float64Op) Next() coldata.Batch {
+func (p *selEQInt32Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -4839,7 +4937,7 @@ func (p *selEQInt32Float64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -4849,11 +4947,14 @@ type selEQInt32DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selEQInt32DecimalConstOp) Next() coldata.Batch {
+func (p *selEQInt32DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -4972,7 +5073,7 @@ func (p *selEQInt32DecimalConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -4981,11 +5082,14 @@ type selEQInt32DecimalOp struct {
 	selOpBase
 }
 
-func (p *selEQInt32DecimalOp) Next() coldata.Batch {
+func (p *selEQInt32DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -5115,7 +5219,7 @@ func (p *selEQInt32DecimalOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -5125,11 +5229,14 @@ type selEQInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p *selEQInt64Int16ConstOp) Next() coldata.Batch {
+func (p *selEQInt64Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -5268,7 +5375,7 @@ func (p *selEQInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -5277,11 +5384,14 @@ type selEQInt64Int16Op struct {
 	selOpBase
 }
 
-func (p *selEQInt64Int16Op) Next() coldata.Batch {
+func (p *selEQInt64Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -5431,7 +5541,7 @@ func (p *selEQInt64Int16Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -5441,11 +5551,14 @@ type selEQInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selEQInt64Int32ConstOp) Next() coldata.Batch {
+func (p *selEQInt64Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -5584,7 +5697,7 @@ func (p *selEQInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -5593,11 +5706,14 @@ type selEQInt64Int32Op struct {
 	selOpBase
 }
 
-func (p *selEQInt64Int32Op) Next() coldata.Batch {
+func (p *selEQInt64Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -5747,7 +5863,7 @@ func (p *selEQInt64Int32Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -5757,11 +5873,14 @@ type selEQInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selEQInt64Int64ConstOp) Next() coldata.Batch {
+func (p *selEQInt64Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -5900,7 +6019,7 @@ func (p *selEQInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -5909,11 +6028,14 @@ type selEQInt64Int64Op struct {
 	selOpBase
 }
 
-func (p *selEQInt64Int64Op) Next() coldata.Batch {
+func (p *selEQInt64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -6063,7 +6185,7 @@ func (p *selEQInt64Int64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -6073,11 +6195,14 @@ type selEQInt64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selEQInt64Float64ConstOp) Next() coldata.Batch {
+func (p *selEQInt64Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -6248,7 +6373,7 @@ func (p *selEQInt64Float64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -6257,11 +6382,14 @@ type selEQInt64Float64Op struct {
 	selOpBase
 }
 
-func (p *selEQInt64Float64Op) Next() coldata.Batch {
+func (p *selEQInt64Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -6443,7 +6571,7 @@ func (p *selEQInt64Float64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -6453,11 +6581,14 @@ type selEQInt64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selEQInt64DecimalConstOp) Next() coldata.Batch {
+func (p *selEQInt64DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -6576,7 +6707,7 @@ func (p *selEQInt64DecimalConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -6585,11 +6716,14 @@ type selEQInt64DecimalOp struct {
 	selOpBase
 }
 
-func (p *selEQInt64DecimalOp) Next() coldata.Batch {
+func (p *selEQInt64DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -6719,7 +6853,7 @@ func (p *selEQInt64DecimalOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -6729,11 +6863,14 @@ type selEQFloat64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p *selEQFloat64Int16ConstOp) Next() coldata.Batch {
+func (p *selEQFloat64Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -6904,7 +7041,7 @@ func (p *selEQFloat64Int16ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -6913,11 +7050,14 @@ type selEQFloat64Int16Op struct {
 	selOpBase
 }
 
-func (p *selEQFloat64Int16Op) Next() coldata.Batch {
+func (p *selEQFloat64Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -7099,7 +7239,7 @@ func (p *selEQFloat64Int16Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -7109,11 +7249,14 @@ type selEQFloat64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selEQFloat64Int32ConstOp) Next() coldata.Batch {
+func (p *selEQFloat64Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -7284,7 +7427,7 @@ func (p *selEQFloat64Int32ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -7293,11 +7436,14 @@ type selEQFloat64Int32Op struct {
 	selOpBase
 }
 
-func (p *selEQFloat64Int32Op) Next() coldata.Batch {
+func (p *selEQFloat64Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -7479,7 +7625,7 @@ func (p *selEQFloat64Int32Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -7489,11 +7635,14 @@ type selEQFloat64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selEQFloat64Int64ConstOp) Next() coldata.Batch {
+func (p *selEQFloat64Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -7664,7 +7813,7 @@ func (p *selEQFloat64Int64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -7673,11 +7822,14 @@ type selEQFloat64Int64Op struct {
 	selOpBase
 }
 
-func (p *selEQFloat64Int64Op) Next() coldata.Batch {
+func (p *selEQFloat64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -7859,7 +8011,7 @@ func (p *selEQFloat64Int64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -7869,11 +8021,14 @@ type selEQFloat64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selEQFloat64Float64ConstOp) Next() coldata.Batch {
+func (p *selEQFloat64Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -8044,7 +8199,7 @@ func (p *selEQFloat64Float64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -8053,11 +8208,14 @@ type selEQFloat64Float64Op struct {
 	selOpBase
 }
 
-func (p *selEQFloat64Float64Op) Next() coldata.Batch {
+func (p *selEQFloat64Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -8239,7 +8397,7 @@ func (p *selEQFloat64Float64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -8249,11 +8407,14 @@ type selEQFloat64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selEQFloat64DecimalConstOp) Next() coldata.Batch {
+func (p *selEQFloat64DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -8380,7 +8541,7 @@ func (p *selEQFloat64DecimalConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -8389,11 +8550,14 @@ type selEQFloat64DecimalOp struct {
 	selOpBase
 }
 
-func (p *selEQFloat64DecimalOp) Next() coldata.Batch {
+func (p *selEQFloat64DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -8531,7 +8695,7 @@ func (p *selEQFloat64DecimalOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -8541,11 +8705,14 @@ type selEQTimestampTimestampConstOp struct {
 	constArg time.Time
 }
 
-func (p *selEQTimestampTimestampConstOp) Next() coldata.Batch {
+func (p *selEQTimestampTimestampConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -8668,7 +8835,7 @@ func (p *selEQTimestampTimestampConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -8677,11 +8844,14 @@ type selEQTimestampTimestampOp struct {
 	selOpBase
 }
 
-func (p *selEQTimestampTimestampOp) Next() coldata.Batch {
+func (p *selEQTimestampTimestampOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -8815,7 +8985,7 @@ func (p *selEQTimestampTimestampOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -8825,11 +8995,14 @@ type selEQIntervalIntervalConstOp struct {
 	constArg duration.Duration
 }
 
-func (p *selEQIntervalIntervalConstOp) Next() coldata.Batch {
+func (p *selEQIntervalIntervalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -8924,7 +9097,7 @@ func (p *selEQIntervalIntervalConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -8933,11 +9106,14 @@ type selEQIntervalIntervalOp struct {
 	selOpBase
 }
 
-func (p *selEQIntervalIntervalOp) Next() coldata.Batch {
+func (p *selEQIntervalIntervalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -9043,7 +9219,7 @@ func (p *selEQIntervalIntervalOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -9053,11 +9229,14 @@ type selEQJSONJSONConstOp struct {
 	constArg json.JSON
 }
 
-func (p *selEQJSONJSONConstOp) Next() coldata.Batch {
+func (p *selEQJSONJSONConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -9174,7 +9353,7 @@ func (p *selEQJSONJSONConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -9183,11 +9362,14 @@ type selEQJSONJSONOp struct {
 	selOpBase
 }
 
-func (p *selEQJSONJSONOp) Next() coldata.Batch {
+func (p *selEQJSONJSONOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -9313,7 +9495,7 @@ func (p *selEQJSONJSONOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -9323,11 +9505,14 @@ type selEQDatumDatumConstOp struct {
 	constArg interface{}
 }
 
-func (p *selEQDatumDatumConstOp) Next() coldata.Batch {
+func (p *selEQDatumDatumConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -9428,7 +9613,7 @@ func (p *selEQDatumDatumConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -9437,11 +9622,14 @@ type selEQDatumDatumOp struct {
 	selOpBase
 }
 
-func (p *selEQDatumDatumOp) Next() coldata.Batch {
+func (p *selEQDatumDatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -9551,7 +9739,7 @@ func (p *selEQDatumDatumOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -9561,11 +9749,14 @@ type selNEBoolBoolConstOp struct {
 	constArg bool
 }
 
-func (p *selNEBoolBoolConstOp) Next() coldata.Batch {
+func (p *selNEBoolBoolConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -9692,7 +9883,7 @@ func (p *selNEBoolBoolConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -9701,11 +9892,14 @@ type selNEBoolBoolOp struct {
 	selOpBase
 }
 
-func (p *selNEBoolBoolOp) Next() coldata.Batch {
+func (p *selNEBoolBoolOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -9843,7 +10037,7 @@ func (p *selNEBoolBoolOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -9853,11 +10047,14 @@ type selNEBytesBytesConstOp struct {
 	constArg []byte
 }
 
-func (p *selNEBytesBytesConstOp) Next() coldata.Batch {
+func (p *selNEBytesBytesConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -9950,7 +10147,7 @@ func (p *selNEBytesBytesConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -9959,11 +10156,14 @@ type selNEBytesBytesOp struct {
 	selOpBase
 }
 
-func (p *selNEBytesBytesOp) Next() coldata.Batch {
+func (p *selNEBytesBytesOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -10065,7 +10265,7 @@ func (p *selNEBytesBytesOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -10075,11 +10275,14 @@ type selNEDecimalInt16ConstOp struct {
 	constArg int16
 }
 
-func (p *selNEDecimalInt16ConstOp) Next() coldata.Batch {
+func (p *selNEDecimalInt16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -10198,7 +10401,7 @@ func (p *selNEDecimalInt16ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -10207,11 +10410,14 @@ type selNEDecimalInt16Op struct {
 	selOpBase
 }
 
-func (p *selNEDecimalInt16Op) Next() coldata.Batch {
+func (p *selNEDecimalInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -10341,7 +10547,7 @@ func (p *selNEDecimalInt16Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -10351,11 +10557,14 @@ type selNEDecimalInt32ConstOp struct {
 	constArg int32
 }
 
-func (p *selNEDecimalInt32ConstOp) Next() coldata.Batch {
+func (p *selNEDecimalInt32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -10474,7 +10683,7 @@ func (p *selNEDecimalInt32ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -10483,11 +10692,14 @@ type selNEDecimalInt32Op struct {
 	selOpBase
 }
 
-func (p *selNEDecimalInt32Op) Next() coldata.Batch {
+func (p *selNEDecimalInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -10617,7 +10829,7 @@ func (p *selNEDecimalInt32Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -10627,11 +10839,14 @@ type selNEDecimalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p *selNEDecimalInt64ConstOp) Next() coldata.Batch {
+func (p *selNEDecimalInt64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -10750,7 +10965,7 @@ func (p *selNEDecimalInt64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -10759,11 +10974,14 @@ type selNEDecimalInt64Op struct {
 	selOpBase
 }
 
-func (p *selNEDecimalInt64Op) Next() coldata.Batch {
+func (p *selNEDecimalInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -10893,7 +11111,7 @@ func (p *selNEDecimalInt64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -10903,11 +11121,14 @@ type selNEDecimalFloat64ConstOp struct {
 	constArg float64
 }
 
-func (p *selNEDecimalFloat64ConstOp) Next() coldata.Batch {
+func (p *selNEDecimalFloat64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -11034,7 +11255,7 @@ func (p *selNEDecimalFloat64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -11043,11 +11264,14 @@ type selNEDecimalFloat64Op struct {
 	selOpBase
 }
 
-func (p *selNEDecimalFloat64Op) Next() coldata.Batch {
+func (p *selNEDecimalFloat64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -11185,7 +11409,7 @@ func (p *selNEDecimalFloat64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -11195,11 +11419,14 @@ type selNEDecimalDecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selNEDecimalDecimalConstOp) Next() coldata.Batch {
+func (p *selNEDecimalDecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -11294,7 +11521,7 @@ func (p *selNEDecimalDecimalConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -11303,11 +11530,14 @@ type selNEDecimalDecimalOp struct {
 	selOpBase
 }
 
-func (p *selNEDecimalDecimalOp) Next() coldata.Batch {
+func (p *selNEDecimalDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -11413,7 +11643,7 @@ func (p *selNEDecimalDecimalOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -11423,11 +11653,14 @@ type selNEInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p *selNEInt16Int16ConstOp) Next() coldata.Batch {
+func (p *selNEInt16Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -11566,7 +11799,7 @@ func (p *selNEInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -11575,11 +11808,14 @@ type selNEInt16Int16Op struct {
 	selOpBase
 }
 
-func (p *selNEInt16Int16Op) Next() coldata.Batch {
+func (p *selNEInt16Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -11729,7 +11965,7 @@ func (p *selNEInt16Int16Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -11739,11 +11975,14 @@ type selNEInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selNEInt16Int32ConstOp) Next() coldata.Batch {
+func (p *selNEInt16Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -11882,7 +12121,7 @@ func (p *selNEInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -11891,11 +12130,14 @@ type selNEInt16Int32Op struct {
 	selOpBase
 }
 
-func (p *selNEInt16Int32Op) Next() coldata.Batch {
+func (p *selNEInt16Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -12045,7 +12287,7 @@ func (p *selNEInt16Int32Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -12055,11 +12297,14 @@ type selNEInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selNEInt16Int64ConstOp) Next() coldata.Batch {
+func (p *selNEInt16Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -12198,7 +12443,7 @@ func (p *selNEInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -12207,11 +12452,14 @@ type selNEInt16Int64Op struct {
 	selOpBase
 }
 
-func (p *selNEInt16Int64Op) Next() coldata.Batch {
+func (p *selNEInt16Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -12361,7 +12609,7 @@ func (p *selNEInt16Int64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -12371,11 +12619,14 @@ type selNEInt16Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selNEInt16Float64ConstOp) Next() coldata.Batch {
+func (p *selNEInt16Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -12546,7 +12797,7 @@ func (p *selNEInt16Float64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -12555,11 +12806,14 @@ type selNEInt16Float64Op struct {
 	selOpBase
 }
 
-func (p *selNEInt16Float64Op) Next() coldata.Batch {
+func (p *selNEInt16Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -12741,7 +12995,7 @@ func (p *selNEInt16Float64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -12751,11 +13005,14 @@ type selNEInt16DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selNEInt16DecimalConstOp) Next() coldata.Batch {
+func (p *selNEInt16DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -12874,7 +13131,7 @@ func (p *selNEInt16DecimalConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -12883,11 +13140,14 @@ type selNEInt16DecimalOp struct {
 	selOpBase
 }
 
-func (p *selNEInt16DecimalOp) Next() coldata.Batch {
+func (p *selNEInt16DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -13017,7 +13277,7 @@ func (p *selNEInt16DecimalOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -13027,11 +13287,14 @@ type selNEInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p *selNEInt32Int16ConstOp) Next() coldata.Batch {
+func (p *selNEInt32Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -13170,7 +13433,7 @@ func (p *selNEInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -13179,11 +13442,14 @@ type selNEInt32Int16Op struct {
 	selOpBase
 }
 
-func (p *selNEInt32Int16Op) Next() coldata.Batch {
+func (p *selNEInt32Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -13333,7 +13599,7 @@ func (p *selNEInt32Int16Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -13343,11 +13609,14 @@ type selNEInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selNEInt32Int32ConstOp) Next() coldata.Batch {
+func (p *selNEInt32Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -13486,7 +13755,7 @@ func (p *selNEInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -13495,11 +13764,14 @@ type selNEInt32Int32Op struct {
 	selOpBase
 }
 
-func (p *selNEInt32Int32Op) Next() coldata.Batch {
+func (p *selNEInt32Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -13649,7 +13921,7 @@ func (p *selNEInt32Int32Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -13659,11 +13931,14 @@ type selNEInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selNEInt32Int64ConstOp) Next() coldata.Batch {
+func (p *selNEInt32Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -13802,7 +14077,7 @@ func (p *selNEInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -13811,11 +14086,14 @@ type selNEInt32Int64Op struct {
 	selOpBase
 }
 
-func (p *selNEInt32Int64Op) Next() coldata.Batch {
+func (p *selNEInt32Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -13965,7 +14243,7 @@ func (p *selNEInt32Int64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -13975,11 +14253,14 @@ type selNEInt32Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selNEInt32Float64ConstOp) Next() coldata.Batch {
+func (p *selNEInt32Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -14150,7 +14431,7 @@ func (p *selNEInt32Float64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -14159,11 +14440,14 @@ type selNEInt32Float64Op struct {
 	selOpBase
 }
 
-func (p *selNEInt32Float64Op) Next() coldata.Batch {
+func (p *selNEInt32Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -14345,7 +14629,7 @@ func (p *selNEInt32Float64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -14355,11 +14639,14 @@ type selNEInt32DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selNEInt32DecimalConstOp) Next() coldata.Batch {
+func (p *selNEInt32DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -14478,7 +14765,7 @@ func (p *selNEInt32DecimalConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -14487,11 +14774,14 @@ type selNEInt32DecimalOp struct {
 	selOpBase
 }
 
-func (p *selNEInt32DecimalOp) Next() coldata.Batch {
+func (p *selNEInt32DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -14621,7 +14911,7 @@ func (p *selNEInt32DecimalOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -14631,11 +14921,14 @@ type selNEInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p *selNEInt64Int16ConstOp) Next() coldata.Batch {
+func (p *selNEInt64Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -14774,7 +15067,7 @@ func (p *selNEInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -14783,11 +15076,14 @@ type selNEInt64Int16Op struct {
 	selOpBase
 }
 
-func (p *selNEInt64Int16Op) Next() coldata.Batch {
+func (p *selNEInt64Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -14937,7 +15233,7 @@ func (p *selNEInt64Int16Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -14947,11 +15243,14 @@ type selNEInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selNEInt64Int32ConstOp) Next() coldata.Batch {
+func (p *selNEInt64Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -15090,7 +15389,7 @@ func (p *selNEInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -15099,11 +15398,14 @@ type selNEInt64Int32Op struct {
 	selOpBase
 }
 
-func (p *selNEInt64Int32Op) Next() coldata.Batch {
+func (p *selNEInt64Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -15253,7 +15555,7 @@ func (p *selNEInt64Int32Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -15263,11 +15565,14 @@ type selNEInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selNEInt64Int64ConstOp) Next() coldata.Batch {
+func (p *selNEInt64Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -15406,7 +15711,7 @@ func (p *selNEInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -15415,11 +15720,14 @@ type selNEInt64Int64Op struct {
 	selOpBase
 }
 
-func (p *selNEInt64Int64Op) Next() coldata.Batch {
+func (p *selNEInt64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -15569,7 +15877,7 @@ func (p *selNEInt64Int64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -15579,11 +15887,14 @@ type selNEInt64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selNEInt64Float64ConstOp) Next() coldata.Batch {
+func (p *selNEInt64Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -15754,7 +16065,7 @@ func (p *selNEInt64Float64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -15763,11 +16074,14 @@ type selNEInt64Float64Op struct {
 	selOpBase
 }
 
-func (p *selNEInt64Float64Op) Next() coldata.Batch {
+func (p *selNEInt64Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -15949,7 +16263,7 @@ func (p *selNEInt64Float64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -15959,11 +16273,14 @@ type selNEInt64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selNEInt64DecimalConstOp) Next() coldata.Batch {
+func (p *selNEInt64DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -16082,7 +16399,7 @@ func (p *selNEInt64DecimalConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -16091,11 +16408,14 @@ type selNEInt64DecimalOp struct {
 	selOpBase
 }
 
-func (p *selNEInt64DecimalOp) Next() coldata.Batch {
+func (p *selNEInt64DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -16225,7 +16545,7 @@ func (p *selNEInt64DecimalOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -16235,11 +16555,14 @@ type selNEFloat64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p *selNEFloat64Int16ConstOp) Next() coldata.Batch {
+func (p *selNEFloat64Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -16410,7 +16733,7 @@ func (p *selNEFloat64Int16ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -16419,11 +16742,14 @@ type selNEFloat64Int16Op struct {
 	selOpBase
 }
 
-func (p *selNEFloat64Int16Op) Next() coldata.Batch {
+func (p *selNEFloat64Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -16605,7 +16931,7 @@ func (p *selNEFloat64Int16Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -16615,11 +16941,14 @@ type selNEFloat64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selNEFloat64Int32ConstOp) Next() coldata.Batch {
+func (p *selNEFloat64Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -16790,7 +17119,7 @@ func (p *selNEFloat64Int32ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -16799,11 +17128,14 @@ type selNEFloat64Int32Op struct {
 	selOpBase
 }
 
-func (p *selNEFloat64Int32Op) Next() coldata.Batch {
+func (p *selNEFloat64Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -16985,7 +17317,7 @@ func (p *selNEFloat64Int32Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -16995,11 +17327,14 @@ type selNEFloat64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selNEFloat64Int64ConstOp) Next() coldata.Batch {
+func (p *selNEFloat64Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -17170,7 +17505,7 @@ func (p *selNEFloat64Int64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -17179,11 +17514,14 @@ type selNEFloat64Int64Op struct {
 	selOpBase
 }
 
-func (p *selNEFloat64Int64Op) Next() coldata.Batch {
+func (p *selNEFloat64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -17365,7 +17703,7 @@ func (p *selNEFloat64Int64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -17375,11 +17713,14 @@ type selNEFloat64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selNEFloat64Float64ConstOp) Next() coldata.Batch {
+func (p *selNEFloat64Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -17550,7 +17891,7 @@ func (p *selNEFloat64Float64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -17559,11 +17900,14 @@ type selNEFloat64Float64Op struct {
 	selOpBase
 }
 
-func (p *selNEFloat64Float64Op) Next() coldata.Batch {
+func (p *selNEFloat64Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -17745,7 +18089,7 @@ func (p *selNEFloat64Float64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -17755,11 +18099,14 @@ type selNEFloat64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selNEFloat64DecimalConstOp) Next() coldata.Batch {
+func (p *selNEFloat64DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -17886,7 +18233,7 @@ func (p *selNEFloat64DecimalConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -17895,11 +18242,14 @@ type selNEFloat64DecimalOp struct {
 	selOpBase
 }
 
-func (p *selNEFloat64DecimalOp) Next() coldata.Batch {
+func (p *selNEFloat64DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -18037,7 +18387,7 @@ func (p *selNEFloat64DecimalOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -18047,11 +18397,14 @@ type selNETimestampTimestampConstOp struct {
 	constArg time.Time
 }
 
-func (p *selNETimestampTimestampConstOp) Next() coldata.Batch {
+func (p *selNETimestampTimestampConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -18174,7 +18527,7 @@ func (p *selNETimestampTimestampConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -18183,11 +18536,14 @@ type selNETimestampTimestampOp struct {
 	selOpBase
 }
 
-func (p *selNETimestampTimestampOp) Next() coldata.Batch {
+func (p *selNETimestampTimestampOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -18321,7 +18677,7 @@ func (p *selNETimestampTimestampOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -18331,11 +18687,14 @@ type selNEIntervalIntervalConstOp struct {
 	constArg duration.Duration
 }
 
-func (p *selNEIntervalIntervalConstOp) Next() coldata.Batch {
+func (p *selNEIntervalIntervalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -18430,7 +18789,7 @@ func (p *selNEIntervalIntervalConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -18439,11 +18798,14 @@ type selNEIntervalIntervalOp struct {
 	selOpBase
 }
 
-func (p *selNEIntervalIntervalOp) Next() coldata.Batch {
+func (p *selNEIntervalIntervalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -18549,7 +18911,7 @@ func (p *selNEIntervalIntervalOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -18559,11 +18921,14 @@ type selNEJSONJSONConstOp struct {
 	constArg json.JSON
 }
 
-func (p *selNEJSONJSONConstOp) Next() coldata.Batch {
+func (p *selNEJSONJSONConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -18680,7 +19045,7 @@ func (p *selNEJSONJSONConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -18689,11 +19054,14 @@ type selNEJSONJSONOp struct {
 	selOpBase
 }
 
-func (p *selNEJSONJSONOp) Next() coldata.Batch {
+func (p *selNEJSONJSONOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -18819,7 +19187,7 @@ func (p *selNEJSONJSONOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -18829,11 +19197,14 @@ type selNEDatumDatumConstOp struct {
 	constArg interface{}
 }
 
-func (p *selNEDatumDatumConstOp) Next() coldata.Batch {
+func (p *selNEDatumDatumConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -18934,7 +19305,7 @@ func (p *selNEDatumDatumConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -18943,11 +19314,14 @@ type selNEDatumDatumOp struct {
 	selOpBase
 }
 
-func (p *selNEDatumDatumOp) Next() coldata.Batch {
+func (p *selNEDatumDatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -19057,7 +19431,7 @@ func (p *selNEDatumDatumOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -19067,11 +19441,14 @@ type selLTBoolBoolConstOp struct {
 	constArg bool
 }
 
-func (p *selLTBoolBoolConstOp) Next() coldata.Batch {
+func (p *selLTBoolBoolConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -19198,7 +19575,7 @@ func (p *selLTBoolBoolConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -19207,11 +19584,14 @@ type selLTBoolBoolOp struct {
 	selOpBase
 }
 
-func (p *selLTBoolBoolOp) Next() coldata.Batch {
+func (p *selLTBoolBoolOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -19349,7 +19729,7 @@ func (p *selLTBoolBoolOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -19359,11 +19739,14 @@ type selLTBytesBytesConstOp struct {
 	constArg []byte
 }
 
-func (p *selLTBytesBytesConstOp) Next() coldata.Batch {
+func (p *selLTBytesBytesConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -19456,7 +19839,7 @@ func (p *selLTBytesBytesConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -19465,11 +19848,14 @@ type selLTBytesBytesOp struct {
 	selOpBase
 }
 
-func (p *selLTBytesBytesOp) Next() coldata.Batch {
+func (p *selLTBytesBytesOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -19571,7 +19957,7 @@ func (p *selLTBytesBytesOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -19581,11 +19967,14 @@ type selLTDecimalInt16ConstOp struct {
 	constArg int16
 }
 
-func (p *selLTDecimalInt16ConstOp) Next() coldata.Batch {
+func (p *selLTDecimalInt16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -19704,7 +20093,7 @@ func (p *selLTDecimalInt16ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -19713,11 +20102,14 @@ type selLTDecimalInt16Op struct {
 	selOpBase
 }
 
-func (p *selLTDecimalInt16Op) Next() coldata.Batch {
+func (p *selLTDecimalInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -19847,7 +20239,7 @@ func (p *selLTDecimalInt16Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -19857,11 +20249,14 @@ type selLTDecimalInt32ConstOp struct {
 	constArg int32
 }
 
-func (p *selLTDecimalInt32ConstOp) Next() coldata.Batch {
+func (p *selLTDecimalInt32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -19980,7 +20375,7 @@ func (p *selLTDecimalInt32ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -19989,11 +20384,14 @@ type selLTDecimalInt32Op struct {
 	selOpBase
 }
 
-func (p *selLTDecimalInt32Op) Next() coldata.Batch {
+func (p *selLTDecimalInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -20123,7 +20521,7 @@ func (p *selLTDecimalInt32Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -20133,11 +20531,14 @@ type selLTDecimalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p *selLTDecimalInt64ConstOp) Next() coldata.Batch {
+func (p *selLTDecimalInt64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -20256,7 +20657,7 @@ func (p *selLTDecimalInt64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -20265,11 +20666,14 @@ type selLTDecimalInt64Op struct {
 	selOpBase
 }
 
-func (p *selLTDecimalInt64Op) Next() coldata.Batch {
+func (p *selLTDecimalInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -20399,7 +20803,7 @@ func (p *selLTDecimalInt64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -20409,11 +20813,14 @@ type selLTDecimalFloat64ConstOp struct {
 	constArg float64
 }
 
-func (p *selLTDecimalFloat64ConstOp) Next() coldata.Batch {
+func (p *selLTDecimalFloat64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -20540,7 +20947,7 @@ func (p *selLTDecimalFloat64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -20549,11 +20956,14 @@ type selLTDecimalFloat64Op struct {
 	selOpBase
 }
 
-func (p *selLTDecimalFloat64Op) Next() coldata.Batch {
+func (p *selLTDecimalFloat64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -20691,7 +21101,7 @@ func (p *selLTDecimalFloat64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -20701,11 +21111,14 @@ type selLTDecimalDecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selLTDecimalDecimalConstOp) Next() coldata.Batch {
+func (p *selLTDecimalDecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -20800,7 +21213,7 @@ func (p *selLTDecimalDecimalConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -20809,11 +21222,14 @@ type selLTDecimalDecimalOp struct {
 	selOpBase
 }
 
-func (p *selLTDecimalDecimalOp) Next() coldata.Batch {
+func (p *selLTDecimalDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -20919,7 +21335,7 @@ func (p *selLTDecimalDecimalOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -20929,11 +21345,14 @@ type selLTInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p *selLTInt16Int16ConstOp) Next() coldata.Batch {
+func (p *selLTInt16Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -21072,7 +21491,7 @@ func (p *selLTInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -21081,11 +21500,14 @@ type selLTInt16Int16Op struct {
 	selOpBase
 }
 
-func (p *selLTInt16Int16Op) Next() coldata.Batch {
+func (p *selLTInt16Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -21235,7 +21657,7 @@ func (p *selLTInt16Int16Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -21245,11 +21667,14 @@ type selLTInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selLTInt16Int32ConstOp) Next() coldata.Batch {
+func (p *selLTInt16Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -21388,7 +21813,7 @@ func (p *selLTInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -21397,11 +21822,14 @@ type selLTInt16Int32Op struct {
 	selOpBase
 }
 
-func (p *selLTInt16Int32Op) Next() coldata.Batch {
+func (p *selLTInt16Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -21551,7 +21979,7 @@ func (p *selLTInt16Int32Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -21561,11 +21989,14 @@ type selLTInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selLTInt16Int64ConstOp) Next() coldata.Batch {
+func (p *selLTInt16Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -21704,7 +22135,7 @@ func (p *selLTInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -21713,11 +22144,14 @@ type selLTInt16Int64Op struct {
 	selOpBase
 }
 
-func (p *selLTInt16Int64Op) Next() coldata.Batch {
+func (p *selLTInt16Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -21867,7 +22301,7 @@ func (p *selLTInt16Int64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -21877,11 +22311,14 @@ type selLTInt16Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selLTInt16Float64ConstOp) Next() coldata.Batch {
+func (p *selLTInt16Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -22052,7 +22489,7 @@ func (p *selLTInt16Float64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -22061,11 +22498,14 @@ type selLTInt16Float64Op struct {
 	selOpBase
 }
 
-func (p *selLTInt16Float64Op) Next() coldata.Batch {
+func (p *selLTInt16Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -22247,7 +22687,7 @@ func (p *selLTInt16Float64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -22257,11 +22697,14 @@ type selLTInt16DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selLTInt16DecimalConstOp) Next() coldata.Batch {
+func (p *selLTInt16DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -22380,7 +22823,7 @@ func (p *selLTInt16DecimalConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -22389,11 +22832,14 @@ type selLTInt16DecimalOp struct {
 	selOpBase
 }
 
-func (p *selLTInt16DecimalOp) Next() coldata.Batch {
+func (p *selLTInt16DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -22523,7 +22969,7 @@ func (p *selLTInt16DecimalOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -22533,11 +22979,14 @@ type selLTInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p *selLTInt32Int16ConstOp) Next() coldata.Batch {
+func (p *selLTInt32Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -22676,7 +23125,7 @@ func (p *selLTInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -22685,11 +23134,14 @@ type selLTInt32Int16Op struct {
 	selOpBase
 }
 
-func (p *selLTInt32Int16Op) Next() coldata.Batch {
+func (p *selLTInt32Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -22839,7 +23291,7 @@ func (p *selLTInt32Int16Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -22849,11 +23301,14 @@ type selLTInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selLTInt32Int32ConstOp) Next() coldata.Batch {
+func (p *selLTInt32Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -22992,7 +23447,7 @@ func (p *selLTInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -23001,11 +23456,14 @@ type selLTInt32Int32Op struct {
 	selOpBase
 }
 
-func (p *selLTInt32Int32Op) Next() coldata.Batch {
+func (p *selLTInt32Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -23155,7 +23613,7 @@ func (p *selLTInt32Int32Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -23165,11 +23623,14 @@ type selLTInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selLTInt32Int64ConstOp) Next() coldata.Batch {
+func (p *selLTInt32Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -23308,7 +23769,7 @@ func (p *selLTInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -23317,11 +23778,14 @@ type selLTInt32Int64Op struct {
 	selOpBase
 }
 
-func (p *selLTInt32Int64Op) Next() coldata.Batch {
+func (p *selLTInt32Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -23471,7 +23935,7 @@ func (p *selLTInt32Int64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -23481,11 +23945,14 @@ type selLTInt32Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selLTInt32Float64ConstOp) Next() coldata.Batch {
+func (p *selLTInt32Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -23656,7 +24123,7 @@ func (p *selLTInt32Float64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -23665,11 +24132,14 @@ type selLTInt32Float64Op struct {
 	selOpBase
 }
 
-func (p *selLTInt32Float64Op) Next() coldata.Batch {
+func (p *selLTInt32Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -23851,7 +24321,7 @@ func (p *selLTInt32Float64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -23861,11 +24331,14 @@ type selLTInt32DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selLTInt32DecimalConstOp) Next() coldata.Batch {
+func (p *selLTInt32DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -23984,7 +24457,7 @@ func (p *selLTInt32DecimalConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -23993,11 +24466,14 @@ type selLTInt32DecimalOp struct {
 	selOpBase
 }
 
-func (p *selLTInt32DecimalOp) Next() coldata.Batch {
+func (p *selLTInt32DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -24127,7 +24603,7 @@ func (p *selLTInt32DecimalOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -24137,11 +24613,14 @@ type selLTInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p *selLTInt64Int16ConstOp) Next() coldata.Batch {
+func (p *selLTInt64Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -24280,7 +24759,7 @@ func (p *selLTInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -24289,11 +24768,14 @@ type selLTInt64Int16Op struct {
 	selOpBase
 }
 
-func (p *selLTInt64Int16Op) Next() coldata.Batch {
+func (p *selLTInt64Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -24443,7 +24925,7 @@ func (p *selLTInt64Int16Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -24453,11 +24935,14 @@ type selLTInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selLTInt64Int32ConstOp) Next() coldata.Batch {
+func (p *selLTInt64Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -24596,7 +25081,7 @@ func (p *selLTInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -24605,11 +25090,14 @@ type selLTInt64Int32Op struct {
 	selOpBase
 }
 
-func (p *selLTInt64Int32Op) Next() coldata.Batch {
+func (p *selLTInt64Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -24759,7 +25247,7 @@ func (p *selLTInt64Int32Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -24769,11 +25257,14 @@ type selLTInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selLTInt64Int64ConstOp) Next() coldata.Batch {
+func (p *selLTInt64Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -24912,7 +25403,7 @@ func (p *selLTInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -24921,11 +25412,14 @@ type selLTInt64Int64Op struct {
 	selOpBase
 }
 
-func (p *selLTInt64Int64Op) Next() coldata.Batch {
+func (p *selLTInt64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -25075,7 +25569,7 @@ func (p *selLTInt64Int64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -25085,11 +25579,14 @@ type selLTInt64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selLTInt64Float64ConstOp) Next() coldata.Batch {
+func (p *selLTInt64Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -25260,7 +25757,7 @@ func (p *selLTInt64Float64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -25269,11 +25766,14 @@ type selLTInt64Float64Op struct {
 	selOpBase
 }
 
-func (p *selLTInt64Float64Op) Next() coldata.Batch {
+func (p *selLTInt64Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -25455,7 +25955,7 @@ func (p *selLTInt64Float64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -25465,11 +25965,14 @@ type selLTInt64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selLTInt64DecimalConstOp) Next() coldata.Batch {
+func (p *selLTInt64DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -25588,7 +26091,7 @@ func (p *selLTInt64DecimalConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -25597,11 +26100,14 @@ type selLTInt64DecimalOp struct {
 	selOpBase
 }
 
-func (p *selLTInt64DecimalOp) Next() coldata.Batch {
+func (p *selLTInt64DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -25731,7 +26237,7 @@ func (p *selLTInt64DecimalOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -25741,11 +26247,14 @@ type selLTFloat64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p *selLTFloat64Int16ConstOp) Next() coldata.Batch {
+func (p *selLTFloat64Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -25916,7 +26425,7 @@ func (p *selLTFloat64Int16ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -25925,11 +26434,14 @@ type selLTFloat64Int16Op struct {
 	selOpBase
 }
 
-func (p *selLTFloat64Int16Op) Next() coldata.Batch {
+func (p *selLTFloat64Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -26111,7 +26623,7 @@ func (p *selLTFloat64Int16Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -26121,11 +26633,14 @@ type selLTFloat64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selLTFloat64Int32ConstOp) Next() coldata.Batch {
+func (p *selLTFloat64Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -26296,7 +26811,7 @@ func (p *selLTFloat64Int32ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -26305,11 +26820,14 @@ type selLTFloat64Int32Op struct {
 	selOpBase
 }
 
-func (p *selLTFloat64Int32Op) Next() coldata.Batch {
+func (p *selLTFloat64Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -26491,7 +27009,7 @@ func (p *selLTFloat64Int32Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -26501,11 +27019,14 @@ type selLTFloat64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selLTFloat64Int64ConstOp) Next() coldata.Batch {
+func (p *selLTFloat64Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -26676,7 +27197,7 @@ func (p *selLTFloat64Int64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -26685,11 +27206,14 @@ type selLTFloat64Int64Op struct {
 	selOpBase
 }
 
-func (p *selLTFloat64Int64Op) Next() coldata.Batch {
+func (p *selLTFloat64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -26871,7 +27395,7 @@ func (p *selLTFloat64Int64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -26881,11 +27405,14 @@ type selLTFloat64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selLTFloat64Float64ConstOp) Next() coldata.Batch {
+func (p *selLTFloat64Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -27056,7 +27583,7 @@ func (p *selLTFloat64Float64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -27065,11 +27592,14 @@ type selLTFloat64Float64Op struct {
 	selOpBase
 }
 
-func (p *selLTFloat64Float64Op) Next() coldata.Batch {
+func (p *selLTFloat64Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -27251,7 +27781,7 @@ func (p *selLTFloat64Float64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -27261,11 +27791,14 @@ type selLTFloat64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selLTFloat64DecimalConstOp) Next() coldata.Batch {
+func (p *selLTFloat64DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -27392,7 +27925,7 @@ func (p *selLTFloat64DecimalConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -27401,11 +27934,14 @@ type selLTFloat64DecimalOp struct {
 	selOpBase
 }
 
-func (p *selLTFloat64DecimalOp) Next() coldata.Batch {
+func (p *selLTFloat64DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -27543,7 +28079,7 @@ func (p *selLTFloat64DecimalOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -27553,11 +28089,14 @@ type selLTTimestampTimestampConstOp struct {
 	constArg time.Time
 }
 
-func (p *selLTTimestampTimestampConstOp) Next() coldata.Batch {
+func (p *selLTTimestampTimestampConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -27680,7 +28219,7 @@ func (p *selLTTimestampTimestampConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -27689,11 +28228,14 @@ type selLTTimestampTimestampOp struct {
 	selOpBase
 }
 
-func (p *selLTTimestampTimestampOp) Next() coldata.Batch {
+func (p *selLTTimestampTimestampOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -27827,7 +28369,7 @@ func (p *selLTTimestampTimestampOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -27837,11 +28379,14 @@ type selLTIntervalIntervalConstOp struct {
 	constArg duration.Duration
 }
 
-func (p *selLTIntervalIntervalConstOp) Next() coldata.Batch {
+func (p *selLTIntervalIntervalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -27936,7 +28481,7 @@ func (p *selLTIntervalIntervalConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -27945,11 +28490,14 @@ type selLTIntervalIntervalOp struct {
 	selOpBase
 }
 
-func (p *selLTIntervalIntervalOp) Next() coldata.Batch {
+func (p *selLTIntervalIntervalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -28055,7 +28603,7 @@ func (p *selLTIntervalIntervalOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -28065,11 +28613,14 @@ type selLTJSONJSONConstOp struct {
 	constArg json.JSON
 }
 
-func (p *selLTJSONJSONConstOp) Next() coldata.Batch {
+func (p *selLTJSONJSONConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -28186,7 +28737,7 @@ func (p *selLTJSONJSONConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -28195,11 +28746,14 @@ type selLTJSONJSONOp struct {
 	selOpBase
 }
 
-func (p *selLTJSONJSONOp) Next() coldata.Batch {
+func (p *selLTJSONJSONOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -28325,7 +28879,7 @@ func (p *selLTJSONJSONOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -28335,11 +28889,14 @@ type selLTDatumDatumConstOp struct {
 	constArg interface{}
 }
 
-func (p *selLTDatumDatumConstOp) Next() coldata.Batch {
+func (p *selLTDatumDatumConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -28440,7 +28997,7 @@ func (p *selLTDatumDatumConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -28449,11 +29006,14 @@ type selLTDatumDatumOp struct {
 	selOpBase
 }
 
-func (p *selLTDatumDatumOp) Next() coldata.Batch {
+func (p *selLTDatumDatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -28563,7 +29123,7 @@ func (p *selLTDatumDatumOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -28573,11 +29133,14 @@ type selLEBoolBoolConstOp struct {
 	constArg bool
 }
 
-func (p *selLEBoolBoolConstOp) Next() coldata.Batch {
+func (p *selLEBoolBoolConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -28704,7 +29267,7 @@ func (p *selLEBoolBoolConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -28713,11 +29276,14 @@ type selLEBoolBoolOp struct {
 	selOpBase
 }
 
-func (p *selLEBoolBoolOp) Next() coldata.Batch {
+func (p *selLEBoolBoolOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -28855,7 +29421,7 @@ func (p *selLEBoolBoolOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -28865,11 +29431,14 @@ type selLEBytesBytesConstOp struct {
 	constArg []byte
 }
 
-func (p *selLEBytesBytesConstOp) Next() coldata.Batch {
+func (p *selLEBytesBytesConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -28962,7 +29531,7 @@ func (p *selLEBytesBytesConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -28971,11 +29540,14 @@ type selLEBytesBytesOp struct {
 	selOpBase
 }
 
-func (p *selLEBytesBytesOp) Next() coldata.Batch {
+func (p *selLEBytesBytesOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -29077,7 +29649,7 @@ func (p *selLEBytesBytesOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -29087,11 +29659,14 @@ type selLEDecimalInt16ConstOp struct {
 	constArg int16
 }
 
-func (p *selLEDecimalInt16ConstOp) Next() coldata.Batch {
+func (p *selLEDecimalInt16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -29210,7 +29785,7 @@ func (p *selLEDecimalInt16ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -29219,11 +29794,14 @@ type selLEDecimalInt16Op struct {
 	selOpBase
 }
 
-func (p *selLEDecimalInt16Op) Next() coldata.Batch {
+func (p *selLEDecimalInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -29353,7 +29931,7 @@ func (p *selLEDecimalInt16Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -29363,11 +29941,14 @@ type selLEDecimalInt32ConstOp struct {
 	constArg int32
 }
 
-func (p *selLEDecimalInt32ConstOp) Next() coldata.Batch {
+func (p *selLEDecimalInt32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -29486,7 +30067,7 @@ func (p *selLEDecimalInt32ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -29495,11 +30076,14 @@ type selLEDecimalInt32Op struct {
 	selOpBase
 }
 
-func (p *selLEDecimalInt32Op) Next() coldata.Batch {
+func (p *selLEDecimalInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -29629,7 +30213,7 @@ func (p *selLEDecimalInt32Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -29639,11 +30223,14 @@ type selLEDecimalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p *selLEDecimalInt64ConstOp) Next() coldata.Batch {
+func (p *selLEDecimalInt64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -29762,7 +30349,7 @@ func (p *selLEDecimalInt64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -29771,11 +30358,14 @@ type selLEDecimalInt64Op struct {
 	selOpBase
 }
 
-func (p *selLEDecimalInt64Op) Next() coldata.Batch {
+func (p *selLEDecimalInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -29905,7 +30495,7 @@ func (p *selLEDecimalInt64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -29915,11 +30505,14 @@ type selLEDecimalFloat64ConstOp struct {
 	constArg float64
 }
 
-func (p *selLEDecimalFloat64ConstOp) Next() coldata.Batch {
+func (p *selLEDecimalFloat64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -30046,7 +30639,7 @@ func (p *selLEDecimalFloat64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -30055,11 +30648,14 @@ type selLEDecimalFloat64Op struct {
 	selOpBase
 }
 
-func (p *selLEDecimalFloat64Op) Next() coldata.Batch {
+func (p *selLEDecimalFloat64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -30197,7 +30793,7 @@ func (p *selLEDecimalFloat64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -30207,11 +30803,14 @@ type selLEDecimalDecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selLEDecimalDecimalConstOp) Next() coldata.Batch {
+func (p *selLEDecimalDecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -30306,7 +30905,7 @@ func (p *selLEDecimalDecimalConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -30315,11 +30914,14 @@ type selLEDecimalDecimalOp struct {
 	selOpBase
 }
 
-func (p *selLEDecimalDecimalOp) Next() coldata.Batch {
+func (p *selLEDecimalDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -30425,7 +31027,7 @@ func (p *selLEDecimalDecimalOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -30435,11 +31037,14 @@ type selLEInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p *selLEInt16Int16ConstOp) Next() coldata.Batch {
+func (p *selLEInt16Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -30578,7 +31183,7 @@ func (p *selLEInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -30587,11 +31192,14 @@ type selLEInt16Int16Op struct {
 	selOpBase
 }
 
-func (p *selLEInt16Int16Op) Next() coldata.Batch {
+func (p *selLEInt16Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -30741,7 +31349,7 @@ func (p *selLEInt16Int16Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -30751,11 +31359,14 @@ type selLEInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selLEInt16Int32ConstOp) Next() coldata.Batch {
+func (p *selLEInt16Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -30894,7 +31505,7 @@ func (p *selLEInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -30903,11 +31514,14 @@ type selLEInt16Int32Op struct {
 	selOpBase
 }
 
-func (p *selLEInt16Int32Op) Next() coldata.Batch {
+func (p *selLEInt16Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -31057,7 +31671,7 @@ func (p *selLEInt16Int32Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -31067,11 +31681,14 @@ type selLEInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selLEInt16Int64ConstOp) Next() coldata.Batch {
+func (p *selLEInt16Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -31210,7 +31827,7 @@ func (p *selLEInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -31219,11 +31836,14 @@ type selLEInt16Int64Op struct {
 	selOpBase
 }
 
-func (p *selLEInt16Int64Op) Next() coldata.Batch {
+func (p *selLEInt16Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -31373,7 +31993,7 @@ func (p *selLEInt16Int64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -31383,11 +32003,14 @@ type selLEInt16Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selLEInt16Float64ConstOp) Next() coldata.Batch {
+func (p *selLEInt16Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -31558,7 +32181,7 @@ func (p *selLEInt16Float64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -31567,11 +32190,14 @@ type selLEInt16Float64Op struct {
 	selOpBase
 }
 
-func (p *selLEInt16Float64Op) Next() coldata.Batch {
+func (p *selLEInt16Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -31753,7 +32379,7 @@ func (p *selLEInt16Float64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -31763,11 +32389,14 @@ type selLEInt16DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selLEInt16DecimalConstOp) Next() coldata.Batch {
+func (p *selLEInt16DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -31886,7 +32515,7 @@ func (p *selLEInt16DecimalConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -31895,11 +32524,14 @@ type selLEInt16DecimalOp struct {
 	selOpBase
 }
 
-func (p *selLEInt16DecimalOp) Next() coldata.Batch {
+func (p *selLEInt16DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -32029,7 +32661,7 @@ func (p *selLEInt16DecimalOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -32039,11 +32671,14 @@ type selLEInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p *selLEInt32Int16ConstOp) Next() coldata.Batch {
+func (p *selLEInt32Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -32182,7 +32817,7 @@ func (p *selLEInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -32191,11 +32826,14 @@ type selLEInt32Int16Op struct {
 	selOpBase
 }
 
-func (p *selLEInt32Int16Op) Next() coldata.Batch {
+func (p *selLEInt32Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -32345,7 +32983,7 @@ func (p *selLEInt32Int16Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -32355,11 +32993,14 @@ type selLEInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selLEInt32Int32ConstOp) Next() coldata.Batch {
+func (p *selLEInt32Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -32498,7 +33139,7 @@ func (p *selLEInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -32507,11 +33148,14 @@ type selLEInt32Int32Op struct {
 	selOpBase
 }
 
-func (p *selLEInt32Int32Op) Next() coldata.Batch {
+func (p *selLEInt32Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -32661,7 +33305,7 @@ func (p *selLEInt32Int32Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -32671,11 +33315,14 @@ type selLEInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selLEInt32Int64ConstOp) Next() coldata.Batch {
+func (p *selLEInt32Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -32814,7 +33461,7 @@ func (p *selLEInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -32823,11 +33470,14 @@ type selLEInt32Int64Op struct {
 	selOpBase
 }
 
-func (p *selLEInt32Int64Op) Next() coldata.Batch {
+func (p *selLEInt32Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -32977,7 +33627,7 @@ func (p *selLEInt32Int64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -32987,11 +33637,14 @@ type selLEInt32Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selLEInt32Float64ConstOp) Next() coldata.Batch {
+func (p *selLEInt32Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -33162,7 +33815,7 @@ func (p *selLEInt32Float64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -33171,11 +33824,14 @@ type selLEInt32Float64Op struct {
 	selOpBase
 }
 
-func (p *selLEInt32Float64Op) Next() coldata.Batch {
+func (p *selLEInt32Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -33357,7 +34013,7 @@ func (p *selLEInt32Float64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -33367,11 +34023,14 @@ type selLEInt32DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selLEInt32DecimalConstOp) Next() coldata.Batch {
+func (p *selLEInt32DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -33490,7 +34149,7 @@ func (p *selLEInt32DecimalConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -33499,11 +34158,14 @@ type selLEInt32DecimalOp struct {
 	selOpBase
 }
 
-func (p *selLEInt32DecimalOp) Next() coldata.Batch {
+func (p *selLEInt32DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -33633,7 +34295,7 @@ func (p *selLEInt32DecimalOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -33643,11 +34305,14 @@ type selLEInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p *selLEInt64Int16ConstOp) Next() coldata.Batch {
+func (p *selLEInt64Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -33786,7 +34451,7 @@ func (p *selLEInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -33795,11 +34460,14 @@ type selLEInt64Int16Op struct {
 	selOpBase
 }
 
-func (p *selLEInt64Int16Op) Next() coldata.Batch {
+func (p *selLEInt64Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -33949,7 +34617,7 @@ func (p *selLEInt64Int16Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -33959,11 +34627,14 @@ type selLEInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selLEInt64Int32ConstOp) Next() coldata.Batch {
+func (p *selLEInt64Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -34102,7 +34773,7 @@ func (p *selLEInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -34111,11 +34782,14 @@ type selLEInt64Int32Op struct {
 	selOpBase
 }
 
-func (p *selLEInt64Int32Op) Next() coldata.Batch {
+func (p *selLEInt64Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -34265,7 +34939,7 @@ func (p *selLEInt64Int32Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -34275,11 +34949,14 @@ type selLEInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selLEInt64Int64ConstOp) Next() coldata.Batch {
+func (p *selLEInt64Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -34418,7 +35095,7 @@ func (p *selLEInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -34427,11 +35104,14 @@ type selLEInt64Int64Op struct {
 	selOpBase
 }
 
-func (p *selLEInt64Int64Op) Next() coldata.Batch {
+func (p *selLEInt64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -34581,7 +35261,7 @@ func (p *selLEInt64Int64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -34591,11 +35271,14 @@ type selLEInt64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selLEInt64Float64ConstOp) Next() coldata.Batch {
+func (p *selLEInt64Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -34766,7 +35449,7 @@ func (p *selLEInt64Float64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -34775,11 +35458,14 @@ type selLEInt64Float64Op struct {
 	selOpBase
 }
 
-func (p *selLEInt64Float64Op) Next() coldata.Batch {
+func (p *selLEInt64Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -34961,7 +35647,7 @@ func (p *selLEInt64Float64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -34971,11 +35657,14 @@ type selLEInt64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selLEInt64DecimalConstOp) Next() coldata.Batch {
+func (p *selLEInt64DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -35094,7 +35783,7 @@ func (p *selLEInt64DecimalConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -35103,11 +35792,14 @@ type selLEInt64DecimalOp struct {
 	selOpBase
 }
 
-func (p *selLEInt64DecimalOp) Next() coldata.Batch {
+func (p *selLEInt64DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -35237,7 +35929,7 @@ func (p *selLEInt64DecimalOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -35247,11 +35939,14 @@ type selLEFloat64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p *selLEFloat64Int16ConstOp) Next() coldata.Batch {
+func (p *selLEFloat64Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -35422,7 +36117,7 @@ func (p *selLEFloat64Int16ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -35431,11 +36126,14 @@ type selLEFloat64Int16Op struct {
 	selOpBase
 }
 
-func (p *selLEFloat64Int16Op) Next() coldata.Batch {
+func (p *selLEFloat64Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -35617,7 +36315,7 @@ func (p *selLEFloat64Int16Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -35627,11 +36325,14 @@ type selLEFloat64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selLEFloat64Int32ConstOp) Next() coldata.Batch {
+func (p *selLEFloat64Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -35802,7 +36503,7 @@ func (p *selLEFloat64Int32ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -35811,11 +36512,14 @@ type selLEFloat64Int32Op struct {
 	selOpBase
 }
 
-func (p *selLEFloat64Int32Op) Next() coldata.Batch {
+func (p *selLEFloat64Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -35997,7 +36701,7 @@ func (p *selLEFloat64Int32Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -36007,11 +36711,14 @@ type selLEFloat64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selLEFloat64Int64ConstOp) Next() coldata.Batch {
+func (p *selLEFloat64Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -36182,7 +36889,7 @@ func (p *selLEFloat64Int64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -36191,11 +36898,14 @@ type selLEFloat64Int64Op struct {
 	selOpBase
 }
 
-func (p *selLEFloat64Int64Op) Next() coldata.Batch {
+func (p *selLEFloat64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -36377,7 +37087,7 @@ func (p *selLEFloat64Int64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -36387,11 +37097,14 @@ type selLEFloat64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selLEFloat64Float64ConstOp) Next() coldata.Batch {
+func (p *selLEFloat64Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -36562,7 +37275,7 @@ func (p *selLEFloat64Float64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -36571,11 +37284,14 @@ type selLEFloat64Float64Op struct {
 	selOpBase
 }
 
-func (p *selLEFloat64Float64Op) Next() coldata.Batch {
+func (p *selLEFloat64Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -36757,7 +37473,7 @@ func (p *selLEFloat64Float64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -36767,11 +37483,14 @@ type selLEFloat64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selLEFloat64DecimalConstOp) Next() coldata.Batch {
+func (p *selLEFloat64DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -36898,7 +37617,7 @@ func (p *selLEFloat64DecimalConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -36907,11 +37626,14 @@ type selLEFloat64DecimalOp struct {
 	selOpBase
 }
 
-func (p *selLEFloat64DecimalOp) Next() coldata.Batch {
+func (p *selLEFloat64DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -37049,7 +37771,7 @@ func (p *selLEFloat64DecimalOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -37059,11 +37781,14 @@ type selLETimestampTimestampConstOp struct {
 	constArg time.Time
 }
 
-func (p *selLETimestampTimestampConstOp) Next() coldata.Batch {
+func (p *selLETimestampTimestampConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -37186,7 +37911,7 @@ func (p *selLETimestampTimestampConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -37195,11 +37920,14 @@ type selLETimestampTimestampOp struct {
 	selOpBase
 }
 
-func (p *selLETimestampTimestampOp) Next() coldata.Batch {
+func (p *selLETimestampTimestampOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -37333,7 +38061,7 @@ func (p *selLETimestampTimestampOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -37343,11 +38071,14 @@ type selLEIntervalIntervalConstOp struct {
 	constArg duration.Duration
 }
 
-func (p *selLEIntervalIntervalConstOp) Next() coldata.Batch {
+func (p *selLEIntervalIntervalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -37442,7 +38173,7 @@ func (p *selLEIntervalIntervalConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -37451,11 +38182,14 @@ type selLEIntervalIntervalOp struct {
 	selOpBase
 }
 
-func (p *selLEIntervalIntervalOp) Next() coldata.Batch {
+func (p *selLEIntervalIntervalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -37561,7 +38295,7 @@ func (p *selLEIntervalIntervalOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -37571,11 +38305,14 @@ type selLEJSONJSONConstOp struct {
 	constArg json.JSON
 }
 
-func (p *selLEJSONJSONConstOp) Next() coldata.Batch {
+func (p *selLEJSONJSONConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -37692,7 +38429,7 @@ func (p *selLEJSONJSONConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -37701,11 +38438,14 @@ type selLEJSONJSONOp struct {
 	selOpBase
 }
 
-func (p *selLEJSONJSONOp) Next() coldata.Batch {
+func (p *selLEJSONJSONOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -37831,7 +38571,7 @@ func (p *selLEJSONJSONOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -37841,11 +38581,14 @@ type selLEDatumDatumConstOp struct {
 	constArg interface{}
 }
 
-func (p *selLEDatumDatumConstOp) Next() coldata.Batch {
+func (p *selLEDatumDatumConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -37946,7 +38689,7 @@ func (p *selLEDatumDatumConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -37955,11 +38698,14 @@ type selLEDatumDatumOp struct {
 	selOpBase
 }
 
-func (p *selLEDatumDatumOp) Next() coldata.Batch {
+func (p *selLEDatumDatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -38069,7 +38815,7 @@ func (p *selLEDatumDatumOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -38079,11 +38825,14 @@ type selGTBoolBoolConstOp struct {
 	constArg bool
 }
 
-func (p *selGTBoolBoolConstOp) Next() coldata.Batch {
+func (p *selGTBoolBoolConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -38210,7 +38959,7 @@ func (p *selGTBoolBoolConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -38219,11 +38968,14 @@ type selGTBoolBoolOp struct {
 	selOpBase
 }
 
-func (p *selGTBoolBoolOp) Next() coldata.Batch {
+func (p *selGTBoolBoolOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -38361,7 +39113,7 @@ func (p *selGTBoolBoolOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -38371,11 +39123,14 @@ type selGTBytesBytesConstOp struct {
 	constArg []byte
 }
 
-func (p *selGTBytesBytesConstOp) Next() coldata.Batch {
+func (p *selGTBytesBytesConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -38468,7 +39223,7 @@ func (p *selGTBytesBytesConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -38477,11 +39232,14 @@ type selGTBytesBytesOp struct {
 	selOpBase
 }
 
-func (p *selGTBytesBytesOp) Next() coldata.Batch {
+func (p *selGTBytesBytesOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -38583,7 +39341,7 @@ func (p *selGTBytesBytesOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -38593,11 +39351,14 @@ type selGTDecimalInt16ConstOp struct {
 	constArg int16
 }
 
-func (p *selGTDecimalInt16ConstOp) Next() coldata.Batch {
+func (p *selGTDecimalInt16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -38716,7 +39477,7 @@ func (p *selGTDecimalInt16ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -38725,11 +39486,14 @@ type selGTDecimalInt16Op struct {
 	selOpBase
 }
 
-func (p *selGTDecimalInt16Op) Next() coldata.Batch {
+func (p *selGTDecimalInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -38859,7 +39623,7 @@ func (p *selGTDecimalInt16Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -38869,11 +39633,14 @@ type selGTDecimalInt32ConstOp struct {
 	constArg int32
 }
 
-func (p *selGTDecimalInt32ConstOp) Next() coldata.Batch {
+func (p *selGTDecimalInt32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -38992,7 +39759,7 @@ func (p *selGTDecimalInt32ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -39001,11 +39768,14 @@ type selGTDecimalInt32Op struct {
 	selOpBase
 }
 
-func (p *selGTDecimalInt32Op) Next() coldata.Batch {
+func (p *selGTDecimalInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -39135,7 +39905,7 @@ func (p *selGTDecimalInt32Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -39145,11 +39915,14 @@ type selGTDecimalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p *selGTDecimalInt64ConstOp) Next() coldata.Batch {
+func (p *selGTDecimalInt64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -39268,7 +40041,7 @@ func (p *selGTDecimalInt64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -39277,11 +40050,14 @@ type selGTDecimalInt64Op struct {
 	selOpBase
 }
 
-func (p *selGTDecimalInt64Op) Next() coldata.Batch {
+func (p *selGTDecimalInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -39411,7 +40187,7 @@ func (p *selGTDecimalInt64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -39421,11 +40197,14 @@ type selGTDecimalFloat64ConstOp struct {
 	constArg float64
 }
 
-func (p *selGTDecimalFloat64ConstOp) Next() coldata.Batch {
+func (p *selGTDecimalFloat64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -39552,7 +40331,7 @@ func (p *selGTDecimalFloat64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -39561,11 +40340,14 @@ type selGTDecimalFloat64Op struct {
 	selOpBase
 }
 
-func (p *selGTDecimalFloat64Op) Next() coldata.Batch {
+func (p *selGTDecimalFloat64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -39703,7 +40485,7 @@ func (p *selGTDecimalFloat64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -39713,11 +40495,14 @@ type selGTDecimalDecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selGTDecimalDecimalConstOp) Next() coldata.Batch {
+func (p *selGTDecimalDecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -39812,7 +40597,7 @@ func (p *selGTDecimalDecimalConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -39821,11 +40606,14 @@ type selGTDecimalDecimalOp struct {
 	selOpBase
 }
 
-func (p *selGTDecimalDecimalOp) Next() coldata.Batch {
+func (p *selGTDecimalDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -39931,7 +40719,7 @@ func (p *selGTDecimalDecimalOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -39941,11 +40729,14 @@ type selGTInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p *selGTInt16Int16ConstOp) Next() coldata.Batch {
+func (p *selGTInt16Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -40084,7 +40875,7 @@ func (p *selGTInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -40093,11 +40884,14 @@ type selGTInt16Int16Op struct {
 	selOpBase
 }
 
-func (p *selGTInt16Int16Op) Next() coldata.Batch {
+func (p *selGTInt16Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -40247,7 +41041,7 @@ func (p *selGTInt16Int16Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -40257,11 +41051,14 @@ type selGTInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selGTInt16Int32ConstOp) Next() coldata.Batch {
+func (p *selGTInt16Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -40400,7 +41197,7 @@ func (p *selGTInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -40409,11 +41206,14 @@ type selGTInt16Int32Op struct {
 	selOpBase
 }
 
-func (p *selGTInt16Int32Op) Next() coldata.Batch {
+func (p *selGTInt16Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -40563,7 +41363,7 @@ func (p *selGTInt16Int32Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -40573,11 +41373,14 @@ type selGTInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selGTInt16Int64ConstOp) Next() coldata.Batch {
+func (p *selGTInt16Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -40716,7 +41519,7 @@ func (p *selGTInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -40725,11 +41528,14 @@ type selGTInt16Int64Op struct {
 	selOpBase
 }
 
-func (p *selGTInt16Int64Op) Next() coldata.Batch {
+func (p *selGTInt16Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -40879,7 +41685,7 @@ func (p *selGTInt16Int64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -40889,11 +41695,14 @@ type selGTInt16Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selGTInt16Float64ConstOp) Next() coldata.Batch {
+func (p *selGTInt16Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -41064,7 +41873,7 @@ func (p *selGTInt16Float64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -41073,11 +41882,14 @@ type selGTInt16Float64Op struct {
 	selOpBase
 }
 
-func (p *selGTInt16Float64Op) Next() coldata.Batch {
+func (p *selGTInt16Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -41259,7 +42071,7 @@ func (p *selGTInt16Float64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -41269,11 +42081,14 @@ type selGTInt16DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selGTInt16DecimalConstOp) Next() coldata.Batch {
+func (p *selGTInt16DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -41392,7 +42207,7 @@ func (p *selGTInt16DecimalConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -41401,11 +42216,14 @@ type selGTInt16DecimalOp struct {
 	selOpBase
 }
 
-func (p *selGTInt16DecimalOp) Next() coldata.Batch {
+func (p *selGTInt16DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -41535,7 +42353,7 @@ func (p *selGTInt16DecimalOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -41545,11 +42363,14 @@ type selGTInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p *selGTInt32Int16ConstOp) Next() coldata.Batch {
+func (p *selGTInt32Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -41688,7 +42509,7 @@ func (p *selGTInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -41697,11 +42518,14 @@ type selGTInt32Int16Op struct {
 	selOpBase
 }
 
-func (p *selGTInt32Int16Op) Next() coldata.Batch {
+func (p *selGTInt32Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -41851,7 +42675,7 @@ func (p *selGTInt32Int16Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -41861,11 +42685,14 @@ type selGTInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selGTInt32Int32ConstOp) Next() coldata.Batch {
+func (p *selGTInt32Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -42004,7 +42831,7 @@ func (p *selGTInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -42013,11 +42840,14 @@ type selGTInt32Int32Op struct {
 	selOpBase
 }
 
-func (p *selGTInt32Int32Op) Next() coldata.Batch {
+func (p *selGTInt32Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -42167,7 +42997,7 @@ func (p *selGTInt32Int32Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -42177,11 +43007,14 @@ type selGTInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selGTInt32Int64ConstOp) Next() coldata.Batch {
+func (p *selGTInt32Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -42320,7 +43153,7 @@ func (p *selGTInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -42329,11 +43162,14 @@ type selGTInt32Int64Op struct {
 	selOpBase
 }
 
-func (p *selGTInt32Int64Op) Next() coldata.Batch {
+func (p *selGTInt32Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -42483,7 +43319,7 @@ func (p *selGTInt32Int64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -42493,11 +43329,14 @@ type selGTInt32Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selGTInt32Float64ConstOp) Next() coldata.Batch {
+func (p *selGTInt32Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -42668,7 +43507,7 @@ func (p *selGTInt32Float64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -42677,11 +43516,14 @@ type selGTInt32Float64Op struct {
 	selOpBase
 }
 
-func (p *selGTInt32Float64Op) Next() coldata.Batch {
+func (p *selGTInt32Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -42863,7 +43705,7 @@ func (p *selGTInt32Float64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -42873,11 +43715,14 @@ type selGTInt32DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selGTInt32DecimalConstOp) Next() coldata.Batch {
+func (p *selGTInt32DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -42996,7 +43841,7 @@ func (p *selGTInt32DecimalConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -43005,11 +43850,14 @@ type selGTInt32DecimalOp struct {
 	selOpBase
 }
 
-func (p *selGTInt32DecimalOp) Next() coldata.Batch {
+func (p *selGTInt32DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -43139,7 +43987,7 @@ func (p *selGTInt32DecimalOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -43149,11 +43997,14 @@ type selGTInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p *selGTInt64Int16ConstOp) Next() coldata.Batch {
+func (p *selGTInt64Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -43292,7 +44143,7 @@ func (p *selGTInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -43301,11 +44152,14 @@ type selGTInt64Int16Op struct {
 	selOpBase
 }
 
-func (p *selGTInt64Int16Op) Next() coldata.Batch {
+func (p *selGTInt64Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -43455,7 +44309,7 @@ func (p *selGTInt64Int16Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -43465,11 +44319,14 @@ type selGTInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selGTInt64Int32ConstOp) Next() coldata.Batch {
+func (p *selGTInt64Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -43608,7 +44465,7 @@ func (p *selGTInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -43617,11 +44474,14 @@ type selGTInt64Int32Op struct {
 	selOpBase
 }
 
-func (p *selGTInt64Int32Op) Next() coldata.Batch {
+func (p *selGTInt64Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -43771,7 +44631,7 @@ func (p *selGTInt64Int32Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -43781,11 +44641,14 @@ type selGTInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selGTInt64Int64ConstOp) Next() coldata.Batch {
+func (p *selGTInt64Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -43924,7 +44787,7 @@ func (p *selGTInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -43933,11 +44796,14 @@ type selGTInt64Int64Op struct {
 	selOpBase
 }
 
-func (p *selGTInt64Int64Op) Next() coldata.Batch {
+func (p *selGTInt64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -44087,7 +44953,7 @@ func (p *selGTInt64Int64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -44097,11 +44963,14 @@ type selGTInt64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selGTInt64Float64ConstOp) Next() coldata.Batch {
+func (p *selGTInt64Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -44272,7 +45141,7 @@ func (p *selGTInt64Float64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -44281,11 +45150,14 @@ type selGTInt64Float64Op struct {
 	selOpBase
 }
 
-func (p *selGTInt64Float64Op) Next() coldata.Batch {
+func (p *selGTInt64Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -44467,7 +45339,7 @@ func (p *selGTInt64Float64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -44477,11 +45349,14 @@ type selGTInt64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selGTInt64DecimalConstOp) Next() coldata.Batch {
+func (p *selGTInt64DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -44600,7 +45475,7 @@ func (p *selGTInt64DecimalConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -44609,11 +45484,14 @@ type selGTInt64DecimalOp struct {
 	selOpBase
 }
 
-func (p *selGTInt64DecimalOp) Next() coldata.Batch {
+func (p *selGTInt64DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -44743,7 +45621,7 @@ func (p *selGTInt64DecimalOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -44753,11 +45631,14 @@ type selGTFloat64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p *selGTFloat64Int16ConstOp) Next() coldata.Batch {
+func (p *selGTFloat64Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -44928,7 +45809,7 @@ func (p *selGTFloat64Int16ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -44937,11 +45818,14 @@ type selGTFloat64Int16Op struct {
 	selOpBase
 }
 
-func (p *selGTFloat64Int16Op) Next() coldata.Batch {
+func (p *selGTFloat64Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -45123,7 +46007,7 @@ func (p *selGTFloat64Int16Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -45133,11 +46017,14 @@ type selGTFloat64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selGTFloat64Int32ConstOp) Next() coldata.Batch {
+func (p *selGTFloat64Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -45308,7 +46195,7 @@ func (p *selGTFloat64Int32ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -45317,11 +46204,14 @@ type selGTFloat64Int32Op struct {
 	selOpBase
 }
 
-func (p *selGTFloat64Int32Op) Next() coldata.Batch {
+func (p *selGTFloat64Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -45503,7 +46393,7 @@ func (p *selGTFloat64Int32Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -45513,11 +46403,14 @@ type selGTFloat64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selGTFloat64Int64ConstOp) Next() coldata.Batch {
+func (p *selGTFloat64Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -45688,7 +46581,7 @@ func (p *selGTFloat64Int64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -45697,11 +46590,14 @@ type selGTFloat64Int64Op struct {
 	selOpBase
 }
 
-func (p *selGTFloat64Int64Op) Next() coldata.Batch {
+func (p *selGTFloat64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -45883,7 +46779,7 @@ func (p *selGTFloat64Int64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -45893,11 +46789,14 @@ type selGTFloat64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selGTFloat64Float64ConstOp) Next() coldata.Batch {
+func (p *selGTFloat64Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -46068,7 +46967,7 @@ func (p *selGTFloat64Float64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -46077,11 +46976,14 @@ type selGTFloat64Float64Op struct {
 	selOpBase
 }
 
-func (p *selGTFloat64Float64Op) Next() coldata.Batch {
+func (p *selGTFloat64Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -46263,7 +47165,7 @@ func (p *selGTFloat64Float64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -46273,11 +47175,14 @@ type selGTFloat64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selGTFloat64DecimalConstOp) Next() coldata.Batch {
+func (p *selGTFloat64DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -46404,7 +47309,7 @@ func (p *selGTFloat64DecimalConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -46413,11 +47318,14 @@ type selGTFloat64DecimalOp struct {
 	selOpBase
 }
 
-func (p *selGTFloat64DecimalOp) Next() coldata.Batch {
+func (p *selGTFloat64DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -46555,7 +47463,7 @@ func (p *selGTFloat64DecimalOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -46565,11 +47473,14 @@ type selGTTimestampTimestampConstOp struct {
 	constArg time.Time
 }
 
-func (p *selGTTimestampTimestampConstOp) Next() coldata.Batch {
+func (p *selGTTimestampTimestampConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -46692,7 +47603,7 @@ func (p *selGTTimestampTimestampConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -46701,11 +47612,14 @@ type selGTTimestampTimestampOp struct {
 	selOpBase
 }
 
-func (p *selGTTimestampTimestampOp) Next() coldata.Batch {
+func (p *selGTTimestampTimestampOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -46839,7 +47753,7 @@ func (p *selGTTimestampTimestampOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -46849,11 +47763,14 @@ type selGTIntervalIntervalConstOp struct {
 	constArg duration.Duration
 }
 
-func (p *selGTIntervalIntervalConstOp) Next() coldata.Batch {
+func (p *selGTIntervalIntervalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -46948,7 +47865,7 @@ func (p *selGTIntervalIntervalConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -46957,11 +47874,14 @@ type selGTIntervalIntervalOp struct {
 	selOpBase
 }
 
-func (p *selGTIntervalIntervalOp) Next() coldata.Batch {
+func (p *selGTIntervalIntervalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -47067,7 +47987,7 @@ func (p *selGTIntervalIntervalOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -47077,11 +47997,14 @@ type selGTJSONJSONConstOp struct {
 	constArg json.JSON
 }
 
-func (p *selGTJSONJSONConstOp) Next() coldata.Batch {
+func (p *selGTJSONJSONConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -47198,7 +48121,7 @@ func (p *selGTJSONJSONConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -47207,11 +48130,14 @@ type selGTJSONJSONOp struct {
 	selOpBase
 }
 
-func (p *selGTJSONJSONOp) Next() coldata.Batch {
+func (p *selGTJSONJSONOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -47337,7 +48263,7 @@ func (p *selGTJSONJSONOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -47347,11 +48273,14 @@ type selGTDatumDatumConstOp struct {
 	constArg interface{}
 }
 
-func (p *selGTDatumDatumConstOp) Next() coldata.Batch {
+func (p *selGTDatumDatumConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -47452,7 +48381,7 @@ func (p *selGTDatumDatumConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -47461,11 +48390,14 @@ type selGTDatumDatumOp struct {
 	selOpBase
 }
 
-func (p *selGTDatumDatumOp) Next() coldata.Batch {
+func (p *selGTDatumDatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -47575,7 +48507,7 @@ func (p *selGTDatumDatumOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -47585,11 +48517,14 @@ type selGEBoolBoolConstOp struct {
 	constArg bool
 }
 
-func (p *selGEBoolBoolConstOp) Next() coldata.Batch {
+func (p *selGEBoolBoolConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -47716,7 +48651,7 @@ func (p *selGEBoolBoolConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -47725,11 +48660,14 @@ type selGEBoolBoolOp struct {
 	selOpBase
 }
 
-func (p *selGEBoolBoolOp) Next() coldata.Batch {
+func (p *selGEBoolBoolOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -47867,7 +48805,7 @@ func (p *selGEBoolBoolOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -47877,11 +48815,14 @@ type selGEBytesBytesConstOp struct {
 	constArg []byte
 }
 
-func (p *selGEBytesBytesConstOp) Next() coldata.Batch {
+func (p *selGEBytesBytesConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -47974,7 +48915,7 @@ func (p *selGEBytesBytesConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -47983,11 +48924,14 @@ type selGEBytesBytesOp struct {
 	selOpBase
 }
 
-func (p *selGEBytesBytesOp) Next() coldata.Batch {
+func (p *selGEBytesBytesOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -48089,7 +49033,7 @@ func (p *selGEBytesBytesOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -48099,11 +49043,14 @@ type selGEDecimalInt16ConstOp struct {
 	constArg int16
 }
 
-func (p *selGEDecimalInt16ConstOp) Next() coldata.Batch {
+func (p *selGEDecimalInt16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -48222,7 +49169,7 @@ func (p *selGEDecimalInt16ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -48231,11 +49178,14 @@ type selGEDecimalInt16Op struct {
 	selOpBase
 }
 
-func (p *selGEDecimalInt16Op) Next() coldata.Batch {
+func (p *selGEDecimalInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -48365,7 +49315,7 @@ func (p *selGEDecimalInt16Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -48375,11 +49325,14 @@ type selGEDecimalInt32ConstOp struct {
 	constArg int32
 }
 
-func (p *selGEDecimalInt32ConstOp) Next() coldata.Batch {
+func (p *selGEDecimalInt32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -48498,7 +49451,7 @@ func (p *selGEDecimalInt32ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -48507,11 +49460,14 @@ type selGEDecimalInt32Op struct {
 	selOpBase
 }
 
-func (p *selGEDecimalInt32Op) Next() coldata.Batch {
+func (p *selGEDecimalInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -48641,7 +49597,7 @@ func (p *selGEDecimalInt32Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -48651,11 +49607,14 @@ type selGEDecimalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p *selGEDecimalInt64ConstOp) Next() coldata.Batch {
+func (p *selGEDecimalInt64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -48774,7 +49733,7 @@ func (p *selGEDecimalInt64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -48783,11 +49742,14 @@ type selGEDecimalInt64Op struct {
 	selOpBase
 }
 
-func (p *selGEDecimalInt64Op) Next() coldata.Batch {
+func (p *selGEDecimalInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -48917,7 +49879,7 @@ func (p *selGEDecimalInt64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -48927,11 +49889,14 @@ type selGEDecimalFloat64ConstOp struct {
 	constArg float64
 }
 
-func (p *selGEDecimalFloat64ConstOp) Next() coldata.Batch {
+func (p *selGEDecimalFloat64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -49058,7 +50023,7 @@ func (p *selGEDecimalFloat64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -49067,11 +50032,14 @@ type selGEDecimalFloat64Op struct {
 	selOpBase
 }
 
-func (p *selGEDecimalFloat64Op) Next() coldata.Batch {
+func (p *selGEDecimalFloat64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -49209,7 +50177,7 @@ func (p *selGEDecimalFloat64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -49219,11 +50187,14 @@ type selGEDecimalDecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selGEDecimalDecimalConstOp) Next() coldata.Batch {
+func (p *selGEDecimalDecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -49318,7 +50289,7 @@ func (p *selGEDecimalDecimalConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -49327,11 +50298,14 @@ type selGEDecimalDecimalOp struct {
 	selOpBase
 }
 
-func (p *selGEDecimalDecimalOp) Next() coldata.Batch {
+func (p *selGEDecimalDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -49437,7 +50411,7 @@ func (p *selGEDecimalDecimalOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -49447,11 +50421,14 @@ type selGEInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p *selGEInt16Int16ConstOp) Next() coldata.Batch {
+func (p *selGEInt16Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -49590,7 +50567,7 @@ func (p *selGEInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -49599,11 +50576,14 @@ type selGEInt16Int16Op struct {
 	selOpBase
 }
 
-func (p *selGEInt16Int16Op) Next() coldata.Batch {
+func (p *selGEInt16Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -49753,7 +50733,7 @@ func (p *selGEInt16Int16Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -49763,11 +50743,14 @@ type selGEInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selGEInt16Int32ConstOp) Next() coldata.Batch {
+func (p *selGEInt16Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -49906,7 +50889,7 @@ func (p *selGEInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -49915,11 +50898,14 @@ type selGEInt16Int32Op struct {
 	selOpBase
 }
 
-func (p *selGEInt16Int32Op) Next() coldata.Batch {
+func (p *selGEInt16Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -50069,7 +51055,7 @@ func (p *selGEInt16Int32Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -50079,11 +51065,14 @@ type selGEInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selGEInt16Int64ConstOp) Next() coldata.Batch {
+func (p *selGEInt16Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -50222,7 +51211,7 @@ func (p *selGEInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -50231,11 +51220,14 @@ type selGEInt16Int64Op struct {
 	selOpBase
 }
 
-func (p *selGEInt16Int64Op) Next() coldata.Batch {
+func (p *selGEInt16Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -50385,7 +51377,7 @@ func (p *selGEInt16Int64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -50395,11 +51387,14 @@ type selGEInt16Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selGEInt16Float64ConstOp) Next() coldata.Batch {
+func (p *selGEInt16Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -50570,7 +51565,7 @@ func (p *selGEInt16Float64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -50579,11 +51574,14 @@ type selGEInt16Float64Op struct {
 	selOpBase
 }
 
-func (p *selGEInt16Float64Op) Next() coldata.Batch {
+func (p *selGEInt16Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -50765,7 +51763,7 @@ func (p *selGEInt16Float64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -50775,11 +51773,14 @@ type selGEInt16DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selGEInt16DecimalConstOp) Next() coldata.Batch {
+func (p *selGEInt16DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -50898,7 +51899,7 @@ func (p *selGEInt16DecimalConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -50907,11 +51908,14 @@ type selGEInt16DecimalOp struct {
 	selOpBase
 }
 
-func (p *selGEInt16DecimalOp) Next() coldata.Batch {
+func (p *selGEInt16DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -51041,7 +52045,7 @@ func (p *selGEInt16DecimalOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -51051,11 +52055,14 @@ type selGEInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p *selGEInt32Int16ConstOp) Next() coldata.Batch {
+func (p *selGEInt32Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -51194,7 +52201,7 @@ func (p *selGEInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -51203,11 +52210,14 @@ type selGEInt32Int16Op struct {
 	selOpBase
 }
 
-func (p *selGEInt32Int16Op) Next() coldata.Batch {
+func (p *selGEInt32Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -51357,7 +52367,7 @@ func (p *selGEInt32Int16Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -51367,11 +52377,14 @@ type selGEInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selGEInt32Int32ConstOp) Next() coldata.Batch {
+func (p *selGEInt32Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -51510,7 +52523,7 @@ func (p *selGEInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -51519,11 +52532,14 @@ type selGEInt32Int32Op struct {
 	selOpBase
 }
 
-func (p *selGEInt32Int32Op) Next() coldata.Batch {
+func (p *selGEInt32Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -51673,7 +52689,7 @@ func (p *selGEInt32Int32Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -51683,11 +52699,14 @@ type selGEInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selGEInt32Int64ConstOp) Next() coldata.Batch {
+func (p *selGEInt32Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -51826,7 +52845,7 @@ func (p *selGEInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -51835,11 +52854,14 @@ type selGEInt32Int64Op struct {
 	selOpBase
 }
 
-func (p *selGEInt32Int64Op) Next() coldata.Batch {
+func (p *selGEInt32Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -51989,7 +53011,7 @@ func (p *selGEInt32Int64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -51999,11 +53021,14 @@ type selGEInt32Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selGEInt32Float64ConstOp) Next() coldata.Batch {
+func (p *selGEInt32Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -52174,7 +53199,7 @@ func (p *selGEInt32Float64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -52183,11 +53208,14 @@ type selGEInt32Float64Op struct {
 	selOpBase
 }
 
-func (p *selGEInt32Float64Op) Next() coldata.Batch {
+func (p *selGEInt32Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -52369,7 +53397,7 @@ func (p *selGEInt32Float64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -52379,11 +53407,14 @@ type selGEInt32DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selGEInt32DecimalConstOp) Next() coldata.Batch {
+func (p *selGEInt32DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -52502,7 +53533,7 @@ func (p *selGEInt32DecimalConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -52511,11 +53542,14 @@ type selGEInt32DecimalOp struct {
 	selOpBase
 }
 
-func (p *selGEInt32DecimalOp) Next() coldata.Batch {
+func (p *selGEInt32DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -52645,7 +53679,7 @@ func (p *selGEInt32DecimalOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -52655,11 +53689,14 @@ type selGEInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p *selGEInt64Int16ConstOp) Next() coldata.Batch {
+func (p *selGEInt64Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -52798,7 +53835,7 @@ func (p *selGEInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -52807,11 +53844,14 @@ type selGEInt64Int16Op struct {
 	selOpBase
 }
 
-func (p *selGEInt64Int16Op) Next() coldata.Batch {
+func (p *selGEInt64Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -52961,7 +54001,7 @@ func (p *selGEInt64Int16Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -52971,11 +54011,14 @@ type selGEInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selGEInt64Int32ConstOp) Next() coldata.Batch {
+func (p *selGEInt64Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -53114,7 +54157,7 @@ func (p *selGEInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -53123,11 +54166,14 @@ type selGEInt64Int32Op struct {
 	selOpBase
 }
 
-func (p *selGEInt64Int32Op) Next() coldata.Batch {
+func (p *selGEInt64Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -53277,7 +54323,7 @@ func (p *selGEInt64Int32Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -53287,11 +54333,14 @@ type selGEInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selGEInt64Int64ConstOp) Next() coldata.Batch {
+func (p *selGEInt64Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -53430,7 +54479,7 @@ func (p *selGEInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -53439,11 +54488,14 @@ type selGEInt64Int64Op struct {
 	selOpBase
 }
 
-func (p *selGEInt64Int64Op) Next() coldata.Batch {
+func (p *selGEInt64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -53593,7 +54645,7 @@ func (p *selGEInt64Int64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -53603,11 +54655,14 @@ type selGEInt64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selGEInt64Float64ConstOp) Next() coldata.Batch {
+func (p *selGEInt64Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -53778,7 +54833,7 @@ func (p *selGEInt64Float64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -53787,11 +54842,14 @@ type selGEInt64Float64Op struct {
 	selOpBase
 }
 
-func (p *selGEInt64Float64Op) Next() coldata.Batch {
+func (p *selGEInt64Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -53973,7 +55031,7 @@ func (p *selGEInt64Float64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -53983,11 +55041,14 @@ type selGEInt64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selGEInt64DecimalConstOp) Next() coldata.Batch {
+func (p *selGEInt64DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -54106,7 +55167,7 @@ func (p *selGEInt64DecimalConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -54115,11 +55176,14 @@ type selGEInt64DecimalOp struct {
 	selOpBase
 }
 
-func (p *selGEInt64DecimalOp) Next() coldata.Batch {
+func (p *selGEInt64DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -54249,7 +55313,7 @@ func (p *selGEInt64DecimalOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -54259,11 +55323,14 @@ type selGEFloat64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p *selGEFloat64Int16ConstOp) Next() coldata.Batch {
+func (p *selGEFloat64Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -54434,7 +55501,7 @@ func (p *selGEFloat64Int16ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -54443,11 +55510,14 @@ type selGEFloat64Int16Op struct {
 	selOpBase
 }
 
-func (p *selGEFloat64Int16Op) Next() coldata.Batch {
+func (p *selGEFloat64Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -54629,7 +55699,7 @@ func (p *selGEFloat64Int16Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -54639,11 +55709,14 @@ type selGEFloat64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selGEFloat64Int32ConstOp) Next() coldata.Batch {
+func (p *selGEFloat64Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -54814,7 +55887,7 @@ func (p *selGEFloat64Int32ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -54823,11 +55896,14 @@ type selGEFloat64Int32Op struct {
 	selOpBase
 }
 
-func (p *selGEFloat64Int32Op) Next() coldata.Batch {
+func (p *selGEFloat64Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -55009,7 +56085,7 @@ func (p *selGEFloat64Int32Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -55019,11 +56095,14 @@ type selGEFloat64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selGEFloat64Int64ConstOp) Next() coldata.Batch {
+func (p *selGEFloat64Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -55194,7 +56273,7 @@ func (p *selGEFloat64Int64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -55203,11 +56282,14 @@ type selGEFloat64Int64Op struct {
 	selOpBase
 }
 
-func (p *selGEFloat64Int64Op) Next() coldata.Batch {
+func (p *selGEFloat64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -55389,7 +56471,7 @@ func (p *selGEFloat64Int64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -55399,11 +56481,14 @@ type selGEFloat64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selGEFloat64Float64ConstOp) Next() coldata.Batch {
+func (p *selGEFloat64Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -55574,7 +56659,7 @@ func (p *selGEFloat64Float64ConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -55583,11 +56668,14 @@ type selGEFloat64Float64Op struct {
 	selOpBase
 }
 
-func (p *selGEFloat64Float64Op) Next() coldata.Batch {
+func (p *selGEFloat64Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -55769,7 +56857,7 @@ func (p *selGEFloat64Float64Op) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -55779,11 +56867,14 @@ type selGEFloat64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selGEFloat64DecimalConstOp) Next() coldata.Batch {
+func (p *selGEFloat64DecimalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -55910,7 +57001,7 @@ func (p *selGEFloat64DecimalConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -55919,11 +57010,14 @@ type selGEFloat64DecimalOp struct {
 	selOpBase
 }
 
-func (p *selGEFloat64DecimalOp) Next() coldata.Batch {
+func (p *selGEFloat64DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -56061,7 +57155,7 @@ func (p *selGEFloat64DecimalOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -56071,11 +57165,14 @@ type selGETimestampTimestampConstOp struct {
 	constArg time.Time
 }
 
-func (p *selGETimestampTimestampConstOp) Next() coldata.Batch {
+func (p *selGETimestampTimestampConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -56198,7 +57295,7 @@ func (p *selGETimestampTimestampConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -56207,11 +57304,14 @@ type selGETimestampTimestampOp struct {
 	selOpBase
 }
 
-func (p *selGETimestampTimestampOp) Next() coldata.Batch {
+func (p *selGETimestampTimestampOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -56345,7 +57445,7 @@ func (p *selGETimestampTimestampOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -56355,11 +57455,14 @@ type selGEIntervalIntervalConstOp struct {
 	constArg duration.Duration
 }
 
-func (p *selGEIntervalIntervalConstOp) Next() coldata.Batch {
+func (p *selGEIntervalIntervalConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -56454,7 +57557,7 @@ func (p *selGEIntervalIntervalConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -56463,11 +57566,14 @@ type selGEIntervalIntervalOp struct {
 	selOpBase
 }
 
-func (p *selGEIntervalIntervalOp) Next() coldata.Batch {
+func (p *selGEIntervalIntervalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -56573,7 +57679,7 @@ func (p *selGEIntervalIntervalOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -56583,11 +57689,14 @@ type selGEJSONJSONConstOp struct {
 	constArg json.JSON
 }
 
-func (p *selGEJSONJSONConstOp) Next() coldata.Batch {
+func (p *selGEJSONJSONConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -56704,7 +57813,7 @@ func (p *selGEJSONJSONConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -56713,11 +57822,14 @@ type selGEJSONJSONOp struct {
 	selOpBase
 }
 
-func (p *selGEJSONJSONOp) Next() coldata.Batch {
+func (p *selGEJSONJSONOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -56843,7 +57955,7 @@ func (p *selGEJSONJSONOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -56853,11 +57965,14 @@ type selGEDatumDatumConstOp struct {
 	constArg interface{}
 }
 
-func (p *selGEDatumDatumConstOp) Next() coldata.Batch {
+func (p *selGEDatumDatumConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec := batch.ColVec(p.colIdx)
@@ -56958,7 +58073,7 @@ func (p *selGEDatumDatumConstOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
@@ -56967,11 +58082,14 @@ type selGEDatumDatumOp struct {
 	selOpBase
 }
 
-func (p *selGEDatumDatumOp) Next() coldata.Batch {
+func (p *selGEDatumDatumOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := p.Input.Next()
+		batch, meta := p.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return batch
+			return batch, nil
 		}
 
 		vec1 := batch.ColVec(p.col1Idx)
@@ -57081,7 +58199,7 @@ func (p *selGEDatumDatumOp) Next() coldata.Batch {
 		}
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }

--- a/pkg/sql/colexec/colexecsel/selection_ops_test.go
+++ b/pkg/sql/colexec/colexecsel/selection_ops_test.go
@@ -186,7 +186,7 @@ func runSelOpBenchmarks(
 			b.Run(fmt.Sprintf("useSel=%t,hasNulls=%t", useSel, hasNulls), func(b *testing.B) {
 				b.SetBytes(int64(len(inputTypes) * 8 * coldata.BatchSize()))
 				for i := 0; i < b.N; i++ {
-					op.Next()
+					colexecop.NextNoMeta(op)
 				}
 			})
 		}

--- a/pkg/sql/colexec/colexecspan/BUILD.bazel
+++ b/pkg/sql/colexec/colexecspan/BUILD.bazel
@@ -60,6 +60,7 @@ go_test(
         "//pkg/sql/colconv",
         "//pkg/sql/colexec/colexectestutils",
         "//pkg/sql/colexecerror",
+        "//pkg/sql/colexecop",
         "//pkg/sql/colmem",
         "//pkg/sql/execinfra",
         "//pkg/sql/rowenc",

--- a/pkg/sql/colexec/colexecspan/span_assembler_test.go
+++ b/pkg/sql/colexec/colexecspan/span_assembler_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/colconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexectestutils"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
@@ -134,7 +135,7 @@ func TestSpanAssembler(t *testing.T) {
 									}()
 
 									var testSpans roachpb.Spans
-									for batch := source.Next(); ; batch = source.Next() {
+									for batch := colexecop.NextNoMeta(source); ; batch = colexecop.NextNoMeta(source) {
 										if batch.Length() == 0 {
 											// Reached the end of the input.
 											testSpans = append(testSpans, colBuilder.GetSpans()...)
@@ -149,7 +150,7 @@ func TestSpanAssembler(t *testing.T) {
 									}
 
 									var oracleSpans roachpb.Spans
-									for batch := oracleSource.Next(); batch.Length() > 0; batch = oracleSource.Next() {
+									for batch := colexecop.NextNoMeta(oracleSource); batch.Length() > 0; batch = colexecop.NextNoMeta(oracleSource) {
 										batch.SetSelection(true)
 										copy(batch.Selection(), sel)
 										batch.SetLength(len(sel))

--- a/pkg/sql/colexec/colexectestutils/utils_test.go
+++ b/pkg/sql/colexec/colexectestutils/utils_test.go
@@ -51,11 +51,11 @@ func TestRepeatableBatchSource(t *testing.T) {
 	input := colexecop.NewRepeatableBatchSource(testAllocator, batch, typs)
 	input.Init(context.Background())
 
-	b := input.Next()
+	b := colexecop.NextNoMeta(input)
 	b.SetLength(0)
 	b.SetSelection(true)
 
-	b = input.Next()
+	b = colexecop.NextNoMeta(input)
 	if b.Length() != batchLen {
 		t.Fatalf("expected RepeatableBatchSource to reset batch length to %d, found %d", batchLen, b.Length())
 	}
@@ -81,11 +81,11 @@ func TestRepeatableBatchSourceWithFixedSel(t *testing.T) {
 	copy(batch.Selection(), sel)
 	input := colexecop.NewRepeatableBatchSource(testAllocator, batch, typs)
 	input.Init(context.Background())
-	b := input.Next()
+	b := colexecop.NextNoMeta(input)
 
 	b.SetLength(0)
 	b.SetSelection(false)
-	b = input.Next()
+	b = colexecop.NextNoMeta(input)
 	if b.Length() != batchLen {
 		t.Fatalf("expected RepeatableBatchSource to reset batch length to %d, found %d", batchLen, b.Length())
 	}
@@ -104,7 +104,7 @@ func TestRepeatableBatchSourceWithFixedSel(t *testing.T) {
 	b.SetLength(newBatchLen)
 	b.SetSelection(true)
 	copy(b.Selection(), newSel)
-	b = input.Next()
+	b = colexecop.NextNoMeta(input)
 	if b.Length() != batchLen {
 		t.Fatalf("expected RepeatableBatchSource to reset batch length to %d, found %d", batchLen, b.Length())
 	}

--- a/pkg/sql/colexec/colexecutils/cancel_checker.go
+++ b/pkg/sql/colexec/colexecutils/cancel_checker.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/util/cancelchecker"
 )
 
@@ -49,7 +50,7 @@ func (c *CancelChecker) Init(ctx context.Context) {
 }
 
 // Next is part of colexecop.Operator interface.
-func (c *CancelChecker) Next() coldata.Batch {
+func (c *CancelChecker) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	c.CheckEveryCall()
 	return c.Input.Next()
 }

--- a/pkg/sql/colexec/colexecutils/cancel_checker_test.go
+++ b/pkg/sql/colexec/colexecutils/cancel_checker_test.go
@@ -31,7 +31,7 @@ func TestCancelChecker(t *testing.T) {
 	op.Init(ctx)
 	cancel()
 	err := colexecerror.CatchVectorizedRuntimeError(func() {
-		op.Next()
+		colexecop.NextNoMeta(op)
 	})
 	require.True(t, errors.Is(err, cancelchecker.QueryCanceledError))
 }

--- a/pkg/sql/colexec/colexecutils/deselector_test.go
+++ b/pkg/sql/colexec/colexecutils/deselector_test.go
@@ -110,7 +110,7 @@ func BenchmarkDeselector(b *testing.B) {
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
 					input.ResetBatchesToReturn(nBatches)
-					for b := op.Next(); b.Length() != 0; b = op.Next() {
+					for b := colexecop.NextNoMeta(op); b.Length() != 0; b = colexecop.NextNoMeta(op) {
 					}
 					// We don't need to reset the deselector because it doesn't keep any
 					// state. We do, however, want to keep its already allocated memory

--- a/pkg/sql/colexec/colexecutils/spilling_buffer_test.go
+++ b/pkg/sql/colexec/colexecutils/spilling_buffer_test.go
@@ -156,7 +156,7 @@ func TestSpillingBuffer(t *testing.T) {
 			// Append input tuples.
 			var b coldata.Batch
 			for {
-				b = op.Next()
+				b = colexecop.NextNoMeta(op)
 				if b.Length() == 0 {
 					break
 				}

--- a/pkg/sql/colexec/colexecutils/spilling_queue_test.go
+++ b/pkg/sql/colexec/colexecutils/spilling_queue_test.go
@@ -176,7 +176,7 @@ func TestSpillingQueue(t *testing.T) {
 			}
 
 			for {
-				b = op.Next()
+				b = colexecop.NextNoMeta(op)
 				q.Enqueue(ctx, b)
 				if b.Length() == 0 {
 					break
@@ -296,7 +296,7 @@ func TestSpillingQueueDidntSpill(t *testing.T) {
 	)
 
 	for {
-		b := op.Next()
+		b := colexecop.NextNoMeta(op)
 		q.Enqueue(ctx, b)
 		b, err := q.Dequeue(ctx)
 		require.NoError(t, err)

--- a/pkg/sql/colexec/colexecwindow/partitioner.go
+++ b/pkg/sql/colexec/colexecwindow/partitioner.go
@@ -59,10 +59,13 @@ type windowSortingPartitioner struct {
 	partitionColIdx int
 }
 
-func (p *windowSortingPartitioner) Next() coldata.Batch {
-	b := p.Input.Next()
+func (p *windowSortingPartitioner) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	b, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	if b.Length() == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	partitionVec := b.ColVec(p.partitionColIdx)
 	partitionCol := partitionVec.Bool()
@@ -74,5 +77,5 @@ func (p *windowSortingPartitioner) Next() coldata.Batch {
 	} else {
 		copy(partitionCol, p.distinctCol[:b.Length()])
 	}
-	return b
+	return b, nil
 }

--- a/pkg/sql/colexec/colexecwindow/rank.eg.go
+++ b/pkg/sql/colexec/colexecwindow/rank.eg.go
@@ -98,11 +98,14 @@ func (r *rankNoPartitionOp) Init(ctx context.Context) {
 	r.rankIncrement = 1
 }
 
-func (r *rankNoPartitionOp) Next() coldata.Batch {
-	batch := r.Input.Next()
+func (r *rankNoPartitionOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := r.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	peersCol := batch.ColVec(r.peersColIdx).Bool()
 	rankVec := batch.ColVec(r.outputColIdx)
@@ -136,7 +139,7 @@ func (r *rankNoPartitionOp) Next() coldata.Batch {
 			}
 		}
 	}
-	return batch
+	return batch, nil
 }
 
 type rankWithPartitionOp struct {
@@ -163,11 +166,14 @@ func (r *rankWithPartitionOp) Init(ctx context.Context) {
 	r.rankIncrement = 1
 }
 
-func (r *rankWithPartitionOp) Next() coldata.Batch {
-	batch := r.Input.Next()
+func (r *rankWithPartitionOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := r.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	partitionCol := batch.ColVec(r.partitionColIdx).Bool()
 	peersCol := batch.ColVec(r.peersColIdx).Bool()
@@ -220,7 +226,7 @@ func (r *rankWithPartitionOp) Next() coldata.Batch {
 			}
 		}
 	}
-	return batch
+	return batch, nil
 }
 
 type denseRankNoPartitionOp struct {
@@ -247,11 +253,14 @@ func (r *denseRankNoPartitionOp) Init(ctx context.Context) {
 	r.rankIncrement = 1
 }
 
-func (r *denseRankNoPartitionOp) Next() coldata.Batch {
-	batch := r.Input.Next()
+func (r *denseRankNoPartitionOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := r.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	peersCol := batch.ColVec(r.peersColIdx).Bool()
 	rankVec := batch.ColVec(r.outputColIdx)
@@ -283,7 +292,7 @@ func (r *denseRankNoPartitionOp) Next() coldata.Batch {
 			}
 		}
 	}
-	return batch
+	return batch, nil
 }
 
 type denseRankWithPartitionOp struct {
@@ -310,11 +319,14 @@ func (r *denseRankWithPartitionOp) Init(ctx context.Context) {
 	r.rankIncrement = 1
 }
 
-func (r *denseRankWithPartitionOp) Next() coldata.Batch {
-	batch := r.Input.Next()
+func (r *denseRankWithPartitionOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := r.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	partitionCol := batch.ColVec(r.partitionColIdx).Bool()
 	peersCol := batch.ColVec(r.peersColIdx).Bool()
@@ -365,5 +377,5 @@ func (r *denseRankWithPartitionOp) Next() coldata.Batch {
 			}
 		}
 	}
-	return batch
+	return batch, nil
 }

--- a/pkg/sql/colexec/colexecwindow/rank_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/rank_tmpl.go
@@ -163,11 +163,14 @@ func (r *_RANK_STRINGOp) Init(ctx context.Context) {
 	r.rankIncrement = 1
 }
 
-func (r *_RANK_STRINGOp) Next() coldata.Batch {
-	batch := r.Input.Next()
+func (r *_RANK_STRINGOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := r.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 	// {{if .HasPartition}}
 	partitionCol := batch.ColVec(r.partitionColIdx).Bool()
@@ -190,7 +193,7 @@ func (r *_RANK_STRINGOp) Next() coldata.Batch {
 			_COMPUTE_RANK(false)
 		}
 	}
-	return batch
+	return batch, nil
 }
 
 // {{end}}

--- a/pkg/sql/colexec/colexecwindow/relative_rank.eg.go
+++ b/pkg/sql/colexec/colexecwindow/relative_rank.eg.go
@@ -198,7 +198,7 @@ func (r *percentRankNoPartitionOp) Init(ctx context.Context) {
 	r.rankIncrement = 1
 }
 
-func (r *percentRankNoPartitionOp) Next() coldata.Batch {
+func (r *percentRankNoPartitionOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	var err error
 	for {
 		switch r.state {
@@ -229,7 +229,10 @@ func (r *percentRankNoPartitionOp) Next() coldata.Batch {
 			// This example also shows why we need to use two different queues
 			// (since every partition can have multiple peer groups, the
 			// schedule of "flushing" is different).
-			batch := r.Input.Next()
+			batch, meta := r.Input.Next()
+			if meta != nil {
+				return nil, meta
+			}
 			n := batch.Length()
 			if n == 0 {
 				r.bufferedTuples.Enqueue(r.Ctx, coldata.ZeroBatch)
@@ -307,18 +310,18 @@ func (r *percentRankNoPartitionOp) Next() coldata.Batch {
 				r.rankIncrement++
 			}
 			r.output.SetLength(n)
-			return r.output
+			return r.output, nil
 
 		case relativeRankFinished:
 			if err := r.Close(r.Ctx); err != nil {
 				colexecerror.InternalError(err)
 			}
-			return coldata.ZeroBatch
+			return coldata.ZeroBatch, nil
 
 		default:
 			colexecerror.InternalError(errors.AssertionFailedf("percent rank operator in unhandled state"))
 			// This code is unreachable, but the compiler cannot infer that.
-			return nil
+			return nil, nil
 		}
 	}
 }
@@ -394,7 +397,7 @@ func (r *percentRankWithPartitionOp) Init(ctx context.Context) {
 	r.rankIncrement = 1
 }
 
-func (r *percentRankWithPartitionOp) Next() coldata.Batch {
+func (r *percentRankWithPartitionOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	var err error
 	for {
 		switch r.state {
@@ -425,7 +428,10 @@ func (r *percentRankWithPartitionOp) Next() coldata.Batch {
 			// This example also shows why we need to use two different queues
 			// (since every partition can have multiple peer groups, the
 			// schedule of "flushing" is different).
-			batch := r.Input.Next()
+			batch, meta := r.Input.Next()
+			if meta != nil {
+				return nil, meta
+			}
 			n := batch.Length()
 			if n == 0 {
 				r.bufferedTuples.Enqueue(r.Ctx, coldata.ZeroBatch)
@@ -586,18 +592,18 @@ func (r *percentRankWithPartitionOp) Next() coldata.Batch {
 				r.rankIncrement++
 			}
 			r.output.SetLength(n)
-			return r.output
+			return r.output, nil
 
 		case relativeRankFinished:
 			if err := r.Close(r.Ctx); err != nil {
 				colexecerror.InternalError(err)
 			}
-			return coldata.ZeroBatch
+			return coldata.ZeroBatch, nil
 
 		default:
 			colexecerror.InternalError(errors.AssertionFailedf("percent rank operator in unhandled state"))
 			// This code is unreachable, but the compiler cannot infer that.
-			return nil
+			return nil, nil
 		}
 	}
 }
@@ -672,7 +678,7 @@ func (r *cumeDistNoPartitionOp) Init(ctx context.Context) {
 	r.output = r.allocator.NewMemBatchWithFixedCapacity(append(r.inputTypes, types.Float), coldata.BatchSize())
 }
 
-func (r *cumeDistNoPartitionOp) Next() coldata.Batch {
+func (r *cumeDistNoPartitionOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	var err error
 	for {
 		switch r.state {
@@ -703,7 +709,10 @@ func (r *cumeDistNoPartitionOp) Next() coldata.Batch {
 			// This example also shows why we need to use two different queues
 			// (since every partition can have multiple peer groups, the
 			// schedule of "flushing" is different).
-			batch := r.Input.Next()
+			batch, meta := r.Input.Next()
+			if meta != nil {
+				return nil, meta
+			}
 			n := batch.Length()
 			if n == 0 {
 				r.bufferedTuples.Enqueue(r.Ctx, coldata.ZeroBatch)
@@ -853,18 +862,18 @@ func (r *cumeDistNoPartitionOp) Next() coldata.Batch {
 				relativeRankOutputCol[i] = float64(r.numPrecedingTuples+r.numPeers) / float64(r.numTuplesInPartition)
 			}
 			r.output.SetLength(n)
-			return r.output
+			return r.output, nil
 
 		case relativeRankFinished:
 			if err := r.Close(r.Ctx); err != nil {
 				colexecerror.InternalError(err)
 			}
-			return coldata.ZeroBatch
+			return coldata.ZeroBatch, nil
 
 		default:
 			colexecerror.InternalError(errors.AssertionFailedf("percent rank operator in unhandled state"))
 			// This code is unreachable, but the compiler cannot infer that.
-			return nil
+			return nil, nil
 		}
 	}
 }
@@ -953,7 +962,7 @@ func (r *cumeDistWithPartitionOp) Init(ctx context.Context) {
 	r.output = r.allocator.NewMemBatchWithFixedCapacity(append(r.inputTypes, types.Float), coldata.BatchSize())
 }
 
-func (r *cumeDistWithPartitionOp) Next() coldata.Batch {
+func (r *cumeDistWithPartitionOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	var err error
 	for {
 		switch r.state {
@@ -984,7 +993,10 @@ func (r *cumeDistWithPartitionOp) Next() coldata.Batch {
 			// This example also shows why we need to use two different queues
 			// (since every partition can have multiple peer groups, the
 			// schedule of "flushing" is different).
-			batch := r.Input.Next()
+			batch, meta := r.Input.Next()
+			if meta != nil {
+				return nil, meta
+			}
 			n := batch.Length()
 			if n == 0 {
 				r.bufferedTuples.Enqueue(r.Ctx, coldata.ZeroBatch)
@@ -1215,18 +1227,18 @@ func (r *cumeDistWithPartitionOp) Next() coldata.Batch {
 				relativeRankOutputCol[i] = float64(r.numPrecedingTuples+r.numPeers) / float64(r.numTuplesInPartition)
 			}
 			r.output.SetLength(n)
-			return r.output
+			return r.output, nil
 
 		case relativeRankFinished:
 			if err := r.Close(r.Ctx); err != nil {
 				colexecerror.InternalError(err)
 			}
-			return coldata.ZeroBatch
+			return coldata.ZeroBatch, nil
 
 		default:
 			colexecerror.InternalError(errors.AssertionFailedf("percent rank operator in unhandled state"))
 			// This code is unreachable, but the compiler cannot infer that.
-			return nil
+			return nil, nil
 		}
 	}
 }

--- a/pkg/sql/colexec/colexecwindow/row_number_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/row_number_tmpl.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 )
 
@@ -87,11 +88,14 @@ type _ROW_NUMBER_STRINGOp struct {
 
 var _ colexecop.Operator = &_ROW_NUMBER_STRINGOp{}
 
-func (r *_ROW_NUMBER_STRINGOp) Next() coldata.Batch {
-	batch := r.Input.Next()
+func (r *_ROW_NUMBER_STRINGOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := r.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 
 	// {{if .HasPartition}}
@@ -113,7 +117,7 @@ func (r *_ROW_NUMBER_STRINGOp) Next() coldata.Batch {
 			_COMPUTE_ROW_NUMBER(false)
 		}
 	}
-	return batch
+	return batch, nil
 }
 
 // {{end}}

--- a/pkg/sql/colexec/colexecwindow/window_functions_test.go
+++ b/pkg/sql/colexec/colexecwindow/window_functions_test.go
@@ -1293,7 +1293,7 @@ func BenchmarkWindowFunctions(b *testing.B) {
 										s := getWindowFn(fun, source, partitionInput, orderInput)
 										s.Init(ctx)
 										b.StartTimer()
-										for b := s.Next(); b.Length() != 0; b = s.Next() {
+										for b := colexecop.NextNoMeta(s); b.Length() != 0; b = colexecop.NextNoMeta(s) {
 										}
 										b.StopTimer()
 									}

--- a/pkg/sql/colexec/colexecwindow/window_peer_grouper.eg.go
+++ b/pkg/sql/colexec/colexecwindow/window_peer_grouper.eg.go
@@ -92,11 +92,14 @@ type windowPeerGrouperNoPartitionOp struct {
 
 var _ colexecop.Operator = &windowPeerGrouperNoPartitionOp{}
 
-func (p *windowPeerGrouperNoPartitionOp) Next() coldata.Batch {
-	b := p.Input.Next()
+func (p *windowPeerGrouperNoPartitionOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	b, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := b.Length()
 	if n == 0 {
-		return b
+		return b, nil
 	}
 	sel := b.Selection()
 	peersVec := b.ColVec(p.outputColIdx)
@@ -113,7 +116,7 @@ func (p *windowPeerGrouperNoPartitionOp) Next() coldata.Batch {
 		// p.distinctCol.
 		copy(peersCol[:n], p.distinctCol[:n])
 	}
-	return b
+	return b, nil
 }
 
 type windowPeerGrouperWithPartitionOp struct {
@@ -122,11 +125,14 @@ type windowPeerGrouperWithPartitionOp struct {
 
 var _ colexecop.Operator = &windowPeerGrouperWithPartitionOp{}
 
-func (p *windowPeerGrouperWithPartitionOp) Next() coldata.Batch {
-	b := p.Input.Next()
+func (p *windowPeerGrouperWithPartitionOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	b, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := b.Length()
 	if n == 0 {
-		return b
+		return b, nil
 	}
 	partitionCol := b.ColVec(p.partitionColIdx).Bool()
 	sel := b.Selection()
@@ -153,7 +159,7 @@ func (p *windowPeerGrouperWithPartitionOp) Next() coldata.Batch {
 			peersCol[i] = partitionCol[i] || distinctCol[i]
 		}
 	}
-	return b
+	return b, nil
 }
 
 type windowPeerGrouperAllPeersNoPartitionOp struct {
@@ -163,11 +169,14 @@ type windowPeerGrouperAllPeersNoPartitionOp struct {
 
 var _ colexecop.Operator = &windowPeerGrouperAllPeersNoPartitionOp{}
 
-func (p *windowPeerGrouperAllPeersNoPartitionOp) Next() coldata.Batch {
-	b := p.Input.Next()
+func (p *windowPeerGrouperAllPeersNoPartitionOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	b, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := b.Length()
 	if n == 0 {
-		return b
+		return b, nil
 	}
 	sel := b.Selection()
 	peersVec := b.ColVec(p.outputColIdx)
@@ -186,7 +195,7 @@ func (p *windowPeerGrouperAllPeersNoPartitionOp) Next() coldata.Batch {
 		peersCol[0] = !p.seenFirstTuple
 		p.seenFirstTuple = true
 	}
-	return b
+	return b, nil
 }
 
 type windowPeerGrouperAllPeersWithPartitionOp struct {
@@ -195,11 +204,14 @@ type windowPeerGrouperAllPeersWithPartitionOp struct {
 
 var _ colexecop.Operator = &windowPeerGrouperAllPeersWithPartitionOp{}
 
-func (p *windowPeerGrouperAllPeersWithPartitionOp) Next() coldata.Batch {
-	b := p.Input.Next()
+func (p *windowPeerGrouperAllPeersWithPartitionOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	b, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := b.Length()
 	if n == 0 {
-		return b
+		return b, nil
 	}
 	partitionCol := b.ColVec(p.partitionColIdx).Bool()
 	sel := b.Selection()
@@ -216,5 +228,5 @@ func (p *windowPeerGrouperAllPeersWithPartitionOp) Next() coldata.Batch {
 		// over partitionCol.
 		copy(peersCol[:n], partitionCol[:n])
 	}
-	return b
+	return b, nil
 }

--- a/pkg/sql/colexec/colexecwindow/window_peer_grouper_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/window_peer_grouper_tmpl.go
@@ -106,11 +106,14 @@ type _PEER_GROUPER_STRINGOp struct {
 
 var _ colexecop.Operator = &_PEER_GROUPER_STRINGOp{}
 
-func (p *_PEER_GROUPER_STRINGOp) Next() coldata.Batch {
-	b := p.Input.Next()
+func (p *_PEER_GROUPER_STRINGOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	b, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := b.Length()
 	if n == 0 {
-		return b
+		return b, nil
 	}
 	// {{if .HasPartition}}
 	partitionCol := b.ColVec(p.partitionColIdx).Bool()
@@ -179,7 +182,7 @@ func (p *_PEER_GROUPER_STRINGOp) Next() coldata.Batch {
 		// {{end}}
 		// {{end}}
 	}
-	return b
+	return b, nil
 }
 
 // {{end}}

--- a/pkg/sql/colexec/crossjoiner_test.go
+++ b/pkg/sql/colexec/crossjoiner_test.go
@@ -476,7 +476,7 @@ func BenchmarkCrossJoiner(b *testing.B) {
 						require.NoError(b, err)
 						cj := result.Root
 						cj.Init(ctx)
-						for b := cj.Next(); b.Length() > 0; b = cj.Next() {
+						for b := colexecop.NextNoMeta(cj); b.Length() > 0; b = colexecop.NextNoMeta(cj) {
 						}
 						afterEachRun()
 					}

--- a/pkg/sql/colexec/distinct_test.go
+++ b/pkg/sql/colexec/distinct_test.go
@@ -610,7 +610,7 @@ func runDistinctBenchmarks(
 									b.Fatal(err)
 								}
 								distinct.Init(ctx)
-								for b := distinct.Next(); b.Length() > 0; b = distinct.Next() {
+								for b := colexecop.NextNoMeta(distinct); b.Length() > 0; b = colexecop.NextNoMeta(distinct) {
 								}
 								afterEachRun()
 							}

--- a/pkg/sql/colexec/execgen/cmd/execgen/default_cmp_proj_ops_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/default_cmp_proj_ops_gen.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra/execreleasable"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 

--- a/pkg/sql/colexec/execgen/cmd/execgen/distinct_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/distinct_gen.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"

--- a/pkg/sql/colexec/execgen/cmd/execgen/like_ops_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/like_ops_gen.go
@@ -37,6 +37,7 @@ import (
 	"regexp"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 )
 
 {{range .}}

--- a/pkg/sql/colexec/external_hash_joiner_test.go
+++ b/pkg/sql/colexec/external_hash_joiner_test.go
@@ -177,7 +177,7 @@ func TestExternalHashJoinerFallbackToSortMergeJoin(t *testing.T) {
 	// squared in the output.
 	expectedTuplesCount := nBatches * nBatches * coldata.BatchSize() * coldata.BatchSize()
 	actualTuplesCount := 0
-	for b := hj.Next(); b.Length() > 0; b = hj.Next() {
+	for b := colexecop.NextNoMeta(hj); b.Length() > 0; b = colexecop.NextNoMeta(hj) {
 		actualTuplesCount += b.Length()
 	}
 	require.True(t, spilled)
@@ -289,7 +289,7 @@ func BenchmarkExternalHashJoiner(b *testing.B) {
 							)
 							require.NoError(b, err)
 							hj.Init(ctx)
-							for b := hj.Next(); b.Length() > 0; b = hj.Next() {
+							for b := colexecop.NextNoMeta(hj); b.Length() > 0; b = colexecop.NextNoMeta(hj) {
 							}
 							afterEachRun()
 						}

--- a/pkg/sql/colexec/external_sort_test.go
+++ b/pkg/sql/colexec/external_sort_test.go
@@ -280,7 +280,7 @@ func BenchmarkExternalSort(b *testing.B) {
 							)
 							require.NoError(b, err)
 							sorter.Init(ctx)
-							for out := sorter.Next(); out.Length() != 0; out = sorter.Next() {
+							for out := colexecop.NextNoMeta(sorter); out.Length() != 0; out = colexecop.NextNoMeta(sorter) {
 							}
 							afterEachRun()
 							require.Equal(b, spillForced, spilled, fmt.Sprintf(

--- a/pkg/sql/colexec/hashjoiner_test.go
+++ b/pkg/sql/colexec/hashjoiner_test.go
@@ -1140,7 +1140,7 @@ func BenchmarkHashJoiner(b *testing.B) {
 									hj.Init(ctx)
 
 									b.StartTimer()
-									for hj.Next().Length() != 0 {
+									for colexecop.NextNoMeta(hj).Length() != 0 {
 									}
 									b.StopTimer()
 									leftSource.Reset(ctx)
@@ -1219,7 +1219,7 @@ func TestHashJoinerProjection(t *testing.T) {
 	hjOp, err := colexecargs.TestNewColOperator(ctx, flowCtx, args)
 	require.NoError(t, err)
 	hjOp.Root.Init(ctx)
-	for b := hjOp.Root.Next(); b.Length() > 0; b = hjOp.Root.Next() {
+	for b := colexecop.NextNoMeta(hjOp.Root); b.Length() > 0; b = colexecop.NextNoMeta(hjOp.Root) {
 		// The output types should be {Int64, Int64, Bool, Decimal, Float64, Bytes}
 		// and we check this explicitly.
 		b.ColVec(0).Int64()

--- a/pkg/sql/colexec/mergejoiner_test.go
+++ b/pkg/sql/colexec/mergejoiner_test.go
@@ -1749,7 +1749,7 @@ func TestFullOuterMergeJoinWithMaximumNumberOfGroups(t *testing.T) {
 	}
 	leftSource := colexectestutils.NewChunkingBatchSource(testAllocator, typs, colsLeft, nTuples)
 	rightSource := colexectestutils.NewChunkingBatchSource(testAllocator, typs, colsRight, nTuples)
-	a := colexecjoin.NewMergeJoinOp(
+	a, _ := colexecjoin.NewMergeJoinOp(
 		ctx, testAllocator, execinfra.DefaultMemoryLimit, queueCfg,
 		colexecop.NewTestingSemaphore(mjFDLimit), descpb.FullOuterJoin,
 		leftSource, rightSource, typs, typs,
@@ -1759,7 +1759,7 @@ func TestFullOuterMergeJoinWithMaximumNumberOfGroups(t *testing.T) {
 	)
 	a.Init(ctx)
 	i, count, expVal := 0, 0, int64(0)
-	for b := a.Next(); b.Length() != 0; b = a.Next() {
+	for b := colexecop.NextNoMeta(a); b.Length() != 0; b = colexecop.NextNoMeta(a) {
 		count += b.Length()
 		leftOutCol := b.ColVec(0).Int64()
 		leftNulls := b.ColVec(0).Nulls()
@@ -1821,7 +1821,7 @@ func TestMergeJoinerMultiBatch(t *testing.T) {
 				}
 				leftSource := colexectestutils.NewChunkingBatchSource(testAllocator, typs, cols, nTuples)
 				rightSource := colexectestutils.NewChunkingBatchSource(testAllocator, typs, cols, nTuples)
-				a := colexecjoin.NewMergeJoinOp(
+				a, _ := colexecjoin.NewMergeJoinOp(
 					ctx, testAllocator, execinfra.DefaultMemoryLimit,
 					queueCfg, colexecop.NewTestingSemaphore(mjFDLimit), descpb.InnerJoin,
 					leftSource, rightSource, typs, typs,
@@ -1834,7 +1834,7 @@ func TestMergeJoinerMultiBatch(t *testing.T) {
 				count := 0
 				// Keep track of the last comparison value.
 				expVal := int64(0)
-				for b := a.Next(); b.Length() != 0; b = a.Next() {
+				for b := colexecop.NextNoMeta(a); b.Length() != 0; b = colexecop.NextNoMeta(a) {
 					count += b.Length()
 					outCol := b.ColVec(0).Int64()
 					for j := int64(0); j < int64(b.Length()); j++ {
@@ -1898,7 +1898,7 @@ func TestMergeJoinerMultiBatchRuns(t *testing.T) {
 					}
 					leftSource := colexectestutils.NewChunkingBatchSource(testAllocator, typs, cols, nTuples)
 					rightSource := colexectestutils.NewChunkingBatchSource(testAllocator, typs, cols, nTuples)
-					a := colexecjoin.NewMergeJoinOp(
+					a, _ := colexecjoin.NewMergeJoinOp(
 						ctx, testAllocator, execinfra.DefaultMemoryLimit,
 						queueCfg, colexecop.NewTestingSemaphore(mjFDLimit), descpb.InnerJoin,
 						leftSource, rightSource, typs, typs,
@@ -1911,7 +1911,7 @@ func TestMergeJoinerMultiBatchRuns(t *testing.T) {
 					count := 0
 					// Keep track of the last comparison value.
 					lastVal := int64(0)
-					for b := a.Next(); b.Length() != 0; b = a.Next() {
+					for b := colexecop.NextNoMeta(a); b.Length() != 0; b = colexecop.NextNoMeta(a) {
 						count += b.Length()
 						outCol := b.ColVec(0).Int64()
 						for j := int64(0); j < int64(b.Length()); j++ {
@@ -2023,7 +2023,7 @@ func TestMergeJoinerRandomized(t *testing.T) {
 					leftSource := colexectestutils.NewChunkingBatchSource(testAllocator, typs, lCols, nTuples)
 					rightSource := colexectestutils.NewChunkingBatchSource(testAllocator, typs, rCols, nTuples)
 
-					a := colexecjoin.NewMergeJoinOp(
+					a, _ := colexecjoin.NewMergeJoinOp(
 						ctx, testAllocator, execinfra.DefaultMemoryLimit,
 						queueCfg, colexecop.NewTestingSemaphore(mjFDLimit), descpb.InnerJoin,
 						leftSource, rightSource, typs, typs,
@@ -2035,7 +2035,7 @@ func TestMergeJoinerRandomized(t *testing.T) {
 					i := 0
 					count := 0
 					cpIdx := 0
-					for b := a.Next(); b.Length() != 0; b = a.Next() {
+					for b := colexecop.NextNoMeta(a); b.Length() != 0; b = colexecop.NextNoMeta(a) {
 						count += b.Length()
 						outCol := b.ColVec(0).Int64()
 						for j := 0; j < b.Length(); j++ {

--- a/pkg/sql/colexec/offset_test.go
+++ b/pkg/sql/colexec/offset_test.go
@@ -74,6 +74,6 @@ func BenchmarkOffset(b *testing.B) {
 	b.SetBytes(int64(2 * coldata.BatchSize()))
 	for i := 0; i < b.N; i++ {
 		o.(*offsetOp).seen = 0
-		o.Next()
+		colexecop.NextNoMeta(o)
 	}
 }

--- a/pkg/sql/colexec/ordered_synchronizer_test.go
+++ b/pkg/sql/colexec/ordered_synchronizer_test.go
@@ -219,6 +219,6 @@ func BenchmarkOrderedSynchronizer(b *testing.B) {
 	b.SetBytes(8 * int64(coldata.BatchSize()) * numInputs)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		op.Next()
+		colexecop.NextNoMeta(op)
 	}
 }

--- a/pkg/sql/colexec/ordered_synchronizer_tmpl.go
+++ b/pkg/sql/colexec/ordered_synchronizer_tmpl.go
@@ -89,6 +89,9 @@ type OrderedSynchronizer struct {
 	// continueBatch, if set, indicates that the current output batch should be
 	// continued.
 	continueBatch bool
+	// tempBufferedMeta contains temporarily buffered metadata until the next
+	// input batch from the minimum input is fetched.
+	tempBufferedMeta []execinfrapb.ProducerMetadata
 }
 
 var (
@@ -135,8 +138,23 @@ func NewOrderedSynchronizer(
 	return os
 }
 
+// maybeEmitMeta checks whether the synchronizer has temporarily buffered any
+// metadata and returns one object if so.
+func (o *OrderedSynchronizer) maybeEmitMeta() *execinfrapb.ProducerMetadata {
+	if len(o.tempBufferedMeta) == 0 {
+		return nil
+	}
+	meta := o.tempBufferedMeta[0]
+	o.tempBufferedMeta[0] = execinfrapb.ProducerMetadata{}
+	o.tempBufferedMeta = o.tempBufferedMeta[1:]
+	return &meta
+}
+
 // Next is part of the Operator interface.
 func (o *OrderedSynchronizer) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	if meta := o.maybeEmitMeta(); meta != nil {
+		return nil, meta
+	}
 	if !o.heapInitialized {
 		for i := range o.inputs {
 			if o.inputBatches[i] != nil {
@@ -168,6 +186,10 @@ func (o *OrderedSynchronizer) Next() (coldata.Batch, *execinfrapb.ProducerMetada
 	}
 	o.continueBatch = false
 	for batchDone := false; !batchDone; {
+		if meta := o.maybeEmitMeta(); meta != nil {
+			o.continueBatch = true
+			return nil, meta
+		}
 		if o.advanceMinBatch {
 			// Advance the minimum input batch, fetching a new batch if
 			// necessary.
@@ -175,12 +197,19 @@ func (o *OrderedSynchronizer) Next() (coldata.Batch, *execinfrapb.ProducerMetada
 			if o.inputIndices[minBatch]+1 < o.inputBatches[minBatch].Length() {
 				o.inputIndices[minBatch]++
 			} else {
-				batch, meta := o.inputs[minBatch].Root.Next()
-				if meta != nil {
-					o.continueBatch = true
-					return nil, meta
+				// We're in the middle of updating the heap, so we need to fetch
+				// the next batch and update the comparators before we can emit
+				// any metadata. Thus, we'll temporarily buffer all meta and
+				// emit it at a convenient point in time.
+				for {
+					batch, meta := o.inputs[minBatch].Root.Next()
+					if meta != nil {
+						o.tempBufferedMeta = append(o.tempBufferedMeta, *meta)
+						continue
+					}
+					o.inputBatches[minBatch] = batch
+					break
 				}
-				o.inputBatches[minBatch] = batch
 				o.inputIndices[minBatch] = 0
 				o.updateComparators(minBatch)
 			}
@@ -266,7 +295,11 @@ func (o *OrderedSynchronizer) Init(ctx context.Context) {
 }
 
 func (o *OrderedSynchronizer) DrainMeta() []execinfrapb.ProducerMetadata {
-	var bufferedMeta []execinfrapb.ProducerMetadata
+	// We generally don't expect any temporarily buffered metadata here, but in
+	// some edge cases it's possible - guarantee that it's emitted at least
+	// during DrainMeta.
+	bufferedMeta := o.tempBufferedMeta
+	o.tempBufferedMeta = nil
 	if o.span != nil {
 		for i := range o.inputs {
 			for _, stats := range o.inputs[i].StatsCollectors {

--- a/pkg/sql/colexec/select_in.eg.go
+++ b/pkg/sql/colexec/select_in.eg.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -431,11 +432,14 @@ func cmpInBool(
 	}
 }
 
-func (si *selectInOpBool) Next() coldata.Batch {
+func (si *selectInOpBool) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := si.Input.Next()
+		batch, meta := si.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return coldata.ZeroBatch
+			return coldata.ZeroBatch, nil
 		}
 
 		vec := batch.ColVec(si.colIdx)
@@ -499,15 +503,18 @@ func (si *selectInOpBool) Next() coldata.Batch {
 
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
 
-func (pi *projectInOpBool) Next() coldata.Batch {
-	batch := pi.Input.Next()
+func (pi *projectInOpBool) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := pi.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	if batch.Length() == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 
 	vec := batch.ColVec(pi.colIdx)
@@ -584,7 +591,7 @@ func (pi *projectInOpBool) Next() coldata.Batch {
 			}
 		}
 	}
-	return batch
+	return batch, nil
 }
 
 type selectInOpBytes struct {
@@ -657,11 +664,14 @@ func cmpInBytes(
 	}
 }
 
-func (si *selectInOpBytes) Next() coldata.Batch {
+func (si *selectInOpBytes) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := si.Input.Next()
+		batch, meta := si.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return coldata.ZeroBatch
+			return coldata.ZeroBatch, nil
 		}
 
 		vec := batch.ColVec(si.colIdx)
@@ -723,15 +733,18 @@ func (si *selectInOpBytes) Next() coldata.Batch {
 
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
 
-func (pi *projectInOpBytes) Next() coldata.Batch {
-	batch := pi.Input.Next()
+func (pi *projectInOpBytes) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := pi.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	if batch.Length() == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 
 	vec := batch.ColVec(pi.colIdx)
@@ -806,7 +819,7 @@ func (pi *projectInOpBytes) Next() coldata.Batch {
 			}
 		}
 	}
-	return batch
+	return batch, nil
 }
 
 type selectInOpDecimal struct {
@@ -879,11 +892,14 @@ func cmpInDecimal(
 	}
 }
 
-func (si *selectInOpDecimal) Next() coldata.Batch {
+func (si *selectInOpDecimal) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := si.Input.Next()
+		batch, meta := si.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return coldata.ZeroBatch
+			return coldata.ZeroBatch, nil
 		}
 
 		vec := batch.ColVec(si.colIdx)
@@ -947,15 +963,18 @@ func (si *selectInOpDecimal) Next() coldata.Batch {
 
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
 
-func (pi *projectInOpDecimal) Next() coldata.Batch {
-	batch := pi.Input.Next()
+func (pi *projectInOpDecimal) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := pi.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	if batch.Length() == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 
 	vec := batch.ColVec(pi.colIdx)
@@ -1032,7 +1051,7 @@ func (pi *projectInOpDecimal) Next() coldata.Batch {
 			}
 		}
 	}
-	return batch
+	return batch, nil
 }
 
 type selectInOpInt16 struct {
@@ -1117,11 +1136,14 @@ func cmpInInt16(
 	}
 }
 
-func (si *selectInOpInt16) Next() coldata.Batch {
+func (si *selectInOpInt16) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := si.Input.Next()
+		batch, meta := si.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return coldata.ZeroBatch
+			return coldata.ZeroBatch, nil
 		}
 
 		vec := batch.ColVec(si.colIdx)
@@ -1185,15 +1207,18 @@ func (si *selectInOpInt16) Next() coldata.Batch {
 
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
 
-func (pi *projectInOpInt16) Next() coldata.Batch {
-	batch := pi.Input.Next()
+func (pi *projectInOpInt16) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := pi.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	if batch.Length() == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 
 	vec := batch.ColVec(pi.colIdx)
@@ -1270,7 +1295,7 @@ func (pi *projectInOpInt16) Next() coldata.Batch {
 			}
 		}
 	}
-	return batch
+	return batch, nil
 }
 
 type selectInOpInt32 struct {
@@ -1355,11 +1380,14 @@ func cmpInInt32(
 	}
 }
 
-func (si *selectInOpInt32) Next() coldata.Batch {
+func (si *selectInOpInt32) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := si.Input.Next()
+		batch, meta := si.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return coldata.ZeroBatch
+			return coldata.ZeroBatch, nil
 		}
 
 		vec := batch.ColVec(si.colIdx)
@@ -1423,15 +1451,18 @@ func (si *selectInOpInt32) Next() coldata.Batch {
 
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
 
-func (pi *projectInOpInt32) Next() coldata.Batch {
-	batch := pi.Input.Next()
+func (pi *projectInOpInt32) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := pi.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	if batch.Length() == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 
 	vec := batch.ColVec(pi.colIdx)
@@ -1508,7 +1539,7 @@ func (pi *projectInOpInt32) Next() coldata.Batch {
 			}
 		}
 	}
-	return batch
+	return batch, nil
 }
 
 type selectInOpInt64 struct {
@@ -1592,11 +1623,14 @@ func cmpInInt64(
 	}
 }
 
-func (si *selectInOpInt64) Next() coldata.Batch {
+func (si *selectInOpInt64) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := si.Input.Next()
+		batch, meta := si.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return coldata.ZeroBatch
+			return coldata.ZeroBatch, nil
 		}
 
 		vec := batch.ColVec(si.colIdx)
@@ -1660,15 +1694,18 @@ func (si *selectInOpInt64) Next() coldata.Batch {
 
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
 
-func (pi *projectInOpInt64) Next() coldata.Batch {
-	batch := pi.Input.Next()
+func (pi *projectInOpInt64) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := pi.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	if batch.Length() == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 
 	vec := batch.ColVec(pi.colIdx)
@@ -1745,7 +1782,7 @@ func (pi *projectInOpInt64) Next() coldata.Batch {
 			}
 		}
 	}
-	return batch
+	return batch, nil
 }
 
 type selectInOpFloat64 struct {
@@ -1837,11 +1874,14 @@ func cmpInFloat64(
 	}
 }
 
-func (si *selectInOpFloat64) Next() coldata.Batch {
+func (si *selectInOpFloat64) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := si.Input.Next()
+		batch, meta := si.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return coldata.ZeroBatch
+			return coldata.ZeroBatch, nil
 		}
 
 		vec := batch.ColVec(si.colIdx)
@@ -1905,15 +1945,18 @@ func (si *selectInOpFloat64) Next() coldata.Batch {
 
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
 
-func (pi *projectInOpFloat64) Next() coldata.Batch {
-	batch := pi.Input.Next()
+func (pi *projectInOpFloat64) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := pi.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	if batch.Length() == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 
 	vec := batch.ColVec(pi.colIdx)
@@ -1990,7 +2033,7 @@ func (pi *projectInOpFloat64) Next() coldata.Batch {
 			}
 		}
 	}
-	return batch
+	return batch, nil
 }
 
 type selectInOpTimestamp struct {
@@ -2070,11 +2113,14 @@ func cmpInTimestamp(
 	}
 }
 
-func (si *selectInOpTimestamp) Next() coldata.Batch {
+func (si *selectInOpTimestamp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := si.Input.Next()
+		batch, meta := si.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return coldata.ZeroBatch
+			return coldata.ZeroBatch, nil
 		}
 
 		vec := batch.ColVec(si.colIdx)
@@ -2138,15 +2184,18 @@ func (si *selectInOpTimestamp) Next() coldata.Batch {
 
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
 
-func (pi *projectInOpTimestamp) Next() coldata.Batch {
-	batch := pi.Input.Next()
+func (pi *projectInOpTimestamp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := pi.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	if batch.Length() == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 
 	vec := batch.ColVec(pi.colIdx)
@@ -2223,7 +2272,7 @@ func (pi *projectInOpTimestamp) Next() coldata.Batch {
 			}
 		}
 	}
-	return batch
+	return batch, nil
 }
 
 type selectInOpInterval struct {
@@ -2296,11 +2345,14 @@ func cmpInInterval(
 	}
 }
 
-func (si *selectInOpInterval) Next() coldata.Batch {
+func (si *selectInOpInterval) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := si.Input.Next()
+		batch, meta := si.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return coldata.ZeroBatch
+			return coldata.ZeroBatch, nil
 		}
 
 		vec := batch.ColVec(si.colIdx)
@@ -2364,15 +2416,18 @@ func (si *selectInOpInterval) Next() coldata.Batch {
 
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
 
-func (pi *projectInOpInterval) Next() coldata.Batch {
-	batch := pi.Input.Next()
+func (pi *projectInOpInterval) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := pi.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	if batch.Length() == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 
 	vec := batch.ColVec(pi.colIdx)
@@ -2449,7 +2504,7 @@ func (pi *projectInOpInterval) Next() coldata.Batch {
 			}
 		}
 	}
-	return batch
+	return batch, nil
 }
 
 type selectInOpJSON struct {
@@ -2528,11 +2583,14 @@ func cmpInJSON(
 	}
 }
 
-func (si *selectInOpJSON) Next() coldata.Batch {
+func (si *selectInOpJSON) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := si.Input.Next()
+		batch, meta := si.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return coldata.ZeroBatch
+			return coldata.ZeroBatch, nil
 		}
 
 		vec := batch.ColVec(si.colIdx)
@@ -2594,15 +2652,18 @@ func (si *selectInOpJSON) Next() coldata.Batch {
 
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
 
-func (pi *projectInOpJSON) Next() coldata.Batch {
-	batch := pi.Input.Next()
+func (pi *projectInOpJSON) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := pi.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	if batch.Length() == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 
 	vec := batch.ColVec(pi.colIdx)
@@ -2677,7 +2738,7 @@ func (pi *projectInOpJSON) Next() coldata.Batch {
 			}
 		}
 	}
-	return batch
+	return batch, nil
 }
 
 type selectInOpDatum struct {
@@ -2752,11 +2813,14 @@ func cmpInDatum(
 	}
 }
 
-func (si *selectInOpDatum) Next() coldata.Batch {
+func (si *selectInOpDatum) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	for {
-		batch := si.Input.Next()
+		batch, meta := si.Input.Next()
+		if meta != nil {
+			return nil, meta
+		}
 		if batch.Length() == 0 {
-			return coldata.ZeroBatch
+			return coldata.ZeroBatch, nil
 		}
 
 		vec := batch.ColVec(si.colIdx)
@@ -2818,15 +2882,18 @@ func (si *selectInOpDatum) Next() coldata.Batch {
 
 		if idx > 0 {
 			batch.SetLength(idx)
-			return batch
+			return batch, nil
 		}
 	}
 }
 
-func (pi *projectInOpDatum) Next() coldata.Batch {
-	batch := pi.Input.Next()
+func (pi *projectInOpDatum) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := pi.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	if batch.Length() == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 
 	vec := batch.ColVec(pi.colIdx)
@@ -2901,5 +2968,5 @@ func (pi *projectInOpDatum) Next() coldata.Batch {
 			}
 		}
 	}
-	return batch
+	return batch, nil
 }

--- a/pkg/sql/colexec/select_in_test.go
+++ b/pkg/sql/colexec/select_in_test.go
@@ -137,7 +137,7 @@ func benchmarkSelectInInt64(b *testing.B, useSelectionVector bool, hasNulls bool
 	b.SetBytes(int64(8 * coldata.BatchSize()))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		inOp.Next()
+		colexecop.NextNoMeta(inOp)
 	}
 }
 

--- a/pkg/sql/colexec/serial_unordered_synchronizer_test.go
+++ b/pkg/sql/colexec/serial_unordered_synchronizer_test.go
@@ -62,7 +62,7 @@ func TestSerialUnorderedSynchronizer(t *testing.T) {
 	s.Init(ctx)
 	resultBatches := 0
 	for {
-		b := s.Next()
+		b := colexecop.NextNoMeta(s)
 		if b.Length() == 0 {
 			require.Equal(t, len(inputs), len(s.DrainMeta()))
 			break

--- a/pkg/sql/colexec/sort_chunks_test.go
+++ b/pkg/sql/colexec/sort_chunks_test.go
@@ -275,7 +275,7 @@ func BenchmarkSortChunks(b *testing.B) {
 									sorter := sorterConstructor(testAllocator, source, typs, ordCols, matchLen, execinfra.DefaultMemoryLimit)
 
 									sorter.Init(ctx)
-									for out := sorter.Next(); out.Length() != 0; out = sorter.Next() {
+									for out := colexecop.NextNoMeta(sorter); out.Length() != 0; out = colexecop.NextNoMeta(sorter) {
 									}
 								}
 								b.StopTimer()

--- a/pkg/sql/colexec/sort_test.go
+++ b/pkg/sql/colexec/sort_test.go
@@ -322,7 +322,7 @@ func BenchmarkSort(b *testing.B) {
 							sorter = NewSorter(testAllocator, source, typs, ordCols, execinfra.DefaultMemoryLimit)
 						}
 						sorter.Init(ctx)
-						for out := sorter.Next(); out.Length() != 0; out = sorter.Next() {
+						for out := colexecop.NextNoMeta(sorter); out.Length() != 0; out = colexecop.NextNoMeta(sorter) {
 						}
 					}
 				})
@@ -381,7 +381,7 @@ func BenchmarkSortUUID(b *testing.B) {
 						source := colexectestutils.NewFiniteBatchSource(testAllocator, batch, typs, nBatches)
 						sorter := NewSorter(testAllocator, source, typs, ordCols, execinfra.DefaultMemoryLimit)
 						sorter.Init(ctx)
-						for out := sorter.Next(); out.Length() != 0; out = sorter.Next() {
+						for out := colexecop.NextNoMeta(sorter); out.Length() != 0; out = colexecop.NextNoMeta(sorter) {
 						}
 					}
 				})

--- a/pkg/sql/colexec/sorttopk.eg.go
+++ b/pkg/sql/colexec/sorttopk.eg.go
@@ -18,6 +18,7 @@ import (
 	"container/heap"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/errors"
 )
@@ -26,7 +27,7 @@ import (
 const _ = "template_nextBatch"
 
 // processGroupsInBatch associates a row in the top K heap with its distinct
-// partially ordered column group. It returns the most recently found groupId.
+// partially ordered column group.
 // execgen:inline
 const _ = "template_processGroupsInBatch"
 
@@ -61,12 +62,11 @@ const _ = "template_compareRow"
 // After all the input has been read, we pop everything off the heap to
 // determine the final output ordering. This is used in emit() to output the rows
 // in sorted order.
-func (t *topKSorter) spool() {
+func (t *topKSorter) spool() *execinfrapb.ProducerMetadata {
 	if t.hasPartialOrder {
-		spool_true(t)
-	} else {
-		spool_false(t)
+		return spool_true(t)
 	}
+	return spool_false(t)
 }
 
 // topKHeaper implements part of the heap.Interface for non-ordered input.
@@ -106,100 +106,151 @@ func (t *topKPartialOrderHeaper) Less(i, j int) bool {
 // on the partially ordered input, and stop adding to the max heap after K rows
 // and the group of the Kth row have been processed. If it's false, we assume
 // that the input is unordered, and process all rows.
-func spool_true(t *topKSorter) {
-	// Fill up t.topK by spooling up to K rows from the input.
-	// We don't need to check for distinct groups until after we have filled
-	// t.topK.
-	// TODO(harding): We could emit the first N < K rows if the N rows are in one
-	// or more distinct and complete groups, and then use a K-N size heap to find
-	// the remaining top K-N rows.
-	{
-		t.cancelChecker.CheckEveryCall()
-		t.inputBatch = t.Input.Next()
-		t.orderState.distincterInput.SetBatch(t.inputBatch)
-		t.orderState.distincter.Next()
-		t.firstUnprocessedTupleIdx = 0
-	}
-	remainingRows := t.k
-	groupId := 0
-	for remainingRows > 0 && t.inputBatch.Length() > 0 {
-		fromLength := t.inputBatch.Length()
-		if remainingRows < uint64(t.inputBatch.Length()) {
-			// t.topK will be full after this batch.
-			fromLength = int(remainingRows)
-		}
-		// Find the group id for each tuple just added to topK.
-		sel := t.inputBatch.Selection()
-		if sel != nil {
+func spool_true(t *topKSorter) *execinfrapb.ProducerMetadata {
+	if !t.heapInitialized {
+		var meta *execinfrapb.ProducerMetadata
+		// Fill up t.topK by spooling up to K rows from the input.
+		// We don't need to check for distinct groups until after we have filled
+		// t.topK.
+		// TODO(harding): We could emit the first N < K rows if the N rows are in one
+		// or more distinct and complete groups, and then use a K-N size heap to find
+		// the remaining top K-N rows.
+		{
+			var __retval_0 *execinfrapb.ProducerMetadata
 			{
-				var __retval_groupId int
+				t.cancelChecker.CheckEveryCall()
+				t.inputBatch, meta = t.Input.Next()
+				if meta != nil {
+					{
+						__retval_0 = meta
+					}
+					goto nextBatch_true_return_0
+				}
+				t.orderState.distincterInput.SetBatch(t.inputBatch)
+				colexecop.NextNoMeta(t.orderState.distincter)
+				t.firstUnprocessedTupleIdx = 0
 				{
-					var groupIdStart int = groupId
-					groupId = groupIdStart
+					__retval_0 = nil
+				}
+			nextBatch_true_return_0:
+			}
+			// Fill up t.topK by spooling up to K rows from the input.
+			// We don't need to check for distinct groups until after we have filled
+			// t.topK.
+			// TODO(harding): We could emit the first N < K rows if the N rows are in one
+			// or more distinct and complete groups, and then use a K-N size heap to find
+			// the remaining top K-N rows.
+			meta = __retval_0
+		}
+		if meta != nil {
+			return meta
+		}
+		remainingRows := t.k - uint64(t.topK.Length())
+		for remainingRows > 0 && t.inputBatch.Length() > 0 {
+			fromLength := t.inputBatch.Length()
+			if remainingRows < uint64(t.inputBatch.Length()) {
+				// t.topK will be full after this batch.
+				fromLength = int(remainingRows)
+			}
+			// Find the group id for each tuple just added to topK.
+			sel := t.inputBatch.Selection()
+			if sel != nil {
+				{
 					for i, k := 0, t.topK.Length(); i < fromLength; i, k = i+1, k+1 {
 						idx := sel[i]
 						if t.orderState.distinctOutput[idx] {
-							groupId++
+							t.orderState.groupId++
 						}
-						t.orderState.group[k] = groupId
-					}
-					{
-						__retval_groupId = groupId
+						t.orderState.group[k] = t.orderState.groupId
 					}
 				}
-				groupId = __retval_groupId
-			}
-		} else {
-			{
-				var __retval_groupId int
+			} else {
 				{
-					var groupIdStart int = groupId
-					groupId = groupIdStart
 					for i, k := 0, t.topK.Length(); i < fromLength; i, k = i+1, k+1 {
 						idx := i
 						if t.orderState.distinctOutput[idx] {
-							groupId++
+							t.orderState.groupId++
 						}
-						t.orderState.group[k] = groupId
-					}
-					{
-						__retval_groupId = groupId
+						t.orderState.group[k] = t.orderState.groupId
 					}
 				}
-				groupId = __retval_groupId
+			}
+			// Importantly, the memory limit can only be reached _after_ the tuples
+			// are appended to topK, so all fromLength tuples are considered
+			// "processed".
+			t.firstUnprocessedTupleIdx = fromLength
+			t.topK.AppendTuples(t.inputBatch, 0 /* startIdx */, fromLength)
+			remainingRows -= uint64(fromLength)
+			if fromLength == t.inputBatch.Length() {
+				{
+					var __retval_0 *execinfrapb.ProducerMetadata
+					{
+						t.cancelChecker.CheckEveryCall()
+						t.inputBatch, meta = t.Input.Next()
+						if meta != nil {
+							{
+								__retval_0 = meta
+							}
+							goto nextBatch_true_return_3
+						}
+						t.orderState.distincterInput.SetBatch(t.inputBatch)
+						colexecop.NextNoMeta(t.orderState.distincter)
+						t.firstUnprocessedTupleIdx = 0
+						{
+							__retval_0 = nil
+						}
+					nextBatch_true_return_3:
+					}
+					meta = __retval_0
+				}
+				if meta != nil {
+					return meta
+				}
 			}
 		}
-		// Importantly, the memory limit can only be reached _after_ the tuples
-		// are appended to topK, so all fromLength tuples are considered
-		// "processed".
-		t.firstUnprocessedTupleIdx = fromLength
-		t.topK.AppendTuples(t.inputBatch, 0 /* startIdx */, fromLength)
-		remainingRows -= uint64(fromLength)
-		if fromLength == t.inputBatch.Length() {
-			{
-				t.cancelChecker.CheckEveryCall()
-				t.inputBatch = t.Input.Next()
-				t.orderState.distincterInput.SetBatch(t.inputBatch)
-				t.orderState.distincter.Next()
-				t.firstUnprocessedTupleIdx = 0
-			}
+		t.updateComparators(topKVecIdx, t.topK)
+		// Initialize the heap.
+		if cap(t.heap) < t.topK.Length() {
+			t.heap = make([]int, t.topK.Length())
+		} else {
+			t.heap = t.heap[:t.topK.Length()]
 		}
+		for i := range t.heap {
+			t.heap[i] = i
+		}
+		heap.Init(t.heaper)
+		t.heapInitialized = true
 	}
-	t.updateComparators(topKVecIdx, t.topK)
-	// Initialize the heap.
-	if cap(t.heap) < t.topK.Length() {
-		t.heap = make([]int, t.topK.Length())
-	} else {
-		t.heap = t.heap[:t.topK.Length()]
-	}
-	for i := range t.heap {
-		t.heap[i] = i
-	}
-	heap.Init(t.heaper)
 	// Read the remainder of the input. Whenever a row is less than the heap max,
 	// swap it in. When we find the end of the group, we can finish reading the
 	// input.
-	_ = true
+	if t.inputBatch == nil {
+		var meta *execinfrapb.ProducerMetadata
+		{
+			var __retval_0 *execinfrapb.ProducerMetadata
+			{
+				t.cancelChecker.CheckEveryCall()
+				t.inputBatch, meta = t.Input.Next()
+				if meta != nil {
+					{
+						__retval_0 = meta
+					}
+					goto nextBatch_true_return_4
+				}
+				t.orderState.distincterInput.SetBatch(t.inputBatch)
+				colexecop.NextNoMeta(t.orderState.distincter)
+				t.firstUnprocessedTupleIdx = 0
+				{
+					__retval_0 = nil
+				}
+			nextBatch_true_return_4:
+			}
+			meta = __retval_0
+		}
+		if meta != nil {
+			return meta
+		}
+	}
 	groupDone := false
 	for t.inputBatch.Length() > 0 {
 		t.updateComparators(inputVecIdx, t.inputBatch)
@@ -219,23 +270,23 @@ func spool_true(t *topKSorter) {
 									{
 										__retval_groupDone = true
 									}
-									goto processBatch_true_true_return_4
+									goto processBatch_true_true_return_5
 								}
 								maxIdx := t.heap[0]
 								groupMaxIdx := 0
 								groupMaxIdx = t.orderState.group[maxIdx]
-								if compareRow_true(t, inputVecIdx, topKVecIdx, idx, maxIdx, groupId, groupMaxIdx) < 0 {
+								if compareRow_true(t, inputVecIdx, topKVecIdx, idx, maxIdx, t.orderState.groupId, groupMaxIdx) < 0 {
 									for j := range t.inputTypes {
 										t.comparators[j].set(inputVecIdx, topKVecIdx, idx, maxIdx)
 									}
-									t.orderState.group[maxIdx] = groupId
+									t.orderState.group[maxIdx] = t.orderState.groupId
 									heap.Fix(t.heaper, 0)
 								}
 							}
 							{
 								__retval_groupDone = false
 							}
-						processBatch_true_true_return_4:
+						processBatch_true_true_return_5:
 						}
 						groupDone = __retval_groupDone
 					}
@@ -251,23 +302,23 @@ func spool_true(t *topKSorter) {
 									{
 										__retval_groupDone = true
 									}
-									goto processBatch_true_false_return_5
+									goto processBatch_true_false_return_6
 								}
 								maxIdx := t.heap[0]
 								groupMaxIdx := 0
 								groupMaxIdx = t.orderState.group[maxIdx]
-								if compareRow_true(t, inputVecIdx, topKVecIdx, idx, maxIdx, groupId, groupMaxIdx) < 0 {
+								if compareRow_true(t, inputVecIdx, topKVecIdx, idx, maxIdx, t.orderState.groupId, groupMaxIdx) < 0 {
 									for j := range t.inputTypes {
 										t.comparators[j].set(inputVecIdx, topKVecIdx, idx, maxIdx)
 									}
-									t.orderState.group[maxIdx] = groupId
+									t.orderState.group[maxIdx] = t.orderState.groupId
 									heap.Fix(t.heaper, 0)
 								}
 							}
 							{
 								__retval_groupDone = false
 							}
-						processBatch_true_false_return_5:
+						processBatch_true_false_return_6:
 						}
 						groupDone = __retval_groupDone
 					}
@@ -277,12 +328,30 @@ func spool_true(t *topKSorter) {
 		if groupDone {
 			break
 		}
+		var meta *execinfrapb.ProducerMetadata
 		{
-			t.cancelChecker.CheckEveryCall()
-			t.inputBatch = t.Input.Next()
-			t.orderState.distincterInput.SetBatch(t.inputBatch)
-			t.orderState.distincter.Next()
-			t.firstUnprocessedTupleIdx = 0
+			var __retval_0 *execinfrapb.ProducerMetadata
+			{
+				t.cancelChecker.CheckEveryCall()
+				t.inputBatch, meta = t.Input.Next()
+				if meta != nil {
+					{
+						__retval_0 = meta
+					}
+					goto nextBatch_true_return_7
+				}
+				t.orderState.distincterInput.SetBatch(t.inputBatch)
+				colexecop.NextNoMeta(t.orderState.distincter)
+				t.firstUnprocessedTupleIdx = 0
+				{
+					__retval_0 = nil
+				}
+			nextBatch_true_return_7:
+			}
+			meta = __retval_0
+		}
+		if meta != nil {
+			return meta
 		}
 	}
 	// t.topK now contains the top K rows unsorted. Create a selection vector
@@ -293,6 +362,7 @@ func spool_true(t *topKSorter) {
 	for i := 0; i < t.topK.Length(); i++ {
 		t.sel[len(t.sel)-i-1] = heap.Pop(t.heaper).(int)
 	}
+	return nil
 }
 
 // spool reads in the entire input, always storing the top K rows it has seen so
@@ -308,55 +378,122 @@ func spool_true(t *topKSorter) {
 // on the partially ordered input, and stop adding to the max heap after K rows
 // and the group of the Kth row have been processed. If it's false, we assume
 // that the input is unordered, and process all rows.
-func spool_false(t *topKSorter) {
-	// Fill up t.topK by spooling up to K rows from the input.
-	// We don't need to check for distinct groups until after we have filled
-	// t.topK.
-	// TODO(harding): We could emit the first N < K rows if the N rows are in one
-	// or more distinct and complete groups, and then use a K-N size heap to find
-	// the remaining top K-N rows.
-	{
-		t.cancelChecker.CheckEveryCall()
-		t.inputBatch = t.Input.Next()
-		t.firstUnprocessedTupleIdx = 0
-	}
-	remainingRows := t.k
-	groupId := 0
-	for remainingRows > 0 && t.inputBatch.Length() > 0 {
-		fromLength := t.inputBatch.Length()
-		if remainingRows < uint64(t.inputBatch.Length()) {
-			// t.topK will be full after this batch.
-			fromLength = int(remainingRows)
-		}
-		// Importantly, the memory limit can only be reached _after_ the tuples
-		// are appended to topK, so all fromLength tuples are considered
-		// "processed".
-		t.firstUnprocessedTupleIdx = fromLength
-		t.topK.AppendTuples(t.inputBatch, 0 /* startIdx */, fromLength)
-		remainingRows -= uint64(fromLength)
-		if fromLength == t.inputBatch.Length() {
+func spool_false(t *topKSorter) *execinfrapb.ProducerMetadata {
+	if !t.heapInitialized {
+		var meta *execinfrapb.ProducerMetadata
+		// Fill up t.topK by spooling up to K rows from the input.
+		// We don't need to check for distinct groups until after we have filled
+		// t.topK.
+		// TODO(harding): We could emit the first N < K rows if the N rows are in one
+		// or more distinct and complete groups, and then use a K-N size heap to find
+		// the remaining top K-N rows.
+		{
+			var __retval_0 *execinfrapb.ProducerMetadata
 			{
 				t.cancelChecker.CheckEveryCall()
-				t.inputBatch = t.Input.Next()
+				t.inputBatch, meta = t.Input.Next()
+				if meta != nil {
+					{
+						__retval_0 = meta
+					}
+					goto nextBatch_false_return_8
+				}
 				t.firstUnprocessedTupleIdx = 0
+				{
+					__retval_0 = nil
+				}
+			nextBatch_false_return_8:
+			}
+			// Fill up t.topK by spooling up to K rows from the input.
+			// We don't need to check for distinct groups until after we have filled
+			// t.topK.
+			// TODO(harding): We could emit the first N < K rows if the N rows are in one
+			// or more distinct and complete groups, and then use a K-N size heap to find
+			// the remaining top K-N rows.
+			meta = __retval_0
+		}
+		if meta != nil {
+			return meta
+		}
+		remainingRows := t.k - uint64(t.topK.Length())
+		for remainingRows > 0 && t.inputBatch.Length() > 0 {
+			fromLength := t.inputBatch.Length()
+			if remainingRows < uint64(t.inputBatch.Length()) {
+				// t.topK will be full after this batch.
+				fromLength = int(remainingRows)
+			}
+			// Importantly, the memory limit can only be reached _after_ the tuples
+			// are appended to topK, so all fromLength tuples are considered
+			// "processed".
+			t.firstUnprocessedTupleIdx = fromLength
+			t.topK.AppendTuples(t.inputBatch, 0 /* startIdx */, fromLength)
+			remainingRows -= uint64(fromLength)
+			if fromLength == t.inputBatch.Length() {
+				{
+					var __retval_0 *execinfrapb.ProducerMetadata
+					{
+						t.cancelChecker.CheckEveryCall()
+						t.inputBatch, meta = t.Input.Next()
+						if meta != nil {
+							{
+								__retval_0 = meta
+							}
+							goto nextBatch_false_return_9
+						}
+						t.firstUnprocessedTupleIdx = 0
+						{
+							__retval_0 = nil
+						}
+					nextBatch_false_return_9:
+					}
+					meta = __retval_0
+				}
+				if meta != nil {
+					return meta
+				}
 			}
 		}
+		t.updateComparators(topKVecIdx, t.topK)
+		// Initialize the heap.
+		if cap(t.heap) < t.topK.Length() {
+			t.heap = make([]int, t.topK.Length())
+		} else {
+			t.heap = t.heap[:t.topK.Length()]
+		}
+		for i := range t.heap {
+			t.heap[i] = i
+		}
+		heap.Init(t.heaper)
+		t.heapInitialized = true
 	}
-	t.updateComparators(topKVecIdx, t.topK)
-	// Initialize the heap.
-	if cap(t.heap) < t.topK.Length() {
-		t.heap = make([]int, t.topK.Length())
-	} else {
-		t.heap = t.heap[:t.topK.Length()]
-	}
-	for i := range t.heap {
-		t.heap[i] = i
-	}
-	heap.Init(t.heaper)
 	// Read the remainder of the input. Whenever a row is less than the heap max,
 	// swap it in. When we find the end of the group, we can finish reading the
 	// input.
-	_ = true
+	if t.inputBatch == nil {
+		var meta *execinfrapb.ProducerMetadata
+		{
+			var __retval_0 *execinfrapb.ProducerMetadata
+			{
+				t.cancelChecker.CheckEveryCall()
+				t.inputBatch, meta = t.Input.Next()
+				if meta != nil {
+					{
+						__retval_0 = meta
+					}
+					goto nextBatch_false_return_10
+				}
+				t.firstUnprocessedTupleIdx = 0
+				{
+					__retval_0 = nil
+				}
+			nextBatch_false_return_10:
+			}
+			meta = __retval_0
+		}
+		if meta != nil {
+			return meta
+		}
+	}
 	for t.inputBatch.Length() > 0 {
 		t.updateComparators(inputVecIdx, t.inputBatch)
 		sel := t.inputBatch.Selection()
@@ -369,7 +506,7 @@ func spool_false(t *topKSorter) {
 							idx := sel[t.firstUnprocessedTupleIdx]
 							maxIdx := t.heap[0]
 							groupMaxIdx := 0
-							if compareRow_false(t, inputVecIdx, topKVecIdx, idx, maxIdx, groupId, groupMaxIdx) < 0 {
+							if compareRow_false(t, inputVecIdx, topKVecIdx, idx, maxIdx, t.orderState.groupId, groupMaxIdx) < 0 {
 								for j := range t.inputTypes {
 									t.comparators[j].set(inputVecIdx, topKVecIdx, idx, maxIdx)
 								}
@@ -383,7 +520,7 @@ func spool_false(t *topKSorter) {
 							idx := t.firstUnprocessedTupleIdx
 							maxIdx := t.heap[0]
 							groupMaxIdx := 0
-							if compareRow_false(t, inputVecIdx, topKVecIdx, idx, maxIdx, groupId, groupMaxIdx) < 0 {
+							if compareRow_false(t, inputVecIdx, topKVecIdx, idx, maxIdx, t.orderState.groupId, groupMaxIdx) < 0 {
 								for j := range t.inputTypes {
 									t.comparators[j].set(inputVecIdx, topKVecIdx, idx, maxIdx)
 								}
@@ -394,10 +531,28 @@ func spool_false(t *topKSorter) {
 				}
 			},
 		)
+		var meta *execinfrapb.ProducerMetadata
 		{
-			t.cancelChecker.CheckEveryCall()
-			t.inputBatch = t.Input.Next()
-			t.firstUnprocessedTupleIdx = 0
+			var __retval_0 *execinfrapb.ProducerMetadata
+			{
+				t.cancelChecker.CheckEveryCall()
+				t.inputBatch, meta = t.Input.Next()
+				if meta != nil {
+					{
+						__retval_0 = meta
+					}
+					goto nextBatch_false_return_13
+				}
+				t.firstUnprocessedTupleIdx = 0
+				{
+					__retval_0 = nil
+				}
+			nextBatch_false_return_13:
+			}
+			meta = __retval_0
+		}
+		if meta != nil {
+			return meta
 		}
 	}
 	// t.topK now contains the top K rows unsorted. Create a selection vector
@@ -408,6 +563,7 @@ func spool_false(t *topKSorter) {
 	for i := 0; i < t.topK.Length(); i++ {
 		t.sel[len(t.sel)-i-1] = heap.Pop(t.heaper).(int)
 	}
+	return nil
 }
 
 func compareRow_false(
@@ -473,12 +629,12 @@ func compareRow_true(
 const _ = "inlined_nextBatch_true"
 
 // processGroupsInBatch associates a row in the top K heap with its distinct
-// partially ordered column group. It returns the most recently found groupId.
+// partially ordered column group.
 // execgen:inline
 const _ = "inlined_processGroupsInBatch_true"
 
 // processGroupsInBatch associates a row in the top K heap with its distinct
-// partially ordered column group. It returns the most recently found groupId.
+// partially ordered column group.
 // execgen:inline
 const _ = "inlined_processGroupsInBatch_false"
 

--- a/pkg/sql/colexec/sorttopk_test.go
+++ b/pkg/sql/colexec/sorttopk_test.go
@@ -142,7 +142,7 @@ func TestTopKSortRandomized(t *testing.T) {
 				oracle := NewSorter(testAllocator, input, typs[:nCols], ordCols, execinfra.DefaultMemoryLimit)
 				oracle.Init(ctx)
 				var expected colexectestutils.Tuples
-				for expectedOut := oracle.Next(); expectedOut.Length() != 0; expectedOut = oracle.Next() {
+				for expectedOut := colexecop.NextNoMeta(oracle); expectedOut.Length() != 0; expectedOut = colexecop.NextNoMeta(oracle) {
 					for i := 0; i < expectedOut.Length(); i++ {
 						expected = append(expected, colexectestutils.GetTupleFromBatch(expectedOut, i))
 					}
@@ -194,7 +194,7 @@ func BenchmarkSortTopK(b *testing.B) {
 								source := colexectestutils.NewFiniteChunksSource(testAllocator, batch, typs, nBatches, matchLen)
 								sorter = NewTopKSorter(testAllocator, source, typs, ordCols, matchLen, k, execinfra.DefaultMemoryLimit)
 								sorter.Init(ctx)
-								for out := sorter.Next(); out.Length() != 0; out = sorter.Next() {
+								for out := colexecop.NextNoMeta(sorter); out.Length() != 0; out = colexecop.NextNoMeta(sorter) {
 								}
 							}
 							b.StopTimer()

--- a/pkg/sql/colexec/substring.eg.go
+++ b/pkg/sql/colexec/substring.eg.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/errors"
@@ -90,11 +91,17 @@ type substringInt64Int16Operator struct {
 
 var _ colexecop.Operator = &substringInt64Int16Operator{}
 
-func (s *substringInt64Int16Operator) Next() coldata.Batch {
-	batch := s.Input.Next()
+func (s *substringInt64Int16Operator) Next() (
+	coldata.Batch,
+	*execinfrapb.ProducerMetadata,
+) {
+	batch, meta := s.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 
 	sel := batch.Selection()
@@ -182,7 +189,7 @@ func (s *substringInt64Int16Operator) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type substringInt64Int32Operator struct {
@@ -191,11 +198,17 @@ type substringInt64Int32Operator struct {
 
 var _ colexecop.Operator = &substringInt64Int32Operator{}
 
-func (s *substringInt64Int32Operator) Next() coldata.Batch {
-	batch := s.Input.Next()
+func (s *substringInt64Int32Operator) Next() (
+	coldata.Batch,
+	*execinfrapb.ProducerMetadata,
+) {
+	batch, meta := s.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 
 	sel := batch.Selection()
@@ -283,7 +296,7 @@ func (s *substringInt64Int32Operator) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type substringInt64Int64Operator struct {
@@ -292,11 +305,17 @@ type substringInt64Int64Operator struct {
 
 var _ colexecop.Operator = &substringInt64Int64Operator{}
 
-func (s *substringInt64Int64Operator) Next() coldata.Batch {
-	batch := s.Input.Next()
+func (s *substringInt64Int64Operator) Next() (
+	coldata.Batch,
+	*execinfrapb.ProducerMetadata,
+) {
+	batch, meta := s.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 
 	sel := batch.Selection()
@@ -384,7 +403,7 @@ func (s *substringInt64Int64Operator) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type substringInt16Int16Operator struct {
@@ -393,11 +412,17 @@ type substringInt16Int16Operator struct {
 
 var _ colexecop.Operator = &substringInt16Int16Operator{}
 
-func (s *substringInt16Int16Operator) Next() coldata.Batch {
-	batch := s.Input.Next()
+func (s *substringInt16Int16Operator) Next() (
+	coldata.Batch,
+	*execinfrapb.ProducerMetadata,
+) {
+	batch, meta := s.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 
 	sel := batch.Selection()
@@ -485,7 +510,7 @@ func (s *substringInt16Int16Operator) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type substringInt16Int32Operator struct {
@@ -494,11 +519,17 @@ type substringInt16Int32Operator struct {
 
 var _ colexecop.Operator = &substringInt16Int32Operator{}
 
-func (s *substringInt16Int32Operator) Next() coldata.Batch {
-	batch := s.Input.Next()
+func (s *substringInt16Int32Operator) Next() (
+	coldata.Batch,
+	*execinfrapb.ProducerMetadata,
+) {
+	batch, meta := s.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 
 	sel := batch.Selection()
@@ -586,7 +617,7 @@ func (s *substringInt16Int32Operator) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type substringInt16Int64Operator struct {
@@ -595,11 +626,17 @@ type substringInt16Int64Operator struct {
 
 var _ colexecop.Operator = &substringInt16Int64Operator{}
 
-func (s *substringInt16Int64Operator) Next() coldata.Batch {
-	batch := s.Input.Next()
+func (s *substringInt16Int64Operator) Next() (
+	coldata.Batch,
+	*execinfrapb.ProducerMetadata,
+) {
+	batch, meta := s.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 
 	sel := batch.Selection()
@@ -687,7 +724,7 @@ func (s *substringInt16Int64Operator) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type substringInt32Int16Operator struct {
@@ -696,11 +733,17 @@ type substringInt32Int16Operator struct {
 
 var _ colexecop.Operator = &substringInt32Int16Operator{}
 
-func (s *substringInt32Int16Operator) Next() coldata.Batch {
-	batch := s.Input.Next()
+func (s *substringInt32Int16Operator) Next() (
+	coldata.Batch,
+	*execinfrapb.ProducerMetadata,
+) {
+	batch, meta := s.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 
 	sel := batch.Selection()
@@ -788,7 +831,7 @@ func (s *substringInt32Int16Operator) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type substringInt32Int32Operator struct {
@@ -797,11 +840,17 @@ type substringInt32Int32Operator struct {
 
 var _ colexecop.Operator = &substringInt32Int32Operator{}
 
-func (s *substringInt32Int32Operator) Next() coldata.Batch {
-	batch := s.Input.Next()
+func (s *substringInt32Int32Operator) Next() (
+	coldata.Batch,
+	*execinfrapb.ProducerMetadata,
+) {
+	batch, meta := s.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 
 	sel := batch.Selection()
@@ -889,7 +938,7 @@ func (s *substringInt32Int32Operator) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 type substringInt32Int64Operator struct {
@@ -898,11 +947,17 @@ type substringInt32Int64Operator struct {
 
 var _ colexecop.Operator = &substringInt32Int64Operator{}
 
-func (s *substringInt32Int64Operator) Next() coldata.Batch {
-	batch := s.Input.Next()
+func (s *substringInt32Int64Operator) Next() (
+	coldata.Batch,
+	*execinfrapb.ProducerMetadata,
+) {
+	batch, meta := s.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 
 	sel := batch.Selection()
@@ -990,5 +1045,5 @@ func (s *substringInt32Int64Operator) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }

--- a/pkg/sql/colexec/substring_tmpl.go
+++ b/pkg/sql/colexec/substring_tmpl.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/errors"
@@ -90,11 +91,17 @@ type substring_StartType_LengthTypeOperator struct {
 
 var _ colexecop.Operator = &substring_StartType_LengthTypeOperator{}
 
-func (s *substring_StartType_LengthTypeOperator) Next() coldata.Batch {
-	batch := s.Input.Next()
+func (s *substring_StartType_LengthTypeOperator) Next() (
+	coldata.Batch,
+	*execinfrapb.ProducerMetadata,
+) {
+	batch, meta := s.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
 	n := batch.Length()
 	if n == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 
 	sel := batch.Selection()
@@ -182,7 +189,7 @@ func (s *substring_StartType_LengthTypeOperator) Next() coldata.Batch {
 			}
 		},
 	)
-	return batch
+	return batch, nil
 }
 
 // {{end}}

--- a/pkg/sql/colexec/types_integration_test.go
+++ b/pkg/sql/colexec/types_integration_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/randgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
@@ -139,8 +140,8 @@ func newArrowTestOperator(
 	}
 }
 
-func (a *arrowTestOperator) Next() coldata.Batch {
-	batchIn := a.Input.Next()
+func (a *arrowTestOperator) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batchIn := colexecop.NextNoMeta(a.Input)
 	// Note that we don't need to handle zero-length batches in a special way.
 	var buf bytes.Buffer
 	arrowDataIn, err := a.c.BatchToArrow(a.Ctx, batchIn)
@@ -160,5 +161,5 @@ func (a *arrowTestOperator) Next() coldata.Batch {
 	if err := a.c.ArrowToBatch(arrowDataOut, batchLength, batchOut); err != nil {
 		colexecerror.InternalError(err)
 	}
-	return batchOut
+	return batchOut, nil
 }

--- a/pkg/sql/colexec/values.go
+++ b/pkg/sql/colexec/values.go
@@ -75,9 +75,9 @@ func (v *valuesOp) Init(ctx context.Context) {
 	v.row = make(rowenc.EncDatumRow, len(v.typs))
 }
 
-func (v *valuesOp) Next() coldata.Batch {
+func (v *valuesOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	if len(v.data) == 0 {
-		return coldata.ZeroBatch
+		return coldata.ZeroBatch, nil
 	}
 
 	var reallocated bool
@@ -120,5 +120,5 @@ func (v *valuesOp) Next() coldata.Batch {
 	}
 
 	v.batch.SetLength(nRows)
-	return v.batch
+	return v.batch, nil
 }

--- a/pkg/sql/colexec/values_test.go
+++ b/pkg/sql/colexec/values_test.go
@@ -115,7 +115,7 @@ func subBenchmarkValues(
 					b.Fatal(err)
 				}
 				op.Init(ctx)
-				for batch := op.Next(); batch.Length() > 0; batch = op.Next() {
+				for batch := colexecop.NextNoMeta(op); batch.Length() > 0; batch = colexecop.NextNoMeta(op) {
 				}
 			}
 		})

--- a/pkg/sql/colexecop/BUILD.bazel
+++ b/pkg/sql/colexecop/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/sql/execinfrapb",
         "//pkg/sql/execstats",
         "//pkg/sql/types",
+        "//pkg/util/buildutil",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -236,7 +236,7 @@ func (s *ColBatchScan) Init(ctx context.Context) {
 }
 
 // Next is part of the colexecop.Operator interface.
-func (s *ColBatchScan) Next() coldata.Batch {
+func (s *ColBatchScan) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	bat, err := s.cf.NextBatch(s.Ctx)
 	if err != nil {
 		colexecerror.InternalError(err)
@@ -247,7 +247,7 @@ func (s *ColBatchScan) Next() coldata.Batch {
 	s.mu.Lock()
 	s.mu.rowsRead += int64(bat.Length())
 	s.mu.Unlock()
-	return bat
+	return bat, nil
 }
 
 // DrainMeta is part of the colexecop.MetadataSource interface.

--- a/pkg/sql/colflow/colbatch_scan_test.go
+++ b/pkg/sql/colflow/colbatch_scan_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/fetchpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colbuilder"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecargs"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
@@ -193,7 +194,7 @@ func BenchmarkColBatchScan(b *testing.B) {
 				b.StartTimer()
 				tr.Init(ctx)
 				for {
-					bat := tr.Next()
+					bat := colexecop.NextNoMeta(tr)
 					if bat.Length() == 0 {
 						break
 					}

--- a/pkg/sql/colflow/colrpc/outbox_test.go
+++ b/pkg/sql/colflow/colrpc/outbox_test.go
@@ -67,7 +67,7 @@ func TestOutboxCatchesPanics(t *testing.T) {
 	// propagate the panic.
 	err = colexecerror.CatchVectorizedRuntimeError(func() {
 		inbox.Init(ctx)
-		inbox.Next()
+		colexecop.NextNoMeta(inbox)
 	})
 	require.Error(t, err)
 

--- a/pkg/sql/colflow/panic_injector.go
+++ b/pkg/sql/colflow/panic_injector.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/errors"
@@ -57,7 +58,7 @@ func (i *panicInjector) Init(ctx context.Context) {
 	i.Input.Init(i.Ctx)
 }
 
-func (i *panicInjector) Next() coldata.Batch {
+func (i *panicInjector) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	if i.rng.Float64() < nextPanicInjectionProbability {
 		log.Dev.Info(i.Ctx, "injecting panic in Next")
 		colexecerror.ExpectedError(errors.New("injected panic in Next"))

--- a/pkg/sql/colflow/vectorized_flow_space_test.go
+++ b/pkg/sql/colflow/vectorized_flow_space_test.go
@@ -246,8 +246,8 @@ func TestVectorizeAllocatorSpaceError(t *testing.T) {
 				}); err == nil {
 					err = colexecerror.CatchVectorizedRuntimeError(func() {
 						result.Root.Init(ctx)
-						result.Root.Next()
-						result.Root.Next()
+						colexecop.NextNoMeta(result.Root)
+						colexecop.NextNoMeta(result.Root)
 					})
 				}
 				if expectNoMemoryError {

--- a/pkg/sql/colflow/vectorized_panic_propagation_test.go
+++ b/pkg/sql/colflow/vectorized_panic_propagation_test.go
@@ -115,7 +115,7 @@ func newTestVectorizedInternalPanicEmitter(input colexecop.Operator) colexecop.O
 }
 
 // Next is part of colexecop.Operator interface.
-func (e *testVectorizedInternalPanicEmitter) Next() coldata.Batch {
+func (e *testVectorizedInternalPanicEmitter) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	if !e.emitBatch {
 		e.emitBatch = true
 		colexecerror.InternalError(errors.AssertionFailedf(""))
@@ -143,7 +143,7 @@ func newTestNonVectorizedPanicEmitter(input colexecop.Operator) colexecop.Operat
 }
 
 // Next is part of colexecop.Operator interface.
-func (e *testNonVectorizedPanicEmitter) Next() coldata.Batch {
+func (e *testNonVectorizedPanicEmitter) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 	if !e.emitBatch {
 		e.emitBatch = true
 		colexecerror.NonCatchablePanic("")

--- a/pkg/sql/distsql/columnar_utils_test.go
+++ b/pkg/sql/distsql/columnar_utils_test.go
@@ -198,11 +198,16 @@ func verifyColOperator(t *testing.T, args verifyColOperatorArgs) error {
 			colOpRows = append(colOpRows, printRowForChecking(rowColOp))
 		}
 		if metaColOp != nil {
-			if metaColOp.Err == nil {
+			if metaColOp.RowNum != nil {
+				// In test builds, the invariantsChecker can inject RowNum
+				// metadata in arbitrary Operator chains, so we'll just silently
+				// swallow it.
+			} else if metaColOp.Err == nil {
 				return errors.Errorf("unexpectedly columnar operator returned "+
 					"non-error meta\n%+v", metaColOp)
+			} else {
+				colOpMetas = append(colOpMetas, *metaColOp)
 			}
-			colOpMetas = append(colOpMetas, *metaColOp)
 		}
 
 		if rowProc == nil && metaProc == nil &&

--- a/pkg/sql/physicalplan/aggregator_funcs_test.go
+++ b/pkg/sql/physicalplan/aggregator_funcs_test.go
@@ -95,7 +95,7 @@ func runTestFlow(
 			if meta.Err != nil {
 				return nil, meta.Err
 			}
-			if meta.LeafTxnFinalState != nil || meta.Metrics != nil || meta.TraceData != nil {
+			if meta.LeafTxnFinalState != nil || meta.Metrics != nil || meta.TraceData != nil || meta.RowNum != nil {
 				continue
 			}
 			t.Fatalf("unexpected metadata: %v", meta)

--- a/pkg/sql/sem/eval/eval_test/BUILD.bazel
+++ b/pkg/sql/sem/eval/eval_test/BUILD.bazel
@@ -23,6 +23,7 @@ go_test(
         "//pkg/sql/execinfra",
         "//pkg/sql/execinfrapb",
         "//pkg/sql/parser",
+        "//pkg/sql/rowenc",
         "//pkg/sql/rowexec",
         "//pkg/sql/sem/builtins",
         "//pkg/sql/sem/eval",


### PR DESCRIPTION
Backport 1/1 commits from #157869.
Backport 1/1 commits from #158029.
Backport 2/2 commits from #160908.

/cc @cockroachdb/release

---

**colexecop: modify Operator.Next to return metadata**

This commit changes `Operator.Next` interface to add an ability to
return metadata in the "streaming" fashion, similar to how it's done in
the row-by-row engine. This will allow us to support features like
estimated query progress (based on the number of rows scanned so far).
Note that we still preserve the concept of MetadataSources, but it'll
become similar to "trailing metadata" concept in the row-by-row engine,
i.e. it'll only handle metadata that is produced when the component is
being drained.

The following Operators are affected have non-trivial state transitions:
- columnarizer - we're buffering multiple rows into a batch, so we need
to continue building the current batch if there is some metadata between
rows. Note that we don't change the error propagation and still throw it
immediately. Additionally, since we no longer buffer the metadata, we
can remove some memory accounting.
- ordered synchronizer is similar to columnarizer - we need to ensure
continuing building the current output batch if we get a metadata when
fetching the new batch from one of the inputs. Additionaly we need
handle the heap initialization carefully if we get a metadata object
before any batches from some inputs.
- parallel unordered synchronizer - here we needed to augment the logic
so that metadata can be propagated in the streaming fashion. Previously,
if an input sent the metadata, then it meant that the input has been
drained, which is no longer true so we store the last message from one
of the inputs and emit the metadata from it until exhausted. This
allowed us to simplify some other logic about buffering the metadata
though.
- top K sort is somewhat similar to the ordered synchronizer - it first
spills some number of batches to reach the desired K total, and then it
reads one batch at a time comparing against the current maximum row (one
input row from the batch at a time). Here we needed to adjust the logic
to initialize the heap only once as well as maintain some state across
Next calls.
- hashBasedPartitioner - if the metadata is received from the 2nd input
after having read a batch from the 1st input, then that batch must be
used on the next iteration
- hashJoiner - whenever the metadata is received from either input, it's
propagated immediately, but then the execution flow can just be resumed
(because the hashJoiner already has the necessary state machine)
- crossJoiner and mergeJoiner read from inputs at different points in
time and have non-trivial state transitions, so we handle them by
introducing a helper struct that buffers the metadata, and then the
operator must check for metadata as soon as its convenient. In the merge
joiner we also need to continue building the output batch without
resetting. Additionally, just to be safe, we mark both as MetadataSources to
guarantee that all metadata is emitted (I think that only with
ungraceful shutdown we can have some metadata still buffered in these
two).
- index joiner - need to preserve the row count that we've buffered for
span generation so far, across Next calls, as well as reset the input
batch mem size only when we're transitioning to constructing spans.
- hash router - here we'll forward the metadata to the first stream
(similar to what we do in the row-by-row routers). Additionally each
router output is responsible for emitting forwarded to it metadata on
its DrainMeta implementation (if unable to emit that forwarded metadata
in the streaming fashion).
- inbox - simply need to ensure that all metadata is returned as soon
as possible, or at the very least during DrainMeta. Note that we still
panic with an error in the metadata since we're not changing how errors
are propagated throughout the vectorized engine.
- outbox - here we send a new message for every metadata object from the
input. Note that we could consider buffering up some metadata and
sending together with the next batch, but that's left as a TODO (I doubt
that minor increase in DistSQL messages will be noticeable, unless we
start emitting metadata very frequently).

This commit also extends the invariantsChecker (which is an operator that we
plan in test-only builds that verifies some assumptions) to randomly
inject metadata on its Next calls. This improves the test coverage of
the streaming metadata in the vectorized engine (and it uncovered one
bug in the top K sorter). We inject RowNum metadata that is only used in
tests, and then we needed to adjust some tests to allow for that type of
metadata. `NextNoMeta` helper method has been adjusted to silently
swallow this metadata.

Fixes: #55758.

Release note: None

**colfetcher: emit periodic query progress update metadata**

This commit extends the query progress reporting that we do in the row-by-row tableReader to the vectorized scan operators too. Namely, after about 20k rows have been output, we'll emit the RowsRead metadata that we then use in DistSQLReceiver to update progressAtomic. Then the result shows up in `phase` column of SHOW QUERIES.

Fixes: #26639.

Release note (sql change): Queries executed via the vectorized engine now display their progress in `phase` column of SHOW QUERIES. Previously, this feature was only available in the row-by-row engine.

**colexec: fix recent bug in ordered synchronizer**

In a recent change to introduce streaming metadata propagation, at least
one (hopefully no more) bug slipped in. Namely, in the ordered
synchronizer if we get a metadata when advancing one of the inputs, we
need to complete the heap update before we can emit that metadata. So
the behavior for the ordered synchronizer is closer to that of cross
and merge joiners where we temporarily buffer metadata and emit it at
a safe point in time some time soon (and guarantee to emit it during
DrainMeta).

There is no regression test - it was discovered via SQLite suite with
metamorphic randomizations - but I have an idea that should improve our
colexec testing framework (haven't managed to reproduce the problem
though).

Fixes: #160853.

**colflow: ignore recently added RowsRead meta in BenchmarkColBatchScan**

This metadata is expected - it powers query progress estimate.

Fixes: #160883

----

Release justification: medium risk high reward change.