### PR TITLE
release-26.1: roachtest: fix tpcc/large-schema-benchmark TPCC worker validation error

### DIFF
--- a/pkg/cmd/roachtest/tests/large_schema_benchmark.go
+++ b/pkg/cmd/roachtest/tests/large_schema_benchmark.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/cockroachdb/cockroach/pkg/workload/tpcc"
 	"github.com/stretchr/testify/require"
 )
 
@@ -210,8 +211,7 @@ func registerLargeSchemaBenchmark(r registry.Registry, numTables int, isMultiReg
 			}
 			// Next, start up the workload for our list of databases from earlier.
 			tpccDatabaseLists := [][]string{activeDBList, inactiveDBList}
-			// Since we will spawn two sets of TPCC clients, split the
-			// total workers between them.
+			// Cap the number of workers to reduce noise in measurements.
 			numWorkers := numTotalWorkers / len(tpccDatabaseLists)
 			for dbListType, dbList := range tpccDatabaseLists {
 				dbList := dbList
@@ -221,10 +221,14 @@ func registerLargeSchemaBenchmark(r registry.Registry, numTables int, isMultiReg
 					waitEnabled := "--wait 0.0"
 					var wlInstance []workloadInstance
 					disableHistogram := false
+					numWarehouses := len(c.All()) - 1
 					// Inactive databases will intentionally have wait time on
 					// them and not include them in our histograms.
 					if dbListType == inactiveDbListType {
 						waitEnabled = "--wait 1.0"
+						// TPCC requires workers = warehouses * 10 when --wait > 0.
+						// Use 1 warehouse to allow running with fewer workers.
+						numWarehouses = 1
 
 						// disable histogram since they shouldn't be included
 						disableHistogram = true
@@ -239,10 +243,17 @@ func registerLargeSchemaBenchmark(r registry.Registry, numTables int, isMultiReg
 							},
 						)
 					}
+					// TPCC requires workers = warehouses * 10 when --wait > 0.
+					// For active DBs (--wait 0), we can use reduced workers.
+					// For inactive DBs (--wait 1.0), we use 1 warehouse to allow 10 workers.
+					tpccWorkers := numWorkers
+					if dbListType == inactiveDbListType {
+						tpccWorkers = numWarehouses * tpcc.NumWorkersPerWarehouse
+					}
 					options := tpccOptions{
 						WorkloadCmd:       "tpccmultidb",
 						DB:                strings.Split(dbList[0], ".")[0],
-						Warehouses:        len(c.All()) - 1,
+						Warehouses:        numWarehouses,
 						SkipSetup:         true,
 						DisablePrometheus: true,
 						DisableHistogram:  disableHistogram, // We setup the flag above.
@@ -256,7 +267,7 @@ func registerLargeSchemaBenchmark(r registry.Registry, numTables int, isMultiReg
 							"roachadmin",
 							"roacher",
 							numWorkers,
-							numWorkers,
+							tpccWorkers,
 							waitEnabled),
 					}
 					runTPCC(ctx, t, t.L(), c, options)


### PR DESCRIPTION
Backport 1/1 commits from #161372 on behalf of @rafiss.

----

PR #160955 reduced the number of workers in the large-schema-benchmark test to limit concurrency and reduce noise in measurements. However, for the "inactive" databases that use `--wait 1.0`, TPCC requires exactly 10 workers per warehouse to satisfy its validation requirements.

The fix reduces the number of warehouses for inactive databases to 1, which allows using 10 workers (1 * 10 = 10) while satisfying the TPCC validation. Active databases continue to use the reduced worker count since `--wait 0.0` has no validation requirement.

Resolves: #161349
Resolves: #161352
Resolves: #161355
Resolves: #161360
Resolves: #161361
Resolves: #161362
Epic: None

Release note: None

----

Release justification: test only change