### PR TITLE
rowexec: skip flake TestJoinReaderDiskSpill

### DIFF
--- a/pkg/sql/rowexec/joinreader_test.go
+++ b/pkg/sql/rowexec/joinreader_test.go
@@ -1218,6 +1218,8 @@ func TestJoinReaderDiskSpill(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	skip.WithIssue(t, 161212)
+
 	ctx := context.Background()
 
 	srv, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})


### PR DESCRIPTION
We added more metamorphic randomizations recently which made this test flaky. Let's skip it for now.

Informs: #161212
Epic: None
Release note: None