### PR TITLE
release-26.1: tpcc/large-schema-benchmark: limit concurrency for workload

### DIFF
--- a/pkg/cmd/roachtest/tests/large_schema_benchmark.go
+++ b/pkg/cmd/roachtest/tests/large_schema_benchmark.go
@@ -74,7 +74,9 @@ func registerLargeSchemaBenchmark(r registry.Registry, numTables int, isMultiReg
 		Suites:           registry.Suites(registry.Weekly),
 		Timeout:          testTimeout,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			numWorkers := (len(c.All()) - 1) * 10
+			// Cap the total number of workers based on the number of
+			// nodes and CPUs on them.
+			numTotalWorkers := len(c.All()) - 1
 			// Number of tables per-database from the TPCC template.
 			const numTablesForTPCC = 9
 			// Active databases will continually execute a mix of TPCC + ORM
@@ -206,8 +208,12 @@ func registerLargeSchemaBenchmark(r registry.Registry, numTables int, isMultiReg
 			for urlIdx := range webConsoleURLs {
 				webConsoleURLs[urlIdx] = "https://" + webConsoleURLs[urlIdx]
 			}
-			// Next startup the workload for our list of databases from earlier.
-			for dbListType, dbList := range [][]string{activeDBList, inactiveDBList} {
+			// Next, start up the workload for our list of databases from earlier.
+			tpccDatabaseLists := [][]string{activeDBList, inactiveDBList}
+			// Since we will spawn two sets of TPCC clients, split the
+			// total workers between them.
+			numWorkers := numTotalWorkers / len(tpccDatabaseLists)
+			for dbListType, dbList := range tpccDatabaseLists {
 				dbList := dbList
 				dbListType := dbListType
 				populateFileName := fmt.Sprintf("populate_%d", dbListType)


### PR DESCRIPTION
Backport 1/1 commits from #160955 on behalf of @fqazi.

----

Previously, this workload had empty tables for a good chunk of the TPCC workload. This meant that there was very little work being done on individual connections, allow us to easy support 180 connections across the cluster. Once we started populating the tables we noticed a regression. This patch limits the connection concurrency, so that there is a lot less noise measuring the performance of this workload.

Fixes: #159008

Release note: None


----

Release justification: test only change