### PR TITLE
ttljob: deflake TestRowLevelTTLJobCancelPrivileges

### DIFF
--- a/pkg/sql/ttl/ttljob/ttljob_test.go
+++ b/pkg/sql/ttl/ttljob/ttljob_test.go
@@ -1359,6 +1359,7 @@ func TestMakeTTLJobDescription(t *testing.T) {
 func TestRowLevelTTLJobCancelPrivileges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.UnderDuress(t, "job adoption interval is longer under duress, so the test is too slow")
 
 	type testCase struct {
 		name string
@@ -1487,7 +1488,7 @@ func TestRowLevelTTLJobCancelPrivileges(t *testing.T) {
 						return errors.Newf("job status is %q, waiting for 'canceled'", status)
 					}
 					return nil
-				}, 30*time.Second)
+				}, 5*time.Minute)
 			} else {
 				require.Errorf(t, err, "expected %s to not be able to cancel the job", tc.cancelUser)
 				require.ErrorContains(t, err, "does not have privileges")


### PR DESCRIPTION
This test was recently added. Under duress, job adoption is slower, so it takes longer for the CANCEL to work. This can make the SucceedsSoon assertion time out, so we skip under duress.

Also, increase the SucceedsSoon duration to reduce flakiness in general.

fixes #161845
Release note: None