### PR TITLE
release-26.1: sql: add a couple of metrics about SetupFlowRequest RPCs

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -7615,6 +7615,14 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+    - name: sql.distsql.parallel_runner.count
+      exported_name: sql_distsql_parallel_runner_count
+      description: Number of SetupFlowRequest RPCs executed concurrently via DistSQL runners
+      y_axis_label: Requests
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
     - name: sql.distsql.queries.active
       exported_name: sql_distsql_queries_active
       description: Number of invocations of the execution engine currently active (multiple of which may occur for a single SQL statement)
@@ -7667,6 +7675,14 @@ layers:
       exported_name: sql_distsql_select_distributed_exec_count_internal
       description: Number of SELECT statements that were distributed (internal queries)
       y_axis_label: SQL Internal Statements
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: sql.distsql.sequential_runner.count
+      exported_name: sql_distsql_sequential_runner_count
+      description: Number of SetupFlowRequest RPCs executed sequentially via the main gateway goroutine
+      y_axis_label: Requests
       type: COUNTER
       unit: COUNT
       aggregation: AVG

--- a/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
+++ b/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
@@ -1924,6 +1924,7 @@ sql_distsql_exec_latency_internal_sum: sql.distsql.exec.latency.internal.sum
 sql_distsql_exec_latency_sum: sql.distsql.exec.latency.sum
 sql_distsql_flows_active: sql.distsql.flows.active
 sql_distsql_flows_total: sql.distsql.flows.total
+sql_distsql_parallel_runner_count: sql.distsql.parallel_runner.count
 sql_distsql_queries_active: sql.distsql.queries.active
 sql_distsql_queries_spilled: sql.distsql.queries.spilled
 sql_distsql_queries_total: sql.distsql.queries.total
@@ -1931,6 +1932,7 @@ sql_distsql_select_count: sql.distsql.select.count
 sql_distsql_select_count_internal: sql.distsql.select.internal
 sql_distsql_select_distributed_exec_count: sql.distsql.select.distributed_exec.count
 sql_distsql_select_distributed_exec_count_internal: sql.distsql.select.distributed_exec.count.internal
+sql_distsql_sequential_runner_count: sql.distsql.sequential_runner.count
 sql_distsql_service_latency: sql.distsql.service.latency
 sql_distsql_service_latency_bucket: sql.distsql.service.latency.bucket
 sql_distsql_service_latency_count: sql.distsql.service.latency.count

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -222,7 +222,7 @@ func NewDistSQLPlanner(
 		rpcCtx.Stopper.AddCloser(dsp.parallelLocalScansSem.Closer("stopper"))
 	}
 
-	dsp.runnerCoordinator.init(ctx, stopper, &st.SV)
+	dsp.runnerCoordinator.init(ctx, stopper, &st.SV, distSQLSrv.Metrics.RunnerReqParallelCount)
 	dsp.initCancelingWorkers(ctx)
 	return dsp
 }

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -56,6 +56,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log/severity"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
 	"github.com/cockroachdb/cockroach/pkg/util/ring"
@@ -158,7 +159,12 @@ type runnerCoordinator struct {
 	}
 }
 
-func (c *runnerCoordinator) init(ctx context.Context, stopper *stop.Stopper, sv *settings.Values) {
+func (c *runnerCoordinator) init(
+	ctx context.Context,
+	stopper *stop.Stopper,
+	sv *settings.Values,
+	parallelCountMetric *metric.Counter,
+) {
 	// This channel has to be unbuffered because we want to only be able to send
 	// requests if a worker is actually there to receive them.
 	c.runnerChan = make(chan runnerRequest)
@@ -167,6 +173,7 @@ func (c *runnerCoordinator) init(ctx context.Context, stopper *stop.Stopper, sv 
 		for {
 			select {
 			case req := <-c.runnerChan:
+				parallelCountMetric.Inc(1)
 				_ = req.run()
 			case <-stopWorkerChan:
 				return
@@ -620,6 +627,7 @@ func (dsp *DistSQLPlanner) setupFlows(
 		case dsp.runnerCoordinator.runnerChan <- runReq:
 			usedWorker = true
 		default:
+			dsp.distSQLSrv.Metrics.RunnerReqSequentialCount.Inc(1)
 			// Use the context of the local flow since we're executing this
 			// SetupFlow RPC synchronously.
 			runReq.ctx = ctx

--- a/pkg/sql/execinfra/metrics.go
+++ b/pkg/sql/execinfra/metrics.go
@@ -22,6 +22,8 @@ type DistSQLMetrics struct {
 	CumulativeContentionNanos   *aggmetric.SQLCounter
 	FlowsActive                 *metric.Gauge
 	FlowsTotal                  *metric.Counter
+	RunnerReqParallelCount      *metric.Counter
+	RunnerReqSequentialCount    *metric.Counter
 	MaxBytesHist                metric.IHistogram
 	CurBytesCount               *metric.Gauge
 	VecOpenFDs                  *metric.Gauge
@@ -83,6 +85,18 @@ var (
 		Name:        "sql.distsql.flows.total",
 		Help:        "Number of distributed SQL flows executed",
 		Measurement: "Flows",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaRunnerReqParallelCount = metric.Metadata{
+		Name:        "sql.distsql.parallel_runner.count",
+		Help:        "Number of SetupFlowRequest RPCs executed concurrently via DistSQL runners",
+		Measurement: "Requests",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaRunnerReqSequentialCount = metric.Metadata{
+		Name:        "sql.distsql.sequential_runner.count",
+		Help:        "Number of SetupFlowRequest RPCs executed sequentially via the main gateway goroutine",
+		Measurement: "Requests",
 		Unit:        metric.Unit_COUNT,
 	}
 	metaMemMaxBytes = metric.Metadata{
@@ -161,6 +175,8 @@ func MakeDistSQLMetrics(histogramWindow time.Duration) DistSQLMetrics {
 		CumulativeContentionNanos: aggmetric.NewSQLCounter(metaCumulativeContentionNanos),
 		FlowsActive:               metric.NewGauge(metaFlowsActive),
 		FlowsTotal:                metric.NewCounter(metaFlowsTotal),
+		RunnerReqParallelCount:    metric.NewCounter(metaRunnerReqParallelCount),
+		RunnerReqSequentialCount:  metric.NewCounter(metaRunnerReqSequentialCount),
 		MaxBytesHist: metric.NewHistogram(metric.HistogramOptions{
 			Metadata:     metaMemMaxBytes,
 			Duration:     histogramWindow,


### PR DESCRIPTION
Backport 1/1 commits from #160673 on behalf of @yuzefovich.

----

We have a pool of distsql runner workers (proportional to vCPUs per node) that execute SetupFlowRequest RPCs in parallel with the main goroutine of the gateway flow. This commit adds two counters to track number of requests done via those parallel workers as well as sequentially via the main goroutine, which should give us signal whether a cluster needs adjustment of `sql.distsql.num_runners` cluster setting.

Epic: None
Release note: None

----

Release justification: low-risk supportability improvement.