### PR TITLE
sql: fix nil LeafTxnInputState assertion in inner plans

### DIFF
--- a/pkg/sql/execinfra/flow_context.go
+++ b/pkg/sql/execinfra/flow_context.go
@@ -50,7 +50,8 @@ type FlowCtx struct {
 	// higher-level txn (like backfills).
 	Txn *kv.Txn
 
-	// MakeLeafTxn returns a new LeafTxn, different from Txn.
+	// MakeLeafTxn returns a new LeafTxn, different from Txn. MakeLeafTxn could be
+	// unset if it's not possible to create a leaf transaction.
 	MakeLeafTxn func(context.Context) (*kv.Txn, error)
 
 	// Descriptors is used to look up leased table descriptors and to construct


### PR DESCRIPTION
Previously, when inner plans (such as apply-join iterations or routines) were executed with a LeafTxn inherited from an outer plan, an assertion failure could occur. The issue was that `MakeLeafTxn` was always set on the flow context, even when `LeafTxnInputState` was not available.

When a JoinReader in the inner plan called `UseStreamer()`, it would see that `flowCtx.Txn.Type() == kv.LeafTxn` and `flowCtx.MakeLeafTxn != nil`, and attempt to create a new leaf transaction. This would hit the assertion "nil LeafTxnInputState when trying to create the LeafTxn" because inner plans that inherit a LeafTxn cannot call `GetLeafTxnInputState()` (that method only works on RootTxn).

This commit fixes the issue by only setting `MakeLeafTxn` on the flow context when `LeafTxnInputState` is actually available. This way, `UseStreamer()` will see `MakeLeafTxn == nil` and simply use the existing `flowCtx.Txn` directly instead of trying to create a new leaf transaction.

(No release note because this is a rare failure.)

Fixes: #161168

Release note: None