### PR TITLE
concurrency,cache: add TypedUnorderedCache and benchmark against txnCache

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -6235,6 +6235,16 @@ def go_deps():
         ],
     )
     go_repository(
+        name = "com_github_maypok86_otter_v2",
+        build_file_proto_mode = "disable_global",
+        importpath = "github.com/maypok86/otter/v2",
+        sha256 = "19088c673edb6d384346aa5ee5bd587501e4d35bd7dd2df6edc11f63b84f512e",
+        strip_prefix = "github.com/maypok86/otter/v2@v2.3.0",
+        urls = [
+            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/maypok86/otter/v2/com_github_maypok86_otter_v2-v2.3.0.zip",
+        ],
+    )
+    go_repository(
         name = "com_github_mgutz_ansi",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/mgutz/ansi",

--- a/build/bazelutil/distdir_files.bzl
+++ b/build/bazelutil/distdir_files.bzl
@@ -772,6 +772,7 @@ DISTDIR_FILES = {
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/mattn/go-tty/com_github_mattn_go_tty-v0.0.0-20180907095812-13ff1204f104.zip": "e7384ae06bb54cc8f615d86e6397b11849be12c270d66460856f3fc6ad72aacb",
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/mattn/go-zglob/com_github_mattn_go_zglob-v0.0.3.zip": "8ef2dfc44aa352edd72e50287b7ac836c4c48fa439ca2648d8c1a4067f49e504",
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/matttproud/golang_protobuf_extensions/com_github_matttproud_golang_protobuf_extensions-v1.0.4.zip": "0b44aabaa9aea5d28e667849ad4d9821351466c3591dd7beddb2d025db6d55f2",
+    "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/maypok86/otter/v2/com_github_maypok86_otter_v2-v2.3.0.zip": "19088c673edb6d384346aa5ee5bd587501e4d35bd7dd2df6edc11f63b84f512e",
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/mgutz/ansi/com_github_mgutz_ansi-v0.0.0-20200706080929-d51e80ef957d.zip": "2e0c063f9597cb225904292981732f10298e95aa22a1b815297e318ba103dc1d",
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/microcosm-cc/bluemonday/com_github_microcosm_cc_bluemonday-v1.0.23.zip": "d720813b959b6713e000407778188cdc3b88cf3235a3dfda6543d7c5e748da6d",
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/miekg/dns/com_github_miekg_dns-v1.1.43.zip": "98eaddff5c30e475850f8f9c170bfb1adf33f0aaeeb280f71e77808a1dd902aa",

--- a/go.mod
+++ b/go.mod
@@ -206,6 +206,7 @@ require (
 	github.com/maruel/panicparse/v2 v2.2.2
 	github.com/marusama/semaphore v0.0.0-20190110074507-6952cef993b2
 	github.com/mattn/go-isatty v0.0.20
+	github.com/maypok86/otter/v2 v2.3.0
 	github.com/mitchellh/reflectwalk v1.0.0
 	github.com/mkungla/bexp/v3 v3.0.1
 	github.com/montanaflynn/stats v0.7.1

--- a/go.sum
+++ b/go.sum
@@ -1762,6 +1762,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/maypok86/otter/v2 v2.3.0 h1:8H8AVVFUSzJwIegKwv1uF5aGitTY+AIrtktg7OcLs8w=
+github.com/maypok86/otter/v2 v2.3.0/go.mod h1:XgIdlpmL6jYz882/CAx1E4C1ukfgDKSaw4mWq59+7l8=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.22/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=

--- a/pkg/kv/kvserver/concurrency/BUILD.bazel
+++ b/pkg/kv/kvserver/concurrency/BUILD.bazel
@@ -103,6 +103,7 @@ go_test(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_maruel_panicparse_v2//stack",
+        "@com_github_maypok86_otter_v2//:otter",
         "@com_github_petermattis_goid//:goid",
         "@com_github_stretchr_testify//require",
         "@in_gopkg_yaml_v2//:yaml_v2",

--- a/pkg/kv/kvserver/concurrency/BUILD.bazel
+++ b/pkg/kv/kvserver/concurrency/BUILD.bazel
@@ -88,6 +88,7 @@ go_test(
         "//pkg/testutils/skip",
         "//pkg/util",
         "//pkg/util/allstacks",
+        "//pkg/util/cache",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/log",

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter.go
@@ -878,6 +878,8 @@ func (c *txnStatusCache) clear() {
 	c.pendingTxns.clear()
 }
 
+const txnCacheSize = 8
+
 // finalizedTxnCache is a small LRU cache that holds finalized Transaction
 // objects (COMMITTED or ABORTED). Since finalized transactions don't need
 // clock observations for uncertainty checks, we only store the Transaction.
@@ -885,7 +887,7 @@ func (c *txnStatusCache) clear() {
 // The zero value of this struct is ready for use.
 type finalizedTxnCache struct {
 	mu   syncutil.Mutex
-	txns [8]*roachpb.Transaction // [MRU, ..., LRU]
+	txns [txnCacheSize]*roachpb.Transaction // [MRU, ..., LRU]
 }
 
 func (c *finalizedTxnCache) get(id uuid.UUID) (*roachpb.Transaction, bool) {
@@ -949,7 +951,7 @@ func (c *finalizedTxnCache) insertFrontLocked(txn *roachpb.Transaction) {
 type pendingTxnCache struct {
 	mu     syncutil.Mutex
 	nodeID roachpb.NodeID           // set on first add, asserted thereafter
-	txns   [8]*pendingTxnCacheEntry // [MRU, ..., LRU]
+	txns   [txnCacheSize]*pendingTxnCacheEntry // [MRU, ..., LRU]
 }
 
 // pendingTxnCacheEntry holds a pending transaction and the clock observation

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/maypok86/otter/v2"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1232,6 +1233,18 @@ func (a *typedAdapter) add(txn *roachpb.Transaction) {
 	a.c.Add(txn.ID, txn)
 }
 
+type otterAdapter struct {
+	c *otter.Cache[uuid.UUID, *roachpb.Transaction]
+}
+
+func (a *otterAdapter) add(txn *roachpb.Transaction) {
+	a.c.Set(txn.ID, txn)
+}
+
+func (a *otterAdapter) get(id uuid.UUID) (*roachpb.Transaction, bool) {
+	return a.c.GetIfPresent(id)
+}
+
 func (a *typedAdapter) get(id uuid.UUID) (*roachpb.Transaction, bool) {
 	a.Lock()
 	defer a.Unlock()
@@ -1239,94 +1252,220 @@ func (a *typedAdapter) get(id uuid.UUID) (*roachpb.Transaction, bool) {
 }
 
 func BenchmarkFinalizedTxnCache(b *testing.B) {
-	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
-	numOps := txnCacheSize * 4 // TODO
-	txns := make([]roachpb.Transaction, numOps)
-	for i := range txns {
-		txns[i] = makeTxnProto(fmt.Sprintf("txn %d", i))
+	const numOps = 10000
+
+	type workload struct {
+		name           string
+		readPct        int // percentage of operations that are reads
+		initialEntries int // number of entries pre-populated before benchmark
+	}
+	workloads := []workload{
+		{"reads=100/init=1000", 100, 1000},
+		{"reads=100/init=80000", 100, 80000},
+		{"reads=99/init=1000", 99, 1000},
+		{"reads=99/init=80000", 99, 80000},
+		{"reads=95/init=1000", 95, 1000},
+		{"reads=95/init=80000", 95, 80000},
+		{"reads=50/init=0", 50, 0},
+		{"reads=50/init=1000", 50, 1000},
+		{"reads=50/init=80000", 50, 80000},
+		{"reads=0/init=0", 0, 0},
+		{"reads=0/init=80000", 0, 80000},
 	}
 
-	makeOps := func(b *testing.B) []*roachpb.Transaction {
-		txnOps := make([]*roachpb.Transaction, b.N)
-		for i := range txnOps {
-			txnOps[i] = &txns[rng.Intn(len(txns))]
-		}
-		return txnOps
+	// Pre-generate a pool of transactions large enough for all workloads.
+	const txnPoolSize = 200000
+	txnPool := make([]roachpb.Transaction, txnPoolSize)
+	for i := range txnPool {
+		txnPool[i] = makeTxnProto(fmt.Sprintf("txn %d", i))
 	}
-	allAdd := func(b *testing.B, c tCache) {
-		txnOps := makeOps(b)
-		b.ResetTimer()
-		for _, txnOp := range txnOps {
-			c.add(txnOp)
+
+	runWorkload := func(b *testing.B, c tCache, wl workload) {
+		rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
+
+		// Pre-populate the cache with initialEntries distinct transactions.
+		for i := 0; i < wl.initialEntries; i++ {
+			c.add(&txnPool[i])
 		}
-	}
-	allGet := func(b *testing.B, c tCache) {
-		txnOps := makeOps(b)
-		for _, txnOp := range txnOps {
-			c.add(txnOp)
+
+		// Build the operation sequence. Reads target pre-populated entries
+		// (if any exist); writes use transactions beyond the initial set to
+		// ensure they are new insertions.
+		type op struct {
+			isRead bool
+			txn    *roachpb.Transaction
 		}
-		b.ResetTimer()
-		for _, txnOp := range txnOps {
-			_, _ = c.get(txnOp.ID)
-		}
-	}
-	halfAndHalf := func(b *testing.B, c tCache) {
-		txnOps := makeOps(b)
-		b.ResetTimer()
-		for i, txnOp := range txnOps {
-			if i%2 == 0 {
-				c.add(txnOp)
+		ops := make([]op, numOps)
+		for i := range ops {
+			if rng.Intn(100) < wl.readPct && wl.initialEntries > 0 {
+				ops[i] = op{isRead: true, txn: &txnPool[rng.Intn(wl.initialEntries)]}
 			} else {
-				_, _ = c.get(txnOp.ID)
+				ops[i] = op{isRead: false, txn: &txnPool[wl.initialEntries+rng.Intn(txnPoolSize-wl.initialEntries)]}
+			}
+		}
+
+		b.ResetTimer()
+		for n := 0; n < b.N; n++ {
+			for _, o := range ops {
+				if o.isRead {
+					_, _ = c.get(o.txn.ID)
+				} else {
+					c.add(o.txn)
+				}
 			}
 		}
 	}
 
-	workloads := []struct {
-		name string
-		fn   func(b *testing.B, c tCache)
-	}{
-		{"all-get", allGet},
-		{"all-add", allAdd},
-		{"half-and-half", halfAndHalf},
+	// runWorkloadParallel distributes operations across GOMAXPROCS goroutines
+	// using b.RunParallel. Each goroutine uses its own RNG to avoid contention.
+	runWorkloadParallel := func(b *testing.B, c tCache, wl workload) {
+		for i := 0; i < wl.initialEntries; i++ {
+			c.add(&txnPool[i])
+		}
+
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
+			for pb.Next() {
+				for i := 0; i < numOps; i++ {
+					if rng.Intn(100) < wl.readPct && wl.initialEntries > 0 {
+						_, _ = c.get(txnPool[rng.Intn(wl.initialEntries)].ID)
+					} else {
+						idx := wl.initialEntries + rng.Intn(txnPoolSize-wl.initialEntries)
+						c.add(&txnPool[idx])
+					}
+				}
+			}
+		})
 	}
 
-	b.Run("txnCache", func(b *testing.B) {
-		var c finalizedTxnCache
-		for _, tc := range workloads {
-			b.Run(tc.name, func(b *testing.B) {
-				tc.fn(b, &c)
+	type runner struct {
+		name string
+		fn   func(*testing.B, tCache, workload)
+	}
+	runners := []runner{
+		{"serial", runWorkload},
+		{"parallel", runWorkloadParallel},
+	}
+
+	for _, r := range runners {
+		b.Run(r.name, func(b *testing.B) {
+			b.Run("txnCache", func(b *testing.B) {
+				for _, wl := range workloads {
+					b.Run(wl.name, func(b *testing.B) {
+						var c finalizedTxnCache
+						r.fn(b, &c, wl)
+					})
+				}
 			})
-		}
-	})
-	b.Run("cache.UnorderedCache", func(b *testing.B) {
-		bc := cache.NewUnorderedCache(cache.Config{
-			Policy: cache.CacheLRU,
-			ShouldEvict: func(size int, _, _ interface{}) bool {
-				return size > txnCacheSize
-			},
+			b.Run("cache.UnorderedCache", func(b *testing.B) {
+				for _, wl := range workloads {
+					b.Run(wl.name, func(b *testing.B) {
+						bc := cache.NewUnorderedCache(cache.Config{
+							Policy: cache.CacheLRU,
+							ShouldEvict: func(size int, _, _ interface{}) bool {
+								return size > txnCacheSize
+							},
+						})
+						c := &adapter{c: bc}
+						r.fn(b, c, wl)
+					})
+				}
+			})
+			b.Run("cache.TypedUnorderedCache", func(b *testing.B) {
+				for _, wl := range workloads {
+					b.Run(wl.name, func(b *testing.B) {
+						bc := cache.NewTypedUnorderedCache(cache.TypedConfig[uuid.UUID, *roachpb.Transaction]{
+							Policy: cache.CacheLRU,
+							ShouldEvict: func(size int, _ uuid.UUID, _ *roachpb.Transaction) bool {
+								return size > txnCacheSize
+							},
+						})
+						c := &typedAdapter{c: bc}
+						r.fn(b, c, wl)
+					})
+				}
+			})
+			b.Run("otter.Cache", func(b *testing.B) {
+				for _, wl := range workloads {
+					b.Run(wl.name, func(b *testing.B) {
+						oc, err := otter.New(&otter.Options[uuid.UUID, *roachpb.Transaction]{
+							MaximumSize:     txnCacheSize,
+							InitialCapacity: 8,
+						})
+						require.NoError(b, err)
+						c := &otterAdapter{c: oc}
+						r.fn(b, c, wl)
+					})
+				}
+			})
 		})
-		c := &adapter{c: bc}
-		for _, tc := range workloads {
-			b.Run(tc.name, func(b *testing.B) {
-				tc.fn(b, c)
-			})
+	}
+}
+
+// BenchmarkFinalizedTxnCacheContention measures per-operation throughput under
+// high goroutine contention.
+func BenchmarkFinalizedTxnCacheContention(b *testing.B) {
+	const txnPoolSize = 200000
+	txnPool := make([]roachpb.Transaction, txnPoolSize)
+	for i := range txnPool {
+		txnPool[i] = makeTxnProto(fmt.Sprintf("txn %d", i))
+	}
+
+	for _, parallelism := range []int{1, 4, 16} {
+		for _, readPct := range []int{100, 95, 50} {
+			for _, initEntries := range []int{1000, 80000} {
+				name := fmt.Sprintf("P=%d/reads=%d/init=%d", parallelism, readPct, initEntries)
+
+				makeTypedCache := func(b *testing.B) tCache {
+					bc := cache.NewTypedUnorderedCache(cache.TypedConfig[uuid.UUID, *roachpb.Transaction]{
+						Policy: cache.CacheLRU,
+						ShouldEvict: func(size int, _ uuid.UUID, _ *roachpb.Transaction) bool {
+							return size > txnCacheSize
+						},
+					})
+					return &typedAdapter{c: bc}
+				}
+				makeOtterCache := func(b *testing.B) tCache {
+					oc, err := otter.New(&otter.Options[uuid.UUID, *roachpb.Transaction]{
+						MaximumSize:     txnCacheSize,
+						InitialCapacity: 8,
+					})
+					require.NoError(b, err)
+					return &otterAdapter{c: oc}
+				}
+
+				for _, cc := range []struct {
+					name   string
+					makeFn func(*testing.B) tCache
+				}{
+					{"TypedUnorderedCache", makeTypedCache},
+					{"otter.Cache", makeOtterCache},
+				} {
+					b.Run(name+"/"+cc.name, func(b *testing.B) {
+						c := cc.makeFn(b)
+						for i := 0; i < initEntries; i++ {
+							c.add(&txnPool[i])
+						}
+
+						b.SetParallelism(parallelism)
+						b.ResetTimer()
+						b.RunParallel(func(pb *testing.PB) {
+							rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
+							for pb.Next() {
+								if rng.Intn(100) < readPct && initEntries > 0 {
+									_, _ = c.get(txnPool[rng.Intn(initEntries)].ID)
+								} else {
+									idx := initEntries + rng.Intn(txnPoolSize-initEntries)
+									c.add(&txnPool[idx])
+								}
+							}
+						})
+					})
+				}
+			}
 		}
-	})
-	b.Run("cache.TypedUnorderedCache", func(b *testing.B) {
-		bc := cache.NewTypedUnorderedCache(cache.TypedConfig[uuid.UUID, *roachpb.Transaction]{
-			Policy: cache.CacheLRU,
-			ShouldEvict: func(size int, _ uuid.UUID, _ *roachpb.Transaction) bool {
-				return size > txnCacheSize
-			},
-		})
-		c := &typedAdapter{c: bc}
-		for _, tc := range workloads {
-			b.Run(tc.name, func(b *testing.B) {
-				tc.fn(b, c)
-			})
-		}
-	})
+	}
 }
 
 func TestContentionEventTracer(t *testing.T) {

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
@@ -22,13 +22,16 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/util/cache"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1192,25 +1195,138 @@ func TestFinalizedTxnCacheUpdatesTxn(t *testing.T) {
 	require.Equal(t, txnPushed.WriteTimestamp, entryInCache.WriteTimestamp)
 }
 
+type tCache interface {
+	add(*roachpb.Transaction)
+	get(id uuid.UUID) (*roachpb.Transaction, bool)
+}
+
+type adapter struct {
+	syncutil.Mutex
+	c *cache.UnorderedCache
+}
+
+func (a *adapter) add(txn *roachpb.Transaction) {
+	a.Lock()
+	defer a.Unlock()
+	a.c.Add(txn.ID, txn)
+}
+
+func (a *adapter) get(id uuid.UUID) (*roachpb.Transaction, bool) {
+	a.Lock()
+	defer a.Unlock()
+	txn, ok := a.c.Get(id)
+	if !ok {
+		return nil, ok
+	}
+	return txn.(*roachpb.Transaction), ok
+}
+
+type typedAdapter struct {
+	syncutil.Mutex
+	c *cache.TypedUnorderedCache[uuid.UUID, *roachpb.Transaction]
+}
+
+func (a *typedAdapter) add(txn *roachpb.Transaction) {
+	a.Lock()
+	defer a.Unlock()
+	a.c.Add(txn.ID, txn)
+}
+
+func (a *typedAdapter) get(id uuid.UUID) (*roachpb.Transaction, bool) {
+	a.Lock()
+	defer a.Unlock()
+	return a.c.Get(id)
+}
+
 func BenchmarkFinalizedTxnCache(b *testing.B) {
 	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
-	var c finalizedTxnCache
-	var txns [len(c.txns) + 4]roachpb.Transaction
+	numOps := txnCacheSize * 4 // TODO
+	txns := make([]roachpb.Transaction, numOps)
 	for i := range txns {
 		txns[i] = makeTxnProto(fmt.Sprintf("txn %d", i))
 	}
-	txnOps := make([]*roachpb.Transaction, b.N)
-	for i := range txnOps {
-		txnOps[i] = &txns[rng.Intn(len(txns))]
+
+	makeOps := func(b *testing.B) []*roachpb.Transaction {
+		txnOps := make([]*roachpb.Transaction, b.N)
+		for i := range txnOps {
+			txnOps[i] = &txns[rng.Intn(len(txns))]
+		}
+		return txnOps
 	}
-	b.ResetTimer()
-	for i, txnOp := range txnOps {
-		if i%2 == 0 {
+	allAdd := func(b *testing.B, c tCache) {
+		txnOps := makeOps(b)
+		b.ResetTimer()
+		for _, txnOp := range txnOps {
 			c.add(txnOp)
-		} else {
+		}
+	}
+	allGet := func(b *testing.B, c tCache) {
+		txnOps := makeOps(b)
+		for _, txnOp := range txnOps {
+			c.add(txnOp)
+		}
+		b.ResetTimer()
+		for _, txnOp := range txnOps {
 			_, _ = c.get(txnOp.ID)
 		}
 	}
+	halfAndHalf := func(b *testing.B, c tCache) {
+		txnOps := makeOps(b)
+		b.ResetTimer()
+		for i, txnOp := range txnOps {
+			if i%2 == 0 {
+				c.add(txnOp)
+			} else {
+				_, _ = c.get(txnOp.ID)
+			}
+		}
+	}
+
+	workloads := []struct {
+		name string
+		fn   func(b *testing.B, c tCache)
+	}{
+		{"all-get", allGet},
+		{"all-add", allAdd},
+		{"half-and-half", halfAndHalf},
+	}
+
+	b.Run("txnCache", func(b *testing.B) {
+		var c finalizedTxnCache
+		for _, tc := range workloads {
+			b.Run(tc.name, func(b *testing.B) {
+				tc.fn(b, &c)
+			})
+		}
+	})
+	b.Run("cache.UnorderedCache", func(b *testing.B) {
+		bc := cache.NewUnorderedCache(cache.Config{
+			Policy: cache.CacheLRU,
+			ShouldEvict: func(size int, _, _ interface{}) bool {
+				return size > txnCacheSize
+			},
+		})
+		c := &adapter{c: bc}
+		for _, tc := range workloads {
+			b.Run(tc.name, func(b *testing.B) {
+				tc.fn(b, c)
+			})
+		}
+	})
+	b.Run("cache.TypedUnorderedCache", func(b *testing.B) {
+		bc := cache.NewTypedUnorderedCache(cache.TypedConfig[uuid.UUID, *roachpb.Transaction]{
+			Policy: cache.CacheLRU,
+			ShouldEvict: func(size int, _ uuid.UUID, _ *roachpb.Transaction) bool {
+				return size > txnCacheSize
+			},
+		})
+		c := &typedAdapter{c: bc}
+		for _, tc := range workloads {
+			b.Run(tc.name, func(b *testing.B) {
+				tc.fn(b, c)
+			})
+		}
+	})
 }
 
 func TestContentionEventTracer(t *testing.T) {

--- a/pkg/util/cache/BUILD.bazel
+++ b/pkg/util/cache/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "cache",
-    srcs = ["cache.go"],
+    srcs = [
+        "cache.go",
+        "typed_unordered_cache.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/util/cache",
     visibility = ["//visibility:public"],
     deps = [
@@ -14,7 +17,10 @@ go_library(
 go_test(
     name = "cache_test",
     size = "small",
-    srcs = ["cache_test.go"],
+    srcs = [
+        "cache_test.go",
+        "typed_unordered_cache_test.go",
+    ],
     embed = [":cache"],
     deps = [
         "//pkg/util/log",

--- a/pkg/util/cache/cache_test.go
+++ b/pkg/util/cache/cache_test.go
@@ -59,7 +59,7 @@ func TestCacheGet(t *testing.T) {
 		val, ok := mc.Get(tt.keyToGet)
 		if ok != tt.expectedOk {
 			t.Fatalf("%s: cache hit = %v; want %v", tt.name, ok, !ok)
-		} else if ok && val != 1234 {
+		} else if ok && val.(int) != 1234 {
 			t.Fatalf("%s expected get to return 1234 but got %v", tt.name, val)
 		}
 	}

--- a/pkg/util/cache/typed_unordered_cache.go
+++ b/pkg/util/cache/typed_unordered_cache.go
@@ -1,0 +1,239 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+//
+// This code largely duplicates that of UnorderedCache and baseCache, but with
+// generic type parameters to avoid allocations incurred during interface{}
+// conversions.
+
+package cache
+
+// typedCachePoolSize is the fixed size of the pre-allocated entry pool
+// used by TypedUnorderedCache.
+//
+// TODO(ssd): Make this configurable? This is likely much smaller than will be
+// useful for most users.
+const typedCachePoolSize = 8
+
+// typedEntry holds the key and value and a pointer to the linked list
+// which defines the eviction ordering. This is a generic version of Entry
+// that avoids interface{} boxing allocations.
+type typedEntry[K comparable, V any] struct {
+	Key        K
+	Value      V
+	next, prev *typedEntry[K, V]
+	poolIdx    int // index in pool, for returning to free stack
+}
+
+// typedEntryList is a double-linked circular list of *TypedEntry elements.
+// The code is derived from entryList but customized for generics.
+type typedEntryList[K comparable, V any] struct {
+	root typedEntry[K, V]
+}
+
+func (l *typedEntryList[K, V]) init() {
+	l.root.next = &l.root
+	l.root.prev = &l.root
+}
+
+func (l *typedEntryList[K, V]) back() *typedEntry[K, V] {
+	return l.root.prev
+}
+
+func (l *typedEntryList[K, V]) insertAfter(e, at *typedEntry[K, V]) {
+	n := at.next
+	at.next = e
+	e.prev = at
+	e.next = n
+	n.prev = e
+}
+
+func (l *typedEntryList[K, V]) remove(e *typedEntry[K, V]) *typedEntry[K, V] {
+	if e == &l.root {
+		panic("cannot remove root list node")
+	}
+	if e.next != nil {
+		e.prev.next = e.next
+		e.next.prev = e.prev
+		e.next = nil
+		e.prev = nil
+	}
+	return e
+}
+
+func (l *typedEntryList[K, V]) pushFront(e *typedEntry[K, V]) {
+	l.insertAfter(e, &l.root)
+}
+
+func (l *typedEntryList[K, V]) moveToFront(e *typedEntry[K, V]) {
+	if l.root.next == e {
+		return
+	}
+	l.insertAfter(l.remove(e), &l.root)
+}
+
+// TypedConfig specifies the eviction policy, eviction trigger callback,
+// and eviction listener callback for a TypedUnorderedCache.
+type TypedConfig[K comparable, V any] struct {
+	// Policy is one of the consts listed for EvictionPolicy.
+	Policy EvictionPolicy
+
+	// ShouldEvict is a callback function executed each time a new entry
+	// is added to the cache. It supplies cache size, and potential
+	// evictee's key and value. The function should return true if the
+	// entry may be evicted; false otherwise.
+	ShouldEvict func(size int, key K, value V) bool
+
+	// OnEvicted optionally specifies a callback function to be
+	// executed when an entry is purged from the cache.
+	OnEvicted func(key K, value V)
+}
+
+// TypedUnorderedCache is a generic cache which supports custom eviction
+// triggers and two eviction policies: LRU and FIFO. This cache uses a
+// hashmap for storing elements, making it performant. Only exact lookups
+// are supported.
+//
+// TypedUnorderedCache is not safe for concurrent access.
+type TypedUnorderedCache[K comparable, V any] struct {
+	config TypedConfig[K, V]
+	hmap   map[K]*typedEntry[K, V]
+	ll     typedEntryList[K, V]
+
+	// TODO(ssd): Think about this more. This is a small pool of pre-allocated
+	// TypedEntries, to avoid allocations. But, perhaps the user should pass us a
+	// sync.Pool or something instead.
+	pool    [typedCachePoolSize]typedEntry[K, V] // pre-allocated entry storage
+	free    [typedCachePoolSize]int              // stack of free indices into pool
+	freeLen int                                  // number of entries in free stack
+}
+
+// NewTypedUnorderedCache creates a new TypedUnorderedCache backed by a hash map.
+func NewTypedUnorderedCache[K comparable, V any](
+	config TypedConfig[K, V],
+) *TypedUnorderedCache[K, V] {
+	c := &TypedUnorderedCache[K, V]{
+		config:  config,
+		hmap:    make(map[K]*typedEntry[K, V], typedCachePoolSize),
+		freeLen: typedCachePoolSize,
+	}
+	c.ll.init()
+	for i := range c.pool {
+		c.pool[i].poolIdx = i
+		c.free[i] = i
+	}
+	return c
+}
+
+// Get looks up a key's value from the cache.
+func (c *TypedUnorderedCache[K, V]) Get(key K) (V, bool) {
+	if e, ok := c.hmap[key]; ok {
+		c.access(e)
+		return e.Value, true
+	}
+	var zero V
+	return zero, false
+}
+
+// Add adds a value to the cache.
+func (c *TypedUnorderedCache[K, V]) Add(key K, value V) {
+	if e, ok := c.hmap[key]; ok {
+		c.access(e)
+		e.Value = value
+		return
+	}
+
+	var e *typedEntry[K, V]
+	if c.freeLen > 0 {
+		// Pop from free stack.
+		c.freeLen--
+		idx := c.free[c.freeLen]
+		e = &c.pool[idx]
+	} else {
+		// Pool exhausted, allocate on heap. This entry will be discarded on eviction.
+		e = &typedEntry[K, V]{poolIdx: -1}
+	}
+
+	e.Key = key
+	e.Value = value
+	c.ll.pushFront(e)
+	c.hmap[e.Key] = e
+
+	// Evict as many elements as we can.
+	for c.evict() {
+	}
+}
+
+// Del removes the provided key from the cache.
+func (c *TypedUnorderedCache[K, V]) Del(key K) {
+	if e, ok := c.hmap[key]; ok {
+		c.removeElement(e)
+	}
+}
+
+// Len returns the number of items in the cache.
+func (c *TypedUnorderedCache[K, V]) Len() int {
+	return len(c.hmap)
+}
+
+// Clear clears all entries from the cache.
+func (c *TypedUnorderedCache[K, V]) Clear() {
+	if c.config.OnEvicted != nil {
+		for e := c.ll.back(); e != &c.ll.root; e = e.prev {
+			c.config.OnEvicted(e.Key, e.Value)
+		}
+	}
+	c.ll.init()
+	c.hmap = make(map[K]*typedEntry[K, V], typedCachePoolSize)
+	// Reset pool entries and free stack.
+	var zeroEntry typedEntry[K, V]
+	for i := range c.pool {
+		c.pool[i] = zeroEntry
+		c.pool[i].poolIdx = i
+		c.free[i] = i
+	}
+	c.freeLen = typedCachePoolSize
+}
+
+func (c *TypedUnorderedCache[K, V]) access(e *typedEntry[K, V]) {
+	if c.config.Policy == CacheLRU {
+		c.ll.moveToFront(e)
+	}
+}
+
+func (c *TypedUnorderedCache[K, V]) removeElement(e *typedEntry[K, V]) {
+	c.ll.remove(e)
+	delete(c.hmap, e.Key)
+	if c.config.OnEvicted != nil {
+		c.config.OnEvicted(e.Key, e.Value)
+	}
+
+	// Return to free stack if it came from our pool.
+	if e.poolIdx >= 0 {
+		var zeroK K
+		var zeroV V
+		e.Key = zeroK
+		e.Value = zeroV
+		c.free[c.freeLen] = e.poolIdx
+		c.freeLen++
+	}
+}
+
+// evict removes the oldest item from the cache for FIFO and
+// the least recently used item for LRU. Returns true if an
+// entry was evicted, false otherwise.
+func (c *TypedUnorderedCache[K, V]) evict() bool {
+	if c.config.ShouldEvict == nil || c.config.Policy == CacheNone {
+		return false
+	}
+	l := len(c.hmap)
+	if l > 0 {
+		e := c.ll.back()
+		if c.config.ShouldEvict(l, e.Key, e.Value) {
+			c.removeElement(e)
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/util/cache/typed_unordered_cache_test.go
+++ b/pkg/util/cache/typed_unordered_cache_test.go
@@ -1,0 +1,141 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+//
+// This code is based on: https://github.com/golang/groupcache/
+
+package cache
+
+import "testing"
+
+func noEvictionTyped(size int, key testKey, value int) bool {
+	return false
+}
+
+func evictTwoOrMoreTyped(size int, key testKey, value int) bool {
+	return size > 1
+}
+
+func evictThreeOrMoreTyped(size int, key testKey, value int) bool {
+	return size > 2
+}
+
+func TestTypedUnorderedCacheGet(t *testing.T) {
+	for _, tt := range getTests {
+		mc := NewTypedUnorderedCache[testKey, int](TypedConfig[testKey, int]{Policy: CacheLRU, ShouldEvict: noEvictionTyped})
+		mc.Add(tt.keyToAdd, 1234)
+		val, ok := mc.Get(tt.keyToGet)
+		if ok != tt.expectedOk {
+			t.Fatalf("%s: cache hit = %v; want %v", tt.name, ok, !ok)
+		} else if ok && val != 1234 {
+			t.Fatalf("%s expected get to return 1234 but got %v", tt.name, val)
+		}
+	}
+}
+
+func TestTypedUnderedCacheClear(t *testing.T) {
+	mc := NewTypedUnorderedCache[testKey, int](TypedConfig[testKey, int]{Policy: CacheLRU, ShouldEvict: noEvictionTyped})
+	mc.Add(testKey("a"), 1)
+	mc.Add(testKey("b"), 2)
+	mc.Clear()
+	if _, ok := mc.Get(testKey("a")); ok {
+		t.Error("expected cache cleared")
+	}
+	if _, ok := mc.Get(testKey("b")); ok {
+		t.Error("expected cache cleared")
+	}
+	mc.Add(testKey("a"), 1)
+	if _, ok := mc.Get(testKey("a")); !ok {
+		t.Error("expected reinsert to succeed")
+	}
+}
+
+func TestTypedUnorderedCacheDel(t *testing.T) {
+	mc := NewUnorderedCache(Config{Policy: CacheLRU, ShouldEvict: noEviction})
+	mc.Add(testKey("myKey"), 1234)
+	if val, ok := mc.Get(testKey("myKey")); !ok {
+		t.Fatal("TestDel returned no match")
+	} else if val != 1234 {
+		t.Fatalf("TestDel failed. Expected %d, got %v", 1234, val)
+	}
+
+	mc.Del(testKey("myKey"))
+	if _, ok := mc.Get(testKey("myKey")); ok {
+		t.Fatal("TestRemove returned a removed entry")
+	}
+}
+
+func TestTypedUnorderedCacheEviction(t *testing.T) {
+	mc := NewTypedUnorderedCache[testKey, int](TypedConfig[testKey, int]{Policy: CacheLRU, ShouldEvict: evictTwoOrMoreTyped})
+	// Insert two keys into cache which only holds 1.
+	mc.Add(testKey("a"), 1234)
+	val, ok := mc.Get(testKey("a"))
+	if !ok || val != 1234 {
+		t.Fatal("expected get to succeed with value 1234")
+	}
+	mc.Add(testKey("b"), 4321)
+	val, ok = mc.Get(testKey("b"))
+	if !ok || val != 4321 {
+		t.Fatal("expected get to succeed with value 4321")
+	}
+	// Verify eviction of first key.
+	if _, ok = mc.Get(testKey("a")); ok {
+		t.Fatal("unexpected success getting evicted key")
+	}
+}
+
+func TestTypedUnorderedCacheLRU(t *testing.T) {
+	mc := NewTypedUnorderedCache[testKey, int](TypedConfig[testKey, int]{Policy: CacheLRU, ShouldEvict: evictThreeOrMoreTyped})
+	// Insert two keys into cache.
+	mc.Add(testKey("a"), 1)
+	mc.Add(testKey("b"), 2)
+	// Get "a" now to make it more recently used.
+	if _, ok := mc.Get(testKey("a")); !ok {
+		t.Fatal("failed to get key a")
+	}
+	// Add another entry to cause an eviction; should evict key "b".
+	mc.Add(testKey("c"), 3)
+	// Verify eviction of least recently used key "b".
+	if _, ok := mc.Get(testKey("b")); ok {
+		t.Fatal("unexpected success getting evicted key")
+	}
+}
+
+func TestTypedUnorderedCacheFIFO(t *testing.T) {
+	mc := NewTypedUnorderedCache[testKey, int](TypedConfig[testKey, int]{
+		Policy:      CacheFIFO,
+		ShouldEvict: evictThreeOrMoreTyped,
+	})
+	// Insert two keys into cache.
+	mc.Add(testKey("a"), 1)
+	mc.Add(testKey("b"), 2)
+	// Get "a" now to make it more recently used.
+	if _, ok := mc.Get(testKey("a")); !ok {
+		t.Fatal("failed to get key a")
+	}
+	// Add another entry to evict; should evict key "a" still, as that was first in.
+	mc.Add(testKey("c"), 3)
+	// Verify eviction of first key "a".
+	if _, ok := mc.Get(testKey("a")); ok {
+		t.Fatal("unexpected success getting evicted key")
+	}
+}
+
+func BenchmarkTypedUnorderedCache(b *testing.B) {
+	mc := NewTypedUnorderedCache[testKey, int](TypedConfig[testKey, int]{Policy: CacheLRU, ShouldEvict: noEvictionTyped})
+	testKeys := []testKey{
+		testKey("a"),
+		testKey("b"),
+		testKey("c"),
+		testKey("d"),
+		testKey("e"),
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < len(testKeys); j++ {
+			mc.Add(testKeys[j], j)
+		}
+		mc.Clear()
+	}
+}


### PR DESCRIPTION
We want to move the txnStatusCache to the node level so that it can be shared across nodes. As part of this, we would like to dramatically increase its size. Towards that ends, this PR adds a new cache.TypedUnorderedCache and compares txnStatusCache against both cache.TypedUnorderedCache and cache.UnorderedCache.

TypedUnorderedCache was introduced primarily to remove allocations on the Get path in which a uuid.UUID required an allocation when being converted to an interface{}.

At the current cache size of 8, the fixed-size array of course blows both alternatives out of the water:

```
BenchmarkTxnCache/txnCache/all-get      85077721                14.35 ns/op            0 B/op          0 allocs/op
BenchmarkTxnCache/txnCache/all-add      58132791                20.83 ns/op            0 B/op          0 allocs/op
BenchmarkTxnCache/txnCache/half-and-half                60125712                20.41 ns/op            0 B/op          0 allocs/op

BenchmarkTxnCache/cache.UnorderedCache/all-get          28425801                52.17 ns/op           16 B/op          1 allocs/op
BenchmarkTxnCache/cache.UnorderedCache/all-add           8359720               133.8 ns/op            52 B/op          1 allocs/op
BenchmarkTxnCache/cache.UnorderedCache/half-and-half            12318646                96.64 ns/op           34 B/op          1 allocs/op

BenchmarkTxnCache/cache.TypedUnorderedCache/all-get             43166826                28.56 ns/op            0 B/op          0 allocs/op
BenchmarkTxnCache/cache.TypedUnorderedCache/all-add             16352476                66.71 ns/op            4 B/op          0 allocs/op
BenchmarkTxnCache/cache.TypedUnorderedCache/half-and-half       23817000                47.70 ns/op            1 B/op          0 allocs/op
```

But, when increased to 128, we start to look better:

```
BenchmarkTxnCache/txnCache/all-get                              14360722     83.67 ns/op        0 B/op          0 allocs/op
BenchmarkTxnCache/txnCache/all-add                              10706299     100.9 ns/op        0 B/op          0 allocs/op
BenchmarkTxnCache/txnCache/half-and-half                        11158084     97.90 ns/op        0 B/op          0 allocs/op

BenchmarkTxnCache/cache.UnorderedCache/all-get                  21284488     61.78 ns/op        16 B/op          1 allocs/op
BenchmarkTxnCache/cache.UnorderedCache/all-add                   6931818     164.6 ns/op        52 B/op          1 allocs/op
BenchmarkTxnCache/cache.UnorderedCache/half-and-half            10163343     113.4 ns/op        34 B/op          1 allocs/op

BenchmarkTxnCache/cache.TypedUnorderedCache/all-get             41612544     38.06 ns/op        0 B/op          0 allocs/op
BenchmarkTxnCache/cache.TypedUnorderedCache/all-add             10178464     118.0 ns/op       33 B/op          0 allocs/op
BenchmarkTxnCache/cache.TypedUnorderedCache/half-and-half       15938071     69.52 ns/op       16 B/op          0 allocs/op
```

At 1024 the benchmark is probably a bit unfair to even post, but the TypedUnorderedCache wins my a large margin.

What hasn't been evaluated yet is how mutex contention will be when all replicas are sharing this cache.

Epic: none
Release note: None