### PR TITLE
sql: row count tables without regard to secondary indexes

### DIFF
--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -368,6 +368,15 @@ func (r *importResumer) Resume(ctx context.Context, execCtx interface{}) error {
 				return err
 			}
 			tableName = tblDesc.GetName()
+
+			// TODO(bghal): Get the initial row count so it can be included in the expected.
+			if !details.Table.WasEmpty {
+				log.Eventf(ctx, "skipping row count check on table %q: non-empty tables are not supported", tableName)
+
+				checks, err = inspect.ChecksForTable(ctx, nil /* p */, tblDesc, nil /* expectedRowCount */)
+				return err
+			}
+
 			expectedRowCount := uint64(r.res.Rows)
 			checks, err = inspect.ChecksForTable(ctx, nil /* p */, tblDesc, &expectedRowCount)
 			return err

--- a/pkg/sql/inspect/inspect_job_entry.go
+++ b/pkg/sql/inspect/inspect_job_entry.go
@@ -136,27 +136,12 @@ func ChecksForTable(
 	}
 
 	if expectedRowCount != nil {
-		var includesRowCounterCheck bool
-		for _, check := range checks {
-			switch check.Type {
-			case jobspb.InspectCheckIndexConsistency:
-				includesRowCounterCheck = true
-			}
-		}
-
-		// If none of the previous checks provide a row count, skip the check.
-		if includesRowCounterCheck {
-			checks = append(checks, &jobspb.InspectDetails_Check{
-				Type:     jobspb.InspectCheckRowCount,
-				TableID:  table.GetID(),
-				RowCount: *expectedRowCount,
-			})
-		} else {
-			if p != nil {
-				p.BufferClientNotice(ctx, pgnotice.Newf(
-					"skipping row count on table %q: no other checks provide a row count", table.GetName()))
-			}
-		}
+		checks = append(checks, &jobspb.InspectDetails_Check{
+			Type:         jobspb.InspectCheckRowCount,
+			TableID:      table.GetID(),
+			TableVersion: table.GetVersion(),
+			RowCount:     *expectedRowCount,
+		})
 	}
 
 	return checks, nil

--- a/pkg/sql/inspect/row_count_check.go
+++ b/pkg/sql/inspect/row_count_check.go
@@ -7,14 +7,18 @@ package inspect
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/inspect/inspectpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
@@ -28,7 +32,7 @@ type inspectCheckRowCount interface {
 }
 
 // rowCountCheck verifies a table's row count matches the expected count.
-// It relies on other jobs to perform the row count.
+// It uses row counts exposed by other checks when possible.
 type rowCountCheck struct {
 	rowCountCheckApplicability
 
@@ -119,6 +123,7 @@ func (c *rowCountCheck) CheckSpan(
 	logger *inspectLoggerBundle,
 	data *inspectpb.InspectProcessorSpanCheckData,
 ) error {
+	// Find the row count among the registered checks.
 	for _, check := range checks {
 		// TODO(#160989): Handle inconsistency btwn checks on the same span.
 		if check, ok := check.(inspectCheckRowCount); ok {
@@ -127,7 +132,33 @@ func (c *rowCountCheck) CheckSpan(
 		}
 	}
 
-	return errors.AssertionFailedf("rowCountCheck requires an inspectCheckRowCount to be registered")
+	// If none of the checks provide a row count, do the count on the primary index.
+	tableDesc, err := loadTableDesc(ctx, c.execCfg, c.tableID, c.tableVersion, c.asOf)
+	if err != nil {
+		return err
+	}
+	c.tableDesc = tableDesc
+
+	predicate, queryArgs, err := getPredicateAndQueryArgs(
+		ctx,
+		&c.execCfg.DistSQLSrv.ServerConfig,
+		span,
+		c.tableDesc,
+		c.tableDesc.GetPrimaryIndex(),
+		c.asOf,
+		c.tableDesc.TableDesc().PrimaryIndex.KeyColumnNames,
+	)
+	if err != nil {
+		return err
+	}
+
+	rowCount, err := c.computeRowCount(ctx, predicate, queryArgs)
+	if err != nil {
+		return err
+	}
+	data.SpanRowCount = uint64(rowCount)
+
+	return nil
 }
 
 // StartedCluster implements the inspectClusterCheck interface.
@@ -185,4 +216,49 @@ func (c *rowCountCheck) DoneCluster(ctx context.Context) bool {
 // CloseCluster implements the inspectClusterCheck interface.
 func (c *rowCountCheck) CloseCluster(ctx context.Context) error {
 	return nil
+}
+
+// computeRowCount executes a row count query for the primary index and returns
+// the row count.
+func (c *rowCountCheck) computeRowCount(
+	ctx context.Context, predicate string, queryArgs []interface{},
+) (int64, error) {
+	query := c.buildRowCountQuery(c.tableDesc.GetID(), c.tableDesc.GetPrimaryIndex(), predicate)
+	queryWithAsOf := fmt.Sprintf("SELECT * FROM (%s) AS OF SYSTEM TIME %s", query, c.asOf.AsOfSystemTime())
+
+	qos := getInspectQoS(&c.execCfg.Settings.SV)
+	row, err := c.execCfg.DistSQLSrv.DB.Executor().QueryRowEx(
+		ctx, "inspect-row-count", nil, /* txn */
+		sessiondata.InternalExecutorOverride{
+			User:             username.NodeUserName(),
+			QualityOfService: &qos,
+		},
+		queryWithAsOf,
+		queryArgs...,
+	)
+	if err != nil {
+		return 0, err
+	}
+	if row == nil {
+		return 0, errors.AssertionFailedf("row count query returned no rows")
+	}
+	if len(row) != 1 {
+		return 0, errors.AssertionFailedf("row count query returned unexpected column count: %d", len(row))
+	}
+	return int64(tree.MustBeDInt(row[0])), nil
+}
+
+// buildRowCountQuery constructs a query that computes row count for the specified index.
+func (c *rowCountCheck) buildRowCountQuery(
+	tableID descpb.ID, index catalog.Index, predicate string,
+) string {
+	whereClause := buildWhereClause(predicate, nil /* nullFilters */)
+	return fmt.Sprintf(`
+SELECT
+  count(*) AS row_count
+FROM [%d AS t]@{FORCE_INDEX=[%d]}%s`,
+		tableID,
+		index.GetID(),
+		whereClause,
+	)
 }

--- a/pkg/sql/inspect/row_count_check_test.go
+++ b/pkg/sql/inspect/row_count_check_test.go
@@ -34,79 +34,176 @@ func TestRowCountCheck(t *testing.T) {
 	execCfg := s.ApplicationLayer().ExecutorConfig().(sql.ExecutorConfig)
 	r := sqlutils.MakeSQLRunner(db)
 
-	// Create a table and populate it with 100 rows.
-	r.ExecMultiple(t,
-		`CREATE DATABASE test`,
-		`CREATE TABLE test.t (id INT PRIMARY KEY, INDEX idx (id))`,
-		`INSERT INTO test.t SELECT * FROM generate_series(1, 100)`,
-	)
+	r.Exec(t, `CREATE DATABASE test`)
 
-	// Get the table descriptor
-	tableDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, codec, "test", "t")
+	testCases := []struct {
+		name               string
+		createTableStmts   []string // statements to create and populate the table
+		skipTablePopulate  bool     // if true, do not populate the table with data
+		expectedCheckCount int      // expected number of checks from ChecksForTable
+	}{
+		{
+			name:               "primary_index_only",
+			createTableStmts:   []string{`CREATE TABLE test.t (id INT PRIMARY KEY)`},
+			expectedCheckCount: 1,
+		},
+		{
+			name:               "with_secondary_index",
+			createTableStmts:   []string{`CREATE TABLE test.t (id INT PRIMARY KEY, INDEX idx (id))`},
+			expectedCheckCount: 2,
+		},
+		{
+			name:               "with_unsupported_index_type",
+			createTableStmts:   []string{`CREATE TABLE test.t (id INT PRIMARY KEY, data JSONB DEFAULT '{}'::JSONB, INVERTED INDEX idx (data))`},
+			expectedCheckCount: 1,
+		},
+		{
+			name:               "hash_sharded_primary_index_only",
+			createTableStmts:   []string{`CREATE TABLE test.t (id INT PRIMARY KEY USING HASH)`},
+			expectedCheckCount: 1,
+		},
+		{
+			name:               "hash_sharded_primary_index_with_secondary_index",
+			createTableStmts:   []string{`CREATE TABLE test.t (id INT PRIMARY KEY USING HASH, INDEX idx (id))`},
+			expectedCheckCount: 2,
+		},
+		{
+			name:               "empty_table",
+			createTableStmts:   []string{`CREATE TABLE test.t (id INT PRIMARY KEY)`},
+			skipTablePopulate:  true,
+			expectedCheckCount: 1,
+		},
+		{
+			name: "multiple_spans",
+			createTableStmts: []string{
+				`CREATE TABLE test.t (id INT PRIMARY KEY)`,
+				`ALTER TABLE test.t SPLIT AT VALUES (33), (36)`},
+			expectedCheckCount: 1,
+		},
+	}
 
-	// Create checks for the table with expected row count of 105 which will
-	// report an error.
-	badExpectedRowCount := uint64(105)
-	checks, err := ChecksForTable(ctx, nil /* PlanHookState */, tableDesc, &badExpectedRowCount)
-	require.NoError(t, err)
-	require.Len(t, checks, 2)
+	for _, tc := range testCases {
+		expectedCheckCount := tc.expectedCheckCount
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a table and populate it with 100 rows.
+			actualRowCount := uint64(100)
+			var stmts []string
+			stmts = append(stmts, tc.createTableStmts...)
+			if !tc.skipTablePopulate {
+				stmts = append(stmts, `INSERT INTO test.t SELECT * FROM generate_series(1, 100)`)
+			} else {
+				actualRowCount = 0
+			}
 
-	// Get a timestamp for AS OF SYSTEM TIME
-	var timestampStr string
-	r.QueryRow(t, "SELECT cluster_logical_timestamp()::STRING").Scan(&timestampStr)
-	asOfTimestamp, err := hlc.ParseHLC(timestampStr)
-	require.NoError(t, err)
+			r.ExecMultiple(t,
+				stmts...,
+			)
+			defer r.Exec(t, `DROP TABLE test.t`)
 
-	// Trigger the inspect job directly
-	job, err := TriggerJob(
-		ctx,
-		"test row count check",
-		&execCfg,
-		checks,
-		asOfTimestamp,
-	)
-	require.NoError(t, err)
-	require.NotNil(t, job)
+			// Get the table descriptor
+			tableDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, codec, "test", "t")
 
-	// Wait for the job to complete
-	err = job.AwaitCompletion(ctx)
-	require.Error(t, err, "inspect job should error on the row count mismatch")
+			// badExpectedRowCount is a deliberately wrong value used by the
+			// "mismatch" sub-test to trigger a row count error.
+			badExpectedRowCount := uint64(105)
 
-	// Verify the job succeeded
-	var jobStatus string
-	var fractionCompleted float64
-	r.QueryRow(t,
-		`SELECT status, fraction_completed FROM [SHOW JOBS] WHERE job_type = 'INSPECT' ORDER BY created DESC LIMIT 1`,
-	).Scan(&jobStatus, &fractionCompleted)
-	require.Equal(t, "failed", jobStatus, "inspect job should fail with mismatching row count")
-	require.InEpsilon(t, 1.0, fractionCompleted, 0.01, "progress should reach 100% on successful completion")
+			matchCases := []struct {
+				name             string
+				expectedRowCount uint64
+			}{
+				{
+					name:             "match",
+					expectedRowCount: actualRowCount,
+				},
+				{
+					name:             "mismatch",
+					expectedRowCount: badExpectedRowCount,
+				},
+			}
 
-	// Query the inspect_errors table to verify a row count mismatch issue was reported
-	// There should be exactly one error (row count checks produce one error per table)
-	var errorType string
-	var databaseName, schemaName, tableName, primaryKey, aost, details string
-	var jobID int64
-	var errorCount int
-	r.QueryRow(t,
-		fmt.Sprintf(`SELECT count(*) FROM [SHOW INSPECT ERRORS FOR JOB %d]`, job.ID()),
-	).Scan(&errorCount)
-	require.Equal(t, 1, errorCount, "should have exactly one row count mismatch error")
+			for _, tc := range matchCases {
+				t.Run(tc.name, func(t *testing.T) {
+					checks, err := ChecksForTable(ctx, nil /* PlanHookState */, tableDesc, &tc.expectedRowCount)
+					require.NoError(t, err)
+					require.Len(t, checks, expectedCheckCount)
 
-	r.QueryRow(t,
-		fmt.Sprintf(`SHOW INSPECT ERRORS FOR JOB %d WITH DETAILS`, job.ID()),
-	).Scan(&errorType, &databaseName, &schemaName, &tableName, &primaryKey, &jobID, &aost, &details)
+					// Get a timestamp for AS OF SYSTEM TIME
+					var timestampStr string
+					r.QueryRow(t, "SELECT cluster_logical_timestamp()::STRING").Scan(&timestampStr)
+					asOfTimestamp, err := hlc.ParseHLC(timestampStr)
+					require.NoError(t, err)
 
-	require.Equal(t, string(RowCountMismatch), errorType)
-	require.Equal(t, "test", databaseName, "issue should reference the correct database")
-	require.Equal(t, "public", schemaName, "issue should reference the correct schema")
-	require.Equal(t, "t", tableName, "issue should reference the correct table")
+					// Trigger the inspect job directly
+					job, err := TriggerJob(
+						ctx,
+						"test row count check",
+						&execCfg,
+						checks,
+						asOfTimestamp,
+					)
+					require.NoError(t, err)
+					require.NotNil(t, job)
 
-	// Parse the details JSON to verify expected and actual counts
-	var detailsMap map[string]interface{}
-	err = json.Unmarshal([]byte(details), &detailsMap)
-	require.NoError(t, err, "details should be valid JSON")
-	require.Contains(t, detailsMap, "expected", "details should contain expected count")
-	require.Contains(t, detailsMap, "actual", "details should contain actual count")
-	require.Equal(t, float64(badExpectedRowCount), detailsMap["expected"], "expected count should match")
-	require.Equal(t, float64(100), detailsMap["actual"], "actual count should be 100")
+					expectedSuccess := tc.expectedRowCount == actualRowCount
+
+					// Wait for the job to complete
+					err = job.AwaitCompletion(ctx)
+					if expectedSuccess {
+						require.NoError(t, err, "inspect job should complete successfully")
+					} else {
+						require.Error(t, err, "inspect job should error on the row count mismatch")
+					}
+
+					// Verify the job succeeded
+					var jobStatus string
+					var fractionCompleted float64
+					r.QueryRow(t,
+						`SELECT status, fraction_completed FROM [SHOW JOBS] WHERE job_id = $1`,
+						job.ID(),
+					).Scan(&jobStatus, &fractionCompleted)
+					if expectedSuccess {
+						require.Equal(t, "succeeded", jobStatus, "inspect job should complete successfully")
+					} else {
+						require.Equal(t, "failed", jobStatus, "inspect job should fail with mismatching row count")
+					}
+					require.InEpsilon(t, 1.0, fractionCompleted, 0.01, "progress should reach 100% on successful completion")
+
+					// Query the inspect_errors table to verify a row count mismatch
+					// issue was reported. There should be exactly zero or one errors:
+					// Row count checks produce one error per table.
+					var errorType string
+					var databaseName, schemaName, tableName, primaryKey, aost, details string
+					var jobID int64
+					var errorCount int
+					r.QueryRow(t,
+						fmt.Sprintf(`SELECT count(*) FROM [SHOW INSPECT ERRORS FOR JOB %d]`, job.ID()),
+					).Scan(&errorCount)
+					if expectedSuccess {
+						require.Equal(t, 0, errorCount, "should be no row count mismatch errors")
+						return
+					} else {
+						require.Equal(t, 1, errorCount, "should have exactly one row count mismatch error")
+					}
+
+					r.QueryRow(t,
+						fmt.Sprintf(`SHOW INSPECT ERRORS FOR JOB %d WITH DETAILS`, job.ID()),
+					).Scan(&errorType, &databaseName, &schemaName, &tableName, &primaryKey, &jobID, &aost, &details)
+
+					require.Equal(t, string(RowCountMismatch), errorType)
+					require.Equal(t, "test", databaseName, "issue should reference the correct database")
+					require.Equal(t, "public", schemaName, "issue should reference the correct schema")
+					require.Equal(t, "t", tableName, "issue should reference the correct table")
+
+					// Parse the details JSON to verify expected and actual counts
+					var detailsMap map[string]interface{}
+					err = json.Unmarshal([]byte(details), &detailsMap)
+					require.NoError(t, err, "details should be valid JSON")
+					require.Contains(t, detailsMap, "expected", "details should contain expected count")
+					require.Contains(t, detailsMap, "actual", "details should contain actual count")
+					require.Equal(t, float64(badExpectedRowCount), detailsMap["expected"], "expected count should match")
+					require.Equal(t, float64(actualRowCount), detailsMap["actual"], "actual count should match")
+				})
+			}
+		})
+	}
 }


### PR DESCRIPTION
The row count check depends on the index consistency check to perform
the actual scans. As such, it inherits the same limitations: Tables
without supported secondary indexes (e.g., those with only a primary
index or with only unsupported secondary indexes) or with a hash-sharded
primary index are not supported. This change adds a fallback row count
to the check; the other checks are still used where possible as an
optimization.

Fixes: #161276

Epic: CRDB-58692
Part of: #154551

Part of: #155472
Part of: #161279

Release note: None

**Note**: Has stacked PRs/commits.