### PR TITLE
release-26.1: sql/schemachanger: deflake TestPause.*

### DIFF
--- a/pkg/sql/schemachanger/sctest/cumulative.go
+++ b/pkg/sql/schemachanger/sctest/cumulative.go
@@ -410,8 +410,12 @@ func pause(t *testing.T, factory TestServerFactory, cs CumulativeTestCaseSpec) {
 			// Resume the job and check that it succeeds.
 			tdb.Exec(t, "RESUME JOB $1", jobID)
 			t.Logf("job %d is resuming", jobID)
+			// Wait for the schema change to complete.
+			// Note: This has a longer timeout than normal succeeds soon.
+			waitForSchemaChangesToFinish(t, tdb)
+			// Validate the terminal status of the schema change.
 			qStatusWithError := fmt.Sprintf(`SELECT status, error FROM [SHOW JOB %d]`, jobID)
-			tdb.CheckQueryResultsRetry(t, qStatusWithError, [][]string{{"succeeded", ""}})
+			tdb.CheckQueryResults(t, qStatusWithError, [][]string{{"succeeded", ""}})
 		}
 		waitForSchemaChangesToFinish(t, tdb)
 		require.Equal(t, uint32(1), atomic.LoadUint32(&numInjectedFailures))


### PR DESCRIPTION
Backport 1/1 commits from #161884 on behalf of @fqazi.

----

Previously, these tests could timeout, because they had a short time interval to wait for schema changes to complete (the default of 45 seconds). This patch makes the pause tests wait for completion before checking the final status.

Fixes: #161743
Fixes: #161742
Fixes: #161693
Fixes: #161456

Release note: None

----

Release justification: test only change