### PR TITLE
sql: fix panic on index backfill

### DIFF
--- a/pkg/sql/index_split_scatter.go
+++ b/pkg/sql/index_split_scatter.go
@@ -214,6 +214,9 @@ func (is *indexSplitAndScatter) MaybeSplitIndexSpans(
 	const backfillSplitExpiration = time.Hour
 	tableID := table.GetID()
 	preservedSplitsMultiple := int(PreservedSplitCountMultiple.Get(is.sv))
+	if preservedSplitsMultiple == 0 {
+		return nil
+	}
 	nNodes := is.nodeDescs.GetNodeDescriptorCount()
 	nSplits := preservedSplitsMultiple * nNodes
 	var copySplitsFromIndexID descpb.IndexID

--- a/pkg/sql/logictest/testdata/logic_test/create_index
+++ b/pkg/sql/logictest/testdata/logic_test/create_index
@@ -705,3 +705,30 @@ statement error pgcode 42P07 index with name \"t_index_name_conflicts_with_prima
 CREATE INDEX t_index_name_conflicts_with_primary_key_pkey ON t_index_name_conflicts_with_primary_key (a);
 
 subtest end
+
+# Regression test for an internal setting's effect on index backfills.
+subtest issue-161408
+
+statement ok
+SET CLUSTER SETTING sql.schema.preserved_split_count_multiple = 0
+
+statement ok
+CREATE TABLE t161408 (
+  a INT PRIMARY KEY,
+  b INT,
+  c STRING
+)
+
+statement ok
+INSERT INTO t161408 SELECT i, i % 100, repeat('x', 10) FROM generate_series(1, 10000) AS g(i)
+
+statement ok
+CREATE STATISTICS st FROM t161408
+
+statement ok
+CREATE INDEX idx_b ON t161408 (b)
+
+statement ok
+DROP TABLE t161408;
+
+subtest end

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -154,9 +154,10 @@ var PreservedSplitCountMultiple = settings.RegisterIntSetting(
 		"from the table's indexes or copy them from the primary index. The multiple "+
 		"given will be multiplied with the number of nodes in the cluster to produce "+
 		"the number of preserved range splits. This can improve performance when "+
-		"truncating or backlling an index from a table with significant write traffic.",
+		"truncating or backfilling an index from a table with significant write traffic.",
 	4,
 	settings.WithName("sql.schema.preserved_split_count_multiple"),
+	settings.IntWithMinimum(0),
 )
 
 // truncateTable truncates the data of a table in a single transaction. It does


### PR DESCRIPTION
This internal setting can be 0 which causes a division by zero panic
during index backfill. This change checks the setting to prevent that
and adds a test.

Fixes: #161408
Part of: CRDB-58856

Release note: None
