### PR TITLE
release-26.1: sql: increase page size when iterating over range descs

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -4534,7 +4534,7 @@ CREATE TABLE crdb_internal.ranges_no_leases (
 		}
 
 		execCfg := p.ExecCfg()
-		pageSize := int64(128)
+		pageSize := int64(10000)
 		if limit > 0 {
 			pageSize = min(limit, pageSize)
 		}


### PR DESCRIPTION
Backport 1/1 commits from #161162 on behalf of @yuzefovich.

----

Empirical testing has showed that if we increase the page size when iterating over the range descriptors for
`crdb_internal.ranges_no_leases`, we get a minor performance improvement. Thus, this commit bumps the page size from 128 to 10k. Going higher didn't show any meaningful difference because the overhead of the virtual table generation dominated. (Testing was done on a single region cluster, so _perhaps_ it could benefit from still higher page size in multi-region clusters, but I don't think it would matter much in practice still.)

Informs: #160196.
Epic: None
Release note: None

----

Release justification: low-risk improvement for large clusters.