### PR TITLE
release-26.1: builtins, eventpb: add rewrite_inline_hints event logging

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -681,6 +681,33 @@ preserved in each tenant's own system.eventlog table.
 Events in this category are logged to the `OPS` channel.
 
 
+### `rewrite_inline_hints`
+
+An event of type `rewrite_inline_hints` is recorded when a new inline-hints rewrite rule is added
+via information_schema.crdb_rewrite_inline_hints.
+
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `StatementFingerprint` | The target statement fingerprint for which inline hints are being rewritten. | no |
+| `DonorSQL` | The donor statement providing the inline hints. | no |
+| `HintID` | The hint ID of the newly created statement hint. | no |
+
+
+#### Common fields
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
+| `EventType` | The type of the event. | no |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
+| `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
+| `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
+| `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
+| `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
+
 ### `set_cluster_setting`
 
 An event of type `set_cluster_setting` is recorded when a cluster setting is changed.

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -618,6 +618,11 @@ func (ep *DummyEvalPlanner) GetHintIDs() []int64 {
 	return nil
 }
 
+// LogEvent is part of the eval.Planner interface.
+func (ep *DummyEvalPlanner) LogEvent(ctx context.Context, event interface{}) error {
+	return nil
+}
+
 // DummyPrivilegedAccessor implements the tree.PrivilegedAccessor interface by returning errors.
 type DummyPrivilegedAccessor struct{}
 

--- a/pkg/sql/logictest/testdata/logic_test/statement_hint_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/statement_hint_builtins
@@ -23,7 +23,7 @@ SELECT information_schema.crdb_rewrite_inline_hints(
 query T
 SELECT fingerprint FROM system.statement_hints WHERE row_id = $hint1;
 ----
-SELECT * FROM xy WHERE y = 10
+SELECT * FROM xy WHERE y = _
 
 let $hint2
 SELECT information_schema.crdb_rewrite_inline_hints(
@@ -35,7 +35,7 @@ SELECT information_schema.crdb_rewrite_inline_hints(
 query T
 SELECT fingerprint FROM system.statement_hints WHERE row_id = $hint2;
 ----
-SELECT * FROM xy WHERE y = 10
+SELECT * FROM xy WHERE y = _
 
 let $hint3
 SELECT information_schema.crdb_rewrite_inline_hints(
@@ -55,7 +55,7 @@ SELECT count(*) FROM system.statement_hints;
 3
 
 query I
-SELECT count(*) FROM system.statement_hints WHERE fingerprint = 'SELECT * FROM xy WHERE y = 10';
+SELECT count(*) FROM system.statement_hints WHERE fingerprint = 'SELECT * FROM xy WHERE y = _';
 ----
 2
 
@@ -79,16 +79,16 @@ FROM system.eventlog
 WHERE "eventType" = 'rewrite_inline_hints'
 ORDER BY "timestamp"
 ----
-1  SELECT * FROM xy WHERE y = 10                     SELECT * FROM xy@primary WHERE y = 10
-1  SELECT * FROM xy WHERE y = 10                     SELECT * FROM xy@xy_y_idx WHERE y = 10
-1  SELECT * FROM xy INNER JOIN ab ON xy.x = ab.b    SELECT * FROM xy INNER JOIN ab ON xy.x = ab.b
+1  SELECT * FROM xy WHERE y = _                   SELECT * FROM xy@primary WHERE y = _
+1  SELECT * FROM xy WHERE y = _                   SELECT * FROM xy@xy_y_idx WHERE y = _
+1  SELECT * FROM xy INNER JOIN ab ON xy.x = ab.b  SELECT * FROM xy INNER JOIN ab ON xy.x = ab.b
 
 # Verify that the HintID in the event matches the returned hint ID.
 query B
 SELECT (info::JSONB->>'HintID')::INT = $hint1
 FROM system.eventlog
 WHERE "eventType" = 'rewrite_inline_hints'
-  AND info::JSONB->>'StatementFingerprint' = 'SELECT * FROM xy WHERE y = 10'
+  AND info::JSONB->>'StatementFingerprint' = 'SELECT * FROM xy WHERE y = _'
 ORDER BY "timestamp"
 LIMIT 1
 ----
@@ -124,7 +124,7 @@ SELECT information_schema.crdb_rewrite_inline_hints(
 query T
 SELECT fingerprint FROM system.statement_hints WHERE row_id = $hint4;
 ----
-SELECT * FROM xy WHERE y = 10
+SELECT * FROM xy WHERE y = _
 
 # Verify the event was logged within the transaction.
 query I
@@ -804,7 +804,7 @@ SELECT information_schema.crdb_rewrite_inline_hints(
   'SELECT b FROM ab'
 )
 
-statement error hint injection donor statement AST node \$1 did not match AST node 5
+statement ok
 SELECT information_schema.crdb_rewrite_inline_hints(
   'SELECT a FROM ab WHERE b = 5',
   'SELECT a FROM ab WHERE b = $1'
@@ -1026,3 +1026,54 @@ statement ok
 SELECT information_schema.crdb_rewrite_inline_hints('SELECT _', 'SELECT _')
 
 user root
+
+# Test for #160308, in which ROWS FROM is added to the fingerprint.
+
+query T noticetrace
+SELECT crdb_internal.inject_hint(
+  'SELECT * FROM abc JOIN (SELECT i FROM generate_series(_, _) g(i)) ON b = i',
+  'SELECT * FROM abc INNER MERGE JOIN (SELECT i FROM generate_series(_, _) g(i)) ON b = i'
+)
+----
+NOTICE: statement fingerprint changed to: SELECT * FROM abc JOIN (SELECT i FROM ROWS FROM (generate_series(_, _)) AS g (i)) ON b = i
+NOTICE: hint donor statement changed to: SELECT * FROM abc INNER MERGE JOIN (SELECT i FROM ROWS FROM (generate_series(_, _)) AS g (i)) ON b = i
+
+query TT
+SELECT fingerprint, hint_type
+FROM [SHOW STATEMENT HINTS FOR 'SELECT * FROM abc JOIN (SELECT i FROM ROWS FROM (generate_series(_, _)) AS g (i)) ON b = i']
+----
+SELECT * FROM abc JOIN (SELECT i FROM ROWS FROM (generate_series(_, _)) AS g (i)) ON b = i  rewrite_inline_hints
+
+statement ok
+SELECT crdb_internal.await_statement_hints_cache()
+
+onlyif config local
+query T
+EXPLAIN
+SELECT * FROM abc
+JOIN (SELECT i FROM generate_series(1, 10000) g(i))
+ON b = i
+----
+distribution: local
+vectorized: true
+statement hints count: 1
+·
+• merge join
+│ equality: (b) = (generate_series)
+│
+├── • sort
+│   │ order: +b
+│   │
+│   └── • scan
+│         missing stats
+│         table: abc@abc_pkey
+│         spans: FULL SCAN
+│
+└── • sort
+    │ estimated row count: 10
+    │ order: +generate_series
+    │
+    └── • project set
+        │ estimated row count: 10
+        │
+        └── • emptyrow

--- a/pkg/sql/logictest/testdata/logic_test/statement_hint_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/statement_hint_builtins
@@ -1,5 +1,6 @@
 # LogicTest: !local-prepared
 # cluster-opt: disable-mvcc-range-tombstones-for-point-deletes
+# knob-opt: sync-event-log
 
 statement ok
 CREATE TABLE xy (x INT PRIMARY KEY, y INT, INDEX (y));
@@ -63,6 +64,45 @@ SELECT count(*) FROM system.statement_hints WHERE fingerprint = 'SELECT * FROM x
 ----
 1
 
+# Verify that rewrite_inline_hints events were logged.
+
+query I
+SELECT count(*) FROM system.eventlog WHERE "eventType" = 'rewrite_inline_hints';
+----
+3
+
+query ITT
+SELECT "reportingID",
+       info::JSONB->>'StatementFingerprint',
+       info::JSONB->>'DonorSQL'
+FROM system.eventlog
+WHERE "eventType" = 'rewrite_inline_hints'
+ORDER BY "timestamp"
+----
+1  SELECT * FROM xy WHERE y = 10                     SELECT * FROM xy@primary WHERE y = 10
+1  SELECT * FROM xy WHERE y = 10                     SELECT * FROM xy@xy_y_idx WHERE y = 10
+1  SELECT * FROM xy INNER JOIN ab ON xy.x = ab.b    SELECT * FROM xy INNER JOIN ab ON xy.x = ab.b
+
+# Verify that the HintID in the event matches the returned hint ID.
+query B
+SELECT (info::JSONB->>'HintID')::INT = $hint1
+FROM system.eventlog
+WHERE "eventType" = 'rewrite_inline_hints'
+  AND info::JSONB->>'StatementFingerprint' = 'SELECT * FROM xy WHERE y = 10'
+ORDER BY "timestamp"
+LIMIT 1
+----
+true
+
+# Verify the full event structure (excluding non-deterministic fields).
+query IT
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'TxnReadTimestamp' - 'HintID'
+FROM system.eventlog
+WHERE "eventType" = 'rewrite_inline_hints'
+  AND info::JSONB->>'StatementFingerprint' = 'SELECT * FROM xy INNER JOIN ab ON xy.x = ab.b'
+----
+1  {"DonorSQL": "SELECT * FROM xy INNER JOIN ab ON xy.x = ab.b", "EventType": "rewrite_inline_hints", "Statement": "SELECT information_schema.crdb_rewrite_inline_hints('SELECT * FROM xy INNER JOIN ab ON xy.x = ab.b', 'SELECT * FROM xy INNER JOIN ab ON xy.x = ab.b')", "StatementFingerprint": "SELECT * FROM xy INNER JOIN ab ON xy.x = ab.b", "Tag": "SELECT", "User": "root"}
+
 statement ok
 DELETE FROM system.statement_hints WHERE true;
 
@@ -86,11 +126,27 @@ SELECT fingerprint FROM system.statement_hints WHERE row_id = $hint4;
 ----
 SELECT * FROM xy WHERE y = 10
 
+# Verify the event was logged within the transaction.
+query I
+SELECT count(*) FROM system.eventlog
+WHERE "eventType" = 'rewrite_inline_hints'
+  AND (info::JSONB->>'HintID')::INT = $hint4;
+----
+1
+
 statement ok
 ROLLBACK;
 
 query I
 SELECT count(*) FROM system.statement_hints;
+----
+0
+
+# Verify the event log entry was also rolled back.
+query I
+SELECT count(*) FROM system.eventlog
+WHERE "eventType" = 'rewrite_inline_hints'
+  AND (info::JSONB->>'HintID')::INT = $hint4;
 ----
 0
 

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -55,6 +55,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/upgrade"
 	"github.com/cockroachdb/cockroach/pkg/util/cancelchecker"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
@@ -1155,6 +1156,11 @@ func (p *planner) InsertStatementHint(
 // UsingHintInjection is part of the eval.Planner interface.
 func (p *planner) UsingHintInjection() bool {
 	return p.usingHintInjection
+}
+
+// LogEvent is part of the eval.Planner interface.
+func (p *planner) LogEvent(ctx context.Context, event interface{}) error {
+	return p.logEvent(ctx, 0 /* descID */, event.(logpb.EventPayload))
 }
 
 // GetHintIDs is part of the eval.Planner interface.

--- a/pkg/sql/sem/builtins/BUILD.bazel
+++ b/pkg/sql/sem/builtins/BUILD.bazel
@@ -119,6 +119,7 @@ go_library(
         "//pkg/util/json",
         "//pkg/util/jsonpath/eval",
         "//pkg/util/log",
+        "//pkg/util/log/eventpb",
         "//pkg/util/ltree",
         "//pkg/util/mon",
         "//pkg/util/pretty",

--- a/pkg/sql/sem/builtins/BUILD.bazel
+++ b/pkg/sql/sem/builtins/BUILD.bazel
@@ -72,6 +72,7 @@ go_library(
         "//pkg/sql/memsize",
         "//pkg/sql/oidext",
         "//pkg/sql/opt/workloadindexrec",
+        "//pkg/sql/parser/statements",
         "//pkg/sql/parserutils",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -49,6 +49,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/hintpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
 	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser/statements"
 	"github.com/cockroachdb/cockroach/pkg/sql/parserutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -12858,40 +12859,54 @@ var rewriteInlineHintsOverload = tree.Overload{
 			return nil, err
 		}
 
-		stmtFingerprint := string(tree.MustBeDString(args[0]))
-		donorSQL := string(tree.MustBeDString(args[1]))
+		targetArg := string(tree.MustBeDString(args[0]))
+		donorArg := string(tree.MustBeDString(args[1]))
 
-		// Validate that the donor statement matches the target statement
-		// without hints.
+		// First, parse both arguments and convert both to statement fingerprints if
+		// they are not already.
 		fingerprintFlags := tree.FmtFlags(tree.QueryFormattingForFingerprintsMask.Get(
 			&evalCtx.Settings.SV,
 		))
-		stmts, err := parserutils.Parse(stmtFingerprint)
+		parse := func(arg, which string) (stmt statements.Statement[tree.Statement], fingerprint string, err error) {
+			stmts, err := parserutils.Parse(arg)
+			if err != nil {
+				return stmt, fingerprint, pgerror.Wrapf(
+					err, pgcode.InvalidParameterValue, "could not parse %s", which,
+				)
+			}
+			if len(stmts) != 1 {
+				return stmt, fingerprint, pgerror.Newf(
+					pgcode.InvalidParameterValue, "could not parse %s as a single SQL statement", which,
+				)
+			}
+			stmt = stmts[0]
+			fingerprint = tree.FormatStatementHideConstants(stmt.AST, fingerprintFlags)
+			if fingerprint != arg {
+				evalCtx.ClientNoticeSender.BufferClientNotice(
+					ctx, pgnotice.Newf("%s changed to: %s", which, fingerprint),
+				)
+				// Re-parse the statement fingerprint to get an updated AST.
+				stmt, err = parserutils.ParseOne(fingerprint)
+				if err != nil {
+					// Assertion failure is appropriate here, so no error wrapping.
+					return stmt, fingerprint, err
+				}
+			}
+			return stmt, fingerprint, nil
+		}
+
+		targetStmt, targetSQL, err := parse(targetArg, "statement fingerprint")
 		if err != nil {
-			return nil, pgerror.Wrap(
-				err, pgcode.InvalidParameterValue, "could not parse statement fingerprint",
-			)
+			return nil, err
 		}
-		if len(stmts) != 1 {
-			return nil, pgerror.New(
-				pgcode.InvalidParameterValue,
-				"could not parse statement fingerprint as a single SQL statement",
-			)
-		}
-		targetStmt := stmts[0]
-		stmts, err = parserutils.Parse(donorSQL)
+
+		donorStmt, donorSQL, err := parse(donorArg, "hint donor statement")
 		if err != nil {
-			return nil, pgerror.Wrap(
-				err, pgcode.InvalidParameterValue, "could not parse hint donor statement",
-			)
+			return nil, err
 		}
-		if len(stmts) != 1 {
-			return nil, pgerror.New(
-				pgcode.InvalidParameterValue,
-				"could not parse hint donor statement as a single SQL statement",
-			)
-		}
-		donorStmt := stmts[0]
+
+		// Validate that the donor statement matches the target statement
+		// without hints.
 		donor, err := tree.NewHintInjectionDonor(donorStmt.AST, fingerprintFlags)
 		if err != nil {
 			return nil, errors.NewAssertionErrorWithWrappedErrf(err, "error while creating donor")
@@ -12906,9 +12921,8 @@ var rewriteInlineHintsOverload = tree.Overload{
 		if err != nil {
 			return nil, pgerror.WithCandidateCode(err, pgcode.InvalidParameterValue)
 		}
-		// Either the target statement or the donor statement could be
-		// non-fingerprint or fingerprint, so for an apples-to-apples comparison
-		// we need to convert both to fingerprints.
+		// The donor statement could be non-fingerprint or fingerprint, so for an
+		// apples-to-apples comparison we convert both to fingerprints.
 		resultFingerprint := tree.FormatStatementHideConstants(result, fingerprintFlags)
 		donorFingerprint := tree.FormatStatementHideConstants(donorStmt.AST, fingerprintFlags)
 		if resultFingerprint != donorFingerprint {
@@ -12919,17 +12933,17 @@ var rewriteInlineHintsOverload = tree.Overload{
 			)
 		}
 
-		// Insert into statement_hints.
+		// Now that we've passed some basic validation, insert into statement_hints.
 		var hint hintpb.StatementHintUnion
 		hint.SetValue(&hintpb.InjectHints{DonorSQL: donorSQL})
-		hintID, err := evalCtx.Planner.InsertStatementHint(ctx, stmtFingerprint, hint)
+		hintID, err := evalCtx.Planner.InsertStatementHint(ctx, targetSQL, hint)
 		if err != nil {
 			return nil, err
 		}
 
 		// Log the statement hint injection event.
 		if err := evalCtx.Planner.LogEvent(ctx, &eventpb.RewriteInlineHints{
-			StatementFingerprint: stmtFingerprint,
+			StatementFingerprint: targetSQL,
 			DonorSQL:             donorSQL,
 			HintID:               hintID,
 		}); err != nil {

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -85,6 +85,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 	jsonpath "github.com/cockroachdb/cockroach/pkg/util/jsonpath/eval"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/cockroach/pkg/util/ltree"
 	"github.com/cockroachdb/cockroach/pkg/util/pretty"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -12923,6 +12924,15 @@ var rewriteInlineHintsOverload = tree.Overload{
 		hint.SetValue(&hintpb.InjectHints{DonorSQL: donorSQL})
 		hintID, err := evalCtx.Planner.InsertStatementHint(ctx, stmtFingerprint, hint)
 		if err != nil {
+			return nil, err
+		}
+
+		// Log the statement hint injection event.
+		if err := evalCtx.Planner.LogEvent(ctx, &eventpb.RewriteInlineHints{
+			StatementFingerprint: stmtFingerprint,
+			DonorSQL:             donorSQL,
+			HintID:               hintID,
+		}); err != nil {
 			return nil, err
 		}
 

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -491,6 +491,11 @@ type Planner interface {
 	// GetHintIDs returns the external statement hints we're using for this
 	// statement.
 	GetHintIDs() []int64
+
+	// LogEvent logs an event to both the system.eventlog table and external
+	// structured logs. This is exposed on the Planner interface to allow builtins
+	// to log events.
+	LogEvent(ctx context.Context, event interface{}) error
 }
 
 // InternalRows is an iterator interface that's exposed by the internal

--- a/pkg/sql/sem/tree/inject_hints.go
+++ b/pkg/sql/sem/tree/inject_hints.go
@@ -31,9 +31,10 @@ type HintInjectionDonor struct {
 	walk []any
 }
 
-// NewHintInjectionDonor creates a HintInjectionDonor from a parsed AST. The
-// parsed donor statement could be a regular SQL statement or a statement
-// fingerprint.
+// NewHintInjectionDonor creates a HintInjectionDonor from a parsed AST. This
+// code does not make any assumptions about whether the parsed AST is a regular
+// SQL statement or a statement fingerprint. Either way, it should successfully
+// validate and match against a target statement.
 //
 // After NewHintInjectionDonor returns a HintInjectionDonor, the donor becomes
 // read-only to allow concurrent use from multiple goroutines.
@@ -325,8 +326,8 @@ func (v *hintInjectionVisitor) VisitStatementPost(expr Statement) Statement {
 	return expr
 }
 
-// Validate checks that the target statement exactly matches the donor (except
-// for hints).
+// Validate checks that the target statement exactly matches the donor statement
+// when both are converted to statement fingerprints (except for hints).
 //
 // It is safe to call Validate concurrently from multiple goroutines.
 func (hd *HintInjectionDonor) Validate(stmt Statement, fingerprintFlags FmtFlags) error {

--- a/pkg/util/log/eventpb/eventlog_channels_generated.go
+++ b/pkg/util/log/eventpb/eventlog_channels_generated.go
@@ -83,6 +83,9 @@ func (m *Restore) LoggingChannel() logpb.Channel { return logpb.Channel_OPS }
 func (m *StatusChange) LoggingChannel() logpb.Channel { return logpb.Channel_OPS }
 
 // LoggingChannel implements the EventPayload interface.
+func (m *RewriteInlineHints) LoggingChannel() logpb.Channel { return logpb.Channel_OPS }
+
+// LoggingChannel implements the EventPayload interface.
 func (m *SetClusterSetting) LoggingChannel() logpb.Channel { return logpb.Channel_OPS }
 
 // LoggingChannel implements the EventPayload interface.

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -4366,6 +4366,45 @@ func (m *ReverseSchemaChange) AppendJSONFields(printComma bool, b redact.Redacta
 }
 
 // AppendJSONFields implements the EventPayload interface.
+func (m *RewriteInlineHints) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
+
+	printComma, b = m.CommonEventDetails.AppendJSONFields(printComma, b)
+
+	printComma, b = m.CommonSQLEventDetails.AppendJSONFields(printComma, b)
+
+	if m.StatementFingerprint != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"StatementFingerprint\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.StatementFingerprint)))
+		b = append(b, '"')
+	}
+
+	if m.DonorSQL != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"DonorSQL\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.DonorSQL)))
+		b = append(b, '"')
+	}
+
+	if m.HintID != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"HintID\":"...)
+		b = strconv.AppendInt(b, int64(m.HintID), 10)
+	}
+
+	return printComma, b
+}
+
+// AppendJSONFields implements the EventPayload interface.
 func (m *RoleBasedAuditEvent) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
 
 	printComma, b = m.CommonEventDetails.AppendJSONFields(printComma, b)

--- a/pkg/util/log/eventpb/misc_sql_events.proto
+++ b/pkg/util/log/eventpb/misc_sql_events.proto
@@ -52,3 +52,16 @@ message SetTenantClusterSetting {
   // Whether the override applies to all tenants.
   bool all_tenants = 6 [(gogoproto.jsontag) = ",omitempty"];
 }
+
+// RewriteInlineHints is recorded when a new inline-hints rewrite rule is added
+// via information_schema.crdb_rewrite_inline_hints.
+message RewriteInlineHints {
+  CommonEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+  CommonSQLEventDetails sql = 2 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+  // The target statement fingerprint for which inline hints are being rewritten.
+  string statement_fingerprint = 3 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+  // The donor statement providing the inline hints.
+  string donor_sql = 4 [(gogoproto.customname) = "DonorSQL", (gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+  // The hint ID of the newly created statement hint.
+  int64 hint_id = 5 [(gogoproto.customname) = "HintID", (gogoproto.jsontag) = ",omitempty"];
+}


### PR DESCRIPTION
Backport 2/2 commits from #160901.

/cc @cockroachdb/release

---

**builtins, eventpb: add rewrite_inline_hints event logging**

Add a new `rewrite_inline_hints` structured event. In order to do this from the builtin, a new `planner.LogEvent` method is needed.

Fixes: #159085

Release note (ops change): A structured event of type `rewrite_inline_hints` is now emitted when a new inline-hints rewrite rule is added using `information_schema.crdb_rewrite_inline_hints`. This event is written to both the event log and the OPS channel.

---

**builtins: convert crdb_rewrite_inline_hints args to fingerprints**

When looking up statement hints from the hints cache in `ReloadHintsIfStale`, we always use the statement fingerprint to search for hints. This means that hints added with `crdb_rewrite_inline_hints` won't have any effect if they use a regular SQL statement instead of a statement fingerprint. To avoid any confusion, we now convert both arguments to `crdb_rewrite_inline_hints` to statement fingerprints if they're not fingerprints already.

Fixes: #160308

Release note: None

---

Release justification: low-risk fix for GA-blocker before cutting RC.