### PR TITLE
release-24.3: backup: deflake TestBackupRestoreChecksum under race

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -4088,6 +4088,11 @@ func TestBackupRestoreChecksum(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	// Test Server too slow under deadlock.
+	skip.UnderDeadlock(t)
+	// Flaky under race.
+	skip.UnderRace(t)
+
 	const numAccounts = 1000
 	_, sqlDB, dir, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
 	defer cleanupFn()


### PR DESCRIPTION
Backport 1/1 commits from #161622.

/cc @cockroachdb/release

---

Fixes: #160062

Release note: None

---

Release justification: Test only change.