### PR TITLE
sql: fix STORING clause position for hash sharded indexes in pg_indexes

### DIFF
--- a/pkg/sql/catalog/catformat/index.go
+++ b/pkg/sql/catalog/catformat/index.go
@@ -142,12 +142,7 @@ func indexForDisplay(
 	f.WriteByte(')')
 
 	if index.IsSharded() {
-		if f.HasFlags(tree.FmtPGCatalog) {
-			fmt.Fprintf(f, " USING HASH WITH (bucket_count=%v)",
-				index.Sharded.ShardBuckets)
-		} else {
-			f.WriteString(" USING HASH")
-		}
+		f.WriteString(" USING HASH")
 	}
 
 	if !isPrimary && len(index.StoreColumnNames) > 0 {
@@ -163,10 +158,8 @@ func indexForDisplay(
 
 	f.WriteString(partition)
 
-	if !f.HasFlags(tree.FmtPGCatalog) {
-		if err := formatStorageConfigs(table, index, f); err != nil {
-			return "", err
-		}
+	if err := formatStorageConfigs(table, index, f); err != nil {
+		return "", err
 	}
 
 	if index.IsPartial() {

--- a/pkg/sql/catalog/catformat/index_test.go
+++ b/pkg/sql/catalog/catformat/index_test.go
@@ -112,6 +112,10 @@ func TestIndexForDisplay(t *testing.T) {
 		ColumnNames:  []string{"a"},
 	}
 
+	// Hash Sharded INDEX baz (a) STORING (c)
+	shardedStoringIndex := shardedIndex
+	shardedStoringIndex.StoreColumnNames = []string{"c"}
+
 	// VECTOR INDEX baz (a)
 	vectorIndex := baseIndex
 	vectorIndex.Type = idxtype.VECTOR
@@ -271,6 +275,24 @@ func TestIndexForDisplay(t *testing.T) {
 			displayMode: IndexDisplayShowCreate,
 			expected:    "CREATE INDEX baz ON foo.public.bar (a DESC) USING HASH WITH (bucket_count=8)",
 			pgExpected:  "CREATE INDEX baz ON foo.public.bar USING btree (a DESC) USING HASH WITH (bucket_count=8)",
+		},
+		// Regression test for #161516: STORING should appear before WITH (bucket_count=...)
+		// so the output is valid SQL.
+		{
+			index:       shardedStoringIndex,
+			tableName:   descpb.AnonymousTable,
+			partition:   "",
+			displayMode: IndexDisplayDefOnly,
+			expected:    "INDEX baz (a DESC) USING HASH STORING (c) WITH (bucket_count=8)",
+			pgExpected:  "INDEX baz USING btree (a DESC) USING HASH STORING (c) WITH (bucket_count=8)",
+		},
+		{
+			index:       shardedStoringIndex,
+			tableName:   tableName,
+			partition:   "",
+			displayMode: IndexDisplayShowCreate,
+			expected:    "CREATE INDEX baz ON foo.public.bar (a DESC) USING HASH STORING (c) WITH (bucket_count=8)",
+			pgExpected:  "CREATE INDEX baz ON foo.public.bar USING btree (a DESC) USING HASH STORING (c) WITH (bucket_count=8)",
 		},
 		{
 			index:       vectorIndex,

--- a/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
+++ b/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
@@ -78,6 +78,45 @@ ORDER BY 1, 2, 3
 tablename        indexname  indexdef
 sharded_primary  primary    CREATE UNIQUE INDEX "primary" ON test.public.sharded_primary USING btree (a ASC) USING HASH WITH (bucket_count=10)
 
+# Test that the indexdef output from pg_indexes is round-trippable. This is a
+# regression test for #161516.
+statement ok
+CREATE TABLE store_columns_test (c1 INT, c2 INT, c3 INT)
+
+statement ok
+CREATE INDEX idx1 ON store_columns_test (c1, c2) USING HASH STORING (c3)
+
+query TTT colnames
+SELECT tablename, indexname, indexdef
+FROM pg_indexes
+WHERE tablename = 'store_columns_test' AND indexname = 'idx1'
+----
+tablename           indexname  indexdef
+store_columns_test  idx1       CREATE INDEX idx1 ON test.public.store_columns_test USING btree (c1 ASC, c2 ASC) USING HASH STORING (c3) WITH (bucket_count=16)
+
+# Verify that the CREATE INDEX statement from pg_indexes can be executed.
+# First, save the index definition.
+let $idx_def
+SELECT indexdef FROM pg_indexes WHERE tablename = 'store_columns_test' AND indexname = 'idx1'
+
+statement ok
+DROP INDEX idx1
+
+# Re-create the index using the definition from pg_indexes.
+statement ok
+$idx_def
+
+query TTT colnames
+SELECT tablename, indexname, indexdef
+FROM pg_indexes
+WHERE tablename = 'store_columns_test' AND indexname = 'idx1'
+----
+tablename           indexname  indexdef
+store_columns_test  idx1       CREATE INDEX idx1 ON test.public.store_columns_test USING btree (c1 ASC, c2 ASC) USING HASH STORING (c3) WITH (bucket_count=16)
+
+statement ok
+DROP TABLE store_columns_test
+
 query TTB
 SELECT index_name, column_name, implicit FROM [SHOW INDEXES FROM sharded_primary]
 ORDER BY index_name, seq_in_index
@@ -868,8 +907,8 @@ SELECT descriptor_id, descriptor_name, index_id, index_name, index_type, is_uniq
  WHERE descriptor_name = 'poor_t'
 ----
 descriptor_id  descriptor_name  index_id  index_name   index_type  is_unique  is_inverted  is_sharded  shard_bucket_count
-121            poor_t           1         poor_t_pkey  primary     true       false        false       NULL
-121            poor_t           2         t_idx_b      secondary   false      false        true        8
+122            poor_t           1         poor_t_pkey  primary     true       false        false       NULL
+122            poor_t           2         t_idx_b      secondary   false      false        true        8
 
 statement ok
 DROP TABLE poor_t
@@ -1092,7 +1131,7 @@ SELECT table_name, table_id, index_name, start_key, end_key
   FROM [SHOW RANGES FROM DATABASE test WITH INDEXES]
  WHERE table_name = 't_hash_pre_split'
 ----
-t_hash_pre_split  133  t_hash_pre_split_pkey  /Table/128/3/7  /Max
+t_hash_pre_split  134  t_hash_pre_split_pkey  /Table/129/3/7  /Max
 
 statement ok
 CREATE INDEX t_hash_pre_split_idx_b ON t_hash_pre_split (b) USING HASH WITH (bucket_count=8);
@@ -1104,16 +1143,16 @@ SELECT table_name, table_id, index_name, start_key, end_key
  WHERE table_name = 't_hash_pre_split'
 ----
 table_name        table_id  index_name              start_key       end_key
-t_hash_pre_split  133       t_hash_pre_split_pkey   /Table/128/3/7  /Table/133/2
-t_hash_pre_split  133       t_hash_pre_split_idx_b  /Table/133/2    /Table/133/2/0
-t_hash_pre_split  133       t_hash_pre_split_idx_b  /Table/133/2/0  /Table/133/2/1
-t_hash_pre_split  133       t_hash_pre_split_idx_b  /Table/133/2/1  /Table/133/2/2
-t_hash_pre_split  133       t_hash_pre_split_idx_b  /Table/133/2/2  /Table/133/2/3
-t_hash_pre_split  133       t_hash_pre_split_idx_b  /Table/133/2/3  /Table/133/2/4
-t_hash_pre_split  133       t_hash_pre_split_idx_b  /Table/133/2/4  /Table/133/2/5
-t_hash_pre_split  133       t_hash_pre_split_idx_b  /Table/133/2/5  /Table/133/2/6
-t_hash_pre_split  133       t_hash_pre_split_idx_b  /Table/133/2/6  /Table/133/2/7
-t_hash_pre_split  133       t_hash_pre_split_idx_b  /Table/133/2/7  /Table/133/3
+t_hash_pre_split  134       t_hash_pre_split_pkey   /Table/129/3/7  /Table/134/2
+t_hash_pre_split  134       t_hash_pre_split_idx_b  /Table/134/2    /Table/134/2/0
+t_hash_pre_split  134       t_hash_pre_split_idx_b  /Table/134/2/0  /Table/134/2/1
+t_hash_pre_split  134       t_hash_pre_split_idx_b  /Table/134/2/1  /Table/134/2/2
+t_hash_pre_split  134       t_hash_pre_split_idx_b  /Table/134/2/2  /Table/134/2/3
+t_hash_pre_split  134       t_hash_pre_split_idx_b  /Table/134/2/3  /Table/134/2/4
+t_hash_pre_split  134       t_hash_pre_split_idx_b  /Table/134/2/4  /Table/134/2/5
+t_hash_pre_split  134       t_hash_pre_split_idx_b  /Table/134/2/5  /Table/134/2/6
+t_hash_pre_split  134       t_hash_pre_split_idx_b  /Table/134/2/6  /Table/134/2/7
+t_hash_pre_split  134       t_hash_pre_split_idx_b  /Table/134/2/7  /Table/134/3
 
 subtest test_default_bucket_count
 

--- a/pkg/sql/parser/testdata/create_index
+++ b/pkg/sql/parser/testdata/create_index
@@ -540,3 +540,66 @@ CREATE VECTOR INDEX a ON b (c) -- normalized!
 CREATE VECTOR INDEX a ON b (c) -- fully parenthesized
 CREATE VECTOR INDEX a ON b (c) -- literals removed
 CREATE VECTOR INDEX _ ON _ (_) -- identifiers removed
+
+parse
+CREATE INDEX a ON b (c) USING HASH
+----
+CREATE INDEX a ON b (c) USING HASH
+CREATE INDEX a ON b (c) USING HASH -- fully parenthesized
+CREATE INDEX a ON b (c) USING HASH -- literals removed
+CREATE INDEX _ ON _ (_) USING HASH -- identifiers removed
+
+parse
+CREATE INDEX a ON b (c) USING HASH WITH (bucket_count = 16)
+----
+CREATE INDEX a ON b (c) USING HASH WITH ('bucket_count' = 16) -- normalized!
+CREATE INDEX a ON b (c) USING HASH WITH ('bucket_count' = (16)) -- fully parenthesized
+CREATE INDEX a ON b (c) USING HASH WITH ('bucket_count' = _) -- literals removed
+CREATE INDEX _ ON _ (_) USING HASH WITH ('bucket_count' = 16) -- identifiers removed
+
+# Also test the legacy way of defining bucket_count.
+# See https://github.com/cockroachdb/cockroach/pull/76112 for a discussion
+# of why we changed the format.
+parse
+CREATE INDEX a ON b (c) USING HASH WITH BUCKET_COUNT = 16
+----
+CREATE INDEX a ON b (c) USING HASH WITH BUCKET_COUNT = 16
+CREATE INDEX a ON b (c) USING HASH WITH BUCKET_COUNT = (16) -- fully parenthesized
+CREATE INDEX a ON b (c) USING HASH WITH BUCKET_COUNT = _ -- literals removed
+CREATE INDEX _ ON _ (_) USING HASH WITH BUCKET_COUNT = 16 -- identifiers removed
+
+parse
+CREATE INDEX a ON b (c) USING HASH STORING (d)
+----
+CREATE INDEX a ON b (c) USING HASH STORING (d)
+CREATE INDEX a ON b (c) USING HASH STORING (d) -- fully parenthesized
+CREATE INDEX a ON b (c) USING HASH STORING (d) -- literals removed
+CREATE INDEX _ ON _ (_) USING HASH STORING (_) -- identifiers removed
+
+parse
+CREATE INDEX a ON b (c) USING HASH STORING (d) WITH (bucket_count = 16)
+----
+CREATE INDEX a ON b (c) USING HASH STORING (d) WITH ('bucket_count' = 16) -- normalized!
+CREATE INDEX a ON b (c) USING HASH STORING (d) WITH ('bucket_count' = (16)) -- fully parenthesized
+CREATE INDEX a ON b (c) USING HASH STORING (d) WITH ('bucket_count' = _) -- literals removed
+CREATE INDEX _ ON _ (_) USING HASH STORING (_) WITH ('bucket_count' = 16) -- identifiers removed
+
+# Also test the legacy way of defining bucket_count, which must always be at
+# the end of the statement.
+# See https://github.com/cockroachdb/cockroach/pull/76112 for a discussion
+# of why we changed the format.
+parse
+CREATE INDEX a ON b (c) USING HASH WITH BUCKET_COUNT = 16 STORING (d)
+----
+CREATE INDEX a ON b (c) USING HASH WITH BUCKET_COUNT = 16 STORING (d)
+CREATE INDEX a ON b (c) USING HASH WITH BUCKET_COUNT = (16) STORING (d) -- fully parenthesized
+CREATE INDEX a ON b (c) USING HASH WITH BUCKET_COUNT = _ STORING (d) -- literals removed
+CREATE INDEX _ ON _ (_) USING HASH WITH BUCKET_COUNT = 16 STORING (_) -- identifiers removed
+
+parse
+CREATE INDEX a ON b (c) USING HASH STORING (d) WITH (fillfactor = 100, bucket_count = 10)
+----
+CREATE INDEX a ON b (c) USING HASH STORING (d) WITH ('fillfactor' = 100, 'bucket_count' = 10) -- normalized!
+CREATE INDEX a ON b (c) USING HASH STORING (d) WITH ('fillfactor' = (100), 'bucket_count' = (10)) -- fully parenthesized
+CREATE INDEX a ON b (c) USING HASH STORING (d) WITH ('fillfactor' = _, 'bucket_count' = _) -- literals removed
+CREATE INDEX _ ON _ (_) USING HASH STORING (_) WITH ('fillfactor' = 100, 'bucket_count' = 10) -- identifiers removed


### PR DESCRIPTION
Previously, when displaying hash sharded indexes with STORING columns in pg_indexes, the STORING clause appeared after the WITH (bucket_count=...) clause. This produced invalid SQL that could not be re-executed:

    CREATE INDEX idx ON tbl USING btree (c1, c2) USING HASH WITH (bucket_count=16) STORING (c3)

The SQL grammar requires STORING to come before storage parameters.

This commit fixes the output order so that STORING appears before WITH (bucket_count=...):

    CREATE INDEX idx ON tbl USING btree (c1, c2) USING HASH STORING (c3) WITH (bucket_count=16)

This matches the grammar and allows the statement to be re-executed.

This bug was introduced in https://github.com/cockroachdb/cockroach/pull/76112.

Fixes #161516

Release note (bug fix): Fixed a bug where the index definition shown in pg_indexes for hash sharded indexes with STORING columns was not valid SQL. The STORING clause now appears in the correct position.