### PR TITLE
cloud: enable DRPC testing randomly

### DIFF
--- a/pkg/cloud/userfile/filetable/filetabletest/main_test.go
+++ b/pkg/cloud/userfile/filetable/filetabletest/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -21,6 +22,7 @@ import (
 func TestMain(m *testing.M) {
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
 	randutil.SeedForTests()
-	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestServerFactory(server.TestServerFactory,
+		serverutils.WithDRPCOption(base.TestDRPCEnabledRandomly))
 	os.Exit(m.Run())
 }

--- a/pkg/cloud/userfile/main_test.go
+++ b/pkg/cloud/userfile/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -21,6 +22,7 @@ import (
 func TestMain(m *testing.M) {
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
 	randutil.SeedForTests()
-	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestServerFactory(server.TestServerFactory,
+		serverutils.WithDRPCOption(base.TestDRPCEnabledRandomly))
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
Before this change, cloud packages lacked DRPC test coverage,
creating a gap in testing for DRPC functionality in cloud tests.

This commit enables DRPC testing randomly for `pkg/cloud/userfile/filetable/filetabletest`,
 and `pkg/cloud/userfile` by adding the `WithDRPCOption(base.TestDRPCEnabledRandomly)` 
configuration to their `TestServerFactory` initialization in `main_test.go`. This ensures
that cloud tests run with DRPC enabled randomly, providing better test
coverage for the DRPC implementation.

Fixes: #162162
Epic: CRDB-55382

Release note: None