### PR TITLE
sql/opt: allow plans with routines to be cached

### DIFF
--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -302,18 +302,6 @@ func (tc *Collection) GetLeaseGeneration() int64 {
 	return tc.leaseGeneration
 }
 
-// HasUncommittedTables returns true if the Collection contains uncommitted
-// tables.
-func (tc *Collection) HasUncommittedTables() (has bool) {
-	_ = tc.uncommitted.iterateUncommittedByID(func(desc catalog.Descriptor) error {
-		if _, has = desc.(catalog.TableDescriptor); has {
-			return iterutil.StopIteration()
-		}
-		return nil
-	})
-	return has
-}
-
 // HasUncommittedDescriptors returns true if the collection contains any
 // uncommitted descriptors.
 func (tc *Collection) HasUncommittedDescriptors() bool {

--- a/pkg/sql/opt/exec/execbuilder/testdata/prepare_cache
+++ b/pkg/sql/opt/exec/execbuilder/testdata/prepare_cache
@@ -358,7 +358,7 @@ reusing cached memo
 reusing cached memo
 
 # ------------------------------------------------------------------------------
-# TODO(#162055): Queries with UDFs don't cache properly.
+# Plan caching should work for queries with UDFs.
 # ------------------------------------------------------------------------------
 statement ok
 PREPARE p1 AS SELECT f();
@@ -381,8 +381,28 @@ SET TRACING = "off";
 query T
 SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%' OR message LIKE '%cached memo%';
 ----
+reusing cached memo
+reusing cached memo
+reusing cached memo
+reusing cached memo
+reusing cached memo
+
+# Modifying the function should force a rebuild.
+statement ok
+ALTER FUNCTION f() LEAKPROOF;
+
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+EXECUTE p1;
+EXECUTE p1;
+
+statement ok
+SET TRACING = "off";
+
+query T
+SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%' OR message LIKE '%cached memo%';
+----
 rebuilding cached memo
-rebuilding cached memo
-rebuilding cached memo
-rebuilding cached memo
-rebuilding cached memo
+reusing cached memo

--- a/pkg/sql/opt/exec/execbuilder/testdata/prepare_cache
+++ b/pkg/sql/opt/exec/execbuilder/testdata/prepare_cache
@@ -1,0 +1,388 @@
+# LogicTest: local
+
+# Test plan caching behavior for various prepared statement types.
+
+# Create all DDL objects up front.
+statement ok
+CREATE TABLE t (a INT PRIMARY KEY, b INT, INDEX(b))
+
+statement ok
+CREATE TABLE t2 (x INT PRIMARY KEY, y INT, INDEX(y))
+
+statement ok
+CREATE SEQUENCE seq
+
+statement ok
+CREATE VIEW v AS SELECT a, b FROM t WHERE a > 10
+
+statement ok
+CREATE FUNCTION f() RETURNS INT IMMUTABLE AS $$ SELECT 1 $$ LANGUAGE SQL;
+
+statement ok
+CREATE FUNCTION g(x INT) RETURNS INT STABLE AS $$ SELECT b FROM t WHERE a = x $$ LANGUAGE SQL;
+
+statement ok
+CREATE PROCEDURE proc(x INT) AS $$ SELECT x $$ LANGUAGE SQL;
+
+# ------------------------------------------------------------------------------
+# Simple queries without placeholders should cache.
+# ------------------------------------------------------------------------------
+
+statement ok
+PREPARE simple1 AS SELECT a FROM t WHERE a = 1;
+PREPARE simple2 AS SELECT a FROM t WHERE b = 2;
+PREPARE simple3 AS SELECT a, b FROM t WHERE a > 10 ORDER BY b;
+
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+EXECUTE simple1;
+EXECUTE simple1;
+EXECUTE simple2;
+EXECUTE simple2;
+EXECUTE simple3;
+EXECUTE simple3;
+
+statement ok
+SET TRACING = "off";
+
+query T
+SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%' OR message LIKE '%cached memo%';
+----
+reusing cached memo
+reusing cached memo
+reusing cached memo
+reusing cached memo
+reusing cached memo
+reusing cached memo
+
+# ------------------------------------------------------------------------------
+# Queries with placeholders should cache and reuse plans.
+# ------------------------------------------------------------------------------
+statement ok
+PREPARE ph1 AS SELECT a FROM t WHERE a = $1;
+PREPARE ph2 AS SELECT a FROM t WHERE b = $1;
+PREPARE ph3 AS SELECT a FROM t WHERE a = $1 AND b = $2;
+
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+EXECUTE ph1(1);
+EXECUTE ph1(2);
+EXECUTE ph1(3);
+EXECUTE ph2(10);
+EXECUTE ph2(20);
+EXECUTE ph3(1, 10);
+EXECUTE ph3(2, 20);
+
+statement ok
+SET TRACING = "off";
+
+query T
+SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%' OR message LIKE '%cached memo%';
+----
+reusing cached memo
+reusing cached memo
+reusing cached memo
+reusing cached memo
+reusing cached memo
+reusing cached memo
+reusing cached memo
+
+# ------------------------------------------------------------------------------
+# INSERT, UPDATE, DELETE statements should cache.
+# ------------------------------------------------------------------------------
+statement ok
+PREPARE ins AS INSERT INTO t VALUES ($1, $2);
+PREPARE upd AS UPDATE t SET b = $1 WHERE a = $2;
+PREPARE del AS DELETE FROM t WHERE a = $1;
+
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+EXECUTE ins(100, 1);
+EXECUTE ins(101, 2);
+EXECUTE upd(10, 100);
+EXECUTE upd(20, 101);
+EXECUTE del(100);
+EXECUTE del(101);
+
+statement ok
+SET TRACING = "off";
+
+query T
+SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%' OR message LIKE '%cached memo%';
+----
+reusing cached memo
+reusing cached memo
+reusing cached memo
+reusing cached memo
+reusing cached memo
+reusing cached memo
+
+# ------------------------------------------------------------------------------
+# Queries with subqueries should cache.
+# ------------------------------------------------------------------------------
+statement ok
+PREPARE subq1 AS SELECT a FROM t WHERE b IN (SELECT b FROM t WHERE a < $1);
+PREPARE subq2 AS SELECT a FROM t WHERE EXISTS (SELECT 1 FROM t t2 WHERE t2.a = t.a AND t2.b = $1);
+
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+EXECUTE subq1(10);
+EXECUTE subq1(20);
+EXECUTE subq2(5);
+EXECUTE subq2(15);
+
+statement ok
+SET TRACING = "off";
+
+query T
+SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%' OR message LIKE '%cached memo%';
+----
+reusing cached memo
+reusing cached memo
+reusing cached memo
+reusing cached memo
+
+# ------------------------------------------------------------------------------
+# Queries with joins should cache.
+# ------------------------------------------------------------------------------
+statement ok
+PREPARE join1 AS SELECT t.a, t2.x FROM t JOIN t2 ON t.b = t2.y WHERE t.a = $1;
+PREPARE join2 AS SELECT t.a, t2.x FROM t LEFT JOIN t2 ON t.a = t2.x WHERE t2.y = $1;
+
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+EXECUTE join1(1);
+EXECUTE join1(2);
+EXECUTE join2(10);
+EXECUTE join2(20);
+
+statement ok
+SET TRACING = "off";
+
+query T
+SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%' OR message LIKE '%cached memo%';
+----
+reusing cached memo
+reusing cached memo
+reusing cached memo
+reusing cached memo
+
+# ------------------------------------------------------------------------------
+# Aggregates and window functions should cache.
+# ------------------------------------------------------------------------------
+statement ok
+PREPARE agg1 AS SELECT b, count(*) FROM t WHERE a > $1 GROUP BY b;
+PREPARE agg2 AS SELECT sum(b) FROM t WHERE a BETWEEN $1 AND $2;
+PREPARE win1 AS SELECT a, b, row_number() OVER (PARTITION BY b ORDER BY a) FROM t WHERE b > $1;
+
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+EXECUTE agg1(5);
+EXECUTE agg1(10);
+EXECUTE agg2(1, 50);
+EXECUTE agg2(10, 100);
+EXECUTE win1(5);
+EXECUTE win1(10);
+
+statement ok
+SET TRACING = "off";
+
+query T
+SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%' OR message LIKE '%cached memo%';
+----
+reusing cached memo
+reusing cached memo
+reusing cached memo
+reusing cached memo
+reusing cached memo
+reusing cached memo
+
+# ------------------------------------------------------------------------------
+# CTEs should cache.
+# ------------------------------------------------------------------------------
+statement ok
+PREPARE cte1 AS WITH cte AS (SELECT a, b FROM t WHERE a > $1) SELECT * FROM cte WHERE b < $2;
+PREPARE cte2 AS WITH RECURSIVE cte(n) AS (SELECT $1::INT UNION ALL SELECT n+1 FROM cte WHERE n < $2) SELECT * FROM cte;
+
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+EXECUTE cte1(10, 50);
+EXECUTE cte1(20, 100);
+EXECUTE cte2(1, 5);
+EXECUTE cte2(10, 20);
+
+statement ok
+SET TRACING = "off";
+
+query T
+SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%' OR message LIKE '%cached memo%';
+----
+reusing cached memo
+reusing cached memo
+reusing cached memo
+reusing cached memo
+
+# ------------------------------------------------------------------------------
+# Queries with different types of placeholders.
+# ------------------------------------------------------------------------------
+statement ok
+PREPARE types1 AS SELECT a FROM t WHERE b = $1::INT;
+PREPARE types2 AS SELECT a FROM t WHERE b::TEXT = $1::TEXT;
+PREPARE types3 AS SELECT a FROM t WHERE a = ANY($1::INT[]);
+
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+EXECUTE types1(5);
+EXECUTE types1(10);
+EXECUTE types2('5');
+EXECUTE types2('10');
+EXECUTE types3(ARRAY[1,2,3]);
+EXECUTE types3(ARRAY[4,5,6]);
+
+statement ok
+SET TRACING = "off";
+
+query T
+SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%' OR message LIKE '%cached memo%';
+----
+reusing cached memo
+reusing cached memo
+reusing cached memo
+reusing cached memo
+reusing cached memo
+reusing cached memo
+
+# ------------------------------------------------------------------------------
+# Multiple executions with same placeholder values should still cache.
+# ------------------------------------------------------------------------------
+statement ok
+PREPARE same_val AS SELECT a FROM t WHERE a = $1;
+
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+EXECUTE same_val(1);
+EXECUTE same_val(1);
+EXECUTE same_val(1);
+EXECUTE same_val(2);
+EXECUTE same_val(2);
+EXECUTE same_val(2);
+
+statement ok
+SET TRACING = "off";
+
+query T
+SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%' OR message LIKE '%cached memo%';
+----
+reusing cached memo
+reusing cached memo
+reusing cached memo
+reusing cached memo
+reusing cached memo
+reusing cached memo
+
+# ------------------------------------------------------------------------------
+# Queries with sequence references should cache.
+# ------------------------------------------------------------------------------
+statement ok
+PREPARE seq1 AS SELECT nextval('seq');
+PREPARE seq2 AS SELECT currval('seq');
+PREPARE seq3 AS SELECT setval('seq', $1::INT);
+
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+EXECUTE seq1;
+EXECUTE seq1;
+EXECUTE seq2;
+EXECUTE seq2;
+EXECUTE seq3(100);
+EXECUTE seq3(200);
+
+statement ok
+SET TRACING = "off";
+
+query T
+SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%' OR message LIKE '%cached memo%';
+----
+reusing cached memo
+reusing cached memo
+reusing cached memo
+reusing cached memo
+reusing cached memo
+reusing cached memo
+
+# ------------------------------------------------------------------------------
+# Queries with view references should cache.
+# ------------------------------------------------------------------------------
+statement ok
+PREPARE view1 AS SELECT a FROM v WHERE b = $1;
+PREPARE view2 AS SELECT * FROM v WHERE a BETWEEN $1 AND $2;
+
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+EXECUTE view1(5);
+EXECUTE view1(10);
+EXECUTE view2(1, 50);
+EXECUTE view2(10, 100);
+
+statement ok
+SET TRACING = "off";
+
+query T
+SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%' OR message LIKE '%cached memo%';
+----
+reusing cached memo
+reusing cached memo
+reusing cached memo
+reusing cached memo
+
+# ------------------------------------------------------------------------------
+# TODO(#162055): Queries with UDFs don't cache properly.
+# ------------------------------------------------------------------------------
+statement ok
+PREPARE p1 AS SELECT f();
+PREPARE p2 AS SELECT g($1::INT);
+PREPARE p3 AS SELECT g($1::INT + $2::INT);
+
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+EXECUTE p1;
+EXECUTE p2(1);
+EXECUTE p2(2);
+EXECUTE p3(1, 2);
+EXECUTE p3(3, 4);
+
+statement ok
+SET TRACING = "off";
+
+query T
+SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%' OR message LIKE '%cached memo%';
+----
+rebuilding cached memo
+rebuilding cached memo
+rebuilding cached memo
+rebuilding cached memo
+rebuilding cached memo

--- a/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
@@ -501,6 +501,13 @@ func TestExecBuild_prepare(
 	runExecBuildLogicTest(t, "prepare")
 }
 
+func TestExecBuild_prepare_cache(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runExecBuildLogicTest(t, "prepare_cache")
+}
+
 func TestExecBuild_range_stats(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -573,15 +573,20 @@ func (md *Metadata) CheckDependencies(
 					false, /* inDropContext */
 					tryDefaultExprs,
 				)
-				if err != nil || toCheck.Oid != overload.Oid || toCheck.Version != overload.Version {
+				// We cannot check the version here, because we only resolve the
+				// function signature by name. We will check the version below when
+				// resolving by OID.
+				if err != nil || toCheck.Oid != overload.Oid {
 					return false, maybeSwallowMetadataResolveErr(err)
 				}
 			}
-		} else {
-			_, toCheck, err := optCatalog.ResolveFunctionByOID(ctx, overload.Oid)
-			if err != nil || overload.Version != toCheck.Version {
-				return false, maybeSwallowMetadataResolveErr(err)
-			}
+		}
+		// Resolve the routine by OID regardless of whether it was referenced
+		// by name or by ID. This allows us to check the version using the full
+		// overload, rather than just the signature.
+		_, toCheck, err := optCatalog.ResolveFunctionByOID(ctx, overload.Oid)
+		if err != nil || overload.Version != toCheck.Version {
+			return false, maybeSwallowMetadataResolveErr(err)
 		}
 	}
 

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -507,7 +507,7 @@ func (opc *optPlanningCtx) reset(ctx context.Context) {
 		// potential reuse of versions. To avoid these issues, we prevent saving a
 		// memo (for prepare) or reusing a saved memo (for execute).
 		// We only allow reusing memo if this plan is not going to use canary stats.
-		opc.allowMemoReuse = !p.Descriptors().HasUncommittedTables() &&
+		opc.allowMemoReuse = !p.Descriptors().HasUncommittedDescriptors() &&
 			p.EvalContext().StatsRollout != eval.StatsRolloutCanary
 		opc.useCache = opc.allowMemoReuse && queryCacheEnabled.Get(&p.execCfg.Settings.SV)
 


### PR DESCRIPTION
#### sql/opt: add execbuilder test for query caching behavior

We didn't catch #162055 in our opt tests because they go through the
test catalog, while #162055 requires a real catalog to reproduce. This
commit adds an execbuilder test to show the query plan caching behavior
for different types of prepared statements, including some that contain
a reference to a routine.

Informs #162055

Release note: None

#### sql/opt: disable memo reuse when any uncommitted descriptors exist

Previously, we only disabled query plan caching when there were
uncommitted tables (HasUncommittedTables). This missed other descriptor
types, notably functions. When a function was created in an uncommitted
transaction, a query referencing it could cache a plan. If the
transaction was later aborted, the stale cache entry persisted. A
subsequent transaction that recreated the function could then reuse
the stale plan because the OID and descriptor version happened to
match.

In production this is unlikely to have been an issue because the
non-transactional descriptor ID generator ensures that recreated
descriptors get fresh IDs, which the staleness check detects via OID
mismatch. However, tests use a transactional ID generator for
determinism, which reclaims IDs on abort and can produce collisions.

Fix by replacing HasUncommittedTables with the broader
HasUncommittedDescriptors, which covers functions, types, schemas,
and databases in addition to tables. The existing comment already
described the rationale — "transactions can be aborted leading to
potential reuse of versions" — it just was not applied broadly enough.

Informs #162055

Release note: None

#### sql/opt: allow plans with routines to be cached

This commit slightly modifies the metadata staleness check so that:
* The version is not checked when resolving a routine by name. This is
  necessary because overloads looked up by name are not fully hydrated
  and do not have the version set.
* All routines are checked against the overload resolved by OID regardless
  of whether the reference in the query was by name. This lets us do the
  version check with the correct version.

As a result of these changes, the staleness check now correctly identifies
when a routine descriptor has not changed since a query plan was cached.

Fixes #162055

Release note (performance improvement): Fixed a performance bug that
prevented query plans containing user-defined functions from being
cached. Repeated executions of prepared statements containing UDFs
will now have less planning overhead.