### PR TITLE
tree: walk all of Insert, Delete, and Update

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/statement_hint_builtins
+++ b/pkg/sql/opt/exec/execbuilder/testdata/statement_hint_builtins
@@ -1420,3 +1420,99 @@ FROM crdb_internal.node_metrics
 WHERE name = 'sql.query.with_statement_hints.count'
 ----
 true
+
+# Test hints in update and delete statements.
+
+query T
+EXPLAIN UPDATE abc SET c = c + 1 WHERE a > 5 AND b = 6
+----
+distribution: local
+·
+• update
+│ table: abc
+│ set: c
+│ auto commit
+│
+└── • render
+    │
+    └── • index join
+        │ table: abc@abc_pkey
+        │ locking strength: for update
+        │
+        └── • scan
+              missing stats
+              table: abc@abc_b_idx
+              spans: [/6/6 - /6]
+              locking strength: for update
+
+statement ok
+SELECT information_schema.crdb_rewrite_inline_hints(
+  'UPDATE abc SET c = c + _ WHERE (a > _) AND (b = _)',
+  'UPDATE abc@abc_pkey SET c = c + _ WHERE (a > _) AND (b = _)'
+);
+
+statement ok
+SELECT crdb_internal.await_statement_hints_cache()
+
+query T
+EXPLAIN UPDATE abc SET c = c + 1 WHERE a > 5 AND b = 6
+----
+distribution: local
+statement hints count: 1
+·
+• update
+│ table: abc
+│ set: c
+│ auto commit
+│
+└── • render
+    │
+    └── • filter
+        │ filter: b = 6
+        │
+        └── • scan
+              missing stats
+              table: abc@abc_pkey
+              spans: [/6 - ]
+
+query T
+EXPLAIN DELETE FROM abc WHERE a > 5 AND b = 6
+----
+distribution: local
+·
+• delete
+│ from: abc
+│ auto commit
+│
+└── • scan
+      missing stats
+      table: abc@abc_b_idx
+      spans: [/6/6 - /6]
+      locking strength: for update
+
+statement ok
+SELECT information_schema.crdb_rewrite_inline_hints(
+  'DELETE FROM abc WHERE (a > _) AND (b = _)',
+  'DELETE FROM abc@abc_pkey WHERE (a > _) AND (b = _)'
+);
+
+statement ok
+SELECT crdb_internal.await_statement_hints_cache()
+
+query T
+EXPLAIN DELETE FROM abc WHERE a > 5 AND b = 6
+----
+distribution: local
+statement hints count: 1
+·
+• delete
+│ from: abc
+│ auto commit
+│
+└── • filter
+    │ filter: b = 6
+    │
+    └── • scan
+          missing stats
+          table: abc@abc_pkey
+          spans: [/6 - ]


### PR DESCRIPTION
Teach ExtendedVisitor to walk all of Insert, Delete, and Update AST nodes. This allows hint injection for mutation statements.

Fixes: #161729

Release note (bug fix): Fix a bug which prevented successfully injecting hints using `information_schema.crdb_rewrite_inline_hints` for INSERT, UPSERT, UPDATE, and DELETE statements. This bug has existed since hint injection was introduced in v26.1.0-alpha.2.