### PR TITLE
release-26.1: sql: fix hint injection for EXPLAIN ANALYZE

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -531,6 +531,9 @@ func (ex *connExecutor) execStmtInOpenState(
 		// Strip off the explain node to execute the inner statement.
 		stmt.AST = e.Statement
 		ast = e.Statement
+		if e2, ok := stmt.ASTWithInjectedHints.(*tree.ExplainAnalyze); ok {
+			stmt.ASTWithInjectedHints = e2.Statement
+		}
 		// TODO(radu): should we trim the "EXPLAIN ANALYZE (DEBUG)" part from
 		// stmt.SQL?
 
@@ -1433,6 +1436,9 @@ func (ex *connExecutor) execStmtInOpenStateWithPausablePortal(
 		// Strip off the explain node to execute the inner statement.
 		vars.stmt.AST = e.Statement
 		vars.ast = e.Statement
+		if e2, ok := vars.stmt.ASTWithInjectedHints.(*tree.ExplainAnalyze); ok {
+			vars.stmt.ASTWithInjectedHints = e2.Statement
+		}
 		// TODO(radu): should we trim the "EXPLAIN ANALYZE (DEBUG)" part from
 		// stmt.SQL?
 

--- a/pkg/sql/logictest/testdata/logic_test/statement_hint_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/statement_hint_builtins
@@ -2,11 +2,33 @@
 # cluster-opt: disable-mvcc-range-tombstones-for-point-deletes
 # knob-opt: sync-event-log
 
+# TODO(michae2): move explain tests into execbuilder
+
+# Speed up the rangefeed.
+user host-cluster-root
+
+statement ok
+SET CLUSTER SETTING kv.closed_timestamp.target_duration = '50ms';
+
+statement ok
+SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '50ms';
+
+statement ok
+SET CLUSTER SETTING kv.rangefeed.closed_timestamp_refresh_interval = '50ms';
+
+user root
+
 statement ok
 CREATE TABLE xy (x INT PRIMARY KEY, y INT, INDEX (y));
 
 statement ok
 CREATE TABLE ab (a INT PRIMARY KEY, b INT, INDEX (b));
+
+statement ok
+INSERT INTO xy VALUES (10, 10)
+
+statement ok
+INSERT INTO ab VALUES (10, 10)
 
 query I
 SELECT count(*) FROM system.statement_hints;
@@ -300,6 +322,44 @@ statement hints count: 1
       table: abc@abc_b_idx
       spans: FULL SCAN
 
+onlyif config local
+query T
+EXPLAIN ANALYZE SELECT a FROM abc WHERE a = 10
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: custom
+statement hints count: 1
+maximum memory usage: <hidden>
+DistSQL network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• filter
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ execution time: 0µs
+│ filter: a = 10
+│
+└── • scan
+      sql nodes: <hidden>
+      kv nodes: <hidden>
+      regions: <hidden>
+      actual row count: 0
+      KV time: 0µs
+      KV rows decoded: 0
+      KV bytes read: 0 B
+      KV gRPC calls: 0
+      estimated max memory allocated: 0 B
+      missing stats
+      table: abc@abc_b_idx
+      spans: FULL SCAN
+
 # Try injecting a join hint.
 
 onlyif config local
@@ -366,6 +426,62 @@ statement hints count: 1
       table: xy@xy_pkey
       spans: FULL SCAN
 
+onlyif config local
+query T
+EXPLAIN ANALYZE SELECT a, x FROM abc JOIN xy ON y = b WHERE a = 10
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: custom
+statement hints count: 1
+rows decoded from KV: 1 (8 B, 2 KVs, 1 gRPC calls)
+maximum memory usage: <hidden>
+DistSQL network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• hash join
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ execution time: 0µs
+│ estimated max memory allocated: 0 B
+│ equality: (b) = (y)
+│ left cols are key
+│
+├── • scan
+│     sql nodes: <hidden>
+│     kv nodes: <hidden>
+│     regions: <hidden>
+│     actual row count: 0
+│     KV time: 0µs
+│     KV rows decoded: 0
+│     KV bytes read: 0 B
+│     KV gRPC calls: 0
+│     estimated max memory allocated: 0 B
+│     missing stats
+│     table: abc@abc_pkey
+│     spans: [/10 - /10]
+│
+└── • scan
+      sql nodes: <hidden>
+      kv nodes: <hidden>
+      regions: <hidden>
+      actual row count: 1
+      KV time: 0µs
+      KV rows decoded: 1
+      KV pairs read: 2
+      KV bytes read: 8 B
+      KV gRPC calls: 1
+      estimated max memory allocated: 0 B
+      missing stats
+      table: xy@xy_pkey
+      spans: FULL SCAN
+
 # Try removing a hint.
 
 statement ok
@@ -403,6 +519,37 @@ vectorized: true
 statement hints count: 1
 ·
 • scan
+  missing stats
+  table: abc@abc_b_idx
+  spans: [/10 - /10]
+
+onlyif config local
+query T
+EXPLAIN ANALYZE SELECT a FROM abc@abc_pkey WHERE b = 10
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: custom
+statement hints count: 1
+maximum memory usage: <hidden>
+DistSQL network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• scan
+  sql nodes: <hidden>
+  kv nodes: <hidden>
+  regions: <hidden>
+  actual row count: 0
+  KV time: 0µs
+  KV rows decoded: 0
+  KV bytes read: 0 B
+  KV gRPC calls: 0
+  estimated max memory allocated: 0 B
   missing stats
   table: abc@abc_b_idx
   spans: [/10 - /10]
@@ -448,6 +595,39 @@ statement hints count: 1
 • render
 │
 └── • scan
+      missing stats
+      table: abc@abc_pkey
+      spans: [/10 - /10]
+
+onlyif config local
+query T
+EXPLAIN ANALYZE SELECT a + 1 FROM abc WHERE a = 10
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: custom
+statement hints count: 1
+maximum memory usage: <hidden>
+DistSQL network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• render
+│
+└── • scan
+      sql nodes: <hidden>
+      kv nodes: <hidden>
+      regions: <hidden>
+      actual row count: 0
+      KV time: 0µs
+      KV rows decoded: 0
+      KV bytes read: 0 B
+      KV gRPC calls: 0
+      estimated max memory allocated: 0 B
       missing stats
       table: abc@abc_pkey
       spans: [/10 - /10]
@@ -504,6 +684,62 @@ statement hints count: 1
       table: xy@xy_pkey
       spans: [/10 - /10]
 
+onlyif config local
+query T
+EXPLAIN ANALYZE SELECT c FROM xy JOIN abc ON c = y WHERE x = 10
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, re-optimized
+statement hints count: 1
+rows decoded from KV: 1 (8 B, 2 KVs, 1 gRPC calls)
+maximum memory usage: <hidden>
+DistSQL network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• hash join
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ execution time: 0µs
+│ estimated max memory allocated: 0 B
+│ equality: (c) = (y)
+│ right cols are key
+│
+├── • scan
+│     sql nodes: <hidden>
+│     kv nodes: <hidden>
+│     regions: <hidden>
+│     actual row count: 0
+│     KV time: 0µs
+│     KV rows decoded: 0
+│     KV bytes read: 0 B
+│     KV gRPC calls: 0
+│     estimated max memory allocated: 0 B
+│     missing stats
+│     table: abc@abc_pkey
+│     spans: FULL SCAN
+│
+└── • scan
+      sql nodes: <hidden>
+      kv nodes: <hidden>
+      regions: <hidden>
+      actual row count: 1
+      KV time: 0µs
+      KV rows decoded: 1
+      KV pairs read: 2
+      KV bytes read: 8 B
+      KV gRPC calls: 1
+      estimated max memory allocated: 0 B
+      missing stats
+      table: xy@xy_pkey
+      spans: [/10 - /10]
+
 # Try a prepared statement with an injected hint.
 
 let $hint_p1
@@ -536,6 +772,44 @@ injected hints from external statement hint x
 injected hints from external statement hint x
 trying preparing with injected hints
 trying planning with injected hints
+
+onlyif config local
+query T
+EXPLAIN ANALYZE EXECUTE p1 (5)
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: custom
+statement hints count: 1
+maximum memory usage: <hidden>
+DistSQL network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• filter
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ execution time: 0µs
+│ filter: b > 5
+│
+└── • scan
+      sql nodes: <hidden>
+      kv nodes: <hidden>
+      regions: <hidden>
+      actual row count: 0
+      KV time: 0µs
+      KV rows decoded: 0
+      KV bytes read: 0 B
+      KV gRPC calls: 0
+      estimated max memory allocated: 0 B
+      missing stats
+      table: abc@abc_pkey
+      spans: FULL SCAN
 
 # Try injecting a hint between prepare and execute.
 
@@ -579,6 +853,46 @@ WHERE message LIKE '%injected hints%'
 injected hints from external statement hint x
 trying planning with injected hints
 
+onlyif config local
+query T
+EXPLAIN ANALYZE EXECUTE p2 (5)
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: custom
+statement hints count: 1
+maximum memory usage: <hidden>
+DistSQL network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• render
+│
+└── • filter
+    │ sql nodes: <hidden>
+    │ regions: <hidden>
+    │ actual row count: 0
+    │ execution time: 0µs
+    │ filter: b > 5
+    │
+    └── • revscan
+          sql nodes: <hidden>
+          kv nodes: <hidden>
+          regions: <hidden>
+          actual row count: 0
+          KV time: 0µs
+          KV rows decoded: 0
+          KV bytes read: 0 B
+          KV gRPC calls: 0
+          estimated max memory allocated: 0 B
+          missing stats
+          table: abc@abc_pkey
+          spans: FULL SCAN
+
 # Try removing an injected hint between prepare and execute.
 
 # (Re-use p1.)
@@ -601,6 +915,43 @@ query empty
 SELECT regexp_replace(split_part(message, ': SELECT', 1), E'\\d+', 'x')
 FROM [SHOW TRACE FOR SESSION]
 WHERE message LIKE '%injected hints%'
+
+onlyif config local
+query T
+EXPLAIN ANALYZE EXECUTE p1 (6)
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: custom
+maximum memory usage: <hidden>
+DistSQL network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• filter
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ execution time: 0µs
+│ filter: b > 6
+│
+└── • scan
+      sql nodes: <hidden>
+      kv nodes: <hidden>
+      regions: <hidden>
+      actual row count: 0
+      KV time: 0µs
+      KV rows decoded: 0
+      KV bytes read: 0 B
+      KV gRPC calls: 0
+      estimated max memory allocated: 0 B
+      missing stats
+      table: abc@abc_pkey
+      spans: FULL SCAN
 
 # Check that we do not use an invalid index hint injected into a prepared
 # statement.
@@ -640,6 +991,50 @@ trying planning with injected hints
 planning with injected hints failed with: index "abc_foo" not found
 falling back to planning without injected hints
 
+onlyif config local
+query T
+EXPLAIN ANALYZE EXECUTE p3 (5)
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: custom
+statement hints count: 1
+maximum memory usage: <hidden>
+DistSQL network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• group (scalar)
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 1
+│ execution time: 0µs
+│
+└── • filter
+    │ sql nodes: <hidden>
+    │ regions: <hidden>
+    │ actual row count: 0
+    │ execution time: 0µs
+    │ filter: c = 5
+    │
+    └── • scan
+          sql nodes: <hidden>
+          kv nodes: <hidden>
+          regions: <hidden>
+          actual row count: 0
+          KV time: 0µs
+          KV rows decoded: 0
+          KV bytes read: 0 B
+          KV gRPC calls: 0
+          estimated max memory allocated: 0 B
+          missing stats
+          table: abc@abc_pkey
+          spans: FULL SCAN
+
 # Check that we do not use an unsatisfiable hint injected into a prepared
 # statement.
 
@@ -675,6 +1070,62 @@ trying preparing with injected hints
 trying planning with injected hints
 planning with injected hints failed with: could not produce a query plan conforming to the FORCE_ZIGZAG hint
 falling back to planning without injected hints
+
+onlyif config local
+query T
+EXPLAIN ANALYZE EXECUTE p4 (5, 6)
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: custom
+statement hints count: 1
+maximum memory usage: <hidden>
+DistSQL network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• group (scalar)
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 1
+│ execution time: 0µs
+│
+└── • filter
+    │ sql nodes: <hidden>
+    │ regions: <hidden>
+    │ actual row count: 0
+    │ execution time: 0µs
+    │ filter: c = 6
+    │
+    └── • index join (streamer)
+        │ sql nodes: <hidden>
+        │ regions: <hidden>
+        │ actual row count: 0
+        │ KV time: 0µs
+        │ KV rows decoded: 0
+        │ KV bytes read: 0 B
+        │ KV gRPC calls: 0
+        │ estimated max memory allocated: 0 B
+        │ estimated max sql temp disk usage: 0 B
+        │ table: abc@abc_pkey
+        │
+        └── • scan
+              sql nodes: <hidden>
+              kv nodes: <hidden>
+              regions: <hidden>
+              actual row count: 0
+              KV time: 0µs
+              KV rows decoded: 0
+              KV bytes read: 0 B
+              KV gRPC calls: 0
+              estimated max memory allocated: 0 B
+              missing stats
+              table: abc@abc_b_idx
+              spans: [/5 - /5]
 
 # Check that we can inject hints into generic query plans.
 
@@ -716,6 +1167,46 @@ trying preparing with injected hints
 trying planning with injected hints
 optimizing (generic)
 trying planning with injected hints
+
+onlyif config local
+query T
+EXPLAIN ANALYZE EXECUTE p5 (6)
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, reused
+statement hints count: 1
+maximum memory usage: <hidden>
+DistSQL network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• render
+│
+└── • filter
+    │ sql nodes: <hidden>
+    │ regions: <hidden>
+    │ actual row count: 0
+    │ execution time: 0µs
+    │ filter: b > 6
+    │
+    └── • scan
+          sql nodes: <hidden>
+          kv nodes: <hidden>
+          regions: <hidden>
+          actual row count: 0
+          KV time: 0µs
+          KV rows decoded: 0
+          KV bytes read: 0 B
+          KV gRPC calls: 0
+          estimated max memory allocated: 0 B
+          missing stats
+          table: abc@abc_pkey
+          spans: FULL SCAN
 
 # Check that we can inject hints when using plan_cache_mode=auto.
 
@@ -777,6 +1268,46 @@ trying planning with injected hints
 trying planning with injected hints
 optimizing (generic)
 trying planning with injected hints
+
+onlyif config local
+query T
+EXPLAIN ANALYZE EXECUTE p6 (11)
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, reused
+statement hints count: 1
+maximum memory usage: <hidden>
+DistSQL network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• render
+│
+└── • filter
+    │ sql nodes: <hidden>
+    │ regions: <hidden>
+    │ actual row count: 0
+    │ execution time: 0µs
+    │ filter: b = 11
+    │
+    └── • scan
+          sql nodes: <hidden>
+          kv nodes: <hidden>
+          regions: <hidden>
+          actual row count: 0
+          KV time: 0µs
+          KV rows decoded: 0
+          KV bytes read: 0 B
+          KV gRPC calls: 0
+          estimated max memory allocated: 0 B
+          missing stats
+          table: abc@abc_pkey
+          spans: FULL SCAN
 
 statement ok
 RESET plan_cache_mode
@@ -874,6 +1405,63 @@ statement hints count: 1
       table: xy@xy_pkey
       spans: FULL SCAN
 
+onlyif config local
+query T
+EXPLAIN ANALYZE SELECT y FROM abc JOIN xy ON x = b WHERE a = 10
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: custom
+statement hints count: 1
+rows decoded from KV: 1 (8 B, 2 KVs, 1 gRPC calls)
+maximum memory usage: <hidden>
+DistSQL network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• hash join
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ execution time: 0µs
+│ estimated max memory allocated: 0 B
+│ equality: (b) = (x)
+│ left cols are key
+│ right cols are key
+│
+├── • scan
+│     sql nodes: <hidden>
+│     kv nodes: <hidden>
+│     regions: <hidden>
+│     actual row count: 0
+│     KV time: 0µs
+│     KV rows decoded: 0
+│     KV bytes read: 0 B
+│     KV gRPC calls: 0
+│     estimated max memory allocated: 0 B
+│     missing stats
+│     table: abc@abc_pkey
+│     spans: [/10 - /10]
+│
+└── • scan
+      sql nodes: <hidden>
+      kv nodes: <hidden>
+      regions: <hidden>
+      actual row count: 1
+      KV time: 0µs
+      KV rows decoded: 1
+      KV pairs read: 2
+      KV bytes read: 8 B
+      KV gRPC calls: 1
+      estimated max memory allocated: 0 B
+      missing stats
+      table: xy@xy_pkey
+      spans: FULL SCAN
+
 statement ok
 SELECT information_schema.crdb_rewrite_inline_hints(
   'SELECT y FROM abc JOIN xy ON x = b WHERE a = _',
@@ -900,6 +1488,58 @@ statement hints count: 1
     │ filter: a = 10
     │
     └── • scan
+          missing stats
+          table: abc@abc_b_idx
+          spans: FULL SCAN
+
+onlyif config local
+query T
+EXPLAIN ANALYZE SELECT y FROM abc JOIN xy ON x = b WHERE a = 10
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, re-optimized
+statement hints count: 1
+maximum memory usage: <hidden>
+DistSQL network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• lookup join (streamer)
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ KV time: 0µs
+│ KV rows decoded: 0
+│ KV bytes read: 0 B
+│ KV gRPC calls: 0
+│ execution time: 0µs
+│ estimated max memory allocated: 0 B
+│ table: xy@xy_pkey
+│ equality: (b) = (x)
+│ equality cols are key
+│
+└── • filter
+    │ sql nodes: <hidden>
+    │ regions: <hidden>
+    │ actual row count: 0
+    │ execution time: 0µs
+    │ filter: a = 10
+    │
+    └── • scan
+          sql nodes: <hidden>
+          kv nodes: <hidden>
+          regions: <hidden>
+          actual row count: 0
+          KV time: 0µs
+          KV rows decoded: 0
+          KV bytes read: 0 B
+          KV gRPC calls: 0
+          estimated max memory allocated: 0 B
           missing stats
           table: abc@abc_b_idx
           spans: FULL SCAN
@@ -953,6 +1593,51 @@ statement hints count: 1
       table: abc@abc_pkey
       spans: [/10 - /10]
 
+onlyif config local
+query T
+EXPLAIN ANALYZE SELECT y FROM abc JOIN xy ON x = b WHERE a = 10
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, re-optimized
+statement hints count: 1
+maximum memory usage: <hidden>
+DistSQL network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• lookup join (streamer)
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ KV time: 0µs
+│ KV rows decoded: 0
+│ KV bytes read: 0 B
+│ KV gRPC calls: 0
+│ execution time: 0µs
+│ estimated max memory allocated: 0 B
+│ table: xy@xy_pkey
+│ equality: (b) = (x)
+│ equality cols are key
+│
+└── • scan
+      sql nodes: <hidden>
+      kv nodes: <hidden>
+      regions: <hidden>
+      actual row count: 0
+      KV time: 0µs
+      KV rows decoded: 0
+      KV bytes read: 0 B
+      KV gRPC calls: 0
+      estimated max memory allocated: 0 B
+      missing stats
+      table: abc@abc_pkey
+      spans: [/10 - /10]
+
 # If there are multiple hint rewrites for the same fingerprint added in the
 # same transaction, we should pick the last one added.
 
@@ -996,6 +1681,64 @@ statement hints count: 1
 │     spans: [/10 - /10]
 │
 └── • scan
+      missing stats
+      table: xy@xy_pkey
+      spans: FULL SCAN
+
+onlyif config local
+query T
+EXPLAIN ANALYZE SELECT y FROM abc JOIN xy ON x = b WHERE a = 10
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, re-optimized
+statement hints count: 1
+rows decoded from KV: 1 (8 B, 2 KVs, 1 gRPC calls)
+maximum memory usage: <hidden>
+DistSQL network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• merge join
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ execution time: 0µs
+│ estimated max memory allocated: 0 B
+│ estimated max sql temp disk usage: 0 B
+│ equality: (b) = (x)
+│ left cols are key
+│ right cols are key
+│
+├── • scan
+│     sql nodes: <hidden>
+│     kv nodes: <hidden>
+│     regions: <hidden>
+│     actual row count: 0
+│     KV time: 0µs
+│     KV rows decoded: 0
+│     KV bytes read: 0 B
+│     KV gRPC calls: 0
+│     estimated max memory allocated: 0 B
+│     missing stats
+│     table: abc@abc_pkey
+│     spans: [/10 - /10]
+│
+└── • scan
+      sql nodes: <hidden>
+      kv nodes: <hidden>
+      regions: <hidden>
+      actual row count: 1
+      KV time: 0µs
+      KV rows decoded: 1
+      KV pairs read: 2
+      KV bytes read: 8 B
+      KV gRPC calls: 1
+      estimated max memory allocated: 0 B
       missing stats
       table: xy@xy_pkey
       spans: FULL SCAN
@@ -1051,7 +1794,7 @@ onlyif config local
 query T
 EXPLAIN
 SELECT * FROM abc
-JOIN (SELECT i FROM generate_series(1, 10000) g(i))
+JOIN (SELECT i FROM generate_series(1, 1) g(i))
 ON b = i
 ----
 distribution: local
@@ -1077,6 +1820,79 @@ statement hints count: 1
         │ estimated row count: 10
         │
         └── • emptyrow
+
+onlyif config local
+query T
+EXPLAIN ANALYZE
+SELECT * FROM abc
+JOIN (SELECT i FROM generate_series(1, 1) g(i))
+ON b = i
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: custom
+statement hints count: 1
+maximum memory usage: <hidden>
+DistSQL network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• merge join
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ execution time: 0µs
+│ estimated max memory allocated: 0 B
+│ estimated max sql temp disk usage: 0 B
+│ equality: (b) = (generate_series)
+│
+├── • sort
+│   │ sql nodes: <hidden>
+│   │ regions: <hidden>
+│   │ actual row count: 0
+│   │ execution time: 0µs
+│   │ estimated max memory allocated: 0 B
+│   │ order: +b
+│   │
+│   └── • scan
+│         sql nodes: <hidden>
+│         kv nodes: <hidden>
+│         regions: <hidden>
+│         actual row count: 0
+│         KV time: 0µs
+│         KV rows decoded: 0
+│         KV bytes read: 0 B
+│         KV gRPC calls: 0
+│         estimated max memory allocated: 0 B
+│         missing stats
+│         table: abc@abc_pkey
+│         spans: FULL SCAN
+│
+└── • sort
+    │ sql nodes: <hidden>
+    │ regions: <hidden>
+    │ actual row count: 1
+    │ execution time: 0µs
+    │ estimated max memory allocated: 0 B
+    │ estimated row count: 10
+    │ order: +generate_series
+    │
+    └── • project set
+        │ sql nodes: <hidden>
+        │ regions: <hidden>
+        │ actual row count: 1
+        │ execution time: 0µs
+        │ estimated row count: 10
+        │
+        └── • emptyrow
+              sql nodes: <hidden>
+              regions: <hidden>
+              actual row count: 1
+              execution time: 0µs
 
 # Test the sql.query.with_statement_hints.count metric.
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze
@@ -296,6 +296,7 @@ distribution: <hidden>
 vectorized: <hidden>
 plan type: custom
 statement hints count: 1
+rows decoded from KV: 1 (8 B, 2 KVs, 1 gRPC calls)
 maximum memory usage: <hidden>
 DistSQL network usage: <hidden>
 regions: <hidden>
@@ -303,16 +304,24 @@ isolation level: serializable
 priority: normal
 quality of service: regular
 ·
-• scan
-  sql nodes: <hidden>
-  kv nodes: <hidden>
-  regions: <hidden>
-  actual row count: 0
-  KV time: 0µs
-  KV rows decoded: 0
-  KV bytes read: 0 B
-  KV gRPC calls: 0
-  estimated max memory allocated: 0 B
-  missing stats
-  table: kv@kv_pkey
-  spans: [/100 - ]
+• filter
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ execution time: 0µs
+│ filter: k >= 100
+│
+└── • scan
+      sql nodes: <hidden>
+      kv nodes: <hidden>
+      regions: <hidden>
+      actual row count: 1
+      KV time: 0µs
+      KV rows decoded: 1
+      KV pairs read: 2
+      KV bytes read: 8 B
+      KV gRPC calls: 1
+      estimated max memory allocated: 0 B
+      missing stats
+      table: kv@kv_v_idx
+      spans: FULL SCAN


### PR DESCRIPTION
Backport 1/1 commits from #161273.

/cc @cockroachdb/release

---

Fixes: #161264

Release note (bug fix): Fix a bug in which inline-hints rewrite rules created with `information_schema.crdb_rewrite_inline_hints` were not correctly applied to statements run with `EXPLAIN ANALYZE`. This bug was introduced in version v26.1.0-alpha.2 and is now fixed.

---

Release justification: low-risk fix for new 26.1 feature