### PR TITLE
release-25.4: sql: fix test flake in TestIndexBackfillerResumePreservesProgress

### DIFF
--- a/pkg/sql/indexbackfiller_test.go
+++ b/pkg/sql/indexbackfiller_test.go
@@ -579,11 +579,29 @@ INSERT INTO foo VALUES (1), (10), (100);
 func TestIndexBackfillerResumePreservesProgress(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderDeadlock(t, "slow timing sensitive test")
-	skip.UnderRace(t, "slow timing sensitive test")
+	skip.UnderDuress(t, "slow timing sensitive test")
 
 	ctx := context.Background()
-	backfillProgressCompletedCh := make(chan []roachpb.Span)
+
+	// progressUpdate wraps completed spans with a generation tag to detect
+	// stale messages from previous backfill runs.
+	type progressUpdate struct {
+		generation uint64
+		spans      []roachpb.Span
+	}
+
+	// backfillProgressCompletedCh will be used to communicate completed spans.
+	backfillProgressCompletedCh := make(chan progressUpdate)
+	// backfillGeneration tracks the current backfill run. It increments each
+	// time RunBeforeBackfill is called, allowing us to discard stale progress
+	// updates from previous runs.
+	var backfillGeneration atomic.Uint64
+	// backfillStartedCh signals when RunBeforeBackfill is called, indicating
+	// a new backfill run has started. receiveProgressUpdate waits on this to
+	// ensure it doesn't accept stale updates from the previous run.
+	// Buffered to allow RunBeforeBackfill to signal even if receiveProgressUpdate
+	// isn't waiting yet.
+	backfillStartedCh := make(chan struct{}, 1)
 	const numRows = 100
 	const numSpans = 20
 	var isBlockingBackfillProgress atomic.Bool
@@ -599,18 +617,41 @@ func TestIndexBackfillerResumePreservesProgress(t *testing.T) {
 				BulkAdderFlushesEveryBatch: true,
 				RunBeforeIndexBackfillProgressUpdate: func(ctx context.Context, completed []roachpb.Span) {
 					if isBlockingBackfillProgress.Load() {
+						// Capture current generation to tag this progress update.
+						currentGen := backfillGeneration.Load()
+						update := progressUpdate{
+							generation: currentGen,
+							spans:      completed,
+						}
+
 						select {
 						case <-ctx.Done():
-						case backfillProgressCompletedCh <- completed:
-							t.Logf("before index backfill progress update, completed spans: %v", completed)
+							t.Logf("before index backfill progress update, got context done")
+						case backfillProgressCompletedCh <- update:
+							t.Logf("before index backfill progress update, generation=%d, completed spans: %v",
+								currentGen, completed)
 						}
 					}
 				},
 			},
 			SQLDeclarativeSchemaChanger: &scexec.TestingKnobs{
 				RunBeforeBackfill: func(progresses []scexec.BackfillProgress) error {
+					// Increment generation to mark start of new backfill run.
+					// First run is generation 1, subsequent resumes increment further.
+					newGen := backfillGeneration.Add(1)
+					t.Logf("starting backfill generation %d (new run=%v)", newGen, progresses == nil)
 					if progresses != nil {
 						t.Logf("before resuming backfill, checkpointed spans: %v", progresses[0].CompletedSpans)
+					}
+					// Signal that the backfill has started so receiveProgressUpdate
+					// can begin accepting updates from this generation.
+					select {
+					case backfillStartedCh <- struct{}{}:
+					default:
+						// Channel may already have a value if this is not the first call.
+						// It is safe to skip because the receiver synchronizes using
+						// backfillGeneration to filter stale updates, not the number of
+						// signals in this channel.
 					}
 					return nil
 				},
@@ -689,8 +730,30 @@ func TestIndexBackfillerResumePreservesProgress(t *testing.T) {
 	var observedSpans []roachpb.Span
 	receiveProgressUpdate := func() {
 		updateCount := 2
+		// Wait for the backfill to actually start (or resume) before we start
+		// accepting progress updates. This ensures we don't accept stale updates
+		// from a previous backfill run.
+		<-backfillStartedCh
+		// Capture the minimum acceptable generation at the start of receiving.
+		// We'll accept updates from this generation or later, but discard
+		// updates from earlier generations (which are stale from previous runs).
+		minAcceptableGen := backfillGeneration.Load()
+		t.Logf("receiveProgressUpdate: accepting generation %d or later", minAcceptableGen)
+
 		for isBlockingBackfillProgress.Load() && updateCount > 0 {
-			progressUpdate := <-backfillProgressCompletedCh
+			update := <-backfillProgressCompletedCh
+
+			// Discard stale updates from previous backfill runs.
+			// Updates with generation >= minAcceptableGen are from the current or
+			// subsequent runs and should be processed.
+			if update.generation < minAcceptableGen {
+				t.Logf("discarding stale progress update from generation %d (min acceptable: %d), spans: %v",
+					update.generation, minAcceptableGen, update.spans)
+				continue
+			}
+
+			progressUpdate := update.spans
+
 			// Make sure the progress update does not contain overlapping spans.
 			for i, span1 := range progressUpdate {
 				for j, span2 := range progressUpdate {


### PR DESCRIPTION
Backport 1/1 commits from #161504.

/cc @cockroachdb/release

---

This testcase does repeated pause/resume in a loop. Each iteration resumes the job, waits for progress updates, then ensures they are checkpointed before pausing again. There was a timing hole in this test. The callback to notify the test about progress updates happens before the completed spans are actually written to the checkpoint. This created a race:

1. Backfill run N sends progress update, callback fires to send progress update
2. Channel send blocks (unbuffered, no receiver waiting)
3. Test pauses the job and waits for it to reach "paused" state
4. The callback goroutine remains blocked on the channel send. Job is paused and callback context is cancelled, but otherwise callback is still running because it's waiting on the channel send.
4. Test resumes the job → new backfill run N+1 starts
4. Test's receiveProgressUpdate() starts waiting for updates
5. Stale update from run N arrives and gets accepted
6. Callback continues and attempts to write out checkpoint but fails due to cancelled context.
6. Checkpoint validation fails - expects only run N+1 spans, but sees run N spans

The fix adds two synchronization mechanisms:
- backfillStartedCh: A channel that signals when RunBeforeBackfill is called. receiveProgressUpdate() waits on this channel before accepting any updates, ensuring it doesn't start listening until the new backfill run has actually started.
- backfillGeneration counter: Tags each progress update with the backfill generation that produced it. receiveProgressUpdate() discards updates from earlier generations, filtering out stale in-flight updates from previous pause/resume cycles.

Together, these ensure that each pause/resume iteration only processes progress updates from its own backfill run.

Note: I was able to reproduce this problem by adding a small sleep at the very end of the RunBeforeIndexBackfillProgressUpdate callback. I was able to see stale messages, and used that to verify this fix.

Release note: none
Epic: None
Closes #160714
Closes #158738

Release justification: test only change