### PR TITLE
release-25.4: sql: prevent rare fatal with parallel checks

### DIFF
--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -494,7 +494,13 @@ func (ds *ServerImpl) newFlowContext(
 		DiskMonitor:    diskMonitor,
 	}
 
-	if localState.IsLocal && localState.Collection != nil {
+	// Don't reuse the collection when we're running a parallel check off the
+	// main goroutine - in this case we might have multiple goroutines using the
+	// collection concurrently, so we choose to create a fresh one. The parallel
+	// check running on the main goroutine can keep on using the planner's one.
+	reuseCollection := localState.ParallelCheckMainGoroutine || // on main goroutine
+		localState.GetConcurrency()&ConcurrencyParallelChecks == 0 // not a parallel check
+	if localState.IsLocal && localState.Collection != nil && reuseCollection {
 		// If we were passed a descs.Collection to use, then take it. In this
 		// case, the caller will handle releasing the used descriptors, so we
 		// don't need to clean up the descriptors when cleaning up the flow.
@@ -572,6 +578,11 @@ type LocalState struct {
 	// concurrency tracks the types of concurrency present when accessing the
 	// Txn.
 	concurrency ConcurrencyKind
+
+	// ParallelCheckMainGoroutine, if set, indicates that this plan is part of
+	// parallel checks and is run on the main goroutine (i.e. the one that
+	// executed the main plan of the query).
+	ParallelCheckMainGoroutine bool
 
 	// Txn is filled in on the gateway only. It is the RootTxn that the query is running in.
 	// This will be used directly by the flow if the flow has no concurrency and IsLocal is set.

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -1039,6 +1039,11 @@ type PlanningCtx struct {
 	// based on other "regular" factors).
 	flowConcurrency distsql.ConcurrencyKind
 
+	// parallelCheckMainGoroutine, if set, indicates that this plan is part of
+	// parallel checks and is run on the main goroutine (i.e. the one that
+	// executed the main plan of the query).
+	parallelCheckMainGoroutine bool
+
 	// onFlowCleanup contains non-nil functions that will be called after the
 	// local flow finished running and is being cleaned up. It allows us to
 	// release the resources that are acquired during the physical planning and

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -763,6 +763,7 @@ func (dsp *DistSQLPlanner) Run(
 	localState.EvalContext = evalCtx
 	localState.IsLocal = planCtx.isLocal
 	localState.AddConcurrency(planCtx.flowConcurrency)
+	localState.ParallelCheckMainGoroutine = planCtx.parallelCheckMainGoroutine
 	localState.Txn = txn
 	localState.LocalProcs = plan.LocalProcessors
 	localState.LocalVectorSources = plan.LocalVectorSources
@@ -2555,7 +2556,7 @@ func (dsp *DistSQLPlanner) PlanAndRunPostQueries(
 						planner,
 						evalCtxFactory(false /* usedConcurrently */),
 						recv,
-						false, /* parallelCheck */
+						sequentialPostquery,
 						defaultGetSaveFlowsFunc,
 						planner.instrumentation.getAssociateNodeWithComponentsFn(),
 						recv.stats.add,
@@ -2663,7 +2664,7 @@ func (dsp *DistSQLPlanner) planAndRunCascadeOrTrigger(
 		planner,
 		evalCtx,
 		recv,
-		false, /* parallelCheck */
+		sequentialPostquery,
 		defaultGetSaveFlowsFunc,
 		planner.instrumentation.getAssociateNodeWithComponentsFn(),
 		recv.stats.add,
@@ -2729,13 +2730,21 @@ var parallelChecksConcurrencyLimit = settings.RegisterIntSetting(
 	settings.NonNegativeInt,
 )
 
+type postqueryInfo byte
+
+const (
+	sequentialPostquery postqueryInfo = iota
+	parallelCheckMainGoroutine
+	parallelCheckWorkerGoroutine
+)
+
 // planAndRunPostquery runs a cascade or check query. Can be safe for concurrent
 // use if parallelCheck is true.
 //
-// - parallelCheck indicates whether this is a check query that runs in parallel
-// with other check queries. If parallelCheck is true, then getSaveFlowsFunc,
-// associateNodeWithComponents, and addTopLevelQueryStats must be
-// concurrency-safe (if non-nil).
+// - postqueryInfo indicates whether this is a check query that runs in parallel
+// with other check queries. If parallelCheck is not sequentialPostquery, then
+// getSaveFlowsFunc, associateNodeWithComponents, and addTopLevelQueryStats must
+// be concurrency-safe (if non-nil).
 // - getSaveFlowsFunc will only be called if
 // planner.instrumentation.ShouldSaveFlows() returns true.
 func (dsp *DistSQLPlanner) planAndRunPostquery(
@@ -2744,7 +2753,7 @@ func (dsp *DistSQLPlanner) planAndRunPostquery(
 	planner *planner,
 	evalCtx *extendedEvalContext,
 	recv *DistSQLReceiver,
-	parallelCheck bool,
+	postqueryInfo postqueryInfo,
 	getSaveFlowsFunc func() SaveFlowsFunc,
 	associateNodeWithComponents func(exec.Node, execComponents),
 	addTopLevelQueryStats func(stats *topLevelQueryStats),
@@ -2766,8 +2775,9 @@ func (dsp *DistSQLPlanner) planAndRunPostquery(
 	}
 	postqueryPlanCtx.associateNodeWithComponents = associateNodeWithComponents
 	postqueryPlanCtx.collectExecStats = planner.instrumentation.ShouldCollectExecStats()
-	if parallelCheck {
+	if postqueryInfo != sequentialPostquery {
 		postqueryPlanCtx.flowConcurrency = distsql.ConcurrencyParallelChecks
+		postqueryPlanCtx.parallelCheckMainGoroutine = postqueryInfo == parallelCheckMainGoroutine
 	}
 
 	postqueryPhysPlan, physPlanCleanup, err := dsp.createPhysPlan(ctx, postqueryPlanCtx, postqueryPlan)
@@ -2873,14 +2883,14 @@ func (dsp *DistSQLPlanner) planAndRunChecksInParallel(
 	// needed in order to return the error for the "earliest" plan (which makes
 	// the tests deterministic when multiple checks fail).
 	errs := make([]error, len(checkPlans))
-	runCheck := func(ctx context.Context, checkPlanIdx int) {
+	runCheck := func(ctx context.Context, checkPlanIdx int, postqueryInfo postqueryInfo) {
 		log.VEventf(ctx, 3, "begin check %d", checkPlanIdx)
 		errs[checkPlanIdx] = dsp.planAndRunPostquery(
 			ctx, checkPlans[checkPlanIdx].plan,
 			planner,
 			evalCtxFactory(true /* usedConcurrently */),
 			recv,
-			true, /* parallelCheck */
+			postqueryInfo,
 			getSaveFlowsFunc,
 			associateNodeWithComponents,
 			addTopLevelQueryStats,
@@ -2930,7 +2940,7 @@ func (dsp *DistSQLPlanner) planAndRunChecksInParallel(
 			},
 			func(ctx context.Context) {
 				defer wg.Done()
-				runCheck(ctx, checkPlanIdx)
+				runCheck(ctx, checkPlanIdx, parallelCheckWorkerGoroutine)
 			}); err != nil {
 			// The server is quiescing, so we just make sure to wait for all
 			// already started checks to complete after canceling them.
@@ -2944,7 +2954,7 @@ func (dsp *DistSQLPlanner) planAndRunChecksInParallel(
 	}
 	// Execute all other checks serially in the current goroutine.
 	for checkPlanIdx := numParallelChecks; checkPlanIdx < len(checkPlans); checkPlanIdx++ {
-		runCheck(ctx, checkPlanIdx)
+		runCheck(ctx, checkPlanIdx, parallelCheckMainGoroutine)
 	}
 	// Wait for all concurrent checks to complete and return the error from the
 	// earliest check (if there were any errors).

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -905,13 +905,14 @@ func TestDistSQLPlannerParallelChecks(t *testing.T) {
 
 	sqlDB := sqlutils.MakeSQLRunner(db)
 	// Set up a child table with two foreign keys into two parent tables.
-	sqlDB.Exec(t, `CREATE TABLE parent1 (id1 INT8 PRIMARY KEY)`)
-	sqlDB.Exec(t, `CREATE TABLE parent2 (id2 INT8 PRIMARY KEY)`)
+	sqlDB.Exec(t, `CREATE TYPE status AS ENUM ('open')`)
+	sqlDB.Exec(t, `CREATE TABLE parent1 (e1 status, id1 INT8, PRIMARY KEY (e1, id1))`)
+	sqlDB.Exec(t, `CREATE TABLE parent2 (e2 status, id2 INT8, PRIMARY KEY (e2, id2))`)
 	sqlDB.Exec(t, `
 CREATE TABLE child (
-    id INT8 PRIMARY KEY, parent_id1 INT8 NOT NULL, parent_id2 INT8 NOT NULL,
-    FOREIGN KEY (parent_id1) REFERENCES parent1 (id1),
-    FOREIGN KEY (parent_id2) REFERENCES parent2 (id2)
+    e status, id INT8, parent_id1 INT8 NOT NULL, parent_id2 INT8 NOT NULL,
+    FOREIGN KEY (e, parent_id1) REFERENCES parent1 (e1, id1),
+    FOREIGN KEY (e, parent_id2) REFERENCES parent2 (e2, id2)
 );`)
 	// Disable the insert fast path in order for the foreign key checks to be
 	// planned as parallel postqueries.
@@ -924,8 +925,8 @@ CREATE TABLE child (
 
 	const numIDs = 1000
 	for id := 0; id < numIDs; id++ {
-		sqlDB.Exec(t, `INSERT INTO parent1 VALUES ($1)`, id)
-		sqlDB.Exec(t, `INSERT INTO parent2 VALUES ($1)`, id)
+		sqlDB.Exec(t, `INSERT INTO parent1 VALUES ('open', $1)`, id)
+		sqlDB.Exec(t, `INSERT INTO parent2 VALUES ('open', $1)`, id)
 		var prefix string
 		if rng.Float64() < 0.5 {
 			// In 50% of the cases, run the INSERT query with FK checks via
@@ -947,12 +948,12 @@ CREATE TABLE child (
 			// error for parent_id1 is always chosen.
 			sqlDB.ExpectErr(
 				t,
-				`insert on table "child" violates foreign key constraint "child_parent_id1_fkey"`,
-				fmt.Sprintf(`%[1]sINSERT INTO child VALUES (%[2]d, %[2]d, %[2]d)`, prefix, invalidID),
+				`insert on table "child" violates foreign key constraint "child_e_parent_id1_fkey"`,
+				fmt.Sprintf(`%[1]sINSERT INTO child VALUES ('open', %[2]d, %[2]d, %[2]d)`, prefix, invalidID),
 			)
 			continue
 		}
-		sqlDB.Exec(t, fmt.Sprintf(`%[1]sINSERT INTO child VALUES (%[2]d, %[2]d, %[2]d)`, prefix, id))
+		sqlDB.Exec(t, fmt.Sprintf(`%[1]sINSERT INTO child VALUES ('open', %[2]d, %[2]d, %[2]d)`, prefix, id))
 	}
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #159101 on behalf of @yuzefovich.

----

We just saw a test failure where a node crashed because of `fatal error: concurrent map writes`. This happened during the flow setup of parallel checks and is traced back to using the same `descs.Collection` across multiple goroutines that might modify it concurrently. This patch ensures that only the "main" goroutine of parallel checks is using the planner's collection while forcing all other goroutines to create a separate one. I was unable to reproduce this problem in a unit test, but I still decided to include the test changes.

Given that we've only seen it once in a test setup, I chose to not include the release note.

Fixes: #158239.
Release note (bug fix): CockroachDB could previously encounter a crash `fatal error: concurrent map writes` when executing FOREIGN KEY and UNIQUE constraint checks in parallel. This could happen due to a rare race and was introduced when the parallel execution of CHECKs was added in 23.1. This is now fixed.

----

Release justification: low-risk rare crash fix.