### PR TITLE
kvserver: deflake TestMaybeMarkReplicaUnavailableInLeaderlessWatcher

### DIFF
--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -244,6 +244,15 @@ func (lw *leaderlessWatcher) IsUnavailable() bool {
 	return lw.mu.unavailable
 }
 
+// LeaderlessSince returns the time at which the replica was first observed to
+// be leaderless. It is reset to zero if the replica has a leader.
+func (lw *leaderlessWatcher) LeaderlessSince() time.Time {
+	lw.mu.RLock()
+	defer lw.mu.RUnlock()
+
+	return lw.mu.leaderlessTimestamp
+}
+
 // refreshUnavailableState refreshes the unavailable state on the leaderless
 // watcher. Replicas are considered unavailable if they have been leaderless for
 // a long time, where long is defined by the ReplicaUnavailableThreshold.


### PR DESCRIPTION
In #160692, this test failed with:

```
Error Trace:	pkg/kv/kvserver/replica_raft_test.go:495
Error:      	Expect "<nil>" to match "replica has been leaderless for 1m0s"
```

My suspicion is that under race, we are sometimes slow enough for the actual raft tick to come around and mark us as having a leader.

Here, I set the RaftTickInterval to MaxInt32 and also add subtests so that it is easier to know which subcase is failing if it fails again.

Fixes #160692
Release note: none