### PR TITLE
build: add label validation for release-25.4 branch in CI essentials

### DIFF
--- a/.github/workflows/github-actions-essential-ci.yml
+++ b/.github/workflows/github-actions-essential-ci.yml
@@ -131,6 +131,19 @@ jobs:
       - name: clean up
         run: ./cockroach/build/github/cleanup-engflow-keys.sh
         if: always()
+  label_validation:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: startsWith(github.base_ref, 'release-')
+    steps:
+      - name: Check for do-not-merge label on release branches
+        run: |
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'do-not-merge') }}" == "true" ]]; then
+            echo "Error: PR has 'do-not-merge' label and cannot be merged to release branch"
+            exit 1
+          else
+            echo "Label validation passed for release branch"
+          fi
   lint:
     runs-on: [self-hosted, ubuntu_huge_2004]
     timeout-minutes: 120


### PR DESCRIPTION
Trunk merge queue will be enabled on `release-25.4` branch. Currently, Trunk does not have option for [block_labels](https://github.com/cockroachdb/cockroach/blob/master/.github/bors.toml#L29C1-L29C13). `backport` label is not added as all the PRs to `release-25.4` branch will have backport label.

Part of: CODESYS-228