### PR TITLE
clusterversion: prefix version keys below 25.4 with TODO_Delete_

### DIFF
--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -191,46 +191,46 @@ const (
 	// V25_2 is CockroachDB v25.2. It's used for all v25.2.x patch releases.
 	V25_2
 
-	V25_3_Start
+	TODO_Delete_V25_3_Start
 
-	V25_3_AddEventLogColumnAndIndex
+	TODO_Delete_V25_3_AddEventLogColumnAndIndex
 
-	V25_3_AddEstimatedLastLoginTime
+	TODO_Delete_V25_3_AddEstimatedLastLoginTime
 
-	V25_3_AddHotRangeLoggerJob
+	TODO_Delete_V25_3_AddHotRangeLoggerJob
 
 	// V25_3 is CockroachDB v25.3. It's used for all v25.3.x patch releases.
 	V25_3
 
-	V25_4_Start
+	TODO_Delete_V25_4_Start
 
-	// V25_4_WriteInitialTruncStateBeforeSplitApplication is the version above
+	// TODO_Delete_V25_4_WriteInitialTruncStateBeforeSplitApplication is the version above
 	// which we write the initial truncated state before applying a split. By
 	// extension, we no longer need to replicate the truncated state when
 	// constructing the split write batch.
-	V25_4_WriteInitialTruncStateBeforeSplitApplication
+	TODO_Delete_V25_4_WriteInitialTruncStateBeforeSplitApplication
 
-	// V25_4_PebbleFormatV2BlobFiles bumps the pebble format to FormatV2BlobFiles.
-	V25_4_PebbleFormatV2BlobFiles
+	// TODO_Delete_V25_4_PebbleFormatV2BlobFiles bumps the pebble format to FormatV2BlobFiles.
+	TODO_Delete_V25_4_PebbleFormatV2BlobFiles
 
-	// V25_4_InspectErrorsTable adds the system.inspect_errors table. The table
+	// TODO_Delete_V25_4_InspectErrorsTable adds the system.inspect_errors table. The table
 	// will be used to log the results of INSPECT jobs.
-	V25_4_InspectErrorsTable
+	TODO_Delete_V25_4_InspectErrorsTable
 
-	// V25_4_TransactionDiagnosticsSupport adds the system.transaction_diagnostics_requests and
+	// TODO_Delete_V25_4_TransactionDiagnosticsSupport adds the system.transaction_diagnostics_requests and
 	// system.transaction_diagnostics tables, and adds a transaction_diagnostics_id column to
 	// system.statement_diagnostics to support transaction-level diagnostic bundle collection.
-	V25_4_TransactionDiagnosticsSupport
+	TODO_Delete_V25_4_TransactionDiagnosticsSupport
 
-	// V25_4_SystemStatsTablesAutostatsFraction sets the autostats fraction for
+	// TODO_Delete_V25_4_SystemStatsTablesAutostatsFraction sets the autostats fraction for
 	// system.statement_statistics and system.transaction_statistics to 0.9
 	// to reduce frequent automatic statistics collection.
-	V25_4_SystemStatsTablesAutostatsFraction
+	TODO_Delete_V25_4_SystemStatsTablesAutostatsFraction
 
-	// V25_4_AddSystemStatementHintsTable adds the system.statement_hints table.
+	// TODO_Delete_V25_4_AddSystemStatementHintsTable adds the system.statement_hints table.
 	// The table is used to contain "external" hints, i.e. hints that are
 	// associated with a query without modifying the query or application itself.
-	V25_4_AddSystemStatementHintsTable
+	TODO_Delete_V25_4_AddSystemStatementHintsTable
 
 	// V25_4 is CockroachDB v25.4. It's used for all v25.4.x patch releases.
 	V25_4
@@ -285,29 +285,29 @@ var versionTable = [numKeys]roachpb.Version{
 	V25_2: {Major: 25, Minor: 2, Internal: 0},
 
 	// v25.3 versions. Internal versions must be even.
-	V25_3_Start: {Major: 25, Minor: 2, Internal: 2},
+	TODO_Delete_V25_3_Start: {Major: 25, Minor: 2, Internal: 2},
 
-	V25_3_AddEventLogColumnAndIndex: {Major: 25, Minor: 2, Internal: 4},
+	TODO_Delete_V25_3_AddEventLogColumnAndIndex: {Major: 25, Minor: 2, Internal: 4},
 
-	V25_3_AddEstimatedLastLoginTime: {Major: 25, Minor: 2, Internal: 6},
+	TODO_Delete_V25_3_AddEstimatedLastLoginTime: {Major: 25, Minor: 2, Internal: 6},
 
-	V25_3_AddHotRangeLoggerJob: {Major: 25, Minor: 2, Internal: 8},
+	TODO_Delete_V25_3_AddHotRangeLoggerJob: {Major: 25, Minor: 2, Internal: 8},
 
 	V25_3: {Major: 25, Minor: 3, Internal: 0},
 
 	// v25.4 versions. Internal versions must be even.
-	V25_4_Start: {Major: 25, Minor: 3, Internal: 2},
+	TODO_Delete_V25_4_Start: {Major: 25, Minor: 3, Internal: 2},
 
-	V25_4_WriteInitialTruncStateBeforeSplitApplication: {Major: 25, Minor: 3, Internal: 4},
-	V25_4_PebbleFormatV2BlobFiles:                      {Major: 25, Minor: 3, Internal: 6},
+	TODO_Delete_V25_4_WriteInitialTruncStateBeforeSplitApplication: {Major: 25, Minor: 3, Internal: 4},
+	TODO_Delete_V25_4_PebbleFormatV2BlobFiles:                      {Major: 25, Minor: 3, Internal: 6},
 
-	V25_4_InspectErrorsTable: {Major: 25, Minor: 3, Internal: 8},
+	TODO_Delete_V25_4_InspectErrorsTable: {Major: 25, Minor: 3, Internal: 8},
 
-	V25_4_TransactionDiagnosticsSupport: {Major: 25, Minor: 3, Internal: 10},
+	TODO_Delete_V25_4_TransactionDiagnosticsSupport: {Major: 25, Minor: 3, Internal: 10},
 
-	V25_4_SystemStatsTablesAutostatsFraction: {Major: 25, Minor: 3, Internal: 12},
+	TODO_Delete_V25_4_SystemStatsTablesAutostatsFraction: {Major: 25, Minor: 3, Internal: 12},
 
-	V25_4_AddSystemStatementHintsTable: {Major: 25, Minor: 3, Internal: 14},
+	TODO_Delete_V25_4_AddSystemStatementHintsTable: {Major: 25, Minor: 3, Internal: 14},
 
 	V25_4: {Major: 25, Minor: 4, Internal: 0},
 

--- a/pkg/clusterversion/runbooks/M4_bump_minsupported_version_QUICK.md
+++ b/pkg/clusterversion/runbooks/M4_bump_minsupported_version_QUICK.md
@@ -382,3 +382,49 @@ Before creating PR, verify these files were updated:
 | Duplicate statement errors | Manually review files with `onlyif` - see full runbook |
 
 **Full troubleshooting:** See main runbook section "Common Errors and Solutions"
+
+---
+
+## Third PR: Prefix Old Version Gates with TODO_Delete_
+
+After both MinSupported bump PRs are merged, create a third PR to mark obsolete version gates.
+
+### What to Do
+
+Prefix all non-permanent version keys below MinSupported with `TODO_Delete_`:
+
+**Example:**
+```go
+// Before:
+V25_2_Start
+V25_3_AddEventLogColumnAndIndex
+
+// After:
+TODO_Delete_V25_2_Start
+TODO_Delete_V25_3_AddEventLogColumnAndIndex
+```
+
+**Rules:**
+- Prefix if: `Internal != 0` AND version value `< MinSupported`
+- Do NOT prefix: Final release keys (e.g., `V25_2`, `V25_3`)
+- Do NOT prefix: Bootstrap keys (`Major: 0, Minor: 0`)
+
+### Files to Update
+
+1. `pkg/clusterversion/cockroach_versions.go` - Add prefix to key names and versionTable
+2. Update all references: `git grep V25_2_Start` and replace with `TODO_Delete_V25_2_Start`
+3. Update test files that use these keys
+
+**Example PR:** #160852
+
+### After Merging: Create Cleanup Issues
+
+Create GitHub issues for teams to remove the TODO_Delete_ gates:
+
+1. Find original PRs: `git log -S "V25_3_GateName"`
+2. Determine team ownership from PR approvals (use GraphQL API)
+3. Create one issue per team with their gates listed
+
+**Example issues:** #160856, #160857, #160858, #160859, #160860, #160861
+
+**Full details:** See main runbook "Post-Commit: Create Cleanup Issues for Teams"

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -1554,11 +1554,11 @@ func splitTriggerHelper(
 			return enginepb.MVCCStats{}, result.Result{}, errors.Wrap(err, "unable to write initial Replica state")
 		}
 		// TODO(arulajmani): This can be removed once all nodes are past the
-		// V25_4_WriteInitialTruncStateBeforeSplitApplication cluster version.
+		// TODO_Delete_V25_4_WriteInitialTruncStateBeforeSplitApplication cluster version.
 		// At that point, we'll no longer need to replicate the truncated state
 		// as all replicas will be responsible for writing it locally before
 		// applying the split.
-		if !rec.ClusterSettings().Version.IsActive(ctx, clusterversion.V25_4_WriteInitialTruncStateBeforeSplitApplication) {
+		if !rec.ClusterSettings().Version.IsActive(ctx, clusterversion.TODO_Delete_V25_4_WriteInitialTruncStateBeforeSplitApplication) {
 			if err := kvstorage.WriteInitialTruncState(ctx,
 				spanset.DisableForbiddenSpanAssertions(batch), split.RightDesc.RangeID); err != nil {
 				return enginepb.MVCCStats{}, result.Result{}, errors.Wrap(err, "unable to write initial Replica state")

--- a/pkg/upgrade/upgrades/upgrades.go
+++ b/pkg/upgrade/upgrades/upgrades.go
@@ -59,11 +59,11 @@ var upgrades = []upgradebase.Upgrade{
 		bootstrapCluster,
 		upgrade.RestoreActionNotRequired("initialization runs before restore")),
 
-	newFirstUpgrade(clusterversion.V25_3_Start.Version()),
+	newFirstUpgrade(clusterversion.TODO_Delete_V25_3_Start.Version()),
 
 	upgrade.NewTenantUpgrade(
 		"add 'payload' column to system.eventlog table and add new index on eventType column",
-		clusterversion.V25_3_AddEventLogColumnAndIndex.Version(),
+		clusterversion.TODO_Delete_V25_3_AddEventLogColumnAndIndex.Version(),
 		upgrade.NoPrecondition,
 		eventLogTableMigration,
 		upgrade.RestoreActionNotRequired("cluster restore does not restore the new column or index"),
@@ -71,7 +71,7 @@ var upgrades = []upgradebase.Upgrade{
 
 	upgrade.NewTenantUpgrade(
 		"add 'estimated_last_login_time' column to system.users table",
-		clusterversion.V25_3_AddEstimatedLastLoginTime.Version(),
+		clusterversion.TODO_Delete_V25_3_AddEstimatedLastLoginTime.Version(),
 		upgrade.NoPrecondition,
 		usersLastLoginTimeTableMigration,
 		upgrade.RestoreActionNotRequired("cluster restore does not restore the new column"),
@@ -79,17 +79,17 @@ var upgrades = []upgradebase.Upgrade{
 
 	upgrade.NewTenantUpgrade(
 		"add new hot range logger job",
-		clusterversion.V25_3_AddHotRangeLoggerJob.Version(),
+		clusterversion.TODO_Delete_V25_3_AddHotRangeLoggerJob.Version(),
 		upgrade.NoPrecondition,
 		addHotRangeLoggerJob,
 		upgrade.RestoreActionNotRequired("cluster restore does not restore this job"),
 	),
 
-	newFirstUpgrade(clusterversion.V25_4_Start.Version()),
+	newFirstUpgrade(clusterversion.TODO_Delete_V25_4_Start.Version()),
 
 	upgrade.NewTenantUpgrade(
 		"add new system.inspect_errors table",
-		clusterversion.V25_4_InspectErrorsTable.Version(),
+		clusterversion.TODO_Delete_V25_4_InspectErrorsTable.Version(),
 		upgrade.NoPrecondition,
 		createInspectErrorsTable,
 		upgrade.RestoreActionNotRequired("cluster restore does not restore this table"),
@@ -97,7 +97,7 @@ var upgrades = []upgradebase.Upgrade{
 
 	upgrade.NewTenantUpgrade(
 		"add transaction diagnostics tables and update statement_diagnostics table",
-		clusterversion.V25_4_TransactionDiagnosticsSupport.Version(),
+		clusterversion.TODO_Delete_V25_4_TransactionDiagnosticsSupport.Version(),
 		upgrade.NoPrecondition,
 		createTransactionDiagnosticsTables,
 		upgrade.RestoreActionNotRequired("cluster restore does not restore these tables"),
@@ -105,7 +105,7 @@ var upgrades = []upgradebase.Upgrade{
 
 	upgrade.NewTenantUpgrade(
 		"set autostats fraction for system stats tables",
-		clusterversion.V25_4_SystemStatsTablesAutostatsFraction.Version(),
+		clusterversion.TODO_Delete_V25_4_SystemStatsTablesAutostatsFraction.Version(),
 		upgrade.NoPrecondition,
 		systemStatsTablesAutostatsFractionMigration,
 		upgrade.RestoreActionNotRequired("cluster restore does not restore table storage parameters"),
@@ -113,7 +113,7 @@ var upgrades = []upgradebase.Upgrade{
 
 	upgrade.NewTenantUpgrade(
 		"create statement_hints table",
-		clusterversion.V25_4_AddSystemStatementHintsTable.Version(),
+		clusterversion.TODO_Delete_V25_4_AddSystemStatementHintsTable.Version(),
 		upgrade.NoPrecondition,
 		createStatementHintsTable,
 		upgrade.RestoreActionNotRequired(

--- a/pkg/upgrade/upgrades/v25_3_add_event_log_column_and_index_test.go
+++ b/pkg/upgrade/upgrades/v25_3_add_event_log_column_and_index_test.go
@@ -88,7 +88,7 @@ func TestEventLogTableMigration(t *testing.T) {
 	upgrades.Upgrade(
 		t,
 		sqlDB,
-		clusterversion.V25_3_AddEventLogColumnAndIndex,
+		clusterversion.TODO_Delete_V25_3_AddEventLogColumnAndIndex,
 		nil,   /* done */
 		false, /* expectError */
 	)

--- a/pkg/upgrade/upgrades/v25_3_add_users_last_login_time_column_test.go
+++ b/pkg/upgrade/upgrades/v25_3_add_users_last_login_time_column_test.go
@@ -85,7 +85,7 @@ func TestUsersLastLoginTimeTableMigration(t *testing.T) {
 	upgrades.Upgrade(
 		t,
 		sqlDB,
-		clusterversion.V25_3_AddEstimatedLastLoginTime,
+		clusterversion.TODO_Delete_V25_3_AddEstimatedLastLoginTime,
 		nil,   /* done */
 		false, /* expectError */
 	)

--- a/pkg/upgrade/upgrades/v25_4_inspect_errors_table_test.go
+++ b/pkg/upgrade/upgrades/v25_4_inspect_errors_table_test.go
@@ -45,7 +45,7 @@ func TestInspectErrorsTable(t *testing.T) {
 	require.True(t, s.ExecutorConfig().(sql.ExecutorConfig).Codec.ForSystemTenant())
 	_, err := sqlDB.Exec("SELECT * FROM system.inspect_errors")
 	require.Error(t, err, "system.inspect_errors rates columns should not exist")
-	upgrades.Upgrade(t, sqlDB, clusterversion.V25_4_InspectErrorsTable, nil, false)
+	upgrades.Upgrade(t, sqlDB, clusterversion.TODO_Delete_V25_4_InspectErrorsTable, nil, false)
 	_, err = sqlDB.Exec("SELECT * FROM system.inspect_errors")
 	require.NoError(t, err, "system.inspect_errors rates columns should exist")
 }

--- a/pkg/upgrade/upgrades/v25_4_system_statement_hints_test.go
+++ b/pkg/upgrade/upgrades/v25_4_system_statement_hints_test.go
@@ -45,7 +45,7 @@ func TestStatementHintsTable(t *testing.T) {
 	require.True(t, s.ExecutorConfig().(sql.ExecutorConfig).Codec.ForSystemTenant())
 	_, err := sqlDB.Exec("SELECT * FROM system.statement_hints")
 	require.Error(t, err, "system.statement_hints should not exist")
-	upgrades.Upgrade(t, sqlDB, clusterversion.V25_4_AddSystemStatementHintsTable, nil, false)
+	upgrades.Upgrade(t, sqlDB, clusterversion.TODO_Delete_V25_4_AddSystemStatementHintsTable, nil, false)
 	_, err = sqlDB.Exec("SELECT * FROM system.statement_hints")
 	require.NoError(t, err, "system.statement_hints should exist")
 }

--- a/pkg/upgrade/upgrades/v25_4_system_stats_tables_autostats_fraction_test.go
+++ b/pkg/upgrade/upgrades/v25_4_system_stats_tables_autostats_fraction_test.go
@@ -75,7 +75,7 @@ func TestStatsTablesAutostatsFunctionMigration(t *testing.T) {
 	upgrades.Upgrade(
 		t,
 		sqlDB,
-		clusterversion.V25_4_SystemStatsTablesAutostatsFraction,
+		clusterversion.TODO_Delete_V25_4_SystemStatsTablesAutostatsFraction,
 		nil,   /* done */
 		false, /* expectError */
 	)

--- a/pkg/upgrade/upgrades/v25_4_transaction_diagnostics_tables_test.go
+++ b/pkg/upgrade/upgrades/v25_4_transaction_diagnostics_tables_test.go
@@ -90,7 +90,7 @@ func TestTransactionDiagnosticsTableMigration(t *testing.T) {
 	upgrades.Upgrade(
 		t,
 		sqlDB,
-		clusterversion.V25_4_TransactionDiagnosticsSupport,
+		clusterversion.TODO_Delete_V25_4_TransactionDiagnosticsSupport,
 		nil,   /* done */
 		false, /* expectError */
 	)


### PR DESCRIPTION
Part of the quarterly M.4 "Bump MinSupported" task (part 3) as outlined in `pkg/clusterversion/README.md`.

This commit marks version keys below v25.4 with the TODO_Delete_ prefix to indicate they will be removed in the next major release.

After bumping MinSupported from v25.2 to v25.4, all version gates for v25.2 and v25.3 features are always active and can be simplified. This prefix helps track which version checks are obsolete.

### Changes
- Prefixed all V25_3_* internal version keys with `TODO_Delete_`
- Updated all references in upgrade code and tests
- Build and tests passing

Part of the cleanup following the MinSupported bump.

### Tracking issues for version gate cleanup

- T-observability (4 gates): https://github.com/cockroachdb/cockroach/issues/160856
- T-release (2 gates): https://github.com/cockroachdb/cockroach/issues/160857
- T-sql-foundations (2 gates): https://github.com/cockroachdb/cockroach/issues/160858
- T-kv (1 gate): https://github.com/cockroachdb/cockroach/issues/160859
- T-storage (1 gate): https://github.com/cockroachdb/cockroach/issues/160860
- T-sql-queries (1 gate): https://github.com/cockroachdb/cockroach/issues/160861


Release note: None
Epic: None
