### PR TITLE
sql/bulkmerge: scatter ranges after final merge splits

### DIFF
--- a/pkg/sql/bulkmerge/merge_processor.go
+++ b/pkg/sql/bulkmerge/merge_processor.go
@@ -367,7 +367,7 @@ func (m *bulkMergeProcessor) ingestFinalIteration(
 		m.flowCtx.EvalCtx.Settings,
 		disallowShadowingBelow,
 		false, // writeAtBatchTs
-		false, // scatterSplitRanges
+		true,  // scatterSplitRanges
 		m.flowCtx.Cfg.BackupMonitor.MakeConcurrentBoundAccount(),
 		m.flowCtx.Cfg.BulkSenderLimiter,
 		nil, // range cache


### PR DESCRIPTION
During final merge ingestion in the distributed merge pipeline, SSTBatcher may split ranges. Previously, the new RHS range stayed on the same node, concentrating bulk ingestion traffic and creating hotspots.

Enable scatterSplitRanges in SSTBatcher to redistribute newly split ranges across the cluster. In a 5B-row test of distributed merge, this reduced completion time by 12% and I/O operations by 14%.

Epic: CRDB-48845
Release note: None