### PR TITLE
kvserver: remove kv.Sender implementation from Store, Stores, Replica

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
@@ -183,7 +183,7 @@ func TestTxnCoordSenderHeartbeat(t *testing.T) {
 		kvcoord.NewDistSenderForLocalTestCluster(
 			ctx,
 			s.Cfg.Settings, &roachpb.NodeDescriptor{NodeID: 1},
-			ambient.Tracer, s.Clock, s.Latency, s.Stores, s.Stopper(), s.Gossip,
+			ambient.Tracer, s.Clock, s.Latency, kvserver.ToSenderForTesting(s.Stores), s.Stopper(), s.Gossip,
 		),
 	)
 	quickHeartbeatDB := kv.NewDB(ambient, tsf, s.Clock, s.Stopper())
@@ -287,7 +287,7 @@ func TestDB_PrepareForRetryAfterHeartbeatFailure(t *testing.T) {
 		kvcoord.NewDistSenderForLocalTestCluster(
 			ctx,
 			s.Cfg.Settings, &roachpb.NodeDescriptor{NodeID: 1},
-			ambient.Tracer, s.Clock, s.Latency, s.Stores, s.Stopper(), s.Gossip,
+			ambient.Tracer, s.Clock, s.Latency, kvserver.ToSenderForTesting(s.Stores), s.Stopper(), s.Gossip,
 		),
 	)
 	db := kv.NewDB(ambient, tsf, s.Clock, s.Stopper())

--- a/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
+++ b/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
@@ -1315,7 +1315,7 @@ func (cbt *circuitBreakerTest) SendCtxTS(
 	// going to leak memory.
 	ctx = context.WithValue(ctx, req, struct{}{})
 
-	_, pErr := repl.Send(ctx, ba)
+	_, pErr := kvserver.ToSenderForTesting(repl.Replica).Send(ctx, ba)
 	// If our context got canceled, return an opaque error regardless of presence or
 	// absence of actual error. This makes sure we don't accidentally pass tests as
 	// a result of our context cancellation.

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -541,7 +541,7 @@ func ProposeAddSSTable(ctx context.Context, key, val string, ts hlc.Timestamp, s
 	addReq.EndKey = addReq.Key.Next()
 	ba.Add(&addReq)
 
-	_, pErr := store.Send(ctx, ba)
+	_, pErr := ToSenderForTesting(store).Send(ctx, ba)
 	if pErr != nil {
 		return pErr.GoError()
 	}

--- a/pkg/kv/kvserver/raft_log_queue_test.go
+++ b/pkg/kv/kvserver/raft_log_queue_test.go
@@ -842,7 +842,7 @@ func TestTruncateLogRecompute(t *testing.T) {
 		ba.Add(put)
 		ba.RangeID = repl.RangeID
 
-		if _, pErr := tc.store.Send(ctx, ba); pErr != nil {
+		if _, pErr := ToSenderForTesting(tc.store).Send(ctx, ba); pErr != nil {
 			t.Fatal(pErr)
 		}
 	}

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -344,6 +344,8 @@ func (mu *ReplicaMutex) RLocker() sync.Locker {
 	return (*syncutil.RWMutex)(mu).RLocker()
 }
 
+var _ SenderWithWriteBytes = &Replica{}
+
 // A Replica is a contiguous keyspace with writes managed via an
 // instance of the Raft consensus algorithm. Many ranges may exist
 // in a store and they are unlikely to be contiguous. Ranges are

--- a/pkg/kv/kvserver/replica_closedts_internal_test.go
+++ b/pkg/kv/kvserver/replica_closedts_internal_test.go
@@ -1012,7 +1012,7 @@ func TestServerSideBoundedStalenessNegotiation(t *testing.T) {
 				}
 				ba.Add(test.reqs...)
 
-				br, pErr := tc.store.Send(ctx, ba)
+				br, pErr := ToSenderForTesting(tc.store).Send(ctx, ba)
 				if test.expErr == "" {
 					require.Nil(t, pErr)
 					require.NotNil(t, br)
@@ -1176,7 +1176,7 @@ func TestServerSideBoundedStalenessNegotiationWithResumeSpan(t *testing.T) {
 			expRespTS := earliestIntentTS.Prev()
 
 			// Issue the request.
-			br, pErr := tc.store.Send(ctx, ba)
+			br, pErr := ToSenderForTesting(tc.store).Send(ctx, ba)
 			require.Nil(t, pErr)
 			require.NotNil(t, br)
 			require.Equal(t, expRespTS, br.Timestamp)

--- a/pkg/kv/kvserver/replica_closedts_test.go
+++ b/pkg/kv/kvserver/replica_closedts_test.go
@@ -774,7 +774,7 @@ func TestNonBlockingReadsAtResolvedTimestamp(t *testing.T) {
 				RangeID:         rangeID,
 				ReadConsistency: kvpb.INCONSISTENT,
 			}
-			resp, pErr := kv.SendWrappedWith(ctx, store, queryResTSHeader, &queryResTS)
+			resp, pErr := kv.SendWrappedWith(ctx, kvserver.ToSenderForTesting(store), queryResTSHeader, &queryResTS)
 			if pErr != nil {
 				return pErr.GoError()
 			}
@@ -805,7 +805,7 @@ func TestNonBlockingReadsAtResolvedTimestamp(t *testing.T) {
 				Txn:             &txn,
 				WaitPolicy:      lock.WaitPolicy_Error,
 			}
-			_, pErr = kv.SendWrappedWith(ctx, store, scanHeader, &scan)
+			_, pErr = kv.SendWrappedWith(ctx, kvserver.ToSenderForTesting(store), scanHeader, &scan)
 			return pErr.GoError()
 		}
 	})
@@ -847,7 +847,7 @@ func TestNonBlockingReadsWithServerSideBoundedStalenessNegotiation(t *testing.T)
 			ba.Add(&kvpb.ScanRequest{
 				RequestHeader: kvpb.RequestHeaderFromSpan(keySpan),
 			})
-			br, pErr := store.Send(ctx, ba)
+			br, pErr := kvserver.ToSenderForTesting(store).Send(ctx, ba)
 			if pErr != nil {
 				return pErr.GoError()
 			}

--- a/pkg/kv/kvserver/replica_learner_test.go
+++ b/pkg/kv/kvserver/replica_learner_test.go
@@ -1681,7 +1681,7 @@ func TestLearnerAndVoterOutgoingFollowerRead(t *testing.T) {
 			// replicas cannot serve follower reads` branch that we're trying to test.
 			sendCtx, getRecAndFinish := tracing.ContextWithRecordingSpan(ctx, tr, "manual read request")
 			defer getRecAndFinish()
-			_, pErr := repl.Send(sendCtx, req)
+			_, pErr := kvserver.ToSenderForTesting(repl).Send(sendCtx, req)
 			err := pErr.GoError()
 			if !testutils.IsError(err, `not lease holder`) {
 				// NB: errors.Wrapf(nil, ...) returns nil.

--- a/pkg/kv/kvserver/replica_probe_test.go
+++ b/pkg/kv/kvserver/replica_probe_test.go
@@ -171,7 +171,7 @@ func TestReplicaProbeRequest(t *testing.T) {
 		ba := &kvpb.BatchRequest{}
 		ba.Add(probeReq)
 		ba.Timestamp = srv.Clock().Now()
-		_, pErr := repl.Send(ctx, ba)
+		_, pErr := kvserver.ToSenderForTesting(repl).Send(ctx, ba)
 		require.NoError(t, pErr.GoError())
 	}
 
@@ -189,7 +189,7 @@ func TestReplicaProbeRequest(t *testing.T) {
 		ba := &kvpb.BatchRequest{}
 		ba.Timestamp = srv.Clock().Now()
 		ba.Add(probeReq)
-		_, pErr := repl.Send(ctx, ba)
+		_, pErr := kvserver.ToSenderForTesting(repl).Send(ctx, ba)
 		require.True(t, errors.Is(pErr.GoError(), injErr.GoError()), "%+v", pErr.GoError())
 	}
 }

--- a/pkg/kv/kvserver/replica_proposal_bench_test.go
+++ b/pkg/kv/kvserver/replica_proposal_bench_test.go
@@ -88,7 +88,7 @@ func runBenchmarkReplicaProposal(b *testing.B, bytes int64, withFollower bool) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		ba.Timestamp = repl.Clock().Now()
-		_, pErr := repl.Send(ctx, &ba)
+		_, pErr := kvserver.ToSenderForTesting(repl).Send(ctx, &ba)
 		if err := pErr.GoError(); err != nil {
 			b.Fatal(err)
 		}

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -676,7 +676,8 @@ func (p *pendingLeaseRequest) requestLease(
 		CreateTime: timeutil.Now().UnixNano(),
 		Source:     kvpb.AdmissionHeader_OTHER,
 	}
-	_, pErr := p.repl.Send(ctx, ba)
+	_, writeBytes, pErr := p.repl.SendWithWriteBytes(ctx, ba)
+	writeBytes.Release()
 	return pErr.GoError()
 }
 

--- a/pkg/kv/kvserver/replica_rangefeed_test.go
+++ b/pkg/kv/kvserver/replica_rangefeed_test.go
@@ -548,7 +548,7 @@ func TestReplicaRangefeed(t *testing.T) {
 	ba := &kvpb.BatchRequest{}
 	ba.RangeID = rangeID
 	ba.Add(gcReq)
-	if _, pErr := firstStore.Send(ctx, ba); pErr != nil {
+	if _, pErr := kvserver.ToSenderForTesting(firstStore).Send(ctx, ba); pErr != nil {
 		t.Fatal(pErr)
 	}
 

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -46,9 +46,9 @@ var optimisticEvalLimitedScans = settings.RegisterBoolSetting(
 	true,
 )
 
-// Send executes a command on this range, dispatching it to the
-// read-only, read-write, or admin execution path as appropriate.
-// ctx should contain the log tags from the store (and up).
+// SendWithWriteBytes executes a command on this range, dispatching it to the
+// read-only, read-write, or admin execution path as appropriate. ctx should
+// contain the log tags from the store (and up).
 //
 // A rough schematic for the path requests take through a Replica
 // is presented below, with a focus on where requests may spend
@@ -65,7 +65,7 @@ var optimisticEvalLimitedScans = settings.RegisterBoolSetting(
 //	               Admission control
 //	                       │
 //	                       ▼
-//	                  Replica.Send
+//	              Replica.SendWithWriteBytes
 //	                       │
 //	                 Circuit breaker
 //	                       │
@@ -111,16 +111,6 @@ var optimisticEvalLimitedScans = settings.RegisterBoolSetting(
 //
 //	to commit the command, then signaling proposer and
 //	applying the command)
-func (r *Replica) Send(
-	ctx context.Context, ba *kvpb.BatchRequest,
-) (*kvpb.BatchResponse, *kvpb.Error) {
-	br, writeBytes, pErr := r.SendWithWriteBytes(ctx, ba)
-	writeBytes.Release()
-	return br, pErr
-}
-
-// SendWithWriteBytes is the implementation of Send with an additional
-// *StoreWriteBytes return value.
 func (r *Replica) SendWithWriteBytes(
 	ctx context.Context, ba *kvpb.BatchRequest,
 ) (*kvpb.BatchResponse, *kvadmission.StoreWriteBytes, *kvpb.Error) {

--- a/pkg/kv/kvserver/replica_sideload_test.go
+++ b/pkg/kv/kvserver/replica_sideload_test.go
@@ -66,7 +66,7 @@ func TestRaftSSTableSideloadingProposal(t *testing.T) {
 		ba.Add(&get)
 		ba.Header.RangeID = tc.repl.RangeID
 
-		br, pErr := tc.store.Send(ctx, ba)
+		br, pErr := ToSenderForTesting(tc.store).Send(ctx, ba)
 		if pErr != nil {
 			t.Fatal(pErr)
 		}
@@ -160,7 +160,7 @@ func TestRaftSSTableSideloading(t *testing.T) {
 		addReq.EndKey = addReq.Key.Next()
 		ba.Add(&addReq)
 
-		_, pErr := tc.store.Send(ctx, ba)
+		_, pErr := ToSenderForTesting(tc.store).Send(ctx, ba)
 		if pErr != nil {
 			t.Fatal(pErr)
 		}

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1150,7 +1150,7 @@ type Store struct {
 	diskMonitor *disk.Monitor
 }
 
-var _ kv.Sender = &Store{}
+var _ SenderWithWriteBytes = &Store{}
 var _ IncomingRaftMessageHandler = &Store{}
 var _ OutgoingRaftMessageHandler = &Store{}
 

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -82,7 +82,7 @@ var testIdent = roachpb.StoreIdent{
 }
 
 func (s *Store) TestSender() kv.Sender {
-	return kv.Wrap(s, func(ba *kvpb.BatchRequest) *kvpb.BatchRequest {
+	return kv.Wrap(ToSenderForTesting(s), func(ba *kvpb.BatchRequest) *kvpb.BatchRequest {
 		if ba.RangeID != 0 {
 			return ba
 		}
@@ -292,7 +292,7 @@ func createTestStoreWithoutStart(
 	require.Nil(t, cfg.DB)
 	cfg.DB = kv.NewDB(cfg.AmbientCtx, txnCoordSenderFactory, cfg.Clock, stopper)
 	store := NewStore(ctx, *cfg, eng, nodeDesc)
-	storeSender.Sender = store
+	storeSender.Sender = ToSenderForTesting(store)
 
 	storeIdent := roachpb.StoreIdent{NodeID: 1, StoreID: 1}
 	cv := clusterversion.TestingClusterVersion

--- a/pkg/kv/kvserver/ts_maintenance_queue_test.go
+++ b/pkg/kv/kvserver/ts_maintenance_queue_test.go
@@ -124,7 +124,7 @@ func TestTimeSeriesMaintenanceQueue(t *testing.T) {
 	for _, k := range splitKeys {
 		repl := store.LookupReplica(roachpb.RKey(k))
 		args := adminSplitArgs(k)
-		if _, pErr := kv.SendWrappedWith(ctx, store, kvpb.Header{
+		if _, pErr := kv.SendWrappedWith(ctx, kvserver.ToSenderForTesting(store), kvpb.Header{
 			RangeID: repl.RangeID,
 		}, args); pErr != nil {
 			t.Fatal(pErr)

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -177,7 +177,8 @@ func (ltc *LocalTestCluster) Start(t testing.TB, initFactory InitFactoryFn) {
 		CPUUsageMovingAverageAge:   20,
 	})
 
-	factory := initFactory(ctx, cfg.Settings, nodeDesc, ltc.stopper.Tracer(), ltc.Clock, ltc.Latency, ltc.Stores, ltc.stopper, ltc.Gossip)
+	factory := initFactory(ctx, cfg.Settings, nodeDesc, ltc.stopper.Tracer(), ltc.Clock, ltc.Latency,
+		kvserver.ToSenderForTesting(ltc.Stores), ltc.stopper, ltc.Gossip)
 
 	var nodeIDContainer base.NodeIDContainer
 	nodeIDContainer.Set(context.Background(), nodeID)


### PR DESCRIPTION
Previously, Store, Stores, and Replica all implemented kv.Sender via their Send methods. This allowed callers to use them interchangeably with other Senders, but obscured an important detail: these Send methods were called from code that did not integrate with admission control.

This commit removes the Send methods from these types. They now implement only SenderWithWriteBytes, which returns the StoreWriteBytes that callers that use admission control must handle appropriately.

For test code that needs a kv.Sender, ToSenderForTesting provides an explicit wrapper that discards the StoreWriteBytes. The "ForTesting" suffix makes it clear that this wrapper bypasses admission control accounting and should only be used in tests.

This change makes admission control bypass explicit: any code path that converts these types to kv.Sender must now visibly call ToSenderForTesting, making it easy to audit which paths skip admission control.

Release note: None

Epic: None