### PR TITLE
sql: clean up stale inspect TODO

### DIFF
--- a/pkg/sql/inspect/inspect_job_entry.go
+++ b/pkg/sql/inspect/inspect_job_entry.go
@@ -34,7 +34,6 @@ func TriggerJob(
 	checks []*jobspb.InspectDetails_Check,
 	asOf hlc.Timestamp,
 ) (*jobs.StartableJob, error) {
-	// TODO(sql-queries): add row count check when that is implemented.
 	record := jobs.Record{
 		JobID:       execCfg.JobRegistry.MakeJobID(),
 		Description: jobRecordDescription,


### PR DESCRIPTION
Support added in #159320.

Part of:#155472
Epic: CRDB-55075

Release note: None
