### PR TITLE
flaky-test-notifier: bootstrap flaky test notifier bot

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -1223,6 +1223,8 @@ GO_TARGETS = [
     "//pkg/cmd/drtprod/helpers:helpers",
     "//pkg/cmd/drtprod:drtprod",
     "//pkg/cmd/drtprod:drtprod_lib",
+    "//pkg/cmd/flaky-test-notifier:flaky-test-notifier",
+    "//pkg/cmd/flaky-test-notifier:flaky-test-notifier_lib",
     "//pkg/cmd/fuzz:fuzz",
     "//pkg/cmd/fuzz:fuzz_lib",
     "//pkg/cmd/generate-acceptance-tests:generate-acceptance-tests",

--- a/pkg/cmd/flaky-test-notifier/BUILD.bazel
+++ b/pkg/cmd/flaky-test-notifier/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "flaky-test-notifier_lib",
+    srcs = ["main.go"],
+    embedsrcs = [
+        "failed-github-engflow-tests.sql",
+        "failed-tc-engflow-tests.sql",
+        "failed-tc-tests.sql",
+    ],
+    importpath = "github.com/cockroachdb/cockroach/pkg/cmd/flaky-test-notifier",
+    visibility = ["//visibility:private"],
+    deps = ["@com_github_snowflakedb_gosnowflake//:gosnowflake"],
+)
+
+go_binary(
+    name = "flaky-test-notifier",
+    embed = [":flaky-test-notifier_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/cmd/flaky-test-notifier/failed-github-engflow-tests.sql
+++ b/pkg/cmd/flaky-test-notifier/failed-github-engflow-tests.sql
@@ -1,0 +1,27 @@
+WITH ENGFLOW_GH_EXECUTED_TESTS AS (
+    SELECT
+        server,
+        github_job AS build_type,
+	label,
+	test_name,
+        lower(status) AS test_status,
+	invocation_id
+    FROM
+        DATAMART_PROD.ENGINEERING.ENGFLOW_DATA_DAILY_SNAPSHOT
+    WHERE
+        github_job IS NOT NULL
+        AND test_name IS NOT NULL
+        AND started_at > dateadd(DAY, -?, current_date())
+        AND branch = 'master'
+)
+SELECT
+    server,
+    build_type,
+    label,
+    test_name,
+    sum(CASE WHEN test_status = 'success' THEN 1 ELSE 0 END) AS pass_cnt,
+    array_agg(CASE WHEN test_status = 'failure' THEN invocation_id END) AS failed_builds
+FROM
+    ENGFLOW_GH_EXECUTED_TESTS
+GROUP BY 1, 2, 3, 4
+HAVING array_size(failed_builds) > 0 AND pass_cnt + array_size(failed_builds) > 5 AND TO_NUMBER((array_size(failed_builds) / (array_size(failed_builds) + pass_cnt)) * 100, 10, 1) > 0.01

--- a/pkg/cmd/flaky-test-notifier/failed-tc-engflow-tests.sql
+++ b/pkg/cmd/flaky-test-notifier/failed-tc-engflow-tests.sql
@@ -1,0 +1,57 @@
+-- NB: The TC_BUILDS thing is duplicated in failed-tc-engflow-tests.sql.
+-- If it changes in one place, it should probably change in the other.
+WITH TC_BUILDS AS (
+    SELECT
+        id AS build_id,
+        name AS build_name,
+        build_type_id AS build_type
+    FROM
+        DATAMART_PROD.TEAMCITY.BUILDS
+    WHERE
+        branch_name = 'master' AND
+        start_date > dateadd(DAY, -?, current_date()) AND
+        -- exclude roachtest
+        build_name NOT ILIKE '%roachtest%' AND
+        -- exclude managed-service builds
+        build_type NOT LIKE 'Internal_ManagedService%' AND
+        -- exclude pipelines
+        build_name NOT IN (
+            'Bazel CI',
+            'Bazel Extended CI',
+            'Merged Bazel Extended CI',
+            'Cockroach_Nightlies_NightlySuiteBazel',
+            'Cockroach_PostMerge_MergedArm64Tests'
+        ) -- exclude scratch pipelines and builds
+        AND build_type NOT LIKE 'Cockroach_ScratchProject%'
+),
+ENGFLOW_TC AS (
+    SELECT
+        server,
+        teamcity_build_id as build_id,
+	label,
+	test_name,
+        lower(status) as status,
+	invocation_id
+    FROM
+        DATAMART_PROD.ENGINEERING.ENGFLOW_DATA_DAILY_SNAPSHOT
+    WHERE
+        teamcity_build_id IS NOT NULL AND
+        started_at > dateadd(DAY, -?, current_date()) AND
+        branch = 'master'
+)
+SELECT
+    b.build_type,
+    b.build_name,
+    a.label,
+    a.test_name,
+    a.server,
+    sum(CASE WHEN a.status = 'success' THEN 1 ELSE 0 END) AS pass_cnt,
+    array_agg(CASE WHEN a.status = 'failure' THEN invocation_id END) AS failed_builds
+FROM
+    ENGFLOW_TC a
+    INNER JOIN TC_BUILDS b ON (a.build_id = b.build_id)
+WHERE
+    test_name IS NOT NULL
+    AND a.status NOT IN ('unknown', 'skipped', 'error')
+GROUP BY 1, 2, 3, 4, 5
+HAVING array_size(failed_builds) > 0 AND pass_cnt + array_size(failed_builds) > 5 AND TO_NUMBER((array_size(failed_builds) / (array_size(failed_builds) + pass_cnt)) * 100, 10, 1) > 0.01

--- a/pkg/cmd/flaky-test-notifier/failed-tc-tests.sql
+++ b/pkg/cmd/flaky-test-notifier/failed-tc-tests.sql
@@ -1,0 +1,49 @@
+-- NB: The TC_BUILDS thing is duplicated in failed-tc-engflow-tests.sql.
+-- If it changes in one place, it should probably change in the other.
+WITH TC_BUILDS AS (
+    SELECT
+        id AS build_id,
+        name AS build_name,
+        build_type_id AS build_type
+    FROM
+        DATAMART_PROD.TEAMCITY.BUILDS
+    WHERE
+        branch_name = 'master' AND
+        start_date > dateadd(DAY, -?, current_date()) AND
+        -- exclude roachtest
+        build_name NOT ILIKE '%roachtest%' AND
+        -- exclude managed-service builds
+        build_type NOT LIKE 'Internal_ManagedService%' AND
+        -- exclude pipelines
+        build_name NOT IN (
+            'Bazel CI',
+            'Bazel Extended CI',
+            'Merged Bazel Extended CI',
+            'Cockroach_Nightlies_NightlySuiteBazel',
+            'Cockroach_PostMerge_MergedArm64Tests'
+        ) -- exclude scratch pipelines and builds
+        AND build_type NOT LIKE 'Cockroach_ScratchProject%'
+),
+TC_EXECUTED_TESTS AS (
+    SELECT
+	b.build_name AS build_name,
+        b.build_id AS build_id,
+        build_type,
+        test_name,
+        lower(status) AS test_status
+    FROM
+        datamart_prod.teamcity.tests a
+        INNER JOIN TC_BUILDS b ON (a.BUILD_ID = b.BUILD_ID)
+    WHERE
+        test_name IS NOT NULL
+        AND test_status NOT IN ('unknown', 'skipped', 'error')
+)
+SELECT
+    build_type,
+    build_name,
+    test_name,
+    sum(CASE WHEN test_status = 'success' THEN 1 ELSE 0 END) AS pass_cnt,
+    array_agg(CASE WHEN test_status = 'failure' THEN build_id END) AS failed_builds
+FROM TC_EXECUTED_TESTS
+GROUP BY 1, 2, 3
+HAVING array_size(failed_builds) > 0 AND pass_cnt + array_size(failed_builds) > 5 AND TO_NUMBER((array_size(failed_builds) / (array_size(failed_builds) + pass_cnt)) * 100, 10, 1) > 0.01

--- a/pkg/cmd/flaky-test-notifier/main.go
+++ b/pkg/cmd/flaky-test-notifier/main.go
@@ -1,0 +1,556 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+//
+// Command flaky-test-notifier notifies about flaky tests in the CockroachDB repo.
+package main
+
+import (
+	"cmp"
+	"context"
+	"crypto/rsa"
+	"crypto/x509"
+	gosql "database/sql"
+	_ "embed"
+	"encoding/json"
+	"encoding/pem"
+	"flag"
+	"fmt"
+	"log"
+	"maps"
+	"net/url"
+	"os"
+	"slices"
+	"strconv"
+	"strings"
+
+	sf "github.com/snowflakedb/gosnowflake"
+)
+
+const (
+	account   = "lt53838.us-central1.gcp"
+	database  = "DATAMART_PROD"
+	schema    = "TEAMCITY"
+	warehouse = "COMPUTE_WH"
+
+	// snowflakeUsernameEnv and snowflakePrivateKeyEnv are the environment
+	// variables that are used for Snowflake access
+	snowflakeUsernameEnv   = "SNOWFLAKE_USER"
+	snowflakePrivateKeyEnv = "SNOWFLAKE_PRIVATE_KEY"
+
+	failRateCutoff = 0.05
+	maxAlerts      = 3
+
+	description = `Example usage:
+
+    ./bin/flaky-test-notifier [options]
+
+The following options are available:
+
+    lookback-days (default 7): configure how many days to look back for flaky tests.
+    dry-run: do not post any GitHub issues. Just print what would be posted.
+
+The following environment variables must be set:
+
+    SNOWFLAKE_USER
+    SNOWFLAKE_PRIVATE_KEY
+`
+)
+
+var (
+	flags                     = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	dryRun                    = flags.Bool("dry-run", false, "if true, only print what would be done without making any changes")
+	lookbackDays              = flags.Int("lookback-days", 7, "number of days to look back for flaky tests")
+	snowflakeUsername         = os.Getenv(snowflakeUsernameEnv)
+	snowflakePrivateKeyString = os.Getenv(snowflakePrivateKeyEnv)
+
+	tcHost *url.URL = func() *url.URL {
+		u, err := url.Parse("https://teamcity.cockroachdb.com")
+		if err != nil {
+			panic(err)
+		}
+		return u
+	}()
+)
+
+//go:embed failed-tc-tests.sql
+var failedTeamCityTestsQuery string
+
+//go:embed failed-tc-engflow-tests.sql
+var failedEngflowTestsQuery string
+
+//go:embed failed-github-engflow-tests.sql
+var failedGithubEngflowTestsQuery string
+
+type TestFailure interface {
+	Build() string // the name of the build, like unit_tests.
+	Package() string
+	Test() string
+	Links() []*url.URL
+	FailureRate() float64 // 0.0-1.0
+}
+
+// A TeamCityTest is a test that is executed directly on TeamCity, not via
+// remote execution.
+type TeamCityTest struct {
+	BuildType    string
+	BuildName    string
+	TestName     string
+	PassCount    int64
+	FailedBuilds []int64
+}
+
+func (tc *TeamCityTest) Build() string {
+	return tc.BuildName
+}
+
+func (tc *TeamCityTest) Package() string {
+	return trimPackagePrefix(strings.TrimSpace(strings.Split(tc.TestName, ":")[0]))
+}
+
+func (tc *TeamCityTest) Test() string {
+	return strings.TrimSpace(strings.Split(tc.TestName, ":")[1])
+}
+
+func (tc *TeamCityTest) Links() []*url.URL {
+	var ret []*url.URL
+	for _, b := range tc.FailedBuilds {
+		ret = append(ret, tcHost.JoinPath("buildConfiguration", tc.BuildType, strconv.FormatInt(b, 10)))
+	}
+	return ret
+}
+
+func (tc *TeamCityTest) FailureRate() float64 {
+	return float64(len(tc.FailedBuilds)) / float64(tc.PassCount+int64(len(tc.FailedBuilds)))
+}
+
+// A TeamCityEngflowTest is a test that is executed via EngFlow remote execution,
+// but driven by a machine in TeamCity.
+type TeamCityEngflowTest struct {
+	BuildType    string
+	BuildName    string
+	Label        string
+	TestName     string
+	Server       string
+	PassCount    int64
+	FailedBuilds []string // Array of invocation IDs
+}
+
+func (tce *TeamCityEngflowTest) Build() string {
+	return tce.BuildName
+}
+
+func (tce *TeamCityEngflowTest) Package() string {
+	return labelToPkg(tce.Label)
+}
+
+func (tce *TeamCityEngflowTest) Test() string {
+	return tce.TestName
+}
+
+func (tce *TeamCityEngflowTest) Links() []*url.URL {
+	return invocationsToLinks(tce.Server, tce.FailedBuilds)
+}
+
+func (tce *TeamCityEngflowTest) FailureRate() float64 {
+	return float64(len(tce.FailedBuilds)) / float64(tce.PassCount+int64(len(tce.FailedBuilds)))
+}
+
+// A GithubEngflowTest is a test that is executed via EngFlow remote execution,
+// but driven by a machine in GitHub Actions.
+type GithubEngflowTest struct {
+	Server       string
+	BuildType    string
+	Label        string
+	TestName     string
+	PassCount    int64
+	FailedBuilds []string // Array of invocation IDs
+}
+
+func (get *GithubEngflowTest) Build() string {
+	return get.BuildType
+}
+
+func (get *GithubEngflowTest) Package() string {
+	return labelToPkg(get.Label)
+}
+
+func (get *GithubEngflowTest) Test() string {
+	return get.TestName
+}
+
+func (get *GithubEngflowTest) Links() []*url.URL {
+	return invocationsToLinks(get.Server, get.FailedBuilds)
+}
+
+func (get *GithubEngflowTest) FailureRate() float64 {
+	return float64(len(get.FailedBuilds)) / float64(get.PassCount+int64(len(get.FailedBuilds)))
+}
+
+func isSubtest(test string) bool {
+	return strings.Contains(test, "/")
+}
+
+func labelToPkg(label string) string {
+	label = strings.TrimPrefix(label, "//")
+	return strings.Split(label, ":")[0]
+}
+
+func invocationsToLinks(server string, invocations []string) []*url.URL {
+	host, err := url.Parse(fmt.Sprintf("https://%s.cluster.engflow.com", server))
+	if err != nil {
+		panic(err)
+	}
+	var ret []*url.URL
+	for _, b := range invocations {
+		ret = append(ret, host.JoinPath("invocation", b))
+	}
+	return ret
+}
+
+func summarizeTest(t TestFailure) {
+	var urlsToPrint []string
+	for _, link := range t.Links() {
+		urlsToPrint = append(urlsToPrint, link.String())
+	}
+	fmt.Printf("%s: %s.%s (%+v), %f\n", t.Build(), t.Package(), t.Test(), urlsToPrint, t.FailureRate())
+}
+
+func trimPackagePrefix(p string) string {
+	return strings.TrimPrefix(p, "github.com/cockroachdb/cockroach/")
+}
+
+// cmpFailureRate is a helper function used for sorting the tests by failure rate.
+// Notice that the return values are flipped from how they're expected to be
+// since we sort in descending order.
+func cmpFailureRate(a, b float64) int {
+	return -cmp.Compare(a, b)
+}
+
+func usage() {
+	fmt.Fprint(flags.Output(), description)
+	flags.PrintDefaults()
+	fmt.Println("")
+}
+
+func main() {
+	flags.Usage = usage
+	if err := flags.Parse(os.Args[1:]); err != nil {
+		usage()
+		log.Fatal(err)
+	}
+
+	if snowflakeUsername == "" {
+		log.Fatalf("must set %s\n", snowflakeUsernameEnv)
+	}
+	if snowflakePrivateKeyString == "" {
+		log.Fatalf("must set %s\n", snowflakePrivateKeyEnv)
+	}
+
+	ctx := context.Background()
+
+	if err := impl(ctx); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func impl(ctx context.Context) error {
+	db, err := connectToSnowflake(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+
+	tcTests, err := loadTeamCityTests(ctx, db)
+	if err != nil {
+		return err
+	}
+
+	tcEngflowTests, err := loadTCEngflowTests(ctx, db)
+	if err != nil {
+		return err
+	}
+
+	ghEngflowTests, err := loadGithubEngflowTests(ctx, db)
+	if err != nil {
+		return err
+	}
+
+	// Aggregate all tests into a single slice
+	var allTests []TestFailure
+	for _, t := range tcTests {
+		allTests = append(allTests, t)
+	}
+	for _, t := range tcEngflowTests {
+		allTests = append(allTests, t)
+	}
+	for _, t := range ghEngflowTests {
+		allTests = append(allTests, t)
+	}
+	testsToAlert := chooseTests(allTests)
+
+	if *dryRun {
+		// Print summary of tests to alert on
+		fmt.Printf("\nFound %d flaky tests to alert on:\n", len(testsToAlert))
+		for _, fs := range testsToAlert {
+			fmt.Printf("Test %s.%s:\n", fs[0].Package(), fs[0].Test())
+			for _, t := range fs {
+				summarizeTest(t)
+			}
+			fmt.Println("")
+		}
+	}
+
+	// TODO: Create GitHub issues for testsToAlert
+	return nil
+}
+
+func loadTeamCityTests(ctx context.Context, db *gosql.DB) ([]*TeamCityTest, error) {
+	fmt.Println("loading tests run on TC...")
+	statement, err := db.Prepare(failedTeamCityTestsQuery)
+	if err != nil {
+		return nil, fmt.Errorf("preparing query: %w", err)
+	}
+	defer func() { _ = statement.Close() }()
+
+	rows, err := statement.QueryContext(ctx, *lookbackDays)
+	if err != nil {
+		return nil, fmt.Errorf("executing query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var tests []*TeamCityTest
+	for rows.Next() {
+		var test TeamCityTest
+		var failedBuildsRaw string
+		if err := rows.Scan(&test.BuildType, &test.BuildName, &test.TestName, &test.PassCount, &failedBuildsRaw); err != nil {
+			return nil, fmt.Errorf("scanning row: %w", err)
+		}
+
+		// Parse the Snowflake array string into []int64.
+		// No, the Go SQL API cannot handle slices. :(
+		test.FailedBuilds, err = parseSnowflakeArray(failedBuildsRaw)
+		if err != nil {
+			return nil, fmt.Errorf("parsing failed builds array: %w", err)
+		}
+
+		tests = append(tests, &test)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating rows: %w", err)
+	}
+
+	fmt.Printf("loaded %d tests\n", len(tests))
+
+	return tests, nil
+}
+
+func loadTCEngflowTests(ctx context.Context, db *gosql.DB) ([]*TeamCityEngflowTest, error) {
+	fmt.Println("loading EngFlow tests run in TC...")
+	statement, err := db.Prepare(failedEngflowTestsQuery)
+	if err != nil {
+		return nil, fmt.Errorf("preparing query: %w", err)
+	}
+	defer func() { _ = statement.Close() }()
+
+	rows, err := statement.QueryContext(ctx, *lookbackDays, *lookbackDays)
+	if err != nil {
+		return nil, fmt.Errorf("executing query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var tests []*TeamCityEngflowTest
+	for rows.Next() {
+		var test TeamCityEngflowTest
+		var failedBuildsRaw string
+		if err := rows.Scan(&test.BuildType, &test.BuildName, &test.Label, &test.TestName, &test.Server, &test.PassCount, &failedBuildsRaw); err != nil {
+			return nil, fmt.Errorf("scanning row: %w", err)
+		}
+
+		// Parse the Snowflake array string into []string
+		test.FailedBuilds, err = parseSnowflakeStringArray(failedBuildsRaw)
+		if err != nil {
+			return nil, fmt.Errorf("parsing failed builds array: %w", err)
+		}
+
+		tests = append(tests, &test)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating rows: %w", err)
+	}
+
+	fmt.Printf("loaded %d tests\n", len(tests))
+
+	return tests, nil
+}
+
+func loadGithubEngflowTests(ctx context.Context, db *gosql.DB) ([]*GithubEngflowTest, error) {
+	fmt.Println("loading EngFlow tests run in GitHub Actions...")
+	statement, err := db.Prepare(failedGithubEngflowTestsQuery)
+	if err != nil {
+		return nil, fmt.Errorf("preparing query: %w", err)
+	}
+	defer func() { _ = statement.Close() }()
+
+	rows, err := statement.QueryContext(ctx, *lookbackDays)
+	if err != nil {
+		return nil, fmt.Errorf("executing query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var tests []*GithubEngflowTest
+	for rows.Next() {
+		var test GithubEngflowTest
+		var failedBuildsRaw string
+		if err := rows.Scan(&test.Server, &test.BuildType, &test.Label, &test.TestName, &test.PassCount, &failedBuildsRaw); err != nil {
+			return nil, fmt.Errorf("scanning row: %w", err)
+		}
+
+		// Parse the Snowflake array string into []string
+		test.FailedBuilds, err = parseSnowflakeStringArray(failedBuildsRaw)
+		if err != nil {
+			return nil, fmt.Errorf("parsing failed builds array: %w", err)
+		}
+
+		tests = append(tests, &test)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating rows: %w", err)
+	}
+
+	fmt.Printf("loaded %d tests\n", len(tests))
+
+	return tests, nil
+}
+
+// parseSnowflakeArray parses a Snowflake array string (JSON format) into a slice of int64
+func parseSnowflakeArray(arrayStr string) ([]int64, error) {
+	if arrayStr == "" || arrayStr == "[]" {
+		return []int64{}, nil
+	}
+
+	var result []int64
+	if err := json.Unmarshal([]byte(arrayStr), &result); err != nil {
+		return nil, fmt.Errorf("failed to parse array: %w", err)
+	}
+
+	return result, nil
+}
+
+// parseSnowflakeStringArray parses a Snowflake array string (JSON format) into a slice of strings
+func parseSnowflakeStringArray(arrayStr string) ([]string, error) {
+	if arrayStr == "" || arrayStr == "[]" {
+		return []string{}, nil
+	}
+
+	var result []string
+	if err := json.Unmarshal([]byte(arrayStr), &result); err != nil {
+		return nil, fmt.Errorf("failed to parse array: %w", err)
+	}
+
+	return result, nil
+}
+
+func connectToSnowflake(_ context.Context) (*gosql.DB, error) {
+	dsn, err := getDSN()
+	if err != nil {
+		return nil, err
+	}
+	db, err := gosql.Open("snowflake", dsn)
+	if err != nil {
+		return nil, err
+	}
+	return db, nil
+}
+
+// getDSN returns the dataSource name for snowflake driver
+func getDSN() (string, error) {
+	privateKey, err := loadPrivateKey()
+	if err != nil {
+		return "", err
+	}
+	return sf.DSN(&sf.Config{
+		Account:       account,
+		Database:      database,
+		Schema:        schema,
+		Warehouse:     warehouse,
+		Authenticator: sf.AuthTypeJwt,
+		User:          snowflakeUsername,
+		PrivateKey:    privateKey,
+	})
+}
+
+// loadPrivateKey loads an RSA private key by parsing the PEM-encoded key bytes.
+func loadPrivateKey() (privateKey *rsa.PrivateKey, err error) {
+	block, _ := pem.Decode([]byte(snowflakePrivateKeyString))
+	if block == nil {
+		return nil, fmt.Errorf("failed to decode PEM block containing the key")
+	}
+
+	var parsedKey interface{}
+	if parsedKey, err = x509.ParsePKCS8PrivateKey(block.Bytes); err != nil {
+		parsedKey, err = x509.ParsePKCS1PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	privateKey, ok := parsedKey.(*rsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("not an RSA private key")
+	}
+
+	return privateKey, nil
+}
+
+func chooseTests(failures []TestFailure) [][]TestFailure {
+	// Group tests by Package() and Test()
+	type testKey struct {
+		pkg  string
+		test string
+	}
+	grouped := make(map[testKey][]TestFailure)
+	for _, t := range failures {
+		// Skip sub-tests: the parent test will fail too, we'll get that failure.
+		if isSubtest(t.Test()) {
+			continue
+		}
+		key := testKey{pkg: t.Package(), test: t.Test()}
+		grouped[key] = append(grouped[key], t)
+	}
+
+	// Sort so each test has the build with the highest failure rate in front.
+	for _, failures := range grouped {
+		slices.SortFunc(failures, func(a, b TestFailure) int {
+			return cmpFailureRate(a.FailureRate(), b.FailureRate())
+		})
+	}
+
+	var groupedFailures [][]TestFailure
+	for fails := range maps.Values(grouped) {
+		groupedFailures = append(groupedFailures, fails)
+	}
+
+	slices.SortFunc(groupedFailures, func(a, b []TestFailure) int {
+		// NB: the slices are already sorted by failure rate in
+		// descending order so we can just look at the first element.
+		return cmpFailureRate(a[0].FailureRate(), b[0].FailureRate())
+	})
+
+	cutoff := 0
+	for cutoff < len(groupedFailures) {
+		if cutoff >= maxAlerts {
+			break
+		}
+		if groupedFailures[cutoff][0].FailureRate() < failRateCutoff {
+			break
+		}
+		cutoff += 1
+	}
+
+	return groupedFailures[0:cutoff]
+}


### PR DESCRIPTION
This contains the basic logic to look up the tests and determine which ones we will alert on. We will follow this up with logic to file the appropriate GitHub issues.

Release note: none
Epic: none