### PR TITLE
cli,rpc: enable --use-new-rpc flag for all CLI commands

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -100,6 +100,7 @@ type TestServerArgs struct {
 
 	// Fields copied to the server.Config.
 	Insecure                    bool
+	UseDRPC                     bool
 	RetryOptions                retry.Options // TODO(tbg): make testing knob.
 	SocketFile                  string
 	ScanInterval                time.Duration

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/cli/clierrorplus"
+	"github.com/cockroachdb/cockroach/pkg/cli/cliflagcfg"
 	"github.com/cockroachdb/cockroach/pkg/cli/cliflags"
 	"github.com/cockroachdb/cockroach/pkg/cli/syncbench"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
@@ -1601,6 +1602,8 @@ func init() {
 	f.Var(&debugLogChanSel, "only-channels", "selection of channels to include in the output diagram.")
 
 	f = debugTimeSeriesDumpCmd.Flags()
+	cliflagcfg.BoolFlag(f, &baseCfg.UseDRPC, cliflags.UseNewRPC)
+	_ = f.MarkHidden(cliflags.UseNewRPC.Name)
 	f.Var(&debugTimeSeriesDumpOpts.format, "format", "output format (text, csv, tsv, raw, openmetrics)")
 	f.StringVarP(&debugTimeSeriesDumpOpts.output, "output", "o", "", "output file path; writes output to file instead of stdout")
 	f.Var(&debugTimeSeriesDumpOpts.from, "from", "oldest timestamp to include (inclusive)")

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1492,11 +1492,15 @@ func init() {
 		"maximum number of concurrent compactions")
 
 	f = debugRecoverCollectInfoCmd.Flags()
+	cliflagcfg.BoolFlag(f, &baseCfg.UseDRPC, cliflags.UseNewRPC)
+	_ = f.MarkHidden(cliflags.UseNewRPC.Name)
 	f.VarP(&debugRecoverCollectInfoOpts.Stores, cliflags.RecoverStore.Name, cliflags.RecoverStore.Shorthand, cliflags.RecoverStore.Usage())
 	f.IntVarP(&debugRecoverCollectInfoOpts.maxConcurrency, "max-concurrency", "c", debugRecoverDefaultMaxConcurrency,
 		"maximum concurrency when fanning out RPCs to nodes in the cluster")
 
 	f = debugRecoverPlanCmd.Flags()
+	cliflagcfg.BoolFlag(f, &baseCfg.UseDRPC, cliflags.UseNewRPC)
+	_ = f.MarkHidden(cliflags.UseNewRPC.Name)
 	f.StringVarP(&debugRecoverPlanOpts.outputFileName, "plan", "o", "",
 		"filename to write plan to")
 	f.IntSliceVar(&debugRecoverPlanOpts.deadStoreIDs, "dead-store-ids", nil,
@@ -1514,6 +1518,8 @@ func init() {
 		formatHelper.maxPrintedKeyLength, cliflags.PrintKeyLength.Usage())
 
 	f = debugRecoverExecuteCmd.Flags()
+	cliflagcfg.BoolFlag(f, &baseCfg.UseDRPC, cliflags.UseNewRPC)
+	_ = f.MarkHidden(cliflags.UseNewRPC.Name)
 	f.VarP(&debugRecoverExecuteOpts.Stores, cliflags.RecoverStore.Name, cliflags.RecoverStore.Shorthand, cliflags.RecoverStore.Usage())
 	f.VarP(&debugRecoverExecuteOpts.confirmAction, cliflags.ConfirmActions.Name, cliflags.ConfirmActions.Shorthand,
 		cliflags.ConfirmActions.Usage())
@@ -1525,6 +1531,8 @@ func init() {
 		"maximum concurrency when fanning out RPCs to nodes in the cluster")
 
 	f = debugRecoverVerifyCmd.Flags()
+	cliflagcfg.BoolFlag(f, &baseCfg.UseDRPC, cliflags.UseNewRPC)
+	_ = f.MarkHidden(cliflags.UseNewRPC.Name)
 	f.IntVarP(&debugRecoverVerifyOpts.maxConcurrency, "max-concurrency", "c", debugRecoverDefaultMaxConcurrency,
 		"maximum concurrency when fanning out RPCs to nodes in the cluster")
 

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1632,6 +1632,8 @@ func init() {
 	f.StringVar(&debugTimeSeriesDumpOpts.metricsListFile, "metrics-list-file", "", "text file containing metric names or regex patterns to dump (one per line). Prefixes cr.node., cr.store., and cockroachdb. are automatically stripped if present. When specified, only matching metrics are dumped instead of all metrics.")
 
 	f = debugSendKVBatchCmd.Flags()
+	cliflagcfg.BoolFlag(f, &baseCfg.UseDRPC, cliflags.UseNewRPC)
+	_ = f.MarkHidden(cliflags.UseNewRPC.Name)
 	f.StringVar(&debugSendKVBatchContext.traceFormat, "trace", debugSendKVBatchContext.traceFormat,
 		"which format to use for the trace output (off, text, jaeger)")
 	f.BoolVar(&debugSendKVBatchContext.keepCollectedSpans, "keep-collected-spans", debugSendKVBatchContext.keepCollectedSpans,

--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -211,6 +211,8 @@ func runDemoInternal(
 	ctx := context.Background()
 
 	demoCtx.WorkloadGenerator = gen
+	// Copy the DRPC flag from baseCfg to demoCtx so it's available to the demo cluster.
+	demoCtx.UseDRPC = baseCfg.UseDRPC
 
 	c, err := democluster.NewDemoCluster(ctx, &demoCtx.Context,
 		log.Dev.Infof,

--- a/pkg/cli/democluster/context.go
+++ b/pkg/cli/democluster/context.go
@@ -105,6 +105,10 @@ type Context struct {
 	// DisableServerController is true if we want to avoid the server
 	// controller to instantiate tenant secondary servers.
 	DisableServerController bool
+
+	// UseDRPC indicates whether to use DRPC instead of gRPC for
+	// inter-node RPC communication in the demo cluster.
+	UseDRPC bool
 }
 
 // IsInteractive returns true if the demo cluster configuration

--- a/pkg/cli/democluster/demo_cluster.go
+++ b/pkg/cli/democluster/demo_cluster.go
@@ -930,6 +930,7 @@ func (demoCtx *Context) testServerArgsForTransientCluster(
 		CacheSize:               demoCtx.CacheSize,
 		NoAutoInitializeCluster: true,
 		EnableDemoLoginEndpoint: true,
+		UseDRPC:                 demoCtx.UseDRPC,
 		// Demo clusters by default will create their own tenants, so we
 		// don't need to create them here.
 		DefaultTestTenant: base.TestControlsTenantsExplicitly,

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -1025,6 +1025,11 @@ func init() {
 		_ = f.MarkHidden(cliflags.UseNewRPC.Name)
 	}
 	{
+		f := debugResetQuorumCmd.Flags()
+		cliflagcfg.BoolFlag(f, &baseCfg.UseDRPC, cliflags.UseNewRPC)
+		_ = f.MarkHidden(cliflags.UseNewRPC.Name)
+	}
+	{
 		f := debugBallastCmd.Flags()
 		cliflagcfg.VarFlag(f, newSizeFlagVal(&debugCtx.ballastSize), cliflags.Size)
 	}

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -629,6 +629,8 @@ func init() {
 		f := initCmd.Flags()
 		cliflagcfg.BoolFlag(f, &initCmdOptions.virtualized, cliflags.Virtualized)
 		cliflagcfg.BoolFlag(f, &initCmdOptions.virtualizedEmpty, cliflags.VirtualizedEmpty)
+		cliflagcfg.BoolFlag(f, &baseCfg.UseDRPC, cliflags.UseNewRPC)
+		_ = f.MarkHidden(cliflags.UseNewRPC.Name)
 	}
 
 	// Multi-tenancy start-sql command flags.

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -820,10 +820,12 @@ func init() {
 	cliflagcfg.VarFlag(decommissionNodeCmd.Flags(), &nodeCtx.nodeDecommissionChecks, cliflags.NodeDecommissionChecks)
 	cliflagcfg.BoolFlag(decommissionNodeCmd.Flags(), &nodeCtx.nodeDecommissionDryRun, cliflags.NodeDecommissionDryRun)
 
-	// Decommission and recommission share --self.
+	// Decommission and recommission share --self and --use-new-rpc.
 	for _, cmd := range []*cobra.Command{decommissionNodeCmd, recommissionNodeCmd} {
 		f := cmd.Flags()
 		cliflagcfg.BoolFlag(f, &nodeCtx.nodeDecommissionSelf, cliflags.NodeDecommissionSelf)
+		cliflagcfg.BoolFlag(f, &baseCfg.UseDRPC, cliflags.UseNewRPC)
+		_ = f.MarkHidden(cliflags.UseNewRPC.Name)
 	}
 
 	// node drain command.
@@ -832,6 +834,8 @@ func init() {
 		cliflagcfg.DurationFlag(f, &drainCtx.drainWait, cliflags.DrainWait)
 		cliflagcfg.BoolFlag(f, &drainCtx.nodeDrainSelf, cliflags.NodeDrainSelf)
 		cliflagcfg.BoolFlag(f, &drainCtx.shutdown, cliflags.NodeDrainShutdown)
+		cliflagcfg.BoolFlag(f, &baseCfg.UseDRPC, cliflags.UseNewRPC)
+		_ = f.MarkHidden(cliflags.UseNewRPC.Name)
 	}
 
 	// Commands that establish a SQL connection.

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -801,6 +801,14 @@ func init() {
 		cliflagcfg.BoolFlag(f, &zipCtx.includeStacks, cliflags.ZipIncludeGoroutineStacks)
 		cliflagcfg.BoolFlag(f, &zipCtx.includeRunningJobTraces, cliflags.ZipIncludeRunningJobTraces)
 		cliflagcfg.BoolFlag(f, &zipCtx.validateZipFile, cliflags.ZipValidateFile)
+		cliflagcfg.BoolFlag(f, &baseCfg.UseDRPC, cliflags.UseNewRPC)
+		_ = f.MarkHidden(cliflags.UseNewRPC.Name)
+	}
+	// List-files command.
+	{
+		f := debugListFilesCmd.Flags()
+		cliflagcfg.BoolFlag(f, &baseCfg.UseDRPC, cliflags.UseNewRPC)
+		_ = f.MarkHidden(cliflags.UseNewRPC.Name)
 	}
 	// List-files + Zip commands.
 	for _, cmd := range []*cobra.Command{debugZipCmd, debugListFilesCmd} {
@@ -1013,6 +1021,8 @@ func init() {
 	{
 		f := debugGossipValuesCmd.Flags()
 		cliflagcfg.StringFlag(f, &debugCtx.inputFile, cliflags.GossipInputFile)
+		cliflagcfg.BoolFlag(f, &baseCfg.UseDRPC, cliflags.UseNewRPC)
+		_ = f.MarkHidden(cliflags.UseNewRPC.Name)
 	}
 	{
 		f := debugBallastCmd.Flags()

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -950,6 +950,9 @@ func init() {
 		_ = f.MarkHidden(cliflags.DemoMultitenant.Name)
 		_ = f.MarkHidden(cliflags.DemoDisableServerController.Name)
 
+		cliflagcfg.BoolFlag(f, &baseCfg.UseDRPC, cliflags.UseNewRPC)
+		_ = f.MarkHidden(cliflags.UseNewRPC.Name)
+
 		cliflagcfg.BoolFlag(f, &demoCtx.SimulateLatency, cliflags.Global)
 		// We also support overriding the GEOS library path for 'demo'.
 		// Even though the demoCtx uses mostly different configuration

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -1930,6 +1930,31 @@ func TestUseNewRPC(t *testing.T) {
 	// Avoid leaking configuration changes after the test ends.
 	defer initCLIDefaults()
 
+	// List of all commands that should have the --use-new-rpc flag.
+	// These commands were modified to support DRPC for inter-node communication.
+	testCommands := []*cobra.Command{
+		initCmd,       // init
+		genHAProxyCmd, // gen haproxy
+		demoCmd,       // demo
+
+		// debug commands
+		debugGossipValuesCmd,
+		debugTimeSeriesDumpCmd,
+		debugZipCmd,
+		debugListFilesCmd,
+		debugSendKVBatchCmd,
+		debugResetQuorumCmd,
+		debugRecoverCollectInfoCmd,
+		debugRecoverPlanCmd,
+		debugRecoverExecuteCmd,
+		debugRecoverVerifyCmd,
+
+		// node commands
+		decommissionNodeCmd,
+		recommissionNodeCmd,
+		drainNodeCmd,
+	}
+
 	testCases := []struct {
 		args        []string
 		expectedVal bool

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -1923,6 +1923,8 @@ func TestWALFailoverWrapperRoundtrip(t *testing.T) {
 	})
 }
 
+// TestUseNewRPC verifies that the --use-new-rpc flag is properly configured
+// on all commands that support DRPC for inter-node communication.
 func TestUseNewRPC(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1956,27 +1958,43 @@ func TestUseNewRPC(t *testing.T) {
 	}
 
 	testCases := []struct {
+		name        string
 		args        []string
 		expectedVal bool
 	}{
-		{[]string{}, false},                      // Default value
-		{[]string{"--use-new-rpc"}, true},        // Flag enabled
-		{[]string{"--use-new-rpc=true"}, true},   // Flag explicitly enabled
-		{[]string{"--use-new-rpc=false"}, false}, // Flag explicitly disabled
+		{"default", []string{}, false},
+		{"enabled", []string{"--use-new-rpc"}, true},
+		{"explicitly_enabled", []string{"--use-new-rpc=true"}, true},
+		{"explicitly_disabled", []string{"--use-new-rpc=false"}, false},
 	}
 
-	for _, tc := range testCases {
-		t.Run(fmt.Sprintf("%v", tc.args), func(t *testing.T) {
-			// Reset to defaults before each test
-			initCLIDefaults()
+	for _, cmd := range testCommands {
+		cmdName := cmd.Use
+		t.Run(cmdName, func(t *testing.T) {
+			for _, tc := range testCases {
+				t.Run(tc.name, func(t *testing.T) {
+					// Reset to defaults before each test
+					initCLIDefaults()
 
-			f := startCmd.Flags()
-			if err := f.Parse(tc.args); err != nil {
-				t.Fatal(err)
-			}
+					f := cmd.Flags()
+					if err := f.Parse(tc.args); err != nil {
+						t.Fatal(err)
+					}
 
-			if baseCfg.UseDRPC != tc.expectedVal {
-				t.Errorf("expected UseDRPC=%v, but got %v", tc.expectedVal, baseCfg.UseDRPC)
+					// Verify the flag exists
+					flag := f.Lookup(cliflags.UseNewRPC.Name)
+					if flag == nil {
+						t.Fatalf("command %s is missing --%s flag", cmdName, cliflags.UseNewRPC.Name)
+					}
+
+					// Verify the flag is hidden
+					require.True(t, flag.Hidden, "flag --%s should be hidden on command %s", cliflags.UseNewRPC.Name, cmdName)
+
+					// Verify the flag has the correct value
+					if baseCfg.UseDRPC != tc.expectedVal {
+						t.Errorf("command %s: expected --%s=%v, but got %v", cmdName, cliflags.UseNewRPC.Name, tc.expectedVal, baseCfg.UseDRPC)
+					}
+				})
 			}
 		})
 	}

--- a/pkg/cli/gen.go
+++ b/pkg/cli/gen.go
@@ -351,6 +351,8 @@ func init() {
 	genHAProxyCmd.PersistentFlags().StringVar(&haProxyPath, "out", "haproxy.cfg",
 		"path to generated haproxy configuration file")
 	cliflagcfg.VarFlag(genHAProxyCmd.Flags(), &haProxyLocality, cliflags.Locality)
+	cliflagcfg.BoolFlag(genHAProxyCmd.Flags(), &baseCfg.UseDRPC, cliflags.UseNewRPC)
+	_ = genHAProxyCmd.Flags().MarkHidden(cliflags.UseNewRPC.Name)
 
 	f := genSettingsListCmd.PersistentFlags()
 	f.BoolVar(&includeAllSettings, "all-settings", false,

--- a/pkg/cli/rpc_clients.go
+++ b/pkg/cli/rpc_clients.go
@@ -101,7 +101,10 @@ func makeRPCClientConfig(cfg server.Config) rpc.ClientConnConfig {
 
 func newClientConn(ctx context.Context, cfg server.Config) (rpcConn, func(), error) {
 	ccfg := makeRPCClientConfig(cfg)
-	if !rpcbase.DRPCEnabled(ctx, cfg.Settings) {
+	// Use DRPC if either the CLI flag is set (ccfg.UseDRPC) or the cluster
+	// setting is enabled. The CLI flag takes precedence for CLI commands.
+	useDRPC := ccfg.UseDRPC || rpcbase.DRPCEnabled(ctx, cfg.Settings)
+	if !useDRPC {
 		cc, finish, err := rpc.NewClientConn(ctx, ccfg)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "failed to connect to the node")

--- a/pkg/rpc/client.go
+++ b/pkg/rpc/client.go
@@ -67,6 +67,10 @@ type ClientConnConfig struct {
 	// Clock is the HLC clock to use. This can be nil to disable
 	// maxoffset verification.
 	Clock *hlc.Clock
+
+	// UseDRPC indicates whether to use DRPC for this connection.
+	// This is typically set via the --use-new-rpc CLI flag.
+	UseDRPC bool
 }
 
 // MakeClientConnConfigFromBaseConfig creates a ClientConnConfig from a
@@ -93,6 +97,7 @@ func MakeClientConnConfigFromBaseConfig(
 		RPCHeartbeatInterval:           cfg.RPCHeartbeatInterval,
 		RPCHeartbeatTimeout:            cfg.RPCHeartbeatTimeout,
 		HistogramWindowInterval:        cfg.HistogramWindowInterval(),
+		UseDRPC:                        cfg.UseDRPC,
 	}
 }
 

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -188,6 +188,7 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	cfg.ClusterName = params.ClusterName
 	cfg.ExternalIODirConfig = params.ExternalIODirConfig
 	cfg.Insecure = params.Insecure
+	cfg.UseDRPC = params.UseDRPC
 	cfg.AutoInitializeCluster = !params.NoAutoInitializeCluster
 	cfg.SocketFile = params.SocketFile
 	cfg.RetryOptions = params.RetryOptions


### PR DESCRIPTION
This change extends the `--use-new-rpc` flag support to all CLI commands that use RPC connections to communicate with the cluster.

Previously, the `--use-new-rpc` flag was only available for the start command. This PR adds the flag to all CLI commands that establish RPC connections to the cluster, including:
- `init` command
- Node commands (`decommission`, `recommission`, `drain`)
- Debug info commands (`gossip-values`, `tsdump`, `zip`, `list-files`)
- Debug operation commands (`send-kv-batch`, `reset-quorum`)
- Debug recover commands (`collect-info`, `plan`, `execute`, `verify`)
- `gen haproxy` command

Fixes: #155593
Fixes: #155597
Fixes: #155596
Fixes: #155598
Fixes: #155595
Informs: #155599

Epic: CRDB-55200
Release note: None