### PR TITLE
changefeedccl: add context cancel check to kafkav1

### DIFF
--- a/pkg/ccl/changefeedccl/sink_kafka.go
+++ b/pkg/ccl/changefeedccl/sink_kafka.go
@@ -671,6 +671,8 @@ func (s *kafkaSink) handleBufferedRetries(msgs []*sarama.ProducerMessage, retryE
 
 	for {
 		select {
+		case <-s.ctx.Done():
+			return s.ctx.Err()
 		case <-s.stopWorkerCh:
 			log.Changefeed.Infof(s.ctx, "kafka sink ending retries due to worker close")
 			return lastSendErr


### PR DESCRIPTION
Added a missing context check to handleBufferedRetries.

Epic: none
Fixes: cockroachdb#131223

Release note (bug fix): Fixes a bug in kafka v1 where a changefeed could potentially hang if the changefeed was shutting down.