### PR TITLE
release-24.3: roachtest: ignore flaky gopg BeforeQuery/AfterQuery CopyFrom tests

### DIFF
--- a/pkg/cmd/roachtest/tests/gopg_blocklist.go
+++ b/pkg/cmd/roachtest/tests/gopg_blocklist.go
@@ -34,7 +34,8 @@ var gopgBlockList = blocklist{
 }
 
 var gopgIgnoreList = blocklist{
-	`pg | BeforeQuery and AfterQuery CopyFrom | is called for CopyFrom with model`: "unknown",
+	`pg | BeforeQuery and AfterQuery CopyFrom | is called for CopyFrom with model`:    "160602",
+	`pg | BeforeQuery and AfterQuery CopyFrom | is called for CopyFrom without model`: "160602",
 	// These "fetching" tests assume a particular order when ORDER BY clause is
 	// omitted from the query by the ORM itself.
 	"pg | ORM slice model | fetches Book relations":       "41690",


### PR DESCRIPTION
Backport 1/1 commits from #161300 on behalf of @rafiss.

----

These tests are flaky and have been observed to fail intermittently. Add them to the gopg ignore list to prevent spurious test failures.

Resolves: #160602
Epic: None

Release note: None

----

Release justification: