### PR TITLE
release: add s390x docker images to multi-arch manifests

### DIFF
--- a/build/teamcity/internal/release/process/build-cockroach-release-docker.sh
+++ b/build/teamcity/internal/release/process/build-cockroach-release-docker.sh
@@ -11,6 +11,12 @@ set -euxo pipefail
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
 source "$dir/release/teamcity-support.sh"
 
+# TODO: remove this block after we upgrade to Ubuntu 22.04+
+# this is needed to support s390x builds on Ubuntu 20.04 hosts
+docker run --privileged --rm tonistiigi/binfmt@sha256:8f58e6214f4cc9dc83ce8f5acad1ece508eb6b20e696a8c1e9f274481982c541 --uninstall qemu-s390x
+docker run --privileged --rm tonistiigi/binfmt@sha256:8f58e6214f4cc9dc83ce8f5acad1ece508eb6b20e696a8c1e9f274481982c541 --install s390x
+# End of TODO
+
 tc_start_block "Variable Setup"
 telemetry_disabled="${TELEMETRY_DISABLED:-false}"
 cockroach_archive_prefix="${COCKROACH_ARCHIVE_PREFIX:-cockroach}"
@@ -33,12 +39,12 @@ tc_end_block "Variable Setup"
 gcr_tag="${gcr_staged_repository}:${version}"
 docker_login_gcr "$gcr_staged_repository" "$gcr_credentials"
 docker manifest rm "${gcr_tag}" || :
-docker manifest create "${gcr_tag}" "${gcr_staged_repository}:amd64-${version}" "${gcr_staged_repository}:arm64-${version}"
+docker manifest create "${gcr_tag}" "${gcr_staged_repository}:amd64-${version}" "${gcr_staged_repository}:arm64-${version}" "${gcr_staged_repository}:s390x-${version}"
 docker manifest push "${gcr_tag}"
 
 tc_start_block "Verify docker images"
 error=0
-for arch in amd64 arm64; do
+for arch in amd64 arm64 s390x; do
     tc_start_block "Verify $gcr_tag on $arch"
     if ! verify_docker_image "$gcr_tag" "linux/$arch" "$BUILD_VCS_NUMBER" "$version" false "$telemetry_disabled"; then
       error=1

--- a/build/teamcity/internal/release/process/make-and-publish-build-artifacts-docker.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-artifacts-docker.sh
@@ -10,6 +10,12 @@ set -euxo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
 source "$dir/release/teamcity-support.sh"
+#
+# TODO: remove this block after we upgrade to Ubuntu 22.04+
+# this is needed to support s390x builds on Ubuntu 20.04 hosts
+docker run --privileged --rm tonistiigi/binfmt@sha256:8f58e6214f4cc9dc83ce8f5acad1ece508eb6b20e696a8c1e9f274481982c541 --uninstall qemu-s390x
+docker run --privileged --rm tonistiigi/binfmt@sha256:8f58e6214f4cc9dc83ce8f5acad1ece508eb6b20e696a8c1e9f274481982c541 --install s390x
+# End of TODO
 
 tc_start_block "Variable Setup"
 
@@ -54,6 +60,6 @@ tc_start_block "Make and push multi-arch docker image"
 docker_login_with_google
 gcr_tag="${gcr_repository}:${build_name}"
 docker manifest rm "${gcr_tag}" || :
-docker manifest create "${gcr_tag}" "${gcr_repository}:amd64-${build_name}" "${gcr_repository}:arm64-${build_name}"
+docker manifest create "${gcr_tag}" "${gcr_repository}:amd64-${build_name}" "${gcr_repository}:arm64-${build_name}" "${gcr_repository}:s390x-${build_name}"
 docker manifest push "${gcr_tag}"
 tc_end_block "Make and push multi-arch docker images"

--- a/build/teamcity/internal/release/process/make-and-publish-build-artifacts-linux-s390x-no-telemetry.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-artifacts-linux-s390x-no-telemetry.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
+PLATFORM=linux-s390x TELEMETRY_DISABLED=true ./build/teamcity/internal/release/process/make-and-publish-build-artifacts-per-platform.sh

--- a/build/teamcity/internal/release/process/make-and-publish-build-artifacts-per-platform.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-artifacts-per-platform.sh
@@ -12,6 +12,12 @@ dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
 source "$dir/release/teamcity-support.sh"
 source "$dir/teamcity-bazel-support.sh"  # for run_bazel
 
+# TODO: remove this block after we upgrade to Ubuntu 22.04+
+# this is needed to support s390x builds on Ubuntu 20.04 hosts
+docker run --privileged --rm tonistiigi/binfmt@sha256:8f58e6214f4cc9dc83ce8f5acad1ece508eb6b20e696a8c1e9f274481982c541 --uninstall qemu-s390x
+docker run --privileged --rm tonistiigi/binfmt@sha256:8f58e6214f4cc9dc83ce8f5acad1ece508eb6b20e696a8c1e9f274481982c541 --install s390x
+# End of TODO
+#
 tc_start_block "Variable Setup"
 
 platform="${PLATFORM:?PLATFORM must be specified}"
@@ -108,10 +114,13 @@ $BAZEL_BIN/pkg/cmd/publish-artifacts/publish-artifacts_/publish-artifacts releas
 EOF
 tc_end_block "Compile and publish artifacts"
 
-if [[ $platform == "linux-amd64" || $platform == "linux-arm64" || $platform == "linux-amd64-fips" ]]; then
+if [[ $platform == "linux-amd64" || $platform == "linux-arm64" || $platform == "linux-amd64-fips" || $platform == "linux-s390x" ]]; then
   arch="amd64"
   if [[ $platform == "linux-arm64" ]]; then
     arch="arm64"
+  fi
+  if [[ $platform == "linux-s390x" ]]; then
+    arch="s390x"
   fi
 
   tc_start_block "Make and push docker image"


### PR DESCRIPTION
Previously, the multiarch Docker images for CockroachDB releases included support for amd64 and arm64 architectures only. This change adds support for the s390x architecture, enabling users on IBM Z systems to utilize CockroachDB Docker images.

The current host environment for building Docker images is based on Ubuntu 20.04, which does not have built-in support for s390x architecture emulation. To work around this limitation, QEMU emulation for s390x has been set up using the `tonistiigi/binfmt` Docker image. This allows the build process to create and test s390x Docker images even when the host system does not natively support the architecture.

Fixes: RE-1076
Release notes: The multiarch Docker images for CockroachDB releases now include support for the s390x architecture.