### PR TITLE
roachtest: deflake decommission/mixed-versions

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_decommission.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_decommission.go
@@ -42,9 +42,16 @@ func runDecommissionMixedVersions(ctx context.Context, t test.Test, c cluster.Cl
 	mvt.OnStartup(
 		"set suspect duration",
 		func(ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper) error {
-			return h.System.Exec(
+			if err := h.System.Exec(
 				rng,
 				"SET CLUSTER SETTING server.time_after_store_suspect = $1",
+				suspectDuration.String(),
+			); err != nil {
+				return err
+			}
+			return h.System.Exec(
+				rng,
+				"SET CLUSTER SETTING server.time_after_store_suspect_in_store_liveness = $1",
 				suspectDuration.String(),
 			)
 		})


### PR DESCRIPTION
After 70bea57, the allocator uses store liveness in addition to node liveness to mark a store as suspect. This test overrides the node liveness suspect duration from the default 30s to 10s, and sleeps for twice the suspect duration (20s) before decommissioning a node. This is not enough time for a store to be considered live from a store liveness perspective, which uses the default 30s suspect duration.

This commit overrides the store liveness suspect duration to 10s so it matches the node livesness one.

Fixes: #161333

Release note: None