### PR TITLE
roachtest: skip post run validation in distributed merge scale tests

### DIFF
--- a/pkg/cmd/roachtest/tests/schemachange.go
+++ b/pkg/cmd/roachtest/tests/schemachange.go
@@ -740,14 +740,15 @@ func makeSchemaChangeBulkIngestScaleTest(
 	}
 
 	return registry.TestSpec{
-		Name:             name,
-		Owner:            registry.OwnerSQLFoundations,
-		Benchmark:        true,
-		Cluster:          r.MakeClusterSpec(numNodes, clusterOpts...),
-		CompatibleClouds: compatibleClouds,
-		Suites:           registry.ManualOnly, // Manual-only for investigation
-		Leases:           registry.LeaderLeases,
-		Timeout:          timeout,
+		Name:                name,
+		Owner:               registry.OwnerSQLFoundations,
+		Benchmark:           true,
+		Cluster:             r.MakeClusterSpec(numNodes, clusterOpts...),
+		CompatibleClouds:    compatibleClouds,
+		Suites:              registry.ManualOnly, // Manual-only for investigation
+		Leases:              registry.LeaderLeases,
+		Timeout:             timeout,
+		SkipPostValidations: registry.PostValidationAll,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runBulkIngestScaleTest(ctx, t, c, numRows, distributedMerge, disks, order, disk)
 		},


### PR DESCRIPTION
Previously, roachtest performed a full cluster validation after distributed merge scale tests completed, adding roughly 10 minutes to each run.

Distributed merge already performs its own validation during index backfill, so the additional post test validation is redundant for these tests. Skipping it to reduce test runtime.

Informs: #161866
Epic: CRDB-48845
Release note: none