### PR TITLE
backup: add support for `WITH STRICT STORAGE LOCALITY` to locality-aware backup compactions.

### DIFF
--- a/pkg/backup/backup_processor.go
+++ b/pkg/backup/backup_processor.go
@@ -725,10 +725,16 @@ func selectLocalityMatchingURI(
 		}
 		if localitySinkURI != "" {
 			destURI = localitySinkURI
-			log.Dev.Infof(ctx, "processor backing up to destination URI %s with locality %s", destURI, destLocalityKV)
+			log.Dev.Infof(ctx,
+				"processor backing up to destination URI %s with locality %s",
+				destURI, destLocalityKV,
+			)
 		} else if strict {
 			// This shouldn't happen unless there was a bug in distsql planning.
-			return "", "", errors.Errorf("sql processor locality %s does not match any of the backup localities %v: cannot proceed with strict locality", processorLocality, urisByLocalityKV)
+			return "", "", errors.Errorf(
+				"sql processor locality %s does not match any of the backup localities %v: cannot proceed with strict locality",
+				processorLocality, urisByLocalityKV,
+			)
 		}
 	}
 

--- a/pkg/backup/compaction_dist.go
+++ b/pkg/backup/compaction_dist.go
@@ -180,7 +180,9 @@ func createCompactionPlan(
 		}
 		instanceLocalities[i] = desc.Locality
 	}
-	localitySets, err := buildLocalitySets(ctx, instanceIDs, instanceLocalities, genSpan)
+	localitySets, err := buildLocalitySets(
+		ctx, instanceIDs, instanceLocalities, details.StrictLocalityFiltering, genSpan,
+	)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "building locality sets")
 	}
@@ -241,16 +243,17 @@ func (set *localitySet) maybeUpdateTargetInstance() {
 // If there is no data in the default URI to compact, the default set will not be in the returned map.
 //
 // If any of our sets (including the default set) has a locality which does not match any
-// available nodes, we assign all available nodes to that set. In that case, compactions may
-// output data to a different URI than they recieved it from. This is an edge case that would occur
-// if the cluster topology has changed between backup time and compaction time such that all nodes
-// matching one of our URIs become unavailable (for example, a region going down).
-//
-// TODO(at): update comment with implications for strict
+// available nodes, this function has two behaviors, depending on whether strict is set.
+// If strict is true, this function will return an error. If strict is false, we fall back to
+// assigning all available nodes. In that case, compactions may output data to a different URI
+// than they recieved it from. This is an edge case that would occur if the cluster topology has
+// changed between backup time and compaction time such that all nodes matching one of our URIs
+// become unavailable (for example, a region going down).
 func buildLocalitySets(
 	ctx context.Context,
 	instanceIDs []base.SQLInstanceID,
 	instanceLocalities []roachpb.Locality,
+	strict bool,
 	genSpan func(ctx context.Context, spanCh chan execinfrapb.RestoreSpanEntry) error,
 ) (map[string]*localitySet, error) {
 	localitySets := make(map[string]*localitySet)
@@ -263,6 +266,10 @@ func buildLocalitySets(
 				if err != nil {
 					return err
 				}
+				if locality == "" {
+					locality = "default"
+				}
+
 				if set, ok := localitySets[locality]; ok {
 					set.totalEntries += 1
 				} else {
@@ -311,12 +318,16 @@ func buildLocalitySets(
 		}
 	}
 
-	for _, set := range localitySets {
+	for setLocality, set := range localitySets {
 		if len(set.instanceIDs) == 0 {
+			if strict {
+				return nil, errors.Newf(
+					"no nodes available for processing data from locality %s in strict locality-aware compaction",
+					setLocality,
+				)
+			}
 			// In a non-strict setting, if we don't have any nodes available that match the locality
 			// filter, we just evenly distribute the work across all available nodes.
-			//
-			// TODO(at): add WITH STRICT STORAGE LOCALITY support
 			set.instanceIDs = instanceIDs
 		}
 		slices.Sort(set.instanceIDs)
@@ -358,6 +369,9 @@ func createCompactionCorePlacements(
 			if err != nil {
 				return err
 			}
+			if entryLocality == "" {
+				entryLocality = "default"
+			}
 
 			set, ok := localitySets[entryLocality]
 			if !ok {
@@ -393,6 +407,7 @@ func createCompactionCorePlacements(
 					TargetSize:       targetSize,
 					MaxFiles:         maxFiles,
 					URIsByLocalityKV: details.URIsByLocalityKV,
+					StrictLocality:   details.StrictLocalityFiltering,
 					AssignedSpans:    entries.Slice(),
 				}}})
 	}
@@ -401,7 +416,7 @@ func createCompactionCorePlacements(
 }
 
 // entryLocality returns the locality filter string attached to the URI of the most recent file in
-// the entry. If the URI does not have a locality filter attached to it, it will return "default".
+// the entry. If the URI does not have a locality filter attached to it, it will return an empty string.
 func entryLocality(entry execinfrapb.RestoreSpanEntry) (string, error) {
 	if len(entry.Files) == 0 {
 		return "", errors.AssertionFailedf("restore span entry has no files")
@@ -411,13 +426,7 @@ func entryLocality(entry execinfrapb.RestoreSpanEntry) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	loc := uri.Query().Get("COCKROACH_LOCALITY")
-	switch loc {
-	case "", "default":
-		return "default", nil
-	default:
-		return loc, nil
-	}
+	return uri.Query().Get("COCKROACH_LOCALITY"), nil
 }
 
 // getSpansToCompact returns all remaining spans the backup manifest that

--- a/pkg/backup/compaction_processor.go
+++ b/pkg/backup/compaction_processor.go
@@ -210,8 +210,7 @@ func (p *compactBackupsProcessor) runCompactBackups(ctx context.Context) error {
 
 	destURI, destLocalityKV, err := selectLocalityMatchingURI(
 		ctx, p.spec.DefaultURI, p.spec.URIsByLocalityKV,
-		// TODO(at): replace with spec field when strict is implemented
-		false, /* strict */
+		p.spec.StrictLocality,
 		p.FlowCtx.EvalCtx.Locality,
 	)
 	if err != nil {
@@ -288,10 +287,15 @@ func (p *compactBackupsProcessor) processSpanEntries(
 				continue
 			}
 
-			// TODO(at): assertion fail if this doesn't match the processor and strict is set
 			entryLocality, err := entryLocality(entry)
 			if err != nil {
 				return errors.Wrap(err, "finding entry locality")
+			}
+			if entryLocality != destLocality && p.spec.StrictLocality {
+				return errors.Newf(
+					"entry locality %s does not match destination locality %s in strict locality-aware compaction",
+					entryLocality, destLocality,
+				)
 			}
 			if backupKnobs, ok := p.FlowCtx.TestingKnobs().BackupRestoreTestingKnobs.(*sql.BackupRestoreTestingKnobs); ok {
 				if backupKnobs.OnCompactionFileAccess != nil && *backupKnobs.OnCompactionFileAccess != nil {

--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -608,8 +608,8 @@ message CompactBackupsSpec {
 	optional int64 target_size = 11 [(gogoproto.nullable) = false];
 	optional int64 max_files = 12 [(gogoproto.nullable) = false];
   map<string, string> uris_by_locality_kv = 13 [(gogoproto.customname) = "URIsByLocalityKV"];
-
-	// NEXT ID: 14.
+  optional bool strict_locality = 14 [(gogoproto.nullable) = false];
+	// NEXT ID: 15.
 }
 
 message BulkMergeSpec {


### PR DESCRIPTION
Previously, strict locality-aware backup compactions were not supported. This patch adds this support by introducing an error when the option is set when the processing distribution would otherwise fallback to even assignment.

Fixes: #162049

Release note: None