### PR TITLE
schemachangerccl: enable DRPC randomly for tests

### DIFF
--- a/pkg/ccl/schemachangerccl/main_test.go
+++ b/pkg/ccl/schemachangerccl/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
@@ -24,7 +25,10 @@ func TestMain(m *testing.M) {
 	defer ccl.TestingEnableEnterprise()()
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
 	randutil.SeedForTests()
-	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestServerFactory(
+		server.TestServerFactory,
+		serverutils.WithDRPCOption(base.TestDRPCEnabledRandomly),
+	)
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
 	os.Exit(m.Run())
 }

--- a/pkg/ccl/schemachangerccl/sctestbackupccl/BUILD.bazel
+++ b/pkg/ccl/schemachangerccl/sctestbackupccl/BUILD.bazel
@@ -15,6 +15,7 @@ go_test(
     shard_count = 48,
     tags = ["cpu:4"],
     deps = [
+        "//pkg/base",
         "//pkg/ccl",
         "//pkg/ccl/schemachangerccl",
         "//pkg/security/securityassets",

--- a/pkg/ccl/schemachangerccl/sctestbackupccl/main_test.go
+++ b/pkg/ccl/schemachangerccl/sctestbackupccl/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/schemachangerccl"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
@@ -25,7 +26,10 @@ func TestMain(m *testing.M) {
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
 	randutil.SeedForTests()
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
-	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestServerFactory(
+		server.TestServerFactory,
+		serverutils.WithDRPCOption(base.TestDRPCEnabledRandomly),
+	)
 	os.Exit(m.Run())
 }
 

--- a/pkg/ccl/schemachangerccl/sctestbackupmrccl/BUILD.bazel
+++ b/pkg/ccl/schemachangerccl/sctestbackupmrccl/BUILD.bazel
@@ -15,6 +15,7 @@ go_test(
     shard_count = 48,
     tags = ["cpu:4"],
     deps = [
+        "//pkg/base",
         "//pkg/ccl",
         "//pkg/ccl/schemachangerccl",
         "//pkg/security/securityassets",

--- a/pkg/ccl/schemachangerccl/sctestbackupmrccl/main_test.go
+++ b/pkg/ccl/schemachangerccl/sctestbackupmrccl/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/schemachangerccl"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
@@ -25,7 +26,10 @@ func TestMain(m *testing.M) {
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
 	randutil.SeedForTests()
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
-	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestServerFactory(
+		server.TestServerFactory,
+		serverutils.WithDRPCOption(base.TestDRPCEnabledRandomly),
+	)
 	os.Exit(m.Run())
 }
 


### PR DESCRIPTION
This commit enables DRPC randomly at the package level for the schemachangerccl package and its subpackages (sctestbackupccl and sctestbackupmrccl).

All tests pass with DRPC enabled across default, shared, and external tenant modes (verified with 10 runs each).

Epic: CRDB-48935
Issue: None
Release note: None