### PR TITLE
release-25.2: kvserver: deflake TestLeaderlessWatcherErrorRefreshedOnUnavailabilityTransition

### DIFF
--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -2987,6 +2987,12 @@ func TestLeaderlessWatcherErrorRefreshedOnUnavailabilityTransition(t *testing.T)
 				Server: &server.TestingKnobs{
 					WallClock: manual,
 				},
+				Store: &kvserver.StoreTestingKnobs{
+					// Disable raft ticks from refreshing the leaderless watcher
+					// state, allowing the test full control over the leaderless
+					// watcher state.
+					DisableLeaderlessWatcherRefreshOnRaftTick: true,
+				},
 			},
 		},
 	})

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1510,9 +1510,11 @@ func (r *Replica) tick(
 	postTickStatus := r.mu.internalRaftGroup.BasicStatus()
 
 	// Refresh the unavailability state on the leaderlessWatcher.
-	r.LeaderlessWatcher.refreshUnavailableState(
-		ctx, postTickStatus.Lead, nowPhysicalTime, r.store.cfg.Settings, r.replicaUnavailableErrorRLocked,
-	)
+	if !r.store.TestingKnobs().DisableLeaderlessWatcherRefreshOnRaftTick {
+		r.LeaderlessWatcher.refreshUnavailableState(
+			ctx, postTickStatus.Lead, nowPhysicalTime, r.store.cfg.Settings, r.replicaUnavailableErrorRLocked,
+		)
+	}
 
 	if preTickStatus.RaftState != postTickStatus.RaftState {
 		if postTickStatus.RaftState == raftpb.StatePreCandidate {

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -570,6 +570,10 @@ type StoreTestingKnobs struct {
 	// NodeIsLiveCallbackWorkDone, if set, is called after nodeIsLiveCallback
 	// completes its iteration over all replicas on the store.
 	NodeIsLiveCallbackWorkDone func(livenesspb.Liveness)
+
+	// DisableLeaderlessWatcherRefreshOnRaftTick, if set, disables refreshing
+	// the leaderless watcher's unavailable state during raft ticks.
+	DisableLeaderlessWatcherRefreshOnRaftTick bool
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.


### PR DESCRIPTION
Backport 1/1 commits from #161063 on behalf of @arulajmani.

----


This patch fixes a race condition where the test's refreshing of the leaderless watcher could race with the Raft tick loop's update of it.

Closes https://github.com/cockroachdb/cockroach/issues/161044

Release note: None

----

Release justification: testing only change