### PR TITLE
sql: refactor table loading into helper

### DIFF
--- a/pkg/sql/inspect/BUILD.bazel
+++ b/pkg/sql/inspect/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "inspect",
     srcs = [
+        "check_helpers.go",
         "cluster_runner.go",
         "index_consistency_check.go",
         "inspect_job_entry.go",

--- a/pkg/sql/inspect/check_helpers.go
+++ b/pkg/sql/inspect/check_helpers.go
@@ -1,0 +1,63 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package inspect
+
+import (
+	"context"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/errors"
+)
+
+func loadTableDesc(
+	ctx context.Context,
+	execCfg *sql.ExecutorConfig,
+	tableID descpb.ID,
+	tableVersion descpb.DescriptorVersion,
+	asOf hlc.Timestamp,
+) (catalog.TableDescriptor, error) {
+	var tableDesc catalog.TableDescriptor
+	if err := execCfg.DistSQLSrv.DB.DescsTxn(ctx, func(ctx context.Context, txn descs.Txn) error {
+		if !asOf.IsEmpty() {
+			if err := txn.KV().SetFixedTimestamp(ctx, asOf); err != nil {
+				return err
+			}
+		}
+
+		byIDGetter := txn.Descriptors().ByIDWithLeased(txn.KV())
+		if !asOf.IsEmpty() {
+			byIDGetter = txn.Descriptors().ByIDWithoutLeased(txn.KV())
+		}
+
+		var err error
+		tableDesc, err = byIDGetter.WithoutNonPublic().Get().Table(ctx, tableID)
+		if err != nil {
+			return err
+		}
+		if tableVersion != 0 && tableDesc.GetVersion() != tableVersion {
+			return errors.WithHintf(
+				errors.Newf(
+					"table %s [%d] has had a schema change since the job has started at %s",
+					tableDesc.GetName(),
+					tableDesc.GetID(),
+					tableDesc.GetModificationTime().GoTime().Format(time.RFC3339),
+				),
+				"use AS OF SYSTEM TIME to avoid schema changes during inspection",
+			)
+		}
+
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return tableDesc, nil
+}


### PR DESCRIPTION
This logic is intended to be used by multiple inspect checks. The helper
reduces code duplication.

Epic: CRDB-58692
Part of: #154551

Release note: None
