### PR TITLE
release-25.2.12-rc: release: add FIPS with no-telemetry wrapper

### DIFF
--- a/build/teamcity/internal/release/process/build-cockroach-release-linux-amd64-fips-no-telemetry.sh
+++ b/build/teamcity/internal/release/process/build-cockroach-release-linux-amd64-fips-no-telemetry.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
+PLATFORM=linux-amd64-fips TELEMETRY_DISABLED=true ./build/teamcity/internal/release/process/build-cockroach-release-per-platform.sh


### PR DESCRIPTION
Backport 1/1 commits from #152291 on behalf of @rail.

----

Epic: none
Release note: none


----

Release justification: release automation changes