### PR TITLE
release-25.2: sql: add pgcode to CREATE TABLE AS GC timestamp error

### DIFF
--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -502,7 +502,7 @@ func (sc *SchemaChanger) backfillQueryIntoTable(
 	// as a permanent error.
 	if errors.HasType(err, (*kvpb.BatchTimestampBeforeGCError)(nil)) {
 		return jobs.MarkAsPermanentJobError(
-			errors.Wrap(err, "unable to retry backfill since fixed timestamp is before the GC timestamp"),
+			pgerror.Wrap(err, pgcode.InvalidParameterValue, "unable to retry backfill since fixed timestamp is before the GC timestamp"),
 		)
 	}
 	return err


### PR DESCRIPTION
Backport 1/1 commits from #161462 on behalf of @rafiss.

----

Previously, when CREATE TABLE AS with AS OF SYSTEM TIME failed because the timestamp was before the GC threshold, the error lacked a PostgreSQL error code and generated excessive log noise (full stack trace at ERROR level).

This change adds pgcode.InvalidParameterValue to the error. This allows clients to programmatically detect and handle this user error. It also reduces log verbosity because the job registry treats errors with pgcodes as expected errors and logs them at Info level instead of Error level with full stack traces.

Fixes #161460

Release note: None

----

Release justification: