### PR TITLE
backup: permit backup IDs in RESTORE/SHOW without session var

### DIFF
--- a/pkg/backup/restore_planning.go
+++ b/pkg/backup/restore_planning.go
@@ -2407,7 +2407,8 @@ func resolveRestoreSubdirAndEndTime(
 	aost hlc.Timestamp,
 ) (string, hlc.Timestamp, error) {
 	useIDs := p.SessionData().UseBackupsWithIDs
-	if !useIDs {
+	_, _, err := backupinfo.DecodeBackupID(backupToken)
+	if err != nil && !(useIDs && strings.EqualFold(backupToken, backupbase.LatestFileName)) {
 		// Revert to legacy behavior, backupToken is either a subdir or using the
 		// legacy interpretation of LATEST (latest full backup).
 		subdir := backupToken
@@ -2420,6 +2421,7 @@ func resolveRestoreSubdirAndEndTime(
 			}
 			subdir = latest
 		}
+		//nolint:returnerrcheck
 		return subdir, aost, nil
 	}
 

--- a/pkg/backup/restore_planning_test.go
+++ b/pkg/backup/restore_planning_test.go
@@ -618,7 +618,7 @@ func TestRestoreWithBackupIDs(t *testing.T) {
 	//				i.   t0 (0 rows)
 	//				ii.  t1 (1 row)
 	//				iii. t2 (2 rows)
-	//	b. Incremental backup @ t4
+	//		b. Incremental backup @ t4
 	//				i.   t3 (3 row)
 	//				ii.  t4 (4 rows)
 	{
@@ -824,12 +824,24 @@ func TestRestoreWithBackupIDs(t *testing.T) {
 			expectedErr: "not a revision history backup and cannot be used for AS OF SYSTEM TIME restores",
 		},
 		{
+			name:         "legacy/restore works on subdir",
+			collection:   classicColl,
+			token:        backupSubdirsByColl[classicColl][0],
+			expectedRows: 3,
+		},
+		{
+			name:         "legacy/LATEST resolves to legacy path",
+			collection:   classicColl,
+			token:        "LATEST",
+			expectedRows: 2,
+			disableIDs:   true,
+		},
+		{
 			name:         "legacy/AOST restore works on subdir",
 			collection:   classicColl,
 			token:        backupSubdirsByColl[classicColl][0],
 			aost:         classicTimes[2],
 			expectedRows: 2,
-			disableIDs:   true,
 		},
 		{
 			name:         "legacy/AOST restore works on LATEST",
@@ -838,12 +850,6 @@ func TestRestoreWithBackupIDs(t *testing.T) {
 			aost:         classicTimes[2],
 			expectedRows: 2,
 			disableIDs:   true,
-		},
-		{
-			name:        "subdir is not a valid backup ID",
-			collection:  classicColl,
-			token:       backupSubdirsByColl[classicColl][0],
-			expectedErr: "failed decoding backup ID",
 		},
 	}
 

--- a/pkg/backup/show.go
+++ b/pkg/backup/show.go
@@ -244,8 +244,9 @@ func collectBackupInfo(
 	collectionURIs []string,
 	backupToken string,
 ) (info backupInfo, memReserved int64, err error) {
+	_, _, err = backupinfo.DecodeBackupID(backupToken)
 	useIDs := p.SessionData().UseBackupsWithIDs
-	if !useIDs {
+	if err != nil && !(useIDs && strings.EqualFold(backupToken, backupbase.LatestFileName)) {
 		return legacyCollectBackupInfo(ctx, p, mem, kmsEnv, stmt, collectionURIs, backupToken)
 	}
 	mkStore := p.ExecCfg().DistSQLSrv.ExternalStorageFromURI


### PR DESCRIPTION
Previously, the `use_backups_with_ids` was required for backup IDs to be permitted in `SHOW BACKUP` and `RESTORE`. This commit updates the logic such that backup IDs can be used regardless of the session variable setting. The setting will only configure what codepath is used to resolve `LATEST`.

Epic: CRDB-57536

Release note: `SHOW BACKUP` and `RESTORE` now allow backup IDs even if the `use_backups_with_ids` session variable is not set. Setting the variable only configures whether `LATEST` is resolved using the new or legacy path.