### PR TITLE
release-25.2.12-rc: sql: fix identity computed columns with projection with generic plans

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/prepare
+++ b/pkg/sql/opt/exec/execbuilder/testdata/prepare
@@ -167,3 +167,148 @@ quality of service: regular
   estimated row count: 1
   table: ab@ab_pkey
   spans: [/2 - /2]
+
+# Regression test for #161978. Identity computed columns (where the
+# computed expression is just another column) should work correctly with
+# generic plans and lookup joins.
+statement ok
+SET plan_cache_mode = force_generic_plan
+
+statement ok
+CREATE TABLE t161978 (
+  x INT NOT NULL,
+  y INT NOT NULL,
+  y_identity INT AS (y) STORED NOT NULL,
+  INDEX t_y (y_identity, x)
+)
+
+statement ok
+PREPARE p161978 AS SELECT t0.y
+FROM t161978@t_y t0
+WHERE t0.x = $1::INT AND y = $2::INT
+
+# This query was failing with "cannot map variable 2 to an indexed var" before
+# the fix. The issue was that identity column (y_identity) weren't properly
+# replaced with the placeholder `$2` when generating the projection.
+query T
+EXPLAIN ANALYZE EXECUTE p161978(1, 20)
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, re-optimized
+maximum memory usage: <hidden>
+DistSQL network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• lookup join
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ KV time: 0µs
+│ KV rows decoded: 0
+│ KV bytes read: 0 B
+│ KV gRPC calls: 0
+│ execution time: 0µs
+│ estimated max memory allocated: 0 B
+│ table: t161978@t161978_pkey
+│ equality: (rowid) = (rowid)
+│ equality cols are key
+│ pred: y = "$2"
+│
+└── • lookup join
+    │ sql nodes: <hidden>
+    │ kv nodes: <hidden>
+    │ regions: <hidden>
+    │ actual row count: 0
+    │ KV time: 0µs
+    │ KV rows decoded: 0
+    │ KV bytes read: 0 B
+    │ KV gRPC calls: 0
+    │ execution time: 0µs
+    │ estimated max memory allocated: 0 B
+    │ table: t161978@t_y
+    │ equality: (y_identity_eq, $1) = (y_identity, x)
+    │
+    └── • render
+        │
+        └── • values
+              sql nodes: <hidden>
+              regions: <hidden>
+              actual row count: 1
+              execution time: 0µs
+              size: 2 columns, 1 row
+
+# Also test with a non-identity virtual column to ensure it still works.
+statement ok
+CREATE TABLE t161978_nonidentity (
+  x INT NOT NULL,
+  y INT NOT NULL,
+  y_notidentity INT AS (y + 13) VIRTUAL NOT NULL,
+  INDEX t_y (y_notidentity, x)
+)
+
+statement ok
+PREPARE p161978_nonidentity AS SELECT t0.y
+  FROM t161978_nonidentity@t_y t0
+  WHERE t0.x = $1::INT AND y = $2::INT
+
+query T
+EXPLAIN ANALYZE EXECUTE p161978_nonidentity(1, 20)
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, re-optimized
+maximum memory usage: <hidden>
+DistSQL network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• lookup join
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ KV time: 0µs
+│ KV rows decoded: 0
+│ KV bytes read: 0 B
+│ KV gRPC calls: 0
+│ execution time: 0µs
+│ estimated max memory allocated: 0 B
+│ table: t161978_nonidentity@t161978_nonidentity_pkey
+│ equality: (rowid) = (rowid)
+│ equality cols are key
+│ pred: y = "$2"
+│
+└── • lookup join
+    │ sql nodes: <hidden>
+    │ kv nodes: <hidden>
+    │ regions: <hidden>
+    │ actual row count: 0
+    │ KV time: 0µs
+    │ KV rows decoded: 0
+    │ KV bytes read: 0 B
+    │ KV gRPC calls: 0
+    │ execution time: 0µs
+    │ estimated max memory allocated: 0 B
+    │ table: t161978_nonidentity@t_y
+    │ equality: (y_notidentity_eq, $1) = (y_notidentity, x)
+    │
+    └── • render
+        │
+        └── • values
+              sql nodes: <hidden>
+              regions: <hidden>
+              actual row count: 1
+              execution time: 0µs
+              size: 2 columns, 1 row
+
+statement ok
+RESET plan_cache_mode

--- a/pkg/sql/opt/lookupjoin/constraint_builder.go
+++ b/pkg/sql/opt/lookupjoin/constraint_builder.go
@@ -297,7 +297,7 @@ func (b *ConstraintBuilder) Build(
 				}
 				return b.f.Replace(e, replace)
 			}
-			projection := b.f.ConstructProjectionsItem(b.f.Replace(expr, replace).(opt.ScalarExpr), compEqCol)
+			projection := b.f.ConstructProjectionsItem(replace(expr).(opt.ScalarExpr), compEqCol)
 			inputProjections = append(inputProjections, projection)
 			addEqualityColumns(compEqCol, idxCol)
 			derivedEquivCols.Add(compEqCol)

--- a/pkg/sql/opt/lookupjoin/testdata/computed
+++ b/pkg/sql/opt/lookupjoin/testdata/computed
@@ -1,5 +1,18 @@
 # Tests for computed columns.
 
+# Test for identity computed column (regression test for #161978) When a
+# computed column is defined as identical to another column (e.g., v AS
+# x), and the base column is in the equality set, the constraint builder
+# should properly replace the column reference in the projection.
+lookup-constraints left=(a int, b int) right=(x int not null, v int not null as (x) stored) index=(v, x)
+x = a
+----
+key cols:
+  v = v_eq
+  x = a
+input projections:
+  v_eq = a [type=INT8]
+
 lookup-constraints left=(a int, b int) right=(x int, v int not null as (x + 10) stored) index=(v, x)
 x = a
 ----


### PR DESCRIPTION
Backport 1/1 commits from #162137

----

Backport 1/1 commit from #162036

----

Previously, when a computed column was defined as a identical to another column (e.g., vcol AS (col)), and a generic plan was used with a lookup join on an index containing that column (vcol), the query would fail with "cannot map variable %d to an indexed var".

This occurred because the `Factory.Replace` function doesn't invoke the replacement callback for leaf nodes like `VariableExpr`, as it only traverses children. Thus, with the computed column expression a simple `VariableExpr`, table column references weren't getting replaced with their corresponding placeholder columns. As a result, when constructing the projection, we went through the MergeProjectWithValues rule incorrectly.

This fix adds special handling in the constraint builder to directly apply the replacement function when the computed column expression is a simple VariableExpr, ensuring table columns are properly replaced with their corresponding placeholder columns.

Fixes #161978

Release note (bug fix): Fixed an error that occurred when using generic plan that generates a lookup join on indexes containing identity computed columns.

Release justification: Resolve a correctness issue where queries using identity computed columns with generic plans would fail with an error, preventing customers from executing valid queries.