### PR TITLE
roachprod: bump node_exporter to v1.10.2

### DIFF
--- a/pkg/roachprod/vm/aws/testdata/startup_script
+++ b/pkg/roachprod/vm/aws/testdata/startup_script
@@ -380,7 +380,7 @@ sudo service ssh restart
 export ARCH=$(dpkg --print-architecture)
 export DEFAULT_USER_HOME="/home/$(id -nu 1000)"
 mkdir -p ${DEFAULT_USER_HOME}/node_exporter && curl -fsSL \
-	https://storage.googleapis.com/cockroach-test-artifacts/prometheus/node_exporter-1.2.2.linux-${ARCH}.tar.gz |
+	https://storage.googleapis.com/cockroach-test-artifacts/prometheus/node_exporter-1.10.2.linux-${ARCH}.tar.gz |
 	tar zxv --strip-components 1 -C ${DEFAULT_USER_HOME}/node_exporter \
 	&& chown -R 1000:1000 ${DEFAULT_USER_HOME}/node_exporter
 

--- a/pkg/roachprod/vm/azure/testdata/startup_script
+++ b/pkg/roachprod/vm/azure/testdata/startup_script
@@ -378,7 +378,7 @@ sudo service ssh restart
 export ARCH=$(dpkg --print-architecture)
 export DEFAULT_USER_HOME="/home/$(id -nu 1000)"
 mkdir -p ${DEFAULT_USER_HOME}/node_exporter && curl -fsSL \
-	https://storage.googleapis.com/cockroach-test-artifacts/prometheus/node_exporter-1.2.2.linux-${ARCH}.tar.gz |
+	https://storage.googleapis.com/cockroach-test-artifacts/prometheus/node_exporter-1.10.2.linux-${ARCH}.tar.gz |
 	tar zxv --strip-components 1 -C ${DEFAULT_USER_HOME}/node_exporter \
 	&& chown -R 1000:1000 ${DEFAULT_USER_HOME}/node_exporter
 

--- a/pkg/roachprod/vm/gce/testdata/startup_script
+++ b/pkg/roachprod/vm/gce/testdata/startup_script
@@ -376,7 +376,7 @@ sudo service ssh restart
 export ARCH=$(dpkg --print-architecture)
 export DEFAULT_USER_HOME="/home/$(id -nu 1000)"
 mkdir -p ${DEFAULT_USER_HOME}/node_exporter && curl -fsSL \
-	https://storage.googleapis.com/cockroach-test-artifacts/prometheus/node_exporter-1.2.2.linux-${ARCH}.tar.gz |
+	https://storage.googleapis.com/cockroach-test-artifacts/prometheus/node_exporter-1.10.2.linux-${ARCH}.tar.gz |
 	tar zxv --strip-components 1 -C ${DEFAULT_USER_HOME}/node_exporter \
 	&& chown -R 1000:1000 ${DEFAULT_USER_HOME}/node_exporter
 

--- a/pkg/roachprod/vm/ibm/testdata/startup_script
+++ b/pkg/roachprod/vm/ibm/testdata/startup_script
@@ -358,7 +358,7 @@ sudo service ssh restart
 export ARCH=$(dpkg --print-architecture)
 export DEFAULT_USER_HOME="/home/$(id -nu 1000)"
 mkdir -p ${DEFAULT_USER_HOME}/node_exporter && curl -fsSL \
-	https://storage.googleapis.com/cockroach-test-artifacts/prometheus/node_exporter-1.2.2.linux-${ARCH}.tar.gz |
+	https://storage.googleapis.com/cockroach-test-artifacts/prometheus/node_exporter-1.10.2.linux-${ARCH}.tar.gz |
 	tar zxv --strip-components 1 -C ${DEFAULT_USER_HOME}/node_exporter \
 	&& chown -R 1000:1000 ${DEFAULT_USER_HOME}/node_exporter
 

--- a/pkg/roachprod/vm/startup.go
+++ b/pkg/roachprod/vm/startup.go
@@ -22,7 +22,7 @@ const (
 	PrometheusVersion = "2.27.1"
 	// NodeExporterVersion is the version of NodeExporter installed on each node
 	// in the startup script and during the grafana-start command.
-	NodeExporterVersion = "1.2.2"
+	NodeExporterVersion = "1.10.2"
 	// NodeExporterPort is the port that NodeExporter listens on.
 	NodeExporterPort = 9100
 	// NodeExporterMetricsPath is the path that NodeExporter serves metrics on.


### PR DESCRIPTION
We've been running node_exporter 1.2.2 for the last 4 years or so, and while it has been pretty reliable, we've seen some issues [1].

This patch bumps node_exporter to the latest version, released a few months ago. It is noted that an issue has been identified around the reporting of readonly filesystems [2] in this version, but this should not impact our use of node_exporter. That being said, we should probably bump to the next version when it is released.

This patch also ensures improves the process starting of `node_exporter` in case of tests with local prometheus and grafana if a systemd service existed in a stopped or failed state.

[1] https://github.com/cockroachdb/cockroach/issues/160527
[2] https://github.com/prometheus/node_exporter/issues/3484

Fixes: #160527
Closes: #160375
Release note: None