### PR TITLE
sql/backfill: add phased progress tracking for distributed merge

### DIFF
--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -898,6 +898,14 @@ message BackfillProgress {
   //   0: Map phase complete, no merge iterations completed yet.
   //   N (N >= 1): Merge iteration N completed.
   int32 distributed_merge_phase = 8;
+
+  // MergeIterationTasksTotal is the total number of tasks in the current merge
+  // iteration. Used for progress calculation.
+  int64 merge_iteration_tasks_total = 9;
+
+  // MergeIterationCompletedTasks contains the task IDs that have been
+  // completed in the current merge iteration.
+  repeated int64 merge_iteration_completed_tasks = 10;
 }
 
 // IndexBackfillSSTManifest describes an SST produced by the backfill map stage.

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -63,6 +63,16 @@ var IndexBackfillCheckpointInterval = settings.RegisterDurationSetting(
 	30*time.Second,
 )
 
+// IndexBackfillProgressInterval is the duration between backfill progress
+// fraction updates. This is distinct from the checkpoint interval which
+// controls how often the backfill progress details are persisted.
+var IndexBackfillProgressInterval = settings.RegisterDurationSetting(
+	settings.ApplicationLevel,
+	"bulkio.index_backfill.progress_interval",
+	"the amount of time between index backfill progress fraction updates",
+	10*time.Second,
+)
+
 // MutationFilter is the type of a simple predicate on a mutation.
 type MutationFilter func(catalog.Mutation) bool
 

--- a/pkg/sql/bulk_bridge.go
+++ b/pkg/sql/bulk_bridge.go
@@ -25,6 +25,7 @@ type bulkMergeFunc func(
 	maxIterations int,
 	writeTimestamp *hlc.Timestamp,
 	enforceUniqueness bool,
+	onProgress func(context.Context, *execinfrapb.ProducerMetadata) error,
 ) ([]execinfrapb.BulkMergeSpec_SST, error)
 
 var registeredBulkMerge bulkMergeFunc
@@ -45,6 +46,7 @@ func invokeBulkMerge(
 	maxIterations int,
 	writeTimestamp *hlc.Timestamp,
 	enforceUniqueness bool,
+	onProgress func(context.Context, *execinfrapb.ProducerMetadata) error,
 ) ([]execinfrapb.BulkMergeSpec_SST, error) {
 	if registeredBulkMerge == nil {
 		return nil, errors.AssertionFailedf("bulk merge implementation not registered")
@@ -52,5 +54,6 @@ func invokeBulkMerge(
 	return registeredBulkMerge(
 		ctx, execCtx, ssts, spans, genOutputURIAndRecordPrefix,
 		iteration, maxIterations, writeTimestamp, enforceUniqueness,
+		onProgress,
 	)
 }

--- a/pkg/sql/bulkmerge/BUILD.bazel
+++ b/pkg/sql/bulkmerge/BUILD.bazel
@@ -46,6 +46,7 @@ go_library(
         "//pkg/util/taskset",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_pebble//objstorage",
+        "@com_github_gogo_protobuf//types",
     ],
 )
 

--- a/pkg/sql/bulkmerge/merge.go
+++ b/pkg/sql/bulkmerge/merge.go
@@ -142,21 +142,24 @@ func makeMergeReceiver(
 }
 
 // logMergeInputs logs the input SSTs for the current merge iteration.
-// All logging is opt-in via log.V(2) for detailed iteration tracking.
+// The main iteration message is always logged; detailed per-SST logging
+// is opt-in via log.V(2).
 func logMergeInputs(
 	ctx context.Context, ssts []execinfrapb.BulkMergeSpec_SST, iteration int, maxIterations int,
 ) {
-	// All iteration logging is verbose (opt-in).
-	if !log.V(2) {
-		return
-	}
-
 	iterType := "local"
 	if iteration == maxIterations {
 		iterType = "final"
 	}
-	log.Dev.Infof(ctx, "Distributed merge iteration %d (%s) starting with %d input SSTs",
-		iteration, iterType, len(ssts))
+
+	// Always log the phase transition.
+	log.Dev.Infof(ctx, "distributed merge: starting iteration %d of %d (%s) with %d input SSTs",
+		iteration, maxIterations, iterType, len(ssts))
+
+	// Detailed per-SST logging is verbose (opt-in).
+	if !log.V(2) {
+		return
+	}
 
 	var totalInputKeys uint64
 	for i, sst := range ssts {
@@ -164,7 +167,7 @@ func logMergeInputs(
 		log.Dev.Infof(ctx, "  input SST[%d]: %d keys, span=[%s, %s), uri=%s",
 			i, sst.KeyCount, sst.StartKey, sst.EndKey, sst.URI)
 	}
-	log.Dev.Infof(ctx, "  Total input keys: %d", totalInputKeys)
+	log.Dev.Infof(ctx, "  total input keys: %d", totalInputKeys)
 }
 
 func init() {

--- a/pkg/sql/bulkmerge/merge_coordinator.go
+++ b/pkg/sql/bulkmerge/merge_coordinator.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/taskset"
 	"github.com/cockroachdb/errors"
+	pbtypes "github.com/gogo/protobuf/types"
 )
 
 var (
@@ -43,6 +44,10 @@ type mergeCoordinator struct {
 
 	done    bool
 	results execinfrapb.BulkMergeSpec_Output
+
+	// output is the receiver to push progress metadata to. It is captured
+	// from Run() so that handleRow() can send progress updates.
+	output execinfra.RowReceiver
 }
 
 type mergeCoordinatorInput struct {
@@ -154,7 +159,7 @@ func (m *mergeCoordinator) closeLoopback() {
 }
 
 // handleRow accepts a row output by the merge processor, marks its task as
-// complete
+// complete, and pushes progress metadata to track task completion.
 func (m *mergeCoordinator) handleRow(row rowenc.EncDatumRow) error {
 	input, err := parseCoordinatorInput(row)
 	if err != nil {
@@ -162,6 +167,23 @@ func (m *mergeCoordinator) handleRow(row rowenc.EncDatumRow) error {
 	}
 
 	m.results.SSTs = append(m.results.SSTs, input.outputSSTs...)
+
+	// Push progress metadata to report task completion.
+	if m.output != nil {
+		progress := &execinfrapb.MergeIterationProgress{
+			CompletedTaskID: int64(input.taskID),
+			TasksTotal:      m.spec.TaskCount,
+		}
+		progressAny, err := pbtypes.MarshalAny(progress)
+		if err != nil {
+			return errors.Wrap(err, "unable to marshal merge iteration progress")
+		}
+		_ = m.output.Push(nil, &execinfrapb.ProducerMetadata{
+			BulkProcessorProgress: &execinfrapb.RemoteProducerMetadata_BulkProcessorProgress{
+				ProgressDetails: *progressAny,
+			},
+		})
+	}
 
 	next := m.tasks.ClaimNext(input.taskID)
 	if next.IsDone() {
@@ -182,6 +204,13 @@ func (m *mergeCoordinator) Start(ctx context.Context) {
 	m.StartInternal(ctx, "mergeCoordinator")
 	m.input.Start(ctx)
 	m.publishInitialTasks()
+}
+
+// Run implements execinfra.Processor. It captures the output receiver so that
+// handleRow can push progress metadata, then delegates to the base processor.
+func (m *mergeCoordinator) Run(ctx context.Context, output execinfra.RowReceiver) {
+	m.output = output
+	m.ProcessorBase.Run(ctx, output)
 }
 
 func init() {

--- a/pkg/sql/execinfrapb/data.proto
+++ b/pkg/sql/execinfrapb/data.proto
@@ -377,6 +377,15 @@ message RemoteProducerMetadata {
   // NEXT ID: 13
 }
 
+// MergeIterationProgress reports task completion progress during distributed
+// merge iterations. This message is passed via BulkProcessorProgress.progress_details.
+message MergeIterationProgress {
+  // Task ID that was completed.
+  optional int64 completed_task_id = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "CompletedTaskID"];
+  // Total number of tasks in the current merge iteration.
+  optional int64 tasks_total = 2 [(gogoproto.nullable) = false, (gogoproto.customname) = "TasksTotal"];
+}
+
 // DistSQLDrainingInfo represents the DistSQL draining state that gets gossiped
 // for each node. This is used by planners to avoid planning on nodes that are
 // known to be draining.

--- a/pkg/sql/index_backfiller.go
+++ b/pkg/sql/index_backfiller.go
@@ -229,6 +229,10 @@ func (ib *IndexBackfillPlanner) BackfillIndexes(
 	// We always run 2 merge iterations: a local merge (iteration 1) followed by
 	// a final cross-node merge (iteration 2). The local merge reduces network
 	// traffic by having each node merge its local SSTs first.
+	//
+	// WARNING: The phased progress tracking in calculatePhasedProgress assumes
+	// exactly 2 iterations. Changing this value requires updating the progress
+	// calculation in that function.
 	const maxIterations = 2
 	startIteration := int(progress.DistributedMergePhase) + 1
 

--- a/pkg/sql/indexbackfiller_test.go
+++ b/pkg/sql/indexbackfiller_test.go
@@ -1168,6 +1168,200 @@ func TestMultiMergeIndexBackfill(t *testing.T) {
 	require.GreaterOrEqual(t, manifestCountByIteration[1], 12)
 }
 
+// TestDistributedMergePhasedProgress verifies the 3-phase progress model for
+// distributed merge backfills. The model divides progress as:
+//   - Phase 0 (map): 0-33% (span-based progress during backfill)
+//   - Phase 1 (merge iteration 1): 34-66%
+//   - Phase 2 (merge iteration 2): 67-100%
+//
+// This test verifies that after each phase completes, the DistributedMergePhase
+// and task tracking fields are correctly set in the job payload, and that the
+// fraction_completed reported by SHOW JOBS reflects the expected progress.
+func TestDistributedMergePhasedProgress(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	skip.UnderDuress(t, "slow timing sensitive test")
+
+	ctx := context.Background()
+	tempDir := t.TempDir()
+
+	// Coordination channels for controlling test flow.
+	mapPhaseCh := make(chan struct{})
+	iterationCh := make(chan struct{})
+	var mapPhaseComplete atomic.Bool
+	var currentIteration atomic.Int32
+
+	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		ExternalIODir: tempDir,
+		Knobs: base.TestingKnobs{
+			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+			DistSQL: &execinfra.TestingKnobs{
+				BulkAdderFlushesEveryBatch: true,
+				AfterDistributedMergeMapPhase: func(ctx context.Context, manifests []jobspb.IndexBackfillSSTManifest) {
+					t.Logf("map phase complete, manifests=%d", len(manifests))
+					mapPhaseComplete.Store(true)
+					// Block to allow test to check progress after map phase.
+					select {
+					case <-mapPhaseCh:
+					case <-ctx.Done():
+					}
+				},
+				AfterDistributedMergeIteration: func(ctx context.Context, iteration int, manifests []jobspb.IndexBackfillSSTManifest) {
+					currentIteration.Store(int32(iteration))
+					t.Logf("iteration %d complete, manifests=%d", iteration, len(manifests))
+					// Block after iteration 1 (which has manifests) to check progress.
+					if iteration == 1 && len(manifests) > 0 {
+						select {
+						case <-iterationCh:
+						case <-ctx.Done():
+						}
+					}
+				},
+			},
+		},
+	})
+	defer srv.Stopper().Stop(ctx)
+
+	tdb := sqlutils.MakeSQLRunner(db)
+
+	tdb.Exec(t, `SET CLUSTER SETTING bulkio.index_backfill.distributed_merge.mode = 'declarative'`)
+	tdb.Exec(t, `SET CLUSTER SETTING bulkio.merge.file_size = '50KiB'`)
+	tdb.Exec(t, `SET CLUSTER SETTING bulkio.index_backfill.checkpoint_interval = '10ms'`)
+	tdb.Exec(t, `SET CLUSTER SETTING bulkio.index_backfill.progress_interval = '100ms'`)
+
+	tdb.Exec(t, `CREATE TABLE t (k INT PRIMARY KEY, v TEXT)`)
+	tdb.Exec(t, `INSERT INTO t SELECT i, repeat('x', 100) || i::text FROM generate_series(1, 5000) AS g(i)`)
+
+	// Run CREATE INDEX in background.
+	var jobID int64
+	g := ctxgroup.WithContext(ctx)
+	g.GoCtx(func(ctx context.Context) error {
+		_, err := db.ExecContext(ctx, `CREATE INDEX idx ON t (v)`)
+		return err
+	})
+
+	// Wait for the job to be created.
+	testutils.SucceedsWithin(t, func() error {
+		row := db.QueryRow(`
+			SELECT job_id FROM crdb_internal.jobs
+			WHERE job_type = 'NEW SCHEMA CHANGE'
+			AND description LIKE '%CREATE INDEX idx%'
+			ORDER BY created DESC LIMIT 1
+		`)
+		return row.Scan(&jobID)
+	}, 30*time.Second)
+
+	// Helper to get fraction_completed from SHOW JOBS.
+	getFractionCompleted := func() float32 {
+		var fraction float32
+		err := db.QueryRow(
+			`SELECT fraction_completed FROM [SHOW JOBS] WHERE job_id = $1`, jobID,
+		).Scan(&fraction)
+		require.NoError(t, err)
+		return fraction
+	}
+
+	// === Verify progress after map phase (~33%) ===
+	testutils.SucceedsWithin(t, func() error {
+		if mapPhaseComplete.Load() {
+			return nil
+		}
+		return errors.New("waiting for map phase")
+	}, 60*time.Second)
+
+	// Helper to check the fraction is within epsilon of expected.
+	fractionInEpsilon := func(fraction, expected float32) bool {
+		const epsilon float32 = 0.01
+		return fraction >= expected-epsilon && fraction <= expected+epsilon
+	}
+
+	// Wait for progress to be flushed and verify it's ~33% (after map phase = 1/3).
+	var fractionAfterMap float32
+	testutils.SucceedsWithin(t, func() error {
+		fractionAfterMap = getFractionCompleted()
+		if fractionInEpsilon(fractionAfterMap, 0.33) {
+			return nil
+		}
+		return errors.Errorf("waiting for fraction ~0.33, got %.4f", fractionAfterMap)
+	}, 10*time.Second)
+	t.Logf("fraction_completed after map phase: %.4f", fractionAfterMap)
+
+	// Unblock map phase.
+	close(mapPhaseCh)
+
+	// === Verify progress after iteration 1 (~66%) ===
+	// Wait for iteration 1 to complete and block.
+	testutils.SucceedsWithin(t, func() error {
+		if currentIteration.Load() >= 1 {
+			return nil
+		}
+		return errors.New("waiting for iteration 1")
+	}, 60*time.Second)
+
+	// Wait for checkpoint to reflect iteration 1 completion.
+	testutils.SucceedsWithin(t, func() error {
+		phase, _, _ := getMergeIterationProgress(t, db, int(jobID))
+		if phase >= 1 {
+			return nil
+		}
+		return errors.New("waiting for iteration 1 checkpoint")
+	}, 10*time.Second)
+
+	// Verify the phased progress fields after iteration 1.
+	// After an iteration completes, task tracking fields are cleared to ensure
+	// accurate progress calculation for the next iteration.
+	phase, tasksTotal, completedTasks := getMergeIterationProgress(t, db, int(jobID))
+	t.Logf("after iteration 1: phase=%d, tasksTotal=%d, completedTasks=%v", phase, tasksTotal, completedTasks)
+
+	require.Equal(t, int32(1), phase,
+		"DistributedMergePhase should be 1 after iteration 1")
+	require.Equal(t, int64(0), tasksTotal,
+		"MergeIterationTasksTotal should be cleared after iteration completion")
+	require.Equal(t, 0, len(completedTasks),
+		"MergeIterationCompletedTasks should be cleared after iteration completion")
+
+	// Verify fraction_completed from SHOW JOBS reflects iteration 1 progress (~66%).
+	// Wait for the progress flusher to update the job's fraction_completed.
+	var fractionAfterIter1 float32
+	testutils.SucceedsWithin(t, func() error {
+		fractionAfterIter1 = getFractionCompleted()
+		// After iteration 1, progress should be ~66% (phase 1 complete = 2/3).
+		if fractionInEpsilon(fractionAfterIter1, 0.66) {
+			return nil
+		}
+		return errors.Errorf("waiting for fraction >= 0.60, got %.4f", fractionAfterIter1)
+	}, 10*time.Second)
+	t.Logf("fraction_completed after iteration 1: %.4f", fractionAfterIter1)
+	require.GreaterOrEqual(t, fractionAfterIter1, float32(0.60),
+		"fraction_completed after iteration 1 should be >= 60%%")
+	require.LessOrEqual(t, fractionAfterIter1, float32(0.72),
+		"fraction_completed after iteration 1 should be <= 72%%")
+
+	// Unblock iteration 1 and let job complete.
+	close(iterationCh)
+
+	require.NoError(t, g.Wait())
+
+	// Verify the final state after completion.
+	phaseFinal, tasksTotalFinal, completedTasksFinal := getMergeIterationProgress(t, db, int(jobID))
+	t.Logf("after completion: phase=%d, tasksTotal=%d, completedTasks=%v",
+		phaseFinal, tasksTotalFinal, completedTasksFinal)
+
+	// After final iteration, phase should be 2, tasks fields cleared (since completion resets them).
+	require.Equal(t, int32(2), phaseFinal,
+		"DistributedMergePhase should be 2 after completion")
+	// Final iteration clears task tracking fields.
+	require.Equal(t, int64(0), tasksTotalFinal,
+		"MergeIterationTasksTotal should be 0 after completion")
+	require.Empty(t, completedTasksFinal,
+		"MergeIterationCompletedTasks should be empty after completion")
+
+	// Verify final fraction_completed is ~100%.
+	fractionFinal := getFractionCompleted()
+	require.InEpsilon(t, float32(1.0), fractionFinal, 0.01,
+		"fraction_completed should be ~100%% after completion")
+}
+
 // TestDistributedMergeAcrossNodes verifies that the distributed merge pipeline
 // involves multiple nodes. It creates a multi-node cluster, distributes data
 // across nodes via split/scatter, and verifies that multiple nodes participate
@@ -1386,6 +1580,28 @@ func waitForCheckpointPersisted(
 		t.Logf("checkpoint contains %d SST manifests", len(ssts))
 		return nil
 	}, 5*time.Second)
+}
+
+// getMergeIterationProgress extracts merge iteration progress fields from
+// the job payload. Returns the distributed merge phase, total tasks count,
+// and completed task IDs.
+func getMergeIterationProgress(
+	t *testing.T, db *gosql.DB, jobID int,
+) (phase int32, tasksTotal int64, completedTasks []int64) {
+	t.Helper()
+	var payloadBytes []byte
+	err := db.QueryRow(`SELECT payload FROM crdb_internal.system_jobs WHERE id = $1`, jobID).Scan(&payloadBytes)
+	require.NoError(t, err, "failed to query job payload")
+
+	payload := &jobspb.Payload{}
+	require.NoError(t, protoutil.Unmarshal(payloadBytes, payload), "failed to unmarshal job payload")
+
+	details := payload.Details.(*jobspb.Payload_NewSchemaChange).NewSchemaChange
+	if len(details.BackfillProgress) == 0 {
+		return 0, 0, nil
+	}
+	bp := details.BackfillProgress[0]
+	return bp.DistributedMergePhase, bp.MergeIterationTasksTotal, bp.MergeIterationCompletedTasks
 }
 
 // TestDistributedMergeResumePreservesProgress tests that spans completed during
@@ -1658,6 +1874,18 @@ func TestDistributedMergeResumePreservesProgress(t *testing.T) {
 
 				if tc.waitForCheckpoint {
 					waitForCheckpointPersisted(t, ctx, db, jobID, nil)
+
+					// Verify merge iteration progress is checkpointed before pause.
+					// After an iteration completes, task tracking fields are cleared.
+					phase, tasksTotal, completedTasks := getMergeIterationProgress(t, db, jobID)
+					require.Equal(t, int32(tc.pauseAfterIteration), phase,
+						"DistributedMergePhase should match pause iteration")
+					require.Equal(t, int64(0), tasksTotal,
+						"MergeIterationTasksTotal should be cleared after iteration completion")
+					require.Equal(t, 0, len(completedTasks),
+						"MergeIterationCompletedTasks should be cleared after iteration completion")
+					t.Logf("before pause: phase=%d, tasksTotal=%d, completedTasks=%v",
+						phase, tasksTotal, completedTasks)
 				}
 
 				// Pause the job while it's blocked in the hook.

--- a/pkg/sql/mvcc_backfiller.go
+++ b/pkg/sql/mvcc_backfiller.go
@@ -356,9 +356,7 @@ func newPeriodicProgressFlusher(settings *cluster.Settings) scexec.PeriodicProgr
 			return backfill.IndexBackfillCheckpointInterval.Get(&settings.SV)
 		},
 		func() time.Duration {
-			// fractionInterval is copied from the logic in existing backfill code.
-			const fractionInterval = 10 * time.Second
-			return fractionInterval
+			return backfill.IndexBackfillProgressInterval.Get(&settings.SV)
 		},
 	)
 }

--- a/pkg/sql/rowexec/indexbackfiller.go
+++ b/pkg/sql/rowexec/indexbackfiller.go
@@ -315,6 +315,8 @@ func (ib *indexBackfiller) maybeReencodeAndWriteVectorIndexEntry(
 // execinfrapb.BackfillerSpec.
 func (ib *indexBackfiller) makeIndexBackfillSink(ctx context.Context) (indexBackfillSink, error) {
 	if ib.spec.UseDistributedMergeSink {
+		log.Dev.Infof(ctx, "distributed merge: map phase starting with %d spans", len(ib.spec.Spans))
+
 		// Construct the full nodelocal URI using this processors's node ID. The spec
 		// stores just the path portion so that each processor writes to its own
 		// node's local storage.

--- a/pkg/sql/schemachanger/scexec/backfiller/periodic_progress_flusher.go
+++ b/pkg/sql/schemachanger/scexec/backfiller/periodic_progress_flusher.go
@@ -40,10 +40,7 @@ func NewPeriodicProgressFlusherForIndexBackfill(
 
 		},
 		func() time.Duration {
-			// fractionInterval is copied from the logic in existing backfill code.
-			// TODO(ajwerner): Add a cluster setting to control this.
-			const fractionInterval = 10 * time.Second
-			return fractionInterval
+			return backfill.IndexBackfillProgressInterval.Get(&settings.SV)
 		},
 	)
 }

--- a/pkg/sql/schemachanger/scexec/backfiller/progress.go
+++ b/pkg/sql/schemachanger/scexec/backfiller/progress.go
@@ -31,14 +31,16 @@ func convertToJobBackfillProgress(
 			return nil, err
 		}
 		ret = append(ret, jobspb.BackfillProgress{
-			TableID:               bp.TableID,
-			SourceIndexID:         bp.SourceIndexID,
-			DestIndexIDs:          bp.DestIndexIDs,
-			WriteTimestamp:        bp.MinimumWriteTimestamp,
-			CompletedSpans:        strippedSpans,
-			SSTManifests:          manifests,
-			SSTStoragePrefixes:    bp.SSTStoragePrefixes,
-			DistributedMergePhase: bp.DistributedMergePhase,
+			TableID:                      bp.TableID,
+			SourceIndexID:                bp.SourceIndexID,
+			DestIndexIDs:                 bp.DestIndexIDs,
+			WriteTimestamp:               bp.MinimumWriteTimestamp,
+			CompletedSpans:               strippedSpans,
+			SSTManifests:                 manifests,
+			SSTStoragePrefixes:           bp.SSTStoragePrefixes,
+			DistributedMergePhase:        bp.DistributedMergePhase,
+			MergeIterationTasksTotal:     bp.MergeIterationTasksTotal,
+			MergeIterationCompletedTasks: bp.MergeIterationCompletedTasks,
 		})
 	}
 	return ret, nil
@@ -55,11 +57,13 @@ func convertFromJobBackfillProgress(
 				SourceIndexID: bp.SourceIndexID,
 				DestIndexIDs:  bp.DestIndexIDs,
 			},
-			MinimumWriteTimestamp: bp.WriteTimestamp,
-			CompletedSpans:        addTenantPrefixToSpans(codec, bp.CompletedSpans),
-			SSTManifests:          backfill.AddTenantPrefixToSSTManifests(codec, bp.SSTManifests),
-			SSTStoragePrefixes:    bp.SSTStoragePrefixes,
-			DistributedMergePhase: bp.DistributedMergePhase,
+			MinimumWriteTimestamp:        bp.WriteTimestamp,
+			CompletedSpans:               addTenantPrefixToSpans(codec, bp.CompletedSpans),
+			SSTManifests:                 backfill.AddTenantPrefixToSSTManifests(codec, bp.SSTManifests),
+			SSTStoragePrefixes:           bp.SSTStoragePrefixes,
+			DistributedMergePhase:        bp.DistributedMergePhase,
+			MergeIterationTasksTotal:     bp.MergeIterationTasksTotal,
+			MergeIterationCompletedTasks: bp.MergeIterationCompletedTasks,
 		})
 	}
 	return ret

--- a/pkg/sql/schemachanger/scexec/dependencies.go
+++ b/pkg/sql/schemachanger/scexec/dependencies.go
@@ -291,6 +291,12 @@ type BackfillProgress struct {
 	// N (N >= 1) = merge iteration N completed.
 	// See jobspb.BackfillProgress.DistributedMergePhase for full semantics.
 	DistributedMergePhase int32
+
+	// MergeIterationTasksTotal is the total number of tasks in current iteration.
+	MergeIterationTasksTotal int64
+
+	// MergeIterationCompletedTasks contains IDs of completed tasks for resumability.
+	MergeIterationCompletedTasks []int64
 }
 
 // Backfill corresponds to a definition of a backfill from a source


### PR DESCRIPTION
Previously, index backfills that used the distributed merge pipeline only reported progress based on span completion during the initial map phase. Once merge iterations began, progress reporting stalled, making it difficult for users to understand how much work remained in each iteration.

This change introduces phased progress tracking that divides the backfill into three phases, each contributing roughly one third of overall progress:
- Phase 0 (map): 0–33% — span-based progress during the initial backfill
- Phase 1 (merge iteration 1): 34–66% — task-based progress
- Phase 2 (merge iteration 2): 67–100% — task-based progress

Note: I am also adding a logging change so we can see the start of each phase in the log.

Epic: CRDB-48845
Informs: #161866
Release note: none