### PR TITLE
sql: silence expected internal error around nil metadata forwarder

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/do
+++ b/pkg/sql/logictest/testdata/logic_test/do
@@ -326,3 +326,17 @@ BEGIN
   SELECT _float8, _int8, crdb_internal_mvcc_timestamp FROM seed@seed__int8__float8_idx;
 END;
 $$;
+
+# Regression test for hitting an internal error due to unset metadataForwarder
+# when a routine is evaluated during the physical planning (#161486).
+statement ok
+DO $$
+DECLARE
+BEGIN
+  SELECT sum(_float8) OVER (
+    PARTITION BY _int8 ROWS BETWEEN
+      UNBOUNDED PRECEDING AND
+      (SELECT _int8 FROM seed LIMIT 1) FOLLOWING
+  ) FROM seed;
+END;
+$$;


### PR DESCRIPTION
A few months ago we fixed the propagation of some query-level metricsfrom routines. This required introducing a special `metadataForwarder` on the planner, and then we had to be careful to not use the wrong one when running plan inside the plan, so the field might be unset - until the plan is almost ready to be run. In production builds, the unset forwarder is ok - we simply drop some metadata. In test builds, we panic with an internal error.

We just saw a test case where - with the current setup - it's expected that this panic would occur. In particular, if we evaluate a routine during the physical planning, before the forwarder is set, we would run into the nil pointer. It's not easy to change things to set the proper forwarder earlier, so, instead, this commit simply sets the noop forwarder implementation as an expected exception - if we're still in the physical planning, we now simply drop metadata too. This shouldn't be that frequent (on a quick glance only frame bounds from window functions as well as VALUES clauses are affected).

Fixes: #161486.
Release note: None