### PR TITLE
sem/builtins: fix an internal error around empty array string in builtins

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -2501,3 +2501,28 @@ SELECT * FROM t95158 WHERE c !~ ANY (ARRAY['x']::STRING[])
 query I
 SELECT * FROM t95158 WHERE c !~ SOME (ARRAY['x']::STRING[])
 ----
+
+# Regression tests for internal errors on an empty array string (#89969).
+query error pgcode 42804 could not determine polymorphic type because input has type unknown
+SELECT array_length('{}', 1);
+
+query I
+SELECT array_length('{}'::text[], 1);
+----
+NULL
+
+query error pgcode 42804 could not determine polymorphic type because input has type unknown
+SELECT cardinality('{}');
+
+query I
+SELECT width_bucket(true, '{}'::BOOL[]);
+----
+0
+
+# TODO(yuzefovich): this works in PG because 'thresholds' argument uses
+# anycompatiblearray type, not anyarray.
+query error pgcode 42804 could not determine polymorphic type because input has type unknown
+SELECT width_bucket(true, '{}');
+
+query error pgcode 42804 could not determine polymorphic type because input has type unknown
+SELECT array_to_string('{}', 'foo');

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -3711,7 +3711,10 @@ value if you rely on the HLC for accuracy.`,
 				if args[0] == tree.DNull || args[1] == tree.DNull {
 					return tree.DNull, nil
 				}
-				arr := tree.MustBeDArray(args[0])
+				arr, err := checkIfDArrayErrOnDString(args[0])
+				if err != nil {
+					return nil, err
+				}
 				delim := string(tree.MustBeDString(args[1]))
 				return arrayToString(evalCtx, arr, delim, nil)
 			},
@@ -3726,7 +3729,10 @@ value if you rely on the HLC for accuracy.`,
 				if args[0] == tree.DNull || args[1] == tree.DNull {
 					return tree.DNull, nil
 				}
-				arr := tree.MustBeDArray(args[0])
+				arr, err := checkIfDArrayErrOnDString(args[0])
+				if err != nil {
+					return nil, err
+				}
 				delim := string(tree.MustBeDString(args[1]))
 				nullStr := stringOrNil(args[2])
 				return arrayToString(evalCtx, arr, delim, nullStr)
@@ -3742,7 +3748,10 @@ value if you rely on the HLC for accuracy.`,
 			Types:      tree.ParamTypes{{Name: "input", Typ: types.AnyArray}, {Name: "array_dimension", Typ: types.Int}},
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
-				arr := tree.MustBeDArray(args[0])
+				arr, err := checkIfDArrayErrOnDString(args[0])
+				if err != nil {
+					return nil, err
+				}
 				dimen := int64(tree.MustBeDInt(args[1]))
 				return arrayLength(arr, dimen), nil
 			},
@@ -3758,7 +3767,10 @@ value if you rely on the HLC for accuracy.`,
 			Types:      tree.ParamTypes{{Name: "input", Typ: types.AnyArray}},
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
-				arr := tree.MustBeDArray(args[0])
+				arr, err := checkIfDArrayErrOnDString(args[0])
+				if err != nil {
+					return nil, err
+				}
 				return cardinality(arr), nil
 			},
 			Info:       "Calculates the number of elements contained in `input`",
@@ -3771,7 +3783,10 @@ value if you rely on the HLC for accuracy.`,
 			Types:      tree.ParamTypes{{Name: "input", Typ: types.AnyArray}, {Name: "array_dimension", Typ: types.Int}},
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
-				arr := tree.MustBeDArray(args[0])
+				arr, err := checkIfDArrayErrOnDString(args[0])
+				if err != nil {
+					return nil, err
+				}
 				dimen := int64(tree.MustBeDInt(args[1]))
 				return arrayLower(arr, dimen), nil
 			},
@@ -3787,7 +3802,10 @@ value if you rely on the HLC for accuracy.`,
 			Types:      tree.ParamTypes{{Name: "input", Typ: types.AnyArray}, {Name: "array_dimension", Typ: types.Int}},
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
-				arr := tree.MustBeDArray(args[0])
+				arr, err := checkIfDArrayErrOnDString(args[0])
+				if err != nil {
+					return nil, err
+				}
 				dimen := int64(tree.MustBeDInt(args[1]))
 				return arrayLength(arr, dimen), nil
 			},
@@ -11862,6 +11880,29 @@ func stringOrNil(d tree.Datum) *string {
 	return &s
 }
 
+var anyArrayEmptyStringErr = pgerror.Newf(
+	pgcode.DatatypeMismatch,
+	"could not determine polymorphic type because input has type unknown",
+)
+
+// checkIfDArrayErrOnDString checks whether d corresponds to an empty array
+// stored as DString and returns an error if so, otherwise it checks whether d
+// is a DArray and returns an assertion failure if not.
+//
+// It should only be called when d corresponds to an argument of AnyArray type.
+func checkIfDArrayErrOnDString(d tree.Datum) (*tree.DArray, error) {
+	if s, ok := d.(*tree.DString); ok {
+		if *s == "{}" {
+			return nil, anyArrayEmptyStringErr
+		}
+	}
+	a, ok := d.(*tree.DArray)
+	if !ok {
+		return nil, errors.AssertionFailedf("expected *DArray, found %T", d)
+	}
+	return a, nil
+}
+
 // stringToArray implements the string_to_array builtin - str is split on delim to form an array of strings.
 // If nullStr is set, any elements equal to it will be NULL.
 func stringToArray(str string, delimPtr *string, nullStr *string) (tree.Datum, error) {
@@ -12434,7 +12475,10 @@ func arrayNumInvertedIndexEntries(
 	if val == tree.DNull {
 		return tree.DZero, nil
 	}
-	arr := tree.MustBeDArray(val)
+	arr, err := checkIfDArrayErrOnDString(val)
+	if err != nil {
+		return nil, err
+	}
 
 	v := descpb.EmptyArraysInInvertedIndexesVersion
 	if version != tree.DNull {

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -1274,7 +1274,11 @@ func makeVariadicUnnestGenerator(
 ) (eval.ValueGenerator, error) {
 	var arrays []*tree.DArray
 	for _, a := range args {
-		arrays = append(arrays, tree.MustBeDArray(a))
+		arr, err := checkIfDArrayErrOnDString(a)
+		if err != nil {
+			return nil, err
+		}
+		arrays = append(arrays, arr)
 	}
 	g := &multipleArrayValueGenerator{arrays: arrays}
 	return g, nil
@@ -1424,7 +1428,10 @@ func (w *WorkloadIndexRecsGenerator) Close(ctx context.Context) {
 func makeArrayGenerator(
 	_ context.Context, _ *eval.Context, args tree.Datums,
 ) (eval.ValueGenerator, error) {
-	arr := tree.MustBeDArray(args[0])
+	arr, err := checkIfDArrayErrOnDString(args[0])
+	if err != nil {
+		return nil, err
+	}
 	return &arrayValueGenerator{array: arr}, nil
 }
 
@@ -1466,7 +1473,10 @@ func (s *arrayValueGenerator) Values() (tree.Datums, error) {
 func makeExpandArrayGenerator(
 	_ context.Context, _ *eval.Context, args tree.Datums,
 ) (eval.ValueGenerator, error) {
-	arr := tree.MustBeDArray(args[0])
+	arr, err := checkIfDArrayErrOnDString(args[0])
+	if err != nil {
+		return nil, err
+	}
 	g := &expandArrayValueGenerator{avg: arrayValueGenerator{array: arr}}
 	g.buf[1] = tree.NewDInt(tree.DInt(-1))
 	return g, nil
@@ -1522,7 +1532,11 @@ func makeGenerateSubscriptsGenerator(
 	}
 	// We sadly only support 1D arrays right now.
 	if dim == 1 {
-		arr = tree.MustBeDArray(args[0])
+		var err error
+		arr, err = checkIfDArrayErrOnDString(args[0])
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		arr = &tree.DArray{}
 	}

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -908,7 +908,10 @@ var geoBuiltins = map[string]builtinDefinition{
 			ReturnType: tree.FixedReturnType(types.Geometry),
 			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				outer := tree.MustBeDGeometry(args[0])
-				interiorArr := tree.MustBeDArray(args[1])
+				interiorArr, err := checkIfDArrayErrOnDString(args[1])
+				if err != nil {
+					return nil, err
+				}
 				interior := make([]geo.Geometry, len(interiorArr.Array))
 				for i, v := range interiorArr.Array {
 					g, ok := v.(*tree.DGeometry)


### PR DESCRIPTION
This commit teaches all builtins that have `types.AnyArray` as one of its param types to handle `'{}'` (an empty array parsed as a string) to return a regular error, matching Postgres.

All existing builtins have been audited. In order to not miss any new builtins from using the correct method, an init-time check is included.

The only caveat is that `width_bucket` has incorrectly marked parameter type in one of the overloads - `thresholds` should be `anycompatiblearray` and not `anyarray`. This is not fixed in this patch and will be followed up on separately, but we still convert an internal error into a regular error.

Addresses: #89969.
Epic: None

Release note (bug fix): Previously, CockroachDB could hit an internal error when evaluating builtin functions with `'{}'` as an argument (without explicit type casts) (e.g. on a query like "SELECT cardinality('{}');"). This is now fixed and a regular error is returned instead (matching PG).