### PR TITLE
sql: row count the import table after offlining

### DIFF
--- a/pkg/jobs/jobstest/logutils.go
+++ b/pkg/jobs/jobstest/logutils.go
@@ -67,7 +67,7 @@ func CheckEmittedEvents(
 				require.Equal(t, expectedJobType, ev.JobType)
 				require.Equal(t, jobID, ev.JobID)
 				if matchingEntryIndex >= len(expectedStatus) {
-					return errors.New("more events fround in log than expected")
+					return errors.New("more events found in log than expected")
 				}
 				require.Equal(t, expectedStatus[matchingEntryIndex], ev.Status)
 				matchingEntryIndex++

--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -5397,7 +5397,11 @@ func TestImportJobEventLogging(t *testing.T) {
 	sqlDB.QueryRow(t, importQuery, simpleOcf).Scan(&jobID, &unused, &unused, &unused, &unused,
 		&unused)
 
-	expectedStatus := []string{string(jobs.StateSucceeded), string(jobs.StateRunning)}
+	expectedStatus := []string{
+		string(jobs.StateSucceeded),
+		string(jobs.StateRunning), // after row count check
+		string(jobs.StateRunning), // after prepare
+	}
 	expectedRecoveryEvent := eventpb.RecoveryEvent{
 		RecoveryType: importJobRecoveryEventType,
 		NumRows:      int64(1000),
@@ -5416,8 +5420,10 @@ func TestImportJobEventLogging(t *testing.T) {
 	row.Scan(&jobID)
 
 	expectedStatus = []string{
-		string(jobs.StateFailed), string(jobs.StateReverting),
-		string(jobs.StateRunning),
+		string(jobs.StateFailed),
+		string(jobs.StateReverting),
+		string(jobs.StateRunning), // after row count check
+		string(jobs.StateRunning), // after prepare
 	}
 	expectedRecoveryEvent = eventpb.RecoveryEvent{
 		RecoveryType: importJobRecoveryEventType,


### PR DESCRIPTION
Previously, the row count prior to import was run in the same
transaction as the offlining of the table. The shared transaction did
not protect against concurrent transactions inserting or deleting rows.
This change scans the table in full after it's taken offline to store a
correct initial row count.

Epic: CRDB-58692

Part of: #161276
Part of: #155472
Part of: #161279

Release note: None
