### PR TITLE
ui,e2e: fix cypress element targeting

### DIFF
--- a/pkg/ui/workspaces/e2e-tests/cypress/e2e/pages/metrics.cy.ts
+++ b/pkg/ui/workspaces/e2e-tests/cypress/e2e/pages/metrics.cy.ts
@@ -94,27 +94,31 @@ describe("metrics page", () => {
   });
 
   it("displays summary side bar", () => {
-    cy.get(".summary-section").within(() => {
-      cy.get(".summary-label").contains("Summary");
+    cy.get(".summary-section")
+      .eq(0)
+      .within(() => {
+        cy.get(".summary-label").contains("Summary");
 
-      cy.contains("Total Nodes").should("exist");
-      cy.contains("View nodes list").should(
-        "have.attr",
-        "href",
-        "#/overview/list",
-      );
-      cy.contains("Capacity Usage").should("exist");
-      cy.contains("Unavailable ranges").should("exist");
-      cy.contains("Queries per second").should("exist");
-      cy.contains("P99 latency").should("exist");
-    });
+        cy.contains("Total Nodes").should("exist");
+        cy.contains("View nodes list").should(
+          "have.attr",
+          "href",
+          "#/overview/list",
+        );
+        cy.contains("Capacity Usage").should("exist");
+        cy.contains("Unavailable ranges").should("exist");
+        cy.contains("Queries per second").should("exist");
+        cy.contains("P99 latency").should("exist");
+      });
   });
 
   it("displays events section", () => {
-    cy.get(".summary-section").within(() => {
-      cy.contains(".summary-label", "Events");
+    cy.get(".summary-section")
+      .eq(1)
+      .within(() => {
+        cy.contains(".summary-label", "Events");
 
-      cy.contains("View all events").should("have.attr", "href", "#/events");
-    });
+        cy.contains("View all events").should("have.attr", "href", "#/events");
+      });
   });
 });


### PR DESCRIPTION
The test requires narrowing down the subject into a single element before calling within(). This occurs when there are more than one element resulting from a get().

Fixes: #161488
Epic: None
Release Note: None