### PR TITLE
sql: sanitize some links to remove binary versions

### DIFF
--- a/pkg/clusterversion/runbooks/M1_bump_current_version.md
+++ b/pkg/clusterversion/runbooks/M1_bump_current_version.md
@@ -523,35 +523,7 @@ These are logic errors in code that references version gates OR new regression t
 
 These are straightforward test output updates that happen because version numbers and URLs changed. **Do NOT modify production code for these failures.**
 
-##### A. Documentation URL Updates (v25.4 → dev)
-
-**Pattern:** After bumping from X.Y to next major version, all doc URLs referencing `vX.Y` must change to `dev`.
-
-**Files typically affected:**
-- `pkg/sql/logictest/testdata/logic_test/*`
-- `pkg/sql/pgwire/testdata/pgtest/*`
-- `pkg/ccl/logictestccl/testdata/logic_test/*`
-
-**Changes needed:**
-```bash
-# Documentation URLs
-www.cockroachlabs.com/docs/v25.4/* → www.cockroachlabs.com/docs/dev/*
-
-# Issue tracker URLs
-go.crdb.dev/issue-v/*/v25.4 → go.crdb.dev/issue-v/*/dev
-```
-
-**Quick fix:**
-```bash
-# Find all files with v25.4 references
-grep -r "v25\.4" pkg/sql pkg/ccl --include="*.md" --include="logic_test*" --include="pgtest*"
-
-# Replace with sed (example for URLs)
-sed -i '' 's|www.cockroachlabs.com/docs/v25.4|www.cockroachlabs.com/docs/dev|g' <file>
-sed -i '' 's|go.crdb.dev/issue-v/\([0-9]*\)/v25.4|go.crdb.dev/issue-v/\1/dev|g' <file>
-```
-
-##### B. Version Number Updates in Test Outputs
+##### A. Version Number Updates in Test Outputs
 
 **Pattern:** Tests that query version information expect the new version number.
 
@@ -575,7 +547,7 @@ sed -i '' 's|go.crdb.dev/issue-v/\([0-9]*\)/v25.4|go.crdb.dev/issue-v/\1/dev|g' 
 sed -i '' 's/^25\.4$/26.1/' <file>
 ```
 
-##### C. systemDatabaseSchemaVersion Update
+##### B. systemDatabaseSchemaVersion Update
 
 **Pattern:** After bumping to version X.Y, the systemDatabaseSchemaVersion must reflect `VX_Y_Start`.
 
@@ -608,7 +580,7 @@ sed -i '' 's/^25\.4$/26.1/' <file>
 ./dev test pkg/sql/logictest --filter='TestReadCommittedLogic/crdb_internal_catalog'
 ```
 
-##### D. Bootstrap Schema Hash Mismatches
+##### C. Bootstrap Schema Hash Mismatches
 
 **Pattern:** Bootstrap hash values change when system schema versions change.
 
@@ -635,7 +607,7 @@ bazel test //pkg/sql/catalog/bootstrap:bootstrap_test \
 ./dev test pkg/sql/catalog/bootstrap -f='TestInitialValuesToString'
 ```
 
-##### E. Mixedversion Test Failures (TRICKY!)
+##### D. Mixedversion Test Failures (TRICKY!)
 
 **Pattern:** Tests show unexpected upgrade paths or version selections.
 

--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -1727,7 +1727,7 @@ statement error duplicate key value violates unique constraint
 CREATE UNIQUE INDEX ON unique_array(b)
 
 # Create an indexes on a bad type.
-statement error column x has type geography\[\], which is not indexable in a non-inverted index\nHINT: you may want to create an inverted index instead. See the documentation for inverted indexes: https://www.cockroachlabs.com/docs/dev/inverted-indexes.html
+statement error column x has type geography\[\], which is not indexable in a non-inverted index\nHINT: you may want to create an inverted index instead. See the documentation for inverted indexes: https://www.cockroachlabs.com/docs/.+/inverted-indexes.html
 CREATE TABLE tbad (x GEOGRAPHY[] PRIMARY KEY)
 
 # Test arrays of composite types.

--- a/pkg/sql/logictest/testdata/logic_test/cluster_settings
+++ b/pkg/sql/logictest/testdata/logic_test/cluster_settings
@@ -456,7 +456,7 @@ query T noticetrace
 SET CLUSTER SETTING sql.ttl.default_delete_rate_limit = 90;
 ----
 NOTICE: The TTL rate limit is per node per table.
-DETAIL: See the documentation for additional details: https://www.cockroachlabs.com/docs/dev/row-level-ttl#ttl-storage-parameters
+DETAIL: See the documentation for additional details: https://www.cockroachlabs.com/docs/.../row-level-ttl#ttl-storage-parameters
 
 statement ok
 SET CLUSTER SETTING sql.ttl.default_delete_rate_limit = 100;
@@ -465,7 +465,7 @@ query T noticetrace
 SET CLUSTER SETTING sql.ttl.default_select_rate_limit = 100;
 ----
 NOTICE: The TTL rate limit is per node per table.
-DETAIL: See the documentation for additional details: https://www.cockroachlabs.com/docs/dev/row-level-ttl#ttl-storage-parameters
+DETAIL: See the documentation for additional details: https://www.cockroachlabs.com/docs/.../row-level-ttl#ttl-storage-parameters
 
 statement ok
 SET CLUSTER SETTING sql.ttl.default_select_rate_limit = 0;

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -140,16 +140,16 @@ geog    GEOGRAPHY(GEOMETRY,4326)  true   NULL  ·  {geo_table_geog_idx,geo_table
 geom    GEOMETRY(POINT)           true   NULL  ·  {geo_table_geom_idx,geo_table_pkey}                     false
 orphan  GEOGRAPHY                 true   NULL  ·  {geo_table_pkey}                                        false
 
-statement error column bad_pk has type geography, which is not indexable in a non-inverted index\nHINT: you may want to create an inverted index instead. See the documentation for inverted indexes: https://www.cockroachlabs.com/docs/dev/inverted-indexes.html
+statement error column bad_pk has type geography, which is not indexable in a non-inverted index\nHINT: you may want to create an inverted index instead. See the documentation for inverted indexes: https://www.cockroachlabs.com/docs/.+/inverted-indexes.html
 CREATE TABLE bad_geog_table(bad_pk geography primary key)
 
-statement error column bad_pk has type geometry, which is not indexable in a non-inverted index\nHINT: you may want to create an inverted index instead. See the documentation for inverted indexes: https://www.cockroachlabs.com/docs/dev/inverted-indexes.html
+statement error column bad_pk has type geometry, which is not indexable in a non-inverted index\nHINT: you may want to create an inverted index instead. See the documentation for inverted indexes: https://www.cockroachlabs.com/docs/.+/inverted-indexes.html
 CREATE TABLE bad_geom_table(bad_pk geometry primary key)
 
-statement error column geog has type geography, which is not indexable in a non-inverted index\nHINT: you may want to create an inverted index instead. See the documentation for inverted indexes: https://www.cockroachlabs.com/docs/dev/inverted-indexes.html
+statement error column geog has type geography, which is not indexable in a non-inverted index\nHINT: you may want to create an inverted index instead. See the documentation for inverted indexes: https://www.cockroachlabs.com/docs/.+/inverted-indexes.html
 CREATE INDEX geog_idx ON geo_table(geog)
 
-statement error column geom has type geometry, which is not indexable in a non-inverted index\nHINT: you may want to create an inverted index instead. See the documentation for inverted indexes: https://www.cockroachlabs.com/docs/dev/inverted-indexes.html
+statement error column geom has type geometry, which is not indexable in a non-inverted index\nHINT: you may want to create an inverted index instead. See the documentation for inverted indexes: https://www.cockroachlabs.com/docs/.+/inverted-indexes.html
 CREATE INDEX geom_idx ON geo_table(geom)
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/row_level_ttl
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_ttl
@@ -937,7 +937,7 @@ CREATE TABLE tbl_set_ttl_params (
 )
 ----
 NOTICE: The TTL rate limit is per node per table.
-DETAIL: See the documentation for additional details: https://www.cockroachlabs.com/docs/dev/row-level-ttl#ttl-storage-parameters
+DETAIL: See the documentation for additional details: https://www.cockroachlabs.com/docs/.../row-level-ttl#ttl-storage-parameters
 
 onlyif config schema-locked-disabled
 query T
@@ -964,7 +964,7 @@ query T noticetrace
 ALTER TABLE tbl_set_ttl_params SET (ttl_select_batch_size = 110, ttl_delete_batch_size = 120, ttl_select_rate_limit = 130, ttl_delete_rate_limit = 140, ttl_row_stats_poll_interval = '2m0s')
 ----
 NOTICE: The TTL rate limit is per node per table.
-DETAIL: See the documentation for additional details: https://www.cockroachlabs.com/docs/dev/row-level-ttl#ttl-storage-parameters
+DETAIL: See the documentation for additional details: https://www.cockroachlabs.com/docs/.../row-level-ttl#ttl-storage-parameters
 
 onlyif config local-read-committed local-repeatable-read
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/unimplemented
+++ b/pkg/sql/logictest/testdata/logic_test/unimplemented
@@ -5,7 +5,7 @@ CREATE TABLE legacy();
 
 # Since all the below statements use a common method for the hint and detail part
 # of the error message, we only test this first one with the entire error message.
-statement error pq: CREATE POLICY is only implemented in the declarative schema changer\nHINT: This error may be happening due to running it in a multi-statement transaction. Try sending each schema change statement in its own implicit transaction.\nDETAIL:  See the documentation for additional details:https://www.cockroachlabs.com/docs/dev/online-schema-changes#declarative-schema-changer
+statement error pq: CREATE POLICY is only implemented in the declarative schema changer\nHINT: This error may be happening due to running it in a multi-statement transaction. Try sending each schema change statement in its own implicit transaction.\nDETAIL:  See the documentation for additional details:https://www.cockroachlabs.com/docs/.+/online-schema-changes#declarative-schema-changer
 CREATE POLICY p1 on legacy;
 
 subtest policy_statements

--- a/pkg/sql/logictest/testdata/logic_test/vector_index
+++ b/pkg/sql/logictest/testdata/logic_test/vector_index
@@ -346,7 +346,7 @@ statement error column c has type vector, which is only allowed as the last colu
 CREATE TABLE t (a INT PRIMARY KEY, b INT, c VECTOR(3), VECTOR INDEX (c, b))
 
 # Try to use inverted indexable type in vector index.
-statement error column b has type tsvector, which is not indexable in a non-inverted index\nHINT: you may want to create an inverted index instead. See the documentation for inverted indexes: https://www.cockroachlabs.com/docs/dev/inverted-indexes.html
+statement error column b has type tsvector, which is not indexable in a non-inverted index\nHINT: you may want to create an inverted index instead. See the documentation for inverted indexes: https://www.cockroachlabs.com/docs/.+/inverted-indexes.html
 CREATE TABLE t (a INT PRIMARY KEY, b TSVECTOR, c VECTOR(3), VECTOR INDEX (b, c))
 
 statement error pq: a vector index does not support the ASC option
@@ -406,7 +406,7 @@ statement error column vec1 has type vector, which is only allowed as the last c
 CREATE VECTOR INDEX ON vec_errors (vec1, b)
 
 # Try to use inverted indexable type in vector index.
-statement error column c has type tsvector, which is not indexable in a non-inverted index\nHINT: you may want to create an inverted index instead. See the documentation for inverted indexes: https://www.cockroachlabs.com/docs/dev/inverted-indexes.html
+statement error column c has type tsvector, which is not indexable in a non-inverted index\nHINT: you may want to create an inverted index instead. See the documentation for inverted indexes: https://www.cockroachlabs.com/docs/.+/inverted-indexes.html
 CREATE VECTOR INDEX ON vec_errors (c, vec1)
 
 statement error pq: a vector index does not support the DESC option

--- a/pkg/sql/pgwire/testdata/pgtest/multiple_active_portals
+++ b/pkg/sql/pgwire/testdata/pgtest/multiple_active_portals
@@ -468,7 +468,7 @@ ReadyForQuery
 {"Type":"PortalSuspended"}
 {"Type":"DataRow","Values":[{"text":"2"}]}
 {"Type":"PortalSuspended"}
-{"Type":"ErrorResponse","Code":"0A000","Message":"unimplemented: the statement for a pausable portal must be a read-only SELECT query with no sub-queries or post-queries","Detail":"cannot execute a portal while a different one is open","Hint":"You have attempted to use a feature that is not yet implemented.\nSee: https://go.crdb.dev/issue-v/98911/dev"}
+{"Type":"ErrorResponse","Code":"0A000","Message":"unimplemented: the statement for a pausable portal must be a read-only SELECT query with no sub-queries or post-queries","Detail":"cannot execute a portal while a different one is open","Hint":"You have attempted to use a feature that is not yet implemented.\nSee: https://go.crdb.dev/issue-v/98911/..."}
 {"Type":"ReadyForQuery","TxStatus":"E"}
 
 send crdb_only
@@ -515,7 +515,7 @@ ReadyForQuery
 {"Type":"BindComplete"}
 {"Type":"DataRow","Values":[{"text":"f"}]}
 {"Type":"PortalSuspended"}
-{"Type":"ErrorResponse","Code":"0A000","Message":"unimplemented: the statement for a pausable portal must be a read-only SELECT query with no sub-queries or post-queries","Detail":"cannot execute a portal while a different one is open","Hint":"You have attempted to use a feature that is not yet implemented.\nSee: https://go.crdb.dev/issue-v/98911/dev"}
+{"Type":"ErrorResponse","Code":"0A000","Message":"unimplemented: the statement for a pausable portal must be a read-only SELECT query with no sub-queries or post-queries","Detail":"cannot execute a portal while a different one is open","Hint":"You have attempted to use a feature that is not yet implemented.\nSee: https://go.crdb.dev/issue-v/98911/..."}
 {"Type":"ReadyForQuery","TxStatus":"E"}
 
 send crdb_only
@@ -564,7 +564,7 @@ ReadyForQuery
 {"Type":"BindComplete"}
 {"Type":"DataRow","Values":[{"text":"10"}]}
 {"Type":"PortalSuspended"}
-{"Type":"ErrorResponse","Code":"0A000","Message":"unimplemented: the statement for a pausable portal must be a read-only SELECT query with no sub-queries or post-queries","Detail":"cannot execute a portal while a different one is open","Hint":"You have attempted to use a feature that is not yet implemented.\nSee: https://go.crdb.dev/issue-v/98911/dev"}
+{"Type":"ErrorResponse","Code":"0A000","Message":"unimplemented: the statement for a pausable portal must be a read-only SELECT query with no sub-queries or post-queries","Detail":"cannot execute a portal while a different one is open","Hint":"You have attempted to use a feature that is not yet implemented.\nSee: https://go.crdb.dev/issue-v/98911/..."}
 {"Type":"ReadyForQuery","TxStatus":"E"}
 
 send crdb_only
@@ -613,7 +613,7 @@ ReadyForQuery
 {"Type":"BindComplete"}
 {"Type":"DataRow","Values":[{"text":"1"}]}
 {"Type":"PortalSuspended"}
-{"Type":"ErrorResponse","Code":"0A000","Message":"unimplemented: the statement for a pausable portal must be a read-only SELECT query with no sub-queries or post-queries","Detail":"cannot execute a portal while a different one is open","Hint":"You have attempted to use a feature that is not yet implemented.\nSee: https://go.crdb.dev/issue-v/98911/dev"}
+{"Type":"ErrorResponse","Code":"0A000","Message":"unimplemented: the statement for a pausable portal must be a read-only SELECT query with no sub-queries or post-queries","Detail":"cannot execute a portal while a different one is open","Hint":"You have attempted to use a feature that is not yet implemented.\nSee: https://go.crdb.dev/issue-v/98911/..."}
 {"Type":"ReadyForQuery","TxStatus":"E"}
 
 send crdb_only
@@ -957,7 +957,7 @@ ReadyForQuery
 {"Type":"PortalSuspended"}
 {"Type":"DataRow","Values":[{"text":"10"}]}
 {"Type":"PortalSuspended"}
-{"Type":"ErrorResponse","Code":"0A000","Message":"unimplemented: the statement for a pausable portal must be a read-only SELECT query with no sub-queries or post-queries","Detail":"cannot execute a portal while a different one is open","Hint":"You have attempted to use a feature that is not yet implemented.\nSee: https://go.crdb.dev/issue-v/98911/dev"}
+{"Type":"ErrorResponse","Code":"0A000","Message":"unimplemented: the statement for a pausable portal must be a read-only SELECT query with no sub-queries or post-queries","Detail":"cannot execute a portal while a different one is open","Hint":"You have attempted to use a feature that is not yet implemented.\nSee: https://go.crdb.dev/issue-v/98911/..."}
 {"Type":"ReadyForQuery","TxStatus":"E"}
 
 send
@@ -1494,7 +1494,7 @@ ReadyForQuery
 ----
 {"Type":"ParseComplete"}
 {"Type":"BindComplete"}
-{"Type":"ErrorResponse","Code":"0A000","Message":"unimplemented: the statement for a pausable portal must be a read-only SELECT query with no sub-queries or post-queries","Hint":"You have attempted to use a feature that is not yet implemented.\nSee: https://go.crdb.dev/issue-v/98911/dev"}
+{"Type":"ErrorResponse","Code":"0A000","Message":"unimplemented: the statement for a pausable portal must be a read-only SELECT query with no sub-queries or post-queries","Hint":"You have attempted to use a feature that is not yet implemented.\nSee: https://go.crdb.dev/issue-v/98911/..."}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
 # If calling this procedure without `"MaxRows": 100` (i.e. make it a non-pausable portal),
@@ -1600,7 +1600,7 @@ ReadyForQuery
 {"Type":"ParseComplete"}
 {"Type":"BindComplete"}
 {"Type":"BindComplete"}
-{"Type":"ErrorResponse","Code":"0A000","Message":"unimplemented: the statement for a pausable portal must be a read-only SELECT query with no sub-queries or post-queries","Hint":"You have attempted to use a feature that is not yet implemented.\nSee: https://go.crdb.dev/issue-v/98911/dev"}
+{"Type":"ErrorResponse","Code":"0A000","Message":"unimplemented: the statement for a pausable portal must be a read-only SELECT query with no sub-queries or post-queries","Hint":"You have attempted to use a feature that is not yet implemented.\nSee: https://go.crdb.dev/issue-v/98911/..."}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
 # Both PG and CRDB allows procedure with non-pausable portal.

--- a/pkg/sql/pgwire/testdata/pgtest/portals_crbugs
+++ b/pkg/sql/pgwire/testdata/pgtest/portals_crbugs
@@ -400,7 +400,7 @@ ReadyForQuery
 {"Type":"BindComplete"}
 {"Type":"DataRow","Values":[{"text":"(1,1)"}]}
 {"Type":"PortalSuspended"}
-{"Type":"ErrorResponse","Code":"0A000","Message":"unimplemented: the statement for a pausable portal must be a read-only SELECT query with no sub-queries or post-queries","Detail":"cannot execute a portal while a different one is open","Hint":"You have attempted to use a feature that is not yet implemented.\nSee: https://go.crdb.dev/issue-v/98911/dev"}
+{"Type":"ErrorResponse","Code":"0A000","Message":"unimplemented: the statement for a pausable portal must be a read-only SELECT query with no sub-queries or post-queries","Detail":"cannot execute a portal while a different one is open","Hint":"You have attempted to use a feature that is not yet implemented.\nSee: https://go.crdb.dev/issue-v/98911/..."}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
 subtest end


### PR DESCRIPTION
This will reduce test churn when creating a new cluster version.

Epic: None
Release note: None