### PR TITLE
stats: skip a couple recently flaky tests

### DIFF
--- a/pkg/sql/stats/create_stats_job_test.go
+++ b/pkg/sql/stats/create_stats_job_test.go
@@ -221,10 +221,12 @@ func TestCreateStatisticsCanBeCancelled(t *testing.T) {
 // don't run when an auto full stats job is running. It also tests that manual
 // stat jobs (full or partial) are always allowed to run.
 func TestAtMostOneRunningCreateStats(t *testing.T) {
+	skip.WithIssue(t, 161973)
 	testAtMostOneRunningCreateStatsImpl(t, false /* shouldError */)
 }
 
 func TestAtMostOneRunningCreateStatsWithErrorOnConcurrentCreateStats(t *testing.T) {
+	skip.WithIssue(t, 161974)
 	testAtMostOneRunningCreateStatsImpl(t, true /* shouldError */)
 }
 


### PR DESCRIPTION
The flakiness must have been caused by increasing the concurrency. Skip two tests until I figure that out.

Informs: #161973
Informs: #161974
Epic: None
Release note: None