### PR TITLE
server/license: enable DRPC testing randomly

### DIFF
--- a/pkg/server/license/main_test.go
+++ b/pkg/server/license/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -18,7 +19,8 @@ import (
 
 func TestMain(m *testing.M) {
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
-	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestServerFactory(server.TestServerFactory,
+		serverutils.WithDRPCOption(base.TestDRPCEnabledRandomly))
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
Before this change, the server/license package lacked DRPC test
coverage, creating a gap in testing for DRPC functionality.

This commit enables DRPC testing randomly for `pkg/server/license`
by adding the `WithDRPCOption(base.TestDRPCEnabledRandomly)` configuration
to the `TestServerFactory` initialization in `main_test.go`.

Fixes: #162166
Epic: CRDB-55382

Release note: None