### PR TITLE
importer: add debug logging for AVRO data loss investigation

### DIFF
--- a/pkg/cloud/cloud_io.go
+++ b/pkg/cloud/cloud_io.go
@@ -332,11 +332,15 @@ func (r *ResumingReader) Read(ctx context.Context, p []byte) (int, error) {
 			n, readErr := r.Reader.Read(p[read:])
 			read += n
 			r.Pos += int64(n)
+
 			if readErr == nil || readErr == io.EOF {
 				return read, readErr
 			}
 			if r.Size > 0 && r.Pos == r.Size {
 				log.Dev.Warningf(ctx, "read %s ignoring read error received after completed read (%d): %v", r.Filename, r.Pos, readErr)
+				// Debug logging for AVRO import data loss investigation.
+				log.Dev.Warningf(ctx, "IMPORT_DEBUG: ResumingReader[%s] EOF_CONVERSION pos=%d size=%d ignoring err=%v",
+					r.Filename, r.Pos, r.Size, readErr)
 				return read, io.EOF
 			}
 			lastErr = errors.Wrapf(readErr, "read %s", r.Filename)

--- a/pkg/sql/importer/read_import_avro.go
+++ b/pkg/sql/importer/read_import_avro.go
@@ -390,10 +390,11 @@ func (r *avroRecordStream) readNative() {
 	r.row = nil
 
 	canReadMoreData := func() bool {
-		return !r.eof && len(r.buf) < r.maxBufSize
+		return !r.eof && r.err == nil && len(r.buf) < r.maxBufSize
 	}
 
-	for sz := r.readSize; r.row == nil && (len(r.buf) > 0 || canReadMoreData()); sz *= 2 {
+	// Loop until we either have a row or we we have a an incomplete row and can't read more data.
+	for sz := r.readSize; r.row == nil; sz *= 2 {
 		r.fill(sz)
 
 		if r.trimLeft {
@@ -403,11 +404,15 @@ func (r *avroRecordStream) readNative() {
 		if len(r.buf) > 0 {
 			r.row, remaining, decodeErr = r.decode()
 		}
-		// If we've already read all we can (either to eof or to max size), then
-		// any error during decoding should just be returned as an error.
-		if decodeErr != nil && (r.eof || len(r.buf) > r.maxBufSize) {
+
+		// If we have a partial or empty row and can't read more data, bail out.
+		if (decodeErr != nil || len(r.buf) == 0) && !canReadMoreData() {
 			break
 		}
+	}
+
+	if r.err != nil {
+		return
 	}
 
 	if decodeErr != nil {

--- a/pkg/sql/importer/read_import_base.go
+++ b/pkg/sql/importer/read_import_base.go
@@ -708,6 +708,9 @@ func runParallelImport(
 		if producer.Err() == nil {
 			return importer.close(ctx)
 		}
+		// Debug logging for AVRO import data loss investigation.
+		log.Dev.Infof(ctx, "IMPORT_DEBUG: runParallelImport() PRODUCER_ERROR source=%d err=%v",
+			fileCtx.source, producer.Err())
 		return producer.Err()
 	})
 


### PR DESCRIPTION
This patch adds targeted debug logging to diagnose silent data loss
during AVRO imports when HTTP/2 stream errors occur. The investigation
is based on a customer issue where an import job succeeded but had
5-7% missing data despite HTTP/2 CANCEL errors being logged.

The suspected bug is in ResumingReader.Read() which converts non-EOF
errors to io.EOF when r.Pos == r.Size. This could cause the AVRO
decoder to think it reached end-of-file normally, leaving unprocessed
data in its internal buffer (up to 4MB) and causing silent data loss.

Instrumentation points (all prefixed with "IMPORT_DEBUG:"):

1. ResumingReader.Read() - Logs EOF conversion at size boundary
   Example: "IMPORT_DEBUG: ResumingReader[file.avro] EOF_CONVERSION
   pos=1000000 size=1000000 ignoring err=stream error: CANCEL"

2. avroRecordStream.fill() - Logs read errors and EOF
   Example: "IMPORT_DEBUG: AVRO fill() requested=2048 copied=1024
   err=stream error: CANCEL"

3. avroRecordStream.readNative() - Logs exit with errors
   Example: "IMPORT_DEBUG: readNative() EXIT_WITH_READ_ERROR
   buflen=100000 eof=false err=stream error: CANCEL"

4. avroRecordStream.Scan() - Logs when returning false
   Example: "IMPORT_DEBUG: Scan() RETURNING_FALSE eof=true err=<nil>"

5. runParallelImport() - Logs producer errors
   Example: "IMPORT_DEBUG: runParallelImport() PRODUCER_ERROR
   source=0 err=stream error: CANCEL"

Expected log pattern if EOF conversion bug is triggered:
  - ResumingReader logs EOF_CONVERSION at size boundary
  - AVRO fill() logs EOF (not error) with buffered data
  - Scan() returns false with eof=true and err=<nil>
  - No PRODUCER_ERROR logged (job succeeds with data loss)

Expected log pattern if error propagates correctly:
  - No EOF_CONVERSION logged
  - AVRO fill() logs non-EOF error
  - readNative() logs EXIT_WITH_READ_ERROR
  - Scan() returns false with err set
  - runParallelImport() logs PRODUCER_ERROR (job fails correctly)

Epic: None

Release note: None