### PR TITLE
sql: add pgcode for exclude_data_from_backup inbound FK error

### DIFF
--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_set_storage_param.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_set_storage_param.go
@@ -485,7 +485,8 @@ func validateExcludeDataFromBackup(b BuildCtx, tbl *scpb.Table, key string) {
 	// we only allow a table with no incoming FK references to be marked as
 	// ephemeral.
 	if isTableReferencedByFK(b, tbl) {
-		panic(errors.New("cannot set data in a table with inbound foreign key constraints to be excluded from backup"))
+		panic(pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
+			"cannot set data in a table with inbound foreign key constraints to be excluded from backup"))
 	}
 }
 

--- a/pkg/sql/storageparam/tablestorageparam/table_storage_param.go
+++ b/pkg/sql/storageparam/tablestorageparam/table_storage_param.go
@@ -574,7 +574,8 @@ var tableParams = map[string]tableParam{
 			// we only allow a table with no incoming FK references to be marked as
 			// ephemeral.
 			if len(po.TableDesc.InboundFKs) != 0 {
-				return errors.New("cannot set data in a table with inbound foreign key constraints to be excluded from backup")
+				return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
+					"cannot set data in a table with inbound foreign key constraints to be excluded from backup")
 			}
 
 			excludeDataFromBackup, err := strconv.ParseBool(value)

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -5810,6 +5810,10 @@ func (og *operationGenerator) setTableStorageParam(
 		// set schema_locked cannot be combined with other operations
 		// and will return an error if it does.
 		stmt.potentialExecErrors.add(pgcode.InvalidParameterValue)
+	} else if param == "exclude_data_from_backup" {
+		// exclude_data_from_backup cannot be set on tables with inbound FK
+		// references.
+		stmt.potentialExecErrors.add(pgcode.ObjectNotInPrerequisiteState)
 	}
 
 	return stmt, nil


### PR DESCRIPTION
Previously, when attempting to set `exclude_data_from_backup` on a table with inbound foreign key constraints, the error was raised without a proper pgcode (defaulting to XXUUU). This made it difficult for the schemachange workload to handle the error appropriately.

This change adds `pgcode.ObjectNotInPrerequisiteState` (55000) to the error in both the legacy and declarative schema changers, and updates the schemachange workload to expect this error as a potential execution error when setting the `exclude_data_from_backup` storage parameter.

Fixes: #161167

Release note: None