### PR TITLE
roachtestutil: add failure injection helper methods

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "commandbuilder.go",
         "disk_stall.go",
         "disk_usage.go",
+        "failure_injection.go",
         "httpclient.go",
         "jaeger.go",
         "load_group.go",

--- a/pkg/cmd/roachtest/roachtestutil/disk_stall.go
+++ b/pkg/cmd/roachtest/roachtestutil/disk_stall.go
@@ -159,11 +159,13 @@ type dmsetupDiskStaller struct {
 var _ DiskStaller = (*dmsetupDiskStaller)(nil)
 
 func MakeDmsetupDiskStaller(f Fataler, c cluster.Cluster, disableStateValidation bool) DiskStaller {
-	diskStaller, err := c.GetFailer(f.L(), c.CRDBNodes(), failures.DmsetupDiskStallName, disableStateValidation)
+	// Use MakeDmsetupDiskStallFailer to get the failer, ignoring the returned args
+	// since the DiskStaller interface creates args dynamically in its methods.
+	failer, _, err := MakeDmsetupDiskStallFailer(f.L(), c, c.CRDBNodes(), disableStateValidation)
 	if err != nil {
 		f.Fatalf("failed to get failer: %s", err)
 	}
-	return &dmsetupDiskStaller{Failer: diskStaller, f: f, c: c}
+	return &dmsetupDiskStaller{Failer: failer, f: f, c: c}
 }
 
 func (s *dmsetupDiskStaller) Setup(ctx context.Context) {

--- a/pkg/cmd/roachtest/roachtestutil/failure_injection.go
+++ b/pkg/cmd/roachtest/roachtestutil/failure_injection.go
@@ -1,0 +1,161 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package roachtestutil
+
+import (
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/failureinjection/failures"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
+)
+
+// MakeNetworkPartitionFailer creates a Failer for network partition injection.
+// Returns the failer and pre-configured args ready for Setup/Inject.
+func MakeNetworkPartitionFailer(
+	l *logger.Logger,
+	c cluster.Cluster,
+	source, dest option.NodeListOption,
+	partitionType failures.PartitionType,
+) (*failures.Failer, failures.NetworkPartitionArgs, error) {
+	failer, err := c.GetFailer(l, c.CRDBNodes(), failures.IPTablesNetworkPartitionName, false)
+	if err != nil {
+		return nil, failures.NetworkPartitionArgs{}, err
+	}
+	args := failures.NetworkPartitionArgs{
+		Partitions: []failures.NetworkPartition{{
+			Source:      source.InstallNodes(),
+			Destination: dest.InstallNodes(),
+			Type:        partitionType,
+		}},
+	}
+	return failer, args, nil
+}
+
+// MakeBidirectionalPartitionFailer creates a Failer for bidirectional network
+// partition injection between source and destination nodes.
+func MakeBidirectionalPartitionFailer(
+	l *logger.Logger, c cluster.Cluster, source, dest option.NodeListOption,
+) (*failures.Failer, failures.NetworkPartitionArgs, error) {
+	return MakeNetworkPartitionFailer(l, c, source, dest, failures.Bidirectional)
+}
+
+// MakeIncomingPartitionFailer creates a Failer that drops incoming traffic
+// on source nodes from destination nodes.
+func MakeIncomingPartitionFailer(
+	l *logger.Logger, c cluster.Cluster, source, dest option.NodeListOption,
+) (*failures.Failer, failures.NetworkPartitionArgs, error) {
+	return MakeNetworkPartitionFailer(l, c, source, dest, failures.Incoming)
+}
+
+// MakeOutgoingPartitionFailer creates a Failer that drops outgoing traffic
+// from source nodes to destination nodes.
+func MakeOutgoingPartitionFailer(
+	l *logger.Logger, c cluster.Cluster, source, dest option.NodeListOption,
+) (*failures.Failer, failures.NetworkPartitionArgs, error) {
+	return MakeNetworkPartitionFailer(l, c, source, dest, failures.Outgoing)
+}
+
+// MakeNetworkLatencyFailer creates a Failer for network latency injection.
+// The delay is applied to traffic from source to destination nodes.
+func MakeNetworkLatencyFailer(
+	l *logger.Logger, c cluster.Cluster, source, dest option.NodeListOption, delay time.Duration,
+) (*failures.Failer, failures.NetworkLatencyArgs, error) {
+	failer, err := c.GetFailer(l, c.All(), failures.NetworkLatencyName, false)
+	if err != nil {
+		return nil, failures.NetworkLatencyArgs{}, err
+	}
+	args := failures.NetworkLatencyArgs{
+		ArtificialLatencies: []failures.ArtificialLatency{{
+			Source:      source.InstallNodes(),
+			Destination: dest.InstallNodes(),
+			Delay:       delay,
+		}},
+	}
+	return failer, args, nil
+}
+
+// MakeProcessKillFailer creates a Failer for process kill injection.
+// If graceful is true, sends SIGTERM and allows the process to drain before
+// killing with SIGKILL after gracePeriod. If graceful is false, sends SIGKILL
+// immediately and gracePeriod is ignored.
+func MakeProcessKillFailer(
+	l *logger.Logger,
+	c cluster.Cluster,
+	nodes option.NodeListOption,
+	graceful bool,
+	gracePeriod time.Duration,
+) (*failures.Failer, failures.ProcessKillArgs, error) {
+	failer, err := c.GetFailer(l, c.CRDBNodes(), failures.ProcessKillFailureName, false)
+	if err != nil {
+		return nil, failures.ProcessKillArgs{}, err
+	}
+	args := failures.ProcessKillArgs{
+		Nodes:            nodes.InstallNodes(),
+		GracefulShutdown: graceful,
+		GracePeriod:      gracePeriod,
+	}
+	return failer, args, nil
+}
+
+// MakeVMResetFailer creates a Failer for VM reset injection.
+// If stopProcesses is true, the cockroach processes are stopped before resetting the VM.
+func MakeVMResetFailer(
+	l *logger.Logger, c cluster.Cluster, nodes option.NodeListOption, stopProcesses bool,
+) (*failures.Failer, failures.ResetVMArgs, error) {
+	failer, err := c.GetFailer(l, c.CRDBNodes(), failures.ResetVMFailureName, false)
+	if err != nil {
+		return nil, failures.ResetVMArgs{}, err
+	}
+	args := failures.ResetVMArgs{
+		Nodes:         nodes.InstallNodes(),
+		StopProcesses: stopProcesses,
+	}
+	return failer, args, nil
+}
+
+// MakeCgroupDiskStallFailer creates a Failer for cgroup disk stall injection.
+// This uses cgroups v2 to throttle I/O to extremely low values.
+func MakeCgroupDiskStallFailer(
+	l *logger.Logger,
+	c cluster.Cluster,
+	nodes option.NodeListOption,
+	stallWrites, stallReads, stallLogs bool,
+) (*failures.Failer, failures.DiskStallArgs, error) {
+	failer, err := c.GetFailer(l, c.CRDBNodes(), failures.CgroupsDiskStallName, false)
+	if err != nil {
+		return nil, failures.DiskStallArgs{}, err
+	}
+	args := failures.DiskStallArgs{
+		StallLogs:    stallLogs,
+		StallReads:   stallReads,
+		StallWrites:  stallWrites,
+		Nodes:        nodes.InstallNodes(),
+		RestartNodes: true,
+	}
+	return failer, args, nil
+}
+
+// MakeDmsetupDiskStallFailer creates a Failer for dmsetup disk stall injection.
+// This uses dmsetup to completely suspend I/O to the data disk.
+//
+// Note: MakeDmsetupDiskStaller in disk_stall.go wraps this function to provide
+// the legacy DiskStaller interface for backward compatibility with existing tests.
+func MakeDmsetupDiskStallFailer(
+	l *logger.Logger, c cluster.Cluster, nodes option.NodeListOption, disableStateValidation bool,
+) (*failures.Failer, failures.DiskStallArgs, error) {
+	failer, err := c.GetFailer(l, c.CRDBNodes(), failures.DmsetupDiskStallName, disableStateValidation)
+	if err != nil {
+		return nil, failures.DiskStallArgs{}, err
+	}
+	args := failures.DiskStallArgs{
+		Nodes:        nodes.InstallNodes(),
+		StallWrites:  true,
+		RestartNodes: true,
+	}
+	return failer, args, nil
+}

--- a/pkg/cmd/roachtest/tests/FAILURE_INJECTION_README.md
+++ b/pkg/cmd/roachtest/tests/FAILURE_INJECTION_README.md
@@ -1,0 +1,201 @@
+# Failure Injection in Roachtests
+
+This document describes how to use the failure injection framework within roachtests
+to simulate various failure scenarios like network partitions, disk stalls, and
+process crashes.
+
+## Overview
+
+The failure injection framework provides a structured way to inject, validate, and
+recover from failures during roachtests. It is built on two main components:
+
+1. **FailureMode Interface**: Defines the contract for individual failure types
+   (e.g., network partition, disk stall). Each failure mode implements methods for
+   setup, injection, recovery, and cleanup.
+
+2. **Failer Wrapper**: A state-machine wrapper around FailureMode that ensures
+   methods are called in the correct order and handles error states gracefully.
+
+### When to Use Failure Injection
+
+Use failure injection when you want to test:
+- Cluster behavior during network partitions between nodes
+- Database resilience to disk I/O stalls or failures
+- Recovery behavior after node crashes or restarts
+- Replication and rebalancing under failure conditions
+
+## Failure Lifecycle
+
+Every failure injection follows this lifecycle:
+
+```
+Setup() -> Inject() -> [WaitForFailureToPropagate()] -> Recover() -> [WaitForFailureToRecover()] -> Cleanup()
+```
+
+1. **Setup()**: Prepare any dependencies required for the failure (e.g., install tools,
+   configure cgroups). Called once before any injections.
+
+2. **Inject()**: Actually inject the failure into the system.
+
+3. **WaitForFailureToPropagate()** *(optional)*: Block until the failure has taken full
+   effect (e.g., node is marked as dead, replicas have moved). Use this when you need
+   to ensure the cluster has reacted to the failure before proceeding.
+
+4. **Recover()**: Reverse the effects of Inject() (e.g., remove iptables rules,
+   restart nodes).
+
+5. **WaitForFailureToRecover()** *(optional)*: Block until the cluster has fully
+   recovered (e.g., replicas are balanced, nodes are healthy). Use this when you need
+   to verify the cluster is stable before continuing with other operations.
+
+6. **Cleanup()**: Uninstall any dependencies installed during Setup().
+
+## Available Failure Modes
+
+| Failure Name | Constant | Description |
+|-------------|----------|-------------|
+| Network Partition | `failures.IPTablesNetworkPartitionName` | Block traffic between nodes using iptables |
+| Network Latency | `failures.NetworkLatencyName` | Add artificial latency between nodes using tc |
+| CGroup Disk Stall | `failures.CgroupsDiskStallName` | Stall disk I/O using cgroups v2 throttling |
+| Dmsetup Disk Stall | `failures.DmsetupDiskStallName` | Stall disk I/O using dmsetup suspend |
+| Process Kill | `failures.ProcessKillFailureName` | Kill CockroachDB processes (graceful or forced) |
+| VM Reset | `failures.ResetVMFailureName` | Simulate VM reboot |
+
+## API Reference
+
+### Helper Methods (Recommended)
+
+The `roachtestutil` package provides convenient helper methods that create pre-configured
+Failers with the appropriate args. These reduce boilerplate and make tests easier to read.
+
+#### Network Partition Helpers
+
+```go
+// Bidirectional partition (drops traffic both ways)
+failer, args, err := roachtestutil.MakeBidirectionalPartitionFailer(
+    t.L(), c, c.Node(1), c.Node(2))
+
+// Incoming partition (drops incoming traffic on source from destination)
+failer, args, err := roachtestutil.MakeIncomingPartitionFailer(
+    t.L(), c, c.Node(1), c.Node(2))
+
+// Outgoing partition (drops outgoing traffic from source to destination)
+failer, args, err := roachtestutil.MakeOutgoingPartitionFailer(
+    t.L(), c, c.Node(1), c.Node(2))
+
+// Custom partition type
+failer, args, err := roachtestutil.MakeNetworkPartitionFailer(
+    t.L(), c, c.Node(1), c.Node(2), failures.Bidirectional)
+```
+
+#### Network Latency Helpers
+
+```go
+failer, args, err := roachtestutil.MakeNetworkLatencyFailer(
+    t.L(), c, c.Node(1), c.Node(2), 100*time.Millisecond)
+```
+
+#### Process Kill Helpers
+
+```go
+// Hard kill (SIGKILL, immediate)
+failer, args, err := roachtestutil.MakeProcessKillFailer(
+    t.L(), c, c.Node(1), false /* graceful */, 0)
+
+// Graceful kill (SIGTERM + drain, then SIGKILL after grace period)
+failer, args, err := roachtestutil.MakeProcessKillFailer(
+    t.L(), c, c.Node(1), true /* graceful */, 5*time.Minute)
+```
+
+#### VM Reset Helpers
+
+```go
+failer, args, err := roachtestutil.MakeVMResetFailer(
+    t.L(), c, c.Node(1), true /* stopProcesses */)
+```
+
+#### Disk Stall Helpers
+
+```go
+// Cgroup disk stall (uses cgroups v2 I/O throttling)
+failer, args, err := roachtestutil.MakeCgroupDiskStallFailer(
+    t.L(), c, c.Node(1),
+    true,  // stallWrites
+    false, // stallReads
+    false, // stallLogs
+)
+
+// Dmsetup disk stall (uses dmsetup suspend)
+failer, args, err := roachtestutil.MakeDmsetupDiskStallFailer(t.L(), c, c.Node(1), failer /*disableStateValidation*/)
+```
+
+## Usage Pattern
+
+The basic pattern for using failure injection in a roachtest:
+
+```go
+// 1. Start the cluster first (required for certificate handling in secure mode)
+c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.CRDBNodes())
+
+// 2. Create the failer using a helper method (AFTER c.Start)
+failer, args, err := roachtestutil.MakeBidirectionalPartitionFailer(
+    t.L(), c, c.Node(1), c.Node(2))
+if err != nil {
+    t.Fatal(err)
+}
+
+// 3. Always defer cleanup
+defer func() {
+    if err := failer.Cleanup(context.Background(), t.L()); err != nil {
+        t.L().Printf("cleanup failed: %v", err)
+    }
+}()
+
+// 4. Setup the failure mode
+if err := failer.Setup(ctx, t.L(), args); err != nil {
+    t.Fatal(err)
+}
+
+// 5. Run your workload or test setup here...
+
+// 6. Inject the failure
+if err := failer.Inject(ctx, t.L(), args); err != nil {
+    t.Fatal(err)
+}
+
+// 7. (Optional) Wait for failure to take effect.
+// Use this when you need to ensure the cluster has reacted to the failure
+// (e.g., node marked dead, replicas moved) before proceeding.
+if err := failer.WaitForFailureToPropagate(ctx, t.L()); err != nil {
+    t.Fatal(err)
+}
+
+// 8. Test behavior under failure...
+
+// 9. Recover from the failure
+if err := failer.Recover(ctx, t.L()); err != nil {
+    t.Fatal(err)
+}
+
+// 10. (Optional) Wait for cluster to stabilize.
+// Use this when you need to verify the cluster is stable (e.g., replicas
+// rebalanced, nodes healthy) before continuing with other operations.
+if err := failer.WaitForFailureToRecover(ctx, t.L()); err != nil {
+    t.Fatal(err)
+}
+```
+
+**Important:** The failer must be created AFTER `c.Start()` completes. This is because
+`c.Start()` downloads SSL certificates for secure clusters, and `c.GetFailer()` needs
+access to those certificates.
+
+For complete working examples, see:
+- `runNetworkPartitionExample` in `pkg/cmd/roachtest/tests/failure_injection.go`
+- `runDiskStallExample` in `pkg/cmd/roachtest/tests/failure_injection.go`
+
+
+## See Also
+
+- `pkg/roachprod/failureinjection/failures/` - Failure mode implementations
+- `pkg/cmd/roachtest/roachtestutil/failure_injection.go` - Helper methods for creating Failers
+- `pkg/cmd/roachtest/tests/failure_injection.go` - Smoke tests for all failure modes

--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -70,6 +70,7 @@ func RegisterTests(r registry.Registry) {
 	registerHotSpotSplits(r)
 	registerHTTPRestart(r)
 	registerFISmokeTest(r)
+	registerFIExamples(r)
 	registerImport(r)
 	registerImportMixedVersions(r)
 	registerImportTPCC(r)


### PR DESCRIPTION
This change adds helper methods in roachtestutil that create pre-configured Failers with the appropriate args. The helpers cover common failure types:
- Network partitions (bidirectional, incoming, outgoing)
- Network latency injection
- Process kill (graceful and hard)
- VM reset
- Disk stalls (cgroup and dmsetup)

Additionally, adds README which documents the failure injection framework, available failure modes, and usage patterns.

Epic: none

Release note: None