### PR TITLE
sql,stats: a couple of minor improvements

### DIFF
--- a/pkg/sql/stats/automatic_stats_test.go
+++ b/pkg/sql/stats/automatic_stats_test.go
@@ -792,8 +792,8 @@ func TestMutationsAndSettingOverrideChannels(t *testing.T) {
 	AutomaticStatisticsClusterMode.Override(ctx, &st.SV, true)
 	r := Refresher{
 		st:        st,
-		mutations: make(chan mutation, refreshChanBufferLen),
-		settings:  make(chan settingOverride, refreshChanBufferLen),
+		mutations: make(chan mutation, mutationsChanBufferLen),
+		settings:  make(chan settingOverride, settingsChanBufferLen),
 	}
 
 	tbl := descpb.TableDescriptor{ID: 53, ParentID: 52, Name: "foo"}
@@ -801,11 +801,11 @@ func TestMutationsAndSettingOverrideChannels(t *testing.T) {
 
 	// Test that the mutations channel doesn't block even when we add 10 more
 	// items than can fit in the buffer.
-	for i := 0; i < refreshChanBufferLen+10; i++ {
+	for i := 0; i < mutationsChanBufferLen+10; i++ {
 		r.NotifyMutation(ctx, tableDesc, 5 /* rowsAffected */)
 	}
 
-	if expected, actual := refreshChanBufferLen, len(r.mutations); expected != actual {
+	if expected, actual := mutationsChanBufferLen, len(r.mutations); expected != actual {
 		t.Fatalf("expected channel size %d but found %d", expected, actual)
 	}
 
@@ -815,13 +815,13 @@ func TestMutationsAndSettingOverrideChannels(t *testing.T) {
 	tableDesc.TableDesc().AutoStatsSettings = autoStatsSettings
 	minStaleRows := int64(1)
 	autoStatsSettings.MinStaleRows = &minStaleRows
-	for i := 0; i < refreshChanBufferLen+10; i++ {
+	for i := 0; i < settingsChanBufferLen+10; i++ {
 		int64CurrIteration := int64(i)
 		autoStatsSettings.MinStaleRows = &int64CurrIteration
 		r.NotifyMutation(ctx, tableDesc, 5 /* rowsAffected */)
 	}
 
-	if expected, actual := refreshChanBufferLen, len(r.settings); expected != actual {
+	if expected, actual := settingsChanBufferLen, len(r.settings); expected != actual {
 		t.Fatalf("expected channel size %d but found %d", expected, actual)
 	}
 }


### PR DESCRIPTION
**stats: increase mutations buffered channel size from 256 to 32768**

Whenever we perform a mutation, we call `NotifyMutation` with rows
affected on the stats refresher, which sends a struct on the mutations
channel, and if that channel is full, the struct is dropped. Previously,
we had a hard-coded size of 256 which seems far too small given that
this is a global node-wide singleton. If there is some delay in the
stats refresh goroutine (e.g. it's currently processing the previous
mutation counts), it seems quite likely that we'll have some mutation
structs dropped (quick search on glean reveals that there have been
a few cases in recent past). This commit bumps the size to 32768 which
seems ok given the struct size is 24B (for a total max memory usage of
256KiB). It keeps the capacity of the settings' overrides channel
unchanged (which required introducing a separate constant).

**sql: limit "skipping stat ... due to failed type check" warning**

This commit makes this warning to be printed at most once per second.

Fixes: #146556

Release note: None