### PR TITLE
ttl: make TTL job owner match schedule owner

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -2203,6 +2203,12 @@ type TTLTestingKnobs struct {
 	// ExtraStatsQuery is an additional query to run while gathering stats if
 	// the ttl_row_stats_poll_interval is set. It is always run first.
 	ExtraStatsQuery string
+	// BeforeProcessorStart is called in the TTL job coordinator before the
+	// DistSQL plan is executed. This can be used for test synchronization. The
+	// context is the job's context, which will be canceled when the job is
+	// canceled. Return an error to abort the job (e.g., ctx.Err() when context
+	// is canceled).
+	BeforeProcessorStart func(ctx context.Context) error
 }
 
 // ModuleTestingKnobs implements the base.ModuleTestingKnobs interface.

--- a/pkg/sql/ttl/ttljob/ttljob.go
+++ b/pkg/sql/ttl/ttljob/ttljob.go
@@ -295,6 +295,13 @@ func (t *rowLevelTTLResumer) Resume(ctx context.Context, execCtx interface{}) (r
 		return err
 	}
 
+	// Call the BeforeProcessorStart hook for test synchronization.
+	if knobs.BeforeProcessorStart != nil {
+		if err := knobs.BeforeProcessorStart(ctx); err != nil {
+			return err
+		}
+	}
+
 	if err := t.progressTracker.initJobProgress(ctx, int64(jobSpanCount)); err != nil {
 		return err
 	}


### PR DESCRIPTION
Previously, TTL jobs were always owned by the `node` user, which is an
admin. This prevented non-admin users with the CONTROLJOB privilege from
canceling TTL jobs, since CONTROLJOB does not grant control over
admin-owned jobs.

This change makes the TTL job owner match the TTL schedule owner,
following the same pattern used by backup and changefeed executors. All
TTL jobs created by the schedule are now owned by the schedule owner
(the user who created the table with TTL). This allows:
- The schedule owner to cancel their own TTL jobs
- Non-admin users with CONTROLJOB to cancel any TTL job (since TTL jobs
  are no longer admin-owned)
- Admin users to continue canceling any TTL job

Fixes: https://github.com/cockroachdb/cockroach/issues/161006

Release note (ops change): TTL jobs are now owned by the schedule owner
instead of the node user. This allows users with CONTROLJOB privilege to
cancel TTL jobs, provided the schedule owner is not an admin (CONTROLJOB
does not grant control over admin-owned jobs).