### PR TITLE
roachtest,cli: add roachtest sql proxy support

### DIFF
--- a/pkg/ccl/cliccl/BUILD.bazel
+++ b/pkg/ccl/cliccl/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "demo.go",
         "flags.go",
         "mt.go",
+        "mt_http_test_directory.go",
         "mt_proxy.go",
         "mt_test_directory.go",
     ],
@@ -17,6 +18,7 @@ go_library(
     deps = [
         "//pkg/ccl/securityccl/fipsccl",
         "//pkg/ccl/sqlproxyccl",
+        "//pkg/ccl/sqlproxyccl/tenant",
         "//pkg/ccl/sqlproxyccl/tenantdirsvr",
         "//pkg/ccl/utilccl",
         "//pkg/ccl/workloadccl/cliccl",
@@ -27,6 +29,7 @@ go_library(
         "//pkg/cli/cliflags",
         "//pkg/cli/democluster",
         "//pkg/cli/exit",
+        "//pkg/roachpb",
         "//pkg/util/log",
         "//pkg/util/log/severity",
         "//pkg/util/stop",
@@ -36,6 +39,7 @@ go_library(
         "@com_github_olekukonko_tablewriter//:tablewriter",
         "@com_github_spf13_cobra//:cobra",
         "@com_github_spf13_pflag//:pflag",
+        "@org_golang_google_grpc//:grpc",
     ],
 )
 

--- a/pkg/ccl/cliccl/context.go
+++ b/pkg/ccl/cliccl/context.go
@@ -14,6 +14,7 @@ import (
 func init() {
 	setProxyContextDefaults()
 	setTestDirectorySvrContextDefaults()
+	setHTTPTestDirectorySvrContextDefaults()
 }
 
 // proxyContext captures the command-line parameters of the `mt start-proxy` command.
@@ -46,4 +47,14 @@ var testDirectorySvrContext struct {
 
 func setTestDirectorySvrContextDefaults() {
 	testDirectorySvrContext.port = 36257
+}
+
+var httpTestDirectorySvrContext struct {
+	grpcPort int
+	httpPort int
+}
+
+func setHTTPTestDirectorySvrContextDefaults() {
+	httpTestDirectorySvrContext.grpcPort = 46258
+	httpTestDirectorySvrContext.httpPort = 46259
 }

--- a/pkg/ccl/cliccl/flags.go
+++ b/pkg/ccl/cliccl/flags.go
@@ -91,6 +91,12 @@ func init() {
 		cliflagcfg.StringFlagDepth(1, f, &testDirectorySvrContext.kvAddrs, cliflags.KVAddrs)
 	})
 
+	cli.RegisterFlags(func() {
+		f := mtHTTPTestDirectorySvr.Flags()
+		cliflagcfg.IntFlag(f, &httpTestDirectorySvrContext.grpcPort, cliflags.HTTPTestDirectoryGRPCPort)
+		cliflagcfg.IntFlag(f, &httpTestDirectorySvrContext.httpPort, cliflags.HTTPTestDirectoryHTTPPort)
+	})
+
 	// FIPS verification flags.
 	cli.RegisterFlags(func() {
 		cmd := cli.CockroachCmd()

--- a/pkg/ccl/cliccl/mt.go
+++ b/pkg/ccl/cliccl/mt.go
@@ -12,4 +12,6 @@ func init() {
 	cli.RegisterCommandWithCustomLogging(mtStartSQLProxyCmd)
 	cli.MTCmd.AddCommand(mtTestDirectorySvr)
 	cli.RegisterCommandWithCustomLogging(mtTestDirectorySvr)
+	cli.MTCmd.AddCommand(mtHTTPTestDirectorySvr)
+	cli.RegisterCommandWithCustomLogging(mtHTTPTestDirectorySvr)
 }

--- a/pkg/ccl/cliccl/mt_http_test_directory.go
+++ b/pkg/ccl/cliccl/mt_http_test_directory.go
@@ -1,0 +1,268 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cliccl
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/tenant"
+	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/tenantdirsvr"
+	"github.com/cockroachdb/cockroach/pkg/cli"
+	"github.com/cockroachdb/cockroach/pkg/cli/clierrorplus"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+)
+
+var mtHTTPTestDirectorySvr = &cobra.Command{
+	Use:   "http-test-directory",
+	Short: "start a test directory server that exposes an HTTP API to manage pod lifecycles",
+	Long: `
+http-test-directory is like test-directory, but instead of managing tenant SQL instances as
+processes on the local machine, it expects instances to be created externally and provides
+an HTTP API to update pod state.
+
+HTTP API endpoints:
+  POST /api/create-tenant  - Create a tenant
+  POST /api/add-pod        - Add a pod to a tenant (RUNNING state)
+  POST /api/remove-pod     - Remove a pod from a tenant
+  POST /api/drain-pod      - Drain a pod (DRAINING state for connection migration)
+`,
+	RunE: clierrorplus.MaybeDecorateError(runStaticTestDirectory),
+	Args: cobra.NoArgs,
+}
+
+func runStaticTestDirectory(cmd *cobra.Command, args []string) (returnErr error) {
+	ctx := context.Background()
+	stopper, err := cli.ClearStoresAndSetupLoggingForMTCommands(cmd, ctx)
+	if err != nil {
+		return err
+	}
+	defer stopper.Stop(ctx)
+
+	log.Ops.Infof(ctx, "Starting static test directory server (GRPC:%d, HTTP:%d)",
+		httpTestDirectorySvrContext.grpcPort, httpTestDirectorySvrContext.httpPort)
+
+	dir := tenantdirsvr.NewTestStaticDirectoryServer(stopper, nil)
+	if err := dir.Start(ctx); err != nil {
+		return err
+	}
+
+	srv := &staticDirectoryServer{dir: dir}
+
+	// Start GRPC server for proxy connections
+	grpcServer := grpc.NewServer()
+	tenant.RegisterDirectoryServer(grpcServer, dir)
+
+	grpcListener, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", httpTestDirectorySvrContext.grpcPort))
+	if err != nil {
+		return err
+	}
+	stopper.AddCloser(stop.CloserFn(func() { grpcServer.GracefulStop() }))
+
+	if err := stopper.RunAsyncTask(ctx, "serve-grpc", func(ctx context.Context) {
+		log.Ops.Infof(ctx, "GRPC server listening at %s", grpcListener.Addr())
+		if err := grpcServer.Serve(grpcListener); err != nil {
+			log.Ops.Infof(ctx, "GRPC server stopped: %v", err)
+		}
+	}); err != nil {
+		return err
+	}
+
+	// Start HTTP control API for test management
+	http.HandleFunc("/api/create-tenant", srv.handleCreateTenant)
+	http.HandleFunc("/api/add-pod", srv.handleAddPod)
+	http.HandleFunc("/api/remove-pod", srv.handleRemovePod)
+	http.HandleFunc("/api/drain-pod", srv.handleDrainPod)
+
+	httpListener, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", httpTestDirectorySvrContext.httpPort))
+	if err != nil {
+		return err
+	}
+	stopper.AddCloser(stop.CloserFn(func() { _ = httpListener.Close() }))
+
+	if err := stopper.RunAsyncTask(ctx, "serve-http", func(ctx context.Context) {
+		log.Ops.Infof(ctx, "HTTP API listening at %s", httpListener.Addr())
+		if err := http.Serve(httpListener, nil); err != nil {
+			log.Ops.Infof(ctx, "HTTP server stopped: %v", err)
+		}
+	}); err != nil {
+		return err
+	}
+
+	log.Ops.Infof(ctx, "Directory server ready - use Ctrl+C to stop")
+
+	// Wait for shutdown signal
+	signalCh := make(chan os.Signal, 1)
+	signal.Notify(signalCh, cli.DrainSignals...)
+
+	select {
+	case <-stopper.ShouldQuiesce():
+		<-stopper.IsStopped()
+	case sig := <-signalCh:
+		log.Ops.Infof(ctx, "received signal '%s', shutting down", sig)
+		// Close listeners to unblock Serve() calls
+		_ = grpcListener.Close()
+		_ = httpListener.Close()
+		stopper.Stop(ctx)
+		<-stopper.IsStopped()
+		if sig == os.Interrupt {
+			returnErr = errors.New("interrupted")
+		}
+	case <-log.FatalChan():
+		stopper.Stop(ctx)
+		select {}
+	}
+
+	return returnErr
+}
+
+type staticDirectoryServer struct {
+	dir *tenantdirsvr.TestStaticDirectoryServer
+}
+
+func (s *staticDirectoryServer) handleCreateTenant(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req struct {
+		TenantID          uint64   `json:"tenant_id"`
+		Name              string   `json:"name"`
+		AllowedCIDRRanges []string `json:"allowed_cidr_ranges"`
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	tenantID, err := roachpb.MakeTenantID(req.TenantID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	s.dir.CreateTenant(tenantID, &tenant.Tenant{
+		TenantID:          req.TenantID,
+		ClusterName:       req.Name,
+		AllowedCIDRRanges: req.AllowedCIDRRanges,
+	})
+
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+func (s *staticDirectoryServer) handleAddPod(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req struct {
+		TenantID uint64 `json:"tenant_id"`
+		Addr     string `json:"addr"`
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	tenantID, err := roachpb.MakeTenantID(req.TenantID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	success := s.dir.AddPod(tenantID, &tenant.Pod{
+		TenantID:       req.TenantID,
+		Addr:           req.Addr,
+		State:          tenant.RUNNING,
+		StateTimestamp: timeutil.Now(),
+	})
+
+	if !success {
+		http.Error(w, "Failed to add pod", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+func (s *staticDirectoryServer) handleRemovePod(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req struct {
+		TenantID uint64 `json:"tenant_id"`
+		Addr     string `json:"addr"`
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	tenantID, err := roachpb.MakeTenantID(req.TenantID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	success := s.dir.RemovePod(tenantID, req.Addr)
+
+	if !success {
+		http.Error(w, "Failed to remove pod", http.StatusNotFound)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+func (s *staticDirectoryServer) handleDrainPod(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req struct {
+		TenantID uint64 `json:"tenant_id"`
+		Addr     string `json:"addr"`
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	tenantID, err := roachpb.MakeTenantID(req.TenantID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	success := s.dir.DrainPod(tenantID, req.Addr)
+
+	if !success {
+		http.Error(w, "Failed to drain pod", http.StatusNotFound)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}

--- a/pkg/cli/cliflags/flags_mt.go
+++ b/pkg/cli/cliflags/flags_mt.go
@@ -125,6 +125,16 @@ listeners, if the headers are allowed.`,
 		Description: "Test directory server binds and listens on this port.",
 	}
 
+	HTTPTestDirectoryGRPCPort = FlagInfo{
+		Name:        "grpc-port",
+		Description: "HTTP test directory server binds and listens on this port.",
+	}
+
+	HTTPTestDirectoryHTTPPort = FlagInfo{
+		Name:        "http-port",
+		Description: "HTTP test directory server exposes pod lifecycle API on this port.",
+	}
+
 	TestDirectoryTenantCertsDir = FlagInfo{
 		Name:        "certs-dir",
 		Description: CertsDir.Description,

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2365,6 +2365,12 @@ func (c *clusterImpl) RefetchCertsFromNode(ctx context.Context, node int) error 
 	return roachprod.FetchCertsDir(ctx, c.l, c.MakeNodes(c.Node(node)), fmt.Sprintf("./%s", install.CockroachNodeCertsDir), c.localCertsDir)
 }
 
+// LocalCertsDir returns the local directory where the cluster's
+// certificates are stored, i.e. the roachtest runner's certs.
+func (c *clusterImpl) LocalCertsDir() string {
+	return c.localCertsDir
+}
+
 func (c *clusterImpl) SetDefaultVirtualCluster(name string) {
 	c.defaultVirtualCluster = name
 }

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -181,6 +181,7 @@ type Cluster interface {
 	FetchTimeseriesData(ctx context.Context, l *logger.Logger) error
 	FetchDebugZip(ctx context.Context, l *logger.Logger, dest string, opts ...option.Option) error
 	RefetchCertsFromNode(ctx context.Context, node int) error
+	LocalCertsDir() string
 
 	StartGrafana(ctx context.Context, l *logger.Logger, promCfg *prometheus.Config) error
 	StopGrafana(ctx context.Context, l *logger.Logger, dumpDir string) error

--- a/pkg/cmd/roachtest/cluster/mock/mock_cluster_generated.go
+++ b/pkg/cmd/roachtest/cluster/mock/mock_cluster_generated.go
@@ -554,6 +554,20 @@ func (mr *MockClusterMockRecorder) ListSnapshots(arg0, arg1 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSnapshots", reflect.TypeOf((*MockCluster)(nil).ListSnapshots), arg0, arg1)
 }
 
+// LocalCertsDir mocks base method.
+func (m *MockCluster) LocalCertsDir() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LocalCertsDir")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// LocalCertsDir indicates an expected call of LocalCertsDir.
+func (mr *MockClusterMockRecorder) LocalCertsDir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LocalCertsDir", reflect.TypeOf((*MockCluster)(nil).LocalCertsDir))
+}
+
 // MakeNodes mocks base method.
 func (m *MockCluster) MakeNodes(arg0 ...option.Option) string {
 	m.ctrl.T.Helper()

--- a/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "metric_utils.go",
         "profile.go",
         "replication.go",
+        "sql_proxy.go",
         "utils.go",
         "validation_check.go",
     ],

--- a/pkg/cmd/roachtest/roachtestutil/sql_proxy.go
+++ b/pkg/cmd/roachtest/roachtestutil/sql_proxy.go
@@ -1,0 +1,291 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package roachtestutil
+
+import (
+	"bytes"
+	"context"
+	gosql "database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/roachprod"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
+	"github.com/cockroachdb/errors"
+)
+
+// SQLProxy is a helper to help spin up SQL proxy and a directory service for roachtests.
+type SQLProxy struct {
+	c             cluster.Cluster
+	l             *logger.Logger
+	tenantIDCache map[string]int
+	proxyOpts     install.SQLProxyOpts
+	proxyNode     option.NodeListOption
+	directoryNode option.NodeListOption
+	dirOpts       install.DirectoryServerOpts
+	httpClient    *http.Client
+	httpURL       string
+}
+
+func NewSQLProxy(
+	c cluster.Cluster,
+	l *logger.Logger,
+	proxyNode option.NodeListOption,
+	directoryNode option.NodeListOption,
+) *SQLProxy {
+	return &SQLProxy{
+		c:             c,
+		l:             l,
+		tenantIDCache: make(map[string]int),
+		proxyNode:     proxyNode,
+		directoryNode: directoryNode,
+		httpClient:    http.DefaultClient,
+	}
+}
+
+// Start starts both the directory server and the SQL proxy.
+func (p *SQLProxy) Start(ctx context.Context) error {
+	p.dirOpts = install.DirectoryServerOpts{}
+	err := roachprod.StartProxyDirectory(ctx, p.l, p.c.Name(), p.directoryNode.InstallNodes()[0], p.dirOpts)
+	if err != nil {
+		return err
+	}
+	externalIPs, err := p.c.ExternalIP(ctx, p.l, p.directoryNode)
+	if err != nil {
+		return err
+	}
+	internalIPs, err := p.c.InternalIP(ctx, p.l, p.directoryNode)
+	if err != nil {
+		return err
+	}
+
+	p.httpURL = fmt.Sprintf("http://%s:%d", externalIPs[0], install.DirectoryServerHTTPPort(p.dirOpts))
+	p.proxyOpts = install.SQLProxyOpts{
+		DirectoryAddr: fmt.Sprintf("%s:%d", internalIPs[0], install.DirectoryServerGRPCPort(p.dirOpts)),
+		Insecure:      !p.c.IsSecure(),
+		SkipVerify:    true,
+	}
+	return roachprod.StartSQLProxy(ctx, p.l, p.c.Name(), p.proxyNode.InstallNodes()[0], p.proxyOpts)
+}
+
+// AddTenant adds a new tenant to the directory server.
+func (p *SQLProxy) AddTenant(ctx context.Context, name string) error {
+	// Enable session revival tokens for connection migration
+	db := p.c.Conn(ctx, p.l, 1)
+	defer db.Close()
+	_, err := db.ExecContext(ctx, `ALTER TENANT $1 SET CLUSTER SETTING server.user_login.session_revival_token.enabled = true`, name)
+	if err != nil {
+		return err
+	}
+
+	tenantID, err := TenantID(ctx, p.l, p.c, name)
+	if err != nil {
+		return err
+	}
+
+	reqBody := map[string]interface{}{
+		"tenant_id":           tenantID,
+		"name":                name,
+		"allowed_cidr_ranges": []string{"0.0.0.0/0"}, // Allow all IPs for roachtests
+	}
+
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return err
+	}
+
+	url := fmt.Sprintf("%s/api/create-tenant", p.httpURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("create tenant failed: status=%d, body=%s", resp.StatusCode, string(body))
+	}
+
+	p.l.Printf("Created tenant %d (%s) in directory server", tenantID, name)
+	return nil
+}
+
+func (p *SQLProxy) podOperation(
+	ctx context.Context,
+	nodes option.NodeListOption,
+	virtualClusterName string,
+	sqlInstance int,
+	operation string,
+) error {
+	tenantID, err := TenantID(ctx, p.l, p.c, virtualClusterName)
+	if err != nil {
+		return err
+	}
+	addrs, err := p.PodAddr(ctx, nodes, virtualClusterName, sqlInstance)
+	if err != nil {
+		return err
+	}
+
+	for _, addr := range addrs {
+		reqBody := map[string]interface{}{
+			"tenant_id": tenantID,
+			"addr":      addr,
+		}
+
+		bodyBytes, err := json.Marshal(reqBody)
+		if err != nil {
+			return err
+		}
+
+		apiURL := fmt.Sprintf("%s/api/%s", p.httpURL, operation)
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewReader(bodyBytes))
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := p.httpClient.Do(req)
+		if err != nil {
+			return err
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			return errors.Errorf("%s failed: status=%d, body=%s", operation, resp.StatusCode, string(body))
+		}
+		resp.Body.Close()
+
+		p.l.Printf("%s pod %s on tenant %s", operation, addr, virtualClusterName)
+	}
+	return nil
+}
+
+// AddPod adds a new pod for the specified tenant in the directory server.
+func (p *SQLProxy) AddPod(
+	ctx context.Context, nodes option.NodeListOption, virtualClusterName string, sqlInstance int,
+) error {
+	err := p.podOperation(ctx, nodes, virtualClusterName, sqlInstance, "add-pod")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *SQLProxy) RemovePod(
+	ctx context.Context, nodes option.NodeListOption, virtualClusterName string, sqlInstance int,
+) error {
+	err := p.podOperation(ctx, nodes, virtualClusterName, sqlInstance, "remove-pod")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *SQLProxy) DrainPod(
+	ctx context.Context, nodes option.NodeListOption, virtualClusterName string, sqlInstance int,
+) error {
+	err := p.podOperation(ctx, nodes, virtualClusterName, sqlInstance, "drain-pod")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *SQLProxy) TenantID(ctx context.Context, virtualClusterName string) (int, error) {
+	if id, found := p.tenantIDCache[virtualClusterName]; found {
+		return id, nil
+	}
+	id, err := TenantID(ctx, p.l, p.c, virtualClusterName)
+	if err != nil {
+		return 0, err
+	}
+	p.tenantIDCache[virtualClusterName] = id
+	return id, nil
+}
+
+func (p *SQLProxy) PodAddr(
+	ctx context.Context, nodes option.NodeListOption, virtualClusterName string, sqlInstance int,
+) ([]string, error) {
+	internalIPs, err := p.c.InternalIP(ctx, p.l, nodes)
+	if err != nil {
+		return nil, err
+	}
+
+	sqlPorts, err := p.c.SQLPorts(ctx, p.l, nodes, virtualClusterName, sqlInstance)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(sqlPorts) != len(internalIPs) {
+		return nil, fmt.Errorf("SQL ports and IPs count mismatch: %d ports, %d IPs",
+			len(sqlPorts), len(internalIPs))
+	}
+
+	var addrs []string
+	for i := range internalIPs {
+		addr := fmt.Sprintf("%s:%d", internalIPs[i], sqlPorts[i])
+		addrs = append(addrs, addr)
+	}
+
+	return addrs, nil
+}
+
+func (p *SQLProxy) InternalURL(ctx context.Context, virtualClusterName string) (string, error) {
+	tenantID, err := p.TenantID(ctx, virtualClusterName)
+	if err != nil {
+		return "", err
+	}
+	return roachprod.SQLProxyURL(p.l, p.c.MakeNodes(p.proxyNode), install.SimpleSecureOption(p.c.IsSecure()), virtualClusterName, tenantID, install.CockroachNodeCertsDir, p.proxyOpts)
+}
+
+func (p *SQLProxy) ExternalURL(ctx context.Context, virtualClusterName string) (string, error) {
+	tenantID, err := p.TenantID(ctx, virtualClusterName)
+	if err != nil {
+		return "", err
+	}
+	return roachprod.SQLProxyURL(p.l, p.c.MakeNodes(p.proxyNode), install.SimpleSecureOption(p.c.IsSecure()), virtualClusterName, tenantID, p.c.LocalCertsDir(), p.proxyOpts)
+}
+
+func (p *SQLProxy) Conn(ctx context.Context, virtualClusterName string) (*gosql.DB, error) {
+	proxyURL, err := p.ExternalURL(ctx, virtualClusterName)
+	if err != nil {
+		return nil, err
+	}
+	vals := make(url.Values)
+	vals["allow_unsafe_internals"] = []string{"true"}
+	dataSource := proxyURL + "&" + vals.Encode()
+	return gosql.Open("postgres", dataSource)
+}
+
+// TenantID retrieves the tenant ID for a given virtual cluster name from the
+// system.tenants table. It creates a connection to the system virtual cluster,
+// queries the tenant ID, and closes the connection.
+func TenantID(
+	ctx context.Context, l *logger.Logger, c cluster.Cluster, virtualClusterName string,
+) (int, error) {
+	systemDB := c.Conn(ctx, l, 1, option.VirtualClusterName("system"))
+	defer systemDB.Close()
+
+	var tenantID int
+	err := systemDB.QueryRowContext(ctx, "SELECT id FROM system.tenants WHERE name = $1", virtualClusterName).Scan(&tenantID)
+	if err != nil {
+		return 0, err
+	}
+	return tenantID, nil
+}

--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -112,6 +112,7 @@ func RegisterTests(r registry.Registry) {
 	registerMultiStoreRemove(r)
 	registerMultiTenantDistSQL(r)
 	registerMultiTenantMultiregion(r)
+	registerMultiTenantSQLProxy(r)
 	registerMultiTenantTPCH(r)
 	registerMultiTenantUpgrade(r)
 	registerMultiTenantSharedProcess(r)

--- a/pkg/roachprod/install/BUILD.bazel
+++ b/pkg/roachprod/install/BUILD.bazel
@@ -25,6 +25,8 @@ go_library(
         "scripts/open_ports.sh",
         "scripts/monitor_remote.sh",
         "scripts/monitor_local.sh",
+        "scripts/start_directory_server.sh",
+        "scripts/start_sql_proxy.sh",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/roachprod/install",
     visibility = ["//visibility:public"],

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -1531,6 +1531,7 @@ fi
 %[3]s cert create-node %[4]s $SHARED_ARGS
 %[3]s cert create-tenant-client %[5]d %[4]s $SHARED_ARGS
 %[3]s cert create-client root $TENANT_SCOPE_OPT $SHARED_ARGS
+%[3]s mt cert create-tenant-signing --certs-dir=$CERT_DIR %[5]d
 tar cvf %[6]s $CERT_DIR
 `,
 				CockroachNodeTenantCertsDir,

--- a/pkg/roachprod/install/scripts/start_directory_server.sh
+++ b/pkg/roachprod/install/scripts/start_directory_server.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# Copyright 2026 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+set -euo pipefail
+
+# These values are substituted in the Go code that uses this. We use custom
+# delimiters for the Go text template so that this bash script is valid
+# before template evaluation (so we can use shellcheck).
+LOCAL=#{if .Local#}true#{end#}
+LOG_DIR=#{shesc .LogDir#}
+BINARY=#{shesc .Binary#}
+MEMORY_MAX=#{.MemoryMax#}
+NUM_FILES_LIMIT=#{.NumFilesLimit#}
+VIRTUAL_CLUSTER_LABEL=#{.VirtualClusterLabel#}
+#{if .AutoRestart#}
+AUTO_RESTART=1
+#{end#}
+
+ARGS=(
+#{range .Args -#}
+#{shesc .#}
+#{end -#}
+)
+ENV_VARS=(
+#{range .EnvVars -#}
+#{shesc .#}
+#{end -#}
+)
+
+# End of templated code.
+
+if [[ -n "${LOCAL}" || "${1-}" == "run" ]]; then
+  mkdir -p "${LOG_DIR}"
+  echo "directory server start: $(date), logging to ${LOG_DIR}" | tee -a "${LOG_DIR}"/{roachprod,cockroach.std{out,err}}.log
+  # NB: ENV_VARS is never empty.
+  export "${ENV_VARS[@]}"
+  CODE=0
+
+  if [[ -n "${LOCAL}" ]]; then
+    # For local clusters, run in background with a PID file
+    PID_FILE="${LOG_DIR}/cockroach.pid"
+    rm -f "${PID_FILE}"
+    ROACHPROD_VIRTUAL_CLUSTER="${VIRTUAL_CLUSTER_LABEL}" "${BINARY}" "${ARGS[@]}" >> "${LOG_DIR}/cockroach.stdout.log" 2>> "${LOG_DIR}/cockroach.stderr.log" &
+    PID=$!
+    echo ${PID} > "${PID_FILE}"
+    echo "directory server started with PID ${PID}: $(date)" | tee -a "${LOG_DIR}/roachprod.log"
+    exit 0
+  else
+    ROACHPROD_VIRTUAL_CLUSTER="${VIRTUAL_CLUSTER_LABEL}" "${BINARY}" "${ARGS[@]}" >> "${LOG_DIR}/cockroach.stdout.log" 2>> "${LOG_DIR}/cockroach.stderr.log" || CODE="$?"
+    echo "directory server exited with code ${CODE}: $(date)" | tee -a "${LOG_DIR}"/{roachprod,cockroach.{exit,std{out,err}}}.log
+    exit "${CODE}"
+  fi
+fi
+
+# Set up systemd unit and start it, which will recursively
+# invoke this script but hit the above conditional.
+
+if systemctl is-active -q "${VIRTUAL_CLUSTER_LABEL}"; then
+  echo "${VIRTUAL_CLUSTER_LABEL} service already active"
+  echo "To get more information: systemctl status ${VIRTUAL_CLUSTER_LABEL}"
+  exit 1
+fi
+
+# If the server failed, the service still exists; we need to clean it up before
+# we can start it again.
+sudo systemctl reset-failed "${VIRTUAL_CLUSTER_LABEL}" 2>/dev/null || true
+
+# The first time we run, install a small script that shows some helpful
+# information when we ssh in.
+if [ ! -e "${HOME}/.profile-${VIRTUAL_CLUSTER_LABEL}" ]; then
+  cat > "${HOME}/.profile-${VIRTUAL_CLUSTER_LABEL}" <<EOQ
+echo ""
+if systemctl is-active -q ${VIRTUAL_CLUSTER_LABEL}; then
+  echo "${VIRTUAL_CLUSTER_LABEL} is running; see: systemctl status ${VIRTUAL_CLUSTER_LABEL}"
+elif systemctl is-failed -q ${VIRTUAL_CLUSTER_LABEL}; then
+  echo "${VIRTUAL_CLUSTER_LABEL} stopped; see: systemctl status ${VIRTUAL_CLUSTER_LABEL}"
+else
+  echo "${VIRTUAL_CLUSTER_LABEL} not started"
+fi
+echo ""
+EOQ
+  echo ". ${HOME}/.profile-${VIRTUAL_CLUSTER_LABEL}" >> "${HOME}/.profile"
+fi
+
+# We run this script (with arg "run") as a service unit. We do not use --user
+# because memory limiting doesn't work in that mode. Instead we pass the uid and
+# gid that the process will run under.
+# The "notify" service type is not needed for directory server as it doesn't support
+# systemd notifications.
+sudo systemd-run --unit "${VIRTUAL_CLUSTER_LABEL}" \
+  --same-dir --uid "$(id -u)" --gid "$(id -g)" \
+  -p "MemoryMax=${MEMORY_MAX}" \
+  -p LimitCORE=infinity \
+  -p "LimitNOFILE=${NUM_FILES_LIMIT}" \
+  ${AUTO_RESTART:+-p Restart=always -p RestartSec=5s -p StartLimitIntervalSec=60s -p StartLimitBurst=3} \
+  bash "${0}" run

--- a/pkg/roachprod/install/scripts/start_sql_proxy.sh
+++ b/pkg/roachprod/install/scripts/start_sql_proxy.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# Copyright 2026 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+set -euo pipefail
+
+# These values are substituted in the Go code that uses this. We use custom
+# delimiters for the Go text template so that this bash script is valid
+# before template evaluation (so we can use shellcheck).
+LOCAL=#{if .Local#}true#{end#}
+LOG_DIR=#{shesc .LogDir#}
+BINARY=#{shesc .Binary#}
+MEMORY_MAX=#{.MemoryMax#}
+NUM_FILES_LIMIT=#{.NumFilesLimit#}
+VIRTUAL_CLUSTER_LABEL=#{.VirtualClusterLabel#}
+#{if .AutoRestart#}
+AUTO_RESTART=1
+#{end#}
+
+ARGS=(
+#{range .Args -#}
+#{shesc .#}
+#{end -#}
+)
+ENV_VARS=(
+#{range .EnvVars -#}
+#{shesc .#}
+#{end -#}
+)
+
+# End of templated code.
+
+if [[ -n "${LOCAL}" || "${1-}" == "run" ]]; then
+  mkdir -p "${LOG_DIR}"
+  echo "sqlproxy start: $(date), logging to ${LOG_DIR}" | tee -a "${LOG_DIR}"/{roachprod,cockroach.std{out,err}}.log
+  # NB: ENV_VARS is never empty.
+  export "${ENV_VARS[@]}"
+  CODE=0
+
+  if [[ -n "${LOCAL}" ]]; then
+    # For local clusters, run in background with a PID file
+    # NB: mt start-proxy doesn't support --background flag like cockroach does
+    PID_FILE="${LOG_DIR}/cockroach.pid"
+    rm -f "${PID_FILE}"
+    ROACHPROD_VIRTUAL_CLUSTER="${VIRTUAL_CLUSTER_LABEL}" "${BINARY}" "${ARGS[@]}" >> "${LOG_DIR}/cockroach.stdout.log" 2>> "${LOG_DIR}/cockroach.stderr.log" &
+    PID=$!
+    echo ${PID} > "${PID_FILE}"
+    echo "sqlproxy started with PID ${PID}: $(date)" | tee -a "${LOG_DIR}/roachprod.log"
+    exit 0
+  else
+    ROACHPROD_VIRTUAL_CLUSTER="${VIRTUAL_CLUSTER_LABEL}" "${BINARY}" "${ARGS[@]}" >> "${LOG_DIR}/cockroach.stdout.log" 2>> "${LOG_DIR}/cockroach.stderr.log" || CODE="$?"
+    echo "sqlproxy exited with code ${CODE}: $(date)" | tee -a "${LOG_DIR}"/{roachprod,cockroach.{exit,std{out,err}}}.log
+    exit "${CODE}"
+  fi
+fi
+
+# Set up systemd unit and start it, which will recursively
+# invoke this script but hit the above conditional.
+
+if systemctl is-active -q "${VIRTUAL_CLUSTER_LABEL}"; then
+  echo "${VIRTUAL_CLUSTER_LABEL} service already active"
+  echo "To get more information: systemctl status ${VIRTUAL_CLUSTER_LABEL}"
+  exit 1
+fi
+
+# If the proxy failed, the service still exists; we need to clean it up before
+# we can start it again.
+sudo systemctl reset-failed "${VIRTUAL_CLUSTER_LABEL}" 2>/dev/null || true
+
+# The first time we run, install a small script that shows some helpful
+# information when we ssh in.
+if [ ! -e "${HOME}/.profile-${VIRTUAL_CLUSTER_LABEL}" ]; then
+  cat > "${HOME}/.profile-${VIRTUAL_CLUSTER_LABEL}" <<EOQ
+echo ""
+if systemctl is-active -q ${VIRTUAL_CLUSTER_LABEL}; then
+  echo "${VIRTUAL_CLUSTER_LABEL} is running; see: systemctl status ${VIRTUAL_CLUSTER_LABEL}"
+elif systemctl is-failed -q ${VIRTUAL_CLUSTER_LABEL}; then
+  echo "${VIRTUAL_CLUSTER_LABEL} stopped; see: systemctl status ${VIRTUAL_CLUSTER_LABEL}"
+else
+  echo "${VIRTUAL_CLUSTER_LABEL} not started"
+fi
+echo ""
+EOQ
+  echo ". ${HOME}/.profile-${VIRTUAL_CLUSTER_LABEL}" >> "${HOME}/.profile"
+fi
+
+# We run this script (with arg "run") as a service unit. We do not use --user
+# because memory limiting doesn't work in that mode. Instead we pass the uid and
+# gid that the process will run under.
+# The "notify" service type is not needed for sqlproxy as it doesn't support
+# systemd notifications.
+sudo systemd-run --unit "${VIRTUAL_CLUSTER_LABEL}" \
+  --same-dir --uid "$(id -u)" --gid "$(id -g)" \
+  -p "MemoryMax=${MEMORY_MAX}" \
+  -p LimitCORE=infinity \
+  -p "LimitNOFILE=${NUM_FILES_LIMIT}" \
+  ${AUTO_RESTART:+-p Restart=always -p RestartSec=5s -p StartLimitIntervalSec=60s -p StartLimitBurst=3} \
+  bash "${0}" run

--- a/pkg/roachprod/multitenant.go
+++ b/pkg/roachprod/multitenant.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
+	"github.com/cockroachdb/errors"
 )
 
 // StartServiceForVirtualCluster starts SQL/HTTP instances for a
@@ -66,4 +67,97 @@ func StopServiceForVirtualCluster(
 
 	label := install.VirtualClusterLabel(stopOpts.VirtualClusterName, stopOpts.SQLInstance)
 	return c.Stop(ctx, l, stopOpts.Sig, stopOpts.Wait, stopOpts.GracePeriod, label)
+}
+
+// StartSQLProxy starts a SQL proxy process on the specified node. The proxy
+// routes connections to virtual clusters based on the provided routing rules.
+// This is useful for testing multi-tenant scenarios with connection pooling
+// and routing. Returns a database connection to the proxy.
+func StartSQLProxy(
+	ctx context.Context,
+	l *logger.Logger,
+	clusterName string,
+	node install.Node,
+	proxyOpts install.SQLProxyOpts,
+	clusterSettingsOpts ...install.ClusterSettingOption,
+) error {
+	c, err := newCluster(l, clusterName, clusterSettingsOpts...)
+	if err != nil {
+		return err
+	}
+
+	return c.StartSQLProxy(ctx, l, node, proxyOpts)
+}
+
+// StopSQLProxy stops the SQL proxy process on all nodes in the cluster.
+func StopSQLProxy(
+	ctx context.Context,
+	l *logger.Logger,
+	clusterName string,
+	node install.Node,
+	secure install.SecureOption,
+	opts install.SQLProxyOpts,
+) error {
+	c, err := newCluster(l, clusterName, secure)
+	if err != nil {
+		return err
+	}
+
+	return c.StopSQLProxy(ctx, l, node, opts)
+}
+
+func SQLProxyURL(
+	l *logger.Logger,
+	clusterName string,
+	secure install.SecureOption,
+	virtualClusterName string,
+	tenantID int,
+	certsDir string,
+	opts install.SQLProxyOpts,
+) (string, error) {
+	c, err := GetClusterFromCache(l, clusterName, secure)
+	if err != nil {
+		return "", err
+	}
+
+	if len(c.Nodes) != 1 {
+		return "", errors.Errorf("expected 1 node, got %d", len(c.Nodes))
+	}
+
+	return c.SQLProxyURL(c.Nodes[0], virtualClusterName, tenantID, certsDir, opts), nil
+}
+
+// StartProxyDirectory starts a directory server process on the specified node.
+// The directory server provides a static pod registry for SQL proxies to discover tenant pods.
+func StartProxyDirectory(
+	ctx context.Context,
+	l *logger.Logger,
+	clusterName string,
+	node install.Node,
+	dirOpts install.DirectoryServerOpts,
+	clusterSettingsOpts ...install.ClusterSettingOption,
+) error {
+	c, err := newCluster(l, clusterName, clusterSettingsOpts...)
+	if err != nil {
+		return err
+	}
+
+	return c.StartDirectoryServer(ctx, l, node, dirOpts)
+}
+
+// StopProxyDirectory stops the directory server process on the specified node.
+func StopProxyDirectory(
+	ctx context.Context,
+	l *logger.Logger,
+	clusterName string,
+	node install.Node,
+	dirOpts install.DirectoryServerOpts,
+	clusterSettingsOpts ...install.ClusterSettingOption,
+) error {
+	c, err := newCluster(l, clusterName, clusterSettingsOpts...)
+	if err != nil {
+		return err
+	}
+
+	return c.StopDirectoryServer(ctx, l, node, dirOpts)
 }

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1276,6 +1276,7 @@ func TestLint(t *testing.T) {
 			":!server/server_obs_service.go",
 			":!server/testserver.go",
 			":!util/tracing/*_test.go",
+			":!ccl/cliccl/mt_http_test_directory.go",
 			":!ccl/sqlproxyccl/tenantdirsvr/test_directory_svr.go",
 			":!ccl/sqlproxyccl/tenantdirsvr/test_simple_directory_svr.go",
 			":!ccl/sqlproxyccl/tenantdirsvr/test_static_directory_svr.go",


### PR DESCRIPTION
This PR adds support for using SQL proxy to connect to virtual clusters in roachtests. In order to support this, an http test directory was added to the CLI which allows externally managing pod lifecycles without the full heavyweight k8s implementation used in cloud.

See individual commits for more details.

Informs: https://github.com/cockroachdb/cockroach/issues/159922
Fixes: none
Epic: none