### PR TITLE
release-25.3: sql/importer: capture OCF reader errors to prevent silent data loss

### DIFF
--- a/pkg/sql/importer/read_import_avro.go
+++ b/pkg/sql/importer/read_import_avro.go
@@ -265,7 +265,6 @@ var _ importRowConsumer = &avroConsumer{}
 type ocfStream struct {
 	ocf      *goavro.OCFReader
 	progress func() float32
-	err      error
 }
 
 var _ importRowProducer = &ocfStream{}
@@ -285,7 +284,7 @@ func (o *ocfStream) Scan() bool {
 
 // Err implements importRowProducer interface.
 func (o *ocfStream) Err() error {
-	return o.err
+	return o.ocf.Err()
 }
 
 // Row implements importRowProducer interface.
@@ -295,8 +294,8 @@ func (o *ocfStream) Row() (interface{}, error) {
 
 // Skip implements importRowProducer interface.
 func (o *ocfStream) Skip() error {
-	_, o.err = o.ocf.Read()
-	return o.err
+	_, err := o.ocf.Read()
+	return err
 }
 
 // A scanner over a file containing avro records in json or binary format.

--- a/pkg/sql/importer/read_import_avro_test.go
+++ b/pkg/sql/importer/read_import_avro_test.go
@@ -553,6 +553,72 @@ func BenchmarkBinaryJSONImport(b *testing.B) {
 	}, datapathutils.TestDataPath(b, "avro", "stock-10000.bjson"))
 }
 
+// failingReader simulates an S3/storage error after reading a certain number of
+// bytes.
+type failingReader struct {
+	data      *bytes.Buffer
+	failAfter int
+	bytesRead int
+	failErr   error
+}
+
+func (f *failingReader) Read(p []byte) (n int, err error) {
+	if f.failErr != nil && f.bytesRead >= f.failAfter {
+		return 0, f.failErr
+	}
+	n, err = f.data.Read(p)
+	f.bytesRead += n
+	if f.failErr != nil && f.bytesRead >= f.failAfter {
+		return n, f.failErr
+	}
+	return n, err
+}
+
+// TestOcfStreamCapturesUnderlyingErrors tests that ocfStream properly captures
+// errors from the underlying goavro.OCFReader, such as when S3 returns an error
+// during read. This test reproduces the bug where such errors were silently
+// ignored, leading to incomplete data being imported.
+func TestOcfStreamCapturesUnderlyingErrors(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	th := newTestHelper(ctx, t)
+
+	ocfData := bytes.NewBuffer(nil)
+	th.genOcfData(t, 10, ocfData)
+	ocfBytes := ocfData.Bytes()
+
+	// Create a failing reader that will error after reading after half the
+	// data.
+	failAfter := len(ocfBytes) / 2
+	expectedErr := fmt.Errorf("simulated S3 read error")
+
+	failingInput := &failingReader{
+		data:      bytes.NewBuffer(ocfBytes),
+		failAfter: failAfter,
+		failErr:   expectedErr,
+	}
+
+	ocf, err := goavro.NewOCFReader(failingInput)
+	require.NoError(t, err)
+	stream := &ocfStream{ocf: ocf}
+
+	var recordCount int
+	for stream.Scan() {
+		_, err := stream.Row()
+		if err != nil {
+			break
+		}
+		recordCount++
+	}
+
+	// The bug: stream.Err() returns nil even though the underlying reader
+	// failed - it should return the error.
+	err = stream.Err()
+	require.Error(t, err, "ocfStream should capture underlying read errors")
+	require.Less(t, recordCount, 10, "should not have read all records due to the error")
+}
+
 func benchmarkAvroImport(b *testing.B, avroOpts roachpb.AvroOptions, testData string) {
 	defer log.Scope(b).Close(b)
 	ctx := context.Background()


### PR DESCRIPTION
Backport 1/1 commits from #161318 on behalf of @yuzefovich.

----

Previously, we could have ignored an error on the OCF reader since we didn't properly implement `Err` method. This meant storage backend errors (e.g., from S3) during import could be silently ignored, resulting in incomplete data imports without any error reported to the user. This is now fixed.


Fixes: #161317.

Release note (bug fix): Fixed a bug where IMPORT with AVRO data using OCF format could silently lose data if the underlying storage (e.g., S3) returned an error during read. Such errors are now properly reported. Other formats (specified via `data_as_binary_records` and `data_as_json_records` options) are unaffected. The bug has been present since about v20.1.

Co-Authored-By: Matt White <matt.white@cockroachlabs.com>
Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

----

Release justification: critical bug fix.