### PR TITLE
sql: harden recent improvement to the stmt bundle

### DIFF
--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -931,8 +931,9 @@ func (b *stmtBundleBuilder) addEnv(ctx context.Context) {
 		// systems (e.g. Windows is particularly picky), we also replace many
 		// special characters with underscores - which might lose the uniqueness
 		// property. Thus, we additionally might append a count to guarantee
-		// uniqueness again.
-		fileName := stmtBundleStatsFileRE.ReplaceAllString(tables[i].FQString(), `_`)
+		// uniqueness again. We also convert everything to the lower case since
+		// Windows is case-insensitive by default.
+		fileName := strings.ToLower(stmtBundleStatsFileRE.ReplaceAllString(tables[i].FQString(), `_`))
 		statsFileNames[fileName]++
 		if statsFileNames[fileName] > 1 { // don't touch the first occurrency of this file name
 			fileName = fileName + "_" + strconv.Itoa(statsFileNames[fileName])

--- a/pkg/sql/explain_bundle_test.go
+++ b/pkg/sql/explain_bundle_test.go
@@ -929,12 +929,12 @@ CREATE TABLE users(id UUID DEFAULT gen_random_uuid() PRIMARY KEY, promo_id INT R
 
 	t.Run("multiple databases and special characters", func(t *testing.T) {
 		r.Exec(t, `CREATE DATABASE "db""name";`)
-		r.Exec(t, `CREATE DATABASE "db''name";`)
+		r.Exec(t, `CREATE DATABASE "db''Name";`)
 		r.Exec(t, `CREATE SCHEMA "db""name"."sc""name"`)
-		r.Exec(t, `CREATE SCHEMA "db''name"."sc''name"`)
+		r.Exec(t, `CREATE SCHEMA "db''Name"."sc''name"`)
 		r.Exec(t, `CREATE TABLE "db""name"."sc""name".t (pk INT PRIMARY KEY);`)
-		r.Exec(t, `CREATE TABLE "db''name"."sc''name".t (pk INT PRIMARY KEY);`)
-		rows := r.QueryStr(t, `EXPLAIN ANALYZE (DEBUG) SELECT * FROM "db""name"."sc""name".t, "db''name"."sc''name".t;`)
+		r.Exec(t, `CREATE TABLE "db''Name"."sc''name".t (pk INT PRIMARY KEY);`)
+		rows := r.QueryStr(t, `EXPLAIN ANALYZE (DEBUG) SELECT * FROM "db""name"."sc""name".t, "db''Name"."sc''name".t;`)
 		checkBundle(
 			t, fmt.Sprint(rows), `"sc""name".t`, nil, false, /* expectErrors */
 			base, plans, `distsql.html vec.txt vec-v.txt stats-_db__name_._sc__name_.t.sql stats-_db__name_._sc__name_.t_2.sql`,


### PR DESCRIPTION
In addition to replacing special characters with underscores we now will convert the file names to the lower case (TIL Windows is case-insensitive by default).

Epic: None
Release note: None