### PR TITLE
execinfra: fix inconsistent spelling in same sentence

### DIFF
--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -557,7 +557,7 @@ func (pb *ProcessorBaseNoHelper) MoveToDraining(err error) {
 		// reflect that, making cancellation detectable by callers.
 		if pb.Ctx().Err() != nil {
 			if !errors.Is(err, pb.Ctx().Err()) {
-				log.Dev.Warningf(pb.Ctx(), "overriding non-cancelation emitted after context cancellation: %+v", err)
+				log.Dev.Warningf(pb.Ctx(), "overriding non-cancellation emitted after context cancellation: %+v", err)
 			}
 			err = pb.Ctx().Err()
 		}


### PR DESCRIPTION
Small nit, noticed in
https://github.com/cockroachdb/cockroach/pull/161427#pullrequestreview-3683696814.

Epic: none

Release note: None