### PR TITLE
roachtest/typeorm: skip FIPS architecture

### DIFF
--- a/pkg/cmd/roachtest/tests/typeorm.go
+++ b/pkg/cmd/roachtest/tests/typeorm.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 )
@@ -180,7 +181,7 @@ func registerTypeORM(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:             "typeorm",
 		Owner:            registry.OwnerSQLFoundations,
-		Cluster:          r.MakeClusterSpec(1),
+		Cluster:          r.MakeClusterSpec(1, spec.Arch(spec.AllExceptFIPS)),
 		Leases:           registry.MetamorphicLeases,
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly, registry.ORM),


### PR DESCRIPTION
Currently, the typeorm test can be incorrectly be executed on the FIPs configuration, which this test suite does not support. To address this, this patch excludes FIPs from the roachtest.

Fixes: #161499

Release note: None