### PR TITLE
backup: skip `TestRestoreAsOfSystemTimeGCBounds`

### DIFF
--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -3866,6 +3866,8 @@ func TestRestoreAsOfSystemTimeGCBounds(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	skip.WithIssue(t, 161220)
+
 	const numAccounts = 10
 	ctx := context.Background()
 	args := base.TestClusterArgs{}


### PR DESCRIPTION
This test has become very flaky. See #161220.

Release note: none
Epic: none