### PR TITLE
storageapi: enable DRPC for TestAdminDecommissionedOperations test

### DIFF
--- a/pkg/server/storage_api/decommission_test.go
+++ b/pkg/server/storage_api/decommission_test.go
@@ -818,7 +818,6 @@ func TestAdminDecommissionedOperations(t *testing.T) {
 		ReplicationMode: base.ReplicationManual, // saves time
 		ServerArgs: base.TestServerArgs{
 			DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(81590),
-			DefaultDRPCOption: base.TestDRPCDisabled,
 		},
 	})
 	defer tc.Stopper().Stop(ctx)


### PR DESCRIPTION
Previously, `TestAdminDecommissionedOperations` was explicitly disabled for DRPC. The test now passes, likely due to [recent changes that classify connection errors as `Unavailable`](https://github.com/cockroachdb/drpc/pull/25), which resolved the underlying issue. This change re-enables the test to run with DRPC.

Fixes: CRDB-58977
Epic: CRDB-55382
Release note: None