### PR TITLE
sql: add support for DROP TRIGGER ... CASCADE

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/triggers
+++ b/pkg/ccl/logictestccl/testdata/logic_test/triggers
@@ -749,6 +749,20 @@ DROP TRIGGER foo ON xy;
 statement ok
 DROP TRIGGER IF EXISTS foo ON xy;
 
+# CASCADE and RESTRICT are accepted for PostgreSQL compatibility. Since triggers
+# don't have dependents, they behave identically to a drop without these options.
+statement ok
+CREATE TRIGGER foo AFTER INSERT ON xy FOR EACH ROW EXECUTE FUNCTION f();
+
+statement ok
+DROP TRIGGER foo ON xy CASCADE;
+
+statement ok
+CREATE TRIGGER foo AFTER INSERT ON xy FOR EACH ROW EXECUTE FUNCTION f();
+
+statement ok
+DROP TRIGGER foo ON xy RESTRICT;
+
 # ==============================================================================
 # Test dependency tracking for a relation reference.
 # ==============================================================================
@@ -4089,9 +4103,6 @@ subtest unsupported
 
 statement error pgcode 0A000 pq: unimplemented: CREATE OR REPLACE TRIGGER is not supported
 CREATE OR REPLACE TRIGGER foo AFTER INSERT ON xy FOR EACH ROW EXECUTE FUNCTION f();
-
-statement error pgcode 0A000 pq: unimplemented: cascade dropping triggers
-DROP TRIGGER foo ON xy CASCADE;
 
 statement error pgcode 0A000 pq: unimplemented: statement-level triggers are not yet supported
 CREATE TRIGGER foo AFTER INSERT ON xy FOR EACH STATEMENT EXECUTE FUNCTION f();

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_trigger.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_trigger.go
@@ -9,14 +9,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 )
 
+// DropTrigger builds the schema change for a DROP TRIGGER command.
+// NOTE: CASCADE is accepted for PostgreSQL compatibility. Since triggers
+// don't have dependents that would need cascading, CASCADE behaves
+// identically to a non-cascade drop (or RESTRICT).
 func DropTrigger(b BuildCtx, n *tree.DropTrigger) {
 	noticeSender := b.EvalCtx().ClientNoticeSender
-	if n.DropBehavior == tree.DropCascade {
-		panic(unimplemented.NewWithIssue(128151, "cascade dropping triggers"))
-	}
 
 	// NOTE: DROP TRIGGER requires the user to have ownership of the table.
 	tableElems := b.ResolveTable(n.Table, ResolveParams{


### PR DESCRIPTION
Previously, using CASCADE with DROP TRIGGER would return an unimplemented error. This change adds support for the CASCADE option, which behaves identically to a regular drop (or RESTRICT) since triggers don't have dependents that would need cascading. This improves PostgreSQL compatibility.

Resolves: #128151
Epic: CRDB-42942

Release note (sql change): DROP TRIGGER now accepts the CASCADE option for PostgreSQL compatibility. Since triggers in CockroachDB cannot have dependents, CASCADE behaves the same as RESTRICT or omitting the option entirely.