### PR TITLE
sql: expose span in span-check interface

### DIFF
--- a/pkg/sql/inspect/inspect_processor.go
+++ b/pkg/sql/inspect/inspect_processor.go
@@ -335,7 +335,7 @@ func (p *inspectProcessor) processSpan(
 	}
 	for _, check := range checks {
 		if check, ok := check.(inspectSpanCheck); ok {
-			err := check.CheckSpan(ctx, checks, p.loggerBundle, progressMsg.SpanCheckData)
+			err := check.CheckSpan(ctx, checks, span, p.loggerBundle, progressMsg.SpanCheckData)
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/inspect/inspect_processor_test.go
+++ b/pkg/sql/inspect/inspect_processor_test.go
@@ -258,6 +258,7 @@ func (*testingInspectCheckSpan) Close(ctx context.Context) error {
 func (t *testingInspectCheckSpan) CheckSpan(
 	ctx context.Context,
 	checks inspectChecks,
+	span roachpb.Span,
 	logger *inspectLoggerBundle,
 	msg *inspectpb.InspectProcessorSpanCheckData,
 ) error {

--- a/pkg/sql/inspect/row_count_check.go
+++ b/pkg/sql/inspect/row_count_check.go
@@ -115,6 +115,7 @@ func (c *rowCountCheck) Close(context.Context) error {
 func (c *rowCountCheck) CheckSpan(
 	ctx context.Context,
 	checks inspectChecks,
+	span roachpb.Span,
 	logger *inspectLoggerBundle,
 	data *inspectpb.InspectProcessorSpanCheckData,
 ) error {

--- a/pkg/sql/inspect/runner.go
+++ b/pkg/sql/inspect/runner.go
@@ -102,7 +102,7 @@ type inspectSpanCheck interface {
 	// CheckSpan performs a validation using the other checks run on the span
 	// and updates the processor progress with any span information for use by
 	// the cluster-level checks.
-	CheckSpan(ctx context.Context, checks inspectChecks, logger *inspectLoggerBundle, data *inspectpb.InspectProcessorSpanCheckData) error
+	CheckSpan(ctx context.Context, checks inspectChecks, span roachpb.Span, logger *inspectLoggerBundle, data *inspectpb.InspectProcessorSpanCheckData) error
 }
 
 // checkClusterState represents the state of a cluster-level check.


### PR DESCRIPTION
Previously, the span-check interface only exposed the other checks which
allowed it to be used as a meta-check. The updated row count check needs
the span to perform the fallback count when other checks don't provide a
row count.

Epic: CRDB-58692
Part of: #154551
Part of: #155472
Part of: #161279
Part of: #161276

Release note: None
