### PR TITLE
release-26.1: ttljob: move AOST calculation into loop

### DIFF
--- a/pkg/sql/ttl/ttljob/ttljob_processor.go
+++ b/pkg/sql/ttl/ttljob/ttljob_processor.go
@@ -300,8 +300,8 @@ func (t *ttlProcessor) work(ctx context.Context, output execinfra.RowReceiver) e
 		// Compute the AOST timestamp for SpanToQueryBounds. This aligns the bounds
 		// computation with the historical time used by the SELECT queries, reducing
 		// contention with foreground traffic.
-		aostTimestamp := kvDB.Clock().Now().AddDuration(ttlSpec.AOSTDuration)
 		for i, span := range ttlSpec.Spans {
+			aostTimestamp := kvDB.Clock().Now().AddDuration(ttlSpec.AOSTDuration)
 			if bounds, hasRows, err := spanutils.SpanToQueryBounds(
 				ctx,
 				kvDB,


### PR DESCRIPTION
Backport 1/1 commits from #161979 on behalf of @rafiss.

----

We noticed the following error in our SLI dashboard review:

```
SpanToQueryBounds error ... batch timestamp ... must be after replica GC threshold
```

This can occur when the processor has a large number of spans to process. The intention in the original commit (93fae4e6582) was to choose a recent timestamp for each query, but the timestamp was accidentally being calculated outside of the loop so could become old.

fixes https://github.com/cockroachlabs/support/issues/3536
Release note (bug fix): Fixed a bug introduced in v26.1.0-beta.1 in which row-level TTL jobs could encounter GC threshold errors if each node had a large number of spans to process.

----

Release justification: bug fix