### PR TITLE
sql,roachtest: unskip locality-related tests

### DIFF
--- a/pkg/ccl/multiregionccl/datadriven_test.go
+++ b/pkg/ccl/multiregionccl/datadriven_test.go
@@ -59,7 +59,6 @@ func TestMultiRegionDataDriven_regional_by_row(t *testing.T) {
 func TestMultiRegionDataDriven_regional_by_table(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.WithIssue(t, 160803)
 	testMultiRegionDataDriven(t, "regional_by_table")
 }
 

--- a/pkg/cmd/roachtest/tests/acceptance.go
+++ b/pkg/cmd/roachtest/tests/acceptance.go
@@ -116,7 +116,6 @@ func registerAcceptance(r registry.Registry) {
 			{
 				name:     "mismatched-locality",
 				fn:       runMismatchedLocalityTest,
-				skip:     "TODO(#160845): unskip this",
 				numNodes: 3,
 			},
 		},


### PR DESCRIPTION
These tests were skipped due to flakiness caused by StoreLiveness being used as a signal to mark stores as dead. Now that 8397e9bdf99 has fixed that issue, these tests can be re-enabled.

Fixes: #160848
Fixes: #160845
Fixes: #160803

Release note: None