### PR TITLE
tracing: fix DRPC span naming

### DIFF
--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -358,6 +358,7 @@ go_library(
         "//pkg/util/timeutil/ptp",
         "//pkg/util/tracing",
         "//pkg/util/tracing/collector",
+        "//pkg/util/tracing/drpcinterceptor",
         "//pkg/util/tracing/goexectrace",
         "//pkg/util/tracing/service",
         "//pkg/util/tracing/tracingpb",

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -74,6 +74,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing/drpcinterceptor"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingutil"
 	"github.com/cockroachdb/cockroach/pkg/util/unique"
@@ -2018,12 +2019,20 @@ func setupSpanForIncomingRPC(
 ) (context.Context, spanForRequest) {
 	var newSpan *tracing.Span
 	remoteParent := !ba.TraceInfo.Empty()
+	// DRPC server interceptors inject the method name into the context
+	// because DRPC uses different method names (/cockroach.roachpb.KVBatch/Batch).
+	// For gRPC and local requests, we fall back to tracingutil.BatchMethodName
+	// (/cockroach.roachpb.Internal/Batch), so gRPC interceptors don't need to inject it.
+	methodName := tracingutil.BatchMethodName
+	if drpcinterceptor.IsDRPCRequest(ctx) {
+		methodName = tracingutil.KVBatchMethodName
+	}
 	if !remoteParent {
 		// This is either a local request which circumvented gRPC, or a remote
 		// request that didn't specify tracing information. We make a child span
 		// if the incoming request would like to be traced.
 		ctx, newSpan = tracing.ChildSpan(ctx,
-			tracingutil.BatchMethodName, tracing.WithServerSpanKind)
+			methodName, tracing.WithServerSpanKind)
 	} else {
 		// Non-local call. Tracing information comes from the request proto.
 
@@ -2035,7 +2044,7 @@ func setupSpanForIncomingRPC(
 		}
 
 		ctx, newSpan = tr.StartSpanCtx(
-			ctx, tracingutil.BatchMethodName,
+			ctx, methodName,
 			tracing.WithRemoteParentFromTraceInfo(ba.TraceInfo),
 			tracing.WithServerSpanKind)
 	}

--- a/pkg/testutils/serverutils/test_cluster_shim.go
+++ b/pkg/testutils/serverutils/test_cluster_shim.go
@@ -248,6 +248,10 @@ type TestClusterInterface interface {
 	// default tenant for testing.
 	StartedDefaultTestTenant() bool
 
+	// IsDRPCEnabled returns whether DRPC is enabled for inter-node
+	// communication in this cluster.
+	IsDRPCEnabled() bool
+
 	// ApplicationLayer calls .ApplicationLayer() on the ith server in
 	// the cluster.
 	ApplicationLayer(idx int) ApplicationLayerInterface

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -680,7 +680,6 @@ func ShouldEnableDRPC(
 		}
 		return base.TestDRPCEnabled
 	}
-
 	return base.TestDRPCDisabled
 }
 

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -130,6 +130,12 @@ func (tc *TestCluster) StartedDefaultTestTenant() bool {
 	return tc.Servers[0].TenantController().StartedDefaultTestTenant()
 }
 
+// IsDRPCEnabled returns whether DRPC is enabled for inter-node communication
+// in this cluster.
+func (tc *TestCluster) IsDRPCEnabled() bool {
+	return tc.defaultDRPCOption == base.TestDRPCEnabled
+}
+
 // ApplicationLayer calls .ApplicationLayer() on the ith server in
 // the cluster.
 func (tc *TestCluster) ApplicationLayer(idx int) serverutils.ApplicationLayerInterface {

--- a/pkg/util/tracing/drpcinterceptor/drpc_interceptor.go
+++ b/pkg/util/tracing/drpcinterceptor/drpc_interceptor.go
@@ -22,6 +22,14 @@ import (
 	"storj.io/drpc/drpcmux"
 )
 
+// drpcRequestKey is a context key type used to mark a request as coming via DRPC.
+type drpcRequestKey struct{}
+
+// IsDRPCRequest returns true if the context indicates this request came via DRPC.
+func IsDRPCRequest(ctx context.Context) bool {
+	return ctx.Value(drpcRequestKey{}) != nil
+}
+
 // ExtractSpanMetaFromDRPCCtx retrieves trace context (as a SpanMeta) that has
 // been propagated through DRPC metadata in the context.
 func ExtractSpanMetaFromDRPCCtx(
@@ -45,6 +53,7 @@ func ServerInterceptor(tracer *tracing.Tracer) drpcmux.UnaryServerInterceptor {
 		rpc string,
 		handler drpcmux.UnaryHandler,
 	) (interface{}, error) {
+		ctx = context.WithValue(ctx, drpcRequestKey{}, struct{}{})
 		if tracingutil.MethodExcludedFromTracing(rpc) {
 			return handler(ctx, req)
 		}
@@ -83,6 +92,10 @@ func StreamServerInterceptor(tracer *tracing.Tracer) drpcmux.StreamServerInterce
 		rpc string,
 		handler drpcmux.StreamHandler,
 	) (interface{}, error) {
+		stream = &tracingServerStream{
+			Stream: stream,
+			ctx:    context.WithValue(stream.Context(), drpcRequestKey{}, struct{}{}),
+		}
 		if tracingutil.MethodExcludedFromTracing(rpc) {
 			return handler(stream)
 		}


### PR DESCRIPTION
Previously, when DRPC was enabled, the server-side span naming in
`setupSpanForIncomingRPC` always used the gRPC method name
(/cockroach.roachpb.Internal/Batch) regardless of whether the request
came via gRPC or DRPC. This caused TestTrace to fail when DRPC was
enabled because it expected specific span names.

This commit fixes the issue by injecting the RPC method name into the
context in DRPC server interceptors and updates setupSpanForIncomingRPC
to use that method name for span naming. More details in : https://github.com/cockroachdb/cockroach/issues/158323#issuecomment-3890481696

Epic: CRDB-55382
Fixes: #158323
Release note: None