### PR TITLE
release-26.1: builtins: make crdb_datums_to_bytes documented

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -3349,6 +3349,8 @@ may increase either contention or retry errors, or both.</p>
 </span></td><td>Stable</td></tr>
 <tr><td><a name="current_user"></a><code>current_user() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the current user. This function is provided for compatibility with PostgreSQL.</p>
 </span></td><td>Stable</td></tr>
+<tr><td><a name="information_schema.crdb_datums_to_bytes"></a><code>information_schema.crdb_datums_to_bytes(any...) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Converts datums into key-encoded bytes. Supports NULLs and all data types which may be used in index keys</p>
+</span></td><td>Immutable</td></tr>
 <tr><td><a name="session_user"></a><code>session_user() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the session user. This function is provided for compatibility with PostgreSQL.</p>
 </span></td><td>Stable</td></tr>
 <tr><td><a name="to_regclass"></a><code>to_regclass(text: <a href="string.html">string</a>) &rarr; regtype</code></td><td><span class="funcdesc"><p>Translates a textual relation name to its OID</p>

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4750,8 +4750,17 @@ value if you rely on the HLC for accuracy.`,
 			Volatility: volatility.Volatile,
 		}),
 
-	"crdb_internal.datums_to_bytes":           datumsToBytes,
-	"information_schema.crdb_datums_to_bytes": datumsToBytes,
+	"crdb_internal.datums_to_bytes": makeBuiltin(
+		tree.FunctionProperties{
+			Category:             builtinconstants.CategorySystemInfo,
+			Undocumented:         true,
+			CompositeInsensitive: true,
+		}, datumsToBytesOverload),
+	"information_schema.crdb_datums_to_bytes": makeBuiltin(
+		tree.FunctionProperties{
+			Category:             builtinconstants.CategorySystemInfo,
+			CompositeInsensitive: true,
+		}, datumsToBytesOverload),
 	"crdb_internal.merge_statement_stats": makeBuiltin(arrayProps(),
 		tree.Overload{
 			Types:      tree.ParamTypes{{Name: "input", Typ: types.JSONBArray}},
@@ -12811,37 +12820,30 @@ func exprSliceToStrSlice(exprs []tree.Expr) []string {
 	})
 }
 
-var datumsToBytes = makeBuiltin(
-	tree.FunctionProperties{
-		Category:             builtinconstants.CategorySystemInfo,
-		Undocumented:         true,
-		CompositeInsensitive: true,
-	},
-	tree.Overload{
-		// Note that datums_to_bytes(a) == datums_to_bytes(b) iff (a IS NOT DISTINCT FROM b)
-		Info: "Converts datums into key-encoded bytes. " +
-			"Supports NULLs and all data types which may be used in index keys",
-		Types:      tree.VariadicType{VarType: types.Any},
-		ReturnType: tree.FixedReturnType(types.Bytes),
-		Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
-			var out []byte
-			for i, arg := range args {
-				var err error
-				out, err = keyside.Encode(out, arg, encoding.Ascending)
-				if err != nil {
-					return nil, pgerror.Newf(
-						pgcode.DatatypeMismatch,
-						"illegal argument %d of type %s",
-						i, arg.ResolvedType(),
-					)
-				}
+var datumsToBytesOverload = tree.Overload{
+	// Note that datums_to_bytes(a) == datums_to_bytes(b) iff (a IS NOT DISTINCT FROM b)
+	Info: "Converts datums into key-encoded bytes. " +
+		"Supports NULLs and all data types which may be used in index keys",
+	Types:      tree.VariadicType{VarType: types.Any},
+	ReturnType: tree.FixedReturnType(types.Bytes),
+	Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
+		var out []byte
+		for i, arg := range args {
+			var err error
+			out, err = keyside.Encode(out, arg, encoding.Ascending)
+			if err != nil {
+				return nil, pgerror.Newf(
+					pgcode.DatatypeMismatch,
+					"illegal argument %d of type %s",
+					i, arg.ResolvedType(),
+				)
 			}
-			return tree.NewDBytes(tree.DBytes(out)), nil
-		},
-		Volatility:        volatility.Immutable,
-		CalledOnNullInput: true,
+		}
+		return tree.NewDBytes(tree.DBytes(out)), nil
 	},
-)
+	Volatility:        volatility.Immutable,
+	CalledOnNullInput: true,
+}
 
 var nilRegionsError = errors.AssertionFailedf("evalCtx.Regions is nil")
 


### PR DESCRIPTION
Backport 1/1 commits from #160486.

/cc @cockroachdb/release

---

PR #156963 added crdb_datums_to_bytes to the information_schema, but inadvertently copied over the undocumented property that it borrowed from crdb_internal.datums_to_bytes. This change remediates this for future releases.

Fixes: none
Epic: none
Release note (sql change): makes the
information_schema.crdb_datums_to_bytes builtin documented.

Release justification: surfaces crdb_internal.datums_to_bytes, which is now allowlisted as a "safe unsafe internal" in the documentation
