### PR TITLE
release-25.3: toolchains: remove `default` pool EngFlow configuration

### DIFF
--- a/build/toolchains/BUILD.bazel
+++ b/build/toolchains/BUILD.bazel
@@ -34,7 +34,6 @@ platform(
     exec_properties = {
         "container-image": "docker://us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel@sha256:8e28252850bdd6f996d3d4087839be7a2e37d441f6f1e0d5c0a08fae82feacc3",
         "dockerReuse": "True",
-        "Pool": "default",
     },
 )
 
@@ -139,7 +138,6 @@ platform(
     exec_properties = {
         "container-image": "docker://us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel@sha256:a60cd34ece7f75930169653ce55eb6825775a5204152fb563276e6eb25c73ed1",
         "dockerReuse": "True",
-        "Pool": "default",
     },
 )
 


### PR DESCRIPTION
Backport 1/1 commits from #162226 on behalf of @rickystewart.

----

`default` is the default EngFlow pool either way so this does nothing. Removing it will enable EngFlow to make a change on their side to simplify our setup w.r.t. pool assignments (specifically the change to put `GoLink` actions in the `large` pool).

Release note: none
Epic: none

----

Release justification: Non-production code changes