### PR TITLE
backup: fix aost bug in GetSystemTableIDsToExcludeFromClusterBackup

### DIFF
--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -3867,8 +3867,6 @@ func TestRestoreAsOfSystemTimeGCBounds(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.WithIssue(t, 161220)
-
 	const numAccounts = 10
 	ctx := context.Background()
 	args := base.TestClusterArgs{}

--- a/pkg/backup/targets.go
+++ b/pkg/backup/targets.go
@@ -73,7 +73,9 @@ func getRelevantDescChanges(
 	// point in the interval.
 	interestingIDs := make(map[descpb.ID]struct{}, len(descriptors))
 
-	systemTableIDsToExcludeFromBackup, err := GetSystemTableIDsToExcludeFromClusterBackup(ctx, execCfg)
+	systemTableIDsToExcludeFromBackup, err := GetSystemTableIDsToExcludeFromClusterBackup(
+		ctx, execCfg, endTime,
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Previously, this function asked the catalog for descriptors without specifying a timestamp, which would result in reading them as of the current time. This fix specifies the read timestamp to be the backup's end time.

Informs: #161220

Release note: None