### PR TITLE
roachtest: add --start-env and --start-setting flags

### DIFF
--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -123,6 +123,7 @@ go_test(
         "//pkg/roachprod",
         "//pkg/roachprod/cloud",
         "//pkg/roachprod/errors",
+        "//pkg/roachprod/install",
         "//pkg/roachprod/logger",
         "//pkg/roachprod/vm",
         "//pkg/roachprod/vm/azure",

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2191,6 +2191,16 @@ func (c *clusterImpl) StartE(
 		settings.ClusterSettings["server.cpu_profile.total_dump_size_limit"] = "256 MiB"
 	}
 
+	// Inject CLI-specified environment variables and cluster settings. These are
+	// applied before test-specific settings in the options array, so tests can
+	// override them if needed.
+	if len(roachtestflags.StartEnv) > 0 {
+		settings.Env = append(settings.Env, roachtestflags.StartEnv...)
+	}
+	for name, value := range roachtestflags.StartSettings {
+		settings.ClusterSettings[name] = value
+	}
+
 	clusterSettingsOpts := c.configureClusterSettingOptions(c.clusterSettings, settings)
 
 	startOpts.RoachprodOpts.PreStartHooks = append(startOpts.RoachprodOpts.PreStartHooks, c.preStartHooks...)

--- a/pkg/cmd/roachtest/roachtestflags/flags.go
+++ b/pkg/cmd/roachtest/roachtestflags/flags.go
@@ -512,6 +512,25 @@ var (
 						On Darwin, prevent the system from sleeping while roachtest is running
 						by invoking caffeinate -i -w <pid>. Default is true.`,
 	})
+
+	StartEnv []string
+	_        = registerRunFlag(&StartEnv, FlagInfo{
+		Name: "start-env",
+		Usage: `
+			Environment variable to inject at cluster Start() time. Can be specified
+			multiple times. These are applied before test-specific settings, so tests
+			may override them. Example: --start-env=GODEBUG=gctrace=1`,
+	})
+
+	StartSettings map[string]string
+	_             = registerRunFlag(&StartSettings, FlagInfo{
+		Name: "start-setting",
+		Usage: `
+			Cluster setting to apply at cluster Start() time (key=value format). Can
+			be specified multiple times. These are applied via SQL after cluster
+			startup but before the test body runs, so tests may override them.
+			Example: --start-setting=kv.range_split.by_load_enabled=false`,
+	})
 )
 
 // The flags below override the final cluster configuration. They have no

--- a/pkg/cmd/roachtest/roachtestflags/manager.go
+++ b/pkg/cmd/roachtest/roachtestflags/manager.go
@@ -73,6 +73,8 @@ func (m *manager) AddFlagsToCommand(cmd cmdID, cmdFlags *pflag.FlagSet) {
 			cmdFlags.StringVarP(p, f.Name, f.Shorthand, *p, usage)
 		case *map[string]string:
 			cmdFlags.StringToStringVarP(p, f.Name, f.Shorthand, *p, usage)
+		case *[]string:
+			cmdFlags.StringArrayVarP(p, f.Name, f.Shorthand, *p, usage)
 		case *spec.Cloud:
 			cmdFlags.VarP(&cloudValue{val: p}, f.Name, f.Shorthand, usage)
 		case *vm.Filesystem:


### PR DESCRIPTION
Previously, to adjust an environment variable or cluster setting for A/B testing across roachtest runs required modifying the test code, rebuilding, and re-running. This made it less obvious that the only alteration between experimental runs was the intended variable.

This change adds two new flags to roachtest:
- `--start-env`: inject environment variables at cluster Start() time
- `--start-setting`: apply cluster settings at cluster Start() time

These flags are automatically applied to all tests without requiring any test code modifications. The values are injected in StartE() before the test body runs, so tests can override them if needed.

Example usage:
  roachtest run my-test \
    --start-env="GODEBUG=gctrace=1" \
    --start-setting="kv.range_split.by_load_enabled=false"

Release note: None
Epic: None