### PR TITLE
release-26.1: ui: Exclude closed sessions by default

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/sessionsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/sessionsApi.ts
@@ -14,10 +14,21 @@ export type SessionsRequestMessage =
 export type SessionsResponseMessage =
   cockroach.server.serverpb.ListSessionsResponse;
 
+export interface SessionsRequest {
+  excludeClosedSessions?: boolean;
+}
+
 // getSessions gets all cluster sessions.
-export const getSessions = (): Promise<SessionsResponseMessage> => {
-  return fetchData(
-    cockroach.server.serverpb.ListSessionsResponse,
-    SESSIONS_PATH,
-  );
+export const getSessions = (
+  req?: SessionsRequest,
+): Promise<SessionsResponseMessage> => {
+  const params = new URLSearchParams();
+  if (req?.excludeClosedSessions) {
+    params.set("exclude_closed_sessions", "true");
+  }
+  const path =
+    params.toString() !== ""
+      ? `${SESSIONS_PATH}?${params.toString()}`
+      : SESSIONS_PATH;
+  return fetchData(cockroach.server.serverpb.ListSessionsResponse, path);
 };

--- a/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.tsx
@@ -195,6 +195,7 @@ export const handleFiltersFromQueryString = (
         database: filters.database,
         regions: filters.regions,
         nodes: filters.nodes,
+        sessionStatus: filters.sessionStatus,
       },
       history,
     );
@@ -238,6 +239,7 @@ export const updateFiltersQueryParamsOnTab = (
         database: filters.database,
         regions: filters.regions,
         nodes: filters.nodes,
+        sessionStatus: filters.sessionStatus,
       },
       history,
     );

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
@@ -12,6 +12,7 @@ import React from "react";
 import { Helmet } from "react-helmet";
 import { RouteComponentProps } from "react-router-dom";
 
+import { SessionsRequest } from "src/api/sessionsApi";
 import { commonStyles } from "src/common";
 import { SqlBox, SqlBoxSize } from "src/sql/box";
 import statementsPageStyles from "src/statementsPage/statementsPage.module.scss";
@@ -57,7 +58,7 @@ export interface OwnProps {
   nodeNames: { [nodeId: string]: string };
   session: SessionInfo;
   sessionError: Error | null;
-  refreshSessions: () => void;
+  refreshSessions: (req?: SessionsRequest) => void;
   refreshNodes: () => void;
   refreshNodesLiveness: () => void;
   cancelSession: (payload: ICancelSessionRequest) => void;

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.fixture.ts
@@ -13,9 +13,12 @@ import {
   CancelSessionRequestMessage,
 } from "src/api/terminateQueryApi";
 
-import { defaultFilters, Filters } from "../queryFilter";
+import { Filters } from "../queryFilter";
 
-import { SessionsPageProps } from "./sessionsPage";
+import {
+  SessionsPageProps,
+  defaultFiltersForSessionsPage,
+} from "./sessionsPage";
 import { SessionInfo } from "./sessionsTable";
 
 const Status = cockroach.server.serverpb.Session.Status;
@@ -200,7 +203,7 @@ export const filters: Filters = {
 };
 
 export const sessionsPagePropsFixture: SessionsPageProps = {
-  filters: defaultFilters,
+  filters: defaultFiltersForSessionsPage,
   history,
   location: {
     pathname: "/sessions",
@@ -229,7 +232,7 @@ export const sessionsPagePropsFixture: SessionsPageProps = {
 };
 
 export const sessionsPagePropsEmptyFixture: SessionsPageProps = {
-  filters: defaultFilters,
+  filters: defaultFiltersForSessionsPage,
   history,
   location: {
     pathname: "/sessions",

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPageConnected.tsx
@@ -8,6 +8,7 @@ import { RouteComponentProps, withRouter } from "react-router-dom";
 import { Dispatch } from "redux";
 import { createSelector } from "reselect";
 
+import { SessionsRequest } from "src/api/sessionsApi";
 import { analyticsActions, AppState } from "src/store";
 import { actions as localStorageActions } from "src/store/localStorage";
 import { SessionsState, actions as sessionsActions } from "src/store/sessions";
@@ -79,7 +80,8 @@ export const SessionsPageConnected = withRouter(
       filters: selectFilters(state),
     }),
     (dispatch: Dispatch) => ({
-      refreshSessions: () => dispatch(sessionsActions.refresh()),
+      refreshSessions: (req?: SessionsRequest) =>
+        dispatch(sessionsActions.refresh(req)),
       cancelSession: (payload: ICancelSessionRequest) =>
         dispatch(terminateQueryActions.terminateSession(payload)),
       cancelQuery: (payload: ICancelQueryRequest) =>

--- a/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
@@ -11,6 +11,7 @@ import {
 } from "src/api/statementsApi";
 import { WorkloadInsightEventFilters } from "src/insights";
 import { defaultFilters, Filters } from "src/queryFilter/";
+import { defaultFiltersForSessionsPage } from "src/sessions/sessionsPage";
 
 import { TimeScale, defaultTimeScaleSelected } from "../../timeScaleDropdown";
 import { DOMAIN_NAME } from "../utils";
@@ -150,6 +151,26 @@ const defaultJobTypeSetting = 0;
 
 const defaultIsAutoRefreshEnabledSetting = true;
 
+// Helper function to get sessions page filters with proper default for sessionStatus.
+// This handles migration for existing localStorage values that may have empty sessionStatus.
+const getSessionsPageFilters = (): Filters => {
+  const storedFilters = JSON.parse(
+    localStorage.getItem("filters/SessionsPage"),
+  );
+  if (!storedFilters) {
+    return defaultFiltersForSessionsPage;
+  }
+  // If stored filters exist but sessionStatus is empty or not set,
+  // apply the default sessionStatus (Active,Idle)
+  if (!storedFilters.sessionStatus) {
+    return {
+      ...storedFilters,
+      sessionStatus: defaultFiltersForSessionsPage.sessionStatus,
+    };
+  }
+  return storedFilters;
+};
+
 // TODO (koorosh): initial state should be restored from preserved keys in LocalStorage
 const initialState: LocalStorageState = {
   "adminUi/showDiagnosticsModal":
@@ -241,8 +262,7 @@ const initialState: LocalStorageState = {
   [LocalStorageKeys.DB_FILTERS]:
     JSON.parse(localStorage.getItem(LocalStorageKeys.DB_FILTERS)) ||
     defaultFilters,
-  "filters/SessionsPage":
-    JSON.parse(localStorage.getItem("filters/SessionsPage")) || defaultFilters,
+  "filters/SessionsPage": getSessionsPageFilters(),
   "filters/InsightsPage":
     JSON.parse(localStorage.getItem("filters/InsightsPage")) ||
     defaultFiltersInsights,

--- a/pkg/ui/workspaces/cluster-ui/src/store/sessions/sessions.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/sessions/sessions.reducer.ts
@@ -7,7 +7,9 @@ import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import moment, { Moment } from "moment-timezone";
 
-import { DOMAIN_NAME, noopReducer } from "../utils";
+import { SessionsRequest } from "src/api/sessionsApi";
+
+import { DOMAIN_NAME } from "../utils";
 
 type SessionsResponse = cockroach.server.serverpb.ListSessionsResponse;
 
@@ -42,9 +44,15 @@ const sessionsSlice = createSlice({
     invalidated: state => {
       state.valid = false;
     },
-    // Define actions that don't change state
-    refresh: noopReducer,
-    request: noopReducer,
+    // Define actions with optional payload using prepare callback
+    refresh: {
+      reducer: () => {},
+      prepare: (payload?: SessionsRequest) => ({ payload }),
+    },
+    request: {
+      reducer: () => {},
+      prepare: (payload?: SessionsRequest) => ({ payload }),
+    },
   },
 });
 

--- a/pkg/ui/workspaces/cluster-ui/src/store/sessions/sessions.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/sessions/sessions.sagas.ts
@@ -3,6 +3,7 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
+import { PayloadAction } from "@reduxjs/toolkit";
 import {
   all,
   call,
@@ -14,7 +15,7 @@ import {
   select,
 } from "redux-saga/effects";
 
-import { getSessions } from "src/api/sessionsApi";
+import { getSessions, SessionsRequest } from "src/api/sessionsApi";
 
 import { maybeError } from "../../util";
 import { actions as clusterLockActions } from "../clusterLocks/clusterLocks.reducer";
@@ -22,20 +23,25 @@ import { selectIsTenant } from "../uiConfig";
 
 import { actions } from "./sessions.reducer";
 
-export function* refreshSessionsAndClusterLocksSaga(): Generator<
-  AllEffect<PutEffect> | SelectEffect | PutEffect
-> {
+export function* refreshSessionsAndClusterLocksSaga(
+  action: PayloadAction<SessionsRequest | undefined>,
+): Generator<AllEffect<PutEffect> | SelectEffect | PutEffect> {
   const isTenant = yield select(selectIsTenant);
   if (isTenant) {
-    yield put(actions.request());
+    yield put(actions.request(action?.payload));
     return;
   }
-  yield all([put(actions.request()), put(clusterLockActions.request())]);
+  yield all([
+    put(actions.request(action?.payload)),
+    put(clusterLockActions.request()),
+  ]);
 }
 
-export function* requestSessionsSaga(): any {
+export function* requestSessionsSaga(
+  action: PayloadAction<SessionsRequest | undefined>,
+): any {
   try {
-    const result = yield call(getSessions);
+    const result = yield call(getSessions, action?.payload);
     yield put(actions.received(result));
   } catch (e) {
     yield put(actions.failed(maybeError(e)));

--- a/pkg/ui/workspaces/db-console/src/app.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.spec.tsx
@@ -679,10 +679,11 @@ describe("Routing to", () => {
   });
 
   describe("'/sessions' path", () => {
-    test("redirected to '/sql-activity?tab=Sessions'", () => {
+    // The default filters are set to Active and Idle.
+    test("redirected to '/sql-activity?tab=Sessions&timeNumber=0&timeUnit=seconds&fullScan=false&sessionStatus=Active%2CIdle'", () => {
       navigateToPath("/sessions");
       expect(history.location.pathname + history.location.search).toBe(
-        "/sql-activity?tab=Sessions",
+        "/sql-activity?tab=Sessions&timeNumber=0&timeUnit=seconds&fullScan=false&sessionStatus=Active%2CIdle",
       );
     });
   });

--- a/pkg/ui/workspaces/db-console/src/util/api.ts
+++ b/pkg/ui/workspaces/db-console/src/util/api.ts
@@ -657,15 +657,18 @@ export function getSettings(
 
 // getSessions gets all cluster sessions.
 export function getSessions(
-  _req: SessionsRequestMessage,
+  req: SessionsRequestMessage,
   timeout?: moment.Duration,
 ): Promise<SessionsResponseMessage> {
-  return timeoutFetch(
-    serverpb.ListSessionsResponse,
-    `${STATUS_PREFIX}/sessions`,
-    null,
-    timeout,
-  );
+  const params = new URLSearchParams();
+  if (req?.exclude_closed_sessions) {
+    params.set("exclude_closed_sessions", "true");
+  }
+  const queryString = params.toString();
+  const path = queryString
+    ? `${STATUS_PREFIX}/sessions?${queryString}`
+    : `${STATUS_PREFIX}/sessions`;
+  return timeoutFetch(serverpb.ListSessionsResponse, path, null, timeout);
 }
 
 // cancelSession cancels the session with the given id on the given node.


### PR DESCRIPTION
Backport 1/1 commits from #160576 on behalf of @alyshanjahani-crl.

----

This commit modifies the UI to set the Session Status filter to Idle, Active by default.

And it makes the ListSessions API call use the exclude_closed_sessions parameter accordingly.

Fixes: #159785
Release note (ui change): The sessions page sets the Session Status filter by default. It is set to Active,Idle.

----

Release justification: The linked issue is categorized as a 300 node qualification blocker. The change is UI only, setting a more appropriate default, and correcting the API call to use parameters appropriately.