### PR TITLE
cspann: reduce unneccessary fixups

### DIFF
--- a/pkg/sql/vecindex/cspann/BUILD.bazel
+++ b/pkg/sql/vecindex/cspann/BUILD.bazel
@@ -67,6 +67,7 @@ go_test(
         "partition_test.go",
         "query_vector_test.go",
         "rot_test.go",
+        "searcher_fixups_test.go",
         "search_set_test.go",
     ],
     data = glob(["testdata/**"]),

--- a/pkg/sql/vecindex/cspann/fixup_merge.go
+++ b/pkg/sql/vecindex/cspann/fixup_merge.go
@@ -153,7 +153,8 @@ func (fw *fixupWorker) startMerge(
 		// is not yet normalized.
 		fw.tempIndexCtx.Init(txn)
 		fw.index.setupContext(&fw.tempIndexCtx, fw.treeKey, metadata.Level+1, SearchOptions{
-			SkipRerank: true,
+			SkipRerank:              true,
+			DisableSplitMergeFixups: !fw.index.options.IsDeterministic,
 		})
 		fw.tempIndexCtx.query.InitCentroid(fw.index.quantizer.GetDistanceMetric(), metadata.Centroid)
 

--- a/pkg/sql/vecindex/cspann/fixup_split.go
+++ b/pkg/sql/vecindex/cspann/fixup_split.go
@@ -537,8 +537,9 @@ func (fw *fixupWorker) reassignFromSameLevel(
 			// has already been randomized, but is not yet normalized.
 			fw.tempIndexCtx.Init(txn)
 			fw.index.setupContext(&fw.tempIndexCtx, fw.treeKey, metadata.Level, SearchOptions{
-				BaseBeamSize: fw.index.options.BaseBeamSize * 2,
-				SkipRerank:   true,
+				BaseBeamSize:            fw.index.options.BaseBeamSize * 2,
+				SkipRerank:              true,
+				DisableSplitMergeFixups: !fw.index.options.IsDeterministic,
 			})
 			fw.tempIndexCtx.query.InitCentroid(fw.index.quantizer.GetDistanceMetric(), metadata.Centroid)
 

--- a/pkg/sql/vecindex/cspann/index.go
+++ b/pkg/sql/vecindex/cspann/index.go
@@ -127,6 +127,11 @@ type SearchOptions struct {
 	// UpdateStats specifies whether index statistics will be modified by this
 	// search. These stats are used for adaptive search.
 	UpdateStats bool
+	// DisableSplitMergeFixups disables enqueueing background split/merge fixups
+	// based on partition sizes observed during the search. This is useful for
+	// internal maintenance searches that are immediately followed by vector
+	// moves, which can render the size check stale.
+	DisableSplitMergeFixups bool
 }
 
 // Context contains per-thread state needed during index operations. Callers

--- a/pkg/sql/vecindex/cspann/searcher.go
+++ b/pkg/sql/vecindex/cspann/searcher.go
@@ -450,22 +450,24 @@ func (s *levelSearcher) searchChildPartitions(
 			}
 		}
 
-		// Enqueue background fixup if a split or merge operation needs to be
-		// started or continued after stalling. Split if the partition is over-
-		// sized. Merge if the partition is under-sized and if there are multiple
-		// search partitions, indicating there are siblings/cousins.
-		state := s.idxCtx.tempToSearch[i].StateDetails
-		needSplit := count > s.idx.options.MaxPartitionSize
-		needSplit = needSplit || state.MaybeSplitStalled(s.idx.options.StalledOpTimeout())
-		needMerge := count < s.idx.options.MinPartitionSize && len(parentResults) > 1 &&
-			state.State.AllowMerge()
-		needMerge = needMerge || state.MaybeMergeStalled(s.idx.options.StalledOpTimeout())
-		if needSplit {
-			s.idx.fixups.AddSplit(ctx, s.idxCtx.treeKey,
-				parentResults[i].ParentPartitionKey, partitionKey, false /* singleStep */)
-		} else if needMerge {
-			s.idx.fixups.AddMerge(ctx, s.idxCtx.treeKey,
-				parentResults[i].ParentPartitionKey, partitionKey, false /* singleStep */)
+		if !s.idxCtx.options.DisableSplitMergeFixups {
+			// Enqueue background fixup if a split or merge operation needs to be
+			// started or continued after stalling. Split if the partition is over-
+			// sized. Merge if the partition is under-sized and if there are multiple
+			// search partitions, indicating there are siblings/cousins.
+			state := s.idxCtx.tempToSearch[i].StateDetails
+			needSplit := count > s.idx.options.MaxPartitionSize
+			needSplit = needSplit || state.MaybeSplitStalled(s.idx.options.StalledOpTimeout())
+			needMerge := count < s.idx.options.MinPartitionSize && len(parentResults) > 1 && state.State.AllowMerge()
+			needMerge = needMerge || state.MaybeMergeStalled(s.idx.options.StalledOpTimeout())
+
+			if needSplit {
+				s.idx.fixups.AddSplit(ctx, s.idxCtx.treeKey,
+					parentResults[i].ParentPartitionKey, partitionKey, false /* singleStep */)
+			} else if needMerge {
+				s.idx.fixups.AddMerge(ctx, s.idxCtx.treeKey,
+					parentResults[i].ParentPartitionKey, partitionKey, false /* singleStep */)
+			}
 		}
 	}
 

--- a/pkg/sql/vecindex/cspann/searcher_fixups_test.go
+++ b/pkg/sql/vecindex/cspann/searcher_fixups_test.go
@@ -1,0 +1,171 @@
+package cspann_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/cspann"
+	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/cspann/memstore"
+	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/cspann/quantize"
+	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/vecpb"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/vector"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSearchOptionsDisableSplitMergeFixupsSplit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	for _, tc := range []struct {
+		name    string
+		disable bool
+		want    int
+	}{
+		{name: "enabled", disable: false, want: 1},
+		{name: "disabled", disable: true, want: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stopper := stop.NewStopper()
+			defer stopper.Stop(ctx)
+
+			q := quantize.NewUnQuantizer(2, vecpb.L2SquaredDistance)
+			store := memstore.New(q, 42)
+			opts := cspann.IndexOptions{
+				RotAlgorithm:          vecpb.RotNone,
+				IsDeterministic:       true,
+				DisableAdaptiveSearch: true,
+				MinPartitionSize:      1,
+				MaxPartitionSize:      2,
+				MaxWorkers:            1,
+			}
+			idx, err := cspann.NewIndex(ctx, store, q, 42, &opts, stopper)
+			require.NoError(t, err)
+
+			treeKey := memstore.ToTreeKey(1)
+			rootMD := cspann.MakeReadyPartitionMetadata(cspann.LeafLevel, make(vector.T, q.GetDims()))
+			require.NoError(t, store.TryCreateEmptyPartition(ctx, treeKey, cspann.RootKey, rootMD))
+
+			require.NoError(t, store.RunTransaction(ctx, func(txn cspann.Txn) error {
+				if err := txn.AddToPartition(ctx, treeKey, cspann.RootKey, cspann.LeafLevel, vector.T{0, 0},
+					cspann.ChildKey{KeyBytes: cspann.KeyBytes("a")}, nil); err != nil {
+					return err
+				}
+				if err := txn.AddToPartition(ctx, treeKey, cspann.RootKey, cspann.LeafLevel, vector.T{1, 1},
+					cspann.ChildKey{KeyBytes: cspann.KeyBytes("b")}, nil); err != nil {
+					return err
+				}
+				if err := txn.AddToPartition(ctx, treeKey, cspann.RootKey, cspann.LeafLevel, vector.T{2, 2},
+					cspann.ChildKey{KeyBytes: cspann.KeyBytes("c")}, nil); err != nil {
+					return err
+				}
+				return nil
+			}))
+			require.Equal(t, 0, idx.Fixups().PendingSplitsMerges())
+
+			require.NoError(t, store.RunTransaction(ctx, func(txn cspann.Txn) error {
+				var idxCtx cspann.Context
+				idxCtx.Init(txn)
+
+				searchSet := cspann.SearchSet{MaxResults: 1}
+				return idx.Search(ctx, &idxCtx, treeKey, vector.T{0, 0}, &searchSet, cspann.SearchOptions{
+					SkipRerank:              true,
+					DisableSplitMergeFixups: tc.disable,
+				})
+			}))
+
+			require.Equal(t, tc.want, idx.Fixups().PendingSplitsMerges())
+		})
+	}
+}
+
+func TestSearchOptionsDisableSplitMergeFixupsMerge(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	for _, tc := range []struct {
+		name    string
+		disable bool
+		want    int
+	}{
+		{name: "enabled", disable: false, want: 1},
+		{name: "disabled", disable: true, want: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stopper := stop.NewStopper()
+			defer stopper.Stop(ctx)
+
+			q := quantize.NewUnQuantizer(2, vecpb.L2SquaredDistance)
+			store := memstore.New(q, 42)
+			opts := cspann.IndexOptions{
+				RotAlgorithm:          vecpb.RotNone,
+				IsDeterministic:       true,
+				DisableAdaptiveSearch: true,
+				MinPartitionSize:      2,
+				MaxPartitionSize:      128,
+				BaseBeamSize:          2,
+				MaxWorkers:            1,
+			}
+			idx, err := cspann.NewIndex(ctx, store, q, 42, &opts, stopper)
+			require.NoError(t, err)
+
+			treeKey := memstore.ToTreeKey(1)
+
+			leaf1 := store.MakePartitionKey()
+			leaf2 := store.MakePartitionKey()
+
+			leaf1MD := cspann.MakeReadyPartitionMetadata(cspann.LeafLevel, vector.T{0, 0})
+			leaf2MD := cspann.MakeReadyPartitionMetadata(cspann.LeafLevel, vector.T{10, 10})
+			require.NoError(t, store.TryCreateEmptyPartition(ctx, treeKey, leaf1, leaf1MD))
+			require.NoError(t, store.TryCreateEmptyPartition(ctx, treeKey, leaf2, leaf2MD))
+
+			rootMD := cspann.MakeReadyPartitionMetadata(cspann.SecondLevel, make(vector.T, q.GetDims()))
+			require.NoError(t, store.TryCreateEmptyPartition(ctx, treeKey, cspann.RootKey, rootMD))
+
+			require.NoError(t, store.RunTransaction(ctx, func(txn cspann.Txn) error {
+				if err := txn.AddToPartition(ctx, treeKey, cspann.RootKey, cspann.SecondLevel, leaf1MD.Centroid,
+					cspann.ChildKey{PartitionKey: leaf1}, nil); err != nil {
+					return err
+				}
+				if err := txn.AddToPartition(ctx, treeKey, cspann.RootKey, cspann.SecondLevel, leaf2MD.Centroid,
+					cspann.ChildKey{PartitionKey: leaf2}, nil); err != nil {
+					return err
+				}
+
+				// leaf1 is under-sized, leaf2 is not.
+				if err := txn.AddToPartition(ctx, treeKey, leaf1, cspann.LeafLevel, vector.T{0, 0},
+					cspann.ChildKey{KeyBytes: cspann.KeyBytes("a")}, nil); err != nil {
+					return err
+				}
+				if err := txn.AddToPartition(ctx, treeKey, leaf2, cspann.LeafLevel, vector.T{10, 10},
+					cspann.ChildKey{KeyBytes: cspann.KeyBytes("b")}, nil); err != nil {
+					return err
+				}
+				if err := txn.AddToPartition(ctx, treeKey, leaf2, cspann.LeafLevel, vector.T{11, 11},
+					cspann.ChildKey{KeyBytes: cspann.KeyBytes("c")}, nil); err != nil {
+					return err
+				}
+				return nil
+			}))
+			require.Equal(t, 0, idx.Fixups().PendingSplitsMerges())
+
+			require.NoError(t, store.RunTransaction(ctx, func(txn cspann.Txn) error {
+				var idxCtx cspann.Context
+				idxCtx.Init(txn)
+
+				searchSet := cspann.SearchSet{MaxResults: 1}
+				return idx.Search(ctx, &idxCtx, treeKey, vector.T{0, 0}, &searchSet, cspann.SearchOptions{
+					BaseBeamSize:            2,
+					SkipRerank:              true,
+					DisableSplitMergeFixups: tc.disable,
+				})
+			}))
+
+			require.Equal(t, tc.want, idx.Fixups().PendingSplitsMerges())
+		})
+	}
+}


### PR DESCRIPTION
- Added SearchOptions.DisableSplitMergeFixups (`pkg/sql/vecindex/cspann/index.go:117`), whereby the searcher skips ‘size-based’ split/merge fixups when this option is enabled enqueue operations (stalled-op fixups are still enqueued) (`pkg/sql/vecindex/cspann/searcher.go:453`).
- The internal search for reassignFromSameLevel / startMerge enables this option under non-deterministic indexes, preventing the enqueuing of potentially stale fixups before subsequent TryMoveVector operations alter partition sizes enqueue a batch of potentially stale fixups before TryMoveVector alters partition size (`pkg/sql/vecindex/cspann/fixup_split.go:539`, `pkg/sql/vecindex/cspann/fixup_merge.go:145`).
- Added test pkg/sql/vecindex/cspann/searcher_fixups_test.go and included Bazel target (`pkg/sql/vecindex/cspann/BUILD.bazel:55`); `bazel test //pkg/sql/vecindex/cspann:cspann_test` has been run.

Epic: None
Release: None