### PR TITLE
release-26.1: sqlccl: minor improvements to TestExplainGist

### DIFF
--- a/pkg/ccl/testccl/sqlccl/explain_test.go
+++ b/pkg/ccl/testccl/sqlccl/explain_test.go
@@ -203,7 +203,6 @@ func TestExplainGist(t *testing.T) {
 					"type check failed while initializing stat",                          // #125620
 					"argument expression has type RECORD, need type USER DEFINED RECORD", // #139910
 					"invalid datum type given: RECORD, expected RECORD",                  // #140773
-					"not in index", // #148405
 				} {
 					if strings.Contains(err.Error(), knownErr) {
 						// Don't fail the test on a set of known errors.
@@ -305,11 +304,11 @@ func TestExplainGist(t *testing.T) {
 				} else {
 					logStmt(stmt, true /* successful */)
 				}
-			case <-time.After(time.Minute):
+			case <-time.After(3 * time.Minute):
 				t.Log(stmts.String())
 				sl := allstacks.Get()
 				t.Logf("stacks:\n\n%s", sl)
-				t.Fatalf("stmt wasn't canceled by statement_timeout of 0.1s - ran at least for 1m: %s", stmt)
+				t.Fatalf("stmt wasn't canceled by statement_timeout of 0.1s - ran at least for 3m: %s", stmt)
 			}
 		}
 	})


### PR DESCRIPTION
Backport 1/1 commits from #162158 on behalf of @yuzefovich.

----

Increase the time we wait for the statement to be cancelled due to the statement timeout from 1 min to 3 min - the idea is that if we're blocked on something, then we'll now be able to see 1-2 min blockages (whereas previously it wasn't as clear whether the goroutine is running or is blocked since it's been in that state for less than 1 min).

Additionally, unskip one "expected" error that has been fixed in 25.4+.

Fixes: #161233.
Release note: None

----

Release justification: test-only change.