### PR TITLE
release-25.4: sql/hints: skip shared mode in TestHintCacheMultiNode under race

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -413,6 +413,11 @@ var (
 	// worth the cost of never running that test with the virtualization
 	// layer active.
 	TestNeedsTightIntegrationBetweenAPIsAndTestingKnobs = TestIsSpecificToStorageLayerAndNeedsASystemTenant
+
+	// TestSkipSecondaryTenantsUnderDuress should be used whenever we want to
+	// disable test tenant randomization under heavy configs (e.g. under race)
+	// due to overload.
+	TestSkipSecondaryTenantsUnderDuress = TestIsSpecificToStorageLayerAndNeedsASystemTenant
 )
 
 func (do DefaultTestTenantOptions) AllowAdditionalTenants() bool {

--- a/pkg/sql/hints/hint_cache_test.go
+++ b/pkg/sql/hints/hint_cache_test.go
@@ -234,10 +234,10 @@ func TestHintCacheMultiNode(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	// Skip external mode when running under race to avoid flakes.
+	// Skip secondary tenants when running under race to avoid flakes.
 	var serverArgs base.TestServerArgs
 	if util.RaceEnabled {
-		serverArgs.DefaultTestTenant = base.TestSkippedForExternalModeDueToPerformance(161857)
+		serverArgs.DefaultTestTenant = base.TestSkipSecondaryTenantsUnderDuress
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
Backport 1/1 commits from #162331 on behalf of @yuzefovich.

----

We've already skipped the external mode, but we just saw a failure on the shared mode, so let's skip both under race.

Fixes: #162305.
Release note: None

----

Release justification: test-only change.