### PR TITLE
admission: report admission control metrics in nanosecond durations

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -10819,10 +10819,10 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
     - name: admission.elastic_cpu.nanos_exhausted_duration
       exported_name: admission_elastic_cpu_nanos_exhausted_duration
-      description: Total duration (in micros) when elastic CPU tokens (tokens measured in nanoseconds) were exhausted, as observed by the token granter (not waiters)
-      y_axis_label: Microseconds
+      description: Total duration when elastic CPU tokens (tokens measured in nanoseconds) were exhausted, as observed by the token granter (not waiters). This is reported in nanoseconds from 26.1 onwards, and was microseconds before that.
+      y_axis_label: Nanoseconds
       type: COUNTER
-      unit: COUNT
+      unit: NANOSECONDS
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
     - name: admission.elastic_cpu.over_limit_durations
@@ -11043,18 +11043,18 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
     - name: admission.granter.cpu_load_long_period_duration.kv
       exported_name: admission_granter_cpu_load_long_period_duration_kv
-      description: Total duration when CPULoad was being called with a long period, in micros
-      y_axis_label: Microseconds
+      description: Total duration when CPULoad was being called with a long period. This is reported in nanoseconds from 26.1 onwards, and was microseconds before that.
+      y_axis_label: Nanoseconds
       type: COUNTER
-      unit: COUNT
+      unit: NANOSECONDS
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
     - name: admission.granter.cpu_load_short_period_duration.kv
       exported_name: admission_granter_cpu_load_short_period_duration_kv
-      description: Total duration when CPULoad was being called with a short period, in micros
-      y_axis_label: Microseconds
+      description: Total duration when CPULoad was being called with a short period. This is reported in nanoseconds from 26.1 onwards, and was microseconds before that.
+      y_axis_label: Nanoseconds
       type: COUNTER
-      unit: COUNT
+      unit: NANOSECONDS
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
     - name: admission.granter.elastic_io_tokens_available.kv
@@ -11067,10 +11067,10 @@ layers:
       derivative: NONE
     - name: admission.granter.elastic_io_tokens_exhausted_duration.kv
       exported_name: admission_granter_elastic_io_tokens_exhausted_duration_kv
-      description: Total duration (in micros) when Elastic IO tokens were exhausted, as observed by the token granter (not waiters)
-      y_axis_label: Microseconds
+      description: Total duration when Elastic IO tokens were exhausted, as observed by the token granter (not waiters). This is reported in nanoseconds from 26.1 onwards, and was microseconds before that.
+      y_axis_label: Nanoseconds
       type: COUNTER
-      unit: COUNT
+      unit: NANOSECONDS
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
     - name: admission.granter.io_tokens_available.kv
@@ -11091,10 +11091,10 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
     - name: admission.granter.io_tokens_exhausted_duration.kv
       exported_name: admission_granter_io_tokens_exhausted_duration_kv
-      description: Total duration (in micros) when IO tokens were exhausted, as observed by the token granter (not waiters)
-      y_axis_label: Microseconds
+      description: Total duration when IO tokens were exhausted, as observed by the token granter (not waiters). This is reported in nanoseconds from 26.1 onwards, and was microseconds before that.
+      y_axis_label: Nanoseconds
       type: COUNTER
-      unit: COUNT
+      unit: NANOSECONDS
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
     - name: admission.granter.io_tokens_returned.kv
@@ -11131,10 +11131,10 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
     - name: admission.granter.slots_exhausted_duration.kv
       exported_name: admission_granter_slots_exhausted_duration_kv
-      description: Total duration (in micros) when KV slots were exhausted, as observed by the slot granter (not waiters)
-      y_axis_label: Microseconds
+      description: Total duration when KV slots were exhausted, as observed by the slot granter (not waiters). This is repored in nanoseconds from 26.1 onwards, and was microseconds before that.
+      y_axis_label: Nanoseconds
       type: COUNTER
-      unit: COUNT
+      unit: NANOSECONDS
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
     - name: admission.granter.total_slots.kv

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overload.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overload.tsx
@@ -46,9 +46,9 @@ export default function (props: GraphDashboardProps) {
       sources={nodeSources}
       tenantSource={tenantSource}
       showMetricsInTooltip={true}
-      tooltip={`Relative time the node had exhausted slots for foreground (regular) CPU work per second of wall time, measured in microseconds/second. Increased slot exhausted duration indicates CPU resource exhaustion.`}
+      tooltip={`Relative time the node had exhausted slots for foreground (regular) CPU work per second of wall time. Increased slot exhausted duration indicates CPU resource exhaustion. This is measured in nanoseconds/second from 26.1 onwards, and was microseconds/second before that.`}
     >
-      <Axis label="Duration (micros/sec)">
+      <Axis units={AxisUnits.DurationMillis} label="Duration/sec">
         {nodeIDs.map(nid => (
           <Metric
             key={nid}
@@ -66,9 +66,9 @@ export default function (props: GraphDashboardProps) {
       sources={storeSources}
       tenantSource={tenantSource}
       showMetricsInTooltip={true}
-      tooltip={`Relative time the store had exhausted foreground (regular) IO tokens for all IO-bound work per second of wall time, measured in microseconds/second. Increased IO token exhausted duration indicates IO resource exhaustion.`}
+      tooltip={`Relative time the store had exhausted foreground (regular) IO tokens for all IO-bound work per second of wall time. Increased IO token exhausted duration indicates IO resource exhaustion. This is measured in nanoseconds/second from 26.1 onwards, and was microseconds/second before that.`}
     >
-      <Axis label="Duration (micros/sec)">
+      <Axis units={AxisUnits.DurationMillis} label="Duration/sec">
         {storeMetrics(
           {
             name: "cr.store.admission.granter.io_tokens_exhausted_duration.kv",
@@ -87,9 +87,9 @@ export default function (props: GraphDashboardProps) {
       sources={storeSources}
       tenantSource={tenantSource}
       showMetricsInTooltip={true}
-      tooltip={`Relative time the store had exhausted background (elastic) IO tokens for all IO-bound work per second of wall time, measured in microseconds/second. Increased IO token exhausted duration indicates IO resource exhaustion.`}
+      tooltip={`Relative time the store had exhausted background (elastic) IO tokens for all IO-bound work per second of wall time. Increased IO token exhausted duration indicates IO resource exhaustion. This is measured in nanoseconds/second from 26.1 onwards, and was microseconds/second before that.`}
     >
-      <Axis label="Duration (micros/sec)">
+      <Axis units={AxisUnits.DurationMillis} label="Duration/sec">
         {storeMetrics(
           {
             name: "cr.store.admission.granter.elastic_io_tokens_exhausted_duration.kv",
@@ -126,10 +126,10 @@ export default function (props: GraphDashboardProps) {
       title="Elastic CPU Tokens Exhausted Duration Per Second"
       sources={nodeSources}
       tenantSource={tenantSource}
-      tooltip={`Relative time the node had exhausted tokens for background (elastic) CPU work per second of wall time, measured in microseconds/second. Increased token exhausted duration indicates CPU resource exhaustion, specifically for background (elastic) work.`}
+      tooltip={`Relative time the node had exhausted tokens for background (elastic) CPU work per second of wall time. Increased token exhausted duration indicates CPU resource exhaustion, specifically for background (elastic) work. This is measured in nanoseconds/second from 26.1 onwards, and was microseconds/second before that.`}
       showMetricsInTooltip={true}
     >
-      <Axis label="Duration (micros/sec)">
+      <Axis units={AxisUnits.DurationMillis} label="Duration/sec">
         {nodeIDs.map(nid => (
           <Metric
             key={nid}

--- a/pkg/util/admission/elastic_cpu_granter.go
+++ b/pkg/util/admission/elastic_cpu_granter.go
@@ -213,7 +213,7 @@ func (e *elasticCPUGranter) setUtilizationLimit(utilizationLimit float64) {
 		e.mu.tb.EnsureLowerBound(0)
 		e.mu.tbLastReset = now
 	}
-	e.metrics.NanosExhaustedDuration.Update(e.mu.tb.Exhausted().Microseconds())
+	e.metrics.NanosExhaustedDuration.Update(e.mu.tb.Exhausted().Nanoseconds())
 	e.metrics.AvailableNanos.Update(int64(e.mu.tb.Available()))
 
 	e.metrics.UtilizationLimit.Update(utilizationLimit)
@@ -309,10 +309,11 @@ var ( // granter-side metrics (some of these have parallels on the requester sid
 
 	elasticCPUNanosExhaustedDuration = metric.Metadata{
 		Name: "admission.elastic_cpu.nanos_exhausted_duration",
-		Help: "Total duration (in micros) when elastic CPU tokens (tokens measured in nanoseconds) " +
-			"were exhausted, as observed by the token granter (not waiters)",
-		Measurement: "Microseconds",
-		Unit:        metric.Unit_COUNT,
+		Help: "Total duration when elastic CPU tokens (tokens measured in nanoseconds) " +
+			"were exhausted, as observed by the token granter (not waiters). This is reported in " +
+			"nanoseconds from 26.1 onwards, and was microseconds before that.",
+		Measurement: "Nanoseconds",
+		Unit:        metric.Unit_NANOSECONDS,
 	}
 
 	elasticCPUOverLimitDurations = metric.Metadata{

--- a/pkg/util/admission/granter.go
+++ b/pkg/util/admission/granter.go
@@ -83,8 +83,8 @@ func (sg *slotGranter) returnGrantLocked(count int64, _ int8) {
 	}
 	if sg.usedSlots == sg.totalSlots {
 		now := timeutil.Now()
-		exhaustedMicros := now.Sub(sg.exhaustedStart).Microseconds()
-		sg.slotsExhaustedDurationMetric.Inc(exhaustedMicros)
+		exhaustedDuration := now.Sub(sg.exhaustedStart)
+		sg.slotsExhaustedDurationMetric.Inc(exhaustedDuration.Nanoseconds())
 	}
 	sg.usedSlots--
 	if sg.usedSlots < 0 {
@@ -150,8 +150,8 @@ func (sg *slotGranter) setTotalSlotsLockedInternal(totalSlots int) {
 	if totalSlots > sg.totalSlots {
 		if sg.totalSlots <= sg.usedSlots && totalSlots > sg.usedSlots {
 			now := timeutil.Now()
-			exhaustedMicros := now.Sub(sg.exhaustedStart).Microseconds()
-			sg.slotsExhaustedDurationMetric.Inc(exhaustedMicros)
+			exhaustedDuration := now.Sub(sg.exhaustedStart)
+			sg.slotsExhaustedDurationMetric.Inc(exhaustedDuration.Nanoseconds())
 		}
 	} else if totalSlots < sg.totalSlots {
 		if sg.totalSlots > sg.usedSlots && totalSlots <= sg.usedSlots {
@@ -583,8 +583,8 @@ func (sg *kvStoreTokenGranter) subtractTokensLockedForWorkClass(
 		// don't show a sudden change in the metric after minutes of exhaustion
 		// (we had observed such behavior prior to this change).
 		now := timeutil.Now()
-		exhaustedMicros := now.Sub(sg.mu.exhaustedStart[wc]).Microseconds()
-		sg.ioTokensExhaustedDurationMetric[wc].Inc(exhaustedMicros)
+		exhaustedDuration := now.Sub(sg.mu.exhaustedStart[wc])
+		sg.ioTokensExhaustedDurationMetric[wc].Inc(exhaustedDuration.Nanoseconds())
 		if sg.mu.availableIOTokens[wc] <= 0 {
 			sg.mu.exhaustedStart[wc] = now
 		}
@@ -846,26 +846,29 @@ var (
 	// or not.
 	kvSlotsExhaustedDuration = metric.Metadata{
 		Name: "admission.granter.slots_exhausted_duration.kv",
-		Help: "Total duration (in micros) when KV slots were exhausted, as observed by the slot " +
-			"granter (not waiters)",
-		Measurement: "Microseconds",
-		Unit:        metric.Unit_COUNT,
+		Help: "Total duration when KV slots were exhausted, as observed by the slot " +
+			"granter (not waiters). This is repored in nanoseconds from 26.1 onwards, " +
+			"and was microseconds before that.",
+		Measurement: "Nanoseconds",
+		Unit:        metric.Unit_NANOSECONDS,
 	}
 	// We have a metric for both short and long period. These metrics use the
 	// period provided in CPULoad and not wall time. So if the sum of the rate
 	// of these two is < 1sec/sec, the CPULoad ticks are not happening at the
 	// expected frequency (this could happen due to CPU overload).
 	kvCPULoadShortPeriodDuration = metric.Metadata{
-		Name:        "admission.granter.cpu_load_short_period_duration.kv",
-		Help:        "Total duration when CPULoad was being called with a short period, in micros",
-		Measurement: "Microseconds",
-		Unit:        metric.Unit_COUNT,
+		Name: "admission.granter.cpu_load_short_period_duration.kv",
+		Help: "Total duration when CPULoad was being called with a short period. This is " +
+			"reported in nanoseconds from 26.1 onwards, and was microseconds before that.",
+		Measurement: "Nanoseconds",
+		Unit:        metric.Unit_NANOSECONDS,
 	}
 	kvCPULoadLongPeriodDuration = metric.Metadata{
-		Name:        "admission.granter.cpu_load_long_period_duration.kv",
-		Help:        "Total duration when CPULoad was being called with a long period, in micros",
-		Measurement: "Microseconds",
-		Unit:        metric.Unit_COUNT,
+		Name: "admission.granter.cpu_load_long_period_duration.kv",
+		Help: "Total duration when CPULoad was being called with a long period. This is " +
+			"reported in nanoseconds from 26.1 onwards, and was microseconds before that.",
+		Measurement: "Nanoseconds",
+		Unit:        metric.Unit_NANOSECONDS,
 	}
 	kvSlotAdjusterIncrements = metric.Metadata{
 		Name:        "admission.granter.slot_adjuster_increments.kv",
@@ -881,17 +884,19 @@ var (
 	}
 	kvIOTokensExhaustedDuration = metric.Metadata{
 		Name: "admission.granter.io_tokens_exhausted_duration.kv",
-		Help: "Total duration (in micros) when IO tokens were exhausted, as observed by " +
-			"the token granter (not waiters)",
-		Measurement: "Microseconds",
-		Unit:        metric.Unit_COUNT,
+		Help: "Total duration when IO tokens were exhausted, as observed by the token granter " +
+			"(not waiters). This is reported in nanoseconds from 26.1 onwards, and was " +
+			"microseconds before that.",
+		Measurement: "Nanoseconds",
+		Unit:        metric.Unit_NANOSECONDS,
 	}
 	kvElasticIOTokensExhaustedDuration = metric.Metadata{
 		Name: "admission.granter.elastic_io_tokens_exhausted_duration.kv",
-		Help: "Total duration (in micros) when Elastic IO tokens were exhausted, as observed by " +
-			"the token granter (not waiters)",
-		Measurement: "Microseconds",
-		Unit:        metric.Unit_COUNT,
+		Help: "Total duration when Elastic IO tokens were exhausted, as observed by the token " +
+			"granter (not waiters). This is reported in nanoseconds from 26.1 onwards, and was " +
+			"microseconds before that.",
+		Measurement: "Nanoseconds",
+		Unit:        metric.Unit_NANOSECONDS,
 	}
 	kvIOTokensTaken = metric.Metadata{
 		Name:        "admission.granter.io_tokens_taken.kv",

--- a/pkg/util/admission/granter_test.go
+++ b/pkg/util/admission/granter_test.go
@@ -154,13 +154,13 @@ func TestCPUGranterBasic(t *testing.T) {
 			coord.CPULoad(runnable, procs, samplePeriod)
 			str := flushAndReset()
 			kvsa := coord.mu.cpuLoadListener.(*kvSlotAdjuster)
-			microsToMillis := func(micros int64) int64 {
-				return micros * int64(time.Microsecond) / int64(time.Millisecond)
+			nanosToMillis := func(nanos int64) int64 {
+				return nanos * int64(time.Nanosecond) / int64(time.Millisecond)
 			}
 			return fmt.Sprintf("%sSlotAdjuster metrics: slots: %d, duration (short, long) millis: (%d, %d), inc: %d, dec: %d\n",
 				str, kvsa.totalSlotsMetric.Value(),
-				microsToMillis(kvsa.cpuLoadShortPeriodDurationMetric.Count()),
-				microsToMillis(kvsa.cpuLoadLongPeriodDurationMetric.Count()),
+				nanosToMillis(kvsa.cpuLoadShortPeriodDurationMetric.Count()),
+				nanosToMillis(kvsa.cpuLoadLongPeriodDurationMetric.Count()),
 				kvsa.slotAdjusterIncrementsMetric.Count(), kvsa.slotAdjusterDecrementsMetric.Count(),
 			)
 

--- a/pkg/util/admission/kv_slot_adjuster.go
+++ b/pkg/util/admission/kv_slot_adjuster.go
@@ -45,11 +45,10 @@ var _ CPULoadListener = &kvSlotAdjuster{}
 func (kvsa *kvSlotAdjuster) CPULoad(runnable int, procs int, samplePeriod time.Duration) {
 	threshold := int(KVSlotAdjusterOverloadThreshold.Get(&kvsa.settings.SV))
 
-	periodDurationMicros := samplePeriod.Microseconds()
 	if samplePeriod > time.Millisecond {
-		kvsa.cpuLoadLongPeriodDurationMetric.Inc(periodDurationMicros)
+		kvsa.cpuLoadLongPeriodDurationMetric.Inc(samplePeriod.Nanoseconds())
 	} else {
-		kvsa.cpuLoadShortPeriodDurationMetric.Inc(periodDurationMicros)
+		kvsa.cpuLoadShortPeriodDurationMetric.Inc(samplePeriod.Nanoseconds())
 	}
 
 	// Simple heuristic, which worked ok in experiments. More sophisticated ones


### PR DESCRIPTION
This updates the following admission control metrics to be reported in nanoseconds instead of microseconds, and updates their units to `Unit_NANOSECONDS` instead of `Unit_COUNT`
- `admission.granter.slots_exhausted_duration.kv`
- `admission.granter.cpu_load_short_period_duration.kv`
- `admission.granter.cpu_load_long_period_duration.kv`
- `admission.granter.io_tokens_exhausted_duration.kv`
- `admission.granter.elastic_io_tokens_exhausted_duration.kv`
- `admission.elastic_cpu.nanos_exhausted_duration`

Graphs in the DBConsole which use these metrics are also updated to reflect this change, and use units of time on the Y-axis instead of the raw count.

Fixes: #159384
Release note (ui change): Standardizes nanoseconds as the unit of measurement for admission control duration metrics, instead of microseconds.

----

Note that dashboards in dbconsole and datadog which graph these metrics will appear skewed for existing clusters that upgrade to 26.1. Specifically, the values prior to the upgrade will appear to go to zero, due to the orders of magnitude change between microseconds to nanoseconds. 

For example, the cluster for the below screenshot was updated to include this change at 18:59. Around 18:34, the cluster was experiencing CPU slot exhaustion of ~7.5ms/s, but after applying this change it is displayed as 7.5us/s. These metrics are not commonly used, so we're willing to accept risk of slight confusion during this upgrade to avoid a more involved workaround of duplicating the metrics.

<img width="974" height="413" alt="Screenshot 2026-01-13 at 2 45 18 PM" src="https://github.com/user-attachments/assets/598e104d-c46b-4fe1-8c3d-51d1613ba542" />
