### PR TITLE
sql: improve parallelism in distributed index backfill map phase

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1052,8 +1052,7 @@ func (sc *SchemaChanger) distIndexBackfill(
 		chunkSize := sc.getChunkSize(indexBatchSize)
 		spec := initIndexBackfillerSpec(*tableDesc.TableDesc(), writeAsOf, writeAtRequestTimestamp, chunkSize, addedIndexes, 0)
 		if useDistributedMerge {
-			storagePrefix := fmt.Sprintf("nodelocal://%d/", sc.execCfg.NodeInfo.NodeID.SQLInstanceID())
-			backfill.EnableDistributedMergeIndexBackfillSink(storagePrefix, sc.job.ID(), &spec)
+			backfill.EnableDistributedMergeIndexBackfillSink(sc.job.ID(), &spec)
 		}
 		p, err = sc.distSQLPlanner.createBackfillerPhysicalPlan(ctx, planCtx, spec, todoSpans)
 		return err

--- a/pkg/sql/backfill/distributed_merge_mode.go
+++ b/pkg/sql/backfill/distributed_merge_mode.go
@@ -103,14 +103,11 @@ func shouldEnableDistributedMergeIndexBackfill(
 }
 
 // EnableDistributedMergeIndexBackfillSink updates the backfiller spec to use the
-// distributed merge sink and file prefix for the provided storage prefix and job.
-// The storagePrefix should be in the form "nodelocal://<nodeID>/" and is used as
-// the base path for temporary SST files.
-func EnableDistributedMergeIndexBackfillSink(
-	storagePrefix string, jobID jobspb.JobID, spec *execinfrapb.BackfillerSpec,
-) {
+// distributed merge sink. The file prefix stores just the path portion; each
+// processor constructs the full nodelocal URI using its own node ID at runtime.
+func EnableDistributedMergeIndexBackfillSink(jobID jobspb.JobID, spec *execinfrapb.BackfillerSpec) {
 	spec.UseDistributedMergeSink = true
-	spec.DistributedMergeFilePrefix = fmt.Sprintf("%sjob/%d/map", storagePrefix, jobID)
+	spec.DistributedMergeFilePrefix = fmt.Sprintf("job/%d/map", jobID)
 }
 
 // DetermineDistributedMergeMode evaluates the cluster setting to decide

--- a/pkg/sql/index_backfiller.go
+++ b/pkg/sql/index_backfiller.go
@@ -134,16 +134,27 @@ func (ib *IndexBackfillPlanner) BackfillIndexes(
 	}
 	useDistributedMerge := mode == jobspb.IndexBackfillDistributedMergeMode_Enabled
 
-	// addStoragePrefix records a storage prefix before any SST is written to that
-	// location, ensuring cleanup can occur even if the job fails mid-backfill or
+	// addStoragePrefix records storage prefixes before any SST is written to those
+	// locations, ensuring cleanup can occur even if the job fails mid-backfill or
 	// mid-merge. Duplicates are skipped by checking the existing prefixes.
-	addStoragePrefix := func(ctx context.Context, prefix string) error {
+	addStoragePrefix := func(ctx context.Context, prefixes []string) error {
+		existingSet := make(map[string]struct{}, len(progress.SSTStoragePrefixes))
 		for _, existing := range progress.SSTStoragePrefixes {
-			if existing == prefix {
-				return nil // Already recorded.
+			existingSet[existing] = struct{}{}
+		}
+
+		var newPrefixes []string
+		for _, prefix := range prefixes {
+			if _, exists := existingSet[prefix]; !exists {
+				newPrefixes = append(newPrefixes, prefix)
+				existingSet[prefix] = struct{}{}
 			}
 		}
-		progress.SSTStoragePrefixes = append(progress.SSTStoragePrefixes, prefix)
+
+		if len(newPrefixes) == 0 {
+			return nil
+		}
+		progress.SSTStoragePrefixes = append(progress.SSTStoragePrefixes, newPrefixes...)
 		return tracker.SetBackfillProgress(ctx, progress)
 	}
 
@@ -278,7 +289,7 @@ func (ib *IndexBackfillPlanner) plan(
 	sourceIndexID descpb.IndexID,
 	useDistributedMerge bool,
 	callback func(_ context.Context, meta *execinfrapb.ProducerMetadata) error,
-	addStoragePrefix func(ctx context.Context, prefix string) error,
+	addStoragePrefix func(ctx context.Context, prefixes []string) error,
 ) (runFunc func(context.Context) error, _ error) {
 
 	var p *PhysicalPlan
@@ -302,18 +313,27 @@ func (ib *IndexBackfillPlanner) plan(
 			indexesToBackfill, sourceIndexID,
 		)
 		if useDistributedMerge {
-			// Record the storage prefix before any SSTs are written.
-			storagePrefix := fmt.Sprintf("nodelocal://%d/", ib.execCfg.NodeInfo.NodeID.SQLInstanceID())
-			backfill.EnableDistributedMergeIndexBackfillSink(storagePrefix, jobID, &spec)
-			if err := addStoragePrefix(ctx, storagePrefix); err != nil {
-				return err
-			}
+			backfill.EnableDistributedMergeIndexBackfillSink(jobID, &spec)
 		}
 		var err error
 		p, err = ib.execCfg.DistSQLPlanner.createBackfillerPhysicalPlan(ctx, planCtx, spec, sourceSpans)
 		return err
 	}); err != nil {
 		return nil, err
+	}
+
+	// Pre-register storage prefixes for all nodes that will run processors.
+	// This must happen before any SSTs are written to ensure cleanup can find
+	// orphaned files if the job fails mid-write.
+	if useDistributedMerge {
+		prefixes := make([]string, 0, len(p.Processors))
+		for i := range p.Processors {
+			prefix := fmt.Sprintf("nodelocal://%d/", p.Processors[i].SQLInstanceID)
+			prefixes = append(prefixes, prefix)
+		}
+		if err := addStoragePrefix(ctx, prefixes); err != nil {
+			return nil, err
+		}
 	}
 
 	return func(ctx context.Context) error {
@@ -352,8 +372,8 @@ func getIndexBackfillDistributedMergeMode(
 // progress with the new manifests; the final iteration ingests the files directly
 // into KV and clears the manifests.
 //
-// The addStoragePrefix callback is invoked before any SST is written to a new
-// storage location, allowing the caller to persist the prefix for cleanup.
+// The addStoragePrefix callback is invoked before any SST is written to new
+// storage locations, allowing the caller to persist the prefixes for cleanup.
 func (ib *IndexBackfillPlanner) runDistributedMerge(
 	ctx context.Context,
 	job *jobs.Job,
@@ -363,7 +383,7 @@ func (ib *IndexBackfillPlanner) runDistributedMerge(
 	manifests []jobspb.IndexBackfillSSTManifest,
 	startIteration int,
 	maxIterations int,
-	addStoragePrefix func(ctx context.Context, prefix string) error,
+	addStoragePrefix func(ctx context.Context, prefixes []string) error,
 ) error {
 	if len(manifests) == 0 {
 		return nil
@@ -408,7 +428,7 @@ func (ib *IndexBackfillPlanner) runDistributedMerge(
 			// only needed during the lifetime of the job. Record the storage prefix
 			// for cleanup on job completion - this must happen before writing any SST.
 			prefix := fmt.Sprintf("nodelocal://%d/", instanceID)
-			if err := addStoragePrefix(ctx, prefix); err != nil {
+			if err := addStoragePrefix(ctx, []string{prefix}); err != nil {
 				return "", err
 			}
 			// The '/job/<jobID>' prefix allows for easy cleanup in the event of job

--- a/pkg/sql/indexbackfiller_test.go
+++ b/pkg/sql/indexbackfiller_test.go
@@ -10,6 +10,7 @@ import (
 	gosql "database/sql"
 	"fmt"
 	"os"
+	"regexp"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -53,6 +54,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/oserror"
 	"github.com/stretchr/testify/require"
@@ -797,25 +799,61 @@ func TestIndexBackfillerResumePreservesProgress(t *testing.T) {
 func TestDistributedMergeStoragePrefixTracking(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.UnderDuress(t)
 
 	ctx := context.Background()
 
-	// Create a temp directory for nodelocal storage used by distributed merge.
-	tempDir := t.TempDir()
+	// Track which nodes wrote manifests during the map phase.
+	var manifestNodeIDs syncutil.Map[string, struct{}]
 
-	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{
-		ExternalIODir: tempDir,
-		Knobs: base.TestingKnobs{
-			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+	const numNodes = 3
+
+	// Create separate temp directories for each node to avoid file collisions.
+	tempDirs := make([]string, numNodes)
+	for i := 0; i < numNodes; i++ {
+		tempDirs[i] = t.TempDir()
+	}
+
+	// Shared testing knobs for all nodes.
+	testingKnobs := base.TestingKnobs{
+		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+		DistSQL: &execinfra.TestingKnobs{
+			AfterDistributedMergeMapPhase: func(_ context.Context, manifests []jobspb.IndexBackfillSSTManifest) {
+				// Extract node IDs from manifest URIs (format: nodelocal://<nodeID>/...).
+				nodeIDRegex := regexp.MustCompile(`^nodelocal://(\d+)/`)
+				for _, m := range manifests {
+					if matches := nodeIDRegex.FindStringSubmatch(m.URI); len(matches) > 1 {
+						manifestNodeIDs.Store(matches[1], &struct{}{})
+					}
+				}
+			},
 		},
-	})
-	defer srv.Stopper().Stop(ctx)
+	}
 
+	// Configure each node with its own isolated external storage directory.
+	serverArgsPerNode := make(map[int]base.TestServerArgs)
+	for i := 0; i < numNodes; i++ {
+		serverArgsPerNode[i] = base.TestServerArgs{
+			ExternalIODir: tempDirs[i],
+			Knobs:         testingKnobs,
+		}
+	}
+
+	tc := serverutils.StartCluster(t, numNodes, base.TestClusterArgs{
+		ServerArgsPerNode: serverArgsPerNode,
+	})
+	defer tc.Stopper().Stop(ctx)
+
+	db := tc.ServerConn(0)
 	tdb := sqlutils.MakeSQLRunner(db)
 
 	tdb.Exec(t, `SET CLUSTER SETTING bulkio.index_backfill.distributed_merge.mode = 'declarative'`)
 	tdb.Exec(t, `CREATE TABLE t (k INT PRIMARY KEY, v INT)`)
-	tdb.Exec(t, `INSERT INTO t SELECT i, i*10 FROM generate_series(1, 100) AS g(i)`)
+	tdb.Exec(t, `INSERT INTO t SELECT i, i*10 FROM generate_series(1, 10000) AS g(i)`)
+
+	// Split and scatter the table to distribute data across nodes.
+	tdb.Exec(t, `ALTER TABLE t SPLIT AT SELECT i*1000 FROM generate_series(1, 9) AS g(i)`)
+	tdb.Exec(t, `ALTER TABLE t SCATTER`)
 
 	// Create a non-unique index. This triggers the distributed merge pipeline.
 	tdb.Exec(t, `CREATE INDEX idx ON t (v)`)
@@ -841,13 +879,35 @@ func TestDistributedMergeStoragePrefixTracking(t *testing.T) {
 	require.NotNil(t, schemaChangeDetails)
 	require.NotEmpty(t, schemaChangeDetails.BackfillProgress)
 	backfillProgress := schemaChangeDetails.BackfillProgress[0]
-	require.NotEmpty(t, backfillProgress.SSTStoragePrefixes)
 
-	// Verify the prefix format matches nodelocal://<nodeID>/.
+	// Collect unique node IDs from the storage prefixes.
+	prefixNodeIDs := make(map[string]struct{})
 	for _, prefix := range backfillProgress.SSTStoragePrefixes {
 		t.Logf("found storage prefix: %s", prefix)
 		require.Regexp(t, `^nodelocal://\d+/$`, prefix,
 			"storage prefix should match nodelocal://<nodeID>/ format")
+		// Extract the node ID from the prefix.
+		nodeIDRegex := regexp.MustCompile(`^nodelocal://(\d+)/$`)
+		if matches := nodeIDRegex.FindStringSubmatch(prefix); len(matches) > 1 {
+			prefixNodeIDs[matches[1]] = struct{}{}
+		}
+	}
+
+	// Collect node IDs that wrote manifests during the map phase.
+	nodesWithManifests := make(map[string]struct{})
+	manifestNodeIDs.Range(func(nodeID string, _ *struct{}) bool {
+		nodesWithManifests[nodeID] = struct{}{}
+		t.Logf("node %s wrote manifests during map phase", nodeID)
+		return true
+	})
+
+	// Verify that every node that wrote manifests has a corresponding storage prefix.
+	require.Greater(t, len(nodesWithManifests), 1,
+		"expected more than one node to write manifests to verify multi-node behavior")
+	for nodeID := range nodesWithManifests {
+		_, hasPrefix := prefixNodeIDs[nodeID]
+		require.True(t, hasPrefix,
+			"node %s wrote manifests but has no storage prefix registered", nodeID)
 	}
 }
 


### PR DESCRIPTION
Previously, the coordinator constructed a full `nodelocal://<nodeID>/...` URI and passed it to all processors. This caused all SST writes in the map phase to go through the coordinator, limiting parallelism.

This change delays the URI construction until runtime, so each processor writes to its own local store. This allows the map phase of index backfill to distribute load across nodes.

Informs #160478
Epic: CRDB-48845
Release note: none