### PR TITLE
ui: convert sql activity class components to functional components

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/sql/box.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sql/box.tsx
@@ -42,17 +42,19 @@ export interface SqlBoxProps {
 
 const cx = classNames.bind(styles);
 
-export class SqlBox extends React.Component<SqlBoxProps> {
-  preNode: React.RefObject<HTMLPreElement> = React.createRef();
-  render(): React.ReactElement {
-    const value = this.props.format
-      ? FormatQuery(this.props.value)
-      : this.props.value;
-    const sizeClass = this.props.size ? this.props.size : "";
-    return (
-      <div className={cx("box-highlight", this.props.className, sizeClass)}>
-        <Highlight {...this.props} value={value} />
-      </div>
-    );
-  }
+export function SqlBox({
+  value: rawValue,
+  format,
+  size,
+  className,
+  ...restProps
+}: SqlBoxProps): React.ReactElement {
+  const value = format ? FormatQuery(rawValue) : rawValue;
+  const sizeClass = size ? size : "";
+
+  return (
+    <div className={cx("box-highlight", className, sizeClass)}>
+      <Highlight {...restProps} value={value} format={format} size={size} />
+    </div>
+  );
 }

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.tsx
@@ -7,7 +7,7 @@ import { Button, Icon, InlineAlert } from "@cockroachlabs/ui-components";
 import classnames from "classnames/bind";
 import classNames from "classnames/bind";
 import moment from "moment-timezone";
-import React from "react";
+import React, { useState, useEffect, useCallback, useMemo } from "react";
 import { Link } from "react-router-dom";
 
 import emptyListResultsImg from "src/assets/emptyState/empty-list-results.svg";
@@ -64,10 +64,6 @@ export interface DiagnosticsViewOwnProps {
 export type DiagnosticsViewProps = DiagnosticsViewOwnProps &
   DiagnosticsViewStateProps &
   DiagnosticsViewDispatchProps;
-
-interface DiagnosticsViewState {
-  sortSetting: SortSetting;
-}
 
 const cx = classnames.bind(styles);
 
@@ -153,218 +149,233 @@ const StmtDiagnosticLabel = ({
   );
 };
 
-export class DiagnosticsView extends React.Component<
-  DiagnosticsViewProps,
-  DiagnosticsViewState
-> {
-  constructor(props: DiagnosticsViewProps) {
-    super(props);
-    this.state = {
-      sortSetting: {
-        ascending: true,
-        columnTitle: "activatedOn",
-      },
-    };
-  }
+export function DiagnosticsView({
+  diagnosticsReports,
+  showDiagnosticsViewLink,
+  statementFingerprint,
+  activateDiagnosticsRef,
+  currentScale,
+  onChangeTimeScale,
+  planGists,
+  dismissAlertMessage,
+  onDownloadDiagnosticBundleClick,
+  onDiagnosticCancelRequestClick,
+  onSortingChange,
+  requestTime,
+}: DiagnosticsViewProps): React.ReactElement {
+  const [sortSetting, setSortSetting] = useState<SortSetting>({
+    ascending: true,
+    columnTitle: "activatedOn",
+  });
 
-  columns: ColumnDescriptor<StatementDiagnosticsReport>[] = [
-    {
-      name: "activatedOn",
-      title: "Activated on",
-      hideTitleUnderline: true,
-      cell: (diagnostic: StatementDiagnosticsReport) => (
-        <Timestamp time={diagnostic.requested_at} format={DATE_FORMAT_24_TZ} />
-      ),
-      sort: (diagnostic: StatementDiagnosticsReport) =>
-        moment(diagnostic.requested_at)?.unix(),
+  // Cleanup on unmount - dismiss alert message
+  useEffect(() => {
+    return () => {
+      dismissAlertMessage();
+    };
+  }, [dismissAlertMessage]);
+
+  const handleSortingChange = useCallback(
+    (ss: SortSetting): void => {
+      if (onSortingChange) {
+        onSortingChange("Diagnostics", ss.columnTitle, ss.ascending);
+      }
+      setSortSetting({
+        ascending: ss.ascending,
+        columnTitle: ss.columnTitle,
+      });
     },
-    {
-      name: "status",
-      title: "Status",
-      hideTitleUnderline: true,
-      className: cx("column-size-small"),
-      cell: (diagnostic: StatementDiagnosticsReport) => {
-        const status = getDiagnosticsStatus(diagnostic);
-        return (
-          <DiagnosticStatusBadge
-            status={status}
-            enableTooltip={status !== "READY"}
+    [onSortingChange],
+  );
+
+  const columns: ColumnDescriptor<StatementDiagnosticsReport>[] = useMemo(
+    () => [
+      {
+        name: "activatedOn",
+        title: "Activated on",
+        hideTitleUnderline: true,
+        cell: (diagnostic: StatementDiagnosticsReport) => (
+          <Timestamp
+            time={diagnostic.requested_at}
+            format={DATE_FORMAT_24_TZ}
           />
-        );
+        ),
+        sort: (diagnostic: StatementDiagnosticsReport) =>
+          moment(diagnostic.requested_at)?.unix(),
       },
-      sort: (diagnostic: StatementDiagnosticsReport) =>
-        String(diagnostic.completed),
-    },
-    {
-      name: "actions",
-      title: "",
-      hideTitleUnderline: true,
-      className: cx("column-size-medium"),
-      cell: (diagnostic: StatementDiagnosticsReport) => {
-        if (diagnostic.completed) {
+      {
+        name: "status",
+        title: "Status",
+        hideTitleUnderline: true,
+        className: cx("column-size-small"),
+        cell: (diagnostic: StatementDiagnosticsReport) => {
+          const status = getDiagnosticsStatus(diagnostic);
+          return (
+            <DiagnosticStatusBadge
+              status={status}
+              enableTooltip={status !== "READY"}
+            />
+          );
+        },
+        sort: (diagnostic: StatementDiagnosticsReport) =>
+          String(diagnostic.completed),
+      },
+      {
+        name: "actions",
+        title: "",
+        hideTitleUnderline: true,
+        className: cx("column-size-medium"),
+        cell: (diagnostic: StatementDiagnosticsReport) => {
+          if (diagnostic.completed) {
+            return (
+              <div
+                className={cx(
+                  "crl-statements-diagnostics-view__actions-column",
+                )}
+              >
+                <Button
+                  as="a"
+                  size="small"
+                  intent="tertiary"
+                  href={withBasePath(
+                    `_admin/v1/stmtbundle/${diagnostic.statement_diagnostics_id}`,
+                  )}
+                  onClick={() =>
+                    onDownloadDiagnosticBundleClick &&
+                    onDownloadDiagnosticBundleClick(
+                      diagnostic.statement_fingerprint,
+                    )
+                  }
+                  className={cx("download-bundle-button")}
+                >
+                  <Icon iconName="Download" />
+                  Bundle (.zip)
+                </Button>
+              </div>
+            );
+          }
           return (
             <div
               className={cx("crl-statements-diagnostics-view__actions-column")}
             >
-              <Button
-                as="a"
+              <CancelButton
                 size="small"
-                intent="tertiary"
-                href={withBasePath(
-                  `_admin/v1/stmtbundle/${diagnostic.statement_diagnostics_id}`,
-                )}
+                type="secondary"
                 onClick={() =>
-                  this.props.onDownloadDiagnosticBundleClick &&
-                  this.props.onDownloadDiagnosticBundleClick(
-                    diagnostic.statement_fingerprint,
-                  )
+                  onDiagnosticCancelRequestClick &&
+                  onDiagnosticCancelRequestClick(diagnostic)
                 }
-                className={cx("download-bundle-button")}
               >
-                <Icon iconName="Download" />
-                Bundle (.zip)
-              </Button>
+                Cancel request
+              </CancelButton>
             </div>
           );
-        }
-        return (
-          <div
-            className={cx("crl-statements-diagnostics-view__actions-column")}
-          >
-            <CancelButton
-              size="small"
-              type="secondary"
-              onClick={() =>
-                this.props.onDiagnosticCancelRequestClick &&
-                this.props.onDiagnosticCancelRequestClick(diagnostic)
-              }
-            >
-              Cancel request
-            </CancelButton>
-          </div>
-        );
+        },
+        sort: (diagnostic: StatementDiagnosticsReport) =>
+          String(diagnostic.completed),
       },
-      sort: (diagnostic: StatementDiagnosticsReport) =>
-        String(diagnostic.completed),
-    },
-  ];
+    ],
+    [onDownloadDiagnosticBundleClick, onDiagnosticCancelRequestClick],
+  );
 
-  componentWillUnmount(): void {
-    this.props.dismissAlertMessage();
-  }
+  const readyToRequestDiagnostics = diagnosticsReports.every(
+    diagnostic => diagnostic.completed,
+  );
 
-  onSortingChange = (ss: SortSetting): void => {
-    if (this.props.onSortingChange) {
-      this.props.onSortingChange("Diagnostics", ss.columnTitle, ss.ascending);
-    }
-    this.setState({
-      sortSetting: {
-        ascending: ss.ascending,
-        columnTitle: ss.columnTitle,
-      },
-    });
-  };
+  // Get diagnostic reports within the time window.
+  const dataSource = filterByTimeScale(
+    diagnosticsReports.map((diagnosticsReport, idx) => ({
+      ...diagnosticsReport,
+      key: idx,
+    })),
+    currentScale,
+  );
 
-  render(): React.ReactElement {
-    const {
-      diagnosticsReports,
-      showDiagnosticsViewLink,
-      statementFingerprint,
-      activateDiagnosticsRef,
-      currentScale,
-      onChangeTimeScale,
-      planGists,
-    } = this.props;
+  // Get active report not within the time window if exists.
+  const undisplayedActiveReportExists: boolean =
+    diagnosticsReports.findIndex(
+      report =>
+        !report.completed && !dataSource.find(data => data.id === report.id),
+    ) !== -1;
 
-    const readyToRequestDiagnostics = diagnosticsReports.every(
-      diagnostic => diagnostic.completed,
-    );
-
-    // Get diagnostic reports within the time window.
-    const dataSource = filterByTimeScale(
-      diagnosticsReports.map((diagnosticsReport, idx) => ({
-        ...diagnosticsReport,
-        key: idx,
-      })),
-      currentScale,
-    );
-
-    // Get active report not within the time window if exists.
-    const undisplayedActiveReportExists: boolean =
-      diagnosticsReports.findIndex(
-        report =>
-          !report.completed && !dataSource.find(data => data.id === report.id),
-      ) !== -1;
-
-    if (dataSource.length === 0) {
-      return (
-        <>
-          <TimeScaleDropdown
-            options={timeScale1hMinOptions}
-            currentScale={currentScale}
-            setTimeScale={onChangeTimeScale}
-            className={cx("timescale-small", "margin-bottom")}
-          />
-          <StmtDiagnosticLabel
-            currentScale={this.props.currentScale}
-            requestTime={moment(this.props.requestTime)}
-            undisplayedActiveReportExists={undisplayedActiveReportExists}
-          />
-          <SummaryCard>
-            <EmptyDiagnosticsView {...this.props} />
-          </SummaryCard>
-        </>
-      );
-    }
-
+  if (dataSource.length === 0) {
     return (
       <>
-        <div className={cx("crl-statements-diagnostics-view__header")}>
-          <TimeScaleDropdown
-            options={timeScale1hMinOptions}
-            currentScale={currentScale}
-            setTimeScale={onChangeTimeScale}
-            className={cx("timescale-small")}
-          />
-          {readyToRequestDiagnostics && (
-            <Button
-              onClick={() =>
-                activateDiagnosticsRef?.current?.showModalFor(
-                  statementFingerprint,
-                  planGists,
-                )
-              }
-              disabled={!readyToRequestDiagnostics}
-              intent="secondary"
-            >
-              Activate diagnostics
-            </Button>
-          )}
-        </div>
+        <TimeScaleDropdown
+          options={timeScale1hMinOptions}
+          currentScale={currentScale}
+          setTimeScale={onChangeTimeScale}
+          className={cx("timescale-small", "margin-bottom")}
+        />
         <StmtDiagnosticLabel
-          currentScale={this.props.currentScale}
-          requestTime={moment(this.props.requestTime)}
+          currentScale={currentScale}
+          requestTime={moment(requestTime)}
           undisplayedActiveReportExists={undisplayedActiveReportExists}
         />
-        <SortedTable
-          data={dataSource}
-          columns={this.columns}
-          className={cx("jobs-table")}
-          sortSetting={this.state.sortSetting}
-          onChangeSortSetting={this.onSortingChange}
-          tableWrapperClassName={cx("sorted-table")}
-        />
-        {showDiagnosticsViewLink && (
-          <div className={cx("crl-statements-diagnostics-view__footer")}>
-            <Link
-              component={NavButton}
-              to="/reports/statements/diagnosticshistory"
-            >
-              All statement diagnostics
-            </Link>
-          </div>
-        )}
+        <SummaryCard>
+          <EmptyDiagnosticsView
+            diagnosticsReports={diagnosticsReports}
+            showDiagnosticsViewLink={showDiagnosticsViewLink}
+            activateDiagnosticsRef={activateDiagnosticsRef}
+            currentScale={currentScale}
+            requestTime={requestTime}
+            dismissAlertMessage={dismissAlertMessage}
+            onChangeTimeScale={onChangeTimeScale}
+            statementFingerprint={statementFingerprint}
+            planGists={planGists}
+          />
+        </SummaryCard>
       </>
     );
   }
+
+  return (
+    <>
+      <div className={cx("crl-statements-diagnostics-view__header")}>
+        <TimeScaleDropdown
+          options={timeScale1hMinOptions}
+          currentScale={currentScale}
+          setTimeScale={onChangeTimeScale}
+          className={cx("timescale-small")}
+        />
+        {readyToRequestDiagnostics && (
+          <Button
+            onClick={() =>
+              activateDiagnosticsRef?.current?.showModalFor(
+                statementFingerprint,
+                planGists,
+              )
+            }
+            disabled={!readyToRequestDiagnostics}
+            intent="secondary"
+          >
+            Activate diagnostics
+          </Button>
+        )}
+      </div>
+      <StmtDiagnosticLabel
+        currentScale={currentScale}
+        requestTime={moment(requestTime)}
+        undisplayedActiveReportExists={undisplayedActiveReportExists}
+      />
+      <SortedTable
+        data={dataSource}
+        columns={columns}
+        className={cx("jobs-table")}
+        sortSetting={sortSetting}
+        onChangeSortSetting={handleSortingChange}
+        tableWrapperClassName={cx("sorted-table")}
+      />
+      {showDiagnosticsViewLink && (
+        <div className={cx("crl-statements-diagnostics-view__footer")}>
+          <Link
+            component={NavButton}
+            to="/reports/statements/diagnosticshistory"
+          >
+            All statement diagnostics
+          </Link>
+        </div>
+      )}
+    </>
+  );
 }

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/planView/planView.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/planView/planView.spec.tsx
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
-import { assert } from "chai";
 
 import {
   FlatPlanNode,
@@ -112,7 +111,7 @@ describe("planView", () => {
           ],
         };
 
-        assert.deepEqual(flattenTreeAttributes(node), nodeFlattened);
+        expect(flattenTreeAttributes(node)).toEqual(nodeFlattened);
       });
     });
     describe("when there are nodes with multiple attributes with the same key", () => {
@@ -153,7 +152,7 @@ describe("planView", () => {
           ],
         };
 
-        assert.deepEqual(flattenTreeAttributes(node), nodeFlattened);
+        expect(flattenTreeAttributes(node)).toEqual(nodeFlattened);
       });
     });
   });
@@ -161,16 +160,14 @@ describe("planView", () => {
   describe("flattenAttributes", () => {
     describe("when all attributes have different keys", () => {
       it("creates array with exactly one value for each attribute", () => {
-        assert.deepEqual(
-          flattenAttributes(testAttrsDistinctKeys),
+        expect(flattenAttributes(testAttrsDistinctKeys)).toEqual(
           expectedTestAttrsDistinctKeys,
         );
       });
     });
     describe("when there are multiple attributes with same key", () => {
       it("collects values into one array for same key", () => {
-        assert.deepEqual(
-          flattenAttributes(testAttrsDuplicatedKeys),
+        expect(flattenAttributes(testAttrsDuplicatedKeys)).toEqual(
           expectedTestAttrsFlattened,
         );
       });
@@ -200,7 +197,7 @@ describe("planView", () => {
           },
         ];
 
-        assert.deepEqual(flattenAttributes(testAttrs), expectedTestAttrs);
+        expect(flattenAttributes(testAttrs)).toEqual(expectedTestAttrs);
       });
     });
     describe("when keys are unsorted", () => {
@@ -241,21 +238,21 @@ describe("planView", () => {
           },
         ];
 
-        assert.deepEqual(flattenAttributes(testAttrs), expectedTestAttrs);
+        expect(flattenAttributes(testAttrs)).toEqual(expectedTestAttrs);
       });
     });
   });
 
   describe("standardizeKey", () => {
     it("should convert strings to camel case", () => {
-      assert.equal(standardizeKey("hello world"), "helloWorld");
-      assert.equal(standardizeKey("camels-are-cool"), "camelsAreCool");
-      assert.equal(standardizeKey("cockroach"), "cockroach");
+      expect(standardizeKey("hello world")).toBe("helloWorld");
+      expect(standardizeKey("camels-are-cool")).toBe("camelsAreCool");
+      expect(standardizeKey("cockroach")).toBe("cockroach");
     });
 
     it("should remove '(anti)' from the key", () => {
-      assert.equal(standardizeKey("lookup join (anti)"), "lookupJoin");
-      assert.equal(standardizeKey("(anti) hello world"), "helloWorld");
+      expect(standardizeKey("lookup join (anti)")).toBe("lookupJoin");
+      expect(standardizeKey("(anti) hello world")).toBe("helloWorld");
     });
   });
 
@@ -277,7 +274,7 @@ describe("planView", () => {
       const expectedString =
         "Into users(id, city, name, address, credit_card) Size 5 columns, 3 rows";
 
-      assert.equal(planNodeAttrsToString(testNodeAttrs), expectedString);
+      expect(planNodeAttrsToString(testNodeAttrs)).toBe(expectedString);
     });
   });
 
@@ -303,7 +300,7 @@ describe("planView", () => {
       const expectedString =
         "insert fast path Into users(id, city, name, address, credit_card) Size 5 columns, 3 rows";
 
-      assert.equal(planNodeToString(testPlanNode), expectedString);
+      expect(planNodeToString(testPlanNode)).toBe(expectedString);
     });
 
     it("should recursively convert a FlatPlanNode (with children) into a string.", () => {
@@ -345,7 +342,7 @@ describe("planView", () => {
 
       const expectedString =
         "render  group (scalar)  filter filter variable = _ virtual table table cluster_settings@primary";
-      assert.equal(planNodeToString(testPlanNode), expectedString);
+      expect(planNodeToString(testPlanNode)).toBe(expectedString);
     });
   });
 });

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.spec.tsx
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 import { render, screen, fireEvent } from "@testing-library/react";
-import { assert } from "chai";
 import React from "react";
 import { MemoryRouter as Router } from "react-router-dom";
 import { createSandbox } from "sinon";
@@ -90,19 +89,10 @@ describe("StatementDetails page", () => {
 
       // Expect calls to refresh page information on load and update events. Node
       // and liveness refreshes should not happen for tenants.
-      assert.equal(
-        refreshNodesClickSpy.callCount,
-        isTenant ? 0 : 3,
-        "refresh nodes",
-      );
-      assert.equal(
-        refreshNodesLivenessClickSpy.callCount,
-        isTenant ? 0 : 3,
-        "refresh liveness",
-      );
-      assert.isTrue(
-        refreshStatementDiagnosticsRequestsClickSpy.calledThrice,
-        "refresh diagnostics requests",
+      expect(refreshNodesClickSpy.callCount).toBe(isTenant ? 0 : 3);
+      expect(refreshNodesLivenessClickSpy.callCount).toBe(isTenant ? 0 : 3);
+      expect(refreshStatementDiagnosticsRequestsClickSpy.calledThrice).toBe(
+        true,
       );
     });
 

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.spec.tsx
@@ -3,8 +3,6 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
-import { assert } from "chai";
-
 import { filterBySearchQuery } from "src/sqlActivity/util";
 
 import { FlatPlanNode } from "../statementDetails";
@@ -66,15 +64,15 @@ describe("StatementsPage", () => {
       },
     };
 
-    assert.equal(filterBySearchQuery(statement, "select"), true);
-    assert.equal(filterBySearchQuery(statement, "count"), true);
-    assert.equal(filterBySearchQuery(statement, "select count"), true);
-    assert.equal(filterBySearchQuery(statement, "cluster settings"), true);
+    expect(filterBySearchQuery(statement, "select")).toBe(true);
+    expect(filterBySearchQuery(statement, "count")).toBe(true);
+    expect(filterBySearchQuery(statement, "select count")).toBe(true);
+    expect(filterBySearchQuery(statement, "cluster settings")).toBe(true);
 
     // Searching by plan should be false.
-    assert.equal(filterBySearchQuery(statement, "virtual table"), false);
-    assert.equal(filterBySearchQuery(statement, "group (scalar)"), false);
-    assert.equal(filterBySearchQuery(statement, "node_build_info"), false);
-    assert.equal(filterBySearchQuery(statement, "crdb_internal"), false);
+    expect(filterBySearchQuery(statement, "virtual table")).toBe(false);
+    expect(filterBySearchQuery(statement, "group (scalar)")).toBe(false);
+    expect(filterBySearchQuery(statement, "node_build_info")).toBe(false);
+    expect(filterBySearchQuery(statement, "crdb_internal")).toBe(false);
   });
 });

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -10,7 +10,7 @@ import groupBy from "lodash/groupBy";
 import isString from "lodash/isString";
 import merge from "lodash/merge";
 import moment from "moment-timezone";
-import React from "react";
+import React, { useState, useEffect, useCallback, useRef } from "react";
 import { RouteComponentProps } from "react-router-dom";
 
 import {
@@ -184,38 +184,87 @@ function stmtsRequestFromParams(params: RequestParams): StatementsRequest {
   });
 }
 
-export class StatementsPage extends React.Component<
-  StatementsPageProps,
-  StatementsPageState
-> {
-  activateDiagnosticsRef: React.RefObject<ActivateDiagnosticsModalRef>;
+export function StatementsPage(props: StatementsPageProps): React.ReactElement {
+  const {
+    history,
+    search,
+    sortSetting,
+    filters: propsFilters,
+    onSearchComplete,
+    onFilterChange,
+    onSortingChange,
+    refreshDatabases,
+    refreshStatements,
+    refreshStatementDiagnosticsRequests,
+    refreshNodes,
+    refreshUserSQLRoles,
+    resetSQLStats: resetSQLStatsAction,
+    dismissAlertMessage,
+    onActivateStatementDiagnostics,
+    onDiagnosticsModalOpen,
+    onPageChanged,
+    onSelectDiagnosticsReportDropdownOption,
+    onStatementClick,
+    columns: userSelectedColumnsToShow,
+    onColumnsChange,
+    onTimeScaleChange,
+    onChangeLimit: onChangeLimitProp,
+    onChangeReqSort: onChangeReqSortProp,
+    onApplySearchCriteria,
+    onRequestTimeChange,
+    statementsResponse,
+    timeScale: propsTimeScale,
+    limit: propsLimit,
+    reqSortSetting: propsReqSortSetting,
+    databases,
+    nodeRegions,
+    isTenant,
+    hasViewActivityRedactedRole,
+    hasAdminRole,
+    stmtsTotalRuntimeSecs,
+    statementDiagnostics,
+    requestTime,
+    oldestDataAvailable,
+  } = props;
 
-  constructor(props: StatementsPageProps) {
-    super(props);
-    const defaultState = {
+  const activateDiagnosticsRef = useRef<ActivateDiagnosticsModalRef>(null);
+
+  // Refs to hold latest values for mount effects, avoiding stale closures
+  // while preserving "run once on mount" semantics.
+  const refreshDatabasesRef = useRef(refreshDatabases);
+  const propsTimeScaleRef = useRef(propsTimeScale);
+  const statementsResponseRef = useRef(statementsResponse);
+  const refreshUserSQLRolesRef = useRef(refreshUserSQLRoles);
+  const isTenantRef = useRef(isTenant);
+  const refreshNodesRef = useRef(refreshNodes);
+  const hasViewActivityRedactedRoleRef = useRef(hasViewActivityRedactedRole);
+  const refreshStatementDiagnosticsRequestsRef = useRef(
+    refreshStatementDiagnosticsRequests,
+  );
+
+  // Keep refs up to date on each render
+  refreshDatabasesRef.current = refreshDatabases;
+  propsTimeScaleRef.current = propsTimeScale;
+  statementsResponseRef.current = statementsResponse;
+  refreshUserSQLRolesRef.current = refreshUserSQLRoles;
+  isTenantRef.current = isTenant;
+  refreshNodesRef.current = refreshNodes;
+  hasViewActivityRedactedRoleRef.current = hasViewActivityRedactedRole;
+  refreshStatementDiagnosticsRequestsRef.current =
+    refreshStatementDiagnosticsRequests;
+
+  // Compute initial state from history once
+  const getInitialState = (): StatementsPageState => {
+    const defaultState: StatementsPageState = {
       pagination: {
         pageSize: 50,
         current: 1,
       },
-      limit: this.props.limit,
-      timeScale: this.props.timeScale,
-      reqSortSetting: this.props.reqSortSetting,
+      limit: propsLimit,
+      timeScale: propsTimeScale,
+      reqSortSetting: propsReqSortSetting,
     };
-    const stateFromHistory = this.getStateFromHistory();
-    this.state = merge(defaultState, stateFromHistory);
-    this.activateDiagnosticsRef = React.createRef();
-  }
 
-  getStateFromHistory = (): Partial<StatementsPageState> => {
-    const {
-      history,
-      search,
-      sortSetting,
-      filters,
-      onSearchComplete,
-      onFilterChange,
-      onSortingChange,
-    } = this.props;
     const searchParams = new URLSearchParams(history.location.search);
 
     // Search query.
@@ -235,133 +284,151 @@ export class StatementsPage extends React.Component<
     // Filters.
     const latestFilter = handleFiltersFromQueryString(
       history,
-      filters,
+      propsFilters,
       onFilterChange,
     );
 
-    return {
+    const stateFromHistory: Partial<StatementsPageState> = {
       filters: latestFilter,
       activeFilters: calculateActiveFilters(latestFilter),
     };
+
+    return merge(defaultState, stateFromHistory);
   };
 
-  changeSortSetting = (ss: SortSetting): void => {
-    syncHistory(
-      {
-        ascending: ss.ascending.toString(),
-        columnTitle: ss.columnTitle,
-      },
-      this.props.history,
-    );
-    if (this.props.onSortingChange) {
-      this.props.onSortingChange("Statements", ss.columnTitle, ss.ascending);
-    }
-  };
+  const [pagination, setPagination] = useState<ISortedTablePagination>(
+    () => getInitialState().pagination,
+  );
+  const [filters, setFilters] = useState<Filters | undefined>(
+    () => getInitialState().filters,
+  );
+  const [activeFilters, setActiveFilters] = useState<number | undefined>(
+    () => getInitialState().activeFilters,
+  );
+  const [localTimeScale, setLocalTimeScale] = useState<TimeScale>(
+    () => getInitialState().timeScale,
+  );
+  const [localLimit, setLocalLimit] = useState<number>(
+    () => getInitialState().limit,
+  );
+  const [localReqSortSetting, setLocalReqSortSetting] =
+    useState<SqlStatsSortType>(() => getInitialState().reqSortSetting);
 
-  isSortSettingSameAsReqSort = (): boolean => {
-    return (
-      getSortColumn(this.props.reqSortSetting) ===
-      this.props.sortSetting.columnTitle
-    );
-  };
+  // Track pending update for setState callback pattern
+  const pendingUpdateRef = useRef<(() => void) | null>(null);
 
-  changeTimeScale = (ts: TimeScale): void => {
-    this.setState(prevState => ({
-      ...prevState,
-      timeScale: ts,
+  const resetPagination = (): void => {
+    setPagination(prev => ({
+      current: 1,
+      pageSize: prev.pageSize,
     }));
   };
 
-  updateRequestParams = (): void => {
-    if (this.props.limit !== this.state.limit) {
-      this.props.onChangeLimit(this.state.limit);
+  const refreshStatementsInternal = useCallback((): void => {
+    const req = stmtsRequestFromParams({
+      limit: localLimit,
+      reqSortSetting: localReqSortSetting,
+      timeScale: localTimeScale,
+    });
+    refreshStatements(req);
+  }, [localLimit, localReqSortSetting, localTimeScale, refreshStatements]);
+
+  // Ref for mount effect
+  const refreshStatementsInternalRef = useRef(refreshStatementsInternal);
+  refreshStatementsInternalRef.current = refreshStatementsInternal;
+
+  const changeSortSetting = useCallback(
+    (ss: SortSetting): void => {
+      syncHistory(
+        {
+          ascending: ss.ascending.toString(),
+          columnTitle: ss.columnTitle,
+        },
+        history,
+      );
+      if (onSortingChange) {
+        onSortingChange("Statements", ss.columnTitle, ss.ascending);
+      }
+    },
+    [history, onSortingChange],
+  );
+
+  const isSortSettingSameAsReqSort = (): boolean => {
+    return getSortColumn(propsReqSortSetting) === sortSetting.columnTitle;
+  };
+
+  const changeTimeScale = (ts: TimeScale): void => {
+    setLocalTimeScale(ts);
+  };
+
+  const updateRequestParams = useCallback((): void => {
+    if (propsLimit !== localLimit) {
+      onChangeLimitProp(localLimit);
     }
 
-    if (this.props.reqSortSetting !== this.state.reqSortSetting) {
-      this.props.onChangeReqSort(this.state.reqSortSetting);
+    if (propsReqSortSetting !== localReqSortSetting) {
+      onChangeReqSortProp(localReqSortSetting);
     }
 
-    if (this.props.timeScale !== this.state.timeScale) {
-      this.props.onTimeScaleChange(this.state.timeScale);
+    if (propsTimeScale !== localTimeScale) {
+      onTimeScaleChange(localTimeScale);
     }
-    if (this.props.onApplySearchCriteria) {
-      this.props.onApplySearchCriteria(
-        this.state.timeScale,
-        this.state.limit,
-        getSortLabel(this.state.reqSortSetting, "Statement"),
+    if (onApplySearchCriteria) {
+      onApplySearchCriteria(
+        localTimeScale,
+        localLimit,
+        getSortLabel(localReqSortSetting, "Statement"),
       );
     }
-    this.props.onRequestTimeChange(moment());
-    this.refreshStatements();
+    onRequestTimeChange(moment());
+
+    // Refresh statements with the new params
+    const req = stmtsRequestFromParams({
+      limit: localLimit,
+      reqSortSetting: localReqSortSetting,
+      timeScale: localTimeScale,
+    });
+    refreshStatements(req);
+
     const ss: SortSetting = {
       ascending: false,
-      columnTitle: getSortColumn(this.state.reqSortSetting),
+      columnTitle: getSortColumn(localReqSortSetting),
     };
-    this.changeSortSetting(ss);
-  };
+    changeSortSetting(ss);
+  }, [
+    propsLimit,
+    localLimit,
+    propsReqSortSetting,
+    localReqSortSetting,
+    propsTimeScale,
+    localTimeScale,
+    onChangeLimitProp,
+    onChangeReqSortProp,
+    onTimeScaleChange,
+    onApplySearchCriteria,
+    onRequestTimeChange,
+    refreshStatements,
+    changeSortSetting,
+  ]);
 
-  onUpdateSortSettingAndApply = (): void => {
-    this.setState(
-      {
-        reqSortSetting: getReqSortColumn(this.props.sortSetting.columnTitle),
-      },
-      () => {
-        this.updateRequestParams();
-      },
-    );
-  };
+  const onUpdateSortSettingAndApply = useCallback((): void => {
+    setLocalReqSortSetting(getReqSortColumn(sortSetting.columnTitle));
+    pendingUpdateRef.current = updateRequestParams;
+  }, [sortSetting.columnTitle, updateRequestParams]);
 
-  resetPagination = (): void => {
-    this.setState(prevState => {
-      return {
-        pagination: {
-          current: 1,
-          pageSize: prevState.pagination.pageSize,
-        },
-      };
-    });
-  };
-
-  refreshStatements = (): void => {
-    const req = stmtsRequestFromParams(this.state);
-    this.props.refreshStatements(req);
-  };
-
-  refreshDatabases = (): void => {
-    this.props.refreshDatabases();
-  };
-
-  resetSQLStats = (): void => {
-    this.props.resetSQLStats();
-  };
-
-  componentDidMount(): void {
-    this.refreshDatabases();
-    // In case the user selected a option not available on this page,
-    // force a selection of a valid option. This is necessary for the case
-    // where the value 10/30 min is selected on the Metrics page.
-    const ts = getValidOption(this.props.timeScale, timeScale1hMinOptions);
-    if (ts !== this.props.timeScale) {
-      this.changeTimeScale(ts);
-    } else if (
-      !this.props.statementsResponse.valid ||
-      !this.props.statementsResponse.data ||
-      !this.props.statementsResponse.lastUpdated
-    ) {
-      this.refreshStatements();
+  // Execute pending update after state changes
+  useEffect(() => {
+    if (pendingUpdateRef.current) {
+      pendingUpdateRef.current();
+      pendingUpdateRef.current = null;
     }
+  }, [localReqSortSetting]);
 
-    this.props.refreshUserSQLRoles();
-    if (!this.props.isTenant) {
-      this.props.refreshNodes();
-    }
-    if (!this.props.hasViewActivityRedactedRole) {
-      this.props.refreshStatementDiagnosticsRequests();
-    }
-  }
+  const resetSQLStats = (): void => {
+    resetSQLStatsAction();
+  };
 
-  updateQueryParams(): void {
-    const { history, search, sortSetting } = this.props;
+  const updateQueryParams = useCallback((): void => {
     const tab = "Statements";
 
     // Search.
@@ -378,7 +445,7 @@ export class StatementsPage extends React.Component<
     }
 
     // Filters.
-    updateFiltersQueryParamsOnTab(tab, this.state.filters, history);
+    updateFiltersQueryParamsOnTab(tab, filters, history);
 
     // Sort Setting.
     updateSortSettingQueryParamsOnTab(
@@ -390,95 +457,73 @@ export class StatementsPage extends React.Component<
       },
       history,
     );
-  }
+  }, [history, search, filters, sortSetting]);
 
-  componentDidUpdate = (): void => {
-    this.updateQueryParams();
-    if (!this.props.isTenant) {
-      this.props.refreshNodes();
-    }
-    if (!this.props.hasViewActivityRedactedRole) {
-      this.props.refreshStatementDiagnosticsRequests();
+  const onChangePage = (current: number, pageSize: number): void => {
+    setPagination(prev => ({ ...prev, current, pageSize }));
+    if (onPageChanged) {
+      onPageChanged(current);
     }
   };
 
-  componentWillUnmount(): void {
-    this.props.dismissAlertMessage();
-  }
-
-  onChangePage = (current: number, pageSize: number): void => {
-    const { pagination } = this.state;
-    this.setState(prevState => ({
-      ...prevState,
-      pagination: { ...pagination, current, pageSize },
-    }));
-    if (this.props.onPageChanged) {
-      this.props.onPageChanged(current);
+  const onSubmitSearchField = (searchValue: string): void => {
+    if (onSearchComplete) {
+      onSearchComplete(searchValue);
     }
-  };
-
-  onSubmitSearchField = (search: string): void => {
-    if (this.props.onSearchComplete) {
-      this.props.onSearchComplete(search);
-    }
-    this.resetPagination();
+    resetPagination();
     syncHistory(
       {
-        q: search,
+        q: searchValue,
       },
-      this.props.history,
+      history,
     );
   };
 
-  onSubmitFilters = (filters: Filters): void => {
-    if (this.props.onFilterChange) {
-      this.props.onFilterChange(filters);
+  const onSubmitFilters = (newFilters: Filters): void => {
+    if (onFilterChange) {
+      onFilterChange(newFilters);
     }
 
-    this.setState({
-      filters: filters,
-      activeFilters: calculateActiveFilters(filters),
-    });
+    setFilters(newFilters);
+    setActiveFilters(calculateActiveFilters(newFilters));
 
-    this.resetPagination();
+    resetPagination();
     syncHistory(
       {
-        app: filters.app,
-        timeNumber: filters.timeNumber,
-        timeUnit: filters.timeUnit,
-        fullScan: filters.fullScan.toString(),
-        sqlType: filters.sqlType,
-        database: filters.database,
-        regions: filters.regions,
-        nodes: filters.nodes,
+        app: newFilters.app,
+        timeNumber: newFilters.timeNumber,
+        timeUnit: newFilters.timeUnit,
+        fullScan: newFilters.fullScan.toString(),
+        sqlType: newFilters.sqlType,
+        database: newFilters.database,
+        regions: newFilters.regions,
+        nodes: newFilters.nodes,
       },
-      this.props.history,
+      history,
     );
   };
 
-  onClearSearchField = (): void => {
-    if (this.props.onSearchComplete) {
-      this.props.onSearchComplete("");
+  const onClearSearchField = (): void => {
+    if (onSearchComplete) {
+      onSearchComplete("");
     }
     syncHistory(
       {
         q: undefined,
       },
-      this.props.history,
+      history,
     );
   };
 
-  onClearFilters = (): void => {
-    if (this.props.onFilterChange) {
-      this.props.onFilterChange(defaultFilters);
+  const onClearFilters = (): void => {
+    if (onFilterChange) {
+      onFilterChange(defaultFilters);
     }
 
-    this.setState({
-      filters: defaultFilters,
-      activeFilters: 0,
-    });
+    setFilters(defaultFilters);
+    setActiveFilters(0);
 
-    this.resetPagination();
+    resetPagination();
     syncHistory(
       {
         app: undefined,
@@ -490,51 +535,85 @@ export class StatementsPage extends React.Component<
         regions: undefined,
         nodes: undefined,
       },
-      this.props.history,
+      history,
     );
   };
 
-  onChangeLimit = (newLimit: number): void => {
-    this.setState(prevState => ({ ...prevState, limit: newLimit }));
+  const onChangeLimit = (newLimit: number): void => {
+    setLocalLimit(newLimit);
   };
 
-  onChangeReqSort = (newSort: SqlStatsSortType): void => {
-    this.setState(prevState => ({ ...prevState, reqSortSetting: newSort }));
+  const onChangeReqSort = (newSort: SqlStatsSortType): void => {
+    setLocalReqSortSetting(newSort);
   };
 
-  hasReqSortOption = (): boolean => {
+  const hasReqSortOption = (): boolean => {
     let found = false;
     Object.values(SqlStatsSortOptions).forEach(option => {
       const optionString = isString(option) ? option : getSortColumn(option);
-      if (optionString === this.props.sortSetting.columnTitle) {
+      if (optionString === sortSetting.columnTitle) {
         found = true;
       }
     });
     return found;
   };
 
-  renderStatements = (
+  // componentDidMount
+  useEffect(() => {
+    refreshDatabasesRef.current();
+    // In case the user selected a option not available on this page,
+    // force a selection of a valid option. This is necessary for the case
+    // where the value 10/30 min is selected on the Metrics page.
+    const ts = getValidOption(propsTimeScaleRef.current, timeScale1hMinOptions);
+    if (ts !== propsTimeScaleRef.current) {
+      changeTimeScale(ts);
+    } else if (
+      !statementsResponseRef.current.valid ||
+      !statementsResponseRef.current.data ||
+      !statementsResponseRef.current.lastUpdated
+    ) {
+      refreshStatementsInternalRef.current();
+    }
+
+    refreshUserSQLRolesRef.current();
+    if (!isTenantRef.current) {
+      refreshNodesRef.current();
+    }
+    if (!hasViewActivityRedactedRoleRef.current) {
+      refreshStatementDiagnosticsRequestsRef.current();
+    }
+  }, []);
+
+  // componentDidUpdate - update query params and refresh data
+  useEffect(() => {
+    updateQueryParams();
+    if (!isTenant) {
+      refreshNodes();
+    }
+    if (!hasViewActivityRedactedRole) {
+      refreshStatementDiagnosticsRequests();
+    }
+  }, [
+    updateQueryParams,
+    isTenant,
+    refreshNodes,
+    hasViewActivityRedactedRole,
+    refreshStatementDiagnosticsRequests,
+  ]);
+
+  // componentWillUnmount
+  useEffect(() => {
+    return () => {
+      dismissAlertMessage();
+    };
+  }, [dismissAlertMessage]);
+
+  const renderStatements = (
     statements: AggregateStatistics[],
   ): React.ReactElement => {
-    const { pagination, filters, activeFilters } = this.state;
-    const {
-      onSelectDiagnosticsReportDropdownOption,
-      onStatementClick,
-      columns: userSelectedColumnsToShow,
-      onColumnsChange,
-      nodeRegions,
-      isTenant,
-      hasViewActivityRedactedRole,
-      sortSetting,
-      search,
-      databases,
-      hasAdminRole,
-    } = this.props;
     const data = filterStatementsData(filters, search, statements, isTenant);
 
-    const apps = getAppsFromStmtsResponseMemoized(
-      this.props.statementsResponse?.data,
-    );
+    const apps = getAppsFromStmtsResponseMemoized(statementsResponse?.data);
 
     const isEmptySearchResults = statements?.length > 0 && search?.length > 0;
     const nodes = Object.keys(nodeRegions)
@@ -555,13 +634,13 @@ export class StatementsPage extends React.Component<
     // hiding columns that won't be displayed for virtual clusters.
     const columns = makeStatementsColumns(
       statements,
-      filters.app?.split(","),
-      this.props.stmtsTotalRuntimeSecs,
+      filters?.app?.split(","),
+      stmtsTotalRuntimeSecs,
       "statement",
       isTenant,
       hasViewActivityRedactedRole,
       search,
-      this.activateDiagnosticsRef,
+      activateDiagnosticsRef,
       onSelectDiagnosticsReportDropdownOption,
       onStatementClick,
     )
@@ -587,32 +666,29 @@ export class StatementsPage extends React.Component<
       isSelectedColumn(userSelectedColumnsToShow, c),
     );
 
-    const sortSettingLabel = getSortLabel(
-      this.props.reqSortSetting,
-      "Statement",
-    );
+    const sortSettingLabel = getSortLabel(propsReqSortSetting, "Statement");
     const showSortWarning =
-      !this.isSortSettingSameAsReqSort() &&
-      this.hasReqSortOption() &&
-      data.length === this.props.limit;
+      !isSortSettingSameAsReqSort() &&
+      hasReqSortOption() &&
+      data.length === propsLimit;
 
     return (
       <>
         <h5 className={`${commonStyles("base-heading")} ${cx("margin-top")}`}>
-          {`Results - Top ${this.props.limit} Statement Fingerprints by ${sortSettingLabel}`}
+          {`Results - Top ${propsLimit} Statement Fingerprints by ${sortSettingLabel}`}
         </h5>
         <section className={cx("filter-area")}>
           <PageConfig className={cx("float-left")}>
             <PageConfigItem>
               <Search
-                onSubmit={this.onSubmitSearchField}
-                onClear={this.onClearSearchField}
+                onSubmit={onSubmitSearchField}
+                onClear={onClearSearchField}
                 defaultValue={search}
               />
             </PageConfigItem>
             <PageConfigItem>
               <Filter
-                onSubmitFilters={this.onSubmitFilters}
+                onSubmitFilters={onSubmitFilters}
                 appNames={apps}
                 dbNames={databases}
                 regions={regions}
@@ -637,11 +713,11 @@ export class StatementsPage extends React.Component<
             <PageConfigItem>
               <p className={timeScaleStylesCx("time-label")}>
                 <TimeScaleLabel
-                  timeScale={this.props.timeScale}
-                  requestTime={moment(this.props.requestTime)}
+                  timeScale={propsTimeScale}
+                  requestTime={moment(requestTime)}
                   oldestDataTime={
-                    this.props.oldestDataAvailable &&
-                    TimestampToMoment(this.props.oldestDataAvailable)
+                    oldestDataAvailable &&
+                    TimestampToMoment(oldestDataAvailable)
                   }
                 />
                 {", "}
@@ -659,7 +735,7 @@ export class StatementsPage extends React.Component<
                 )} `}
               >
                 <ClearStats
-                  resetSQLStats={this.resetSQLStats}
+                  resetSQLStats={resetSQLStats}
                   tooltipType="statement"
                 />
               </PageConfigItem>
@@ -669,18 +745,18 @@ export class StatementsPage extends React.Component<
         <section className={sortableTableCx("cl-table-container")}>
           <SelectedFilters
             filters={filters}
-            onRemoveFilter={this.onSubmitFilters}
-            onClearFilters={this.onClearFilters}
+            onRemoveFilter={onSubmitFilters}
+            onClearFilters={onClearFilters}
           />
           {showSortWarning && (
             <InlineAlert
               intent="warning"
               title={getSubsetWarning(
                 "statement",
-                this.props.limit,
+                propsLimit,
                 sortSettingLabel,
-                this.props.sortSetting.columnTitle as StatisticTableColumnKeys,
-                this.onUpdateSortSettingAndApply,
+                sortSetting.columnTitle as StatisticTableColumnKeys,
+                onUpdateSortSettingAndApply,
               )}
               className={cx("margin-bottom")}
             />
@@ -690,7 +766,7 @@ export class StatementsPage extends React.Component<
             data={data}
             columns={displayColumns}
             sortSetting={sortSetting}
-            onChangeSortSetting={this.changeSortSetting}
+            onChangeSortSetting={changeSortSetting}
             renderNoResult={
               <EmptyStatementsPlaceholder
                 isEmptySearchResults={isEmptySearchResults}
@@ -704,84 +780,74 @@ export class StatementsPage extends React.Component<
           pageSize={pagination.pageSize}
           current={pagination.current}
           total={data.length}
-          onChange={this.onChangePage}
-          onShowSizeChange={this.onChangePage}
+          onChange={onChangePage}
+          onShowSizeChange={onChangePage}
         />
       </>
     );
   };
 
-  render(): React.ReactElement {
-    const {
-      refreshStatementDiagnosticsRequests,
-      onActivateStatementDiagnostics,
-      onDiagnosticsModalOpen,
-      statementDiagnostics,
-    } = this.props;
+  const diagnosticsByStatement = groupBy(
+    statementDiagnostics,
+    sd => sd.statement_fingerprint,
+  );
 
-    const diagnosticsByStatement = groupBy(
-      statementDiagnostics,
-      sd => sd.statement_fingerprint,
-    );
+  const statements = convertRawStmtsToAggregateStatisticsMemoized(
+    statementsResponse?.data?.statements,
+  ).map(
+    (s): AggregateStatistics => ({
+      ...s,
+      diagnosticsReports: diagnosticsByStatement[s.label] || [],
+    }),
+  );
 
-    const statements = convertRawStmtsToAggregateStatisticsMemoized(
-      this.props.statementsResponse?.data?.statements,
-    ).map(
-      (s): AggregateStatistics => ({
-        ...s,
-        diagnosticsReports: diagnosticsByStatement[s.label] || [],
-      }),
-    );
+  const longLoadingMessage = (
+    <Delayed delay={STATS_LONG_LOADING_DURATION}>
+      <InlineAlert
+        intent="info"
+        title="If the selected time interval contains a large amount of data, this page might take a few minutes to load."
+      />
+    </Delayed>
+  );
 
-    const longLoadingMessage = (
-      <Delayed delay={STATS_LONG_LOADING_DURATION}>
-        <InlineAlert
-          intent="info"
-          title="If the selected time interval contains a large amount of data, this page might take a few minutes to load."
+  return (
+    <div className={cx("root")}>
+      <SearchCriteria
+        searchType="Statement"
+        topValue={localLimit}
+        byValue={localReqSortSetting}
+        currentScale={localTimeScale}
+        onChangeTop={onChangeLimit}
+        onChangeBy={onChangeReqSort}
+        onChangeTimeScale={changeTimeScale}
+        onApply={updateRequestParams}
+      />
+      <div className={cx("table-area")}>
+        <Loading
+          loading={statementsResponse.inFlight}
+          page={"statements"}
+          error={statementsResponse.error}
+          render={() => renderStatements(statements)}
+          renderError={() =>
+            LoadingError({
+              statsType: "statements",
+              error: statementsResponse?.error,
+              sourceTables: statementsResponse?.data?.stmts_source_table && [
+                statementsResponse?.data?.stmts_source_table,
+              ],
+            })
+          }
         />
-      </Delayed>
-    );
-
-    return (
-      <div className={cx("root")}>
-        <SearchCriteria
-          searchType="Statement"
-          topValue={this.state.limit}
-          byValue={this.state.reqSortSetting}
-          currentScale={this.state.timeScale}
-          onChangeTop={this.onChangeLimit}
-          onChangeBy={this.onChangeReqSort}
-          onChangeTimeScale={this.changeTimeScale}
-          onApply={this.updateRequestParams}
+        {statementsResponse.inFlight &&
+          getValidErrorsList(statementsResponse.error) == null &&
+          longLoadingMessage}
+        <ActivateStatementDiagnosticsModal
+          ref={activateDiagnosticsRef}
+          activate={onActivateStatementDiagnostics}
+          refreshDiagnosticsReports={refreshStatementDiagnosticsRequests}
+          onOpenModal={onDiagnosticsModalOpen}
         />
-        <div className={cx("table-area")}>
-          <Loading
-            loading={this.props.statementsResponse.inFlight}
-            page={"statements"}
-            error={this.props.statementsResponse.error}
-            render={() => this.renderStatements(statements)}
-            renderError={() =>
-              LoadingError({
-                statsType: "statements",
-                error: this.props.statementsResponse?.error,
-                sourceTables: this.props.statementsResponse?.data
-                  ?.stmts_source_table && [
-                  this.props.statementsResponse?.data?.stmts_source_table,
-                ],
-              })
-            }
-          />
-          {this.props.statementsResponse.inFlight &&
-            getValidErrorsList(this.props.statementsResponse.error) == null &&
-            longLoadingMessage}
-          <ActivateStatementDiagnosticsModal
-            ref={this.activateDiagnosticsRef}
-            activate={onActivateStatementDiagnostics}
-            refreshDiagnosticsReports={refreshStatementDiagnosticsRequests}
-            onOpenModal={onDiagnosticsModalOpen}
-          />
-        </div>
       </div>
-    );
-  }
+    </div>
+  );
 }

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -7,9 +7,8 @@ import { InlineAlert } from "@cockroachlabs/ui-components";
 import classNames from "classnames/bind";
 import flatMap from "lodash/flatMap";
 import isString from "lodash/isString";
-import merge from "lodash/merge";
 import moment from "moment-timezone";
-import React from "react";
+import React, { useState, useEffect, useCallback, useRef } from "react";
 import { RouteComponentProps } from "react-router-dom";
 
 import {
@@ -89,14 +88,6 @@ import {
 const cx = classNames.bind(styles);
 const timeScaleStylesCx = classNames.bind(timeScaleStyles);
 
-interface TState {
-  filters?: Filters;
-  pagination: ISortedTablePagination;
-  timeScale: TimeScale;
-  limit: number;
-  reqSortSetting: SqlStatsSortType;
-}
-
 export interface TransactionsPageStateProps {
   columns: string[];
   txnsResp: RequestState<SqlStatsResponse>;
@@ -137,7 +128,11 @@ export type TransactionsPageProps = TransactionsPageStateProps &
   TransactionsPageDispatchProps &
   RouteComponentProps;
 
-type RequestParams = Pick<TState, "timeScale" | "limit" | "reqSortSetting">;
+interface RequestParams {
+  timeScale: TimeScale;
+  limit: number;
+  reqSortSetting: SqlStatsSortType;
+}
 
 function stmtsRequestFromParams(params: RequestParams): StatementsRequest {
   const [start, end] = toRoundedDateRange(params.timeScale);
@@ -148,227 +143,255 @@ function stmtsRequestFromParams(params: RequestParams): StatementsRequest {
     sort: params.reqSortSetting,
   });
 }
-export class TransactionsPage extends React.Component<
-  TransactionsPageProps,
-  TState
-> {
-  constructor(props: TransactionsPageProps) {
-    super(props);
 
-    this.state = {
-      limit: this.props.limit,
-      timeScale: this.props.timeScale,
-      reqSortSetting: this.props.reqSortSetting,
-      pagination: {
-        pageSize: 50,
-        current: 1,
-      },
-    };
-    const stateFromHistory = this.getStateFromHistory();
-    this.state = merge(this.state, stateFromHistory);
-  }
+export function TransactionsPage(
+  props: TransactionsPageProps,
+): React.ReactElement {
+  const {
+    columns: userSelectedColumnsToShow,
+    txnsResp,
+    timeScale: propsTimeScale,
+    limit: propsLimit,
+    reqSortSetting: propsReqSortSetting,
+    filters: propsFilters,
+    isTenant,
+    nodeRegions,
+    search,
+    sortSetting,
+    hasAdminRole,
+    requestTime,
+    oldestDataAvailable,
+    refreshData,
+    refreshNodes,
+    refreshUserSQLRoles,
+    resetSQLStats,
+    onTimeScaleChange,
+    onChangeLimit: propsOnChangeLimit,
+    onChangeReqSort: propsOnChangeReqSort,
+    onColumnsChange,
+    onFilterChange,
+    onSearchComplete,
+    onSortingChange,
+    onApplySearchCriteria,
+    onRequestTimeChange,
+    history,
+  } = props;
 
-  getStateFromHistory = (): Partial<TState> => {
-    const {
+  // Local state for search criteria (can differ from props until applied)
+  const [localTimeScale, setLocalTimeScale] =
+    useState<TimeScale>(propsTimeScale);
+  const [localLimit, setLocalLimit] = useState<number>(propsLimit);
+  const [localReqSortSetting, setLocalReqSortSetting] =
+    useState<SqlStatsSortType>(propsReqSortSetting);
+
+  const [filters, setFilters] = useState<Filters | undefined>(() => {
+    // Initialize filters from query string
+    const latestFilter = handleFiltersFromQueryString(
       history,
-      search,
-      sortSetting,
-      filters,
-      onSearchComplete,
-      onSortingChange,
+      propsFilters,
       onFilterChange,
-    } = this.props;
-    const searchParams = new URLSearchParams(history.location.search);
+    );
+    return latestFilter;
+  });
 
-    // Search query.
+  const [pagination, setPagination] = useState<ISortedTablePagination>({
+    pageSize: 50,
+    current: 1,
+  });
+
+  // Refs to hold latest values for mount effects, avoiding stale closures
+  // while preserving "run once on mount" semantics.
+  const onSearchCompleteRef = useRef(onSearchComplete);
+  const searchRef = useRef(search);
+  const sortSettingRef = useRef(sortSetting);
+  const onSortingChangeRef = useRef(onSortingChange);
+  const propsTimeScaleRef = useRef(propsTimeScale);
+  const onTimeScaleChangeRef = useRef(onTimeScaleChange);
+  const onRequestTimeChangeRef = useRef(onRequestTimeChange);
+  const txnsRespRef = useRef(txnsResp);
+  const isTenantRef = useRef(isTenant);
+  const refreshNodesRef = useRef(refreshNodes);
+  const refreshUserSQLRolesRef = useRef(refreshUserSQLRoles);
+
+  // Keep refs up to date on each render
+  onSearchCompleteRef.current = onSearchComplete;
+  searchRef.current = search;
+  sortSettingRef.current = sortSetting;
+  onSortingChangeRef.current = onSortingChange;
+  propsTimeScaleRef.current = propsTimeScale;
+  onTimeScaleChangeRef.current = onTimeScaleChange;
+  onRequestTimeChangeRef.current = onRequestTimeChange;
+  txnsRespRef.current = txnsResp;
+  isTenantRef.current = isTenant;
+  refreshNodesRef.current = refreshNodes;
+  refreshUserSQLRolesRef.current = refreshUserSQLRoles;
+
+  // Initialize search from query string
+  useEffect(() => {
+    const searchParams = new URLSearchParams(history.location.search);
     const searchQuery = searchParams.get("q") || undefined;
-    if (onSearchComplete && searchQuery && search !== searchQuery) {
-      onSearchComplete(searchQuery);
+    if (
+      onSearchCompleteRef.current &&
+      searchQuery &&
+      searchRef.current !== searchQuery
+    ) {
+      onSearchCompleteRef.current(searchQuery);
     }
 
-    // Sort Settings.
+    // Sort Settings from query string
     handleSortSettingFromQueryString(
       "Transactions",
       history.location.search,
-      sortSetting,
-      onSortingChange,
+      sortSettingRef.current,
+      onSortingChangeRef.current,
     );
+  }, [history.location.search]);
 
-    // Filters.
-    const latestFilter = handleFiltersFromQueryString(
-      history,
-      filters,
-      onFilterChange,
-    );
+  const refreshDataFromState = useCallback((): void => {
+    const req = stmtsRequestFromParams({
+      timeScale: localTimeScale,
+      limit: localLimit,
+      reqSortSetting: localReqSortSetting,
+    });
+    refreshData(req);
+  }, [localTimeScale, localLimit, localReqSortSetting, refreshData]);
 
-    return {
-      filters: latestFilter,
-    };
+  // Ref for mount effect
+  const refreshDataFromStateRef = useRef(refreshDataFromState);
+  refreshDataFromStateRef.current = refreshDataFromState;
+
+  const doResetSQLStats = (): void => {
+    resetSQLStats();
   };
 
-  refreshData = (): void => {
-    const req = stmtsRequestFromParams(this.state);
-    this.props.refreshData(req);
-  };
-
-  resetSQLStats = (): void => {
-    this.props.resetSQLStats();
-  };
-
-  componentDidMount(): void {
-    // In case the user selected a option not available on this page,
-    // force a selection of a valid option. This is necessary for the case
-    // where the value 10/30 min is selected on the Metrics page.
-    const ts = getValidOption(this.props.timeScale, timeScale1hMinOptions);
-    if (ts !== this.props.timeScale) {
-      this.changeTimeScale(ts);
+  // componentDidMount equivalent
+  useEffect(() => {
+    // In case the user selected an option not available on this page,
+    // force a selection of a valid option.
+    const ts = getValidOption(propsTimeScaleRef.current, timeScale1hMinOptions);
+    if (ts !== propsTimeScaleRef.current) {
+      setLocalTimeScale(ts);
+      if (onTimeScaleChangeRef.current) {
+        onTimeScaleChangeRef.current(ts);
+      }
+      onRequestTimeChangeRef.current(moment());
     } else if (
-      !this.props.txnsResp.valid ||
-      !this.props.txnsResp.data ||
-      !this.props.txnsResp.lastUpdated
+      !txnsRespRef.current.valid ||
+      !txnsRespRef.current.data ||
+      !txnsRespRef.current.lastUpdated
     ) {
-      this.refreshData();
+      refreshDataFromStateRef.current();
     }
 
-    if (!this.props.isTenant) {
-      this.props.refreshNodes();
+    if (!isTenantRef.current) {
+      refreshNodesRef.current();
     }
 
-    this.props.refreshUserSQLRoles();
-  }
+    refreshUserSQLRolesRef.current();
+  }, []);
 
-  updateQueryParams(): void {
-    const { history, search, sortSetting } = this.props;
+  // Update query params when relevant state changes
+  const updateQueryParams = useCallback((): void => {
     const tab = "Transactions";
 
-    // Search.
+    // Search
     const searchParams = new URLSearchParams(history.location.search);
     const currentTab = searchParams.get("tab") || "";
     const searchQueryString = searchParams.get("q") || "";
     if (currentTab === tab && search && search !== searchQueryString) {
-      syncHistory(
-        {
-          q: search,
-        },
-        history,
-      );
+      syncHistory({ q: search }, history);
     }
 
-    // Filters.
-    updateFiltersQueryParamsOnTab(tab, this.state.filters, history);
+    // Filters
+    updateFiltersQueryParamsOnTab(tab, filters, history);
 
-    // Sort Setting.
+    // Sort Setting
     updateSortSettingQueryParamsOnTab(
       tab,
       sortSetting,
+      { ascending: false, columnTitle: "executionCount" },
+      history,
+    );
+  }, [history, search, filters, sortSetting]);
+
+  // componentDidUpdate equivalent
+  useEffect(() => {
+    updateQueryParams();
+    if (!isTenant) {
+      refreshNodes();
+    }
+  }, [updateQueryParams, isTenant, refreshNodes]);
+
+  const onChangeSortSetting = useCallback(
+    (ss: SortSetting): void => {
+      syncHistory(
+        {
+          ascending: ss.ascending.toString(),
+          columnTitle: ss.columnTitle,
+        },
+        history,
+      );
+      if (onSortingChange) {
+        onSortingChange("Transactions", ss.columnTitle, ss.ascending);
+      }
+    },
+    [history, onSortingChange],
+  );
+
+  const isSortSettingSameAsReqSort = (): boolean => {
+    return getSortColumn(propsReqSortSetting) === sortSetting.columnTitle;
+  };
+
+  const onChangePage = (current: number, pageSize: number): void => {
+    setPagination(prev => ({ ...prev, current, pageSize }));
+  };
+
+  const resetPagination = (): void => {
+    setPagination(prev => ({
+      current: 1,
+      pageSize: prev.pageSize,
+    }));
+  };
+
+  const onClearSearchField = (): void => {
+    if (onSearchComplete) {
+      onSearchComplete("");
+    }
+    syncHistory({ q: undefined }, history);
+  };
+
+  const onSubmitSearchField = (searchValue: string): void => {
+    if (onSearchComplete) {
+      onSearchComplete(searchValue);
+    }
+    resetPagination();
+    syncHistory({ q: searchValue }, history);
+  };
+
+  const onSubmitFilters = (newFilters: Filters): void => {
+    if (onFilterChange) {
+      onFilterChange(newFilters);
+    }
+    setFilters(newFilters);
+    resetPagination();
+    syncHistory(
       {
-        ascending: false,
-        columnTitle: "executionCount",
+        app: newFilters.app,
+        timeNumber: newFilters.timeNumber,
+        timeUnit: newFilters.timeUnit,
+        regions: newFilters.regions,
+        nodes: newFilters.nodes,
       },
       history,
     );
-  }
+  };
 
-  componentDidUpdate(): void {
-    this.updateQueryParams();
-    if (!this.props.isTenant) {
-      this.props.refreshNodes();
+  const onClearFilters = (): void => {
+    if (onFilterChange) {
+      onFilterChange(defaultFilters);
     }
-  }
-
-  onChangeSortSetting = (ss: SortSetting): void => {
-    syncHistory(
-      {
-        ascending: ss.ascending.toString(),
-        columnTitle: ss.columnTitle,
-      },
-      this.props.history,
-    );
-    if (this.props.onSortingChange) {
-      this.props.onSortingChange("Transactions", ss.columnTitle, ss.ascending);
-    }
-  };
-
-  isSortSettingSameAsReqSort = (): boolean => {
-    return (
-      getSortColumn(this.props.reqSortSetting) ===
-      this.props.sortSetting.columnTitle
-    );
-  };
-
-  onChangePage = (current: number, pageSize: number): void => {
-    const { pagination } = this.state;
-    this.setState({ pagination: { ...pagination, current, pageSize } });
-  };
-
-  resetPagination = (): void => {
-    this.setState((prevState: TState) => {
-      return {
-        pagination: {
-          current: 1,
-          pageSize: prevState.pagination.pageSize,
-        },
-      };
-    });
-  };
-
-  onClearSearchField = (): void => {
-    if (this.props.onSearchComplete) {
-      this.props.onSearchComplete("");
-    }
-    syncHistory(
-      {
-        q: undefined,
-      },
-      this.props.history,
-    );
-  };
-
-  onSubmitSearchField = (search: string): void => {
-    if (this.props.onSearchComplete) {
-      this.props.onSearchComplete(search);
-    }
-    this.resetPagination();
-    syncHistory(
-      {
-        q: search,
-      },
-      this.props.history,
-    );
-  };
-
-  onSubmitFilters = (filters: Filters): void => {
-    if (this.props.onFilterChange) {
-      this.props.onFilterChange(filters);
-    }
-
-    this.setState({
-      filters: filters,
-    });
-    this.resetPagination();
-    syncHistory(
-      {
-        app: filters.app,
-        timeNumber: filters.timeNumber,
-        timeUnit: filters.timeUnit,
-        regions: filters.regions,
-        nodes: filters.nodes,
-      },
-      this.props.history,
-    );
-  };
-
-  onClearFilters = (): void => {
-    if (this.props.onFilterChange) {
-      this.props.onFilterChange(defaultFilters);
-    }
-
-    this.setState({
-      filters: {
-        ...defaultFilters,
-      },
-    });
-    this.resetPagination();
+    setFilters({ ...defaultFilters });
+    resetPagination();
     syncHistory(
       {
         app: undefined,
@@ -377,99 +400,112 @@ export class TransactionsPage extends React.Component<
         regions: undefined,
         nodes: undefined,
       },
-      this.props.history,
+      history,
     );
   };
 
-  lastReset = (): Date => {
-    return new Date(
-      Number(this.props.txnsResp?.data?.last_reset.seconds) * 1000,
-    );
+  const changeTimeScale = (ts: TimeScale): void => {
+    setLocalTimeScale(ts);
   };
 
-  changeTimeScale = (ts: TimeScale): void => {
-    this.setState(prevState => ({ ...prevState, timeScale: ts }));
+  const onChangeLimit = (newLimit: number): void => {
+    setLocalLimit(newLimit);
   };
 
-  onChangeLimit = (newLimit: number): void => {
-    this.setState(prevState => ({ ...prevState, limit: newLimit }));
+  const onChangeReqSort = (newSort: SqlStatsSortType): void => {
+    setLocalReqSortSetting(newSort);
   };
 
-  onChangeReqSort = (newSort: SqlStatsSortType): void => {
-    this.setState(prevState => ({ ...prevState, reqSortSetting: newSort }));
-  };
-
-  updateRequestParams = (): void => {
-    if (this.props.limit !== this.state.limit) {
-      this.props.onChangeLimit(this.state.limit);
+  const updateRequestParams = useCallback((): void => {
+    if (propsLimit !== localLimit) {
+      propsOnChangeLimit(localLimit);
     }
 
-    if (this.props.reqSortSetting !== this.state.reqSortSetting) {
-      this.props.onChangeReqSort(this.state.reqSortSetting);
+    if (propsReqSortSetting !== localReqSortSetting) {
+      propsOnChangeReqSort(localReqSortSetting);
     }
 
-    if (this.props.timeScale !== this.state.timeScale) {
-      this.props.onTimeScaleChange(this.state.timeScale);
+    if (propsTimeScale !== localTimeScale) {
+      if (onTimeScaleChange) {
+        onTimeScaleChange(localTimeScale);
+      }
     }
 
-    if (this.props.onApplySearchCriteria) {
-      this.props.onApplySearchCriteria(
-        this.state.timeScale,
-        this.state.limit,
-        getSortLabel(this.state.reqSortSetting, "Transaction"),
+    if (onApplySearchCriteria) {
+      onApplySearchCriteria(
+        localTimeScale,
+        localLimit,
+        getSortLabel(localReqSortSetting, "Transaction"),
       );
     }
-    this.props.onRequestTimeChange(moment());
-    this.refreshData();
+    onRequestTimeChange(moment());
+
+    const req = stmtsRequestFromParams({
+      timeScale: localTimeScale,
+      limit: localLimit,
+      reqSortSetting: localReqSortSetting,
+    });
+    refreshData(req);
+
     const ss: SortSetting = {
       ascending: false,
-      columnTitle: getSortColumn(this.state.reqSortSetting),
+      columnTitle: getSortColumn(localReqSortSetting),
     };
-    this.onChangeSortSetting(ss);
-  };
+    onChangeSortSetting(ss);
+  }, [
+    propsLimit,
+    localLimit,
+    propsReqSortSetting,
+    localReqSortSetting,
+    propsTimeScale,
+    localTimeScale,
+    propsOnChangeLimit,
+    propsOnChangeReqSort,
+    onTimeScaleChange,
+    onApplySearchCriteria,
+    onRequestTimeChange,
+    refreshData,
+    onChangeSortSetting,
+  ]);
 
-  onUpdateSortSettingAndApply = (): void => {
-    this.setState(
-      {
-        reqSortSetting: getReqSortColumn(this.props.sortSetting.columnTitle),
-      },
-      () => {
-        this.updateRequestParams();
-      },
-    );
-  };
+  // Track when we need to call updateRequestParams after sort setting change
+  const pendingUpdateRef = useRef(false);
+  const prevLocalReqSortSettingRef = useRef(localReqSortSetting);
 
-  hasReqSortOption = (): boolean => {
+  useEffect(() => {
+    if (
+      pendingUpdateRef.current &&
+      prevLocalReqSortSettingRef.current !== localReqSortSetting
+    ) {
+      pendingUpdateRef.current = false;
+      updateRequestParams();
+    }
+    prevLocalReqSortSettingRef.current = localReqSortSetting;
+  }, [localReqSortSetting, updateRequestParams]);
+
+  const onUpdateSortSettingAndApplyWithPending = useCallback((): void => {
+    const newReqSort = getReqSortColumn(sortSetting.columnTitle);
+    pendingUpdateRef.current = true;
+    setLocalReqSortSetting(newReqSort);
+  }, [sortSetting.columnTitle]);
+
+  const hasReqSortOption = (): boolean => {
     let found = false;
     Object.values(SqlStatsSortOptions).forEach(option => {
       const optionString = isString(option) ? option : getSortColumn(option);
-      if (optionString === this.props.sortSetting.columnTitle) {
+      if (optionString === sortSetting.columnTitle) {
         found = true;
       }
     });
     return found;
   };
 
-  renderTransactions(): React.ReactElement {
-    const {
-      nodeRegions,
-      isTenant,
-      onColumnsChange,
-      columns: userSelectedColumnsToShow,
-      sortSetting,
-      search,
-      hasAdminRole,
-    } = this.props;
-    const data = this.props.txnsResp.data;
-    const { pagination, filters } = this.state;
+  const renderTransactions = (): React.ReactElement => {
+    const data = txnsResp.data;
     const internalAppNamePrefix = data?.internal_app_name_prefix || "";
     const statements = data?.statements || [];
 
     // We apply the search filters and app name filters prior to aggregating across Node IDs
-    // in order to match what's done on the Statements Page.
-    //
-    // TODO(davidh): Once the redux layer for TransactionsPage is added to this repo,
-    // extract this work into the selector
     const { transactions: filteredTransactions, activeFilters } =
       filterTransactions(
         searchTransactionsData(search, data?.transactions || [], statements),
@@ -506,9 +542,7 @@ export class TransactionsPage extends React.Component<
         : nodes.map(node => nodeRegions[node.toString()]),
     ).sort();
 
-    // Creates a list of all possible columns,
-    // hiding nodeRegions if is not multi-region and
-    // hiding columns that won't be displayed for virtual clusters.
+    // Creates a list of all possible columns
     const columns = makeTransactionsColumns(
       transactionsToDisplay,
       statements,
@@ -519,9 +553,7 @@ export class TransactionsPage extends React.Component<
       .filter(c => !(c.name === "regionNodes" && regions.length < 2))
       .filter(c => !(isTenant && c.hideIfTenant));
 
-    // Iterate over all available columns and create list of SelectOptions with initial selection
-    // values based on stored user selections in local storage and default column configs.
-    // Columns that are set to alwaysShow are filtered from the list.
+    // Create list of SelectOptions
     const tableColumns = columns
       .filter(c => !c.alwaysShow)
       .map(
@@ -537,32 +569,29 @@ export class TransactionsPage extends React.Component<
       isSelectedColumn(userSelectedColumnsToShow, c),
     );
 
-    const sortSettingLabel = getSortLabel(
-      this.props.reqSortSetting,
-      "Transaction",
-    );
+    const sortSettingLabel = getSortLabel(propsReqSortSetting, "Transaction");
     const showSortWarning =
-      !this.isSortSettingSameAsReqSort() &&
-      this.hasReqSortOption() &&
-      transactionsToDisplay.length === this.props.limit;
+      !isSortSettingSameAsReqSort() &&
+      hasReqSortOption() &&
+      transactionsToDisplay.length === propsLimit;
 
     return (
       <>
         <h5 className={`${commonStyles("base-heading")} ${cx("margin-top")}`}>
-          {`Results - Top ${this.props.limit} Transaction Fingerprints by ${sortSettingLabel}`}
+          {`Results - Top ${propsLimit} Transaction Fingerprints by ${sortSettingLabel}`}
         </h5>
         <section className={cx("filter-area")}>
           <PageConfig className={cx("float-left")}>
             <PageConfigItem>
               <Search
-                onSubmit={this.onSubmitSearchField}
-                onClear={this.onClearSearchField}
+                onSubmit={onSubmitSearchField}
+                onClear={onClearSearchField}
                 defaultValue={search}
               />
             </PageConfigItem>
             <PageConfigItem>
               <Filter
-                onSubmitFilters={this.onSubmitFilters}
+                onSubmitFilters={onSubmitFilters}
                 appNames={appNames}
                 regions={regions}
                 timeLabel={"Transaction fingerprint"}
@@ -584,11 +613,11 @@ export class TransactionsPage extends React.Component<
             <PageConfigItem>
               <p className={timeScaleStylesCx("time-label")}>
                 <TimeScaleLabel
-                  timeScale={this.props.timeScale}
-                  requestTime={moment(this.props.requestTime)}
+                  timeScale={propsTimeScale}
+                  requestTime={moment(requestTime)}
                   oldestDataTime={
-                    this.props.oldestDataAvailable &&
-                    TimestampToMoment(this.props.oldestDataAvailable)
+                    oldestDataAvailable &&
+                    TimestampToMoment(oldestDataAvailable)
                   }
                 />
                 {", "}
@@ -609,7 +638,7 @@ export class TransactionsPage extends React.Component<
                 )} `}
               >
                 <ClearStats
-                  resetSQLStats={this.resetSQLStats}
+                  resetSQLStats={doResetSQLStats}
                   tooltipType="transaction"
                 />
               </PageConfigItem>
@@ -619,18 +648,18 @@ export class TransactionsPage extends React.Component<
         <section className={statisticsClasses.tableContainerClass}>
           <SelectedFilters
             filters={filters}
-            onRemoveFilter={this.onSubmitFilters}
-            onClearFilters={this.onClearFilters}
+            onRemoveFilter={onSubmitFilters}
+            onClearFilters={onClearFilters}
           />
           {showSortWarning && (
             <InlineAlert
               intent="warning"
               title={getSubsetWarning(
                 "transaction",
-                this.props.limit,
+                propsLimit,
                 sortSettingLabel,
-                this.props.sortSetting.columnTitle as StatisticTableColumnKeys,
-                this.onUpdateSortSettingAndApply,
+                sortSetting.columnTitle as StatisticTableColumnKeys,
+                onUpdateSortSettingAndApplyWithPending,
               )}
               className={cx("margin-bottom")}
             />
@@ -639,7 +668,7 @@ export class TransactionsPage extends React.Component<
             columns={displayColumns}
             transactions={transactionsToDisplay}
             sortSetting={sortSetting}
-            onChangeSortSetting={this.onChangeSortSetting}
+            onChangeSortSetting={onChangeSortSetting}
             pagination={pagination}
             renderNoResult={
               <EmptyTransactionsPlaceholder
@@ -653,55 +682,53 @@ export class TransactionsPage extends React.Component<
           pageSize={pageSize}
           current={current}
           total={transactionsToDisplay.length}
-          onChange={this.onChangePage}
-          onShowSizeChange={this.onChangePage}
+          onChange={onChangePage}
+          onShowSizeChange={onChangePage}
         />
       </>
     );
-  }
+  };
 
-  render(): React.ReactElement {
-    const longLoadingMessage = (
-      <Delayed delay={STATS_LONG_LOADING_DURATION}>
-        <InlineAlert
-          intent="info"
-          title="If the selected time interval contains a large amount of data, this page might take a few minutes to load."
-        />
-      </Delayed>
-    );
+  const longLoadingMessage = (
+    <Delayed delay={STATS_LONG_LOADING_DURATION}>
+      <InlineAlert
+        intent="info"
+        title="If the selected time interval contains a large amount of data, this page might take a few minutes to load."
+      />
+    </Delayed>
+  );
 
-    return (
-      <>
-        <SearchCriteria
-          searchType="Transaction"
-          topValue={this.state.limit}
-          byValue={this.state.reqSortSetting}
-          currentScale={this.state.timeScale}
-          onChangeTop={this.onChangeLimit}
-          onChangeBy={this.onChangeReqSort}
-          onChangeTimeScale={this.changeTimeScale}
-          onApply={this.updateRequestParams}
+  return (
+    <>
+      <SearchCriteria
+        searchType="Transaction"
+        topValue={localLimit}
+        byValue={localReqSortSetting}
+        currentScale={localTimeScale}
+        onChangeTop={onChangeLimit}
+        onChangeBy={onChangeReqSort}
+        onChangeTimeScale={changeTimeScale}
+        onApply={updateRequestParams}
+      />
+      <div className={cx("table-area")}>
+        <Loading
+          loading={txnsResp.inFlight}
+          page={"transactions"}
+          error={txnsResp?.error}
+          render={() => renderTransactions()}
+          renderError={() =>
+            LoadingError({
+              statsType: "transactions",
+              error: txnsResp.error,
+              sourceTables: txnsResp?.data?.txns_source_table && [
+                txnsResp?.data?.txns_source_table,
+                txnsResp?.data?.stmts_source_table,
+              ],
+            })
+          }
         />
-        <div className={cx("table-area")}>
-          <Loading
-            loading={this.props.txnsResp.inFlight}
-            page={"transactions"}
-            error={this.props.txnsResp?.error}
-            render={() => this.renderTransactions()}
-            renderError={() =>
-              LoadingError({
-                statsType: "transactions",
-                error: this.props.txnsResp.error,
-                sourceTables: this.props.txnsResp?.data?.txns_source_table && [
-                  this.props.txnsResp?.data?.txns_source_table,
-                  this.props.txnsResp?.data?.stmts_source_table,
-                ],
-              })
-            }
-          />
-          {this.props.txnsResp.inFlight && longLoadingMessage}
-        </div>
-      </>
-    );
-  }
+        {txnsResp.inFlight && longLoadingMessage}
+      </div>
+    </>
+  );
 }

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.spec.ts
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 import * as protos from "@cockroachlabs/crdb-protobuf-client";
-import { assert } from "chai";
 import Long from "long";
 
 import { Filters } from "../queryFilter";
@@ -34,10 +33,10 @@ describe("getStatementsByFingerprintId", () => {
         { id: Long.fromString("5554049045071304794") },
       ],
     );
-    assert.lengthOf(selectedStatements, 1);
-    assert.isTrue(
+    expect(selectedStatements).toHaveLength(1);
+    expect(
       selectedStatements[0].id.eq(Long.fromString("4104049045071304794")),
-    );
+    ).toBe(true);
   });
 });
 
@@ -52,7 +51,7 @@ describe("Filter transactions", () => {
       nodes: "",
       regions: "",
     };
-    assert.equal(
+    expect(
       filterTransactions(
         txData,
         filter,
@@ -61,8 +60,7 @@ describe("Filter transactions", () => {
         nodeRegions,
         false,
       ).transactions.length,
-      11,
-    );
+    ).toBe(11);
   });
 
   it("filters by app", () => {
@@ -73,7 +71,7 @@ describe("Filter transactions", () => {
       nodes: "",
       regions: "",
     };
-    assert.equal(
+    expect(
       filterTransactions(
         txData,
         filter,
@@ -82,8 +80,7 @@ describe("Filter transactions", () => {
         nodeRegions,
         false,
       ).transactions.length,
-      3,
-    );
+    ).toBe(3);
   });
 
   it("filters by app exactly", () => {
@@ -94,7 +91,7 @@ describe("Filter transactions", () => {
       nodes: "",
       regions: "",
     };
-    assert.equal(
+    expect(
       filterTransactions(
         txData,
         filter,
@@ -103,8 +100,7 @@ describe("Filter transactions", () => {
         nodeRegions,
         false,
       ).transactions.length,
-      1,
-    );
+    ).toBe(1);
   });
 
   it("filters by 2 apps", () => {
@@ -115,7 +111,7 @@ describe("Filter transactions", () => {
       nodes: "",
       regions: "",
     };
-    assert.equal(
+    expect(
       filterTransactions(
         txData,
         filter,
@@ -124,8 +120,7 @@ describe("Filter transactions", () => {
         nodeRegions,
         false,
       ).transactions.length,
-      4,
-    );
+    ).toBe(4);
   });
 
   it("filters by internal prefix", () => {
@@ -136,7 +131,7 @@ describe("Filter transactions", () => {
       nodes: "",
       regions: "",
     };
-    assert.equal(
+    expect(
       filterTransactions(
         txData,
         filter,
@@ -145,8 +140,7 @@ describe("Filter transactions", () => {
         nodeRegions,
         false,
       ).transactions.length,
-      7,
-    );
+    ).toBe(7);
   });
 
   it("filters by time", () => {
@@ -157,7 +151,7 @@ describe("Filter transactions", () => {
       nodes: "",
       regions: "",
     };
-    assert.equal(
+    expect(
       filterTransactions(
         txData,
         filter,
@@ -166,8 +160,7 @@ describe("Filter transactions", () => {
         nodeRegions,
         false,
       ).transactions.length,
-      8,
-    );
+    ).toBe(8);
   });
 
   it("filters by one node", () => {
@@ -178,7 +171,7 @@ describe("Filter transactions", () => {
       nodes: "n1",
       regions: "",
     };
-    assert.equal(
+    expect(
       filterTransactions(
         txData,
         filter,
@@ -187,8 +180,7 @@ describe("Filter transactions", () => {
         nodeRegions,
         false,
       ).transactions.length,
-      6,
-    );
+    ).toBe(6);
   });
 
   it("filters by multiple nodes", () => {
@@ -199,7 +191,7 @@ describe("Filter transactions", () => {
       nodes: "n2,n4",
       regions: "",
     };
-    assert.equal(
+    expect(
       filterTransactions(
         txData,
         filter,
@@ -208,8 +200,7 @@ describe("Filter transactions", () => {
         nodeRegions,
         false,
       ).transactions.length,
-      8,
-    );
+    ).toBe(8);
   });
 
   it("filters by one region", () => {
@@ -220,7 +211,7 @@ describe("Filter transactions", () => {
       nodes: "",
       regions: "gcp-europe-west1",
     };
-    assert.equal(
+    expect(
       filterTransactions(
         txData,
         filter,
@@ -229,8 +220,7 @@ describe("Filter transactions", () => {
         nodeRegions,
         false,
       ).transactions.length,
-      4,
-    );
+    ).toBe(4);
   });
 
   it("filters by multiple regions", () => {
@@ -241,7 +231,7 @@ describe("Filter transactions", () => {
       nodes: "",
       regions: "gcp-us-west1,gcp-europe-west1",
     };
-    assert.equal(
+    expect(
       filterTransactions(
         txData,
         filter,
@@ -250,8 +240,7 @@ describe("Filter transactions", () => {
         nodeRegions,
         false,
       ).transactions.length,
-      9,
-    );
+    ).toBe(9);
   });
 });
 
@@ -282,13 +271,11 @@ describe("statementFingerprintIdsToText", () => {
       Long.fromString("4104049045071304794"),
     ];
 
-    assert.equal(
-      statementFingerprintIdsToText(statementFingerprintIds, statements),
-      `SELECT _
+    expect(statementFingerprintIdsToText(statementFingerprintIds, statements))
+      .toBe(`SELECT _
 SELECT _, _
 SELECT _
-SELECT _`,
-    );
+SELECT _`);
   });
 });
 
@@ -306,13 +293,12 @@ describe("generateRegion", () => {
   }
 
   it("gathers up the list of regions for the transaction, sorted", () => {
-    assert.deepEqual(
+    expect(
       generateRegion(transaction(42, 43, 44), [
         statement(42, "gcp-us-west1", "gcp-us-east1"),
         statement(43, "gcp-us-west1"),
         statement(44, "gcp-us-central1"),
       ]),
-      ["gcp-us-central1", "gcp-us-east1", "gcp-us-west1"],
-    );
+    ).toEqual(["gcp-us-central1", "gcp-us-east1", "gcp-us-west1"]);
   });
 });


### PR DESCRIPTION
This change converts the following class components into their functional style equivalent:
 - statementsPage
 - statementDetails
 - transactionsPage
 - transactionDetails
 - diagnosticsView
 - SQL box
 - SQL highlight

The conversion was done by iteratively using a claude skill.
Human intervention was needed to remove previously unused components which were faithfully
converted. The skill was then updated accordingly
Existing Enzyme + Chai tests were converted into pure react-testing-library tests.
The pages under sql-activity have been manually verified and cypress tested.

Epic: CRDB-58145
Release Note: None