### PR TITLE
ui,e2e: fix more sql activity page cypress tests

### DIFF
--- a/pkg/ui/workspaces/e2e-tests/cypress/e2e/pages/sqlActivity.cy.ts
+++ b/pkg/ui/workspaces/e2e-tests/cypress/e2e/pages/sqlActivity.cy.ts
@@ -92,6 +92,7 @@ describe("SQL Activity page - Statements Tab", () => {
     cy.get(".statements-table").should("not.contain.text", "Min Latency");
     cy.contains("Columns").click();
     cy.get('[class*="dropdown-area"]')
+      .eq(2)
       .should("exist")
       .within(() => {
         cy.contains("Min Latency").click();
@@ -142,9 +143,11 @@ describe("SQL Activity page - Statements Tab", () => {
 
   it("clicks into sql statement details page", () => {
     // should have at least one row
-    cy.get(".statements-table tbody tr").within(() => {
-      cy.get("a").first().click();
-    });
+    cy.get(".statements-table tbody tr")
+      .first()
+      .within(() => {
+        cy.get("a").first().click();
+      });
 
     cy.location("hash").should("include", "/statement/");
 
@@ -304,9 +307,11 @@ describe("SQL Activity page - Transactions Tab", () => {
 
   it("clicks into sql transaction details page", () => {
     // should have at least one row
-    cy.get(".statements-table tbody tr").within(() => {
-      cy.get("a").first().click();
-    });
+    cy.get(".statements-table tbody tr")
+      .first()
+      .within(() => {
+        cy.get("a").first().click();
+      });
 
     cy.location("hash").should("include", "/transaction/");
 


### PR DESCRIPTION
Flushed out more errors around the targetting of tags in the new test that were not detected on the local testing. Which are fixed by updating the targeting of within().

Fixes: cockroachdb#161841
Epic: None
Release note: None