### PR TITLE
admission: wrap context errors

### DIFF
--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -887,12 +887,14 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 		recordAdmissionWorkQueueStats(span, waitDur, q.queueKind, info.Priority, true)
 		if deadline, hasDeadline := ctx.Deadline(); hasDeadline {
 			log.Eventf(ctx, "deadline expired, waited in %s queue with pri %s for %v", q.queueKind, admissionpb.WorkPriorityDict[info.Priority], waitDur)
-			return AdmitResponse{}, errors.Newf("deadline expired while waiting in queue: %s, pri: %s, deadline: %v, start: %v, dur: %v",
+			return AdmitResponse{}, errors.Wrapf(ctx.Err(),
+				"deadline expired while waiting in queue: %s, pri: %s, deadline: %v, start: %v, dur: %v",
 				q.queueKind, admissionpb.WorkPriorityDict[info.Priority], deadline, startTime, waitDur)
 		}
 		// This is a pure context cancellation.
 		log.Eventf(ctx, "context canceled, waited in %s queue with pri %s for %v", q.queueKind, admissionpb.WorkPriorityDict[info.Priority], waitDur)
-		return AdmitResponse{}, errors.Newf("context canceled while waiting in queue: %s, pri: %s, start: %v, dur: %v",
+		return AdmitResponse{}, errors.Wrapf(ctx.Err(),
+			"context canceled while waiting in queue: %s, pri: %s, start: %v, dur: %v",
 			q.queueKind, admissionpb.WorkPriorityDict[info.Priority], startTime, waitDur)
 	case chainID, ok := <-work.ch:
 		if !ok {


### PR DESCRIPTION
The code was replacing the error, which is not appropriate. Additionally, this was resulting in long stack traces being logged from the SQL layer:
```
sql/execinfra/processorsbase.go:560 ��� [T1,Vsystem,n1,client=10.142.0.201:57222,hostssl,user=���roachprod���] 777  overriding non-cancelation emitted after context cancellation: context canceled while waiting in queue: sql-kv-response, pri: ���locking-normal-pri���, start: 2026-01-17 22:35:02.696018101 +0000 UTC m=+1626.019540140, dur: 20.94022ms
sql/execinfra/processorsbase.go:560 ��� [T1,Vsystem,n1,client=10.142.0.201:57222,hostssl,user=���roachprod���] 777 +(1) attached stack trace
sql/execinfra/processorsbase.go:560 ��� [T1,Vsystem,n1,client=10.142.0.201:57222,hostssl,user=���roachprod���] 777 +  -- stack trace:
sql/execinfra/processorsbase.go:560 ��� [T1,Vsystem,n1,client=10.142.0.201:57222,hostssl,user=���roachprod���] 777 +  | github.com/cockroachdb/cockroach/pkg/util/admission.(*WorkQueue).Admit
sql/execinfra/processorsbase.go:560 ��� [T1,Vsystem,n1,client=10.142.0.201:57222,hostssl,user=���roachprod���] 777 +  | 	pkg/util/admission/work_queue.go:895
sql/execinfra/processorsbase.go:560 ��� [T1,Vsystem,n1,client=10.142.0.201:57222,hostssl,user=���roachprod���] 777 +  | github.com/cockroachdb/cockroach/pkg/sql.(*tableWriterBase).tryDoResponseAdmission
sql/execinfra/processorsbase.go:560 ��� [T1,Vsystem,n1,client=10.142.0.201:57222,hostssl,user=���roachprod���] 777 +  | 	pkg/sql/tablewriter.go:215
sql/execinfra/processorsbase.go:560 ��� [T1,Vsystem,n1,client=10.142.0.201:57222,hostssl,user=���roachprod���] 777 +  | g
```

Epic: none

Release note: None