### PR TITLE
sql: add initial row count to `IMPORT` job details

### DIFF
--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -692,7 +692,11 @@ message ImportDetails {
     sqlbase.TableDescriptor desc = 1;
     string name = 18;
     int64 seq_val = 19;
-    bool was_empty = 22;
+    // WasEmpty is true if the table was empty at the start of the import. It is
+    // deprecated; use InitialRowCount.
+    // TODO(bghal): remove when v26.1 is past support.
+    bool was_empty = 22 [deprecated = true];
+    uint64 initial_row_count = 23;
     repeated string target_cols = 21;
     reserved 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 20;
   }


### PR DESCRIPTION
The table field of the import job only indicates if a table was empty at
the beginning of the import job. This change adds an initial row count
field so the inspect job can be provided with an expected row count for
those non-empty tables.

Epic: CRDB-58692

Part of: #161276
Part of: #154551
Part of: #155472
Part of: #161279

Release note: None
