### PR TITLE
sql/importer: capture OCF reader errors to prevent silent data loss

### DIFF
--- a/pkg/sql/importer/read_import_avro.go
+++ b/pkg/sql/importer/read_import_avro.go
@@ -265,7 +265,6 @@ var _ importRowConsumer = &avroConsumer{}
 type ocfStream struct {
 	ocf      *goavro.OCFReader
 	progress func() float32
-	err      error
 }
 
 var _ importRowProducer = &ocfStream{}
@@ -285,7 +284,7 @@ func (o *ocfStream) Scan() bool {
 
 // Err implements importRowProducer interface.
 func (o *ocfStream) Err() error {
-	return o.err
+	return o.ocf.Err()
 }
 
 // Row implements importRowProducer interface.
@@ -295,8 +294,8 @@ func (o *ocfStream) Row() (interface{}, error) {
 
 // Skip implements importRowProducer interface.
 func (o *ocfStream) Skip() error {
-	_, o.err = o.ocf.Read()
-	return o.err
+	_, err := o.ocf.Read()
+	return err
 }
 
 // A scanner over a file containing avro records in json or binary format.


### PR DESCRIPTION
Previously, we could have ignored an error on the OCF reader since we didn't properly implement `Err` method. This meant storage backend errors (e.g., from S3) during import could be silently ignored, resulting in incomplete data imports without any error reported to the user. This is now fixed.


Fixes: #161317.

Release note (bug fix): Fixed a bug where IMPORT with AVRO data using OCF format could silently lose data if the underlying storage (e.g., S3) returned an error during read. Such errors are now properly reported. Other formats (specified via `data_as_binary_records` and `data_as_json_records` options) are unaffected. The bug has been present since about v20.1.

Co-Authored-By: Matt White <matt.white@cockroachlabs.com>
Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>