### PR TITLE
sslocal: fix flaky TestSQLStatsDiscardStatsOnFingerprintLimit

### DIFF
--- a/pkg/sql/sqlstats/sslocal/sql_stats_test.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_test.go
@@ -1781,10 +1781,10 @@ func TestSQLStatsDiscardStatsOnFingerprintLimit(t *testing.T) {
 					sqlstatstestutil.StatementFilter{AllowInternal: true})
 			}
 			if tc.txnLimit == 0 {
-				sqlstatstestutil.WaitForTransactionEntriesAtLeast(t, utilConn, tc.minTxns,
-					sqlstatstestutil.TransactionFilter{AllowInternal: true})
+				sqlstatstestutil.WaitForTransactionEntriesAtLeast(t, utilConn, tc.minTxns)
 			} else {
-				sqlstatstestutil.WaitForTransactionEntriesEqual(t, utilConn, tc.txnLimit-1)
+				sqlstatstestutil.WaitForTransactionEntriesEqual(t, utilConn, tc.txnLimit-1,
+					sqlstatstestutil.TransactionFilter{AllowInternal: true})
 			}
 			testutils.SucceedsSoon(t, func() error {
 				if discardedMetric.Count() < int64(tc.totalSkipped) {


### PR DESCRIPTION
The test was failing intermittently because the transaction entry check used inconsistent filtering compared to the statement entry check.

When a fingerprint limit is set, the limit is enforced globally across all fingerprints (internal + user). The statement check correctly used AllowInternal: true to count all fingerprints, but the transaction check did not, causing it to miss internal transactions that consumed limit slots.

This fix makes the transaction checks consistent with statement checks:
- With limit: AllowInternal: true (count all, because limit is global)
- Without limit: No filter (count only user fingerprints)

Fixes: #160851

Release note: None