### PR TITLE
release-25.4: sql/backfill: skip a test under deadlock

### DIFF
--- a/pkg/sql/backfill/backfill_test.go
+++ b/pkg/sql/backfill/backfill_test.go
@@ -341,17 +341,11 @@ func TestVectorIndexMergingDuringBackfillWithPrefix(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	skip.UnderRace(t, "too slow")
+	skip.UnderDeadlock(t, "produces false positives")
 
 	// Channel to block the backfill process
 	blockBackfill := make(chan struct{})
 	backfillBlocked := make(chan struct{})
-
-	var testTenant base.DefaultTestTenantOptions
-	if syncutil.DeadlockEnabled {
-		// The cluster can get overloaded under deadlock with external process
-		// mode.
-		testTenant = base.TestSkipForExternalProcessMode()
-	}
 
 	ctx := context.Background()
 	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{
@@ -364,7 +358,6 @@ func TestVectorIndexMergingDuringBackfillWithPrefix(t *testing.T) {
 				},
 			},
 		},
-		DefaultTestTenant: testTenant,
 	})
 	defer srv.Stopper().Stop(ctx)
 	sqlDB := sqlutils.MakeSQLRunner(db)


### PR DESCRIPTION
Backport 1/1 commits from #161347 on behalf of @yuzefovich.

----

`TestVectorIndexMergingDuringBackfillWithPrefix` occasionally produces false positives under deadlock. Let's just skip it in this heavy config.

See #155755.
Fixes: #161236.
Release note: None

----

Release justification: test-only change.