### PR TITLE
backup: compactions can now trigger more compactions after completion

### DIFF
--- a/pkg/backup/backupinfo/manifest_handling.go
+++ b/pkg/backup/backupinfo/manifest_handling.go
@@ -948,10 +948,11 @@ func UnzipBackupTreeEntries(
 	return defaultURIs, mainBackupManifests, localityInfo
 }
 
-// ValidateEndTimeAndTruncate checks that the requested target time, if
-// specified, is valid for the list of incremental backups resolved, truncating
-// the results to the backup that contains the target time.
-// The method also performs additional sanity checks to ensure the backups cover
+// ValidateEndTimeAndTruncate checks that the requested target time is valid for
+// the list of incremental backups resolved, truncating the results to the
+// backup that contains the target time. If the endTime is empty, it is assumed
+// that the endTime is the end time of the last backup in the chain. The
+// function also performs additional sanity checks to ensure the backups cover
 // the requested time.
 //
 // Note: This function assumes that the manifests in the chain are sorted by end


### PR DESCRIPTION
This teaches backup compactions to potentially trigger another compaction job after completion. This contrasts against the current implementation where we must wait until the next run of the schedule. This means that during the downtime in between backups, compactions can gradually repair the chain.

Epic: None

Fixes: #161373

Fixes: #161353 

Fixes: #157913

Fixes: #157912

Fixes: #157110

Release note: None