### PR TITLE
backup: validate end times when encoding backup ID

### DIFF
--- a/pkg/backup/backupbase/constants.go
+++ b/pkg/backup/backupbase/constants.go
@@ -5,6 +5,8 @@
 
 package backupbase
 
+import "time"
+
 // TODO(adityamaru): Move constants to relevant backup packages.
 const (
 	// LatestFileName is the name of a file in the collection which contains the
@@ -67,5 +69,11 @@ const (
 
 	// BackupIndexFilenameTimestampFormat is the format used for the human
 	// readable start and end times in the index file names.
+	// NB: If this is for whatever reason updated, make sure to update the
+	// granularity specified by BackupIndexFilenameTimestampGranularity.
 	BackupIndexFilenameTimestampFormat = "20060102-150405.00"
+
+	// BackupIndexFilenameTimestampGranularity represents the granularity of the
+	// times encoded in the backup index filenames.
+	BackupIndexFilenameTSGranularity = 10 * time.Millisecond
 )


### PR DESCRIPTION
This commit teaches the backup ID encoder to first validate that the provided end times' granularity do not exceed that of the index filenames.

Epic: CRDB-57536

Release note: None