### PR TITLE
sqlliveness: add jitter to sqlliveness heartbeat

### DIFF
--- a/pkg/sql/sqlliveness/slbase/slbase.go
+++ b/pkg/sql/sqlliveness/slbase/slbase.go
@@ -26,4 +26,13 @@ var (
 		"duration heart beats to push session expiration further out in time",
 		5*time.Second,
 	)
+	// HeartbeatJitter specifies the jitter applied to heartbeat intervals.
+	// This prevents thundering herd effects on the system.sqlliveness table.
+	HeartbeatJitter = settings.RegisterFloatSetting(
+		settings.ApplicationLevel,
+		"server.sqlliveness.heartbeat_jitter",
+		"jitter fraction for sqlliveness heartbeat interval (0.0 to 0.95)",
+		0.1, //defaultValue
+		settings.FloatInRange(0.0, 0.95),
+	)
 )


### PR DESCRIPTION
Previously, the SQL liveness heartbeat interval had no jitter, which could cause thundering herd effects when many SQL instances heartbeat simultaneously to the system.sqlliveness table.

This commit introduces a new cluster setting
`server.sqlliveness.heartbeat_jitter` that adds randomized jitter to the heartbeat interval. This spreads out heartbeat operations over time, reducing peak concurrency on the sqlliveness table. 
For the heartbeat :
```go
hb: func() time.Duration {
			defaultHB := slbase.DefaultHeartBeat.Get(&settings.SV)
			hbJitter := slbase.HeartbeatJitter.Get(&settings.SV)
			frac := 1 + (2*rand.Float64()-1)*hbJitter
			return time.Duration(frac * float64(defaultHB.Nanoseconds()))
		}
```
`hbJitter` gets the value from the cluster setting.
The jitter calculation works as follows:
```md
  - `2*rand.Float64()-1` generates a random value in [-1, 1)
  - Multiplying by hbJitter and adding 1 shifts interval to 
 	 [1-hbJitter, 1+hbJitter)

Example: with defaultHB=5s and hbJitter=0.1 (10%):
  - frac will be in [0.9, 1.1)
  - Result will be in [4.5s, 5.5s)
```
The default jitter is 0.1 (10%) and was decided after benchmarking on different jitter values on peak concurrency.

```
Jitter value							  b.N	  runtime/iter				avg_peak_conc_iter				max_peak_conc					updates_per_iter	
BenchmarkHeartbeatThroughput/NoJitter-14   9	 122964458 ns/op	        14.33 avg_peak_conc	        	21.00 max_peak_conc	    	  5344 updates_per_iter
BenchmarkHeartbeatThroughput/Jitter5-14    9	 122437532 ns/op	        11.56 avg_peak_conc	       		 14.00 max_peak_conc	      5663 updates_per_iter
BenchmarkHeartbeatThroughput/Jitter10-14   9	 122125625 ns/op	         2.444 avg_peak_conc	         3.000 max_peak_conc	      5938 updates_per_iter
BenchmarkHeartbeatThroughput/Jitter15-14   9	 122003694 ns/op	         2.222 avg_peak_conc	         3.000 max_peak_conc	      5951 updates_per_iter
BenchmarkHeartbeatThroughput/Jitter20-14   9	 122116153 ns/op	         2.444 avg_peak_conc	         4.000 max_peak_conc	      5966 updates_per_iter
BenchmarkHeartbeatThroughput/Jitter50-14   9	 125554639 ns/op	         2.333 avg_peak_conc	         4.000 max_peak_conc	      5998 updates_per_iter
```

Epic: CRDB-52349
Fixes: #147653
Release note: None