### PR TITLE
release-25.4: kvcoord: force split batch in txnWriteBuffer for mid txn flush

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
@@ -1769,7 +1769,13 @@ func (twb *txnWriteBuffer) flushBufferAndSendBatch(
 	}
 
 	midTxnFlush := !hasEndTxn
-	splitBatchRequired := separateBatchIsNeeded(ba, endTxnArg)
+	// We'll require a separate batch when flushing in the middle of the txn to
+	// avoid almost all read-write batches, plus it gives us protection against
+	// different edge cases.
+	//
+	// Separately, we might need to have a separate batch even when the EndTxn
+	// request is present.
+	splitBatchRequired := midTxnFlush || separateBatchIsNeeded(ba, endTxnArg)
 
 	// Flush all buffered writes by pre-pending them to the requests being sent
 	// in the batch.
@@ -1872,11 +1878,24 @@ func separateBatchIsNeeded(ba *kvpb.BatchRequest, optEndTxn kvpb.Request) bool {
 		}
 	}
 
-	return ba.MightStopEarly() ||
+	if ba.MightStopEarly() ||
 		ba.ReadConsistency != 0 ||
 		ba.WaitPolicy != 0 ||
 		ba.WriteOptions != nil && (*ba.WriteOptions != kvpb.WriteOptions{}) ||
-		ba.IsReverse
+		ba.IsReverse {
+		return true
+	}
+
+	// If we find any CPuts, then we need a separate batch because these can
+	// fail in a way that both (1) isn't retried at levels below us, and (2)
+	// can be recovered from in the same transaction at higher levels.
+	for _, ru := range ba.Requests {
+		if _, ok := ru.GetInner().(*kvpb.ConditionalPutRequest); ok {
+			return true
+		}
+	}
+
+	return false
 }
 
 // clearBatchRequestOptions clears any options that should not be present on a

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_client_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_client_test.go
@@ -148,12 +148,14 @@ func TestTxnCoordSenderWriteBufferingReEnablesPipelining(t *testing.T) {
 		return nil
 	}))
 
-	require.Equal(t, 4, batchCount)
+	require.Equal(t, 5, batchCount)
 	require.Equal(t, []kvpb.Method{
 		// The initial setup
 		kvpb.Put,
-		// The first (buffered) Put and the DeleteRange that flushes the buffer.
-		kvpb.Put, kvpb.DeleteRange,
+		// The first (buffered) Put and the DeleteRange that flushes the buffer,
+		// sent as separate batches.
+		kvpb.Put,
+		kvpb.DeleteRange,
 		// The second (pipelined) Put
 		kvpb.Put,
 		// EndTxn with the QueryIntent because pipelining was turned back on.

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
@@ -1616,11 +1616,19 @@ func TestTxnWriteBufferFlushesWhenOverBudget(t *testing.T) {
 	delB := delArgs(keyB, txn.Sequence)
 	ba.Add(delB)
 
+	var batchCount int
 	mockSender.MockSend(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
-		require.Len(t, ba.Requests, 2)
-
-		require.IsType(t, &kvpb.PutRequest{}, ba.Requests[0].GetInner())
-		require.IsType(t, &kvpb.DeleteRequest{}, ba.Requests[1].GetInner())
+		batchCount++
+		switch batchCount {
+		case 1:
+			require.Len(t, ba.Requests, 1)
+			require.IsType(t, &kvpb.PutRequest{}, ba.Requests[0].GetInner())
+		case 2:
+			require.Len(t, ba.Requests, 1)
+			require.IsType(t, &kvpb.DeleteRequest{}, ba.Requests[0].GetInner())
+		default:
+			t.Fatalf("too many requests: %d", batchCount)
+		}
 
 		br = ba.CreateReply()
 		br.Txn = ba.Txn
@@ -1829,11 +1837,20 @@ func TestTxnWriteBufferFlushesIfBatchRequiresFlushing(t *testing.T) {
 				b.Add(delRangeArgs(keyA, keyB, b.Txn.Sequence))
 			},
 			baSender: func(t *testing.T) batchSendMock {
+				var batchCount int
 				return func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
-					require.Len(t, ba.Requests, 3)
-					require.IsType(t, &kvpb.PutRequest{}, ba.Requests[0].GetInner())
-					require.IsType(t, &kvpb.DeleteRequest{}, ba.Requests[1].GetInner())
-					require.IsType(t, &kvpb.DeleteRangeRequest{}, ba.Requests[2].GetInner())
+					batchCount++
+					switch batchCount {
+					case 1:
+						require.Len(t, ba.Requests, 2)
+						require.IsType(t, &kvpb.PutRequest{}, ba.Requests[0].GetInner())
+						require.IsType(t, &kvpb.DeleteRequest{}, ba.Requests[1].GetInner())
+					case 2:
+						require.Len(t, ba.Requests, 1)
+						require.IsType(t, &kvpb.DeleteRangeRequest{}, ba.Requests[0].GetInner())
+					default:
+						t.Fatalf("too many requests: %d", batchCount)
+					}
 
 					br := ba.CreateReply()
 					br.Txn = ba.Txn
@@ -1856,11 +1873,20 @@ func TestTxnWriteBufferFlushesIfBatchRequiresFlushing(t *testing.T) {
 				})
 			},
 			baSender: func(t *testing.T) batchSendMock {
+				var batchCount int
 				return func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
-					require.Len(t, ba.Requests, 3)
-					require.IsType(t, &kvpb.PutRequest{}, ba.Requests[0].GetInner())
-					require.IsType(t, &kvpb.DeleteRequest{}, ba.Requests[1].GetInner())
-					require.IsType(t, &kvpb.IncrementRequest{}, ba.Requests[2].GetInner())
+					batchCount++
+					switch batchCount {
+					case 1:
+						require.Len(t, ba.Requests, 2)
+						require.IsType(t, &kvpb.PutRequest{}, ba.Requests[0].GetInner())
+						require.IsType(t, &kvpb.DeleteRequest{}, ba.Requests[1].GetInner())
+					case 2:
+						require.Len(t, ba.Requests, 1)
+						require.IsType(t, &kvpb.IncrementRequest{}, ba.Requests[0].GetInner())
+					default:
+						t.Fatalf("too many requests: %d", batchCount)
+					}
 
 					br := ba.CreateReply()
 					br.Txn = ba.Txn
@@ -2265,8 +2291,8 @@ func TestTxnWriteBufferFlushesAfterDisabling(t *testing.T) {
 	require.False(t, twb.flushOnNextBatch)
 	require.Equal(t, int64(1), twb.txnMetrics.TxnWriteBufferDisabledAfterBuffering.Count())
 
-	// Both Put and Del should make it to the server in a single bath.
-	require.Equal(t, numCalledBefore+1, mockSender.NumCalled())
+	// Put and Del should make it to the server in different batches.
+	require.Equal(t, numCalledBefore+2, mockSender.NumCalled())
 
 	// Even though we flushed the Put, it shouldn't make it back to the response.
 	require.Len(t, br.Responses, 1)
@@ -3769,16 +3795,30 @@ func TestTxnWriteBufferLockingGetFlushing(t *testing.T) {
 	type testCase struct {
 		ops                []string
 		midTxn             bool
-		validateFinalBatch func(t *testing.T, ba *kvpb.BatchRequest)
+		validateFinalBatch func(t *testing.T, ba *kvpb.BatchRequest, midTxn bool)
 	}
 
-	expectEndTxnOnly := func(t *testing.T, ba *kvpb.BatchRequest) {
+	expectEndTxnOnly := func(t *testing.T, ba *kvpb.BatchRequest, _ bool) {
 		require.Len(t, ba.Requests, 1)
 		require.IsType(t, &kvpb.EndTxnRequest{}, ba.Requests[0].GetInner())
 	}
-	expectRequests := func(strs ...lock.Strength) func(t *testing.T, ba *kvpb.BatchRequest) {
-		return func(t *testing.T, ba *kvpb.BatchRequest) {
-			require.Len(t, ba.Requests, len(strs)+1) // The +1 is whatever flushed us.
+	expectRequests := func(strs ...lock.Strength) func(t *testing.T, ba *kvpb.BatchRequest, midTxn bool) {
+		var batchCount int
+		return func(t *testing.T, ba *kvpb.BatchRequest, midTxn bool) {
+			batchCount++
+			if midTxn {
+				switch batchCount {
+				case 1:
+					require.Len(t, ba.Requests, len(strs))
+				case 2:
+					require.Len(t, ba.Requests, 1)
+					return
+				default:
+					t.Fatalf("too many requests: %d", batchCount)
+				}
+			} else {
+				require.Len(t, ba.Requests, len(strs)+1) // The +1 is whatever flushed us.
+			}
 			for i, str := range strs {
 				if str == lock.Intent {
 					require.IsType(t, &kvpb.PutRequest{}, ba.Requests[i].GetInner())
@@ -4002,7 +4042,7 @@ func TestTxnWriteBufferLockingGetFlushing(t *testing.T) {
 				ba.Add(&kvpb.EndTxnRequest{Commit: true})
 			}
 			mockSender.MockSend(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
-				tc.validateFinalBatch(t, ba)
+				tc.validateFinalBatch(t, ba, tc.midTxn)
 				resp := ba.CreateReply()
 				resp.Txn = ba.Txn
 				return resp, nil

--- a/pkg/sql/logictest/testdata/logic_test/buffered_writes
+++ b/pkg/sql/logictest/testdata/logic_test/buffered_writes
@@ -622,3 +622,46 @@ COMMIT
 
 statement ok
 RESET enable_durable_locking_for_serializable
+
+# A regression test for the case when a batch with a CPut (for which the
+# condition fails) forced the txnWriteBuffer to flush, and we didn't split
+# buffered writes into a separate batch, while they would be preserved due to
+# usage of the savepoint.
+subtest regression_161722
+
+statement ok
+CREATE TABLE xy (
+  x INT PRIMARY KEY,
+  y INT,
+  FAMILY (x, y)
+)
+
+# Use specific buffer size that allows the first INSERT to be buffered, yet the
+# second one would exceed the limit.
+statement ok
+SET CLUSTER SETTING kv.transaction.write_buffering.max_buffer_size = '400B';
+
+statement ok
+BEGIN
+
+statement ok
+INSERT INTO xy VALUES (1, 1)
+
+statement ok
+SAVEPOINT s
+
+query error duplicate key value violates unique constraint "xy_pkey"
+INSERT INTO xy VALUES (1, 2)
+
+statement ok
+ROLLBACK TO SAVEPOINT s
+
+statement ok
+COMMIT
+
+query II
+SELECT * FROM xy ORDER BY x
+----
+1  1
+
+subtest end


### PR DESCRIPTION
Backport 1/1 commits from #161972 on behalf of @yuzefovich.

----

We just found a case where - if a BatchRequest with a CPut forces the txn write buffer to flush (e.g. because of buffer size limit) - we could lose some buffered writes in case that CPut's condition failed the evaluation. This was the case since we could have included the CPut into the same batch as all buffered writes, and the ConditionFailedError would make us discard the whole batch, whereas the higher level (i.e. SQL) could have discarded that error by using savepoints. To prevent this from happening we'll now require a separate batch for the buffered writes for all mid-txn flushes. Additionally, even in the end-txn flush batch case we now require a separate batch if a CPut is found.

Fixes: #161722.

Release note (bug fix): Previously, if buffered writes were enabled (which is a public preview feature, off by default), multi-stmt explicit txns that use SAVEPOINTs to recover from certain errors (like duplicate key value violations) could lose the writes that were performed _before_ the savepoint was created in rare cases. The bug has been present since the buffered writes feature was added in 25.2 and is now fixed.

----

Release justification: bug fix.