### PR TITLE
cli: fix TestTenantZip flake

### DIFF
--- a/pkg/cli/testdata/zip/testzip_external_process_virtualization
+++ b/pkg/cli/testdata/zip/testzip_external_process_virtualization
@@ -11,13 +11,9 @@ debug zip --concurrency=1 --cpu-profile-duration=1s --validate-zip-file=false /d
 [cluster] requesting data for debug/reports/problemranges... received response...
 [cluster] requesting data for debug/reports/problemranges: last request failed: rpc error: ...
 [cluster] requesting data for debug/reports/problemranges: creating error output: debug/reports/problemranges.json.err.txt... done
-<dumping SQL tables>
 [cluster] retrieving SQL data for crdb_internal.kv_node_liveness: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
-<dumping SQL tables>
 [cluster] retrieving SQL data for crdb_internal.kv_node_status: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
-<dumping SQL tables>
 [cluster] retrieving SQL data for crdb_internal.kv_store_status: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
-<dumping SQL tables>
 [cluster] requesting nodes... received response... writing JSON output: debug/nodes.json... done
 [cluster] requesting liveness... received response... writing JSON output: debug/liveness.json... done
 [cluster] requesting tenant ranges... received response...
@@ -29,15 +25,10 @@ debug zip --concurrency=1 --cpu-profile-duration=1s --validate-zip-file=false /d
 [cluster] profile for node 1... writing binary output: debug/nodes/1/cpu.pprof... done
 [node 1] node status... writing JSON output: debug/nodes/1/status.json... done
 [node 1] using SQL connection URL: postgresql://...
-<dumping SQL tables>
 [node 1] retrieving SQL data for crdb_internal.gossip_alerts: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
-<dumping SQL tables>
 [node 1] retrieving SQL data for crdb_internal.gossip_liveness: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
-<dumping SQL tables>
 [node 1] retrieving SQL data for crdb_internal.gossip_nodes: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
-<dumping SQL tables>
 [node 1] retrieving SQL data for crdb_internal.node_tenant_capabilities_cache: last request failed: ERROR: operation node_tenant_capabilities_cache supported only by system tenant (SQLSTATE XXUUU)
-<dumping SQL tables>
 [node 1] requesting data for debug/nodes/1/details... received response... writing JSON output: debug/nodes/1/details.json... done
 [node 1] requesting data for debug/nodes/1/gossip... received response... writing JSON output: debug/nodes/1/gossip.json... done
 [node 1] requesting stacks... received response... writing binary output: debug/nodes/1/stacks.txt... done

--- a/pkg/cli/testdata/zip/testzip_shared_process_virtualization
+++ b/pkg/cli/testdata/zip/testzip_shared_process_virtualization
@@ -9,7 +9,6 @@ debug zip --concurrency=1 --cpu-profile-duration=1s --validate-zip-file=false /d
 [cluster] requesting data for debug/rangelog... received response... writing JSON output: debug/rangelog.json... done
 [cluster] requesting data for debug/settings... received response... writing JSON output: debug/settings.json... done
 [cluster] requesting data for debug/reports/problemranges... received response... writing JSON output: debug/reports/problemranges.json... done
-<dumping SQL tables>
 [cluster] requesting nodes... received response... writing JSON output: debug/nodes.json... done
 [cluster] requesting liveness... received response... writing JSON output: debug/liveness.json... done
 [cluster] requesting tenant ranges... received response...
@@ -21,7 +20,6 @@ debug zip --concurrency=1 --cpu-profile-duration=1s --validate-zip-file=false /d
 [cluster] profile for node 1... writing binary output: debug/nodes/1/cpu.pprof... done
 [node 1] node status... writing JSON output: debug/nodes/1/status.json... done
 [node 1] using SQL connection URL: postgresql://...
-<dumping SQL tables>
 [node 1] requesting data for debug/nodes/1/details... received response... writing JSON output: debug/nodes/1/details.json... done
 [node 1] requesting data for debug/nodes/1/gossip... received response... writing JSON output: debug/nodes/1/gossip.json... done
 [node 1] requesting stacks... received response... writing binary output: debug/nodes/1/stacks.txt... done
@@ -53,13 +51,9 @@ debug zip --concurrency=1 --cpu-profile-duration=1s --validate-zip-file=false /d
 [cluster] requesting data for debug/cluster/test-tenant/reports/problemranges... received response...
 [cluster] requesting data for debug/cluster/test-tenant/reports/problemranges: last request failed: rpc error: ...
 [cluster] requesting data for debug/cluster/test-tenant/reports/problemranges: creating error output: debug/cluster/test-tenant/reports/problemranges.json.err.txt... done
-<dumping SQL tables>
 [cluster] retrieving SQL data for crdb_internal.kv_node_liveness: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
-<dumping SQL tables>
 [cluster] retrieving SQL data for crdb_internal.kv_node_status: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
-<dumping SQL tables>
 [cluster] retrieving SQL data for crdb_internal.kv_store_status: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
-<dumping SQL tables>
 [cluster] requesting nodes... received response... writing JSON output: debug/nodes.json... done
 [cluster] requesting liveness... received response... writing JSON output: debug/cluster/test-tenant/liveness.json... done
 [cluster] requesting tenant ranges... received response...
@@ -71,15 +65,10 @@ debug zip --concurrency=1 --cpu-profile-duration=1s --validate-zip-file=false /d
 [cluster] profile for node 1... writing binary output: debug/cluster/test-tenant/nodes/1/cpu.pprof... done
 [node 1] node status... writing JSON output: debug/cluster/test-tenant/nodes/1/status.json... done
 [node 1] using SQL connection URL: postgresql://...
-<dumping SQL tables>
 [node 1] retrieving SQL data for crdb_internal.gossip_alerts: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
-<dumping SQL tables>
 [node 1] retrieving SQL data for crdb_internal.gossip_liveness: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
-<dumping SQL tables>
 [node 1] retrieving SQL data for crdb_internal.gossip_nodes: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
-<dumping SQL tables>
 [node 1] retrieving SQL data for crdb_internal.node_tenant_capabilities_cache: last request failed: ERROR: operation node_tenant_capabilities_cache supported only by system tenant (SQLSTATE XXUUU)
-<dumping SQL tables>
 [node 1] requesting data for debug/cluster/test-tenant/nodes/1/details... received response... writing JSON output: debug/cluster/test-tenant/nodes/1/details.json... done
 [node 1] requesting data for debug/cluster/test-tenant/nodes/1/gossip... received response... writing JSON output: debug/cluster/test-tenant/nodes/1/gossip.json... done
 [node 1] requesting stacks... received response... writing binary output: debug/cluster/test-tenant/nodes/1/stacks.txt... done

--- a/pkg/cli/testdata/zip/testzip_shared_process_virtualization_with_default_tenant
+++ b/pkg/cli/testdata/zip/testzip_shared_process_virtualization_with_default_tenant
@@ -9,7 +9,6 @@ debug zip --concurrency=1 --cpu-profile-duration=1s --validate-zip-file=false /d
 [cluster] requesting data for debug/rangelog... received response... writing JSON output: debug/rangelog.json... done
 [cluster] requesting data for debug/settings... received response... writing JSON output: debug/settings.json... done
 [cluster] requesting data for debug/reports/problemranges... received response... writing JSON output: debug/reports/problemranges.json... done
-<dumping SQL tables>
 [cluster] requesting nodes... received response... writing JSON output: debug/nodes.json... done
 [cluster] requesting liveness... received response... writing JSON output: debug/liveness.json... done
 [cluster] requesting tenant ranges... received response...
@@ -21,7 +20,6 @@ debug zip --concurrency=1 --cpu-profile-duration=1s --validate-zip-file=false /d
 [cluster] profile for node 1... writing binary output: debug/nodes/1/cpu.pprof... done
 [node 1] node status... writing JSON output: debug/nodes/1/status.json... done
 [node 1] using SQL connection URL: postgresql://...
-<dumping SQL tables>
 [node 1] requesting data for debug/nodes/1/details... received response... writing JSON output: debug/nodes/1/details.json... done
 [node 1] requesting data for debug/nodes/1/gossip... received response... writing JSON output: debug/nodes/1/gossip.json... done
 [node 1] requesting stacks... received response... writing binary output: debug/nodes/1/stacks.txt... done
@@ -53,13 +51,9 @@ debug zip --concurrency=1 --cpu-profile-duration=1s --validate-zip-file=false /d
 [cluster] requesting data for debug/cluster/test-tenant/reports/problemranges... received response...
 [cluster] requesting data for debug/cluster/test-tenant/reports/problemranges: last request failed: rpc error: ...
 [cluster] requesting data for debug/cluster/test-tenant/reports/problemranges: creating error output: debug/cluster/test-tenant/reports/problemranges.json.err.txt... done
-<dumping SQL tables>
 [cluster] retrieving SQL data for crdb_internal.kv_node_liveness: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
-<dumping SQL tables>
 [cluster] retrieving SQL data for crdb_internal.kv_node_status: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
-<dumping SQL tables>
 [cluster] retrieving SQL data for crdb_internal.kv_store_status: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
-<dumping SQL tables>
 [cluster] requesting nodes... received response... writing JSON output: debug/nodes.json... done
 [cluster] requesting liveness... received response... writing JSON output: debug/cluster/test-tenant/liveness.json... done
 [cluster] requesting tenant ranges... received response...
@@ -71,15 +65,10 @@ debug zip --concurrency=1 --cpu-profile-duration=1s --validate-zip-file=false /d
 [cluster] profile for node 1... writing binary output: debug/cluster/test-tenant/nodes/1/cpu.pprof... done
 [node 1] node status... writing JSON output: debug/cluster/test-tenant/nodes/1/status.json... done
 [node 1] using SQL connection URL: postgresql://...
-<dumping SQL tables>
 [node 1] retrieving SQL data for crdb_internal.gossip_alerts: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
-<dumping SQL tables>
 [node 1] retrieving SQL data for crdb_internal.gossip_liveness: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
-<dumping SQL tables>
 [node 1] retrieving SQL data for crdb_internal.gossip_nodes: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
-<dumping SQL tables>
 [node 1] retrieving SQL data for crdb_internal.node_tenant_capabilities_cache: last request failed: ERROR: operation node_tenant_capabilities_cache supported only by system tenant (SQLSTATE XXUUU)
-<dumping SQL tables>
 [node 1] requesting data for debug/cluster/test-tenant/nodes/1/details... received response... writing JSON output: debug/cluster/test-tenant/nodes/1/details.json... done
 [node 1] requesting data for debug/cluster/test-tenant/nodes/1/gossip... received response... writing JSON output: debug/cluster/test-tenant/nodes/1/gossip.json... done
 [node 1] requesting stacks... received response... writing binary output: debug/cluster/test-tenant/nodes/1/stacks.txt... done

--- a/pkg/cli/zip_tenant_test.go
+++ b/pkg/cli/zip_tenant_test.go
@@ -7,6 +7,7 @@ package cli
 
 import (
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -98,6 +99,13 @@ func TestTenantZip(t *testing.T) {
 
 			// Strip any non-deterministic messages.
 			out = eraseNonDeterministicZipOutput(out)
+			// Remove all "dumping SQL tables" messages since non-deterministic order in
+			// which the original messages interleave with other messages means the
+			// number of them after each series is collapsed is also non-deterministic.
+			// Also remove orphaned " done" lines that can appear when output interleaving
+			// separates a "retrieving SQL data for..." line from its " done" suffix.
+			out = regexp.MustCompile(`<dumping SQL tables>\n`).ReplaceAllString(out, "")
+			out = regexp.MustCompile(`(?m)^ done\n`).ReplaceAllString(out, "")
 
 			// We use datadriven simply to read the golden output file; we don't actually
 			// run any commands. Using datadriven allows TESTFLAGS=-rewrite.


### PR DESCRIPTION
Remove `dumping SQL tables` messages from output
since the order is non-deterministic. This matches the approach in TestConcurrentZip.

Resolves: #161152
Epic: None
Release note: None