### PR TITLE
sql: track and update UDT versions in prepared statements

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -342,6 +342,59 @@ func (ex *connExecutor) execPortal(
 	}
 }
 
+func (ex *connExecutor) checkUDTStaleness(
+	ctx context.Context, prep *prep.Statement,
+) (stale bool, staleEnumNames []string, err error) {
+	if len(prep.UDTs) == 0 {
+		return false, nil, nil
+	}
+	staleEnumNames = make([]string, 0)
+	for i, typ := range prep.UDTs {
+		toCheck, err := ex.planner.ResolveTypeByOID(ctx, typ.Oid())
+		if err != nil {
+			return stale, nil, err
+		}
+		if typ.TypeMeta.Version != toCheck.TypeMeta.Version {
+			stale = true
+			prep.UDTs[i] = toCheck
+			staleEnumNames = append(staleEnumNames, typ.Name())
+		}
+	}
+	return stale, staleEnumNames, nil
+}
+
+// maybeReparsePrepStmt is to reparse the prepared statement so that the
+// stored udt datum is up-to-date. The reparse is needed because AST can
+// be modified at type chekcing, with tree.StrVal component replaced
+// with a versioned tree.DEnum. If the UDT's version changed, this
+// tree.DEnum would be outdated.
+func (ex *connExecutor) maybeReparsePrepStmt(
+	ctx context.Context, prep *prep.Statement, name string,
+) error {
+	stale, staleEnumNames, err := ex.checkUDTStaleness(ctx, prep)
+	if err != nil {
+		return err
+	}
+	if !stale {
+		return nil
+	}
+	log.Eventf(ctx, "reparsing prepared statament %q for the user defined types are stale: %s", name, staleEnumNames)
+	newStmt, err := parser.ParseOne(prep.SQL)
+	if err != nil {
+		return err
+	}
+	prep.Statement = newStmt
+	prep.AST = newStmt.AST
+	// Since the udt is outdated, the stored memo will be stale and we will need to
+	// regenerate the memo anyways, so we just reset all the memo related fields as well.
+	prep.BaseMemo = nil
+	prep.GenericMemo = nil
+	prep.IdealGenericPlan = false
+	prep.Costs.Reset()
+	prep.HintsGeneration = 0
+	return nil
+}
+
 // execStmtInOpenState executes one statement in the context of the session's
 // current transaction.
 // It handles statements that affect the transaction state (BEGIN, COMMIT)
@@ -553,6 +606,10 @@ func (ex *connExecutor) execStmtInOpenState(
 		ps, ok := ex.extraTxnState.prepStmtsNamespace.prepStmts.Get(name)
 		if !ok {
 			return makeErrEvent(newPreparedStmtDNEError(ex.sessionData(), name))
+		}
+
+		if err := ex.maybeReparsePrepStmt(ctx, ps, name); err != nil {
+			return makeErrEvent(err)
 		}
 
 		var err error
@@ -1458,6 +1515,10 @@ func (ex *connExecutor) execStmtInOpenStateWithPausablePortal(
 		ps, ok := ex.extraTxnState.prepStmtsNamespace.prepStmts.Get(name)
 		if !ok {
 			return makeErrEvent(newPreparedStmtDNEError(ex.sessionData(), name))
+		}
+
+		if err := ex.maybeReparsePrepStmt(ctx, ps, name); err != nil {
+			return makeErrEvent(err)
 		}
 
 		var err error

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -195,6 +195,7 @@ func (ex *connExecutor) prepare(
 	}
 
 	var flags planFlags
+	var udts []*types.T
 	prepare := func(ctx context.Context, txn *kv.Txn) (err error) {
 		p := &ex.planner
 		if origin == prep.StatementOriginWire {
@@ -262,7 +263,14 @@ func (ex *connExecutor) prepare(
 		p.stmt = stmt
 		p.semaCtx.Annotations = tree.MakeAnnotations(stmt.NumAnnotations)
 		p.extendedEvalCtx.Annotations = &p.semaCtx.Annotations
-		flags, err = ex.populatePrepared(ctx, txn, placeholderHints, p, origin)
+		flags, udts, err = ex.populatePrepared(ctx, txn, placeholderHints, p, origin)
+		// Copy the udts slice to ensure prepared statements and memos
+		// maintain independent references. The reason for the separation is
+		// that, when UDT versions change, we update only the prepared
+		// statement's udts while keeping the memo's udts unchanged, so that
+		// the memo is properly invalidated during plan generation.
+		prepared.UDTs = make([]*types.T, len(udts))
+		copy(prepared.UDTs, udts)
 		return err
 	}
 
@@ -294,10 +302,10 @@ func (ex *connExecutor) populatePrepared(
 	placeholderHints tree.PlaceholderTypes,
 	p *planner,
 	origin prep.StatementOrigin,
-) (planFlags, error) {
+) (planFlags, []*types.T, error) {
 	if before := ex.server.cfg.TestingKnobs.BeforePrepare; before != nil {
 		if err := before(ctx, ex.planner.stmt.String(), txn); err != nil {
-			return 0, err
+			return 0, nil, err
 		}
 	}
 	stmt := &p.stmt
@@ -311,7 +319,7 @@ func (ex *connExecutor) populatePrepared(
 	// for pgwire- or SQL-level prepared statements.
 	if origin != prep.StatementOriginSessionMigration {
 		if err := ex.handleAOST(ctx, p.stmt.AST); err != nil {
-			return 0, err
+			return 0, nil, err
 		}
 	}
 
@@ -322,14 +330,14 @@ func (ex *connExecutor) populatePrepared(
 	// However, we must be able to handle every type of statement below because
 	// the Postgres extended protocol requires running statements via the prepare
 	// and execute paths.
-	flags, err := p.prepareUsingOptimizer(ctx, origin)
+	flags, udts, err := p.prepareUsingOptimizer(ctx, origin)
 	if err != nil {
 		log.VEventf(ctx, 1, "optimizer prepare failed: %v", err)
-		return 0, err
+		return 0, nil, err
 	}
 	log.VEvent(ctx, 2, "optimizer prepare succeeded")
 	// stmt.Prepared fields have been populated.
-	return flags, nil
+	return flags, udts, nil
 }
 
 func (ex *connExecutor) execBind(

--- a/pkg/sql/opt/exec/execbuilder/testdata/prepare
+++ b/pkg/sql/opt/exec/execbuilder/testdata/prepare
@@ -266,3 +266,139 @@ regions: <hidden>
 
 statement ok
 RESET plan_cache_mode
+
+subtest prepare-enum-update
+
+statement ok
+CREATE TYPE enum132105 AS ENUM ('hi');
+
+statement ok
+PREPARE p132105_hi AS SELECT $1::enum132105 = 'hi';
+
+statement ok
+ALTER TYPE enum132105 ADD VALUE 'hello';
+
+query B
+EXECUTE p132105_hi('hi');
+----
+true
+
+statement ok
+ALTER TYPE enum132105 RENAME VALUE 'hi' to 'aloha';
+
+# Note, here our behavior differs from postgres -- pg would return true.
+statement error invalid input value for enum enum132105: "hi"
+EXECUTE p132105_hi('aloha');
+
+# Test if we change the value back.
+statement ok
+ALTER TYPE enum132105 RENAME VALUE 'aloha' to 'hi';
+
+statement error invalid input value for enum enum132105: "aloha"
+EXECUTE p132105_hi('aloha');
+
+query B
+EXECUTE p132105_hi('hi');
+----
+true
+
+statement ok
+PREPARE p132105_hello AS SELECT $1::enum132105 = 'hello';
+
+query B
+EXECUTE p132105_hello('hello');
+----
+true
+
+statement ok
+ALTER TYPE enum132105 DROP VALUE 'hello';
+
+statement error invalid input value for enum enum132105: "hello"
+EXECUTE p132105_hello('hello');
+
+# Test with implicit casting to udt.
+statement ok
+CREATE TABLE t132105 (enumcol enum132105);
+
+statement ok
+PREPARE p132105count AS SELECT count(*) FROM t132105 WHERE enumcol = 'hi';
+
+statement ok
+INSERT INTO t132105 VALUES ('hi'), ('hi')
+
+query I
+EXECUTE p132105count;
+----
+2
+
+statement ok
+ALTER TYPE enum132105 RENAME VALUE 'hi' to 'ciao';
+
+# Note that here our behavior is different from pg -- pg would return 2.
+statement error invalid input value for enum enum132105: "hi"
+EXECUTE p132105count;
+
+statement ok
+CREATE TABLE t132105arr (enumarrcol enum132105[]);
+
+statement ok
+PREPARE p132105arrcount AS SELECT count(*) FROM t132105arr WHERE enumarrcol = ARRAY[('ciao'::enum132105)];
+
+statement ok
+ALTER TYPE enum132105 ADD VALUE 'privet';
+
+statement ok
+EXECUTE p132105arrcount;
+
+statement ok
+ALTER TYPE enum132105 RENAME VALUE 'ciao' TO 'konnichiwa';
+
+# PG returns 0 here.
+statement error invalid input value for enum enum132105: "ciao"
+EXECUTE p132105arrcount;
+
+statement ok
+PREPARE p132105enum_range_null AS SELECT enum_range(NULL::enum132105);
+
+statement ok
+PREPARE p132105enum_range_datum AS SELECT enum_range('konnichiwa'::enum132105);
+
+query T
+EXECUTE p132105enum_range_null;
+----
+{konnichiwa,privet}
+
+query T
+EXECUTE p132105enum_range_datum;
+----
+{konnichiwa,privet}
+
+# If we alter the name of an irrelevant value in the enum type,
+# the EXECUTE will run successfully.
+statement ok
+ALTER TYPE enum132105 RENAME VALUE 'privet' TO '안녕하세요';
+
+query T
+EXECUTE p132105enum_range_null;
+----
+{konnichiwa,안녕하세요}
+
+query T
+EXECUTE p132105enum_range_datum;
+----
+{konnichiwa,안녕하세요}
+
+# If we alter the name of the relevant value ('konnichiwa'), the
+# EXECUTE for p132105enum_range_datum would fail.
+statement ok
+ALTER TYPE enum132105 RENAME VALUE 'konnichiwa' TO 'bonjour';
+
+query T
+EXECUTE p132105enum_range_null;
+----
+{bonjour,안녕하세요}
+
+statement error invalid input value for enum enum132105: "konnichiwa"
+EXECUTE p132105enum_range_datum;
+
+subtest end

--- a/pkg/sql/prep/metadata.go
+++ b/pkg/sql/prep/metadata.go
@@ -56,6 +56,11 @@ type Metadata struct {
 
 	// ASTWithInjectedHints is the AST rewritten with injected hints.
 	ASTWithInjectedHints tree.Statement
+
+	// UDTs contains all user defined types referenced in the prepared
+	// statement. It is used to detect type version change, so the
+	// statement can be reparsed with updated versions.
+	UDTs []*types.T
 }
 
 // MemoryEstimate returns an estimation (in bytes) of how much memory is used by
@@ -82,6 +87,6 @@ func (pm *Metadata) MemoryEstimate() int64 {
 		res += pm.Hints[i].Size()
 	}
 	res += int64(len(pm.HintIDs)) * int64(unsafe.Sizeof(int64(0)))
-
+	res += int64(len(pm.UDTs)) * int64(unsafe.Sizeof((*types.T)(nil)))
 	return res
 }

--- a/pkg/sql/querycache/query_cache_test.go
+++ b/pkg/sql/querycache/query_cache_test.go
@@ -202,7 +202,7 @@ func TestSynchronization(t *testing.T) {
 					c.Purge(sql)
 				case r <= 35:
 					// 25% of the time, add an entry.
-					c.Add(&s, data(sql, &memo.Memo{}, int64(288+rng.Intn(10*avgCachedSize))))
+					c.Add(&s, data(sql, &memo.Memo{}, int64(299+rng.Intn(10*avgCachedSize))))
 				default:
 					// The rest of the time, find an entry.
 					_, _ = c.Find(&s, sql)


### PR DESCRIPTION
Previously, prepared statements referencing UDTs could fail with version
mismatch errors after the UDT was altered (e.g., via ALTER TYPE
ADD|RENAME|DROP VALUE). This occurred because the prepared statement
retained stale type information obtained from the type check during the
preparing stage, while new executions used updated type versions.

This commit fixes it by tracking all UDTs referenced in prep stmts
during preparation, checking UDT versions for staleness before each execution
and updating UDT references and re-parsing when versions change.

Note: Our behavior intentionally differs from PG, which resolves
enum values to version-agnostic OIDs.

Example:
PREPARE p AS SELECT $1::my_enum = 'enum_a';
ALTER TYPE my_enum RENAME VALUE 'enum_a' TO 'enum_aa';
EXECUTE p('enum_aa');  -- PG returns true, CRDB returns error.

Fixes: https://github.com/cockroachdb/cockroach/issues/132105

Release note (bug fix): Fixed prepared statements failing with "version
mismatch" errors when user-defined types are modified between preparation
and execution. Prepared statements now automatically detect UDT changes
and re-parse to use current type definitions.