### PR TITLE
sniffarg: fix parsing for - string flags

### DIFF
--- a/pkg/testutils/sniffarg/sniffarg.go
+++ b/pkg/testutils/sniffarg/sniffarg.go
@@ -38,7 +38,15 @@ func Do(args []string, name string, out interface{}) error {
 	pf.ParseErrorsWhitelist = pflag.ParseErrorsWhitelist{UnknownFlags: true}
 	args = append([]string(nil), args...)
 	for i, arg := range args {
-		if !strings.HasPrefix(arg, "-") {
+		if !strings.HasPrefix(arg, "-") || len(arg) == 1 {
+			// NB: `-` does not get transformed into `--` because consider that
+			// it's a valid string value, for example `-test.run -`. Unfortunately,
+			// `-asd` is also a valid string value. At this level, we really can't
+			// tell - we'd need to see the flag definitions. But at least we're not
+			// accidentally converting `-` into `--` which would instruct pflag
+			// parsing to stop looking for flags after this argument, which could
+			// lead to it missing the flag we're looking for.
+			// See TestRegressionSingleDashStringValue.
 			continue
 		}
 

--- a/pkg/testutils/sniffarg/sniffarg_test.go
+++ b/pkg/testutils/sniffarg/sniffarg_test.go
@@ -47,6 +47,19 @@ func TestDo(t *testing.T) {
 
 }
 
+func TestRegressionSingleDashStringValue(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// Regression test verifying that a `-` string value doesn't get transformed
+	// into `--` which would stop pflag's flag parsing.
+	args := []string{
+		`-test.run`, `-`, `-test.memprofile`, `benchdiff/3c4a71e/artifacts/mem_last.prof`,
+	}
+	var benchMem string
+	require.NoError(t, Do(args, "test.memprofile", &benchMem))
+	require.NotEmpty(t, benchMem)
+}
+
 func TestDoBoolUnknownSingleDashFlag(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 


### PR DESCRIPTION
We were wondering in #161285 why the benchmark did not create the expected "inner" memory profile that avoids capturing the setup/teardown phase of the test.

This was because of the bug fixed here: we were passing the args in order `-test.run - -test.memprofile foo.pb.gz` but the `-` was transformed into `--` by sniffarg to facilitate pflag parsing. But `--` stops pflag parsing, so really it should have been left alone.

Arg sniffing remains somewhat fragile, but at least now this particular case works like a charm.

Epic: none