### PR TITLE
release-24.3: roachtest: fix leaked runBackgroundWorkload call

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
@@ -170,7 +170,14 @@ func backupRestoreRoundTrip(
 		if err != nil {
 			return err
 		}
-		defer stopBackgroundCommands()
+		defer func() {
+			if stopBackgroundCommands != nil {
+				// Since stopBackgroundCommands may get reassigned below, call
+				// stopBackgroundCommands within an anonymous function to ensure the up
+				// to date assignment gets called on defer.
+				stopBackgroundCommands()
+			}
+		}()
 
 		for i := 0; i < numFullBackups; i++ {
 			allNodes := labeledNodes{Nodes: c.CRDBNodes(), Version: clusterupgrade.CurrentVersion().String()}
@@ -221,7 +228,6 @@ func backupRestoreRoundTrip(
 				}
 			}
 		}
-		stopBackgroundCommands()
 		return nil
 	})
 


### PR DESCRIPTION
Backport 1/1 commits from #161034.

/cc @cockroachdb/release

---

This commit fixes the backup restore roundtrip tests where a background workload would be leaked and never stopped. This specifically occurs because we directly defer the stopping of the first workload call. By doing so, it is specifically the first workload call that is cleaned up. However, whenever we perform a full cluster restore, we stop the background workload, run the restore, and then restart the workload. If after restarting the workload we run into an error, we never run the cleanup from the new workload. The solution is to defer the cleanup in a closure, which allows us to always call the cleanup from the latest reset.

Fixes: #160762

Release note: None

---

Release justification: None