### PR TITLE
spanconfigkvsubscriber: use realistic buffer entry size estimate

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -859,7 +859,6 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		clock,
 		rangeFeedFactory,
 		keys.SpanConfigurationsTableID,
-		4<<20, /* 4 MB */
 		fallbackConf,
 		cfg.Settings,
 		spanconfigstore.NewBoundsReader(tenantCapabilitiesWatcher),

--- a/pkg/spanconfig/spanconfigkvsubscriber/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigkvsubscriber/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//pkg/sql/rowenc/valueside",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
+        "//pkg/util/envutil",
         "//pkg/util/hlc",
         "//pkg/util/log",
         "//pkg/util/metric",

--- a/pkg/spanconfig/spanconfigkvsubscriber/datadriven_test.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/datadriven_test.go
@@ -144,7 +144,6 @@ func TestDataDriven(t *testing.T) {
 			ts.Clock(),
 			ts.RangeFeedFactory().(*rangefeed.Factory),
 			dummyTableID,
-			10<<20, /* 10 MB */
 			spanconfigtestutils.ParseConfig(t, "FALLBACK"),
 			ts.ClusterSettings(),
 			spanconfigstore.NewEmptyBoundsReader(),

--- a/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber_test.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber_test.go
@@ -92,7 +92,6 @@ func TestGetProtectionTimestamps(t *testing.T) {
 		hlc.NewClockForTesting(mt),
 		nil, /* rangeFeedFactory */
 		keys.SpanConfigurationsTableID,
-		1<<20, /* 1 MB */
 		roachpb.SpanConfig{},
 		cluster.MakeTestingClusterSettings(),
 		spanconfigstore.NewEmptyBoundsReader(),

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -266,7 +266,6 @@ func (ltc *LocalTestCluster) Start(t testing.TB, initFactory InitFactoryFn) {
 		clock,
 		rangeFeedFactory,
 		keys.SpanConfigurationsTableID,
-		1<<20, /* 1 MB */
 		cfg.DefaultSpanConfig,
 		cfg.Settings,
 		spanconfigstore.NewEmptyBoundsReader(),


### PR DESCRIPTION
The KVSubscriber's rangefeed buffer capacity is calculated by dividing the memory limit (4 MB) by an estimated entry size. The previous estimate of 5 KB per entry was overly conservative and "pulled out of thin air" (per the original comment), resulting in a buffer capacity of only ~819 events.

This change updates the estimate to 512 bytes based on actual struct sizes:
- Target.Span (start/end keys): ~80 bytes
- roachpb.SpanConfig proto: ~150 bytes
- hlc.Timestamp: 16 bytes
- Go slice/pointer overhead: ~50 bytes

The new estimate increases buffer capacity from ~819 to ~8,192 events, reducing "rangefeed buffer limit exceeded" errors during bulk schema operations like creating hundreds of thousands of tables.

The constants for buffer size and buffer entry size are also now configurable via environment variables.

fixes #161327
Release note: None