### PR TITLE
release-25.4: sql/tablemetadatacache: improve the batch query

### DIFF
--- a/pkg/sql/tablemetadatacache/table_metadata_batch_iterator.go
+++ b/pkg/sql/tablemetadatacache/table_metadata_batch_iterator.go
@@ -228,13 +228,31 @@ func (batchIter *tableMetadataBatchIterator) fetchNextBatch(ctx context.Context)
 // system.table_metadata.
 func newBatchQueryStatement(aostClause string) string {
 	return fmt.Sprintf(`
-SELECT 
-    n.id,
-    n.name,
-    n."parentID",
-    db_name.name as db_name,
-    n."parentSchemaID",
-    schema_name.name as schema_name,
+WITH cte (n_id, n_name, "n_parentID", db_name, "n_parentSchemaID", schema_name, d) AS (
+   SELECT
+       n.id,
+       n.name,
+       n."parentID",
+       db_name.name,
+       n."parentSchemaID",
+       schema_name.name,
+       crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', enc_desc.descriptor)
+   FROM system.namespace n
+   JOIN system.descriptor enc_desc ON n.id = enc_desc.id
+   JOIN system.namespace db_name ON n."parentID" = db_name.id AND db_name."parentID" = 0
+   JOIN system.namespace schema_name ON n."parentSchemaID" = schema_name.id AND schema_name."parentID" = n."parentID"
+   WHERE (n."parentID", n."parentSchemaID", n.name) > ($1, $2, $3)
+     AND n."parentSchemaID" != 0
+   ORDER BY n."parentID", n."parentSchemaID", n.name
+   LIMIT $4
+)
+SELECT
+    n_id AS id,
+    n_name AS name,
+    "n_parentID" AS "parentID",
+    db_name,
+    "n_parentSchemaID" AS "parentSchemaID",
+    schema_name,
     json_array_length(d->'table' -> 'columns') as columns,
     COALESCE(json_array_length(d->'table' -> 'indexes'), 0) as indexes,
     CASE
@@ -244,22 +262,15 @@ SELECT
         ELSE 'TABLE'
     END as table_type,
     (d->'table'->'autoStatsSettings'->>'enabled')::BOOL as auto_stats_enabled,
-    ts.last_updated as stats_last_updated,
-    crdb_internal.table_span(n.id) as span
-FROM system.namespace n
-JOIN system.descriptor enc_desc ON n.id = enc_desc.id
-CROSS JOIN LATERAL crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', enc_desc.descriptor) AS d
-JOIN system.namespace db_name ON n."parentID" = db_name.id AND db_name."parentID" = 0
-JOIN system.namespace schema_name ON n."parentSchemaID" = schema_name.id AND schema_name."parentID" = n."parentID"
-LEFT JOIN (
-    SELECT "tableID", max("createdAt") as last_updated 
-    FROM system.table_statistics 
-    GROUP BY "tableID"
-) ts ON ts."tableID" = n.id
+    (
+        SELECT max("createdAt") as stats_last_updated
+        FROM system.table_statistics
+        WHERE "tableID" = n_id
+        GROUP BY "tableID"
+    ),
+    crdb_internal.table_span(n_id) as span
+FROM
+    cte
 %[1]s
-WHERE (n."parentID", n."parentSchemaID", n.name) > ($1, $2, $3) 
-  AND n."parentSchemaID" != 0
-ORDER BY n."parentID", n."parentSchemaID", n.name
-LIMIT $4
 `, aostClause)
 }

--- a/pkg/sql/tablemetadatacache/testdata/explain_tmj_select
+++ b/pkg/sql/tablemetadatacache/testdata/explain_tmj_select
@@ -2,13 +2,31 @@ explain-select-query
 ----
 ----
 EXPLAIN (REDACT) 
-SELECT 
-    n.id,
-    n.name,
-    n."parentID",
-    db_name.name as db_name,
-    n."parentSchemaID",
-    schema_name.name as schema_name,
+WITH cte (n_id, n_name, "n_parentID", db_name, "n_parentSchemaID", schema_name, d) AS (
+   SELECT
+       n.id,
+       n.name,
+       n."parentID",
+       db_name.name,
+       n."parentSchemaID",
+       schema_name.name,
+       crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', enc_desc.descriptor)
+   FROM system.namespace n
+   JOIN system.descriptor enc_desc ON n.id = enc_desc.id
+   JOIN system.namespace db_name ON n."parentID" = db_name.id AND db_name."parentID" = 0
+   JOIN system.namespace schema_name ON n."parentSchemaID" = schema_name.id AND schema_name."parentID" = n."parentID"
+   WHERE (n."parentID", n."parentSchemaID", n.name) > ($1, $2, $3)
+     AND n."parentSchemaID" != 0
+   ORDER BY n."parentID", n."parentSchemaID", n.name
+   LIMIT $4
+)
+SELECT
+    n_id AS id,
+    n_name AS name,
+    "n_parentID" AS "parentID",
+    db_name,
+    "n_parentSchemaID" AS "parentSchemaID",
+    schema_name,
     json_array_length(d->'table' -> 'columns') as columns,
     COALESCE(json_array_length(d->'table' -> 'indexes'), 0) as indexes,
     CASE
@@ -18,80 +36,68 @@ SELECT
         ELSE 'TABLE'
     END as table_type,
     (d->'table'->'autoStatsSettings'->>'enabled')::BOOL as auto_stats_enabled,
-    ts.last_updated as stats_last_updated,
-    crdb_internal.table_span(n.id) as span
-FROM system.namespace n
-JOIN system.descriptor enc_desc ON n.id = enc_desc.id
-CROSS JOIN LATERAL crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', enc_desc.descriptor) AS d
-JOIN system.namespace db_name ON n."parentID" = db_name.id AND db_name."parentID" = 0
-JOIN system.namespace schema_name ON n."parentSchemaID" = schema_name.id AND schema_name."parentID" = n."parentID"
-LEFT JOIN (
-    SELECT "tableID", max("createdAt") as last_updated 
-    FROM system.table_statistics 
-    GROUP BY "tableID"
-) ts ON ts."tableID" = n.id
+    (
+        SELECT max("createdAt") as stats_last_updated
+        FROM system.table_statistics
+        WHERE "tableID" = n_id
+        GROUP BY "tableID"
+    ),
+    crdb_internal.table_span(n_id) as span
+FROM
+    cte
 AS OF SYSTEM TIME '-1us'
-WHERE (n."parentID", n."parentSchemaID", n.name) > ($1, $2, $3) 
-  AND n."parentSchemaID" != 0
-ORDER BY n."parentID", n."parentSchemaID", n.name
-LIMIT $4
 
 ---
 distribution: local
 vectorized: true
 
-• sort
-│ order: +"parentID",+"parentSchemaID",+name
+• render
 │
-└── • render
+└── • apply join (left outer)
     │
-    └── • hash join (right outer)
-        │ equality: (tableID) = (id)
-        │ left cols are key
+    ├── • render
+    │   │
+    │   └── • limit
+    │       │ count: ‹×›
+    │       │
+    │       └── • lookup join
+    │           │ table: descriptor@primary
+    │           │ equality: (id) = (id)
+    │           │ equality cols are key
+    │           │
+    │           └── • sort
+    │               │ order: +"parentID",+"parentSchemaID",+name
+    │               │
+    │               └── • hash join
+    │                   │ equality: (parentID, parentSchemaID) = (id, id)
+    │                   │
+    │                   ├── • filter
+    │                   │   │ filter: "parentSchemaID" != ‹×›
+    │                   │   │
+    │                   │   └── • scan
+    │                   │         missing stats
+    │                   │         table: namespace@primary
+    │                   │         spans: 1 span
+    │                   │
+    │                   └── • lookup join
+    │                       │ table: namespace@primary
+    │                       │ equality: (id) = (parentID)
+    │                       │ pred: id != ‹×›
+    │                       │
+    │                       └── • scan
+    │                             missing stats
+    │                             table: namespace@primary
+    │                             spans: 1 span
+    │
+    └── • inner loop (unoptimized)
         │
-        ├── • group (streaming)
-        │   │ group by: tableID
-        │   │ ordered: +"tableID"
-        │   │
-        │   └── • scan
-        │         missing stats
-        │         table: table_statistics@primary
-        │         spans: FULL SCAN
-        │
-        └── • top-k
-            │ order: +"parentID",+"parentSchemaID",+name
-            │ k: 20
-            │
-            └── • hash join
-                │ equality: (parentID, parentSchemaID) = (id, id)
-                │
-                ├── • project set
-                │   │
-                │   └── • hash join
-                │       │ equality: (id) = (id)
-                │       │ left cols are key
-                │       │
-                │       ├── • scan
-                │       │     missing stats
-                │       │     table: descriptor@primary
-                │       │     spans: FULL SCAN
-                │       │
-                │       └── • filter
-                │           │ filter: "parentSchemaID" != ‹×›
-                │           │
-                │           └── • scan
-                │                 missing stats
-                │                 table: namespace@primary
-                │                 spans: 1 span
-                │
-                └── • lookup join
-                    │ table: namespace@primary
-                    │ equality: (id) = (parentID)
-                    │ pred: id != ‹×›
-                    │
-                    └── • scan
-                          missing stats
-                          table: namespace@primary
-                          spans: 1 span
+        └── • group-by (streaming)
+               ├── select
+               │    ├── scan table_statistics
+               │    └── filters
+               │         └── tableID = n_id
+               └── aggregations
+                    └── max
+                         └── createdAt
 ----
 ----


### PR DESCRIPTION
Backport 1/1 commits from #161143 on behalf of @yuzefovich.

----

We noticed that the batch metadata query can take very long time on a cluster with many tables (e.g. with 470k it takes 3 minutes) with vast majority being spent in decoding each table descriptor to fetch some information. The query has a LIMIT (20 by default), but it's applied _after_ decoding all descriptors. This commit performs a manual rewrite of the query so that we first determine the target set of tables and only then decode all LIMIT number of descriptors. This brings down the execution time to under 5s on 470k table cluster. (Additionally, we now automatically avoid the full table scan of system.table_statistics - by performing a few apply join iterations.)

Fixes: #160987.
Release note: None

----

Release justification: low-risk performance efficiency improvement.