### PR TITLE
backup: limit revision_history to inc backup schedules

### DIFF
--- a/pkg/backup/create_scheduled_backup_test.go
+++ b/pkg/backup/create_scheduled_backup_test.go
@@ -504,16 +504,10 @@ func TestSerializesScheduledBackupExecutionArgs(t *testing.T) {
 			},
 		},
 		{
-			name:  "full-cluster-always",
-			query: "CREATE SCHEDULE FOR BACKUP INTO 'nodelocal://1/backup' WITH revision_history RECURRING '@hourly' FULL BACKUP ALWAYS",
-			user:  enterpriseUser,
-			expectedSchedules: []expectedSchedule{
-				{
-					nameRe:     "BACKUP .+",
-					backupStmt: "BACKUP INTO 'nodelocal://1/backup' WITH OPTIONS (revision_history = true, detached)",
-					period:     time.Hour,
-				},
-			},
+			name:   "full-cluster-always",
+			query:  "CREATE SCHEDULE FOR BACKUP INTO 'nodelocal://1/backup' WITH revision_history RECURRING '@hourly' FULL BACKUP ALWAYS",
+			user:   enterpriseUser,
+			errMsg: "revision_history is not supported with FULL BACKUP ALWAYS",
 		},
 		{
 			name: "multiple-tables-with-revision-history",
@@ -534,7 +528,7 @@ func TestSerializesScheduledBackupExecutionArgs(t *testing.T) {
 				{
 					nameRe: "BACKUP .+",
 					backupStmt: "BACKUP TABLE system.public.jobs, " +
-						"system.public.scheduled_jobs INTO 'nodelocal://1/backup' WITH OPTIONS (revision_history = true, detached)",
+						"system.public.scheduled_jobs INTO 'nodelocal://1/backup' WITH OPTIONS (detached)",
 					period:                        24 * time.Hour,
 					runsNow:                       true,
 					chainProtectedTimestampRecord: true,
@@ -557,7 +551,7 @@ func TestSerializesScheduledBackupExecutionArgs(t *testing.T) {
 				},
 				{
 					nameRe:                        "BACKUP .+",
-					backupStmt:                    "BACKUP DATABASE system INTO 'nodelocal://1/backup' WITH OPTIONS (revision_history = true, detached)",
+					backupStmt:                    "BACKUP DATABASE system INTO 'nodelocal://1/backup' WITH OPTIONS (detached)",
 					period:                        24 * time.Hour,
 					runsNow:                       true,
 					chainProtectedTimestampRecord: true,
@@ -580,7 +574,7 @@ func TestSerializesScheduledBackupExecutionArgs(t *testing.T) {
 				},
 				{
 					nameRe:                        "BACKUP .+",
-					backupStmt:                    "BACKUP TABLE system.* INTO 'nodelocal://1/backup' WITH OPTIONS (revision_history = true, detached)",
+					backupStmt:                    "BACKUP TABLE system.* INTO 'nodelocal://1/backup' WITH OPTIONS (detached)",
 					period:                        24 * time.Hour,
 					runsNow:                       true,
 					chainProtectedTimestampRecord: true,
@@ -602,7 +596,7 @@ func TestSerializesScheduledBackupExecutionArgs(t *testing.T) {
 				},
 				{
 					nameRe:                        "my_backup_name",
-					backupStmt:                    "BACKUP INTO 'nodelocal://1/backup' WITH OPTIONS (revision_history = true, detached)",
+					backupStmt:                    "BACKUP INTO 'nodelocal://1/backup' WITH OPTIONS (detached)",
 					period:                        24 * time.Hour,
 					runsNow:                       true,
 					chainProtectedTimestampRecord: true,
@@ -624,7 +618,7 @@ func TestSerializesScheduledBackupExecutionArgs(t *testing.T) {
 				},
 				{
 					nameRe:                        "my_backup_name",
-					backupStmt:                    "BACKUP INTO 'nodelocal://1/backup' WITH OPTIONS (revision_history = true, detached)",
+					backupStmt:                    "BACKUP INTO 'nodelocal://1/backup' WITH OPTIONS (detached)",
 					period:                        24 * time.Hour,
 					runsNow:                       true,
 					chainProtectedTimestampRecord: true,
@@ -637,16 +631,24 @@ func TestSerializesScheduledBackupExecutionArgs(t *testing.T) {
 			query: `
 		CREATE SCHEDULE FOR BACKUP TABLE system.jobs, system.scheduled_jobs INTO 'nodelocal://1/backup'
 		WITH revision_history, encryption_passphrase = 'secret' RECURRING '@weekly'`,
+			// @weekly is too infrequent for incremental backups, so it becomes
+			// full-only. revision_history is not supported with full-only schedules.
+			errMsg: "revision_history is not supported with FULL BACKUP ALWAYS",
+		},
+		{
+			// Verify that @weekly without revision_history succeeds and creates a
+			// full-only schedule, since it's too infrequent for incrementals.
+			name: "infrequent-schedule-becomes-full-only",
+			user: enterpriseUser,
+			query: `
+		CREATE SCHEDULE FOR BACKUP TABLE system.jobs, system.scheduled_jobs INTO 'nodelocal://1/backup'
+		WITH encryption_passphrase = 'secret' RECURRING '@weekly'`,
 			expectedSchedules: []expectedSchedule{
 				{
-					nameRe: "BACKUP .*",
-					backupStmt: "BACKUP TABLE system.public.jobs, " +
-						"system.public.scheduled_jobs INTO 'nodelocal://1/backup' WITH" +
-						" OPTIONS (revision_history = true, encryption_passphrase = 'secret', detached)",
-					shownStmt: "BACKUP TABLE system.public.jobs, " +
-						"system.public.scheduled_jobs INTO 'nodelocal://1/backup' WITH" +
-						" OPTIONS (revision_history = true, encryption_passphrase = '*****', detached)",
-					period: 7 * 24 * time.Hour,
+					nameRe:     "BACKUP .+",
+					backupStmt: "BACKUP TABLE system.public.jobs, system.public.scheduled_jobs INTO 'nodelocal://1/backup' WITH OPTIONS (encryption_passphrase = 'secret', detached)",
+					shownStmt:  "BACKUP TABLE system.public.jobs, system.public.scheduled_jobs INTO 'nodelocal://1/backup' WITH OPTIONS (encryption_passphrase = '*****', detached)",
+					period:     7 * 24 * time.Hour,
 				},
 			},
 		},
@@ -662,15 +664,7 @@ func TestSerializesScheduledBackupExecutionArgs(t *testing.T) {
 		WITH SCHEDULE OPTIONS first_run=$1
 		`,
 			queryArgs: []interface{}{th.env.Now().Add(time.Minute)},
-			expectedSchedules: []expectedSchedule{
-				{
-					nameRe: "BACKUP .+",
-					backupStmt: "BACKUP DATABASE system INTO " +
-						"('nodelocal://1/backup?COCKROACH_LOCALITY=x%3Dy', 'nodelocal://1/backup2?COCKROACH_LOCALITY=default') " +
-						"WITH OPTIONS (revision_history = true, detached)",
-					period: 24 * time.Hour,
-				},
-			},
+			errMsg:    "revision_history is not supported with FULL BACKUP ALWAYS",
 		},
 		{
 			name: "exec-loc",
@@ -684,14 +678,7 @@ func TestSerializesScheduledBackupExecutionArgs(t *testing.T) {
 		WITH SCHEDULE OPTIONS first_run=$1
 		`,
 			queryArgs: []interface{}{th.env.Now().Add(time.Minute)},
-			expectedSchedules: []expectedSchedule{
-				{
-					nameRe: "BACKUP .+",
-					backupStmt: "BACKUP DATABASE system INTO 'nodelocal://1/backup' " +
-						"WITH OPTIONS (revision_history = true, detached, execution locality = 'region=of-france')",
-					period: 24 * time.Hour,
-				},
-			},
+			errMsg:    "revision_history is not supported with FULL BACKUP ALWAYS",
 		},
 		{
 			name:   "missing-destination-placeholder",
@@ -893,8 +880,8 @@ INSERT INTO t1 values (-1), (10), (-100);
 			),
 		},
 		{
-			name:         "tables-backup-with-history",
-			schedule:     "CREATE SCHEDULE FOR BACKUP db.t2, db.t3 INTO $1 WITH revision_history RECURRING '@hourly' FULL BACKUP ALWAYS",
+			name:         "tables-backup",
+			schedule:     "CREATE SCHEDULE FOR BACKUP db.t2, db.t3 INTO $1 RECURRING '@hourly' FULL BACKUP ALWAYS",
 			verifyTables: expectBackupTables(dbTables{"db", []string{"t2", "t3"}}),
 		},
 		{

--- a/pkg/backup/testdata/backup-restore/alter-schedule/backup-options
+++ b/pkg/backup/testdata/backup-restore/alter-schedule/backup-options
@@ -46,7 +46,7 @@ alter backup schedule $incID set with updates_cluster_monitoring_metrics = false
 query-sql
 with schedules as (show schedules for backup) select command from schedules where label='datatest' order by backup_type asc;
 ----
-BACKUP INTO 'nodelocal://1/example-schedule' WITH OPTIONS (revision_history = false, detached, execution locality = 'region=us-east-1', updates_cluster_monitoring_metrics = false)
+BACKUP INTO 'nodelocal://1/example-schedule' WITH OPTIONS (detached, execution locality = 'region=us-east-1', updates_cluster_monitoring_metrics = false)
 BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH OPTIONS (revision_history = false, detached, execution locality = 'region=us-east-1', updates_cluster_monitoring_metrics = false)
 
 # Change an option and set another.
@@ -58,7 +58,7 @@ alter backup schedule $incID set with revision_history = true, set with executio
 query-sql
 with schedules as (show schedules for backup) select command from schedules where label='datatest' order by backup_type asc;
 ----
-BACKUP INTO 'nodelocal://1/example-schedule' WITH OPTIONS (revision_history = true, encryption_passphrase = '*****', detached, updates_cluster_monitoring_metrics = true)
+BACKUP INTO 'nodelocal://1/example-schedule' WITH OPTIONS (encryption_passphrase = '*****', detached, updates_cluster_monitoring_metrics = true)
 BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH OPTIONS (revision_history = true, encryption_passphrase = '*****', detached, updates_cluster_monitoring_metrics = true)
 
 # Add an incompatible option
@@ -78,7 +78,7 @@ alter backup schedule $incID set with kms = ('aws:///key1?region=r1', 'aws:///ke
 query-sql
 with schedules as (show schedules for backup) select command from schedules where label='datatest' order by backup_type asc;
 ----
-BACKUP INTO 'nodelocal://1/example-schedule' WITH OPTIONS (revision_history = true, detached, kms = ('aws:///redacted?region=r1', 'aws:///redacted?region=r2'), updates_cluster_monitoring_metrics = true)
+BACKUP INTO 'nodelocal://1/example-schedule' WITH OPTIONS (detached, kms = ('aws:///redacted?region=r1', 'aws:///redacted?region=r2'), updates_cluster_monitoring_metrics = true)
 BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH OPTIONS (revision_history = true, detached, kms = ('aws:///redacted?region=r1', 'aws:///redacted?region=r2'), updates_cluster_monitoring_metrics = true)
 
 # Set options to empty (unset).
@@ -90,7 +90,7 @@ alter backup schedule $incID set with kms = '';
 query-sql
 with schedules as (show schedules for backup) select command from schedules where label='datatest' order by backup_type asc;
 ----
-BACKUP INTO 'nodelocal://1/example-schedule' WITH OPTIONS (revision_history = true, detached, updates_cluster_monitoring_metrics = true)
+BACKUP INTO 'nodelocal://1/example-schedule' WITH OPTIONS (detached, updates_cluster_monitoring_metrics = true)
 BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH OPTIONS (revision_history = true, detached, updates_cluster_monitoring_metrics = true)
 
 # Setting DETACHED throws an error.
@@ -108,7 +108,7 @@ regex matches error
 query-sql
 with schedules as (show schedules for backup) select command from schedules where label='datatest' order by backup_type asc;
 ----
-BACKUP INTO 'nodelocal://1/example-schedule' WITH OPTIONS (revision_history = true, detached, updates_cluster_monitoring_metrics = true)
+BACKUP INTO 'nodelocal://1/example-schedule' WITH OPTIONS (detached, updates_cluster_monitoring_metrics = true)
 BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH OPTIONS (revision_history = true, detached, updates_cluster_monitoring_metrics = true)
 
 exec-sql
@@ -118,7 +118,7 @@ alter backup schedule $incID set with include_all_virtual_clusters = true
 query-sql
 with schedules as (show schedules for backup) select command from schedules where label='datatest' order by backup_type asc;
 ----
-BACKUP INTO 'nodelocal://1/example-schedule' WITH OPTIONS (revision_history = true, detached, include_all_virtual_clusters = true, updates_cluster_monitoring_metrics = true)
+BACKUP INTO 'nodelocal://1/example-schedule' WITH OPTIONS (detached, include_all_virtual_clusters = true, updates_cluster_monitoring_metrics = true)
 BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH OPTIONS (revision_history = true, detached, include_all_virtual_clusters = true, updates_cluster_monitoring_metrics = true)
 
 exec-sql


### PR DESCRIPTION
Revision history is used to restore to a particular point in time covered by the backup. Incremental backups cover a well-defined time period -- from the prior backup to the time they are backing up -- and can thus capture the revision history for that time period. Full backups on the other hand do not really cover a well defined time _period_ since they are just a snapshot in time, not a delta from a prior time. While they _can_ be executed with the revision history option, the amount of history they end up capturing is not well defined or predictable -- and if they are being executed in conjuction with scheduled incremental backups, that history is being captured in those incremental backups. Thus, when full backups are paired with inc backups in a schedule, it does not make sense to have them capture revision history that is unreliable in duration and duplicative with the history in the inc backups, and we can instead limit the revision history option to applying only to the incremental backup schedule.

Note: this only applies to _scheduled_ backups; a manually executed one-off full backup can still speccify revision history if desired, as this can be a viable method of capturing recent mvcc history immediately after some event occurs and then restoring from that to the time just before the event, i.e. a just-in-time backup. Such manual full backups with revision history are not affected by this change.

In addition to the space and cost savings of eliding revision history from full backups, it will also ensure they are compatible with direct-file-linking faster restoration approaches (aka 'online restore') on the roadmap.

Release note (ops change): Backup schedules that utilize the 'revision_history' option now apply that option only to incremental backups triggered by that schedule, rather than duplicating the revision history in the full backups as well.
Epic: CRDB-48162.