### PR TITLE
sql: resolve udt from array type and append it to metadata

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
@@ -3173,7 +3173,7 @@ distribution: local
 │           │ equality: (crdb_region, id) = (crdb_region, user_id)
 │           │
 │           └── • distinct
-│               │ estimated row count: 100
+│               │ estimated row count: 40
 │               │ distinct on: id, crdb_region
 │               │
 │               └── • scan buffer

--- a/pkg/sql/opt/optbuilder/testdata/create_view
+++ b/pkg/sql/opt/optbuilder/testdata/create_view
@@ -413,7 +413,8 @@ create-view t.public.v26
  ├── SELECT fb FROM t.public.foobars
  ├── columns: fb:1
  └── dependencies
-      └── foobars [columns: fb]
+      ├── foobars [columns: fb]
+      └── foobar
 
 # Test UDFs called from a view.
 build


### PR DESCRIPTION
Fixes #146126

Previously, the metadata would lose track of a udt type if the column is defined as an array of udt. This is revealed that in the stmt bundle, the CREATE TYPE stmt is not included in the schema.sql. This commit is to fix it by unwrapping the array type and registerring the udt in metadata.userDefinedTypes.

Release note (bug fix): have statement bundles contains the CREATE TYPE for udts where columns are of udt array type.