### PR TITLE
sql: add test for recent error code change

### DIFF
--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -552,7 +552,7 @@ func (sc *SchemaChanger) backfillQueryIntoTable(
 	// as a permanent error.
 	if errors.HasType(err, (*kvpb.BatchTimestampBeforeGCError)(nil)) {
 		return jobs.MarkAsPermanentJobError(
-			pgerror.Wrap(err, pgcode.InvalidParameterValue, "unable to retry backfill since fixed timestamp is before the GC timestamp"),
+			pgerror.Wrap(err, pgcode.InvalidParameterValue, "unable to backfill since fixed timestamp is before the GC timestamp"),
 		)
 	}
 	if err != nil {


### PR DESCRIPTION
The error code was added in fb70bb33bd3b2785c524df4301d8147ba5880231 without a test. The testing is relevant for user-facing behavior since it changes the error from an internal error with included stack trace into a more user-friendly error with a well defined error code.

Epic: None
Release note: None