### PR TITLE
sql/hints: skip external process mode under race for TestHintCacheMultiNode

### DIFF
--- a/pkg/sql/hints/BUILD.bazel
+++ b/pkg/sql/hints/BUILD.bazel
@@ -76,6 +76,7 @@ go_test(
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
+        "//pkg/util",
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/randutil",

--- a/pkg/sql/hints/hint_cache_test.go
+++ b/pkg/sql/hints/hint_cache_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
@@ -268,10 +269,14 @@ func TestHintCacheMultiNode(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	// Skip external mode when running under race to avoid flakes.
+	var serverArgs base.TestServerArgs
+	if util.RaceEnabled {
+		serverArgs.DefaultTestTenant = base.TestSkippedForExternalModeDueToPerformance(161857)
+	}
+
 	ctx := context.Background()
-	tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{
-		ServerArgs: base.TestServerArgs{},
-	})
+	tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{ServerArgs: serverArgs})
 	defer tc.Stopper().Stop(ctx)
 
 	// Use node 0 as the primary node for the cache.


### PR DESCRIPTION
This commit adds a skip for TestHintCacheMultiNode in external process mode if the test is also running under race to avoid flakes.

Informs #161857

Release note: None