### PR TITLE
sql/stats: improve delete-statistics-for-dropped-tables query

### DIFF
--- a/pkg/sql/stats/delete_stats.go
+++ b/pkg/sql/stats/delete_stats.go
@@ -125,9 +125,7 @@ func DeleteOldStatsForOtherColumns(
 func deleteStatsForDroppedTables(ctx context.Context, db isql.DB, limit int64) error {
 	_, err := db.Executor().Exec(
 		ctx, "delete-statistics-for-dropped-tables", nil, /* txn */
-		fmt.Sprintf(`DELETE FROM system.table_statistics
-                            WHERE "tableID" NOT IN (SELECT table_id FROM crdb_internal.tables)
-                            LIMIT %d`, limit),
+		fmt.Sprintf(`DELETE FROM system.table_statistics WHERE "tableID" NOT IN (SELECT id FROM system.descriptor) LIMIT %d;`, limit),
 	)
 	return err
 }


### PR DESCRIPTION
Previously, the query to delete statistics for dropped tables used the virtual table `crdb_internal.tables` to anti-join against, but populating that vtable can take non-trivial amount of time on a cluster with many tables. This commit rewrites the query to an equivalent one that uses `system.descriptor` table instead. On a cluster with 485k tables it reduces the execution time from 38s (almost all spent in vtable population) to under 2s.

Fixes: #161320.
Release note: None