### PR TITLE
server: implement ProblemsOnly flag for lighter RangesResponse

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -1487,6 +1487,7 @@ Support status: [reserved](#support-status)
 | limit | [int32](#cockroach.server.serverpb.RangesRequest-int32) |  | The pagination limit to use, if set. NB: Pagination is based on ascending RangeID. | [reserved](#support-status) |
 | offset | [int32](#cockroach.server.serverpb.RangesRequest-int32) |  | The pagination offset to use, if set. NB: Pagination is based on ascending RangeID. | [reserved](#support-status) |
 | redact | [bool](#cockroach.server.serverpb.RangesRequest-bool) |  | redact, if true, requests redaction of sensitive data away from the API response. | [reserved](#support-status) |
+| problems_only | [bool](#cockroach.server.serverpb.RangesRequest-bool) |  | If `problems_only is true, will return response with only `problems` field populated. | [reserved](#support-status) |
 
 
 

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1302,6 +1302,13 @@ func (r *Replica) descRLocked() *roachpb.RangeDescriptor {
 	return r.shMu.state.Desc
 }
 
+// HasCircuitBreakerError returns true if the replica's circuit breaker is
+// currently tripped. This is a lightweight check that avoids the expensive
+// State() call when only the circuit breaker status is needed.
+func (r *Replica) HasCircuitBreakerError() bool {
+	return r.breaker.Signal().Err() != nil
+}
+
 // toClientClosedTsPolicy converts a side-transport closed timestamp policy
 // (ctpb) to its client-facing equivalent (roachpb).
 func toClientClosedTsPolicy(

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -579,6 +579,9 @@ message RangesRequest {
   // redact, if true, requests redaction of sensitive data away
   // from the API response.
   bool redact = 5;
+  // If `problems_only is true, will return response with only
+  // `problems` field populated.
+  bool problems_only = 6;
 }
 
 message RangesResponse {


### PR DESCRIPTION
The ProblemRanges endpoint was fetching full RangeInfo structs for every range in the cluster, even though it only needed 3 fields: ErrorMessage, State.Desc.RangeID, and the Problems struct. This caused the problem ranges page to load very slowly or crash the browser on clusters with many ranges.

This change implements support for a `problems_only` boolean proto field in RangesRequest:

- Add `HasCircuitBreakerError()` method to Replica for lightweight circuit breaker status checks without calling the expensive `State()` method which involves proto cloning and RPC calls.

- Add `constructRangeInfoForProblems()` in status.go that returns a minimal RangeInfo containing only State.Desc (for RangeID), Problems, SourceNodeID, and SourceStoreID. This avoids serializing RaftState, RACStatus, LeaseHistory, Stats, Locality, and lock/latch metrics.

- Enable `ProblemsOnly: true` in ProblemRanges requests.

- Remove unnecessary sorting of problem range IDs since replicas are already visited in sorted order via `kvserver.WithReplicasInOrder()`.

This should reduce the overhead in cpu and response size when dealing with clusters containing hundreds of thousands of ranges.

Resolves: #121706
Epic: None

Release note: None