### PR TITLE
release-26.1: roachtest: skip schemachange/bulkingest on s390x

### DIFF
--- a/pkg/cmd/roachtest/tests/schemachange.go
+++ b/pkg/cmd/roachtest/tests/schemachange.go
@@ -337,11 +337,12 @@ func makeSchemaChangeBulkIngestTest(
 	operation bulkIngestSchemaChangeOp,
 ) registry.TestSpec {
 	return registry.TestSpec{
-		Name:             fmt.Sprintf("schemachange/bulkingest/nodes=%d/rows=%d/%s", numNodes, numRows, operation),
-		Owner:            registry.OwnerSQLFoundations,
-		Benchmark:        true,
-		Cluster:          r.MakeClusterSpec(numNodes, spec.WorkloadNode(), spec.Disks(4)),
-		CompatibleClouds: registry.AllExceptAWS,
+		Name:      fmt.Sprintf("schemachange/bulkingest/nodes=%d/rows=%d/%s", numNodes, numRows, operation),
+		Owner:     registry.OwnerSQLFoundations,
+		Benchmark: true,
+		Cluster:   r.MakeClusterSpec(numNodes, spec.WorkloadNode(), spec.Disks(4)),
+		// Skip s390x, see https://github.com/cockroachdb/cockroach/issues/161453.
+		CompatibleClouds: registry.AllExceptAWS.NoIBM(),
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.LeaderLeases,
 		Timeout:          length * 2,


### PR DESCRIPTION
Backport 1/1 commits from #162353 on behalf of @rafiss.

----

This benchmark test times out on IBM cloud (s390x) due to slower hardware. Skip it by excluding IBM cloud from the compatible clouds.

Fixes #161453

Release note: None

----

Release justification: