### PR TITLE
kvstreamer: relax TestStreamerRandomAccess a bit

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/streamer_test.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer_test.go
@@ -702,7 +702,7 @@ ALTER TABLE t SPLIT AT SELECT i*2000 FROM generate_series(0, 2) AS g(i);
 				}
 			}
 			require.Greater(t, gRPCCalls, 0, rows)
-			require.Greater(t, 150, gRPCCalls, rows)
+			require.Greater(t, 250, gRPCCalls, rows)
 		}
 	}
 }


### PR DESCRIPTION
We just saw two test failures in TestStreamerRandomAccess where the number of KV gRPC requests exceeded the expected maximum of 150 by a little bit. I was unable to reproduce this with 10k runs on the gceworker, but my guess this is due to a recent change in 476daff9cc2c7b437f8e0665266a40a4dfa03f12: namely, we now pool BatchTruncationHelpers, and it reuses `requestsScratch`, so if we happen to pick the helper that has huge scratch slice, that would reduce our available work memory which will force the streamer to use smaller TargetBytes limits resulting in more KV batches.

Let's bump the expected maximum to 250 which keeps the test serving its purpose.

Separately, there is a question of whether we want to enforce the maximum capacity of the requestsScratch slice that we keep in the sync.Pool, and for now my answer is that "probably no" given that we generally don't impose such hard limits in other places where we're pooling and reusing objects.

Fixes: #162280.
Release note: None