### PR TITLE
release-25.4: workload/roachtest: add a gopg test to the ignore list

### DIFF
--- a/pkg/cmd/roachtest/tests/gopg_blocklist.go
+++ b/pkg/cmd/roachtest/tests/gopg_blocklist.go
@@ -33,6 +33,7 @@ var gopgBlockList = blocklist{
 }
 
 var gopgIgnoreList = blocklist{
+	`pg | BeforeQuery and AfterQuery CopyFrom | is called for CopyFrom with model`: "unknown",
 	// These "fetching" tests assume a particular order when ORDER BY clause is
 	// omitted from the query by the ORM itself.
 	"pg | ORM slice model | fetches Book relations":       "41690",


### PR DESCRIPTION
Backport 1/1 commits from #158049 on behalf of @spilchen.

----

We have seen this test fail every once in a while:
```
pg | BeforeQuery and AfterQuery CopyFrom | is called for CopyFrom with model
```

Adding this to the ignore list to tolerate the occasional failure.

Closes #157873
Release note: none

----

Release justification: test only change