### PR TITLE
release-26.1: mmaintegration: add StoreStatus to mma status translation plumbing

### DIFF
--- a/pkg/kv/kvserver/allocator/mmaprototype/allocator.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/allocator.go
@@ -60,6 +60,11 @@ type Allocator interface {
 	// associated node in the cluster.
 	ProcessStoreLoadMsg(ctx context.Context, msg *StoreLoadMsg)
 
+	// UpdateStoreStatus updates the health and disposition for the stores in storeStatuses according to the statuses in storeStatuses.
+	// Stores not known to the allocator are ignored with logging.
+	// TODO(wenyihu6): if this is too expensive, we should only update status for stores that have changed.
+	UpdateStoreStatus(ctx context.Context, storeStatuses map[roachpb.StoreID]Status)
+
 	// Methods related to making changes.
 
 	// AdjustPendingChangeDisposition is optional feedback to inform the

--- a/pkg/kv/kvserver/allocator/mmaprototype/allocator.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/allocator.go
@@ -60,10 +60,10 @@ type Allocator interface {
 	// associated node in the cluster.
 	ProcessStoreLoadMsg(ctx context.Context, msg *StoreLoadMsg)
 
-	// UpdateStoreStatus updates the health and disposition for the stores in storeStatuses according to the statuses in storeStatuses.
-	// Stores not known to the allocator are ignored with logging.
-	// TODO(wenyihu6): if this is too expensive, we should only update status for stores that have changed.
-	UpdateStoreStatus(ctx context.Context, storeStatuses map[roachpb.StoreID]Status)
+	// UpdateStoresStatuses updates the health and disposition for the stores in
+	// storeStatuses. Stores unknown to the allocator are ignored with logging.
+	// to the allocator are ignored with logging.
+	UpdateStoresStatuses(ctx context.Context, storeStatuses map[roachpb.StoreID]Status)
 
 	// Methods related to making changes.
 

--- a/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
@@ -698,8 +698,43 @@ func sortTargetCandidateSetAndPick(
 				cmp.Compare(a.StoreID, b.StoreID))
 		})
 	}
-	// Candidates are sorted by non-decreasing leasePreferenceIndex. Eliminate
-	// ones that have notMatchedLeasePreferenceIndex.
+	// Candidates are sorted by non-decreasing leasePreferenceIndex (lower is
+	// better). Eliminate ones that have notMatchedLeasePreferenceIndex (i.e.,
+	// candidates that don't match ANY lease preference). This filter only has an
+	// effect when the span config has lease preferences configured; otherwise all
+	// candidates have leasePreferenceIndex=0 (see matchedLeasePreferenceIndex).
+	//
+	// For lease transfers: This check is usually redundant because
+	// candidatesToMoveLease already filters candidates to those with
+	// leasePreferenceIndex <= the current leaseholder's index. However, if the
+	// current leaseholder matches NO preference (LPI =
+	// notMatchedLeasePreferenceIndex), then candidatesToMoveLease returns all
+	// voters (since all LPIs <= MaxInt32), and this filter becomes necessary to
+	// remove candidates that also match no preference.
+	//
+	// TODO(wenyihu6): Is this expected behavior? Another thought is that
+	// rebalancing should not need to improve lease preference satisfaction: we
+	// are here because the source is overloaded or wanting to shed leases for
+	// some reason. Doing that work without making the lease preference worse is
+	// sufficient. Improving the lease preference should be the job of the lease
+	// queue. If the current leaseholder matches no preference, perhaps we should
+	// allow transferring to any candidate (even those also matching no
+	// preference) rather than requiring candidates to match some preference.
+	//
+	// For replica transfers from the leaseholder: This is the only lease
+	// preference filtering applied. matchedLeasePreferenceIndex is called
+	// directly on candidates in rebalanceReplicas.
+	//
+	// Note: There's an asymmetry between lease transfers and replica transfers.
+	// Lease transfers enforce "don't make lease preference worse" (via
+	// candidatesToMoveLease filtering to LPI <= current). Replica transfers from
+	// the leaseholder only enforce "must match some preference" (via this
+	// filter), meaning a replica transfer could move the leaseholder's replica to
+	// a store with a worse lease preference (e.g., LPI=0 -> LPI=2). This is
+	// consistent with SMA behavior: SMA's rankedCandidateListForRebalancing (used
+	// by RebalanceTarget) doesn't consider lease preferences for replica
+	// transfers. The rationale is likely that the lease queue will fix any lease
+	// preference violations after the replica transfer completes.
 	j = 0
 	for _, cand := range cands.candidates {
 		if cand.leasePreferenceIndex == notMatchedLeasePreferenceIndex {

--- a/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
@@ -204,8 +204,8 @@ func (a *allocatorState) ProcessStoreLoadMsg(ctx context.Context, msg *StoreLoad
 	a.cs.processStoreLoadMsg(ctx, msg)
 }
 
-// UpdateStoreStatus implements the Allocator interface.
-func (a *allocatorState) UpdateStoreStatus(
+// UpdateStoresStatus implements the Allocator interface.
+func (a *allocatorState) UpdateStoresStatuses(
 	ctx context.Context, storeStatuses map[roachpb.StoreID]Status,
 ) {
 	a.mu.Lock()

--- a/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
@@ -204,6 +204,15 @@ func (a *allocatorState) ProcessStoreLoadMsg(ctx context.Context, msg *StoreLoad
 	a.cs.processStoreLoadMsg(ctx, msg)
 }
 
+// UpdateStoreStatus implements the Allocator interface.
+func (a *allocatorState) UpdateStoreStatus(
+	ctx context.Context, storeStatuses map[roachpb.StoreID]Status,
+) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.cs.updateStoreStatuses(ctx, storeStatuses)
+}
+
 // AdjustPendingChangeDisposition implements the Allocator interface.
 func (a *allocatorState) AdjustPendingChangeDisposition(
 	ctx context.Context, change ExternalRangeChange, success bool,

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
@@ -2180,16 +2180,10 @@ func (cs *clusterState) setStore(sal storeAttributesAndLocalityWithNodeTier) {
 	if !ok {
 		// This is the first time seeing this store.
 		ss := newStoreState()
-		// TODO(tbg): below is what we should be doing once asim and production code actually
-		// have a way to update the health status. For now, we just set it to healthy initially
-		// and that's where it will stay (outside of unit tests).
-		//
-		// At this point, the store's health is unknown. It will need to be marked
-		// as healthy separately. Until we know more, we won't place leases or
-		// replicas on it (nor will we try to shed any that are already reported to
-		// have replicas on it).
-		// ss.status = MakeStatus(HealthUnknown, LeaseDispositionRefusing, ReplicaDispositionRefusing)
-		ss.status = MakeStatus(HealthOK, LeaseDispositionOK, ReplicaDispositionOK)
+		// At this point, the store's health is unknown. It will be updated by cs.updateStoreStatuses. Until we know more, we
+		// won't place leases or replicas on it (nor will we try to shed any that
+		// are already reported to have replicas on it).
+		ss.status = MakeStatus(HealthUnknown, LeaseDispositionRefusing, ReplicaDispositionRefusing)
 		ss.overloadStartTime = cs.ts.Now()
 		ss.overloadEndTime = cs.ts.Now()
 		cs.stores[sal.StoreID] = ss

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/store_status_exclusion.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/store_status_exclusion.txt
@@ -1,0 +1,208 @@
+# This test verifies mma's candidate exclusion and shedding behavior based on
+# store status. Note that this test does not verify the correctness of the 
+# actual translation from store pool status to mma status. That is tested in 
+# the mmaintegration package.
+#
+# Setup: 3 stores
+# - s1: source store (overloaded, wants to shed)
+# - s2: always available (good target)
+# - s3: test store (status changes to test each scenario)
+set-store
+  store-id=1 node-id=1
+  store-id=2 node-id=2
+  store-id=3 node-id=3
+----
+node-id=1 locality-tiers=node=1
+  store-id=1 attrs=
+node-id=2 locality-tiers=node=2
+  store-id=2 attrs=
+node-id=3 locality-tiers=node=3
+  store-id=3 attrs=
+
+# s1 is overloaded, s2 and s3 are low load
+store-load-msg
+  store-id=1 node-id=1 load=[1000,0,0] capacity=[1000,1000,1000] secondary-load=0 load-time=0s
+  store-id=2 node-id=2 load=[100,0,0] capacity=[1000,1000,1000] secondary-load=0 load-time=0s
+  store-id=3 node-id=3 load=[100,0,0] capacity=[1000,1000,1000] secondary-load=0 load-time=0s
+----
+
+# Range r1: lease on s1, replicas on s1, s2, s3
+store-leaseholder-msg
+store-id=1
+  range-id=1 load=[100,0,0] raft-cpu=100
+    store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
+    store-id=2 replica-id=2 type=VOTER_FULL
+    store-id=3 replica-id=3 type=VOTER_FULL
+    config=num_replicas=3 constraints={} voter_constraints={}
+----
+
+# Baseline: all stores available
+retain-ready-replica-target-stores-only in=(2,3)
+----
+[2 3]
+
+retain-ready-lease-target-stores-only in=(2,3) range-id=1
+----
+[2 3]
+
+# Dead: excluded from all targets (shedding leases, shedding replicas)
+set-store-status store-id=3 health=dead leases=shedding replicas=shedding
+----
+dead shedding=leases,replicas
+
+retain-ready-replica-target-stores-only in=(2,3)
+----
+skipping s3 for replica transfer: replica disposition shedding (health dead)
+[2]
+
+retain-ready-lease-target-stores-only in=(2,3) range-id=1
+----
+skipping s3 for lease transfer: lease disposition shedding (health dead)
+[2]
+
+# Unknown: excluded from all targets (refusing leases, refusing replicas)
+set-store-status store-id=3 health=unknown leases=refusing replicas=refusing
+----
+unknown refusing=leases,replicas
+
+retain-ready-replica-target-stores-only in=(2,3)
+----
+skipping s3 for replica transfer: replica disposition refusing (health unknown)
+[2]
+
+retain-ready-lease-target-stores-only in=(2,3) range-id=1
+----
+skipping s3 for lease transfer: lease disposition refusing (health unknown)
+[2]
+
+# Decommissioning: excluded from all targets (shedding leases, shedding replicas)
+set-store-status store-id=3 health=ok leases=shedding replicas=shedding
+----
+ok shedding=leases,replicas
+
+retain-ready-replica-target-stores-only in=(2,3)
+----
+skipping s3 for replica transfer: replica disposition shedding (health ok)
+[2]
+
+retain-ready-lease-target-stores-only in=(2,3) range-id=1
+----
+skipping s3 for lease transfer: lease disposition shedding (health ok)
+[2]
+
+# Draining: excluded from all targets (shedding leases, refusing replicas)
+set-store-status store-id=3 health=ok leases=shedding replicas=refusing
+----
+ok refusing=replicas shedding=leases
+
+retain-ready-replica-target-stores-only in=(2,3)
+----
+skipping s3 for replica transfer: replica disposition refusing (health ok)
+[2]
+
+retain-ready-lease-target-stores-only in=(2,3) range-id=1
+----
+skipping s3 for lease transfer: lease disposition shedding (health ok)
+[2]
+
+# Suspect: excluded from all targets (shedding leases, refusing replicas)
+set-store-status store-id=3 health=unhealthy leases=shedding replicas=refusing
+----
+unhealthy refusing=replicas shedding=leases
+
+retain-ready-replica-target-stores-only in=(2,3)
+----
+skipping s3 for replica transfer: replica disposition refusing (health unhealthy)
+[2]
+
+retain-ready-lease-target-stores-only in=(2,3) range-id=1
+----
+skipping s3 for lease transfer: lease disposition shedding (health unhealthy)
+[2]
+
+# Throttled: excluded from replica targets, can receive leases
+set-store-status store-id=3 health=ok leases=ok replicas=refusing
+----
+ok refusing=replicas
+
+retain-ready-replica-target-stores-only in=(2,3)
+----
+skipping s3 for replica transfer: replica disposition refusing (health ok)
+[2]
+
+retain-ready-lease-target-stores-only in=(2,3) range-id=1
+----
+[2 3]
+
+# Available: accepts everything
+set-store-status store-id=3 health=ok leases=ok replicas=ok
+----
+ok accepting all
+
+retain-ready-replica-target-stores-only in=(2,3)
+----
+[2 3]
+
+retain-ready-lease-target-stores-only in=(2,3) range-id=1
+----
+[2 3]
+
+# Rebalance test: verify s3 (dead) is excluded during actual rebalance
+set-store-status store-id=3 health=dead leases=shedding replicas=shedding
+----
+dead shedding=leases,replicas
+
+rebalance-stores store-id=1
+----
+[mmaid=1] rebalanceStores begins
+[mmaid=1] cluster means: (stores-load [cpu:400ns/s, write-bandwidth:0 B/s, byte-size:0 B]) (stores-capacity [cpu:1µs/s, write-bandwidth:1.0 kB/s, byte-size:1.0 kB]) (nodes-cpu-load 400) (nodes-cpu-capacity 1000)
+[mmaid=1] load summary for dim=CPURate (s1): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=400 fractionUsed=100.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n1): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=400 fractionUsed=100.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] evaluating s1: node load overloadUrgent, store load overloadUrgent, worst dim CPURate
+[mmaid=1] overload-continued s1 ((store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true))) - within grace period
+[mmaid=1] store s1 was added to shedding store list
+[mmaid=1] load summary for dim=CPURate (s2): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n2): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] evaluating s2: node load loadLow, store load loadNormal, worst dim WriteBandwidth
+[mmaid=1] load summary for dim=CPURate (s3): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n3): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] evaluating s3: node load loadLow, store load loadNormal, worst dim WriteBandwidth
+[mmaid=1] start processing shedding store s1: cpu node load overloadUrgent, store load overloadUrgent, worst dim CPURate
+[mmaid=1] top-K[CPURate] ranges for s1 with lease on local s1: r1:[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B]
+[mmaid=1] local store s1 is CPU overloaded (overloadUrgent >= overloadSlow), attempting lease transfers first
+[mmaid=1] considering lease-transfer r1 from s1: candidates are [2 3]
+[mmaid=1] skipping s3 for lease transfer: lease disposition shedding (health dead)
+[mmaid=1] load summary for dim=CPURate (s1): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=550 fractionUsed=100.00% meanUtil=55.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n1): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=550 fractionUsed=100.00% meanUtil=55.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (s2): loadLow, reason: load is >10% below mean [load=100 meanLoad=550 fractionUsed=10.00% meanUtil=55.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n2): loadLow, reason: load is >10% below mean [load=100 meanLoad=550 fractionUsed=10.00% meanUtil=55.00% capacity=1000]
+[mmaid=1] sortTargetCandidateSetAndPick: candidates: s2(SLS:loadNormal, overloadedDimLoadSummary:loadLow), overloadedDim:CPURate, picked s2
+[mmaid=1] load summary for dim=CPURate (s2): loadLow, reason: load is >10% below mean [load=100 meanLoad=550 fractionUsed=10.00% meanUtil=55.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n2): loadLow, reason: load is >10% below mean [load=100 meanLoad=550 fractionUsed=10.00% meanUtil=55.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (s1): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=550 fractionUsed=100.00% meanUtil=55.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n1): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=550 fractionUsed=100.00% meanUtil=55.00% capacity=1000]
+[mmaid=1] can add load to n2s2: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))] srcSLS[(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true))]
+[mmaid=1] result(success): shedding r1 lease from s1 to s2 [change:r1=[transfer_to=2 cids=1,2]] with resulting loads source:[cpu:1µs/s, write-bandwidth:0 B/s, byte-size:0 B] target:[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B] (means: [cpu:550ns/s, write-bandwidth:0 B/s, byte-size:0 B]) (frac_pending: (src:0.00,target:0.00) (src:0.00,target:0.00))
+[mmaid=1] skipping replica transfers for s1 to try more leases next time
+[mmaid=1] rebalancing pass shed: {s1}
+pending(2)
+change-id=1 store-id=1 node-id=1 range-id=1 load-delta=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=1m0s
+  prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
+  next=(replica-id=1 type=VOTER_FULL)
+change-id=2 store-id=2 node-id=2 range-id=1 load-delta=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=1m0s
+  prev=(replica-id=2 type=VOTER_FULL)
+  next=(replica-id=2 type=VOTER_FULL leaseholder=true)

--- a/pkg/kv/kvserver/allocator/storepool/store_pool.go
+++ b/pkg/kv/kvserver/allocator/storepool/store_pool.go
@@ -713,6 +713,21 @@ func (sp *StorePool) GetStores() map[roachpb.StoreID]roachpb.StoreDescriptor {
 	return stores
 }
 
+// GetStoreStatuses returns a map of store ID to store status for all known stores.
+// TODO(wenyihu6): optimize for the allocation cost on this
+func (sp *StorePool) GetStoreStatuses() map[roachpb.StoreID]StoreStatus {
+	now := sp.clock.Now()
+	timeUntilNodeDead := liveness.TimeUntilNodeDead.Get(&sp.st.SV)
+	timeAfterNodeSuspect := liveness.TimeAfterNodeSuspect.Get(&sp.st.SV)
+
+	result := make(map[roachpb.StoreID]StoreStatus)
+	sp.Details.StoreDetails.Range(func(storeID roachpb.StoreID, sd *StoreDetailMu) bool {
+		result[storeID] = sd.status(now, timeUntilNodeDead, sp.NodeLivenessFn, timeAfterNodeSuspect)
+		return true
+	})
+	return result
+}
+
 // GetStoreDetail returns the store detail for the given storeID.
 func (sp *StorePool) GetStoreDetail(storeID roachpb.StoreID) *StoreDetailMu {
 	detail, ok := sp.Details.StoreDetails.Load(storeID)

--- a/pkg/kv/kvserver/allocator/storepool/store_pool.go
+++ b/pkg/kv/kvserver/allocator/storepool/store_pool.go
@@ -78,38 +78,38 @@ type StoreDetailMu struct {
 	LastUnavailable hlc.Timestamp
 }
 
-// storeStatus is the current status of a store.
-type storeStatus int
+// StoreStatus is the current status of a store.
+type StoreStatus int
 
-// These are the possible values for a storeStatus.
+// These are the possible values for a StoreStatus.
 const (
-	_ storeStatus = iota
+	_ StoreStatus = iota
 	// The store's node is not live or no gossip has been received from
 	// the store for more than the timeUntilNodeDead threshold.
-	storeStatusDead
+	StoreStatusDead
 	// The store isn't available because it hasn't gossiped yet. This
 	// status lasts until either gossip is received from the store or
 	// the timeUntilNodeDead threshold has passed, at which point its
 	// status will change to dead.
-	storeStatusUnknown
+	StoreStatusUnknown
 	// The store is alive but it is throttled.
-	storeStatusThrottled
+	StoreStatusThrottled
 	// The store is alive and available.
-	storeStatusAvailable
+	StoreStatusAvailable
 	// The store is decommissioning.
-	storeStatusDecommissioning
+	StoreStatusDecommissioning
 	// The store failed it's liveness heartbeat recently and is considered
-	// suspect. Consequently, stores always move from `storeStatusUnknown`
+	// suspect. Consequently, stores always move from `StoreStatusUnknown`
 	// (indicating a node that has a non-live node liveness record) to
-	// `storeStatusSuspect`.
-	storeStatusSuspect
+	// `StoreStatusSuspect`.
+	StoreStatusSuspect
 	// The store is alive but is currently marked as draining, so it is not a
 	// candidate for lease transfers or replica rebalancing.
-	storeStatusDraining
+	StoreStatusDraining
 )
 
-func (ss storeStatus) String() string {
-	if ss < storeStatusDead || ss > storeStatusDraining {
+func (ss StoreStatus) String() string {
+	if ss < StoreStatusDead || ss > StoreStatusDraining {
 		panic(fmt.Sprintf("unknown store status: %d", ss))
 	}
 	return [...]string{"",
@@ -118,7 +118,7 @@ func (ss storeStatus) String() string {
 }
 
 // SafeValue implements the redact.SafeValue interface.
-func (ss storeStatus) SafeValue() {}
+func (ss StoreStatus) SafeValue() {}
 
 // Copy returns a deep copy of the StoreDetailMu.
 func (sd *StoreDetailMu) Copy() *StoreDetailMu {
@@ -146,25 +146,25 @@ func (sd *StoreDetailMu) status(
 	deadThreshold time.Duration,
 	nl NodeLivenessFunc,
 	suspectDuration time.Duration,
-) storeStatus {
+) StoreStatus {
 	sd.RLock() // all exist paths will RUnlock() the lock.
 	// During normal operation, we expect the state transitions for stores to look like the following:
 	//
 	//      +-----------------------+
-	//   +- |  storeStatusUnknown   |
+	//   +- |  StoreStatusUnknown   |
 	//   |  +-----------------------+             Successful heartbeats
 	//   |                                        throughout the suspect
 	//   |      +-----------------------+         duration
-	//   +----->| storeStatusAvailable  |<-+---------------------------+
+	//   +----->| StoreStatusAvailable  |<-+---------------------------+
 	//          +-----------------------+  |                           |
 	//                                     |                   +--------------------+
-	//                                     |                   | storeStatusSuspect |
+	//                                     |                   | StoreStatusSuspect |
 	//      +------------------------------+                   +--------------------+
 	//      |      Failed liveness                                     ^
 	//      |      heartbeat                                           |
 	//      |                                                          |
 	//      |  +-------------------------+                             |
-	//      +->|  storeStatusUnavailable |-----------------------------+
+	//      +->|  StoreStatusUnavailable |-----------------------------+
 	//         +-------------------------+    Successful liveness
 	//                                        heartbeat
 	//
@@ -173,8 +173,8 @@ func (sd *StoreDetailMu) status(
 	// write lock, updates the LastUnavailable timestamp, returns the store
 	// status, and unlocks the write lock.
 	updateLastUnavailableAndReturnStatusRLocked := func(
-		lastUnavailable hlc.Timestamp, returnStatus storeStatus,
-	) storeStatus {
+		lastUnavailable hlc.Timestamp, returnStatus StoreStatus,
+	) StoreStatus {
 		sd.RUnlock()
 		sd.Lock()
 		defer sd.Unlock()
@@ -183,7 +183,7 @@ func (sd *StoreDetailMu) status(
 	}
 
 	// returnStatusRLocked unlocks the read lock and returns the store status.
-	returnStatusRLocked := func(returnStatus storeStatus) storeStatus {
+	returnStatusRLocked := func(returnStatus StoreStatus) StoreStatus {
 		defer sd.RUnlock()
 		return returnStatus
 	}
@@ -194,12 +194,12 @@ func (sd *StoreDetailMu) status(
 	// even before the first gossip arrives for a store.
 	deadAsOf := sd.LastUpdatedTime.AddDuration(deadThreshold)
 	if now.After(deadAsOf) {
-		return updateLastUnavailableAndReturnStatusRLocked(now, storeStatusDead)
+		return updateLastUnavailableAndReturnStatusRLocked(now, StoreStatusDead)
 	}
 	// If there's no descriptor (meaning no gossip ever arrived for this
 	// store), return unavailable.
 	if sd.Desc == nil {
-		return returnStatusRLocked(storeStatusUnknown)
+		return returnStatusRLocked(StoreStatusUnknown)
 	}
 
 	// Even if the store has been updated via gossip, we still rely on
@@ -209,31 +209,31 @@ func (sd *StoreDetailMu) status(
 	// dead -> decommissioning -> unknown -> draining -> suspect -> available.
 	switch nl(sd.Desc.Node.NodeID) {
 	case livenesspb.NodeLivenessStatus_DEAD, livenesspb.NodeLivenessStatus_DECOMMISSIONED:
-		return updateLastUnavailableAndReturnStatusRLocked(now, storeStatusDead)
+		return updateLastUnavailableAndReturnStatusRLocked(now, StoreStatusDead)
 	case livenesspb.NodeLivenessStatus_DECOMMISSIONING:
-		return returnStatusRLocked(storeStatusDecommissioning)
+		return returnStatusRLocked(StoreStatusDecommissioning)
 	case livenesspb.NodeLivenessStatus_UNAVAILABLE:
-		return updateLastUnavailableAndReturnStatusRLocked(now, storeStatusUnknown)
+		return updateLastUnavailableAndReturnStatusRLocked(now, StoreStatusUnknown)
 	case livenesspb.NodeLivenessStatus_UNKNOWN:
-		return returnStatusRLocked(storeStatusUnknown)
+		return returnStatusRLocked(StoreStatusUnknown)
 	case livenesspb.NodeLivenessStatus_DRAINING:
-		return updateLastUnavailableAndReturnStatusRLocked(now, storeStatusDraining)
+		return updateLastUnavailableAndReturnStatusRLocked(now, StoreStatusDraining)
 	}
 
 	// A store is throttled if it has missed receiving snapshots recently.
 	if sd.ThrottledUntil.After(now) {
-		return returnStatusRLocked(storeStatusThrottled)
+		return returnStatusRLocked(StoreStatusThrottled)
 	}
 
 	// Check whether the store is currently suspect. We measure that by
 	// looking at the time it was last unavailable making sure we have not seen any
 	// failures for a period of time defined by StoreSuspectDuration.
 	if sd.LastUnavailable.AddDuration(suspectDuration).After(now) {
-		return returnStatusRLocked(storeStatusSuspect)
+		return returnStatusRLocked(StoreStatusSuspect)
 	}
 
 	// Clear out the LastUnavailable once we return available status.
-	return returnStatusRLocked(storeStatusAvailable)
+	return returnStatusRLocked(StoreStatusAvailable)
 }
 
 // localityWithString maintains a string representation of each locality along
@@ -462,7 +462,7 @@ func (sp *StorePool) statusString(nl NodeLivenessFunc) redact.RedactableString {
 		}
 		buf.Print(id)
 		status := detail.status(now, timeUntilNodeDead, nl, timeAfterNodeSuspect)
-		if status != storeStatusAvailable {
+		if status != StoreStatusAvailable {
 			buf.Printf(" (status=%s)", status)
 		}
 		detail.RLock()
@@ -766,7 +766,7 @@ func (sp *StorePool) decommissioningReplicasWithLiveness(
 	for _, repl := range repls {
 		detail := sp.GetStoreDetail(repl.StoreID)
 		switch detail.status(now, timeUntilNodeDead, nl, timeAfterNodeSuspect) {
-		case storeStatusDecommissioning:
+		case StoreStatusDecommissioning:
 			decommissioningReplicas = append(decommissioningReplicas, repl)
 		}
 	}
@@ -817,7 +817,7 @@ func (sp *StorePool) IsDead(storeID roachpb.StoreID) (bool, time.Duration, error
 	return false, deadAsOf.GoTime().Sub(now.GoTime()), nil
 }
 
-// IsUnknown returns true if the given store's status is `storeStatusUnknown`
+// IsUnknown returns true if the given store's status is `StoreStatusUnknown`
 // (i.e. it just failed a liveness heartbeat and we cannot ascertain its
 // liveness or deadness at the moment) or an error if the store is not found in
 // the pool.
@@ -826,17 +826,17 @@ func (sp *StorePool) IsUnknown(storeID roachpb.StoreID) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return status == storeStatusUnknown, nil
+	return status == StoreStatusUnknown, nil
 }
 
-// IsDraining returns true if the given store's status is `storeStatusDraining`
+// IsDraining returns true if the given store's status is `StoreStatusDraining`
 // or an error if the store is not found in the pool.
 func (sp *StorePool) IsDraining(storeID roachpb.StoreID) (bool, error) {
 	status, err := sp.storeStatus(storeID, sp.NodeLivenessFn)
 	if err != nil {
 		return false, err
 	}
-	return status == storeStatusDraining, nil
+	return status == StoreStatusDraining, nil
 }
 
 // IsLive returns true if the node is considered alive by the store pool or an error
@@ -846,7 +846,7 @@ func (sp *StorePool) IsLive(storeID roachpb.StoreID) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return status == storeStatusAvailable, nil
+	return status == StoreStatusAvailable, nil
 }
 
 // IsStoreHealthy returns whether we believe this store can serve requests
@@ -859,7 +859,7 @@ func (sp *StorePool) IsStoreHealthy(storeID roachpb.StoreID) bool {
 		return false
 	}
 	switch status {
-	case storeStatusAvailable, storeStatusDecommissioning, storeStatusDraining:
+	case StoreStatusAvailable, StoreStatusDecommissioning, StoreStatusDraining:
 		return true
 	default:
 		return false
@@ -868,10 +868,10 @@ func (sp *StorePool) IsStoreHealthy(storeID roachpb.StoreID) bool {
 
 func (sp *StorePool) storeStatus(
 	storeID roachpb.StoreID, nl NodeLivenessFunc,
-) (storeStatus, error) {
+) (StoreStatus, error) {
 	sd, ok := sp.Details.StoreDetails.Load(storeID)
 	if !ok {
-		return storeStatusUnknown, errors.Errorf("store %d was not found", storeID)
+		return StoreStatusUnknown, errors.Errorf("store %d was not found", storeID)
 	}
 	// NB: We use clock.Now() instead of clock.PhysicalTime() is order to
 	// take clock signals from remote nodes into consideration.
@@ -885,7 +885,7 @@ func (sp *StorePool) storeStatus(
 // first for live replicas, and the second for dead replicas.
 //
 // - Replicas for which liveness or deadness cannot be ascertained
-// (storeStatusUnknown) are excluded from the returned slices.
+// (StoreStatusUnknown) are excluded from the returned slices.
 //
 // - Replicas on decommissioning node/store are considered live.
 //
@@ -915,17 +915,17 @@ func (sp *StorePool) liveAndDeadReplicasWithLiveness(
 		// Mark replica as dead if store is dead.
 		status := detail.status(now, timeUntilNodeDead, nl, timeAfterNodeSuspect)
 		switch status {
-		case storeStatusDead:
+		case StoreStatusDead:
 			deadReplicas = append(deadReplicas, repl)
-		case storeStatusAvailable, storeStatusThrottled, storeStatusDecommissioning:
+		case StoreStatusAvailable, StoreStatusThrottled, StoreStatusDecommissioning:
 			// We count both available and throttled stores to be live for the
 			// purpose of computing quorum.
 			// We count decommissioning replicas to be alive because they are readable
 			// and should be used for up-replication if necessary.
 			liveReplicas = append(liveReplicas, repl)
-		case storeStatusUnknown:
+		case StoreStatusUnknown:
 		// No-op.
-		case storeStatusSuspect, storeStatusDraining:
+		case StoreStatusSuspect, StoreStatusDraining:
 			if includeSuspectAndDrainingStores {
 				liveReplicas = append(liveReplicas, repl)
 			}
@@ -1216,7 +1216,7 @@ func (sp *StorePool) getStoreListFromIDs(
 			continue
 		}
 		switch s := detail.status(now, timeUntilNodeDead, nl, timeAfterNodeSuspect); s {
-		case storeStatusThrottled:
+		case StoreStatusThrottled:
 			aliveStoreCount++
 			detail.RLock()
 			throttled = append(throttled, detail.throttledBecause)
@@ -1224,14 +1224,14 @@ func (sp *StorePool) getStoreListFromIDs(
 				storeDescriptors = append(storeDescriptors, *detail.Desc)
 			}
 			detail.RUnlock()
-		case storeStatusAvailable:
+		case StoreStatusAvailable:
 			aliveStoreCount++
 			detail.RLock()
 			storeDescriptors = append(storeDescriptors, *detail.Desc)
 			detail.RUnlock()
-		case storeStatusDraining:
+		case StoreStatusDraining:
 			throttled = append(throttled, fmt.Sprintf("s%d: draining", storeID))
-		case storeStatusSuspect:
+		case StoreStatusSuspect:
 			aliveStoreCount++
 			throttled = append(throttled, fmt.Sprintf("s%d: suspect", storeID))
 			if filter != StoreFilterThrottled && filter != StoreFilterSuspect {
@@ -1239,7 +1239,7 @@ func (sp *StorePool) getStoreListFromIDs(
 				storeDescriptors = append(storeDescriptors, *detail.Desc)
 				detail.RUnlock()
 			}
-		case storeStatusDead, storeStatusUnknown, storeStatusDecommissioning:
+		case StoreStatusDead, StoreStatusUnknown, StoreStatusDecommissioning:
 			// Do nothing; this store cannot be used.
 		default:
 			panic(fmt.Sprintf("unknown store status: %d", s))
@@ -1400,9 +1400,9 @@ func (sp *StorePool) isStoreReadyForRoutineReplicaTransferInternal(
 		return false
 	}
 	switch status {
-	case storeStatusThrottled, storeStatusAvailable:
+	case StoreStatusThrottled, StoreStatusAvailable:
 		return true
-	case storeStatusDead, storeStatusUnknown, storeStatusDecommissioning, storeStatusSuspect, storeStatusDraining:
+	case StoreStatusDead, StoreStatusUnknown, StoreStatusDecommissioning, StoreStatusSuspect, StoreStatusDraining:
 		log.VEventf(ctx, 3,
 			"not considering non-live store s%d (%v)", targetStoreID, status)
 		return false

--- a/pkg/kv/kvserver/allocator/storepool/store_pool_test.go
+++ b/pkg/kv/kvserver/allocator/storepool/store_pool_test.go
@@ -617,7 +617,7 @@ func TestStorePoolSuspected(t *testing.T) {
 	// Verify a store that we haven't seen yet is unknown status.
 	detail := sp.GetStoreDetail(0)
 	s := detail.status(now, timeUntilNodeDead, sp.NodeLivenessFn, timeAfterNodeSuspect)
-	require.Equal(t, s, storeStatusUnknown)
+	require.Equal(t, s, StoreStatusUnknown)
 	require.Equal(t, hlc.Timestamp{}, detail.LastUnavailable)
 
 	// Now start gossiping the stores statuses.
@@ -630,54 +630,54 @@ func TestStorePoolSuspected(t *testing.T) {
 	detail = sp.GetStoreDetail(store.StoreID)
 
 	s = detail.status(now, timeUntilNodeDead, sp.NodeLivenessFn, timeAfterNodeSuspect)
-	require.Equal(t, s, storeStatusAvailable)
+	require.Equal(t, s, StoreStatusAvailable)
 	require.Equal(t, hlc.Timestamp{}, detail.LastUnavailable)
 
 	// When the store transitions to unavailable, its status changes to temporarily unknown.
 	mnl.SetNodeStatus(store.Node.NodeID, livenesspb.NodeLivenessStatus_UNAVAILABLE)
 	s = detail.status(now, timeUntilNodeDead, sp.NodeLivenessFn, timeAfterNodeSuspect)
-	require.Equal(t, s, storeStatusUnknown)
+	require.Equal(t, s, StoreStatusUnknown)
 	require.NotEqual(t, hlc.Timestamp{}, detail.LastUnavailable)
 
 	// When the store transitions back to live, it passes through suspect for a period.
 	mnl.SetNodeStatus(store.Node.NodeID, livenesspb.NodeLivenessStatus_LIVE)
 	s = detail.status(now, timeUntilNodeDead, sp.NodeLivenessFn, timeAfterNodeSuspect)
-	require.Equal(t, s, storeStatusSuspect)
+	require.Equal(t, s, StoreStatusSuspect)
 
 	// Once the window has passed, it will return to available.
 	now = now.AddDuration(timeAfterNodeSuspect).AddDuration(time.Millisecond)
 	s = detail.status(now, timeUntilNodeDead, sp.NodeLivenessFn, timeAfterNodeSuspect)
-	require.Equal(t, s, storeStatusAvailable)
+	require.Equal(t, s, StoreStatusAvailable)
 
 	// Return a liveness of dead.
 	mnl.SetNodeStatus(store.Node.NodeID, livenesspb.NodeLivenessStatus_DEAD)
 	s = detail.status(now, timeUntilNodeDead, sp.NodeLivenessFn, timeAfterNodeSuspect)
-	require.Equal(t, s, storeStatusDead)
+	require.Equal(t, s, StoreStatusDead)
 
 	// When the store transitions back to live, it passes through suspect for a period.
 	mnl.SetNodeStatus(store.Node.NodeID, livenesspb.NodeLivenessStatus_LIVE)
 	s = detail.status(now, timeUntilNodeDead, sp.NodeLivenessFn, timeAfterNodeSuspect)
-	require.Equal(t, s, storeStatusSuspect)
+	require.Equal(t, s, StoreStatusSuspect)
 
 	// Verify it also returns correctly to available after suspect time.
 	now = now.AddDuration(timeAfterNodeSuspect).AddDuration(time.Millisecond)
 	s = detail.status(now, timeUntilNodeDead, sp.NodeLivenessFn, timeAfterNodeSuspect)
-	require.Equal(t, s, storeStatusAvailable)
+	require.Equal(t, s, StoreStatusAvailable)
 
 	// Verify that restart after draining also makes it temporarily suspect.
 	mnl.SetNodeStatus(store.Node.NodeID, livenesspb.NodeLivenessStatus_DRAINING)
 	s = detail.status(now, timeUntilNodeDead, sp.NodeLivenessFn, timeAfterNodeSuspect)
-	require.Equal(t, s, storeStatusDraining)
+	require.Equal(t, s, StoreStatusDraining)
 
 	// Verify suspect when restarting after a drain.
 	mnl.SetNodeStatus(store.Node.NodeID, livenesspb.NodeLivenessStatus_LIVE)
 	s = detail.status(now, timeUntilNodeDead, sp.NodeLivenessFn, timeAfterNodeSuspect)
-	require.Equal(t, s, storeStatusSuspect)
+	require.Equal(t, s, StoreStatusSuspect)
 
 	now = now.AddDuration(timeAfterNodeSuspect).AddDuration(time.Millisecond)
 	mnl.SetNodeStatus(store.Node.NodeID, livenesspb.NodeLivenessStatus_LIVE)
 	s = detail.status(now, timeUntilNodeDead, sp.NodeLivenessFn, timeAfterNodeSuspect)
-	require.Equal(t, s, storeStatusAvailable)
+	require.Equal(t, s, StoreStatusAvailable)
 }
 
 func TestGetLocalities(t *testing.T) {

--- a/pkg/kv/kvserver/asim/mmaintegration/mma_store_rebalancer.go
+++ b/pkg/kv/kvserver/asim/mmaintegration/mma_store_rebalancer.go
@@ -152,6 +152,11 @@ func (msr *MMAStoreRebalancer) Tick(ctx context.Context, tick time.Time, s state
 			msr.pendingChangeIdx = 0
 			msr.lastRebalanceTime = tick
 			log.KvDistribution.VInfof(ctx, 1, "no more pending changes to process, will call compute changes again")
+			// Refresh store status from StorePool before computing changes.
+			// This uses the real production RefreshStoreStatus, which queries
+			// StorePool (backed by StatusTracker via NodeLivenessFn) and
+			// translates to MMA's status model.
+			msr.allocator.UpdateStoreStatus(ctx, msr.as.GetMMAStoreStatuses())
 			storeLeaseholderMsg := MakeStoreLeaseholderMsgFromState(s, msr.localStoreID)
 			pendingChanges := msr.allocator.ComputeChanges(ctx, &storeLeaseholderMsg, mmaprototype.ChangeOptions{
 				LocalStoreID: roachpb.StoreID(msr.localStoreID),

--- a/pkg/kv/kvserver/asim/mmaintegration/mma_store_rebalancer.go
+++ b/pkg/kv/kvserver/asim/mmaintegration/mma_store_rebalancer.go
@@ -156,7 +156,7 @@ func (msr *MMAStoreRebalancer) Tick(ctx context.Context, tick time.Time, s state
 			// This uses the real production RefreshStoreStatus, which queries
 			// StorePool (backed by StatusTracker via NodeLivenessFn) and
 			// translates to MMA's status model.
-			msr.allocator.UpdateStoreStatus(ctx, msr.as.GetMMAStoreStatuses())
+			msr.allocator.UpdateStoresStatuses(ctx, msr.as.GetMMAStoreStatuses())
 			storeLeaseholderMsg := MakeStoreLeaseholderMsgFromState(s, msr.localStoreID)
 			pendingChanges := msr.allocator.ComputeChanges(ctx, &storeLeaseholderMsg, mmaprototype.ChangeOptions{
 				LocalStoreID: roachpb.StoreID(msr.localStoreID),

--- a/pkg/kv/kvserver/asim/tests/testdata/non_rand/mma/store_status_shedding.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/non_rand/mma/store_status_shedding.txt
@@ -42,21 +42,12 @@ assertion type=stat stat=replicas ticks=6 exact_bound=0 stores=(4)
 eval duration=6m seed=42 metrics=(replicas,leases,write_bytes_per_second) cfgs=(mma-only)
 ----
 leases#1: first: [s1=40, s2=0, s3=0, s4=0] (stddev=17.32, mean=10.00, sum=40)
-leases#1: last:  [s1=35, s2=0, s3=0, s4=5] (stddev=14.58, mean=10.00, sum=40)
+leases#1: last:  [s1=40, s2=0, s3=0, s4=0] (stddev=17.32, mean=10.00, sum=40)
 leases#1: thrash_pct: [s1=0%, s2=0%, s3=0%, s4=0%]  (sum=0%)
 replicas#1: first: [s1=40, s2=40, s3=40, s4=0] (stddev=17.32, mean=30.00, sum=120)
-replicas#1: last:  [s1=35, s2=40, s3=40, s4=5] (stddev=14.58, mean=30.00, sum=120)
+replicas#1: last:  [s1=40, s2=40, s3=40, s4=0] (stddev=17.32, mean=30.00, sum=120)
 replicas#1: thrash_pct: [s1=0%, s2=0%, s3=0%, s4=0%]  (sum=0%)
-write_bytes_per_second#1: last:  [s1=17489677, s2=19989215, s3=19989215, s4=2499537] (stddev=7284303.98, mean=14991911.00, sum=59967644)
-write_bytes_per_second#1: thrash_pct: [s1=1%, s2=27%, s3=27%, s4=2%]  (sum=57%)
-artifacts[mma-only]: 50eedac335e03fb8
-failed assertion sample 1
-  stat=replicas value=(=0.00) ticks=6
-	store=4 stat=5.00
-	store=4 stat=5.00
-	store=4 stat=5.00
-	store=4 stat=5.00
-	store=4 stat=5.00
-	store=4 stat=5.00
-	store=4 stat=5.00
+write_bytes_per_second#1: last:  [s1=19999999, s2=19999999, s3=19999999, s4=0] (stddev=8660253.60, mean=14999999.25, sum=59999997)
+write_bytes_per_second#1: thrash_pct: [s1=27020%, s2=27020%, s3=27020%, s4=0%]  (sum=81060%)
+artifacts[mma-only]: 9bd6f2a583adcd74
 ==========================

--- a/pkg/kv/kvserver/asim/tests/testdata/non_rand/mma/store_status_shedding.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/non_rand/mma/store_status_shedding.txt
@@ -1,0 +1,62 @@
+# This test verifies MMA's write bandwidth rebalancing respects store status.
+#
+# Setup: 4 nodes, 40 ranges (RF=3). All replicas start on s1,s2,s3 with s1
+# as leaseholder. s4 starts dead. Heavy write load (~19 MiB/s) creates
+# pressure on all replicas. Replicate queue is disabled to isolate MMA behavior.
+#
+# Write bandwidth affects ALL replicas (not just leaseholder), so MMA should
+# move replicas to balance write load. However, since s4 is dead, MMA should
+# NOT move replicas there.
+#
+# Expected: MMA should avoid moving replicas to s4 (dead store).
+gen_cluster nodes=4
+----
+
+setting split_queue_enabled=false
+----
+
+setting replicate_queue_enabled=false
+----
+
+# All ranges start on s1,s2,s3 with s1 as leaseholder. s4 has no replicas.
+gen_ranges ranges=40 placement_type=replica_placement
+{s1:*,s2,s3}:40
+----
+{s1:*,s2,s3}:40
+
+# Write-heavy workload (rw_ratio=0 means 100% writes).
+# High write bandwidth creates pressure on ALL replicas, not just leaseholder.
+# This forces MMA to move replicas, not just leases.
+gen_load rate=20000 rw_ratio=0 min_block=1000 max_block=1000
+----
+19 MiB/s goodput
+
+# Node 4 becomes dead.
+set_status node=4 liveness=dead 
+----
+
+# Assert s4 (dead) should have 0 replicas.
+assertion type=stat stat=replicas ticks=6 exact_bound=0 stores=(4)
+----
+
+eval duration=6m seed=42 metrics=(replicas,leases,write_bytes_per_second) cfgs=(mma-only)
+----
+leases#1: first: [s1=40, s2=0, s3=0, s4=0] (stddev=17.32, mean=10.00, sum=40)
+leases#1: last:  [s1=35, s2=0, s3=0, s4=5] (stddev=14.58, mean=10.00, sum=40)
+leases#1: thrash_pct: [s1=0%, s2=0%, s3=0%, s4=0%]  (sum=0%)
+replicas#1: first: [s1=40, s2=40, s3=40, s4=0] (stddev=17.32, mean=30.00, sum=120)
+replicas#1: last:  [s1=35, s2=40, s3=40, s4=5] (stddev=14.58, mean=30.00, sum=120)
+replicas#1: thrash_pct: [s1=0%, s2=0%, s3=0%, s4=0%]  (sum=0%)
+write_bytes_per_second#1: last:  [s1=17489677, s2=19989215, s3=19989215, s4=2499537] (stddev=7284303.98, mean=14991911.00, sum=59967644)
+write_bytes_per_second#1: thrash_pct: [s1=1%, s2=27%, s3=27%, s4=2%]  (sum=57%)
+artifacts[mma-only]: 50eedac335e03fb8
+failed assertion sample 1
+  stat=replicas value=(=0.00) ticks=6
+	store=4 stat=5.00
+	store=4 stat=5.00
+	store=4 stat=5.00
+	store=4 stat=5.00
+	store=4 stat=5.00
+	store=4 stat=5.00
+	store=4 stat=5.00
+==========================

--- a/pkg/kv/kvserver/mma_store_rebalancer.go
+++ b/pkg/kv/kvserver/mma_store_rebalancer.go
@@ -125,6 +125,7 @@ func (m *mmaStoreRebalancer) start(ctx context.Context, stopper *stop.Stopper) {
 // rebalance may return true if errors happen in the process and fail to apply
 // the changes successfully.
 func (m *mmaStoreRebalancer) rebalance(ctx context.Context, periodicCall bool) bool {
+	m.mma.UpdateStoreStatus(ctx, m.as.GetMMAStoreStatuses())
 	knownStoresByMMA := m.mma.KnownStores()
 	storeLeaseholderMsg, numIgnoredRanges := m.store.MakeStoreLeaseholderMsg(ctx, knownStoresByMMA)
 	if numIgnoredRanges > 0 {

--- a/pkg/kv/kvserver/mma_store_rebalancer.go
+++ b/pkg/kv/kvserver/mma_store_rebalancer.go
@@ -125,7 +125,7 @@ func (m *mmaStoreRebalancer) start(ctx context.Context, stopper *stop.Stopper) {
 // rebalance may return true if errors happen in the process and fail to apply
 // the changes successfully.
 func (m *mmaStoreRebalancer) rebalance(ctx context.Context, periodicCall bool) bool {
-	m.mma.UpdateStoreStatus(ctx, m.as.GetMMAStoreStatuses())
+	m.mma.UpdateStoresStatuses(ctx, m.as.GetMMAStoreStatuses())
 	knownStoresByMMA := m.mma.KnownStores()
 	storeLeaseholderMsg, numIgnoredRanges := m.store.MakeStoreLeaseholderMsg(ctx, knownStoresByMMA)
 	if numIgnoredRanges > 0 {

--- a/pkg/kv/kvserver/mma_store_rebalancer.go
+++ b/pkg/kv/kvserver/mma_store_rebalancer.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/mmaprototype"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/storepool"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/mmaintegration"
@@ -48,18 +47,16 @@ type mmaStoreRebalancer struct {
 	store *mmaStore
 	mma   mmaprototype.Allocator
 	st    *cluster.Settings
-	sp    *storepool.StorePool
 	as    *mmaintegration.AllocatorSync
 }
 
 func newMMAStoreRebalancer(
-	s *Store, mma mmaprototype.Allocator, st *cluster.Settings, sp *storepool.StorePool,
+	s *Store, mma mmaprototype.Allocator, st *cluster.Settings,
 ) *mmaStoreRebalancer {
 	return &mmaStoreRebalancer{
 		store: (*mmaStore)(s),
 		mma:   mma,
 		st:    st,
-		sp:    sp,
 		as:    s.cfg.AllocatorSync,
 	}
 }

--- a/pkg/kv/kvserver/mmaintegration/BUILD.bazel
+++ b/pkg/kv/kvserver/mmaintegration/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "allocator_sync.go",
         "mma_conversion.go",
         "store_load_msg.go",
+        "store_status.go",
         "testing_knobs.go",
         "thrashing.go",
     ],
@@ -16,6 +17,7 @@ go_library(
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver/allocator",
         "//pkg/kv/kvserver/allocator/mmaprototype",
+        "//pkg/kv/kvserver/allocator/storepool",
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/roachpb",
         "//pkg/settings/cluster",
@@ -28,15 +30,20 @@ go_library(
 
 go_test(
     name = "mmaintegration_test",
-    srcs = ["mma_conversion_test.go"],
+    srcs = [
+        "mma_conversion_test.go",
+        "store_status_test.go",
+    ],
     data = glob(["testdata/**"]),
     embed = [":mmaintegration"],
     deps = [
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver/allocator",
         "//pkg/kv/kvserver/allocator/mmaprototype",
+        "//pkg/kv/kvserver/allocator/storepool",
         "//pkg/roachpb",
         "//pkg/testutils/datapathutils",
+        "//pkg/testutils/echotest",
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "@com_github_cockroachdb_datadriven//:datadriven",

--- a/pkg/kv/kvserver/mmaintegration/store_status.go
+++ b/pkg/kv/kvserver/mmaintegration/store_status.go
@@ -1,0 +1,101 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package mmaintegration
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/mmaprototype"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/storepool"
+)
+
+// translateStorePoolStatusToMMA translates a StorePool status to MMA's (health,
+// disposition) model.
+/*
+ StorePool Status Meanings (see storepool.StoreDetailMu.status()):
+
+   - Dead:             No gossip for 5min (TimeUntilNodeDead) OR NodeLivenessStatus is DEAD/DECOMMISSIONED.
+   - Unknown:          No gossip received yet (Desc == nil) OR NodeLivenessStatus is UNAVAILABLE/UNKNOWN.
+   - Decommissioning:  NodeLivenessStatus is DECOMMISSIONING.
+   - Draining:         NodeLivenessStatus is DRAINING.
+   - Throttled:        Rejected snapshots in last 5s (FailedReservationsTimeout).
+   - Suspect:          LastUnavailable was within last 5min (TimeAfterNodeSuspect).
+   - Available:        None of the above; store is healthy.
+
+     | StorePool Status | MMA Health      | Lease Disposition | Replica Disposition | Rationale
+     |------------------|-----------------|-------------------|---------------------|------------------------------------------------------------------------------------------------|
+     | Dead             | HealthDead      | Shedding          | Shedding            | Store is gone: shed everything   (matches SMA)
+     | Decommissioning  | HealthOK        | Shedding          | Shedding            | Store is leaving cluster: shed everything   (SMA allows leases, MMA more aggressive)
+     | Unknown          | HealthUnknown   | Refusing          | Refusing            | State is unknown: don't add but don't remove either   (SMA sheds leases, MMA more conservative)
+     | Draining         | HealthOK        | Shedding          | Refusing            | Store is draining: shed leases, don't add new replicas   (matches SMA)
+     | Throttled        | HealthOK        | OK                | Refusing            | Store recently rejected snapshots: accept leases but not replicas   (matches SMA)
+     | Suspect          | HealthUnhealthy | Shedding          | Refusing            | Recently unavailable: shed leases for safety and don't accept replicas   (matches SMA)
+     | Available        | HealthOK        | OK                | OK                  | Healthy store: accept all   (matches SMA)
+
+ SMA Behavior Reference:
+ Replica Shedding:
+   - Dead: AllocatorReplaceDeadVoter, AllocatorRemoveDeadVoter
+   - Decommissioning: AllocatorReplaceDecommissioningVoter, AllocatorRemoveDecommissioningVoter
+
+ Replica Refusing (excluded as targets):
+   - isStoreReadyForRoutineReplicaTransfer excludes: Dead, Unknown, Decommissioning, Suspect, Draining
+   - StoreFilterThrottled (used for allocation): excludes all except Available
+
+ Lease Shedding (LeaseholderShouldMoveDueToPreferences triggers for):
+   - Dead, Unknown, Suspect, Draining (excluded from LiveAndDeadReplicas candidates)
+   - Decommissioning: leases move indirectly when replicas are shed (SMA doesn't actively shed leases)
+
+ Lease Refusing (excluded as targets via ValidLeaseTargets):
+   - LiveAndDeadReplicas(includeSuspectAndDrainingStores=false) excludes: Dead, Unknown, Suspect, Draining
+*/
+func translateStorePoolStatusToMMA(spStatus storepool.StoreStatus) mmaprototype.Status {
+	switch spStatus {
+	case storepool.StoreStatusDead:
+		return mmaprototype.MakeStatus(
+			mmaprototype.HealthDead,
+			mmaprototype.LeaseDispositionShedding,
+			mmaprototype.ReplicaDispositionShedding,
+		)
+	case storepool.StoreStatusDecommissioning:
+		return mmaprototype.MakeStatus(
+			mmaprototype.HealthOK,
+			mmaprototype.LeaseDispositionShedding,
+			mmaprototype.ReplicaDispositionShedding,
+		)
+	case storepool.StoreStatusUnknown:
+		return mmaprototype.MakeStatus(
+			mmaprototype.HealthUnknown,
+			mmaprototype.LeaseDispositionRefusing,
+			mmaprototype.ReplicaDispositionRefusing,
+		)
+	case storepool.StoreStatusDraining:
+		return mmaprototype.MakeStatus(
+			mmaprototype.HealthOK,
+			mmaprototype.LeaseDispositionShedding,
+			mmaprototype.ReplicaDispositionRefusing,
+		)
+	case storepool.StoreStatusThrottled:
+		return mmaprototype.MakeStatus(
+			mmaprototype.HealthOK,
+			mmaprototype.LeaseDispositionOK,
+			mmaprototype.ReplicaDispositionRefusing,
+		)
+	case storepool.StoreStatusSuspect:
+		return mmaprototype.MakeStatus(
+			mmaprototype.HealthUnhealthy,
+			mmaprototype.LeaseDispositionShedding,
+			mmaprototype.ReplicaDispositionRefusing,
+		)
+	case storepool.StoreStatusAvailable:
+		return mmaprototype.MakeStatus(
+			mmaprototype.HealthOK,
+			mmaprototype.LeaseDispositionOK,
+			mmaprototype.ReplicaDispositionOK,
+		)
+	default:
+		panic(fmt.Sprintf("unknown store status: %d", spStatus))
+	}
+}

--- a/pkg/kv/kvserver/mmaintegration/store_status_test.go
+++ b/pkg/kv/kvserver/mmaintegration/store_status_test.go
@@ -1,0 +1,91 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package mmaintegration
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/mmaprototype"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/storepool"
+	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/echotest"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+// TestTranslateStorePoolStatusToMMA verifies the translation from StorePool
+// status to MMA's (Health, Disposition) model by printing the translation
+// table for all store statuses.
+func TestTranslateStorePoolStatusToMMA(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// All possible StorePool statuses.
+	statuses := []storepool.StoreStatus{
+		storepool.StoreStatusDead,
+		storepool.StoreStatusUnknown,
+		storepool.StoreStatusThrottled,
+		storepool.StoreStatusAvailable,
+		storepool.StoreStatusDecommissioning,
+		storepool.StoreStatusSuspect,
+		storepool.StoreStatusDraining,
+	}
+
+	var output string
+	for _, spStatus := range statuses {
+		mmaStatus := translateStorePoolStatusToMMA(spStatus)
+		output += fmt.Sprintf("%s: health=%s, lease=%s, replica=%s\n",
+			spStatus.String(),
+			formatHealth(mmaStatus.Health),
+			formatLeaseDisposition(mmaStatus.Disposition.Lease),
+			formatReplicaDisposition(mmaStatus.Disposition.Replica),
+		)
+	}
+
+	echotest.Require(t, output, datapathutils.TestDataPath(t, t.Name()))
+}
+
+func formatHealth(h mmaprototype.Health) string {
+	switch h {
+	case mmaprototype.HealthOK:
+		return "OK"
+	case mmaprototype.HealthUnhealthy:
+		return "Unhealthy"
+	case mmaprototype.HealthDead:
+		return "Dead"
+	case mmaprototype.HealthUnknown:
+		return "Unknown"
+	default:
+		return fmt.Sprintf("Unknown(%d)", h)
+	}
+}
+
+func formatLeaseDisposition(d mmaprototype.LeaseDisposition) string {
+	switch d {
+	case mmaprototype.LeaseDispositionOK:
+		return "OK"
+	case mmaprototype.LeaseDispositionShedding:
+		return "Shedding"
+	case mmaprototype.LeaseDispositionRefusing:
+		return "Refusing"
+	default:
+		return fmt.Sprintf("Unknown(%d)", d)
+	}
+}
+
+func formatReplicaDisposition(d mmaprototype.ReplicaDisposition) string {
+	switch d {
+	case mmaprototype.ReplicaDispositionOK:
+		return "OK"
+	case mmaprototype.ReplicaDispositionShedding:
+		return "Shedding"
+	case mmaprototype.ReplicaDispositionRefusing:
+		return "Refusing"
+	default:
+		return fmt.Sprintf("Unknown(%d)", d)
+	}
+}

--- a/pkg/kv/kvserver/mmaintegration/testdata/TestTranslateStorePoolStatusToMMA
+++ b/pkg/kv/kvserver/mmaintegration/testdata/TestTranslateStorePoolStatusToMMA
@@ -1,0 +1,11 @@
+# This test verifies the translation layer from StorePool status to mma's
+# (Health, Disposition) model.
+echo
+----
+dead: health=Dead, lease=Shedding, replica=Shedding
+unknown: health=Unknown, lease=Refusing, replica=Refusing
+throttled: health=OK, lease=OK, replica=Refusing
+available: health=OK, lease=OK, replica=OK
+decommissioning: health=OK, lease=Shedding, replica=Shedding
+suspect: health=Unhealthy, lease=Shedding, replica=Refusing
+draining: health=OK, lease=Shedding, replica=Refusing

--- a/pkg/kv/kvserver/mmaintegration/testdata/TestTranslateStorePoolStatusToMMA
+++ b/pkg/kv/kvserver/mmaintegration/testdata/TestTranslateStorePoolStatusToMMA
@@ -3,9 +3,9 @@
 echo
 ----
 dead: health=Dead, lease=Shedding, replica=Shedding
-unknown: health=Unknown, lease=Refusing, replica=Refusing
+unknown: health=Unknown, lease=Shedding, replica=Refusing
 throttled: health=OK, lease=OK, replica=Refusing
 available: health=OK, lease=OK, replica=OK
-decommissioning: health=OK, lease=Shedding, replica=Shedding
+decommissioning: health=OK, lease=Refusing, replica=Shedding
 suspect: health=Unhealthy, lease=Shedding, replica=Refusing
 draining: health=OK, lease=Shedding, replica=Refusing

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1773,7 +1773,7 @@ func NewStore(
 		s.splitQueue = newSplitQueue(s, s.db)
 		s.replicateQueue = newReplicateQueue(s, s.allocator)
 		s.replicaGCQueue = newReplicaGCQueue(s, s.db)
-		s.mmaStoreRebalancer = newMMAStoreRebalancer(s, s.cfg.MMAllocator, s.cfg.Settings, s.cfg.StorePool)
+		s.mmaStoreRebalancer = newMMAStoreRebalancer(s, s.cfg.MMAllocator, s.cfg.Settings)
 		s.raftLogQueue = newRaftLogQueue(s, s.db)
 		s.raftSnapshotQueue = newRaftSnapshotQueue(s)
 		s.consistencyQueue = newConsistencyQueue(s)

--- a/pkg/testutils/lint/passes/redactcheck/redactcheck.go
+++ b/pkg/testutils/lint/passes/redactcheck/redactcheck.go
@@ -108,7 +108,7 @@ func runAnalyzer(pass *analysis.Pass) (interface{}, error) {
 						"Dimension": {},
 					},
 					"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/storepool": {
-						"storeStatus": {},
+						"StoreStatus": {},
 					},
 					"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/mmaprototype": {
 						"LoadValue": {},


### PR DESCRIPTION
Backport:
  * 1/1 commits from "mmaprototype: improve comments on gaps in health status" (#160015)
  * 2/2 commits from "storepool: export GetStoreStatuses for mma health signal plumbing" (#160555)
  * 3/3 commits from "mmaintegration: add StoreStatus to mma status translation plumbing" (#160623)
  * 1/1 commits from "mmaintegration: update Unknown and Decommissioning translation" (#160698)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: low risk mmaprototype work 
