### PR TITLE
spanconfig: use context with cancel for span config manager

### DIFF
--- a/pkg/spanconfig/spanconfigmanager/manager.go
+++ b/pkg/spanconfig/spanconfigmanager/manager.go
@@ -86,6 +86,9 @@ func New(
 // recreating it if it doesn't.
 func (m *Manager) Start(ctx context.Context) error {
 	return m.stopper.RunAsyncTask(ctx, "span-config-mgr", func(ctx context.Context) {
+		ctx, cancel := m.stopper.WithCancelOnQuiesce(ctx)
+		defer cancel()
+
 		m.run(ctx)
 	})
 }


### PR DESCRIPTION
Per the discussion in #161166, it is possible for the span config reconciliation job to be deprioritised for a long time by admission control in a resource starved environment. The context in the span config manager background task must support cancellation so that the job check does not block during a shutdown.

Epic: None
Fixes: #161166
Release note: None