### PR TITLE
docgen: update SHOW STATEMENT HINTS and EXPLAIN diagrams

### DIFF
--- a/docs/generated/sql/bnf/BUILD.bazel
+++ b/docs/generated/sql/bnf/BUILD.bazel
@@ -281,7 +281,7 @@ FILES = [
     "show_session_stmt",
     "show_sessions",
     "show_statements",
-    "show_statement_hints_stmt",
+    "show_statement_hints",
     "show_stats",
     "show_survival_goal_stmt",
     "show_tables",

--- a/docs/generated/sql/bnf/explain_stmt.bnf
+++ b/docs/generated/sql/bnf/explain_stmt.bnf
@@ -1,3 +1,3 @@
 explain_stmt ::=
 	'EXPLAIN' explainable_stmt
-	| 'EXPLAIN' '(' ( 'VERBOSE' | 'TYPES' | 'OPT' | 'ENV' | 'MEMO' | 'REDACT' | 'DISTSQL' | 'VEC' ) ( ( ',' ( 'VERBOSE' | 'TYPES' | 'OPT' | 'ENV' | 'MEMO' | 'REDACT' | 'DISTSQL' | 'VEC' ) ) )* ')' explainable_stmt
+	| 'EXPLAIN' '(' ( 'VERBOSE' | 'TYPES' | 'OPT' | 'ENV' | 'MEMO' | 'REDACT' | 'DISTSQL' | 'VEC' | 'FINGERPRINT' ) ( ( ',' ( 'VERBOSE' | 'TYPES' | 'OPT' | 'ENV' | 'MEMO' | 'REDACT' | 'DISTSQL' | 'VEC' | 'FINGERPRINT' ) ) )* ')' explainable_stmt

--- a/docs/generated/sql/bnf/show_statement_hints.bnf
+++ b/docs/generated/sql/bnf/show_statement_hints.bnf
@@ -1,0 +1,4 @@
+show_statement_hints_stmt ::=
+	'SHOW' 'STATEMENT' 'HINTS' 'FOR' string_or_placeholder 'WITH' 'DETAILS' ( ( ',' ( 'DETAILS' ) ) )*
+	| 'SHOW' 'STATEMENT' 'HINTS' 'FOR' string_or_placeholder 'WITH' 'OPTIONS' '(' 'DETAILS' ( ( ',' ( 'DETAILS' ) ) )* ')'
+	| 'SHOW' 'STATEMENT' 'HINTS' 'FOR' string_or_placeholder 

--- a/docs/generated/sql/bnf/show_statement_hints_stmt.bnf
+++ b/docs/generated/sql/bnf/show_statement_hints_stmt.bnf
@@ -1,2 +1,0 @@
-show_statement_hints_stmt ::=
-	'SHOW' 'STATEMENT' 'HINTS' 'FOR' string_or_placeholder opt_with_show_hints_options

--- a/pkg/cmd/docgen/diagrams.go
+++ b/pkg/cmd/docgen/diagrams.go
@@ -1130,7 +1130,7 @@ var specs = []stmtSpec{
 		name:   "explain_stmt",
 		inline: []string{"explain_option_list"},
 		replace: map[string]string{
-			"explain_option_name": "( 'VERBOSE' | 'TYPES' | 'OPT' | 'ENV' | 'MEMO' | 'REDACT' | 'DISTSQL' | 'VEC' )",
+			"explain_option_name": "( 'VERBOSE' | 'TYPES' | 'OPT' | 'ENV' | 'MEMO' | 'REDACT' | 'DISTSQL' | 'VEC' | 'FINGERPRINT' )",
 		},
 		exclude: []*regexp.Regexp{
 			regexp.MustCompile("'ANALYZE'"),
@@ -1595,6 +1595,11 @@ var specs = []stmtSpec{
 	{
 		name: "show_regions",
 		stmt: "show_regions_stmt",
+	},
+	{
+		name:   "show_statement_hints",
+		stmt:   "show_statement_hints_stmt",
+		inline: []string{"opt_with_show_hints_options", "show_hints_options_list", "show_hints_options"},
 	},
 	{
 		name:   "show_statements",

--- a/pkg/gen/bnf.bzl
+++ b/pkg/gen/bnf.bzl
@@ -281,7 +281,7 @@ BNF_SRCS = [
     "//docs/generated/sql/bnf:show_sequences.bnf",
     "//docs/generated/sql/bnf:show_session_stmt.bnf",
     "//docs/generated/sql/bnf:show_sessions.bnf",
-    "//docs/generated/sql/bnf:show_statement_hints_stmt.bnf",
+    "//docs/generated/sql/bnf:show_statement_hints.bnf",
     "//docs/generated/sql/bnf:show_statements.bnf",
     "//docs/generated/sql/bnf:show_stats.bnf",
     "//docs/generated/sql/bnf:show_survival_goal_stmt.bnf",

--- a/pkg/gen/docs.bzl
+++ b/pkg/gen/docs.bzl
@@ -291,7 +291,7 @@ DOCS_SRCS = [
     "//docs/generated/sql/bnf:show_sequences.bnf",
     "//docs/generated/sql/bnf:show_session_stmt.bnf",
     "//docs/generated/sql/bnf:show_sessions.bnf",
-    "//docs/generated/sql/bnf:show_statement_hints_stmt.bnf",
+    "//docs/generated/sql/bnf:show_statement_hints.bnf",
     "//docs/generated/sql/bnf:show_statements.bnf",
     "//docs/generated/sql/bnf:show_stats.bnf",
     "//docs/generated/sql/bnf:show_survival_goal_stmt.bnf",


### PR DESCRIPTION
Updated the diagram for `SHOW STATEMENT HINTS` (exposing the `DETAILS` option). Diagram looks like:

<img width="547" height="274" alt="image" src="https://github.com/user-attachments/assets/1c66f39b-30b1-4dbf-a32b-893e4222db75" />

Also updated the `EXPLAIN` diagram to include the `FINGERPRINT` option:

<img width="605" height="453" alt="image" src="https://github.com/user-attachments/assets/1f9d9b27-b8b4-4c60-b1d2-3b4ad6aafb87" />

This is related to the docs PR https://github.com/cockroachdb/docs/pull/20830

Epic: none
Release note: none
Release justification: non-production code change