### PR TITLE
server: Add SkipApproxTotalStats to SpanStatsRequest

### DIFF
--- a/pkg/roachpb/span_stats.proto
+++ b/pkg/roachpb/span_stats.proto
@@ -28,7 +28,22 @@ message SpanStatsRequest {
 
   repeated Span spans = 4 [(gogoproto.nullable) = false];
 
+  // SkipMvccStats when set will result in nodes only collecting stats on the physical data
+  // from their local stores. Nodes will not make a RangeStats RPC to determine stats on
+  // logical data.
   bool skip_mvcc_stats = 5;
+
+  // SkipApproxTotalStats when set allows for an optimization for SpanStats calls that perform
+  // fan outs. Specifically, only one node per span will make RangeStats RPCs to determine
+  // stats on the logical data (MVCC stats). When set ApproximateTotalStats will equal
+  // TotalStats since MVCC stats are collected from only one node rather than accumulated
+  // across all replicas.
+  bool skip_approx_total_stats = 6;
+
+  // SpansRequiringMvcc specifies which spans in the request need MVCC stats collected.
+  // When populated, MVCC stats will only be collected for spans in this list.
+  // This facilitates the SkipApproxTotalStats optimization used during fan outs.
+  repeated Span spans_requiring_mvcc = 7 [(gogoproto.nullable) = false];
 }
 
 message SpanStats {

--- a/pkg/sql/tablemetadatacache/table_metadata_batch_iterator.go
+++ b/pkg/sql/tablemetadatacache/table_metadata_batch_iterator.go
@@ -218,6 +218,9 @@ func (batchIter *tableMetadataBatchIterator) fetchNextBatch(
 	res, err := batchIter.spanStatsFetcher.SpanStats(ctx, &roachpb.SpanStatsRequest{
 		Spans:  spans,
 		NodeID: "0", // Fan out.
+		// Tablemetadata does not use the ApproximateTotalStats field, so we can skip the
+		// nodes making additional RangeStats RPCs to collect the MVCC stats across all replicas.
+		SkipApproxTotalStats: true,
 	})
 
 	if err != nil {


### PR DESCRIPTION
In a SpanStats fan out, if the ApproximateTotalStats (post-replication logical
stats) are not needed then an optimization can be made so that only a single
node performs MVCC (logical) stats collection for that span.

This commit adds a field to the SpanStatsRequest that when set, allows the
fan out coordinator to designate a single node per span to retrieve the MVCC
stats for that span.

This should overall reduce the total number of RangeStats RPCs that are made
during SpanStats fan outs.

Fixes: #138792
Part of: #147760
Release note: None