### PR TITLE
restore: suffix temp systemdb with jobID

### DIFF
--- a/pkg/backup/restore_job.go
+++ b/pkg/backup/restore_job.go
@@ -150,6 +150,17 @@ var replanFrequency = settings.RegisterDurationSetting(
 	settings.PositiveDuration,
 )
 
+func restoreTempSystemName(
+	jobCreationClusterVersion roachpb.Version, restoreJobID jobspb.JobID,
+) string {
+
+	const restoreTempSystemDBPrefix = "crdb_temp_system"
+	if jobCreationClusterVersion.AtLeast(clusterversion.V26_2.Version()) {
+		return fmt.Sprintf("%s_%d", restoreTempSystemDBPrefix, restoreJobID)
+	}
+	return restoreTempSystemDBPrefix
+}
+
 var laggingRestoreProcErr = errors.New("try re-planning due to lagging restore processors")
 
 // rewriteBackupSpanKey rewrites a backup span start key for the purposes of
@@ -1614,8 +1625,9 @@ func createImportingDescriptors(
 	}
 
 	tempSystemDBID := tempSystemDatabaseID(details, tables)
+	tempSystemDBName := restoreTempSystemName(r.job.Payload().CreationClusterVersion, r.job.ID())
 	if tempSystemDBID != descpb.InvalidID {
-		tempSystemDB := dbdesc.NewInitial(tempSystemDBID, restoreTempSystemDB,
+		tempSystemDB := dbdesc.NewInitial(tempSystemDBID, tempSystemDBName,
 			username.AdminRoleName(), dbdesc.WithPublicSchemaID(keys.SystemPublicSchemaID))
 		databases = append(databases, tempSystemDB)
 	}
@@ -1775,7 +1787,7 @@ func createImportingDescriptors(
 		typesByID,
 		dbsByID,
 		details.RemoveRegions,
-		restoreTempSystemDB,
+		tempSystemDBName,
 	); err != nil {
 		return err
 	}
@@ -1796,7 +1808,7 @@ func createImportingDescriptors(
 		includePublicSchemaCreatePriv := sqlclustersettings.PublicSchemaCreatePrivilegeEnabled.Get(&p.ExecCfg().Settings.SV)
 		if err := ingesting.WriteDescriptors(
 			ctx, txn.KV(), p.User(), descsCol, databases, writtenSchemas, tables, writtenTypes, writtenFunctions,
-			details.DescriptorCoverage, nil /* extra */, restoreTempSystemDB, includePublicSchemaCreatePriv,
+			details.DescriptorCoverage, nil /* extra */, tempSystemDBName, includePublicSchemaCreatePriv,
 			true, /* deprecatedAllowCrossDatabaseRefs */
 		); err != nil {
 			return errors.Wrapf(err, "restoring %d TableDescriptors from %d databases", len(tables), len(databases))
@@ -3665,8 +3677,10 @@ func (r *restoreResumer) restoreSystemUsers(
 	ctx context.Context, db isql.DB, systemTables []catalog.TableDescriptor,
 ) error {
 	return db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-		selectNonExistentUsers := "SELECT * FROM crdb_temp_system.users temp " +
-			"WHERE NOT EXISTS (SELECT * FROM system.users u WHERE temp.username = u.username)"
+		tempSystemDBName := restoreTempSystemName(r.job.Payload().CreationClusterVersion, r.job.ID())
+		selectNonExistentUsers := fmt.Sprintf("SELECT * FROM %s.users temp "+
+			"WHERE NOT EXISTS (SELECT * FROM system.users u WHERE temp.username = u.username)",
+			tempSystemDBName)
 		users, err := txn.QueryBuffered(ctx, "get-users",
 			txn.KV(), selectNonExistentUsers)
 		if err != nil {
@@ -3694,8 +3708,9 @@ func (r *restoreResumer) restoreSystemUsers(
 
 		// We skip granting roles if the backup does not contain system.role_members.
 		if hasSystemRoleMembersTable(systemTables) {
-			selectNonExistentRoleMembers := "SELECT * FROM crdb_temp_system.role_members temp_rm WHERE " +
-				"NOT EXISTS (SELECT * FROM system.role_members rm WHERE temp_rm.role = rm.role AND temp_rm.member = rm.member)"
+			selectNonExistentRoleMembers := fmt.Sprintf("SELECT * FROM %s.role_members temp_rm WHERE "+
+				"NOT EXISTS (SELECT * FROM system.role_members rm WHERE temp_rm.role = rm.role AND temp_rm.member = rm.member)",
+				tempSystemDBName)
 			roleMembers, err := txn.QueryBuffered(ctx, "get-role-members",
 				txn.KV(), selectNonExistentRoleMembers)
 			if err != nil {
@@ -3722,8 +3737,9 @@ VALUES ($1, $2, $3, (SELECT user_id FROM system.users WHERE username = $1), (SEL
 		}
 
 		if hasSystemRoleOptionsTable(systemTables) {
-			selectNonExistentRoleOptions := "SELECT * FROM crdb_temp_system.role_options temp_ro WHERE " +
-				"NOT EXISTS (SELECT * FROM system.role_options ro WHERE temp_ro.username = ro.username AND temp_ro.option = ro.option)"
+			selectNonExistentRoleOptions := fmt.Sprintf("SELECT * FROM %s.role_options temp_ro WHERE "+
+				"NOT EXISTS (SELECT * FROM system.role_options ro WHERE temp_ro.username = ro.username AND temp_ro.option = ro.option)",
+				tempSystemDBName)
 			roleOptions, err := txn.QueryBuffered(ctx, "get-role-options", txn.KV(), selectNonExistentRoleOptions)
 			if err != nil {
 				return err
@@ -3775,9 +3791,10 @@ func (r *restoreResumer) restoreSystemTables(
 	// to the temporary system DB then populate the metadata required to restore
 	// to the real system table.
 	systemTablesToRestore := make([]systemTableNameWithConfig, 0)
+	tempSystemDBName := restoreTempSystemName(r.job.Payload().CreationClusterVersion, r.job.ID())
 	for _, table := range tables {
 		systemTableName := table.GetName()
-		stagingTableName := restoreTempSystemDB + "." + systemTableName
+		stagingTableName := tempSystemDBName + "." + systemTableName
 
 		config, ok := systemTableBackupConfiguration[systemTableName]
 		if !ok {
@@ -3855,26 +3872,33 @@ func (r *restoreResumer) restoreSystemTables(
 
 func (r *restoreResumer) cleanupTempSystemTables(ctx context.Context) error {
 	executor := r.execCfg.InternalDB.Executor()
+
+	dbName := restoreTempSystemName(r.job.Payload().CreationClusterVersion, r.job.ID())
+
 	// Check if the temp system database has already been dropped. This can happen
 	// if the restore job fails after the system database has cleaned up.
 	checkIfDatabaseExists := "SELECT database_name FROM [SHOW DATABASES] WHERE database_name=$1"
-	if row, err := executor.QueryRow(ctx, "checking-for-temp-system-db" /* opName */, nil /* txn */, checkIfDatabaseExists, restoreTempSystemDB); err != nil {
-		return errors.Wrap(err, "checking for temporary system db")
-	} else if row == nil {
-		// Temporary system DB might already have been dropped by the restore job.
+	row, err := executor.QueryRow(ctx, "checking-for-temp-system-db" /* opName */, nil /* txn */, checkIfDatabaseExists, dbName)
+	if err != nil {
+		return errors.Wrapf(err, "checking for temporary system db %q", dbName)
+	}
+	if row == nil {
+		// Temporary system DB doesn't exist, nothing to clean up.
 		return nil
 	}
 
 	// After restoring the system tables, drop the temporary database holding the
 	// system tables.
-	gcTTLQuery := fmt.Sprintf("ALTER DATABASE %s CONFIGURE ZONE USING gc.ttlseconds=1", restoreTempSystemDB)
+	gcTTLQuery := fmt.Sprintf("ALTER DATABASE %s CONFIGURE ZONE USING gc.ttlseconds=1", dbName)
 	if _, err := executor.Exec(ctx, "altering-gc-ttl-temp-system" /* opName */, nil /* txn */, gcTTLQuery); err != nil {
-		log.Dev.Errorf(ctx, "failed to update the GC TTL of %q: %+v", restoreTempSystemDB, err)
+		log.Dev.Errorf(ctx, "failed to update the GC TTL of %q: %+v", dbName, err)
 	}
-	dropTableQuery := fmt.Sprintf("DROP DATABASE %s CASCADE", restoreTempSystemDB)
+
+	dropTableQuery := fmt.Sprintf("DROP DATABASE %s CASCADE", dbName)
 	if _, err := executor.Exec(ctx, "drop-temp-system-db" /* opName */, nil /* txn */, dropTableQuery); err != nil {
-		return errors.Wrap(err, "dropping temporary system db")
+		return errors.Wrapf(err, "dropping temporary system db %q", dbName)
 	}
+
 	return nil
 }
 

--- a/pkg/backup/restore_planning.go
+++ b/pkg/backup/restore_planning.go
@@ -792,7 +792,7 @@ func allocateDescriptorRewrites(
 	opts tree.RestoreOptions,
 	intoDB string,
 	newDBName string,
-) (jobspb.DescRewriteMap, error) {
+) (jobspb.DescRewriteMap, descpb.ID, error) {
 	descriptorRewrites := make(jobspb.DescRewriteMap)
 
 	restoreDBNames := make(map[string]catalog.DatabaseDescriptor, len(restoreDBs))
@@ -801,7 +801,7 @@ func allocateDescriptorRewrites(
 	}
 
 	if len(restoreDBNames) > 0 && intoDB != "" {
-		return nil, errors.Errorf("cannot use %q option when restoring database(s)", restoreOptIntoDB)
+		return nil, 0, errors.Errorf("cannot use %q option when restoring database(s)", restoreOptIntoDB)
 	}
 
 	// The logic at the end of this function leaks table IDs, so fail fast if
@@ -810,7 +810,7 @@ func allocateDescriptorRewrites(
 	// Fail fast if the tables to restore are incompatible with the specified
 	// options.
 	if err := validateTableDependenciesForOptions(tablesByID, typesByID, functionsByID, &opts); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	txn := p.InternalSQLTxn()
@@ -821,30 +821,32 @@ func allocateDescriptorRewrites(
 	if newDBName != "" {
 		dbID, err := col.LookupDatabaseID(ctx, txn.KV(), newDBName)
 		if err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 		if dbID != descpb.InvalidID {
-			return nil, errors.Errorf("database %q already exists", newDBName)
+			return nil, 0, errors.Errorf("database %q already exists", newDBName)
 		}
 	} else {
 		for name := range restoreDBNames {
 			dbID, err := col.LookupDatabaseID(ctx, txn.KV(), name)
 			if err != nil {
-				return nil, err
+				return nil, 0, err
 			}
 			if dbID != descpb.InvalidID {
-				return nil, errors.Errorf("database %q already exists", name)
+				return nil, 0, errors.Errorf("database %q already exists", name)
 			}
 		}
 	}
 
+	tempSysDBID := descpb.InvalidID
 	if descriptorCoverage == tree.AllDescriptors || descriptorCoverage == tree.SystemUsers {
 		// Increment the DescIDSequenceKey so that it is higher than both the max desc ID
 		// in the backup and current max desc ID in the restoring cluster. This generator
 		// keeps produced the next descriptor ID.
-		tempSysDBID, err := p.ExecCfg().DescIDGenerator.GenerateUniqueDescID(ctx)
+		var err error
+		tempSysDBID, err = p.ExecCfg().DescIDGenerator.GenerateUniqueDescID(ctx)
 		if err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 		remapSystemDBDescsToTempDB(schemasByID, tablesByID, typesByID, functionsByID, tempSysDBID, descriptorRewrites)
 	}
@@ -856,7 +858,7 @@ func allocateDescriptorRewrites(
 		ctx, p, databasesByID, schemasByID, descriptorCoverage, intoDB, restoreDBNames,
 		databasesWithDeprecatedPrivileges, descriptorRewrites,
 	); err != nil {
-		return nil, err
+		return nil, 0, err
 	} else {
 		shouldBufferDeprecatedPrivilegeNotice = b || shouldBufferDeprecatedPrivilegeNotice
 	}
@@ -865,7 +867,7 @@ func allocateDescriptorRewrites(
 		ctx, p, databasesByID, tablesByID, descriptorCoverage, intoDB, restoreDBNames,
 		databasesWithDeprecatedPrivileges, descriptorRewrites,
 	); err != nil {
-		return nil, err
+		return nil, 0, err
 	} else {
 		shouldBufferDeprecatedPrivilegeNotice = b || shouldBufferDeprecatedPrivilegeNotice
 	}
@@ -874,7 +876,7 @@ func allocateDescriptorRewrites(
 		ctx, p, databasesByID, typesByID, descriptorCoverage, intoDB, restoreDBNames,
 		databasesWithDeprecatedPrivileges, descriptorRewrites,
 	); err != nil {
-		return nil, err
+		return nil, 0, err
 	} else {
 		shouldBufferDeprecatedPrivilegeNotice = b || shouldBufferDeprecatedPrivilegeNotice
 	}
@@ -882,7 +884,7 @@ func allocateDescriptorRewrites(
 	if err := remapFunctions(
 		databasesByID, functionsByID, descriptorCoverage, intoDB, restoreDBNames, descriptorRewrites,
 	); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	remapDatabases(restoreDBs, newDBName, descriptorRewrites)
@@ -905,10 +907,10 @@ func allocateDescriptorRewrites(
 		typesByID,
 		functionsByID,
 		descriptorRewrites); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
-	return descriptorRewrites, nil
+	return descriptorRewrites, tempSysDBID, nil
 }
 
 func getDatabaseIDAndDesc(
@@ -958,7 +960,6 @@ func resolveTargetDB(
 	if intoDB != "" {
 		return intoDB, nil
 	}
-
 	if descriptorCoverage == tree.AllDescriptors && catalog.IsSystemDescriptor(descriptor) {
 		if descriptor.GetParentID() == systemschema.SystemDB.GetID() {
 			return "", errors.AssertionFailedf("system descriptors should have been processed")
@@ -1886,7 +1887,7 @@ func doRestorePlan(
 		}
 	}
 
-	descriptorRewrites, err := allocateDescriptorRewrites(
+	descriptorRewrites, tempSysDBID, err := allocateDescriptorRewrites(
 		ctx,
 		p,
 		databasesByID,
@@ -2004,6 +2005,7 @@ func doRestorePlan(
 		ExperimentalCopy:                 restoreStmt.Options.ExperimentalCopy,
 		RemoveRegions:                    restoreStmt.Options.RemoveRegions,
 		UnsafeRestoreIncompatibleVersion: restoreStmt.Options.UnsafeRestoreIncompatibleVersion,
+		TempSystemID:                     tempSysDBID,
 	}
 
 	jr := jobs.Record{

--- a/pkg/backup/restore_planning.go
+++ b/pkg/backup/restore_planning.go
@@ -76,10 +76,6 @@ const (
 	restoreOptSkipLocalitiesCheck       = "skip_localities_check"
 	restoreOptAsTenant                  = "virtual_cluster_name"
 	restoreOptForceTenantID             = "virtual_cluster"
-
-	// The temporary database system tables will be restored into for full
-	// cluster backups.
-	restoreTempSystemDB = "crdb_temp_system"
 )
 
 // featureRestoreEnabled is used to enable and disable the RESTORE feature.
@@ -254,6 +250,7 @@ func remapSystemDBDescsToTempDB(
 	schemasByID map[descpb.ID]*schemadesc.Mutable,
 	tablesByID map[descpb.ID]*tabledesc.Mutable,
 	typesByID map[descpb.ID]*typedesc.Mutable,
+	funcsByID map[descpb.ID]*funcdesc.Mutable,
 	tempSysDBID catid.DescID,
 	descriptorRewrites jobspb.DescRewriteMap,
 ) {
@@ -275,6 +272,13 @@ func remapSystemDBDescsToTempDB(
 			descriptorRewrites[typ.GetID()] = &jobspb.DescriptorRewrite{
 				ParentID:       tempSysDBID,
 				ParentSchemaID: keys.PublicSchemaIDForBackup,
+			}
+		}
+	}
+	for _, fn := range funcsByID {
+		if fn.GetParentID() == systemschema.SystemDB.GetID() {
+			descriptorRewrites[fn.GetID()] = &jobspb.DescriptorRewrite{
+				ParentID: tempSysDBID,
 			}
 		}
 	}
@@ -842,7 +846,7 @@ func allocateDescriptorRewrites(
 		if err != nil {
 			return nil, err
 		}
-		remapSystemDBDescsToTempDB(schemasByID, tablesByID, typesByID, tempSysDBID, descriptorRewrites)
+		remapSystemDBDescsToTempDB(schemasByID, tablesByID, typesByID, functionsByID, tempSysDBID, descriptorRewrites)
 	}
 
 	var shouldBufferDeprecatedPrivilegeNotice bool
@@ -956,13 +960,10 @@ func resolveTargetDB(
 	}
 
 	if descriptorCoverage == tree.AllDescriptors && catalog.IsSystemDescriptor(descriptor) {
-		var targetDB string
 		if descriptor.GetParentID() == systemschema.SystemDB.GetID() {
-			// For full cluster backups, put the system tables in the temporary
-			// system table.
-			targetDB = restoreTempSystemDB
+			return "", errors.AssertionFailedf("system descriptors should have been processed")
 		}
-		return targetDB, nil
+		return "", nil
 	}
 
 	database, ok := databasesByID[descriptor.GetParentID()]

--- a/pkg/backup/restore_planning_test.go
+++ b/pkg/backup/restore_planning_test.go
@@ -317,7 +317,7 @@ func TestAllocateDescriptorRewrites(t *testing.T) {
 
 	t.Run("allocateDescriptorRewrite", func(t *testing.T) {
 		t.Run("succeeds on empty input", func(t *testing.T) {
-			rewrites, err := allocateDescriptorRewrites(
+			rewrites, _, err := allocateDescriptorRewrites(
 				ctx,
 				planner,
 				nil,
@@ -334,7 +334,7 @@ func TestAllocateDescriptorRewrites(t *testing.T) {
 			require.Equal(t, jobspb.DescRewriteMap{}, rewrites)
 		})
 		t.Run("allocates into existing db", func(t *testing.T) {
-			rewrites, err := allocateDescriptorRewrites(
+			rewrites, _, err := allocateDescriptorRewrites(
 				ctx,
 				planner,
 				map[descpb.ID]*dbdesc.Mutable{
@@ -392,7 +392,7 @@ func TestAllocateDescriptorRewrites(t *testing.T) {
 		})
 
 		t.Run("allocates into new db", func(t *testing.T) {
-			rewrites, err := allocateDescriptorRewrites(
+			rewrites, _, err := allocateDescriptorRewrites(
 				ctx,
 				planner,
 				map[descpb.ID]*dbdesc.Mutable{
@@ -460,7 +460,7 @@ func TestAllocateDescriptorRewrites(t *testing.T) {
 		})
 
 		t.Run("allocates functions into new db", func(t *testing.T) {
-			rewrites, err := allocateDescriptorRewrites(
+			rewrites, _, err := allocateDescriptorRewrites(
 				ctx,
 				planner,
 				map[descpb.ID]*dbdesc.Mutable{
@@ -504,7 +504,7 @@ func TestAllocateDescriptorRewrites(t *testing.T) {
 			// Get a new plan state after dropping the DB.
 			setupPlanner()
 
-			rewrites, err := allocateDescriptorRewrites(
+			rewrites, _, err := allocateDescriptorRewrites(
 				ctx,
 				planner,
 				map[descpb.ID]*dbdesc.Mutable{

--- a/pkg/backup/system_schema.go
+++ b/pkg/backup/system_schema.go
@@ -908,8 +908,7 @@ func rekeySystemTable(
 		// these tables we will need to cast to int to do the addition/subtraction
 		// of the offset, and then cast back to the desired type determined here.
 		typ := "int"
-		switch tempTableName {
-		case "crdb_temp_system.database_role_settings":
+		if strings.HasSuffix(tempTableName, "database_role_settings") {
 			typ = "oid"
 		}
 

--- a/pkg/backup/testdata/backup-restore/restore-on-fail-or-cancel-schema-objects
+++ b/pkg/backup/testdata/backup-restore/restore-on-fail-or-cancel-schema-objects
@@ -174,7 +174,7 @@ job cancel=d
 
 # Make sure the temp system db is not present.
 query-sql
-SELECT * FROM [SHOW DATABASES] WHERE database_name = 'crdb_temp_system';
+SELECT * FROM [SHOW DATABASES] WHERE database_name LIKE 'crdb_temp_system%';
 ----
 
 # Make sure defaultdb and postgres are recreated with new IDs.

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -664,7 +664,12 @@ message RestoreDetails {
 
   bool experimental_copy = 37;
 
-  // NEXT ID: 38.
+  uint32 temp_system_id = 38 [
+    (gogoproto.customname) = "TempSystemID",
+    (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb.ID"
+  ];
+
+  // NEXT ID: 39.
 }
 
 


### PR DESCRIPTION
restore: suffix temp systemdb with jobID

Previously the tempDB used by cluster restore was hardcoded to crdb_temp_system. With this patch, the name is suffixed with restore's jobID. In order to partially restore zone config data or user data during table or database restores, we will temporarily store the backed up tables in a temporary system db. However, since a user can run multiple db or table restores at once, the restore jobs must use their own temp dbs; hence the need to suffix the temp system db.

Informs: #159929

Release note: none

----

restore: persist temp system db id in job record

To prep for temporarily restoring system.users and system.zone during certain
database and table restores, this patch simplifies the logic for finding the
temp system db id during job resumption. The previous logic could find the id
after checking if the restore was full cluster (or system users), but this
branch will not be as clear cut in the future.

Informs https://github.com/cockroachdb/cockroach/issues/159929

Release note: none
