### PR TITLE
.claude: hide reduce-unoptimized-query-oracle skill from claude

### DIFF
--- a/.claude/skills/reduce-unoptimized-query-oracle/SKILL.md
+++ b/.claude/skills/reduce-unoptimized-query-oracle/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: reduce-unoptimized-query-oracle
 description: Reduce an unoptimized-query-oracle test failure log to the simplest possible reproduction case. Use when you have unoptimized-query-oracle*.log files from a failed roachtest and need to find the minimal SQL to reproduce the bug.
+disable-model-invocation: true
 ---
 
 # Reduce Unoptimized Query Oracle Test Failure


### PR DESCRIPTION
Add `disable-model-invocation: true` to this skill so that it's not available by default to Claude. This also saves 65 tokens in everyone's context.

Epic: None

Release note: None