### PR TITLE
testutils/floatcmp: increase CloseMargin to handle distributed execution errors

### DIFF
--- a/pkg/cmd/roachtest/tests/query_comparison_util.go
+++ b/pkg/cmd/roachtest/tests/query_comparison_util.go
@@ -625,6 +625,15 @@ func joinAndSortRows(rowMatrix1, rowMatrix2 [][]string, sep string) (rows1, rows
 	return rows1, rows2
 }
 
+func isFloat(colType string) bool {
+	switch colType {
+	case "FLOAT4", "FLOAT8":
+		return true
+	default:
+		return false
+	}
+}
+
 func isFloatArray(colType string) bool {
 	switch colType {
 	case "[]FLOAT4", "[]FLOAT8", "_FLOAT4", "_FLOAT8":
@@ -657,7 +666,7 @@ func needApproximateMatch(colType string) bool {
 	// approximately equal to take into account platform differences in floating
 	// point calculations. On other architectures, check float values only.
 	return (runtime.GOARCH == "s390x" && (isDecimal(colType) || isDecimalArray(colType))) ||
-		colType == "FLOAT4" || colType == "FLOAT8" || isFloatArray(colType)
+		isFloat(colType) || isFloatArray(colType)
 }
 
 // sortRowsWithFloatComp is similar to joinAndSortRows, but it uses float
@@ -759,8 +768,10 @@ func unsortedMatricesDiffWithFloatComp(
 					cmpFn = floatcmp.FloatArraysMatchApprox
 				case runtime.GOARCH == "s390x" && !isFloatOrDecimalArray:
 					cmpFn = floatcmp.FloatsMatchApprox
-				case isFloatOrDecimalArray:
-					cmpFn = floatcmp.FloatArraysMatch
+				case isFloatArray(colType):
+					cmpFn = floatcmp.FloatArraysMatchApprox
+				case isFloat(colType):
+					cmpFn = floatcmp.FloatsMatchApprox
 				}
 				match, err := cmpFn(row1[j], row2[j])
 				if err != nil {

--- a/pkg/testutils/floatcmp/floatcmp.go
+++ b/pkg/testutils/floatcmp/floatcmp.go
@@ -30,14 +30,16 @@ const (
 	// argument of functions in this package. It should typically be used with
 	// the CloseFraction constant for the fraction argument.
 	//
-	// It is set to the square of CloseFraction so it is only used when the
-	// smaller of the absolute expected and actual values is in the range:
-	//
-	//   -CloseFraction <= 0 <= CloseFraction
+	// It is set to CloseFraction / 10 to handle cases where one value is zero
+	// (or very close to zero) and the other is a small non-zero value resulting
+	// from floating-point errors in different execution paths. This allows
+	// values that differ by up to ~1e-15 to be considered equal when comparing
+	// against zero, which is appropriate for numerical noise from distributed
+	// vs local query execution.
 	//
 	// CloseMargin is greater than 0 otherwise if either expected or actual were
 	// 0 the calculated tolerance from the fraction would be 0.
-	CloseMargin = CloseFraction * CloseFraction
+	CloseMargin = CloseFraction / 10
 )
 
 // EqualApprox reports whether expected and actual are deeply equal with the


### PR DESCRIPTION
Previously, the `CloseMargin` constant was set to
`CloseFraction * CloseFraction` (1e-28), which was far too small to handle real-world floating-point rounding errors that occur when comparing results from different query execution paths (distributed vs local). This caused the `unoptimized-query-oracle` roachtest to flake when aggregate functions like `stddev_pop` and `var_samp` produced values differing by ~1e-16 due to different aggregation ordering.

Additionally, the test only used approximate float matching (`FloatsMatchApprox`) on s390x architecture, while using exact significant-digit matching on other platforms, which didn't leverage the `CloseMargin` tolerance at all.

This commit makes two changes:

1. Increases `CloseMargin` from `CloseFraction * CloseFraction` (1e-28) to `CloseFraction / 10` (1e-15), which is appropriate for catching the numerical noise observed in distributed aggregate computations.

2. Changes `unsortedMatricesDiffWithFloatComp` to always use `FloatsMatchApprox` for float comparisons on all architectures, not just s390x. This ensures the `CloseMargin` tolerance is consistently applied.

Fixes #150902

Release note: none

Epic: None