### PR TITLE
ui,sql: introduce a way to identify query plan distribution shifts

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -4435,6 +4435,7 @@ StatementDetailsRequest requests the details of a Statement, based on its keys.
 | statement_statistics_per_aggregated_ts | [StatementDetailsResponse.CollectedStatementGroupedByAggregatedTs](#cockroach.server.serverpb.StatementDetailsResponse-cockroach.server.serverpb.StatementDetailsResponse.CollectedStatementGroupedByAggregatedTs) | repeated | statement_statistics_per_aggregated_ts returns the same statement from above, but with its statistics separated by the aggregated timestamp. | [reserved](#support-status) |
 | statement_statistics_per_plan_hash | [StatementDetailsResponse.CollectedStatementGroupedByPlanHash](#cockroach.server.serverpb.StatementDetailsResponse-cockroach.server.serverpb.StatementDetailsResponse.CollectedStatementGroupedByPlanHash) | repeated | statement_statistics_per_plan_hash returns the same statement from above, but with its statistics separated by the plan hash. | [reserved](#support-status) |
 | internal_app_name_prefix | [string](#cockroach.server.serverpb.StatementDetailsResponse-string) |  | If set and non-empty, indicates the prefix to application_name used for statements/queries issued internally by CockroachDB. | [reserved](#support-status) |
+| statement_statistics_per_aggregated_ts_and_plan_hash | [StatementDetailsResponse.StatementPlanDistribution](#cockroach.server.serverpb.StatementDetailsResponse-cockroach.server.serverpb.StatementDetailsResponse.StatementPlanDistribution) | repeated | statement_statistics_per_aggregated_ts_and_plan_hash returns execution counts grouped by both aggregated timestamp and plan hash for visualizing plan distribution over time. | [reserved](#support-status) |
 
 
 
@@ -4485,6 +4486,22 @@ StatementDetailsRequest requests the details of a Statement, based on its keys.
 | explain_plan | [string](#cockroach.server.serverpb.StatementDetailsResponse-string) |  |  | [reserved](#support-status) |
 | plan_hash | [uint64](#cockroach.server.serverpb.StatementDetailsResponse-uint64) |  |  | [reserved](#support-status) |
 | index_recommendations | [string](#cockroach.server.serverpb.StatementDetailsResponse-string) | repeated |  | [reserved](#support-status) |
+
+
+
+
+
+<a name="cockroach.server.serverpb.StatementDetailsResponse-cockroach.server.serverpb.StatementDetailsResponse.StatementPlanDistribution"></a>
+#### StatementDetailsResponse.StatementPlanDistribution
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| execution_count | [int64](#cockroach.server.serverpb.StatementDetailsResponse-int64) |  |  | [reserved](#support-status) |
+| aggregated_ts | [google.protobuf.Timestamp](#cockroach.server.serverpb.StatementDetailsResponse-google.protobuf.Timestamp) |  |  | [reserved](#support-status) |
+| plan_hash | [uint64](#cockroach.server.serverpb.StatementDetailsResponse-uint64) |  |  | [reserved](#support-status) |
+| plan_gist | [string](#cockroach.server.serverpb.StatementDetailsResponse-string) |  |  | [reserved](#support-status) |
 
 
 

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -499,6 +499,7 @@ go_test(
         "settings_cache_test.go",
         "span_stats_server_test.go",
         "span_stats_test.go",
+        "statement_details_test.go",
         "statements_test.go",
         "status_ext_test.go",
         "status_test.go",

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -1785,6 +1785,13 @@ message StatementDetailsResponse {
     repeated string index_recommendations = 6;
   }
 
+  message StatementPlanDistribution {
+    int64 execution_count = 1;
+    google.protobuf.Timestamp aggregated_ts = 2 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
+    uint64 plan_hash = 3;
+    string plan_gist = 4;
+  }
+
   // statement returns the total statistics for the statement.
   CollectedStatementSummary statement = 1 [(gogoproto.nullable) = false];
   // statement_statistics_per_aggregated_ts returns the same statement from above, but with its statistics
@@ -1796,6 +1803,9 @@ message StatementDetailsResponse {
   // If set and non-empty, indicates the prefix to application_name
   // used for statements/queries issued internally by CockroachDB.
   string internal_app_name_prefix = 4;
+  // statement_statistics_per_aggregated_ts_and_plan_hash returns execution counts grouped by both
+  // aggregated timestamp and plan hash for visualizing plan distribution over time.
+  repeated StatementPlanDistribution statement_statistics_per_aggregated_ts_and_plan_hash = 5 [(gogoproto.nullable) = false];
 }
 
 message StatementDiagnosticsReport {

--- a/pkg/server/statement_details_test.go
+++ b/pkg/server/statement_details_test.go
@@ -1,0 +1,100 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats/sqlstatstestutil"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStatementDetails(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	testServer, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			SQLStatsKnobs: &sqlstats.TestingKnobs{
+				SynchronousSQLStats: true,
+			},
+		},
+	})
+	defer testServer.Stopper().Stop(ctx)
+
+	client := testServer.GetStatusClient(t)
+	conn := sqlutils.MakeSQLRunner(db)
+
+	conn.Exec(t, "CREATE DATABASE testdb;")
+	conn.Exec(t, "USE testdb;")
+	conn.Exec(t, "CREATE TABLE samples (id INT PRIMARY KEY, body TEXT);")
+	conn.Exec(t, "INSERT INTO samples VALUES (1, 'foo'), (2, 'bar'), (3, 'baz');")
+
+	// generate statistics.
+	testQuery := "SELECT * FROM samples"
+	for i := 0; i < 5; i++ {
+		_, err := db.Exec(testQuery)
+		require.NoError(t, err)
+	}
+
+	sqlstatstestutil.WaitForStatementEntriesAtLeast(t, conn, 1,
+		sqlstatstestutil.StatementFilter{Query: testQuery})
+
+	stmts, err := client.Statements(ctx, &serverpb.StatementsRequest{})
+	require.NoError(t, err)
+
+	var fingerprintID string
+	for _, stmt := range stmts.Statements {
+		if stmt.Key.KeyData.Query == testQuery {
+			fingerprintID = stmt.ID.String()
+			break
+		}
+	}
+	require.NotEmpty(t, fingerprintID, "fingerprint ID not found for test query")
+
+	resp, err := client.StatementDetails(ctx, &serverpb.StatementDetailsRequest{
+		FingerprintId: fingerprintID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	require.NotNil(t, resp.Statement)
+	require.NotEmpty(t, resp.Statement.Metadata.Query)
+	require.NotEmpty(t, resp.Statement.Metadata.FingerprintID)
+	require.Greater(t, resp.Statement.Stats.Count, int64(0))
+
+	require.NotEmpty(t, resp.StatementStatisticsPerAggregatedTs,
+		"should have statistics grouped by aggregated timestamp")
+	for _, stat := range resp.StatementStatisticsPerAggregatedTs {
+		require.NotZero(t, stat.AggregatedTs)
+		require.Greater(t, stat.Stats.Count, int64(0))
+	}
+
+	require.NotEmpty(t, resp.StatementStatisticsPerPlanHash,
+		"should have statistics grouped by plan hash")
+	for _, stat := range resp.StatementStatisticsPerPlanHash {
+		require.NotZero(t, stat.PlanHash)
+		require.Greater(t, stat.Stats.Count, int64(0))
+		require.Greater(t, stat.Metadata.TotalCount, int64(0))
+	}
+
+	require.NotEmpty(t, resp.StatementStatisticsPerAggregatedTsAndPlanHash,
+		"should have plan distribution over time")
+	for _, stat := range resp.StatementStatisticsPerAggregatedTsAndPlanHash {
+		require.NotZero(t, stat.AggregatedTs)
+		require.NotZero(t, stat.PlanHash)
+		require.Greater(t, stat.ExecutionCount, int64(0))
+	}
+}

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.fixture.ts
@@ -68,6 +68,7 @@ const statementDetailsNoData: StatementDetailsResponse = {
   internal_app_name_prefix: "$ internal",
   statement_statistics_per_aggregated_ts: [],
   statement_statistics_per_plan_hash: [],
+  statement_statistics_per_aggregated_ts_and_plan_hash: [],
 };
 
 const statementDetailsData: StatementDetailsResponse = {
@@ -819,6 +820,7 @@ const statementDetailsData: StatementDetailsResponse = {
     },
   ],
   internal_app_name_prefix: "$ internal",
+  statement_statistics_per_aggregated_ts_and_plan_hash: [],
 };
 
 export const getStatementDetailsPropsFixture = (

--- a/pkg/ui/workspaces/db-console/src/views/statements/statements.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statements.spec.tsx
@@ -249,6 +249,7 @@ function makeDetails(
       },
       statement_statistics_per_aggregated_ts: [],
       statement_statistics_per_plan_hash: [],
+      statement_statistics_per_aggregated_ts_and_plan_hash: [],
       internal_app_name_prefix: "$ internal",
     },
   };


### PR DESCRIPTION
Add a new timeseries bargraph under the statement page - explain plan tab. This graph is powered by a new protobuff that returns statement execution counts, grouped by plan gists and timestamps.

Partial: #118579
Epic: None
Release Note(ui): introduce a new way to investigate query plan distributions over time.