### PR TITLE
norm: remove UDF body copy from AssignPlaceholders

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -3705,8 +3705,8 @@ func (b *Builder) buildCall(c *memo.CallExpr) (_ execPlan, outputCols colOrdMap,
 		}
 	}
 
-	for _, s := range udf.Def.Body {
-		if s.Relational().CanMutate {
+	if udf.Def.BodyCanMutate {
+		for _, s := range udf.Def.Body {
 			b.setMutationFlags(s)
 		}
 	}

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -986,8 +986,8 @@ func (b *Builder) buildUDF(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.Typ
 		return nil, err
 	}
 
-	for _, s := range udf.Def.Body {
-		if s.Relational().CanMutate {
+	if udf.Def.BodyCanMutate {
+		for _, s := range udf.Def.Body {
 			b.setMutationFlags(s)
 		}
 	}

--- a/pkg/sql/opt/norm/inline_funcs.go
+++ b/pkg/sql/opt/norm/inline_funcs.go
@@ -470,8 +470,9 @@ func (c *CustomFuncs) ConvertUDFToSubquery(
 		return nil, false
 	}
 
-	// replace substitutes variables that are UDF parameters with the
-	// corresponding argument from the invocation of the UDF.
+	// replace makes a copy of the UDF body expressions, and substitutes variables
+	// that are UDF parameters with the corresponding argument from the invocation
+	// of the UDF.
 	var replace ReplaceFunc
 	replace = func(nd opt.Expr) opt.Expr {
 		if t, ok := nd.(*memo.VariableExpr); ok {
@@ -479,7 +480,7 @@ func (c *CustomFuncs) ConvertUDFToSubquery(
 				return arg
 			}
 		}
-		return c.f.Replace(nd, replace)
+		return c.f.CopyAndReplaceDefault(nd, replace)
 	}
 
 	// The presentation and ordering in the physical properties of the UDF

--- a/pkg/sql/opt/norm/testdata/rules/assign_placeholders
+++ b/pkg/sql/opt/norm/testdata/rules/assign_placeholders
@@ -170,3 +170,67 @@ project
       │              ├── unnest(e'{1\\x2c 2}'::INT8[]) [stable]
       │              └── unnest(e'{3\\x2c 4}'::INT8[]) [stable]
       └── filters (true)
+
+# ----------------------------------------------------------------------
+# UDF tests with placeholder assignment
+# These tests verify that poisoned UDF body expressions are properly
+# copied before use.
+# ----------------------------------------------------------------------
+
+exec-ddl
+CREATE FUNCTION test_add(a INT, b INT) RETURNS INT IMMUTABLE LANGUAGE SQL AS $$
+  SELECT a + b
+$$
+----
+
+# Inlinable UDF with placeholder - tests ConvertUDFToSubquery path.
+# The InlineUDF rule fires during normalization after placeholder assignment.
+# This tests that c.f.CopyAndReplaceDefault properly copies the poisoned body.
+assign-placeholders-opt query-args=(42)
+SELECT test_add($1, 10)
+----
+values
+ ├── columns: test_add:4!null
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(4)
+ └── (52,)
+
+exec-ddl
+CREATE FUNCTION test_volatile(a INT) RETURNS INT VOLATILE LANGUAGE SQL AS $$
+  SELECT a + 1
+$$
+----
+
+# Non-inlinable UDF with placeholder - tests buildRoutinePlanGenerator path.
+# Volatile UDFs cannot be inlined, so the body is copied at execution time
+# via CopyAndReplace in buildRoutinePlanGenerator.
+assign-placeholders-opt query-args=(7)
+SELECT test_volatile($1)
+----
+values
+ ├── columns: test_volatile:3
+ ├── cardinality: [1 - 1]
+ ├── volatile
+ ├── key: ()
+ ├── fd: ()-->(3)
+ └── (test_volatile(7),)
+
+exec-ddl
+CREATE FUNCTION test_multi_stmt(a INT) RETURNS INT STABLE LANGUAGE SQL AS $$
+  SELECT 1;
+  SELECT a + 1
+$$
+----
+
+# Multi-statement UDF cannot be inlined - tests buildRoutinePlanGenerator.
+assign-placeholders-opt query-args=(5)
+SELECT test_multi_stmt($1)
+----
+values
+ ├── columns: test_multi_stmt:4
+ ├── cardinality: [1 - 1]
+ ├── stable
+ ├── key: ()
+ ├── fd: ()-->(4)
+ └── (test_multi_stmt(5),)

--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -2288,9 +2288,13 @@ func (b *plpgsqlBuilder) appendBodyStmtFromScope(
 	// Set the volatility of the continuation routine to the least restrictive
 	// volatility level in the Relational properties of the body statements.
 	bodyExpr := bodyScope.expr
-	vol := bodyExpr.Relational().VolatilitySet.ToVolatility()
+	relational := bodyExpr.Relational()
+	vol := relational.VolatilitySet.ToVolatility()
 	if con.def.Volatility < vol {
 		con.def.Volatility = vol
+	}
+	if relational.CanMutate {
+		con.def.BodyCanMutate = true
 	}
 	con.def.Body = append(con.def.Body, bodyExpr)
 	con.def.BodyProps = append(con.def.BodyProps, bodyScope.makePhysicalProps())

--- a/pkg/sql/opt/optbuilder/trigger.go
+++ b/pkg/sql/opt/optbuilder/trigger.go
@@ -856,6 +856,7 @@ func (b *Builder) buildTriggerFunction(
 	udfDef.BodyProps = []*physical.Required{stmtScope.makePhysicalProps()}
 	// Placeholder that ensure the length of BodyTags is the same as Body.
 	udfDef.BodyTags = make([]string, 1)
+	udfDef.BodyCanMutate = stmtScope.expr.Relational().CanMutate
 
 	return f.ConstructUDFCall(args, &memo.UDFCallPrivate{Def: udfDef}), resolvedDef
 }

--- a/pkg/sql/opt/optgen/cmd/optgen/exprs_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/exprs_gen.go
@@ -382,6 +382,13 @@ func (g *exprsGen) genExprFuncs(define *lang.DefineExpr) {
 		fmt.Fprintf(g.w, "  e.grp = member.group()\n")
 		fmt.Fprintf(g.w, "  LastGroupMember(member).setNext(e)\n")
 		fmt.Fprintf(g.w, "}\n\n")
+
+		// Generate the Poison method.
+		fmt.Fprintf(g.w, "func (e *%s) Poison() {\n", opTyp.name)
+		fmt.Fprintf(g.w, "  if e.grp != nil {\n")
+		fmt.Fprintf(g.w, "    e.grp = MakePoisonedGroup(e.grp)\n")
+		fmt.Fprintf(g.w, "  }\n")
+		fmt.Fprintf(g.w, "}\n\n")
 	}
 }
 

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/exprs
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/exprs
@@ -158,6 +158,10 @@ func (e *ProjectExpr) setGroup(member RelExpr) {
 	LastGroupMember(member).setNext(e)
 }
 
+func (e *ProjectExpr) Poison() {
+	e.grp = PoisonedGroup
+}
+
 type projectGroup struct {
 	rel   props.Relational
 	first ProjectExpr


### PR DESCRIPTION
After #116243 we no longer need to copy each UDF body in AssignPlaceholders, because there should no longer be any references to the memo within the body expressions.

Fixes: #161993

Release note (performance improvement): Calling complex and deeply-nested UDFs from within prepared statements should now be faster.