### PR TITLE
release-26.1: logictest: add 'retry' to RELOCATE statements

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_agg
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_agg
@@ -676,7 +676,12 @@ INSERT INTO t55837 (i, y, x) VALUES
   (3, 2.0,   3),
   (4, 3.0,   3);
 ALTER TABLE t55837 SPLIT AT VALUES (3);
+
+retry
+statement ok
 ALTER TABLE t55837 EXPERIMENTAL_RELOCATE VALUES (ARRAY[3], 2);
+
+statement ok
 SELECT * FROM t55837 -- make sure that the range cache is populated
 
 # Regression test for incorrectly planning a local distinct stage (#55837).
@@ -691,9 +696,19 @@ statement ok
 CREATE TABLE table58683_1 (col1 INT8 PRIMARY KEY);
 INSERT INTO table58683_1 SELECT i FROM generate_series(1, 5) AS g(i);
 ALTER TABLE table58683_1 SPLIT AT SELECT i FROM generate_series(1, 5) AS g(i);
+
+retry
+statement ok
 ALTER TABLE table58683_1 EXPERIMENTAL_RELOCATE SELECT ARRAY[i], i FROM generate_series(1, 5) AS g(i);
+
+statement ok
 CREATE TABLE table58683_2 (col2 BOOL);
+
+retry
+statement ok
 ALTER TABLE table58683_2 EXPERIMENTAL_RELOCATE SELECT ARRAY[2], 2;
+
+statement ok
 SELECT every(col2) FROM table58683_1 JOIN table58683_2 ON col1 = (table58683_2.tableoid)::INT8 GROUP BY col2 HAVING bool_and(col2);
 
 # Regression test for #74736 - missing Get results when:
@@ -703,7 +718,12 @@ SELECT every(col2) FROM table58683_1 JOIN table58683_2 ON col1 = (table58683_2.t
 statement ok
 CREATE TABLE table74736 (k INT PRIMARY KEY, blob STRING);
 ALTER TABLE table74736 SPLIT AT VALUES (1000000);
+
+retry
+statement ok
 ALTER TABLE table74736 EXPERIMENTAL_RELOCATE VALUES (ARRAY[1], 0), (ARRAY[2], 1000000);
+
+statement ok
 INSERT INTO table74736 SELECT x * 10000, repeat('a', 200000) FROM generate_series(1, 130) AS g(x);
 
 query TTTI colnames,rowsort
@@ -729,7 +749,12 @@ SET DISTSQL = ON
 statement ok
 CREATE TABLE t108901 AS SELECT g::FLOAT8 AS _float8 FROM generate_series(1, 5) AS g;
 ALTER TABLE t108901 SPLIT AT VALUES (1), (2), (3);
+
+retry
+statement ok
 ALTER TABLE t108901 RELOCATE VOTERS VALUES (ARRAY[1], 1), (ARRAY[2], 2), (ARRAY[3], 3);
+
+statement ok
 SET disable_optimizer_rules = PruneWindowOutputCols;
 
 statement error integer out of range

--- a/pkg/sql/logictest/testdata/logic_test/distsql_tenant_locality
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_tenant_locality
@@ -26,13 +26,29 @@ ALTER TABLE t SPLIT AT SELECT generate_series(1, 6)
 # - [1-2) and [2-3) are on node 2
 # - [3-4) and [4-5) are on node 3
 # - [5-6) and [6-7) are on node 1.
+retry
 statement ok
-ALTER RANGE RELOCATE LEASE TO 2 FOR SELECT range_id FROM crdb_internal.ranges WHERE start_pretty LIKE '%Tenant%1';
-ALTER RANGE RELOCATE LEASE TO 2 FOR SELECT range_id FROM crdb_internal.ranges WHERE start_pretty LIKE '%Tenant%2';
-ALTER RANGE RELOCATE LEASE TO 3 FOR SELECT range_id FROM crdb_internal.ranges WHERE start_pretty LIKE '%Tenant%3';
-ALTER RANGE RELOCATE LEASE TO 3 FOR SELECT range_id FROM crdb_internal.ranges WHERE start_pretty LIKE '%Tenant%4';
-ALTER RANGE RELOCATE LEASE TO 1 FOR SELECT range_id FROM crdb_internal.ranges WHERE start_pretty LIKE '%Tenant%5';
-ALTER RANGE RELOCATE LEASE TO 1 FOR SELECT range_id FROM crdb_internal.ranges WHERE start_pretty LIKE '%Tenant%6';
+ALTER RANGE RELOCATE LEASE TO 2 FOR SELECT range_id FROM crdb_internal.ranges WHERE start_pretty LIKE '%Tenant%1'
+
+retry
+statement ok
+ALTER RANGE RELOCATE LEASE TO 2 FOR SELECT range_id FROM crdb_internal.ranges WHERE start_pretty LIKE '%Tenant%2'
+
+retry
+statement ok
+ALTER RANGE RELOCATE LEASE TO 3 FOR SELECT range_id FROM crdb_internal.ranges WHERE start_pretty LIKE '%Tenant%3'
+
+retry
+statement ok
+ALTER RANGE RELOCATE LEASE TO 3 FOR SELECT range_id FROM crdb_internal.ranges WHERE start_pretty LIKE '%Tenant%4'
+
+retry
+statement ok
+ALTER RANGE RELOCATE LEASE TO 1 FOR SELECT range_id FROM crdb_internal.ranges WHERE start_pretty LIKE '%Tenant%5'
+
+retry
+statement ok
+ALTER RANGE RELOCATE LEASE TO 1 FOR SELECT range_id FROM crdb_internal.ranges WHERE start_pretty LIKE '%Tenant%6'
 
 # Populate the range cache.
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_agg
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_agg
@@ -1007,6 +1007,9 @@ Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJzMl99v6jYUx9_3V
 statement ok
 CREATE TABLE data2 (a INT, b INT, PRIMARY KEY (a, b), INDEX(b));
 ALTER TABLE data2 SPLIT AT SELECT 1,i FROM generate_series(1, 9) AS g(i);
+
+retry
+statement ok
 ALTER TABLE data2 EXPERIMENTAL_RELOCATE
   SELECT ARRAY[i%5+1], i FROM generate_series(0, 9) AS g(i);
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_auto_mode
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_auto_mode
@@ -13,6 +13,9 @@ SET distsql=auto
 statement ok
 CREATE TABLE kv (k INT PRIMARY KEY, v INT);
 ALTER TABLE kv SPLIT AT SELECT i FROM generate_series(1,5) AS g(i);
+
+retry
+statement ok
 ALTER TABLE kv EXPERIMENTAL_RELOCATE SELECT ARRAY[(i+1)%5+1], i FROM generate_series(1, 5) as g(i);
 
 # Full table scan (no stats) - distribute.
@@ -231,6 +234,9 @@ RESET distribute_join_row_count_threshold;
 statement ok
 CREATE TABLE kw (k INT PRIMARY KEY, w INT);
 ALTER TABLE kw SPLIT AT SELECT i FROM generate_series(1,5) AS g(i);
+
+retry
+statement ok
 ALTER TABLE kw EXPERIMENTAL_RELOCATE SELECT ARRAY[i], i FROM generate_series(1, 5) as g(i)
 
 # Large hash join - distribute.
@@ -248,6 +254,9 @@ distribution: full
 statement ok
 CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT, INDEX b (b));
 ALTER TABLE abc SPLIT AT SELECT i FROM generate_series(1,5) AS g(i);
+
+retry
+statement ok
 ALTER TABLE abc EXPERIMENTAL_RELOCATE SELECT ARRAY[i], i FROM generate_series(1, 5) as g(i)
 
 # Index join - don't distribute.

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_indexjoin
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_indexjoin
@@ -8,6 +8,7 @@ statement ok
 ALTER INDEX t@v SPLIT AT SELECT (i * 10)::int FROM generate_series(1, 4) AS g(i)
 
 # Relocate the five parts to the five nodes.
+retry
 statement ok
 ALTER INDEX t@v EXPERIMENTAL_RELOCATE
   SELECT ARRAY[i+1], (i * 10)::int FROM generate_series(0, 4) AS g(i)

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_join
@@ -256,6 +256,9 @@ CREATE TABLE lineitem (
   CONSTRAINT lineitem_fkey_orders FOREIGN KEY (l_orderkey) REFERENCES orders (o_orderkey)
 );
 ALTER TABLE lineitem SPLIT AT SELECT i FROM generate_series(1, 9) AS g(i);
+
+retry
+statement ok
 ALTER TABLE lineitem EXPERIMENTAL_RELOCATE SELECT ARRAY[i%5+1], i FROM generate_series(0, 9) AS g(i)
 
 # This query checks that there is no type mismatch during the vectorized flow
@@ -287,6 +290,9 @@ RESET vectorize
 statement ok
 CREATE TABLE kv (k INT PRIMARY KEY, v INT, FAMILY (k, v));
 ALTER TABLE kv SPLIT AT SELECT i FROM generate_series(1,5) AS g(i);
+
+retry
+statement ok
 ALTER TABLE kv EXPERIMENTAL_RELOCATE SELECT ARRAY[i], i FROM generate_series(1, 5) as g(i);
 
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_tighten_spans
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_tighten_spans
@@ -82,6 +82,7 @@ retry
 statement ok
 ALTER TABLE p1 EXPERIMENTAL_RELOCATE SELECT ARRAY[i], i FROM generate_series(1,3) AS g(i)
 
+retry
 statement ok
 ALTER INDEX b EXPERIMENTAL_RELOCATE SELECT ARRAY[i+3], i FROM generate_series(1,2) AS g(i)
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_filter_geospatial_dist
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_filter_geospatial_dist
@@ -96,6 +96,7 @@ vectorized: true
 ·
 Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyUlGFv2jwQx98_n8K6NwU9LthJquepX9GWdMsEpYNMW7UglJErjQhxZpuVquK7T0kKLWlDy70wubP9u_PfZx5B_05AgPvjunfmXZFG1xv5o6-9Jhm5PffCJ3NyORz0yQzlxIS_EiTfP7tDl2gziVODSuPU6MZR_1vP964H3pXfaFgti1gtq0lJw24xYrdYs3kkxCd30Hf94Q3NWYsmGQy77pCc35A5UEhlhFfhAjWIn8BhTCFTcopaS5WHHosFXrQCwSjEabY0eXhMYSoVgngEE5sEQYCf1zjEMELVZkAhQhPGSYHdHqGTFzCJ0whXQOFCJstFqgWZl5UBhVEW5oF2AOdBsLqNgmDFWRCs2HsDHB-6hwdAwjQiNiPS3KHSMF5TkEvzfERtwhmC4C808bog2Jp-XBYv_YPKYHQZJwYVqjbf1WYz764yRWRKOlwQnatAtAmVEcWp7P9OgoBZLAgYe28Agml06LZcjIoaFAZLI0iH1-piVXThh-jyRcbpU7dYe7ql_Jpkc3x4q2PqSrMrpVmHlLa9Knu3sDIuqi-Qceaw0qynX854-XF6dro1xp1X_vPKHfvfeeUfiZcPuWM1P3BBTkUF-xAVRlIZVG1nV4MO_7c23UklnXNIuiHqTKYad9LVZWKVTMd8PaaA0QzL_ywtl2qK10pOi7WlOyhARSBCbcpZXjpeupnSRmG42D7zlyS-l2TVk3iVZO0l2fUkq0qy95KcepJdJTl7SSf7dBpTuE3k_SSOQMCmZ4_fGDYG-YZwpvMGGN3J-wLrP2T59d2GiUYK_XCOXTSoFnEaaxNPQRi1xPX6n78BAAD__8kUP_s=
 
+retry
 statement ok
 ALTER INDEX geo_table@geom_index EXPERIMENTAL_RELOCATE VALUES (ARRAY[2], 1152921574000000000)
 
@@ -166,6 +167,7 @@ Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyUlFFv2jAQx9_3K
 # Move all the index data that will be read to node 2 while the query executes
 # at node 1. The filtering moves to node 2 when it is distributable.
 
+retry
 statement ok
 ALTER INDEX geo_table@geom_index EXPERIMENTAL_RELOCATE VALUES (ARRAY[2], 1)
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_filter_json_array_dist
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_filter_json_array_dist
@@ -61,6 +61,7 @@ INSERT INTO json_tab VALUES
 statement ok
 ALTER INDEX json_inv SPLIT AT VALUES (10), (20)
 
+retry
 statement ok
 ALTER INDEX json_inv EXPERIMENTAL_RELOCATE VALUES (ARRAY[1], 1), (ARRAY[2], 10), (ARRAY[3], 20)
 
@@ -347,6 +348,7 @@ ALTER TABLE array_tab VALIDATE CONSTRAINT check_c
 statement ok
 ALTER INDEX arr_inv SPLIT AT VALUES (10), (20)
 
+retry
 statement ok
 ALTER INDEX arr_inv EXPERIMENTAL_RELOCATE VALUES (ARRAY[1], 1), (ARRAY[2], 10), (ARRAY[3], 20)
 


### PR DESCRIPTION
Backport 1/1 commits from #160991 on behalf of @yuzefovich.

----

We just saw a failure on RELOCATE VOTERS command which was missing a `retry` option. I asked Claude to find related ones to add missing retry directives in hopes of reducing such flakes.

Fixes: #160979.
Release note: None

----

Release justification: