### PR TITLE
util/metamorphic: remove ConstantWithTestValue in favor of Range variant

### DIFF
--- a/pkg/sql/row/kv_batch_fetcher.go
+++ b/pkg/sql/row/kv_batch_fetcher.go
@@ -49,10 +49,11 @@ func getKVBatchSize(forceProductionKVBatchSize bool) rowinfra.KeyLimit {
 	return defaultKVBatchSize
 }
 
-var defaultKVBatchSize = rowinfra.KeyLimit(metamorphic.ConstantWithTestValue(
+var defaultKVBatchSize = rowinfra.KeyLimit(metamorphic.ConstantWithTestRange(
 	"kv-batch-size",
 	int(rowinfra.ProductionKVBatchSize), /* defaultValue */
-	1,                                   /* metamorphicValue */
+	1,                                   /* min */
+	100,                                 /* max */
 ))
 
 // elasticCPUDurationPerLowPriReadResponse controls how many CPU tokens are allotted

--- a/pkg/sql/row/row_converter.go
+++ b/pkg/sql/row/row_converter.go
@@ -257,10 +257,11 @@ type DatumRowConverter struct {
 	db *kv.DB
 }
 
-var kvDatumRowConverterBatchSize = metamorphic.ConstantWithTestValue(
+var kvDatumRowConverterBatchSize = metamorphic.ConstantWithTestRange(
 	"datum-row-converter-batch-size",
 	5000, /* defaultValue */
-	1,    /* metamorphicValue */
+	1,    /* min */
+	100,  /* max */
 )
 
 const kvDatumRowConverterBatchMemSize = 4 << 20

--- a/pkg/sql/rowcontainer/datum_row_container.go
+++ b/pkg/sql/rowcontainer/datum_row_container.go
@@ -97,10 +97,11 @@ func NewRowContainerWithCapacity(
 	return c
 }
 
-var rowsPerChunkShift = uint(metamorphic.ConstantWithTestValue(
+var rowsPerChunkShift = uint(metamorphic.ConstantWithTestRange(
 	"row-container-rows-per-chunk-shift",
 	6, /* defaultValue */
-	1, /* metamorphicValue */
+	1, /* min */
+	6, /* max */
 ))
 
 // Init can be used instead of NewRowContainer if we have a RowContainer that is

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -39,10 +39,11 @@ import (
 // higher scan throughput of larger batches and the cost of spilling the
 // scanned rows to disk. The spilling cost will probably be dominated by
 // the de-duping cost, since it incurs a read.
-var invertedJoinerBatchSize = metamorphic.ConstantWithTestValue(
+var invertedJoinerBatchSize = metamorphic.ConstantWithTestRange(
 	"inverted-joiner-batch-size",
 	100, /* defaultValue */
-	1,   /* metamorphicValue */
+	1,   /* min */
+	10,  /* max */
 )
 
 // invertedJoinerState represents the state of the processor.

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -255,10 +255,11 @@ type zigzagJoiner struct {
 // be fetched at a time. Increasing this will improve performance for when
 // matched rows are grouped together, but increasing this too much will result
 // in fetching too many rows and therefore skipping less rows.
-var zigzagJoinerBatchSize = rowinfra.RowLimit(metamorphic.ConstantWithTestValue(
+var zigzagJoinerBatchSize = rowinfra.RowLimit(metamorphic.ConstantWithTestRange(
 	"zig-zag-joiner-batch-size",
 	5, /* defaultValue */
-	1, /* metamorphicValue */
+	1, /* min */
+	5, /* max */
 ))
 
 var _ execinfra.Processor = &zigzagJoiner{}

--- a/pkg/util/metamorphic/constants.go
+++ b/pkg/util/metamorphic/constants.go
@@ -36,11 +36,13 @@ const (
 	metamorphicBoolProbability    = 0.5
 )
 
-// ConstantWithTestValue should be used to initialize "magic constants" that
+// ConstantWithTestRange should be used to initialize "magic constants" that
 // should be varied during test scenarios to check for bugs at boundary
-// conditions. When metamorphicutil.IsMetamorphicBuild is true, the test value will be used with
+// conditions. When metamorphicutil.IsMetamorphicBuild is true, the test value
+// in the semi-open range [min, max) will be used with
 // metamorphicValueProbability probability. In all other cases, the production
 // ("default") value will be used.
+//
 // The constant must be a "metamorphic variable": changing it cannot affect the
 // output of any SQL DMLs. It can only affect the way in which the data is
 // retrieved or processed, because otherwise the main test corpus would fail if
@@ -57,26 +59,7 @@ const (
 //
 // you should write:
 //
-// var batchSize = metamorphic.ConstantWithTestValue("batch-size", 64, 1)
-//
-// This will often give your code a batch size of 1 in the crdb_test build
-// configuration, increasing the amount of exercise the edge conditions get.
-//
-// The given name is used for logging.
-func ConstantWithTestValue(name string, defaultValue, metamorphicValue int) int {
-	return getConstantInternal(name,
-		defaultValue,
-		strconv.Atoi,
-		metamorphicValueProbability,
-		func(r *rand.Rand) int {
-			return metamorphicValue
-		},
-		true)
-}
-
-// ConstantWithTestRange is like ConstantWithTestValue except instead of
-// returning a single metamorphic test value, it returns a random test value in
-// the semi-open range [min, max).
+// var batchSize = metamorphic.ConstantWithTestRange("batch-size", 64, 1, 64)
 //
 // The given name is used for logging.
 func ConstantWithTestRange(name string, defaultValue, min, max int) int {
@@ -94,7 +77,7 @@ func ConstantWithTestRange(name string, defaultValue, min, max int) int {
 		true)
 }
 
-// ConstantWithTestBool is like ConstantWithTestValue except it returns the
+// ConstantWithTestBool is like ConstantWithTestRange except it returns the
 // non-default value half of the time (if running a metamorphic build).
 //
 // The given name is used for logging.
@@ -119,7 +102,7 @@ func constantWithTestBoolInternal(name string, defaultValue bool, doLog bool) bo
 		doLog)
 }
 
-// ConstantWithTestChoice is like ConstantWithTestValue except it returns a
+// ConstantWithTestChoice is like ConstantWithTestRange except it returns a
 // random choice (equally weighted) of the given values. The default value is
 // included in the random choice.
 //


### PR DESCRIPTION
We currently use `ConstantWithTestValue` in a handful of places which always picks the same metamorhic value in metamorphic builds. I think that we'll get better coverage if we replace this with the Range variant: e.g. `kv-batch-size` will now be randomized in `[1, 100)` range providing more test coverage (over time).

Epic: None
Release note: None