### PR TITLE
DNM: release-25.2: cloud: retry "stream error"s from S3-like service unconditionally

### DIFF
--- a/pkg/cloud/BUILD.bazel
+++ b/pkg/cloud/BUILD.bazel
@@ -47,6 +47,7 @@ go_test(
     embed = [":cloud"],
     deps = [
         "//pkg/cloud/cloudpb",
+        "//pkg/settings/cluster",
         "//pkg/util/ioctx",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",

--- a/pkg/cloud/cloud_io.go
+++ b/pkg/cloud/cloud_io.go
@@ -219,7 +219,7 @@ func ResumingReaderRetryOnErrFnForSettings(
 			log.Warningf(ctx, "retrying connection timed out because %s = true", retryConnectionTimedOut.Name())
 			return true
 		}
-		return false
+		return strings.Contains(err.Error(), "stream error") && strings.Contains(err.Error(), "CANCEL; received from peer")
 	}
 }
 


### PR DESCRIPTION
We've observed that an S3-like service used in a POC could hit an error like `foo.avro›: ‹stream error: stream ID 42; CANCEL; received from peer`, which would then fail the IMPORT intermittently. This commit is a temporary workaround for that POC.

Addresses: https://github.com/cockroachlabs/support/issues/3525.
Release note: None