### PR TITLE
spanset: add hook for enabling/disabling assertions

### DIFF
--- a/pkg/kv/kvserver/kvstorage/BUILD.bazel
+++ b/pkg/kv/kvserver/kvstorage/BUILD.bazel
@@ -27,7 +27,6 @@ go_library(
         "//pkg/storage",
         "//pkg/storage/enginepb",
         "//pkg/storage/fs",
-        "//pkg/util",
         "//pkg/util/buildutil",
         "//pkg/util/hlc",
         "//pkg/util/iterutil",

--- a/pkg/kv/kvserver/kvstorage/storage.go
+++ b/pkg/kv/kvserver/kvstorage/storage.go
@@ -10,7 +10,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/errors"
 )
@@ -131,7 +130,7 @@ type Engines struct {
 // MakeEngines creates an Engines handle in which both state machine and log
 // engine reside in the same physical engine.
 func MakeEngines(eng storage.Engine) Engines {
-	if util.RaceEnabled {
+	if spanset.EnableAssertions {
 		// Wrap the engines with span set engines to catch incorrect engine
 		// accesses.
 		return Engines{
@@ -154,7 +153,7 @@ func MakeSeparatedEnginesForTesting(state, log storage.Engine) Engines {
 	if !buildutil.CrdbTestBuild {
 		panic("separated engines are not supported")
 	}
-	if util.RaceEnabled {
+	if spanset.EnableAssertions {
 		// Wrap the engines with span set engines to catch incorrect engine
 		// accesses.
 		return Engines{

--- a/pkg/kv/kvserver/mvcc_gc_queue.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue.go
@@ -695,7 +695,7 @@ func (mgcq *mvccGCQueue) process(
 	}
 
 	snap := repl.store.StateEngine().NewSnapshot(rditer.MakeReplicatedKeySpans(desc)...)
-	if util.RaceEnabled {
+	if spanset.EnableAssertions {
 		ss := rditer.MakeReplicatedKeySpanSet(desc)
 		defer ss.Release()
 		snap = spanset.NewReader(snap, ss, hlc.Timestamp{})

--- a/pkg/kv/kvserver/replica_consistency.go
+++ b/pkg/kv/kvserver/replica_consistency.go
@@ -712,7 +712,7 @@ func (r *Replica) computeChecksumPostApply(
 	// Caller is holding raftMu, so an engine snapshot is automatically
 	// Raft-consistent (i.e. not in the middle of an AddSSTable).
 	snap := r.store.StateEngine().NewSnapshot(rditer.MakeReplicatedKeySpans(&desc)...)
-	if util.RaceEnabled {
+	if spanset.EnableAssertions {
 		ss := rditer.MakeReplicatedKeySpanSet(&desc)
 		defer ss.Release()
 		snap = spanset.NewReader(snap, ss, hlc.Timestamp{})

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
@@ -227,7 +226,7 @@ func (r *Replica) GetSnapshot(
 	startKey := r.shMu.state.Desc.StartKey
 	spans := rditer.MakeReplicatedKeySpans(r.shMu.state.Desc)
 	snap := r.store.StateEngine().NewSnapshot(spans...)
-	if util.RaceEnabled {
+	if spanset.EnableAssertions {
 		ss := rditer.MakeReplicatedKeySpanSet(r.shMu.state.Desc)
 		defer ss.Release()
 		snap = spanset.NewReader(snap, ss, hlc.Timestamp{})

--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/admission"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -94,9 +93,8 @@ func (r *Replica) executeReadOnlyBatch(
 	if err := rw.PinEngineStateForIterators(readCategory); err != nil {
 		return nil, g, nil, kvpb.NewError(err)
 	}
-	if util.RaceEnabled {
-		spans := g.LatchSpans()
-		rw = spanset.NewReadWriterAt(rw, spans, ba.Timestamp)
+	if spanset.EnableAssertions {
+		rw = spanset.NewReadWriterAt(rw, g.LatchSpans(), ba.Timestamp)
 	}
 	defer rw.Close()
 

--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
@@ -808,14 +807,13 @@ func (r *Replica) newBatchedEngine(g *concurrency.Guard) (storage.Batch, *storag
 		opLogger = storage.NewOpLoggerBatch(batch)
 		batch = opLogger
 	}
-	if util.RaceEnabled {
+	if spanset.EnableAssertions {
 		// During writes we may encounter a versioned value newer than the request
 		// timestamp, and may have to retry at a higher timestamp. This is still
 		// safe as we're only ever writing at timestamps higher than the timestamp
 		// any write latch would be declared at. But because of this, we don't
 		// assert on access timestamps using spanset.NewBatchAt.
-		spans := g.LatchSpans()
-		batch = spanset.NewBatch(batch, spans)
+		batch = spanset.NewBatch(batch, g.LatchSpans())
 	}
 
 	return batch, opLogger

--- a/pkg/kv/kvserver/spanset/BUILD.bazel
+++ b/pkg/kv/kvserver/spanset/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/storage",
         "//pkg/storage/enginepb",
         "//pkg/storage/fs",
+        "//pkg/util",
         "//pkg/util/debugutil",
         "//pkg/util/hlc",
         "//pkg/util/log",

--- a/pkg/kv/kvserver/spanset/engine.go
+++ b/pkg/kv/kvserver/spanset/engine.go
@@ -12,10 +12,16 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/metrics"
 )
+
+// EnableAssertions is a convenient entry point to enable/disable spanset
+// assertions in all places that wrap storage types into spanset types. It also
+// helps discover all those places (users of this constant).
+const EnableAssertions = util.RaceEnabled
 
 // spanSetEngine wraps an Engine and asserts that it does not access spans that
 // do not belong to it.


### PR DESCRIPTION
Introduce a constant used everywhere in code where `spanset` assertions are enabled by wrapping `storage` types. This is convenient for bulk-enabling the assertions when needed (e.g. set it to `true` or bump from `util.RaceEnabled` to `buildutil.CrdbTestBuild`).

Part of #158281