### PR TITLE
settings: clarify 4 private cluster settings with vCPU-based defaults

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -413,7 +413,8 @@ var rangeDescriptorCacheSize = settings.RegisterIntSetting(
 var senderConcurrencyLimit = settings.RegisterIntSetting(
 	settings.ApplicationLevel,
 	"kv.dist_sender.concurrency_limit",
-	"maximum number of asynchronous send requests",
+	"maximum number of asynchronous send requests. "+
+		"The default value is computed as the number of vCPUs in a node times 384.",
 	DefaultSenderStreamsPerVCPU*max(MinViableProcs, int64(runtime.GOMAXPROCS(0))),
 	settings.NonNegativeInt,
 )

--- a/pkg/kv/kvclient/kvstreamer/streamer.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer.go
@@ -355,7 +355,8 @@ const (
 var streamerConcurrencyLimit = settings.RegisterIntSetting(
 	settings.ApplicationLevel,
 	"kv.streamer.concurrency_limit",
-	"maximum number of asynchronous requests by a single streamer",
+	"maximum number of asynchronous requests by a single streamer. "+
+		"The default value is computed as the number of vCPUs in a node times 96.",
 	defaultStreamerStreamsPerVCPU*max(kvcoord.MinViableProcs, int64(runtime.GOMAXPROCS(0))),
 	settings.PositiveInt,
 )

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -72,7 +72,8 @@ import (
 var settingDistSQLNumRunners = settings.RegisterIntSetting(
 	settings.ApplicationLevel,
 	"sql.distsql.num_runners",
-	"determines the number of DistSQL runner goroutines used for issuing SetupFlow RPCs",
+	"determines the number of DistSQL runner goroutines used for issuing SetupFlow RPCs. "+
+		"The default value is computed as the number of vCPUs in a node times 4.",
 	// We use GOMAXPROCS instead of NumCPU because the former could be adjusted
 	// based on cgroup limits (see cgroups.AdjustMaxProcs).
 	//
@@ -2730,11 +2731,12 @@ var parallelizeChecks = settings.RegisterBoolSetting(
 var parallelChecksConcurrencyLimit = settings.RegisterIntSetting(
 	settings.ApplicationLevel,
 	"sql.distsql.parallelize_checks.concurrency_limit",
-	"maximum number of additional goroutines to run checks in parallel",
+	"maximum number of additional goroutines to run checks in parallel. "+
+		"The default value is computed as the number of vCPUs in a node times 16.",
 	// The default here is picked somewhat arbitrarily - the thinking is that we
 	// want it to be proportional to the number of CPUs we have, yet this limit
-	// should probably be smaller than kvcoord.senderConcurrencyLimit (which is
-	// 64 x CPUs).
+	// should probably be smaller than kvcoord.senderConcurrencyLimit (which
+	// used to be 64 x CPUs).
 	int64(16*runtime.GOMAXPROCS(0)),
 	settings.NonNegativeInt,
 )


### PR DESCRIPTION
This commit updates the description of 4 cluster settings that use the number of vCPUs to compute their default values to mention this aspect. Additionally, it adjusts the `settings-list` command to show "See description." in place of their default, similar to what we did for `sql.stats.automatic_full_concurrency_limit` (although these don't show up in the generated docs files, it's good to be consistent).

Epic: None
Release note: None