### PR TITLE
storage: use package-level random source in race builds

### DIFF
--- a/pkg/storage/intent_interleaving_iter.go
+++ b/pkg/storage/intent_interleaving_iter.go
@@ -1484,10 +1484,17 @@ type unsafeMVCCIterator struct {
 	rawMVCCKeyBuf []byte
 }
 
+var rng *rand.Rand
+
+func init() {
+	if util.RaceEnabled {
+		rng, _ = randutil.NewLockedPseudoRand()
+	}
+}
+
 // gcassert:inline
 func maybeWrapInUnsafeIter(iter MVCCIterator) MVCCIterator {
 	if util.RaceEnabled {
-		rng, _ := randutil.NewPseudoRand()
 		return &unsafeMVCCIterator{MVCCIterator: iter, rng: rng}
 	}
 	return iter

--- a/pkg/storage/pebbleiter/crdb_test_on.go
+++ b/pkg/storage/pebbleiter/crdb_test_on.go
@@ -24,10 +24,15 @@ import (
 // twice, allowing concurrent use of the same iterator struct.
 type Iterator = *assertionIter
 
+var rng *rand.Rand
+
+func init() {
+	rng, _ = randutil.NewLockedPseudoRand()
+}
+
 // MaybeWrap returns the provided Pebble iterator, wrapped with double close
 // detection.
 func MaybeWrap(iter *pebble.Iterator) Iterator {
-	rng, _ := randutil.NewPseudoRand()
 	return &assertionIter{Iterator: iter, rng: rng, closedCh: make(chan struct{})}
 }
 


### PR DESCRIPTION
When investigating an OOM during a race-test, I was surprised to find 40% of the allocations during the test coming from allocating rand.Rand's. I don't think this was the cause of the OOM because it is unlikely they were leaking, but it does make for some confusing memory profiles.

Epic: none
Release note: None