### PR TITLE
release-25.3: kvserver: ignore SysBytes in assertRecomputedStats

### DIFF
--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -1373,8 +1373,8 @@ func TestStoreRangeMergeStats(t *testing.T) {
 	require.NoError(t, err)
 
 	// Stats should agree with recomputation.
-	assertRecomputedStats(t, "range A before split", snap, lhsDesc, msA, store.Clock().PhysicalNow())
-	assertRecomputedStats(t, "range B before split", snap, rhsDesc, msB, store.Clock().PhysicalNow())
+	assertRecomputedStatsExceptSys(t, "range A before split", snap, lhsDesc, msA, store.Clock().PhysicalNow())
+	assertRecomputedStatsExceptSys(t, "range B before split", snap, rhsDesc, msB, store.Clock().PhysicalNow())
 
 	// Merge the b range back into the a range.
 	args := adminMergeArgs(lhsDesc.StartKey.AsRawKey())
@@ -1391,7 +1391,7 @@ func TestStoreRangeMergeStats(t *testing.T) {
 	// Merged stats should agree with recomputation.
 	nowNanos := tc.Servers[0].Clock().Now().WallTime
 	msMerged.AgeTo(nowNanos)
-	assertRecomputedStats(t, "merged range", snap, replMerged.Desc(), msMerged, nowNanos)
+	assertRecomputedStatsExceptSys(t, "merged range", snap, replMerged.Desc(), msMerged, nowNanos)
 }
 
 func TestStoreRangeMergeInFlightTxns(t *testing.T) {

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -815,7 +815,7 @@ func TestStoreRangeSplitMergeStats(t *testing.T) {
 
 	ms, err := stateloader.Make(repl.RangeID).LoadMVCCStats(ctx, snap)
 	require.NoError(t, err)
-	assertRecomputedStats(t, "before split", snap, repl.Desc(), ms, start.WallTime)
+	assertRecomputedStatsExceptSys(t, "before split", snap, repl.Desc(), ms, start.WallTime)
 
 	require.Equal(t, replMS, ms, "in-memory and on-disk stats diverge")
 
@@ -866,8 +866,8 @@ func TestStoreRangeSplitMergeStats(t *testing.T) {
 	require.GreaterOrEqual(t, msLeft.GCBytesAge+msRight.GCBytesAge, ms.GCBytesAge)
 
 	// Stats should agree with re-computation.
-	assertRecomputedStats(t, "LHS after split", snap, repl.Desc(), msLeft, s.Clock().PhysicalNow())
-	assertRecomputedStats(t, "RHS after split", snap, replRight.Desc(), msRight, s.Clock().PhysicalNow())
+	assertRecomputedStatsExceptSys(t, "LHS after split", snap, repl.Desc(), msLeft, s.Clock().PhysicalNow())
+	assertRecomputedStatsExceptSys(t, "RHS after split", snap, replRight.Desc(), msRight, s.Clock().PhysicalNow())
 	// Expect estimates if the cluster setting is enabled and neither side is empty.
 	expectEstimates := kvserver.EnableEstimatedMVCCStatsInSplit.Get(&store.ClusterSettings().SV) &&
 		msLeft.Total() > 0 && msRight.Total() > 0
@@ -891,7 +891,7 @@ func TestStoreRangeSplitMergeStats(t *testing.T) {
 
 	msMerged, err := stateloader.Make(repl.RangeID).LoadMVCCStats(ctx, snap)
 	require.NoError(t, err)
-	assertRecomputedStats(t, "in-mem after merge", snap, repl.Desc(), msMerged, s.Clock().PhysicalNow())
+	assertRecomputedStatsExceptSys(t, "in-mem after merge", snap, repl.Desc(), msMerged, s.Clock().PhysicalNow())
 
 	msMerged.SysBytes, msMerged.SysCount, msMerged.AbortSpanBytes = 0, 0, 0
 	ms.AgeTo(msMerged.LastUpdateNanos)
@@ -1021,8 +1021,8 @@ func TestStoreRangeSplitWithConcurrentWrites(t *testing.T) {
 						require.Greater(t, rhsStats.ContainsEstimates, int64(0))
 					} else {
 						// Otherwise, the stats should agree with re-computation.
-						assertRecomputedStats(t, "LHS after split", snap, lhsRepl.Desc(), lhsStats, s.Clock().PhysicalNow())
-						assertRecomputedStats(t, "RHS after split", snap, rhsRepl.Desc(), rhsStats, s.Clock().PhysicalNow())
+						assertRecomputedStatsExceptSys(t, "LHS after split", snap, lhsRepl.Desc(), lhsStats, s.Clock().PhysicalNow())
+						assertRecomputedStatsExceptSys(t, "RHS after split", snap, rhsRepl.Desc(), rhsStats, s.Clock().PhysicalNow())
 					}
 
 					// If we used estimated stats while splitting the range, the stats on disk
@@ -1059,10 +1059,10 @@ func TestStoreRangeSplitWithConcurrentWrites(t *testing.T) {
 					// estimates and not re-computing stats at the beginning of splits.
 					expectIncorrectStats := expectContainsEstimates && !recompute
 					if !expectIncorrectStats {
-						assertRecomputedStats(t, "LHS1 after second split", snap, lhsRepl.Desc(), lhs1Stats, s.Clock().PhysicalNow())
-						assertRecomputedStats(t, "LHS2 after second split", snap, lhs2Repl.Desc(), lhs2Stats, s.Clock().PhysicalNow())
-						assertRecomputedStats(t, "RHS1 after second split", snap, rhsRepl.Desc(), rhs1Stats, s.Clock().PhysicalNow())
-						assertRecomputedStats(t, "RHS2 after second split", snap, rhs2Repl.Desc(), rhs2Stats, s.Clock().PhysicalNow())
+						assertRecomputedStatsExceptSys(t, "LHS1 after second split", snap, lhsRepl.Desc(), lhs1Stats, s.Clock().PhysicalNow())
+						assertRecomputedStatsExceptSys(t, "LHS2 after second split", snap, lhs2Repl.Desc(), lhs2Stats, s.Clock().PhysicalNow())
+						assertRecomputedStatsExceptSys(t, "RHS1 after second split", snap, rhsRepl.Desc(), rhs1Stats, s.Clock().PhysicalNow())
+						assertRecomputedStatsExceptSys(t, "RHS2 after second split", snap, rhs2Repl.Desc(), rhs2Stats, s.Clock().PhysicalNow())
 					} else {
 						require.Greater(t, lhs1Stats.ContainsEstimates, int64(0))
 						require.Greater(t, lhs2Stats.ContainsEstimates, int64(0))
@@ -1445,8 +1445,8 @@ func TestStoreRangeSplitStatsWithMerges(t *testing.T) {
 	estimates := kvserver.EnableEstimatedMVCCStatsInSplit.Get(&store.ClusterSettings().SV)
 	recompute := kvserver.EnableMVCCStatsRecomputationInSplit.Get(&store.ClusterSettings().SV)
 	if !estimates || (estimates && recompute) {
-		assertRecomputedStats(t, "LHS after split", snap, repl.Desc(), msLeft, s.Clock().PhysicalNow())
-		assertRecomputedStats(t, "RHS after split", snap, replRight.Desc(), msRight, s.Clock().PhysicalNow())
+		assertRecomputedStatsExceptSys(t, "LHS after split", snap, repl.Desc(), msLeft, s.Clock().PhysicalNow())
+		assertRecomputedStatsExceptSys(t, "RHS after split", snap, replRight.Desc(), msRight, s.Clock().PhysicalNow())
 	}
 }
 
@@ -4534,8 +4534,8 @@ func TestSplitWithExternalFilesFastStats(t *testing.T) {
 				recompute := kvserver.EnableMVCCStatsRecomputationInSplit.Get(&store.ClusterSettings().SV)
 				if !estimates || (estimates && recompute) {
 					now := s.Clock().Now()
-					assertRecomputedStats(t, "lhs after split", snap, lhsRepl.Desc(), lhsStats, now.WallTime)
-					assertRecomputedStats(t, "rhs after split", snap, rhsRepl.Desc(), rhsStats, now.WallTime)
+					assertRecomputedStatsExceptSys(t, "lhs after split", snap, lhsRepl.Desc(), lhsStats, now.WallTime)
+					assertRecomputedStatsExceptSys(t, "rhs after split", snap, rhsRepl.Desc(), rhsStats, now.WallTime)
 				}
 			}
 

--- a/pkg/kv/kvserver/client_test.go
+++ b/pkg/kv/kvserver/client_test.go
@@ -182,7 +182,7 @@ func assertRangeStats(
 	require.Equal(t, expMS, ms, "%s: stats differ", name)
 }
 
-func assertRecomputedStats(
+func assertRecomputedStatsExceptSys(
 	t *testing.T,
 	name string,
 	r storage.Reader,
@@ -201,6 +201,11 @@ func assertRecomputedStats(
 	// Recomputing stats always has ContainsEstimates = 0, while on-disk stats may
 	// have a non-zero value. ContainsEstimates should be asserted separately.
 	ms.ContainsEstimates = expMS.ContainsEstimates
+	// Ignore SysBytes/SysCount/AbortSpanBytes: these can race with lease updates
+	// since RequestLease doesn't acquire latches. See:
+	// https://github.com/cockroachdb/cockroach/issues/93896.
+	expMS.SysBytes, expMS.SysCount, expMS.AbortSpanBytes = 0, 0, 0
+	ms.SysBytes, ms.SysCount, ms.AbortSpanBytes = 0, 0, 0
 	require.Equal(t, expMS, ms, "%s: recomputed stats diverge", name)
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #159885 on behalf of @tbg.

----

SysBytes can race with lease updates since RequestLease doesn't acquire latches. Rename the helper to make this explicit.

Fixes (with 25.4 backport) #159884.
Informs #93896.

Release note: None

----

Fixes-25.3 #161842
Release justification: test deflake