### PR TITLE
sql/schemachanger: support ALTER TABLE DROP CONSTRAINT for UNIQUE constraints

### DIFF
--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -1372,7 +1372,15 @@ func (desc *Mutable) DropConstraint(
 			desc.SetPrimaryIndex(primaryIndex)
 			return nil
 		}
-		return unimplemented.NewWithIssueDetailf(42840, "drop-constraint-unique",
+		// The declarative schema changer supports this already. Supporting it in
+		// the legacy schema changer is more complex because dropping an index
+		// requires managing the mutation lifecycle, handling FK back-references,
+		// cleaning up dependent views/functions/triggers, and managing sharded or
+		// expression index cleanup. This logic exists in dropIndexByName but is
+		// tightly coupled to DROP INDEX statement processing. Given the legacy
+		// schema changer is being deprecated, we direct users to DROP INDEX CASCADE
+		// rather than handling unique constraints here.
+		return unimplemented.Newf("drop-constraint-unique",
 			"cannot drop UNIQUE constraint %q using ALTER TABLE DROP CONSTRAINT, use DROP INDEX CASCADE instead",
 			tree.ErrNameString(u.GetName()))
 	}

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -214,9 +214,13 @@ ALTER TABLE t DROP CONSTRAINT bar
 statement ok
 ALTER TABLE t DROP CONSTRAINT IF EXISTS bar
 
+# Legacy schema changer does not support dropping unique constraints via
+# ALTER TABLE DROP CONSTRAINT.
+onlyif config local-legacy-schema-changer
 statement error cannot drop UNIQUE constraint \"foo\" using ALTER TABLE DROP CONSTRAINT, use DROP INDEX CASCADE instead
 ALTER TABLE t DROP CONSTRAINT foo
 
+onlyif config local-legacy-schema-changer
 statement ok
 DROP INDEX foo CASCADE
 
@@ -231,6 +235,11 @@ LIMIT 2
 SCHEMA CHANGE GC  GC for DROP INDEX test.public.t@foo CASCADE  root  running    0  ·
 SCHEMA CHANGE     DROP INDEX test.public.t@foo CASCADE         root  succeeded  1  ·
 
+# Declarative schema changer supports dropping unique constraints via
+# ALTER TABLE DROP CONSTRAINT.
+skipif config local-legacy-schema-changer
+statement ok
+ALTER TABLE t DROP CONSTRAINT foo
 
 skipif config local-legacy-schema-changer
 query TTTTRT retry
@@ -240,9 +249,8 @@ WHERE job_type = 'NEW SCHEMA CHANGE' OR job_type = 'SCHEMA CHANGE GC'
 ORDER BY created DESC
 LIMIT 2
 ----
-SCHEMA CHANGE GC   GC for DROP INDEX test.public.t@foo CASCADE  node  running    0  ·
-NEW SCHEMA CHANGE  DROP INDEX test.public.t@foo CASCADE         root  succeeded  1  ·
-
+SCHEMA CHANGE GC   GC for ALTER TABLE test.public.t DROP CONSTRAINT foo  node  running    0  ·
+NEW SCHEMA CHANGE  ALTER TABLE test.public.t DROP CONSTRAINT foo         root  succeeded  1  ·
 
 
 query TTBITTTBBBF colnames,rowsort
@@ -1882,8 +1890,20 @@ unique_without_index  unique_d_e                  UNIQUE       UNIQUE WITHOUT IN
 unique_without_index  unique_without_index_c_key  UNIQUE       UNIQUE (c ASC)                          true
 unique_without_index  unique_without_index_pkey   PRIMARY KEY  PRIMARY KEY (rowid ASC)                 true
 
+# Drop an index-backed unique constraint using ALTER TABLE DROP CONSTRAINT.
+skipif config local-legacy-schema-changer
+statement ok
+ALTER TABLE unique_without_index DROP CONSTRAINT unique_without_index_c_key
+
+# Dropping the constraint only works with the declarative schema changer.
+# For the legacy config, drop the index itself.
+onlyif config local-legacy-schema-changer
 statement error pgcode 0A000 cannot drop UNIQUE constraint \"unique_without_index_c_key\"
 ALTER TABLE unique_without_index DROP CONSTRAINT unique_without_index_c_key
+
+onlyif config local-legacy-schema-changer
+statement ok
+DROP INDEX unique_without_index_c_key CASCADE
 
 statement error pgcode 42704 constraint \"unique_b\" of relation \"unique_without_index\" does not exist
 ALTER TABLE unique_without_index DROP CONSTRAINT unique_b
@@ -1907,7 +1927,6 @@ unique_without_index  unique_b_1                  UNIQUE       UNIQUE WITHOUT IN
 unique_without_index  unique_c                    UNIQUE       UNIQUE WITHOUT INDEX (c)                true
 unique_without_index  unique_d                    UNIQUE       UNIQUE WITHOUT INDEX (d)                true
 unique_without_index  unique_d_e                  UNIQUE       UNIQUE WITHOUT INDEX (d, e)             true
-unique_without_index  unique_without_index_c_key  UNIQUE       UNIQUE (c ASC)                          true
 unique_without_index  unique_without_index_pkey   PRIMARY KEY  PRIMARY KEY (rowid ASC)                 true
 
 # Dropping a column in a unique constraint drops the constraint.
@@ -1923,7 +1942,6 @@ unique_without_index  my_unique_f                 UNIQUE       UNIQUE WITHOUT IN
 unique_without_index  unique_c                    UNIQUE       UNIQUE WITHOUT INDEX (c)                true
 unique_without_index  unique_d                    UNIQUE       UNIQUE WITHOUT INDEX (d)                true
 unique_without_index  unique_d_e                  UNIQUE       UNIQUE WITHOUT INDEX (d, e)             true
-unique_without_index  unique_without_index_c_key  UNIQUE       UNIQUE (c ASC)                          true
 unique_without_index  unique_without_index_pkey   PRIMARY KEY  PRIMARY KEY (rowid ASC)                 true
 
 query TTTTB nosort
@@ -1949,7 +1967,6 @@ unique_without_index  my_partial_unique_f         UNIQUE       UNIQUE WITHOUT IN
 unique_without_index  my_unique_e                 UNIQUE       UNIQUE WITHOUT INDEX (e)                true
 unique_without_index  my_unique_f                 UNIQUE       UNIQUE WITHOUT INDEX (f)                true
 unique_without_index  unique_c                    UNIQUE       UNIQUE WITHOUT INDEX (c)                true
-unique_without_index  unique_without_index_c_key  UNIQUE       UNIQUE (c ASC)                          true
 unique_without_index  unique_without_index_pkey   PRIMARY KEY  PRIMARY KEY (rowid ASC)                 true
 
 query TTTTB

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_drop_constraint.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_drop_constraint.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/errors"
 )
 
@@ -45,8 +44,10 @@ func alterTableDropConstraint(
 	if dropPrimaryKeyConstraint(b, constraintElems, stmt, t) {
 		return
 	}
-	// Dropping UNIQUE constraint: error out as not implemented.
-	droppingUniqueConstraintNotImplemented(constraintElems, t)
+	// Dropping UNIQUE constraint backed by an index.
+	if dropUniqueIndexBackedConstraint(b, tn, tbl, constraintElems, stmt, t) {
+		return
+	}
 
 	_, _, constraintNameElem := scpb.FindConstraintWithoutIndexName(constraintElems)
 	constraintID := constraintNameElem.ConstraintID
@@ -133,20 +134,48 @@ func dropPrimaryKeyConstraint(
 	panic(scerrors.NotImplementedError(t))
 }
 
-func droppingUniqueConstraintNotImplemented(
-	constraintElems ElementResultSet, t *tree.AlterTableDropConstraint,
-) {
+// dropUniqueIndexBackedConstraint handles dropping a unique constraint that is
+// backed by a secondary index. Returns true if the constraint was handled,
+// false if not a unique index-backed constraint.
+func dropUniqueIndexBackedConstraint(
+	b BuildCtx,
+	tn *tree.TableName,
+	tbl *scpb.Table,
+	constraintElems ElementResultSet,
+	stmt tree.Statement,
+	t *tree.AlterTableDropConstraint,
+) bool {
 	_, _, sie := scpb.FindSecondaryIndex(constraintElems)
-	if sie != nil {
-		if sie.IsUnique {
-			panic(unimplemented.NewWithIssueDetailf(42840, "drop-constraint-unique",
-				"cannot drop UNIQUE constraint %q using ALTER TABLE DROP CONSTRAINT, use DROP INDEX CASCADE instead",
-				tree.ErrNameString(string(t.Constraint))))
-		} else {
-			panic(errors.AssertionFailedf("dropping an index-backed constraint but the " +
-				"index is not unique"))
-		}
+	if sie == nil {
+		return false
 	}
+	if !sie.IsUnique {
+		panic(errors.AssertionFailedf("dropping an index-backed constraint but the index is not unique"))
+	}
+
+	// Since this will drop the index as well, guard this behind the
+	// sql_safe_updates flag.
+	failIfSafeUpdates(b, t)
+
+	panicIfRegionChangeUnderwayOnRBRTable(b, "ALTER TABLE DROP CONSTRAINT", sie.TableID)
+
+	// Build index name for error messages and dependency handling.
+	_, _, indexNameElem := scpb.FindIndexName(constraintElems)
+	indexName := &tree.TableIndexName{
+		Table: *tn,
+		Index: tree.UnrestrictedName(indexNameElem.Name),
+	}
+
+	// Reuse the DROP INDEX logic which handles all dependencies:
+	// - Dependent views
+	// - Dependent functions
+	// - Dependent FK constraints
+	// - Sharded index cleanup
+	// - Expression index cleanup
+	// - Dependent triggers
+	dropSecondaryIndex(b, indexName, t.DropBehavior, sie, stmt)
+
+	return true
 }
 
 func checkRegionalByRowConstraintConflict(

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
@@ -2209,6 +2209,8 @@ func failIfSafeUpdates(b BuildCtx, n tree.NodeFormatter) {
 				"for certain type conversions or when applying a USING clause")
 		case *tree.DropIndex:
 			errorWithMessage = errors.New("DROP INDEX")
+		case *tree.AlterTableDropConstraint:
+			errorWithMessage = errors.New("ALTER TABLE DROP CONSTRAINT")
 		default:
 			panic(errors.AssertionFailedf("programming error: unexpected node type %T", n))
 		}

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -2001,12 +2001,13 @@ func (og *operationGenerator) dropConstraint(ctx context.Context, tx pgx.Tx) (*o
 	}
 
 	// DROP INDEX CASCADE is preferred for dropping unique constraints, and
-	// dropping the constraint with ALTER TABLE ... DROP CONSTRAINT is unsupported.
+	// dropping the constraint with ALTER TABLE ... DROP CONSTRAINT is not
+	// supported by the legacy schema changer.
 	constraintIsUnique, err := og.constraintIsUnique(ctx, tx, tableName, constraintName)
 	if err != nil {
 		return nil, err
 	}
-	if constraintIsUnique {
+	if constraintIsUnique && !og.useDeclarativeSchemaChanger {
 		stmt.expectedExecErrors.add(pgcode.FeatureNotSupported)
 	}
 


### PR DESCRIPTION


Previously, attempting to drop a UNIQUE constraint using `ALTER TABLE ... DROP CONSTRAINT` would fail with an error directing users to use `DROP INDEX CASCADE` instead. This was inconvenient for users and broke compatibility with ORMs like Liquibase and Laravel that use the standard `ALTER TABLE DROP CONSTRAINT` syntax.

This change implements support for dropping index-backed UNIQUE constraints via `ALTER TABLE DROP CONSTRAINT` in the declarative schema changer. The implementation reuses the existing `dropSecondaryIndex` logic which handles all the complex dependency management including:
- Dependent views and functions
- Dependent FK constraints (with CASCADE support)
- Sharded and expression index cleanup
- Trigger dependencies
- Regional-by-row table validation

The legacy schema changer still does not support this operation and will continue to direct users to use `DROP INDEX CASCADE`.

Fixes #42840
Epic: CRDB-31281

Release note (sql change): `ALTER TABLE ... DROP CONSTRAINT` can now be used to drop UNIQUE constraints. The backing UNIQUE index will also be dropped, as CockroachDB treats the constraint and index as the same thing.