### PR TITLE
microbench-ci: tweak repro instructions

### DIFF
--- a/pkg/cmd/microbench-ci/template/github_summary.md
+++ b/pkg/cmd/microbench-ci/template/github_summary.md
@@ -20,7 +20,15 @@ chmod +x {{index $benchdiff.BinDest $rev}}
 ```
 **benchdiff command**:
 ```shell
-benchdiff --run=^{{$benchdiff.Run}}$ --old={{index $benchdiff.TrimmedSHA $benchdiff.Old}} --new={{index $benchdiff.TrimmedSHA $benchdiff.New}} ./{{$benchdiff.Package}}
+# NB: for best (most stable) results, also add a suitable `--benchtime` that
+# results in ~1s to ~5s of benchmark runs. For example, if ops average ~3ms, a
+# benchtime of `1000x` is appropriate.
+#
+# Some benchmarks (in particular BenchmarkSysbench) output additional memory
+# profiles covering only the execution (excluding the setup/teardown) - those
+# should be preferred for analysis since they more closely correspond to what's
+# reported as B/op and alloc/op.
+benchdiff --run=^{{$benchdiff.Run}}$ --old={{index $benchdiff.TrimmedSHA $benchdiff.Old}} --new={{index $benchdiff.TrimmedSHA $benchdiff.New}} --memprofile ./{{$benchdiff.Package}}
 ```
 
 </details>

--- a/pkg/cmd/microbench-ci/testdata/improved.txt
+++ b/pkg/cmd/microbench-ci/testdata/improved.txt
@@ -110,7 +110,15 @@ chmod +x benchdiff/abcdef1/bin/1058449141/cockroachdb_cockroach_pkg_sql_tests
 ```
 **benchdiff command**:
 ```shell
-benchdiff --run=^BenchmarkSysbench/SQL/3node/oltp_read_write$ --old=abcdef1 --new=qwerty4 ./pkg/sql/tests
+# NB: for best (most stable) results, also add a suitable `--benchtime` that
+# results in ~1s to ~5s of benchmark runs. For example, if ops average ~3ms, a
+# benchtime of `1000x` is appropriate.
+#
+# Some benchmarks (in particular BenchmarkSysbench) output additional memory
+# profiles covering only the execution (excluding the setup/teardown) - those
+# should be preferred for analysis since they more closely correspond to what's
+# reported as B/op and alloc/op.
+benchdiff --run=^BenchmarkSysbench/SQL/3node/oltp_read_write$ --old=abcdef1 --new=qwerty4 --memprofile ./pkg/sql/tests
 ```
 
 </details>

--- a/pkg/cmd/microbench-ci/testdata/regression.txt
+++ b/pkg/cmd/microbench-ci/testdata/regression.txt
@@ -110,7 +110,15 @@ chmod +x benchdiff/abcdef1/bin/1058449141/cockroachdb_cockroach_pkg_sql_tests
 ```
 **benchdiff command**:
 ```shell
-benchdiff --run=^BenchmarkSysbench/SQL/3node/oltp_read_write$ --old=abcdef1 --new=qwerty4 ./pkg/sql/tests
+# NB: for best (most stable) results, also add a suitable `--benchtime` that
+# results in ~1s to ~5s of benchmark runs. For example, if ops average ~3ms, a
+# benchtime of `1000x` is appropriate.
+#
+# Some benchmarks (in particular BenchmarkSysbench) output additional memory
+# profiles covering only the execution (excluding the setup/teardown) - those
+# should be preferred for analysis since they more closely correspond to what's
+# reported as B/op and alloc/op.
+benchdiff --run=^BenchmarkSysbench/SQL/3node/oltp_read_write$ --old=abcdef1 --new=qwerty4 --memprofile ./pkg/sql/tests
 ```
 
 </details>

--- a/pkg/cmd/microbench-ci/testdata/summary.txt
+++ b/pkg/cmd/microbench-ci/testdata/summary.txt
@@ -90,7 +90,15 @@ chmod +x benchdiff/abcdef1/bin/1058449141/cockroachdb_cockroach_pkg_sql_tests
 ```
 **benchdiff command**:
 ```shell
-benchdiff --run=^BenchmarkSysbench/SQL/3node/oltp_read_write$ --old=abcdef1 --new=qwerty4 ./pkg/sql/tests
+# NB: for best (most stable) results, also add a suitable `--benchtime` that
+# results in ~1s to ~5s of benchmark runs. For example, if ops average ~3ms, a
+# benchtime of `1000x` is appropriate.
+#
+# Some benchmarks (in particular BenchmarkSysbench) output additional memory
+# profiles covering only the execution (excluding the setup/teardown) - those
+# should be preferred for analysis since they more closely correspond to what's
+# reported as B/op and alloc/op.
+benchdiff --run=^BenchmarkSysbench/SQL/3node/oltp_read_write$ --old=abcdef1 --new=qwerty4 --memprofile ./pkg/sql/tests
 ```
 
 </details>

--- a/pkg/cmd/microbench-ci/testdata/untracked_metric.txt
+++ b/pkg/cmd/microbench-ci/testdata/untracked_metric.txt
@@ -140,7 +140,15 @@ chmod +x benchdiff/abcdef1/bin/1058449141/cockroachdb_cockroach_pkg_sql_tests
 ```
 **benchdiff command**:
 ```shell
-benchdiff --run=^BenchmarkSysbench/KV/3node/oltp_write_only$ --old=abcdef1 --new=qwerty4 ./pkg/sql/tests
+# NB: for best (most stable) results, also add a suitable `--benchtime` that
+# results in ~1s to ~5s of benchmark runs. For example, if ops average ~3ms, a
+# benchtime of `1000x` is appropriate.
+#
+# Some benchmarks (in particular BenchmarkSysbench) output additional memory
+# profiles covering only the execution (excluding the setup/teardown) - those
+# should be preferred for analysis since they more closely correspond to what's
+# reported as B/op and alloc/op.
+benchdiff --run=^BenchmarkSysbench/KV/3node/oltp_write_only$ --old=abcdef1 --new=qwerty4 --memprofile ./pkg/sql/tests
 ```
 
 </details>


### PR DESCRIPTION
See https://github.com/nvb/benchdiff/pull/17, which in turn was inspired by the alloc/op regression on https://github.com/cockroachdb/cockroach/pull/161285, which we had trouble pinning down using the "regular" mem profiles.

Epic: none