### PR TITLE
sql: add virtual index on descriptor_id to crdb_internal.table_indexes

### DIFF
--- a/pkg/bench/rttanalysis/BUILD.bazel
+++ b/pkg/bench/rttanalysis/BUILD.bazel
@@ -68,6 +68,7 @@ go_test(
         "//pkg/server",
         "//pkg/server/serverpb",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/scheduledlogging",
         "//pkg/testutils/pgurlutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",

--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -130,6 +130,7 @@ exp,benchmark
 0,UDFResolution/select_from_udf
 25,UseManyRoles/use_25_roles
 2,UseManyRoles/use_2_roles
+3,VirtualTableQueries/index_usage_statistics_join
 2,VirtualTableQueries/select_crdb_internal.invalid_objects_with_1_fk
 1,VirtualTableQueries/select_crdb_internal.tables_with_1_fk
 0,VirtualTableQueries/show_create_all_routines

--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -130,7 +130,7 @@ exp,benchmark
 0,UDFResolution/select_from_udf
 25,UseManyRoles/use_25_roles
 2,UseManyRoles/use_2_roles
-3,VirtualTableQueries/index_usage_statistics_join
+3,VirtualTableQueries/capture_index_usage_stats
 2,VirtualTableQueries/select_crdb_internal.invalid_objects_with_1_fk
 1,VirtualTableQueries/select_crdb_internal.tables_with_1_fk
 0,VirtualTableQueries/show_create_all_routines

--- a/pkg/bench/rttanalysis/virtual_table_bench_test.go
+++ b/pkg/bench/rttanalysis/virtual_table_bench_test.go
@@ -85,9 +85,9 @@ SELECT ti.descriptor_name AS table_name, ti.descriptor_id AS table_id,
        ti.index_name, ti.index_id, ti.index_type, ti.is_unique, ti.is_inverted,
        total_reads, last_read, ti.created_at, ns.nspname::STRING
 FROM crdb_internal.index_usage_statistics AS us
-JOIN crdb_internal.table_indexes AS ti ON (us.index_id = ti.index_id) AND (us.table_id = ti.descriptor_id)
-JOIN pg_catalog.pg_class AS c ON ti.descriptor_id::OID = c.oid
-JOIN pg_catalog.pg_namespace AS ns ON ns.oid = c.relnamespace
+INNER LOOKUP JOIN crdb_internal.table_indexes AS ti ON (us.table_id = ti.descriptor_id) AND (us.index_id = ti.index_id)
+INNER LOOKUP JOIN pg_catalog.pg_class AS c ON ti.descriptor_id::OID = c.oid
+INNER LOOKUP JOIN pg_catalog.pg_namespace AS ns ON ns.oid = c.relnamespace
 ORDER BY total_reads ASC;`,
 		},
 	})

--- a/pkg/server/index_usage_stats.go
+++ b/pkg/server/index_usage_stats.go
@@ -248,7 +248,7 @@ func getTableIndexUsageStats(
   	JOIN pg_catalog.pg_index AS pgidx ON indrelid = us.table_id
   	JOIN pg_catalog.pg_indexes AS pgidxs ON pgidxs.crdb_oid = indexrelid
 		AND indexname = ti.index_name
- 		WHERE ti.descriptor_id = $::REGCLASS`,
+		WHERE ti.descriptor_id::OID = $::REGCLASS::OID`,
 		tableID,
 	)
 	it, err := ie.QueryIteratorEx(ctx, "index-usage-stats", nil,

--- a/pkg/sql/scheduledlogging/captured_index_usage_stats.go
+++ b/pkg/sql/scheduledlogging/captured_index_usage_stats.go
@@ -193,10 +193,10 @@ func captureIndexUsageStats(
 		 ti.created_at,
 		 ns.nspname::string
 		FROM crdb_internal.index_usage_statistics AS us
-    JOIN crdb_internal.table_indexes AS ti ON us.index_id = ti.index_id
-                                          AND us.table_id = ti.descriptor_id
-    JOIN pg_catalog.pg_class AS c ON ti.descriptor_id = c.oid
-    JOIN pg_catalog.pg_namespace AS ns ON ns.oid = c.relnamespace
+    INNER LOOKUP JOIN crdb_internal.table_indexes AS ti ON us.table_id = ti.descriptor_id
+                                          AND us.index_id = ti.index_id
+    INNER LOOKUP JOIN pg_catalog.pg_class AS c ON ti.descriptor_id::OID = c.oid
+    INNER LOOKUP JOIN pg_catalog.pg_namespace AS ns ON ns.oid = c.relnamespace
 ORDER BY total_reads ASC`
 
 		it, err := ie.QueryIteratorEx(


### PR DESCRIPTION
Previously, crdb_internal.table_indexes had no virtual index, which meant
any query joining on descriptor_id would load all table descriptors into
memory. This caused significant memory pressure on clusters with large
schemas (e.g., 450k+ tables).

This change adds a virtual index on descriptor_id, allowing the optimizer
to push down join predicates and only fetch descriptors for tables that
match the constraint.

Additionally, update the captured_index_usage_stats query to use an
explicit LOOKUP JOIN hint and cast descriptor_id to OID. The cast is
required because pg_class.oid is of type OID while descriptor_id is INT,
and without the cast the optimizer cannot use the virtual index for the
lookup join.

Resolves: #161351

Release note: None