### PR TITLE
spanset: make forbidden matcher single

### DIFF
--- a/pkg/kv/kvserver/spanset/engine.go
+++ b/pkg/kv/kvserver/spanset/engine.go
@@ -28,15 +28,13 @@ type spanSetEngine struct {
 var _ storage.Engine = &spanSetEngine{}
 
 // NewEngine creates a new spanSetEngine wrapper.
-func NewEngine(engine storage.Engine, forbiddenMatchers ...func(TrickySpan) error) storage.Engine {
+func NewEngine(engine storage.Engine, forbiddenMatcher func(TrickySpan) error) storage.Engine {
 	spans := &SpanSet{}
 	// For engines, we disable undeclared access assertions as we only care about
 	// preventing access to spans that don't belong to this engine.
 	spans.DisableUndeclaredAccessAssertions()
-	// Add the forbidden matchers that assert against access to disallowed keys.
-	for _, matcher := range forbiddenMatchers {
-		spans.AddForbiddenMatcher(matcher)
-	}
+	// Set the forbidden matcher that asserts against access to disallowed keys.
+	spans.SetForbiddenMatcher(forbiddenMatcher)
 	return &spanSetEngine{
 		ReadWriter: makeSpanSetReadWriter(engine, spans),
 		e:          engine,

--- a/pkg/kv/kvserver/spanset/spanset.go
+++ b/pkg/kv/kvserver/spanset/spanset.go
@@ -231,21 +231,6 @@ func (s *SpanSet) SetForbiddenMatcher(matcher func(TrickySpan) error) {
 	s.forbiddenSpansMatcher = matcher
 }
 
-// Merge merges all spans in s2 into s. s2 is not modified.
-func (s *SpanSet) Merge(s2 *SpanSet) {
-	for sa := SpanAccess(0); sa < NumSpanAccess; sa++ {
-		for ss := SpanScope(0); ss < NumSpanScope; ss++ {
-			s.spans[sa][ss] = append(s.spans[sa][ss], s2.spans[sa][ss]...)
-		}
-	}
-	s.forbiddenSpansMatcher = s2.forbiddenSpansMatcher
-	// TODO(ibrahim): Figure out if the merged `allowUndeclared` and
-	// `allowForbidden` should be true if it was true in either `s` or `s2`.
-	s.allowUndeclared = s2.allowUndeclared
-	s.allowForbidden = s2.allowForbidden
-	s.SortAndDedup()
-}
-
 // SortAndDedup sorts the spans in the SpanSet by key and removes duplicate or
 // overlapping / redundant spans. The SpanSet represents the same subset of the
 // {keys}x{timestamps} space before and after this call, but is not guaranteed

--- a/pkg/kv/kvserver/spanset/spanset.go
+++ b/pkg/kv/kvserver/spanset/spanset.go
@@ -89,15 +89,13 @@ type TrickySpan roachpb.Span
 // spans in increasing key order after calls to SortAndDedup.
 type SpanSet struct {
 	spans [NumSpanAccess][NumSpanScope][]Span
-	// forbiddenSpansMatchers are functions that return an error if the given span
+	// forbiddenSpansMatcher is a function that returns an error if the given span
 	// shouldn't be accessed (forbidden). This allows for complex pattern matching
 	// like forbidding specific keys across all range IDs without enumerating them
 	// explicitly.
-	// TODO(ibrahim): consider making this a single matcher given that we
-	// currently only use one matcher at a time.
-	forbiddenSpansMatchers []func(TrickySpan) error
-	allowUndeclared        bool
-	allowForbidden         bool
+	forbiddenSpansMatcher func(TrickySpan) error
+	allowUndeclared       bool
+	allowForbidden        bool
 }
 
 var spanSetPool = sync.Pool{
@@ -126,7 +124,7 @@ func (s *SpanSet) Release() {
 			s.spans[sa][ss] = recycle
 		}
 	}
-	s.forbiddenSpansMatchers = nil
+	s.forbiddenSpansMatcher = nil
 	s.allowForbidden = false
 	s.allowUndeclared = false
 	spanSetPool.Put(s)
@@ -170,7 +168,7 @@ func (s *SpanSet) Copy() *SpanSet {
 			n.spans[sa][ss] = append(n.spans[sa][ss], s.spans[sa][ss]...)
 		}
 	}
-	n.forbiddenSpansMatchers = append(n.forbiddenSpansMatchers, s.forbiddenSpansMatchers...)
+	n.forbiddenSpansMatcher = s.forbiddenSpansMatcher
 	n.allowUndeclared = s.allowUndeclared
 	n.allowForbidden = s.allowForbidden
 	return n
@@ -225,10 +223,12 @@ func (s *SpanSet) AddMVCC(access SpanAccess, span roachpb.Span, timestamp hlc.Ti
 	s.spans[access][scope] = append(s.spans[access][scope], Span{Span: span, Timestamp: timestamp})
 }
 
-// AddForbiddenMatcher adds a forbidden span matcher. The matcher is a function
-// that is called for each span access to check if it should be forbidden.
-func (s *SpanSet) AddForbiddenMatcher(matcher func(TrickySpan) error) {
-	s.forbiddenSpansMatchers = append(s.forbiddenSpansMatchers, matcher)
+// SetForbiddenMatcher sets the forbidden span matcher, a function that is
+// called for each span access to check if it should be forbidden.
+//
+// NB: if the matcher is already set, it gets overridden.
+func (s *SpanSet) SetForbiddenMatcher(matcher func(TrickySpan) error) {
+	s.forbiddenSpansMatcher = matcher
 }
 
 // Merge merges all spans in s2 into s. s2 is not modified.
@@ -238,7 +238,7 @@ func (s *SpanSet) Merge(s2 *SpanSet) {
 			s.spans[sa][ss] = append(s.spans[sa][ss], s2.spans[sa][ss]...)
 		}
 	}
-	s.forbiddenSpansMatchers = append(s.forbiddenSpansMatchers, s2.forbiddenSpansMatchers...)
+	s.forbiddenSpansMatcher = s2.forbiddenSpansMatcher
 	// TODO(ibrahim): Figure out if the merged `allowUndeclared` and
 	// `allowForbidden` should be true if it was true in either `s` or `s2`.
 	s.allowUndeclared = s2.allowUndeclared
@@ -366,13 +366,9 @@ func (s *SpanSet) checkAllowed(
 	access SpanAccess, span TrickySpan, check func(SpanAccess, Span) bool,
 ) error {
 	// Unless explicitly disabled, check if we access any forbidden spans.
-	if !s.allowForbidden {
-		// Check if the span is forbidden.
-		for _, matcher := range s.forbiddenSpansMatchers {
-			if err := matcher(span); err != nil {
-				return errors.Errorf("cannot %s span %s: matches forbidden pattern",
-					access, span)
-			}
+	if !s.allowForbidden && s.forbiddenSpansMatcher != nil {
+		if err := s.forbiddenSpansMatcher(span); err != nil {
+			return errors.Errorf("cannot %s span %s: matches forbidden pattern", access, span)
 		}
 	}
 


### PR DESCRIPTION
This PR makes the forbidden matchers in `spanset` a single func, because this is how it is used de-facto, and any compound predicate (if needed in future) can be done by the caller. This also reduces allocations.

A drive-by commit removes the unused `Merge` method with ambiguous semantics.

Part of #158281