### PR TITLE
catalog/lease: ensure descriptor consistency after timestamp refreshes

### DIFF
--- a/pkg/sql/catalog/descs/leased_descriptors.go
+++ b/pkg/sql/catalog/descs/leased_descriptors.go
@@ -216,6 +216,7 @@ func (ld *leasedDescriptors) maybeAssertExternalRowDataTS(desc catalog.Descripto
 	})
 }
 
+// maybeReleaseReadTimestamp releases the read timestamp if one is set.
 func (ld *leasedDescriptors) maybeReleaseReadTimestamp(ctx context.Context) {
 	if !ld.leaseTimestampSet {
 		return
@@ -225,27 +226,86 @@ func (ld *leasedDescriptors) maybeReleaseReadTimestamp(ctx context.Context) {
 	ld.leaseTimestamp = nil
 }
 
+// maybeAdvanceReadTimestamp advances the read timestamp for the lease manager, if we know
+// that descriptor versions accessed have not been modified at the newer timestamp. Otherwise,
+// a retry error is generated.
+func (ld *leasedDescriptors) maybeAdvanceReadTimestamp(
+	ctx context.Context, txn deadlineHolder,
+) error {
+	// Read timestamp has advanced, so see if a new lease timestamp exists.
+	newLeaseTimestamp := ld.lm.GetReadTimestamp(ctx, txn.ReadTimestamp())
+	leaseToRelease := newLeaseTimestamp
+	defer func() {
+		leaseToRelease.Release(ctx)
+	}()
+	// If the new lease timestamp is the same, nothing needs to be done.
+	// Note: We can safely compare interface pointers because each timestamp,
+	// inside the lease manager has a single shared reference / pointer.
+	if newLeaseTimestamp == ld.leaseTimestamp {
+		return nil
+	}
+	upgradeTimestamp := func() {
+		leaseToRelease = ld.leaseTimestamp
+		ld.leaseTimestamp = newLeaseTimestamp
+	}
+	// If locked leasing is disabled, then we can refresh the timestamp directly.
+	if ld.leaseTimestamp.GetTimestamp() == ld.leaseTimestamp.GetBaseTimestamp() {
+		upgradeTimestamp()
+		return nil
+	}
+	// Otherwise, we need to rescan all descriptors used by this transaction
+	// to confirm their version has not changed at the newer timestamp.
+	err := ld.cache.IterateByID(func(entry catalog.NameEntry) error {
+		// We expect this cache to only store the type of LeasedDescriptor,
+		// so if we ever don't retrieve the correct type then assert below.
+		desc, ok := entry.(lease.LeasedDescriptor)
+		if !ok {
+			return errors.AssertionFailedf("expected leased descriptor, got %T", entry)
+		}
+		newDesc, err := ld.lm.Acquire(ctx, newLeaseTimestamp, desc.GetID())
+		if err != nil {
+			return err
+		}
+		defer newDesc.Release(ctx)
+		if newDesc.Underlying().GetVersion() != desc.Underlying().GetVersion() {
+			// Descriptor used earlier in this transaction was modified,
+			// we are no longer able to upgrade the timestamp.
+			return &retryOnModifiedDescriptor{
+				descName:      desc.GetName(),
+				descID:        desc.GetID(),
+				expiration:    newDesc.Underlying().GetModificationTime(),
+				readTimestamp: txn.ReadTimestamp(),
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	upgradeTimestamp()
+	return nil
+}
+
 // maybeInitReadTimestamp selects a read timestamp for the lease manager.
-func (ld *leasedDescriptors) maybeInitReadTimestamp(ctx context.Context, txn deadlineHolder) {
+func (ld *leasedDescriptors) maybeInitReadTimestamp(ctx context.Context, txn deadlineHolder) error {
 	// Refresh the leased timestamp if the read timestamp has changed on us
 	// or if it hasn't been populated yet.
 	if ld.leaseTimestampSet &&
 		ld.leaseTimestamp.GetBaseTimestamp() == txn.ReadTimestamp() {
-		return
+		return nil
 	} else if ld.leaseTimestampSet {
-		// Timestamp is already set, so release it before picking a new one.
-		// See #159355 can handle this better for correctness.
-		ld.maybeReleaseReadTimestamp(ctx)
+		return ld.maybeAdvanceReadTimestamp(ctx, txn)
 	}
 	readTimestamp := txn.ReadTimestamp()
 	ld.leaseTimestampSet = true
 	// Fixed timestamp queries will use descriptors at the user-selected timestamp.
 	if txn.ReadTimestampFixed() {
 		ld.leaseTimestamp = lease.TimestampToReadTimestamp(readTimestamp)
-		return
+		return nil
 	}
 	// Otherwise, get a safe read timestamp from the lease manager.
 	ld.leaseTimestamp = ld.lm.GetReadTimestamp(ctx, readTimestamp)
+	return nil
 }
 
 // ensureLeasesExist requests that the lease manager acquire leases for the
@@ -279,7 +339,9 @@ func (ld *leasedDescriptors) getByName(
 		desc = cached.(lease.LeasedDescriptor).Underlying()
 		return desc, false, nil
 	}
-	ld.maybeInitReadTimestamp(ctx, txn)
+	if err := ld.maybeInitReadTimestamp(ctx, txn); err != nil {
+		return nil, false, err
+	}
 	timestamp := ld.leaseTimestamp
 	if withoutLockedTimestamp {
 		timestamp = lease.TimestampToReadTimestamp(txn.ReadTimestamp())
@@ -298,7 +360,9 @@ func (ld *leasedDescriptors) getByID(
 	if cached := ld.getCachedByID(ctx, id); cached != nil {
 		return cached, false, nil
 	}
-	ld.maybeInitReadTimestamp(ctx, txn)
+	if err := ld.maybeInitReadTimestamp(ctx, txn); err != nil {
+		return nil, false, err
+	}
 	timestamp := ld.leaseTimestamp
 	if withoutLockedTimestamp {
 		timestamp = lease.TimestampToReadTimestamp(txn.ReadTimestamp())

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -4196,3 +4196,115 @@ func TestLeaseBeforeGC(t *testing.T) {
 	require.NoError(t, err)
 	defer systemDesc.Release(ctx)
 }
+
+// TestLeaseManagerTxnTimestampAdvance confirms that locked timestamp leasing will maintain
+// safety (by restarting the transaction) if the transaction timestamp is advanced
+// beyond the validity window of a leased descriptor.
+func TestLeaseManagerTxnTimestampAdvance(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testutils.RunTrueAndFalse(t, "with-schema-change", func(t *testing.T, withSchemaChange bool) {
+		st := cluster.MakeTestingClusterSettings()
+		ctx := context.Background()
+		lease.LockedLeaseTimestamp.Override(ctx, &st.SV, true)
+
+		var versionToBlock atomic.Int64
+		versionWaitCh := make(chan struct{})
+		versionContinueCh := make(chan struct{})
+		startSchemaChange := make(chan struct{})
+		defer close(startSchemaChange)
+
+		knobs := base.TestingKnobs{
+			SQLLeaseManager: &lease.ManagerTestingKnobs{
+				TestingDescriptorRefreshedEvent: func(descriptor *descpb.Descriptor) {
+					tbl, _, _, _, _ := descpb.GetDescriptors(descriptor)
+					if tbl != nil && versionToBlock.Load() == int64(tbl.ID) {
+						versionWaitCh <- struct{}{}
+						<-versionContinueCh
+					}
+				},
+			},
+		}
+
+		ts, conn, _ := serverutils.StartServer(t, base.TestServerArgs{Settings: st, Knobs: knobs})
+		defer ts.Stopper().Stop(ctx)
+
+		runner := sqlutils.MakeSQLRunner(conn)
+		runner.Exec(t, "SET CLUSTER SETTING sql.catalog.allow_leased_descriptors.enabled = true")
+		runner.Exec(t, "CREATE TABLE t1(id INT PRIMARY KEY, n INT)")
+		runner.Exec(t, "CREATE TABLE t2(n int)")
+		runner.Exec(t, "CREATE TABLE t3(n int)")
+		runner.Exec(t, "INSERT INTO t1 VALUES (1, 100)")
+
+		var tblID int64
+		runner.QueryRow(t, "SELECT 't1'::REGCLASS::OID").Scan(&tblID)
+
+		grp := ctxgroup.WithContext(ctx)
+		if withSchemaChange {
+			versionToBlock.Store(tblID)
+			// Start schema change in background.
+			grp.GoCtx(func(ctx context.Context) error {
+				<-startSchemaChange
+				_, err := conn.Exec("ALTER TABLE t1 ADD COLUMN j int")
+				return err
+			})
+		}
+
+		tx, err := conn.BeginTx(ctx, &gosql.TxOptions{Isolation: gosql.LevelSerializable})
+		require.NoError(t, err)
+		txnCommitted := false
+		defer func() {
+			if txnCommitted {
+				return
+			}
+			require.NoError(t, tx.Rollback())
+		}()
+
+		// 1. Establish Read Timestamp and Spans (Lease Acquisition)
+		_, err = tx.Exec("SELECT * FROM t1 WHERE id = 999")
+		require.NoError(t, err)
+		// 2. Wait for Schema Change to be blocked (modifying descriptor)
+		if withSchemaChange {
+			startSchemaChange <- struct{}{}
+			<-versionWaitCh
+		}
+
+		// 3. Concurrent Write (advances potential timestamp) - Synchronous
+		_, err = conn.Exec("UPDATE t1 SET n = 200 WHERE id = 1")
+		require.NoError(t, err)
+
+		// 4. Unblock Schema Change.
+		if withSchemaChange {
+			versionToBlock.Store(0)
+			close(versionContinueCh)
+		}
+
+		// 5. Txn Write (triggers WriteTooOld -> Refresh -> Timestamp Advance)
+		// Establish read dependency on t2.
+		_, err = tx.Exec("SELECT * FROM t2")
+		require.NoError(t, err)
+
+		_, err = tx.Exec("UPDATE t1 SET n = 300 WHERE id = 1")
+		require.NoError(t, err)
+
+		// 6. Verification trying to access another descriptor, with
+		// the newer timestamp.
+		_, stmtErr := tx.Exec("SELECT 't3'::REGCLASS::OID")
+
+		if withSchemaChange {
+			require.Error(t, stmtErr, "expected error due to stale lease timestamp")
+			require.Regexpf(t,
+				`pq: restart transaction: the descriptor t1\(\d+\) has been modified at timestamp.*`,
+				stmtErr.Error(),
+				"unexpected qerror message")
+			require.NoError(t, tx.Rollback())
+			txnCommitted = true
+		} else {
+			require.NoError(t, stmtErr)
+			require.NoError(t, tx.Commit())
+			txnCommitted = true
+		}
+		require.NoError(t, grp.Wait())
+	})
+}


### PR DESCRIPTION
Previously, when using locked timestamp leasing, moving the transaction read timestamp forward could lead to inconsistencies. The system incorrectly assumed that descriptors leased at a lower timestamp were still valid at the higher timestamp. This assumption fails if a schema change occurs between the old and new timestamps. Using stale descriptors at a higher timestamp can cause inconsistencies, particularly when querying system catalogs like pg_catalog or information_schema. gThis patch updates the lease manager to verify descriptor versions before advancing the read timestamp. If any leased descriptor has been modified at the new timestamp, the transaction now returns a retryable error, ensuring correctness.

Fixes: #159355

Release note: None