### PR TITLE
release-25.2: changefeedccl: add context cancel check to kafkav1

### DIFF
--- a/pkg/ccl/changefeedccl/sink_kafka.go
+++ b/pkg/ccl/changefeedccl/sink_kafka.go
@@ -662,6 +662,8 @@ func (s *kafkaSink) handleBufferedRetries(msgs []*sarama.ProducerMessage, retryE
 
 	for {
 		select {
+		case <-s.ctx.Done():
+			return s.ctx.Err()
 		case <-s.stopWorkerCh:
 			log.Infof(s.ctx, "kafka sink ending retries due to worker close")
 			return lastSendErr


### PR DESCRIPTION
Backport 1/1 commits from #162058 on behalf of @rharding6373.

----

Added a missing context check to handleBufferedRetries.

Epic: none
Fixes: cockroachdb#131223

Release note (bug fix): Fixes a bug in kafka v1 where a changefeed could potentially hang if the changefeed was shutting down.

----

Release justification: Low-risk change to fix a potential hang in a deprecated feature.