### PR TITLE
bulkmerge: add opt-in logging for distributed merge iterations

### DIFF
--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -903,6 +903,7 @@ message IndexBackfillSSTManifest {
   uint64 file_size = 3;
   bytes row_sample = 4 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.Key"];
   util.hlc.Timestamp write_timestamp = 5;
+  uint64 key_count = 6;
 }
 
 // MergeProgress is used to track index merge progress in the declarative

--- a/pkg/sql/bulksst/combine_file_info.go
+++ b/pkg/sql/bulksst/combine_file_info.go
@@ -47,6 +47,7 @@ func CombineFileInfo(
 				StartKey: sst.StartKey,
 				EndKey:   sst.EndKey,
 				URI:      sst.URI,
+				KeyCount: sst.KeyCount,
 			})
 		}
 		for _, sample := range file.RowSamples {

--- a/pkg/sql/bulksst/sst_file_allocator.go
+++ b/pkg/sql/bulksst/sst_file_allocator.go
@@ -30,7 +30,7 @@ type FileAllocator interface {
 	AddFile(ctx context.Context) (objstorage.Writable, string, error)
 
 	// CommitFile records metadata for a successfully written SST file.
-	CommitFile(uri string, span roachpb.Span, rowSample roachpb.Key, fileSize uint64)
+	CommitFile(uri string, span roachpb.Span, rowSample roachpb.Key, fileSize uint64, keyCount uint64)
 
 	// GetFileList gets all the files created by this file allocator.
 	GetFileList() *SSTFiles
@@ -50,7 +50,7 @@ func (f *fileAllocatorBase) GetFileList() *SSTFiles {
 
 // addFile helps track metadata for created SST files.
 func (f *fileAllocatorBase) addFile(
-	uri string, span roachpb.Span, rowSample roachpb.Key, fileSize uint64,
+	uri string, span roachpb.Span, rowSample roachpb.Key, fileSize uint64, keyCount uint64,
 ) {
 	f.fileInfo.SST = append(f.fileInfo.SST, &SSTFileInfo{
 		URI:       uri,
@@ -58,6 +58,7 @@ func (f *fileAllocatorBase) addFile(
 		EndKey:    span.EndKey,
 		FileSize:  fileSize,
 		RowSample: rowSample,
+		KeyCount:  keyCount,
 	})
 	f.fileInfo.TotalSize += fileSize
 	f.recordRowSample(rowSample)
@@ -117,7 +118,7 @@ func (e *ExternalFileAllocator) AddFile(ctx context.Context) (objstorage.Writabl
 
 // CommitFile records metadata for a successfully written SST file.
 func (e *ExternalFileAllocator) CommitFile(
-	uri string, span roachpb.Span, rowSample roachpb.Key, fileSize uint64,
+	uri string, span roachpb.Span, rowSample roachpb.Key, fileSize uint64, keyCount uint64,
 ) {
-	e.fileAllocatorBase.addFile(uri, span, rowSample, fileSize)
+	e.fileAllocatorBase.addFile(uri, span, rowSample, fileSize, keyCount)
 }

--- a/pkg/sql/bulksst/sst_file_allocator_test.go
+++ b/pkg/sql/bulksst/sst_file_allocator_test.go
@@ -32,7 +32,7 @@ func TestRowSampleReservoirCapsSamples(t *testing.T) {
 		key := roachpb.Key(fmt.Sprintf("key-%04d", i))
 		expected[string(key)] = struct{}{}
 		span := roachpb.Span{Key: key, EndKey: key.Next()}
-		base.addFile(fmt.Sprintf("uri-%d", i), span, key, 1)
+		base.addFile(fmt.Sprintf("uri-%d", i), span, key, 1, 1)
 	}
 
 	require.Equal(t, total, base.totalRowSamples)
@@ -52,8 +52,8 @@ func TestRowSampleSkipsEmptyKeys(t *testing.T) {
 	key := roachpb.Key("some-key")
 	span := roachpb.Span{Key: key, EndKey: key.Next()}
 
-	base.addFile("uri-1", span, key, 1)
-	base.addFile("uri-2", span, nil, 1)
+	base.addFile("uri-1", span, key, 1, 1)
+	base.addFile("uri-2", span, nil, 1, 1)
 
 	require.Len(t, base.fileInfo.RowSamples, 1)
 	require.Equal(t, string(key), base.fileInfo.RowSamples[0])
@@ -95,9 +95,9 @@ func (m *mockFailingAllocator) AddFile(ctx context.Context) (objstorage.Writable
 }
 
 func (m *mockFailingAllocator) CommitFile(
-	uri string, span roachpb.Span, rowSample roachpb.Key, fileSize uint64,
+	uri string, span roachpb.Span, rowSample roachpb.Key, fileSize uint64, keyCount uint64,
 ) {
-	m.fileAllocatorBase.addFile(uri, span, rowSample, fileSize)
+	m.fileAllocatorBase.addFile(uri, span, rowSample, fileSize, keyCount)
 }
 
 type failingWritable struct {

--- a/pkg/sql/bulksst/sst_info.proto
+++ b/pkg/sql/bulksst/sst_info.proto
@@ -15,6 +15,7 @@ message SSTFileInfo {
     required bytes end_key = 3 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.Key"];
     required uint64 file_size = 4 [(gogoproto.nullable) = false];
     optional bytes row_sample = 5 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.Key"];
+    optional uint64 key_count = 6 [(gogoproto.nullable) = false];
 }
 
 message SSTFiles {

--- a/pkg/sql/bulksst/sst_writer.go
+++ b/pkg/sql/bulksst/sst_writer.go
@@ -65,6 +65,7 @@ func (s *Writer) SetWriteTS(ts hlc.Timestamp) {
 func (s *Writer) flushSST(ctx context.Context, span roachpb.Span, rowSample roachpb.Key) error {
 	// Allocate a new file in storage.
 	fileSize := uint64(len(s.kvData))
+	keyCount := uint64(len(s.kv))
 	sstFile, uri, err := s.fileAllocator.AddFile(ctx)
 	if err != nil {
 		return err
@@ -82,7 +83,7 @@ func (s *Writer) flushSST(ctx context.Context, span roachpb.Span, rowSample roac
 	if err != nil {
 		return err
 	}
-	s.fileAllocator.CommitFile(uri, span, rowSample, fileSize)
+	s.fileAllocator.CommitFile(uri, span, rowSample, fileSize, keyCount)
 	return nil
 }
 

--- a/pkg/sql/bulksst/sst_writer_test.go
+++ b/pkg/sql/bulksst/sst_writer_test.go
@@ -138,7 +138,7 @@ func (f *fakeFileAllocator) AddFile(ctx context.Context) (objstorage.Writable, s
 }
 
 func (f *fakeFileAllocator) CommitFile(
-	uri string, span roachpb.Span, rowSample roachpb.Key, fileSize uint64,
+	uri string, span roachpb.Span, rowSample roachpb.Key, fileSize uint64, keyCount uint64,
 ) {
 	f.spans = append(f.spans, span)
 }

--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -620,6 +620,8 @@ message BulkMergeSpec {
     optional bytes start_key = 2 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.Key"];
     // end_key is the last key in the SST.
     optional bytes end_key = 3 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.Key"];
+    // key_count is the number of keys in this SST file.
+    optional uint64 key_count = 4 [(gogoproto.nullable) = false];
   };
 
   // ssts is the list of input SSTs to merge.

--- a/pkg/sql/index_backfiller.go
+++ b/pkg/sql/index_backfiller.go
@@ -384,6 +384,7 @@ func (ib *IndexBackfillPlanner) runDistributedMerge(
 			EndKey:    append(roachpb.Key(nil), manifest.Span.EndKey...),
 			FileSize:  manifest.FileSize,
 			RowSample: append(roachpb.Key(nil), manifest.RowSample...),
+			KeyCount:  manifest.KeyCount,
 		})
 		if len(manifest.RowSample) > 0 {
 			rowSamples = append(rowSamples, string(manifest.RowSample))
@@ -486,8 +487,9 @@ func (ib *IndexBackfillPlanner) runDistributedMerge(
 				EndKey: append([]byte(nil), sst.EndKey...),
 			}
 			newManifests = append(newManifests, jobspb.IndexBackfillSSTManifest{
-				URI:  sst.URI,
-				Span: &span,
+				URI:      sst.URI,
+				Span:     &span,
+				KeyCount: sst.KeyCount,
 			})
 		}
 		progress.SSTManifests = newManifests

--- a/pkg/sql/rowexec/indexbackfiller_sst_sink.go
+++ b/pkg/sql/rowexec/indexbackfiller_sst_sink.go
@@ -124,6 +124,7 @@ func (s *sstIndexBackfillSink) collectNewManifests() []jobspb.IndexBackfillSSTMa
 			FileSize:       f.FileSize,
 			RowSample:      append(roachpb.Key(nil), f.RowSample...),
 			WriteTimestamp: &ts,
+			KeyCount:       f.KeyCount,
 		}
 		outputs = append(outputs, output)
 	}

--- a/pkg/sql/rowexec/indexbackfiller_sst_sink_test.go
+++ b/pkg/sql/rowexec/indexbackfiller_sst_sink_test.go
@@ -107,7 +107,7 @@ func (m *manifestTrackingAllocator) AddFile(
 }
 
 func (m *manifestTrackingAllocator) CommitFile(
-	uri string, span roachpb.Span, rowSample roachpb.Key, fileSize uint64,
+	uri string, span roachpb.Span, rowSample roachpb.Key, fileSize uint64, keyCount uint64,
 ) {
 	m.files.SST = append(m.files.SST, &bulksst.SSTFileInfo{
 		URI:       uri,
@@ -115,6 +115,7 @@ func (m *manifestTrackingAllocator) CommitFile(
 		EndKey:    append([]byte(nil), span.EndKey...),
 		FileSize:  fileSize,
 		RowSample: append([]byte(nil), rowSample...),
+		KeyCount:  keyCount,
 	})
 	m.files.RowSamples = append(m.files.RowSamples, string(rowSample))
 }


### PR DESCRIPTION
Add logging to improve visibility into distributed merge operations. The logging is opt-in via log.V(2) (enabled with --vmodule=merge=2) and displays per-iteration details about the SSTs involved.

To support this, a KeyCount field was added to the SST manifests. This enhancement proved useful during debugging and is retained as a general improvement for future diagnostics.

Informs: #160478
Epic: CRDB-48845
Release note: none