### PR TITLE
workflows: add trunk auto-merge support for release-25.4 backport PRs

### DIFF
--- a/.github/workflows/auto-merge-backports.yml
+++ b/.github/workflows/auto-merge-backports.yml
@@ -29,6 +29,7 @@ jobs:
                     ... on PullRequest {
                       number
                       createdAt
+                      baseRefName
                       labels(first: 10) {
                         nodes {
                           name
@@ -78,18 +79,34 @@ jobs:
               }
 
               const labels = pr.labels.nodes.map(l => l.name).join(', ');
-              console.log(`Merging PR #${pr.number}, Created at: ${pr.createdAt}, Approved: ${approved}, Labels: ${labels}`);
+              const baseRef = pr.baseRefName;
+              console.log(`Processing PR #${pr.number}, Created at: ${pr.createdAt}, Approved: ${approved}, Target: ${baseRef}, Labels: ${labels}`);
 
-              // Merge the PR
-              try {
-                console.log(`Merging PR #${pr.number}`);
-                await github.rest.pulls.merge({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  pull_number: pr.number,
-                  merge_method: "merge",
-                });
-              } catch (err) {
-                console.warn(`Failed to merge PR #${pr.number}: ${err.message}`);
+              if (baseRef === 'release-25.4') {
+                // Use comment to trigger trunk merge for release-25.4
+                console.log(`Adding /trunk merge comment for PR #${pr.number} (target: ${baseRef})`);
+                try {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: pr.number,
+                    body: '/trunk merge'
+                  });
+                } catch (err) {
+                  console.warn(`Failed to comment on PR #${pr.number}: ${err.message}`);
+                }
+              } else {
+                // Direct merge for all other branches
+                console.log(`Directly merging PR #${pr.number} (target: ${baseRef})`);
+                try {
+                  await github.rest.pulls.merge({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    pull_number: pr.number,
+                    merge_method: "merge",
+                  });
+                } catch (err) {
+                  console.warn(`Failed to merge PR #${pr.number}: ${err.message}`);
+                }
               }
             }


### PR DESCRIPTION
Previously, the auto-merge workflow merged all qualifying backport PRs directly using the GitHub merge API, regardless of their target branch.

This was inadequate because the release-25.4 branch requires the trunk merge process (triggered via /trunk merge comment) instead of direct merging, while other release branches still need direct merging.

To address this, this patch adds baseRefName to the GraphQL query to identify each PR's target branch, and implements conditional logic that adds a /trunk merge comment for PRs targeting release-25.4 while continuing to directly merge PRs targeting all other branches. The logging was also enhanced to include the target branch for better visibility.

## Testing
- Created a trimmed down version of `auto-merge-backport.yml` where it only logs and adds the `/trunk merge` comment
- [Test PR](https://github.com/crltest-issue-syncing/cockroach-fork/pull/1014)
- [Test Run](https://github.com/crltest-issue-syncing/cockroach-fork/actions/runs/21476797567/job/61862747036#step:2:92)

<img width="925" height="416" alt="image" src="https://github.com/user-attachments/assets/2090c4a4-6d62-4f58-b15e-28df1f208461" />

Release notes: None

Epic: CODESYS-206