### PR TITLE
flaky-test-notifier: improvements to reporting

### DIFF
--- a/pkg/cmd/flaky-test-notifier/failed-github-engflow-tests.sql
+++ b/pkg/cmd/flaky-test-notifier/failed-github-engflow-tests.sql
@@ -2,10 +2,11 @@ WITH ENGFLOW_GH_EXECUTED_TESTS AS (
     SELECT
         server,
         github_job AS build_type,
-	label,
-	test_name,
+        label,
+        test_name,
         lower(status) AS test_status,
-	invocation_id
+        invocation_id,
+        started_at
     FROM
         DATAMART_PROD.ENGINEERING.ENGFLOW_DATA_DAILY_SNAPSHOT
     WHERE
@@ -20,8 +21,9 @@ SELECT
     label,
     test_name,
     sum(CASE WHEN test_status = 'success' THEN 1 ELSE 0 END) AS pass_cnt,
-    array_agg(CASE WHEN test_status = 'failure' THEN invocation_id END) AS failed_builds
+    array_agg(CASE WHEN test_status = 'failure' THEN invocation_id END) AS failed_builds,
+    sum(CASE WHEN test_status = 'failure' AND started_at > dateadd(DAY, -?, current_date()) THEN 1 ELSE 0 END) AS recent_fail_cnt
 FROM
     ENGFLOW_GH_EXECUTED_TESTS
 GROUP BY 1, 2, 3, 4
-HAVING array_size(failed_builds) > 0 AND pass_cnt + array_size(failed_builds) > 5 AND TO_NUMBER((array_size(failed_builds) / (array_size(failed_builds) + pass_cnt)) * 100, 10, 1) > 0.01
+HAVING array_size(failed_builds) > 0 AND pass_cnt + array_size(failed_builds) > 5 AND TO_NUMBER((array_size(failed_builds) / (array_size(failed_builds) + pass_cnt)) * 100, 10, 1) > 0.01 AND recent_fail_cnt > 1


### PR DESCRIPTION
* Only report flakes that have occurred within the last 2 days.
* Group together identical links in the formatted GitHub issue text.
* Add a disclaimer to the GitHub issue text.

Release note: none
Epic: DEVINF-1582
