### PR TITLE
sql,server: fix sql activity update job to respect sql.stats.activity…

### DIFF
--- a/pkg/server/combined_statement_stats.go
+++ b/pkg/server/combined_statement_stats.go
@@ -223,7 +223,7 @@ func activityTablesHaveFullData(
 		return false, nil
 	}
 
-	if (limit > 0 && !isLimitOnActivityTable(limit)) || !isSortOptionOnActivityTable(order) {
+	if (limit > 0 && sql.SqlStatsActivityTopCount.Get(&settings.SV) < limit) || !isSortOptionOnActivityTable(order) {
 		return false, nil
 	}
 
@@ -488,12 +488,6 @@ FROM %s %s`, table, whereClause)
 	}
 
 	return stmtsRuntime, txnsRuntime, oldestDate, stmtSourceTable, txnSourceTable, err
-}
-
-// Return true is the limit request is within the limit
-// on the Activity tables (500)
-func isLimitOnActivityTable(limit int64) bool {
-	return limit <= 500
 }
 
 func isSortOptionOnActivityTable(sort serverpb.StatsSortOptions) bool {

--- a/pkg/sql/sql_activity_update_job_test.go
+++ b/pkg/sql/sql_activity_update_job_test.go
@@ -885,7 +885,7 @@ func TestSqlActivityUpdaterDataDriven(t *testing.T) {
 				}
 
 			case "explain-sql-activity-select-top-transactions":
-				limit := sqlStatsActivityTopCount.Get(&st.SV)
+				limit := SqlStatsActivityTopCount.Get(&st.SV)
 
 				var mockAggTsStr string
 				d.ScanArgs(t, "aggTs", &mockAggTsStr)
@@ -912,7 +912,7 @@ func TestSqlActivityUpdaterDataDriven(t *testing.T) {
 					require.NoError(t, err)
 				}
 			case "explain-sql-activity-select-top-statements":
-				limit := sqlStatsActivityTopCount.Get(&st.SV)
+				limit := SqlStatsActivityTopCount.Get(&st.SV)
 
 				var mockAggTsStr string
 				d.ScanArgs(t, "aggTs", &mockAggTsStr)


### PR DESCRIPTION
….top.max

Previously the SQL activity update job used the sql.stats.activity.top.max cluster setting to compute the top K statements for a subset of stats. When this value was set to be above 500, the corresponding top K was computed, but only the top 500 were stored. This commit fixes this such that all the top K will be stored instead of a hardcoded 500.

Additionally, the CombineStatements API has been updated to use the same cluster setting when determining whether or not to query the activity tables.

Epic: None
Fixes: https://cockroachlabs.atlassian.net/browse/CRDB-56948
Release note: None