### PR TITLE
roachtest: skip weekly/tpcc/headroom

### DIFF
--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -1072,7 +1072,9 @@ func registerTPCC(r registry.Registry) {
 	})
 
 	r.Add(registry.TestSpec{
-		Name:             "weekly/tpcc/headroom",
+		Name: "weekly/tpcc/headroom",
+		// TODO: #141792
+		Skip:             "add back when #141792 is implemented (--tolerate-retry-error)",
 		Owner:            registry.OwnerTestEng,
 		Benchmark:        true,
 		CompatibleClouds: registry.AllExceptAWS,


### PR DESCRIPTION
Skips weekly/tpcc/headroom until a more precise retry mechanism is implemented

Informs #149946
Epic: None
Release note: None