### PR TITLE
kvserverpb: rm SnapshotRequest_Header.RangeKeysInOrder

### DIFF
--- a/pkg/kv/kvserver/kvserverpb/raft.proto
+++ b/pkg/kv/kvserver/kvserverpb/raft.proto
@@ -204,19 +204,7 @@ message SnapshotRequest {
     // file contents.
     bool external_replicate = 13;
 
-    // If true, the snapshot is iterating over range keys and point
-    // keys in key order, as opposed to iterating over point keys first
-    // and range keys second. The receiver can take advantage of this
-    // to split points/range keys into multiple sstables for ingestion.
-    //
-    // MIGRATION: v24.3 and newer will always set this field to true, and v25.3
-    // and newer stop consulting the field altogether (assume it is true). In
-    // v26.1, we can then drop this field altogether, since v26.1 is the first
-    // version that does not have to interop with v25.2 (the last version to
-    // attach meaning to this field being unset/absent) or older.
-    bool range_keys_in_order = 14;
-
-    reserved 1, 4, 6, 7, 8, 9;
+    reserved 1, 4, 6, 7, 8, 9, 14;
   }
 
   // SharedTable represents one shared SSTable present in shared storage.

--- a/pkg/kv/kvserver/obsolete_code_test.go
+++ b/pkg/kv/kvserver/obsolete_code_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
@@ -24,28 +23,11 @@ func TestObsoleteCode(t *testing.T) {
 	msv := clusterversion.RemoveDevOffset(clusterversion.MinSupported.Version())
 	t.Logf("MinSupported: %v", msv)
 
-	v25dot2 := clusterversion.RemoveDevOffset(clusterversion.V25_2.Version())
-
-	// v25.2 is the last version to interpret RangeKeysInOrder. 25.3+ ignores
-	// the field on incoming snapshots but continues to set it on outgoing
-	// snapshots for compatibility reasons. This can be removed when the below
-	// check fires.
+	// Example: https://github.com/cockroachdb/cockroach/pull/144616
 	//
-	// See https://github.com/cockroachdb/cockroach/pull/144613.
-	//
-	// NB: the below comparison intentionally minimizes the number of assumptions
-	// on what release follows 25.2.
-	//
-	// TODO(kvserver): MinSupported is now v25.3, so RangeKeysInOrder can be
-	// removed. This cleanup includes:
-	//   1. Remove the proto field from SnapshotRequest_Header
-	//   2. Remove assignments in replica_command.go:3346 and store_snapshot.go:768
-	//   3. Regenerate proto files
-	// Tracked in: https://github.com/cockroachdb/cockroach/issues/157771
-	_ = v25dot2 // prevent unused variable error
-	_ = kvserverpb.SnapshotRequest_Header{}.RangeKeysInOrder
-	// if !msv.LessEq(v25dot2) {
-	// 	_ = kvserverpb.SnapshotRequest_Header{}.RangeKeysInOrder
-	// 	t.Fatalf("SnapshotRequest_Header.RangeKeysInOrder can be removed")
-	// }
+	//	v25dot2 := clusterversion.RemoveDevOffset(clusterversion.V25_2.Version())
+	//	if !msv.LessEq(v25dot2) {
+	//		_ = some.Type{}.DeprecatedField
+	//		t.Fatalf("DeprecatedField can be removed")
+	//	}
 }

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -3345,7 +3345,6 @@ func (r *Replica) followerSendSnapshot(
 		SenderQueuePriority: req.SenderQueuePriority,
 		SharedReplicate:     sharedReplicate,
 		ExternalReplicate:   externalReplicate,
-		RangeKeysInOrder:    true,
 	}
 	newBatchFn := func() storage.WriteBatch {
 		return r.store.TODOEngine().NewWriteBatch()

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -765,7 +765,6 @@ func SendEmptySnapshot(
 		State:              state,
 		RaftMessageRequest: req,
 		RangeSize:          ms.Total(),
-		RangeKeysInOrder:   true,
 	}
 
 	stream, err := mrc.RaftSnapshot(ctx)


### PR DESCRIPTION
The field has been deprecated and is now safe to remove.

Resolves #157771