### PR TITLE
concurrency: resolve pending transaction for non-locking reads

### DIFF
--- a/pkg/kv/kvserver/client_replica_bench_test.go
+++ b/pkg/kv/kvserver/client_replica_bench_test.go
@@ -279,16 +279,8 @@ func BenchmarkIntentResolution(b *testing.B) {
 	}
 
 	highPriorityScan := func(t testing.TB, ctx context.Context, kvDB *kv.DB, span roachpb.Span) {
-		// TODO(ssd): We are setting a fixed timestamp on this reader transaction
-		// for the side effect of removing the uncertainty interval. When a
-		// transaction has an uncertainty interval, we don't allow it to use the
-		// txnCache and thus this test would end up pushing the conflicting
-		// transaction batchSize times. We should be able to remove this once we
-		// move to a request-scoped transaction cache.
-		readTimestamp := kvDB.Clock().Now()
 		txn2 := kvDB.NewTxn(ctx, "high priority reader")
 		require.NoError(t, txn2.SetUserPriority(roachpb.MaxUserPriority))
-		require.NoError(t, txn2.SetFixedTimestamp(ctx, readTimestamp))
 		_, err := txn2.Scan(ctx, span.Key, span.EndKey, 0 /* maxKeys */)
 		require.NoError(t, err)
 	}

--- a/pkg/kv/kvserver/concurrency/concurrency_control.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_control.go
@@ -775,7 +775,11 @@ type lockTable interface {
 	// This is used by the lock table in a best-effort manner to avoid waiting on
 	// locks of finalized or pushed transactions and telling the caller via
 	// lockTableGuard.ResolveBeforeScanning to resolve a batch of intents.
-	PushedTransactionUpdated(*roachpb.Transaction)
+	//
+	// The clockObs parameter is the clock observation taken before the push. It
+	// is used to establish a lower bound on when the transaction was known to be
+	// pending. This can be zero for finalized transactions.
+	PushedTransactionUpdated(txn *roachpb.Transaction, clockObs roachpb.ObservedTimestamp)
 
 	// QueryLockTableState returns detailed metadata on locks managed by the lockTable.
 	QueryLockTableState(span roachpb.Span, opts QueryLockTableOptions) ([]roachpb.LockStateInfo, QueryLockTableResumeState)

--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -827,6 +827,58 @@ func (g *lockTableGuardImpl) hasObservationAtOrBefore(o roachpb.ObservedTimestam
 	return false
 }
 
+// canResolveKeyForHoldingTransaction returns true and the appropriate
+// LockUpdate if we are able to resolve locks for the given holding
+// transaction.
+//
+// We are able to resolve locks if:
+//
+// 1. The holding transaction is known to be finalized, or
+//
+// 2. The holding transaction is pending and we either have no uncertainty
+// interval or the transaction was known to be pending concurrent with our own
+// transaction.
+//
+// We only allow (2) if lock resolution batching is enabled.
+func (g *lockTableGuardImpl) canResolveKeyForHoldingTransaction(
+	lockHolderTxn *enginepb.TxnMeta, str lock.Strength, key roachpb.Key,
+) (bool, roachpb.LockUpdate) {
+	// If the transaction is known to be finalized, then we are good to go.
+	finalizedTxn, ok := g.lt.txnStatusCache.finalizedTxns.get(lockHolderTxn.ID)
+	if ok {
+		return true, roachpb.MakeLockUpdate(finalizedTxn, roachpb.Span{Key: key})
+	}
+
+	// If the transaction is pending, we only consider resolution if we are a
+	// non-locking reader and batch resolution is enabled.
+	if str == lock.None && g.lt.batchPushedLockResolution() {
+		pushedTxnEntry, ok := g.lt.txnStatusCache.pendingTxns.get(lockHolderTxn.ID)
+		if ok && g.pendingPushedTransactionCanBeResolved(pushedTxnEntry) {
+			up := roachpb.MakeLockUpdate(pushedTxnEntry.Txn, roachpb.Span{Key: key})
+			if g.hasUncertaintyInterval() {
+				up.ClockWhilePending = pushedTxnEntry.ClockWhilePending
+			}
+			return true, up
+		}
+	}
+	return false, roachpb.LockUpdate{}
+}
+
+func (g *lockTableGuardImpl) pendingPushedTransactionCanBeResolved(
+	pushed *pendingTxnCacheEntry,
+) bool {
+	// Txn needs to be pushed above our WriteTimestamp.
+	if !g.ts.Less(pushed.Txn.WriteTimestamp) {
+		return false
+	}
+
+	// In order to usefully resolve a pending transaction, we either need no
+	// uncertainty interval, or we need to be sure that the request was concurrent
+	// with our transaction so that rewritten intent can be ignored even if it is
+	// inside our uncertainty interval.
+	return !g.hasUncertaintyInterval() || g.hasObservationAtOrBefore(pushed.ClockWhilePending)
+}
+
 func (g *lockTableGuardImpl) isSameTxn(txn *enginepb.TxnMeta) bool {
 	return g.txn != nil && g.txn.ID == txn.ID
 }
@@ -2704,60 +2756,25 @@ func (kl *keyLocks) conflictsWithLockHolders(g *lockTableGuardImpl) bool {
 			continue // no conflict with a lock held by our own transaction
 		}
 
-		finalizedTxn, ok := g.lt.txnStatusCache.finalizedTxns.get(lockHolderTxn.ID)
-		if ok {
-			up := roachpb.MakeLockUpdate(finalizedTxn, roachpb.Span{Key: kl.key})
-			// The lock belongs to a finalized transaction. There's no conflict, but
-			// the lock must be resolved -- accumulate it on the appropriate slice.
-			if !tl.isHeldReplicated() { // only held unreplicated
+		if canResolve, up := g.canResolveKeyForHoldingTransaction(lockHolderTxn, g.curStrength(), kl.key); canResolve {
+			if !tl.isHeldReplicated() {
+				// Only held unreplicated. Accumulate it as an unreplicated lock to
+				// resolve, in case any other waiting readers can benefit from the
+				// pushed timestamp.
+				//
+				// TODO(arul): this case is only possible while non-locking reads
+				// block on Exclusive locks. Once non-locking reads start only
+				// blocking on intents, it can be removed and asserted against.
 				g.toResolveUnreplicated = append(g.toResolveUnreplicated, up)
 			} else {
+				// Resolve to push the replicated intent.
 				g.toResolve = append(g.toResolve, up)
 			}
 			continue // check next lock
 		}
 
-		// The lock is held by a different, un-finalized transaction.
-		if g.curStrength() == lock.None && g.lt.batchPushedLockResolution() {
-			// If the non-locking reader is reading at a higher timestamp than the
-			// lock holder, but it knows that the lock holder has been pushed above
-			// its read timestamp, it can proceed after rewriting the lock at its
-			// transaction's pushed timestamp. Intent resolution can be deferred to
-			// maximize batching opportunities.
-			pushedTxnEntry, ok := g.lt.txnStatusCache.pendingTxns.get(lockHolderTxn.ID)
-			if ok && g.ts.Less(pushedTxnEntry.Txn.WriteTimestamp) {
-				// This fast-path is only enabled in two cases:
-				//
-				// 1) For readers without uncertainty intervals
-				//
-				// 2) Readers with uncertainty intervals that have a clock observation
-				// from this node that is <= the known pending time recorded in the
-				// cache.
-				if !g.hasUncertaintyInterval() || g.hasObservationAtOrBefore(pushedTxnEntry.ClockWhilePending) {
-					up := roachpb.MakeLockUpdate(pushedTxnEntry.Txn, roachpb.Span{Key: kl.key})
-					if g.hasUncertaintyInterval() {
-						up.ClockWhilePending = pushedTxnEntry.ClockWhilePending
-					}
-					if !tl.isHeldReplicated() {
-						// Only held unreplicated. Accumulate it as an unreplicated lock to
-						// resolve, in case any other waiting readers can benefit from the
-						// pushed timestamp.
-						//
-						// TODO(arul): this case is only possible while non-locking reads
-						// block on Exclusive locks. Once non-locking reads start only
-						// blocking on intents, it can be removed and asserted against.
-						g.toResolveUnreplicated = append(g.toResolveUnreplicated, up)
-					} else {
-						// Resolve to push the replicated intent.
-						g.toResolve = append(g.toResolve, up)
-					}
-					continue // check next lock
-				}
-			}
-		}
-
 		// The held lock neither belongs to the request's transaction (which has
-		// special handling above) nor to a transaction that has been finalized.
+		// special handling above) nor to a transaction whose keys we can resolve.
 		// Check for conflicts.
 		if lock.Conflicts(tl.getLockMode(), g.curLockMode(), &g.lt.settings.SV) {
 			return true
@@ -4379,24 +4396,9 @@ func (t *lockTableImpl) AddDiscoveredLock(
 		return false, err
 	}
 	if consultTxnStatusCache {
-		finalizedTxn, ok := t.txnStatusCache.finalizedTxns.get(foundLock.Txn.ID)
-		if ok {
-			g.toResolve = append(
-				g.toResolve, roachpb.MakeLockUpdate(finalizedTxn, roachpb.Span{Key: key}))
+		if canResolve, up := g.canResolveKeyForHoldingTransaction(&foundLock.Txn, str, key); canResolve {
+			g.toResolve = append(g.toResolve, up)
 			return true, nil
-		}
-
-		// If the discoverer is a non-locking read, also check whether the lock's
-		// holder is known to have been pushed above the reader's timestamp. See the
-		// comment in scanAndMaybeEnqueue for more details, including why we include
-		// the hasUncertaintyInterval condition.
-		if str == lock.None && !g.hasUncertaintyInterval() && t.batchPushedLockResolution() {
-			pushedTxnEntry, ok := g.lt.txnStatusCache.pendingTxns.get(foundLock.Txn.ID)
-			if ok && g.ts.Less(pushedTxnEntry.Txn.WriteTimestamp) {
-				g.toResolve = append(
-					g.toResolve, roachpb.MakeLockUpdate(pushedTxnEntry.Txn, roachpb.Span{Key: key}))
-				return true, nil
-			}
 		}
 	}
 	var l *keyLocks

--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -2023,10 +2023,10 @@ func (kl *keyLocks) safeFormat(sb *redact.StringBuilder, txnStatusCache *txnStat
 				tl.unreplicatedInfo.safeFormat(sb)
 			}
 			if txnStatusCache != nil {
-				finalizedTxnEntry, ok := txnStatusCache.finalizedTxns.get(txn.ID)
+				finalizedTxn, ok := txnStatusCache.finalizedTxns.get(txn.ID)
 				if ok {
 					var statusStr string
-					switch finalizedTxnEntry.Txn.Status {
+					switch finalizedTxn.Status {
 					case roachpb.COMMITTED:
 						statusStr = "committed"
 					case roachpb.ABORTED:
@@ -2704,9 +2704,9 @@ func (kl *keyLocks) conflictsWithLockHolders(g *lockTableGuardImpl) bool {
 			continue // no conflict with a lock held by our own transaction
 		}
 
-		finalizedTxnEntry, ok := g.lt.txnStatusCache.finalizedTxns.get(lockHolderTxn.ID)
+		finalizedTxn, ok := g.lt.txnStatusCache.finalizedTxns.get(lockHolderTxn.ID)
 		if ok {
-			up := roachpb.MakeLockUpdate(finalizedTxnEntry.Txn, roachpb.Span{Key: kl.key})
+			up := roachpb.MakeLockUpdate(finalizedTxn, roachpb.Span{Key: kl.key})
 			// The lock belongs to a finalized transaction. There's no conflict, but
 			// the lock must be resolved -- accumulate it on the appropriate slice.
 			if !tl.isHeldReplicated() { // only held unreplicated
@@ -4379,10 +4379,10 @@ func (t *lockTableImpl) AddDiscoveredLock(
 		return false, err
 	}
 	if consultTxnStatusCache {
-		finalizedTxnEntry, ok := t.txnStatusCache.finalizedTxns.get(foundLock.Txn.ID)
+		finalizedTxn, ok := t.txnStatusCache.finalizedTxns.get(foundLock.Txn.ID)
 		if ok {
 			g.toResolve = append(
-				g.toResolve, roachpb.MakeLockUpdate(finalizedTxnEntry.Txn, roachpb.Span{Key: key}))
+				g.toResolve, roachpb.MakeLockUpdate(finalizedTxn, roachpb.Span{Key: key}))
 			return true, nil
 		}
 

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -187,6 +187,7 @@ func TestLockTableBasic(t *testing.T) {
 	datadriven.Walk(t, datapathutils.TestDataPath(t, "lock_table"), func(t *testing.T, path string) {
 		var lt lockTable
 		var txnsByName map[string]*enginepb.TxnMeta
+		var uncertaintyLimitsByTxn map[string]hlc.Timestamp
 		var txnCounter uint128.Uint128
 		var requestsByName map[string]Request
 		var guardsByReqName map[string]lockTableGuard
@@ -206,6 +207,7 @@ func TestLockTableBasic(t *testing.T) {
 				ltImpl.lockTableLimitsMu.minKeysLocked = 0
 				lt = maybeWrapInVerifyingLockTable(ltImpl)
 				txnsByName = make(map[string]*enginepb.TxnMeta)
+				uncertaintyLimitsByTxn = make(map[string]hlc.Timestamp)
 				txnCounter = uint128.FromInts(0, 0)
 				requestsByName = make(map[string]Request)
 				guardsByReqName = make(map[string]lockTableGuard)
@@ -243,6 +245,9 @@ func TestLockTableBasic(t *testing.T) {
 					WriteTimestamp: ts,
 					IsoLevel:       iso,
 				}
+				if d.HasArg("uncertainty-limit") {
+					uncertaintyLimitsByTxn[txnName] = scanTimestampWithName(t, d, "uncertainty-limit")
+				}
 				return ""
 
 			case "pushed-txn-updated":
@@ -268,7 +273,25 @@ func TestLockTableBasic(t *testing.T) {
 					ts := scanTimestamp(t, d)
 					txn.WriteTimestamp.Forward(ts)
 				}
-				lt.PushedTransactionUpdated(txn)
+				var clockObs roachpb.ObservedTimestamp
+				if d.HasArg("clock-obs") {
+					// Format: "nodeID@ts" e.g., "1@10,1"
+					obsStr := dd.ScanArg[string](t, d, "clock-obs")
+					parts := strings.Split(obsStr, "@")
+					nodeID, err := strconv.Atoi(parts[0])
+					if err != nil {
+						d.Fatalf(t, "invalid node ID in clock-obs: %s", obsStr)
+					}
+					obsTs, err := hlc.ParseTimestamp(parts[1])
+					if err != nil {
+						d.Fatalf(t, "invalid timestamp in clock-obs: %s", obsStr)
+					}
+					clockObs = roachpb.ObservedTimestamp{
+						NodeID:    roachpb.NodeID(nodeID),
+						Timestamp: hlc.ClockTimestamp{WallTime: obsTs.WallTime, Logical: obsTs.Logical},
+					}
+				}
+				lt.PushedTransactionUpdated(txn, clockObs)
 				return ""
 
 			case "new-request":
@@ -316,6 +339,27 @@ func TestLockTableBasic(t *testing.T) {
 					}
 					if !updateRetainedTxn {
 						ba.Txn.WriteTimestamp = ts
+					}
+					// Apply uncertainty limit if one was specified on the transaction.
+					if ul, ok := uncertaintyLimitsByTxn[txnName]; ok {
+						ba.Txn.GlobalUncertaintyLimit = ul
+					}
+					// Add observed timestamp if specified. Format: "nodeID@ts"
+					if d.HasArg("observed-ts") {
+						obsStr := dd.ScanArg[string](t, d, "observed-ts")
+						parts := strings.Split(obsStr, "@")
+						nodeID, err := strconv.Atoi(parts[0])
+						if err != nil {
+							d.Fatalf(t, "invalid node ID in observed-ts: %s", obsStr)
+						}
+						obsTs, err := hlc.ParseTimestamp(parts[1])
+						if err != nil {
+							d.Fatalf(t, "invalid timestamp in observed-ts: %s", obsStr)
+						}
+						ba.Txn.UpdateObservedTimestamp(
+							roachpb.NodeID(nodeID),
+							obsTs.UnsafeToClockTimestamp(),
+						)
 					}
 
 					req.Txn = ba.Txn
@@ -639,6 +683,14 @@ func nextUUID(counter *uint128.Uint128) uuid.UUID {
 
 func scanTimestamp(t *testing.T, d *datadriven.TestData) hlc.Timestamp {
 	ts, err := hlc.ParseTimestamp(dd.ScanArg[string](t, d, "ts"))
+	if err != nil {
+		d.Fatalf(t, "%v", err)
+	}
+	return ts
+}
+
+func scanTimestampWithName(t *testing.T, d *datadriven.TestData, name string) hlc.Timestamp {
+	ts, err := hlc.ParseTimestamp(dd.ScanArg[string](t, d, name))
 	if err != nil {
 		d.Fatalf(t, "%v", err)
 	}

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -274,23 +274,6 @@ func TestLockTableBasic(t *testing.T) {
 					txn.WriteTimestamp.Forward(ts)
 				}
 				var clockObs roachpb.ObservedTimestamp
-				if d.HasArg("clock-obs") {
-					// Format: "nodeID@ts" e.g., "1@10,1"
-					obsStr := dd.ScanArg[string](t, d, "clock-obs")
-					parts := strings.Split(obsStr, "@")
-					nodeID, err := strconv.Atoi(parts[0])
-					if err != nil {
-						d.Fatalf(t, "invalid node ID in clock-obs: %s", obsStr)
-					}
-					obsTs, err := hlc.ParseTimestamp(parts[1])
-					if err != nil {
-						d.Fatalf(t, "invalid timestamp in clock-obs: %s", obsStr)
-					}
-					clockObs = roachpb.ObservedTimestamp{
-						NodeID:    roachpb.NodeID(nodeID),
-						Timestamp: hlc.ClockTimestamp{WallTime: obsTs.WallTime, Logical: obsTs.Logical},
-					}
-				}
 				lt.PushedTransactionUpdated(txn, clockObs)
 				return ""
 

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
@@ -251,3 +251,88 @@ finish req=req2-retry
 
 reset namespace
 ----
+
+# -------------------------------------------------------------
+# A transactional (txn2) read-only request with an uncertainty
+# interval runs into multiple replicated intents from the same
+# transaction (txn1). After pushing the first intent, the request
+# should be able to proceed past all remaining intents without
+# additional pushes, using the cached push result.
+#
+# This tests the optimization in conflictsWithLockHolders that
+# allows readers with uncertainty intervals to use cached push
+# results if their observed timestamp on the push node is <=
+# the clock observation recorded when the push occurred.
+# -------------------------------------------------------------
+
+new-txn name=txn1 ts=10,1 epoch=0
+----
+
+# txn2 has an uncertainty interval [12,1 to 15,1] and an observed timestamp
+# on node 1 at time 123,1 (the test clock's initial time). This observed
+# timestamp will be <= the clock observation captured before pushing, which
+# allows the optimization in conflictsWithLockHolders to apply.
+new-txn name=txn2 ts=12,1 epoch=0 uncertainty-limit=15,1 observed-ts=1@123,1
+----
+
+new-request name=req1 txn=txn2 ts=12,1
+  scan key=a endkey=z
+----
+
+sequence req=req1
+----
+[1] sequence req1: sequencing request
+[1] sequence req1: acquiring latches
+[1] sequence req1: scanning lock table for conflicting locks
+[1] sequence req1: sequencing complete, returned guard
+
+# Discover 3 intents from txn1 at keys a, b, c.
+handle-lock-conflict-error req=req1 lease-seq=1
+  lock txn=txn1 key=a
+  lock txn=txn1 key=b
+  lock txn=txn1 key=c
+----
+[2] handle lock conflict error req1: handled conflicting locks on ‹"a"›, ‹"b"›, ‹"c"›, released latches
+
+debug-lock-table
+----
+num=3
+ lock: "a"
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
+ lock: "b"
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
+ lock: "c"
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
+
+# Re-sequence. The request will wait on the first intent and push txn1.
+sequence req=req1
+----
+[3] sequence req1: re-sequencing request
+[3] sequence req1: acquiring latches
+[3] sequence req1: scanning lock table for conflicting locks
+[3] sequence req1: waiting in lock wait-queues
+[3] sequence req1: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"a"› (queuedLockingRequests: 0, queuedReaders: 1)
+[3] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
+[3] sequence req1: pushing timestamp of txn 00000001 above 15.000000000,1
+[3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+# Push succeeds - txn1 is pushed above the reader's uncertainty limit.
+on-txn-updated txn=txn1 status=pending ts=15,2
+----
+[-] update txn: increasing timestamp of txn1
+[3] sequence req1: resolving intent ‹"a"› for txn 00000001 with PENDING status and clock observation {1 135.000000000,7}
+[3] sequence req1: lock wait-queue event: done waiting
+[3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
+[3] sequence req1: resolving a batch of 2 intent(s)
+[3] sequence req1: resolving intent ‹"b"› for txn 00000001 with PENDING status and clock observation {1 135.000000000,7}
+[3] sequence req1: resolving intent ‹"c"› for txn 00000001 with PENDING status and clock observation {1 135.000000000,7}
+[3] sequence req1: acquiring latches
+[3] sequence req1: scanning lock table for conflicting locks
+[3] sequence req1: sequencing complete, returned guard
+
+finish req=req1
+----
+[-] finish req1: finishing request
+
+reset namespace
+----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
@@ -336,3 +336,252 @@ finish req=req1
 
 reset namespace
 ----
+
+# -------------------------------------------------------------
+# A transactional (txn2) read-only request WITHOUT an uncertainty
+# interval runs into multiple replicated intents from the same
+# transaction (txn1). After pushing the first intent, the request
+# can proceed past remaining intents using the cached push result,
+# without needing a clock observation check.
+#
+# This tests that readers without uncertainty intervals can always
+# use cached push results in pendingPushedTransactionCanBeResolved.
+# -------------------------------------------------------------
+
+new-txn name=txn1 ts=10,1 epoch=0
+----
+
+# txn2 has NO uncertainty interval (read timestamp equals global uncertainty limit).
+# It also has no observed timestamps.
+new-txn name=txn2 ts=12,1 epoch=0
+----
+
+new-request name=req1 txn=txn2 ts=12,1
+  scan key=a endkey=z
+----
+
+sequence req=req1
+----
+[1] sequence req1: sequencing request
+[1] sequence req1: acquiring latches
+[1] sequence req1: scanning lock table for conflicting locks
+[1] sequence req1: sequencing complete, returned guard
+
+# Discover 3 intents from txn1 at keys a, b, c.
+handle-lock-conflict-error req=req1 lease-seq=1
+  lock txn=txn1 key=a
+  lock txn=txn1 key=b
+  lock txn=txn1 key=c
+----
+[2] handle lock conflict error req1: handled conflicting locks on ‹"a"›, ‹"b"›, ‹"c"›, released latches
+
+debug-lock-table
+----
+num=3
+ lock: "a"
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
+ lock: "b"
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
+ lock: "c"
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
+
+# Re-sequence. The request will wait on the first intent and push txn1.
+sequence req=req1
+----
+[3] sequence req1: re-sequencing request
+[3] sequence req1: acquiring latches
+[3] sequence req1: scanning lock table for conflicting locks
+[3] sequence req1: waiting in lock wait-queues
+[3] sequence req1: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"a"› (queuedLockingRequests: 0, queuedReaders: 1)
+[3] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
+[3] sequence req1: pushing timestamp of txn 00000001 above 12.000000000,1
+[3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+# Push succeeds - txn1 is pushed above the reader's timestamp.
+# Because there's no uncertainty interval, the batch-resolved intents (b, c)
+# don't include the clock observation. The first intent (a) is resolved
+# directly after the push, which always includes the clock observation.
+on-txn-updated txn=txn1 status=pending ts=12,2
+----
+[-] update txn: increasing timestamp of txn1
+[3] sequence req1: resolving intent ‹"a"› for txn 00000001 with PENDING status and clock observation {1 135.000000000,9}
+[3] sequence req1: lock wait-queue event: done waiting
+[3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
+[3] sequence req1: resolving a batch of 2 intent(s)
+[3] sequence req1: resolving intent ‹"b"› for txn 00000001 with PENDING status
+[3] sequence req1: resolving intent ‹"c"› for txn 00000001 with PENDING status
+[3] sequence req1: acquiring latches
+[3] sequence req1: scanning lock table for conflicting locks
+[3] sequence req1: sequencing complete, returned guard
+
+finish req=req1
+----
+[-] finish req1: finishing request
+
+reset namespace
+----
+
+# -------------------------------------------------------------
+# A transactional (txn2) read-only request with an uncertainty
+# interval has an observed timestamp on a DIFFERENT node than
+# the one where the push occurred.
+#
+# The optimization cannot apply because the request doesn't have an
+# observation for the push node. The request must wait and push again for
+# subsequent intents.
+#
+# This test case is contrived. If txn2 is processing a request on node 1 it
+# _should_ have _some_ clock observation from node 1.
+# -------------------------------------------------------------
+
+new-txn name=txn1 ts=10,1 epoch=0
+----
+
+# txn2 has an uncertainty interval and an observed timestamp on node 2,
+# but the push will record a clock observation for node 1 (our node).
+# Since there's no observation for node 1, the optimization doesn't apply.
+new-txn name=txn2 ts=12,1 epoch=0 uncertainty-limit=15,1 observed-ts=2@100,0
+----
+
+new-request name=req1 txn=txn2 ts=12,1
+  scan key=a endkey=z
+----
+
+sequence req=req1
+----
+[1] sequence req1: sequencing request
+[1] sequence req1: acquiring latches
+[1] sequence req1: scanning lock table for conflicting locks
+[1] sequence req1: sequencing complete, returned guard
+
+# Discover 2 intents from txn1 at keys a and b.
+handle-lock-conflict-error req=req1 lease-seq=1
+  lock txn=txn1 key=a
+  lock txn=txn1 key=b
+----
+[2] handle lock conflict error req1: handled conflicting locks on ‹"a"›, ‹"b"›, released latches
+
+debug-lock-table
+----
+num=2
+ lock: "a"
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
+ lock: "b"
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
+
+# Re-sequence. The request will wait on the first intent and push txn1.
+sequence req=req1
+----
+[3] sequence req1: re-sequencing request
+[3] sequence req1: acquiring latches
+[3] sequence req1: scanning lock table for conflicting locks
+[3] sequence req1: waiting in lock wait-queues
+[3] sequence req1: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"a"› (queuedLockingRequests: 0, queuedReaders: 1)
+[3] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
+[3] sequence req1: pushing timestamp of txn 00000001 above 15.000000000,1
+[3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+# Push succeeds. Because txn2 has an observed timestamp on the wrong node,
+# the optimization doesn't apply.
+on-txn-updated txn=txn1 status=pending ts=15,2
+----
+[-] update txn: increasing timestamp of txn1
+[3] sequence req1: resolving intent ‹"a"› for txn 00000001 with PENDING status and clock observation {1 135.000000000,11}
+[3] sequence req1: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"b"› (queuedLockingRequests: 0, queuedReaders: 1)
+[3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
+[3] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
+[3] sequence req1: pushing timestamp of txn 00000001 above 15.000000000,1
+[3] sequence req1: resolving intent ‹"b"› for txn 00000001 with PENDING status and clock observation {1 135.000000000,13}
+[3] sequence req1: lock wait-queue event: done waiting
+[3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"b"› for 0.000s
+[3] sequence req1: acquiring latches
+[3] sequence req1: scanning lock table for conflicting locks
+[3] sequence req1: sequencing complete, returned guard
+
+finish req=req1
+----
+[-] finish req1: finishing request
+
+reset namespace
+----
+
+# -------------------------------------------------------------
+# A transactional (txn2) read-only request with an uncertainty
+# interval has an observed timestamp on the correct node, but
+# the observed timestamp is GREATER than the clock observation
+# recorded when the push occurred. The optimization cannot apply
+# because the request might have started after the push.
+# -------------------------------------------------------------
+
+new-txn name=txn1 ts=10,1 epoch=0
+----
+
+# txn2 has an uncertainty interval and an observed timestamp on node 1
+# at time 200,0 which is GREATER than the clock observation that will
+# be recorded when pushing (around 135,x). The optimization doesn't apply.
+new-txn name=txn2 ts=12,1 epoch=0 uncertainty-limit=15,1 observed-ts=1@200,0
+----
+
+new-request name=req1 txn=txn2 ts=12,1
+  scan key=a endkey=z
+----
+
+sequence req=req1
+----
+[1] sequence req1: sequencing request
+[1] sequence req1: acquiring latches
+[1] sequence req1: scanning lock table for conflicting locks
+[1] sequence req1: sequencing complete, returned guard
+
+# Discover 2 intents from txn1 at keys a and b.
+handle-lock-conflict-error req=req1 lease-seq=1
+  lock txn=txn1 key=a
+  lock txn=txn1 key=b
+----
+[2] handle lock conflict error req1: handled conflicting locks on ‹"a"›, ‹"b"›, released latches
+
+debug-lock-table
+----
+num=2
+ lock: "a"
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
+ lock: "b"
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
+
+# Re-sequence. The request will wait on the first intent and push txn1.
+sequence req=req1
+----
+[3] sequence req1: re-sequencing request
+[3] sequence req1: acquiring latches
+[3] sequence req1: scanning lock table for conflicting locks
+[3] sequence req1: waiting in lock wait-queues
+[3] sequence req1: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"a"› (queuedLockingRequests: 0, queuedReaders: 1)
+[3] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
+[3] sequence req1: pushing timestamp of txn 00000001 above 15.000000000,1
+[3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+# Push succeeds. Because txn2's observed timestamp (200,0) is greater than
+# the clock observation captured during push (135,x), the optimization
+# doesn't apply. The push for "b" completes immediately since the txn
+# is already pushed.
+on-txn-updated txn=txn1 status=pending ts=15,2
+----
+[-] update txn: increasing timestamp of txn1
+[3] sequence req1: resolving intent ‹"a"› for txn 00000001 with PENDING status and clock observation {1 135.000000000,15}
+[3] sequence req1: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"b"› (queuedLockingRequests: 0, queuedReaders: 1)
+[3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
+[3] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
+[3] sequence req1: pushing timestamp of txn 00000001 above 15.000000000,1
+[3] sequence req1: resolving intent ‹"b"› for txn 00000001 with PENDING status and clock observation {1 135.000000000,17}
+[3] sequence req1: lock wait-queue event: done waiting
+[3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"b"› for 0.000s
+[3] sequence req1: acquiring latches
+[3] sequence req1: scanning lock table for conflicting locks
+[3] sequence req1: sequencing complete, returned guard
+
+finish req=req1
+----
+[-] finish req1: finishing request
+
+reset namespace
+----

--- a/pkg/kv/kvserver/concurrency/verifiable_lock_table.go
+++ b/pkg/kv/kvserver/concurrency/verifiable_lock_table.go
@@ -112,8 +112,10 @@ func (v verifyingLockTable) UpdateLocks(up *roachpb.LockUpdate) error {
 }
 
 // PushedTransactionUpdated implements the lockTable interface.
-func (v verifyingLockTable) PushedTransactionUpdated(txn *roachpb.Transaction) {
-	v.lt.PushedTransactionUpdated(txn)
+func (v verifyingLockTable) PushedTransactionUpdated(
+	txn *roachpb.Transaction, clockObs roachpb.ObservedTimestamp,
+) {
+	v.lt.PushedTransactionUpdated(txn, clockObs)
 }
 
 // QueryLockTableState implements the lockTable interface.


### PR DESCRIPTION
Previously, we could only resolve locks held by pending transactions for requests without an uncertainty interval.  Resolving an intent for a pending a transaction is tricky in the presence of uncertainty intervals because the most likely outcome is that the push put the the new WriteTimestamp right into your uncertainty interval.

A request can avoid this if we _know_ the transaction was pending concurrent with its own execution. We can know this if the request that resolves the intent takes a clock observation before pushing the holding transaction and then records that timestamp into the LocalTimestamp header of the intent. Then all readers with a clock observation from before the LocalTimestamp know they were concurrent with writer and can avoid an uncertainty interval restart.

Previously, since a request had no idea when a request entered the pending transactions cache, we had no valid clock observation to use for this resolution.  Here, we now store a clock observation in the pending transaction cache, placed there by the first pusher of the transaction.

An alternative to this we are considering is having every request have its own transaction status cache where it would store information about pending transactions that it pushed over time, allowing it to resolve intends after pushing all of the transactions.  We want to experiment with a shared cache instead since we suspect it might be a bit less complex as it provides a mechanism by which we avoid unnecessary pushes.

In the final commit in this series, I also do a minor refactor that I think will be nice even if we find ourselves reverting back to the per-request caches for whatever reason.