### PR TITLE
storageparam: return proper pgcode for float parsing errors

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -2689,6 +2689,9 @@ ALTER TABLE storage_param_table SET (foo=100)
 statement error parameter "fillfactor" requires a float value
 ALTER TABLE storage_param_table SET (fillfactor=true)
 
+statement error pgcode 22023 error decoding "fillfactor": strconv.ParseFloat: parsing "invalid_val": invalid syntax
+ALTER TABLE storage_param_table SET (fillfactor=invalid_val)
+
 statement error unimplemented: storage parameter "toast_tuple_target"
 ALTER TABLE storage_param_table SET (toast_tuple_target=100)
 
@@ -2976,7 +2979,7 @@ WHERE
 ----
 {}
 
-statement error pq: invalid float value for sql_stats_automatic_collection_fraction_stale_rows: could not parse "hello" as type float: strconv.ParseFloat: parsing "hello": invalid syntax
+statement error pgcode 22P02 pq: invalid float value for sql_stats_automatic_collection_fraction_stale_rows: could not parse "hello" as type float: strconv.ParseFloat: parsing "hello": invalid syntax
 ALTER TABLE t5 SET (sql_stats_automatic_collection_fraction_stale_rows = 'hello')
 
 statement error pq: invalid integer value for sql_stats_automatic_collection_min_stale_rows: could not parse "world" as type int: strconv.ParseInt: parsing "world": invalid syntax
@@ -3122,6 +3125,9 @@ ALTER TABLE t5 RESET (sql_stats_automatic_partial_collection_fraction_stale_rows
 
 statement error pq: invalid float value for sql_stats_automatic_partial_collection_fraction_stale_rows: cannot set to a negative value: -0.500000
 ALTER TABLE t5 SET (sql_stats_automatic_partial_collection_fraction_stale_rows = -0.5)
+
+statement error pgcode 22P02 pq: invalid float value for sql_stats_automatic_partial_collection_fraction_stale_rows: could not parse "invalid" as type float: strconv.ParseFloat: parsing "invalid": invalid syntax
+ALTER TABLE t5 SET (sql_stats_automatic_partial_collection_fraction_stale_rows = 'invalid')
 
 statement ok
 DROP TABLE t5

--- a/pkg/sql/logictest/testdata/logic_test/geospatial_index
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial_index
@@ -26,6 +26,9 @@ CREATE INDEX bad_idx ON geo_table USING GIST(geom) WITH (geometry_min_x=10, geom
 statement error pgcode 22023 geometry_max_y \(0\.000000\) must be greater than geometry_min_y \(10\.000000\)
 CREATE INDEX bad_idx ON geo_table USING GIST(geom) WITH (geometry_min_y=10, geometry_max_y=0)
 
+statement error pgcode 22023 error decoding "geometry_min_x": strconv.ParseFloat: parsing "invalid_val": invalid syntax
+CREATE INDEX bad_idx ON geo_table USING GIST(geom) WITH (geometry_min_x=invalid_val)
+
 statement ok
 CREATE INDEX geom_idx_1 ON geo_table USING GIST(geom) WITH (geometry_min_x=0, s2_max_level=15)
 

--- a/pkg/sql/storageparam/indexstorageparam/index_storage_param.go
+++ b/pkg/sql/storageparam/indexstorageparam/index_storage_param.go
@@ -86,7 +86,7 @@ func (po *Setter) applyGeometryIndexSetting(
 	}
 	val, err := paramparse.DatumAsFloat(ctx, evalCtx, key, expr)
 	if err != nil {
-		return errors.Wrapf(err, "error decoding %q", key)
+		return pgerror.Wrapf(err, pgcode.InvalidParameterValue, "error decoding %q", key)
 	}
 	switch key {
 	case `geometry_min_x`:

--- a/pkg/sql/storageparam/storage_param.go
+++ b/pkg/sql/storageparam/storage_param.go
@@ -113,7 +113,7 @@ func Reset(
 func SetFillFactor(ctx context.Context, evalCtx *eval.Context, key string, datum tree.Datum) error {
 	val, err := paramparse.DatumAsFloat(ctx, evalCtx, key, datum)
 	if err != nil {
-		return err
+		return pgerror.Wrapf(err, pgcode.InvalidParameterValue, "error decoding %q", key)
 	}
 	if val < 0 || val > 100 {
 		return pgerror.Newf(pgcode.InvalidParameterValue, "%q must be between 0 and 100", key)

--- a/pkg/sql/storageparam/tablestorageparam/table_storage_param.go
+++ b/pkg/sql/storageparam/tablestorageparam/table_storage_param.go
@@ -106,12 +106,12 @@ func intFromDatum(
 	intDatum := datum
 	if stringVal, err := paramparse.DatumAsString(ctx, evalCtx, key, datum); err == nil {
 		if intDatum, err = tree.ParseDInt(stringVal); err != nil {
-			return 0, errors.Wrapf(err, "invalid integer value for %s", key)
+			return 0, pgerror.Wrapf(err, pgcode.InvalidParameterValue, "invalid integer value for %s", key)
 		}
 	}
 	s, err := paramparse.DatumAsInt(ctx, evalCtx, key, intDatum)
 	if err != nil {
-		return 0, err
+		return 0, pgerror.Wrapf(err, pgcode.InvalidParameterValue, "error decoding %q", key)
 	}
 	return s, nil
 }
@@ -122,12 +122,12 @@ func floatFromDatum(
 	floatDatum := datum
 	if stringVal, err := paramparse.DatumAsString(ctx, evalCtx, key, datum); err == nil {
 		if floatDatum, err = tree.ParseDFloat(stringVal); err != nil {
-			return 0, errors.Wrapf(err, "invalid float value for %s", key)
+			return 0, pgerror.Wrapf(err, pgcode.InvalidParameterValue, "invalid float value for %s", key)
 		}
 	}
 	s, err := paramparse.DatumAsFloat(ctx, evalCtx, key, floatDatum)
 	if err != nil {
-		return 0, err
+		return 0, pgerror.Wrapf(err, pgcode.InvalidParameterValue, "error decoding %q", key)
 	}
 	return s, nil
 }


### PR DESCRIPTION
Previously, when storage parameters like `fillfactor`, `geometry_min_x`, or `sql_stats_automatic_collection_fraction_stale_rows` received an invalid string value, the error returned had an internal error code (XXUUU) because the raw `strconv.ParseFloat` error was propagated without wrapping.

This change wraps these errors with `pgerror.Wrapf` using `pgcode.InvalidParameterValue` (22023) to provide a proper user-facing error code.

Fixes #161364
Fixes #154926

Release note: None