### PR TITLE
telemetryccl: use 'large' size for tests

### DIFF
--- a/pkg/ccl/telemetryccl/BUILD.bazel
+++ b/pkg/ccl/telemetryccl/BUILD.bazel
@@ -2,6 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "telemetryccl_test",
+    size = "large",
     srcs = [
         "main_test.go",
         "telemetry_logging_test.go",


### PR DESCRIPTION
This test routinely times out because it runs 3 node clusters and needs to wait for replication. This increases the timeout from 5 min to 15 min.

Epic: None
Resolves: #161148
Release note: None