### PR TITLE
kvcoord: force split batch in txnWriteBuffer for mid txn flush

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_client_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_client_test.go
@@ -148,12 +148,14 @@ func TestTxnCoordSenderWriteBufferingReEnablesPipelining(t *testing.T) {
 		return nil
 	}))
 
-	require.Equal(t, 4, batchCount)
+	require.Equal(t, 5, batchCount)
 	require.Equal(t, []kvpb.Method{
 		// The initial setup
 		kvpb.Put,
-		// The first (buffered) Put and the DeleteRange that flushes the buffer.
-		kvpb.Put, kvpb.DeleteRange,
+		// The first (buffered) Put and the DeleteRange that flushes the buffer,
+		// sent as separate batches.
+		kvpb.Put,
+		kvpb.DeleteRange,
 		// The second (pipelined) Put
 		kvpb.Put,
 		// EndTxn with the QueryIntent because pipelining was turned back on.

--- a/pkg/sql/logictest/testdata/logic_test/buffered_writes
+++ b/pkg/sql/logictest/testdata/logic_test/buffered_writes
@@ -626,3 +626,46 @@ COMMIT
 
 statement ok
 RESET enable_durable_locking_for_serializable
+
+# A regression test for the case when a batch with a CPut (for which the
+# condition fails) forced the txnWriteBuffer to flush, and we didn't split
+# buffered writes into a separate batch, while they would be preserved due to
+# usage of the savepoint.
+subtest regression_161722
+
+statement ok
+CREATE TABLE xy (
+  x INT PRIMARY KEY,
+  y INT,
+  FAMILY (x, y)
+)
+
+# Use specific buffer size that allows the first INSERT to be buffered, yet the
+# second one would exceed the limit.
+statement ok
+SET CLUSTER SETTING kv.transaction.write_buffering.max_buffer_size = '400B';
+
+statement ok
+BEGIN
+
+statement ok
+INSERT INTO xy VALUES (1, 1)
+
+statement ok
+SAVEPOINT s
+
+query error duplicate key value violates unique constraint "xy_pkey"
+INSERT INTO xy VALUES (1, 2)
+
+statement ok
+ROLLBACK TO SAVEPOINT s
+
+statement ok
+COMMIT
+
+query II
+SELECT * FROM xy ORDER BY x
+----
+1  1
+
+subtest end


### PR DESCRIPTION
We just found a case where - if a BatchRequest with a CPut forces the txn write buffer to flush (e.g. because of buffer size limit) - we could lose some buffered writes in case that CPut's condition failed the evaluation. This was the case since we could have included the CPut into the same batch as all buffered writes, and the ConditionFailedError would make us discard the whole batch, whereas the higher level (i.e. SQL) could have discarded that error by using savepoints. To prevent this from happening we'll now require a separate batch for the buffered writes for all mid-txn flushes. Additionally, even in the end-txn flush batch case we now require a separate batch if a CPut is found.

Fixes: #161722.

Release note (bug fix): Previously, if buffered writes were enabled (which is a public preview feature, off by default), multi-stmt explicit txns that use SAVEPOINTs to recover from certain errors (like duplicate key value violations) could lose the writes that were performed _before_ the savepoint was created in rare cases. The bug has been present since the buffered writes feature was added in 25.2 and is now fixed.