### PR TITLE
release-26.1: sql: replace "complex" chars with underscores in file names within the bundle

### DIFF
--- a/pkg/sql/explain_bundle_test.go
+++ b/pkg/sql/explain_bundle_test.go
@@ -928,20 +928,20 @@ CREATE TABLE users(id UUID DEFAULT gen_random_uuid() PRIMARY KEY, promo_id INT R
 	})
 
 	t.Run("multiple databases and special characters", func(t *testing.T) {
-		r.Exec(t, `CREATE DATABASE "db.name";`)
-		r.Exec(t, `CREATE DATABASE "db'name";`)
-		r.Exec(t, `CREATE SCHEMA "db.name"."sc.name"`)
-		r.Exec(t, `CREATE SCHEMA "db'name"."sc'name"`)
-		r.Exec(t, `CREATE TABLE "db.name"."sc.name".t (pk INT PRIMARY KEY);`)
-		r.Exec(t, `CREATE TABLE "db'name"."sc'name".t (pk INT PRIMARY KEY);`)
-		rows := r.QueryStr(t, `EXPLAIN ANALYZE (DEBUG) SELECT * FROM "db.name"."sc.name".t, "db'name"."sc'name".t;`)
+		r.Exec(t, `CREATE DATABASE "db""name";`)
+		r.Exec(t, `CREATE DATABASE "db''Name";`)
+		r.Exec(t, `CREATE SCHEMA "db""name"."sc""name"`)
+		r.Exec(t, `CREATE SCHEMA "db''Name"."sc''name"`)
+		r.Exec(t, `CREATE TABLE "db""name"."sc""name".t (pk INT PRIMARY KEY);`)
+		r.Exec(t, `CREATE TABLE "db''Name"."sc''name".t (pk INT PRIMARY KEY);`)
+		rows := r.QueryStr(t, `EXPLAIN ANALYZE (DEBUG) SELECT * FROM "db""name"."sc""name".t, "db''Name"."sc''name".t;`)
 		checkBundle(
-			t, fmt.Sprint(rows), `"sc.name".t`, nil, false, /* expectErrors */
-			base, plans, `distsql.html vec.txt vec-v.txt stats-"db.name"."sc.name".t.sql stats-"db'name"."sc'name".t.sql`,
+			t, fmt.Sprint(rows), `"sc""name".t`, nil, false, /* expectErrors */
+			base, plans, `distsql.html vec.txt vec-v.txt stats-_db__name_._sc__name_.t.sql stats-_db__name_._sc__name_.t_2.sql`,
 		)
 		checkBundle(
-			t, fmt.Sprint(rows), `"sc'name".t`, nil, false, /* expectErrors */
-			base, plans, `distsql.html vec.txt vec-v.txt stats-"db.name"."sc.name".t.sql stats-"db'name"."sc'name".t.sql`,
+			t, fmt.Sprint(rows), `"sc''name".t`, nil, false, /* expectErrors */
+			base, plans, `distsql.html vec.txt vec-v.txt stats-_db__name_._sc__name_.t.sql stats-_db__name_._sc__name_.t_2.sql`,
 		)
 	})
 


### PR DESCRIPTION
Backport 1/1 commits from #162217 on behalf of @yuzefovich.
Backport 1/1 commits from #162354 on behalf of @yuzefovich.

----

It has been [reported](https://cockroachlabs.slack.com/archives/C04U1BTF8/p1770043279677459) that double quotes in the file names within the stmt bundle can cause problems when unzipping on some systems, so let's replace them (as well as other "complex" characters") with underscores. We need to maintain the uniqueness property for the file names, so this commit additionally keeps track of the number of times the updated file name has been used and might append a count to preserve uniqueness.

Epic: None
Release note: None

----

Release justification: low-risk supportability improvement.