### PR TITLE
sql: deflake distsql_inspect logictest timeout

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_inspect
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_inspect
@@ -1,4 +1,4 @@
-# LogicTest: 5node-default-configs
+# LogicTest: 5node-default-configs !metamorphic-batch-sizes
 
 skip under race
 


### PR DESCRIPTION
Using metamorphic constants in distsql_inspect logictest could set kv-batch-size = 1. This was proven to make INSPECT run very slow, causing the test to tiemout. This PR prevenets running distsql_inspect with metamorphic-bach-sizes to avoid this test flake.

Fixes: #160799

Release note: None