### PR TITLE
sql: implement pg_trigger_depth() builtin function

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -3670,6 +3670,8 @@ may increase either contention or retry errors, or both.</p>
 </span></td><td>Volatile</td></tr>
 <tr><td><a name="pg_table_is_visible"></a><code>pg_table_is_visible(oid: oid) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns whether the table with the given OID belongs to one of the schemas on the search path.</p>
 </span></td><td>Stable</td></tr>
+<tr><td><a name="pg_trigger_depth"></a><code>pg_trigger_depth() &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the current nesting level of PostgreSQL triggers (0 if not called, directly or indirectly, from inside a trigger).</p>
+</span></td><td>Volatile</td></tr>
 <tr><td><a name="pg_type_is_visible"></a><code>pg_type_is_visible(oid: oid) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns whether the type with the given OID belongs to one of the schemas on the search path.</p>
 </span></td><td>Stable</td></tr>
 <tr><td><a name="set_config"></a><code>set_config(setting_name: <a href="string.html">string</a>, new_value: <a href="string.html">string</a>, is_local: <a href="bool.html">bool</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>System info</p>

--- a/pkg/ccl/logictestccl/testdata/logic_test/triggers
+++ b/pkg/ccl/logictestccl/testdata/logic_test/triggers
@@ -803,6 +803,116 @@ CREATE TRIGGER foo AFTER INSERT ON xy FOR EACH ROW EXECUTE FUNCTION g();
 statement ok
 DROP FUNCTION g;
 
+subtest pg_trigger_depth
+
+# Test pg_trigger_depth() - based on PostgreSQL regress test.
+
+statement ok
+CREATE TABLE depth_a (id INT NOT NULL PRIMARY KEY);
+
+statement ok
+CREATE TABLE depth_b (id INT NOT NULL PRIMARY KEY);
+
+statement ok
+CREATE TABLE depth_c (id INT NOT NULL PRIMARY KEY);
+
+statement ok
+CREATE FUNCTION depth_a_tf() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$
+BEGIN
+  RAISE NOTICE '%: depth = %', TG_NAME, pg_trigger_depth();
+  INSERT INTO depth_b VALUES ((NEW).id);
+  RAISE NOTICE '%: depth = %', TG_NAME, pg_trigger_depth();
+  RETURN NEW;
+END;
+$$;
+
+statement ok
+CREATE TRIGGER depth_a_tr BEFORE INSERT ON depth_a
+  FOR EACH ROW EXECUTE FUNCTION depth_a_tf();
+
+statement ok
+CREATE FUNCTION depth_b_tf() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$
+BEGIN
+  RAISE NOTICE '%: depth = %', TG_NAME, pg_trigger_depth();
+  INSERT INTO depth_c VALUES ((NEW).id);
+  RAISE NOTICE '%: depth = %', TG_NAME, pg_trigger_depth();
+  RETURN NEW;
+END;
+$$;
+
+statement ok
+CREATE TRIGGER depth_b_tr BEFORE INSERT ON depth_b
+  FOR EACH ROW EXECUTE FUNCTION depth_b_tf();
+
+statement ok
+CREATE FUNCTION depth_c_tf() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$
+BEGIN
+  RAISE NOTICE '%: depth = %', TG_NAME, pg_trigger_depth();
+  RETURN NEW;
+END;
+$$;
+
+statement ok
+CREATE TRIGGER depth_c_tr BEFORE INSERT ON depth_c
+  FOR EACH ROW EXECUTE FUNCTION depth_c_tf();
+
+# pg_trigger_depth() returns 0 outside of triggers.
+query I
+SELECT pg_trigger_depth();
+----
+0
+
+# Insert into depth_a triggers a cascade: depth_a -> depth_b -> depth_c.
+# depth_a_tr fires at depth 1, depth_b_tr at depth 2, depth_c_tr at depth 3.
+query T noticetrace
+INSERT INTO depth_a VALUES (1);
+----
+NOTICE: depth_a_tr: depth = 1
+NOTICE: depth_b_tr: depth = 2
+NOTICE: depth_c_tr: depth = 3
+NOTICE: depth_b_tr: depth = 2
+NOTICE: depth_a_tr: depth = 1
+
+query I
+SELECT pg_trigger_depth();
+----
+0
+
+# Test with AFTER triggers as well.
+statement ok
+CREATE TABLE depth_after (id INT NOT NULL PRIMARY KEY);
+
+statement ok
+CREATE FUNCTION depth_after_tf() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$
+BEGIN
+  RAISE NOTICE '%: depth = %', TG_NAME, pg_trigger_depth();
+  RETURN NULL;
+END;
+$$;
+
+statement ok
+CREATE TRIGGER depth_after_tr AFTER INSERT ON depth_after
+  FOR EACH ROW EXECUTE FUNCTION depth_after_tf();
+
+query T noticetrace
+INSERT INTO depth_after VALUES (1);
+----
+NOTICE: depth_after_tr: depth = 1
+
+statement ok
+DROP TABLE depth_after CASCADE;
+
+statement ok
+DROP FUNCTION depth_after_tf;
+
+statement ok
+DROP TABLE depth_a, depth_b, depth_c CASCADE;
+
+statement ok
+DROP FUNCTION depth_a_tf, depth_b_tf, depth_c_tf;
+
+subtest end
+
 subtest regression_134630
 
 statement ok

--- a/pkg/sql/routine.go
+++ b/pkg/sql/routine.go
@@ -146,17 +146,14 @@ func (p *planner) EvalRoutineExpr(
 		// can be arbitrarily large. To avoid OOM, we enforce a limit on the depth
 		// of nested triggers. This is also a safeguard in case we have a bug that
 		// results in an infinite trigger loop.
-		var triggerDepth int
-		if triggerDepthValue := ctx.Value(triggerDepthKey{}); triggerDepthValue != nil {
-			triggerDepth = triggerDepthValue.(int)
-		}
+		triggerDepth := eval.GetTriggerDepth(ctx)
 		if limit := int(p.SessionData().RecursionDepthLimit); triggerDepth > limit {
 			telemetry.Inc(sqltelemetry.RecursionDepthLimitReached)
 			err = pgerror.Newf(pgcode.TriggeredActionException,
 				"trigger reached recursion depth limit: %d", limit)
 			return nil, err
 		}
-		ctx = context.WithValue(ctx, triggerDepthKey{}, triggerDepth+1)
+		ctx = eval.ContextWithIncrementedTriggerDepth(ctx)
 	}
 	if buildutil.CrdbTestBuild && !tailCallOptimizationEnabled {
 		// In test builds when we disable tail-call optimization, we might hit
@@ -207,8 +204,6 @@ func (p *planner) EvalRoutineExpr(
 	}
 	return res, nil
 }
-
-type triggerDepthKey struct{}
 
 type routineDepthKey struct{}
 

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2866,6 +2866,7 @@ var builtinOidsArray = []string{
 	2911: `information_schema.crdb_datums_to_bytes(any...) -> bytes`,
 	2912: `information_schema.crdb_rewrite_inline_hints(statement_fingerprint: string, donor_sql: string) -> int`,
 	2913: `crdb_internal.decode_key(key: bytes) -> jsonb`,
+	2914: `pg_trigger_depth() -> int`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -637,6 +637,20 @@ var pgBuiltins = map[string]builtinDefinition{
 		},
 	),
 
+	// See https://www.postgresql.org/docs/current/functions-info.html.
+	"pg_trigger_depth": makeBuiltin(defProps(),
+		tree.Overload{
+			Types:      tree.ParamTypes{},
+			ReturnType: tree.FixedReturnType(types.Int),
+			Fn: func(ctx context.Context, _ *eval.Context, _ tree.Datums) (tree.Datum, error) {
+				return tree.NewDInt(tree.DInt(eval.GetTriggerDepth(ctx))), nil
+			},
+			Info:             "Returns the current nesting level of PostgreSQL triggers (0 if not called, directly or indirectly, from inside a trigger).",
+			Volatility:       volatility.Volatile,
+			DistsqlBlocklist: true,
+		},
+	),
+
 	// See https://www.postgresql.org/docs/9.3/static/catalog-pg-database.html.
 	"pg_encoding_to_char": makeBuiltin(defProps(),
 		tree.Overload{


### PR DESCRIPTION
This adds the `pg_trigger_depth()` builtin function for PostgreSQL compatibility. The function returns the current nesting level of trigger execution:
- Returns 0 when not called from inside a trigger
- Returns 1 for the first level of trigger execution
- Increments for each nested trigger call

The implementation moves the trigger depth tracking from a local context key in routine.go to shared helper functions in the eval package, allowing the builtin to access the depth value.

Fixes: #162275
Epic: CRDB-42942

Release note (sql change): Added support for the `pg_trigger_depth()` builtin function, which returns the current nesting level of PostgreSQL triggers (0 if not called from inside a trigger).