### PR TITLE
sql: replace "complex" chars with underscores in file names within the bundle

### DIFF
--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -555,6 +555,10 @@ var stmtBundleIncludeAllFKReferences = settings.RegisterBoolSetting(
 	false,
 )
 
+// stmtBundleStatsFileRE is a regex that matches all "complex" characters that
+// might not be safe when used in file names on some systems.
+var stmtBundleStatsFileRE = regexp.MustCompile(`[^a-zA-Z0-9_.\-]`)
+
 func (b *stmtBundleBuilder) addEnv(ctx context.Context) {
 	c := makeStmtEnvCollector(ctx, b.p, b.ie, b.requesterUsername)
 
@@ -912,13 +916,28 @@ func (b *stmtBundleBuilder) addEnv(ctx context.Context) {
 		buf.WriteString("-- there were no objects used in this query\n")
 	}
 	b.z.AddFile("schema.sql", buf.String())
+	// statsFileNames is a map from the main part of the stats file name to the
+	// number of times it has been used.
+	var statsFileNames = make(map[string]int)
 	for i := range tables {
 		buf.Reset()
 		hideHistograms := b.flags.RedactValues
 		if err = c.PrintTableStats(&buf, &tables[i], hideHistograms); err != nil {
 			b.printError(fmt.Sprintf("-- error getting statistics for table %s: %v", tables[i].FQString(), err), &buf)
 		}
-		b.z.AddFile(fmt.Sprintf("stats-%s.sql", tables[i].FQString()), buf.String())
+		// We use fully-qualified string for the table name as the main part of
+		// the file name that guarantees uniqueness within the bundle. Yet, in
+		// order to ensure that the file names interact well with different
+		// systems (e.g. Windows is particularly picky), we also replace many
+		// special characters with underscores - which might lose the uniqueness
+		// property. Thus, we additionally might append a count to guarantee
+		// uniqueness again.
+		fileName := stmtBundleStatsFileRE.ReplaceAllString(tables[i].FQString(), `_`)
+		statsFileNames[fileName]++
+		if statsFileNames[fileName] > 1 { // don't touch the first occurrency of this file name
+			fileName = fileName + "_" + strconv.Itoa(statsFileNames[fileName])
+		}
+		b.z.AddFile(fmt.Sprintf("stats-%s.sql", fileName), buf.String())
 	}
 }
 

--- a/pkg/sql/explain_bundle_test.go
+++ b/pkg/sql/explain_bundle_test.go
@@ -928,20 +928,20 @@ CREATE TABLE users(id UUID DEFAULT gen_random_uuid() PRIMARY KEY, promo_id INT R
 	})
 
 	t.Run("multiple databases and special characters", func(t *testing.T) {
-		r.Exec(t, `CREATE DATABASE "db.name";`)
-		r.Exec(t, `CREATE DATABASE "db'name";`)
-		r.Exec(t, `CREATE SCHEMA "db.name"."sc.name"`)
-		r.Exec(t, `CREATE SCHEMA "db'name"."sc'name"`)
-		r.Exec(t, `CREATE TABLE "db.name"."sc.name".t (pk INT PRIMARY KEY);`)
-		r.Exec(t, `CREATE TABLE "db'name"."sc'name".t (pk INT PRIMARY KEY);`)
-		rows := r.QueryStr(t, `EXPLAIN ANALYZE (DEBUG) SELECT * FROM "db.name"."sc.name".t, "db'name"."sc'name".t;`)
+		r.Exec(t, `CREATE DATABASE "db""name";`)
+		r.Exec(t, `CREATE DATABASE "db''name";`)
+		r.Exec(t, `CREATE SCHEMA "db""name"."sc""name"`)
+		r.Exec(t, `CREATE SCHEMA "db''name"."sc''name"`)
+		r.Exec(t, `CREATE TABLE "db""name"."sc""name".t (pk INT PRIMARY KEY);`)
+		r.Exec(t, `CREATE TABLE "db''name"."sc''name".t (pk INT PRIMARY KEY);`)
+		rows := r.QueryStr(t, `EXPLAIN ANALYZE (DEBUG) SELECT * FROM "db""name"."sc""name".t, "db''name"."sc''name".t;`)
 		checkBundle(
-			t, fmt.Sprint(rows), `"sc.name".t`, nil, false, /* expectErrors */
-			base, plans, `distsql.html vec.txt vec-v.txt stats-"db.name"."sc.name".t.sql stats-"db'name"."sc'name".t.sql`,
+			t, fmt.Sprint(rows), `"sc""name".t`, nil, false, /* expectErrors */
+			base, plans, `distsql.html vec.txt vec-v.txt stats-_db__name_._sc__name_.t.sql stats-_db__name_._sc__name_.t_2.sql`,
 		)
 		checkBundle(
-			t, fmt.Sprint(rows), `"sc'name".t`, nil, false, /* expectErrors */
-			base, plans, `distsql.html vec.txt vec-v.txt stats-"db.name"."sc.name".t.sql stats-"db'name"."sc'name".t.sql`,
+			t, fmt.Sprint(rows), `"sc''name".t`, nil, false, /* expectErrors */
+			base, plans, `distsql.html vec.txt vec-v.txt stats-_db__name_._sc__name_.t.sql stats-_db__name_._sc__name_.t_2.sql`,
 		)
 	})
 


### PR DESCRIPTION
It has been [reported](https://cockroachlabs.slack.com/archives/C04U1BTF8/p1770043279677459) that double quotes in the file names within the stmt bundle can cause problems when unzipping on some systems, so let's replace them (as well as other "complex" characters") with underscores. We need to maintain the uniqueness property for the file names, so this commit additionally keeps track of the number of times the updated file name has been used and might append a count to preserve uniqueness.

Epic: None
Release note: None