### PR TITLE
release: bump version on RC branches after release

### DIFF
--- a/pkg/cmd/release/update_versions.go
+++ b/pkg/cmd/release/update_versions.go
@@ -466,10 +466,6 @@ func generateRepoList(
 			log.Printf("not bumping version on staging branch %s", branch)
 			continue
 		}
-		if branch == releasedVersion.Format("release-%X.%Y.%Z-rc") {
-			log.Printf("not bumping version on the same branch %s", branch)
-			continue
-		}
 		curVersion, err := fileContent(remoteOrigin+"/"+branch, versionFile)
 		if err != nil {
 			return []prRepo{}, fmt.Errorf("reading git file content: %w", err)


### PR DESCRIPTION
Previously, the version bump logic skipped the RC branch that matched the released version, for example:
- skipping `release-26.1.0-rc` when explicitly wanting to bump the version to `v26.1.0`
- this would also skip bumping `release-26.1.1-rc` after shipping `v26.1.0` (because the .1 is a fast-follow, `release-26.1.1-rc` will be cut before `v26.1.0` ships)

This change removes that exclusion, allowing RC branches to receive version bump PRs alongside the main release branch. Duplicate PRs are still avoided by skipping branches that already contain the target version.

## Changes

- Removed filter that skipped RC branches matching the released version pattern in `pkg/cmd/release/update_versions.go`
- Added `TestBranchSelectionForVersionBump` with test cases documenting expected behavior

## Expected behavior for the version bump PR after this change

| Released Version | Next Version | Branches Bumped |
|-----------------|--------------|-----------------|
| v25.1.0-rc.1 | v25.1.0-rc.2 | release-25.1.0-rc, release-25.1 |
| v25.1.0 | v25.1.1 | release-25.1.0-rc, release-25.1 |
| v25.1.1 | v25.1.2 | release-25.1.1-rc, release-25.1 |


Release note: None

Epic: None