### PR TITLE
ci: remove label_validation step from Trunk

### DIFF
--- a/trunk.yaml
+++ b/trunk.yaml
@@ -19,7 +19,6 @@ merge:
     - "check_generated_code"
     - "docker_image_amd64"
     - "examples_orms"
-    - "label_validation"
     - "lint"
     - "linux_amd64_build"
     - "linux_amd64_fips_build"


### PR DESCRIPTION
Remove label validation step from Trunk config

Release note: None

Epic: CODESYS-84