### PR TITLE
kvadmission: plumb RaftAdmissionMeta via explicit parameter instead o…

### DIFF
--- a/pkg/kv/kvserver/kvadmission/kvadmission.go
+++ b/pkg/kv/kvserver/kvadmission/kvadmission.go
@@ -245,16 +245,30 @@ type Handle struct {
 	cpuKVAdmissionQResp admission.AdmitResponse
 }
 
-// AnnotateCtx annotates the given context with request-scoped admission
-// data, plumbed through the KV stack using context.Contexts.
+// AnnotateCtx annotates the given context with the ElasticCPUWorkHandle,
+// which is used deep in the storage layer (e.g., mvccExportToWriter) to pace
+// CPU intensive operations.
 func (h *Handle) AnnotateCtx(ctx context.Context) context.Context {
 	if h.elasticCPUWorkHandle != nil {
 		ctx = admission.ContextWithElasticCPUWorkHandle(ctx, h.elasticCPUWorkHandle)
 	}
-	if h.raftAdmissionMeta != nil {
-		ctx = kvflowcontrol.ContextWithMeta(ctx, h.raftAdmissionMeta)
-	}
 	return ctx
+}
+
+// AdmissionInfo returns admission control state that should be plumbed
+// through the KV layer via explicit function parameters.
+func (h *Handle) AdmissionInfo() AdmissionInfo {
+	return AdmissionInfo{
+		RaftAdmissionMeta: h.raftAdmissionMeta,
+	}
+}
+
+// AdmissionInfo contains admission control state that is plumbed through the
+// KV layer via explicit function parameters rather than context.
+type AdmissionInfo struct {
+	// RaftAdmissionMeta is the metadata used for replication flow control.
+	// It is populated for requests that will be proposed to Raft.
+	RaftAdmissionMeta *kvflowcontrolpb.RaftAdmissionMeta
 }
 
 // MakeController returns a Controller. All three parameters must together be

--- a/pkg/kv/kvserver/kvflowcontrol/BUILD.bazel
+++ b/pkg/kv/kvserver/kvflowcontrol/BUILD.bazel
@@ -10,12 +10,10 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/base",
-        "//pkg/kv/kvserver/kvflowcontrol/kvflowcontrolpb",
         "//pkg/kv/kvserver/kvflowcontrol/kvflowinspectpb",
         "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/util/admission/admissionpb",
-        "//pkg/util/ctxutil",
         "//pkg/util/humanizeutil",
         "//pkg/util/metamorphic",
         "@com_github_cockroachdb_redact//:redact",

--- a/pkg/kv/kvserver/kvflowcontrol/kvflowcontrol.go
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowcontrol.go
@@ -12,12 +12,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/kvflowcontrolpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/kvflowinspectpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
-	"github.com/cockroachdb/cockroach/pkg/util/ctxutil"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/metamorphic"
 	"github.com/cockroachdb/redact"
@@ -213,29 +211,4 @@ func (s Stream) SafeFormat(p redact.SafePrinter, _ rune) {
 		tenantSt = "1"
 	}
 	p.Printf("t%s/s%s", redact.SafeString(tenantSt), s.StoreID)
-}
-
-var raftAdmissionMetaKey = ctxutil.RegisterFastValueKey()
-
-// ContextWithMeta returns a Context wrapping the supplied raft admission meta,
-// if any.
-//
-// TODO(irfansharif,aaditya): This causes a heap allocation. Revisit as part of
-// #104154.
-func ContextWithMeta(ctx context.Context, meta *kvflowcontrolpb.RaftAdmissionMeta) context.Context {
-	if meta != nil {
-		ctx = ctxutil.WithFastValue(ctx, raftAdmissionMetaKey, meta)
-	}
-	return ctx
-}
-
-// MetaFromContext returns the raft admission meta embedded in the Context, if
-// any.
-func MetaFromContext(ctx context.Context) *kvflowcontrolpb.RaftAdmissionMeta {
-	val := ctxutil.FastValue(ctx, raftAdmissionMetaKey)
-	h, ok := val.(*kvflowcontrolpb.RaftAdmissionMeta)
-	if !ok {
-		return nil
-	}
-	return h
 }

--- a/pkg/kv/kvserver/replica_circuit_breaker.go
+++ b/pkg/kv/kvserver/replica_circuit_breaker.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvadmission"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/raft"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -220,7 +221,9 @@ func sendProbe(ctx context.Context, r replicaInCircuitBreaker) error {
 		// Breakers are disabled now.
 		return nil
 	}
-	_, writeBytes, pErr := r.SendWithWriteBytes(ctx, ba)
+	// Pass empty AdmissionInfo since this is an internal probe request that
+	// bypasses admission control.
+	_, writeBytes, pErr := r.SendWithWriteBytes(ctx, ba, kvadmission.AdmissionInfo{})
 	writeBytes.Release()
 	if err := pErr.GoError(); err != nil {
 		return r.replicaUnavailableError(err)

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/poison"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvadmission"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/kvflowcontrolpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/rac2"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/replica_rac2"
@@ -107,6 +106,7 @@ func (r *Replica) evalAndPropose(
 	st *kvserverpb.LeaseStatus,
 	ui uncertainty.Interval,
 	tok TrackedRequestToken,
+	admissionInfo kvadmission.AdmissionInfo,
 ) (
 	chan proposalResult,
 	abandonToken,
@@ -233,9 +233,7 @@ func (r *Replica) evalAndPropose(
 		// Continue with proposal...
 	}
 
-	if meta := kvflowcontrol.MetaFromContext(ctx); meta != nil {
-		proposal.raftAdmissionMeta = meta
-	}
+	proposal.raftAdmissionMeta = admissionInfo.RaftAdmissionMeta
 
 	// Attach information about the proposer's lease to the command, for
 	// verification below raft. Lease requests are special since they are not

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -46,6 +46,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/constraint"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvadmission"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/leases"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
@@ -676,7 +677,8 @@ func (p *pendingLeaseRequest) requestLease(
 		CreateTime: timeutil.Now().UnixNano(),
 		Source:     kvpb.AdmissionHeader_OTHER,
 	}
-	_, writeBytes, pErr := p.repl.SendWithWriteBytes(ctx, ba)
+	// Pass empty AdmissionInfo since lease acquisition bypasses admission control.
+	_, writeBytes, pErr := p.repl.SendWithWriteBytes(ctx, ba, kvadmission.AdmissionInfo{})
 	writeBytes.Release()
 	return pErr.GoError()
 }

--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -39,7 +39,7 @@ import (
 // iterator to evaluate the batch and then updates the timestamp cache to
 // reflect the key spans that it read.
 func (r *Replica) executeReadOnlyBatch(
-	ctx context.Context, ba *kvpb.BatchRequest, g *concurrency.Guard,
+	ctx context.Context, ba *kvpb.BatchRequest, g *concurrency.Guard, _ kvadmission.AdmissionInfo,
 ) (
 	br *kvpb.BatchResponse,
 	_ *concurrency.Guard,

--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -74,7 +74,10 @@ var migrateApplicationTimeout = settings.RegisterDurationSetting(
 // as this method makes the assumption that it operates on a shallow copy (see
 // call to applyTimestampCache).
 func (r *Replica) executeWriteBatch(
-	ctx context.Context, ba *kvpb.BatchRequest, g *concurrency.Guard,
+	ctx context.Context,
+	ba *kvpb.BatchRequest,
+	g *concurrency.Guard,
+	admissionInfo kvadmission.AdmissionInfo,
 ) (
 	br *kvpb.BatchResponse,
 	_ *concurrency.Guard,
@@ -184,7 +187,7 @@ func (r *Replica) executeWriteBatch(
 	// the concurrency guard will be assumed by Raft, so provide the guard to
 	// evalAndPropose. If we return with an error from executeWriteBatch, we
 	// also return the guard which the caller reassumes ownership of.
-	ch, abandonTok, _, writeBytes, pErr := r.evalAndPropose(ctx, ba, g, &st, ui, tok.Move(ctx))
+	ch, abandonTok, _, writeBytes, pErr := r.evalAndPropose(ctx, ba, g, &st, ui, tok.Move(ctx), admissionInfo)
 	if pErr != nil {
 		if cErr, ok := pErr.GetDetail().(*kvpb.ReplicaCorruptionError); ok {
 			// Need to unlock here because setCorruptRaftMuLock needs readOnlyCmdMu not held.

--- a/pkg/kv/kvserver/stores.go
+++ b/pkg/kv/kvserver/stores.go
@@ -178,7 +178,7 @@ func (ls *Stores) GetReplicaForRangeID(
 // SendWithWriteBytes sends a batch request. The store is looked up from the
 // store map using the ID specified in the request.
 func (ls *Stores) SendWithWriteBytes(
-	ctx context.Context, ba *kvpb.BatchRequest,
+	ctx context.Context, ba *kvpb.BatchRequest, admissionInfo kvadmission.AdmissionInfo,
 ) (*kvpb.BatchResponse, *kvadmission.StoreWriteBytes, *kvpb.Error) {
 	if err := ba.ValidateForEvaluation(); err != nil {
 		return nil, nil, kvpb.NewError(errors.Wrapf(err, "invalid batch (%s)", ba))
@@ -189,7 +189,7 @@ func (ls *Stores) SendWithWriteBytes(
 		return nil, nil, kvpb.NewError(err)
 	}
 
-	br, writeBytes, pErr := store.SendWithWriteBytes(ctx, ba)
+	br, writeBytes, pErr := store.SendWithWriteBytes(ctx, ba, admissionInfo)
 	if br != nil && br.Error != nil {
 		panic(kvpb.ErrorUnexpectedlySet(store, br))
 	}

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1640,7 +1640,12 @@ func (n *Node) batchInternal(
 	if err != nil {
 		return nil, err
 	}
+	// AnnotateCtx embeds ElasticCPUWorkHandle in the context for use deep in
+	// the storage layer (e.g., mvccExportToWriter).
 	ctx = handle.AnnotateCtx(ctx)
+	// AdmissionInfo is passed explicitly through the call chain to evalAndPropose
+	// for replication flow control.
+	admissionInfo := handle.AdmissionInfo()
 
 	var writeBytes *kvadmission.StoreWriteBytes
 	defer func() {
@@ -1665,7 +1670,7 @@ func (n *Node) batchInternal(
 		originalRequest = args.ShallowCopy()
 	}
 	var pErr *kvpb.Error
-	br, writeBytes, pErr = n.stores.SendWithWriteBytes(ctx, args)
+	br, writeBytes, pErr = n.stores.SendWithWriteBytes(ctx, args, admissionInfo)
 	if pErr != nil {
 		if originalRequest != nil {
 			if proxyResponse := n.maybeProxyRequest(ctx, originalRequest, pErr); proxyResponse != nil {


### PR DESCRIPTION
…f context

Previously, RaftAdmissionMeta was stored in the context via kvflowcontrol.ContextWithMeta and retrieved in evalAndPropose via kvflowcontrol.MetaFromContext. This pattern was indirect, and needlessly used a slot in the fastValuesCtx.

This change introduces an AdmissionInfo struct in the kvadmission package that is passed by value through the call chain from Node.batchInternal down to evalAndPropose. The struct currently contains only RaftAdmissionMeta but is designed to be extensible for future admission control metadata.

The call chain now explicitly passes AdmissionInfo through:
  Node.batchInternal
  → Stores.SendWithWriteBytes
  → Store.SendWithWriteBytes
  → Replica.SendWithWriteBytes
  → executeBatchWithConcurrencyRetries
  → executeWriteBatch
  → evalAndPropose

This provides:
- Clear, traceable data flow through explicit parameters
- Type-safe access to admission control metadata
- Extensibility for future admission control needs

The ElasticCPUWorkHandle continues to use context propagation since it is accessed deep in the storage layer (e.g., mvccExportToWriter) where explicit parameter passing would require more extensive API changes.

Release note: None

Epic: None