### PR TITLE
storeliveness: use StateUnknown for stale SupportState after restart

### DIFF
--- a/pkg/kv/kvserver/storeliveness/support_manager.go
+++ b/pkg/kv/kvserver/storeliveness/support_manager.go
@@ -124,6 +124,21 @@ func (sm *SupportManager) SupportFor(id slpb.StoreIdent) (slpb.Epoch, bool) {
 // SupportState implements the SupportStatus interface.
 func (sm *SupportManager) SupportState(id slpb.StoreIdent) (SupportState, hlc.ClockTimestamp) {
 	ss := sm.supporterStateHandler.getSupportFor(id)
+	return computeSupportState(ss)
+}
+
+// computeSupportState determines the SupportState and withdrawal timestamp from
+// a supportState. This is extracted as a standalone function for testability.
+//
+//	Expiration | lastSupportWithdrawnTime | Result
+//	-----------+--------------------------+-------------------------------------------------------
+//	empty      | empty                    | StateUnknown (never supported this store, or support
+//	           |                          | was withdrawn prior to restart)
+//	empty      | non-empty                | StateNotSupporting (withdrawn, timestamp known)
+//	non-empty  | empty                    | StateSupporting (not withdrawn or timestamp lost on
+//	           |                          | restart after re-establishment)
+//	non-empty  | non-empty                | StateSupporting (active, even if withdrawn previously)
+func computeSupportState(ss supportState) (SupportState, hlc.ClockTimestamp) {
 	// If we've never seen this store, return StateUnknown.
 	if ss.empty() {
 		return StateUnknown, hlc.ClockTimestamp{}

--- a/pkg/kv/kvserver/storeliveness/support_manager_test.go
+++ b/pkg/kv/kvserver/storeliveness/support_manager_test.go
@@ -34,6 +34,65 @@ var (
 	}
 )
 
+// TestComputeSupportState verifies the support state determination logic based
+// on the Expiration and lastSupportWithdrawnTime fields.
+func TestComputeSupportState(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	nonEmptyExpiration := hlc.Timestamp{WallTime: 100}
+	nonEmptyWithdrawnTime := hlc.ClockTimestamp{WallTime: 50}
+
+	testCases := []struct {
+		name                     string
+		expiration               hlc.Timestamp
+		lastSupportWithdrawnTime hlc.ClockTimestamp
+		expectedState            SupportState
+		expectedWithdrawnTime    hlc.ClockTimestamp
+	}{
+		{
+			name:                     "empty expiration, empty withdrawn time",
+			expiration:               hlc.Timestamp{},
+			lastSupportWithdrawnTime: hlc.ClockTimestamp{},
+			expectedState:            StateUnknown,
+			expectedWithdrawnTime:    hlc.ClockTimestamp{},
+		},
+		{
+			name:                     "empty expiration, non-empty withdrawn time",
+			expiration:               hlc.Timestamp{},
+			lastSupportWithdrawnTime: nonEmptyWithdrawnTime,
+			expectedState:            StateNotSupporting,
+			expectedWithdrawnTime:    nonEmptyWithdrawnTime,
+		},
+		{
+			name:                     "non-empty expiration, empty withdrawn time",
+			expiration:               nonEmptyExpiration,
+			lastSupportWithdrawnTime: hlc.ClockTimestamp{},
+			expectedState:            StateSupporting,
+			expectedWithdrawnTime:    hlc.ClockTimestamp{},
+		},
+		{
+			name:                     "non-empty expiration, non-empty withdrawn time",
+			expiration:               nonEmptyExpiration,
+			lastSupportWithdrawnTime: nonEmptyWithdrawnTime,
+			expectedState:            StateSupporting,
+			expectedWithdrawnTime:    nonEmptyWithdrawnTime,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ss := supportState{
+				SupportState:             slpb.SupportState{Expiration: tc.expiration},
+				lastSupportWithdrawnTime: tc.lastSupportWithdrawnTime,
+			}
+			state, withdrawnTime := computeSupportState(ss)
+			require.Equal(t, tc.expectedState, state)
+			require.Equal(t, tc.expectedWithdrawnTime, withdrawnTime)
+		})
+	}
+}
+
 // TestSupportManagerRequestsSupport tests that the SupportManager requests and
 // establishes support on behalf of the local store.
 func TestSupportManagerRequestsSupport(t *testing.T) {
@@ -270,10 +329,44 @@ func TestSupportManagerRestart(t *testing.T) {
 		Expiration: clock.Now().AddDuration(sm.options.SupportDuration),
 	}
 	sm.handleMessages(ctx, []*slpb.Message{heartbeatResp, heartbeat})
+
+	// Establish active support for a second store (will NOT be withdrawn).
+	storeWithActiveSupport := slpb.StoreIdent{NodeID: roachpb.NodeID(3), StoreID: roachpb.StoreID(3)}
+	activeHeartbeat := &slpb.Message{
+		Type:       slpb.MsgHeartbeat,
+		From:       storeWithActiveSupport,
+		To:         sm.storeID,
+		Epoch:      slpb.Epoch(1),
+		Expiration: clock.Now().AddDuration(time.Hour), // 1 hour: won't expire during test
+	}
+	sm.handleMessages(ctx, []*slpb.Message{activeHeartbeat})
+
+	// Verify active support for storeWithActiveSupport.
+	state, withdrawnTS := sm.SupportState(storeWithActiveSupport)
+	require.Equal(t, StateSupporting, state)
+	require.True(t, withdrawnTS.IsEmpty())
+
+	// Withdraw support for remoteStore (but not storeWithActiveSupport).
 	manual.Resume()
 	manual.Increment(sm.options.SupportDuration.Nanoseconds())
 	sm.withdrawSupport(ctx)
 	withdrawalTime := sm.supporterStateHandler.supporterState.meta.MaxWithdrawn.ToTimestamp()
+
+	// Verify support was withdrawn for remoteStore.
+	state, withdrawnTS = sm.SupportState(remoteStore)
+	require.Equal(t, StateNotSupporting, state)
+	require.False(t, withdrawnTS.IsEmpty())
+
+	// Verify storeWithActiveSupport still has active support.
+	state, withdrawnTS = sm.SupportState(storeWithActiveSupport)
+	require.Equal(t, StateSupporting, state)
+	require.True(t, withdrawnTS.IsEmpty())
+
+	// A store we've never seen should return StateUnknown.
+	neverSeenStore := slpb.StoreIdent{NodeID: roachpb.NodeID(99), StoreID: roachpb.StoreID(99)}
+	state, withdrawnTS = sm.SupportState(neverSeenStore)
+	require.Equal(t, StateUnknown, state)
+	require.True(t, withdrawnTS.IsEmpty())
 
 	// Simulate a restart by creating a new SupportManager with the same engine.
 	// Use a regressed clock.
@@ -290,6 +383,25 @@ func TestSupportManagerRestart(t *testing.T) {
 	now = sm.clock.Now()
 	require.True(t, requestedTime.Less(now))
 	require.True(t, withdrawalTime.Less(now))
+
+	// After restart, verify SupportState for different scenarios:
+
+	// 1. Store with withdrawn support: should return StateUnknown because
+	//    lastSupportWithdrawnTime is not persisted to disk.
+	state, withdrawnTS = sm.SupportState(remoteStore)
+	require.Equal(t, StateUnknown, state)
+	require.True(t, withdrawnTS.IsEmpty())
+
+	// 2. Store with active support: should return StateSupporting because
+	//    Expiration is persisted to disk.
+	state, withdrawnTS = sm.SupportState(storeWithActiveSupport)
+	require.Equal(t, StateSupporting, state)
+	require.True(t, withdrawnTS.IsEmpty())
+
+	// 3. Store we've never seen: should return StateUnknown.
+	state, withdrawnTS = sm.SupportState(neverSeenStore)
+	require.Equal(t, StateUnknown, state)
+	require.True(t, withdrawnTS.IsEmpty())
 }
 
 // TestSupportManagerDiskStall tests that the SupportManager continues to


### PR DESCRIPTION
Previously, when a store restarted, `SupportManager.SupportState()` would
return `StateNotSupporting` for stores that had support withdrawn before
the restart. This is because the `Expiration` field (which is empty when
support is withdrawn) is persisted to disk, but `lastSupportWithdrawnTime`
is not persisted.

This caused stores to be incorrectly marked as Dead in the store pool
based on stale state after restarts.

This commit adds a check: if `Expiration` is empty and
`lastSupportWithdrawnTime` is also empty, return `StateUnknown` instead
of `StateNotSupporting`.

Release note: None
Epic: None
Informs: https://github.com/cockroachdb/cockroach/issues/161174