### PR TITLE
kvstorage: unify SetMinVersion for Engines

### DIFF
--- a/pkg/kv/kvserver/kvstorage/cluster_version.go
+++ b/pkg/kv/kvserver/kvstorage/cluster_version.go
@@ -19,7 +19,7 @@ import (
 
 // WriteClusterVersion writes the given cluster version to the min version file,
 // for each logical engine.
-func WriteClusterVersion(ctx context.Context, eng Engines, cv clusterversion.ClusterVersion) error {
+func WriteClusterVersion(eng Engines, cv clusterversion.ClusterVersion) error {
 	if err := eng.StateEngine().SetMinVersion(cv.Version); err != nil {
 		return errors.Wrapf(err, "error writing version to engine %s", eng.StateEngine())
 	} else if !eng.Separated() {
@@ -36,11 +36,9 @@ func WriteClusterVersion(ctx context.Context, eng Engines, cv clusterversion.Clu
 //
 // At the time of writing this is used during bootstrap, initial server start
 // (to perhaps fill into additional stores), and during cluster version bumps.
-func WriteClusterVersionToEngines(
-	ctx context.Context, engines []Engines, cv clusterversion.ClusterVersion,
-) error {
+func WriteClusterVersionToEngines(engines []Engines, cv clusterversion.ClusterVersion) error {
 	for _, eng := range engines {
-		if err := WriteClusterVersion(ctx, eng, cv); err != nil {
+		if err := WriteClusterVersion(eng, cv); err != nil {
 			return err
 		}
 	}

--- a/pkg/kv/kvserver/kvstorage/cluster_version.go
+++ b/pkg/kv/kvserver/kvstorage/cluster_version.go
@@ -17,19 +17,6 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// WriteClusterVersion writes the given cluster version to the min version file,
-// for each logical engine.
-func WriteClusterVersion(eng Engines, cv clusterversion.ClusterVersion) error {
-	if err := eng.StateEngine().SetMinVersion(cv.Version); err != nil {
-		return errors.Wrapf(err, "error writing version to engine %s", eng.StateEngine())
-	} else if !eng.Separated() {
-		return nil // there is only one engine
-	} else if err := eng.LogEngine().SetMinVersion(cv.Version); err != nil {
-		return errors.Wrapf(err, "error writing version to engine %s", eng.LogEngine())
-	}
-	return nil
-}
-
 // WriteClusterVersionToEngines writes the given version to the given engines,
 // Returns nil on success; otherwise returns first error encountered writing to
 // the stores. It makes no attempt to validate the supplied version.
@@ -38,7 +25,7 @@ func WriteClusterVersion(eng Engines, cv clusterversion.ClusterVersion) error {
 // (to perhaps fill into additional stores), and during cluster version bumps.
 func WriteClusterVersionToEngines(engines []Engines, cv clusterversion.ClusterVersion) error {
 	for _, eng := range engines {
-		if err := WriteClusterVersion(eng, cv); err != nil {
+		if err := eng.SetMinVersion(cv); err != nil {
 			return err
 		}
 	}

--- a/pkg/kv/kvserver/kvstorage/datadriven_test.go
+++ b/pkg/kv/kvserver/kvstorage/datadriven_test.go
@@ -40,7 +40,7 @@ func newEnv(t *testing.T) *env {
 	// TODO(tbg): ideally this would do full bootstrap, which requires
 	// moving a lot more code from kvserver. But then we could unit test
 	// all of it with the datadriven harness!
-	require.NoError(t, WriteClusterVersion(eng, clusterversion.TestingClusterVersion))
+	require.NoError(t, eng.SetMinVersion(clusterversion.TestingClusterVersion))
 	require.NoError(t, InitEngine(ctx, eng.TODOEngine(), roachpb.StoreIdent{
 		ClusterID: uuid.MakeV4(),
 		NodeID:    1,

--- a/pkg/kv/kvserver/kvstorage/datadriven_test.go
+++ b/pkg/kv/kvserver/kvstorage/datadriven_test.go
@@ -40,7 +40,7 @@ func newEnv(t *testing.T) *env {
 	// TODO(tbg): ideally this would do full bootstrap, which requires
 	// moving a lot more code from kvserver. But then we could unit test
 	// all of it with the datadriven harness!
-	require.NoError(t, WriteClusterVersion(ctx, eng, clusterversion.TestingClusterVersion))
+	require.NoError(t, WriteClusterVersion(eng, clusterversion.TestingClusterVersion))
 	require.NoError(t, InitEngine(ctx, eng.TODOEngine(), roachpb.StoreIdent{
 		ClusterID: uuid.MakeV4(),
 		NodeID:    1,

--- a/pkg/kv/kvserver/kvstorage/datadriven_test.go
+++ b/pkg/kv/kvserver/kvstorage/datadriven_test.go
@@ -40,7 +40,7 @@ func newEnv(t *testing.T) *env {
 	// TODO(tbg): ideally this would do full bootstrap, which requires
 	// moving a lot more code from kvserver. But then we could unit test
 	// all of it with the datadriven harness!
-	require.NoError(t, WriteClusterVersion(ctx, eng.TODOEngine(), clusterversion.TestingClusterVersion))
+	require.NoError(t, WriteClusterVersion(ctx, eng, clusterversion.TestingClusterVersion))
 	require.NoError(t, InitEngine(ctx, eng.TODOEngine(), roachpb.StoreIdent{
 		ClusterID: uuid.MakeV4(),
 		NodeID:    1,

--- a/pkg/kv/kvserver/kvstorage/datadriven_test.go
+++ b/pkg/kv/kvserver/kvstorage/datadriven_test.go
@@ -41,7 +41,7 @@ func newEnv(t *testing.T) *env {
 	// moving a lot more code from kvserver. But then we could unit test
 	// all of it with the datadriven harness!
 	require.NoError(t, eng.SetMinVersion(clusterversion.TestingClusterVersion))
-	require.NoError(t, InitEngine(ctx, eng.TODOEngine(), roachpb.StoreIdent{
+	require.NoError(t, InitEngine(ctx, eng, roachpb.StoreIdent{
 		ClusterID: uuid.MakeV4(),
 		NodeID:    1,
 		StoreID:   1,

--- a/pkg/kv/kvserver/kvstorage/datadriven_test.go
+++ b/pkg/kv/kvserver/kvstorage/datadriven_test.go
@@ -30,18 +30,18 @@ import (
 )
 
 type env struct {
-	eng storage.Engine
+	eng Engines
 	tr  *tracing.Tracer
 }
 
 func newEnv(t *testing.T) *env {
 	ctx := context.Background()
-	eng := storage.NewDefaultInMemForTesting()
+	eng := MakeEngines(storage.NewDefaultInMemForTesting())
 	// TODO(tbg): ideally this would do full bootstrap, which requires
 	// moving a lot more code from kvserver. But then we could unit test
 	// all of it with the datadriven harness!
-	require.NoError(t, WriteClusterVersion(ctx, eng, clusterversion.TestingClusterVersion))
-	require.NoError(t, InitEngine(ctx, eng, roachpb.StoreIdent{
+	require.NoError(t, WriteClusterVersion(ctx, eng.TODOEngine(), clusterversion.TestingClusterVersion))
+	require.NoError(t, InitEngine(ctx, eng.TODOEngine(), roachpb.StoreIdent{
 		ClusterID: uuid.MakeV4(),
 		NodeID:    1,
 		StoreID:   1,
@@ -67,9 +67,9 @@ func (e *env) handleNewReplica(
 	k, ek roachpb.RKey,
 ) *roachpb.RangeDescriptor {
 	sl := MakeStateLoader(id.RangeID)
-	require.NoError(t, sl.SetHardState(ctx, e.eng, raftpb.HardState{}))
+	require.NoError(t, sl.SetHardState(ctx, e.eng.LogEngine(), raftpb.HardState{}))
 	if !skipRaftReplicaID && id.ReplicaID != 0 {
-		require.NoError(t, sl.SetRaftReplicaID(ctx, e.eng, id.ReplicaID))
+		require.NoError(t, sl.SetRaftReplicaID(ctx, e.eng.StateEngine(), id.ReplicaID))
 	}
 	if len(ek) == 0 {
 		return nil
@@ -88,7 +88,7 @@ func (e *env) handleNewReplica(
 	var v roachpb.Value
 	require.NoError(t, v.SetProto(desc))
 	ts := hlc.Timestamp{WallTime: 123}
-	require.NoError(t, e.eng.PutMVCC(storage.MVCCKey{
+	require.NoError(t, e.eng.StateEngine().PutMVCC(storage.MVCCKey{
 		Key:       keys.RangeDescriptorKey(desc.StartKey),
 		Timestamp: ts,
 	}, storage.MVCCValue{Value: v}))
@@ -99,7 +99,7 @@ func (e *env) handleRangeTombstone(
 	t *testing.T, ctx context.Context, rangeID roachpb.RangeID, next roachpb.ReplicaID,
 ) {
 	require.NoError(t, MakeStateLoader(rangeID).SetRangeTombstone(
-		ctx, e.eng, kvserverpb.RangeTombstone{NextReplicaID: next},
+		ctx, e.eng.StateEngine(), kvserverpb.RangeTombstone{NextReplicaID: next},
 	))
 }
 
@@ -162,7 +162,7 @@ func TestDataDriven(t *testing.T) {
 				e.handleRangeTombstone(t, ctx, rangeID, nextID)
 
 			case "load-and-reconcile":
-				replicas, err := LoadAndReconcileReplicas(ctx, e.eng)
+				replicas, err := LoadAndReconcileReplicas(ctx, e.eng.TODOEngine())
 				if err != nil {
 					fmt.Fprintln(&buf, err)
 					break

--- a/pkg/kv/kvserver/loqrecovery/collect_test.go
+++ b/pkg/kv/kvserver/loqrecovery/collect_test.go
@@ -30,11 +30,10 @@ func TestCollectChecksStoreInfo(t *testing.T) {
 	engines := kvstorage.MakeEngines(eng)
 	defer engines.Close()
 
-	v := roachpb.Version{Major: 21, Minor: 2}
-	if err := kvstorage.WriteClusterVersionToEngines(ctx, []kvstorage.Engines{engines},
-		clusterversion.ClusterVersion{Version: v}); err != nil {
-		t.Fatalf("failed to populate test store cluster version: %v", err)
-	}
+	require.NoError(t, kvstorage.WriteClusterVersionToEngines(
+		[]kvstorage.Engines{engines},
+		clusterversion.ClusterVersion{Version: roachpb.Version{Major: 21, Minor: 2}}),
+	)
 
 	_, _, err = CollectStoresReplicaInfo(ctx, []kvstorage.Engines{engines})
 	require.ErrorContains(t, err, "is too old for running version",

--- a/pkg/kv/kvserver/loqrecovery/recovery_env_test.go
+++ b/pkg/kv/kvserver/loqrecovery/recovery_env_test.go
@@ -617,7 +617,7 @@ func (e *quorumRecoveryEnv) getOrCreateStore(
 		))
 
 		require.NoError(t, kvstorage.WriteClusterVersionToEngines(
-			ctx, []kvstorage.Engines{engines},
+			[]kvstorage.Engines{engines},
 			clusterversion.ClusterVersion{Version: clusterversion.Latest.Version()},
 		))
 		wrapped.engines = engines

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -299,7 +299,7 @@ func createTestStoreWithoutStart(
 	if opts.bootstrapVersion != (roachpb.Version{}) {
 		cv = clusterversion.ClusterVersion{Version: opts.bootstrapVersion}
 	}
-	require.NoError(t, kvstorage.WriteClusterVersion(ctx, eng.TODOEngine(), cv))
+	require.NoError(t, kvstorage.WriteClusterVersion(ctx, eng, cv))
 	if err := kvstorage.InitEngine(
 		ctx, eng.TODOEngine(), storeIdent,
 	); err != nil {

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -299,7 +299,7 @@ func createTestStoreWithoutStart(
 	if opts.bootstrapVersion != (roachpb.Version{}) {
 		cv = clusterversion.ClusterVersion{Version: opts.bootstrapVersion}
 	}
-	require.NoError(t, kvstorage.WriteClusterVersion(eng, cv))
+	require.NoError(t, eng.SetMinVersion(cv))
 	if err := kvstorage.InitEngine(
 		ctx, eng.TODOEngine(), storeIdent,
 	); err != nil {

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -299,7 +299,7 @@ func createTestStoreWithoutStart(
 	if opts.bootstrapVersion != (roachpb.Version{}) {
 		cv = clusterversion.ClusterVersion{Version: opts.bootstrapVersion}
 	}
-	require.NoError(t, kvstorage.WriteClusterVersion(ctx, eng, cv))
+	require.NoError(t, kvstorage.WriteClusterVersion(eng, cv))
 	if err := kvstorage.InitEngine(
 		ctx, eng.TODOEngine(), storeIdent,
 	); err != nil {

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -300,11 +300,7 @@ func createTestStoreWithoutStart(
 		cv = clusterversion.ClusterVersion{Version: opts.bootstrapVersion}
 	}
 	require.NoError(t, eng.SetMinVersion(cv))
-	if err := kvstorage.InitEngine(
-		ctx, eng.TODOEngine(), storeIdent,
-	); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, kvstorage.InitEngine(ctx, eng, storeIdent))
 	rangeProv.store = store
 	store.Ident = &storeIdent // would usually be set during Store.Start, but can't call that yet
 	stores.AddStore(store)
@@ -438,7 +434,7 @@ func TestInitializeEngineErrors(t *testing.T) {
 	require.ErrorIs(t, err, &kvstorage.NotBootstrappedError{})
 
 	// Bootstrap should fail on non-empty engine.
-	err = kvstorage.InitEngine(ctx, eng.TODOEngine(), testIdent)
+	err = kvstorage.InitEngine(ctx, eng, testIdent)
 	require.ErrorContains(t, err, "cannot be bootstrapped")
 
 	// Bootstrap should fail on MVCC range key in engine.
@@ -448,7 +444,7 @@ func TestInitializeEngineErrors(t *testing.T) {
 		Timestamp: hlc.MinTimestamp,
 	}, storage.MVCCValue{}))
 
-	err = kvstorage.InitEngine(ctx, eng.TODOEngine(), testIdent)
+	err = kvstorage.InitEngine(ctx, eng, testIdent)
 	require.ErrorContains(t, err, "found mvcc range key")
 }
 

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -508,7 +508,7 @@ func (s *initServer) initializeFirstStoreAfterJoin(
 
 	firstEngine := s.inspectedDiskState.uninitializedEngines[0]
 	clusterVersion := clusterversion.ClusterVersion{Version: *resp.ActiveVersion}
-	if err := kvstorage.WriteClusterVersion(ctx, firstEngine.TODOEngine(), clusterVersion); err != nil {
+	if err := kvstorage.WriteClusterVersion(ctx, firstEngine, clusterVersion); err != nil {
 		return nil, err
 	}
 

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -508,7 +508,7 @@ func (s *initServer) initializeFirstStoreAfterJoin(
 
 	firstEngine := s.inspectedDiskState.uninitializedEngines[0]
 	clusterVersion := clusterversion.ClusterVersion{Version: *resp.ActiveVersion}
-	if err := kvstorage.WriteClusterVersion(ctx, firstEngine, clusterVersion); err != nil {
+	if err := kvstorage.WriteClusterVersion(firstEngine, clusterVersion); err != nil {
 		return nil, err
 	}
 

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -508,7 +508,7 @@ func (s *initServer) initializeFirstStoreAfterJoin(
 
 	firstEngine := s.inspectedDiskState.uninitializedEngines[0]
 	clusterVersion := clusterversion.ClusterVersion{Version: *resp.ActiveVersion}
-	if err := kvstorage.WriteClusterVersion(firstEngine, clusterVersion); err != nil {
+	if err := firstEngine.SetMinVersion(clusterVersion); err != nil {
 		return nil, err
 	}
 

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -516,7 +516,7 @@ func (s *initServer) initializeFirstStoreAfterJoin(
 	if err != nil {
 		return nil, err
 	}
-	if err := kvstorage.InitEngine(ctx, firstEngine.TODOEngine(), sIdent); err != nil {
+	if err := kvstorage.InitEngine(ctx, firstEngine, sIdent); err != nil {
 		return nil, err
 	}
 

--- a/pkg/server/migration.go
+++ b/pkg/server/migration.go
@@ -126,7 +126,7 @@ func bumpClusterVersion(
 	// Whenever the version changes, we want to persist that update to
 	// wherever the CRDB process retrieved the initial version from
 	// (typically a collection of storage.Engines).
-	if err := kvstorage.WriteClusterVersionToEngines(ctx, engines, newCV); err != nil {
+	if err := kvstorage.WriteClusterVersionToEngines(engines, newCV); err != nil {
 		return err
 	}
 

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -481,7 +481,7 @@ func bootstrapCluster(
 
 	// We use our binary version to bootstrap the cluster.
 	bootstrapVersion := clusterversion.ClusterVersion{Version: initCfg.latestVersion}
-	if err := kvstorage.WriteClusterVersionToEngines(ctx, engines, bootstrapVersion); err != nil {
+	if err := kvstorage.WriteClusterVersionToEngines(engines, bootstrapVersion); err != nil {
 		return nil, err
 	}
 

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -497,7 +497,7 @@ func bootstrapCluster(
 
 		// Initialize the engine backing the store with the store ident and cluster
 		// version.
-		if err := kvstorage.InitEngine(ctx, eng.TODOEngine(), sIdent); err != nil {
+		if err := kvstorage.InitEngine(ctx, eng, sIdent); err != nil {
 			return nil, err
 		}
 
@@ -1006,7 +1006,7 @@ func (n *Node) initializeAdditionalStores(ctx context.Context, engines []kvstora
 			StoreID:   startID,
 		}
 		for _, eng := range engines {
-			if err := kvstorage.InitEngine(ctx, eng.TODOEngine(), sIdent); err != nil {
+			if err := kvstorage.InitEngine(ctx, eng, sIdent); err != nil {
 				return err
 			}
 

--- a/pkg/server/node_tombstone_storage_test.go
+++ b/pkg/server/node_tombstone_storage_test.go
@@ -34,7 +34,7 @@ func TestNodeTombstoneStorage(t *testing.T) {
 	// We'll test uninited engines at the end of the test.
 	id := uuid.NewV4()
 	for i := range engs {
-		require.NoError(t, kvstorage.WriteClusterVersion(ctx, engs[i], clusterversion.TestingClusterVersion))
+		require.NoError(t, kvstorage.WriteClusterVersion(engs[i], clusterversion.TestingClusterVersion))
 		require.NoError(t, kvstorage.InitEngine(ctx, engs[i].TODOEngine(), roachpb.StoreIdent{
 			ClusterID: id,
 			NodeID:    1,

--- a/pkg/server/node_tombstone_storage_test.go
+++ b/pkg/server/node_tombstone_storage_test.go
@@ -34,7 +34,7 @@ func TestNodeTombstoneStorage(t *testing.T) {
 	// We'll test uninited engines at the end of the test.
 	id := uuid.NewV4()
 	for i := range engs {
-		require.NoError(t, kvstorage.WriteClusterVersion(ctx, engs[i].LogEngine(), clusterversion.TestingClusterVersion))
+		require.NoError(t, kvstorage.WriteClusterVersion(ctx, engs[i], clusterversion.TestingClusterVersion))
 		require.NoError(t, kvstorage.InitEngine(ctx, engs[i].TODOEngine(), roachpb.StoreIdent{
 			ClusterID: id,
 			NodeID:    1,

--- a/pkg/server/node_tombstone_storage_test.go
+++ b/pkg/server/node_tombstone_storage_test.go
@@ -34,7 +34,7 @@ func TestNodeTombstoneStorage(t *testing.T) {
 	// We'll test uninited engines at the end of the test.
 	id := uuid.NewV4()
 	for i := range engs {
-		require.NoError(t, kvstorage.WriteClusterVersion(engs[i], clusterversion.TestingClusterVersion))
+		require.NoError(t, engs[i].SetMinVersion(clusterversion.TestingClusterVersion))
 		require.NoError(t, kvstorage.InitEngine(ctx, engs[i].TODOEngine(), roachpb.StoreIdent{
 			ClusterID: id,
 			NodeID:    1,

--- a/pkg/server/node_tombstone_storage_test.go
+++ b/pkg/server/node_tombstone_storage_test.go
@@ -35,7 +35,7 @@ func TestNodeTombstoneStorage(t *testing.T) {
 	id := uuid.NewV4()
 	for i := range engs {
 		require.NoError(t, engs[i].SetMinVersion(clusterversion.TestingClusterVersion))
-		require.NoError(t, kvstorage.InitEngine(ctx, engs[i].TODOEngine(), roachpb.StoreIdent{
+		require.NoError(t, kvstorage.InitEngine(ctx, engs[i], roachpb.StoreIdent{
 			ClusterID: id,
 			NodeID:    1,
 			StoreID:   roachpb.StoreID(1 + i),

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1639,7 +1639,7 @@ func (s *topLevelServer) PreStart(ctx context.Context) error {
 		// that version won't be on all engines. For that reason, we backfill
 		// once.
 		if err := kvstorage.WriteClusterVersionToEngines(
-			ctx, s.engines, initialDiskClusterVersion,
+			s.engines, initialDiskClusterVersion,
 		); err != nil {
 			return err
 		}
@@ -1852,7 +1852,7 @@ func (s *topLevelServer) PreStart(ctx context.Context) error {
 		// itself, and then informing the version setting about it (an invariant
 		// we must up hold whenever setting a new active version).
 		if err := kvstorage.WriteClusterVersionToEngines(
-			ctx, s.engines, state.clusterVersion,
+			s.engines, state.clusterVersion,
 		); err != nil {
 			return err
 		}

--- a/pkg/testutils/localtestcluster/BUILD.bazel
+++ b/pkg/testutils/localtestcluster/BUILD.bazel
@@ -40,5 +40,6 @@ go_library(
         "//pkg/util/stop",
         "//pkg/util/timeutil",
         "//pkg/util/tracing",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -254,11 +254,9 @@ func (ltc *LocalTestCluster) Start(t testing.TB, initFactory InitFactoryFn) {
 	cfg.ClosedTimestampReceiver = sidetransport.NewReceiver(nc, ltc.stopper, ltc.Stores, nil /* testingKnobs */)
 
 	require.NoError(t, ltc.Eng.SetMinVersion(clusterversion.TestingClusterVersion))
-	if err := kvstorage.InitEngine(
-		ctx, ltc.Eng.TODOEngine(), roachpb.StoreIdent{NodeID: nodeID, StoreID: 1},
-	); err != nil {
-		t.Fatalf("unable to start local test cluster: %s", err)
-	}
+	require.NoError(t, kvstorage.InitEngine(
+		ctx, ltc.Eng, roachpb.StoreIdent{NodeID: nodeID, StoreID: 1},
+	))
 
 	rangeFeedFactory, err := rangefeed.NewFactory(ltc.stopper, ltc.DB, cfg.Settings, nil /* knobs */)
 	if err != nil {

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -252,7 +252,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, initFactory InitFactoryFn) {
 	cfg.Transport = kvserver.NewDummyRaftTransport(cfg.AmbientCtx, cfg.Settings, ltc.Clock)
 	cfg.ClosedTimestampReceiver = sidetransport.NewReceiver(nc, ltc.stopper, ltc.Stores, nil /* testingKnobs */)
 
-	if err := kvstorage.WriteClusterVersion(ctx, ltc.Eng.LogEngine(), clusterversion.TestingClusterVersion); err != nil {
+	if err := kvstorage.WriteClusterVersion(ctx, ltc.Eng, clusterversion.TestingClusterVersion); err != nil {
 		t.Fatalf("unable to write cluster version: %s", err)
 	}
 	if err := kvstorage.InitEngine(

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -252,7 +252,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, initFactory InitFactoryFn) {
 	cfg.Transport = kvserver.NewDummyRaftTransport(cfg.AmbientCtx, cfg.Settings, ltc.Clock)
 	cfg.ClosedTimestampReceiver = sidetransport.NewReceiver(nc, ltc.stopper, ltc.Stores, nil /* testingKnobs */)
 
-	if err := kvstorage.WriteClusterVersion(ctx, ltc.Eng, clusterversion.TestingClusterVersion); err != nil {
+	if err := kvstorage.WriteClusterVersion(ltc.Eng, clusterversion.TestingClusterVersion); err != nil {
 		t.Fatalf("unable to write cluster version: %s", err)
 	}
 	if err := kvstorage.InitEngine(

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -45,6 +45,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/stretchr/testify/require"
 )
 
 // A LocalTestCluster encapsulates an in-memory instantiation of a
@@ -252,9 +253,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, initFactory InitFactoryFn) {
 	cfg.Transport = kvserver.NewDummyRaftTransport(cfg.AmbientCtx, cfg.Settings, ltc.Clock)
 	cfg.ClosedTimestampReceiver = sidetransport.NewReceiver(nc, ltc.stopper, ltc.Stores, nil /* testingKnobs */)
 
-	if err := kvstorage.WriteClusterVersion(ltc.Eng, clusterversion.TestingClusterVersion); err != nil {
-		t.Fatalf("unable to write cluster version: %s", err)
-	}
+	require.NoError(t, ltc.Eng.SetMinVersion(clusterversion.TestingClusterVersion))
 	if err := kvstorage.InitEngine(
 		ctx, ltc.Eng.TODOEngine(), roachpb.StoreIdent{NodeID: nodeID, StoreID: 1},
 	); err != nil {


### PR DESCRIPTION
This PR encapsulates `SetMinVersion` calls in `Engines.SetMinVersion()` method which is aware if engines are separated, and sets the version for both if so.

Currently, we would ever bump min version for both engines to the same value, which seems sensible since both are Pebble instances. We will do something more complex if we discover migration scenarios in which these need to be out of sync.

Part of #97627