### PR TITLE
sql/stats: fix histogram type check after metadata-only ALTER COLUMN TYPE

### DIFF
--- a/pkg/ccl/testccl/sqlccl/explain_test.go
+++ b/pkg/ccl/testccl/sqlccl/explain_test.go
@@ -200,7 +200,6 @@ func TestExplainGist(t *testing.T) {
 				// Ignore all errors except the internal ones.
 				for _, knownErr := range []string{
 					"expected equivalence dependants to be its closure",                  // #119045
-					"type check failed while initializing stat",                          // #125620
 					"argument expression has type RECORD, need type USER DEFINED RECORD", // #139910
 					"invalid datum type given: RECORD, expected RECORD",                  // #140773
 				} {

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -3968,3 +3968,41 @@ query T
 SELECT info FROM [EXPLAIN SELECT * FROM t155184 WHERE a < 8] WHERE info LIKE '%estimated row count:%'
 ----
   estimated row count: 4 (36% of the table; stats collected <hidden> ago)
+
+# Testcase for issue #125620: check that we can use histograms after a
+# metadata-only type conversion from TIMESTAMPTZ to TIMESTAMP.
+# The histogram should still provide accurate cardinality estimates because
+# TIMESTAMP and TIMESTAMPTZ have identical binary encodings.
+
+statement ok
+CREATE TABLE t125620 (ts TIMESTAMPTZ PRIMARY KEY)
+
+# Insert 100 rows with timestamps spanning a year.
+statement ok
+INSERT INTO t125620 SELECT '2020-01-01 00:00:00+00'::TIMESTAMPTZ + (i * INTERVAL '3 days') FROM generate_series(1, 100) AS g(i)
+
+statement ok
+ANALYZE t125620
+
+# Verify the histogram is being used before the ALTER.
+query T retry
+SELECT info FROM [EXPLAIN SELECT * FROM t125620 WHERE ts < '2020-04-01'::TIMESTAMPTZ] WHERE info LIKE '%estimated row count:%'
+----
+  estimated row count: 30 (30% of the table; stats collected <hidden> ago)
+
+statement ok
+ALTER TABLE t125620 ALTER COLUMN ts SET DATA TYPE TIMESTAMP
+
+# After the ALTER, the histogram (which stores TIMESTAMPTZ bucket bounds) should
+# still work correctly with TIMESTAMP comparisons because both types use
+# identical encoding. The optimizer should use the histogram for estimation.
+query T retry
+SELECT info FROM [EXPLAIN SELECT * FROM t125620 WHERE ts < '2020-04-01'::TIMESTAMP] WHERE info LIKE '%estimated row count:%'
+----
+  estimated row count: 30 (30% of the table; stats collected <hidden> ago)
+
+# Verify the query still returns correct results.
+query I
+SELECT count(*) FROM t125620 WHERE ts < '2020-04-01'::TIMESTAMP
+----
+30

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -2088,8 +2088,9 @@ func (os *optTableStat) init(
 			col.GetType(), string(tab.Name()), col.GetName(), stats.TSFromTime(stat.CreatedAt),
 		); err != nil {
 			// Column type in the histogram differs from column type in the
-			// table. This is only possible if we somehow re-used the same column ID
-			// during an ALTER TABLE statement, which we shouldn't.
+			// table. This can happen after a metadata-only ALTER COLUMN TYPE that
+			// changes the type family (e.g., TIMESTAMPTZ to TIMESTAMP) without
+			// rewriting data or invalidating histograms.
 			if buildutil.CrdbTestBuild {
 				return false, errors.NewAssertionErrorWithWrappedErrf(
 					err, "type check failed while initializing stat %d", stat.StatisticID,


### PR DESCRIPTION
Previously, after a metadata-only ALTER COLUMN TYPE conversion (e.g., TIMESTAMPTZ to TIMESTAMP), histograms would fail a type check because `Equivalent()` requires types to be in the same family. This caused an internal error in test builds or histograms being silently skipped in production, leading to degraded query planning.

This change adds a new `HasIdenticalHistogramEncoding()` method to `types.T` that returns true when two types have identical binary encodings for histogram bucket upper bounds. TIMESTAMP and TIMESTAMPTZ are the only cross-family types that share identical encoding (both store time.Time), so histograms remain valid after conversion between these types.

The histogram `TypeCheck()` function now uses this method instead of `Equivalent()`, allowing histograms to be reused after metadata-only type conversions where the encoding doesn't change.

Fixes: #125620
Epic: None
Release note: None