### PR TITLE
mixedversion: add same series upgrades

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/README.md
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/README.md
@@ -397,6 +397,16 @@ using workload during your test is to execute a workload command on a binary tha
 this option tells the framework to handle staging all the binaries you need for your test on the workload node(s)
 during test setup.
 
+``` go
+mixedversion.WithSameSeriesUpgradeProbability(0.5)
+```
+
+This option controls the probability of inserting same-series upgrades (patch-level upgrades within the same major.minor release series) into the upgrade path. For example, if the upgrade path is `[24.1.5, 24.2.3, 24.3.10, current]`, the framework might insert an older patch before some versions, resulting in `[24.1.2, 24.1.5, 24.2.3, 24.3.7, 24.3.10, current]` where `24.1.2 -> 24.1.5` and `24.3.7 -> 24.3.10` are same-series upgrades.
+
+Same-series upgrades test that patch-level upgrades work correctly, which is important since most customer upgrades are patch upgrades within the same release series. The probability value (0.0 to 1.0) determines how likely it is that same-series upgrades are enabled for a given test run. When enabled, the framework picks a random number of same-series upgrades to insert (bounded by `MaxUpgrades`). A value of 0 disables same-series upgrades entirely.
+
+The framework respects `MinimumBootstrapVersion` and `MinimumSupportedVersion` when inserting same-series upgrades, and the total number of upgrades is bounded by `MaxUpgrades`. See also: `mixedversion.DisableSameSeriesUpgrades()`.
+
 ### Deployment Modes
 
 By default, each run of a `mixedversion` test happens in one of 3 possible _deployment modes_: `system-only`, `shared-process`, and `separate-process`. In the latter two options, the framework will create a test tenant, and tests should exercise the feature they are testing by invoking it on the tenant.

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/same_series_upgrades
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/same_series_upgrades
@@ -1,0 +1,86 @@
+# Test that we are able to generate test plans with same-series upgrades
+# (patch-level upgrades within the same major.minor release series).
+#
+# Same-series upgrades test upgrading between patch releases, e.g.,
+# v24.1.2 -> v24.1.5, which is a common customer scenario that we want
+# to ensure works correctly.
+
+# With same_series_upgrade_probability=1.0, same-series upgrades are always
+# enabled. numUpgrades() then picks majorUpgrades from [1, max_upgrades] and
+# sameSeriesUpgrades from [0, max_upgrades - major]. With max_upgrades=3,
+# this allows up to 2 same-series insertions alongside the cross-series
+# upgrades, bounded by the total max_upgrades.
+mixed-version-test predecessors=(22.1.0, 22.2.0, 23.1.4, 23.2.0, 24.1.1, 24.2.1) max_upgrades=3 same_series_upgrade_probability=1.0
+----
+ok
+
+in-mixed-version name=(mixed-version 1)
+----
+ok
+
+workload name=bank
+----
+ok
+
+after-upgrade-finalized name=(validate upgrade)
+----
+ok
+
+plan
+----
+Seed:               12345
+Upgrades:           v24.1.0 → v24.1.1 → v24.2.1 → v24.3.0 (<current>)
+Deployment mode:    system-only
+Hooks:              bank workload, initialize bank workload, mixed-version 1, validate upgrade
+Plan:
+├── install fixtures for version "v24.1.0" (1)
+├── start cluster at version "v24.1.0" (2)
+├── wait for all nodes (:1-4) to acknowledge cluster version '24.1' on system tenant (3)
+├── run "initialize bank workload" (4)
+├── run "bank workload" (5)
+├── upgrade cluster from "v24.1.0" to "v24.1.1"
+│   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (6)
+│   ├── upgrade nodes :1-4 from "v24.1.0" to "v24.1.1"
+│   │   ├── restart node 2 with binary version v24.1.1 (7)
+│   │   ├── restart node 4 with binary version v24.1.1 (8)
+│   │   ├── run "mixed-version 1" (9)
+│   │   ├── restart node 1 with binary version v24.1.1 (10)
+│   │   └── restart node 3 with binary version v24.1.1 (11)
+│   ├── allow upgrade to happen on system tenant by resetting `preserve_downgrade_option` (12)
+│   ├── wait for all nodes (:1-4) to acknowledge cluster version '24.1' on system tenant (13)
+│   └── run "validate upgrade" (14)
+├── upgrade cluster from "v24.1.1" to "v24.2.1"
+│   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (15)
+│   ├── upgrade nodes :1-4 from "v24.1.1" to "v24.2.1"
+│   │   ├── restart node 4 with binary version v24.2.1 (16)
+│   │   ├── restart node 1 with binary version v24.2.1 (17)
+│   │   ├── run "mixed-version 1" (18)
+│   │   ├── restart node 2 with binary version v24.2.1 (19)
+│   │   └── restart node 3 with binary version v24.2.1 (20)
+│   ├── allow upgrade to happen on system tenant by resetting `preserve_downgrade_option` (21)
+│   ├── wait for all nodes (:1-4) to acknowledge cluster version '24.2' on system tenant (22)
+│   └── run "validate upgrade" (23)
+└── upgrade cluster from "v24.2.1" to "v24.3.0 (<current>)"
+   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (24)
+   ├── upgrade nodes :1-4 from "v24.2.1" to "v24.3.0 (<current>)"
+   │   ├── restart node 3 with binary version v24.3.0 (<current>) (25)
+   │   ├── restart node 1 with binary version v24.3.0 (<current>) (26)
+   │   ├── restart node 4 with binary version v24.3.0 (<current>) (27)
+   │   ├── restart node 2 with binary version v24.3.0 (<current>) (28)
+   │   └── run "mixed-version 1" (29)
+   ├── downgrade nodes :1-4 from "v24.3.0 (<current>)" to "v24.2.1"
+   │   ├── restart node 1 with binary version v24.2.1 (30)
+   │   ├── restart node 4 with binary version v24.2.1 (31)
+   │   ├── restart node 2 with binary version v24.2.1 (32)
+   │   ├── run "mixed-version 1" (33)
+   │   └── restart node 3 with binary version v24.2.1 (34)
+   ├── upgrade nodes :1-4 from "v24.2.1" to "v24.3.0 (<current>)"
+   │   ├── restart node 3 with binary version v24.3.0 (<current>) (35)
+   │   ├── run "mixed-version 1" (36)
+   │   ├── restart node 2 with binary version v24.3.0 (<current>) (37)
+   │   ├── restart node 1 with binary version v24.3.0 (<current>) (38)
+   │   └── restart node 4 with binary version v24.3.0 (<current>) (39)
+   ├── allow upgrade to happen on system tenant by resetting `preserve_downgrade_option` (40)
+   ├── run "mixed-version 1" (41)
+   ├── wait for all nodes (:1-4) to acknowledge cluster version <current> on system tenant (42)
+   └── run "validate upgrade" (43)

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/separate_process
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/separate_process
@@ -44,8 +44,8 @@ Plan:
 ├── delete all-tenants override for the `version` key (9) [stage=system:tenant-setup;tenant:tenant-setup]
 ├── run startup hooks concurrently
 │   ├── run "create tables" hookId="planner_test.go:141", after 3m0s delay (10) [stage=system:on-startup;tenant:on-startup]
-│   └── run "initialize bank workload" hookId="mixedversion.go:885", after 100ms delay (11) [stage=system:on-startup;tenant:on-startup]
-├── run "bank workload" hookId="mixedversion.go:893" (12) [stage=system:background;tenant:background]
+│   └── run "initialize bank workload" hookId="mixedversion.go:907", after 100ms delay (11) [stage=system:on-startup;tenant:on-startup]
+├── run "bank workload" hookId="mixedversion.go:915" (12) [stage=system:background;tenant:background]
 ├── upgrade cluster from "v22.2.3" to "v23.1.4"
 │   ├── upgrade storage cluster
 │   │   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (13) [stage=system:init;tenant:upgrading-system]

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/shared_process
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/shared_process
@@ -53,8 +53,8 @@ Plan:
 ├── delete all-tenants override for the `version` key (16) [stage=system:tenant-setup;tenant:tenant-setup]
 ├── run startup hooks concurrently
 │   ├── run "create tables" hookId="planner_test.go:141", after 30s delay (17) [stage=system:on-startup;tenant:on-startup]
-│   └── run "initialize bank workload" hookId="mixedversion.go:885", after 3m0s delay (18) [stage=system:on-startup;tenant:on-startup]
-├── run "bank workload" hookId="mixedversion.go:893" (19) [stage=system:background;tenant:background]
+│   └── run "initialize bank workload" hookId="mixedversion.go:907", after 3m0s delay (18) [stage=system:on-startup;tenant:on-startup]
+├── run "bank workload" hookId="mixedversion.go:915" (19) [stage=system:background;tenant:background]
 ├── upgrade cluster from "v23.1.12" to "v23.2.0"
 │   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (20) [stage=system:init;tenant:init]
 │   ├── prevent auto-upgrades on mixed-version-tenant-cyvju tenant by setting `preserve_downgrade_option` (21) [stage=system:init;tenant:init]

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/step_stages
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/step_stages
@@ -35,10 +35,10 @@ Plan:
 ├── install fixtures for version "v22.2.3" (1) [stage=system-setup]
 ├── start cluster at version "v22.2.3" (2) [stage=system-setup]
 ├── wait for all nodes (:1-4) to acknowledge cluster version '22.2' on system tenant (3) [stage=system-setup]
-├── run "initialize bank workload" hookId="mixedversion.go:885" (4) [stage=on-startup]
+├── run "initialize bank workload" hookId="mixedversion.go:907" (4) [stage=on-startup]
 ├── start background hooks concurrently
-│   ├── run "bank workload" hookId="mixedversion.go:893", after 0s delay (5) [stage=background]
-│   └── run "csv server" hookId="mixedversion.go:862", after 0s delay (6) [stage=background]
+│   ├── run "bank workload" hookId="mixedversion.go:915", after 0s delay (5) [stage=background]
+│   └── run "csv server" hookId="mixedversion.go:884", after 0s delay (6) [stage=background]
 ├── upgrade cluster from "v22.2.3" to "v23.1.4"
 │   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (7) [stage=init]
 │   ├── upgrade nodes :1-4 from "v22.2.3" to "v23.1.4"

--- a/pkg/cmd/roachtest/tests/versionupgrade.go
+++ b/pkg/cmd/roachtest/tests/versionupgrade.go
@@ -100,7 +100,6 @@ func runVersionUpgrade(ctx context.Context, t test.Test, c cluster.Cluster) {
 	testCtx := ctx
 	opts := []mixedversion.CustomOption{
 		mixedversion.AlwaysUseFixtures,
-		mixedversion.AlwaysUseLatestPredecessors,
 	}
 	if c.IsLocal() {
 		localTimeout := 30 * time.Minute
@@ -109,7 +108,13 @@ func runVersionUpgrade(ctx context.Context, t test.Test, c cluster.Cluster) {
 		defer cancel()
 		opts = append(
 			opts,
+			mixedversion.AlwaysUseLatestPredecessors,
 			mixedversion.NumUpgrades(1),
+		)
+	} else {
+		opts = append(
+			opts,
+			mixedversion.WithSameSeriesUpgradeProbability(0.5),
 		)
 	}
 


### PR DESCRIPTION
Previously, the mixedversion testing framework only exercised cross-series
upgrades (e.g., v24.2 → v24.3). However, customers also perform same-series
patch upgrades (e.g., v24.3.5 → v24.3.12), and these upgrade paths were not
being tested.

This commit adds support for optionally inserting same-series upgrade steps
into mixedversion test plans. When enabled, the framework may insert an older
patch version from the same series before a version in the upgrade path,
creating upgrade steps like v24.3.5 → v24.3.12.

Example: An upgrade path of [24.1.5, 24.2.3, 24.3.10, current] with
probability=1 might become [24.1.2, 24.1.5, 24.2.1, 24.2.3, 24.3.7, 24.3.10, current]
where 24.1.2 → 24.1.5, 24.2.1 → 24.2.3, and 24.3.7 → 24.3.10 are same-series upgrades.


Fixes: [#152694](https://github.com/cockroachdb/cockroach/issues/152694)
Epic: None
Release Note: None