### PR TITLE
release-25.2: backup: deflake TestBackupRestoreChecksum under race

### DIFF
--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -3997,6 +3997,8 @@ func TestBackupRestoreChecksum(t *testing.T) {
 
 	// Test Server too slow under deadlock.
 	skip.UnderDeadlock(t)
+	// Flaky under race.
+	skip.UnderRace(t)
 
 	const numAccounts = 1000
 	_, sqlDB, dir, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)


### PR DESCRIPTION
Backport 1/1 commits from #161622 on behalf of @kev-cao.

----

Fixes: #160062

Release note: None

----

Release justification: Test only change.