### PR TITLE
application_api: skip flaky TestStatusVarsSizeLimit

### DIFF
--- a/pkg/server/application_api/metrics_test.go
+++ b/pkg/server/application_api/metrics_test.go
@@ -256,6 +256,9 @@ func TestStatusVarsTxnMetrics(t *testing.T) {
 func TestStatusVarsSizeLimit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	skip.WithIssue(t, 161937)
+
 	skip.UnderRace(t, "unrelated data race")
 	skip.UnderStress(t, "unnecessary to test this scenario")
 	s := serverutils.StartServerOnly(t, base.TestServerArgs{})


### PR DESCRIPTION
I've seen this test fail multiple times on CI on my PRs and it's very flaky. Skip it until someone takes a closer look.

Informs: #161937.
Epic: None
Release note: None