### PR TITLE
kvcoord: avoid concurrent restarts of active rangefeeds

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
@@ -84,6 +84,9 @@ type rangeFeedConfig struct {
 		captureMuxRangeFeedRequestSender func(nodeID roachpb.NodeID, sender func(req *kvpb.RangeFeedRequest) error)
 		// beforeSendRequest is a mux rangefeed callback invoked prior to sending rangefeed request.
 		beforeSendRequest func()
+		// afterRoutingReset is a mux rangefeed callback invoked after resetRouting
+		// completes. Used for testing race conditions.
+		afterRoutingReset func()
 	}
 }
 
@@ -701,6 +704,14 @@ func TestingWithMuxRangeFeedRequestSenderCapture(
 func TestingWithBeforeSendRequest(fn func()) RangeFeedOption {
 	return optionFunc(func(c *rangeFeedConfig) {
 		c.knobs.beforeSendRequest = fn
+	})
+}
+
+// TestingWithAfterRoutingReset returns a test only option that invokes
+// function after resetRouting completes.
+func TestingWithAfterRoutingReset(fn func()) RangeFeedOption {
+	return optionFunc(func(c *rangeFeedConfig) {
+		c.knobs.afterRoutingReset = fn
 	})
 }
 


### PR DESCRIPTION
There is a concurrency bug in MuxRangeFeed:

0. Goroutine A starts a goroutine B to read events from the stream.
1. Goroutine A adds a new streamID to the muxer's map of active rangefeeds.
2. Goroutine A Sends a new RangeFeedRequest to the stream in a retry loop
3. Concurrenly,

    (a) The Send() returns an error; and

    (b) despite the error, the rangefeed was registered and then returns an
    error event, or Recv() fails and restarts all rangefeeds

4. Then it may be the scase that goroutine B resets the transport to nil.

5. Goroutine A, also in a retry loop, attempts to access this now-nil transport.

There are many ways to solve the NPE itself, but here we try to resolve the more fundamental race: we have two goroutines attempting to restart the same stream.

The best way to solve this would be to refactor this code, but here we first attempt a somewhat backportable fix:

1. Each restart attempt generates a new streamID. 2. Goroutine's A and B delete the streamID from the map before attempting to restart it, and only attempt a restart if they found their ID.

The included test failed with a NPE before the fix.

Fixes #157997
Fixes #161822
Fixes #161479
Fixes-26.1 #161663
Fixes-26.1 #160442

Release note: None