### PR TITLE
release-26.1: roachtest: datadog duration field fix

### DIFF
--- a/pkg/cmd/roachtest/datadog/datadog_test.go
+++ b/pkg/cmd/roachtest/datadog/datadog_test.go
@@ -25,7 +25,7 @@ import (
 var unittestLogMetadata = LogMetadata{
 	TestName:        "acceptance/event-log",
 	Result:          "PASS",
-	Duration:        "6.67s",
+	Duration:        "6.67",
 	Owner:           "test-eng",
 	Cloud:           "gce",
 	Platform:        "linux-amd64",

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1628,8 +1628,8 @@ func (r *testRunner) runTest(
 		t.L().Printf("uploading %s to Datadog", "test.log")
 		logPath := filepath.Join(t.artifactsDir, "test.log")
 		m := datadog.NewLogMetadata(
-			t.L(), t.spec, !t.Failed(), fmt.Sprintf("%.2fs", t.duration().Seconds()), c.cloud, c.os, c.arch, c.name,
-			"test.log")
+			t.L(), t.spec, !t.Failed(), fmt.Sprintf("%.2f", timeutil.Since(t.start).Seconds()), c.cloud, c.os, c.arch,
+			c.name, "test.log")
 		if err := datadog.MaybeUploadTestLog(ctx, t.L(), logPath, m); err != nil {
 			// Best effort
 			t.L().Printf("error uploading logs to Datadog: %v", err)


### PR DESCRIPTION
Backport 1/1 commits from #161706 on behalf of @williamchoe3.

----

Because `t.end` is set after datadog log parsing, need to calculate it beforehand for the logs

Epic: None
Release note: None

----

Release justification: