### PR TITLE
release-24.1: toolchains: remove `default` pool EngFlow configuration

### DIFF
--- a/build/toolchains/BUILD.bazel
+++ b/build/toolchains/BUILD.bazel
@@ -34,7 +34,6 @@ platform(
     exec_properties = {
         "container-image": "docker://us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel@sha256:1277dc9c759382ec85c06af78c2ce6f84db2e19de1a364e0a76fbf4bc6853a24",
         "dockerReuse": "True",
-        "Pool": "default",
     },
 )
 
@@ -139,7 +138,6 @@ platform(
     exec_properties = {
         "container-image": "docker://us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel@sha256:2ff9afdff2e838b218c8b4e80c5c1f398dc25674ba238a7bbf8364040b02fb0a",
         "dockerReuse": "True",
-        "Pool": "default",
     },
 )
 


### PR DESCRIPTION
Backport 1/1 commits from #162226 on behalf of @rickystewart.

----

`default` is the default EngFlow pool either way so this does nothing. Removing it will enable EngFlow to make a change on their side to simplify our setup w.r.t. pool assignments (specifically the change to put `GoLink` actions in the `large` pool).

Release note: none
Epic: none

----

Release justification: Non-production code changes