### PR TITLE
sql: parallelize merge phase in distributed index backfill

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -381,6 +381,7 @@ go_library(
         "//pkg/sql/auditlogging",
         "//pkg/sql/auditlogging/auditevents",
         "//pkg/sql/backfill",
+        "//pkg/sql/bulksst",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/bootstrap",
         "//pkg/sql/catalog/catalogkeys",


### PR DESCRIPTION
Previously, the merge phase in the distributed index backfill process was executed entirely on a single node. This limited parallelism and underutilized cluster resources.

Unlike IMPORT, which calls bulksst.CombineFileInfo to split work into smaller chunks for distribution, the index backfill logic was missing this call. As a result, it did not take advantage of available parallelism.

This change adds a call to CombineFileInfo, enabling the merge phase to be parallelized across the cluster.

Informs: #160478
Epic: CRDB-48845
Release note: none