### PR TITLE
sqlsmith: enable DRPC testing randomly

### DIFF
--- a/pkg/internal/sqlsmith/main_test.go
+++ b/pkg/internal/sqlsmith/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
@@ -23,7 +24,8 @@ import (
 func TestMain(m *testing.M) {
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
 	randutil.SeedForTests()
-	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestServerFactory(server.TestServerFactory,
+		serverutils.WithDRPCOption(base.TestDRPCEnabledRandomly))
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
 	defer ccl.TestingEnableEnterprise()() // allow usage of partitions
 	os.Exit(m.Run())


### PR DESCRIPTION
Before this change, the sqlsmith package lacked DRPC test coverage,
creating a gap in testing for DRPC functionality.

This commit enables DRPC testing randomly for `pkg/internal/sqlsmith`
by adding the `WithDRPCOption(base.TestDRPCEnabledRandomly)` configuration
to the `TestServerFactory` initialization in `main_test.go`.

Fixes: #162164
Epic: CRDB-55382

Release note: None