### PR TITLE
ccl/multiregionccl: skip TestMultiRegionDataDriven_regional_by_table

### DIFF
--- a/pkg/ccl/multiregionccl/datadriven_test.go
+++ b/pkg/ccl/multiregionccl/datadriven_test.go
@@ -59,6 +59,7 @@ func TestMultiRegionDataDriven_regional_by_row(t *testing.T) {
 func TestMultiRegionDataDriven_regional_by_table(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.WithIssue(t, 160803)
 	testMultiRegionDataDriven(t, "regional_by_table")
 }
 


### PR DESCRIPTION
I've seen this test fail a few times in the last couple of days and couldn't immediately reproduce it to investigate further - let's skip until it's stabilized.

Informs: #160803
Release note: None