### PR TITLE
colserde: optimize serialization of Timestamps

### DIFF
--- a/pkg/col/colserde/arrowbatchconverter.go
+++ b/pkg/col/colserde/arrowbatchconverter.go
@@ -265,8 +265,8 @@ func (c *ArrowBatchConverter) BatchToArrow(
 
 			case types.TimestampTZFamily:
 				timestamps := vec.Timestamp()[:n]
-				// See implementation of time.MarshalBinary.
-				const timestampSize = 14
+				// See implementation of time.AppendBinary.
+				const timestampSize = 16
 				if cap(values) < n*timestampSize {
 					values = make([]byte, 0, n*timestampSize)
 				}
@@ -275,11 +275,11 @@ func (c *ArrowBatchConverter) BatchToArrow(
 					if nulls != nil && nulls.NullAt(i) {
 						continue
 					}
-					marshaled, err := timestamps[i].MarshalBinary()
+					var err error
+					values, err = timestamps[i].AppendBinary(values)
 					if err != nil {
 						return nil, err
 					}
-					values = append(values, marshaled...)
 				}
 				offsets = append(offsets, int32(len(values)))
 				unsafeCastOffsetsArray(offsets, &offsetsBytes)

--- a/pkg/col/colserde/record_batch_test.go
+++ b/pkg/col/colserde/record_batch_test.go
@@ -186,7 +186,7 @@ func randomDataFromType(rng *rand.Rand, t *types.T, n int, nullProbability float
 		for i := range data {
 			delta := rng.Int63()
 			ts := now.Add(time.Duration(delta))
-			data[i], err = ts.MarshalBinary()
+			data[i], err = ts.AppendBinary(nil /* b */)
 			if err != nil {
 				panic(err)
 			}


### PR DESCRIPTION
Previously, we would use `MarshalBinary` method that serializes the timestamp into a new temporary slice that we then copied over into the large slice for the whole vector. Recent Go version introduced `AppendBinary` method that allows us to serialize the timestamp directly into the final destination. Additionally, we now pre-allocate the right amount of memory per object (it looks like serialization increased by 2 bytes in recent Go versions).

Fixes: #129698.
Release note: None