### PR TITLE
release-25.4: team: route sqlproxy-prs test failures to T-cloud-platform

### DIFF
--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -8,9 +8,10 @@ cockroachdb/docs:
 cockroachdb/sql-foundations:
   aliases:
     cockroachdb/sql-syntax-prs: other
-    cockroachdb/sqlproxy-prs: other
     cockroachdb/sql-api-prs: other
   label: T-sql-foundations
+cockroachdb/sqlproxy-prs:
+  label: T-cloud-platform
 cockroachdb/sql-queries:
   aliases:
     cockroachdb/sql-queries-prs: other


### PR DESCRIPTION
Backport 1/1 commits from #161193.

/cc @cockroachdb/release

---

Previously, test failures in pkg/ccl/sqlproxyccl were being routed to the SQL Foundations team (T-sql-foundations) because sqlproxy-prs was listed as an alias of sql-foundations in TEAMS.yaml.

This change makes sqlproxy-prs a standalone team entry with the T-cloud-platform label, so test failures are now routed to the appropriate team.

See thread: https://cockroachlabs.slack.com/archives/C05B1BPMJLE/p1766175208508169?thread_ts=1766174662.243349&cid=C05B1BPMJLE

Epic: None
Release note: None

Release justification: non-code changes
