### PR TITLE
authserver,ldapccl: enable ldap authorization for db console

### DIFF
--- a/pkg/ccl/ldapccl/BUILD.bazel
+++ b/pkg/ccl/ldapccl/BUILD.bazel
@@ -35,7 +35,7 @@ go_library(
 
 go_test(
     name = "ldapccl_test",
-    size = "small",
+    size = "large",
     srcs = [
         "authentication_ldap_test.go",
         "authorization_ldap_test.go",
@@ -53,9 +53,13 @@ go_test(
         "//pkg/security/securitytest",
         "//pkg/security/username",
         "//pkg/server",
+        "//pkg/server/authserver",
+        "//pkg/server/serverpb",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
+        "//pkg/util/httputil",
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/randutil",

--- a/pkg/ccl/ldapccl/authorization_ldap_test.go
+++ b/pkg/ccl/ldapccl/authorization_ldap_test.go
@@ -10,13 +10,18 @@ import (
 	gosql "database/sql"
 	"fmt"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security/distinguishedname"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/server/authserver"
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -241,4 +246,146 @@ func TestLDAPRolesAreGranted(t *testing.T) {
 	mockLDAP.SetGroups("cn=foo", []string{"cn=foo_parent_2", "cn=nonexistent_role"})
 	_, err = fooDB.Conn(ctx)
 	require.NoError(t, err)
+}
+
+func TestLDAPAuthorizationDBConsole(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Intercept the call to NewLDAPUtil and return the mocked NewLDAPUtil function.
+	mockLDAP, newMockLDAPUtil := LDAPMocks()
+	defer testutils.TestingHook(
+		&NewLDAPUtil,
+		newMockLDAPUtil,
+	)()
+
+	ctx := context.Background()
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+	ts := s.ApplicationLayer()
+	tdb := sqlutils.MakeSQLRunner(db)
+
+	const hbaConf = `host all all all ldap ldapserver=localhost ldapport=636 ldapbasedn="dc=crdb,dc=io" ldapbinddn="cn=admin,dc=crdb,dc=io" ldapbindpasswd=admin ldapsearchattribute=cn "ldapsearchfilter=(objectClass=*)" "ldapgrouplistfilter=(objectClass=groupOfNames)"`
+	tdb.Exec(t, "SET CLUSTER SETTING server.host_based_authentication.configuration = $1", hbaConf)
+
+	// Create user and roles. Note that 'nonexistent_role' is NOT created.
+	tdb.Exec(t, "CREATE USER alice; CREATE ROLE db_admins; GRANT admin TO db_admins;")
+
+	// Helper function to get the current roles of a user.
+	getRoles := func(user username.SQLUsername) []string {
+		rows := tdb.QueryStr(t, `SELECT role FROM system.role_members WHERE member = $1 ORDER BY role`, user.Normalized())
+		actualRoles := make([]string, len(rows))
+		for i, r := range rows {
+			actualRoles[i] = r[0]
+		}
+		return actualRoles
+	}
+
+	// Helper function to create a username.SQLUsername from a string.
+	makeRole := func(name string) username.SQLUsername {
+		r, err := username.MakeSQLUsernameFromUserInput(name, username.PurposeValidation)
+		require.NoError(t, err)
+		return r
+	}
+
+	// Test cases for DB Console LDAP login.
+	testCases := []struct {
+		name          string
+		username      string
+		password      string
+		setupMock     func(mock *mockLDAPUtil)
+		expectSuccess bool
+		checkRoles    func(t *testing.T)
+	}{
+		{
+			name:     "successful login with partial role grant",
+			username: "alice",
+			password: "password",
+			setupMock: func(mock *mockLDAPUtil) {
+				// The mock's Search function will automatically generate the correct DN for "alice".
+				mock.SetGroups("cn=alice", []string{"cn=db_admins,ou=groups,dc=crdb,dc=io", "cn=nonexistent_role,ou=groups,dc=crdb,dc=io"})
+			},
+			expectSuccess: true,
+			checkRoles: func(t *testing.T) {
+				rows := tdb.QueryStr(t, `SELECT role FROM system.role_members WHERE member = 'alice'`)
+				require.Len(t, rows, 1, "alice should only have one role")
+				require.Equal(t, "db_admins", rows[0][0])
+			},
+		},
+		{
+			name:          "invalid username",
+			username:      "invalid", // The mock is configured to fail search for this user.
+			password:      "password",
+			setupMock:     nil, // No specific setup needed for this case.
+			expectSuccess: false,
+		},
+		{
+			name:     "invalid password",
+			username: "alice",
+			password: "invalid", // The mock is configured to fail bind for this password.
+			setupMock: func(mock *mockLDAPUtil) {
+				// Ensure the user exists in the mock so that search succeeds.
+				mock.SetGroups("cn=alice", []string{})
+			},
+			expectSuccess: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Reset user roles before each test run by revoking any existing roles.
+			currentRoles := getRoles(makeRole("alice"))
+			if len(currentRoles) > 0 {
+				tdb.Exec(t, fmt.Sprintf("REVOKE %s FROM alice", strings.Join(currentRoles, ",")))
+			}
+
+			if tc.setupMock != nil {
+				tc.setupMock(mockLDAP)
+			}
+
+			// Attempt to log in via the DB Console's HTTP endpoint.
+			req := &serverpb.UserLoginRequest{
+				Username: tc.username,
+				Password: tc.password,
+			}
+			var resp serverpb.UserLoginResponse
+			httpClient, err := ts.GetUnauthenticatedHTTPClient()
+			require.NoError(t, err)
+			err = httputil.PostJSON(httpClient, ts.AdminURL().WithPath(authserver.LoginPath).String(), req, &resp)
+
+			if tc.expectSuccess {
+				require.NoError(t, err, "DB Console login should succeed")
+				if tc.checkRoles != nil {
+					tc.checkRoles(t)
+				}
+			} else {
+				require.Error(t, err, "DB Console login should fail")
+				// The error from httputil will contain the status code for auth failures.
+				require.Contains(t, err.Error(), "401 Unauthorized", "expected an authentication error")
+			}
+		})
+	}
+
+	// test the role revocation logic.
+	t.Run("grant and revoke", func(t *testing.T) {
+		// First, log in successfully to ensure 'alice' has the 'db_admins' role.
+		mockLDAP.SetGroups("cn=alice", []string{"cn=db_admins"})
+		req := &serverpb.UserLoginRequest{Username: "alice", Password: "password"}
+		var resp serverpb.UserLoginResponse
+		httpClient, err := ts.GetUnauthenticatedHTTPClient()
+		require.NoError(t, err)
+		err = httputil.PostJSON(httpClient, ts.AdminURL().WithPath(authserver.LoginPath).String(), req, &resp)
+		require.NoError(t, err)
+
+		// Verify the role was granted.
+		require.Equal(t, []string{"db_admins"}, getRoles(username.MakeSQLUsernameFromPreNormalizedString("alice")))
+
+		// Now, update the mock so that 'alice' is no longer in any groups and log in again.
+		mockLDAP.SetGroups("cn=alice", []string{}) // Alice is now in zero groups.
+		err = httputil.PostJSON(httpClient, ts.AdminURL().WithPath(authserver.LoginPath).String(), req, &resp)
+		require.NoError(t, err)
+
+		// Verify the role was successfully revoked.
+		require.Empty(t, getRoles(username.MakeSQLUsernameFromPreNormalizedString("alice")), "alice should have no roles after revocation")
+	})
 }

--- a/pkg/server/authserver/BUILD.bazel
+++ b/pkg/server/authserver/BUILD.bazel
@@ -43,6 +43,7 @@ go_library(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_cockroachdb_redact//:redact",
+        "@com_github_go_ldap_ldap_v3//:ldap",
         "@com_github_grpc_ecosystem_grpc_gateway//runtime:go_default_library",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//codes",

--- a/pkg/server/authserver/authentication.go
+++ b/pkg/server/authserver/authentication.go
@@ -23,7 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/security/password"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
+	secuser "github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/apiutil"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/srverrors"
@@ -43,6 +43,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
+	"github.com/cockroachdb/redact"
+	"github.com/go-ldap/ldap/v3"
 	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -189,7 +191,7 @@ func (s *authenticationServer) userLogin(
 	// here, so that the normalized username is retained in the session
 	// table: the APIs extract the username from the session table
 	// without further normalization.
-	username, _ := username.MakeSQLUsernameFromUserInput(req.Username, username.PurposeValidation)
+	username, _ := secuser.MakeSQLUsernameFromUserInput(req.Username, secuser.PurposeValidation)
 	// Verify the user and check if DB console session could be started.
 	verified, pwRetrieveFn, err := s.VerifyUserSessionDBConsole(ctx, username)
 	if err != nil {
@@ -200,6 +202,7 @@ func (s *authenticationServer) userLogin(
 	}
 
 	ldapAuthSuccess := false
+	var ldapUserDN *ldap.DN
 	originIP := s.lookupIncomingRequestOriginIP(ctx)
 	hbaConf, identMap := s.sqlServer.PGServer().GetAuthenticationConfiguration()
 	authMethod, hbaEntry, err := s.lookupAuthenticationMethodUsingRules(hba.ConnHostSSL, hbaConf, username, originIP)
@@ -217,7 +220,9 @@ func (s *authenticationServer) userLogin(
 				ldapManager.m = pgwire.ConfigureLDAPAuth(ctx, execCfg.AmbientCtx, execCfg.Settings, execCfg.NodeInfo.LogicalClusterID())
 			}
 		})
-		ldapUserDN, detailedErrors, authError := ldapManager.m.FetchLDAPUserDN(ctx, execCfg.Settings, username, hbaEntry, identMap)
+		var detailedErrors redact.RedactableString
+		var authError error
+		ldapUserDN, detailedErrors, authError = ldapManager.m.FetchLDAPUserDN(ctx, execCfg.Settings, username, hbaEntry, identMap)
 		if authError != nil {
 			if log.V(1) {
 				log.Dev.Infof(ctx, "ldap search response error: ldapUserDN %v, authError %v, detailedErrors %v", ldapUserDN, authError, detailedErrors)
@@ -249,6 +254,30 @@ func (s *authenticationServer) userLogin(
 		}
 		if !verified {
 			return nil, errWebAuthenticationFailure
+		}
+	}
+
+	// If LDAP authentication was successful and the HBA entry includes a
+	// group list filter, perform role authorization.
+	if ldapAuthSuccess && hbaEntry.GetOption("ldapgrouplistfilter") != "" {
+		if log.V(1) {
+			log.Dev.Infof(ctx, "LDAP authentication succeeded; attempting authorization for user %s", username)
+		}
+
+		execCfg := s.sqlServer.ExecutorConfig()
+
+		if detailedErrors, authError := pgwire.AuthorizeLDAPHelper(
+			ctx, nil, ldapManager.m, execCfg, ldapUserDN, username, hbaEntry, identMap,
+		); authError != nil {
+			// Construct a detailed error for internal logging.
+			errForLog := errors.Wrapf(authError, "LDAP authorization: error during role sync")
+			if detailedErrors != "" {
+				errForLog = errors.Join(errForLog, errors.Newf("%s", detailedErrors))
+			}
+			log.Ops.VWarningf(ctx, 1, "%v", errForLog)
+
+			// Return only the generic, client-safe error to the API caller.
+			return nil, srverrors.APIInternalError(ctx, authError)
 		}
 	}
 
@@ -294,7 +323,7 @@ func (s *authenticationServer) DemoLogin(w http.ResponseWriter, req *http.Reques
 	// here, so that the normalized username is retained in the session
 	// table: the APIs extract the username from the session table
 	// without further normalization.
-	username, _ := username.MakeSQLUsernameFromUserInput(userInput, username.PurposeValidation)
+	username, _ := secuser.MakeSQLUsernameFromUserInput(userInput, secuser.PurposeValidation)
 	// Verify the user and check if DB console session could be started.
 	verified, pwRetrieveFn, err := s.VerifyUserSessionDBConsole(ctx, username)
 	if err != nil {
@@ -347,7 +376,7 @@ func (s *authenticationServer) UserLoginFromSSO(
 	// here, so that the normalized username is retained in the session
 	// table: the APIs extract the username from the session table
 	// without further normalization.
-	username, _ := username.MakeSQLUsernameFromUserInput(reqUsername, username.PurposeValidation)
+	username, _ := secuser.MakeSQLUsernameFromUserInput(reqUsername, secuser.PurposeValidation)
 
 	exists, _, canLoginDBConsole, _, _, _, _, _, _, err := sql.GetUserSessionInitInfo(
 		ctx,
@@ -370,7 +399,7 @@ func (s *authenticationServer) UserLoginFromSSO(
 //
 // The caller is responsible to ensure the username has been normalized already.
 func (s *authenticationServer) createSessionFor(
-	ctx context.Context, userName username.SQLUsername,
+	ctx context.Context, userName secuser.SQLUsername,
 ) (*http.Cookie, error) {
 	// Create a new database session, generating an ID and secret key.
 	id, secret, err := s.NewAuthSession(ctx, userName)
@@ -559,7 +588,7 @@ WHERE id = $1`
 // session details required for proceeding with DB console login.
 // (CockroachDB has case-insensitive usernames, unlike PostgreSQL.)
 func (s *authenticationServer) VerifyUserSessionDBConsole(
-	ctx context.Context, userName username.SQLUsername,
+	ctx context.Context, userName secuser.SQLUsername,
 ) (
 	verified bool,
 	pwRetrieveFn func(ctx context.Context) (expired bool, hashedPassword password.PasswordHash, err error),
@@ -584,7 +613,7 @@ func (s *authenticationServer) VerifyUserSessionDBConsole(
 // (CockroachDB has case-insensitive usernames, unlike PostgreSQL.)
 func (s *authenticationServer) VerifyPasswordDBConsole(
 	ctx context.Context,
-	userName username.SQLUsername,
+	userName secuser.SQLUsername,
 	passwordStr string,
 	pwRetrieveFn func(ctx context.Context) (expired bool, hashedPassword password.PasswordHash, err error),
 ) (valid bool, expired bool, err error) {
@@ -634,7 +663,7 @@ func (s *authenticationServer) VerifyJWT(
 
 	// Retrieve the matching user identity within the JWT.
 	_, identMap := s.sqlServer.PGServer().GetAuthenticationConfiguration()
-	inputUser, _ := username.MakeSQLUsernameFromUserInput(usernameOptional, username.PurposeValidation)
+	inputUser, _ := secuser.MakeSQLUsernameFromUserInput(usernameOptional, secuser.PurposeValidation)
 	retrievedUser, err := jwtVerifier.j.RetrieveIdentity(
 		ctx,
 		execCfg.Settings,
@@ -698,7 +727,7 @@ func (s *authenticationServer) lookupIncomingRequestOriginIP(ctx context.Context
 }
 
 func (s *authenticationServer) lookupAuthenticationMethodUsingRules(
-	connType hba.ConnType, auth *hba.Conf, user username.SQLUsername, originIP net.IP,
+	connType hba.ConnType, auth *hba.Conf, user secuser.SQLUsername, originIP net.IP,
 ) (authMethod rulebasedscanner.String, entry *hba.Entry, err error) {
 	// Look up the method.
 	for i := range auth.Entries {
@@ -748,7 +777,7 @@ func CreateAuthSecret() (secret, hashedSecret []byte, err error) {
 // The caller is responsible to ensure the username has been
 // normalized already.
 func (s *authenticationServer) NewAuthSession(
-	ctx context.Context, userName username.SQLUsername,
+	ctx context.Context, userName secuser.SQLUsername,
 ) (int64, []byte, error) {
 	st := s.sqlServer.ExecutorConfig().Settings
 

--- a/pkg/sql/pgwire/auth_methods.go
+++ b/pkg/sql/pgwire/auth_methods.go
@@ -809,6 +809,7 @@ func authJwtToken(
 	_ *hba.Entry,
 	identMap *identmap.Conf,
 ) (*AuthBehaviors, error) {
+	// Initialize the jwt verifier if it hasn't been already.
 	if jwtVerifier == nil {
 		jwtVerifier = ConfigureJWTAuth(sctx, execCfg.AmbientCtx, execCfg.Settings, execCfg.NodeInfo.LogicalClusterID())
 	}
@@ -1198,49 +1199,75 @@ func AuthLDAP(
 				return err
 			}
 
-			// Audit the authZ start time.
-			ldapAuthZStartTime := timeutil.Now()
+			detailedErrors, authError := AuthorizeLDAPHelper(
+				ctx, b, ldapManager.m, execCfg, ldapUserDN, sessionUser, entry, identMap,
+			)
 
-			if ldapGroups, detailedErrors, authError := ldapManager.m.FetchLDAPGroups(
-				ctx, execCfg.Settings, ldapUserDN, sessionUser, entry, identMap,
-			); authError != nil {
-				errForLog := errors.Wrapf(authError, "LDAP authorization: error retrieving ldap groups for authorization")
+			if authError != nil {
+				errForLog := errors.Wrapf(authError, "LDAP authorization: error during role sync")
 				if detailedErrors != "" {
 					errForLog = errors.Join(errForLog, errors.Newf("%s", detailedErrors))
 				}
 				c.LogAuthFailed(ctx, eventpb.AuthFailReason_AUTHORIZATION_ERROR, errForLog)
 				return authError
-			} else {
-				// Add the total authZ time to the external auth time.
-				b.AddExternalAuthTime(timeutil.Since(ldapAuthZStartTime))
-
-				c.LogAuthInfof(ctx, redact.Sprintf("LDAP authorization sync succeeded; attempting to assign roles for LDAP groups: %s", ldapGroups))
-				// Parse and apply transformation to LDAP group DNs for roles granter.
-				sqlRoles := make([]username.SQLUsername, 0, len(ldapGroups))
-				for _, ldapGroup := range ldapGroups {
-					// Extract the CN from the LDAP group DN to use as the SQL role.
-					sqlRole, found, err := distinguishedname.ExtractCNAsSQLUsername(ldapGroup)
-					if err != nil {
-						err := errors.Wrapf(err, "LDAP authorization: error finding matching SQL role for group %s", ldapGroup.String())
-						c.LogAuthFailed(ctx, eventpb.AuthFailReason_AUTHORIZATION_ERROR, err)
-						return err
-					}
-					if !found {
-						c.LogAuthInfof(ctx, redact.Sprintf("skipping role assignment for group %s since there is no common name", ldapGroup.String()))
-						continue
-					}
-					sqlRoles = append(sqlRoles, sqlRole)
-				}
-
-				// Assign roles to the user.
-				if err := sql.EnsureUserOnlyBelongsToRoles(ctx, execCfg, sessionUser, sqlRoles); err != nil {
-					err = errors.Wrapf(err, "LDAP authorization: error assigning roles to user %s", sessionUser)
-					c.LogAuthFailed(ctx, eventpb.AuthFailReason_AUTHORIZATION_ERROR, err)
-					return err
-				}
-				return nil
 			}
+
+			return nil
 		})
 	}
 	return b, nil
+}
+
+// AuthorizeLDAPHelper synchronizes a user's roles from their LDAP group memberships.
+// It returns a generic, client-safe error and a detailed error for internal
+// logging.
+func AuthorizeLDAPHelper(
+	ctx context.Context,
+	b *AuthBehaviors,
+	ldapManager LDAPManager,
+	execCfg *sql.ExecutorConfig,
+	ldapUserDN *ldap.DN,
+	user username.SQLUsername,
+	entry *hba.Entry,
+	identMap *identmap.Conf,
+) (redact.RedactableString, error) {
+	// Audit the authZ start time.
+	ldapAuthZStartTime := timeutil.Now()
+
+	ldapGroups, detailedErrors, authError := ldapManager.FetchLDAPGroups(
+		ctx, execCfg.Settings, ldapUserDN, user, entry, identMap,
+	)
+	if authError != nil {
+		return detailedErrors, authError
+	}
+
+	if b != nil {
+		// Add the total authZ time to the external auth time.
+		b.AddExternalAuthTime(timeutil.Since(ldapAuthZStartTime))
+	}
+
+	// Parse and apply transformation to LDAP group DNs for roles granter.
+	sqlRoles := make([]username.SQLUsername, 0, len(ldapGroups))
+	for _, ldapGroup := range ldapGroups {
+		// Extract the CN from the LDAP group DN to use as the SQL role.
+		sqlRole, found, err := distinguishedname.ExtractCNAsSQLUsername(ldapGroup)
+		if err != nil {
+			detailedErr := errors.Wrapf(err, "LDAP authorization: error finding matching SQL role for group %s", ldapGroup.String())
+			clientErr := errors.New("LDAP authorization: could not map LDAP group to a valid role")
+			return redact.Sprint(detailedErr), clientErr
+		}
+		if !found {
+			log.Dev.VInfof(ctx, 1, "LDAP authorization: skipping group %s for user %s as it lacks a common name (CN)", ldapGroup.String(), user.Normalized())
+			continue
+		}
+		sqlRoles = append(sqlRoles, sqlRole)
+	}
+
+	// Assign roles to the user.
+	if err := sql.EnsureUserOnlyBelongsToRoles(ctx, execCfg, user, sqlRoles); err != nil {
+		detailedErr := errors.Wrapf(err, "LDAP authorization: error assigning roles to user %s", user)
+		clientErr := errors.New("LDAP authorization: failed to synchronize roles")
+		return redact.Sprint(detailedErr), clientErr
+	}
+	return "", nil
 }


### PR DESCRIPTION
Previously, when a user authenticated against the DB Console via LDAP, the system would only perform authentication (verifying the user's password) but would not perform authorization (synchronizing the user's roles from their LDAP group memberships).

This was inadequate because it created an inconsistent experience. A user connecting through a SQL client would have their roles correctly synced from LDAP, while the same user logging into the DB Console would not, potentially having different (or no) privileges.

To address this, this patch refactors the LDAP authorization logic into a single, reusable `AuthorizeLDAP` function in the pgwire package.  This shared function is now called by both the pgwire path (for SQL clients) and the DB Console's `UserLogin` HTTP handler. This eliminates code duplication and ensures that both connection methods use the exact same logic for role synchronization, providing a consistent experience for all users.

Epic: none
Fixes: #149654

Release note (enterprise change): LDAP authentication for the DB Console now additionally supports role-based access control (RBAC) through LDAP group membership.

To use this feature, an administrator must first create roles in CockroachDB with names that match the Common Names (CN) of their LDAP groups. These roles should then be granted the desired privileges for DB Console access.

When a user who is a member of a corresponding LDAP group logs into the DB Console, they will be automatically granted the role and its associated privileges, creating consistent behavior with SQL client connections.