### PR TITLE
kvserver: defer stop in TestMaybeMarkReplicaUnavailableInLeaderlessWatcher

### DIFF
--- a/pkg/kv/kvserver/replica_raft_test.go
+++ b/pkg/kv/kvserver/replica_raft_test.go
@@ -467,6 +467,7 @@ func TestMaybeMarkReplicaUnavailableInLeaderlessWatcher(t *testing.T) {
 	for _, tc := range testCases {
 		ctx := context.Background()
 		stopper := stop.NewStopper()
+		defer stopper.Stop(ctx)
 
 		tContext := testContext{}
 		cfg := TestStoreConfig(nil)


### PR DESCRIPTION
We stop this stopper later in the loop, but that doesn't help if we hit an assertion before that point. If we fail to stop the stopper, we do not run any registered cleanups, causing unrelated tests to fail with:

    panic: TestingSetupZoneConfigHook called without restoring state

Fixes #160693

Release note: None