### PR TITLE
release-25.4: ui: fix custom time picker not comparing properly

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "25.4.2",
+  "version": "25.4.3",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",

--- a/pkg/ui/workspaces/cluster-ui/src/dateRangeMenu/dateRangeMenu.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/dateRangeMenu/dateRangeMenu.tsx
@@ -86,11 +86,15 @@ export function DateRangeMenu({
   );
 
   const onChangeStart = (m?: Moment) => {
-    m && setStartMoment(m);
+    // Use keepLocalTime=true to preserve the wall clock time the user entered
+    // while interpreting it in the configured timezone, instead of the user's
+    // timezone.
+    m && setStartMoment(m.tz(timezone, true));
   };
 
   const onChangeEnd = (m?: Moment) => {
-    m && setEndMoment(m);
+    // Same as onChangeStart.
+    m && setEndMoment(m.tz(timezone, true));
   };
 
   const isDisabled = allowedInterval


### PR DESCRIPTION
Backport 1/1 commits from #162038.

/cc @cockroachdb/release

---

This current time picker has split logic between clicking and typing:
    When time is selected from the dropdown, the timezone is set to UTC correctly.
    When time is typed, it is set to the user's timezone, leading to validation errors.

This change sets the user inputted times as UTC and fixes the issue.

Fixes: #143654
Epic: None
Release Note: None

Release justification: low-risk UI only fix, this is a common bug that has impacted many customers