### PR TITLE
crosscluster/logical: allow more create index flavors during LDR

### DIFF
--- a/pkg/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/crosscluster/logical/logical_replication_job_test.go
@@ -2283,6 +2283,7 @@ func TestLogicalReplicationSchemaChanges(t *testing.T) {
 	dbBURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("b"))
 
 	var jobAID jobspb.JobID
+	dbA.Exec(t, "SET CLUSTER SETTING logical_replication.consumer.immediate_mode_writer = 'sql'")
 	dbA.QueryRow(t, "CREATE LOGICAL REPLICATION STREAM FROM TABLE tab ON $1 INTO TABLE tab", dbBURL.String()).Scan(&jobAID)
 
 	// Changing safe table storage parameters is allowed.
@@ -2298,7 +2299,7 @@ func TestLogicalReplicationSchemaChanges(t *testing.T) {
 		{"drop index", "DROP INDEX idx", true},
 
 		// adding unsuppored indexes disallowed
-		{"add virtual column index", "CREATE INDEX virtual_col_idx ON tab(virtual_col)", false},
+		{"add virtual column index", "CREATE INDEX virtual_col_idx ON tab(virtual_col)", true},
 		{"add hash index", "CREATE INDEX hash_idx ON tab(pk) USING HASH WITH (bucket_count = 4)", false},
 		{"add unique index", "CREATE UNIQUE INDEX unique_idx ON tab(composite_col)", false},
 

--- a/pkg/sql/sem/tree/schema_helpers_test.go
+++ b/pkg/sql/sem/tree/schema_helpers_test.go
@@ -19,8 +19,9 @@ func TestIsAllowedLDRSchemaChange(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	for _, tc := range []struct {
-		stmt      string
-		isAllowed bool
+		stmt            string
+		kvWriterEnabled bool
+		isAllowed       bool
 	}{
 		{
 			stmt:      "CREATE INDEX idx ON t (a)",
@@ -44,7 +45,12 @@ func TestIsAllowedLDRSchemaChange(t *testing.T) {
 		},
 		{
 			stmt:      "CREATE INDEX idx ON t (a) WHERE a > 10",
-			isAllowed: false,
+			isAllowed: true,
+		},
+		{
+			stmt:            "CREATE INDEX idx ON t (a) WHERE a > 10",
+			kvWriterEnabled: true,
+			isAllowed:       false,
 		},
 		{
 			stmt:      "DROP INDEX idx",
@@ -118,7 +124,7 @@ func TestIsAllowedLDRSchemaChange(t *testing.T) {
 			}
 			// Tests for virtual column checks are in
 			// TestLogicalReplicationCreationChecks.
-			if got := tree.IsAllowedLDRSchemaChange(stmt.AST, nil /* virtualColNames */, true); got != tc.isAllowed {
+			if got := tree.IsAllowedLDRSchemaChange(stmt.AST, nil /* virtualColNames */, tc.kvWriterEnabled); got != tc.isAllowed {
 				t.Errorf("expected %v, got %v", tc.isAllowed, got)
 			}
 		})


### PR DESCRIPTION
If the kv writer is not being used, the user can create partial indexes and
indexes on virtual columns.

Informs [#133560](https://github.com/cockroachdb/cockroach/issues/133560)

Release note(ops change): THe user can create partial indexes and indexes on
virtual columns while LDR is running.