### PR TITLE
Revert "roachtest: skip distMerge=true import"

### DIFF
--- a/pkg/cmd/roachtest/tests/import.go
+++ b/pkg/cmd/roachtest/tests/import.go
@@ -328,8 +328,7 @@ func registerImport(r registry.Registry) {
 			suites = registry.ManualOnly
 		}
 
-		// TODO(#159956): unskip distMerge=true.
-		for _, distMerge := range []bool{false} {
+		for _, distMerge := range []bool{false, true} {
 			for _, numNodes := range testSpec.nodes {
 				ts := testSpec
 				numNodes := numNodes


### PR DESCRIPTION
This failure (#159956) was likely caused by an issue that was fixed by 0e5489d3b1288e4f605e4df0622cef2baa06d9c2. The issue needs a larger test to repro, so re-enabling this test.

This reverts commit af7950c0dda7ee5b763fc9a6eb6c9c7ad8a9baa5.

Informs: #159956
Release Note: None