### PR TITLE
sql: cleanup temporary SSTs between distributed merge iterations

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -382,6 +382,7 @@ go_library(
         "//pkg/sql/auditlogging/auditevents",
         "//pkg/sql/backfill",
         "//pkg/sql/bulksst",
+        "//pkg/sql/bulkutil",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/bootstrap",
         "//pkg/sql/catalog/catalogkeys",

--- a/pkg/sql/backfill/BUILD.bazel
+++ b/pkg/sql/backfill/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/settings/cluster",
+        "//pkg/sql/bulkutil",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/catenumpb",
         "//pkg/sql/catalog/descpb",

--- a/pkg/sql/backfill/distributed_merge_mode.go
+++ b/pkg/sql/backfill/distributed_merge_mode.go
@@ -7,12 +7,12 @@ package backfill
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/bulkutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -106,7 +106,7 @@ func shouldEnableDistributedMergeIndexBackfill(
 // processor constructs the full nodelocal URI using its own node ID at runtime.
 func EnableDistributedMergeIndexBackfillSink(jobID jobspb.JobID, spec *execinfrapb.BackfillerSpec) {
 	spec.UseDistributedMergeSink = true
-	spec.DistributedMergeFilePrefix = fmt.Sprintf("job/%d/map", jobID)
+	spec.DistributedMergeFilePrefix = bulkutil.NewDistMergePaths(jobID).MapPath()
 }
 
 // DetermineDistributedMergeMode evaluates the cluster setting to decide

--- a/pkg/sql/bulkutil/BUILD.bazel
+++ b/pkg/sql/bulkutil/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "bulkutil",
     srcs = [
         "bulk_job_cleaner.go",
+        "dist_merge_paths.go",
         "external_storage_mux.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/bulkutil",

--- a/pkg/sql/bulkutil/bulk_job_cleaner.go
+++ b/pkg/sql/bulkutil/bulk_job_cleaner.go
@@ -39,18 +39,12 @@ func NewBulkJobCleaner(
 
 // Close releases any cached external storage handles.
 func (c *BulkJobCleaner) Close() error {
-	if c == nil {
-		return nil
-	}
 	return c.mux.Close()
 }
 
 // CleanupURIs deletes the provided URIs. The operation is best-effort; errors
 // are aggregated and returned.
 func (c *BulkJobCleaner) CleanupURIs(ctx context.Context, uris []string) error {
-	if c == nil {
-		return nil
-	}
 	var errOut error
 	for _, uri := range uris {
 		if uri == "" {
@@ -58,6 +52,52 @@ func (c *BulkJobCleaner) CleanupURIs(ctx context.Context, uris []string) error {
 		}
 		if err := c.mux.DeleteFile(ctx, uri); err != nil {
 			errOut = errors.CombineErrors(errOut, err)
+		}
+	}
+	return errOut
+}
+
+// ensureTrailingSlash returns the string with a trailing slash if it doesn't
+// already have one.
+func ensureTrailingSlash(s string) string {
+	if !strings.HasSuffix(s, "/") {
+		return s + "/"
+	}
+	return s
+}
+
+// dedupeDirectories removes duplicate directory paths while preserving order.
+func dedupeDirectories(dirs []string) []string {
+	seen := make(map[string]struct{})
+	var uniqueDirs []string
+	for _, dir := range dirs {
+		if _, exists := seen[dir]; !exists {
+			seen[dir] = struct{}{}
+			uniqueDirs = append(uniqueDirs, dir)
+		}
+	}
+	return uniqueDirs
+}
+
+// deleteFilesInDirectories lists and deletes all files in the given
+// directories. Errors are aggregated and returned. Directories that don't
+// support listing are skipped.
+func (c *BulkJobCleaner) deleteFilesInDirectories(ctx context.Context, dirs []string) error {
+	var errOut error
+	for _, dir := range dirs {
+		listErr := c.mux.ListFiles(ctx, dir, func(name string) error {
+			relativePath := strings.TrimPrefix(name, "/")
+			target := ensureTrailingSlash(dir) + relativePath
+			if err := c.mux.DeleteFile(ctx, target); err != nil {
+				errOut = errors.CombineErrors(errOut, err)
+			}
+			return nil
+		})
+		if errors.Is(listErr, cloud.ErrListingUnsupported) {
+			continue
+		}
+		if listErr != nil {
+			errOut = errors.CombineErrors(errOut, listErr)
 		}
 	}
 	return errOut
@@ -85,54 +125,41 @@ func (c *BulkJobCleaner) CleanupURIs(ctx context.Context, uris []string) error {
 func (c *BulkJobCleaner) CleanupJobDirectories(
 	ctx context.Context, jobID jobspb.JobID, storagePrefixes []string,
 ) error {
-	if c == nil {
-		return nil
-	}
-
 	// Construct full job directory paths from storage prefixes.
 	jobDirs := make([]string, 0, len(storagePrefixes))
 	for _, prefix := range storagePrefixes {
 		if prefix == "" {
 			continue
 		}
-		// Ensure prefix ends with / before appending job path.
-		if !strings.HasSuffix(prefix, "/") {
-			prefix += "/"
-		}
-		jobDir := fmt.Sprintf("%sjob/%d/", prefix, jobID)
+		jobDir := fmt.Sprintf("%sjob/%d/", ensureTrailingSlash(prefix), jobID)
 		jobDirs = append(jobDirs, jobDir)
 	}
 
-	// Remove duplicates.
-	seen := make(map[string]struct{})
-	var uniqueDirs []string
-	for _, dir := range jobDirs {
-		if _, exists := seen[dir]; !exists {
-			seen[dir] = struct{}{}
-			uniqueDirs = append(uniqueDirs, dir)
-		}
-	}
+	uniqueDirs := dedupeDirectories(jobDirs)
+	return c.deleteFilesInDirectories(ctx, uniqueDirs)
+}
 
-	var errOut error
-	for _, jobDir := range uniqueDirs {
-		listErr := c.mux.ListFiles(ctx, jobDir, func(name string) error {
-			trimmed := strings.TrimPrefix(name, "/")
-			target := jobDir
-			if !strings.HasSuffix(target, "/") {
-				target += "/"
-			}
-			target += trimmed
-			if err := c.mux.DeleteFile(ctx, target); err != nil {
-				errOut = errors.CombineErrors(errOut, err)
-			}
-			return nil
-		})
-		if errors.Is(listErr, cloud.ErrListingUnsupported) {
+// CleanupJobSubdirectory enumerates all files under a specific subdirectory
+// within the job-scoped directories and removes them. This is intended for
+// cleaning up intermediate files between merge iterations.
+//
+// The storagePrefixes parameter specifies the storage locations (without the
+// job directory path) where temporary files may exist. The function constructs
+// the full cleanup path as "<prefix>/job/<jobID>/<subdirectory>" and removes
+// all files under that path.
+func (c *BulkJobCleaner) CleanupJobSubdirectory(
+	ctx context.Context, jobID jobspb.JobID, storagePrefixes []string, subdirectory string,
+) error {
+	// Construct full subdirectory paths from storage prefixes.
+	subDirs := make([]string, 0, len(storagePrefixes))
+	for _, prefix := range storagePrefixes {
+		if prefix == "" {
 			continue
 		}
-		if listErr != nil {
-			errOut = errors.CombineErrors(errOut, listErr)
-		}
+		subDir := fmt.Sprintf("%sjob/%d/%s", ensureTrailingSlash(prefix), jobID, subdirectory)
+		subDirs = append(subDirs, subDir)
 	}
-	return errOut
+
+	uniqueDirs := dedupeDirectories(subDirs)
+	return c.deleteFilesInDirectories(ctx, uniqueDirs)
 }

--- a/pkg/sql/bulkutil/dist_merge_paths.go
+++ b/pkg/sql/bulkutil/dist_merge_paths.go
@@ -1,0 +1,64 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package bulkutil
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+)
+
+// DistMergePaths provides path construction for distributed merge operations.
+// It centralizes the directory structure used by index backfill and IMPORT
+// to avoid path proliferation across the codebase.
+//
+// Directory structure:
+//   - Map phase: job/{jobID}/map/
+//   - Merge iteration N: job/{jobID}/merge/iter-{N}/
+type DistMergePaths struct {
+	JobID jobspb.JobID
+}
+
+// NewDistMergePaths creates a DistMergePaths for the given job ID.
+func NewDistMergePaths(jobID jobspb.JobID) DistMergePaths {
+	return DistMergePaths{JobID: jobID}
+}
+
+// MapSubdir returns "map/" - the subdirectory for map phase SSTs.
+func (p DistMergePaths) MapSubdir() string {
+	return "map/"
+}
+
+// MergeSubdir returns the subdirectory for merge iteration output: "merge/iter-{N}/"
+func (p DistMergePaths) MergeSubdir(iteration int) string {
+	return fmt.Sprintf("merge/iter-%d/", iteration)
+}
+
+// InputSubdir returns the subdirectory containing INPUT files for iteration N.
+// This is what needs cleanup after completing iteration N:
+//   - iteration 1: returns "map/" (map phase was input)
+//   - iteration N > 1: returns "merge/iter-{N-1}/"
+func (p DistMergePaths) InputSubdir(iteration int) string {
+	if iteration <= 1 {
+		return p.MapSubdir()
+	}
+	return p.MergeSubdir(iteration - 1)
+}
+
+// JobPrefix returns "job/{jobID}/" - the job-scoped path prefix.
+func (p DistMergePaths) JobPrefix() string {
+	return fmt.Sprintf("job/%d/", p.JobID)
+}
+
+// MapPath returns the full map phase path: "job/{jobID}/map/"
+func (p DistMergePaths) MapPath() string {
+	return p.JobPrefix() + p.MapSubdir()
+}
+
+// MergePath returns the full merge iteration path: "job/{jobID}/merge/iter-{N}/"
+func (p DistMergePaths) MergePath(iteration int) string {
+	return p.JobPrefix() + p.MergeSubdir(iteration)
+}

--- a/pkg/sql/importer/import_processor.go
+++ b/pkg/sql/importer/import_processor.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cloud"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
@@ -21,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/bulksst"
+	"github.com/cockroachdb/cockroach/pkg/sql/bulkutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -547,8 +549,8 @@ func makeIngestHelper(
 
 	var indexAdder kvserverbase.BulkAdder
 	if spec.UseDistributedMerge {
-		uri := fmt.Sprintf("nodelocal://%d/job/%d/map/%s_rows/", flowCtx.Cfg.NodeID.SQLInstanceID(),
-			spec.JobID, table.Desc.Name)
+		uri := fmt.Sprintf("nodelocal://%d/%s%s_rows/", flowCtx.Cfg.NodeID.SQLInstanceID(),
+			bulkutil.NewDistMergePaths(jobspb.JobID(spec.JobID)).MapPath(), table.Desc.Name)
 
 		rowStorage, err := flowCtx.Cfg.ExternalStorageFromURI(ctx, uri, spec.User())
 		if err != nil {

--- a/pkg/sql/importer/import_processor_planning.go
+++ b/pkg/sql/importer/import_processor_planning.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/bulkmerge"
 	"github.com/cockroachdb/cockroach/pkg/sql/bulksst"
+	"github.com/cockroachdb/cockroach/pkg/sql/bulkutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -360,7 +361,7 @@ func distImport(
 			if err := addStoragePrefix(ctx, prefix); err != nil {
 				return "", err
 			}
-			return fmt.Sprintf("%sjob/%d/merge/", prefix, job.ID()), nil
+			return prefix + bulkutil.NewDistMergePaths(job.ID()).MergePath(1), nil
 		}, bulkmerge.MergeOptions{
 			Iteration:      1,
 			MaxIterations:  1,


### PR DESCRIPTION
Previously, the distributed merge phase of index backfill would accumulate temporary SST files across all iterations until job completion. For large indexes requiring multiple merge iterations, this could consume significant disk space on nodelocal storage.

This change adds incremental cleanup of temporary SST files after each merge iteration completes and progress is persisted. Once an iteration's output becomes the input to the next iteration (or is ingested into KV for the final iteration), the previous stage's SSTs are no longer needed.

The cleanup logic:
- After iteration 1 completes: cleans up "map/" directory (map phase SSTs)
- After iteration N > 1 completes: cleans up "merge/iter-{N-1}/" directory

Epic: CRDB-48845
Informs #158354
Release note: None