### PR TITLE
roachprod: extend gce machine type for heterogeneous clusters

### DIFF
--- a/pkg/cmd/roachprod/cli/BUILD.bazel
+++ b/pkg/cmd/roachprod/cli/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "chaos_process.go",
         "chaos_reset.go",
         "commands.go",
+        "create_opts.go",
         "flags.go",
         "handlers.go",
         "registry.go",

--- a/pkg/cmd/roachprod/cli/commands.go
+++ b/pkg/cmd/roachprod/cli/commands.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachprod/grafana"
 	"github.com/cockroachdb/cockroach/pkg/roachprod"
-	"github.com/cockroachdb/cockroach/pkg/roachprod/cloud"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/roachprodutil"
@@ -123,8 +122,11 @@ Local Clusters
 		Args: cobra.ExactArgs(1),
 		Run: Wrap(func(cmd *cobra.Command, args []string) (retErr error) {
 			createVMOpts.ClusterName = args[0]
-			opts := cloud.ClusterCreateOpts{Nodes: numNodes, CreateOpts: createVMOpts, ProviderOptsContainer: providerOptsContainer}
-			return roachprod.Create(context.Background(), config.Logger, username, &opts)
+			opts, err := buildClusterCreateOpts(numNodes, createVMOpts, providerOptsContainer)
+			if err != nil {
+				return err
+			}
+			return roachprod.Create(context.Background(), config.Logger, username, opts...)
 		}),
 	}
 	cr.addToExcludeFromBashCompletion(createCmd)

--- a/pkg/cmd/roachprod/cli/create_opts.go
+++ b/pkg/cmd/roachprod/cli/create_opts.go
@@ -1,0 +1,65 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cli
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/roachprod/cloud"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/gce"
+	"github.com/cockroachdb/errors"
+	"golang.org/x/exp/maps"
+)
+
+func buildClusterCreateOpts(
+	numNodes int, createVMOpts vm.CreateOpts, providerOptsContainer vm.ProviderOptionsContainer,
+) ([]*cloud.ClusterCreateOpts, error) {
+	gceProviderOpts, ok := providerOptsContainer[gce.ProviderName].(*gce.ProviderOpts)
+	if !ok || len(gceProviderOpts.MachineTypeSpecs) == 0 {
+		// Non-GCE provider or no machine type specs; use defaults as-is.
+		return []*cloud.ClusterCreateOpts{{
+			Nodes:                 numNodes,
+			CreateOpts:            createVMOpts,
+			ProviderOptsContainer: providerOptsContainer,
+		}}, nil
+	}
+
+	machineTypeSpecs, err := gce.ParseMachineTypeSpecs(
+		gceProviderOpts.MachineTypeSpecs, numNodes,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(machineTypeSpecs) > 1 && !providerEnabled(createVMOpts.VMProviders, gce.ProviderName) {
+		return nil, errors.Newf("--%s-machine-type requires gce in --clouds", gce.ProviderName)
+	}
+
+	opts := make([]*cloud.ClusterCreateOpts, 0, len(machineTypeSpecs))
+	for _, spec := range machineTypeSpecs {
+		providerOptsCopy := maps.Clone(providerOptsContainer)
+		gceOpts := *gceProviderOpts
+		gceOpts.MachineType = spec.MachineType
+		gceOpts.MachineTypeSpecs = nil
+		providerOptsCopy.SetProviderOpts(gce.ProviderName, &gceOpts)
+
+		opts = append(opts, &cloud.ClusterCreateOpts{
+			Nodes:                 spec.Count,
+			CreateOpts:            createVMOpts,
+			ProviderOptsContainer: providerOptsCopy,
+		})
+	}
+
+	return opts, nil
+}
+
+func providerEnabled(providers []string, name string) bool {
+	for _, provider := range providers {
+		if provider == name {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/roachprod/vm/gce/BUILD.bazel
+++ b/pkg/roachprod/vm/gce/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "fast_dns.go",
         "gcloud.go",
         "infra_provider.go",
+        "machine_type.go",
         "provider_options.go",
         "sdk.go",
         "utils.go",
@@ -50,6 +51,7 @@ go_test(
     size = "small",
     srcs = [
         "gcloud_test.go",
+        "machine_type_test.go",
         "utils_test.go",
     ],
     data = glob(["testdata/**"]),

--- a/pkg/roachprod/vm/gce/machine_type.go
+++ b/pkg/roachprod/vm/gce/machine_type.go
@@ -1,0 +1,100 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package gce
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+)
+
+// MachineTypeSpec describes a machine type and the number of nodes that should
+// use it.
+type MachineTypeSpec struct {
+	MachineType string
+	Count       int
+}
+
+// ParseMachineTypeSpecs parses raw --gce-machine-type flag values into a
+// validated list of MachineTypeSpec entries. Each raw value may be a single
+// machine type (e.g. "n2-standard-16"), a machine type with an explicit node
+// count (e.g. "n2-standard-16=4"), or a comma-separated list thereof.
+//
+// When a single entry is provided without an explicit count, totalNodes is used
+// as the count. When multiple entries are provided, each must specify a count
+// and the sum must equal totalNodes.
+func ParseMachineTypeSpecs(rawSpecs []string, totalNodes int) ([]MachineTypeSpec, error) {
+	if len(rawSpecs) == 0 {
+		return nil, errors.New("gce machine type must be specified at least once")
+	}
+	if totalNodes <= 0 {
+		return nil, errors.Newf("invalid total node count %d", totalNodes)
+	}
+
+	var specs []MachineTypeSpec
+	hasMissingCount := false
+	for _, rawSpec := range rawSpecs {
+		for _, entry := range strings.Split(rawSpec, ",") {
+			spec := strings.TrimSpace(entry)
+			if spec == "" {
+				return nil, errors.New("gce machine type entry cannot be empty")
+			}
+
+			parts := strings.SplitN(spec, "=", 2)
+			machineType := strings.TrimSpace(parts[0])
+			if machineType == "" {
+				return nil, errors.Newf("invalid machine type entry %q", spec)
+			}
+
+			count := 0
+			if len(parts) == 2 {
+				countStr := strings.TrimSpace(parts[1])
+				if countStr == "" {
+					return nil, errors.Newf("missing node count in %q", spec)
+				}
+				parsed, err := strconv.Atoi(countStr)
+				if err != nil || parsed <= 0 {
+					return nil, errors.Newf("invalid node count %q in %q", countStr, spec)
+				}
+				count = parsed
+			} else {
+				hasMissingCount = true
+			}
+
+			specs = append(specs, MachineTypeSpec{
+				MachineType: machineType,
+				Count:       count,
+			})
+		}
+	}
+
+	if len(specs) == 0 {
+		return nil, errors.New("gce machine type must be specified at least once")
+	}
+
+	if hasMissingCount {
+		if len(specs) != 1 {
+			return nil, errors.New(
+				"machine type counts are required when specifying multiple entries",
+			)
+		}
+		specs[0].Count = totalNodes
+		return specs, nil
+	}
+
+	total := 0
+	for _, spec := range specs {
+		total += spec.Count
+	}
+	if total != totalNodes {
+		return nil, errors.Newf(
+			"gce machine type specs cover %d nodes, expected %d", total, totalNodes,
+		)
+	}
+
+	return specs, nil
+}

--- a/pkg/roachprod/vm/gce/machine_type_test.go
+++ b/pkg/roachprod/vm/gce/machine_type_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package gce
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseMachineTypeSpecs(t *testing.T) {
+	testCases := []struct {
+		name    string
+		raw     []string
+		total   int
+		want    []MachineTypeSpec
+		wantErr string
+	}{{
+		name:  "single entry defaults to total",
+		raw:   []string{"n2-standard-16"},
+		total: 3,
+		want: []MachineTypeSpec{
+			{MachineType: "n2-standard-16", Count: 3},
+		},
+	}, {
+		name:  "comma separated counts",
+		raw:   []string{"n2-standard-16=4,n2-standard-8=2"},
+		total: 6,
+		want: []MachineTypeSpec{
+			{MachineType: "n2-standard-16", Count: 4},
+			{MachineType: "n2-standard-8", Count: 2},
+		},
+	}, {
+		name:  "multiple flags",
+		raw:   []string{"n2-standard-16=4", "n2-standard-8=2"},
+		total: 6,
+		want: []MachineTypeSpec{
+			{MachineType: "n2-standard-16", Count: 4},
+			{MachineType: "n2-standard-8", Count: 2},
+		},
+	}, {
+		name:  "trims whitespace",
+		raw:   []string{" n2-standard-16 = 2 "},
+		total: 2,
+		want: []MachineTypeSpec{
+			{MachineType: "n2-standard-16", Count: 2},
+		},
+	}, {
+		name:    "missing counts with multiple entries",
+		raw:     []string{"n2-standard-16,n2-standard-8=2"},
+		total:   6,
+		wantErr: "machine type counts are required",
+	}, {
+		name:    "count mismatch",
+		raw:     []string{"n2-standard-16=4"},
+		total:   6,
+		wantErr: "cover 4 nodes",
+	}, {
+		name:    "invalid count",
+		raw:     []string{"n2-standard-16=0"},
+		total:   1,
+		wantErr: "invalid node count",
+	}, {
+		name:    "empty entry",
+		raw:     []string{","},
+		total:   1,
+		wantErr: "entry cannot be empty",
+	}}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			specs, err := ParseMachineTypeSpecs(tt.raw, tt.total)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, specs)
+		})
+	}
+}


### PR DESCRIPTION
roachprod can now accept GCE machine type flags that include per-type node
counts and validate that the flag values cover the full requested node count.
This enables heterogeneous node sizing in a single create invocation while
preserving the legacy single-type behavior when only one entry is provided.

I one-shotted this using Cursor on gpt-5.2-codex and the following prompt:

<details><summary>Details</summary>
<p>


> You are tasked with producing high-quality, reviewable, and maintainable software. After an initial back-and-forth with the user, you will need to complete this work entirely unsupervised and non-interactively in a timely manner.
> You will create and manage your own TODO list which you expand and consume as you go. You will be done when the functionality/result specified by the user has been reached AND the result is elegant, follows best practices, passes tests, and closely resembles code that could have been written by a Senior Engineer. You will be measured by the quality of the resulting code, which will be reviewed by a human. Human review will highly value self-contained logical commits, separation of mechanical and semantic changes, quality of the comments, and by whether the changes are easy to grasp individually and as part of the entire chain of changes. The entire "arc" of changes also needs to be presented in a single message, which should be suitable for use as a Github Pull Request description.
> Your output will be a fully formed linear and "non-circuituous" `git commit` history in which each step passes tests/quality considerations and the last commit will be empty and exists only to hold the commit message.
> The reviewer is a skilled senior engineer with a high bar for code quality and readability.
> You will think deeply about each change and often perform multiple rounds of improvements (amending commits and/or backtracking if necessary) to arrive at a crisp, well-tested, and elegant result that is easy to maintain. You will need to determine which testing to run to convince yourself of the correctness of each individual commit. You will be mindful of "turnaround" - you will time the duration of each test and strike a sensible balance between coverage and duration of each test you invoke.
> You have my permission to involve git operations on this repository. Individual commits don't need an Epic or Release note line with the exception of the "PR message" commit. Unless given in the prompt or cleanly inferrable from context, use "Epic: TODO" and Release note(TODO): TODO".
> During testing, you prefer using `require` if it is already used in other tests (in the Go module). In Go, use camel case for identifiers (HTTP, not Http).
> With those general instructions out of the way, here is your task:
> 
> Extend the `--gce-machine-type` option so that it allows for the following syntax:
> 
> `n2-standard-16=4,n2-standard-8=2`
> 
> would have n1-n4 on 16vcpu vms, and n5+n6 on 8vcpu. If there are still left nodes to provision after this (i.e. if the flag value isn't exhaustive) roachprod should error. The old syntax `n2-standard-16` should implicitly be interpreted as `n2-standard-16=N` where `N` is the desired number of nodes in the cluster. Please use an appropriate `pflag` primitive for this cluster so that we can also pass multiple args `--gce-machine-type=n2-standard-16=4 --gce-machine-type=n2-standard-8=2` etc.

</p>
</details> 

The proximate motivation for wanting this functionality in roachprod is experimentation around https://github.com/cockroachdb/cockroach/issues/153777

Epic: None

Release note: None

