### PR TITLE
acceptance: skip mismatched-locality test

### DIFF
--- a/pkg/cmd/roachtest/tests/acceptance.go
+++ b/pkg/cmd/roachtest/tests/acceptance.go
@@ -116,6 +116,7 @@ func registerAcceptance(r registry.Registry) {
 			{
 				name:     "mismatched-locality",
 				fn:       runMismatchedLocalityTest,
+				skip:     "TODO(#160845): unskip this",
 				numNodes: 3,
 			},
 		},


### PR DESCRIPTION
I've seen this test timeout multiple times in the last 24 hours via bors staging run, so let's skip it. I only looked into one failure and in there we got stuck waiting for up-replication.

Informs: #160845.
Epic: None
Release note: None