### PR TITLE
sql/optbuilder: allow deserialize_session without unsafe internals

### DIFF
--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -899,6 +899,8 @@ var SupportedCRDBInternalBuiltins = map[string]struct{}{
 	// https://docs.google.com/document/d/1STbb8bljTzK_jXRIJrxtijWsPhGErdH1vZdunzPwXvs/edit?tab=t.0
 	`crdb_internal.datums_to_bytes`:           {},
 	`crdb_internal.increment_feature_counter`: {},
+	// Used by sqlproxy for connection migration.
+	`crdb_internal.deserialize_session`: {},
 }
 
 // isUnsafeBuiltin returns true if the given function definition

--- a/pkg/sql/opt/optbuilder/scalar_test.go
+++ b/pkg/sql/opt/optbuilder/scalar_test.go
@@ -23,6 +23,7 @@ func TestSupportedCRDBInternalBuiltinsNotChanged(t *testing.T) {
 	expectedBuiltins := map[string]struct{}{
 		`crdb_internal.datums_to_bytes`:           {},
 		`crdb_internal.increment_feature_counter`: {},
+		`crdb_internal.deserialize_session`:       {},
 	}
 
 	// Check that the actual map matches the expected map


### PR DESCRIPTION
Previously, the `crdb_internal.deserialize_session` builtin was gated behind the `allow_unsafe_internals` session variable. This caused sqlproxy connection migration to fail when the unsafe internals gate was enabled, because the proxy directly issues a
`SELECT crdb_internal.deserialize_session(...)` query to restore session state on the new SQL pod.

This change adds `crdb_internal.deserialize_session` to the `SupportedCRDBInternalBuiltins` allowlist, permitting it to be called without requiring `allow_unsafe_internals`. This is safe because the builtin is only useful for restoring serialized session state, which requires a valid session token obtained through proper authentication.

Fixes: #160986

Release note: None

Epic: None