### PR TITLE
release-26.1: cmd/roachtest: cdc tests reduce bank workload concurrency

### DIFF
--- a/pkg/ccl/workloadccl/fixture.go
+++ b/pkg/ccl/workloadccl/fixture.go
@@ -419,6 +419,7 @@ func ImportFixture(
 			concurrencyLimit = importLimit
 		}
 	}
+	log.Dev.Infof(ctx, `importing with concurrency limit %d`, concurrencyLimit)
 	concurrentImportLimit := limit.MakeConcurrentRequestLimiter("workload_import", concurrencyLimit)
 	for _, t := range tables {
 		table := t

--- a/pkg/workload/bank/bank.go
+++ b/pkg/workload/bank/bank.go
@@ -72,8 +72,10 @@ var bankMeta = workload.Meta{
 		RandomSeed.AddFlag(&g.flags)
 		g.connFlags = workload.NewConnFlags(&g.flags)
 		// Because this workload can create a large number of objects, the import
-		// concurrent may need to be limited.
-		g.flags.Int(workload.ImportDataLoaderConcurrencyFlag, 32, workload.ImportDataLoaderConcurrencyFlagDescription)
+		// concurrent may need to be limited. With a large number of tables,
+		// high concurrency can cause one of the table imports to fail after
+		// retrying the transaction too many times.
+		g.flags.Int(workload.ImportDataLoaderConcurrencyFlag, 8, workload.ImportDataLoaderConcurrencyFlagDescription)
 		return g
 	},
 }


### PR DESCRIPTION
Backport 1/1 commits from #160705 on behalf of @log-head.

----

While some cdc roachtests ran the bank workload with a large number of tables, there were flakes where importing a bank table hit the limit of retries (100).

This patch reduces the workload's import data loader concurrency for these tests from 32 to 8.

Fixes: #160001
Release note: None

----

Release justification: Test-only fix