### PR TITLE
ttljob: deflake TestRowLevelTTLJobMultipleNodes

### DIFF
--- a/pkg/sql/ttl/ttljob/ttljob_test.go
+++ b/pkg/sql/ttl/ttljob/ttljob_test.go
@@ -87,7 +87,10 @@ func newRowLevelTTLTestJobTestHelper(
 		return st
 	}
 
-	jobsInterval := 2 * time.Second
+	jobsInterval := 5 * time.Second
+	if skip.Duress() {
+		jobsInterval = 30 * time.Second
+	}
 	requestFilter, _ := testutils.TestingRequestFilterRetryTxnWithPrefix(t, "ttljob-", 1)
 	baseTestingKnobs := base.TestingKnobs{
 		Server: &server.TestingKnobs{


### PR DESCRIPTION
The changes in 46a4056 included a change to shorten the job adoption interval in tests to speed up test runs and avoid timeouts.

That change made the teest flaky under slow test configs like deadlock detection, since the job would be planned before the distsql planner was aware of the other nodes in the test cluster. This caused the tests that verified the distsql plan to flake occasionally.

Raising the adoption interval when running under deadlock or stress addresses the flake.

fixes #161337
Release note: None