### PR TITLE
release-25.2: roachprod: bump node_exporter to v1.10.2

### DIFF
--- a/pkg/roachprod/prometheus/prometheus.go
+++ b/pkg/roachprod/prometheus/prometheus.go
@@ -247,15 +247,11 @@ func Init(
 	promAsInstallNodes := install.Nodes{cfg.PrometheusNode}
 
 	if len(cfg.NodeExporter) > 0 {
-		// NB: when upgrading here, make sure to target a version that picks up this PR:
-		// https://github.com/prometheus/node_exporter/pull/2311
-		// At time of writing, there hasn't been a release in over half a year.
 		if err := c.Run(ctx, l, l.Stdout, l.Stderr, install.WithNodes(cfg.NodeExporter).WithShouldRetryFn(install.AlwaysTrue),
 			"download node exporter",
 			fmt.Sprintf(`
 export ARCH=$(dpkg --print-architecture)
-if ! $(systemctl is-active --quiet node_exporter); then
-	(sudo systemctl stop node_exporter || true) &&
+if [ ! -x node_exporter/node_exporter ]; then
 	rm -rf node_exporter && mkdir -p node_exporter && curl -fsSL \
 		https://storage.googleapis.com/cockroach-test-artifacts/prometheus/node_exporter-%s.linux-${ARCH}.tar.gz |
 		tar zxv --strip-components 1 -C node_exporter
@@ -263,7 +259,7 @@ fi
 `,
 				vm.NodeExporterVersion,
 			)); err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "unable to download node_exporter")
 		}
 
 		// Start node_exporter.
@@ -271,17 +267,25 @@ fi
 		if err := c.Run(ctx, l, l.Stdout, l.Stderr, install.WithNodes(cfg.NodeExporter), "init node exporter",
 			fmt.Sprintf(`
 sudo iptables -C INPUT -p tcp -s {ip:%[1]d:public} --dport %[2]d -j ACCEPT || sudo iptables -I INPUT -p tcp -s {ip:%[1]d:public} --dport %[2]d -j ACCEPT;
-if ! $(systemctl is-active --quiet node_exporter); then
-	touch %[4]s &&
-	cd node_exporter &&
-	sudo systemd-run --unit node_exporter --same-dir ./node_exporter \
-		--web.listen-address=":%[2]d" --web.telemetry-path="%[3]s"
+if ! systemctl is-active --quiet node_exporter; then
+	# Flag we're starting a node_exporter instance
+	touch %[4]s
+	if systemctl cat node_exporter &>/dev/null; then
+		# Proper unit exists, just start it after resetting failed state if any
+		sudo systemctl reset-failed node_exporter 2>/dev/null || true
+		sudo systemctl start node_exporter
+	else
+		# Somehow proper unit doesn't exists, create transient one
+		cd node_exporter &&
+		sudo systemd-run --unit node_exporter --same-dir ./node_exporter \
+			--web.listen-address=":%[2]d" --web.telemetry-path="%[3]s"
+	fi
 fi
 `, cfg.PrometheusNode, vm.NodeExporterPort, vm.NodeExporterMetricsPath, nodeExporterStarted),
 		); err != nil {
 			// TODO(msbutler): download binary for target platform. currently we
 			// hardcode downloading the linux binary.
-			return nil, errors.Wrap(err, "grafana-start currently cannot run on darwin")
+			return nil, errors.Wrap(err, "unable to start node_exporter")
 		}
 	}
 	if err := c.Run(
@@ -309,7 +313,7 @@ sudo rm -rf /tmp/prometheus && mkdir /tmp/prometheus && cd /tmp/prometheus &&
 curl -fsSL https://storage.googleapis.com/cockroach-test-artifacts/prometheus/prometheus-%s.linux-${ARCH}.tar.gz | tar zxv --strip-components=1`,
 			vm.PrometheusVersion,
 		)); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "unable to download prometheus")
 	}
 	// create and upload prom config
 	nodeIPs, err := makeNodeIPMap(c)
@@ -329,7 +333,7 @@ curl -fsSL https://storage.googleapis.com/cockroach-test-artifacts/prometheus/pr
 		"/tmp/prometheus/prometheus.yml",
 		0777,
 	); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "unable to push prometheus config")
 	}
 
 	// Start prometheus as systemd.
@@ -344,7 +348,7 @@ curl -fsSL https://storage.googleapis.com/cockroach-test-artifacts/prometheus/pr
 sudo systemd-run --unit prometheus --same-dir \
 	./prometheus --config.file=prometheus.yml --storage.tsdb.path=data/ --web.enable-admin-api`,
 	); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "unable to start prometheus as a transient systemd unit")
 	}
 
 	if cfg.Grafana.Enabled {
@@ -363,7 +367,7 @@ sudo dpkg -i grafana-enterprise_%[1]s_${ARCH}.deb &&
 sudo mkdir -p /var/lib/grafana/dashboards`,
 				vm.GrafanaEnterpriseVersion,
 			)); err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "unable to install grafana")
 		}
 
 		// Provision local prometheus instance as data source.
@@ -372,7 +376,7 @@ sudo mkdir -p /var/lib/grafana/dashboards`,
 			l.Stderr, install.WithNodes(promAsInstallNodes).WithShouldRetryFn(install.AlwaysTrue), "permissions",
 			`sudo chmod -R 777 /etc/grafana/provisioning/datasources /etc/grafana/provisioning/dashboards /var/lib/grafana/dashboards /etc/grafana/grafana.ini`,
 		); err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "unable to set permissions for grafana provisioning")
 		}
 
 		// Set up grafana config.
@@ -384,7 +388,7 @@ datasources:
     uid: localprom
     url: http://localhost:9090
 `, "/etc/grafana/provisioning/datasources/prometheus.yaml", 0777); err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "unable to push prometheus datasource config")
 		}
 		if err := c.PutString(ctx, l, promAsInstallNodes, `apiVersion: 1
 
@@ -398,7 +402,7 @@ providers:
    options:
      path: /var/lib/grafana/dashboards
 `, "/etc/grafana/provisioning/dashboards/cockroach.yaml", 0777); err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "unable to push grafana dashboard config")
 		}
 		if err := c.PutString(ctx, l, promAsInstallNodes, `
 [auth.anonymous]
@@ -406,7 +410,7 @@ enabled = true
 org_role = Admin
 `,
 			"/etc/grafana/grafana.ini", 0777); err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "unable to push grafana config")
 		}
 
 		for idx, u := range cfg.Grafana.DashboardURLs {
@@ -420,14 +424,14 @@ org_role = Admin
 		for idx, json := range cfg.Grafana.DashboardJSON {
 			if err := c.PutString(ctx, l, promAsInstallNodes, json,
 				fmt.Sprintf("/var/lib/grafana/dashboards/s-%d.json", idx), 0777); err != nil {
-				return nil, err
+				return nil, errors.Wrap(err, "unable to push grafana dashboard json")
 			}
 		}
 
 		// Start Grafana. Default port is 3000.
 		if err := c.Run(ctx, l, l.Stdout, l.Stderr, install.WithNodes(promAsInstallNodes), "start grafana",
 			`sudo systemctl restart grafana-server`); err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "unable to start grafana")
 		}
 	}
 

--- a/pkg/roachprod/vm/aws/testdata/startup_script
+++ b/pkg/roachprod/vm/aws/testdata/startup_script
@@ -372,7 +372,7 @@ sudo service ssh restart
 export ARCH=$(dpkg --print-architecture)
 export DEFAULT_USER_HOME="/home/$(id -nu 1000)"
 mkdir -p ${DEFAULT_USER_HOME}/node_exporter && curl -fsSL \
-	https://storage.googleapis.com/cockroach-test-artifacts/prometheus/node_exporter-1.2.2.linux-${ARCH}.tar.gz |
+	https://storage.googleapis.com/cockroach-test-artifacts/prometheus/node_exporter-1.10.2.linux-${ARCH}.tar.gz |
 	tar zxv --strip-components 1 -C ${DEFAULT_USER_HOME}/node_exporter \
 	&& chown -R 1000:1000 ${DEFAULT_USER_HOME}/node_exporter
 

--- a/pkg/roachprod/vm/azure/testdata/startup_script
+++ b/pkg/roachprod/vm/azure/testdata/startup_script
@@ -370,7 +370,7 @@ sudo service ssh restart
 export ARCH=$(dpkg --print-architecture)
 export DEFAULT_USER_HOME="/home/$(id -nu 1000)"
 mkdir -p ${DEFAULT_USER_HOME}/node_exporter && curl -fsSL \
-	https://storage.googleapis.com/cockroach-test-artifacts/prometheus/node_exporter-1.2.2.linux-${ARCH}.tar.gz |
+	https://storage.googleapis.com/cockroach-test-artifacts/prometheus/node_exporter-1.10.2.linux-${ARCH}.tar.gz |
 	tar zxv --strip-components 1 -C ${DEFAULT_USER_HOME}/node_exporter \
 	&& chown -R 1000:1000 ${DEFAULT_USER_HOME}/node_exporter
 

--- a/pkg/roachprod/vm/gce/testdata/startup_script
+++ b/pkg/roachprod/vm/gce/testdata/startup_script
@@ -368,7 +368,7 @@ sudo service ssh restart
 export ARCH=$(dpkg --print-architecture)
 export DEFAULT_USER_HOME="/home/$(id -nu 1000)"
 mkdir -p ${DEFAULT_USER_HOME}/node_exporter && curl -fsSL \
-	https://storage.googleapis.com/cockroach-test-artifacts/prometheus/node_exporter-1.2.2.linux-${ARCH}.tar.gz |
+	https://storage.googleapis.com/cockroach-test-artifacts/prometheus/node_exporter-1.10.2.linux-${ARCH}.tar.gz |
 	tar zxv --strip-components 1 -C ${DEFAULT_USER_HOME}/node_exporter \
 	&& chown -R 1000:1000 ${DEFAULT_USER_HOME}/node_exporter
 

--- a/pkg/roachprod/vm/startup.go
+++ b/pkg/roachprod/vm/startup.go
@@ -22,7 +22,7 @@ const (
 	PrometheusVersion = "2.27.1"
 	// NodeExporterVersion is the version of NodeExporter installed on each node
 	// in the startup script and during the grafana-start command.
-	NodeExporterVersion = "1.2.2"
+	NodeExporterVersion = "1.10.2"
 	// NodeExporterPort is the port that NodeExporter listens on.
 	NodeExporterPort = 9100
 	// NodeExporterMetricsPath is the path that NodeExporter serves metrics on.


### PR DESCRIPTION
Backport 1/1 commits from #161190.

/cc @cockroachdb/release

---

We've been running node_exporter 1.2.2 for the last 4 years or so, and while it has been pretty reliable, we've seen some issues [1].

This patch bumps node_exporter to the latest version, released a few months ago. It is noted that an issue has been identified around the reporting of readonly filesystems [2] in this version, but this should not impact our use of node_exporter. That being said, we should probably bump to the next version when it is released.

This patch also ensures improves the process starting of `node_exporter` in case of tests with local prometheus and grafana if a systemd service existed in a stopped or failed state.

[1] https://github.com/cockroachdb/cockroach/issues/160527
[2] https://github.com/prometheus/node_exporter/issues/3484

Fixes: #160527
Closes: #160375
Release note: None

Release justification: Test-only change
