### PR TITLE
poc: performance tracing

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -2607,6 +2607,7 @@ GO_TARGETS = [
     "//pkg/sql/vtable:vtable",
     "//pkg/sql/zoneconfig:zoneconfig",
     "//pkg/sql/zoneconfig:zoneconfig_test",
+    "//pkg/sql/perftrace",
     "//pkg/sql:sql",
     "//pkg/sql:sql_test",
     "//pkg/storage/disk:disk",

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -246,6 +246,10 @@ const (
 	// table statistics collections.
 	V26_1_AddTableStatisticsLocksTable
 
+	// V26_1_AddWorkSpanTable adds the system.work_span table for query
+	// observability through work span capture.
+	V26_1_AddWorkSpanTable
+
 	// V26_1 is CockroachDB v26.1. It's used for all v26.1.x patch releases.
 	V26_1
 
@@ -322,6 +326,8 @@ var versionTable = [numKeys]roachpb.Version{
 	V26_1_InstallMeta2StaticSplitPoint: {Major: 25, Minor: 4, Internal: 4},
 
 	V26_1_AddTableStatisticsLocksTable: {Major: 25, Minor: 4, Internal: 6},
+
+	V26_1_AddWorkSpanTable: {Major: 25, Minor: 4, Internal: 8},
 
 	V26_1: {Major: 26, Minor: 1, Internal: 0},
 

--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -206,6 +206,7 @@ go_library(
         "//pkg/server/telemetry",
         "//pkg/settings",
         "//pkg/settings/cluster",
+        "//pkg/sql/perftrace",
         "//pkg/spanconfig",
         "//pkg/spanconfig/spanconfigstore",
         "//pkg/storage",

--- a/pkg/kv/kvserver/concurrency/BUILD.bazel
+++ b/pkg/kv/kvserver/concurrency/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/settings/cluster",
+        "//pkg/sql/perftrace",
         "//pkg/storage",
         "//pkg/storage/enginepb",
         "//pkg/util/buildutil",

--- a/pkg/kv/kvserver/spanlatch/BUILD.bazel
+++ b/pkg/kv/kvserver/spanlatch/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/settings/cluster",
+        "//pkg/sql/perftrace",
         "//pkg/util/hlc",
         "//pkg/util/humanizeutil",
         "//pkg/util/log",

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -295,6 +295,7 @@ go_library(
         "//pkg/sql/ttl/ttljob",
         "//pkg/sql/ttl/ttlschedule",
         "//pkg/sql/vecindex",
+        "//pkg/sql/perftrace",
         "//pkg/storage",
         "//pkg/storage/disk",
         "//pkg/storage/enginepb",

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -558,6 +558,7 @@ go_library(
         "//pkg/sql/vecindex/vecstore",
         "//pkg/sql/vtable",
         "//pkg/sql/zoneconfig",
+        "//pkg/sql/perftrace",
         "//pkg/storage",
         "//pkg/storage/enginepb",
         "//pkg/upgrade",

--- a/pkg/sql/catalog/bootstrap/metadata.go
+++ b/pkg/sql/catalog/bootstrap/metadata.go
@@ -475,6 +475,7 @@ func addSystemDescriptorsToSchema(target *MetadataSchema) {
 
 	// Tables introduced in 26.1
 	target.AddDescriptor(systemschema.TableStatisticsLocksTable)
+	target.AddDescriptor(systemschema.WorkSpanTable)
 
 	// Adding a new system table? It should be added here to the metadata schema,
 	// and also created as a migration for older clusters.
@@ -488,7 +489,7 @@ func addSystemDescriptorsToSchema(target *MetadataSchema) {
 // NumSystemTablesForSystemTenant is the number of system tables defined on
 // the system tenant. This constant is only defined to avoid having to manually
 // update auto stats tests every time a new system table is added.
-const NumSystemTablesForSystemTenant = 67
+const NumSystemTablesForSystemTenant = 68
 
 // addSplitIDs adds a split point for each of the PseudoTableIDs to the supplied
 // MetadataSchema.

--- a/pkg/sql/catalog/catprivilege/system.go
+++ b/pkg/sql/catalog/catprivilege/system.go
@@ -84,6 +84,7 @@ var (
 		catconstants.StatementHintsTableName,
 		catconstants.InspectErrorsTableName,
 		catconstants.TableStatisticsLocksTableName,
+		catconstants.WorkSpanTableName,
 	}
 
 	readWriteSystemSequences = []catconstants.SystemTableName{

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -388,6 +388,7 @@ func (ds *ServerImpl) setupFlow(
 		ctx, req.Flow.FlowID, evalCtx, monitor, diskMonitor, makeLeaf, req.TraceKV,
 		req.CollectStats, localState, req.Flow.Gateway == ds.NodeID.SQLInstanceID(),
 	)
+	flowCtx.StatementFingerprintID = req.StatementFingerprintID
 
 	// req always contains the desired vectorize mode, regardless of whether we
 	// have non-nil localState.EvalContext. We don't want to update EvalContext

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -454,6 +454,10 @@ type PlanningCtx struct {
 	// If set, statement execution stats should be collected.
 	collectExecStats bool
 
+	// statementFingerprintID is the fingerprint ID of the statement being
+	// executed. This is propagated to remote nodes for work span capture.
+	statementFingerprintID uint64
+
 	// parallelizeScansIfLocal indicates whether we might want to create
 	// multiple table readers if the physical plan ends up being fully local.
 	// This value is determined based on whether there are any mutations in the
@@ -541,6 +545,7 @@ func (p *PlanningCtx) setUpForMainQuery(
 	}
 	p.associateNodeWithComponents = planner.instrumentation.getAssociateNodeWithComponentsFn()
 	p.collectExecStats = planner.instrumentation.ShouldCollectExecStats()
+	p.statementFingerprintID = uint64(planner.instrumentation.fingerprintId)
 }
 
 // associateWithPlanNode returns a callback function (possibly nil) that should

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -461,11 +461,12 @@ func (dsp *DistSQLPlanner) setupFlows(
 		statementSQL = statementSQL[:setupFlowRequestStmtMaxLength]
 	}
 	setupReq := execinfrapb.SetupFlowRequest{
-		LeafTxnInputState: leafInputState,
-		Version:           execversion.V25_4,
-		TraceKV:           recv.tracing.KVTracingEnabled(),
-		CollectStats:      planCtx.collectExecStats,
-		StatementSQL:      statementSQL,
+		LeafTxnInputState:      leafInputState,
+		Version:                execversion.V25_4,
+		TraceKV:                recv.tracing.KVTracingEnabled(),
+		CollectStats:           planCtx.collectExecStats,
+		StatementSQL:           statementSQL,
+		StatementFingerprintID: planCtx.statementFingerprintID,
 	}
 	if localState.IsLocal {
 		// VectorizeMode is the only field that the setup code expects to be set

--- a/pkg/sql/execinfra/BUILD.bazel
+++ b/pkg/sql/execinfra/BUILD.bazel
@@ -60,6 +60,7 @@ go_library(
         "//pkg/sql/sqlliveness",
         "//pkg/sql/stats",
         "//pkg/sql/types",
+        "//pkg/sql/perftrace",
         "//pkg/util/admission",
         "//pkg/util/buildutil",
         "//pkg/util/intsets",

--- a/pkg/sql/execinfra/flow_context.go
+++ b/pkg/sql/execinfra/flow_context.go
@@ -91,6 +91,10 @@ type FlowCtx struct {
 	// running EXPLAIN ANALYZE. Currently, it is only used by remote flows.
 	// The gateway flow is handled by the connExecutor.
 	TenantCPUMonitor multitenantcpu.CPUUsageHelper
+
+	// StatementFingerprintID is the fingerprint ID of the statement being executed.
+	// Used for work span capture observability.
+	StatementFingerprintID uint64
 }
 
 // NewEvalCtx returns a modifiable copy of the FlowCtx's eval.Context.

--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
+	"github.com/cockroachdb/cockroach/pkg/sql/perftrace"
 	"github.com/cockroachdb/cockroach/pkg/util/admission"
 	"github.com/cockroachdb/cockroach/pkg/util/limit"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -216,6 +217,11 @@ type ServerConfig struct {
 	// for operations on a vector index. It's stored as an `interface{}` due to
 	// package dependency cycles
 	VecIndexManager interface{}
+
+	// WorkSpanCollector manages work span capture for observability.
+	// When non-nil and enabled via cluster setting, processors and other
+	// components can use this to capture spans representing work done.
+	WorkSpanCollector *perftrace.Collector
 }
 
 // RuntimeStats is an interface through which the rowexec layer can get

--- a/pkg/sql/execinfrapb/api.proto
+++ b/pkg/sql/execinfrapb/api.proto
@@ -65,6 +65,11 @@ message SetupFlowRequest {
   // is populated on a best effort basis.
   optional string statement_sql = 10 [(gogoproto.nullable) = false,
     (gogoproto.customname) = "StatementSQL"];
+
+  // StatementFingerprintID is the fingerprint ID of the statement being executed.
+  // Used for work span capture observability.
+  optional uint64 statement_fingerprint_id = 14 [(gogoproto.nullable) = false,
+    (gogoproto.customname) = "StatementFingerprintID"];
 }
 
 // FlowSpec describes a "flow" which is a subgraph of a distributed SQL

--- a/pkg/sql/perftrace/BUILD.bazel
+++ b/pkg/sql/perftrace/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "perftrace",
+    srcs = [
+        "cluster_settings.go",
+        "collector.go",
+        "flush.go",
+        "reservoir.go",
+        "work_span.go",
+    ],
+    importpath = "github.com/cockroachdb/cockroach/pkg/sql/perftrace",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/settings",
+        "//pkg/settings/cluster",
+        "//pkg/sql/isql",
+        "//pkg/sql/sessiondata",
+        "//pkg/util/admission/admissionpb",
+        "//pkg/util/hlc",
+        "//pkg/util/log",
+        "//pkg/util/stop",
+        "//pkg/util/syncutil",
+        "//pkg/util/timeutil",
+    ],
+)

--- a/pkg/sql/perftrace/cluster_settings.go
+++ b/pkg/sql/perftrace/cluster_settings.go
@@ -1,0 +1,47 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package perftrace
+
+import (
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/settings"
+)
+
+// Enabled controls whether work span capture is enabled.
+var Enabled = settings.RegisterBoolSetting(
+	settings.ApplicationLevel,
+	"sql.work_span_capture.enabled",
+	"enables work span capture for query observability (experimental)",
+	true, // enabled by default for POC
+)
+
+// ReservoirSize controls the number of spans to sample per node.
+var ReservoirSize = settings.RegisterIntSetting(
+	settings.ApplicationLevel,
+	"sql.work_span_capture.reservoir_size",
+	"number of work spans to sample per node before flushing",
+	100,
+	settings.IntInRange(10, 10000),
+)
+
+// FlushInterval controls the interval between flushes to the system table.
+var FlushInterval = settings.RegisterDurationSetting(
+	settings.ApplicationLevel,
+	"sql.work_span_capture.flush_interval",
+	"interval between work span flushes to the system table",
+	time.Second*20,
+	settings.DurationInRange(10*time.Second, 10*time.Minute),
+)
+
+// DeleteRatio controls the fraction of existing spans to delete during flush.
+var DeleteRatio = settings.RegisterFloatSetting(
+	settings.ApplicationLevel,
+	"sql.work_span_capture.delete_ratio",
+	"fraction of existing spans to randomly delete during each flush (0.0 to 1.0)",
+	0.01, // 1% by default
+	settings.FloatInRange(0.0, 1.0),
+)

--- a/pkg/sql/perftrace/collector.go
+++ b/pkg/sql/perftrace/collector.go
@@ -1,0 +1,159 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package perftrace
+
+import (
+	"sync/atomic"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+// Collector manages work span capture for a node.
+type Collector struct {
+	reservoir *Reservoir
+	nodeID    int32
+	clock     *hlc.Clock
+	settings  *cluster.Settings
+	// nextSpanID is an atomic counter for generating unique span IDs within this node.
+	nextSpanID atomic.Int64
+}
+
+// NewCollector creates a new Collector.
+func NewCollector(nodeID int32, clock *hlc.Clock, settings *cluster.Settings) *Collector {
+	capacity := int(ReservoirSize.Get(&settings.SV))
+	c := &Collector{
+		reservoir: NewReservoir(capacity),
+		nodeID:    nodeID,
+		clock:     clock,
+		settings:  settings,
+	}
+	// Seed the span ID counter with a pseudo-random value based on the current
+	// timestamp to avoid collisions across node restarts. We use nanoseconds
+	// and mix in the node ID for additional uniqueness.
+	seed := timeutil.Now().UnixNano() ^ (int64(nodeID) << 32)
+	c.nextSpanID.Store(seed)
+	return c
+}
+
+// StartSpan begins tracking a work span if sampled.
+// Returns a SpanHandle that must be finished when the span completes.
+// If the span is not sampled, returns a no-op handle.
+func (c *Collector) StartSpan(
+	spanType SpanType,
+	spanName string,
+	stmtFingerprintID uint64,
+	parentID int64,
+) *SpanHandle {
+	if !Enabled.Get(&c.settings.SV) {
+		return &SpanHandle{shouldCapture: false}
+	}
+
+	token := c.reservoir.MaybeSample()
+	if !token.ShouldCapture() {
+		return &SpanHandle{shouldCapture: false}
+	}
+
+	// Generate a unique span ID
+	spanID := c.nextSpanID.Add(1)
+
+	return &SpanHandle{
+		collector:              c,
+		token:                  token,
+		shouldCapture:          true,
+		id:                     spanID,
+		parentID:               parentID,
+		stmtFingerprintID:      stmtFingerprintID,
+		spanType:               spanType,
+		spanName:               spanName,
+		startTime:              timeutil.Now(),
+		stopWatch:              timeutil.NewStopWatchWithCPU(),
+	}
+}
+
+// Reservoir returns the underlying reservoir (for flushing).
+func (c *Collector) Reservoir() *Reservoir {
+	return c.reservoir
+}
+
+// NodeID returns the node ID of this collector.
+func (c *Collector) NodeID() int32 {
+	return c.nodeID
+}
+
+// SpanHandle tracks an in-progress span.
+type SpanHandle struct {
+	collector         *Collector
+	token             ReservoirToken
+	shouldCapture     bool
+	id                int64
+	parentID          int64
+	stmtFingerprintID uint64
+	spanType          SpanType
+	spanName          string
+	startTime         time.Time
+	stopWatch         *timeutil.StopWatch
+	contentionTime    time.Duration
+}
+
+// ID returns the unique ID of this span.
+// Returns 0 if the span is not being captured.
+func (h *SpanHandle) ID() int64 {
+	if h == nil || !h.shouldCapture {
+		return 0
+	}
+	return h.id
+}
+
+// Start begins timing the span. Must be called after StartSpan.
+func (h *SpanHandle) Start() {
+	if h == nil || !h.shouldCapture {
+		return
+	}
+	h.stopWatch.Start()
+}
+
+// SetContentionTime sets the contention time (lock + latch waits) for this span.
+func (h *SpanHandle) SetContentionTime(d time.Duration) {
+	if h == nil || !h.shouldCapture {
+		return
+	}
+	h.contentionTime = d
+}
+
+// AddContentionTime adds to the contention time for this span.
+func (h *SpanHandle) AddContentionTime(d time.Duration) {
+	if h == nil || !h.shouldCapture {
+		return
+	}
+	h.contentionTime += d
+}
+
+// Finish completes the span and records it to the reservoir if sampled.
+func (h *SpanHandle) Finish() {
+	if h == nil || !h.shouldCapture {
+		return
+	}
+
+	h.stopWatch.Stop()
+
+	span := WorkSpan{
+		ID:                     h.id,
+		ParentID:               h.parentID,
+		NodeID:                 h.collector.nodeID,
+		StatementFingerprintID: h.stmtFingerprintID,
+		Timestamp:              h.startTime,
+		Duration:               h.stopWatch.Elapsed(),
+		CPUTime:                h.stopWatch.ElapsedCPU(),
+		ContentionTime:         h.contentionTime,
+		SpanType:               h.spanType,
+		SpanName:               h.spanName,
+	}
+
+	h.collector.reservoir.Record(h.token, span)
+}

--- a/pkg/sql/perftrace/flush.go
+++ b/pkg/sql/perftrace/flush.go
@@ -1,0 +1,183 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package perftrace
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/isql"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+// Flusher periodically flushes work spans from the collector to the system table.
+type Flusher struct {
+	collector *Collector
+	db        isql.DB
+	settings  *cluster.Settings
+	stopper   *stop.Stopper
+}
+
+// NewFlusher creates a new Flusher.
+func NewFlusher(
+	collector *Collector, db isql.DB, settings *cluster.Settings, stopper *stop.Stopper,
+) *Flusher {
+	return &Flusher{
+		collector: collector,
+		db:        db,
+		settings:  settings,
+		stopper:   stopper,
+	}
+}
+
+// Start begins the background flush loop.
+func (f *Flusher) Start(ctx context.Context) {
+	_ = f.stopper.RunAsyncTask(ctx, "work-span-flusher", func(ctx context.Context) {
+		var timer timeutil.Timer
+		defer timer.Stop()
+
+		for {
+			flushInterval := FlushInterval.Get(&f.settings.SV)
+			timer.Reset(flushInterval)
+
+			select {
+			case <-timer.C:
+				timer.Read = true
+				if Enabled.Get(&f.settings.SV) {
+					if err := f.flush(ctx); err != nil {
+						log.Ops.Warningf(ctx, "work span flush failed: %v", err)
+					}
+				}
+			case <-f.stopper.ShouldQuiesce():
+				return
+			}
+		}
+	})
+}
+
+// flush performs a single flush cycle:
+// 1. Delete a fraction of existing spans for this node
+// 2. Insert new spans from the reservoir
+// 3. Clear the reservoir
+func (f *Flusher) flush(ctx context.Context) error {
+	deleteRatio := DeleteRatio.Get(&f.settings.SV)
+	nodeID := f.collector.NodeID()
+
+	// Step 1: Delete a fraction of existing spans for this node
+	if deleteRatio > 0 {
+		deleteQuery := `DELETE FROM system.work_span WHERE node_id = $1 AND random() < $2`
+		if err := f.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+			_, err := txn.ExecEx(
+				ctx, "work-span-delete", txn.KV(),
+				sessiondata.NodeUserSessionDataOverride,
+				deleteQuery, nodeID, deleteRatio,
+			)
+			return err
+		}, isql.WithPriority(admissionpb.UserLowPri)); err != nil {
+			log.Ops.Warningf(ctx, "work span delete failed: %v", err)
+			// Continue with insert even if delete fails
+		}
+	}
+
+	// Step 2: Drain the reservoir
+	spans := f.collector.Reservoir().Drain()
+	if len(spans) == 0 {
+		return nil
+	}
+
+	// Step 3: Insert new spans
+	return f.insertSpans(ctx, spans)
+}
+
+// insertSpans inserts a batch of spans into the system table.
+func (f *Flusher) insertSpans(ctx context.Context, spans []WorkSpan) error {
+	if len(spans) == 0 {
+		return nil
+	}
+
+	// Build batch insert query
+	// INSERT INTO system.work_span (id, parent_id, node_id, statement_fingerprint_id, ts, duration, cpu_time, lock_wait_time, span_type, span_name)
+	// VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10), ...
+
+	const batchSize = 50 // Insert in batches to avoid query size limits
+	for i := 0; i < len(spans); i += batchSize {
+		end := i + batchSize
+		if end > len(spans) {
+			end = len(spans)
+		}
+		batch := spans[i:end]
+
+		if err := f.insertBatch(ctx, batch); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f *Flusher) insertBatch(ctx context.Context, spans []WorkSpan) error {
+	var valueClauses []string
+	var args []interface{}
+	argIdx := 1
+
+	for _, span := range spans {
+		// Build placeholder clause: ($1, $2, $3, ...)
+		placeholders := make([]string, 10)
+		for j := 0; j < 10; j++ {
+			placeholders[j] = fmt.Sprintf("$%d", argIdx+j)
+		}
+		valueClauses = append(valueClauses, "("+strings.Join(placeholders, ", ")+")")
+
+		// Add arguments
+		var parentID interface{}
+		if span.ParentID != 0 {
+			parentID = span.ParentID
+		}
+		var stmtFingerprintID interface{}
+		if span.StatementFingerprintID != 0 {
+			stmtFingerprintID = int64(span.StatementFingerprintID)
+		}
+
+		args = append(args,
+			span.ID,
+			parentID,
+			span.NodeID,
+			stmtFingerprintID,
+			span.Timestamp,
+			span.Duration.Nanoseconds(),
+			span.CPUTime.Nanoseconds(),
+			span.ContentionTime.Nanoseconds(),
+			string(span.SpanType),
+			span.SpanName,
+		)
+		argIdx += 10
+	}
+
+	query := fmt.Sprintf(`
+		INSERT INTO system.work_span
+		(id, parent_id, node_id, statement_fingerprint_id, ts, duration, cpu_time, contention_time, span_type, span_name)
+		VALUES %s
+	`, strings.Join(valueClauses, ", "))
+
+	return f.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+		_, err := txn.ExecEx(
+			ctx, "work-span-insert", txn.KV(),
+			sessiondata.NodeUserSessionDataOverride,
+			query, args...,
+		)
+		return err
+	}, isql.WithPriority(admissionpb.UserLowPri))
+}
+
+// FlushNow performs an immediate flush (useful for testing).
+func (f *Flusher) FlushNow(ctx context.Context) error {
+	return f.flush(ctx)
+}

--- a/pkg/sql/perftrace/reservoir.go
+++ b/pkg/sql/perftrace/reservoir.go
@@ -1,0 +1,124 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package perftrace
+
+import (
+	"math/rand"
+
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+// ReservoirToken is returned by MaybeSample to track a sampling decision.
+// It contains the index at which the span should be stored if sampled.
+type ReservoirToken struct {
+	shouldCapture bool
+	index         int
+}
+
+// ShouldCapture returns whether this token indicates the span should be captured.
+func (t ReservoirToken) ShouldCapture() bool {
+	return t.shouldCapture
+}
+
+// Reservoir implements reservoir sampling for work spans.
+// It maintains a fixed-size buffer of spans, using standard reservoir sampling
+// to ensure a uniform sample of all spans seen.
+type Reservoir struct {
+	mu struct {
+		syncutil.Mutex
+		// spans is the reservoir buffer.
+		spans []WorkSpan
+		// count is the total number of spans seen (for reservoir sampling probability).
+		count uint64
+		// rng is the random number generator for sampling decisions.
+		rng *rand.Rand
+		// capacity is the maximum number of spans to store.
+		capacity int
+	}
+}
+
+// NewReservoir creates a new Reservoir with the given capacity.
+func NewReservoir(capacity int) *Reservoir {
+	r := &Reservoir{}
+	r.mu.spans = make([]WorkSpan, 0, capacity)
+	r.mu.rng = rand.New(rand.NewSource(rand.Int63()))
+	r.mu.capacity = capacity
+	return r
+}
+
+// MaybeSample decides at span start whether to capture this span.
+// This allows the caller to avoid allocations for non-sampled spans.
+// Returns a token that should be passed to Record() if ShouldCapture() is true.
+func (r *Reservoir) MaybeSample() ReservoirToken {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.mu.count++
+	count := r.mu.count
+	capacity := r.mu.capacity
+
+	// Standard reservoir sampling:
+	// - First K items are always kept
+	// - Subsequent items replace existing with probability K/n
+	if len(r.mu.spans) < capacity {
+		// Reservoir not full yet, always sample
+		return ReservoirToken{shouldCapture: true, index: len(r.mu.spans)}
+	}
+
+	// Reservoir is full, sample with probability capacity/count
+	if r.mu.rng.Float64() < float64(capacity)/float64(count) {
+		// Replace a random existing span
+		replaceIndex := r.mu.rng.Intn(capacity)
+		return ReservoirToken{shouldCapture: true, index: replaceIndex}
+	}
+
+	return ReservoirToken{shouldCapture: false}
+}
+
+// Record adds a completed span to the reservoir.
+// The token must have been obtained from MaybeSample() with ShouldCapture() == true.
+func (r *Reservoir) Record(token ReservoirToken, span WorkSpan) {
+	if !token.shouldCapture {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if token.index < len(r.mu.spans) {
+		// Replace existing span
+		r.mu.spans[token.index] = span
+	} else if token.index == len(r.mu.spans) && len(r.mu.spans) < r.mu.capacity {
+		// Append to reservoir (still filling up)
+		r.mu.spans = append(r.mu.spans, span)
+	}
+	// Otherwise the index is stale (concurrent modification), skip
+}
+
+// Drain removes and returns all spans from the reservoir, resetting the count.
+func (r *Reservoir) Drain() []WorkSpan {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	spans := r.mu.spans
+	r.mu.spans = make([]WorkSpan, 0, r.mu.capacity)
+	r.mu.count = 0
+	return spans
+}
+
+// Len returns the current number of spans in the reservoir.
+func (r *Reservoir) Len() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.mu.spans)
+}
+
+// Count returns the total number of spans seen since the last drain.
+func (r *Reservoir) Count() uint64 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.mu.count
+}

--- a/pkg/sql/perftrace/work_span.go
+++ b/pkg/sql/perftrace/work_span.go
@@ -1,0 +1,133 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package perftrace
+
+import (
+	"context"
+	"time"
+)
+
+// SpanType categorizes the type of work span.
+type SpanType string
+
+const (
+	// SpanTypeGateway represents the entire statement execution from the gateway's perspective.
+	SpanTypeGateway SpanType = "gateway"
+	// SpanTypeProcessor represents a relational operator (TableReader, HashJoiner, etc.).
+	SpanTypeProcessor SpanType = "processor"
+	// SpanTypeKVBatch represents a batch-level KV operation (dist sender send).
+	SpanTypeKVBatch SpanType = "kv_batch"
+)
+
+// WorkSpan represents a captured execution span.
+type WorkSpan struct {
+	// ID is a unique identifier for this span, generated via unique_rowid().
+	ID int64
+	// ParentID is the ID of the parent span (0 if no parent).
+	ParentID int64
+	// NodeID is the SQL instance ID of the node where this span was captured.
+	NodeID int32
+	// StatementFingerprintID is the fingerprint ID of the statement.
+	StatementFingerprintID uint64
+	// Timestamp is when the span started.
+	Timestamp time.Time
+	// Duration is the wall-clock time of the span in nanoseconds.
+	Duration time.Duration
+	// CPUTime is the CPU time consumed by this span in nanoseconds.
+	CPUTime time.Duration
+	// ContentionTime is the time spent waiting on locks and latches in nanoseconds.
+	ContentionTime time.Duration
+	// SpanType categorizes the span (gateway, processor, kv_batch).
+	SpanType SpanType
+	// SpanName is the name of the span (e.g., "TableReader", "dist sender send").
+	SpanName string
+}
+
+// contextKey is used for storing work span context values.
+type contextKey int
+
+const (
+	// parentSpanIDKey is the context key for the parent work span ID.
+	parentSpanIDKey contextKey = iota
+	// fingerprintIDKey is the context key for the statement fingerprint ID.
+	fingerprintIDKey
+	// currentSpanHandleKey is the context key for the current work span handle.
+	currentSpanHandleKey
+)
+
+// WithParentSpanID returns a new context with the parent work span ID set.
+func WithParentSpanID(ctx context.Context, id int64) context.Context {
+	return context.WithValue(ctx, parentSpanIDKey, id)
+}
+
+// GetParentSpanIDFromContext returns the parent work span ID from the context.
+// Returns 0 if not set.
+func GetParentSpanIDFromContext(ctx context.Context) int64 {
+	if v := ctx.Value(parentSpanIDKey); v != nil {
+		return v.(int64)
+	}
+	return 0
+}
+
+// WithFingerprintID returns a new context with the statement fingerprint ID set.
+func WithFingerprintID(ctx context.Context, id uint64) context.Context {
+	return context.WithValue(ctx, fingerprintIDKey, id)
+}
+
+// GetFingerprintFromContext returns the statement fingerprint ID from the context.
+// Returns 0 if not set.
+func GetFingerprintFromContext(ctx context.Context) uint64 {
+	if v := ctx.Value(fingerprintIDKey); v != nil {
+		return v.(uint64)
+	}
+	return 0
+}
+
+// collectorKey is the context key for the work span collector.
+type collectorKeyType struct{}
+
+var collectorKey = collectorKeyType{}
+
+// WithCollector returns a new context with the work span collector set.
+// This is used to make the collector available to the KV layer.
+func WithCollector(ctx context.Context, collector *Collector) context.Context {
+	return context.WithValue(ctx, collectorKey, collector)
+}
+
+// GetCollectorFromContext returns the work span collector from the context.
+// Returns nil if not set.
+func GetCollectorFromContext(ctx context.Context) *Collector {
+	if v := ctx.Value(collectorKey); v != nil {
+		return v.(*Collector)
+	}
+	return nil
+}
+
+// WithCurrentSpanHandle returns a new context with the current work span handle set.
+// This is used to make the span handle available to low-level waiting code
+// (latch manager, lock table waiter) so they can add contention time directly.
+func WithCurrentSpanHandle(ctx context.Context, handle *SpanHandle) context.Context {
+	return context.WithValue(ctx, currentSpanHandleKey, handle)
+}
+
+// GetCurrentSpanHandleFromContext returns the current work span handle from the context.
+// Returns nil if not set.
+func GetCurrentSpanHandleFromContext(ctx context.Context) *SpanHandle {
+	if v := ctx.Value(currentSpanHandleKey); v != nil {
+		return v.(*SpanHandle)
+	}
+	return nil
+}
+
+// AddContentionTimeFromContext adds the given contention duration to the current
+// work span handle in the context. This is a convenience function for use by
+// low-level waiting code that doesn't need to directly manipulate the handle.
+// If there is no current span handle in the context, this is a no-op.
+func AddContentionTimeFromContext(ctx context.Context, d time.Duration) {
+	if h := GetCurrentSpanHandleFromContext(ctx); h != nil {
+		h.AddContentionTime(d)
+	}
+}

--- a/pkg/sql/sem/catconstants/constants.go
+++ b/pkg/sql/sem/catconstants/constants.go
@@ -112,6 +112,7 @@ const (
 	InspectErrorsTableName                  SystemTableName = "inspect_errors"
 	StatementHintsTableName                 SystemTableName = "statement_hints"
 	TableStatisticsLocksTableName           SystemTableName = "table_statistics_locks"
+	WorkSpanTableName                       SystemTableName = "work_span"
 )
 
 // Oid for virtual database and table.

--- a/pkg/upgrade/upgrades/BUILD.bazel
+++ b/pkg/upgrade/upgrades/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "v25_4_system_stats_tables_autostats_fraction.go",
         "v25_4_transaction_diagnostics_tables.go",
         "v26_1_system_table_statistics_locks.go",
+        "v26_1_system_work_span.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/upgrade/upgrades",
     visibility = ["//visibility:public"],

--- a/pkg/upgrade/upgrades/upgrades.go
+++ b/pkg/upgrade/upgrades/upgrades.go
@@ -131,6 +131,14 @@ var upgrades = []upgradebase.Upgrade{
 		upgrade.RestoreActionNotRequired("cluster restore does not restore this table"),
 	),
 
+	upgrade.NewTenantUpgrade(
+		"create work_span table",
+		clusterversion.V26_1_AddWorkSpanTable.Version(),
+		upgrade.NoPrecondition,
+		createWorkSpanTable,
+		upgrade.RestoreActionNotRequired("cluster restore does not restore this table"),
+	),
+
 	newFirstUpgrade(clusterversion.V26_2_Start.Version()),
 
 	// Note: when starting a new release version, the first upgrade (for

--- a/pkg/upgrade/upgrades/v26_1_system_work_span.go
+++ b/pkg/upgrade/upgrades/v26_1_system_work_span.go
@@ -1,0 +1,25 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package upgrades
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/upgrade"
+)
+
+// createWorkSpanTable creates the system.work_span table for query
+// observability through work span capture.
+func createWorkSpanTable(
+	ctx context.Context, _ clusterversion.ClusterVersion, d upgrade.TenantDeps,
+) error {
+	return createSystemTable(
+		ctx, d.DB, d.Settings, d.Codec, systemschema.WorkSpanTable, tree.LocalityLevelTable,
+	)
+}


### PR DESCRIPTION
put simply, this pr adds the probabilistic capture of spans of work in the cluster, defined by the shape

```sql
CREATE TABLE system.work_span (
	id                        INT8        NOT NULL DEFAULT unique_rowid(),
	parent_id                 INT8,
	node_id                   INT4        NOT NULL,
	statement_fingerprint_id  INT8,
	ts                        TIMESTAMPTZ NOT NULL DEFAULT now(),
	duration                  INT8        NOT NULL,
	cpu_time                  INT8,
	contention_time           INT8,
	span_type                 STRING      NOT NULL,
)
```

Having this table allows us to compute answers to generalized questions, in targeted ways. For example, what is consuming all the cpu on node `3` could be:

```
SELECT statement_fingerprint_id, SUM(cpu_time)
  FROM system.work_span
 WHERE node_id=3
 GROUP BY 1
 ORDER BY 2 DESC
```

Figuring out which query had the most wait time per node 10 minutes ago becomes:
```
SELECT statement_fingerprint_id, node_id, SUM(contention_time),
  FROM system.work_span
 WHERE ts BETWEEN NOW - 11 MINUTES AND NOW - 10 MINUTES
 GROUP BY 1, 2
 ORDER BY 3 DESC
```