### PR TITLE
cli/demo: make nodelocal qualify as early boot

### DIFF
--- a/pkg/cli/democluster/BUILD.bazel
+++ b/pkg/cli/democluster/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/cli/clierror",
         "//pkg/cli/cliflags",
         "//pkg/cli/democluster/api",
+        "//pkg/cloud/nodelocal",
         "//pkg/jobs",
         "//pkg/kv/kvserver/liveness/livenesspb",
         "//pkg/multitenant",


### PR DESCRIPTION
The replace-for-testing method makes the implementation qualify for 'early boot' usage i.e. usage in online restore. 'nodelocal' already had a demo-specific configuration, in how it mapped storage directories. This takes that even further, replacing the impl not just the mapped directory, to be the testing impl (that skips RPCs/blobsvc and just uses the directory).

Release note: none.
Epic: none.