### PR TITLE
backup: support RESTORE ... WITH GRANTS (prototype)

### DIFF
--- a/docs/generated/sql/bnf/restore_options.bnf
+++ b/docs/generated/sql/bnf/restore_options.bnf
@@ -20,3 +20,4 @@ restore_options ::=
 	| 'EXPERIMENTAL' 'DEFERRED' 'COPY'
 	| 'EXPERIMENTAL' 'COPY'
 	| 'REMOVE_REGIONS'
+	| 'GRANTS' opt_grants_filter

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -3113,6 +3113,7 @@ restore_options ::=
 	| 'EXPERIMENTAL' 'DEFERRED' 'COPY'
 	| 'EXPERIMENTAL' 'COPY'
 	| 'REMOVE_REGIONS'
+	| 'GRANTS' opt_grants_filter
 
 scrub_option_list ::=
 	( scrub_option ) ( ( ',' scrub_option ) )*
@@ -3710,6 +3711,11 @@ virtual_cluster_name ::=
 
 virtual_cluster_opt ::=
 	'VIRTUAL_CLUSTER'
+
+opt_grants_filter ::=
+	'INCLUDING' '=' string_or_placeholder
+	| 'EXCLUDING' '=' string_or_placeholder
+	| 
 
 scrub_option ::=
 	'INDEX' 'ALL'

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -664,7 +664,11 @@ message RestoreDetails {
 
   bool experimental_copy = 37;
 
-  // NEXT ID: 38.
+  bool grants = 38;
+  repeated string grants_including = 39;
+  repeated string grants_excluding = 40;
+
+  // NEXT ID: 41.
 }
 
 

--- a/pkg/sql/catalog/externalcatalog/external_catalog.go
+++ b/pkg/sql/catalog/externalcatalog/external_catalog.go
@@ -164,6 +164,7 @@ func IngestExternalCatalog(
 		ctx, txn.KV(), user, descsCol, nil, nil, tablesToWrite, nil, nil,
 		tree.RequestedDescriptors, nil /* extra */, "", true,
 		false, /*allowCrossDatabaseRefs*/
+		false,
 	)
 }
 

--- a/pkg/sql/catalog/ingesting/BUILD.bazel
+++ b/pkg/sql/catalog/ingesting/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/sql/catalog/funcdesc",
         "//pkg/sql/catalog/nstree",
         "//pkg/sql/catalog/schemadesc",
+        "//pkg/sql/catalog/systemschema",
         "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/catalog/typedesc",
         "//pkg/sql/pgwire/pgcode",

--- a/pkg/sql/catalog/ingesting/write_descs.go
+++ b/pkg/sql/catalog/ingesting/write_descs.go
@@ -53,6 +53,8 @@ func WriteDescriptors(
 	inheritParentName string,
 	includePublicSchemaCreatePriv bool,
 	allowCrossDatabaseRefs bool,
+	// TODO(at): replace this with something good
+	keep bool,
 ) (err error) {
 	var writtenDescs nstree.MutableCatalog
 	ctx, span := tracing.ChildSpan(ctx, "WriteDescriptors")
@@ -76,7 +78,7 @@ func WriteDescriptors(
 	for i := range databases {
 		desc := databases[i]
 		updatedPrivileges, err := GetIngestingDescriptorPrivileges(ctx, txn, descsCol, desc, user,
-			wroteDBs, wroteSchemas, descCoverage, includePublicSchemaCreatePriv)
+			wroteDBs, wroteSchemas, descCoverage, includePublicSchemaCreatePriv, keep)
 		if err != nil {
 			return err
 		}
@@ -114,7 +116,7 @@ func WriteDescriptors(
 	for i := range schemas {
 		sc := schemas[i]
 		updatedPrivileges, err := GetIngestingDescriptorPrivileges(ctx, txn, descsCol, sc, user,
-			wroteDBs, wroteSchemas, descCoverage, includePublicSchemaCreatePriv)
+			wroteDBs, wroteSchemas, descCoverage, includePublicSchemaCreatePriv, keep)
 		if err != nil {
 			return err
 		}
@@ -143,7 +145,7 @@ func WriteDescriptors(
 	for i := range tables {
 		table := tables[i]
 		updatedPrivileges, err := GetIngestingDescriptorPrivileges(ctx, txn, descsCol, table, user,
-			wroteDBs, wroteSchemas, descCoverage, includePublicSchemaCreatePriv)
+			wroteDBs, wroteSchemas, descCoverage, includePublicSchemaCreatePriv, keep)
 		if err != nil {
 			return err
 		}
@@ -175,7 +177,7 @@ func WriteDescriptors(
 	for i := range types {
 		typ := types[i]
 		updatedPrivileges, err := GetIngestingDescriptorPrivileges(ctx, txn, descsCol, typ, user,
-			wroteDBs, wroteSchemas, descCoverage, includePublicSchemaCreatePriv)
+			wroteDBs, wroteSchemas, descCoverage, includePublicSchemaCreatePriv, keep)
 		if err != nil {
 			return err
 		}
@@ -200,7 +202,7 @@ func WriteDescriptors(
 
 	for _, fn := range functions {
 		updatedPrivileges, err := GetIngestingDescriptorPrivileges(
-			ctx, txn, descsCol, fn, user, wroteDBs, wroteSchemas, descCoverage, includePublicSchemaCreatePriv,
+			ctx, txn, descsCol, fn, user, wroteDBs, wroteSchemas, descCoverage, includePublicSchemaCreatePriv, keep,
 		)
 		if err != nil {
 			return err

--- a/pkg/sql/sem/tree/backup.go
+++ b/pkg/sql/sem/tree/backup.go
@@ -129,6 +129,9 @@ type RestoreOptions struct {
 	ExperimentalOnline               bool
 	ExperimentalCopy                 bool
 	RemoveRegions                    bool
+	Grants                           bool
+	GrantsIncluding                  Expr
+	GrantsExcluding                  Expr
 }
 
 func (opts *RestoreOptions) OnlineImpl() bool {


### PR DESCRIPTION
This is a prototype of RESTORE ... WITH GRANTS, for the purposes of discussing implementation strategies.

The goal is to support two versions of this option:

**`RESTORE ... WITH GRANTS`**
This would allow users to execute a database or table level restore, and restore grants on the restore targets for any users/roles currently in the target cluster.

**`RESTORE ... WITH GRANTS INCLUDING USERS`**
This would function the same as the above option, but first, restore any users/roles which are not currently in the target cluster who have grants on the restore targets.

Note that these will initially only be supported when restoring from a full cluster backup, as these have the descriptor and system table information that we need.

The code is in varying levels of completion, but the rough idea for the implementation is as follows:

For restoring grants, we grab the descriptors of our restore targets from the backup, and do a descriptor rewrite applying the backed up privileges to the descriptor.

For restoring users, we have the added complexity of potentially arbitrarily convoluted user/role hierarchies. If we treat this hierarchy as a DAG, we can modify the system.users and system.role_members table in stages, going level by level in the DAG. First creating users/roles who have direct grants on the restore targets, then grabbing their members from the backed up system tables, and creating those in the next iteration, continuing until we reach the end of the DAG. Note that in the case of restoring users, this would happen before rewriting descriptors.

Also under consideration is creating users/roles and granting privileges via higher level user side commands (`CREATE ROLE`, `ALTER ROLE`, `GRANT`, etc). This would likely be less error prone but would involve teaching these commands to work with offline descriptors.

**some gotchas to consider**
- If we do a database level restore, we would also want to restore any grants on the underlying tables and other objects in that database. Since we are *restoring* these objects, we're already doing descriptor rewrites, but this can get complex pretty quick if we're also restoring users and those users have a mix of grants on different targets that we're restoring.
- If we're restoring grants without users, and some users have been dropped since the backup, we may have some unexpected (albeit semantically correct) behavior. For example, if we have a hierarchy of `org -> dev -> andrew`, where `org` has a grant on our restore target, if we drop `dev` and then restore without users, `org` would regain the grant, but `andrew` would not, since the chain has been broken.
