### PR TITLE
release-26.1: ccl/schemachanger: limit backup flavours for rollbacks

### DIFF
--- a/pkg/sql/schemachanger/sctest/backup.go
+++ b/pkg/sql/schemachanger/sctest/backup.go
@@ -462,8 +462,9 @@ func backupRollbacks(
 				url:                url,
 				mayRollback:        true,
 				expectedOnRollback: postRollback,
-				// Speed up mixed version variants by excluding individual table restores.
-				excludeAllTablesInDatabaseFlavor: isMultiRegion && isMixedVersion,
+				// Speed up multi-region or mixed version variants by excluding
+				// individual table restores, due to the slower speed due to multiple nodes.
+				excludeAllTablesInDatabaseFlavor: isMultiRegion || isMixedVersion,
 			}
 			var name string
 			switch i {


### PR DESCRIPTION
Backport 1/1 commits from #161646 on behalf of @fqazi.

----

Previously, we tested a wide array of backup flavours in the mixed
version using multi-region rollback tests. We limited the number of
tested backup flavours in this configuration hoping to reduce observed
timeouts, as these tests take a long time to run in CI. Unfortunately,
the multi-region tests continued to time out during rollbacks.

This patch further limits the number of restore flavours for
multi-region rollback tests. We can safely do this without losing test
coverage because the successful paths are already tested with all
variants, and these tests focus mainly on rollback scenarios following a
restore. Additionally, the non-mixed version and single-region scenarios
always test all backup/restore variants. We have also validated
rollbacks for all plans in mixed version.

Fixes: #161180

Release note: None

----

Release justification: test only change