### PR TITLE
schemachanger: fix DROP TABLE CASCADE to not drop trigger/policy-owning tables

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/triggers
+++ b/pkg/ccl/logictestccl/testdata/logic_test/triggers
@@ -5035,8 +5035,16 @@ INSERT INTO t1(n,k) VALUES (1,1);
 statement ok
 DROP TABLE other CASCADE;
 
-statement error pq: relation "t1" does not exist
+# Table t1 still exists but the trigger was dropped.
+statement error pq: trigger "audit_trigger" for table "t1" does not exist
 DROP TRIGGER audit_trigger ON t1;
+
+# Verify t1 still works.
+statement ok
+SELECT * FROM t1;
+
+statement ok
+DROP TABLE t1;
 
 statement ok
 DROP TYPE e;

--- a/pkg/sql/logictest/testdata/logic_test/row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_security
@@ -5987,3 +5987,105 @@ statement ok
 DROP ROLE user_158154;
 
 subtest end
+
+# Regression test for #146722. DROP TABLE CASCADE should drop only the policy,
+# not the table that owns the policy.
+subtest drop_referenced_table_cascade_policy
+
+statement ok
+CREATE TABLE ref_table (id INT PRIMARY KEY, allowed_user TEXT);
+
+statement ok
+INSERT INTO ref_table VALUES (1, 'testuser'), (2, 'admin');
+
+statement ok
+CREATE TABLE policy_table (id INT PRIMARY KEY, data TEXT);
+
+statement ok
+ALTER TABLE policy_table ENABLE ROW LEVEL SECURITY;
+
+# Create a function that references ref_table.
+statement ok
+CREATE FUNCTION check_ref_table(check_id INT) RETURNS BOOL AS $$
+  SELECT EXISTS (SELECT 1 FROM ref_table WHERE id = check_id)
+$$ LANGUAGE SQL;
+
+# Create a policy that uses the function (which references ref_table).
+statement ok
+CREATE POLICY check_access ON policy_table
+  FOR ALL
+  USING (check_ref_table(id));
+
+# Verify both tables and the policy exist.
+query T
+SELECT tablename FROM pg_tables WHERE tablename IN ('policy_table', 'ref_table') ORDER BY tablename;
+----
+policy_table
+ref_table
+
+query T
+SELECT polname FROM pg_policy WHERE polname = 'check_access';
+----
+check_access
+
+# DROP TABLE without CASCADE should fail due to dependency (function depends on it).
+statement error pq: cannot drop table ref_table because other objects depend on it
+DROP TABLE ref_table;
+
+# DROP TABLE with CASCADE should succeed. The function is dropped, which causes
+# the policy to be dropped, but policy_table should remain.
+statement ok
+DROP TABLE ref_table CASCADE;
+
+# Verify policy_table still exists.
+query T
+SELECT tablename FROM pg_tables WHERE tablename = 'policy_table';
+----
+policy_table
+
+# Verify the policy was dropped (because the function it depends on was dropped).
+query T
+SELECT polname FROM pg_policy WHERE polname = 'check_access';
+----
+
+# Verify policy_table still works for owner.
+statement ok
+INSERT INTO policy_table VALUES (1, 'test');
+
+query IT
+SELECT * FROM policy_table;
+----
+1  test
+
+# Verify RLS is still enabled on the table.
+query TBB
+SELECT relname, relrowsecurity, relforcerowsecurity FROM pg_class WHERE relname = 'policy_table';
+----
+policy_table  true  false
+
+# Verify deny-by-default behavior for non-owner users. With RLS enabled and no
+# policy, regular users should not be able to see any data.
+statement ok
+CREATE USER cascade_test_user;
+
+statement ok
+GRANT SELECT ON policy_table TO cascade_test_user;
+
+statement ok
+SET ROLE cascade_test_user;
+
+# Non-owner should see no rows due to deny-by-default.
+query IT
+SELECT * FROM policy_table;
+----
+
+statement ok
+SET ROLE root;
+
+statement ok
+DROP TABLE policy_table;
+
+statement ok
+DROP USER cascade_test_user;
+
+subtest end


### PR DESCRIPTION

Previously, when a trigger on table t1 referenced another table "other", executing DROP TABLE other CASCADE would incorrectly drop both "other" AND t1. The same issue existed for row-level security policies.

The root cause was in dropCascadeDescriptor() which, when processing TriggerDeps and PolicyDeps back-references, would call dropCascadeDescriptor() on the table ID that owned the trigger/policy, effectively dropping the entire table instead of just the trigger/policy.

This fix adds helper functions dropTrigger() and dropPolicy() that drop only the specific trigger or policy elements, leaving the owning table intact. This matches PostgreSQL behavior where dropping a referenced table with CASCADE drops dependent triggers/policies but preserves the tables that own them.

Fixes #146722
Epic: CRDB-42942

Release note (bug fix): Fixed a bug where DROP TABLE ... CASCADE would incorrectly drop tables that had triggers or row-level security policies referencing the dropped table. Now only the triggers/policies are dropped, and the tables owning them remain intact.