### PR TITLE
sql: improve error messages for indexes with implicit partitioning columns

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_hash_sharded_index
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_hash_sharded_index
@@ -43,13 +43,13 @@ CREATE TABLE t_partition_all (
    PARTITION us_east VALUES IN (('new york'))
 );
 
-statement error hash sharded indexes cannot include implicit partitioning columns from "PARTITION ALL BY" or "LOCALITY REGIONAL BY ROW"
+statement error cannot explicitly include implicit partitioning columns from "PARTITION ALL BY" in index definition
 CREATE INDEX ON t_partition_all (b, c) USING HASH;
 
-statement error hash sharded indexes cannot include implicit partitioning columns from "PARTITION ALL BY" or "LOCALITY REGIONAL BY ROW"
+statement error cannot explicitly include implicit partitioning columns from "PARTITION ALL BY" in index definition
 CREATE UNIQUE INDEX ON t_partition_all (b, c) USING HASH;
 
-statement error hash sharded indexes cannot include implicit partitioning columns from "PARTITION ALL BY" or "LOCALITY REGIONAL BY ROW"
+statement error hash sharded indexes cannot include implicit partitioning columns from "PARTITION ALL BY"
 ALTER TABLE t_partition_all ALTER PRIMARY KEY USING COLUMNS (b) USING HASH;
 
 statement error hash sharded indexes cannot be explicitly partitioned
@@ -82,7 +82,7 @@ CREATE TABLE t_idx_hashed_bad (
   )
 );
 
-statement error hash sharded indexes cannot include implicit partitioning columns from "PARTITION ALL BY" or "LOCALITY REGIONAL BY ROW"
+statement error hash sharded indexes cannot include implicit partitioning columns from "PARTITION ALL BY"
 CREATE TABLE t_idx_hashed_bad (
   a INT PRIMARY KEY,
   b STRING,

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_index
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_index
@@ -12,23 +12,29 @@ CREATE TABLE t_regional (
   b INT
 ) LOCALITY REGIONAL BY ROW;
 
-statement error hash sharded indexes cannot include implicit partitioning columns from "PARTITION ALL BY" or "LOCALITY REGIONAL BY ROW"
+statement error cannot explicitly include implicit partitioning columns from "LOCALITY REGIONAL BY ROW" in index definition
 CREATE INDEX ON t_regional (crdb_region, b) USING HASH;
 
-statement error hash sharded indexes cannot include implicit partitioning columns from "PARTITION ALL BY" or "LOCALITY REGIONAL BY ROW"
+statement error cannot explicitly include implicit partitioning columns from "LOCALITY REGIONAL BY ROW" in index definition
+CREATE INDEX ON t_regional USING btree(crdb_region, b);
+
+statement error cannot explicitly include implicit partitioning columns from "LOCALITY REGIONAL BY ROW" in index definition
 CREATE UNIQUE INDEX ON t_regional (crdb_region, b) USING HASH;
 
-statement error hash sharded indexes cannot include implicit partitioning columns from "PARTITION ALL BY" or "LOCALITY REGIONAL BY ROW"
+statement error cannot explicitly include implicit partitioning columns from "LOCALITY REGIONAL BY ROW" in index definition
+CREATE UNIQUE INDEX ON t_regional USING btree(crdb_region, b);
+
+statement error hash sharded indexes cannot include implicit partitioning columns from "LOCALITY REGIONAL BY ROW"
 ALTER TABLE t_regional ALTER PRIMARY KEY USING COLUMNS (crdb_region, pk) USING HASH;
 
-statement error hash sharded indexes cannot include implicit partitioning columns from "PARTITION ALL BY" or "LOCALITY REGIONAL BY ROW"
+statement error hash sharded indexes cannot include implicit partitioning columns from "LOCALITY REGIONAL BY ROW"
 CREATE TABLE t_regional_bad (
   pk INT PRIMARY KEY,
   b INT,
   INDEX (crdb_region, b) USING HASH
 ) LOCALITY REGIONAL BY ROW;
 
-statement error hash sharded indexes cannot include implicit partitioning columns from "PARTITION ALL BY" or "LOCALITY REGIONAL BY ROW"
+statement error hash sharded indexes cannot include implicit partitioning columns from "LOCALITY REGIONAL BY ROW"
 CREATE TABLE t_regional_bad (
   pk INT,
   b INT,

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-no-los/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-no-los/generated_test.go
@@ -195,11 +195,11 @@ func TestCCLLogic_regional_by_row_foreign_key(
 	runCCLLogicTest(t, "regional_by_row_foreign_key")
 }
 
-func TestCCLLogic_regional_by_row_hash_sharded_index(
+func TestCCLLogic_regional_by_row_index(
 	t *testing.T,
 ) {
 	defer leaktest.AfterTest(t)()
-	runCCLLogicTest(t, "regional_by_row_hash_sharded_index")
+	runCCLLogicTest(t, "regional_by_row_index")
 }
 
 func TestCCLLogic_regional_by_row_placement_restricted(

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs/generated_test.go
@@ -237,18 +237,18 @@ func TestCCLLogic_regional_by_row_foreign_key(
 	runCCLLogicTest(t, "regional_by_row_foreign_key")
 }
 
-func TestCCLLogic_regional_by_row_hash_sharded_index(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runCCLLogicTest(t, "regional_by_row_hash_sharded_index")
-}
-
 func TestCCLLogic_regional_by_row_hash_sharded_index_query_plan(
 	t *testing.T,
 ) {
 	defer leaktest.AfterTest(t)()
 	runCCLLogicTest(t, "regional_by_row_hash_sharded_index_query_plan")
+}
+
+func TestCCLLogic_regional_by_row_index(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "regional_by_row_index")
 }
 
 func TestCCLLogic_regional_by_row_insert_fast_path(

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -662,10 +662,12 @@ func setupShardedIndex(
 			return nil, nil, err
 		}
 		if anyColumnIsPartitioningField(columns, partitionAllBy) {
-			return nil, nil, pgerror.New(
-				pgcode.FeatureNotSupported,
-				`hash sharded indexes cannot include implicit partitioning columns from "PARTITION ALL BY" or "LOCALITY REGIONAL BY ROW"`,
-			)
+			isRegionalByRow := tableDesc.IsLocalityRegionalByRow()
+			if isRegionalByRow {
+				return nil, nil, sqlerrors.HashIndexIncludesImplicitPartitionColFromRBR
+			} else {
+				return nil, nil, sqlerrors.HashIndexIncludesImplicitPartitionColFromPartitionAllBy
+			}
 		}
 	}
 

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
@@ -1268,6 +1268,13 @@ func panicIfRegionChangeUnderwayOnRBRTable(b BuildCtx, op redact.SafeString, tab
 	}
 }
 
+// isTableLocalityRegionalByRow returns true if the table has LOCALITY REGIONAL BY ROW.
+func isTableLocalityRegionalByRow(b BuildCtx, tableID catid.DescID) bool {
+	tableElems := b.QueryByID(tableID)
+	rbrElem := tableElems.FilterTableLocalityRegionalByRow().MustGetZeroOrOneElement()
+	return rbrElem != nil
+}
+
 // haveSameIndexColsByKind returns true if two indexes have the same index
 // columns of a particular kind.
 func haveSameIndexColsByKind(

--- a/pkg/sql/sqlerrors/errors.go
+++ b/pkg/sql/sqlerrors/errors.go
@@ -584,6 +584,34 @@ var QueryTimeoutError = pgerror.New(
 var TxnTimeoutError = pgerror.New(
 	pgcode.QueryCanceled, "query execution canceled due to transaction timeout")
 
+// HashIndexIncludesImplicitPartitionColFromRBR shows that hash sharded index cannot include
+// implicit cols from an RBR table.
+var HashIndexIncludesImplicitPartitionColFromRBR = pgerror.New(
+	pgcode.FeatureNotSupported,
+	`hash sharded indexes cannot include implicit partitioning columns from "LOCALITY REGIONAL BY ROW"`,
+)
+
+// HashIndexIncludesImplicitPartitionColFromPartitionAllBy shows that hash sharded index cannot include
+// implicit cols from a PARTITION ALL BY table.
+var HashIndexIncludesImplicitPartitionColFromPartitionAllBy = pgerror.New(
+	pgcode.FeatureNotSupported,
+	`hash sharded indexes cannot include implicit partitioning columns from "PARTITION ALL BY"`,
+)
+
+// NewIndexIncludesImplicitPartitionColFromRBR shows that the newly created index cannot include
+// implicit cols from an RBR table.
+var NewIndexIncludesImplicitPartitionColFromRBR = pgerror.New(
+	pgcode.FeatureNotSupported,
+	`cannot explicitly include implicit partitioning columns from "LOCALITY REGIONAL BY ROW" in index definition`,
+)
+
+// NewIndexIncludeImplicitPartitionColFromPartitionAllBy shows that the newly created index cannot include
+// implicit cols from a PARTITION ALL BY table.
+var NewIndexIncludeImplicitPartitionColFromPartitionAllBy = pgerror.New(
+	pgcode.FeatureNotSupported,
+	`cannot explicitly include implicit partitioning columns from "PARTITION ALL BY" in index definition`,
+)
+
 // IsOutOfMemoryError checks whether this is an out of memory error.
 func IsOutOfMemoryError(err error) bool {
 	return errHasCode(err, pgcode.OutOfMemory)


### PR DESCRIPTION
This commit improves error messages when users attempt to create indexes that explicitly include implicit partitioning columns. We now differentiate error messages between PARTITION ALL BY and LOCALITY REGIONAL BY ROW tables for better clarity.

Epic: None
Release Note: None