### PR TITLE
release-24.3: roachtest: increase statement_timeout for ORM tests

### DIFF
--- a/pkg/cmd/roachtest/tests/orm_helpers.go
+++ b/pkg/cmd/roachtest/tests/orm_helpers.go
@@ -74,7 +74,7 @@ func alterZoneConfigAndClusterSettings(
 		`SET CLUSTER SETTING sql.defaults.experimental_temporary_tables.enabled = 'true';`,
 		`ALTER ROLE ALL SET multiple_active_portals_enabled = 'true';`,
 		`ALTER ROLE ALL SET serial_normalization = 'sql_sequence_cached'`,
-		`ALTER ROLE ALL SET statement_timeout = '60s'`,
+		`ALTER ROLE ALL SET statement_timeout = '10m'`,
 		`ALTER ROLE ALL SET default_transaction_isolation = 'read committed'`,
 		`ALTER ROLE ALL SET autocommit_before_ddl = 'true'`,
 	} {


### PR DESCRIPTION
Backport 1/1 commits from #161932 on behalf of @fqazi.

----

Currently, certain ORM tests like Hibernate have flakes because the default statement_timeout of 60 seconds can be insufficient for longer operations like schema changes. This patch increases the statement_timeout for ORM tests to 10 minutes.

Fixes: #161781

Release note: None

----

Release justification: test only change