### PR TITLE
sql/copy: deflake TestLargeCopy

### DIFF
--- a/pkg/sql/copy/BUILD.bazel
+++ b/pkg/sql/copy/BUILD.bazel
@@ -27,6 +27,7 @@ go_test(
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/desctestutils",
         "//pkg/sql/parser",
+        "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/randgen",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sqltestutils",


### PR DESCRIPTION
We previously tried to deflake TestLargeCopy by ignoring retriable errors in atomic mode, which doesn't support automatic retries. However, the error string doesn't always contain the expected substring. This commit hardens the retriable error detection logic. This is a test-only change.

Fixes #161631

Release note: None