### PR TITLE
build: add Trunk merge queue configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,6 +31,8 @@
 /.github/                    @cockroachdb/dev-inf
 #!/.github/CODEOWNERS          @cockroachdb/unowned
 
+/.trunk/                     @cockroachdb/code-systems-prs
+
 /build/                      @cockroachdb/dev-inf
 
 /docs/RFCS/                  @cockroachdb/rfc-prs

--- a/.github/workflows/github-actions-essential-ci.yml
+++ b/.github/workflows/github-actions-essential-ci.yml
@@ -30,6 +30,7 @@ on:
       - "release-*"
       - "staging-*"
       - "staging"
+      - "trunk-merge/**"
       - "trying"
       - "!release-1.0*"
       - "!release-1.1*"

--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -73,6 +73,8 @@ cockroachdb/jobs:
   # see .github/workflows/add-issues-to-project.yml
   label: T-jobs
 cockroachdb/cloud-identity:
+cockroachdb/code-systems-prs:
+  label: T-code-sys
 cockroachdb/unowned:
   aliases:
     cockroachdb/rfc-prs: other

--- a/trunk.yaml
+++ b/trunk.yaml
@@ -1,0 +1,49 @@
+# Trunk configuration file
+# This configuration replicates the bors.toml settings for merge queue functionality
+
+version: 0.1
+
+# CLI configuration
+cli:
+  version: 1.22.2
+
+# Merge queue configuration (equivalent to bors.toml)
+merge:
+  # Use Trunk's merge queue service
+  service: queue
+  
+  # Required status checks that must pass before merging
+  # These correspond to the job names in github-actions-essential-ci.yml
+  required_statuses:
+    - "acceptance"
+    - "check_generated_code"
+    - "docker_image_amd64"
+    - "examples_orms"
+    - "label_validation"
+    - "lint"
+    - "linux_amd64_build"
+    - "linux_amd64_fips_build"
+    - "local_roachtest"
+    - "local_roachtest_fips"
+    - "unit_tests"
+  
+# Actions configuration
+actions:
+  enabled:
+    - merge-queue
+
+  # Disable for other branches to avoid conflicts
+  disabled: []
+
+# Plugins configuration (if needed for additional functionality)
+plugins:
+  sources: []
+
+# Lint configuration (keeping minimal for merge queue focus)
+lint:
+  enabled: []
+
+# Runtimes (if needed)
+runtimes:
+  enabled: []
+


### PR DESCRIPTION
Add trunk.yaml configuration to enable Trunk's merge queue service as a replacement for the existing bors.toml workflow. The configuration includes all essential CI checks required for safe merging and enables merge queue functionality on the master-trunk branch.

Release note: None

Epic: CODESYS-84