### PR TITLE
roachtestutil: fix mixed-version test deadlock during mid-upgrade node failure

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/clusterupgrade/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/clusterupgrade/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/build",
+        "//pkg/clusterversion",
         "//pkg/cmd/roachtest/cluster",
         "//pkg/cmd/roachtest/option",
         "//pkg/cmd/roachtest/roachtestutil",
@@ -16,6 +17,7 @@ go_library(
         "//pkg/roachprod/logger",
         "//pkg/roachprod/vm",
         "//pkg/testutils/release",
+        "//pkg/util/protoutil",
         "//pkg/util/retry",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_version//:version",

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/runner.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/runner.go
@@ -575,7 +575,7 @@ func (tr *testRunner) refreshClusterVersions(ctx context.Context, service *servi
 	availableNodes := tr.getAvailableNodes(service.descriptor)
 	for j, node := range service.descriptor.Nodes {
 		group.GoCtx(func(ctx context.Context) error {
-			cv, err := clusterupgrade.ClusterVersion(ctx, tr.logger, tr.conn(node, service.descriptor.Name))
+			cv, err := clusterupgrade.ClusterVersionFromKV(ctx, tr.logger, tr.conn(node, service.descriptor.Name))
 			if err != nil {
 				if !availableNodes.Contains(node) {
 					return nil


### PR DESCRIPTION
When a node fails during a cluster upgrade, the mixed-version test framework would deadlock. The upgrade's `bumpClusterVersion` loop cannot complete without all nodes, so the KV version never advances. Meanwhile, `SHOW CLUSTER SETTING` version blocks waiting for local and KV versions to match, causing the test to hang until timeout.

Add `ClusterVersionFromKV` which queries `system.settings` directly to get the persisted version without waiting for synchronization. Update the mixed-version runner to use this function when refreshing cluster versions.

Fixes: #160516

Release note: None
Epic: None