### PR TITLE
ts: fix multi-tenant KV metric double-counting in queries

### DIFF
--- a/pkg/kv/kvbase/metrics.go
+++ b/pkg/kv/kvbase/metrics.go
@@ -9,4 +9,6 @@ package kvbase
 // within TenantsStorageMetrics, recorded at the individual tenant level.
 //
 // Made available in kvbase to help avoid import cycles.
+// NOTE: pkg/ts/server.go maintains a hardcoded copy of this set
+// (storeTenantMetrics) for the same reason. Update both if changed.
 var TenantsStorageMetricsSet map[string]struct{}


### PR DESCRIPTION
Previously, the timeseries query logic had two issues causing incorrect values in multi-tenant deployments:

1. TenantServer.Query() only filtered app-level metrics (those in tenantRegistry) by tenant ID, but store-level tenant metrics like livebytes were not filtered. This meant app tenants viewing their own data would see aggregate values instead of their tenant-specific data.

2. When no tenant filter was set (the "All" view), readFromDatabase() and readAllSourcesFromDatabase() would return both aggregate sources AND tenant-prefixed sources. Since the aggregate already contains the sum of all tenants' data, adding the tenant-prefixed sources resulted in double-counting.

This commit fixes both issues:
- TenantServer.Query() now also filters store-level tenant metrics (livebytes, keybytes, valbytes, etc.) by tenant ID
- readFromDatabase() no longer scans for tenant-prefixed sources when no tenant filter is set
- readAllSourcesFromDatabase() now filters out tenant-prefixed sources when no tenant filter is set

Fixes: #160479

Release note: None

Epic: None