### PR TITLE
auth: Add SAN-based auth validation for client certificates

### DIFF
--- a/pkg/security/BUILD.bazel
+++ b/pkg/security/BUILD.bazel
@@ -63,6 +63,7 @@ go_test(
     name = "security_test",
     size = "medium",
     srcs = [
+        "auth_internal_test.go",
         "auth_test.go",
         "certificate_loader_test.go",
         "certificate_manager_test.go",

--- a/pkg/security/auth_internal_test.go
+++ b/pkg/security/auth_internal_test.go
@@ -1,0 +1,360 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package security
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateSANMatchForUser(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tests := []struct {
+		name           string
+		user           string
+		certSANs       []string
+		rootSANsToSet  string
+		nodeSANsToSet  string
+		expectedResult bool
+	}{
+		// Non-root/node users (always return true)
+		{
+			name:           "regular user alice with DNS SAN",
+			user:           "alice",
+			certSANs:       []string{"SAN:DNS:example.com"},
+			rootSANsToSet:  "",
+			nodeSANsToSet:  "",
+			expectedResult: true,
+		},
+		{
+			name:           "regular user bob with URI SAN",
+			user:           "bob",
+			certSANs:       []string{"SAN:URI:spiffe://example.org/service"},
+			rootSANsToSet:  "",
+			nodeSANsToSet:  "",
+			expectedResult: true,
+		},
+		{
+			name:           "regular user charlie with empty SANs",
+			user:           "charlie",
+			certSANs:       []string{},
+			rootSANsToSet:  "",
+			nodeSANsToSet:  "",
+			expectedResult: true,
+		},
+		{
+			name:           "regular user dave with nil SANs",
+			user:           "dave",
+			certSANs:       nil,
+			rootSANsToSet:  "",
+			nodeSANsToSet:  "",
+			expectedResult: true,
+		},
+		{
+			name:           "regular user eve with multiple SANs",
+			user:           "eve",
+			certSANs:       []string{"SAN:DNS:foo.com", "SAN:URI:bar", "SAN:IP:192.168.1.1"},
+			rootSANsToSet:  "",
+			nodeSANsToSet:  "",
+			expectedResult: true,
+		},
+		// Root user without configured root SANs
+		{
+			name:           "root user with empty cert SANs and no configured root SANs",
+			user:           username.RootUser,
+			certSANs:       []string{},
+			rootSANsToSet:  "",
+			nodeSANsToSet:  "",
+			expectedResult: false,
+		},
+		{
+			name:           "root user with DNS cert SAN but no configured root SANs",
+			user:           username.RootUser,
+			certSANs:       []string{"SAN:DNS:example.com"},
+			rootSANsToSet:  "",
+			nodeSANsToSet:  "",
+			expectedResult: false,
+		},
+		// Root user with configured root SANs - exact match
+		{
+			name:           "root user exact match single DNS SAN",
+			user:           username.RootUser,
+			certSANs:       []string{"SAN:DNS:example.com"},
+			rootSANsToSet:  "DNS=example.com",
+			nodeSANsToSet:  "",
+			expectedResult: true,
+		},
+		// Root user with configured root SANs - superset
+		{
+			name:           "root user cert has configured SAN plus additional DNS",
+			user:           username.RootUser,
+			certSANs:       []string{"SAN:DNS:example.com", "SAN:URI:spiffe://foo"},
+			rootSANsToSet:  "DNS=example.com",
+			nodeSANsToSet:  "",
+			expectedResult: true,
+		},
+		{
+			name:           "root user cert has all configured SANs plus more",
+			user:           username.RootUser,
+			certSANs:       []string{"SAN:DNS:a.com", "SAN:DNS:b.com", "SAN:URI:c"},
+			rootSANsToSet:  "DNS=a.com,DNS=b.com",
+			nodeSANsToSet:  "",
+			expectedResult: true,
+		},
+		// Root user with configured root SANs - subset (should fail)
+		{
+			name:           "root user cert missing some configured SANs",
+			user:           username.RootUser,
+			certSANs:       []string{"SAN:DNS:example.com"},
+			rootSANsToSet:  "DNS=example.com,URI=spiffe://foo",
+			nodeSANsToSet:  "",
+			expectedResult: false,
+		},
+		// Root user with configured root SANs - partial overlap
+		{
+			name:           "root user cert has partial overlap with configured SANs",
+			user:           username.RootUser,
+			certSANs:       []string{"SAN:DNS:a.com", "SAN:DNS:b.com"},
+			rootSANsToSet:  "DNS=b.com,DNS=c.com",
+			nodeSANsToSet:  "",
+			expectedResult: false,
+		},
+		// Root user with configured root SANs - completely different
+		{
+			name:           "root user cert completely different from configured SANs",
+			user:           username.RootUser,
+			certSANs:       []string{"SAN:DNS:a.com"},
+			rootSANsToSet:  "DNS=b.com",
+			nodeSANsToSet:  "",
+			expectedResult: false,
+		},
+		// Root user with configured root SANs - empty cert SANs
+		{
+			name:           "root user empty cert SANs with configured root SANs",
+			user:           username.RootUser,
+			certSANs:       []string{},
+			rootSANsToSet:  "DNS=example.com",
+			nodeSANsToSet:  "",
+			expectedResult: false,
+		},
+		// Root user with configured root SANs - multiple types
+		{
+			name:           "root user cert has all configured SANs of different types",
+			user:           username.RootUser,
+			certSANs:       []string{"SAN:DNS:a.com", "SAN:URI:b", "SAN:IP:1.2.3.4", "SAN:IP:5.6.7.8"},
+			rootSANsToSet:  "DNS=a.com,URI=b,IP=5.6.7.8,IP=1.2.3.4",
+			nodeSANsToSet:  "",
+			expectedResult: true,
+		},
+		{
+			name:           "root user cert missing IP SAN from configured SANs",
+			user:           username.RootUser,
+			certSANs:       []string{"SAN:DNS:a.com", "SAN:URI:b"},
+			rootSANsToSet:  "DNS=a.com,URI=b,IP=1.2.3.4",
+			nodeSANsToSet:  "",
+			expectedResult: false,
+		},
+		// Node user without configured node SANs
+		{
+			name:           "node user with empty cert SANs and no configured node SANs",
+			user:           username.NodeUser,
+			certSANs:       []string{},
+			rootSANsToSet:  "",
+			nodeSANsToSet:  "",
+			expectedResult: false,
+		},
+		{
+			name:           "node user with DNS cert SAN but no configured node SANs",
+			user:           username.NodeUser,
+			certSANs:       []string{"SAN:DNS:node.example.com"},
+			rootSANsToSet:  "",
+			nodeSANsToSet:  "",
+			expectedResult: false,
+		},
+		// Node user with configured node SANs - exact match
+		{
+			name:           "node user exact match single DNS SAN",
+			user:           username.NodeUser,
+			certSANs:       []string{"SAN:DNS:node.example.com"},
+			rootSANsToSet:  "",
+			nodeSANsToSet:  "DNS=node.example.com",
+			expectedResult: true,
+		},
+		// Node user with configured node SANs - superset
+		{
+			name:           "node user cert has configured SAN plus additional URI",
+			user:           username.NodeUser,
+			certSANs:       []string{"SAN:DNS:node.example.com", "SAN:DNS:node.example_new.com", "SAN:URI:spiffe://node"},
+			rootSANsToSet:  "",
+			nodeSANsToSet:  "DNS=node.example.com,DNS=node.example_new.com",
+			expectedResult: true,
+		},
+		// Node user with configured node SANs - subset
+		{
+			name:           "node user cert missing some configured SANs",
+			user:           username.NodeUser,
+			certSANs:       []string{"SAN:DNS:node.example.com"},
+			rootSANsToSet:  "",
+			nodeSANsToSet:  "DNS=node.example.com,URI=spiffe://node",
+			expectedResult: false,
+		},
+		// Node user with configured node SANs - completely different
+		{
+			name:           "node user cert completely different from configured SANs",
+			user:           username.NodeUser,
+			certSANs:       []string{"SAN:DNS:a.com"},
+			rootSANsToSet:  "",
+			nodeSANsToSet:  "DNS=b.com",
+			expectedResult: false,
+		},
+		// Node user with configured node SANs - empty cert SANs
+		{
+			name:           "node user empty cert SANs with configured node SANs",
+			user:           username.NodeUser,
+			certSANs:       []string{},
+			rootSANsToSet:  "",
+			nodeSANsToSet:  "DNS=node.example.com",
+			expectedResult: false,
+		},
+		// Both root and node SANs configured
+		{
+			name:           "root user with both root and node SANs configured matches root",
+			user:           username.RootUser,
+			certSANs:       []string{"SAN:DNS:root.com"},
+			rootSANsToSet:  "DNS=root.com",
+			nodeSANsToSet:  "DNS=node.com",
+			expectedResult: true,
+		},
+		{
+			name:           "root user with both root and node SANs configured matches node not root",
+			user:           username.RootUser,
+			certSANs:       []string{"SAN:DNS:node.com"},
+			rootSANsToSet:  "DNS=root.com",
+			nodeSANsToSet:  "DNS=node.com",
+			expectedResult: false, // User-specific: root user must match root SANs
+		},
+		{
+			name:           "node user with both root and node SANs configured matches node",
+			user:           username.NodeUser,
+			certSANs:       []string{"SAN:DNS:node.com"},
+			rootSANsToSet:  "DNS=root.com",
+			nodeSANsToSet:  "DNS=node.com",
+			expectedResult: true,
+		},
+		{
+			name:           "node user with both root and node SANs configured matches root not node",
+			user:           username.NodeUser,
+			certSANs:       []string{"SAN:DNS:root.com"},
+			rootSANsToSet:  "DNS=root.com",
+			nodeSANsToSet:  "DNS=node.com",
+			expectedResult: false, // User-specific: node user must match node SANs
+		},
+		{
+			name:           "root user cert matches both root and node SANs",
+			user:           username.RootUser,
+			certSANs:       []string{"SAN:DNS:shared.com"},
+			rootSANsToSet:  "DNS=shared.com",
+			nodeSANsToSet:  "DNS=shared.com",
+			expectedResult: true,
+		},
+		{
+			name:           "node user cert matches both root and node SANs",
+			user:           username.NodeUser,
+			certSANs:       []string{"SAN:DNS:shared.com"},
+			rootSANsToSet:  "DNS=shared.com",
+			nodeSANsToSet:  "DNS=shared.com",
+			expectedResult: true,
+		},
+
+		// Different SAN type combinations
+		{
+			name:           "root user with URI SPIFFE SAN exact match",
+			user:           username.RootUser,
+			certSANs:       []string{"SAN:URI:spiffe://example.org/root"},
+			rootSANsToSet:  "URI=spiffe://example.org/root",
+			nodeSANsToSet:  "",
+			expectedResult: true,
+		},
+		{
+			name:           "node user with URI SPIFFE SAN exact match",
+			user:           username.NodeUser,
+			certSANs:       []string{"SAN:URI:spiffe://example.org/node"},
+			rootSANsToSet:  "",
+			nodeSANsToSet:  "URI=spiffe://example.org/node",
+			expectedResult: true,
+		},
+		{
+			name:           "root user with IP SAN exact match",
+			user:           username.RootUser,
+			certSANs:       []string{"SAN:IP:192.168.1.1"},
+			rootSANsToSet:  "IP=192.168.1.1",
+			nodeSANsToSet:  "",
+			expectedResult: true,
+		},
+		{
+			name:           "root user with IP SAN mismatch",
+			user:           username.RootUser,
+			certSANs:       []string{"SAN:IP:192.168.1.1"},
+			rootSANsToSet:  "IP=192.168.1.2",
+			nodeSANsToSet:  "",
+			expectedResult: false,
+		},
+		{
+			name:           "root user with mixed type SANs all present",
+			user:           username.RootUser,
+			certSANs:       []string{"SAN:DNS:example.com", "SAN:URI:spiffe://example.org", "SAN:IP:192.168.1.1"},
+			rootSANsToSet:  "DNS=example.com,URI=spiffe://example.org",
+			nodeSANsToSet:  "",
+			expectedResult: true,
+		},
+
+		// Additional edge cases for user-specific validation
+		{
+			name:           "root user when only node SANs are configured",
+			user:           username.RootUser,
+			certSANs:       []string{"SAN:DNS:node.com"},
+			rootSANsToSet:  "",
+			nodeSANsToSet:  "DNS=node.com",
+			expectedResult: false, // No root SANs configured
+		},
+		{
+			name:           "node user when only root SANs are configured",
+			user:           username.NodeUser,
+			certSANs:       []string{"SAN:DNS:root.com"},
+			rootSANsToSet:  "DNS=root.com",
+			nodeSANsToSet:  "",
+			expectedResult: false, // No node SANs configured
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				UnsetRootSAN()
+				UnsetNodeSAN()
+			}()
+
+			if tt.rootSANsToSet != "" {
+				err := SetRootSAN(tt.rootSANsToSet)
+				require.NoError(t, err)
+			}
+
+			if tt.nodeSANsToSet != "" {
+				err := SetNodeSAN(tt.nodeSANsToSet)
+				require.NoError(t, err)
+			}
+
+			result := validateSANMatchForUser(tt.certSANs, tt.user)
+			require.Equal(t, tt.expectedResult, result,
+				"validateSANMatchForUser(%v, %q) = %v, want %v",
+				tt.certSANs, tt.user, result, tt.expectedResult)
+		})
+	}
+}

--- a/pkg/sql/pgwire/BUILD.bazel
+++ b/pkg/sql/pgwire/BUILD.bazel
@@ -111,6 +111,7 @@ go_test(
     name = "pgwire_test",
     size = "medium",
     srcs = [
+        "auth_internal_test.go",
         "auth_test.go",
         "authpipe_test.go",
         "command_result_test.go",
@@ -176,6 +177,7 @@ go_test(
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/log/channel",
+        "//pkg/util/log/eventpb",
         "//pkg/util/log/logconfig",
         "//pkg/util/metric",
         "//pkg/util/metric/aggmetric",

--- a/pkg/sql/pgwire/auth_behaviors.go
+++ b/pkg/sql/pgwire/auth_behaviors.go
@@ -25,14 +25,15 @@ import (
 // associated network connection has been terminated to allow external
 // resources to be released.
 type AuthBehaviors struct {
-	authenticator       Authenticator
-	connClose           func()
-	replacementIdentity string
-	replacedIdentity    bool
-	roleMapper          RoleMapper
-	enhancedRoleMapper  EnhancedRoleMapper
-	authorizer          Authorizer
-	provisioningManager struct {
+	authenticator         Authenticator
+	connClose             func()
+	replacementIdentity   string
+	replacedIdentity      bool
+	roleMapper            RoleMapper
+	enhancedRoleMapper    EnhancedRoleMapper
+	enhancedRoleMapperSet bool
+	authorizer            Authorizer
+	provisioningManager   struct {
 		sync.Once
 		pc provisioning.UserProvisioningConfig
 	}
@@ -136,6 +137,11 @@ func (b *AuthBehaviors) SetRoleMapper(m RoleMapper) {
 // This is used when multiple system identities exist (e.g., certificate SANs).
 func (a *AuthBehaviors) SetEnhancedRoleMapper(fn EnhancedRoleMapper) {
 	a.enhancedRoleMapper = fn
+	a.enhancedRoleMapperSet = true
+}
+
+func (a *AuthBehaviors) IsEnhancedRoleMapperSet() bool {
+	return a.enhancedRoleMapperSet
 }
 
 // SetAuthorizer updates the SetAuthorizer to be used.

--- a/pkg/sql/pgwire/auth_internal_test.go
+++ b/pkg/sql/pgwire/auth_internal_test.go
@@ -1,0 +1,334 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package pgwire
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/identmap"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
+	"github.com/stretchr/testify/require"
+)
+
+// mockAuthConn is a minimal mock implementation of AuthConn for testing.
+// It tracks whether SetDbUser was called and what value was passed.
+type mockAuthConn struct {
+	setDbUserCalled   bool
+	dbUserSet         username.SQLUsername
+	systemIdentitySet string
+}
+
+var _ AuthConn = (*mockAuthConn)(nil)
+
+func (m *mockAuthConn) SendAuthRequest(authType int32, data []byte) error { return nil }
+func (m *mockAuthConn) GetPwdData() ([]byte, error)                       { return nil, nil }
+func (m *mockAuthConn) AuthOK(ctx context.Context)                        {}
+func (m *mockAuthConn) AuthFail(err error)                                {}
+func (m *mockAuthConn) SetAuthMethod(method redact.SafeString)            {}
+func (m *mockAuthConn) SetSystemIdentity(systemIdentity string) {
+	m.systemIdentitySet = systemIdentity
+}
+func (m *mockAuthConn) SetDbUser(dbUser username.SQLUsername) {
+	m.setDbUserCalled = true
+	m.dbUserSet = dbUser
+}
+func (m *mockAuthConn) LogAuthInfof(ctx context.Context, msg redact.RedactableString) {}
+func (m *mockAuthConn) LogAuthFailed(
+	ctx context.Context, reason eventpb.AuthFailReason, err error,
+) {
+}
+func (m *mockAuthConn) LogAuthOK(ctx context.Context)                        {}
+func (m *mockAuthConn) LogSessionEnd(ctx context.Context, endTime time.Time) {}
+func (m *mockAuthConn) GetTenantSpecificMetrics() *tenantSpecificMetrics {
+	return nil
+}
+
+// TestCheckClientUsernameMatchesMapping tests the checkClientUsernameMatchesMapping
+// function which verifies that client-provided usernames match identity mappings.
+func TestCheckClientUsernameMatchesMapping(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	// Helper to create a test conn with specified user
+	makeTestConn := func(t *testing.T, requestedUser username.SQLUsername) *conn {
+		s := newTestServer()
+		c := s.newConn(
+			ctx,
+			func() {}, // cancel function
+			&fakeConn{},
+			sql.SessionArgs{
+				User:                  requestedUser,
+				ConnResultsBufferSize: 16 << 10,
+			},
+			timeutil.Now(),
+		)
+		return c
+	}
+
+	tests := []struct {
+		name                    string
+		requestedUser           string
+		systemIdentity          string
+		sanIdentities           []string
+		mockMapRoleFunc         RoleMapper
+		mockEnhancedMapRoleFunc EnhancedRoleMapper
+		expectedIdentity        string
+		expectedError           string
+		expectSetDbUserCalled   bool
+		expectedDbUser          string
+	}{
+		// SAN Identity Tests (Enhanced Mapping Path)
+		{
+			name:           "SAN path - successful match with single identity",
+			requestedUser:  "alice",
+			systemIdentity: "alice@example.com",
+			sanIdentities:  []string{"SAN:DNS:example.com"},
+			mockEnhancedMapRoleFunc: func(ctx context.Context, ids []string) ([]identmap.IdentityMapping, error) {
+				return []identmap.IdentityMapping{
+					{
+						SystemIdentity: "SAN:DNS:example.com",
+						MappedUser:     username.MakeSQLUsernameFromPreNormalizedString("alice"),
+					},
+				}, nil
+			},
+			expectedIdentity:      "SAN:DNS:example.com",
+			expectSetDbUserCalled: true,
+			expectedDbUser:        "alice",
+		},
+		{
+			name:           "SAN path - EnhancedMapRole returns error",
+			requestedUser:  "alice",
+			systemIdentity: "alice@example.com",
+			sanIdentities:  []string{"SAN:DNS:example.com"},
+			mockEnhancedMapRoleFunc: func(ctx context.Context, ids []string) ([]identmap.IdentityMapping, error) {
+				return nil, errors.New("mapping service unavailable")
+			},
+			expectedError:         "mapping service unavailable",
+			expectSetDbUserCalled: false,
+		},
+		{
+			name:           "SAN path - EnhancedMapRole returns empty mappings",
+			requestedUser:  "alice",
+			systemIdentity: "alice@example.com",
+			sanIdentities:  []string{"SAN:DNS:example.com"},
+			mockEnhancedMapRoleFunc: func(ctx context.Context, ids []string) ([]identmap.IdentityMapping, error) {
+				return []identmap.IdentityMapping{}, nil
+			},
+			expectedError:         `system identities ["SAN:DNS:example.com"] did not map to any database role`,
+			expectSetDbUserCalled: false,
+		},
+		{
+			name:           "SAN path - mappings returned but none match requested user",
+			requestedUser:  "alice",
+			systemIdentity: "alice@example.com",
+			sanIdentities:  []string{"SAN:DNS:example.com"},
+			mockEnhancedMapRoleFunc: func(ctx context.Context, ids []string) ([]identmap.IdentityMapping, error) {
+				return []identmap.IdentityMapping{
+					{
+						SystemIdentity: "SAN:DNS:example.com",
+						MappedUser:     username.MakeSQLUsernameFromPreNormalizedString("bob"),
+					},
+				}, nil
+			},
+			expectedError:         `requested user identity "alice" does not correspond to any mapping for SAN identities ["SAN:DNS:example.com"]`,
+			expectSetDbUserCalled: false,
+		},
+		{
+			name:           "SAN path - multiple mappings, one matches",
+			requestedUser:  "charlie",
+			systemIdentity: "charlie@example.com",
+			sanIdentities:  []string{"SAN:DNS:example.com", "SAN:URI:example.com", "SAN:IP:192.0.2.1"},
+			mockEnhancedMapRoleFunc: func(ctx context.Context, ids []string) ([]identmap.IdentityMapping, error) {
+				return []identmap.IdentityMapping{
+					{
+						SystemIdentity: "SAN:DNS:example.com",
+						MappedUser:     username.MakeSQLUsernameFromPreNormalizedString("alice"),
+					},
+					{
+						SystemIdentity: "SAN:URI:example.com",
+						MappedUser:     username.MakeSQLUsernameFromPreNormalizedString("bob"),
+					},
+					{
+						SystemIdentity: "SAN:IP:192.0.2.1",
+						MappedUser:     username.MakeSQLUsernameFromPreNormalizedString("charlie"),
+					},
+				}, nil
+			},
+			expectedIdentity:      "SAN:IP:192.0.2.1",
+			expectSetDbUserCalled: true,
+			expectedDbUser:        "charlie",
+		},
+		// Regular System Identity Tests (Standard Mapping Path)
+		{
+			name:           "Regular path - successful match",
+			requestedUser:  "alice",
+			systemIdentity: "alice@example.com",
+			sanIdentities:  nil,
+			mockMapRoleFunc: func(ctx context.Context, systemIdentity string) ([]username.SQLUsername, error) {
+				return []username.SQLUsername{
+					username.MakeSQLUsernameFromPreNormalizedString("alice"),
+				}, nil
+			},
+			expectedIdentity:      "alice@example.com",
+			expectSetDbUserCalled: true,
+			expectedDbUser:        "alice",
+		},
+		{
+			name:           "Regular path - MapRole returns error",
+			requestedUser:  "alice",
+			systemIdentity: "alice@example.com",
+			sanIdentities:  nil,
+			mockMapRoleFunc: func(ctx context.Context, systemIdentity string) ([]username.SQLUsername, error) {
+				return nil, errors.New("LDAP server unreachable")
+			},
+			expectedError:         "LDAP server unreachable",
+			expectSetDbUserCalled: false,
+		},
+		{
+			name:           "Regular path - MapRole returns empty mappings",
+			requestedUser:  "alice",
+			systemIdentity: "alice@example.com",
+			sanIdentities:  nil,
+			mockMapRoleFunc: func(ctx context.Context, systemIdentity string) ([]username.SQLUsername, error) {
+				return []username.SQLUsername{}, nil
+			},
+			expectedError:         `system identity "alice@example.com" did not map to a database role`,
+			expectSetDbUserCalled: false,
+		},
+		{
+			name:           "Regular path - mappings returned but none match requested user",
+			requestedUser:  "alice",
+			systemIdentity: "alice@example.com",
+			sanIdentities:  nil,
+			mockMapRoleFunc: func(ctx context.Context, systemIdentity string) ([]username.SQLUsername, error) {
+				return []username.SQLUsername{
+					username.MakeSQLUsernameFromPreNormalizedString("bob"),
+					username.MakeSQLUsernameFromPreNormalizedString("charlie"),
+				}, nil
+			},
+			expectedError:         `requested user identity "alice" does not correspond to any mapping for system identity "alice@example.com"`,
+			expectSetDbUserCalled: false,
+		},
+		{
+			name:           "Regular path - multiple mapped users, one matches",
+			requestedUser:  "charlie",
+			systemIdentity: "charlie@example.com",
+			sanIdentities:  nil,
+			mockMapRoleFunc: func(ctx context.Context, systemIdentity string) ([]username.SQLUsername, error) {
+				return []username.SQLUsername{
+					username.MakeSQLUsernameFromPreNormalizedString("alice"),
+					username.MakeSQLUsernameFromPreNormalizedString("bob"),
+					username.MakeSQLUsernameFromPreNormalizedString("charlie"),
+				}, nil
+			},
+			expectedIdentity:      "charlie@example.com",
+			expectSetDbUserCalled: true,
+			expectedDbUser:        "charlie",
+		},
+		// Edge Cases
+		{
+			name:           "Regular path - empty systemIdentity string",
+			requestedUser:  "alice",
+			systemIdentity: "",
+			sanIdentities:  nil,
+			mockMapRoleFunc: func(ctx context.Context, systemIdentity string) ([]username.SQLUsername, error) {
+				return []username.SQLUsername{
+					username.MakeSQLUsernameFromPreNormalizedString("alice"),
+				}, nil
+			},
+			expectedIdentity:      "",
+			expectSetDbUserCalled: true,
+			expectedDbUser:        "alice",
+		},
+		{
+			name:           "SAN path - exactly one SAN identity",
+			requestedUser:  "alice",
+			systemIdentity: "ignored",
+			sanIdentities:  []string{"SAN:DNS:alice.example.com"},
+			mockEnhancedMapRoleFunc: func(ctx context.Context, ids []string) ([]identmap.IdentityMapping, error) {
+				return []identmap.IdentityMapping{
+					{
+						SystemIdentity: "SAN:DNS:alice.example.com",
+						MappedUser:     username.MakeSQLUsernameFromPreNormalizedString("alice"),
+					},
+				}, nil
+			},
+			expectedIdentity:      "SAN:DNS:alice.example.com",
+			expectSetDbUserCalled: true,
+			expectedDbUser:        "alice",
+		},
+		{
+			name:           "SAN path - empty slice is treated as no SAN identities",
+			requestedUser:  "alice",
+			systemIdentity: "alice@example.com",
+			sanIdentities:  []string{},
+			mockMapRoleFunc: func(ctx context.Context, systemIdentity string) ([]username.SQLUsername, error) {
+				return []username.SQLUsername{
+					username.MakeSQLUsernameFromPreNormalizedString("alice"),
+				}, nil
+			},
+			expectedIdentity:      "alice@example.com",
+			expectSetDbUserCalled: true,
+			expectedDbUser:        "alice",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create mock AuthConn
+			mockAC := &mockAuthConn{}
+
+			// Create AuthBehaviors with appropriate mapper
+			behaviors := &AuthBehaviors{}
+			if tt.mockMapRoleFunc != nil {
+				behaviors.SetRoleMapper(tt.mockMapRoleFunc)
+			}
+			if tt.mockEnhancedMapRoleFunc != nil {
+				behaviors.SetEnhancedRoleMapper(tt.mockEnhancedMapRoleFunc)
+			}
+			behaviors.SetSANIdentities(tt.sanIdentities)
+
+			// Create test conn with requested user
+			requestedUser := username.MakeSQLUsernameFromPreNormalizedString(tt.requestedUser)
+			c := makeTestConn(t, requestedUser)
+
+			// Call the function under test
+			matchedIdentity, err := c.checkClientUsernameMatchesMapping(
+				ctx, mockAC, behaviors, tt.systemIdentity,
+			)
+
+			// Verify error expectations
+			if tt.expectedError != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.expectedError)
+				require.Equal(t, "", matchedIdentity, "matchedIdentity should be empty on error")
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedIdentity, matchedIdentity)
+			}
+
+			// Verify SetDbUser was called appropriately
+			require.Equal(t, tt.expectSetDbUserCalled, mockAC.setDbUserCalled,
+				"SetDbUser called status mismatch")
+
+			if tt.expectSetDbUserCalled {
+				require.Equal(t, tt.expectedDbUser, mockAC.dbUserSet.Normalized(),
+					"SetDbUser called with wrong username")
+			}
+		})
+	}
+}


### PR DESCRIPTION
* Client cert auth only validated the Subject Distinguished Name (DN) and Common Name (CN)
* Modern certificate-based authN uses SANs instead of or in addition to Subject DNs or CN
* Multiple SAN entries in a certificate should be mappable to database users through identity mapping rules
* This PR implements SAN extraction from client certificates in standardised format (SAN:TYPE:value)
* Uses subset validation for root and node users: configured SANs in the start-up flag must all be present in the certificate.
* Implements OR logic between SAN and Subject DN validation when both are enabled as per the PRD and does not fallback to CN in case SAN is enabled.
* For NON-root/node users, SANs are used only for identity mapping, not validation.
    
Release note: None
    
Epic: [CRDB-58375](https://cockroachlabs.atlassian.net/browse/CRDB-58375)