### PR TITLE
asim: updated CPU loads in test one_voter_skewed_cpu_skewed_write

### DIFF
--- a/pkg/kv/kvserver/asim/tests/testdata/non_rand/mma/one_voter_skewed_cpu_skewed_write.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/non_rand/mma/one_voter_skewed_cpu_skewed_write.txt
@@ -18,49 +18,47 @@ gen_ranges ranges=100 repl_factor=1 min_key=10001 max_key=20000 placement_type=r
 ----
 {s2:*}:1
 
-# read cpu load of 1000x100=10k, all hitting s1, which is then at 100% cpu.
-# TODO(tbg): the CPU count is accidentally too low.
-gen_load rate=1000 rw_ratio=1.0 request_cpu_per_access=500000 min_key=1 max_key=10000
+# read cpu load of 1000x1m=1g, all hitting s1, which is then at 100% cpu.
+gen_load rate=1000 rw_ratio=1.0 request_cpu_per_access=1000000 min_key=1 max_key=10000
 ----
-0.50 access-vcpus
+1.00 access-vcpus
 
 # Write only workload, which generates 20% cpu and 5mb of writes per second.
 # over the second half of the keyspace.
-# TODO(tbg): the CPU load is too low.
-gen_load rate=5000 rw_ratio=0 min_block=1000 max_block=1000 raft_cpu_per_write=1 min_key=10001 max_key=20000
+gen_load rate=5000 rw_ratio=0 min_block=1024 max_block=1024 request_cpu_per_access=20000 raft_cpu_per_write=20000 min_key=10001 max_key=20000
 ----
-0.00 raft-vcpus, 4.8 MiB/s goodput
+0.10 access-vcpus, 0.10 raft-vcpus, 4.9 MiB/s goodput
 
 setting split_queue_enabled=false
 ----
 
-eval duration=65m samples=1 seed=42 cfgs=(mma-only,mma-count) metrics=(cpu,cpu_util,write_bytes_per_second,replicas,leases)
+eval duration=75m samples=1 seed=42 cfgs=(mma-only,mma-count) metrics=(cpu,cpu_util,write_bytes_per_second,replicas,leases)
 ----
-cpu#1: last:  [s1=269737583, s2=229946569] (stddev=19895507.00, mean=249842076.00, sum=499684152)
-cpu#1: thrash_pct: [s1=6%, s2=52%]  (sum=58%)
-cpu_util#1: last:  [s1=0.27, s2=0.23] (stddev=0.02, mean=0.25, sum=0)
-cpu_util#1: thrash_pct: [s1=6%, s2=52%]  (sum=58%)
+cpu#1: last:  [s1=654035360, s2=545548889] (stddev=54243235.50, mean=599792124.50, sum=1199584249)
+cpu#1: thrash_pct: [s1=37%, s2=87%]  (sum=124%)
+cpu_util#1: last:  [s1=0.65, s2=0.55] (stddev=0.05, mean=0.60, sum=1)
+cpu_util#1: thrash_pct: [s1=37%, s2=87%]  (sum=124%)
 leases#1: first: [s1=100, s2=100] (stddev=0.00, mean=100.00, sum=200)
-leases#1: last:  [s1=99, s2=101] (stddev=1.00, mean=100.00, sum=200)
-leases#1: thrash_pct: [s1=1503%, s2=1503%]  (sum=3007%)
+leases#1: last:  [s1=103, s2=97] (stddev=3.00, mean=100.00, sum=200)
+leases#1: thrash_pct: [s1=341%, s2=341%]  (sum=681%)
 replicas#1: first: [s1=100, s2=100] (stddev=0.00, mean=100.00, sum=200)
-replicas#1: last:  [s1=99, s2=101] (stddev=1.00, mean=100.00, sum=200)
-replicas#1: thrash_pct: [s1=1503%, s2=1503%]  (sum=3007%)
-write_bytes_per_second#1: last:  [s1=2249893, s2=2749803] (stddev=249955.00, mean=2499848.00, sum=4999696)
-write_bytes_per_second#1: thrash_pct: [s1=25%, s2=3%]  (sum=28%)
-artifacts[mma-only]: 2504eb4c76f8e7c
+replicas#1: last:  [s1=103, s2=97] (stddev=3.00, mean=100.00, sum=200)
+replicas#1: thrash_pct: [s1=341%, s2=341%]  (sum=681%)
+write_bytes_per_second#1: last:  [s1=2407032, s2=2712709] (stddev=152838.50, mean=2559870.50, sum=5119741)
+write_bytes_per_second#1: thrash_pct: [s1=26%, s2=3%]  (sum=29%)
+artifacts[mma-only]: 11c4fca9097a1184
 ==========================
-cpu#1: last:  [s1=269737582, s2=229946569] (stddev=19895506.50, mean=249842075.50, sum=499684151)
-cpu#1: thrash_pct: [s1=6%, s2=52%]  (sum=58%)
-cpu_util#1: last:  [s1=0.27, s2=0.23] (stddev=0.02, mean=0.25, sum=0)
-cpu_util#1: thrash_pct: [s1=6%, s2=52%]  (sum=58%)
+cpu#1: last:  [s1=643963508, s2=556180363] (stddev=43891572.50, mean=600071935.50, sum=1200143871)
+cpu#1: thrash_pct: [s1=45%, s2=96%]  (sum=140%)
+cpu_util#1: last:  [s1=0.64, s2=0.56] (stddev=0.04, mean=0.60, sum=1)
+cpu_util#1: thrash_pct: [s1=45%, s2=96%]  (sum=140%)
 leases#1: first: [s1=100, s2=100] (stddev=0.00, mean=100.00, sum=200)
-leases#1: last:  [s1=99, s2=101] (stddev=1.00, mean=100.00, sum=200)
-leases#1: thrash_pct: [s1=1503%, s2=1503%]  (sum=3007%)
+leases#1: last:  [s1=102, s2=98] (stddev=2.00, mean=100.00, sum=200)
+leases#1: thrash_pct: [s1=482%, s2=482%]  (sum=964%)
 replicas#1: first: [s1=100, s2=100] (stddev=0.00, mean=100.00, sum=200)
-replicas#1: last:  [s1=99, s2=101] (stddev=1.00, mean=100.00, sum=200)
-replicas#1: thrash_pct: [s1=1503%, s2=1503%]  (sum=3007%)
-write_bytes_per_second#1: last:  [s1=2249634, s2=2750072] (stddev=250219.00, mean=2499853.00, sum=4999706)
-write_bytes_per_second#1: thrash_pct: [s1=25%, s2=3%]  (sum=28%)
-artifacts[mma-count]: 58c310aa59e0af1c
+replicas#1: last:  [s1=102, s2=98] (stddev=2.00, mean=100.00, sum=200)
+replicas#1: thrash_pct: [s1=482%, s2=482%]  (sum=964%)
+write_bytes_per_second#1: last:  [s1=2406098, s2=2714619] (stddev=154260.50, mean=2560358.50, sum=5120717)
+write_bytes_per_second#1: thrash_pct: [s1=26%, s2=6%]  (sum=32%)
+artifacts[mma-count]: d268eb8a6d6bf0b8
 ==========================


### PR DESCRIPTION
In file `kv/kvserver/asim/tests/testdata/non_rand/mma/one_voter_skewed _cpu_skewed_write.txt` CPU params `request_cpu_per_access` and `raft_cpu_per_write` were too low, I updated them to generate more realistic CPU loads and verified MMA behaviour against these params.

Fixes: #160548
Epic: CRDB-56265