### PR TITLE
roachtest: increase the number of nodes in cypress-pages test

### DIFF
--- a/pkg/cmd/roachtest/tests/db_console_cypress.go
+++ b/pkg/cmd/roachtest/tests/db_console_cypress.go
@@ -226,7 +226,7 @@ func registerDbConsoleCypress(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:    "db-console/cypress-pages",
 		Owner:   registry.OwnerObservability,
-		Cluster: r.MakeClusterSpec(1, spec.WorkloadNode()),
+		Cluster: r.MakeClusterSpec(4, spec.WorkloadNode()),
 		// Disabled on IBM because of some nodejs dependencies that are not
 		// available on s390x.
 		CompatibleClouds: registry.AllClouds.NoIBM(),


### PR DESCRIPTION
The new cypress-pages test was setup to only have one node, with one workload node. This leads to cluster.CRDBNodes() returning 0, so the test panics when trying to access node 0.

Fixes: #161235
Epic: None
Releaes Note: None