### PR TITLE
 ui: convert core class components to functional components

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeTransactionsTable/execContentionTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeTransactionsTable/execContentionTable.tsx
@@ -100,5 +100,5 @@ export const ExecutionContentionTable: React.FC<
   ContentionTableProps
 > = props => {
   const columns = props.execType === "statement" ? stmtColumns : txnColumns;
-  return <SortedTable columns={columns} {...props} />;
+  return <SortedTable<ContendedExecution> columns={columns} {...props} />;
 };

--- a/pkg/ui/workspaces/cluster-ui/src/columnsSelector/columnsSelector.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/columnsSelector/columnsSelector.spec.tsx
@@ -1,0 +1,188 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import React from "react";
+
+import ColumnsSelector, { SelectOption } from "./columnsSelector";
+
+const defaultOptions: SelectOption[] = [
+  { label: "Column A", value: "colA", isSelected: true },
+  { label: "Column B", value: "colB", isSelected: true },
+  { label: "Column C", value: "colC", isSelected: false },
+];
+
+describe("ColumnsSelector", () => {
+  it("renders the Columns button", () => {
+    render(
+      <ColumnsSelector options={defaultOptions} onSubmitColumns={jest.fn()} />,
+    );
+
+    expect(screen.getByText("Columns")).toBeInTheDocument();
+  });
+
+  it("dropdown is initially hidden", () => {
+    const { container } = render(
+      <ColumnsSelector options={defaultOptions} onSubmitColumns={jest.fn()} />,
+    );
+
+    // The dropdown area should have the "hide" class
+    const dropdownArea = container.querySelector(".hide");
+    expect(dropdownArea).toBeInTheDocument();
+  });
+
+  it("opens dropdown when Columns button is clicked", async () => {
+    const { container } = render(
+      <ColumnsSelector options={defaultOptions} onSubmitColumns={jest.fn()} />,
+    );
+
+    fireEvent.click(screen.getByText("Columns"));
+
+    // After clicking, dropdown should have "dropdown-area" class (visible)
+    await waitFor(() => {
+      expect(container.querySelector(".dropdown-area")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Hide/show columns")).toBeInTheDocument();
+  });
+
+  it("displays all column options plus All option", async () => {
+    render(
+      <ColumnsSelector options={defaultOptions} onSubmitColumns={jest.fn()} />,
+    );
+
+    fireEvent.click(screen.getByText("Columns"));
+
+    await waitFor(() => {
+      expect(screen.getByText("All")).toBeInTheDocument();
+      expect(screen.getByText("Column A")).toBeInTheDocument();
+      expect(screen.getByText("Column B")).toBeInTheDocument();
+      expect(screen.getByText("Column C")).toBeInTheDocument();
+    });
+  });
+
+  it("displays Apply button", async () => {
+    render(
+      <ColumnsSelector options={defaultOptions} onSubmitColumns={jest.fn()} />,
+    );
+
+    fireEvent.click(screen.getByText("Columns"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Apply")).toBeInTheDocument();
+    });
+  });
+
+  it("calls onSubmitColumns with selected values when Apply is clicked", async () => {
+    const onSubmitColumns = jest.fn();
+    render(
+      <ColumnsSelector
+        options={defaultOptions}
+        onSubmitColumns={onSubmitColumns}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Columns"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Apply")).toBeVisible();
+    });
+
+    fireEvent.click(screen.getByText("Apply"));
+
+    // Should be called with initially selected columns (colA and colB)
+    expect(onSubmitColumns).toHaveBeenCalledWith(["colA", "colB"]);
+  });
+
+  it("closes dropdown after Apply is clicked", async () => {
+    const { container } = render(
+      <ColumnsSelector options={defaultOptions} onSubmitColumns={jest.fn()} />,
+    );
+
+    fireEvent.click(screen.getByText("Columns"));
+
+    // After clicking, dropdown should have "dropdown-area" class (visible)
+    await waitFor(() => {
+      expect(container.querySelector(".dropdown-area")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Apply"));
+
+    // After applying, dropdown should have "hide" class
+    await waitFor(() => {
+      expect(container.querySelector(".hide")).toBeInTheDocument();
+    });
+  });
+
+  it("renders checkboxes for each option", async () => {
+    const { container } = render(
+      <ColumnsSelector options={defaultOptions} onSubmitColumns={jest.fn()} />,
+    );
+
+    fireEvent.click(screen.getByText("Columns"));
+
+    await waitFor(() => {
+      // 4 checkboxes: All + 3 columns
+      const checkboxes = container.querySelectorAll('input[type="checkbox"]');
+      expect(checkboxes).toHaveLength(4);
+    });
+  });
+
+  it("initially selected options have checked checkboxes", async () => {
+    const { container } = render(
+      <ColumnsSelector options={defaultOptions} onSubmitColumns={jest.fn()} />,
+    );
+
+    fireEvent.click(screen.getByText("Columns"));
+
+    await waitFor(() => {
+      const checkboxes = container.querySelectorAll('input[type="checkbox"]');
+      // All option is not selected (not all columns are selected)
+      expect(checkboxes[0]).not.toBeChecked();
+      // Column A is selected
+      expect(checkboxes[1]).toBeChecked();
+      // Column B is selected
+      expect(checkboxes[2]).toBeChecked();
+      // Column C is not selected
+      expect(checkboxes[3]).not.toBeChecked();
+    });
+  });
+
+  it("All option is checked when all columns are selected", async () => {
+    const allSelectedOptions: SelectOption[] = [
+      { label: "Column A", value: "colA", isSelected: true },
+      { label: "Column B", value: "colB", isSelected: true },
+    ];
+
+    const { container } = render(
+      <ColumnsSelector
+        options={allSelectedOptions}
+        onSubmitColumns={jest.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Columns"));
+
+    await waitFor(() => {
+      const checkboxes = container.querySelectorAll('input[type="checkbox"]');
+      // All option should be checked when all columns are selected
+      expect(checkboxes[0]).toBeChecked();
+    });
+  });
+
+  it("renders with small size", () => {
+    render(
+      <ColumnsSelector
+        options={defaultOptions}
+        onSubmitColumns={jest.fn()}
+        size="small"
+      />,
+    );
+
+    // The button should still render
+    expect(screen.getByText("Columns")).toBeInTheDocument();
+  });
+});

--- a/pkg/ui/workspaces/cluster-ui/src/dropdown/dropdown.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/dropdown/dropdown.spec.tsx
@@ -1,0 +1,191 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import React from "react";
+
+import { Dropdown, DropdownOption } from "./dropdown";
+
+const defaultItems: DropdownOption[] = [
+  { value: "option1", name: "Option 1" },
+  { value: "option2", name: "Option 2" },
+  { value: "option3", name: "Option 3" },
+];
+
+describe("Dropdown", () => {
+  it("renders the toggle button with children text", () => {
+    render(
+      <Dropdown items={defaultItems} onChange={jest.fn()}>
+        Select Option
+      </Dropdown>,
+    );
+
+    expect(screen.getByText("Select Option")).toBeInTheDocument();
+  });
+
+  it("menu is initially closed", () => {
+    const { container } = render(
+      <Dropdown items={defaultItems} onChange={jest.fn()}>
+        Select
+      </Dropdown>,
+    );
+
+    // Menu should not have the open class initially
+    const menu = container.querySelector(".crl-dropdown__menu");
+    expect(menu).not.toHaveClass("crl-dropdown__menu--open");
+  });
+
+  it("opens menu when toggle button is clicked", async () => {
+    const { container } = render(
+      <Dropdown items={defaultItems} onChange={jest.fn()}>
+        Select
+      </Dropdown>,
+    );
+
+    const toggleButton = screen.getByText("Select");
+    fireEvent.click(toggleButton);
+
+    const menu = container.querySelector(".crl-dropdown__menu");
+    await waitFor(() => {
+      expect(menu).toHaveClass("crl-dropdown__menu--open");
+    });
+
+    // All items should be present
+    expect(screen.getByText("Option 1")).toBeInTheDocument();
+    expect(screen.getByText("Option 2")).toBeInTheDocument();
+    expect(screen.getByText("Option 3")).toBeInTheDocument();
+  });
+
+  it("calls onChange with selected value when item is clicked", async () => {
+    const onChange = jest.fn();
+    const { container } = render(
+      <Dropdown items={defaultItems} onChange={onChange}>
+        Select
+      </Dropdown>,
+    );
+
+    // Open menu
+    fireEvent.click(screen.getByText("Select"));
+
+    const menu = container.querySelector(".crl-dropdown__menu");
+    await waitFor(() => {
+      expect(menu).toHaveClass("crl-dropdown__menu--open");
+    });
+
+    // Click on an item
+    fireEvent.click(screen.getByText("Option 2"));
+
+    expect(onChange).toHaveBeenCalledWith("option2");
+  });
+
+  it("closes menu after selecting an item", async () => {
+    const { container } = render(
+      <Dropdown items={defaultItems} onChange={jest.fn()}>
+        Select
+      </Dropdown>,
+    );
+
+    // Open menu
+    fireEvent.click(screen.getByText("Select"));
+
+    const menu = container.querySelector(".crl-dropdown__menu");
+    await waitFor(() => {
+      expect(menu).toHaveClass("crl-dropdown__menu--open");
+    });
+
+    // Click on an item
+    fireEvent.click(screen.getByText("Option 1"));
+
+    // Menu should close (lose the open class)
+    await waitFor(() => {
+      expect(menu).not.toHaveClass("crl-dropdown__menu--open");
+    });
+  });
+
+  it("renders custom toggle button when provided", () => {
+    render(
+      <Dropdown
+        items={defaultItems}
+        onChange={jest.fn()}
+        customToggleButton={<button>Custom Button</button>}
+      >
+        Default Text
+      </Dropdown>,
+    );
+
+    expect(screen.getByText("Custom Button")).toBeInTheDocument();
+    expect(screen.queryByText("Default Text")).not.toBeInTheDocument();
+  });
+
+  it("renders disabled items with correct styling", async () => {
+    const itemsWithDisabled: DropdownOption[] = [
+      { value: "enabled", name: "Enabled Option" },
+      { value: "disabled", name: "Disabled Option", disabled: true },
+    ];
+
+    const { container } = render(
+      <Dropdown items={itemsWithDisabled} onChange={jest.fn()}>
+        Select
+      </Dropdown>,
+    );
+
+    // Open menu
+    fireEvent.click(screen.getByText("Select"));
+
+    const menu = container.querySelector(".crl-dropdown__menu");
+    await waitFor(() => {
+      expect(menu).toHaveClass("crl-dropdown__menu--open");
+    });
+
+    // Check that disabled item has the disabled class
+    const disabledItem = container.querySelector(
+      ".crl-dropdown__item--disabled",
+    );
+    expect(disabledItem).toBeInTheDocument();
+    expect(disabledItem).toHaveTextContent("Disabled Option");
+  });
+
+  it("supports generic value types", async () => {
+    interface CustomValue {
+      id: number;
+      label: string;
+    }
+
+    const items: DropdownOption<CustomValue>[] = [
+      { value: { id: 1, label: "first" }, name: "First" },
+      { value: { id: 2, label: "second" }, name: "Second" },
+    ];
+
+    const onChange = jest.fn();
+    const { container } = render(
+      <Dropdown<CustomValue> items={items} onChange={onChange}>
+        Select
+      </Dropdown>,
+    );
+
+    fireEvent.click(screen.getByText("Select"));
+
+    const menu = container.querySelector(".crl-dropdown__menu");
+    await waitFor(() => {
+      expect(menu).toHaveClass("crl-dropdown__menu--open");
+    });
+
+    fireEvent.click(screen.getByText("First"));
+
+    expect(onChange).toHaveBeenCalledWith({ id: 1, label: "first" });
+  });
+
+  it("applies menuPosition class correctly", () => {
+    const { container } = render(
+      <Dropdown items={defaultItems} onChange={jest.fn()} menuPosition="right">
+        Select
+      </Dropdown>,
+    );
+
+    const menu = container.querySelector(".crl-dropdown__menu--align-right");
+    expect(menu).toBeInTheDocument();
+  });
+});

--- a/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.tsx
@@ -34,7 +34,7 @@ import styles from "./insightsTable.module.scss";
 
 const cx = classNames.bind(styles);
 
-export class InsightsSortedTable extends SortedTable<InsightRecommendation> {}
+export const InsightsSortedTable = SortedTable<InsightRecommendation>;
 
 const insightColumnLabels = {
   insights: "Insights",

--- a/pkg/ui/workspaces/cluster-ui/src/multiSelectCheckbox/multiSelectCheckbox.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/multiSelectCheckbox/multiSelectCheckbox.tsx
@@ -7,8 +7,6 @@ import classNames from "classnames/bind";
 import React from "react";
 import Select, { components, OptionsType } from "react-select";
 
-import { Filter } from "../queryFilter";
-
 import styles from "./multiSelectCheckbox.module.scss";
 
 const cx = classNames.bind(styles);
@@ -22,9 +20,9 @@ export interface SelectOption {
 export interface MultiSelectCheckboxProps {
   field: string;
   options: SelectOption[];
-  parent: Filter;
   placeholder: string;
   value?: SelectOption[];
+  onChange: (field: string, selected: string) => void;
 }
 
 /**
@@ -83,10 +81,8 @@ const customStyles = {
 
 /**
  * Creates the MultiSelectCheckbox from the props
- * parent (any): the element creating this multiselect that will have its state
- * updated when a new value is selected
- * field (string): the name of the state's field on the parent that will be
- * updated
+ * onChange (callback): called when selection changes with (field, selected) args
+ * field (string): the name of the field that will be updated
  * options (SelectOption[]): a list of options. Each option object must contain a
  * label, value and isSelected parameters
  * placeholder (string): the placeholder for the multiselect
@@ -95,23 +91,14 @@ const customStyles = {
  * @param props
  */
 export const MultiSelectCheckbox = (props: MultiSelectCheckboxProps) => {
-  const handleChange = (
-    selectedOptions: OptionsType<SelectOption>,
-    field: string,
-    parent: Filter,
-  ) => {
+  const handleChange = (selectedOptions: OptionsType<SelectOption>) => {
     const selected =
       selectedOptions
         ?.map(function (option: SelectOption) {
           return option.label;
         })
         .toString() || "";
-    parent.setState({
-      filters: {
-        ...parent.state.filters,
-        [field]: selected,
-      },
-    });
+    props.onChange(props.field, selected);
   };
 
   return (
@@ -120,7 +107,7 @@ export const MultiSelectCheckbox = (props: MultiSelectCheckboxProps) => {
       options={props.options}
       placeholder={props.placeholder}
       value={props.value}
-      onChange={selected => handleChange(selected, props.field, props.parent)}
+      onChange={handleChange}
       hideSelectedOptions={false}
       closeMenuOnSelect={false}
       components={{ Option: CheckboxOption }}

--- a/pkg/ui/workspaces/cluster-ui/src/schedules/schedulesPage/scheduleTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/schedules/schedulesPage/scheduleTable.tsx
@@ -22,7 +22,7 @@ import { Timestamp, Timezone } from "../../timestamp";
 import styles from "../schedules.module.scss";
 const cx = classNames.bind(styles);
 
-class SchedulesSortedTable extends SortedTable<Schedule> {}
+const SchedulesSortedTable = SortedTable<Schedule>;
 
 const schedulesTableColumns: ColumnDescriptor<Schedule>[] = [
   {

--- a/pkg/ui/workspaces/cluster-ui/src/search/search.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/search/search.spec.tsx
@@ -1,0 +1,112 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+
+import { Search } from "./search";
+
+describe("Search", () => {
+  it("renders with default placeholder", () => {
+    render(<Search />);
+    expect(
+      screen.getByPlaceholderText("Search Statements"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders with custom placeholder", () => {
+    render(<Search placeholder="Search Jobs" />);
+    expect(screen.getByPlaceholderText("Search Jobs")).toBeInTheDocument();
+  });
+
+  it("renders with default value", () => {
+    render(<Search defaultValue="initial query" />);
+    expect(screen.getByDisplayValue("initial query")).toBeInTheDocument();
+  });
+
+  it("calls onChange when typing", () => {
+    const onChange = jest.fn();
+    render(<Search onChange={onChange} />);
+
+    const input = screen.getByPlaceholderText("Search Statements");
+    fireEvent.change(input, { target: { value: "test query" } });
+
+    expect(onChange).toHaveBeenCalledWith("test query");
+  });
+
+  it("calls onSubmit when pressing Enter", () => {
+    const onSubmit = jest.fn();
+    render(<Search onSubmit={onSubmit} />);
+
+    const input = screen.getByPlaceholderText("Search Statements");
+    fireEvent.change(input, { target: { value: "search term" } });
+    fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+    expect(onSubmit).toHaveBeenCalledWith("search term");
+  });
+
+  it("shows Enter button when there is text and not yet submitted", () => {
+    render(<Search />);
+
+    const input = screen.getByPlaceholderText("Search Statements");
+    fireEvent.change(input, { target: { value: "some text" } });
+
+    expect(screen.getByText("Enter")).toBeInTheDocument();
+  });
+
+  it("calls onSubmit when clicking Enter button", () => {
+    const onSubmit = jest.fn();
+    render(<Search onSubmit={onSubmit} />);
+
+    const input = screen.getByPlaceholderText("Search Statements");
+    fireEvent.change(input, { target: { value: "click submit" } });
+
+    const enterButton = screen.getByText("Enter");
+    fireEvent.click(enterButton);
+
+    expect(onSubmit).toHaveBeenCalledWith("click submit");
+  });
+
+  it("shows clear button after submission and calls onClear when clicked", () => {
+    const onClear = jest.fn();
+    render(<Search onClear={onClear} />);
+
+    const input = screen.getByPlaceholderText("Search Statements");
+    fireEvent.change(input, { target: { value: "submitted query" } });
+    fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+    // After submission, Enter button should be replaced with clear button
+    expect(screen.queryByText("Enter")).not.toBeInTheDocument();
+
+    // Find and click the clear button (it's a button with the cancel icon)
+    const clearButton = screen.getByRole("button");
+    fireEvent.click(clearButton);
+
+    expect(onClear).toHaveBeenCalled();
+  });
+
+  it("clears the input value when clear button is clicked", () => {
+    render(<Search />);
+
+    const input = screen.getByPlaceholderText("Search Statements");
+    fireEvent.change(input, { target: { value: "to be cleared" } });
+    fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+    const clearButton = screen.getByRole("button");
+    fireEvent.click(clearButton);
+
+    expect(input).toHaveValue("");
+  });
+
+  it("hides suffix when suffix prop is false", () => {
+    render(<Search suffix={false} />);
+
+    const input = screen.getByPlaceholderText("Search Statements");
+    fireEvent.change(input, { target: { value: "some text" } });
+
+    expect(screen.queryByText("Enter")).not.toBeInTheDocument();
+  });
+});

--- a/pkg/ui/workspaces/cluster-ui/src/search/search.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/search/search.tsx
@@ -10,7 +10,7 @@ import {
 import { Button, Input, ConfigProvider } from "antd";
 import classNames from "classnames/bind";
 import noop from "lodash/noop";
-import React from "react";
+import React, { useState } from "react";
 
 import { crlTheme } from "../antdTheme";
 
@@ -19,7 +19,7 @@ import styles from "./search.module.scss";
 import type { InputProps } from "antd/lib/input";
 
 interface ISearchProps {
-  onSubmit: (search: string) => void;
+  onSubmit?: (search: string) => void;
   onChange?: (value: string) => void;
   onClear?: () => void;
   defaultValue?: string;
@@ -27,66 +27,54 @@ interface ISearchProps {
   suffix?: boolean;
 }
 
-interface ISearchState {
-  value: string;
-  submitted: boolean;
-  submit?: boolean;
-}
-
 type TSearchProps = ISearchProps &
   Omit<InputProps, "onSubmit" | "defaultValue" | "placeholder" | "onChange">; // Omit shadowed props by ISearchProps type.
 
 const cx = classNames.bind(styles);
 
-export class Search extends React.Component<TSearchProps, ISearchState> {
-  static defaultProps: Partial<ISearchProps> = {
-    placeholder: "Search Statements",
-    onSubmit: noop,
-    onChange: noop,
-    onClear: noop,
-  };
+export function Search({
+  onSubmit = noop,
+  onChange = noop,
+  onClear = noop,
+  defaultValue = "",
+  placeholder = "Search Statements",
+  suffix,
+  ...inputProps
+}: TSearchProps): React.ReactElement {
+  const [value, setValue] = useState(defaultValue || "");
+  const [submitted, setSubmitted] = useState(false);
 
-  state: ISearchState = {
-    value: this.props.defaultValue || "",
-    submitted: false,
-  };
-
-  onSubmit = (e: React.SyntheticEvent): void => {
+  const handleSubmit = (e: React.SyntheticEvent): void => {
     e?.preventDefault && e.preventDefault();
-    const { value } = this.state;
-    const { onSubmit } = this.props;
     onSubmit(value);
     if (value.length > 0) {
-      this.setState({
-        submitted: true,
-      });
+      setSubmitted(true);
     }
   };
 
-  onChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
-    event.persist();
-    const value: string = event.target.value;
-    const submitted = value.length === 0;
-    this.props.onChange(value);
-    this.setState({ value, submitted });
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    const newValue: string = event.target.value;
+    const isSubmitted = newValue.length === 0;
+    onChange(newValue);
+    setValue(newValue);
+    setSubmitted(isSubmitted);
   };
 
-  onClear = (): void => {
-    const { onClear } = this.props;
-    this.setState({ value: "", submit: false });
+  const handleClear = (): void => {
+    setValue("");
+    setSubmitted(false);
     onClear();
   };
 
-  renderSuffix = (): React.ReactElement => {
-    if (this.props.suffix === false) {
+  const renderSuffix = (): React.ReactElement => {
+    if (suffix === false) {
       return null;
     }
-    const { value, submitted } = this.state;
     if (value.length > 0) {
       if (submitted) {
         return (
           <Button
-            onClick={this.onClear}
+            onClick={handleClear}
             type="text"
             className={cx("clear-search")}
             size="small"
@@ -98,7 +86,7 @@ export class Search extends React.Component<TSearchProps, ISearchState> {
       return (
         <Button
           type="text"
-          onClick={this.onSubmit}
+          onClick={handleSubmit}
           className={cx("submit-search")}
           size="small"
         >
@@ -109,26 +97,19 @@ export class Search extends React.Component<TSearchProps, ISearchState> {
     return null;
   };
 
-  render(): React.ReactElement {
-    const { value } = this.state;
-    // We pull out onSubmit and onClear so that they will not be passed
-    // to the Input component as part of inputProps.
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { onSubmit, onClear, onChange, ...inputProps } = this.props;
-
-    return (
-      <ConfigProvider theme={crlTheme}>
-        <Input
-          className={cx("root")}
-          onChange={this.onChange}
-          onPressEnter={this.onSubmit}
-          prefix={<SearchIcon className={cx("prefix-icon")} />}
-          suffix={this.renderSuffix()}
-          value={value}
-          size={"small"}
-          {...inputProps}
-        />
-      </ConfigProvider>
-    );
-  }
+  return (
+    <ConfigProvider theme={crlTheme}>
+      <Input
+        className={cx("root")}
+        onChange={handleChange}
+        onPressEnter={handleSubmit}
+        prefix={<SearchIcon className={cx("prefix-icon")} />}
+        suffix={renderSuffix()}
+        value={value}
+        placeholder={placeholder}
+        size={"small"}
+        {...inputProps}
+      />
+    </ConfigProvider>
+  );
 }

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsTable.tsx
@@ -44,7 +44,7 @@ export interface SessionInfo {
   session: ISession;
 }
 
-export class SessionsSortedTable extends SortedTable<SessionInfo> {}
+export const SessionsSortedTable = SortedTable<SessionInfo>;
 
 export function byteArrayToUuid(array: Uint8Array): string {
   const hexDigits: string[] = [];

--- a/pkg/ui/workspaces/cluster-ui/src/sortedtable/sortedtable.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sortedtable/sortedtable.spec.tsx
@@ -3,23 +3,18 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
-import { assert } from "chai";
-import classNames from "classnames/bind";
-import { mount, ReactWrapper } from "enzyme";
-import each from "lodash/each";
+import "@testing-library/jest-dom";
+import { render, fireEvent } from "@testing-library/react";
 import sortBy from "lodash/sortBy";
 import sumBy from "lodash/sumBy";
 import React from "react";
 
-import styles from "src/sortabletable/sortabletable.module.scss";
 import {
   SortedTable,
   ColumnDescriptor,
   ISortedTablePagination,
   SortSetting,
 } from "src/sortedtable";
-
-const cx = classNames.bind(styles);
 
 class TestRow {
   constructor(
@@ -44,16 +39,14 @@ const columns: ColumnDescriptor<TestRow>[] = [
   },
 ];
 
-class TestSortedTable extends SortedTable<TestRow> {}
-
-function makeTable(
+function renderTable(
   data: TestRow[],
   sortSetting?: SortSetting,
   onChangeSortSetting?: (ss: SortSetting) => void,
   pagination?: ISortedTablePagination,
 ) {
-  return mount(
-    <TestSortedTable
+  return render(
+    <SortedTable<TestRow>
       data={data}
       sortSetting={sortSetting}
       onChangeSortSetting={onChangeSortSetting}
@@ -63,9 +56,9 @@ function makeTable(
   );
 }
 
-function makeExpandableTable(data: TestRow[], sortSetting: SortSetting) {
-  return mount(
-    <TestSortedTable
+function renderExpandableTable(data: TestRow[], sortSetting: SortSetting) {
+  return render(
+    <SortedTable<TestRow>
       data={data}
       columns={columns}
       sortSetting={sortSetting}
@@ -81,30 +74,38 @@ function makeExpandableTable(data: TestRow[], sortSetting: SortSetting) {
   );
 }
 
-function rowsOf(wrapper: ReactWrapper): Array<Array<string>> {
-  return wrapper.find("tr").map(tr => tr.find("td").map(td => td.text()));
+/**
+ * Get the text content of each cell in each row of a tbody.
+ */
+function getBodyRowContents(container: HTMLElement): Array<Array<string>> {
+  const tbody = container.querySelector("tbody");
+  if (!tbody) return [];
+  const rows = tbody.querySelectorAll("tr");
+  return Array.from(rows).map(tr => {
+    const cells = tr.querySelectorAll("td");
+    return Array.from(cells).map(td => td.textContent || "");
+  });
 }
 
-describe("<SortedTable>", function () {
-  it("renders the expected table structure.", function () {
-    const wrapper = makeTable([new TestRow("test", 1)]);
-    assert.lengthOf(wrapper.find("table"), 1, "one table");
-    assert.lengthOf(wrapper.find("thead").find("tr"), 1, "one header row");
-    assert.lengthOf(
-      wrapper.find(`tr.${cx("head-wrapper__row--header")}`),
-      1,
-      "column header row",
-    );
-    assert.lengthOf(wrapper.find("tbody"), 1, "tbody element");
+describe("<SortedTable>", () => {
+  it("renders the expected table structure.", () => {
+    const { container } = renderTable([new TestRow("test", 1)]);
+
+    expect(container.querySelectorAll("table")).toHaveLength(1);
+    expect(container.querySelectorAll("thead tr")).toHaveLength(1);
+    expect(
+      container.querySelectorAll("tr.head-wrapper__row--header"),
+    ).toHaveLength(1);
+    expect(container.querySelectorAll("tbody")).toHaveLength(1);
   });
 
-  it("correctly uses onChangeSortSetting", function () {
+  it("correctly uses onChangeSortSetting", () => {
     const spy = jest.fn();
-    const wrapper = makeTable([new TestRow("test", 1)], undefined, spy);
-    wrapper
-      .find(`th.${cx("head-wrapper__cell")}`)
-      .first()
-      .simulate("click");
+    const { container } = renderTable([new TestRow("test", 1)], undefined, spy);
+
+    const headerCells = container.querySelectorAll("th.head-wrapper__cell");
+    fireEvent.click(headerCells[0]);
+
     expect(spy).toHaveBeenCalled();
     expect(spy).toHaveBeenCalledWith({
       ascending: false,
@@ -112,137 +113,140 @@ describe("<SortedTable>", function () {
     });
   });
 
-  it("correctly sorts data based on sortSetting", function () {
+  it("correctly sorts data based on sortSetting", () => {
     const data = [
       new TestRow("c", 3),
       new TestRow("d", 4),
       new TestRow("a", 1),
       new TestRow("b", 2),
     ];
-    let wrapper = makeTable(data, undefined);
-    const assertMatches = (expected: TestRow[]) => {
-      const rows = wrapper.find("tbody");
-      each(expected, (rowData, dataIndex) => {
-        const row = rows.childAt(dataIndex);
-        assert.equal(
-          row.childAt(0).childAt(0).text(),
-          rowData.name,
-          "first columns match",
-        );
-        assert.equal(
-          row.childAt(0).childAt(1).text(),
-          rowData.value.toString(),
-          "second columns match",
-        );
+
+    const assertMatches = (container: HTMLElement, expected: TestRow[]) => {
+      const tbody = container.querySelector("tbody");
+      expected.forEach((rowData, dataIndex) => {
+        const row = tbody.children[dataIndex];
+        const cells = row.querySelectorAll("td");
+        expect(cells[0].textContent).toBe(rowData.name);
+        expect(cells[1].textContent).toBe(rowData.value.toString());
       });
     };
-    assertMatches(data);
-    wrapper = makeTable(data, {
+
+    // Unsorted
+    let { container } = renderTable(data, undefined);
+    assertMatches(container, data);
+
+    // Sorted by first column ascending
+    ({ container } = renderTable(data, {
       ascending: true,
       columnTitle: "first",
-    });
-    assertMatches(sortBy(data, r => r.name));
-    wrapper.setProps({
-      uiSortSetting: {
-        ascending: true,
-        columnTitle: "second",
-      } as SortSetting,
-    });
-    assertMatches(sortBy(data, r => r.value));
+    }));
+    assertMatches(
+      container,
+      sortBy(data, r => r.name),
+    );
+
+    // Rerender with sort by second column
+    ({ container } = renderTable(data, {
+      ascending: true,
+      columnTitle: "second",
+    }));
+    assertMatches(
+      container,
+      sortBy(data, r => r.value),
+    );
   });
 
-  describe("with expandableConfig", function () {
-    it("renders the expected table structure", function () {
-      const wrapper = makeExpandableTable([new TestRow("test", 1)], undefined);
-      assert.lengthOf(wrapper.find("table"), 1, "one table");
-      assert.lengthOf(wrapper.find("thead").find("tr"), 1, "one header row");
-      assert.lengthOf(
-        wrapper.find(`tr.${cx("head-wrapper__row--header")}`),
-        1,
-        "column header row",
+  describe("with expandableConfig", () => {
+    it("renders the expected table structure", () => {
+      const { container } = renderExpandableTable(
+        [new TestRow("test", 1)],
+        undefined,
       );
-      assert.lengthOf(wrapper.find("tbody"), 1, "tbody element");
-      assert.lengthOf(wrapper.find("tbody tr"), 1, "one body row");
-      assert.lengthOf(
-        wrapper.find("tbody td"),
-        3,
-        "two body cells plus one expansion control cell",
-      );
-      assert.lengthOf(
-        wrapper.find(`td.${cx("row-wrapper__cell__expansion-control")}`),
-        1,
-        "one expansion control cell",
-      );
+
+      expect(container.querySelectorAll("table")).toHaveLength(1);
+      expect(container.querySelectorAll("thead tr")).toHaveLength(1);
+      expect(
+        container.querySelectorAll("tr.head-wrapper__row--header"),
+      ).toHaveLength(1);
+      expect(container.querySelectorAll("tbody")).toHaveLength(1);
+      expect(container.querySelectorAll("tbody tr")).toHaveLength(1);
+      // Two body cells plus one expansion control cell
+      expect(container.querySelectorAll("tbody td")).toHaveLength(3);
+      expect(
+        container.querySelectorAll("td.row-wrapper__cell__expansion-control"),
+      ).toHaveLength(1);
     });
 
-    it("expands and collapses the clicked row", function () {
-      const wrapper = makeExpandableTable([new TestRow("test", 1)], undefined);
-      assert.lengthOf(
-        wrapper.find(`.${cx("row-wrapper__row--expanded-area")}`),
-        0,
-        "nothing expanded yet",
+    it("expands and collapses the clicked row", () => {
+      const { container } = renderExpandableTable(
+        [new TestRow("test", 1)],
+        undefined,
       );
-      wrapper
-        .find(`.${cx("row-wrapper__cell__expansion-control")}`)
-        .simulate("click");
-      const expandedArea = wrapper.find(".row-wrapper__row--expanded-area");
-      assert.lengthOf(expandedArea, 1, "row is expanded");
-      assert.lengthOf(
-        expandedArea.children(),
-        2,
-        "expanded row contains placeholder and content area",
+
+      // Nothing expanded yet
+      expect(
+        container.querySelectorAll(".row-wrapper__row--expanded-area"),
+      ).toHaveLength(0);
+
+      // Click to expand
+      const expansionControl = container.querySelector(
+        ".row-wrapper__cell__expansion-control",
       );
-      assert.isTrue(expandedArea.contains(<td />));
-      assert.isTrue(
-        expandedArea.contains(
-          <td className={cx("row-wrapper__cell")} colSpan={2}>
-            <div>test=1</div>
-          </td>,
-        ),
+      fireEvent.click(expansionControl);
+
+      // Row is expanded
+      const expandedArea = container.querySelector(
+        ".row-wrapper__row--expanded-area",
       );
-      wrapper
-        .find(`.${cx("row-wrapper__cell__expansion-control")}`)
-        .simulate("click");
-      assert.lengthOf(
-        wrapper.find(`.${cx("row-wrapper__row--expanded-area")}`),
-        0,
-        "row collapsed again",
-      );
+      expect(expandedArea).toBeInTheDocument();
+
+      // Expanded row contains placeholder and content area
+      const expandedChildren = expandedArea.querySelectorAll("td");
+      expect(expandedChildren).toHaveLength(2);
+
+      // First td is empty placeholder
+      expect(expandedChildren[0].innerHTML).toBe("");
+
+      // Second td contains the expanded content
+      expect(expandedChildren[1].textContent).toBe("test=1");
+      expect(expandedChildren[1].getAttribute("colspan")).toBe("2");
+
+      // Click to collapse
+      fireEvent.click(expansionControl);
+      expect(
+        container.querySelectorAll(".row-wrapper__row--expanded-area"),
+      ).toHaveLength(0);
     });
   });
 
-  it("should correctly render rows with pagination and sort settings", function () {
+  it("should correctly render rows with pagination and sort settings", () => {
     const data = [
       new TestRow("c", 3),
       new TestRow("d", 4),
       new TestRow("a", 1),
       new TestRow("b", 2),
     ];
-    let wrapper = makeTable(data, undefined, undefined, {
+
+    // Page 1, unsorted
+    let { container } = renderTable(data, undefined, undefined, {
       current: 1,
       pageSize: 2,
     });
-    let rows = wrapper.find("tbody");
-    assert.lengthOf(wrapper.find("tbody tr"), 2, "two body rows");
-    assert.equal(
-      rows.childAt(1).childAt(0).childAt(0).text(),
-      "d",
-      "second row column at first page match",
-    );
+    let tbody = container.querySelector("tbody");
+    expect(container.querySelectorAll("tbody tr")).toHaveLength(2);
+    expect(tbody.children[1].querySelector("td").textContent).toBe("d");
 
-    wrapper = makeTable(data, undefined, undefined, {
+    // Page 2, unsorted
+    ({ container } = renderTable(data, undefined, undefined, {
       current: 2,
       pageSize: 2,
-    });
-    rows = wrapper.find("tbody");
-    assert.lengthOf(wrapper.find("tbody tr"), 2, "two body rows");
-    assert.equal(
-      rows.childAt(0).childAt(0).childAt(0).text(),
-      "a",
-      "first row column at seconds page match",
-    );
+    }));
+    tbody = container.querySelector("tbody");
+    expect(container.querySelectorAll("tbody tr")).toHaveLength(2);
+    expect(tbody.children[0].querySelector("td").textContent).toBe("a");
 
-    wrapper = makeTable(
+    // Page 1, sorted by first column
+    ({ container } = renderTable(
       data,
       { ascending: true, columnTitle: "first" },
       undefined,
@@ -250,15 +254,12 @@ describe("<SortedTable>", function () {
         current: 1,
         pageSize: 2,
       },
-    );
-    rows = wrapper.find("tbody");
-    assert.equal(
-      rows.childAt(1).childAt(0).childAt(0).text(),
-      "b",
-      "second row column at first page match",
-    );
+    ));
+    tbody = container.querySelector("tbody");
+    expect(tbody.children[1].querySelector("td").textContent).toBe("b");
 
-    wrapper = makeTable(
+    // Page 2, sorted by first column
+    ({ container } = renderTable(
       data,
       { ascending: true, columnTitle: "first" },
       undefined,
@@ -266,39 +267,40 @@ describe("<SortedTable>", function () {
         current: 2,
         pageSize: 2,
       },
-    );
-    rows = wrapper.find("tbody");
-    assert.equal(
-      rows.childAt(0).childAt(0).childAt(0).text(),
-      "c",
-      "first row column at seconds page match",
-    );
+    ));
+    tbody = container.querySelector("tbody");
+    expect(tbody.children[0].querySelector("td").textContent).toBe("c");
   });
 
-  it("should update when pagination changes", function () {
-    const table = makeTable(
-      [
-        new TestRow("c", 3),
-        new TestRow("d", 4),
-        new TestRow("a", 1),
-        new TestRow("b", 2),
-      ],
-      undefined,
-      undefined,
-      {
-        current: 1,
-        pageSize: 2,
-      },
-    );
+  it("should update when pagination changes", () => {
+    const data = [
+      new TestRow("c", 3),
+      new TestRow("d", 4),
+      new TestRow("a", 1),
+      new TestRow("b", 2),
+    ];
 
-    assert.deepEqual(rowsOf(table.find("tbody")), [
+    const { container, rerender } = renderTable(data, undefined, undefined, {
+      current: 1,
+      pageSize: 2,
+    });
+
+    expect(getBodyRowContents(container)).toEqual([
       ["c", "3"],
       ["d", "4"],
     ]);
 
-    table.setProps({ pagination: { current: 2, pageSize: 2 } });
+    rerender(
+      <SortedTable<TestRow>
+        data={data}
+        sortSetting={undefined}
+        onChangeSortSetting={undefined}
+        pagination={{ current: 2, pageSize: 2 }}
+        columns={columns}
+      />,
+    );
 
-    assert.deepEqual(rowsOf(table.find("tbody")), [
+    expect(getBodyRowContents(container)).toEqual([
       ["a", "1"],
       ["b", "2"],
     ]);

--- a/pkg/ui/workspaces/cluster-ui/src/sortedtable/sortedtable.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sortedtable/sortedtable.stories.tsx
@@ -9,7 +9,7 @@ import React from "react";
 import { SortedTable } from "./";
 
 storiesOf("Sorted table", module)
-  .add("Empty state", () => <SortedTable empty />)
+  .add("Empty state", () => <SortedTable empty data={[]} columns={[]} />)
   .add("With data", () => {
     const columns = [
       {

--- a/pkg/ui/workspaces/cluster-ui/src/sortedtable/sortedtable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sortedtable/sortedtable.tsx
@@ -10,8 +10,7 @@ import orderBy from "lodash/orderBy";
 import times from "lodash/times";
 import * as Long from "long";
 import { Moment } from "moment-timezone";
-import React from "react";
-import { createSelector } from "reselect";
+import React, { useState, useMemo, useCallback } from "react";
 
 import { EmptyPanel, EmptyPanelProps } from "../empty";
 
@@ -64,15 +63,15 @@ export interface ColumnDescriptor<T> {
  * SortedTableProps describes the properties expected by a SortedTable
  * component.
  */
-interface SortedTableProps<T> {
+export interface SortedTableProps<T> {
   // The data which should be displayed in the table. This data may be sorted
-  // by this component before display.
-  data: T[];
+  // by this component before display. Defaults to an empty array if not provided.
+  data?: T[];
   // Description of columns to display.
   columns: ColumnDescriptor<T>[];
   // sortSetting specifies how data should be sorted in this table, by
   // specifying a column id and a direction.
-  sortSetting: SortSetting;
+  sortSetting?: SortSetting;
   // Callback that should be invoked when the user want to change the sort
   // setting.
   onChangeSortSetting?: { (ss: SortSetting): void };
@@ -104,10 +103,6 @@ interface SortedTableProps<T> {
   empty?: boolean;
   emptyProps?: EmptyPanelProps;
   dataTestId?: string;
-}
-
-interface SortedTableState {
-  expandedRows: Set<string>;
 }
 
 /**
@@ -182,221 +177,184 @@ export interface ExpandableConfig {
  * 'onChangeSortSetting' callback property.
  */
 
-export class SortedTable<T> extends React.Component<
-  SortedTableProps<T>,
-  SortedTableState
-> {
-  static defaultProps: Partial<SortedTableProps<unknown>> = {
-    rowClass: (_obj: unknown) => "",
-    columns: [],
-    sortSetting: {
-      ascending: false,
-      columnTitle: null,
-    },
-    onChangeSortSetting: _ss => {},
-  };
+const defaultRowClass = (_obj: unknown) => "";
+const defaultOnChangeSortSetting = (_ss: SortSetting) => {};
+const defaultSortSetting: SortSetting = {
+  ascending: false,
+  columnTitle: null,
+};
 
-  rollups = createSelector(
-    (props: SortedTableProps<T>) => props.data,
-    (props: SortedTableProps<T>) => props.columns,
-    (data: T[], columns: ColumnDescriptor<T>[]) => {
-      return columns.map((c): React.ReactNode => {
-        if (c.rollup) {
-          return c.rollup(data);
-        }
-        return undefined;
-      });
-    },
-  );
-
-  sortedAndPaginated = createSelector(
-    (props: SortedTableProps<T>) => props.data,
-    (props: SortedTableProps<T>) => props.sortSetting,
-    (props: SortedTableProps<T>) => props.columns,
-    (props: SortedTableProps<T>) => props.pagination,
-    (
-      data: T[],
-      sortSetting: SortSetting,
-      columns: ColumnDescriptor<T>[],
-      _pagination?: ISortedTablePagination,
-    ): T[] => {
-      if (!sortSetting) {
-        return this.paginatedData();
-      }
-
-      if (
-        this.props.disableSortSizeLimit &&
-        data.length > this.props.disableSortSizeLimit
-      ) {
-        return this.paginatedData();
-      }
-
-      const sortColumn = columns.find(c => c.name === sortSetting.columnTitle);
-      if (!sortColumn || !sortColumn.sort) {
-        return this.paginatedData();
-      }
-      return this.paginatedData(
-        orderBy(data, sortColumn.sort, sortSetting.ascending ? "asc" : "desc"),
-      );
-    },
-  );
-
-  /**
-   * columns is a selector which computes the input columns to the underlying
-   * sortableTable.
-   */
-
-  columns = createSelector(
-    this.sortedAndPaginated,
-    this.rollups,
-    (props: SortedTableProps<T>) => props.columns,
-    (
-      sorted: T[],
-      rollups: React.ReactNode[],
-      columns: ColumnDescriptor<T>[],
-    ) => {
-      const sort =
-        !this.props.disableSortSizeLimit ||
-        this.props.data.length <= this.props.disableSortSizeLimit;
-
-      return columns.map((cd, ii): SortableColumn => {
-        return {
-          name: cd.name,
-          title: cd.title,
-          hideTitleUnderline: cd.hideTitleUnderline,
-          cell: index => cd.cell(sorted[index]),
-          columnTitle: sort && cd.sort ? cd.name : undefined,
-          rollup: rollups[ii],
-          className: cd.className,
-          titleAlign: cd.titleAlign,
-        };
-      });
-    },
-  );
-
-  rowClass = createSelector(
-    this.sortedAndPaginated,
-    (props: SortedTableProps<T>) => props.rowClass,
-    (sorted: T[], rowClass: (obj: T) => string) => {
-      return (index: number) => rowClass(sorted[index]);
-    },
-  );
-
+export function SortedTable<T>({
+  data = [] as T[],
+  columns: columnDescriptors = [],
+  sortSetting = defaultSortSetting,
+  onChangeSortSetting = defaultOnChangeSortSetting,
+  className,
+  tableWrapperClassName,
+  rowClass = defaultRowClass,
+  expandableConfig: expandableConfigProp,
+  firstCellBordered,
+  renderNoResult,
+  pagination,
+  loading,
+  loadingLabel,
+  disableSortSizeLimit,
+  empty,
+  emptyProps,
+  dataTestId,
+}: SortedTableProps<T>): React.ReactElement {
   // TODO(vilterp): use a LocalSetting instead so the expansion state
   // will persist if the user navigates to a different page and back.
-  state: SortedTableState = {
-    expandedRows: new Set<string>(),
-  };
+  const [expandedRows, setExpandedRows] = useState<Set<string>>(
+    () => new Set<string>(),
+  );
 
-  getItemAt(rowIndex: number): T {
-    const sorted = this.sortedAndPaginated(this.props);
-    return sorted[rowIndex];
-  }
+  const paginatedData = useCallback(
+    (sortData?: T[]): T[] => {
+      if (!pagination) {
+        return sortData || data;
+      }
+      const currentDefault = pagination.current - 1;
+      const start = currentDefault * pagination.pageSize;
+      const end = currentDefault * pagination.pageSize + pagination.pageSize;
+      return sortData ? sortData.slice(start, end) : data.slice(start, end);
+    },
+    [data, pagination],
+  );
 
-  getKeyAt(rowIndex: number): string {
-    return this.props.expandableConfig.expansionKey(this.getItemAt(rowIndex));
-  }
-
-  onChangeExpansion = (rowIndex: number, expanded: boolean): void => {
-    const key = this.getKeyAt(rowIndex);
-    const expandedRows = this.state.expandedRows;
-    if (expanded) {
-      expandedRows.add(key);
-    } else {
-      expandedRows.delete(key);
-    }
-    this.setState({
-      expandedRows: expandedRows,
+  const rollups = useMemo((): React.ReactNode[] => {
+    return columnDescriptors.map((c): React.ReactNode => {
+      if (c.rollup) {
+        return c.rollup(data);
+      }
+      return undefined;
     });
-  };
+  }, [data, columnDescriptors]);
 
-  rowIsExpanded = (rowIndex: number): boolean => {
-    const key = this.getKeyAt(rowIndex);
-    return this.state.expandedRows.has(key);
-  };
-
-  expandedContent = (rowIndex: number): React.ReactNode => {
-    const item = this.getItemAt(rowIndex);
-    return this.props.expandableConfig.expandedContent(item);
-  };
-
-  paginatedData = (sortData?: T[]): T[] => {
-    const { pagination, data } = this.props;
-    if (!pagination) {
-      return sortData || data;
-    }
-    const currentDefault = pagination.current - 1;
-    const start = currentDefault * pagination.pageSize;
-    const end = currentDefault * pagination.pageSize + pagination.pageSize;
-    return sortData ? sortData.slice(start, end) : data.slice(start, end);
-  };
-
-  render(): React.ReactElement {
-    const {
-      data,
-      loading,
-      sortSetting,
-      onChangeSortSetting,
-      firstCellBordered,
-      renderNoResult,
-      loadingLabel,
-      empty,
-      emptyProps,
-      className,
-      tableWrapperClassName,
-      dataTestId,
-    } = this.props;
-    let expandableConfig: ExpandableConfig = null;
-    if (this.props.expandableConfig) {
-      expandableConfig = {
-        expandedContent: this.expandedContent,
-        rowIsExpanded: this.rowIsExpanded,
-        onChangeExpansion: this.onChangeExpansion,
-      };
+  const sortedAndPaginatedData = useMemo((): T[] => {
+    if (!sortSetting) {
+      return paginatedData();
     }
 
-    const count = data ? this.paginatedData().length : 0;
-    const columns = this.columns(this.props);
-    const rowClass = this.rowClass(this.props);
-    const tableWrapperClass = cx("cl-table-wrapper", tableWrapperClassName);
-    const tableStyleClass = cx("sort-table", className);
-    const noResultsClass = cx("table__no-results");
-
-    if (empty) {
-      return <EmptyPanel {...emptyProps} />;
+    if (disableSortSizeLimit && data.length > disableSortSizeLimit) {
+      return paginatedData();
     }
 
-    return (
-      <div className={tableWrapperClass}>
-        <table className={tableStyleClass} data-testid={dataTestId}>
-          <TableHead
-            columns={columns}
-            sortSetting={sortSetting}
-            onChangeSortSetting={onChangeSortSetting}
-            expandableConfig={expandableConfig}
-            firstCellBordered={firstCellBordered}
-          />
-          <tbody>
-            {!loading &&
-              times(count, (rowIndex: number) => (
-                <TableRow
-                  key={"row" + rowIndex}
-                  columns={columns}
-                  expandableConfig={expandableConfig}
-                  firstCellBordered={firstCellBordered}
-                  rowIndex={rowIndex}
-                  rowClass={rowClass}
-                />
-              ))}
-          </tbody>
-        </table>
-        {loading && <TableSpinner loadingLabel={loadingLabel} />}
-        {!loading && count === 0 && (
-          <div className={noResultsClass}>{renderNoResult}</div>
-        )}
-      </div>
+    const sortColumn = columnDescriptors.find(
+      c => c.name === sortSetting.columnTitle,
     );
+    if (!sortColumn || !sortColumn.sort) {
+      return paginatedData();
+    }
+    return paginatedData(
+      orderBy(data, sortColumn.sort, sortSetting.ascending ? "asc" : "desc"),
+    );
+  }, [
+    data,
+    sortSetting,
+    columnDescriptors,
+    disableSortSizeLimit,
+    paginatedData,
+  ]);
+
+  const columns = useMemo((): SortableColumn[] => {
+    const sort = !disableSortSizeLimit || data.length <= disableSortSizeLimit;
+
+    return columnDescriptors.map((cd, ii): SortableColumn => {
+      return {
+        name: cd.name,
+        title: cd.title,
+        hideTitleUnderline: cd.hideTitleUnderline,
+        cell: index => cd.cell(sortedAndPaginatedData[index]),
+        columnTitle: sort && cd.sort ? cd.name : undefined,
+        rollup: rollups[ii],
+        className: cd.className,
+        titleAlign: cd.titleAlign,
+      };
+    });
+  }, [
+    sortedAndPaginatedData,
+    rollups,
+    columnDescriptors,
+    disableSortSizeLimit,
+    data.length,
+  ]);
+
+  const rowClassFn = useMemo((): ((index: number) => string) => {
+    return (index: number) => rowClass(sortedAndPaginatedData[index]);
+  }, [sortedAndPaginatedData, rowClass]);
+
+  let expandableConfig: ExpandableConfig = null;
+  if (expandableConfigProp) {
+    const getKeyAt = (rowIndex: number): string => {
+      return expandableConfigProp.expansionKey(
+        sortedAndPaginatedData[rowIndex],
+      );
+    };
+
+    expandableConfig = {
+      expandedContent: (rowIndex: number): React.ReactNode => {
+        return expandableConfigProp.expandedContent(
+          sortedAndPaginatedData[rowIndex],
+        );
+      },
+      rowIsExpanded: (rowIndex: number): boolean => {
+        return expandedRows.has(getKeyAt(rowIndex));
+      },
+      onChangeExpansion: (rowIndex: number, expanded: boolean): void => {
+        const key = getKeyAt(rowIndex);
+        setExpandedRows(prev => {
+          const next = new Set(prev);
+          if (expanded) {
+            next.add(key);
+          } else {
+            next.delete(key);
+          }
+          return next;
+        });
+      },
+    };
   }
+
+  const count = data ? paginatedData().length : 0;
+  const tableWrapperClass = cx("cl-table-wrapper", tableWrapperClassName);
+  const tableStyleClass = cx("sort-table", className);
+  const noResultsClass = cx("table__no-results");
+
+  if (empty) {
+    return <EmptyPanel {...emptyProps} />;
+  }
+
+  return (
+    <div className={tableWrapperClass}>
+      <table className={tableStyleClass} data-testid={dataTestId}>
+        <TableHead
+          columns={columns}
+          sortSetting={sortSetting}
+          onChangeSortSetting={onChangeSortSetting}
+          expandableConfig={expandableConfig}
+          firstCellBordered={firstCellBordered}
+        />
+        <tbody>
+          {!loading &&
+            times(count, (rowIndex: number) => (
+              <TableRow
+                key={"row" + rowIndex}
+                columns={columns}
+                expandableConfig={expandableConfig}
+                firstCellBordered={firstCellBordered}
+                rowIndex={rowIndex}
+                rowClass={rowClassFn}
+              />
+            ))}
+        </tbody>
+      </table>
+      {loading && <TableSpinner loadingLabel={loadingLabel} />}
+      {!loading && count === 0 && (
+        <div className={noResultsClass}>{renderNoResult}</div>
+      )}
+    </div>
+  );
 }
 
 /**

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/plansTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/plansTable.tsx
@@ -27,7 +27,7 @@ import {
 
 export type PlanHashStats =
   cockroach.server.serverpb.StatementDetailsResponse.ICollectedStatementGroupedByPlanHash;
-export class PlansSortedTable extends SortedTable<PlanHashStats> {}
+export const PlansSortedTable = SortedTable<PlanHashStats>;
 
 const planDetailsColumnLabels = {
   avgExecTime: "Average Execution Time",

--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.stories.tsx
@@ -70,4 +70,6 @@ storiesOf("StatementsSortedTable", module)
       }}
     />
   ))
-  .add("empty table", () => <StatementsSortedTable empty />);
+  .add("empty table", () => (
+    <StatementsSortedTable empty data={[]} columns={[]} />
+  ));

--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
@@ -76,7 +76,7 @@ export interface AggregateStatistics {
   regionNodes?: string[];
 }
 
-export class StatementsSortedTable extends SortedTable<AggregateStatistics> {}
+export const StatementsSortedTable = SortedTable<AggregateStatistics>;
 
 export function shortStatement(
   summary: StatementSummary,

--- a/pkg/ui/workspaces/cluster-ui/src/tracez/snapshot/spanMetadataTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/tracez/snapshot/spanMetadataTable.tsx
@@ -19,7 +19,7 @@ import { formatDurationHours } from "./spanTable";
 
 const cx = classNames.bind(styles);
 
-class SpanMetadataSortedTable extends SortedTable<NamedOperationMetadata> {}
+const SpanMetadataSortedTable = SortedTable<NamedOperationMetadata>;
 
 const columns: ColumnDescriptor<NamedOperationMetadata>[] = [
   {

--- a/pkg/ui/workspaces/cluster-ui/src/tracez/snapshot/spanTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/tracez/snapshot/spanTable.tsx
@@ -23,7 +23,7 @@ import RecordingMode = cockroach.util.tracing.tracingpb.RecordingMode;
 import ISpanTag = cockroach.server.serverpb.ISpanTag;
 const cx = classNames.bind(styles);
 
-class SpanSortedTable extends SortedTable<Span> {}
+const SpanSortedTable = SortedTable<Span>;
 
 interface TagRowProps {
   t: ISpanTag;

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/events/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/events/index.tsx
@@ -49,7 +49,7 @@ export interface SimplifiedEvent {
   content: React.ReactNode;
 }
 
-class EventSortedTable extends SortedTable<SimplifiedEvent> {}
+const EventSortedTable = SortedTable<SimplifiedEvent>;
 
 export interface EventRowProps {
   event: clusterUiApi.EventColumns;
@@ -168,18 +168,20 @@ export class EventPageUnconnected extends React.Component<EventPageProps, {}> {
           <EventSortedTable
             data={simplifiedEvents}
             sortSetting={sortSetting}
-            onChangeSortSetting={setting => this.props.setSort(setting)}
+            onChangeSortSetting={(setting: SortSetting) =>
+              this.props.setSort(setting)
+            }
             columns={[
               {
                 title: "Event",
                 name: "event",
-                cell: e => e.content,
+                cell: (e: SimplifiedEvent) => e.content,
               },
               {
                 title: "Timestamp",
                 name: "timestamp",
-                cell: e => e.fromNowString,
-                sort: e => e.sortableTimestamp,
+                cell: (e: SimplifiedEvent) => e.fromNowString,
+                sort: (e: SimplifiedEvent) => e.sortableTimestamp,
               },
             ]}
           />

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/statementDiagnosticsHistory/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/statementDiagnosticsHistory/index.tsx
@@ -84,7 +84,8 @@ interface StatementDiagnosticsHistoryViewProps {
   ) => Promise<void>;
 }
 
-class StatementDiagnosticsHistoryTable extends SortedTable<clusterUiApi.StatementDiagnosticsReport> {}
+const StatementDiagnosticsHistoryTable =
+  SortedTable<clusterUiApi.StatementDiagnosticsReport>;
 
 const StatementColumn: React.FC<{ fingerprint: string }> = ({
   fingerprint,

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/transactionDiagnosticsHistory/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/transactionDiagnosticsHistory/index.tsx
@@ -75,7 +75,8 @@ interface TransactionDiagnosticsHistoryViewProps {
   ) => Promise<void>;
 }
 
-class TransactionDiagnosticsHistoryTable extends SortedTable<clusterUiApi.TransactionDiagnosticsReport> {}
+const TransactionDiagnosticsHistoryTable =
+  SortedTable<clusterUiApi.TransactionDiagnosticsReport>;
 
 const TransactionColumn: React.FC<{ fingerprint: string }> = ({
   fingerprint,


### PR DESCRIPTION
This change converts the following class components into their functional style equivalent:
 - sortedtable
 - outsideEventHandler
 - columnsSelector
 - dropdown
 - queryFilter
 - search

The conversion was done by iteratively using a claude skill with no additional human
intervention needed.
Existing Enzyme + Chai tests were converted into pure react-testing-library tests.
Additional tests were also created by claude for the following components:
 - columnsSelector
 - dropdown
 - search

The following pages import the modified components and were manually verified:
 - sql-activity
 - insights
 - databases
 - jobs
 - schedules
 - statement details
 - events

Epic: CRDB-58145
Release Note: None