### PR TITLE
backup: concurrent compactions (wip)

### DIFF
--- a/pkg/backup/backuppb/backup.proto
+++ b/pkg/backup/backuppb/backup.proto
@@ -210,14 +210,15 @@ message ScheduledBackupExecutionArgs {
    (gogoproto.customname) = "ProtectedTimestampRecord",
    (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/util/uuid.UUID"
   ];
+  // If there already exists a set of automated compaction jobs running on
+  // backups created by this schedule, this field will be set to the IDs of
+  // those jobs. An empty list indicates that there are no compaction jobs
+  // running.
+  repeated int64 compaction_job_ids = 10 [(gogoproto.customname) = "CompactionJobIDs", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/jobs/jobspb.JobID"];
 
   reserved 5;
-  // If an automated compaction is currently running on backups created by this
-  // schedule, this field will be set to the ID of the compaction job.
-  // A value of 0 indicates that there is no compaction job running.
-  int64 compaction_job_id = 9 [(gogoproto.customname) = "CompactionJobID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/jobs/jobspb.JobID"];
-
-  // Next ID: 10
+  reserved 9;
+  // Next ID: 11
 }
 
 // RestoreProgress is the information that the RestoreData processor sends back

--- a/pkg/backup/compaction_policy_test.go
+++ b/pkg/backup/compaction_policy_test.go
@@ -7,6 +7,8 @@ package backup
 
 import (
 	"context"
+	"fmt"
+	"math"
 	"math/rand"
 	"slices"
 	"testing"
@@ -23,59 +25,211 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBackupCompactionHeuristic(t *testing.T) {
+func TestMinSumWindow(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-	ctx := context.Background()
 
 	testcases := []struct {
 		name       string
-		sizes      []int64
+		nums       []int64
 		windowSize int
 		expected   [2]int
+		notFound   bool
 	}{
 		{
-			name:       "optimal at the beginning",
-			sizes:      []int64{1, 2, 2, 5, 1, 2},
+			name:       "no invalids",
+			nums:       []int64{4, 2, 7, 3, 6},
+			windowSize: 1,
+			expected:   [2]int{1, 2},
+		},
+		{
+			name:       "no invalids/optimal at beginning",
+			nums:       []int64{1, 2, 7, 3, 6, 8, 2, 4},
 			windowSize: 3,
 			expected:   [2]int{0, 3},
 		},
 		{
-			name:       "optimal in the middle",
-			sizes:      []int64{1, 3, 4, 5, 5, 2},
+			name:       "no invalids/optimal in middle",
+			nums:       []int64{4, 5, 1, 2, 3, 6, 7},
 			windowSize: 3,
 			expected:   [2]int{2, 5},
 		},
 		{
-			name:       "optimal at the end",
-			sizes:      []int64{1, 3, 4, 3, 2, 2},
+			name:       "no invalids/optimal at end",
+			nums:       []int64{5, 6, 7, 2, 1, 3},
 			windowSize: 3,
 			expected:   [2]int{3, 6},
 		},
 		{
-			name:       "tied heuristic",
-			sizes:      []int64{2, 3, 4, 1, 2, 3},
+			name:       "with invalids/single invalid at beginning",
+			nums:       []int64{math.MaxInt64, 2, 3, 1, 4},
 			windowSize: 3,
-			expected:   [2]int{0, 3},
+			expected:   [2]int{1, 4},
+		},
+		{
+			name:       "with invalids/double invalid to skip",
+			nums:       []int64{math.MaxInt64, math.MaxInt64, 5, 1, 3, 4},
+			windowSize: 3,
+			expected:   [2]int{3, 6},
+		},
+		{
+			name:       "with invalids/double invalid with gap",
+			nums:       []int64{1, math.MaxInt64, 2, math.MaxInt64, 3, 4, 5, 1, 6, 7},
+			windowSize: 3,
+			expected:   [2]int{5, 8},
+		},
+		{
+			name:       "no valid window/all invalids",
+			nums:       []int64{math.MaxInt64, math.MaxInt64, math.MaxInt64},
+			windowSize: 2,
+			notFound:   true,
+		},
+		{
+			name:       "no valid window/interspersed invalids",
+			nums:       []int64{1, math.MaxInt64, 2, math.MaxInt64, 3},
+			windowSize: 2,
+			notFound:   true,
 		},
 	}
 	for _, tc := range testcases {
-		t.Run(tc.name, func(t *testing.T) {
-			start, end := minDeltaWindow(tc.sizes, tc.windowSize)
-			require.Equal(t, tc.expected[0], start)
-			require.Equal(t, tc.expected[1], end)
+		t.Run(fmt.Sprintf("%s/window=%d", tc.name, tc.windowSize), func(t *testing.T) {
+			start, end, ok := minSumWindow(tc.nums, tc.windowSize)
+			if tc.notFound {
+				require.False(t, ok)
+			} else {
+				require.True(t, ok)
+				require.Equal(t, tc.expected, [2]int{start, end}, "start/end did not match")
+			}
 		})
 	}
+}
 
+func TestMinSizeDeltaHeuristic(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
-	t.Run("too large window", func(t *testing.T) {
-		var windowSize int64 = 5
-		chain := make([]backuppb.BackupManifest, 5)
-		backupCompactionWindow.Override(ctx, &st.SV, windowSize)
-		execCfg := &sql.ExecutorConfig{Settings: st}
-		_, _, err := minSizeDeltaHeuristic(ctx, execCfg, chain)
-		require.Error(t, err)
-	})
+
+	testcases := []struct {
+		name string
+		// backupSizes represents the size of the incremental backups in the chain.
+		backupSizes []int
+		windowSize  int
+		concurrency int
+		// Expected indices of the selected windows of the backups specified in
+		// backupSizes.
+		expected [][2]int
+		errMsg   string
+	}{
+		{
+			name:        "simple case",
+			backupSizes: []int{1, 2, 3, 4, 5, 6, 7, 8},
+			windowSize:  3,
+			concurrency: 1,
+			expected:    [][2]int{{0, 3}},
+		},
+		{
+			name:        "non-overlapping min windows",
+			backupSizes: []int{1, 5, 3, 30, 40, 50, 3, 2, 1, 50},
+			windowSize:  3,
+			concurrency: 2,
+			expected:    [][2]int{{6, 9}, {0, 3}},
+		},
+		{
+			// Chain where two minimum windows overlap, so only one can be chosen.
+			name:        "two overlapping min windows",
+			backupSizes: []int{40, 2, 3, 1, 4, 5, 8, 50, 60, 70},
+			windowSize:  3,
+			concurrency: 2,
+			expected:    [][2]int{{1, 4}, {4, 7}},
+		},
+		{
+			name:        "several overlapping min windows",
+			backupSizes: []int{10, 2, 1, 4, 1, 1, 3, 1, 2, 3, 10},
+			windowSize:  3,
+			concurrency: 3,
+			expected:    [][2]int{{4, 7}, {7, 10}, {1, 4}},
+		},
+		{
+			name:        "multiple windows and all backups",
+			backupSizes: []int{1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5},
+			windowSize:  3,
+			concurrency: 5,
+			expected:    [][2]int{{0, 3}, {3, 6}, {6, 9}, {9, 12}, {12, 15}},
+		},
+		{
+			// Due to the greedy nature of the heuristic, it may select an initial
+			// window that prevents other windows from being selected, resulting in
+			// less than the max concurrency.
+			name:        "first window blocks further concurrency",
+			backupSizes: []int{5, 1, 1, 1, 1, 5},
+			windowSize:  3,
+			concurrency: 2,
+			expected:    [][2]int{{1, 4}},
+		},
+		{
+			name:        "chain length blocks further concurrency",
+			backupSizes: []int{1, 2, 3, 4, 5, 6},
+			windowSize:  3,
+			concurrency: 3,
+			expected:    [][2]int{{0, 3}, {3, 6}},
+		},
+		{
+			name:        "invalid window size",
+			backupSizes: []int{1, 2, 3, 4, 5},
+			windowSize:  6,
+			concurrency: 1,
+			errMsg:      "compaction window size must be less than backup chain length",
+		},
+	}
+
+	sizesToWorkload := func(backupSizes ...int) []*fakeWorkloadCfg {
+		workloads := make([]*fakeWorkloadCfg, len(backupSizes))
+		for i, size := range backupSizes {
+			// The type of workload doesn't matter for this test, only the size of the
+			// backup.
+			workloads[i] = newWorkloadCfg(randomWorkload{updateProbability: 0.5}).Backups(1).Keys(size)
+		}
+		return workloads
+	}
+
+	for _, tc := range testcases {
+		t.Run(
+			fmt.Sprintf("%s/window=%d/concurrency=%d", tc.name, tc.windowSize, tc.concurrency),
+			func(t *testing.T) {
+				backupChain := newFakeBackupChainFactory(t, nil, 100).AddWorkload(
+					sizesToWorkload(tc.backupSizes...)...,
+				).CreateBackupChain()
+				backupCompactionWindow.Override(ctx, &st.SV, int64(tc.windowSize))
+				backupCompactionConcurrency.Override(ctx, &st.SV, int64(tc.concurrency))
+				execCfg := &sql.ExecutorConfig{Settings: st}
+				startEndPairs, err := minSizeDeltaHeuristic(
+					ctx, execCfg, backupChain.toBackupManifests(),
+				)
+				if tc.errMsg != "" {
+					require.ErrorContains(t, err, tc.errMsg)
+					return
+				}
+				defer func() {
+					if t.Failed() {
+						backupSizes := make([]int, len(backupChain))
+						for i, backup := range backupChain {
+							backupSizes[i] = backup.Size()
+						}
+						t.Logf("backup sizes: %v", backupSizes)
+					}
+				}()
+				require.NoError(t, err)
+				require.Len(t, startEndPairs, len(tc.expected), "number of windows did not match")
+				// Check that each result pair is expected.
+				for _, pair := range startEndPairs {
+					// Because the indices from the pairs include the full backup, we
+					// offset by one to match the expected indices.
+					offsetPair := [2]int{pair[0] - 1, pair[1] - 1}
+					require.Contains(t, tc.expected, offsetPair, "unexpected window indices")
+				}
+			},
+		)
+	}
 }
 
 func TestSimulateCompactionPolicy(t *testing.T) {
@@ -141,13 +295,29 @@ func TestSimulateCompactionPolicy(t *testing.T) {
 				execCfg := &sql.ExecutorConfig{Settings: st}
 
 				chain := tc.factory.CreateBackupChain()
-				compacted, chain, err := chain.Compact(t, ctx, execCfg, policy)
+				compacted, indices, err := chain.Compact(t, ctx, execCfg, policy)
 				require.NoError(t, err)
 
-				t.Logf(
-					"%s:\n\tchain size: %d\n\tlast backup size: %d\n\tcompacted size: %d",
-					tc.name, chain.Size(), chain[len(chain)-1].Size(), compacted.Size(),
-				)
+				results := "Compaction Results:\n"
+				for i, compactedBackup := range compacted {
+					startEnd := indices[i]
+					results += fmt.Sprintf(
+						" \tCompacted Backup %d:\n", i,
+					)
+					results += fmt.Sprintf(
+						"\t\tCompacted Indexes: [%d, %d)\n",
+						startEnd[0], startEnd[1],
+					)
+					results += fmt.Sprintf(
+						"\t\tSize of last backup in compaction: %d\n",
+						chain[startEnd[1]-1].Size(),
+					)
+					results += fmt.Sprintf(
+						"\t\tCompacted size: %d\n",
+						compactedBackup.Size(),
+					)
+				}
+				t.Logf(results)
 			})
 		}
 	}
@@ -274,7 +444,7 @@ func (w randomWorkload) CreateBackup(
 	}
 
 	// Store keys that can be updated to avoid duplicate updates.
-	updateableKeys := allKeys[:]
+	updateableKeys := slices.Clone(allKeys)
 
 	for range numKeys {
 		if rng.Float64() < w.updateProbability && len(updateableKeys) > 0 {
@@ -344,21 +514,28 @@ func (c fakeBackupChain) Size() int {
 }
 
 // Compact applies the provided compaction policy to the backup chain, returning
-// a compacted backup and the backups that were compacted.
+// the compacted backups and the [start, end) indices of their composite backups.
 func (c fakeBackupChain) Compact(
 	t *testing.T, ctx context.Context, execCfg *sql.ExecutorConfig, policy compactionPolicy,
-) (fakeBackup, []fakeBackup, error) {
+) ([]fakeBackup, [][2]int, error) {
 	manifests := c.toBackupManifests()
-	start, end, err := policy(ctx, execCfg, manifests)
+	windows, err := policy(ctx, execCfg, manifests)
 	if err != nil {
-		return fakeBackup{}, nil, err
+		return nil, nil, err
 	}
-	t.Logf("Compacting backups from index %d to %d", start, end)
-	compacted, err := c.compactWindow(start, end)
-	if err != nil {
-		return fakeBackup{}, nil, err
+	compactedBackups := make([]fakeBackup, 0, len(windows))
+	indices := make([][2]int, 0, len(windows))
+	for _, window := range windows {
+		start, end := window[0], window[1]
+		t.Logf("Compacting backups from index %d to %d", start, end)
+		compacted, err := c.compactWindow(start, end)
+		if err != nil {
+			return nil, nil, err
+		}
+		compactedBackups = append(compactedBackups, compacted)
+		indices = append(indices, [2]int{start, end})
 	}
-	return compacted, c[start:end], nil
+	return compactedBackups, indices, nil
 }
 
 // compactWindow compacts the backups in the chain from the specified start to


### PR DESCRIPTION
This patch teaches backup schedules to run concurrent compactions in the event at the chain has gotten significantly longer than anticipated.

This is mostly a POC, I think this is more complicated than needed.