### PR TITLE
release-25.4: sql: deflake TestBackfillQueryWithProtectedTS by batching initial INSERT

### DIFF
--- a/pkg/sql/backfill_protected_timestamp_test.go
+++ b/pkg/sql/backfill_protected_timestamp_test.go
@@ -364,9 +364,18 @@ func TestBackfillQueryWithProtectedTS(t *testing.T) {
 			for _, sql := range []string{
 				fmt.Sprintf("CREATE TABLE %s(n int primary key)", tc.tableName),
 				fmt.Sprintf("ALTER TABLE %s CONFIGURE ZONE USING range_min_bytes = 0, range_max_bytes = 67108864, gc.ttlseconds = 5", tc.tableName),
-				fmt.Sprintf("INSERT INTO %s(n) SELECT * FROM generate_series(1, %d)", tc.tableName, initialRowCount),
 			} {
 				r.Exec(t, sql)
+			}
+			// Insert initial rows in batches to avoid long-running transactions
+			// that could be affected by the aggressive gc.ttlseconds setting.
+			const insertBatchSize = 10000
+			for i := 1; i <= initialRowCount; i += insertBatchSize {
+				end := i + insertBatchSize - 1
+				if end > initialRowCount {
+					end = initialRowCount
+				}
+				r.Exec(t, fmt.Sprintf("INSERT INTO %s(n) SELECT * FROM generate_series(%d, %d)", tc.tableName, i, end))
 			}
 
 			getTableID := func() (tableID uint32) {


### PR DESCRIPTION
Backport 1/1 commits from #161371 on behalf of @rafiss.

----

The test was flaky because it inserted 500,000 rows in a single transaction while using an aggressive gc.ttlseconds=5 setting. Under slow CI conditions, the INSERT could take 88+ seconds, during which time the GC threshold would advance past the transaction's timestamp, causing the error:
"batch timestamp must be after replica GC threshold"

This changes the initial data population to use batched INSERTs of 10,000 rows each. Each batch completes quickly enough to avoid being affected by the short GC TTL.

Resolves: #160661

Release note: None

----

Release justification: test only change