### PR TITLE
pgwire: Enhancing authCert with SAN identities

### DIFF
--- a/pkg/sql/pgwire/auth_behaviors.go
+++ b/pkg/sql/pgwire/auth_behaviors.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/provisioning"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/identmap"
 	"github.com/cockroachdb/errors"
 	"github.com/go-ldap/ldap/v3"
 )
@@ -29,6 +30,7 @@ type AuthBehaviors struct {
 	replacementIdentity string
 	replacedIdentity    bool
 	roleMapper          RoleMapper
+	enhancedRoleMapper  EnhancedRoleMapper
 	authorizer          Authorizer
 	provisioningManager struct {
 		sync.Once
@@ -36,12 +38,14 @@ type AuthBehaviors struct {
 	}
 	provisioner      Provisioner
 	externalAuthTime time.Duration
+	sanIdentities    []string
 }
 
 // Ensure that an AuthBehaviors is easily composable with itself.
 var _ Authenticator = (*AuthBehaviors)(nil).Authenticate
 var _ func() = (*AuthBehaviors)(nil).ConnClose
 var _ RoleMapper = (*AuthBehaviors)(nil).MapRole
+var _ EnhancedRoleMapper = (*AuthBehaviors)(nil).EnhancedMapRole
 var _ Authorizer = (*AuthBehaviors)(nil).MaybeAuthorize
 
 // This is a hack for the unused-symbols linter. These two functions
@@ -112,9 +116,26 @@ func (b *AuthBehaviors) MapRole(
 	return nil, errors.New("no RoleMapper provided to AuthBehaviors")
 }
 
+// EnhancedMapRole delegates to the EnhancedRoleMapper passed to SetEnhancedRoleMapper
+// or returns an error if SetEnhancedRoleMapper has not been called.
+func (b *AuthBehaviors) EnhancedMapRole(
+	ctx context.Context, systemIdentities []string,
+) ([]identmap.IdentityMapping, error) {
+	if found := b.enhancedRoleMapper; found != nil {
+		return found(ctx, systemIdentities)
+	}
+	return nil, errors.New("no SAN RoleMapper provided to AuthBehaviors.")
+}
+
 // SetRoleMapper updates the RoleMapper to be used.
 func (b *AuthBehaviors) SetRoleMapper(m RoleMapper) {
 	b.roleMapper = m
+}
+
+// SetEnhancedRoleMapper sets the enhanced mapper that returns identity associations.
+// This is used when multiple system identities exist (e.g., certificate SANs).
+func (a *AuthBehaviors) SetEnhancedRoleMapper(fn EnhancedRoleMapper) {
+	a.enhancedRoleMapper = fn
 }
 
 // SetAuthorizer updates the SetAuthorizer to be used.
@@ -193,4 +214,14 @@ func (b *AuthBehaviors) AddExternalAuthTime(t time.Duration) {
 // service during authentication.
 func (b *AuthBehaviors) GetTotalExternalAuthTime() time.Duration {
 	return b.externalAuthTime
+}
+
+// SetSANIdentities sets the SAN identities extracted from the client certificate.
+func (b *AuthBehaviors) SetSANIdentities(sans []string) {
+	b.sanIdentities = sans
+}
+
+// GetSANIdentities returns the SAN identities extracted from the client certificate.
+func (b *AuthBehaviors) GetSANIdentities() []string {
+	return b.sanIdentities
 }

--- a/pkg/sql/pgwire/auth_methods.go
+++ b/pkg/sql/pgwire/auth_methods.go
@@ -426,8 +426,16 @@ func authCert(
 	hbaEntry *hba.Entry,
 	identMap *identmap.Conf,
 ) (*AuthBehaviors, error) {
+	clientCertSANRequired := security.ClientCertSANRequired.Get(&execCfg.Settings.SV)
 	b := &AuthBehaviors{}
-	b.SetRoleMapper(HbaMapper(hbaEntry, identMap))
+	// Choose the appropriate mapper based on whether we have a map option
+	if hbaEntry.GetOption("map") != "" && clientCertSANRequired {
+		// Use enhanced mapper for SAN auth with mapping
+		b.SetEnhancedRoleMapper(HbaEnhancedMapper(hbaEntry, identMap))
+	} else {
+		// Use regular mapper for non-SAN authentication.
+		b.SetRoleMapper(HbaMapper(hbaEntry, identMap))
+	}
 	b.SetAuthenticator(func(
 		ctx context.Context,
 		systemIdentity string,
@@ -463,10 +471,30 @@ func authCert(
 		return hook(ctx, systemIdentity, clientConnection)
 	})
 	if len(tlsState.PeerCertificates) > 0 && hbaEntry.GetOption("map") != "" {
-		// The common name in the certificate is set as the system identity in case we have an HBAEntry for db user.
-		b.SetReplacementIdentity(
-			lexbase.NormalizeName(tlsState.PeerCertificates[0].Subject.CommonName),
-		)
+		if clientCertSANRequired {
+			identityList := make([]string, 0)
+			for _, uri := range tlsState.PeerCertificates[0].URIs {
+				identityList = append(identityList, fmt.Sprintf("SAN:URI:%s", lexbase.NormalizeName(uri.String())))
+			}
+
+			for _, ip := range tlsState.PeerCertificates[0].IPAddresses {
+				identityList = append(identityList, fmt.Sprintf("SAN:IP:%s", lexbase.NormalizeName(ip.String())))
+			}
+
+			for _, dns := range tlsState.PeerCertificates[0].DNSNames {
+				identityList = append(identityList, fmt.Sprintf("SAN:DNS:%s", lexbase.NormalizeName(dns)))
+			}
+
+			if len(identityList) == 0 {
+				return nil, errors.New("client certificate SAN is required, but no SAN found in the certificate.")
+			}
+			b.SetSANIdentities(identityList)
+		} else {
+			// The common name in the certificate is set as the system identity in case we have an HBAEntry for db user.
+			b.SetReplacementIdentity(
+				lexbase.NormalizeName(tlsState.PeerCertificates[0].Subject.CommonName),
+			)
+		}
 	}
 	return b, nil
 }


### PR DESCRIPTION
* authCert initially didn't have provision to handle multiple system identities such as SAN. This PR adds the functionality within the authCert function to extract and set SAN attributes from the cert in the order URI, IP and DNS.
* Enhance the AuthBehavior struct containing all identity related information with the SAN attributes and the newly introduced role mapper for SAN. Each of these attributes include their getter and setter functions.
* Based on the cluster setting for SAN enabled the mapper is set.
* If the cluster setting is enabled, then the SAN identities are extracted from the cert and added to the AuthBehavior struct.
    
Release note: None
    
Epic: [CRDB-58374](https://cockroachlabs.atlassian.net/browse/CRDB-58374)