### PR TITLE
storage: downgrade to WriteBatch in noop sync

### DIFF
--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -1591,17 +1591,12 @@ func ScanLocks(
 
 // WriteSyncNoop carries out a synchronous no-op write to the engine.
 func WriteSyncNoop(eng Engine) error {
-	batch := eng.NewBatch()
+	batch := eng.NewWriteBatch()
 	defer batch.Close()
-
 	if err := batch.LogData(nil); err != nil {
 		return err
 	}
-
-	if err := batch.Commit(true /* sync */); err != nil {
-		return err
-	}
-	return nil
+	return batch.Commit(true /* sync */)
 }
 
 // ClearRangeWithHeuristic clears the keys from start (inclusive) to end


### PR DESCRIPTION
`NewWriteBatch` creates an unindexed batch which is cheaper than the indexed `NewBatch`.

This makes the uses of `WriteSyncNoop` (node liveness, merges, migrations) slightly more efficient.

Epic: none
Release note: none