### PR TITLE
reduce: enable DRPC testing randomly

### DIFF
--- a/pkg/cmd/reduce/reduce/reducesql/main_test.go
+++ b/pkg/cmd/reduce/reduce/reducesql/main_test.go
@@ -9,12 +9,14 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 )
 
 func TestMain(m *testing.M) {
-	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestServerFactory(server.TestServerFactory,
+		serverutils.WithDRPCOption(base.TestDRPCEnabledRandomly))
 	code := m.Run()
 	os.Exit(code)
 }


### PR DESCRIPTION
Before this change, the reduce package lacked DRPC test coverage,
creating a gap in testing for DRPC functionality.

This commit enables DRPC testing randomly for `pkg/cmd/reduce/reduce/reducesql`
by adding the `WithDRPCOption(base.TestDRPCEnabledRandomly)` configuration
to the `TestServerFactory` initialization in `main_test.go`.

Fixes: #162163
Epic: CRDB-55382

Release note: None