### PR TITLE
[DRAFT] Option 1: Restore scoped special case for M.1 skip upgrades

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/mixedversion",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/cmd/roachprod/grafana",
         "//pkg/cmd/roachtest/cluster",
         "//pkg/cmd/roachtest/option",
@@ -38,6 +39,7 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_version//:version",
         "@org_golang_x_exp//maps",
     ],
 )


### PR DESCRIPTION
This implements Option 1 of the proposed paths forward.

### Context

These two tests are in conflict with each other:

- TestSupportsSkipCurrentVersion: expects false for skip to v26.2 when only 1 supported version
- TestSupportsSkipUpgradeTo: expects true for skip to older versions like v24.3.0, v25.2.1

https://github.com/cockroachdb/cockroach/pull/157852 was introduced in November to which similar test failures to what we're seeing on https://github.com/cockroachdb/cockroach/pull/160882

But now with the bump in this PR , `MinSupported = PreviousRelease = V25_4`, making 
`len(SupportedPreviousReleases()) = 1`.

This means that these two tests now conflict:
- TestSupportsSkipCurrentVersion (the Nov 18 regression test): expects false for skip to v26.2 when only 1 supported version
- TestSupportsSkipUpgradeTo (existing): expects true for skip to older versions like v24.3.0, v25.2.1

### Two Options

Option 1: Restore Scoped Special Case (THIS PR)
- [draft PR] https://github.com/cockroachdb/cockroach/pull/161010
- Restore the special case but ONLY for current version series (like the old code before #157852)
- Makes both tests pass
- Production code change

Option 2: Update Regression Test
- [draft PR] https://github.com/cockroachdb/cockroach/pull/161012
- Remove the numSupportedVersions > 1 check from TestSupportsSkipCurrentVersion
- Trusts #157852 was correct that special case isn't needed
- Test-only change

