### PR TITLE
roachtest: disable runtime assertions for IMPORT

### DIFF
--- a/pkg/cmd/roachtest/tests/import.go
+++ b/pkg/cmd/roachtest/tests/import.go
@@ -345,6 +345,9 @@ func registerImport(r registry.Registry) {
 					Suites:            suites,
 					EncryptionSupport: registry.EncryptionMetamorphic,
 					Leases:            registry.MetamorphicLeases,
+					// Never run with runtime assertions as this makes this test
+					// take too long to complete.
+					CockroachBinary: registry.StandardCockroach,
 					Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 						runImportTest(ctx, t, c, ts, numNodes, timeout, distMerge)
 					},


### PR DESCRIPTION
We repeatedly see timeouts with distMerge=false when runtime assertions are enabled and _probably_ that's the expected behavior, so let's opt out of them.

Informs: #159968.
Fixes: #160787.
Fixes: #160792.
Fixes: #160959.

Release note: None