### PR TITLE
sql: disable distsql_prevent_partitioning_soft_limited_scans for internal validation queries

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1582,9 +1582,11 @@ func ValidateConstraint(
 	runHistoricalTxn descs.HistoricalInternalExecTxnRunner,
 	execOverride sessiondata.InternalExecutorOverride,
 ) (err error) {
-	// Validation queries use full table scans which we always want to distribute.
+	// Validation queries use full table scans which we always want to distribute
+	// and partition across nodes.
 	// See https://github.com/cockroachdb/cockroach/issues/152859.
 	execOverride.AlwaysDistributeFullScans = true
+	execOverride.PreventPartitioningSoftLimitedScans = &sessiondata.False
 
 	tableDesc, err = tableDesc.MakeFirstMutationPublic(catalog.IgnoreConstraints)
 	if err != nil {
@@ -1711,9 +1713,11 @@ func ValidateInvertedIndexes(
 	execOverride sessiondata.InternalExecutorOverride,
 	protectedTSManager scexec.ProtectedTimestampManager,
 ) (err error) {
-	// Validation queries use full table scans which we always want to distribute.
+	// Validation queries use full table scans which we always want to distribute
+	// and partition across nodes.
 	// See https://github.com/cockroachdb/cockroach/issues/152859.
 	execOverride.AlwaysDistributeFullScans = true
+	execOverride.PreventPartitioningSoftLimitedScans = &sessiondata.False
 
 	grp := ctxgroup.WithContext(ctx)
 	invalid := make(chan descpb.IndexID, len(indexes))
@@ -1819,9 +1823,11 @@ func countExpectedRowsForInvertedIndex(
 	desc := tableDesc
 	start := timeutil.Now()
 
-	// Validation queries use full table scans which we always want to distribute.
+	// Validation queries use full table scans which we always want to distribute
+	// and partition across nodes.
 	// See https://github.com/cockroachdb/cockroach/issues/152859.
 	execOverride.AlwaysDistributeFullScans = true
+	execOverride.PreventPartitioningSoftLimitedScans = &sessiondata.False
 
 	if withFirstMutationPublic {
 		// Make the mutations public in an in-memory copy of the descriptor and
@@ -1923,9 +1929,11 @@ func ValidateForwardIndexes(
 	execOverride sessiondata.InternalExecutorOverride,
 	protectedTSManager scexec.ProtectedTimestampManager,
 ) (err error) {
-	// Validation queries use full table scans which we always want to distribute.
+	// Validation queries use full table scans which we always want to distribute
+	// and partition across nodes.
 	// See https://github.com/cockroachdb/cockroach/issues/152859.
 	execOverride.AlwaysDistributeFullScans = true
+	execOverride.PreventPartitioningSoftLimitedScans = &sessiondata.False
 
 	grp := ctxgroup.WithContext(ctx)
 
@@ -2043,9 +2051,11 @@ func populateExpectedCounts(
 	runHistoricalTxn descs.HistoricalInternalExecTxnRunner,
 	execOverride sessiondata.InternalExecutorOverride,
 ) (int64, error) {
-	// Validation queries use full table scans which we always want to distribute.
+	// Validation queries use full table scans which we always want to distribute
+	// and partition across nodes.
 	// See https://github.com/cockroachdb/cockroach/issues/152859.
 	execOverride.AlwaysDistributeFullScans = true
+	execOverride.PreventPartitioningSoftLimitedScans = &sessiondata.False
 
 	desc := tableDesc
 	if withFirstMutationPublic {
@@ -2113,9 +2123,11 @@ func countIndexRowsAndMaybeCheckUniqueness(
 	runHistoricalTxn descs.HistoricalInternalExecTxnRunner,
 	execOverride sessiondata.InternalExecutorOverride,
 ) (int64, error) {
-	// Validation queries use full table scans which we always want to distribute.
+	// Validation queries use full table scans which we always want to distribute
+	// and partition across nodes.
 	// See https://github.com/cockroachdb/cockroach/issues/152859.
 	execOverride.AlwaysDistributeFullScans = true
+	execOverride.PreventPartitioningSoftLimitedScans = &sessiondata.False
 
 	// If we are doing a REGIONAL BY ROW locality change, we can
 	// bypass the uniqueness check below as we are only adding or

--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -65,10 +65,12 @@ func validateCheckExpr(
 	}
 	log.Dev.Infof(ctx, "validating check constraint %q with query %q", formattedCkExpr, queryStr)
 
-	// Validation queries use full table scans which we always want to distribute.
+	// Validation queries use full table scans which we always want to distribute
+	// and partition across nodes.
 	// See https://github.com/cockroachdb/cockroach/issues/152859.
 	execOverride := sessiondata.NodeUserSessionDataOverride
 	execOverride.AlwaysDistributeFullScans = true
+	execOverride.PreventPartitioningSoftLimitedScans = &sessiondata.False
 
 	violatingRow, err = txn.QueryRowEx(
 		ctx,

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -962,6 +962,9 @@ func applyOverrides(o sessiondata.InternalExecutorOverride, sd *sessiondata.Sess
 	if o.AlwaysDistributeFullScans {
 		sd.AlwaysDistributeFullScans = true
 	}
+	if o.PreventPartitioningSoftLimitedScans != nil {
+		sd.DistSQLPreventPartitioningSoftLimitedScans = *o.PreventPartitioningSoftLimitedScans
+	}
 	// For 25.2, we're being conservative and explicitly disabling buffered
 	// writes for the internal executor.
 	// TODO(yuzefovich): remove this for 25.3.

--- a/pkg/sql/sessiondata/internal.go
+++ b/pkg/sql/sessiondata/internal.go
@@ -87,11 +87,17 @@ type InternalExecutorOverride struct {
 	// AlwaysDistributeFullScans, if true, overrides the
 	// always_distribute_full_scans session variable.
 	AlwaysDistributeFullScans bool
+	// PreventPartitioningSoftLimitedScans, if set, overrides the
+	// distsql_prevent_partitioning_soft_limited_scans session variable.
+	PreventPartitioningSoftLimitedScans *bool
 }
 
 // NoSessionDataOverride is the empty InternalExecutorOverride which does not
 // override any session data.
 var NoSessionDataOverride = InternalExecutorOverride{}
+
+// False is a helper variable for setting *bool fields in InternalExecutorOverride.
+var False = false
 
 // NodeUserSessionDataOverride is an InternalExecutorOverride which overrides
 // the user to the NodeUser.


### PR DESCRIPTION
The validation queries we run after a backfill all use full table scans which we want to distribute and partition across nodes. Since 7fda5a44b was merged, we need to explicitly set
distsql_prevent_partitioning_soft_limited_scans to false to ensure these scans are properly partitioned.

This is similar to the fix in 27c8606 which set always_distribute_full_scans for these queries.

fixes https://github.com/cockroachdb/cockroach/issues/161015
Release note: None