### PR TITLE
sql: add metric for queries with statement hints

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -1401,6 +1401,22 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
       how_to_use: The rate of this metric shows how frequently new connections are being established. This can be useful in determining if a high rate of incoming new connections is causing additional load on the server due to a misconfigured application.
       visibility: ESSENTIAL
+    - name: sql.query.with_statement_hints.count
+      exported_name: sql_query_with_statement_hints_count
+      description: Number of SQL queries executed with external statement hints
+      y_axis_label: SQL Statements
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: sql.query.with_statement_hints.count.internal
+      exported_name: sql_query_with_statement_hints_count_internal
+      description: Number of SQL queries executed with external statement hints (internal queries)
+      y_axis_label: SQL Internal Statements
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
     - name: sql.routine.delete.count
       exported_name: sql_routine_delete_count
       labeled_name: 'sql.count{query_type: routine_delete}'

--- a/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
+++ b/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
@@ -2122,6 +2122,8 @@ sql_query_started_count: sql.query.started.count
 sql_query_started_count_internal: sql.query.started.internal
 sql_query_unique_count: sql.query.unique.count
 sql_query_unique_count_internal: sql.query.unique.count.internal
+sql_query_with_statement_hints_count: sql.query.with_statement_hints.count
+sql_query_with_statement_hints_count_internal: sql.query.with_statement_hints.count.internal
 sql_restart_savepoint_count: sql.restart_savepoint.count
 sql_restart_savepoint_count_internal: sql.restart_savepoint.internal
 sql_restart_savepoint_release_count: sql.restart_savepoint.release.count

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -680,6 +680,7 @@ func makeMetrics(internal bool, sv *settings.Values) Metrics {
 			StatementBytesRead:                metric.NewCounter(getMetricMeta(MetaStatementBytesRead, internal)),
 			StatementIndexRowsWritten:         metric.NewCounter(getMetricMeta(MetaStatementIndexRowsWritten, internal)),
 			StatementIndexBytesWritten:        metric.NewCounter(getMetricMeta(MetaStatementIndexBytesWritten, internal)),
+			QueryWithStatementHintsCount:      metric.NewCounter(getMetricMeta(MetaQueryWithStatementHints, internal)),
 		},
 		StartedStatementCounters:  makeStartedStatementCounters(internal),
 		ExecutedStatementCounters: makeExecutedStatementCounters(internal),

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -579,6 +579,7 @@ func (ex *connExecutor) execStmtInOpenState(
 
 	if len(stmt.Hints) > 0 {
 		telemetry.Inc(sqltelemetry.StatementHintsCounter)
+		ex.metrics.EngineMetrics.QueryWithStatementHintsCount.Inc(1)
 	}
 
 	// This goroutine is the only one that can modify txnState.mu.priority and
@@ -1480,6 +1481,7 @@ func (ex *connExecutor) execStmtInOpenStateWithPausablePortal(
 
 	if len(vars.stmt.Hints) > 0 {
 		telemetry.Inc(sqltelemetry.StatementHintsCounter)
+		ex.metrics.EngineMetrics.QueryWithStatementHintsCount.Inc(1)
 	}
 
 	// For pausable portal, the instrumentation helper needs to be set up only

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -905,6 +905,13 @@ var (
 		Measurement: "SQL Statements",
 		Unit:        metric.Unit_COUNT,
 	}
+	MetaQueryWithStatementHints = metric.Metadata{
+		Name:        "sql.query.with_statement_hints.count",
+		Help:        "Number of SQL queries executed with external statement hints",
+		Measurement: "SQL Statements",
+		Unit:        metric.Unit_COUNT,
+		Category:    metric.Metadata_SQL,
+	}
 	MetaTxnAbort = metric.Metadata{
 		Name:        "sql.txn.abort.count",
 		Help:        "Number of SQL transaction abort errors",

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -99,6 +99,9 @@ type EngineMetrics struct {
 	// StatementIndexBytesWritten counts the number of primary and secondary index
 	// bytes modified by SQL statements.
 	StatementIndexBytesWritten *metric.Counter
+
+	// QueryWithStatementHintsCount counts queries executed with external statement hints.
+	QueryWithStatementHintsCount *metric.Counter
 }
 
 // EngineMetrics implements the metric.Struct interface.

--- a/pkg/sql/logictest/testdata/logic_test/statement_hint_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/statement_hint_builtins
@@ -1078,3 +1078,27 @@ statement hints count: 1
         │ estimated row count: 10
         │
         └── • emptyrow
+
+# Test the sql.query.with_statement_hints.count metric.
+
+query B
+SELECT value > 0
+FROM crdb_internal.node_metrics
+WHERE name = 'sql.query.with_statement_hints.count'
+----
+true
+
+let $initial_hints_count
+SELECT value::int
+FROM crdb_internal.node_metrics
+WHERE name = 'sql.query.with_statement_hints.count'
+
+statement ok
+SELECT y FROM abc JOIN xy ON x = b WHERE a = 10
+
+query B
+SELECT value::int > $initial_hints_count
+FROM crdb_internal.node_metrics
+WHERE name = 'sql.query.with_statement_hints.count'
+----
+true


### PR DESCRIPTION
Previously, we only had a telemetry counter (StatementHintsCounter) to track SQL statements executed with external statement hints.

This commit adds a new metric `sql.query.with_statement_hints.count` to the EngineMetrics struct. This metric is incremented at the same locations as the existing telemetry counter (in execStmtInOpenState and execPortal functions) to provide consistent tracking. The metric allows operators to monitor statement hint usage through standard metrics infrastructure (Prometheus, DB Console, crdb_internal.node_metrics) and compare it with total statement execution counts.

The metric is implemented as a simple counter without database/application aggregation since statement hints are a global execution path concern rather than a per-statement-type feature.

Fixes: #161042

Release note (ops change): A new metric
`sql.query.with_statement_hints.count` is added which is incremented whenever a statement is executed with one or more external statement hints applied. (One example of an external statement hint is an inline-hints rewrite rule added by calling
`information_schema.crdb_rewrite_inline_hints`.)

🤖 Generated with [Claude Code](https://claude.ai/code)