### PR TITLE
sql/importer: fix post-cancellation row count flakiness in `TestImportIntoCSVCancel`

### DIFF
--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -1405,6 +1405,7 @@ func TestImportIntoCSVCancel(t *testing.T) {
 	conn := tc.ServerConn(0)
 
 	setupDoneCh := make(chan struct{})
+	finishedCancelCh := make(chan struct{})
 	for i := 0; i < tc.NumServers(); i++ {
 		tc.ApplicationLayer(i).JobRegistry().(*jobs.Registry).TestingWrapResumerConstructor(
 			jobspb.TypeImport,
@@ -1412,6 +1413,12 @@ func TestImportIntoCSVCancel(t *testing.T) {
 				r := raw.(*importResumer)
 				r.testingKnobs.onSetupFinish = func(flowinfra.Flow) {
 					close(setupDoneCh)
+				}
+				// We need this to ensure the cancel happens before the descriptor is
+				// marked online, and thus the rows ingested will be reverted.
+				r.testingKnobs.afterImport = func(_ roachpb.RowCount) error {
+					<-finishedCancelCh
+					return nil
 				}
 				return r
 			})
@@ -1427,6 +1434,7 @@ func TestImportIntoCSVCancel(t *testing.T) {
 	row.Scan(&jobID)
 	<-setupDoneCh
 	sqlDB.Exec(t, fmt.Sprintf("CANCEL JOB %d", jobID))
+	close(finishedCancelCh)
 	sqlDB.Exec(t, fmt.Sprintf("SHOW JOB WHEN COMPLETE %d", jobID))
 	sqlDB.CheckQueryResults(t, "SELECT count(*) FROM t", [][]string{{"0"}})
 


### PR DESCRIPTION
Fixes #161045

Following #159627, data rollback during import cancellation only occurs if the table descriptor has not yet been published (set back online). This introduced a race condition in `TestImportIntoCSVCancel` -- the final row count was non-deterministic depending on whether cancellation finished before or after the descriptor update.

This change stabilizes the test by ensuring cancellation is triggered before the descriptor is brought online, guaranteeing that ingested data is always reverted.

Release note: None