### PR TITLE
sql/sqlstats: initialize lastReset to current time on SQLStats creation

### DIFF
--- a/pkg/sql/sqlstats/sslocal/sql_stats.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats.go
@@ -82,6 +82,12 @@ func newSQLStats(
 	s.mu.apps = make(map[string]*ssmemstorage.Container)
 	s.mu.mon = monitor
 	s.mu.mon.StartNoReserved(context.Background(), parentMon)
+	// Initialize lastReset to the current time. This ensures that if an instance
+	// is never explicitly reset, its lastReset will be a reasonable timestamp
+	// rather than the zero value. This is important for multi-node clusters where
+	// the Statements() API returns the minimum lastReset across all nodes - if any
+	// node has a zero lastReset, it would incorrectly pull down the overall value.
+	s.mu.lastReset = timeutil.Now()
 	return s
 }
 


### PR DESCRIPTION
Previously, the lastReset field in SQLStats was not initialized, defaulting to the zero value of time.Time (year 1). This caused flaky test failures in TestClusterResetSQLStats when running with external process virtual clusters.

The issue occurred because:
1. The Statements() API returns the minimum lastReset across all SQL instances
2. In multi-node clusters, there can be a race where the reset fanout doesn't reach all instances if they haven't yet appeared in the sqlInstanceReader's cache
3. Instances that weren't reset still had lastReset at zero value
4. This pulled down the overall LastReset to year 1, causing the test assertion to fail

By initializing lastReset to the current time when SQLStats is created, even instances that haven't been explicitly reset will have a reasonable timestamp, preventing the zero value from incorrectly affecting the cluster-wide minimum.

Fixes: #160839
Epic: None

Release note: None