### PR TITLE
sql: fix EXPLAIN ANALYZE EXECUTE with JDBC binary protocol

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -572,7 +572,14 @@ func (ex *connExecutor) execStmtInOpenState(
 		stmt.HintsGeneration = ps.HintsGeneration
 		stmt.ASTWithInjectedHints = ps.ASTWithInjectedHints
 		stmt.ReloadHintsIfStale(ctx, stmtFingerprintFmtMask, statementHintsCache)
-		res.ResetStmtType(ps.AST)
+		// Don't reset the statement type if we're within EXPLAIN ANALYZE, as this
+		// would break the special case handling in GetFormatCode that relies on
+		// cmdCompleteTag being "EXPLAIN". For EXPLAIN ANALYZE EXECUTE, the format
+		// codes are set up for the EXPLAIN output (1 column), but the inner query
+		// may have more columns. See issue #161382.
+		if ih.outputMode == unmodifiedOutput {
+			res.ResetStmtType(ps.AST)
+		}
 
 		if e.DiscardRows {
 			ih.SetDiscardRows()
@@ -1477,7 +1484,14 @@ func (ex *connExecutor) execStmtInOpenStateWithPausablePortal(
 		vars.stmt.HintsGeneration = ps.HintsGeneration
 		vars.stmt.ASTWithInjectedHints = ps.ASTWithInjectedHints
 		vars.stmt.ReloadHintsIfStale(ctx, stmtFingerprintFmtMask, statementHintsCache)
-		res.ResetStmtType(ps.AST)
+		// Don't reset the statement type if we're within EXPLAIN ANALYZE, as this
+		// would break the special case handling in GetFormatCode that relies on
+		// cmdCompleteTag being "EXPLAIN". For EXPLAIN ANALYZE EXECUTE, the format
+		// codes are set up for the EXPLAIN output (1 column), but the inner query
+		// may have more columns. See issue #161382.
+		if ih.outputMode == unmodifiedOutput {
+			res.ResetStmtType(ps.AST)
+		}
 
 		if e.DiscardRows {
 			ih.SetDiscardRows()

--- a/pkg/sql/pgwire/testdata/pgtest/prepare
+++ b/pkg/sql/pgwire/testdata/pgtest/prepare
@@ -151,3 +151,45 @@ ReadyForQuery
 {"Type":"BindComplete"}
 {"Type":"CommandComplete","CommandTag":"EXPLAIN"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Regression test for #161382: EXPLAIN ANALYZE EXECUTE of a SQL-level PREPARE
+# with binary format codes. The prepared query returns multiple columns, but
+# EXPLAIN ANALYZE returns only one column. This previously caused an assertion
+# failure when trying to get format codes for the inner query's columns.
+send
+Query {"String": "CREATE TABLE t0 (c0 FLOAT);"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "PREPARE prepare_query (float8, float8, float8) AS SELECT ALL sum($1), stddev($2), avg($3) FROM t0 GROUP BY t0.c0;"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"PREPARE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Execute the prepared statement via EXPLAIN ANALYZE EXECUTE with binary format.
+# This reproduces the bug: EXPLAIN ANALYZE has 1 output column, but the inner
+# query has 3 columns, causing a format code mismatch.
+send
+Parse {"Name": "exec_stmt", "Query": "EXPLAIN ANALYZE EXECUTE prepare_query(1.95573964E8::float8, 0.03965984596601002::float8, 0.4293795941585613::float8)"}
+Bind {"DestinationPortal": "exec_portal", "PreparedStatement": "exec_stmt", "ResultFormatCodes": [1]}
+Execute {"Portal": "exec_portal"}
+Sync
+----
+
+until ignore=DataRow
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"EXPLAIN"}
+{"Type":"ReadyForQuery","TxStatus":"I"}


### PR DESCRIPTION
Previously, when executing EXPLAIN ANALYZE EXECUTE on a prepared statement via the JDBC driver (using the extended/binary protocol), the code would reset the statement type after replacing the EXECUTE node with the prepared statement. This caused the cmdCompleteTag to change from "EXPLAIN" to the inner statement type (e.g., "SELECT"), which broke the special case handling in GetFormatCode(). The format code validation expected one format code for EXPLAIN's single output column, but encountered multiple columns from the inner query, resulting in an assertion failure.

This change adds a check to skip the ResetStmtType() call when executing within an EXPLAIN ANALYZE context (when outputMode is not unmodifiedOutput). This preserves the "EXPLAIN" command tag, allowing the existing special case logic to handle the format code mismatch correctly.

Fixes #161382

Release note (bug fix): Fixed an internal error "could not find format code for column N" that occurred when executing EXPLAIN ANALYZE EXECUTE statements via JDBC or other clients using the PostgreSQL binary protocol.

Epic: None