### PR TITLE
sql: resolve test tenant randomization for observability tests

### DIFF
--- a/pkg/sql/crdb_internal_test.go
+++ b/pkg/sql/crdb_internal_test.go
@@ -856,8 +856,11 @@ func TestTxnContentionEventsTableWithRangeDescriptor(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
+	// This test requires system tenant because it tests contention event
+	// handling for range descriptor keys, which are KV-internal keys that
+	// secondary tenants never interact with.
 	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
-		DefaultTestTenant: base.TestDoesNotWorkWithSecondaryTenantsButWeDontKnowWhyYet(156145),
+		DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
 	})
 	defer srv.Stopper().Stop(ctx)
 	s := srv.ApplicationLayer()


### PR DESCRIPTION
This addresses the three tests that had test tenant randomization disabled under issue #156145.

TestShowRangesWithDetails now runs with tenant randomization enabled. The underlying tenant_span_stats() function is designed for tenant use and the test passes with an external process virtual cluster.

TestShowRangesUnavailableReplicas remains disabled for tenants because it requires controlling server lifecycle (stopping servers to create unavailable ranges) and uses manual replication mode - both are KV-layer infrastructure operations that tenants cannot perform.

TestTxnContentionEventsTableWithRangeDescriptor remains disabled for tenants because it tests contention event handling for range descriptor keys, which are KV-internal keys that secondary tenants never interact with. Note that TestTxnContentionEventsTableMultiTenant already tests contention events with tenants enabled and passes.

For the two tests that must remain system-tenant-only, the annotation was changed from TestDoesNotWorkWithSecondaryTenantsButWeDontKnowWhyYet to TestIsSpecificToStorageLayerAndNeedsASystemTenant to clearly indicate these are intentional exclusions, not bugs.

Closes: #156145

Release note: None