### PR TITLE
release-26.1: status: expose Go heap object count metrics

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -10061,6 +10061,14 @@ layers:
       unit: NANOSECONDS
       aggregation: AVG
       derivative: NONE
+    - name: sys.gc.total.ns
+      exported_name: sys_gc_total_ns
+      description: Estimated total CPU time spent performing GC tasks
+      y_axis_label: CPU Time
+      type: COUNTER
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
     - name: sys.go.allocbytes
       exported_name: sys_go_allocbytes
       description: Current bytes of memory allocated by go
@@ -10102,6 +10110,22 @@ layers:
       y_axis_label: Memory
       type: GAUGE
       unit: BYTES
+      aggregation: AVG
+      derivative: NONE
+    - name: sys.go.heap.livebytes
+      exported_name: sys_go_heap_livebytes
+      description: Bytes of live heap objects marked by the previous GC
+      y_axis_label: Memory
+      type: GAUGE
+      unit: BYTES
+      aggregation: AVG
+      derivative: NONE
+    - name: sys.go.heap.objects
+      exported_name: sys_go_heap_objects
+      description: Number of live objects on the heap (live + unswept)
+      y_axis_label: Objects
+      type: GAUGE
+      unit: COUNT
       aggregation: AVG
       derivative: NONE
     - name: sys.go.limitbytes

--- a/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
+++ b/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
@@ -2543,11 +2543,14 @@ sys_gc_count: sys.gc.count
 sys_gc_pause_ns: sys.gc.pause.ns
 sys_gc_pause_percent: sys.gc.pause.percent
 sys_gc_stop_ns: sys.gc.stop.ns
+sys_gc_total_ns: sys.gc.total.ns
 sys_go_allocbytes: sys.go.allocbytes
 sys_go_heap_allocbytes: sys.go.heap.allocbytes
 sys_go_heap_heapfragmentbytes: sys.go.heap.heapfragmentbytes
 sys_go_heap_heapreleasedbytes: sys.go.heap.heapreleasedbytes
 sys_go_heap_heapreservedbytes: sys.go.heap.heapreservedbytes
+sys_go_heap_livebytes: sys.go.heap.livebytes
+sys_go_heap_objects: sys.go.heap.objects
 sys_go_limitbytes: sys.go.limitbytes
 sys_go_pause_other_ns: sys.go.pause.other.ns
 sys_go_stack_systembytes: sys.go.stack.systembytes


### PR DESCRIPTION
Backport 3/3 commits from #160607 on behalf of @tbg.

----

status: expose additional Go runtime metrics

This PR adds three new metrics from Go's runtime/metrics package:

- sys.go.heap.objects: live + unswept object count on heap
- sys.go.heap.livebytes: bytes of live objects marked by previous GC
- sys.gc.total.ns: total CPU time spent on GC tasks

These provide better visibility into GC behavior and object allocation
patterns, useful for diagnosing memory pressure and GC overhead.

Inspired by poking at https://github.com/cockroachdb/cockroach/issues/160195

Epic: none

----

Release justification: