### PR TITLE
release-25.3: rowexec: skip TestPanicDeadlock under duress

### DIFF
--- a/pkg/sql/rowexec/sample_aggregator_test.go
+++ b/pkg/sql/rowexec/sample_aggregator_test.go
@@ -473,7 +473,9 @@ func TestSampleAggregator(t *testing.T) {
 // which drains the channel and unblocks stuck producers.
 func TestPanicDeadlock(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.UnderStress(t, "test has a 10-second timeout to detect deadlock")
+	defer log.Scope(t).Close(t)
+
+	skip.UnderDuress(t, "test has a 10-second timeout to detect deadlock")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
Backport 1/1 commits from #162220 on behalf of @yuzefovich.

----

We just saw a test failure under race config where `TestPanicDeadlock` took longer than given 10s for several goroutines to finish. The test is already skipped under stress, and I think it makes sense to skip it under all heavy configs. (The alternative would be to give longer "execution time" under heavy configs, but that still seems prone to false positives.)

Fixes: #162091
Release note: None

----

Release justification: test-only change.