### PR TITLE
release-26.1: sql/inspect: deflake TestDetectIndexConsistencyErrors

### DIFF
--- a/pkg/sql/inspect/BUILD.bazel
+++ b/pkg/sql/inspect/BUILD.bazel
@@ -112,6 +112,7 @@ go_test(
         "//pkg/sql/execinfrapb",
         "//pkg/sql/isql",
         "//pkg/sql/rowenc",
+        "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/testutils",

--- a/pkg/sql/inspect/index_consistency_check_test.go
+++ b/pkg/sql/inspect/index_consistency_check_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -137,6 +138,9 @@ func TestDetectIndexConsistencyErrors(t *testing.T) {
 				},
 				GCJob: &sql.GCJobTestingKnobs{
 					SkipWaitingForMVCCGC: true,
+				},
+				SQLEvalContext: &eval.TestingKnobs{
+					ForceProductionValues: true,
 				},
 				JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 			},


### PR DESCRIPTION
Backport 1/1 commits from #160704 on behalf of @fqazi.

----

Previously, this test could take longer to run depending on what the KV batch size values were when executing SQL. To ensure more stable performance and less risk of flaking, we are going to force production values for this test.

Fixes: #159521
Release note: None

----

Release justification: test only change