### PR TITLE
jobs: skip stale pts check for cancel requested jobs

### DIFF
--- a/pkg/jobs/metricspoller/job_statistics.go
+++ b/pkg/jobs/metricspoller/job_statistics.go
@@ -241,7 +241,33 @@ func processJobPTSRecord(
 		}
 	}()
 
-	err := execCfg.JobRegistry.UpdateJobWithTxn(ctx, jobspb.JobID(jobID), txn,
+	// Check if job is already in cancel-requested state to avoid unnecessary
+	// payload/progress contention.
+	row, err := txn.QueryRowEx(
+		ctx, "check-job-status-for-pts", txn.KV(), sessiondata.NodeUserSessionDataOverride,
+		"SELECT status FROM system.jobs WHERE id = $1", jobID,
+	)
+	if err != nil {
+		return err
+	}
+	if row == nil {
+		log.Dev.Warningf(ctx, "job %d not found when processing its protected timestamp record %s", jobID, rec.ID)
+		return nil
+	}
+	statusStr, ok := row[0].(*tree.DString)
+	if !ok {
+		return errors.AssertionFailedf("expected *DString for job status, got %T", row[0])
+	}
+
+	st := jobs.State(*statusStr)
+
+	// Only cancel a job that is running, reverting, or paused.
+	if !(st == jobs.StateRunning || st == jobs.StateReverting || st == jobs.StatePaused) {
+		log.Dev.Infof(ctx, "job %d in %s state; skipping PTS age check", jobID, st)
+		return nil
+	}
+
+	err = execCfg.JobRegistry.UpdateJobWithTxn(ctx, jobspb.JobID(jobID), txn,
 		func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
 			p := md.Payload
 			jobType, err := p.CheckType()


### PR DESCRIPTION
The stale pts check will load in job progress/payload, even if the job is already in a cancel requested state. If the cancel requested queue is backed up, we have seen a single job processed over a hundred times, which simply leads to more contention. This patch reduces this contention by quickly checking if the job is in a cancel requested state before payload/progress reading.

Informs: #158979

Release note: none