### PR TITLE
sql,admission: support cpu reporting and admission

### DIFF
--- a/pkg/kv/db.go
+++ b/pkg/kv/db.go
@@ -278,6 +278,8 @@ type DB struct {
 	// Especially SettingsValue.
 	SQLKVResponseAdmissionQ *admission.WorkQueue
 	AdmissionPacerFactory   admission.PacerFactory
+
+	SQLCPUProvider admission.SQLCPUProvider
 }
 
 // NonTransactionalSender returns a Sender that can be used for sending

--- a/pkg/kv/kvserver/kvadmission/kvadmission.go
+++ b/pkg/kv/kvserver/kvadmission/kvadmission.go
@@ -239,6 +239,7 @@ type Handle struct {
 	storeWorkHandle      admission.StoreWorkHandle
 	elasticCPUWorkHandle *admission.ElasticCPUWorkHandle
 	raftAdmissionMeta    *kvflowcontrolpb.RaftAdmissionMeta
+	ghToUnpause          *admission.GoroutineCPUHandle
 
 	cpuStart            time.Duration
 	cpuAdmissionQueue   *admission.WorkQueue
@@ -429,6 +430,21 @@ func (n *controllerImpl) AdmitKVWork(
 			ah.cpuKVAdmissionQResp = resp
 		}
 	}
+	// Pause CPU measurement for SQL work if it is happening locally on this
+	// goroutine.
+	//
+	// NB: if we never reach this point in the function, either there is an
+	// error, or some aspect of admission is disabled (which is never the case
+	// in production). In the latter case, we will not pause measurement, which
+	// we deem acceptable.
+	//
+	// TODO(sumeer): improve the structure of AdmitKVWork to make the behavior
+	// easier to understand.
+	sqlHandle := admission.SQLCPUHandleFromContext(ctx)
+	if sqlHandle != nil {
+		ah.ghToUnpause = sqlHandle.RegisterGoroutine()
+		ah.ghToUnpause.PauseMeasuring()
+	}
 	return ah, nil
 }
 
@@ -463,6 +479,9 @@ func (n *controllerImpl) AdmittedKVWorkDone(ah Handle, writeBytes *StoreWriteByt
 				log.KvDistribution.Errorf(context.Background(), "%s", err)
 			}
 		}
+	}
+	if ah.ghToUnpause != nil {
+		ah.ghToUnpause.UnpauseMeasuring()
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -590,6 +590,8 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 	)
 	db.SQLKVResponseAdmissionQ = gcoords.RegularCPU.GetSQLWorkQueue(admission.SQLKVResponseWork)
 	db.AdmissionPacerFactory = gcoords.ElasticCPU
+	sqlCPUProvider := admission.NewSQLCPUProvider()
+	db.SQLCPUProvider = sqlCPUProvider
 	goschedstats.RegisterSettings(st)
 	if goschedstats.Supported {
 		cbID := goschedstats.RegisterRunnableCountCallback(gcoords.RegularCPU.GetRunnableCountCallback())
@@ -1271,6 +1273,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		monitorAndMetrics:        sqlMonitorAndMetrics,
 		settingsStorage:          settingsWriter,
 		admissionPacerFactory:    gcoords.ElasticCPU,
+		sqlCPUProvider:           sqlCPUProvider,
 		rangeDescIteratorFactory: rangedesc.NewIteratorFactory(db),
 		tenantCapabilitiesReader: sql.MakeSystemTenantOnly[tenantcapabilities.Reader](tenantCapabilitiesWatcher),
 	})

--- a/pkg/server/server_controller_new_server.go
+++ b/pkg/server/server_controller_new_server.go
@@ -95,7 +95,9 @@ func (s *topLevelServer) newTenantServer(
 		serverutils.SetUnsafeOverride(&baseCfg.TestingKnobs)
 	}
 
-	tenantServer, err := newTenantServerInternal(ctx, baseCfg, sqlCfg, tenantStopper, tenantNameContainer, s.db.AdmissionPacerFactory)
+	tenantServer, err := newTenantServerInternal(
+		ctx, baseCfg, sqlCfg, tenantStopper, tenantNameContainer, s.db.AdmissionPacerFactory,
+		s.db.SQLCPUProvider)
 	if err != nil {
 		return nil, err
 	}
@@ -152,6 +154,7 @@ func newTenantServerInternal(
 	stopper *stop.Stopper,
 	tenantNameContainer *roachpb.TenantNameContainer,
 	elastic admission.PacerFactory,
+	sqlCPUProvider admission.SQLCPUProvider,
 ) (*SQLServerWrapper, error) {
 	ambientCtx := baseCfg.AmbientCtx
 	stopper.SetTracer(baseCfg.Tracer)
@@ -163,7 +166,8 @@ func newTenantServerInternal(
 	log.Dev.Infof(newCtx, "creating tenant server")
 
 	// Now instantiate the tenant server proper.
-	return newSharedProcessTenantServer(newCtx, stopper, baseCfg, sqlCfg, tenantNameContainer, elastic)
+	return newSharedProcessTenantServer(
+		newCtx, stopper, baseCfg, sqlCfg, tenantNameContainer, elastic, sqlCPUProvider)
 }
 
 func (s *topLevelServer) makeSharedProcessTenantConfig(

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -414,6 +414,10 @@ type sqlServerArgs struct {
 	// CPU intensive operations, such as CDC event encoding/decoding.
 	admissionPacerFactory admission.PacerFactory
 
+	// sqlCPUProvider is used to report CPU usage and foreground (non-elastic)
+	// SQL CPU admission control.
+	sqlCPUProvider admission.SQLCPUProvider
+
 	// rangeDescIteratorFactory is used to construct iterators over range
 	// descriptors.
 	rangeDescIteratorFactory rangedesc.IteratorFactory
@@ -860,6 +864,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		TenantCostController:     cfg.costController,
 		RangeStatsFetcher:        rangeStatsFetcher,
 		AdmissionPacerFactory:    cfg.admissionPacerFactory,
+		SQLCPUProvider:           cfg.sqlCPUProvider,
 		ExecutorConfig:           execCfg,
 		RootSQLMemoryPoolSize:    cfg.MemoryPoolSize,
 		VecIndexManager:          vecIndexManager,

--- a/pkg/sql/colexec/BUILD.bazel
+++ b/pkg/sql/colexec/BUILD.bazel
@@ -74,6 +74,7 @@ go_library(
         "//pkg/sql/sessiondata",
         "//pkg/sql/sqltelemetry",  # keep
         "//pkg/sql/types",
+        "//pkg/util/admission",
         "//pkg/util/buildutil",
         "//pkg/util/cancelchecker",
         "//pkg/util/duration",  # keep

--- a/pkg/sql/colexec/colexecutils/BUILD.bazel
+++ b/pkg/sql/colexec/colexecutils/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/sqlerrors",
         "//pkg/sql/types",
+        "//pkg/util/admission",
         "//pkg/util/cancelchecker",
         "//pkg/util/log",
         "//pkg/util/metamorphic",

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -719,6 +719,10 @@ func (s *vectorizedFlowCreator) accumulateAsyncComponent(run runFn) {
 		flowinfra.StartableFn(func(ctx context.Context, wg *sync.WaitGroup, flowCtxCancel context.CancelFunc) {
 			wg.Add(1)
 			go func() {
+				if cpuHandle := admission.SQLCPUHandleFromContext(ctx); cpuHandle != nil {
+					gh := cpuHandle.RegisterGoroutine()
+					defer gh.Close(ctx)
+				}
 				growstack.Grow()
 				defer wg.Done()
 				run(ctx, flowCtxCancel)

--- a/pkg/sql/distsql/BUILD.bazel
+++ b/pkg/sql/distsql/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//pkg/sql/sessiondata",
         "//pkg/sql/sessiondatapb",
         "//pkg/sql/sqltelemetry",
+        "//pkg/util/admission",
         "//pkg/util/log",
         "//pkg/util/mon",
         "//pkg/util/pprofutil",

--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -202,6 +202,8 @@ type ServerConfig struct {
 	// with elastic CPU control.
 	AdmissionPacerFactory admission.PacerFactory
 
+	SQLCPUProvider admission.SQLCPUProvider
+
 	// Allow mutation operations to trigger stats refresh.
 	StatsRefresher *stats.Refresher
 

--- a/pkg/sql/rowflow/BUILD.bazel
+++ b/pkg/sql/rowflow/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
+        "//pkg/util/admission",
         "//pkg/util/buildutil",
         "//pkg/util/log",
         "//pkg/util/mon",

--- a/pkg/util/admission/BUILD.bazel
+++ b/pkg/util/admission/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "scheduler_latency_listener.go",
         "sequencer.go",
         "snapshot_queue.go",
+        "sql_cpu_handle.go",
         "store_grant_coordinator.go",
         "store_token_estimation.go",
         "testing_knobs.go",
@@ -39,6 +40,7 @@ go_library(
         "//pkg/util",
         "//pkg/util/admission/admissionpb",
         "//pkg/util/buildutil",
+        "//pkg/util/ctxutil",
         "//pkg/util/goschedstats",
         "//pkg/util/grunning",
         "//pkg/util/humanizeutil",
@@ -57,6 +59,7 @@ go_library(
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_cockroachdb_tokenbucket//:tokenbucket",
         "@com_github_olekukonko_tablewriter//:tablewriter",
+        "@com_github_petermattis_goid//:goid",
     ],
 )
 

--- a/pkg/util/admission/sql_cpu_handle.go
+++ b/pkg/util/admission/sql_cpu_handle.go
@@ -192,7 +192,7 @@ func (h *GoroutineCPUHandle) reset() {
 // will be pooled when SQLCPUHandle.Close is called, so MeasureAndAdmit must
 // never be called after Close.
 func (h *GoroutineCPUHandle) Close(ctx context.Context) {
-	_ = h.measureAndAdmit(ctx, true)
+	_ = h.measureAndAdmit(ctx, true /* noWait */)
 	h.closed.Store(true)
 }
 
@@ -203,7 +203,7 @@ func (h *GoroutineCPUHandle) Close(ctx context.Context) {
 //
 // TODO(sumeer): implement the measurement and admission logic.
 func (h *GoroutineCPUHandle) MeasureAndAdmit(ctx context.Context) error {
-	return h.measureAndAdmit(ctx, false)
+	return h.measureAndAdmit(ctx, false /* noWait */)
 }
 
 // measureAndAdmit is the internal implementation of MeasureAndAdmit. The
@@ -230,8 +230,8 @@ func (h *GoroutineCPUHandle) measureAndAdmit(ctx context.Context, noWait bool) e
 
 // PauseMeasuring is used to pause the CPU accounting for this goroutine. It
 // must be paired with UnpauseMeasuring. Used when the goroutine is being used
-// for KV work. If pause is called multiple times, an equal number of unpause
-// calls are needed to resume measuring.
+// for KV work. If PauseMeasuring is called multiple times, an equal number of
+// UnpauseMeasuring calls are needed to resume measuring.
 func (h *GoroutineCPUHandle) PauseMeasuring() {
 	h.paused++
 	if h.paused == 1 {

--- a/pkg/util/admission/sql_cpu_handle.go
+++ b/pkg/util/admission/sql_cpu_handle.go
@@ -1,0 +1,264 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package admission
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxutil"
+	"github.com/cockroachdb/cockroach/pkg/util/grunning"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/petermattis/goid"
+)
+
+// SQLWorkInfo captures identifying information about SQL work for CPU
+// accounting and admission.
+type SQLWorkInfo struct {
+	// AtGateway is true if the work is being executed at a gateway node.
+	AtGateway bool
+	// TenantID is the id of the tenant. For single-tenant clusters, this will
+	// always be the SystemTenantID.
+	TenantID roachpb.TenantID
+	// Priority is utilized within a tenant.
+	Priority admissionpb.WorkPriority
+	// CreateTime is equivalent to Time.UnixNano() at the creation time of this
+	// work or a parent work (e.g. could be the start time of the transaction,
+	// if this work was created as part of a transaction). It is used to order
+	// work within a (WorkloadID, Priority) pair -- earlier CreateTime is given
+	// preference.
+	CreateTime int64
+}
+
+// SQLCPUProvider is used to get a SQLCPUHandle that is used for CPU
+// accounting and admission.
+type SQLCPUProvider interface {
+	// GetHandle returns a SQLCPUHandle for the supplied work info.
+	GetHandle(work SQLWorkInfo) *SQLCPUHandle
+}
+
+var sqlCPUAdmissionHandleContextKey = ctxutil.RegisterFastValueKey()
+
+// ContextWithSQLCPUHandle returns a Context wrapping the supplied handle, if
+// any.
+func ContextWithSQLCPUHandle(ctx context.Context, h *SQLCPUHandle) context.Context {
+	if h == nil {
+		return ctx
+	}
+	return ctxutil.WithFastValue(ctx, sqlCPUAdmissionHandleContextKey, h)
+}
+
+// SQLCPUHandleFromContext returns the handle contained in the Context, if
+// any.
+func SQLCPUHandleFromContext(ctx context.Context) *SQLCPUHandle {
+	val := ctxutil.FastValue(ctx, sqlCPUAdmissionHandleContextKey)
+	h, ok := val.(*SQLCPUHandle)
+	if !ok {
+		return nil
+	}
+	return h
+}
+
+var goroutineCPUHandlePool = sync.Pool{
+	New: func() interface{} {
+		return &GoroutineCPUHandle{}
+	},
+}
+
+// SQLCPUHandle manages CPU accounting and admission for SQL work across
+// multiple goroutines.
+//
+// TODO(sumeer): fill in more details.
+type SQLCPUHandle struct {
+	workInfo SQLWorkInfo
+	p        *sqlCPUProviderImpl
+
+	mu struct {
+		syncutil.Mutex
+		closed   bool
+		gHandles []*GoroutineCPUHandle
+		// Backing for up to 2 goroutine handles, to avoid allocations in
+		// gHandles when there are 2 or fewer goroutines.
+		handlesBacking [2]*GoroutineCPUHandle
+	}
+}
+
+func newSQLCPUAdmissionHandle(workInfo SQLWorkInfo, p *sqlCPUProviderImpl) *SQLCPUHandle {
+	h := &SQLCPUHandle{
+		workInfo: workInfo,
+		p:        p,
+	}
+	h.mu.gHandles = h.mu.handlesBacking[:0]
+	return h
+}
+
+// TODO(sumeer): see the comment
+// https://github.com/cockroachdb/cockroach/pull/161952#pullrequestreview-3741525716
+// on additional integrations that may need to call RegisterGoroutine.
+
+// RegisterGoroutine returns a GoroutineCPUHandle to use for reporting and
+// admission. If the goroutine was already registered, the existing handle
+// will be returned. CPU time is accounted for at this goroutine from the
+// instant the handle was first created for this goroutine. The cpu accounting
+// will end for this goroutine when it is closed by calling
+// GoroutineCPUHandle.Close, or if never closed, until the last call to
+// GoroutineCPUHandle.MeasureAndAdmit.
+func (h *SQLCPUHandle) RegisterGoroutine() *GoroutineCPUHandle {
+	gid := goid.Get()
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, gh := range h.mu.gHandles {
+		if gh.gid == gid {
+			// Already registered.
+			return gh
+		}
+	}
+	// Not registered, create a new handle.
+	gh := newGoroutineCPUHandle(gid, h)
+	h.mu.gHandles = append(h.mu.gHandles, gh)
+
+	return gh
+}
+
+// Close is called when no more reporting is needed. It pools
+// GoroutineCPUHandles that have been closed. GoroutineCPUHandles that are not
+// yet closed are left for GC.
+func (h *SQLCPUHandle) Close() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.mu.closed = true
+	for i, gh := range h.mu.gHandles {
+		if gh.closed.Load() {
+			gh.reset()
+			goroutineCPUHandlePool.Put(gh)
+		}
+		h.mu.gHandles[i] = nil
+	}
+	h.mu.gHandles = nil
+}
+
+// GoroutineCPUHandle is used for CPU accounting on a single goroutine. It
+// should be closed by calling Close when the goroutine's flow-related work is
+// done. The Close call must be at the goroutine boundary, to structurally
+// guarantee that MeasureAndAdmit is never called after Close. This structural
+// guarantee is essential for safe pooling - the handle may be reused for a
+// different goroutine after being pooled. It is safe to never Close a
+// GoroutineCPUHandle -- it will be garbage collected.
+type GoroutineCPUHandle struct {
+	gid int64
+	h   *SQLCPUHandle
+
+	// cpuStart captures the running time of the calling goroutine when this
+	// handle is constructed.
+	cpuStart time.Duration
+	// cpuAccounted is the total CPU time accounted for on this goroutine.
+	// Monotonically increasing.
+	cpuAccounted time.Duration
+
+	pauseDur   time.Duration
+	paused     int
+	pauseStart time.Duration
+
+	// closed is set to true when Close() is called. This is primarily for
+	// debugging - the structural guarantee (Close at goroutine boundary)
+	// is the primary safety mechanism, not this field.
+	closed atomic.Bool
+}
+
+func newGoroutineCPUHandle(gid int64, h *SQLCPUHandle) *GoroutineCPUHandle {
+	gh := goroutineCPUHandlePool.Get().(*GoroutineCPUHandle)
+	*gh = GoroutineCPUHandle{
+		gid:      gid,
+		h:        h,
+		cpuStart: grunning.Time(),
+	}
+	return gh
+}
+
+// reset clears all fields in preparation for returning to the pool.
+func (h *GoroutineCPUHandle) reset() {
+	*h = GoroutineCPUHandle{}
+}
+
+// Close marks this handle as closed. It must be called at the goroutine
+// boundary when the goroutine's SQL work is done. After Close, the handle
+// will be pooled when SQLCPUHandle.Close is called, so MeasureAndAdmit must
+// never be called after Close.
+func (h *GoroutineCPUHandle) Close(ctx context.Context) {
+	_ = h.measureAndAdmit(ctx, true)
+	h.closed.Store(true)
+}
+
+// MeasureAndAdmit should be called frequently. The callee will measure the
+// CPU time spent in the goroutine and decide whether more CPU needs to be
+// allocated. If more CPU is needed, it can block in acquiring CPU tokens.
+// Returns a non-nil error iff the context is canceled while waiting.
+//
+// TODO(sumeer): implement the measurement and admission logic.
+func (h *GoroutineCPUHandle) MeasureAndAdmit(ctx context.Context) error {
+	return h.measureAndAdmit(ctx, false)
+}
+
+// measureAndAdmit is the internal implementation of MeasureAndAdmit. The
+// noWait parameter should only be set to true when the work is finished, so
+// only measurement is desired (blocking is no longer productive). When noWait
+// is true, this function never returns an error.
+func (h *GoroutineCPUHandle) measureAndAdmit(ctx context.Context, noWait bool) error {
+	if h.paused > 0 {
+		return nil
+	}
+	cpuUsed := grunning.Elapsed(h.cpuStart, grunning.Time()) - h.pauseDur
+	diff := cpuUsed - h.cpuAccounted
+	if diff <= 0 {
+		return nil
+	}
+	// TODO(sumeer): adding this diff to an atomic in SQLCPUHandle may be too
+	// much overhead. An alternative would be implement an atomic here, and
+	// only update the SQLCPUHandle when enough has accumulated. The reason
+	// we would need an atomic here is that when SQLCPUHandle is closed, it
+	// needs to reach in and grab whatever CPU has not yet been reported.
+	h.cpuAccounted += diff
+	return nil
+}
+
+// PauseMeasuring is used to pause the CPU accounting for this goroutine. It
+// must be paired with UnpauseMeasuring. Used when the goroutine is being used
+// for KV work. If pause is called multiple times, an equal number of unpause
+// calls are needed to resume measuring.
+func (h *GoroutineCPUHandle) PauseMeasuring() {
+	h.paused++
+	if h.paused == 1 {
+		h.pauseStart = grunning.Time()
+	}
+}
+
+// UnpauseMeasuring resumes CPU accounting for this goroutine.
+func (h *GoroutineCPUHandle) UnpauseMeasuring() {
+	h.paused--
+	if h.paused == 0 {
+		h.pauseDur += grunning.Elapsed(h.pauseStart, grunning.Time())
+	}
+}
+
+type sqlCPUProviderImpl struct {
+	// TODO(sumeer): implement.
+}
+
+func (p *sqlCPUProviderImpl) GetHandle(workInfo SQLWorkInfo) *SQLCPUHandle {
+	// TODO(sumeer): implement.
+	return newSQLCPUAdmissionHandle(workInfo, p)
+}
+
+// NewSQLCPUProvider creates a new SQLCPUProvider.
+//
+// TODO(sumeer): real implementation.
+func NewSQLCPUProvider() SQLCPUProvider {
+	return &sqlCPUProviderImpl{}
+}

--- a/pkg/util/cancelchecker/BUILD.bazel
+++ b/pkg/util/cancelchecker/BUILD.bazel
@@ -8,5 +8,6 @@ go_library(
     deps = [
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
+        "//pkg/util/admission",
     ],
 )

--- a/pkg/util/cancelchecker/cancel_checker.go
+++ b/pkg/util/cancelchecker/cancel_checker.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/util/admission"
 )
 
 // CancelChecker is a helper object for repeatedly checking whether the associated context
@@ -29,6 +30,8 @@ type CancelChecker struct {
 
 	// The number of Check() calls to skip the context cancellation check.
 	checkInterval uint32
+
+	cpuHandle *admission.GoroutineCPUHandle
 }
 
 // The default interval of Check() calls to wait between checks for context
@@ -47,6 +50,12 @@ func (c *CancelChecker) Check() error {
 			// to Check().
 			return QueryCanceledError
 		default:
+		}
+		if c.cpuHandle != nil {
+			err := c.cpuHandle.MeasureAndAdmit(c.ctx)
+			if err != nil {
+				return QueryCanceledError
+			}
 		}
 	}
 
@@ -68,6 +77,10 @@ func (c *CancelChecker) Reset(ctx context.Context, checkInterval ...uint32) {
 		c.checkInterval = checkInterval[0]
 	} else {
 		c.checkInterval = cancelCheckInterval
+	}
+	cpuHandle := admission.SQLCPUHandleFromContext(ctx)
+	if cpuHandle != nil {
+		c.cpuHandle = cpuHandle.RegisterGoroutine()
 	}
 }
 


### PR DESCRIPTION
The admission.SQLCPUHandle provides the interface for doing CPU reporting
and admission waits from SQL code. It supports registering a goroutine,
and closing it when done. Each registered goroutine gets a
GoroutineCPUHandle, whose MeasureAndAdmit method (which only needs to be
single threaded), is used for measurement and waiting for admission.
Different callers (by definition on the same goroutine) do not need to
coordinate when calling MeasureAndAdmit.

The GoroutineCPUHandle also support {Pause,Unpause}Measuring methods, for
the KV layer to use when the same goroutine calls from SQL into KV.

The current implementation of SQLCPUHandle and GoroutineCPUHandle contains
trivial scaffolding, to illustrate the approach. The implementation for
measuring CPU, as needed by the allocator, will be in a later PR.
Enhancing the implementation for waiting for admission will also be done
later.

Outline of integration of SQLCPUHandle and GoroutineCPUHandle:

flowinfra.MakeCPUHandle is the helper function for initializing a
SQLCPUHandle and injecting it into the context. It is called from
connExecutor.dispatchToExecutionEngine at the gateway, and from
ServerImpl.setupFlow for non-gateway execution.

The registration and closing of GoroutineCPUHandles happens wherever
goroutines are spawned. Specifically, this happens in:
  - FlowBase.StartInternal: processor goroutines
  - accumulateAsyncComponent: vectorized async components (outboxes/routers)
  - Outbox.Start: row-based outbox goroutine
  - routerBase.Start: row-based router output goroutines
  - dispatchToExecutionEngine: gateway flow's main goroutine
  - setupFlow (via onFlowCleanupEnd): remote flow's main goroutine

Periodic calls to MeasureAndAdmit happen via the CancelCheckers, since
these checkers already get exercised during query execution.

Fixes https://github.com/cockroachdb/cockroach/issues/162336

Epic: [CRDB-56265](https://cockroachlabs.atlassian.net/browse/CRDB-56265)

Release note: None