### PR TITLE
roachtest: run tpcc import in parallel to reduce timeouts

### DIFF
--- a/pkg/ccl/workloadccl/allccl/all_test.go
+++ b/pkg/ccl/workloadccl/allccl/all_test.go
@@ -84,6 +84,9 @@ func TestAllRegisteredImportFixture(t *testing.T) {
 		}
 
 		t.Run(meta.Name, func(t *testing.T) {
+			if meta.Name == "tpcc" {
+				t.Parallel() // SAFE FOR TESTING
+			}
 			if bigInitialData(meta) {
 				skip.UnderShort(t, fmt.Sprintf(`%s loads a lot of data`, meta.Name))
 			}


### PR DESCRIPTION
Summary:
Import tests currently run sequentially under a 15-minute global timeout, which can cause intermittent failures. This change runs the tpcc import in parallel, since it is the longest-running test, reducing the likelihood of timeouts. Other imports remain sequential to avoid resource contention.

Fixes: #161919
Release note: None