### PR TITLE
release-25.4: roachprod: use npm to install pnpm in cypress image

### DIFF
--- a/pkg/cmd/roachtest/tests/db-console/Dockerfile
+++ b/pkg/cmd/roachtest/tests/db-console/Dockerfile
@@ -1,8 +1,6 @@
 FROM cypress/included:13.13.2
 
-RUN apt-get -y update
-RUN apt-get -y install curl
-RUN curl -fsSL https://get.pnpm.io/install.sh | env SHELL=bash PNPM_HOME=/usr/local/bin PNPM_VERSION=8.6.11 sh -
+RUN npm install -g pnpm@8.6.11
 RUN mkdir /e2e
 COPY . /e2e
 WORKDIR /e2e


### PR DESCRIPTION
Backport 1/1 commits from #159282 on behalf of @dhartunian.

----

Running `apt-get update` on fips does not succeed because of libgcrypt's use of MD5.

Resolves: #159241
Epic: None
Release note: None

----

Release justification: build-only change to reduce test flakes