### PR TITLE
kvstorage: add SetStoreID to Engines

### DIFF
--- a/pkg/kv/kvserver/kvstorage/init.go
+++ b/pkg/kv/kvserver/kvstorage/init.go
@@ -73,10 +73,9 @@ func InitEngine(ctx context.Context, eng Engines, ident roachpb.StoreIdent) erro
 	// We will set the store ID during start, but we want to set it as quickly as
 	// possible after creating a store (to initialize the shared object creator
 	// ID).
-	if err := eng.TODOEngine().SetStoreID(ctx, int32(ident.StoreID)); err != nil {
+	if err := eng.SetStoreID(ctx, ident.StoreID); err != nil {
 		return errors.Wrap(err, "setting store ID")
 	}
-
 	return nil
 }
 

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2139,9 +2139,8 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 	ctx = s.AnnotateCtx(ctx)
 	log.Event(ctx, "read store identity")
 
-	// Communicate store ID to engine.
-	// TODO(sep-raft-log): do for both engines.
-	if err := s.TODOEngine().SetStoreID(ctx, int32(s.StoreID())); err != nil {
+	// Communicate store ID to storage engines.
+	if err := s.internalEngines.SetStoreID(ctx, s.StoreID()); err != nil {
 		return err
 	}
 

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -726,13 +726,8 @@ func inspectEngines(
 		}
 		nodeID = storeIdent.NodeID
 
-		if err := eng.StateEngine().SetStoreID(ctx, int32(storeIdent.StoreID)); err != nil {
+		if err := eng.SetStoreID(ctx, storeIdent.StoreID); err != nil {
 			return nil, err
-		}
-		if eng.Separated() {
-			if err := eng.LogEngine().SetStoreID(ctx, int32(storeIdent.StoreID)); err != nil {
-				return nil, err
-			}
 		}
 
 		initializedEngines = append(initializedEngines, eng)


### PR DESCRIPTION
The method helps to initialize `StoreID` on both engines if the engine is separated.

Part of #97627