### PR TITLE
restore: teach restore to use backup IDs

### DIFF
--- a/pkg/sql/sem/tree/backup.go
+++ b/pkg/sql/sem/tree/backup.go
@@ -151,6 +151,8 @@ type Restore struct {
 	// Subdir may be set by the parser when the SQL query is of the form `RESTORE
 	// ... FROM 'subdir' IN 'from'...`. Alternatively, restore_planning.go will set
 	// it for the query `RESTORE ... FROM LATEST IN 'from'...`
+	// TODO (kev-cao): Once we fully switch to using backup IDs (or LATEST) for
+	// RESTORE, come back and rename this field. (BackupToken?)
 	Subdir Expr
 }
 


### PR DESCRIPTION
This patch teaches restore to use backup IDs to determine which backups
to restore.

Epic: CRDB-57536
Resolves: #159649

Release note (sql change): If the `use_backups_with_ids` session variable is set, the new `RESTORE` experience will be enabled. `RESTORE` will be able to parse the IDs provided by `SHOW BACKUPS` and will restore the specified backup without the use of `AS OF SYSTEM TIME`.