### PR TITLE
changefeedccl: ShallowCopy RangeFeedCheckpoints

### DIFF
--- a/pkg/ccl/changefeedccl/kvfeed/physical_kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/physical_kv_feed.go
@@ -127,7 +127,8 @@ func (p *rangefeed) addEventsToBuffer(ctx context.Context) error {
 				}
 				stop()
 			case *kvpb.RangeFeedCheckpoint:
-				if !t.ResolvedTS.IsEmpty() && t.ResolvedTS.Less(p.cfg.Frontier) {
+				ev := e.ShallowCopy()
+				if !ev.Checkpoint.ResolvedTS.IsEmpty() && ev.Checkpoint.ResolvedTS.Less(p.cfg.Frontier) {
 					// RangeFeed happily forwards any closed timestamps it receives as
 					// soon as there are no outstanding intents under them.
 					// Changefeeds don't care about these at all, so throw them out.
@@ -138,7 +139,7 @@ func (p *rangefeed) addEventsToBuffer(ctx context.Context) error {
 				}
 				stop := p.st.RangefeedBufferCheckpoint.Start()
 				if err := p.memBuf.Add(
-					ctx, kvevent.MakeResolvedEvent(e.RangeFeedEvent, jobspb.ResolvedSpan_NONE),
+					ctx, kvevent.MakeResolvedEvent(ev, jobspb.ResolvedSpan_NONE),
 				); err != nil {
 					return err
 				}


### PR DESCRIPTION
We suspect that the (*RangeFeedCheckpoint) used here may be shared by other clients and the rangefeed server side code when our rangefeed is being served by a local replica and thus the MuxRangeFeed RPC uses the local client optimization which avoid the network and also avoids marshling and unmarshaling the response across the RPC boundary.

This is currently our best theory for the source of the marshalling error seen in cockroachdb#159166:

1. A *RangeFeedCheckpoint is created by a processor and delivered to 2 registrations. Both of those registrations are for spans that match the checkpoint span exactly and thus neither registration takes a shallow copy.

2. Registration 1 is for a local client and sends it to changefeed 1 via the local client optimization. As a result, changefeed 1's *RangeFeedCheckpoint is the same pointer that we have on the rangefeed server side.

3. Registration 2 begins to marshal the *RangeFeedCheckpoint and takes its Size.

4. Registration 1 overwrites (*RangeFeedCheckpoint).ResolvedTS to a value that has a larger encoded size.

5. Registration 2 continues its marshalling, now using the wrong size (and thus wrongly sized buffer). This leads to a panic.

We have not been able to reproduce this problem locally, but a similar patch deployed to a crashing cluster did resolve the issue in that cluster.

This change is slightly different from #159348. Our goal with this alternative is to bring 24.3 closer in line with master which does the ShallowCopy immediately, potentially defending against other undiscovered modifications of this message.

Informs cockroachdb#159166
Informs cockroachdb#157882
Informs cockroachdb#138895
Informs cockroachdb#158166
Informs cockroachlabs/support#3506

Release note (bug fix): Fixes a bug which could lead to a node crash in the presence of a CHANGEFEED that uses the end_time option.

Release justification: Bug fix for node-crashing bug.