### PR TITLE
release-26.1: cli: update expected goroutine_dump file suffix

### DIFF
--- a/pkg/cli/debug_list_files_test.go
+++ b/pkg/cli/debug_list_files_test.go
@@ -26,6 +26,8 @@ func TestExtractTimestamp(t *testing.T) {
 		{"goroutine_dump.double_since_last_dump.2021-04-23T09_18_23.1231", "2021-04-23 09:18"},
 		// v20.x and later goroutine dumps.
 		{"goroutine_dump.2021-03-11T08_13_57.498.double_since_last_dump.000001137.txt", "2021-03-11 08:13"},
+		// v26.1 and later goroutine dumps.
+		{"goroutine_dump.2021-03-11T08_13_57.498.double_since_last_dump.000001137.pb.gz", "2021-03-11 08:13"},
 		// v20.1 and later memstats.
 		{"memstats.2021-04-22T18_31_54.413.371441664.txt", "2021-04-22 18:31"},
 		// v1.0 heap profile names.

--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -1494,7 +1494,7 @@ func trimNonDeterministicZipOutputFiles(out string) string {
 	out = re.ReplaceAllString(out, ``)
 	re = regexp.MustCompile(`(?m).*(memprof|memstats|memmonitoring).*\.(txt|pprof)$` + "\n")
 	out = re.ReplaceAllString(out, ``)
-	re = regexp.MustCompile(`(?m).*goroutine_dump.*\.txt\.gz$` + "\n")
+	re = regexp.MustCompile(`(?m).*goroutine_dump.*\.pb\.gz$` + "\n")
 	out = re.ReplaceAllString(out, ``)
 	return out
 }

--- a/pkg/server/storage_api/files_test.go
+++ b/pkg/server/storage_api/files_test.go
@@ -94,16 +94,16 @@ func TestStatusGetFiles(t *testing.T) {
 	t.Run("goroutines", func(t *testing.T) {
 
 		// regex for goroutine file names manually added
-		reDump := regexp.MustCompile(`goroutine_dump\d+.txt.gz`)
+		reDump := regexp.MustCompile(`goroutine_dump\d+.pb.gz`)
 		// regex for goroutine file names dumped by goroutinedumper
-		reOOMDump := regexp.MustCompile("goroutine_dump.*.double_since_last_dump.*.txt.gz")
+		reOOMDump := regexp.MustCompile("goroutine_dump.*.double_since_last_dump.*.pb.gz")
 		// regex for content of goroutine files manually added
 		reDumpContent := regexp.MustCompile(`Goroutine dump \d+`)
 
 		const testFilesNo = 3
 		for i := 0; i < testFilesNo; i++ {
 			testGoroutineDir := filepath.Join(storeSpec.Path, "logs", base.GoroutineDumpDir)
-			testGoroutineFile := filepath.Join(testGoroutineDir, fmt.Sprintf("goroutine_dump%d.txt.gz", i))
+			testGoroutineFile := filepath.Join(testGoroutineDir, fmt.Sprintf("goroutine_dump%d.pb.gz", i))
 			if err := os.MkdirAll(testGoroutineDir, os.ModePerm); err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Backport 1/1 commits from #161187 on behalf of @angeladietz.

----

The goroutine dump output format recently changed from a txt.gz to .pb.gz in #160798. This updates the expected file suffix to fix failing unit tests.

Fixes #161113
Fixes #161145
Fixes #161000

Release note: none

----

Release justification: fixes test failures on the 26.1 release branch