### PR TITLE
execbuilder: update three EXPLAIN ANALYZE query outputs for bigendian

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/dist_vectorize
+++ b/pkg/sql/opt/exec/execbuilder/testdata/dist_vectorize
@@ -135,23 +135,16 @@ EXPLAIN ANALYZE (DISTSQL) SELECT * FROM kv JOIN kw ON kv.k = kw.k
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 10 (80 B, 20 KVs, 10 gRPC calls)
-maximum memory usage: <hidden>
 DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • merge join
 │ sql nodes: <hidden>
 │ regions: <hidden>
-│ actual row count: 5
 │ execution time: 0µs
-│ estimated max memory allocated: 0 B
-│ estimated max sql temp disk usage: 0 B
+│ actual row count: 5
 │ equality: (k) = (k)
 │ left cols are key
 │ right cols are key
@@ -160,13 +153,9 @@ quality of service: regular
 │     sql nodes: <hidden>
 │     kv nodes: <hidden>
 │     regions: <hidden>
-│     actual row count: 5
 │     KV time: 0µs
 │     KV rows decoded: 5
-│     KV pairs read: 10
-│     KV bytes read: 40 B
-│     KV gRPC calls: 5
-│     estimated max memory allocated: 0 B
+│     actual row count: 5
 │     missing stats
 │     table: kv@kv_pkey
 │     spans: FULL SCAN
@@ -175,13 +164,9 @@ quality of service: regular
       sql nodes: <hidden>
       kv nodes: <hidden>
       regions: <hidden>
-      actual row count: 5
       KV time: 0µs
       KV rows decoded: 5
-      KV pairs read: 10
-      KV bytes read: 40 B
-      KV gRPC calls: 5
-      estimated max memory allocated: 0 B
+      actual row count: 5
       missing stats
       table: kw@kw_pkey
       spans: FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze_plans
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze_plans
@@ -123,31 +123,24 @@ EXPLAIN ANALYZE (DISTSQL) SELECT kv.k, avg(kw.k) FROM kv JOIN kw ON kv.k=kw.k GR
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 10 (80 B, 20 KVs, 10 gRPC calls)
-maximum memory usage: <hidden>
 DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • group (streaming)
 │ sql nodes: <hidden>
 │ regions: <hidden>
-│ actual row count: 5
 │ execution time: 0µs
+│ actual row count: 5
 │ group by: k
 │ ordered: +k
 │
 └── • merge join
     │ sql nodes: <hidden>
     │ regions: <hidden>
-    │ actual row count: 5
     │ execution time: 0µs
-    │ estimated max memory allocated: 0 B
-    │ estimated max sql temp disk usage: 0 B
+    │ actual row count: 5
     │ equality: (k) = (k)
     │ left cols are key
     │ right cols are key
@@ -156,13 +149,9 @@ quality of service: regular
     │     sql nodes: <hidden>
     │     kv nodes: <hidden>
     │     regions: <hidden>
-    │     actual row count: 5
     │     KV time: 0µs
     │     KV rows decoded: 5
-    │     KV pairs read: 10
-    │     KV bytes read: 40 B
-    │     KV gRPC calls: 5
-    │     estimated max memory allocated: 0 B
+    │     actual row count: 5
     │     missing stats
     │     table: kv@kv_pkey
     │     spans: FULL SCAN
@@ -171,13 +160,9 @@ quality of service: regular
           sql nodes: <hidden>
           kv nodes: <hidden>
           regions: <hidden>
-          actual row count: 5
           KV time: 0µs
           KV rows decoded: 5
-          KV pairs read: 10
-          KV bytes read: 40 B
-          KV gRPC calls: 5
-          estimated max memory allocated: 0 B
+          actual row count: 5
           missing stats
           table: kw@kw_pkey
           spans: FULL SCAN
@@ -251,38 +236,30 @@ EXPLAIN ANALYZE (DISTSQL) SELECT DISTINCT(kw.w) FROM kv JOIN kw ON kv.k = kw.w O
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 10 (80 B, 20 KVs, 10 gRPC calls)
-maximum memory usage: <hidden>
 DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • sort
 │ sql nodes: <hidden>
 │ regions: <hidden>
-│ actual row count: 5
 │ execution time: 0µs
-│ estimated max memory allocated: 0 B
+│ actual row count: 5
 │ order: +w
 │
 └── • distinct
     │ sql nodes: <hidden>
     │ regions: <hidden>
-    │ actual row count: 5
     │ execution time: 0µs
-    │ estimated max memory allocated: 0 B
+    │ actual row count: 5
     │ distinct on: w
     │
     └── • hash join
         │ sql nodes: <hidden>
         │ regions: <hidden>
-        │ actual row count: 5
         │ execution time: 0µs
-        │ estimated max memory allocated: 0 B
+        │ actual row count: 5
         │ equality: (k) = (w)
         │ left cols are key
         │
@@ -290,13 +267,9 @@ quality of service: regular
         │     sql nodes: <hidden>
         │     kv nodes: <hidden>
         │     regions: <hidden>
-        │     actual row count: 5
         │     KV time: 0µs
         │     KV rows decoded: 5
-        │     KV pairs read: 10
-        │     KV bytes read: 40 B
-        │     KV gRPC calls: 5
-        │     estimated max memory allocated: 0 B
+        │     actual row count: 5
         │     missing stats
         │     table: kv@kv_pkey
         │     spans: FULL SCAN
@@ -305,13 +278,9 @@ quality of service: regular
               sql nodes: <hidden>
               kv nodes: <hidden>
               regions: <hidden>
-              actual row count: 5
               KV time: 0µs
               KV rows decoded: 5
-              KV pairs read: 10
-              KV bytes read: 40 B
-              KV gRPC calls: 5
-              estimated max memory allocated: 0 B
+              actual row count: 5
               missing stats
               table: kw@kw_pkey
               spans: FULL SCAN


### PR DESCRIPTION
Last week we merged a change to improve EXPLAIN ANALYZE output, but we forgot to update three spots where we have separate bigendian and littleendian expectations.

See #153361.

Fixes: #160634.
Fixes: #160635.
Release note: None