### PR TITLE
bootstrap-debian.sh: update node version

### DIFF
--- a/build/bootstrap/bootstrap-debian.sh
+++ b/build/bootstrap/bootstrap-debian.sh
@@ -12,7 +12,7 @@
 set -euxo pipefail
 
 curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo apt-key add -
-echo "deb https://deb.nodesource.com/node_16.x focal main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+echo "deb https://deb.nodesource.com/node_22.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
 
 sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"


### PR DESCRIPTION
The old node version is out-of-date with respect to the build and cannot be successfully pulled from the deb repo with the current key (for some reason).

Release note: none
Epic: none