### PR TITLE
sem/tree: fix an internal error around empty array string in builtins

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -2501,3 +2501,21 @@ SELECT * FROM t95158 WHERE c !~ ANY (ARRAY['x']::STRING[])
 query I
 SELECT * FROM t95158 WHERE c !~ SOME (ARRAY['x']::STRING[])
 ----
+
+# Regression tests for internal errors on an empty array string (#89969).
+statement error unknown signature
+SELECT array_length('{}', 1);
+
+query I
+SELECT array_length('{}'::text[], 1);
+----
+NULL
+
+statement error unknown signature
+SELECT cardinality('{}');
+
+statement error unknown signature
+SELECT width_bucket(true, '{}');
+
+statement error unknown signature
+SELECT array_to_string('{}', 'foo');

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -3791,6 +3791,7 @@ default_transaction_use_follower_reads                           off
 default_with_oids                                                off
 descriptor_validation                                            on
 disable_changefeed_replication                                   off
+disable_empty_array_type_checking_fix                            off
 disable_hoist_projection_in_join_limitation                      off
 disable_optimizer_rules                                          ·
 disable_partially_distributed_plans                              off

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3065,6 +3065,7 @@ default_transaction_use_follower_reads                           off            
 default_with_oids                                                off                 NULL      NULL        NULL        string
 descriptor_validation                                            on                  NULL      NULL        NULL        string
 disable_changefeed_replication                                   off                 NULL      NULL        NULL        string
+disable_empty_array_type_checking_fix                            off                 NULL      NULL        NULL        string
 disable_hoist_projection_in_join_limitation                      off                 NULL      NULL        NULL        string
 disable_optimizer_rules                                          ·                   NULL      NULL        NULL        string
 disable_partially_distributed_plans                              off                 NULL      NULL        NULL        string
@@ -3317,6 +3318,7 @@ default_transaction_use_follower_reads                           off            
 default_with_oids                                                off                 NULL  user     NULL      off                 off
 descriptor_validation                                            on                  NULL  user     NULL      on                  on
 disable_changefeed_replication                                   off                 NULL  user     NULL      off                 off
+disable_empty_array_type_checking_fix                            off                 NULL  user     NULL      off                 off
 disable_hoist_projection_in_join_limitation                      off                 NULL  user     NULL      off                 off
 disable_optimizer_rules                                          ·                   NULL  user     NULL      ·                   ·
 disable_partially_distributed_plans                              off                 NULL  user     NULL      off                 off
@@ -3556,6 +3558,7 @@ default_with_oids                                                NULL    NULL   
 descriptor_validation                                            NULL    NULL     NULL     NULL        NULL
 direct_columnar_scans_enabled                                    NULL    NULL     NULL     NULL        NULL
 disable_changefeed_replication                                   NULL    NULL     NULL     NULL        NULL
+disable_empty_array_type_checking_fix                            NULL    NULL     NULL     NULL        NULL
 disable_hoist_projection_in_join_limitation                      NULL    NULL     NULL     NULL        NULL
 disable_optimizer_rules                                          NULL    NULL     NULL     NULL        NULL
 disable_partially_distributed_plans                              NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -79,6 +79,7 @@ default_transaction_use_follower_reads                           off
 default_with_oids                                                off
 descriptor_validation                                            on
 disable_changefeed_replication                                   off
+disable_empty_array_type_checking_fix                            off
 disable_hoist_projection_in_join_limitation                      off
 disable_optimizer_rules                                          ·
 disable_partially_distributed_plans                              off

--- a/pkg/sql/logictest/testdata/logic_test/srfs
+++ b/pkg/sql/logictest/testdata/logic_test/srfs
@@ -1426,10 +1426,10 @@ NULL
 
 # Regression test for #110952 - providing invalid arguments to unnest should
 # not trigger an internal error.
-statement error pgcode 42804 pq: could not determine polymorphic type: unnest\(string\)
+statement error pgcode 42883 pq: unknown signature: unnest\(string\)
 SELECT unnest('{}');
 
-statement error pgcode 42804 pq: could not determine polymorphic type: unnest\(string, string, string\)
+statement error pgcode 42883 pq: unknown signature: unnest\(string, string, string\)
 SELECT unnest('{}', '{}', '{}');
 
 statement error pgcode 42883 pq: unknown signature: unnest\(int\)
@@ -1445,7 +1445,7 @@ statement error pgcode 42804 pq: could not determine polymorphic type: unnest\(u
 SELECT unnest(NULL, NULL, NULL);
 
 # pg_expandarray handles return types similarly to unnest.
-statement error pgcode 42804 pq: could not determine polymorphic type: information_schema._pg_expandarray\(string\)
+statement error pgcode 42883 pq: unknown signature: information_schema._pg_expandarray\(string\)
 SELECT information_schema._pg_expandarray('{}');
 
 query T
@@ -1453,17 +1453,26 @@ SELECT unnest('{1}'::int[], '{2}', '{3}');
 ----
 (1,2,3)
 
+statement error pgcode 42883 pq: unknown signature: unnest\(int\[\], string, string\)
+SELECT unnest('{1}'::int[], '{}', '{}');
+
+# Sanity check that the session variable gives us pre-26.2 behavior which
+# allowed this query.
+statement ok
+SET disable_empty_array_type_checking_fix = true
+
 query T
 SELECT unnest('{1}'::int[], '{}', '{}');
 ----
 (1,,)
+
+statement ok
+RESET disable_empty_array_type_checking_fix
 
 query T
 SELECT unnest('{1}', '{2}', '{3}'::int[]);
 ----
 (1,2,3)
 
-query T
+statement error pgcode 42883 pq: unknown signature: unnest\(string, string, int\[\]\)
 SELECT unnest('{}', '{}', '{3}'::int[]);
-----
-(,,3)

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -219,6 +219,7 @@ type Memo struct {
 	useSwapMutations                           bool
 	preventUpdateSetColumnDrop                 bool
 	useImprovedRoutineDepsTriggersComputedCols bool
+	disableEmptyArrayTypeCheckingFix           bool
 
 	// txnIsoLevel is the isolation level under which the plan was created. This
 	// affects the planning of some locking operations, so it must be included in
@@ -338,6 +339,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		useSwapMutations:                           evalCtx.SessionData().UseSwapMutations,
 		preventUpdateSetColumnDrop:                 evalCtx.SessionData().PreventUpdateSetColumnDrop,
 		useImprovedRoutineDepsTriggersComputedCols: evalCtx.SessionData().UseImprovedRoutineDepsTriggersAndComputedCols,
+		disableEmptyArrayTypeCheckingFix:           evalCtx.SessionData().DisableEmptyArrayTypeCheckingFix,
 		txnIsoLevel:                                evalCtx.TxnIsoLevel,
 	}
 	m.metadata.Init()
@@ -521,6 +523,7 @@ func (m *Memo) IsStale(
 		m.useSwapMutations != evalCtx.SessionData().UseSwapMutations ||
 		m.preventUpdateSetColumnDrop != evalCtx.SessionData().PreventUpdateSetColumnDrop ||
 		m.useImprovedRoutineDepsTriggersComputedCols != evalCtx.SessionData().UseImprovedRoutineDepsTriggersAndComputedCols ||
+		m.disableEmptyArrayTypeCheckingFix != evalCtx.SessionData().DisableEmptyArrayTypeCheckingFix ||
 		m.txnIsoLevel != evalCtx.TxnIsoLevel {
 		return true, nil
 	}

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -623,6 +623,11 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().UseImprovedRoutineDepsTriggersAndComputedCols = false
 	notStale()
 
+	evalCtx.SessionData().DisableEmptyArrayTypeCheckingFix = true
+	stale()
+	evalCtx.SessionData().DisableEmptyArrayTypeCheckingFix = false
+	notStale()
+
 	// User no longer has access to view.
 	catalog.View(tree.NewTableNameWithSchema("t", catconstants.PublicSchemaName, "abcview")).Revoked = true
 	_, err = o.Memo().IsStale(ctx, &evalCtx, catalog)

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -996,6 +996,7 @@ func (p *planner) resetPlanner(
 		p.execCfg.Settings.Version, utc,
 	)
 	p.semaCtx.UsePre_25_2VariadicBuiltins = sd.UsePre_25_2VariadicBuiltins
+	p.semaCtx.DisableEmptyArrayTypeCheckingFix = sd.DisableEmptyArrayTypeCheckingFix
 
 	p.autoCommit = false
 

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -80,6 +80,10 @@ type SemaContext struct {
 	// variadic builtins behavior.
 	UsePre_25_2VariadicBuiltins bool
 
+	// DisableEmptyArrayTypeCheckingFix, if set, indicates that we don't handle
+	// empty arrays parsed as a string in a special way during type checking.
+	DisableEmptyArrayTypeCheckingFix bool
+
 	// TestingKnobs only has effect under buildutil.CrdbTestBuild.
 	TestingKnobs struct {
 		// DisallowAlwaysNullShortCut, if set, disables short-circuiting logic
@@ -239,7 +243,7 @@ type ScalarAncestors byte
 const (
 	// FuncExprAncestor is temporarily added to ScalarAncestors while type
 	// checking the parameters of a function. Used to process
-	// RejectNestedGenerators properly.
+	// RejectNestedGenerators properly as well as some special constant cases.
 	FuncExprAncestor ScalarAncestors = 1 << iota
 
 	// WindowFuncAncestor is temporarily added to ScalarAncestors while type

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -774,6 +774,11 @@ message LocalOnlySessionData {
   // physical planner from partitioning scans with soft limits into multiple
   // TableReaders. When true, this matches the behavior for hard limits.
   bool distsql_prevent_partitioning_soft_limited_scans = 197 [(gogoproto.customname) = "DistSQLPreventPartitioningSoftLimitedScans"];
+  // DisableEmptyArrayTypeCheckingFix, if set, indicates that the fix (to the
+  // special case for empty arrays parsed as a string without explicit type
+  // casts nor type hints within builtins where the input parameter is of the
+  // AnyArray type) should not be used.
+  bool disable_empty_array_type_checking_fix = 198;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/sessionmutator/mutator.go
+++ b/pkg/sql/sessionmutator/mutator.go
@@ -1126,3 +1126,7 @@ func (m *SessionDataMutator) SetDistSQLPreventPartitioningSoftLimitedScans(val b
 func (m *SessionDataMutator) SetUseBackupsWithIDs(val bool) {
 	m.Data.UseBackupsWithIDs = val
 }
+
+func (m *SessionDataMutator) SetDisableEmptyArrayTypeCheckingFix(val bool) {
+	m.Data.DisableEmptyArrayTypeCheckingFix = val
+}

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -4558,6 +4558,23 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalFalse,
 	},
+
+	// CockroachDB extension.
+	`disable_empty_array_type_checking_fix`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`disable_empty_array_type_checking_fix`),
+		Set: func(_ context.Context, m sessionmutator.SessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("disable_empty_array_type_checking_fix", s)
+			if err != nil {
+				return err
+			}
+			m.SetDisableEmptyArrayTypeCheckingFix(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().DisableEmptyArrayTypeCheckingFix), nil
+		},
+		GlobalDefault: globalFalse,
+	},
 }
 
 func ReplicationModeFromString(s string) (sessiondatapb.ReplicationMode, error) {


### PR DESCRIPTION
This commit adds a special case to reject empty array string `'{}'` from becoming of an array type within the FuncExpr context when it corresponds to an input parameter of AnyArray type to prevent an internal error from being hit later. This is ugly, but I don't see a cleaner way, and we now more closely match PG in the test cases affected. (The other way of addressing this issue would be to audit all builtins that use AnyArray type as an input parameter and - instead of simply calling `MustBeDArray` - to first check whether we have an empty string, and convert that into an empty array. We would be more lenient than Postgres in some cases still then.)

Making any type checking changes is always scary, so this commit also introduces `disable_empty_array_type_checking_fix` session variable to get the previous behavior, just in case.

Fixes: #89969.

Release note (bug fix): Previously, CockroachDB could hit an internal error when evaluating builtin functions with `'{}'` as an argument (without explicit type casts). This is now fixed and we now will return a regular error, similar to Postgres. E.g. on a query like "SELECT cardinality('{}');".