### PR TITLE
release-24.3: kvcoord: use expiration leases in TestDistSenderCircuitBreakerModes

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_circuit_breaker_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_circuit_breaker_test.go
@@ -143,10 +143,14 @@ func TestDistSenderCircuitBreakerModes(t *testing.T) {
 			func(t *testing.T, mode kvcoord.DistSenderCircuitBreakersMode) {
 				ctx := context.Background()
 
-				// The lease won't move unless we use expiration-based leases. We also
-				// speed up the test by reducing various intervals and timeouts.
+				// The lease won't move unless we use expiration-based leases. This is
+				// because a deadlocked range with expiration-based leases would
+				// eventually cause the lease to expire. However, with epoch-based or
+				// leader leases, the lease wouldn't expire due to a deadlocked range
+				// since lease extensions are happening at a different layer.
+				// We also speed up the test by reducing various intervals and timeouts.
 				st := cluster.MakeTestingClusterSettings()
-				kvserver.ExpirationLeasesOnly.Override(ctx, &st.SV, true)
+				kvserver.OverrideDefaultLeaseType(ctx, &st.SV, roachpb.LeaseExpiration)
 				kvcoord.CircuitBreakersMode.Override(ctx, &st.SV, mode)
 				kvcoord.CircuitBreakerCancellation.Override(ctx, &st.SV, true)
 				kvcoord.CircuitBreakerProbeThreshold.Override(ctx, &st.SV, time.Second)


### PR DESCRIPTION
Backport 1/1 commits from #136834.

/cc @cockroachdb/release

---

The test already uses expiration-based leases. However, with the recent metamorphic fortification enablement in tests, this test fails if the range is using the fortification logic. The main reason why this fails with fortification is that the deadlocked leader won't step down because it's fortified in the store liveness layer below raft.

Fixes: #136542

Release note: None

Release justification: testing only fixes 

Fixes: https://github.com/cockroachdb/cockroach/issues/160841
