### PR TITLE
release-26.1: cli: audit omitted system tables from debug.zip

### DIFF
--- a/pkg/cli/testdata/zip/file-filters/testzip_file_filters
+++ b/pkg/cli/testdata/zip/file-filters/testzip_file_filters
@@ -88,16 +88,20 @@ debug/system.database_role_settings.txt
 debug/system.descriptor.txt
 debug/system.eventlog.txt
 debug/system.external_connections.txt
+debug/system.inspect_errors.txt
 debug/system.job_info.txt
 debug/system.jobs.txt
 debug/system.lease.txt
 debug/system.locations.txt
 debug/system.migrations.txt
+debug/system.mvcc_statistics.txt
 debug/system.namespace.txt
+debug/system.prepared_transactions.txt
 debug/system.privileges.txt
 debug/system.protected_ts_meta.txt
 debug/system.protected_ts_records.txt
 debug/system.rangelog.txt
+debug/system.region_liveness.txt
 debug/system.replication_constraint_stats.txt
 debug/system.replication_critical_localities.txt
 debug/system.replication_stats.txt
@@ -115,6 +119,7 @@ debug/system.statement_diagnostics.txt
 debug/system.statement_diagnostics_requests.txt
 debug/system.statement_hints.txt
 debug/system.statement_statistics_limit_5000.txt
+debug/system.table_metadata.txt
 debug/system.table_statistics.txt
 debug/system.table_statistics_locks.txt
 debug/system.task_payloads.txt
@@ -122,6 +127,8 @@ debug/system.tenant_settings.txt
 debug/system.tenant_tasks.txt
 debug/system.tenant_usage.txt
 debug/system.tenants.txt
+debug/system.transaction_diagnostics.txt
+debug/system.transaction_diagnostics_requests.txt
 debug/system.zones.txt
 debug/tenant_ranges.err.txt
 
@@ -223,16 +230,20 @@ debug/system.database_role_settings.txt
 debug/system.descriptor.txt
 debug/system.eventlog.txt
 debug/system.external_connections.txt
+debug/system.inspect_errors.txt
 debug/system.job_info.txt
 debug/system.jobs.txt
 debug/system.lease.txt
 debug/system.locations.txt
 debug/system.migrations.txt
+debug/system.mvcc_statistics.txt
 debug/system.namespace.txt
+debug/system.prepared_transactions.txt
 debug/system.privileges.txt
 debug/system.protected_ts_meta.txt
 debug/system.protected_ts_records.txt
 debug/system.rangelog.txt
+debug/system.region_liveness.txt
 debug/system.replication_constraint_stats.txt
 debug/system.replication_critical_localities.txt
 debug/system.replication_stats.txt
@@ -250,6 +261,7 @@ debug/system.statement_diagnostics.txt
 debug/system.statement_diagnostics_requests.txt
 debug/system.statement_hints.txt
 debug/system.statement_statistics_limit_5000.txt
+debug/system.table_metadata.txt
 debug/system.table_statistics.txt
 debug/system.table_statistics_locks.txt
 debug/system.task_payloads.txt
@@ -257,6 +269,8 @@ debug/system.tenant_settings.txt
 debug/system.tenant_tasks.txt
 debug/system.tenant_usage.txt
 debug/system.tenants.txt
+debug/system.transaction_diagnostics.txt
+debug/system.transaction_diagnostics_requests.txt
 debug/system.zones.txt
 debug/tenant_ranges.err.txt
 
@@ -389,16 +403,20 @@ debug/system.database_role_settings.txt
 debug/system.descriptor.txt
 debug/system.eventlog.txt
 debug/system.external_connections.txt
+debug/system.inspect_errors.txt
 debug/system.job_info.txt
 debug/system.jobs.txt
 debug/system.lease.txt
 debug/system.locations.txt
 debug/system.migrations.txt
+debug/system.mvcc_statistics.txt
 debug/system.namespace.txt
+debug/system.prepared_transactions.txt
 debug/system.privileges.txt
 debug/system.protected_ts_meta.txt
 debug/system.protected_ts_records.txt
 debug/system.rangelog.txt
+debug/system.region_liveness.txt
 debug/system.replication_constraint_stats.txt
 debug/system.replication_critical_localities.txt
 debug/system.replication_stats.txt
@@ -416,6 +434,7 @@ debug/system.statement_diagnostics.txt
 debug/system.statement_diagnostics_requests.txt
 debug/system.statement_hints.txt
 debug/system.statement_statistics_limit_5000.txt
+debug/system.table_metadata.txt
 debug/system.table_statistics.txt
 debug/system.table_statistics_locks.txt
 debug/system.task_payloads.txt
@@ -423,6 +442,8 @@ debug/system.tenant_settings.txt
 debug/system.tenant_tasks.txt
 debug/system.tenant_usage.txt
 debug/system.tenants.txt
+debug/system.transaction_diagnostics.txt
+debug/system.transaction_diagnostics_requests.txt
 debug/system.zones.txt
 debug/tenant_ranges.err.txt
 
@@ -530,16 +551,20 @@ debug/system.database_role_settings.txt
 debug/system.descriptor.txt
 debug/system.eventlog.txt
 debug/system.external_connections.txt
+debug/system.inspect_errors.txt
 debug/system.job_info.txt
 debug/system.jobs.txt
 debug/system.lease.txt
 debug/system.locations.txt
 debug/system.migrations.txt
+debug/system.mvcc_statistics.txt
 debug/system.namespace.txt
+debug/system.prepared_transactions.txt
 debug/system.privileges.txt
 debug/system.protected_ts_meta.txt
 debug/system.protected_ts_records.txt
 debug/system.rangelog.txt
+debug/system.region_liveness.txt
 debug/system.replication_constraint_stats.txt
 debug/system.replication_critical_localities.txt
 debug/system.replication_stats.txt
@@ -557,6 +582,7 @@ debug/system.statement_diagnostics.txt
 debug/system.statement_diagnostics_requests.txt
 debug/system.statement_hints.txt
 debug/system.statement_statistics_limit_5000.txt
+debug/system.table_metadata.txt
 debug/system.table_statistics.txt
 debug/system.table_statistics_locks.txt
 debug/system.task_payloads.txt
@@ -564,6 +590,8 @@ debug/system.tenant_settings.txt
 debug/system.tenant_tasks.txt
 debug/system.tenant_usage.txt
 debug/system.tenants.txt
+debug/system.transaction_diagnostics.txt
+debug/system.transaction_diagnostics_requests.txt
 debug/system.zones.txt
 debug/tenant_ranges.err.txt
 

--- a/pkg/cli/zip_table_registry.go
+++ b/pkg/cli/zip_table_registry.go
@@ -1238,47 +1238,43 @@ var zipInternalTablesPerNode = DebugZipTableRegistry{
 // debug.zip:
 //   - system.comments: avoid downloading noise from SQL schema.
 //   - system.join_tokens: avoid downloading secret join keys.
+//   - system.span_count, system.span_stats_buckets, system.span_stats_samples,
+//     system.span_stats_tenant_boundaries, system.span_stats_unique_keys: these
+//     power Key Visualizer and unlikely to be helpful in any investigation.
 //   - system.statement_activity: historical data, usually too much to download.
 //   - system.statement_bundle_chunks: avoid downloading a large table that's
 //     hard to interpret currently.
+//   - system.statement_execution_insights: currently not be used.
+//     TODO(#104714): re-evaluate this.
 //   - system.statement_statistics: historical data, usually too much to
 //     download.
 //   - system.transaction_activity: historical data, usually too much to
 //     download.
+//   - system.transaction_execution_insights: currently not be used.
+//     TODO(#104714): re-evaluate this.
 //   - system.transaction_statistics: historical data, usually too much to
 //     download.
 //   - system.ui: avoid downloading noise from UI customizations.
 //   - system.users: avoid downloading passwords.
 //   - system.web_sessions: avoid downloading active session tokens.
 var disabledSystemTables = map[string]struct{}{
-	"system.comments":                {},
-	"system.join_tokens":             {},
-	"system.statement_activity":      {},
-	"system.statement_bundle_chunks": {},
-	"system.statement_statistics":    {},
-	"system.transaction_activity":    {},
-	"system.transaction_statistics":  {},
-	"system.ui":                      {},
-	"system.users":                   {},
-	"system.web_sessions":            {},
-}
-
-// TODO(yuzefovich): triage these tables and remove this map.
-var toBeTriaged = map[string]struct{}{
-	"system.inspect_errors":                   {},
-	"system.mvcc_statistics":                  {},
-	"system.prepared_transactions":            {},
-	"system.region_liveness":                  {},
-	"system.span_count":                       {},
-	"system.span_stats_buckets":               {},
-	"system.span_stats_samples":               {},
-	"system.span_stats_tenant_boundaries":     {},
-	"system.span_stats_unique_keys":           {},
-	"system.statement_execution_insights":     {},
-	"system.table_metadata":                   {},
-	"system.transaction_diagnostics":          {},
-	"system.transaction_diagnostics_requests": {},
-	"system.transaction_execution_insights":   {},
+	"system.comments":                       {},
+	"system.join_tokens":                    {},
+	"system.span_count":                     {},
+	"system.span_stats_buckets":             {},
+	"system.span_stats_samples":             {},
+	"system.span_stats_tenant_boundaries":   {},
+	"system.span_stats_unique_keys":         {},
+	"system.statement_activity":             {},
+	"system.statement_bundle_chunks":        {},
+	"system.statement_execution_insights":   {},
+	"system.statement_statistics":           {},
+	"system.transaction_activity":           {},
+	"system.transaction_execution_insights": {},
+	"system.transaction_statistics":         {},
+	"system.ui":                             {},
+	"system.users":                          {},
+	"system.web_sessions":                   {},
 }
 
 var zipSystemTables = DebugZipTableRegistry{
@@ -1316,6 +1312,21 @@ var zipSystemTables = DebugZipTableRegistry{
 			"created",
 			"updated",
 			"connection_type",
+		},
+	},
+	"system.inspect_errors": {
+		nonSensitiveCols: NonSensitiveColumns{
+			// 'primary_key' refers to the PK of another table which could
+			// contain PII.
+			"error_id",
+			"job_id",
+			"error_type",
+			"aost",
+			"database_id",
+			"schema_id",
+			"id",
+			"details", // 'details' contain only things added by the INSPECT, so non-sensitive
+			"crdb_internal_expiration",
 		},
 	},
 	"system.jobs": {
@@ -1383,12 +1394,32 @@ var zipSystemTables = DebugZipTableRegistry{
 			"completed_at",
 		},
 	},
+	"system.mvcc_statistics": {
+		nonSensitiveCols: NonSensitiveColumns{
+			"created_at",
+			"database_id",
+			"table_id",
+			"index_id",
+			"statistics",
+		},
+	},
 	"system.namespace": {
 		nonSensitiveCols: NonSensitiveColumns{
 			`"parentID"`,
 			`"parentSchemaID"`,
 			"name",
 			"id",
+		},
+	},
+	"system.prepared_transactions": {
+		nonSensitiveCols: NonSensitiveColumns{
+			"global_id",
+			"transaction_id",
+			"transaction_key",
+			"prepared",
+			"owner",
+			"database",
+			"heuristic",
 		},
 	},
 	"system.privileges": {
@@ -1429,6 +1460,12 @@ var zipSystemTables = DebugZipTableRegistry{
 			`"otherRangeID"`,
 			"info",
 			`"uniqueID"`,
+		},
+	},
+	"system.region_liveness": {
+		nonSensitiveCols: NonSensitiveColumns{
+			"crdb_region",
+			"unavailable_at",
 		},
 	},
 	"system.replication_constraint_stats": {
@@ -1698,6 +1735,27 @@ GROUP BY ss.aggregated_ts,
          ss.index_recommendations
 limit 5000;`,
 	},
+	"system.table_metadata": {
+		nonSensitiveCols: NonSensitiveColumns{
+			"db_id",
+			"table_id",
+			"db_name",
+			"schema_name",
+			"table_name",
+			"total_columns",
+			"total_indexes",
+			"store_ids",
+			"replication_size_bytes",
+			"total_ranges",
+			"total_live_data_bytes",
+			"total_data_bytes",
+			"perc_live_data",
+			"last_update_error",
+			"last_updated",
+			"table_type",
+			"details",
+		},
+	},
 	"system.table_statistics": {
 		// `histogram` may contain sensitive information, such as keys and non-key column data.
 		nonSensitiveCols: NonSensitiveColumns{
@@ -1777,6 +1835,34 @@ limit 5000;`,
 			"id",
 			"active",
 			"info",
+		},
+	},
+	"system.transaction_diagnostics": {
+		nonSensitiveCols: NonSensitiveColumns{
+			// `bundle_chunks` column contains diagnostic bundle bytes, which
+			// contain unredacted information such as SQL arguments and
+			// unredacted trace logs.
+			"id",
+			"transaction_fingerprint_id",
+			"statement_fingerprint_ids",
+			"transaction_fingerprint",
+			"collected_at",
+			"error",
+		},
+	},
+	"system.transaction_diagnostics_requests": {
+		nonSensitiveCols: NonSensitiveColumns{
+			"id",
+			"completed",
+			"transaction_fingerprint_id",
+			"statement_fingerprint_ids",
+			"transaction_diagnostics_id",
+			"requested_at",
+			"min_execution_latency",
+			"expires_at",
+			"sampling_probability",
+			"redacted",
+			"username",
 		},
 	},
 	"system.zones": {

--- a/pkg/cli/zip_table_registry.go
+++ b/pkg/cli/zip_table_registry.go
@@ -1234,21 +1234,53 @@ var zipInternalTablesPerNode = DebugZipTableRegistry{
 	},
 }
 
-// NB: The following system tables explicitly forbidden:
-//   - system.users: avoid downloading passwords.
-//   - system.web_sessions: avoid downloading active session tokens.
-//   - system.join_tokens: avoid downloading secret join keys.
+// disabledSystemTables contains system tables that we don't include into the
+// debug.zip:
 //   - system.comments: avoid downloading noise from SQL schema.
-//   - system.ui: avoid downloading noise from UI customizations.
+//   - system.join_tokens: avoid downloading secret join keys.
+//   - system.statement_activity: historical data, usually too much to download.
 //   - system.statement_bundle_chunks: avoid downloading a large table that's
 //     hard to interpret currently.
 //   - system.statement_statistics: historical data, usually too much to
 //     download.
-//   - system.transaction_statistics: ditto
-//   - system.statement_activity: ditto
-//   - system.transaction_activity: ditto
-//
-// A test makes this assertion in pkg/cli/zip_table_registry.go:TestNoForbiddenSystemTablesInDebugZip
+//   - system.transaction_activity: historical data, usually too much to
+//     download.
+//   - system.transaction_statistics: historical data, usually too much to
+//     download.
+//   - system.ui: avoid downloading noise from UI customizations.
+//   - system.users: avoid downloading passwords.
+//   - system.web_sessions: avoid downloading active session tokens.
+var disabledSystemTables = map[string]struct{}{
+	"system.comments":                {},
+	"system.join_tokens":             {},
+	"system.statement_activity":      {},
+	"system.statement_bundle_chunks": {},
+	"system.statement_statistics":    {},
+	"system.transaction_activity":    {},
+	"system.transaction_statistics":  {},
+	"system.ui":                      {},
+	"system.users":                   {},
+	"system.web_sessions":            {},
+}
+
+// TODO(yuzefovich): triage these tables and remove this map.
+var toBeTriaged = map[string]struct{}{
+	"system.inspect_errors":                   {},
+	"system.mvcc_statistics":                  {},
+	"system.prepared_transactions":            {},
+	"system.region_liveness":                  {},
+	"system.span_count":                       {},
+	"system.span_stats_buckets":               {},
+	"system.span_stats_samples":               {},
+	"system.span_stats_tenant_boundaries":     {},
+	"system.span_stats_unique_keys":           {},
+	"system.statement_execution_insights":     {},
+	"system.table_metadata":                   {},
+	"system.transaction_diagnostics":          {},
+	"system.transaction_diagnostics_requests": {},
+	"system.transaction_execution_insights":   {},
+}
+
 var zipSystemTables = DebugZipTableRegistry{
 	"system.database_role_settings": {
 		nonSensitiveCols: NonSensitiveColumns{

--- a/pkg/cli/zip_table_registry_test.go
+++ b/pkg/cli/zip_table_registry_test.go
@@ -143,10 +143,6 @@ func TestZipContainsAllSystemTables(t *testing.T) {
 	// disabled list.
 	var missingTables []string
 	for _, fullTableName := range allSystemTables {
-		if _, tbd := toBeTriaged[fullTableName]; tbd {
-			// TODO(yuzefovich): remove this.
-			continue
-		}
 		_, inRegistry := zipSystemTables[fullTableName]
 		_, inDisabled := disabledSystemTables[fullTableName]
 		if !inRegistry && !inDisabled {


### PR DESCRIPTION
Backport:
  * 1/1 commits from "cli: refactor TestNoForbiddenSystemTablesInDebugZip" (#161432)
  * 1/1 commits from "cli: audit omitted system tables from debug.zip" (#161697)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: low-risk supportability improvement.
