### PR TITLE
release-25.4: restore: add telemetry log line on restore throughput

### DIFF
--- a/pkg/backup/restore_job.go
+++ b/pkg/backup/restore_job.go
@@ -81,6 +81,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/redact"
 )
 
 var (
@@ -2251,6 +2252,7 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 			telemetry.CountBucketed("restore.speed-mbps.over10mb.per-node", mbps/int64(numNodes))
 		}
 		logutil.LogJobCompletion(ctx, restoreJobEventType, r.job.ID(), true, nil, resTotal.Rows)
+		log.Telemetry.Infof(ctx, "Restore completed in %d seconds, logical size %d MB, node count %d, per node throughput %d MB/s", redact.Safe(sec), redact.Safe(sizeMb), redact.Safe(numNodes), redact.Safe(mbps/int64(numNodes)))
 	}
 	return nil
 }

--- a/pkg/ccl/telemetryccl/telemetry_logging_test.go
+++ b/pkg/ccl/telemetryccl/telemetry_logging_test.go
@@ -201,7 +201,10 @@ func (l *telemetrySpy) Intercept(entry []byte) {
 		l.recoveryEvents = append(l.recoveryEvents, re)
 		return
 	} else {
-		l.t.Errorf("failed unmarshaling %s: %s", rawLog.Message, err)
+		// If the log message cannot be unmarshalled into a recovery event, we're not testing
+		// its existsence in this test.
+		l.t.Logf("not a recovery event: %s", rawLog.Message)
+		return
 	}
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #161519 on behalf of @msbutler.

----

When restore completes, it will now log to the telemetry channel a few performance metrics.

Epic: none

Release note: none

----

Release justification: