### PR TITLE
schedulerlatency: rename runtimeHistogram.counts to .windowedCounts

### DIFF
--- a/pkg/util/schedulerlatency/histogram.go
+++ b/pkg/util/schedulerlatency/histogram.go
@@ -83,13 +83,13 @@ func newRuntimeHistogram(metadata metric.Metadata, buckets []float64) *runtimeHi
 	return h
 }
 
-// update replaces windowedCounts and adds to cumCounts. src is the runtime's
-// histogram with fine-grained buckets containing delta counts accumulated since
-// the last getAndClearLastStatsHistogram() call (~10s ago).
-func (h *runtimeHistogram) update(src *metrics.Float64Histogram) {
+// recordDelta incorporates a delta histogram (not cumulative) into this
+// histogram. It replaces windowedCounts with the delta and adds the delta to
+// cumCounts.
+func (h *runtimeHistogram) recordDelta(delta *metrics.Float64Histogram) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	counts, buckets := src.Counts, src.Buckets
+	counts, buckets := delta.Counts, delta.Buckets
 
 	for i := range h.mu.windowedCounts {
 		h.mu.windowedCounts[i] = 0

--- a/pkg/util/schedulerlatency/histogram_test.go
+++ b/pkg/util/schedulerlatency/histogram_test.go
@@ -87,7 +87,7 @@ func TestRuntimeHistogram(t *testing.T) {
 					Buckets: parseBuckets(t, d.Input),
 				}
 				require.True(t, len(his.Buckets) == len(his.Counts)+1)
-				rh.update(his)
+				rh.recordDelta(his)
 				return ""
 
 			case "print":

--- a/pkg/util/schedulerlatency/sampler.go
+++ b/pkg/util/schedulerlatency/sampler.go
@@ -79,6 +79,11 @@ func StartSampler(
 			// goroutines onto processors, i.e. are in the {micro,milli}-second
 			// range during normal operation. See TestHistogramBuckets for more
 			// details.
+			//
+			// NB: Go guarantees that sample().Buckets will be identical across
+			// calls for the lifetime of the process. This allows runtimeHistogram
+			// to rely on exact boundary alignment when aggregating counts. See:
+			// https://pkg.go.dev/runtime/metrics#Float64Histogram
 			cpuSchedulerLatencyBuckets := reBucketExpAndTrim(
 				sample().Buckets,                   // original buckets
 				1.1,                                // base

--- a/pkg/util/schedulerlatency/sampler.go
+++ b/pkg/util/schedulerlatency/sampler.go
@@ -107,7 +107,7 @@ func StartSampler(
 					if schedulingLatenciesHistogram == nil {
 						continue
 					}
-					schedulerLatencyHistogram.update(schedulingLatenciesHistogram)
+					schedulerLatencyHistogram.recordDelta(schedulingLatenciesHistogram)
 				}
 			}
 		})
@@ -247,7 +247,7 @@ func (s *sampler) recordLocked(
 
 // getAndClearLastStatsHistogram returns the accumulated deltas since the last
 // call and resets the accumulator. Called every statsInterval (~10s) to provide
-// delta counts for runtimeHistogram.update().
+// delta counts for runtimeHistogram.recordDelta().
 func (s *sampler) getAndClearLastStatsHistogram() *metrics.Float64Histogram {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/pkg/util/schedulerlatency/sampler.go
+++ b/pkg/util/schedulerlatency/sampler.go
@@ -215,11 +215,11 @@ func (s *sampler) sampleOnTickAndInvokeCallbacks(period time.Duration) {
 
 	// Accumulate delta (latest - previous) for export via getAndClearDeltaHistogram().
 	if prevSample != nil {
-		sampleDelta := sub(latestCumulative, prevSample)
+		tickDelta := sub(latestCumulative, prevSample)
 		if s.mu.deltaAccumulator == nil {
-			s.mu.deltaAccumulator = sampleDelta
+			s.mu.deltaAccumulator = tickDelta
 		} else {
-			s.mu.deltaAccumulator = add(s.mu.deltaAccumulator, sampleDelta)
+			s.mu.deltaAccumulator = add(s.mu.deltaAccumulator, tickDelta)
 		}
 	}
 

--- a/pkg/util/schedulerlatency/sampler.go
+++ b/pkg/util/schedulerlatency/sampler.go
@@ -103,11 +103,11 @@ func StartSampler(
 				case <-stopper.ShouldQuiesce():
 					return
 				case <-ticker.C:
-					schedulingLatenciesHistogram := s.getAndClearDeltaHistogram()
-					if schedulingLatenciesHistogram == nil {
+					deltaHist := s.getAndClearDeltaHistogram()
+					if deltaHist == nil {
 						continue
 					}
-					schedulerLatencyHistogram.recordDelta(schedulingLatenciesHistogram)
+					schedulerLatencyHistogram.recordDelta(deltaHist)
 				}
 			}
 		})

--- a/pkg/util/schedulerlatency/scheduler_latency_test.go
+++ b/pkg/util/schedulerlatency/scheduler_latency_test.go
@@ -261,7 +261,7 @@ func TestCloneHistogram(t *testing.T) {
 //	Every 100ms (samplePeriod):
 //	  - Sample Go runtime histogram (cumulative since process start)
 //	  - Compute delta from previous sample
-//	  - Accumulate delta into schedulerLatencyAccumulator
+//	  - Accumulate delta into deltaAccumulator
 //
 //	Every 10s (statsInterval):
 //	  - Pass accumulated delta to rh.recordDelta()

--- a/pkg/util/schedulerlatency/scheduler_latency_test.go
+++ b/pkg/util/schedulerlatency/scheduler_latency_test.go
@@ -264,7 +264,7 @@ func TestCloneHistogram(t *testing.T) {
 //	  - Accumulate delta into schedulerLatencyAccumulator
 //
 //	Every 10s (statsInterval):
-//	  - Pass accumulated observations to rh.update()
+//	  - Pass accumulated delta to rh.recordDelta()
 //	  - Clear accumulator
 //
 // Example timeline:
@@ -272,7 +272,7 @@ func TestCloneHistogram(t *testing.T) {
 //	Time 0-10s:  Accumulate ~100 samples of 100ms deltas → 10 total observations
 //	Time 10-20s: Accumulate ~100 samples of 100ms deltas → 6 total observations
 //
-// runtimeHistogram.update() receives these accumulated deltas and must:
+// runtimeHistogram.recordDelta() receives these accumulated deltas and must:
 //   - Accumulate into cumulativeCounts for Prometheus export (10 → 16)
 //   - Replace windowedCounts with latest delta for TSDB percentiles (10 → 6)
 func TestRuntimeHistogramCumulativeVsWindowed(t *testing.T) {
@@ -282,7 +282,7 @@ func TestRuntimeHistogramCumulativeVsWindowed(t *testing.T) {
 
 	// Simulate first statsInterval (e.g., 0s-10s): 10 accumulated observations.
 	// In production, this is the sum of ~100 deltas (one per 100ms sample).
-	rh.update(&metrics.Float64Histogram{
+	rh.recordDelta(&metrics.Float64Histogram{
 		Counts:  []uint64{0, 5, 3, 2, 0}, // 10 total observations
 		Buckets: buckets,
 	})
@@ -298,7 +298,7 @@ func TestRuntimeHistogramCumulativeVsWindowed(t *testing.T) {
 	require.Equal(t, cumSum1, winSum1)
 
 	// Simulate second statsInterval (e.g., 10s-20s): 6 accumulated observations.
-	rh.update(&metrics.Float64Histogram{
+	rh.recordDelta(&metrics.Float64Histogram{
 		Counts:  []uint64{0, 1, 2, 3, 0}, // 6 total observations
 		Buckets: buckets,
 	})


### PR DESCRIPTION
Epic: none 
Release note: none

---
**schedulerlatency: improve comments**


---
**schedulerlatency: rename update to recordDelta**

This commit renames runtimeHistogram.update() to recordDelta()
to clarify that it accepts delta histograms (not cumulative).

---
**schedulerlatency: rename schedulerLatencyAccumulator to deltaAccumulator**

This commit renames the field to clarify it accumulates
delta histograms.

---
**schedulerlatency: rename getAndClearLastStatsHistogram to getAndClearDeltaHistogram**

This commit renames the function to clarify it returns
accumulated deltas.

---
**schedulerlatency: rename schedulingLatenciesHistogram to deltaHist**


---
**schedulerlatency: rename sampleDelta to tickDelta**

This commit clarifies that this is the delta for a
single tick (~100ms).

---
**schedulerlatency: simplify recordLocked**

This commit removes an unnecessary early return that blocked delta
accumulation until the ring buffer was full.

