### PR TITLE
sql: speed up crdb_internal.ranges_no_leases in large clusters

### DIFF
--- a/pkg/backup/backup_processor.go
+++ b/pkg/backup/backup_processor.go
@@ -320,7 +320,7 @@ func runBackupProcessor(
 
 			if rangeSizedSpans {
 				const pageSize = 100
-				rdi, err := flowCtx.Cfg.ExecutorConfig.(*sql.ExecutorConfig).RangeDescIteratorFactory.NewLazyIterator(ctx, fullSpan, pageSize)
+				rdi, err := flowCtx.Cfg.ExecutorConfig.(*sql.ExecutorConfig).RangeDescIteratorFactory.NewLazyIterator(ctx, fullSpan, pageSize, 0 /* pageTargetBytes */)
 				if err != nil {
 					return err
 				}

--- a/pkg/crosscluster/physical/replication_stream_e2e_test.go
+++ b/pkg/crosscluster/physical/replication_stream_e2e_test.go
@@ -1303,7 +1303,7 @@ func TestStreamingRegionalConstraint(t *testing.T) {
 			init := func() {}
 
 			return func() error {
-				return scanner.Scan(ctx, pageSize, init, targetSpan, func(descriptors ...roachpb.RangeDescriptor) error {
+				return scanner.Scan(ctx, pageSize, 0 /* pageTargetBytes */, init, targetSpan, func(descriptors ...roachpb.RangeDescriptor) error {
 					for _, desc := range descriptors {
 						for _, replica := range desc.InternalReplicas {
 							if replica.NodeID != marsNodeID {

--- a/pkg/crosscluster/physical/stream_ingestion_processor.go
+++ b/pkg/crosscluster/physical/stream_ingestion_processor.go
@@ -1127,7 +1127,7 @@ func getRangeStartkeys(
 	rangeStartKeys := make([]roachpb.RKey, 0)
 
 	for i := range rangeKeySpans {
-		iter, err := rangeDescIterFactory.NewLazyIterator(ctx, rangeKeySpans[i], 100)
+		iter, err := rangeDescIterFactory.NewLazyIterator(ctx, rangeKeySpans[i], 100 /* pageSize */, 0 /* pageTargetBytes */)
 		if err != nil {
 			log.Dev.Warningf(ctx, "could not create range descriptor iterator for %s: %v", rangeKeySpans[i], err)
 			continue

--- a/pkg/crosscluster/physical/stream_ingestion_processor_test.go
+++ b/pkg/crosscluster/physical/stream_ingestion_processor_test.go
@@ -888,7 +888,7 @@ func (m *mockIteratorFactory) NewIterator(
 }
 
 func (m *mockIteratorFactory) NewLazyIterator(
-	ctx context.Context, span roachpb.Span, pageSize int,
+	ctx context.Context, span roachpb.Span, pageSize int, pageTargetBytes int64,
 ) (rangedesc.LazyIterator, error) {
 	intersectingRanges := m.filterIntersectingRanges(span)
 	return &mockIterator{ranges: intersectingRanges, index: 0}, nil

--- a/pkg/crosscluster/producer/range_stats.go
+++ b/pkg/crosscluster/producer/range_stats.go
@@ -86,7 +86,7 @@ func computeRangeStats(
 ) (streampb.StreamEvent_RangeStats, error) {
 	var stats streampb.StreamEvent_RangeStats
 	for _, initialSpan := range spans {
-		lazyIterator, err := ranges.NewLazyIterator(ctx, initialSpan, 100)
+		lazyIterator, err := ranges.NewLazyIterator(ctx, initialSpan, 100 /* pageSize */, 0 /* pageTargetBytes */)
 		if err != nil {
 			return streampb.StreamEvent_RangeStats{}, err
 		}

--- a/pkg/crosscluster/producer/range_stats_test.go
+++ b/pkg/crosscluster/producer/range_stats_test.go
@@ -38,7 +38,7 @@ type rangeIteratorFactory struct {
 }
 
 func (r *rangeIteratorFactory) NewLazyIterator(
-	ctx context.Context, span roachpb.Span, pageSize int,
+	ctx context.Context, span roachpb.Span, pageSize int, pageTargetBytes int64,
 ) (rangedesc.LazyIterator, error) {
 	var rangeDescs []roachpb.RangeDescriptor
 	for _, span := range r.ranges {
@@ -48,7 +48,7 @@ func (r *rangeIteratorFactory) NewLazyIterator(
 			EndKey:   roachpb.RKey(rangeSpan.EndKey),
 		})
 	}
-	return rangedesc.NewPaginatedIter(ctx, span, pageSize, func(_ context.Context, span roachpb.Span, _ int) ([]roachpb.RangeDescriptor, error) {
+	return rangedesc.NewPaginatedIter(ctx, span, pageSize, pageTargetBytes, func(_ context.Context, span roachpb.Span, _ int, _ int64) ([]roachpb.RangeDescriptor, error) {
 		var filteredDesc []roachpb.RangeDescriptor
 		for _, desc := range rangeDescs {
 			toRight := span.Key.Compare(desc.EndKey.AsRawKey()) == 1

--- a/pkg/kv/db_test.go
+++ b/pkg/kv/db_test.go
@@ -532,7 +532,7 @@ func TestDB_TxnIterate(t *testing.T) {
 		if err := db.Txn(context.Background(), func(ctx context.Context, txn *kv.Txn) error {
 			p = 0
 			rows = make([]kv.KeyValue, 0)
-			return txn.Iterate(context.Background(), "a", "b", c.pageSize,
+			return txn.Iterate(context.Background(), "a", "b", c.pageSize, 0, /* pageTargetBytes */
 				func(rs []kv.KeyValue) error {
 					p++
 					rows = append(rows, rs...)

--- a/pkg/kv/kvserver/asim/state/impl.go
+++ b/pkg/kv/kvserver/asim/state/impl.go
@@ -1382,6 +1382,7 @@ func (s *state) GetSpanConfigForKey(
 func (s *state) Scan(
 	ctx context.Context,
 	pageSize int,
+	pageTargetBytes int64,
 	init func(),
 	span roachpb.Span,
 	fn func(descriptors ...roachpb.RangeDescriptor) error,

--- a/pkg/kv/kvserver/loqrecovery/server.go
+++ b/pkg/kv/kvserver/loqrecovery/server.go
@@ -184,7 +184,7 @@ func (s Server) ServeClusterReplicas(
 			}
 			defer func() { _ = txn.Rollback(txnCtx) }()
 			log.KvExec.Infof(txnCtx, "serving recovery range descriptors for all ranges")
-			return txn.Iterate(txnCtx, keys.Meta2Prefix, keys.MetaMax, rangeMetadataScanChunkSize,
+			return txn.Iterate(txnCtx, keys.Meta2Prefix, keys.MetaMax, rangeMetadataScanChunkSize, 0, /* pageTargetBytes */
 				func(kvs []kv.KeyValue) error {
 					for _, rangeDescKV := range kvs {
 						var rangeDesc roachpb.RangeDescriptor

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -2756,7 +2756,7 @@ func (s *systemAdminServer) decommissionStatusHelper(
 		for _, nodeID := range nodeIDs {
 			replicaCounts[nodeID] = 0
 		}
-		return txn.Iterate(ctx, keys.Meta2Prefix, keys.MetaMax, pageSize,
+		return txn.Iterate(ctx, keys.Meta2Prefix, keys.MetaMax, pageSize, 0, /* pageTargetBytes */
 			func(rows []kv.KeyValue) error {
 				rangeDesc := roachpb.RangeDescriptor{}
 				for _, row := range rows {

--- a/pkg/server/decommission.go
+++ b/pkg/server/decommission.go
@@ -215,7 +215,7 @@ func (s *topLevelServer) DecommissionPreCheck(
 	// Iterate through all range descriptors using the rangedesc.Scanner, which
 	// will perform the requisite meta1/meta2 lookups, including retries.
 	rangeDescScanner := rangedesc.NewScanner(s.db)
-	err = rangeDescScanner.Scan(ctx, pageSize, initCounters, keys.EverythingSpan, func(descriptors ...roachpb.RangeDescriptor) error {
+	err = rangeDescScanner.Scan(ctx, pageSize, 0 /* pageTargetBytes */, initCounters, keys.EverythingSpan, func(descriptors ...roachpb.RangeDescriptor) error {
 		for _, desc := range descriptors {
 			// Track replicas by node for recording purposes.
 			// Skip checks if this range doesn't exist on a potentially decommissioning node.

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -2948,7 +2948,7 @@ func (n *Node) getRangeDescriptors(
 	args *kvpb.GetRangeDescriptorsRequest, stream kvpb.RPCTenantService_GetRangeDescriptorsStream,
 ) error {
 
-	iter, err := n.execCfg.RangeDescIteratorFactory.NewLazyIterator(stream.Context(), args.Span, int(args.BatchSize))
+	iter, err := n.execCfg.RangeDescIteratorFactory.NewLazyIterator(stream.Context(), args.Span, int(args.BatchSize), 0 /* pageTargetBytes */)
 	if err != nil {
 		return err
 	}

--- a/pkg/server/span_stats_server.go
+++ b/pkg/server/span_stats_server.go
@@ -251,7 +251,7 @@ func (s *systemStatusServer) statsForSpan(
 	var descriptors []roachpb.RangeDescriptor
 	scanner := rangedesc.NewScanner(s.db)
 	pageSize := int(RangeDescPageSize.Get(&s.st.SV))
-	err = scanner.Scan(ctx, pageSize, func() {
+	err = scanner.Scan(ctx, pageSize, 0 /* pageTargetBytes */, func() {
 		// If the underlying txn fails and needs to be retried,
 		// clear the descriptors we've collected so far.
 		descriptors = nil
@@ -419,7 +419,7 @@ func nodeIDsForSpan(
 ) ([]roachpb.NodeID, error) {
 	nodeIDs := make(map[roachpb.NodeID]struct{})
 	scanner := rangedesc.NewScanner(db)
-	err := scanner.Scan(ctx, pageSize, func() {
+	err := scanner.Scan(ctx, pageSize, 0 /* pageTargetBytes */, func() {
 		// If the underlying txn fails and needs to be retried,
 		// clear the nodeIDs we've collected so far.
 		nodeIDs = map[roachpb.NodeID]struct{}{}

--- a/pkg/spanconfig/spanconfigreporter/datadriven_test.go
+++ b/pkg/spanconfig/spanconfigreporter/datadriven_test.go
@@ -249,7 +249,12 @@ func (s *mockCluster) GetStoreDescriptor(storeID roachpb.StoreID) (roachpb.Store
 
 // Scan implements rangedesc.Scanner interface.
 func (s *mockCluster) Scan(
-	_ context.Context, _ int, _ func(), _ roachpb.Span, fn func(...roachpb.RangeDescriptor) error,
+	ctx context.Context,
+	pageSize int,
+	pageTargetBytes int64,
+	init func(),
+	span roachpb.Span,
+	fn func(descriptors ...roachpb.RangeDescriptor) error,
 ) error {
 	var descs []roachpb.RangeDescriptor
 	for _, d := range s.ranges {

--- a/pkg/spanconfig/spanconfigreporter/reporter.go
+++ b/pkg/spanconfig/spanconfigreporter/reporter.go
@@ -135,7 +135,7 @@ func (r *Reporter) SpanConfigConformance(
 	for _, span := range spans {
 		// Build a separate report per span, so that we can handle resets correctly.
 		spanReport := roachpb.SpanConfigConformanceReport{}
-		if err := r.dep.Scan(ctx, int(rangeDescPageSize.Get(&r.settings.SV)),
+		if err := r.dep.Scan(ctx, int(rangeDescPageSize.Get(&r.settings.SV)), 0, /* pageTargetBytes */
 			func() { spanReport = roachpb.SpanConfigConformanceReport{} /* init */ },
 			span,
 			func(descriptors ...roachpb.RangeDescriptor) error {

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -994,7 +994,7 @@ func (sc *SchemaChanger) distIndexBackfill(
 				// TODO(dt): a Count() request would be nice here if the target isn't
 				// empty, since we don't need to drag all the results back just to
 				// then ignore them -- we just need the iteration on the far end.
-				if err := txn.KV().Iterate(ctx, span.Key, span.EndKey, pageSize, noop); err != nil {
+				if err := txn.KV().Iterate(ctx, span.Key, span.EndKey, pageSize, 0 /* pageTargetBytes */, noop); err != nil {
 					return err
 				}
 			}

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -4469,6 +4469,13 @@ func lookupNamesByKey(
 	return tableID, dbName, schemaName, tableName, indexName
 }
 
+var rangesNoLeasesPageSize = settings.RegisterIntSetting(
+	settings.ApplicationLevel,
+	"sql.ranges_no_leases.page_size",
+	"foo",
+	128,
+)
+
 // crdbInternalRangesNoLeasesTable exposes all ranges in the system without the
 // `lease_holder` information.
 //
@@ -4536,7 +4543,7 @@ CREATE TABLE crdb_internal.ranges_no_leases (
 		}
 
 		execCfg := p.ExecCfg()
-		pageSize := int64(128)
+		pageSize := rangesNoLeasesPageSize.Get(&execCfg.Settings.SV)
 		if limit > 0 {
 			pageSize = min(limit, pageSize)
 		}

--- a/pkg/sql/fingerprint/fingerprint_job.go
+++ b/pkg/sql/fingerprint/fingerprint_job.go
@@ -255,7 +255,7 @@ func (p partitionSpans) partition(
 		for part := range spanPartitions {
 			subdivided := make([]roachpb.Span, 0, len(spanPartitions[part].Spans))
 			for _, sp := range spanPartitions[part].Spans {
-				rdi, err := p.JobExecContext.ExecCfg().RangeDescIteratorFactory.NewLazyIterator(ctx, sp, 64)
+				rdi, err := p.JobExecContext.ExecCfg().RangeDescIteratorFactory.NewLazyIterator(ctx, sp, 64 /* pageSize */, 0 /* pageTargetBytes */)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/sql/fingerprint_span.go
+++ b/pkg/sql/fingerprint_span.go
@@ -190,7 +190,7 @@ func (p *planner) fingerprintSpanFanout(
 			}()
 
 			for _, part := range partition {
-				rdi, err := p.execCfg.RangeDescIteratorFactory.NewLazyIterator(ctx, part, 64)
+				rdi, err := p.execCfg.RangeDescIteratorFactory.NewLazyIterator(ctx, part, 64 /* pageSize */, 0 /* pageTargetBytes */)
 				if err != nil {
 					return err
 				}

--- a/pkg/sql/index_backfiller.go
+++ b/pkg/sql/index_backfiller.go
@@ -256,7 +256,7 @@ func scanTargetSpansToPushTimestampCache(
 				// TODO(dt): a Count() request would be nice here if the target isn't
 				// empty, since we don't need to drag all the results back just to
 				// then ignore them -- we just need the iteration on the far end.
-				if err := txn.Iterate(ctx, span.Key, span.EndKey, pageSize, iterateNoop); err != nil {
+				if err := txn.Iterate(ctx, span.Key, span.EndKey, pageSize, 0 /* pageTargetBytes */, iterateNoop); err != nil {
 					return err
 				}
 			}

--- a/pkg/upgrade/upgradecluster/cluster.go
+++ b/pkg/upgrade/upgradecluster/cluster.go
@@ -150,7 +150,7 @@ func (c *Cluster) ForEveryNodeOrServer(
 func (c *Cluster) IterateRangeDescriptors(
 	ctx context.Context, blockSize int, init func(), fn func(...roachpb.RangeDescriptor) error,
 ) error {
-	return c.c.RangeDescScanner.Scan(ctx, blockSize, init, keys.EverythingSpan, fn)
+	return c.c.RangeDescScanner.Scan(ctx, blockSize, 0 /* pageTargetBytes */, init, keys.EverythingSpan, fn)
 }
 
 // ValidateAfterUpdateSystemVersion is part of the upgrade.Cluster interface.


### PR DESCRIPTION
It has been observed that populating `crdb_internal.ranges_no_leases` in
large clusters (with 100k+ ranges) takes non-trivial amount of time.
This is the case since we iterate over all range descriptors in pages of
128 which is way too slow. This commit extends the rangedesc iterator
with an option to specify TargetBytes-based page size (as opposed to
row-count based) and then utilizes this ability when populating this
virtual table in 10MiB chunks (matching the constant we have for regular
scans).

Fixes: #160196
Release note: None