### PR TITLE
sql: add nil check for extendedEvalContext.Placeholders

### DIFF
--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -170,7 +170,9 @@ func (p *planner) getCommonSQLEventDetails() eventpb.CommonSQLEventDetails {
 		commonSQLEventDetails.TxnReadTimestamp = txn.KV().ReadTimestamp().WallTime
 	}
 
-	if pls := p.extendedEvalCtx.Context.Placeholders.Values; len(pls) > 0 {
+	placeholders := p.extendedEvalCtx.Context.Placeholders
+	if placeholders != nil && len(placeholders.Values) > 0 {
+		pls := placeholders.Values
 		commonSQLEventDetails.PlaceholderValues = make([]string, len(pls))
 		for idx, val := range pls {
 			commonSQLEventDetails.PlaceholderValues[idx] = val.String()


### PR DESCRIPTION
Fixes #161674

We saw a nil pointer error with pausable portal, so adding a nil check gate here.

Release note: None