### PR TITLE
roachtest: revert rebalance test names

### DIFF
--- a/pkg/cmd/roachtest/tests/rebalance_load.go
+++ b/pkg/cmd/roachtest/tests/rebalance_load.go
@@ -166,7 +166,7 @@ func registerRebalanceLoad(r registry.Registry) {
 			}
 
 			// Configure the variables for the test specification.
-			name := fmt.Sprintf("rebalance/by-load/mode=%s%s", rebalanceModeNames[rebalanceMode], testKindNames[testKind])
+			name := fmt.Sprintf("rebalance/by-load/%s%s", rebalanceModeNames[rebalanceMode], testKindNames[testKind])
 			clusterSpec := r.MakeClusterSpec(7) // the last node is just used to generate load
 			suites := registry.Suites(registry.Nightly)
 			clouds := registry.AllExceptAWS


### PR DESCRIPTION
Preserve historical names for this test, since it's flaky and we don't want to lose or complicate its history.

```
$ roachtest list | grep ^rebalance

rebalance/by-load/leases [kv]
rebalance/by-load/leases/mixed-version [kv]   randomized
rebalance/by-load/mmc [kv]
rebalance/by-load/mmc/ssds=2 [kv]
rebalance/by-load/replicas [kv]
rebalance/by-load/replicas/mixed-version [kv]   randomized
rebalance/by-load/replicas/ssds=2 [kv]
```

Undoes the rename in #161078.

Related to #161601, #161562
Epic: none
Release note: none