### PR TITLE
rowexec: unskip `TestJoinReaderDiskSpill` with higher number of rows

### DIFF
--- a/pkg/sql/rowexec/joinreader_test.go
+++ b/pkg/sql/rowexec/joinreader_test.go
@@ -1218,8 +1218,6 @@ func TestJoinReaderDiskSpill(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.WithIssue(t, 161212)
-
 	ctx := context.Background()
 
 	srv, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
@@ -1230,7 +1228,7 @@ func TestJoinReaderDiskSpill(t *testing.T) {
 	// a disk spill.
 	key := 0
 	stringColVal := "0123456789"
-	numRows := 100
+	numRows := 1000
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE test;
 CREATE TABLE test.t (a INT, s STRING, INDEX (a, s))`); err != nil {


### PR DESCRIPTION
fixes #161212

Previously, the adoption of metamorphic range for `rowsPerChunkShift` caused `TestJoinReaderDiskSpill` to be flacky. It's because the given memory limit `DefaultPoolAllocationSize` is coincidentally sufficient for the join reader to process 100 rows when the chunk size is of {4, 8, 16, 32} rows, meaning no disk spill is happening. This commit is to increase the number of rows for the join reader to handle in the test, so that the `DefaultPoolAllocationSize` is guaranteed to be insufficient and causing disk spill.

(Locally tested with `--stress --count-5000`.)

Release note: None