### PR TITLE
github: add inline comments to AI PR review workflow

### DIFF
--- a/.github/workflows/pr-analyzer-threestage.yml
+++ b/.github/workflows/pr-analyzer-threestage.yml
@@ -191,7 +191,7 @@ jobs:
             2. 'NO_BUG_DETECTED' if issues are not critical enough
 
             For each issue found, provide:
-            1. The specific line(s) where the issue occurs
+            1. The specific file and line(s) where the issue occurs
             2. A clear description of what is wrong
             3. A suggested fix
 
@@ -217,16 +217,19 @@ jobs:
         env:
           ANTHROPIC_VERTEX_PROJECT_ID: vertex-model-runners
           CLOUD_ML_REGION: global
+          PR_NUM: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           allowed_non_write_users: "*"
           use_vertex: "true"
           claude_args: |
             --model claude-opus-4-5@20251101
-            --allowedTools "Read,Grep,Glob,Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "Read,Grep,Glob,Bash(gh pr diff:*),Bash(gh pr view:*),mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr edit:*)"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
+            RUN URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
             ## Three-Stage Analysis Summary
 
@@ -246,24 +249,29 @@ jobs:
             2. The final determination (critical bug found or no critical bugs)
             3. If bugs were found, what actions are recommended
 
-            **If all three stages detected bugs**, this indicates a potential issue that warrants investigation.
+            ## Actions
 
-      - name: Comment on PR if bugs confirmed
-        if: contains(steps.stage3_result.outputs.result, 'STAGE3_RESULT - POTENTIAL_BUG_CONFIRMED')
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh pr comment ${{ github.event.pull_request.number }} --body "## Potential Bug(s) Detected
+            ### If Stage 3 confirmed bugs (STAGE3_RESULT - POTENTIAL_BUG_CONFIRMED):
 
-          The three-stage Claude Code analysis has identified potential bug(s) in this PR that may warrant investigation.
+            1. For each specific bug identified in the Stage 3 results, use
+               mcp__github_inline_comment__create_inline_comment to post a concise inline
+               comment on the exact file and line where the issue occurs. Each comment should
+               state the issue and suggest a fix in 2-3 sentences.
 
-          **Next Steps:**
-          Please review the detailed findings in the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+            2. Post a summary PR comment using:
+               gh pr comment $PR_NUM --body "<body>"
 
-          **Note:** When viewing the workflow output, scroll to the bottom to find the Final Analysis Summary.
+               The summary body should contain:
+               - A heading: "## AI Review: Potential Issue(s) Detected"
+               - A note that inline comments have been added to the relevant lines
+               - A link: [View full analysis]($RUN_URL)
+               - Feedback instructions:
+                 "If helpful: add `O-AI-Review-Real-Issue-Found` label.
+                  If not helpful: add `O-AI-Review-Not-Helpful` label."
 
-          After you review the findings, please tag the issue as follows:
-          - If the detected issue is real or was helpful in any way, please tag the issue with \`O-AI-Review-Real-Issue-Found\`
-          - If the detected issue was not helpful in any way, please tag the issue with \`O-AI-Review-Not-Helpful\`"
+            3. Add a label to the PR:
+               gh pr edit $PR_NUM --add-label "o-AI-Review-Potential-Issue-Detected"
 
-          gh pr edit ${{ github.event.pull_request.number }} --add-label "o-AI-Review-Potential-Issue-Detected"
+            ### If no bugs were confirmed:
+
+            Provide a brief textual summary only. Do NOT post any PR comments or labels.


### PR DESCRIPTION
## Summary

When the three-stage review confirms bugs, post inline comments directly on the
affected lines of code using the `mcp__github_inline_comment__create_inline_comment`
MCP tool from `claude-code-action`, instead of posting a single summary comment
that directs the reader to the workflow logs.

## Changes

The Final Analysis Report step now handles all PR-facing output:
1. Posts inline comments on specific code lines where bugs were found
2. Posts a summary PR comment with a link to the full analysis
3. Applies the `o-AI-Review-Potential-Issue-Detected` label

This replaces the previous "Comment on PR if bugs confirmed" bash step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)