### PR TITLE
workload: allow rows=0 for workload

### DIFF
--- a/pkg/workload/bank/bank.go
+++ b/pkg/workload/bank/bank.go
@@ -117,8 +117,9 @@ func (b *bank) ConnFlags() *workload.ConnFlags { return b.connFlags }
 func (b *bank) Hooks() workload.Hooks {
 	return workload.Hooks{
 		Validate: func() error {
-			if b.rows < 2 {
+			if b.rows != 0 && b.rows < 2 {
 				// We need at least two rows to do any transfers.
+				// Allow rows=0 for schema-only initialization (e.g., workload init --rows=0).
 				return errors.Errorf(`Value of rows must be greater than one; was %d`, b.rows)
 			}
 			if b.rows < b.ranges {


### PR DESCRIPTION
The validation added in https://github.com/cockroachdb/cockroach/commit/cd6bd43b10ff010fb2a6e21905a56f03a7fd07b8 failed rows=0 which is
legitimately used by the copy/bank
roachtest to create an empty table schema.

This change allows rows=0 (schema-only init) while still rejecting
rows=1.

Fixes: https://github.com/cockroachdb/cockroach/issues/160972
Fixes: https://github.com/cockroachdb/cockroach/issues/161049