### PR TITLE
release-26.1: multiregionccl: add diagnostics and extend timeout for zone config flake

### DIFF
--- a/pkg/ccl/multiregionccl/datadriven_test.go
+++ b/pkg/ccl/multiregionccl/datadriven_test.go
@@ -371,6 +371,10 @@ SET CLUSTER SETTING kv.allocator.min_lease_transfer_interval = '5m'
 				}
 				lookupRKey := keys.MustAddr(lookupKey)
 
+				// Rate limiter for diagnostic logging to help diagnose flakes where
+				// replicas intermittently fail to serve local requests. See #160349.
+				logEvery := log.Every(10 * time.Second)
+
 				// There's a lot going on here and things can fail at various steps, for
 				// completely legitimate reasons, which is why this thing needs to be
 				// wrapped in a succeeds soon.
@@ -387,6 +391,10 @@ SET CLUSTER SETTING kv.allocator.min_lease_transfer_interval = '5m'
 					actualPlacement, err := parseReplicasFromRange(t, ds.tc, desc)
 					if err != nil {
 						return err
+					}
+					if logEvery.ShouldLog() {
+						t.Logf("wait-for-zone-config-changes: initial replica check passed (%d replicas served locally)",
+							len(desc.Replicas().VoterAndNonVoterDescriptors()))
 					}
 
 					leaseHolderNode := ds.tc.Server(actualPlacement.getLeaseholder())
@@ -462,6 +470,10 @@ SET CLUSTER SETTING kv.allocator.min_lease_transfer_interval = '5m'
 					if err != nil {
 						return err
 					}
+					if logEvery.ShouldLog() {
+						t.Logf("wait-for-zone-config-changes: final replica check passed (%d replicas served locally)",
+							len(desc.Replicas().VoterAndNonVoterDescriptors()))
+					}
 					err = actualPlacement.satisfiesExpectedPlacement(expectedPlacement)
 					if err != nil {
 						return err
@@ -485,7 +497,7 @@ SET CLUSTER SETTING kv.allocator.min_lease_transfer_interval = '5m'
 					}
 
 					return nil
-				}, 5*time.Minute); err != nil {
+				}, 7*time.Minute); err != nil {
 					return err.Error()
 				}
 
@@ -670,8 +682,11 @@ func parseReplicasFromInput(
 	return &ret
 }
 
-// parseReplicasFromInput constructs a replicaPlacement from a range descriptor.
-// It also ensures all replicas have the same view of who the leaseholder is.
+// parseReplicasFromRange constructs a replicaPlacement from a range descriptor.
+// In doing so, it:
+//   - verifies that all replicas agree on the current leaseholder
+//   - checks that each replica can serve a lease request locally (using the
+//     QueryLocalNodeOnly policy)
 func parseReplicasFromRange(
 	t *testing.T, tc serverutils.TestClusterInterface, desc roachpb.RangeDescriptor,
 ) (*replicaPlacement, error) {


### PR DESCRIPTION
Backport 1/1 commits from #161065 on behalf of @spilchen.

----

Add logging to parseReplicasFromRange to help diagnose flaky failures in wait-for-zone-config-changes (#160349). I also increased the retry timeout from 5 minutes to 7 minutes again to help combat slow machins as this was seen in s390x, which have been slow.

One hypothesis is that parseReplicasFromRange’s local lease-serving check may pass and fail intermittently while wait-for-zone-config-changes retries. This check depends on the closed timestamp being sufficiently advanced, and on slower machines that timestamp may lag wall clock time. Such lag could cause flip‑flopping behavior that prevents the test from ever reaching a stable success state. The added diagnostics should help clarify whether this is happening.

Closes #160349
Epic: none
Release note: none

----

Release justification: test only fix