### PR TITLE
importer: fix error swallowing in AVRO OCF stream reader

### DIFF
--- a/pkg/sql/importer/read_import_avro.go
+++ b/pkg/sql/importer/read_import_avro.go
@@ -265,7 +265,6 @@ var _ importRowConsumer = &avroConsumer{}
 type ocfStream struct {
 	ocf      *goavro.OCFReader
 	progress func() float32
-	err      error
 }
 
 var _ importRowProducer = &ocfStream{}
@@ -285,7 +284,7 @@ func (o *ocfStream) Scan() bool {
 
 // Err implements importRowProducer interface.
 func (o *ocfStream) Err() error {
-	return o.err
+	return o.ocf.Err()
 }
 
 // Row implements importRowProducer interface.
@@ -295,8 +294,8 @@ func (o *ocfStream) Row() (interface{}, error) {
 
 // Skip implements importRowProducer interface.
 func (o *ocfStream) Skip() error {
-	_, o.err = o.ocf.Read()
-	return o.err
+	_, err := o.ocf.Read()
+	return err
 }
 
 // A scanner over a file containing avro records in json or binary format.


### PR DESCRIPTION
Previously, the ocfStream struct maintained its own error field that was only updated in the Skip() method. This meant that errors occurring during Scan() operations were never captured or propagated, leading to silent data loss when fatal errors occurred during AVRO import.

This change removes the manual error tracking and delegates error reporting to the underlying goavro.OCFReader's Err() method, which properly tracks all errors including those from Scan() operations.

This fixes a customer-reported issue where AVRO import silently lost data due to swallowed errors.

Release note (bug fix): Fixed a bug in AVRO import where errors during file scanning could be silently ignored, potentially causing data loss. The importer now correctly detects and reports all errors encountered during AVRO file processing.

Epic: None