### PR TITLE
ui: fix custom time picker not comparing properly

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/dateRangeMenu/dateRangeMenu.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/dateRangeMenu/dateRangeMenu.tsx
@@ -95,11 +95,15 @@ export function DateRangeMenu({
   );
 
   const onChangeStart = (m: Moment | null) => {
-    m && setStartMoment(m);
+    // Use keepLocalTime=true to preserve the wall clock time the user entered
+    // while interpreting it in the configured timezone, instead of the user's
+    // timezone.
+    m && setStartMoment(m.tz(timezone, true));
   };
 
   const onChangeEnd = (m: Moment | null) => {
-    m && setEndMoment(m);
+    // Same as onChangeStart.
+    m && setEndMoment(m.tz(timezone, true));
   };
 
   const isDisabled = allowedInterval


### PR DESCRIPTION
This current time picker has split logic between clicking and typing:
    When time is selected from the dropdown, the timezone is set to UTC correctly.
    When time is typed, it is set to the user's timezone, leading to validation errors.

This change sets the user inputted times as UTC and fixes the issue.

Fixes: #143654
Epic: None
Release Note: None