### PR TITLE
release-24.3: sql: skip flaky ngpsql roachtests

### DIFF
--- a/pkg/cmd/roachtest/tests/npgsql_blocklist.go
+++ b/pkg/cmd/roachtest/tests/npgsql_blocklist.go
@@ -661,6 +661,9 @@ var npgsqlBlocklist = blocklist{
 }
 
 var npgsqlIgnoreList = blocklist{
+	`Npgsql.Tests.ConnectionTests(Multiplexing).Fail_connect_then_succeed(True)`:                     "flaky",
+	`Npgsql.Tests.CopyTests(Multiplexing).Import_string_array`:                                       "flaky",
+	`Npgsql.Tests.CopyTests(Multiplexing).Prepended_messages`:                                        "flaky",
 	`Npgsql.Tests.TransactionTests(NonMultiplexing).Failed_transaction_on_close_with_custom_timeout`: "flaky",
 	`Npgsql.Tests.TransactionTests(Multiplexing).Failed_transaction_on_close_with_custom_timeout`:    "flaky",
 }


### PR DESCRIPTION
Backport 1/1 commits from #154635.

fixes #161055

---

The tests are timing out.

```
  Failed Import_string_array [30 s]
  Stack Trace:
```

Fixes: #154004 
Fixes: #153691

Release note: None


Release justification: test only change
