### PR TITLE
lint: give `passes` tests more resources

### DIFF
--- a/pkg/testutils/lint/passes/deferloop/BUILD.bazel
+++ b/pkg/testutils/lint/passes/deferloop/BUILD.bazel
@@ -17,6 +17,8 @@ go_test(
     data = glob(["testdata/**"]) + [
         "@go_sdk//:files",
     ],
+    exec_properties = {"test.Pool": "large"},
+    tags = ["cpu:2"],
     deps = [
         ":deferloop",
         "//pkg/build/bazel",

--- a/pkg/testutils/lint/passes/deferunlockcheck/BUILD.bazel
+++ b/pkg/testutils/lint/passes/deferunlockcheck/BUILD.bazel
@@ -20,6 +20,8 @@ go_test(
     data = glob(["testdata/**"]) + [
         "@go_sdk//:files",
     ],
+    exec_properties = {"test.Pool": "large"},
+    tags = ["cpu:2"],
     deps = [
         ":deferunlockcheck",
         "//pkg/build/bazel",

--- a/pkg/testutils/lint/passes/errcmp/BUILD.bazel
+++ b/pkg/testutils/lint/passes/errcmp/BUILD.bazel
@@ -19,6 +19,8 @@ go_test(
     data = glob(["testdata/**"]) + [
         "@go_sdk//:files",
     ],
+    exec_properties = {"test.Pool": "large"},
+    tags = ["cpu:2"],
     deps = [
         ":errcmp",
         "//pkg/build/bazel",

--- a/pkg/testutils/lint/passes/errwrap/BUILD.bazel
+++ b/pkg/testutils/lint/passes/errwrap/BUILD.bazel
@@ -22,6 +22,8 @@ go_test(
     data = glob(["testdata/**"]) + [
         "@go_sdk//:files",
     ],
+    exec_properties = {"test.Pool": "large"},
+    tags = ["cpu:2"],
     deps = [
         ":errwrap",
         "//pkg/build/bazel",

--- a/pkg/testutils/lint/passes/fmtsafe/BUILD.bazel
+++ b/pkg/testutils/lint/passes/fmtsafe/BUILD.bazel
@@ -28,6 +28,8 @@ go_test(
     data = glob(["testdata/**"]) + [
         "@go_sdk//:files",
     ],
+    exec_properties = {"test.Pool": "large"},
+    tags = ["cpu:2"],
     deps = [
         ":fmtsafe",
         "//pkg/build/bazel",

--- a/pkg/testutils/lint/passes/forbiddenmethod/BUILD.bazel
+++ b/pkg/testutils/lint/passes/forbiddenmethod/BUILD.bazel
@@ -35,6 +35,8 @@ go_test(
         ":testdata",
         "@go_sdk//:files",
     ],
+    exec_properties = {"test.Pool": "large"},
+    tags = ["cpu:2"],
     deps = [
         ":forbiddenmethod",
         "//pkg/build/bazel",

--- a/pkg/testutils/lint/passes/hash/BUILD.bazel
+++ b/pkg/testutils/lint/passes/hash/BUILD.bazel
@@ -18,6 +18,8 @@ go_test(
     data = glob(["testdata/**"]) + [
         "@go_sdk//:files",
     ],
+    exec_properties = {"test.Pool": "large"},
+    tags = ["cpu:2"],
     deps = [
         ":hash",
         "//pkg/build/bazel",

--- a/pkg/testutils/lint/passes/leaktestcall/BUILD.bazel
+++ b/pkg/testutils/lint/passes/leaktestcall/BUILD.bazel
@@ -18,6 +18,8 @@ go_test(
     data = glob(["testdata/**"]) + [
         "@go_sdk//:files",
     ],
+    exec_properties = {"test.Pool": "large"},
+    tags = ["cpu:2"],
     deps = [
         ":leaktestcall",
         "//pkg/build/bazel",

--- a/pkg/testutils/lint/passes/nilness/BUILD.bazel
+++ b/pkg/testutils/lint/passes/nilness/BUILD.bazel
@@ -18,6 +18,8 @@ go_test(
     data = glob(["testdata/**"]) + [
         "@go_sdk//:files",
     ],
+    exec_properties = {"test.Pool": "large"},
+    tags = ["cpu:2"],
     deps = [
         ":nilness",
         "//pkg/build/bazel",

--- a/pkg/testutils/lint/passes/nocopy/BUILD.bazel
+++ b/pkg/testutils/lint/passes/nocopy/BUILD.bazel
@@ -19,6 +19,8 @@ go_test(
     data = glob(["testdata/**"]) + [
         "@go_sdk//:files",
     ],
+    exec_properties = {"test.Pool": "large"},
+    tags = ["cpu:2"],
     deps = [
         ":nocopy",
         "//pkg/build/bazel",

--- a/pkg/testutils/lint/passes/passesutil/BUILD.bazel
+++ b/pkg/testutils/lint/passes/passesutil/BUILD.bazel
@@ -20,6 +20,8 @@ go_test(
         "//pkg/testutils/lint/passes/unconvert:testdata",
         "@go_sdk//:files",
     ],
+    exec_properties = {"test.Pool": "large"},
+    tags = ["cpu:2"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/testutils/lint/passes/forbiddenmethod",

--- a/pkg/testutils/lint/passes/returnerrcheck/BUILD.bazel
+++ b/pkg/testutils/lint/passes/returnerrcheck/BUILD.bazel
@@ -21,6 +21,8 @@ go_test(
     data = glob(["testdata/**"]) + [
         "@go_sdk//:files",
     ],
+    exec_properties = {"test.Pool": "large"},
+    tags = ["cpu:2"],
     deps = [
         ":returnerrcheck",
         "//pkg/build/bazel",

--- a/pkg/testutils/lint/passes/unconvert/BUILD.bazel
+++ b/pkg/testutils/lint/passes/unconvert/BUILD.bazel
@@ -27,6 +27,8 @@ go_test(
         ":testdata",
         "@go_sdk//:files",
     ],
+    exec_properties = {"test.Pool": "large"},
+    tags = ["cpu:2"],
     deps = [
         ":unconvert",
         "//pkg/build/bazel",


### PR DESCRIPTION
These tests have become over time more and more prone to timing out. As this normally happens in the `go build` phase, this may be due to contention in the filesystem. We're going to try giving these tests additional resources to see if it gives them enough breathing room.

Release note: none
Epic: DEVINF-1582