### PR TITLE
concurrency: add kv.concurrency.virtual_intent_resolution.enabled cluster setting

### DIFF
--- a/pkg/kv/kvserver/concurrency/BUILD.bazel
+++ b/pkg/kv/kvserver/concurrency/BUILD.bazel
@@ -60,6 +60,7 @@ go_test(
         "datadriven_util_test.go",
         "lock_table_test.go",
         "lock_table_waiter_test.go",
+        "request_test.go",
         ":keylocks_interval_btree_test.go",  # keep
     ],
     data = glob(["testdata/**"]),

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -799,6 +799,19 @@ func (r *Request) isSingle(m kvpb.Method) bool {
 	return r.Requests[0].GetInner().Method() == m
 }
 
+// canVirtuallyResolve returns true if all requests in the batch are read-only
+// and non-locking.
+func (r *Request) canVirtuallyResolve() bool {
+	for _, ru := range r.Requests {
+		req := ru.GetInner()
+		canVirtuallyResolve := kvpb.IsReadOnly(req) && !kvpb.IsLocking(req)
+		if !canVirtuallyResolve {
+			return false
+		}
+	}
+	return true
+}
+
 // Used to avoid allocations.
 var guardPool = sync.Pool{
 	New: func() interface{} { return new(Guard) },

--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -404,6 +404,9 @@ type lockTableGuardImpl struct {
 	spans              *lockspanset.LockSpanSet
 	waitPolicy         lock.WaitPolicy
 	maxWaitQueueLength int
+	// virtuallyResolveIntents represents the state of VirtuallyDeferrerIntents at
+	// the outset of this request.
+	virtuallyResolveIntents bool
 
 	// Snapshot of the tree for which this request has some spans. Note that
 	// the lockStates in this snapshot may have been removed from
@@ -4269,6 +4272,7 @@ func (t *lockTableImpl) newGuardForReq(req Request) *lockTableGuardImpl {
 	g.maxWaitQueueLength = req.MaxLockWaitQueueLength
 	g.str = lock.MaxStrength
 	g.index = -1
+	g.virtuallyResolveIntents = VirtualIntentResolution.Get(&g.lt.settings.SV)
 	return g
 }
 

--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -4272,7 +4272,7 @@ func (t *lockTableImpl) newGuardForReq(req Request) *lockTableGuardImpl {
 	g.maxWaitQueueLength = req.MaxLockWaitQueueLength
 	g.str = lock.MaxStrength
 	g.index = -1
-	g.virtuallyResolveIntents = VirtualIntentResolution.Get(&g.lt.settings.SV)
+	g.virtuallyResolveIntents = VirtualIntentResolution.Get(&g.lt.settings.SV) && req.canVirtuallyResolve()
 	return g
 }
 

--- a/pkg/kv/kvserver/concurrency/request_test.go
+++ b/pkg/kv/kvserver/concurrency/request_test.go
@@ -1,0 +1,91 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package concurrency
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanVirtuallyResolve(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	makeRequest := func(reqs ...kvpb.Request) Request {
+		var reqUnions []kvpb.RequestUnion
+		for _, req := range reqs {
+			var ru kvpb.RequestUnion
+			ru.MustSetInner(req)
+			reqUnions = append(reqUnions, ru)
+		}
+		return Request{Requests: reqUnions}
+	}
+
+	testCases := []struct {
+		name string
+		req  Request
+		exp  bool
+	}{{
+		name: "empty batch",
+		req:  Request{},
+		exp:  true,
+	}, {
+		name: "single non-locking read",
+		req:  makeRequest(&kvpb.GetRequest{}),
+		exp:  true,
+	}, {
+		name: "single non-locking scan",
+		req:  makeRequest(&kvpb.ScanRequest{}),
+		exp:  true,
+	}, {
+		name: "multiple non-locking reads",
+		req: makeRequest(
+			&kvpb.GetRequest{},
+			&kvpb.ScanRequest{},
+			&kvpb.ReverseScanRequest{},
+		),
+		exp: true,
+	}, {
+		name: "single write",
+		req:  makeRequest(&kvpb.PutRequest{}),
+		exp:  false,
+	}, {
+		name: "single locking read with shared strength",
+		req:  makeRequest(&kvpb.GetRequest{KeyLockingStrength: lock.Shared}),
+		exp:  false,
+	}, {
+		name: "single locking read with exclusive strength",
+		req:  makeRequest(&kvpb.GetRequest{KeyLockingStrength: lock.Exclusive}),
+		exp:  false,
+	}, {
+		name: "single locking scan",
+		req:  makeRequest(&kvpb.ScanRequest{KeyLockingStrength: lock.Exclusive}),
+		exp:  false,
+	}, {
+		name: "mixed batch with read and write",
+		req: makeRequest(
+			&kvpb.GetRequest{},
+			&kvpb.PutRequest{},
+		),
+		exp: false,
+	}, {
+		name: "mixed batch with non-locking and locking read",
+		req: makeRequest(
+			&kvpb.GetRequest{},
+			&kvpb.GetRequest{KeyLockingStrength: lock.Shared},
+		),
+		exp: false,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.exp, tc.req.canVirtuallyResolve())
+		})
+	}
+}


### PR DESCRIPTION
This adds a new cluster setting to enable virtual intent resolution. Currently, this setting is a no-op.

Informs #162203

Release Note: none