### PR TITLE
bench: enable DRPC testing randomly

### DIFF
--- a/pkg/bench/main_test.go
+++ b/pkg/bench/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -20,7 +21,8 @@ import (
 func TestMain(m *testing.M) {
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
 	randutil.SeedForTests()
-	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestServerFactory(server.TestServerFactory,
+		serverutils.WithDRPCOption(base.TestDRPCEnabledRandomly))
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
 	os.Exit(m.Run())
 }

--- a/pkg/bench/tpcc/main_test.go
+++ b/pkg/bench/tpcc/main_test.go
@@ -19,7 +19,8 @@ import (
 
 func TestMain(m *testing.M) {
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
-	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestServerFactory(server.TestServerFactory,
+		serverutils.WithDRPCOption(base.TestDRPCEnabledRandomly))
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
 
 	defer serverutils.TestingSetDefaultTenantSelectionOverride(


### PR DESCRIPTION
Before this change, bench packages lacked DRPC test coverage,
creating a gap in testing for DRPC functionality in benchmark tests.

This commit enables DRPC testing randomly for pkg/bench and
pkg/bench/tpcc by adding the WithDRPCOption(base.TestDRPCEnabledRandomly)
configuration to their TestServerFactory initialization in main_test.go.
This ensures that benchmark tests run with DRPC enabled randomly,
providing better test coverage for the DRPC implementation.

All tests pass with DRPC enabled across all three tenant configurations
(external, shared, system), requiring no test-level DRPC disabling.

Fixes: #162160
Epic: CRDB-55382

Release note: None