### PR TITLE
kv/kvclient/rangefeed: deliver prevValue for bulk events

### DIFF
--- a/pkg/crosscluster/producer/event_stream.go
+++ b/pkg/crosscluster/producer/event_stream.go
@@ -272,9 +272,12 @@ func (s *eventStream) onInitialScanDone(ctx context.Context) {
 	log.Dev.VInfof(ctx, 2, "initial scan completed")
 }
 
-func (s *eventStream) onValues(ctx context.Context, values []kv.KeyValue) {
+func (s *eventStream) onValues(ctx context.Context, values []kvpb.RangeFeedValue) {
 	for _, i := range values {
-		s.seb.addKV(streampb.StreamEvent_KV{KeyValue: roachpb.KeyValue{Key: i.Key, Value: *i.Value}})
+		s.seb.addKV(streampb.StreamEvent_KV{
+			KeyValue:  roachpb.KeyValue{Key: i.Key, Value: i.Value},
+			PrevValue: i.PrevValue,
+		})
 	}
 	s.setErr(s.maybeFlushBatch(ctx))
 }

--- a/pkg/crosscluster/replicationtestutils/replication_helpers.go
+++ b/pkg/crosscluster/replicationtestutils/replication_helpers.go
@@ -178,6 +178,17 @@ func (rf *ReplicationFeed) Close(ctx context.Context) {
 	rf.f.Close(ctx)
 }
 
+// ObserveGeneric consumes the feed until the predicate is satisfied.
+// Returns the matching event.
+func (rf *ReplicationFeed) ObserveGeneric(
+	ctx context.Context, pred FeedEventPredicate,
+) crosscluster.Event {
+	rf.consumeUntil(ctx, pred, func(err error) bool {
+		return false
+	})
+	return rf.msg
+}
+
 func (rf *ReplicationFeed) consumeUntil(
 	ctx context.Context, pred FeedEventPredicate, errPred FeedErrorPredicate,
 ) {

--- a/pkg/kv/kvclient/rangefeed/config.go
+++ b/pkg/kv/kvclient/rangefeed/config.go
@@ -184,12 +184,13 @@ func WithRetry(options retry.Options) Option {
 }
 
 // WithOnValues sets up a callback that's invoked whenever a batch of values is
-// passed such as during initial scans, allowing passing it as a batch to the
-// client rather than key-by-key to reduce overhead. This however comes with
-// some limitations: for batches passed this way the rangefeed client will not
-// process individual values and instead leaves this to the caller, meaning that
-// the options WithRowTimestampInInitialScan is implied, and WithDiff is ignored
-// as these are per-key processing that is not performed on batches.
+// passed such as during initial scans or catch-up scans, allowing passing it as
+// a batch to the client rather than key-by-key to reduce overhead. This however
+// comes with some limitations: for batches passed this way the rangefeed client
+// will not process individual values and instead leaves this to the caller,
+// meaning that the option WithRowTimestampInInitialScan is implied. For catch-up
+// scans, PrevValue is available if WithDiff is set; for initial scans, PrevValue
+// is not populated as these are point-in-time snapshots.
 func WithOnValues(fn OnValues) Option {
 	return optionFunc(func(c *config) {
 		c.onValues = fn

--- a/pkg/kv/kvclient/rangefeed/mocks_generated_test.go
+++ b/pkg/kv/kvclient/rangefeed/mocks_generated_test.go
@@ -8,8 +8,8 @@ import (
 	context "context"
 	reflect "reflect"
 
-	kv "github.com/cockroachdb/cockroach/pkg/kv"
 	kvcoord "github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
+	kvpb "github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	roachpb "github.com/cockroachdb/cockroach/pkg/roachpb"
 	hlc "github.com/cockroachdb/cockroach/pkg/util/hlc"
 	span "github.com/cockroachdb/cockroach/pkg/util/span"
@@ -78,7 +78,7 @@ func (mr *MockDBMockRecorder) RangeFeedFromFrontier(arg0, arg1, arg2 interface{}
 }
 
 // Scan mocks base method.
-func (m *MockDB) Scan(arg0 context.Context, arg1 []roachpb.Span, arg2 hlc.Timestamp, arg3 func(roachpb.KeyValue), arg4 func([]kv.KeyValue), arg5 scanConfig) error {
+func (m *MockDB) Scan(arg0 context.Context, arg1 []roachpb.Span, arg2 hlc.Timestamp, arg3 func(roachpb.KeyValue), arg4 func([]kvpb.RangeFeedValue), arg5 scanConfig) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Scan", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(error)

--- a/pkg/kv/kvclient/rangefeed/scanner.go
+++ b/pkg/kv/kvclient/rangefeed/scanner.go
@@ -8,7 +8,6 @@ package rangefeed
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -53,9 +52,9 @@ func (f *RangeFeed) runInitialScan(
 		f.onValue(ctx, &v)
 	}
 
-	var onValues func(kvs []kv.KeyValue)
+	var onValues func(kvs []kvpb.RangeFeedValue)
 	if f.onValues != nil {
-		onValues = func(kvs []kv.KeyValue) {
+		onValues = func(kvs []kvpb.RangeFeedValue) {
 			f.onValues(ctx, kvs)
 		}
 	}


### PR DESCRIPTION
Previously bulk event delivery dropped prev value because it was not available during init scans, but it is available during catch up scans.

Release note: none.
Epic: none.