### PR TITLE
kvcoord: skip TestDistSenderCircuitBreakerModes UnderDuress

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_circuit_breaker_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_circuit_breaker_test.go
@@ -142,6 +142,8 @@ func TestDistSenderCircuitBreakerModes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	skip.UnderDuress(t, "too slow: request gets stuck at gRPC layer before circuit breaker trips.")
+
 	testutils.RunTrueAndFalse(t, "scratchRange", func(t *testing.T, scratchRange bool) {
 		testutils.RunValues(
 			t,


### PR DESCRIPTION
This test validates that the circuit breaker properly routes around
stalled replicas. Under stress/duress conditions, the test can be
slow because requests may get stuck at the gRPC layer before the circuit
breaker takes effect.

Fixes: https://github.com/cockroachdb/cockroach/issues/160841