### PR TITLE
backup: implement online restore in distsql flow

### DIFF
--- a/pkg/backup/bench_covering_test.go
+++ b/pkg/backup/bench_covering_test.go
@@ -109,7 +109,9 @@ func BenchmarkRestoreEntryCover(b *testing.B) {
 													nil,
 													filter,
 													&inclusiveEndKeyComparator{},
-													spanCh)
+													spanCh,
+													false, /* useLink */
+												)
 											})
 
 											var cov []execinfrapb.RestoreSpanEntry

--- a/pkg/backup/compaction_dist.go
+++ b/pkg/backup/compaction_dist.go
@@ -94,6 +94,7 @@ func runCompactionPlan(
 			filter,
 			fsc,
 			spanCh,
+			false, /* useLink */
 		), "generateAndSendImportSpans")
 	}
 	dsp := execCtx.DistSQLPlanner()

--- a/pkg/backup/compaction_processor.go
+++ b/pkg/backup/compaction_processor.go
@@ -213,6 +213,7 @@ func (p *compactBackupsProcessor) runCompactBackups(ctx context.Context) error {
 			filter,
 			fsc,
 			entryCh,
+			false, /* useLink */
 		), "generate and send import spans")
 	}
 

--- a/pkg/backup/generative_split_and_scatter_processor.go
+++ b/pkg/backup/generative_split_and_scatter_processor.go
@@ -461,6 +461,7 @@ func runGenerativeSplitAndScatter(
 ) error {
 	log.Dev.Infof(ctx, "Running generative split and scatter with %d total spans, %d chunk size, %d nodes",
 		spec.NumEntries, spec.ChunkSize, spec.NumNodes)
+
 	g := ctxgroup.WithContext(ctx)
 
 	chunkSplitAndScatterWorkers := len(chunkSplitAndScatterers)
@@ -512,6 +513,7 @@ func runGenerativeSplitAndScatter(
 			filter,
 			fsc,
 			restoreSpanEntriesCh,
+			spec.UseLink,
 		), "generating and sending import spans")
 	})
 

--- a/pkg/backup/restore_job.go
+++ b/pkg/backup/restore_job.go
@@ -404,6 +404,10 @@ func restore(
 	job := resumer.job
 	details := job.Details().(jobspb.RestoreDetails)
 
+	// resolvedURIs holds the main URIs after resolving any external:// aliases.
+	// This is set in the OnlineImpl block below and used by runRestore.
+	resolvedURIs := details.URIs
+
 	if details.OnlineImpl() {
 		var linkPhaseComplete bool
 		if err := execCtx.ExecCfg().InternalDB.Txn(restoreCtx, func(ctx context.Context, txn isql.Txn) error {
@@ -416,6 +420,18 @@ func restore(
 		}
 		if linkPhaseComplete {
 			return emptyRowCount, nil
+		}
+
+		// If any URIs utilize external:// aliases, we need to resolve the alias
+		// to its underlying URI before feeding it into online restore. This
+		// applies to the main URIs, the locality info URIs, and the backup
+		// manifest Dir fields.
+		var err error
+		resolvedURIs, backupLocalityInfo, err = resolveExternalStorageURIs(
+			restoreCtx, execCtx, details.URIs, backupLocalityInfo, backupManifests,
+		)
+		if err != nil {
+			return emptyRowCount, errors.Wrap(err, "resolving external storage URIs for online restore")
 		}
 	}
 
@@ -510,6 +526,7 @@ func restore(
 			filter,
 			fsc,
 			spanCh,
+			false, /* useLink */
 		), "generate and send import spans")
 	}
 
@@ -553,9 +570,15 @@ func restore(
 		tasks = append(tasks, jobProgressLoop)
 	}
 
+	// Check if online restore should use the distributed flow with file linking
+	// instead of the simpler sendAddRemoteSSTs loop.
+	useDistFlow := onlineRestoreUseDistFlow.Get(&execCtx.ExecCfg().Settings.SV)
+
 	progCh := make(chan *execinfrapb.RemoteProducerMetadata_BulkProcessorProgress)
-	if !details.OnlineImpl() {
-		// Online restore tracks progress by pinging requestFinishedCh instead
+	// Start the progress checkpoint loop if this is a traditional restore OR
+	// an online restore using the distributed flow (which also sends progress
+	// updates via progCh).
+	if !details.OnlineImpl() || useDistFlow {
 		generativeCheckpointLoop := func(ctx context.Context) error {
 			defer close(requestFinishedCh)
 			for progress := range progCh {
@@ -599,7 +622,10 @@ func restore(
 	}
 
 	resumeClusterVersion := execCtx.ExecCfg().Settings.Version.ActiveVersion(restoreCtx).Version
-	if clusterversion.V24_3.Version().LessEq(resumeClusterVersion) && !details.OnlineImpl() {
+	// Start the countCompletedProcLoop if this is a traditional restore OR
+	// an online restore using the distributed flow (which also sends processor
+	// completion signals via procCompleteCh).
+	if clusterversion.V24_3.Version().LessEq(resumeClusterVersion) && (!details.OnlineImpl() || useDistFlow) {
 		tasks = append(tasks, countCompletedProcLoop)
 	}
 
@@ -628,25 +654,63 @@ func restore(
 	runRestore := func(ctx context.Context) error {
 		if details.OnlineImpl() {
 			log.Dev.Warningf(ctx, "EXPERIMENTAL ONLINE RESTORE being used")
-			approxRows, approxDataSize, err := sendAddRemoteSSTs(
-				ctx,
-				execCtx,
-				job,
-				dataToRestore,
-				encryption,
-				details.URIs,
-				backupLocalityInfo,
-				requestFinishedCh,
-				tracingAggCh,
-				genSpan,
-			)
-			progressTracker.mu.Lock()
-			defer progressTracker.mu.Unlock()
-			//  During the link phase of online restore, we do not update stats
-			// progress as job occurs.  We merely reuse the `progressTracker.mu.res`
-			// var to reduce the number of local vars floating around in `restore`.
-			progressTracker.mu.res = roachpb.RowCount{Rows: approxRows, DataSize: approxDataSize}
-			return errors.Wrap(err, "sending remote AddSSTable requests")
+
+			// Use the bespoke online restore path that directly splits and links from
+			// the coordinator without a distSQL restore flow.
+			if !useDistFlow {
+				approxRows, approxDataSize, err := sendAddRemoteSSTs(
+					ctx,
+					execCtx,
+					job,
+					dataToRestore,
+					encryption,
+					resolvedURIs,
+					backupLocalityInfo,
+					requestFinishedCh,
+					tracingAggCh,
+					genSpan,
+				)
+				progressTracker.mu.Lock()
+				defer progressTracker.mu.Unlock()
+				//  During the link phase of online restore, we do not update stats
+				// progress as job occurs.  We merely reuse the `progressTracker.mu.res`
+				// var to reduce the number of local vars floating around in `restore`.
+				progressTracker.mu.res = roachpb.RowCount{Rows: approxRows, DataSize: approxDataSize}
+				return errors.Wrap(err, "sending remote AddSSTable requests")
+			}
+
+			// If we did not switch to the bespoke online restore path, we'll proceed
+			// to the normal restore distSQL flow and let its split and scattter
+			// processor direct the restore data processors to link files rather than
+			// ingest them. But we do need to pre-split at the top-level logical spans
+			// that are being restored, as stored in DownloadSpan, as these are what
+			// we will clear via kv/pebble excises if we fail at any point after we
+			// start linking files.
+			//
+			// TODO(dt): we should record in persisted progress when we are ready to
+			// enter the linking/ingesting phase, i.e. *after* we make these splits,
+			// so any failures prior to it can skip cleanup, as that cleanup could
+			// fail if we failed prior to making these splits.
+			var prevSplit roachpb.Key
+			for _, span := range details.DownloadSpans {
+				if !span.Key.Equal(prevSplit) {
+					if err := execCtx.ExecCfg().DB.AdminSplit(ctx, span.Key, hlc.MaxTimestamp); err != nil {
+						return errors.Wrapf(err, "pre-splitting at key %s", span.Key)
+					}
+				}
+				if err := execCtx.ExecCfg().DB.AdminSplit(ctx, span.EndKey, hlc.MaxTimestamp); err != nil {
+					return errors.Wrapf(err, "pre-splitting at key %s", span.EndKey)
+				}
+				prevSplit = span.EndKey
+			}
+		}
+
+		// Use the distributed restore flow. If this is an online restore (with
+		// useDistFlow, since we returned above otherwise), link files instead of
+		// ingesting them.
+		useLink := details.OnlineImpl()
+		if useLink {
+			log.Dev.Infof(ctx, "online restore using distributed flow with file linking")
 		}
 		md := restoreJobMetadata{
 			jobID:                job.ID(),
@@ -654,13 +718,14 @@ func restore(
 			restoreTime:          endTime,
 			encryption:           encryption,
 			kmsEnv:               kmsEnv,
-			uris:                 details.URIs,
+			uris:                 resolvedURIs,
 			backupLocalityInfo:   backupLocalityInfo,
 			spanFilter:           filter,
 			numImportSpans:       numImportSpans,
 			execLocality:         details.ExecutionLocality,
 			exclusiveEndKeys:     fsc.isExclusive(),
 			resumeClusterVersion: resumeClusterVersion,
+			useLink:              useLink,
 		}
 		return errors.Wrap(distRestore(
 			ctx,

--- a/pkg/backup/restore_planning.go
+++ b/pkg/backup/restore_planning.go
@@ -1721,6 +1721,10 @@ func doRestorePlan(
 		if err := checkManifestsForOnlineCompat(ctx, p.ExecCfg().Settings, mainBackupManifests); err != nil {
 			return err
 		}
+		if encryption != nil {
+			return pgerror.Newf(pgcode.FeatureNotSupported,
+				"experimental online restore: encryption not supported")
+		}
 	}
 
 	if restoreStmt.DescriptorCoverage == tree.AllDescriptors {

--- a/pkg/backup/restore_processor_planning.go
+++ b/pkg/backup/restore_processor_planning.go
@@ -40,6 +40,9 @@ type restoreJobMetadata struct {
 	execLocality         roachpb.Locality
 	exclusiveEndKeys     bool
 	resumeClusterVersion roachpb.Version
+	// useLink indicates that the restore should link files via LinkExternalSSTable
+	// rather than downloading and ingesting them via AddSSTable.
+	useLink bool
 }
 
 // distRestore plans a 2 stage distSQL flow for a distributed restore. It
@@ -155,6 +158,7 @@ func distRestore(
 			JobID:                       int64(md.jobID),
 			SQLInstanceIDs:              instanceIDs,
 			ExclusiveFileSpanComparison: md.exclusiveEndKeys,
+			UseLink:                     md.useLink,
 		}
 		spec.CheckpointedSpans = persistFrontier(md.spanFilter.checkpointFrontier, 0)
 

--- a/pkg/backup/restore_span_covering.go
+++ b/pkg/backup/restore_span_covering.go
@@ -279,6 +279,7 @@ func generateAndSendImportSpans(
 	filter spanCoveringFilter,
 	fsc fileSpanComparator,
 	spanCh chan execinfrapb.RestoreSpanEntry,
+	useLink bool,
 ) error {
 
 	startKeyIt, err := newFileSpanStartKeyIterator(ctx, backups, layerToBackupManifestFileIterFactory)
@@ -327,6 +328,7 @@ func generateAndSendImportSpans(
 					ApproximatePhysicalSize: f.ApproximatePhysicalSize,
 					Layer:                   int32(layer),
 					HasRangeKeys:            f.HasRangeKeys,
+					UseLink:                 useLink,
 				}
 				if dir, ok := backupLocalityMap[layer][f.LocalityKV]; ok {
 					fileSpec.Dir = dir

--- a/pkg/backup/restore_span_covering_test.go
+++ b/pkg/backup/restore_span_covering_test.go
@@ -300,7 +300,9 @@ func makeImportSpans(
 		nil,
 		filter,
 		&inclusiveEndKeyComparator{},
-		spanCh)
+		spanCh,
+		false, /* useLink */
+	)
 	close(spanCh)
 
 	if err != nil {

--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -363,7 +363,10 @@ message RestoreFileSpec {
   optional uint64 approximate_physical_size = 8 [(gogoproto.nullable) = false];
   optional int32 layer = 9 [(gogoproto.nullable) = false];
   optional bool has_range_keys = 10 [(gogoproto.nullable) = false];
-  // NEXT ID: 11.
+  // UseLink indicates this file should be linked via LinkExternalSSTable
+  // rather than downloaded and ingested via AddSSTable.
+  optional bool use_link = 11 [(gogoproto.nullable) = false];
+  // NEXT ID: 12.
 }
 
 message TableRekey {
@@ -468,6 +471,10 @@ message GenerativeSplitAndScatterSpec {
   // SQLInstanceIDs is a slice of SQL instance IDs available for dist restore.
   repeated int32 sql_instance_ids = 24[(gogoproto.customname) = "SQLInstanceIDs"];
   reserved 19;
+  // UseLink indicates this is an online restore and files should be linked
+  // via LinkExternalSSTable rather than downloaded and ingested.
+  optional bool use_link = 25 [(gogoproto.nullable) = false];
+  // NEXT ID: 26.
 }
 
 


### PR DESCRIPTION
This implements online restore using the normal restore distsql flow, rather than the bespoke online restore paths used in its initial prototype. This is behind a setting for now, but eventually could be the basis for extending online restore -- now unified with regular restore -- to support ingesting rather than linking some data (such as revision-history layers).

Release note: none.
Epic: none.