### PR TITLE
kvserver,storage: fix incoming handling of snapshots with shared/external ssts

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -319,6 +319,7 @@ go_test(
         "gossip_test.go",
         "helpers_test.go",
         "intent_resolver_integration_test.go",
+        "kv_snapshot_strategy_test.go",
         "lease_history_test.go",
         "lease_queue_test.go",
         "main_test.go",
@@ -451,6 +452,7 @@ go_test(
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/kv/kvserver/kvserverpb",
         "//pkg/kv/kvserver/kvstorage",
+        "//pkg/kv/kvserver/kvstorage/snaprecv",
         "//pkg/kv/kvserver/leases",
         "//pkg/kv/kvserver/liveness",
         "//pkg/kv/kvserver/liveness/livenesspb",
@@ -590,6 +592,7 @@ go_test(
         "@org_golang_x_exp//slices",
         "@org_golang_x_sync//errgroup",
         "@org_golang_x_sync//syncmap",
+        "@org_golang_x_time//rate",
     ],
 )
 

--- a/pkg/kv/kvserver/kv_snapshot_strategy.go
+++ b/pkg/kv/kvserver/kv_snapshot_strategy.go
@@ -201,7 +201,10 @@ func (kvSS *kvBatchSnapshotStrategy) Receive(
 
 			timingTag.start("sst")
 			verifyCheckSum := snapshotChecksumVerification.Get(&s.ClusterSettings().SV)
-			// All batch operations are guaranteed to be point key or range key puts.
+			// All batch operations are guaranteed to be point keys or range keys.
+			// When the snapshot contains shared or external SSTs, Pebble internal
+			// keys (DELS, RANGEDELs etc.), can also appear among the point and
+			// range keys.
 			for batchReader.Next() {
 				// TODO(lyang24): maybe avoid decoding engine key twice.
 				// msstw calls (i.e. putInternalPointKey) can use the decoded engine key here as input.
@@ -219,7 +222,7 @@ func (kvSS *kvBatchSnapshotStrategy) Receive(
 					return noSnap, err
 				}
 				// Verify value checksum to catch data corruption.
-				if verifyCheckSum {
+				if verifyCheckSum && batchReader.IsPointValue() {
 					if err = ek.Verify(batchReader.Value()); err != nil {
 						return noSnap, errors.Wrap(err, "verifying value checksum")
 					}

--- a/pkg/kv/kvserver/kv_snapshot_strategy.go
+++ b/pkg/kv/kvserver/kv_snapshot_strategy.go
@@ -228,7 +228,8 @@ func (kvSS *kvBatchSnapshotStrategy) Receive(
 					}
 				}
 
-				if err := msstw.ReadOne(ctx, ek, header.SharedReplicate, batchReader); err != nil {
+				if err := msstw.ReadOne(
+					ctx, ek, header.SharedReplicate || header.ExternalReplicate, batchReader); err != nil {
 					return noSnap, err
 				}
 			}

--- a/pkg/kv/kvserver/kv_snapshot_strategy_test.go
+++ b/pkg/kv/kvserver/kv_snapshot_strategy_test.go
@@ -1,0 +1,275 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package kvserver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvadmission"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/replica_rac2"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/snaprecv"
+	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/util/admission"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/cockroachdb/pebble"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
+)
+
+// mockIncomingSnapshotStream implements incomingSnapshotStream for testing.
+type mockIncomingSnapshotStream struct {
+	requests []*kvserverpb.SnapshotRequest
+	index    int
+	sent     []*kvserverpb.SnapshotResponse
+}
+
+func (m *mockIncomingSnapshotStream) Send(resp *kvserverpb.SnapshotResponse) error {
+	m.sent = append(m.sent, resp)
+	return nil
+}
+
+func (m *mockIncomingSnapshotStream) Recv() (*kvserverpb.SnapshotRequest, error) {
+	if m.index >= len(m.requests) {
+		return nil, nil
+	}
+	req := m.requests[m.index]
+	m.index++
+	return req, nil
+}
+
+// mockKVAdmissionController is a minimal mock that returns nil for GetSnapshotQueue.
+type mockKVAdmissionController struct{}
+
+func (m *mockKVAdmissionController) AdmitKVWork(
+	_ context.Context, _ roachpb.TenantID, _ roachpb.TenantID, _ *kvpb.BatchRequest,
+) (kvadmission.Handle, error) {
+	return kvadmission.Handle{}, nil
+}
+
+func (m *mockKVAdmissionController) AdmittedKVWorkDone(
+	kvadmission.Handle, *kvadmission.StoreWriteBytes,
+) {
+}
+
+func (m *mockKVAdmissionController) AdmitRangefeedRequest(
+	_ roachpb.TenantID, _ *kvpb.RangeFeedRequest,
+) *admission.Pacer {
+	return nil
+}
+
+func (m *mockKVAdmissionController) SetTenantWeightProvider(
+	kvadmission.TenantWeightProvider, *stop.Stopper,
+) {
+}
+
+func (m *mockKVAdmissionController) SnapshotIngestedOrWritten(
+	_ roachpb.StoreID, _ pebble.IngestOperationStats, _ uint64,
+) {
+}
+
+func (m *mockKVAdmissionController) FollowerStoreWriteBytes(
+	_ roachpb.StoreID, _ kvadmission.FollowerStoreWriteBytes,
+) {
+}
+
+func (m *mockKVAdmissionController) AdmitRaftEntry(
+	_ context.Context, _ roachpb.TenantID, _ roachpb.StoreID, _ roachpb.RangeID, _ raftpb.Entry,
+) (admitted bool, err error) {
+	return true, nil
+}
+
+func (m *mockKVAdmissionController) OnBypassed(_ roachpb.StoreID, _ roachpb.RangeID, _ int64) {
+}
+
+func (m *mockKVAdmissionController) OnDestroyRaftMuLocked(_ roachpb.StoreID, _ roachpb.RangeID) {
+}
+
+func (m *mockKVAdmissionController) Admit(
+	_ context.Context, _ replica_rac2.EntryForAdmission,
+) bool {
+	return true
+}
+
+func (m *mockKVAdmissionController) GetSnapshotQueue(_ roachpb.StoreID) *admission.SnapshotQueue {
+	return nil
+}
+
+func (m *mockKVAdmissionController) GetProvisionedBandwidth(_ roachpb.StoreID) int64 {
+	return 0
+}
+
+// TestKVBatchSnapshotStrategyReceiveExternalReplicate tests the
+// kvBatchSnapshotStrategy.Receive method with ExternalReplicate=true. This
+// ensures the production code correctly handles DEL and other Pebble internal
+// key kinds, when receiving external SST snapshots.
+//
+// The bug fixes covered by this test: (a) when ExternalReplicate=true (but
+// SharedReplicate=false), the code was incorrectly passing false to ReadOne's
+// sharedOrExternal parameter, causing errors when encountering Pebble
+// internal keys, (b) DEL keys were having their value retrieved using
+// BatchReader.Value, which resulted in a panic.
+func TestKVBatchSnapshotStrategyReceiveExternalReplicate(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	// Create test store configuration.
+	manual := timeutil.NewManualTime(timeutil.Unix(0, 123))
+	cfg := TestStoreConfig(hlc.NewClockForTesting(manual))
+	cfg.KVAdmissionController = &mockKVAdmissionController{}
+
+	eng := storage.NewDefaultInMemForTesting()
+	defer eng.Close()
+
+	// Create a minimal Store with only the fields needed by Receive.
+	testIdent := roachpb.StoreIdent{
+		ClusterID: uuid.MakeV4(),
+		NodeID:    1,
+		StoreID:   1,
+	}
+	store := &Store{
+		cfg:   cfg,
+		Ident: &testIdent,
+	}
+
+	// Create range descriptor for the test.
+	desc := &roachpb.RangeDescriptor{
+		RangeID:  1,
+		StartKey: roachpb.RKey("d"),
+		EndKey:   roachpb.RKeyMax,
+	}
+
+	// Create snapshot UUID.
+	snapUUID := uuid.Must(uuid.FromBytes([]byte("foobar1234567890")))
+
+	// Create SST snapshot storage and scratch space.
+	sstSnapshotStorage := snaprecv.NewSSTSnapshotStorage(eng, rate.NewLimiter(rate.Inf, 0))
+	scratch := sstSnapshotStorage.NewScratchSpace(desc.RangeID, snapUUID, nil)
+
+	// Helper to create a batch repr with specified operations.
+	makeBatchRepr := func(fn func(storage.WriteBatch)) []byte {
+		batch := eng.NewWriteBatch()
+		defer batch.Close()
+		fn(batch)
+		repr := batch.Repr()
+		reprCopy := make([]byte, len(repr))
+		copy(reprCopy, repr)
+		return reprCopy
+	}
+
+	now := hlc.Timestamp{WallTime: timeutil.Now().UnixNano()}
+
+	t.Run("external-replicate-with-del-succeeds", func(t *testing.T) {
+		// Create a batch with a DEL operation (which requires sharedOrExternal=true).
+		mvccKey := storage.MVCCKey{Key: roachpb.Key("e"), Timestamp: now}
+		encodedKey := storage.EncodeMVCCKey(mvccKey)
+		kvBatch := makeBatchRepr(func(b storage.WriteBatch) {
+			ik := pebble.InternalKey{
+				UserKey: encodedKey,
+				Trailer: pebble.MakeInternalKeyTrailer(0, pebble.InternalKeyKindDelete),
+			}
+			require.NoError(t, b.PutInternalPointKey(&ik, nil))
+		})
+
+		// Create the mock stream that returns the batch followed by a Final request.
+		stream := &mockIncomingSnapshotStream{
+			requests: []*kvserverpb.SnapshotRequest{
+				{KVBatch: kvBatch},
+				{Final: true},
+			},
+		}
+
+		// Create the header with ExternalReplicate=true.
+		header := kvserverpb.SnapshotRequest_Header{
+			SharedReplicate:   false,
+			ExternalReplicate: true,
+			State: kvserverpb.ReplicaState{
+				Desc: desc,
+			},
+			RaftMessageRequest: kvserverpb.RaftMessageRequest{
+				Message: raftpb.Message{
+					Snapshot: &raftpb.Snapshot{
+						Data: snapUUID.GetBytes(),
+					},
+				},
+			},
+		}
+
+		// Create the kvBatchSnapshotStrategy.
+		kvSS := &kvBatchSnapshotStrategy{
+			st:      cfg.Settings,
+			scratch: scratch,
+		}
+
+		// Call the actual Receive method - this tests the production code.
+		inSnap, err := kvSS.Receive(ctx, store, stream, header, func(int64) {})
+		require.NoError(t, err, "Receive should succeed with ExternalReplicate=true and DEL operation")
+		require.Equal(t, snapUUID, inSnap.SnapUUID)
+	})
+
+	t.Run("no-external-with-del-fails", func(t *testing.T) {
+		// Create a new scratch space for this subtest.
+		scratch2 := sstSnapshotStorage.NewScratchSpace(desc.RangeID, uuid.MakeV4(), nil)
+
+		// Create a batch with a DEL operation.
+		mvccKey := storage.MVCCKey{Key: roachpb.Key("f"), Timestamp: now}
+		encodedKey := storage.EncodeMVCCKey(mvccKey)
+		kvBatch := makeBatchRepr(func(b storage.WriteBatch) {
+			ik := pebble.InternalKey{
+				UserKey: encodedKey,
+				Trailer: pebble.MakeInternalKeyTrailer(0, pebble.InternalKeyKindDelete),
+			}
+			require.NoError(t, b.PutInternalPointKey(&ik, nil))
+		})
+
+		// Create the mock stream.
+		stream := &mockIncomingSnapshotStream{
+			requests: []*kvserverpb.SnapshotRequest{
+				{KVBatch: kvBatch},
+				{Final: true},
+			},
+		}
+
+		// Create the header with ExternalReplicate=false and SharedReplicate=false.
+		snapUUID2 := uuid.MakeV4()
+		header := kvserverpb.SnapshotRequest_Header{
+			SharedReplicate:   false,
+			ExternalReplicate: false,
+			State: kvserverpb.ReplicaState{
+				Desc: desc,
+			},
+			RaftMessageRequest: kvserverpb.RaftMessageRequest{
+				Message: raftpb.Message{
+					Snapshot: &raftpb.Snapshot{
+						Data: snapUUID2.GetBytes(),
+					},
+				},
+			},
+		}
+
+		// Create the kvBatchSnapshotStrategy.
+		kvSS := &kvBatchSnapshotStrategy{
+			st:      cfg.Settings,
+			scratch: scratch2,
+		}
+
+		// Call the actual Receive method - should fail.
+		_, err := kvSS.Receive(ctx, store, stream, header, func(int64) {})
+		require.Error(t, err, "Receive should fail with DEL operation when neither SharedReplicate nor ExternalReplicate is set")
+		require.Contains(t, err.Error(), "unexpected batch entry key kind")
+	})
+}

--- a/pkg/storage/batch.go
+++ b/pkg/storage/batch.go
@@ -123,6 +123,12 @@ func (r *BatchReader) EngineKey() (EngineKey, error) {
 	return key, nil
 }
 
+// IsPointValue returns true if the key is a point key that represents a
+// value.
+func (r *BatchReader) IsPointValue() bool {
+	return r.kind == pebble.InternalKeyKindSet || r.kind == pebble.InternalKeyKindSetWithDelete
+}
+
 // Value returns the value of the current batch entry. Value panics if the
 // kind is a point key deletion.
 func (r *BatchReader) Value() []byte {


### PR DESCRIPTION
Verify checksum only on point values.

Tolerate internal Pebble keys even for external ssts.
External ssts are sent by reference so the sender uses
rditer.IterateReplicaKeySpansShared to send Pebble internal keys (as DELs
etc. can be overlaid over points in the external ssts).

Fixes https://github.com/cockroachdb/cockroach/issues/159974

Epic: none

Release note: None