### PR TITLE
cli: enable DRPC testing randomly

### DIFF
--- a/pkg/cli/clierror/BUILD.bazel
+++ b/pkg/cli/clierror/BUILD.bazel
@@ -32,6 +32,7 @@ go_test(
     ],
     embed = [":clierror"],
     deps = [
+        "//pkg/base",
         "//pkg/build",
         "//pkg/cli",
         "//pkg/cli/clisqlclient",

--- a/pkg/cli/clierror/main_test.go
+++ b/pkg/cli/clierror/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -19,7 +20,8 @@ func TestMain(m *testing.M) {
 	// a version injected. Pretend to be a very up-to-date version.
 	defer build.TestingOverrideVersion("v999.0.0")()
 
-	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestServerFactory(server.TestServerFactory,
+		serverutils.WithDRPCOption(base.TestDRPCEnabledRandomly))
 	os.Exit(m.Run())
 }
 

--- a/pkg/cli/clisqlclient/BUILD.bazel
+++ b/pkg/cli/clisqlclient/BUILD.bazel
@@ -48,6 +48,7 @@ go_test(
     ],
     embed = [":clisqlclient"],
     deps = [
+        "//pkg/base",
         "//pkg/build",
         "//pkg/cli",
         "//pkg/security/username",

--- a/pkg/cli/clisqlclient/main_test.go
+++ b/pkg/cli/clisqlclient/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -19,7 +20,8 @@ func TestMain(m *testing.M) {
 	// a version injected. Pretend to be a very up-to-date version.
 	defer build.TestingOverrideVersion("v999.0.0")()
 
-	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestServerFactory(server.TestServerFactory,
+		serverutils.WithDRPCOption(base.TestDRPCEnabledRandomly))
 	os.Exit(m.Run())
 }
 

--- a/pkg/cli/clisqlexec/BUILD.bazel
+++ b/pkg/cli/clisqlexec/BUILD.bazel
@@ -47,6 +47,7 @@ go_test(
     ],
     embed = [":clisqlexec"],
     deps = [
+        "//pkg/base",
         "//pkg/build",
         "//pkg/cli",
         "//pkg/cli/clisqlclient",

--- a/pkg/cli/clisqlexec/main_test.go
+++ b/pkg/cli/clisqlexec/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -19,7 +20,8 @@ func TestMain(m *testing.M) {
 	// a version injected. Pretend to be a very up-to-date version.
 	defer build.TestingOverrideVersion("v999.0.0")()
 
-	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestServerFactory(server.TestServerFactory,
+		serverutils.WithDRPCOption(base.TestDRPCEnabledRandomly))
 	os.Exit(m.Run())
 }
 

--- a/pkg/cli/clisqlshell/main_test.go
+++ b/pkg/cli/clisqlshell/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
@@ -25,7 +26,8 @@ func TestMain(m *testing.M) {
 	// a version injected. Pretend to be a very up-to-date version.
 	defer build.TestingOverrideVersion("v999.0.0")()
 
-	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestServerFactory(server.TestServerFactory,
+		serverutils.WithDRPCOption(base.TestDRPCEnabledRandomly))
 	os.Exit(m.Run())
 }
 

--- a/pkg/cli/main_test.go
+++ b/pkg/cli/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvtenant"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
@@ -30,7 +31,8 @@ func TestMain(m *testing.M) {
 	// CLI tests are sensitive to the server version, but test binaries don't have
 	// a version injected. Pretend to be a very up-to-date version.
 	defer build.TestingOverrideVersion("v999.0.0")()
-	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestServerFactory(server.TestServerFactory,
+		serverutils.WithDRPCOption(base.TestDRPCEnabledRandomly))
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
 	kvtenant.InitTestConnectorFactory()
 	os.Exit(m.Run())


### PR DESCRIPTION
Before this change, CLI packages lacked DRPC test coverage,
creating a gap in testing for DRPC functionality in CLI tests.

This commit enables DRPC testing randomly for `pkg/cli` and its
subpackages (`clisqlexec`, `clisqlshell`, `clierror`, `clisqlclient`)
by adding the `WithDRPCOption(base.TestDRPCEnabledRandomly)`
configuration to their `TestServerFactory` initialization in
`main_test.go`. This ensures that CLI tests run with DRPC enabled
randomly, providing better test coverage for the DRPC implementation.

Fixes: #162161
Epic: CRDB-55382

Release note: None