### PR TITLE
opt: fix bug and add setting for InlineAnyProjectSet

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -3872,6 +3872,7 @@ optimizer_clamp_low_histogram_selectivity                        on
 optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  on
 optimizer_enable_lock_elision                                    on
 optimizer_hoist_uncorrelated_equality_subqueries                 on
+optimizer_inline_any_unnest_subquery                             off
 optimizer_merge_joins_enabled                                    on
 optimizer_min_row_count                                          1
 optimizer_plan_lookup_joins_with_reverse_scans                   on

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -3872,7 +3872,7 @@ optimizer_clamp_low_histogram_selectivity                        on
 optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  on
 optimizer_enable_lock_elision                                    on
 optimizer_hoist_uncorrelated_equality_subqueries                 on
-optimizer_inline_any_unnest_subquery                             off
+optimizer_inline_any_unnest_subquery                             on
 optimizer_merge_joins_enabled                                    on
 optimizer_min_row_count                                          1
 optimizer_plan_lookup_joins_with_reverse_scans                   on

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3146,7 +3146,7 @@ optimizer_clamp_low_histogram_selectivity                        on             
 optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  on                  NULL      NULL        NULL        string
 optimizer_enable_lock_elision                                    on                  NULL      NULL        NULL        string
 optimizer_hoist_uncorrelated_equality_subqueries                 on                  NULL      NULL        NULL        string
-optimizer_inline_any_unnest_subquery                             off                 NULL      NULL        NULL        string
+optimizer_inline_any_unnest_subquery                             on                  NULL      NULL        NULL        string
 optimizer_merge_joins_enabled                                    on                  NULL      NULL        NULL        string
 optimizer_min_row_count                                          1                   NULL      NULL        NULL        string
 optimizer_plan_lookup_joins_with_reverse_scans                   on                  NULL      NULL        NULL        string
@@ -3399,7 +3399,7 @@ optimizer_clamp_low_histogram_selectivity                        on             
 optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  on                  NULL  user     NULL      on                  on
 optimizer_enable_lock_elision                                    on                  NULL  user     NULL      on                  on
 optimizer_hoist_uncorrelated_equality_subqueries                 on                  NULL  user     NULL      on                  on
-optimizer_inline_any_unnest_subquery                             off                 NULL  user     NULL      off                 off
+optimizer_inline_any_unnest_subquery                             on                  NULL  user     NULL      on                  on
 optimizer_merge_joins_enabled                                    on                  NULL  user     NULL      on                  on
 optimizer_min_row_count                                          1                   NULL  user     NULL      1                   1
 optimizer_plan_lookup_joins_with_reverse_scans                   on                  NULL  user     NULL      on                  on

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3146,6 +3146,7 @@ optimizer_clamp_low_histogram_selectivity                        on             
 optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  on                  NULL      NULL        NULL        string
 optimizer_enable_lock_elision                                    on                  NULL      NULL        NULL        string
 optimizer_hoist_uncorrelated_equality_subqueries                 on                  NULL      NULL        NULL        string
+optimizer_inline_any_unnest_subquery                             off                 NULL      NULL        NULL        string
 optimizer_merge_joins_enabled                                    on                  NULL      NULL        NULL        string
 optimizer_min_row_count                                          1                   NULL      NULL        NULL        string
 optimizer_plan_lookup_joins_with_reverse_scans                   on                  NULL      NULL        NULL        string
@@ -3398,6 +3399,7 @@ optimizer_clamp_low_histogram_selectivity                        on             
 optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  on                  NULL  user     NULL      on                  on
 optimizer_enable_lock_elision                                    on                  NULL  user     NULL      on                  on
 optimizer_hoist_uncorrelated_equality_subqueries                 on                  NULL  user     NULL      on                  on
+optimizer_inline_any_unnest_subquery                             off                 NULL  user     NULL      off                 off
 optimizer_merge_joins_enabled                                    on                  NULL  user     NULL      on                  on
 optimizer_min_row_count                                          1                   NULL  user     NULL      1                   1
 optimizer_plan_lookup_joins_with_reverse_scans                   on                  NULL  user     NULL      on                  on
@@ -3641,6 +3643,7 @@ optimizer_clamp_low_histogram_selectivity                        NULL    NULL   
 optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  NULL    NULL     NULL     NULL        NULL
 optimizer_enable_lock_elision                                    NULL    NULL     NULL     NULL        NULL
 optimizer_hoist_uncorrelated_equality_subqueries                 NULL    NULL     NULL     NULL        NULL
+optimizer_inline_any_unnest_subquery                             NULL    NULL     NULL     NULL        NULL
 optimizer_merge_joins_enabled                                    NULL    NULL     NULL     NULL        NULL
 optimizer_min_row_count                                          NULL    NULL     NULL     NULL        NULL
 optimizer_plan_lookup_joins_with_reverse_scans                   NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -160,7 +160,7 @@ optimizer_clamp_low_histogram_selectivity                        on
 optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  on
 optimizer_enable_lock_elision                                    on
 optimizer_hoist_uncorrelated_equality_subqueries                 on
-optimizer_inline_any_unnest_subquery                             off
+optimizer_inline_any_unnest_subquery                             on
 optimizer_merge_joins_enabled                                    on
 optimizer_min_row_count                                          1
 optimizer_plan_lookup_joins_with_reverse_scans                   on

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -160,6 +160,7 @@ optimizer_clamp_low_histogram_selectivity                        on
 optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  on
 optimizer_enable_lock_elision                                    on
 optimizer_hoist_uncorrelated_equality_subqueries                 on
+optimizer_inline_any_unnest_subquery                             off
 optimizer_merge_joins_enabled                                    on
 optimizer_min_row_count                                          1
 optimizer_plan_lookup_joins_with_reverse_scans                   on

--- a/pkg/sql/logictest/testdata/logic_test/suboperators
+++ b/pkg/sql/logictest/testdata/logic_test/suboperators
@@ -16,6 +16,11 @@ INSERT INTO comp VALUES (ROW(1, 2)), (ROW(3, 4));
 # ANY/SOME with arrays.
 
 query B
+SELECT 1 = ANY(NULL::INT[])
+----
+NULL
+
+query B
 SELECT 1 = ANY(ARRAY[1, 2])
 ----
 true
@@ -144,6 +149,11 @@ true
 
 query B
 SELECT 1 < ANY(SELECT * FROM generate_series(0,1))
+----
+false
+
+query B
+SELECT 1 = ANY(SELECT * FROM unnest(NULL::INT[]))
 ----
 false
 

--- a/pkg/sql/opt/norm/rules/scalar.opt
+++ b/pkg/sql/opt/norm/rules/scalar.opt
@@ -348,16 +348,17 @@ $udf
 [InlineAnyProjectSet, Normalize]
 (Any
     (ProjectSet
-        (Values [ (Tuple []) ])
-        [
-            (ZipItem
-                (Function
-                    [ $arg:* ]
-                    $fnPrivate:(FunctionPrivate "unnest")
+            (Values [ (Tuple []) ])
+            [
+                (ZipItem
+                    (Function
+                        [ $arg:* ]
+                        $fnPrivate:(FunctionPrivate "unnest")
+                    )
                 )
-            )
-        ]
-    )
+            ]
+        ) &
+        (CanInlineAnyUnnestSubquery)
     $scalar:*
     $private:*
 )

--- a/pkg/sql/opt/norm/rules/scalar.opt
+++ b/pkg/sql/opt/norm/rules/scalar.opt
@@ -340,6 +340,11 @@ $udf
 # InlineAnyProjectSet replaces an "unnest" subquery used for an ANY comparison
 # with the "unnest" argument. We only match when the ProjectSet has an empty
 # input and only projects the result of a single unnest function.
+#
+# There is some subtlety if the unnest argument evaluates to NULL. In that case,
+# the result of unnest is empty, and the Any filter evaluates to false. However,
+# AnyScalar with a NULL second argument evaluates to NULL. To handle this, we
+# AND the result of AnyScalar with an IsNot NULL check on the argument.
 [InlineAnyProjectSet, Normalize]
 (Any
     (ProjectSet
@@ -357,7 +362,10 @@ $udf
     $private:*
 )
 =>
-(AnyScalar $scalar $arg (SubqueryCmp $private))
+(And
+    (AnyScalar $scalar $arg (SubqueryCmp $private))
+    (IsNot $arg (Null (TypeOf $arg)))
+)
 
 # SimplifyEqualsAnyTuple converts a scalar ANY operation to an IN comparison.
 # It transforms

--- a/pkg/sql/opt/norm/scalar_funcs.go
+++ b/pkg/sql/opt/norm/scalar_funcs.go
@@ -401,3 +401,9 @@ func (c *CustomFuncs) SplitTupleEq(lhs, rhs *memo.TupleExpr) memo.FiltersExpr {
 func (c *CustomFuncs) CanNormalizeArrayFlatten(input memo.RelExpr, p *memo.SubqueryPrivate) bool {
 	return c.HasOuterCols(input) || p.WithinUDF
 }
+
+// CanInlineAnyUnnestSubquery returns true if the InlineAnyProjectSet rule is
+// enabled by the session setting.
+func (c *CustomFuncs) CanInlineAnyUnnestSubquery() bool {
+	return c.f.evalCtx.SessionData().OptimizerInlineAnyUnnestSubquery
+}

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -1987,7 +1987,7 @@ select
 # --------------------------------------------------
 
 # Basic equality case with unnest.
-norm expect=InlineAnyProjectSet
+norm set=optimizer_inline_any_unnest_subquery=true expect=InlineAnyProjectSet
 SELECT k FROM a WHERE k = ANY(SELECT * FROM unnest($1:::INT[]))
 ----
 select
@@ -2002,7 +2002,7 @@ select
       └── $1 IS DISTINCT FROM CAST(NULL AS INT8[])
 
 # Different comparison operator.
-norm expect=InlineAnyProjectSet
+norm set=optimizer_inline_any_unnest_subquery=true expect=InlineAnyProjectSet
 SELECT k FROM a WHERE k > ANY(SELECT * FROM unnest($1:::INT[]))
 ----
 select
@@ -2017,7 +2017,7 @@ select
       └── $1 IS DISTINCT FROM CAST(NULL AS INT8[])
 
 # String array.
-norm expect=InlineAnyProjectSet
+norm set=optimizer_inline_any_unnest_subquery=true expect=InlineAnyProjectSet
 SELECT s FROM a WHERE s = ANY(SELECT * FROM unnest($1:::STRING[]))
 ----
 select
@@ -2030,7 +2030,7 @@ select
       └── $1 IS DISTINCT FROM CAST(NULL AS STRING[])
 
 # Using a column reference for the array.
-norm expect=InlineAnyProjectSet
+norm set=optimizer_inline_any_unnest_subquery=true expect=InlineAnyProjectSet
 SELECT k FROM a WHERE k = ANY(SELECT * FROM unnest(arr))
 ----
 project
@@ -2049,7 +2049,7 @@ project
            └── arr:5 IS DISTINCT FROM CAST(NULL AS INT8[]) [outer=(5), constraints=(/5: (/NULL - ]; tight)]
 
 # Case with an array-returning expression inside other than a placeholder.
-norm expect=InlineAnyProjectSet
+norm set=optimizer_inline_any_unnest_subquery=true expect=InlineAnyProjectSet
 SELECT k FROM a WHERE k = ANY(SELECT * FROM unnest(ARRAY[1]::int[] || array_remove($1::int[], 5)))
 ----
 select
@@ -2064,7 +2064,7 @@ select
       └── (ARRAY[1] || array_remove($1, 5)) IS DISTINCT FROM CAST(NULL AS INT8[]) [immutable]
 
 # Case with an array containing NULL.
-norm expect=InlineAnyProjectSet
+norm set=optimizer_inline_any_unnest_subquery=true expect=InlineAnyProjectSet
 SELECT k FROM a WHERE k = ANY(SELECT unnest(array_append($1::int[], NULL)::int[]))
 ----
 select
@@ -2079,7 +2079,7 @@ select
       └── array_append($1, NULL) IS DISTINCT FROM CAST(NULL AS INT8[]) [immutable]
 
 # Case with a NULL array.
-norm expect=InlineAnyProjectSet
+norm set=optimizer_inline_any_unnest_subquery=true expect=InlineAnyProjectSet
 SELECT k FROM a WHERE k = ANY(SELECT unnest(NULL::int[]))
 ----
 values
@@ -2101,6 +2101,29 @@ select
  │    └── key: (1)
  └── filters
       └── k:1 IN ($1, NULL) [outer=(1)]
+
+# Rule should not fire when the session variable is disabled.
+norm set=optimizer_inline_any_unnest_subquery=false expect-not=InlineAnyProjectSet
+SELECT k FROM a WHERE k = ANY(SELECT * FROM unnest($1:::INT[]))
+----
+semi-join (hash)
+ ├── columns: k:1!null
+ ├── immutable, has-placeholder
+ ├── key: (1)
+ ├── scan a
+ │    ├── columns: k:1!null
+ │    └── key: (1)
+ ├── project-set
+ │    ├── columns: unnest:8
+ │    ├── immutable, has-placeholder
+ │    ├── values
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    └── ()
+ │    └── zip
+ │         └── unnest($1) [immutable]
+ └── filters
+      └── k:1 = unnest:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
 
 # Rule should not fire when ProjectSet has multiple zip items.
 norm expect-not=InlineAnyProjectSet

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -1998,7 +1998,8 @@ select
  │    ├── columns: k:1!null
  │    └── key: (1)
  └── filters
-      └── k:1 = ANY $1 [outer=(1)]
+      ├── k:1 = ANY $1 [outer=(1)]
+      └── $1 IS DISTINCT FROM CAST(NULL AS INT8[])
 
 # Different comparison operator.
 norm expect=InlineAnyProjectSet
@@ -2012,7 +2013,8 @@ select
  │    ├── columns: k:1!null
  │    └── key: (1)
  └── filters
-      └── k:1 > ANY $1 [outer=(1)]
+      ├── k:1 > ANY $1 [outer=(1)]
+      └── $1 IS DISTINCT FROM CAST(NULL AS INT8[])
 
 # String array.
 norm expect=InlineAnyProjectSet
@@ -2024,7 +2026,8 @@ select
  ├── scan a
  │    └── columns: s:4
  └── filters
-      └── s:4 = ANY $1 [outer=(4)]
+      ├── s:4 = ANY $1 [outer=(4)]
+      └── $1 IS DISTINCT FROM CAST(NULL AS STRING[])
 
 # Using a column reference for the array.
 norm expect=InlineAnyProjectSet
@@ -2034,7 +2037,7 @@ project
  ├── columns: k:1!null
  ├── key: (1)
  └── select
-      ├── columns: k:1!null arr:5
+      ├── columns: k:1!null arr:5!null
       ├── key: (1)
       ├── fd: (1)-->(5)
       ├── scan a
@@ -2042,7 +2045,8 @@ project
       │    ├── key: (1)
       │    └── fd: (1)-->(5)
       └── filters
-           └── k:1 = ANY arr:5 [outer=(1,5)]
+           ├── k:1 = ANY arr:5 [outer=(1,5)]
+           └── arr:5 IS DISTINCT FROM CAST(NULL AS INT8[]) [outer=(5), constraints=(/5: (/NULL - ]; tight)]
 
 # Case with an array-returning expression inside other than a placeholder.
 norm expect=InlineAnyProjectSet
@@ -2056,7 +2060,8 @@ select
  │    ├── columns: k:1!null
  │    └── key: (1)
  └── filters
-      └── k:1 = ANY (ARRAY[1] || array_remove($1, 5)) [outer=(1), immutable]
+      ├── k:1 = ANY (ARRAY[1] || array_remove($1, 5)) [outer=(1), immutable]
+      └── (ARRAY[1] || array_remove($1, 5)) IS DISTINCT FROM CAST(NULL AS INT8[]) [immutable]
 
 # Case with an array containing NULL.
 norm expect=InlineAnyProjectSet
@@ -2070,7 +2075,8 @@ select
  │    ├── columns: k:1!null
  │    └── key: (1)
  └── filters
-      └── k:1 = ANY array_append($1, NULL) [outer=(1), immutable]
+      ├── k:1 = ANY array_append($1, NULL) [outer=(1), immutable]
+      └── array_append($1, NULL) IS DISTINCT FROM CAST(NULL AS INT8[]) [immutable]
 
 # Case with a NULL array.
 norm expect=InlineAnyProjectSet

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -1987,7 +1987,7 @@ select
 # --------------------------------------------------
 
 # Basic equality case with unnest.
-norm set=optimizer_inline_any_unnest_subquery=true expect=InlineAnyProjectSet
+norm expect=InlineAnyProjectSet
 SELECT k FROM a WHERE k = ANY(SELECT * FROM unnest($1:::INT[]))
 ----
 select
@@ -2002,7 +2002,7 @@ select
       └── $1 IS DISTINCT FROM CAST(NULL AS INT8[])
 
 # Different comparison operator.
-norm set=optimizer_inline_any_unnest_subquery=true expect=InlineAnyProjectSet
+norm expect=InlineAnyProjectSet
 SELECT k FROM a WHERE k > ANY(SELECT * FROM unnest($1:::INT[]))
 ----
 select
@@ -2017,7 +2017,7 @@ select
       └── $1 IS DISTINCT FROM CAST(NULL AS INT8[])
 
 # String array.
-norm set=optimizer_inline_any_unnest_subquery=true expect=InlineAnyProjectSet
+norm expect=InlineAnyProjectSet
 SELECT s FROM a WHERE s = ANY(SELECT * FROM unnest($1:::STRING[]))
 ----
 select
@@ -2030,7 +2030,7 @@ select
       └── $1 IS DISTINCT FROM CAST(NULL AS STRING[])
 
 # Using a column reference for the array.
-norm set=optimizer_inline_any_unnest_subquery=true expect=InlineAnyProjectSet
+norm expect=InlineAnyProjectSet
 SELECT k FROM a WHERE k = ANY(SELECT * FROM unnest(arr))
 ----
 project
@@ -2049,7 +2049,7 @@ project
            └── arr:5 IS DISTINCT FROM CAST(NULL AS INT8[]) [outer=(5), constraints=(/5: (/NULL - ]; tight)]
 
 # Case with an array-returning expression inside other than a placeholder.
-norm set=optimizer_inline_any_unnest_subquery=true expect=InlineAnyProjectSet
+norm expect=InlineAnyProjectSet
 SELECT k FROM a WHERE k = ANY(SELECT * FROM unnest(ARRAY[1]::int[] || array_remove($1::int[], 5)))
 ----
 select
@@ -2064,7 +2064,7 @@ select
       └── (ARRAY[1] || array_remove($1, 5)) IS DISTINCT FROM CAST(NULL AS INT8[]) [immutable]
 
 # Case with an array containing NULL.
-norm set=optimizer_inline_any_unnest_subquery=true expect=InlineAnyProjectSet
+norm expect=InlineAnyProjectSet
 SELECT k FROM a WHERE k = ANY(SELECT unnest(array_append($1::int[], NULL)::int[]))
 ----
 select
@@ -2079,7 +2079,7 @@ select
       └── array_append($1, NULL) IS DISTINCT FROM CAST(NULL AS INT8[]) [immutable]
 
 # Case with a NULL array.
-norm set=optimizer_inline_any_unnest_subquery=true expect=InlineAnyProjectSet
+norm expect=InlineAnyProjectSet
 SELECT k FROM a WHERE k = ANY(SELECT unnest(NULL::int[]))
 ----
 values

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -774,6 +774,9 @@ message LocalOnlySessionData {
   // physical planner from partitioning scans with soft limits into multiple
   // TableReaders. When true, this matches the behavior for hard limits.
   bool distsql_prevent_partitioning_soft_limited_scans = 197 [(gogoproto.customname) = "DistSQLPreventPartitioningSoftLimitedScans"];
+  // OptimizerInlineAnyUnnestSubquery, when true, enables the InlineAnyProjectSet
+  // normalization rule that inlines unnest subqueries in ANY comparisons.
+  bool optimizer_inline_any_unnest_subquery = 198;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/sessionmutator/mutator.go
+++ b/pkg/sql/sessionmutator/mutator.go
@@ -1123,6 +1123,10 @@ func (m *SessionDataMutator) SetDistSQLPreventPartitioningSoftLimitedScans(val b
 	m.Data.DistSQLPreventPartitioningSoftLimitedScans = val
 }
 
+func (m *SessionDataMutator) SetOptimizerInlineAnyUnnestSubquery(val bool) {
+	m.Data.OptimizerInlineAnyUnnestSubquery = val
+}
+
 func (m *SessionDataMutator) SetUseBackupsWithIDs(val bool) {
 	m.Data.UseBackupsWithIDs = val
 }

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -4558,6 +4558,23 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalFalse,
 	},
+
+	// CockroachDB extension.
+	`optimizer_inline_any_unnest_subquery`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`optimizer_inline_any_unnest_subquery`),
+		Set: func(_ context.Context, m sessionmutator.SessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("optimizer_inline_any_unnest_subquery", s)
+			if err != nil {
+				return err
+			}
+			m.SetOptimizerInlineAnyUnnestSubquery(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().OptimizerInlineAnyUnnestSubquery), nil
+		},
+		GlobalDefault: globalFalse,
+	},
 }
 
 func ReplicationModeFromString(s string) (sessiondatapb.ReplicationMode, error) {

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -4573,7 +4573,7 @@ var varGen = map[string]sessionVar{
 		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
 			return formatBoolAsPostgresSetting(evalCtx.SessionData().OptimizerInlineAnyUnnestSubquery), nil
 		},
-		GlobalDefault: globalFalse,
+		GlobalDefault: globalTrue,
 	},
 }
 


### PR DESCRIPTION
#### opt: fix bug in InlineAnyProjectSet

The recently introduced InlineAnyProjectSet norm rule has a bug when the
input array is NULL - it returns NULL instead of false as the originally
matched expression would. The fix is simple - just AND the replacement
expression with an IS NOT NULL check. This flips the NULL to false in the
problem case only.

There is no release note, since the bug didn't make it into any release.

Fixes #161871

Release note: None

#### opt: gate new norm rule behind session setting

This commit adds a session setting optimizer_inline_any_unnest_subquery
to gate the new optimizer rule InlineAnyProjectSet in case we want
to backport. The setting is off by default, and will be switched on
in the next commit.

Informs #161871

Release note (sql change): Added a session setting to enable/disable the
optimizer rule InlineAnyProjectSet. The session setting is
optimizer_inline_any_unnest_subquery, and will be on by default in 26.2+.

#### opt: turn on InlineAnyProjectSet rule by default

This commit flips the session variable introduced in the previous
commit.

Informs #161871

Release note: None