### PR TITLE
catalog/lease: handle lease timestamps below GC interval

### DIFF
--- a/pkg/sql/catalog/lease/BUILD.bazel
+++ b/pkg/sql/catalog/lease/BUILD.bazel
@@ -98,6 +98,7 @@ go_test(
         "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/kv",
+        "//pkg/kv/kvclient/kvcoord",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/kvserverbase",


### PR DESCRIPTION
Previously, when locked leasing timestamps were used, it was possible for the lease time to fall below the GC interval in some synthetic scenarios during name resolution. To address this, this patch updates the name resolution logic in the lease manager to treat GC errors as missing descriptors at a given timestamp. This forces the system to use the read timestamp correctly.

Fixes: #161220

Release note: None