### PR TITLE
roachtest: add manual distributed merge scale test

### DIFF
--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -146,6 +146,7 @@ func RegisterTests(r registry.Registry) {
 	registerSQLAlchemy(r)
 	registerSQLSmith(r)
 	registerSchemaChangeBulkIngest(r)
+	registerSchemaChangeBulkIngestScaleTest(r)
 	registerSchemaChangeDuringKV(r)
 	registerSchemaChangeDuringTPCC800(r)
 	registerSchemaChangeIndexTPCC100(r)


### PR DESCRIPTION
Add a new scale test that exercises distributed merge with the index backfiller. This test is currently registered as a manual test and is not run as part of the nightly roachtest suite.

Epic: CRDB-48845
Release note: none