### PR TITLE
sql: add zone configs to end-to-end test dependencies

### DIFF
--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row.explain
@@ -12,7 +12,7 @@ EXPLAIN (DDL) ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUM
 Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_regional_by_row› DROP COLUMN ‹v›, ADD COLUMN ‹j› INT8 UNIQUE DEFAULT unique_rowid(), DROP COLUMN ‹m›, ADD COLUMN ‹l› INT8 UNIQUE DEFAULT unique_rowid();
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
- │         ├── 15 elements transitioning toward PUBLIC
+ │         ├── 18 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → BACKFILL_ONLY    PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey+), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey~)}
  │         │    ├── ABSENT → PUBLIC           IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey+)}
  │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey+)}
@@ -23,11 +23,14 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │         │    ├── ABSENT → PUBLIC           ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (j+), TypeName: "INT8"}
  │         │    ├── ABSENT → PUBLIC           ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j+), Expr: unique_rowid()}
  │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j+), IndexID: 8 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → PUBLIC           TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
  │         │    ├── ABSENT → DELETE_ONLY      Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l+)}
  │         │    ├── ABSENT → PUBLIC           ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 6 (l+)}
  │         │    ├── ABSENT → PUBLIC           ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (l+), TypeName: "INT8"}
  │         │    ├── ABSENT → PUBLIC           ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l+), Expr: unique_rowid()}
- │         │    └── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l+), IndexID: 8 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l+), IndexID: 8 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → PUBLIC           TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+ │         │    └── ABSENT → PUBLIC           TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
  │         ├── 17 elements transitioning toward TRANSIENT_ABSENT
  │         │    ├── ABSENT → BACKFILL_ONLY    PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey~), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
  │         │    ├── ABSENT → PUBLIC           IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey~)}
@@ -53,16 +56,19 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │         │    ├── PUBLIC → ABSENT           ColumnName:{DescID: 108 (table_regional_by_row), Name: "v", ColumnID: 2 (v-)}
  │         │    ├── PUBLIC → WRITE_ONLY       Column:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m-)}
  │         │    └── PUBLIC → ABSENT           ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 3 (m-)}
- │         └── 35 Mutation operations
+ │         └── 38 Mutation operations
  │              ├── SetTableSchemaLocked {"TableID":108}
  │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":5,"TableID":108}}
  │              ├── SetColumnName {"ColumnID":5,"Name":"j","TableID":108}
  │              ├── UpsertColumnType {"ColumnType":{"ColumnID":5,"TableID":108}}
  │              ├── AddColumnDefaultExpression {"Default":{"ColumnID":5,"TableID":108}}
+ │              ├── AddTableZoneConfig {"TableID":108}
  │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":6,"TableID":108}}
  │              ├── SetColumnName {"ColumnID":6,"Name":"l","TableID":108}
  │              ├── UpsertColumnType {"ColumnType":{"ColumnID":6,"TableID":108}}
  │              ├── AddColumnDefaultExpression {"Default":{"ColumnID":6,"TableID":108}}
+ │              ├── AddTableZoneConfig {"TableID":108}
+ │              ├── AddTableZoneConfig {"TableID":108}
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":6,"IndexID":6,"IsUnique":true,"SourceIndexID":1,"TableID":108,"TemporaryIndexID":7}}
  │              ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":6,"TableID":108}}
  │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":6,"TableID":108}
@@ -91,7 +97,7 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │              └── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":108}
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
- │    │    ├── 15 elements transitioning toward PUBLIC
+ │    │    ├── 18 elements transitioning toward PUBLIC
  │    │    │    ├── BACKFILL_ONLY    → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey+), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey~)}
  │    │    │    ├── PUBLIC           → ABSENT IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey+)}
  │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey+)}
@@ -102,11 +108,14 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │    │    │    ├── PUBLIC           → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (j+), TypeName: "INT8"}
  │    │    │    ├── PUBLIC           → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j+), Expr: unique_rowid()}
  │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j+), IndexID: 8 (table_regional_by_row_pkey+)}
+ │    │    │    ├── PUBLIC           → ABSENT TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
  │    │    │    ├── DELETE_ONLY      → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l+)}
  │    │    │    ├── PUBLIC           → ABSENT ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 6 (l+)}
  │    │    │    ├── PUBLIC           → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (l+), TypeName: "INT8"}
  │    │    │    ├── PUBLIC           → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l+), Expr: unique_rowid()}
- │    │    │    └── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l+), IndexID: 8 (table_regional_by_row_pkey+)}
+ │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l+), IndexID: 8 (table_regional_by_row_pkey+)}
+ │    │    │    ├── PUBLIC           → ABSENT TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+ │    │    │    └── PUBLIC           → ABSENT TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
  │    │    ├── 17 elements transitioning toward TRANSIENT_ABSENT
  │    │    │    ├── BACKFILL_ONLY    → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey~), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
  │    │    │    ├── PUBLIC           → ABSENT IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey~)}
@@ -135,7 +144,7 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │    │    └── 1 Mutation operation
  │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
  │    └── Stage 2 of 2 in PreCommitPhase
- │         ├── 15 elements transitioning toward PUBLIC
+ │         ├── 18 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → BACKFILL_ONLY    PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey+), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey~)}
  │         │    ├── ABSENT → PUBLIC           IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey+)}
  │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey+)}
@@ -146,11 +155,14 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │         │    ├── ABSENT → PUBLIC           ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (j+), TypeName: "INT8"}
  │         │    ├── ABSENT → PUBLIC           ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j+), Expr: unique_rowid()}
  │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j+), IndexID: 8 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → PUBLIC           TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
  │         │    ├── ABSENT → DELETE_ONLY      Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l+)}
  │         │    ├── ABSENT → PUBLIC           ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 6 (l+)}
  │         │    ├── ABSENT → PUBLIC           ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (l+), TypeName: "INT8"}
  │         │    ├── ABSENT → PUBLIC           ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l+), Expr: unique_rowid()}
- │         │    └── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l+), IndexID: 8 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l+), IndexID: 8 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → PUBLIC           TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+ │         │    └── ABSENT → PUBLIC           TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
  │         ├── 17 elements transitioning toward TRANSIENT_ABSENT
  │         │    ├── ABSENT → BACKFILL_ONLY    PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey~), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
  │         │    ├── ABSENT → PUBLIC           IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey~)}
@@ -176,16 +188,19 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │         │    ├── PUBLIC → ABSENT           ColumnName:{DescID: 108 (table_regional_by_row), Name: "v", ColumnID: 2 (v-)}
  │         │    ├── PUBLIC → WRITE_ONLY       Column:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m-)}
  │         │    └── PUBLIC → ABSENT           ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 3 (m-)}
- │         └── 40 Mutation operations
+ │         └── 43 Mutation operations
  │              ├── SetTableSchemaLocked {"TableID":108}
  │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":5,"TableID":108}}
  │              ├── SetColumnName {"ColumnID":5,"Name":"j","TableID":108}
  │              ├── UpsertColumnType {"ColumnType":{"ColumnID":5,"TableID":108}}
  │              ├── AddColumnDefaultExpression {"Default":{"ColumnID":5,"TableID":108}}
+ │              ├── AddTableZoneConfig {"TableID":108}
  │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":6,"TableID":108}}
  │              ├── SetColumnName {"ColumnID":6,"Name":"l","TableID":108}
  │              ├── UpsertColumnType {"ColumnType":{"ColumnID":6,"TableID":108}}
  │              ├── AddColumnDefaultExpression {"Default":{"ColumnID":6,"TableID":108}}
+ │              ├── AddTableZoneConfig {"TableID":108}
+ │              ├── AddTableZoneConfig {"TableID":108}
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":6,"IndexID":6,"IsUnique":true,"SourceIndexID":1,"TableID":108,"TemporaryIndexID":7}}
  │              ├── MaybeAddSplitForIndex {"IndexID":6,"TableID":108}
  │              ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":6,"TableID":108}}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row.side_effects
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row.side_effects
@@ -62,7 +62,7 @@ write *eventpb.AlterTable to event log:
     tag: ALTER TABLE
     user: root
   tableName: multiregion_db.public.table_regional_by_row
-## StatementPhase stage 1 of 1 with 35 MutationType ops
+## StatementPhase stage 1 of 1 with 38 MutationType ops
 upsert descriptor #108
   ...
          oid: 20
@@ -323,12 +323,13 @@ upsert descriptor #108
      unexposedParentSchemaId: 105
   -  version: "1"
   +  version: "2"
+upsert zone config for #108
 # end StatementPhase
 # begin PreCommitPhase
 ## PreCommitPhase stage 1 of 2 with 1 MutationType op
 undo all catalog changes within txn #1
 persist all catalog changes to storage
-## PreCommitPhase stage 2 of 2 with 40 MutationType ops
+## PreCommitPhase stage 2 of 2 with 43 MutationType ops
 upsert descriptor #108
   ...
          oid: 20
@@ -625,6 +626,7 @@ upsert descriptor #108
      unexposedParentSchemaId: 105
   -  version: "1"
   +  version: "2"
+upsert zone config for #108
 persist all catalog changes to storage
 create job #1 (non-cancelable: false): "ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), DROP COLUMN m, ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid()"
   descriptor IDs: [108]

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_regional_by_row/add_column_regional_by_row.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_regional_by_row/add_column_regional_by_row.explain
@@ -11,7 +11,7 @@ EXPLAIN (DDL) ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN
 Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_regional_by_row› ADD COLUMN ‹w› STRING NOT NULL DEFAULT ‹'s'›;
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
- │         ├── 11 elements transitioning toward PUBLIC
+ │         ├── 12 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → DELETE_ONLY      Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (w+)}
  │         │    ├── ABSENT → PUBLIC           ColumnName:{DescID: 108 (table_regional_by_row), Name: "w", ColumnID: 4 (w+)}
  │         │    ├── ABSENT → PUBLIC           ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 4 (w+), TypeName: "STRING"}
@@ -22,7 +22,8 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 2 (table_regional_by_row_pkey+)}
  │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 2 (table_regional_by_row_pkey+)}
  │         │    ├── ABSENT → PUBLIC           IndexData:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_pkey+)}
- │         │    └── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (w+), IndexID: 2 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (w+), IndexID: 2 (table_regional_by_row_pkey+)}
+ │         │    └── ABSENT → PUBLIC           TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
  │         ├── 6 elements transitioning toward TRANSIENT_ABSENT
  │         │    ├── ABSENT → DELETE_ONLY      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (table_regional_by_row_pkey-)}
  │         │    ├── ABSENT → TRANSIENT_ABSENT IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 3}
@@ -32,7 +33,7 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │         │    └── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (w+), IndexID: 3}
  │         ├── 1 element transitioning toward TRANSIENT_PUBLIC
  │         │    └── PUBLIC → ABSENT           TableSchemaLocked:{DescID: 108 (table_regional_by_row)}
- │         └── 17 Mutation operations
+ │         └── 18 Mutation operations
  │              ├── SetTableSchemaLocked {"TableID":108}
  │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":4,"TableID":108}}
  │              ├── SetColumnName {"ColumnID":4,"Name":"w","TableID":108}
@@ -49,10 +50,11 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":3,"Ordinal":1,"TableID":108}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":108}
  │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":2,"Kind":2,"Ordinal":1,"TableID":108}
- │              └── AddColumnToIndex {"ColumnID":4,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":108}
+ │              └── AddTableZoneConfig {"TableID":108}
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
- │    │    ├── 11 elements transitioning toward PUBLIC
+ │    │    ├── 12 elements transitioning toward PUBLIC
  │    │    │    ├── DELETE_ONLY      → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (w+)}
  │    │    │    ├── PUBLIC           → ABSENT ColumnName:{DescID: 108 (table_regional_by_row), Name: "w", ColumnID: 4 (w+)}
  │    │    │    ├── PUBLIC           → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 4 (w+), TypeName: "STRING"}
@@ -63,7 +65,8 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 2 (table_regional_by_row_pkey+)}
  │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 2 (table_regional_by_row_pkey+)}
  │    │    │    ├── PUBLIC           → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_pkey+)}
- │    │    │    └── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (w+), IndexID: 2 (table_regional_by_row_pkey+)}
+ │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (w+), IndexID: 2 (table_regional_by_row_pkey+)}
+ │    │    │    └── PUBLIC           → ABSENT TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
  │    │    ├── 6 elements transitioning toward TRANSIENT_ABSENT
  │    │    │    ├── DELETE_ONLY      → ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (table_regional_by_row_pkey-)}
  │    │    │    ├── TRANSIENT_ABSENT → ABSENT IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 3}
@@ -76,7 +79,7 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │    │    └── 1 Mutation operation
  │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
  │    └── Stage 2 of 2 in PreCommitPhase
- │         ├── 11 elements transitioning toward PUBLIC
+ │         ├── 12 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → DELETE_ONLY      Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (w+)}
  │         │    ├── ABSENT → PUBLIC           ColumnName:{DescID: 108 (table_regional_by_row), Name: "w", ColumnID: 4 (w+)}
  │         │    ├── ABSENT → PUBLIC           ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 4 (w+), TypeName: "STRING"}
@@ -87,7 +90,8 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 2 (table_regional_by_row_pkey+)}
  │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 2 (table_regional_by_row_pkey+)}
  │         │    ├── ABSENT → PUBLIC           IndexData:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_pkey+)}
- │         │    └── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (w+), IndexID: 2 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (w+), IndexID: 2 (table_regional_by_row_pkey+)}
+ │         │    └── ABSENT → PUBLIC           TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
  │         ├── 6 elements transitioning toward TRANSIENT_ABSENT
  │         │    ├── ABSENT → DELETE_ONLY      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (table_regional_by_row_pkey-)}
  │         │    ├── ABSENT → TRANSIENT_ABSENT IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 3}
@@ -97,7 +101,7 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │         │    └── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (w+), IndexID: 3}
  │         ├── 1 element transitioning toward TRANSIENT_PUBLIC
  │         │    └── PUBLIC → ABSENT           TableSchemaLocked:{DescID: 108 (table_regional_by_row)}
- │         └── 21 Mutation operations
+ │         └── 22 Mutation operations
  │              ├── SetTableSchemaLocked {"TableID":108}
  │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":4,"TableID":108}}
  │              ├── SetColumnName {"ColumnID":4,"Name":"w","TableID":108}
@@ -117,6 +121,7 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":108}
  │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":2,"Kind":2,"Ordinal":1,"TableID":108}
  │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":108}
+ │              ├── AddTableZoneConfig {"TableID":108}
  │              ├── SetJobStateOnDescriptor {"DescriptorID":108,"Initialize":true}
  │              └── CreateSchemaChangerJob {"RunningStatus":"Pending: Updatin..."}
  ├── PostCommitPhase

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_regional_by_row/add_column_regional_by_row.side_effects
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_regional_by_row/add_column_regional_by_row.side_effects
@@ -30,7 +30,7 @@ write *eventpb.AlterTable to event log:
     tag: ALTER TABLE
     user: root
   tableName: multiregion_db.public.table_regional_by_row
-## StatementPhase stage 1 of 1 with 17 MutationType ops
+## StatementPhase stage 1 of 1 with 18 MutationType ops
 upsert descriptor #108
   ...
        - 2
@@ -170,12 +170,13 @@ upsert descriptor #108
      unexposedParentSchemaId: 105
   -  version: "1"
   +  version: "2"
+upsert zone config for #108
 # end StatementPhase
 # begin PreCommitPhase
 ## PreCommitPhase stage 1 of 2 with 1 MutationType op
 undo all catalog changes within txn #1
 persist all catalog changes to storage
-## PreCommitPhase stage 2 of 2 with 21 MutationType ops
+## PreCommitPhase stage 2 of 2 with 22 MutationType ops
 upsert descriptor #108
   ...
      createAsOfTime:
@@ -349,6 +350,7 @@ upsert descriptor #108
      unexposedParentSchemaId: 105
   -  version: "1"
   +  version: "2"
+upsert zone config for #108
 persist all catalog changes to storage
 create job #1 (non-cancelable: false): "ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN w STRING NOT NULL DEFAULT 's'"
   descriptor IDs: [108]

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr.explain
@@ -12,7 +12,7 @@ EXPLAIN (DDL) alter table multiregion_db.table_regional_by_row add column m int8
 Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_regional_by_row› ADD COLUMN ‹m› INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (‹k›) USING HASH;
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
- │         ├── 18 elements transitioning toward PUBLIC
+ │         ├── 22 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → DELETE_ONLY      Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m+)}
  │         │    ├── ABSENT → PUBLIC           ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 5 (m+)}
  │         │    ├── ABSENT → PUBLIC           ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (m+), TypeName: "INT8"}
@@ -30,7 +30,11 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │         │    ├── ABSENT → PUBLIC           ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16+), TypeName: "INT8"}
  │         │    ├── ABSENT → PUBLIC           ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16+), ReferencedColumnIDs: [1], Usage: REGULAR}
  │         │    ├── ABSENT → PUBLIC           ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16+)}
- │         │    └── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16+), IndexID: 10 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16+), IndexID: 10 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → PUBLIC           TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
+ │         │    ├── ABSENT → PUBLIC           TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+ │         │    ├── ABSENT → PUBLIC           TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
+ │         │    └── ABSENT → PUBLIC           TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 4}
  │         ├── 15 elements transitioning toward TRANSIENT_ABSENT
  │         │    ├── ABSENT → BACKFILL_ONLY    PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey~), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 1 (table_regional_by_row_pkey-)}
  │         │    ├── ABSENT → PUBLIC           IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey~)}
@@ -49,7 +53,7 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │         │    └── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m+), IndexID: 9}
  │         ├── 1 element transitioning toward TRANSIENT_PUBLIC
  │         │    └── PUBLIC → ABSENT           TableSchemaLocked:{DescID: 108 (table_regional_by_row)}
- │         └── 32 Mutation operations
+ │         └── 36 Mutation operations
  │              ├── SetTableSchemaLocked {"TableID":108}
  │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":5,"TableID":108}}
  │              ├── SetColumnName {"ColumnID":5,"Name":"m","TableID":108}
@@ -74,6 +78,10 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │              ├── UpsertColumnType {"ColumnType":{"ColumnID":6,"IsVirtual":true,"TableID":108}}
  │              ├── AddColumnComputeExpression {"ComputeExpression":{"ColumnID":6,"TableID":108}}
  │              ├── MakeColumnHidden {"ColumnID":6,"TableID":108}
+ │              ├── AddTableZoneConfig {"TableID":108}
+ │              ├── AddTableZoneConfig {"TableID":108}
+ │              ├── AddTableZoneConfig {"TableID":108}
+ │              ├── AddTableZoneConfig {"TableID":108}
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":9,"IndexID":10,"IsUnique":true,"SourceIndexID":8,"TableID":108,"TemporaryIndexID":11}}
  │              ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":10,"TableID":108}}
  │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":10,"TableID":108}
@@ -84,7 +92,7 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │              └── AddColumnToIndex {"ColumnID":1,"IndexID":10,"Ordinal":2,"TableID":108}
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
- │    │    ├── 18 elements transitioning toward PUBLIC
+ │    │    ├── 22 elements transitioning toward PUBLIC
  │    │    │    ├── DELETE_ONLY      → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m+)}
  │    │    │    ├── PUBLIC           → ABSENT ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 5 (m+)}
  │    │    │    ├── PUBLIC           → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (m+), TypeName: "INT8"}
@@ -102,7 +110,11 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │    │    │    ├── PUBLIC           → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16+), TypeName: "INT8"}
  │    │    │    ├── PUBLIC           → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16+), ReferencedColumnIDs: [1], Usage: REGULAR}
  │    │    │    ├── PUBLIC           → ABSENT ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16+)}
- │    │    │    └── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16+), IndexID: 10 (table_regional_by_row_pkey+)}
+ │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16+), IndexID: 10 (table_regional_by_row_pkey+)}
+ │    │    │    ├── PUBLIC           → ABSENT TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
+ │    │    │    ├── PUBLIC           → ABSENT TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+ │    │    │    ├── PUBLIC           → ABSENT TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
+ │    │    │    └── PUBLIC           → ABSENT TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 4}
  │    │    ├── 15 elements transitioning toward TRANSIENT_ABSENT
  │    │    │    ├── BACKFILL_ONLY    → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey~), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 1 (table_regional_by_row_pkey-)}
  │    │    │    ├── PUBLIC           → ABSENT IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey~)}
@@ -124,7 +136,7 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │    │    └── 1 Mutation operation
  │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
  │    └── Stage 2 of 2 in PreCommitPhase
- │         ├── 18 elements transitioning toward PUBLIC
+ │         ├── 22 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → DELETE_ONLY      Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m+)}
  │         │    ├── ABSENT → PUBLIC           ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 5 (m+)}
  │         │    ├── ABSENT → PUBLIC           ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (m+), TypeName: "INT8"}
@@ -142,7 +154,11 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │         │    ├── ABSENT → PUBLIC           ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16+), TypeName: "INT8"}
  │         │    ├── ABSENT → PUBLIC           ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16+), ReferencedColumnIDs: [1], Usage: REGULAR}
  │         │    ├── ABSENT → PUBLIC           ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16+)}
- │         │    └── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16+), IndexID: 10 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16+), IndexID: 10 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → PUBLIC           TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
+ │         │    ├── ABSENT → PUBLIC           TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+ │         │    ├── ABSENT → PUBLIC           TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
+ │         │    └── ABSENT → PUBLIC           TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 4}
  │         ├── 15 elements transitioning toward TRANSIENT_ABSENT
  │         │    ├── ABSENT → BACKFILL_ONLY    PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey~), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 1 (table_regional_by_row_pkey-)}
  │         │    ├── ABSENT → PUBLIC           IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey~)}
@@ -161,7 +177,7 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │         │    └── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m+), IndexID: 9}
  │         ├── 1 element transitioning toward TRANSIENT_PUBLIC
  │         │    └── PUBLIC → ABSENT           TableSchemaLocked:{DescID: 108 (table_regional_by_row)}
- │         └── 37 Mutation operations
+ │         └── 41 Mutation operations
  │              ├── SetTableSchemaLocked {"TableID":108}
  │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":5,"TableID":108}}
  │              ├── SetColumnName {"ColumnID":5,"Name":"m","TableID":108}
@@ -188,6 +204,10 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │              ├── UpsertColumnType {"ColumnType":{"ColumnID":6,"IsVirtual":true,"TableID":108}}
  │              ├── AddColumnComputeExpression {"ComputeExpression":{"ColumnID":6,"TableID":108}}
  │              ├── MakeColumnHidden {"ColumnID":6,"TableID":108}
+ │              ├── AddTableZoneConfig {"TableID":108}
+ │              ├── AddTableZoneConfig {"TableID":108}
+ │              ├── AddTableZoneConfig {"TableID":108}
+ │              ├── AddTableZoneConfig {"TableID":108}
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":9,"IndexID":10,"IsUnique":true,"SourceIndexID":8,"TableID":108,"TemporaryIndexID":11}}
  │              ├── MaybeAddSplitForIndex {"IndexID":10,"TableID":108}
  │              ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":10,"TableID":108}}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr.side_effects
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr.side_effects
@@ -40,7 +40,7 @@ write *eventpb.AlterTable to event log:
     tag: ALTER TABLE
     user: root
   tableName: multiregion_db.public.table_regional_by_row
-## StatementPhase stage 1 of 1 with 32 MutationType ops
+## StatementPhase stage 1 of 1 with 36 MutationType ops
 upsert descriptor #108
   ...
        - 3
@@ -257,12 +257,13 @@ upsert descriptor #108
      unexposedParentSchemaId: 105
   -  version: "8"
   +  version: "9"
+upsert zone config for #108
 # end StatementPhase
 # begin PreCommitPhase
 ## PreCommitPhase stage 1 of 2 with 1 MutationType op
 undo all catalog changes within txn #1
 persist all catalog changes to storage
-## PreCommitPhase stage 2 of 2 with 37 MutationType ops
+## PreCommitPhase stage 2 of 2 with 41 MutationType ops
 upsert descriptor #108
   ...
      createAsOfTime:
@@ -519,6 +520,7 @@ upsert descriptor #108
      unexposedParentSchemaId: 105
   -  version: "8"
   +  version: "9"
+upsert zone config for #108
 persist all catalog changes to storage
 create job #1 (non-cancelable: false): "ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k) USING HASH"
   descriptor IDs: [108]

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/create_index_regional_by_row/create_index_regional_by_row.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/create_index_regional_by_row/create_index_regional_by_row.explain
@@ -11,14 +11,15 @@ EXPLAIN (DDL) CREATE INDEX rbr_idx ON multiregion_db.public.table_regional_by_ro
 Schema change plan for CREATE INDEX ‹rbr_idx› ON ‹multiregion_db›.‹public›.‹table_regional_by_row› (‹v›) PARTITION BY ‹crdb_region›) ();
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
- │         ├── 7 elements transitioning toward PUBLIC
+ │         ├── 8 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → BACKFILL_ONLY    SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (rbr_idx+), TemporaryIndexID: 3, SourceIndexID: 1 (table_regional_by_row_pkey), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
  │         │    ├── ABSENT → PUBLIC           IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 2 (rbr_idx+)}
  │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 2 (rbr_idx+)}
  │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 2 (rbr_idx+)}
  │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 2 (rbr_idx+)}
  │         │    ├── ABSENT → PUBLIC           IndexData:{DescID: 108 (table_regional_by_row), IndexID: 2 (rbr_idx+)}
- │         │    └── ABSENT → PUBLIC           IndexName:{DescID: 108 (table_regional_by_row), Name: "rbr_idx", IndexID: 2 (rbr_idx+)}
+ │         │    ├── ABSENT → PUBLIC           IndexName:{DescID: 108 (table_regional_by_row), Name: "rbr_idx", IndexID: 2 (rbr_idx+)}
+ │         │    └── ABSENT → PUBLIC           TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
  │         ├── 5 elements transitioning toward TRANSIENT_ABSENT
  │         │    ├── ABSENT → DELETE_ONLY      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 1, SourceIndexID: 1 (table_regional_by_row_pkey)}
  │         │    ├── ABSENT → TRANSIENT_ABSENT IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 3}
@@ -27,7 +28,7 @@ Schema change plan for CREATE INDEX ‹rbr_idx› ON ‹multiregion_db›.‹pub
  │         │    └── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 3}
  │         ├── 1 element transitioning toward TRANSIENT_PUBLIC
  │         │    └── PUBLIC → ABSENT           TableSchemaLocked:{DescID: 108 (table_regional_by_row)}
- │         └── 12 Mutation operations
+ │         └── 13 Mutation operations
  │              ├── SetTableSchemaLocked {"TableID":108}
  │              ├── MakeAbsentIndexBackfilling {"IsSecondaryIndex":true}
  │              ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":2,"TableID":108}}
@@ -39,17 +40,19 @@ Schema change plan for CREATE INDEX ‹rbr_idx› ON ‹multiregion_db›.‹pub
  │              ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":3,"TableID":108}}
  │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":3,"TableID":108}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":3,"Ordinal":1,"TableID":108}
- │              └── AddColumnToIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":108}
+ │              └── AddTableZoneConfig {"TableID":108}
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
- │    │    ├── 7 elements transitioning toward PUBLIC
+ │    │    ├── 8 elements transitioning toward PUBLIC
  │    │    │    ├── BACKFILL_ONLY    → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (rbr_idx+), TemporaryIndexID: 3, SourceIndexID: 1 (table_regional_by_row_pkey), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
  │    │    │    ├── PUBLIC           → ABSENT IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 2 (rbr_idx+)}
  │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 2 (rbr_idx+)}
  │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 2 (rbr_idx+)}
  │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 2 (rbr_idx+)}
  │    │    │    ├── PUBLIC           → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 2 (rbr_idx+)}
- │    │    │    └── PUBLIC           → ABSENT IndexName:{DescID: 108 (table_regional_by_row), Name: "rbr_idx", IndexID: 2 (rbr_idx+)}
+ │    │    │    ├── PUBLIC           → ABSENT IndexName:{DescID: 108 (table_regional_by_row), Name: "rbr_idx", IndexID: 2 (rbr_idx+)}
+ │    │    │    └── PUBLIC           → ABSENT TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
  │    │    ├── 5 elements transitioning toward TRANSIENT_ABSENT
  │    │    │    ├── DELETE_ONLY      → ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 1, SourceIndexID: 1 (table_regional_by_row_pkey)}
  │    │    │    ├── TRANSIENT_ABSENT → ABSENT IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 3}
@@ -61,14 +64,15 @@ Schema change plan for CREATE INDEX ‹rbr_idx› ON ‹multiregion_db›.‹pub
  │    │    └── 1 Mutation operation
  │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
  │    └── Stage 2 of 2 in PreCommitPhase
- │         ├── 7 elements transitioning toward PUBLIC
+ │         ├── 8 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → BACKFILL_ONLY    SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (rbr_idx+), TemporaryIndexID: 3, SourceIndexID: 1 (table_regional_by_row_pkey), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
  │         │    ├── ABSENT → PUBLIC           IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 2 (rbr_idx+)}
  │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 2 (rbr_idx+)}
  │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 2 (rbr_idx+)}
  │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 2 (rbr_idx+)}
  │         │    ├── ABSENT → PUBLIC           IndexData:{DescID: 108 (table_regional_by_row), IndexID: 2 (rbr_idx+)}
- │         │    └── ABSENT → PUBLIC           IndexName:{DescID: 108 (table_regional_by_row), Name: "rbr_idx", IndexID: 2 (rbr_idx+)}
+ │         │    ├── ABSENT → PUBLIC           IndexName:{DescID: 108 (table_regional_by_row), Name: "rbr_idx", IndexID: 2 (rbr_idx+)}
+ │         │    └── ABSENT → PUBLIC           TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
  │         ├── 5 elements transitioning toward TRANSIENT_ABSENT
  │         │    ├── ABSENT → DELETE_ONLY      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 1, SourceIndexID: 1 (table_regional_by_row_pkey)}
  │         │    ├── ABSENT → TRANSIENT_ABSENT IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 3}
@@ -77,7 +81,7 @@ Schema change plan for CREATE INDEX ‹rbr_idx› ON ‹multiregion_db›.‹pub
  │         │    └── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 3}
  │         ├── 1 element transitioning toward TRANSIENT_PUBLIC
  │         │    └── PUBLIC → ABSENT           TableSchemaLocked:{DescID: 108 (table_regional_by_row)}
- │         └── 16 Mutation operations
+ │         └── 17 Mutation operations
  │              ├── SetTableSchemaLocked {"TableID":108}
  │              ├── MakeAbsentIndexBackfilling {"IsSecondaryIndex":true}
  │              ├── MaybeAddSplitForIndex {"IndexID":2,"TableID":108}
@@ -92,6 +96,7 @@ Schema change plan for CREATE INDEX ‹rbr_idx› ON ‹multiregion_db›.‹pub
  │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":3,"TableID":108}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":3,"Ordinal":1,"TableID":108}
  │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":108}
+ │              ├── AddTableZoneConfig {"TableID":108}
  │              ├── SetJobStateOnDescriptor {"DescriptorID":108,"Initialize":true}
  │              └── CreateSchemaChangerJob {"RunningStatus":"Pending: Updatin..."}
  ├── PostCommitPhase

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/create_index_regional_by_row/create_index_regional_by_row.side_effects
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/create_index_regional_by_row/create_index_regional_by_row.side_effects
@@ -28,7 +28,7 @@ write *eventpb.CreateIndex to event log:
     tag: CREATE INDEX
     user: root
   tableName: multiregion_db.public.table_regional_by_row
-## StatementPhase stage 1 of 1 with 12 MutationType ops
+## StatementPhase stage 1 of 1 with 13 MutationType ops
 upsert descriptor #108
   ...
        regionalByRow: {}
@@ -134,12 +134,13 @@ upsert descriptor #108
      unexposedParentSchemaId: 105
   -  version: "1"
   +  version: "2"
+upsert zone config for #108
 # end StatementPhase
 # begin PreCommitPhase
 ## PreCommitPhase stage 1 of 2 with 1 MutationType op
 undo all catalog changes within txn #1
 persist all catalog changes to storage
-## PreCommitPhase stage 2 of 2 with 16 MutationType ops
+## PreCommitPhase stage 2 of 2 with 17 MutationType ops
 upsert descriptor #108
   ...
      createAsOfTime:
@@ -279,6 +280,7 @@ upsert descriptor #108
      unexposedParentSchemaId: 105
   -  version: "1"
   +  version: "2"
+upsert zone config for #108
 persist all catalog changes to storage
 create job #1 (non-cancelable: false): "CREATE INDEX rbr_idx ON multiregion_db.public.table_regional_by_row (v) PARTITION BY crdb_region) ()"
   descriptor IDs: [108]

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_column_regional_by_row/drop_column_regional_by_row.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_column_regional_by_row/drop_column_regional_by_row.explain
@@ -11,12 +11,13 @@ EXPLAIN (DDL) ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUM
 Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_regional_by_row› DROP COLUMN ‹v›;
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
- │         ├── 5 elements transitioning toward PUBLIC
+ │         ├── 6 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → BACKFILL_ONLY    PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_pkey+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (table_regional_by_row_pkey-)}
  │         │    ├── ABSENT → PUBLIC           IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_pkey+)}
  │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 2 (table_regional_by_row_pkey+)}
  │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 2 (table_regional_by_row_pkey+)}
- │         │    └── ABSENT → PUBLIC           IndexData:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → PUBLIC           IndexData:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_pkey+)}
+ │         │    └── ABSENT → PUBLIC           TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
  │         ├── 4 elements transitioning toward TRANSIENT_ABSENT
  │         │    ├── ABSENT → DELETE_ONLY      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (table_regional_by_row_pkey-)}
  │         │    ├── ABSENT → TRANSIENT_ABSENT IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 3}
@@ -27,7 +28,7 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │         ├── 2 elements transitioning toward ABSENT
  │         │    ├── PUBLIC → WRITE_ONLY       Column:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v-)}
  │         │    └── PUBLIC → ABSENT           ColumnName:{DescID: 108 (table_regional_by_row), Name: "v", ColumnID: 2 (v-)}
- │         └── 11 Mutation operations
+ │         └── 12 Mutation operations
  │              ├── SetTableSchemaLocked {"TableID":108}
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":2,"IndexID":2,"IsUnique":true,"SourceIndexID":1,"TableID":108,"TemporaryIndexID":3}}
  │              ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":2,"TableID":108}}
@@ -37,16 +38,18 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │              ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":3,"TableID":108}}
  │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":3,"TableID":108}
  │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":3,"Ordinal":1,"TableID":108}
+ │              ├── AddTableZoneConfig {"TableID":108}
  │              ├── MakePublicColumnWriteOnly {"ColumnID":2,"TableID":108}
  │              └── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":108}
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
- │    │    ├── 5 elements transitioning toward PUBLIC
+ │    │    ├── 6 elements transitioning toward PUBLIC
  │    │    │    ├── BACKFILL_ONLY    → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_pkey+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (table_regional_by_row_pkey-)}
  │    │    │    ├── PUBLIC           → ABSENT IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_pkey+)}
  │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 2 (table_regional_by_row_pkey+)}
  │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 2 (table_regional_by_row_pkey+)}
- │    │    │    └── PUBLIC           → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_pkey+)}
+ │    │    │    ├── PUBLIC           → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_pkey+)}
+ │    │    │    └── PUBLIC           → ABSENT TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
  │    │    ├── 4 elements transitioning toward TRANSIENT_ABSENT
  │    │    │    ├── DELETE_ONLY      → ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (table_regional_by_row_pkey-)}
  │    │    │    ├── TRANSIENT_ABSENT → ABSENT IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 3}
@@ -60,12 +63,13 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │    │    └── 1 Mutation operation
  │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
  │    └── Stage 2 of 2 in PreCommitPhase
- │         ├── 5 elements transitioning toward PUBLIC
+ │         ├── 6 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → BACKFILL_ONLY    PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_pkey+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (table_regional_by_row_pkey-)}
  │         │    ├── ABSENT → PUBLIC           IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_pkey+)}
  │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 2 (table_regional_by_row_pkey+)}
  │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 2 (table_regional_by_row_pkey+)}
- │         │    └── ABSENT → PUBLIC           IndexData:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → PUBLIC           IndexData:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_pkey+)}
+ │         │    └── ABSENT → PUBLIC           TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
  │         ├── 4 elements transitioning toward TRANSIENT_ABSENT
  │         │    ├── ABSENT → DELETE_ONLY      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (table_regional_by_row_pkey-)}
  │         │    ├── ABSENT → TRANSIENT_ABSENT IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 3}
@@ -76,7 +80,7 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │         ├── 2 elements transitioning toward ABSENT
  │         │    ├── PUBLIC → WRITE_ONLY       Column:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v-)}
  │         │    └── PUBLIC → ABSENT           ColumnName:{DescID: 108 (table_regional_by_row), Name: "v", ColumnID: 2 (v-)}
- │         └── 15 Mutation operations
+ │         └── 16 Mutation operations
  │              ├── SetTableSchemaLocked {"TableID":108}
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":2,"IndexID":2,"IsUnique":true,"SourceIndexID":1,"TableID":108,"TemporaryIndexID":3}}
  │              ├── MaybeAddSplitForIndex {"IndexID":2,"TableID":108}
@@ -88,6 +92,7 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │              ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":3,"TableID":108}}
  │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":3,"TableID":108}
  │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":3,"Ordinal":1,"TableID":108}
+ │              ├── AddTableZoneConfig {"TableID":108}
  │              ├── MakePublicColumnWriteOnly {"ColumnID":2,"TableID":108}
  │              ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":108}
  │              ├── SetJobStateOnDescriptor {"DescriptorID":108,"Initialize":true}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_column_regional_by_row/drop_column_regional_by_row.side_effects
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_column_regional_by_row/drop_column_regional_by_row.side_effects
@@ -28,7 +28,7 @@ write *eventpb.AlterTable to event log:
     tag: ALTER TABLE
     user: root
   tableName: multiregion_db.public.table_regional_by_row
-## StatementPhase stage 1 of 1 with 11 MutationType ops
+## StatementPhase stage 1 of 1 with 12 MutationType ops
 upsert descriptor #108
   ...
          oid: 20
@@ -170,12 +170,13 @@ upsert descriptor #108
      unexposedParentSchemaId: 105
   -  version: "1"
   +  version: "2"
+upsert zone config for #108
 # end StatementPhase
 # begin PreCommitPhase
 ## PreCommitPhase stage 1 of 2 with 1 MutationType op
 undo all catalog changes within txn #1
 persist all catalog changes to storage
-## PreCommitPhase stage 2 of 2 with 15 MutationType ops
+## PreCommitPhase stage 2 of 2 with 16 MutationType ops
 upsert descriptor #108
   ...
          oid: 20
@@ -349,6 +350,7 @@ upsert descriptor #108
      unexposedParentSchemaId: 105
   -  version: "1"
   +  version: "2"
+upsert zone config for #108
 persist all catalog changes to storage
 create job #1 (non-cancelable: false): "ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v"
   descriptor IDs: [108]

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_database_multiregion_primary_region/drop_database_multiregion_primary_region.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_database_multiregion_primary_region/drop_database_multiregion_primary_region.explain
@@ -10,7 +10,7 @@ EXPLAIN (DDL) DROP DATABASE multi_region_test_db CASCADE;
 Schema change plan for DROP DATABASE ‹multi_region_test_db› CASCADE;
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
- │         ├── 64 elements transitioning toward ABSENT
+ │         ├── 66 elements transitioning toward ABSENT
  │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 104 (multi_region_test_db-), Name: "multi_region_test_db", IntValue: 0}
  │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 104 (multi_region_test_db-)}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 104 (multi_region_test_db-), Name: "admin"}
@@ -19,6 +19,7 @@ Schema change plan for DROP DATABASE ‹multi_region_test_db› CASCADE;
  │         │    ├── PUBLIC → DROPPED Database:{DescID: 104 (multi_region_test_db-)}
  │         │    ├── PUBLIC → ABSENT  DatabaseRoleSetting:{DescID: 104 (multi_region_test_db-), Name: "__placeholder_role_name__"}
  │         │    ├── PUBLIC → ABSENT  DatabaseRegionConfig:{DescID: 104 (multi_region_test_db-), ReferencedDescID: 106 (crdb_internal_region-)}
+ │         │    ├── PUBLIC → ABSENT  DatabaseZoneConfig:{DescID: 104 (multi_region_test_db-), SeqNum: 0}
  │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 106 (crdb_internal_region-), Name: "crdb_internal_region", ReferencedDescID: 104 (multi_region_test_db-), IntValue: 105}
  │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 106 (crdb_internal_region-)}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 106 (crdb_internal_region-), Name: "admin"}
@@ -74,6 +75,7 @@ Schema change plan for DROP DATABASE ‹multi_region_test_db› CASCADE;
  │         │    ├── PUBLIC → ABSENT  IndexColumn:{DescID: 108 (table_regional_by_table-), ColumnID: 1 (a-), IndexID: 1 (table_regional_by_table_pkey-)}
  │         │    ├── PUBLIC → ABSENT  PrimaryIndex:{DescID: 108 (table_regional_by_table-), IndexID: 1 (table_regional_by_table_pkey-), ConstraintID: 1}
  │         │    ├── PUBLIC → ABSENT  IndexName:{DescID: 108 (table_regional_by_table-), Name: "table_regional_by_table_pkey", IndexID: 1 (table_regional_by_table_pkey-)}
+ │         │    ├── PUBLIC → ABSENT  TableZoneConfig:{DescID: 108 (table_regional_by_table-), SeqNum: 0}
  │         │    └── PUBLIC → ABSENT  TableSchemaLocked:{DescID: 108 (table_regional_by_table-)}
  │         └── 70 Mutation operations
  │              ├── MarkDescriptorAsDropped {"DescriptorID":106}
@@ -148,7 +150,7 @@ Schema change plan for DROP DATABASE ‹multi_region_test_db› CASCADE;
  │              └── MakeDeleteOnlyColumnAbsent {"ColumnID":1,"TableID":108}
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
- │    │    ├── 64 elements transitioning toward ABSENT
+ │    │    ├── 66 elements transitioning toward ABSENT
  │    │    │    ├── ABSENT  → PUBLIC Namespace:{DescID: 104 (multi_region_test_db-), Name: "multi_region_test_db", IntValue: 0}
  │    │    │    ├── ABSENT  → PUBLIC Owner:{DescID: 104 (multi_region_test_db-)}
  │    │    │    ├── ABSENT  → PUBLIC UserPrivileges:{DescID: 104 (multi_region_test_db-), Name: "admin"}
@@ -157,6 +159,7 @@ Schema change plan for DROP DATABASE ‹multi_region_test_db› CASCADE;
  │    │    │    ├── DROPPED → PUBLIC Database:{DescID: 104 (multi_region_test_db-)}
  │    │    │    ├── ABSENT  → PUBLIC DatabaseRoleSetting:{DescID: 104 (multi_region_test_db-), Name: "__placeholder_role_name__"}
  │    │    │    ├── ABSENT  → PUBLIC DatabaseRegionConfig:{DescID: 104 (multi_region_test_db-), ReferencedDescID: 106 (crdb_internal_region-)}
+ │    │    │    ├── ABSENT  → PUBLIC DatabaseZoneConfig:{DescID: 104 (multi_region_test_db-), SeqNum: 0}
  │    │    │    ├── ABSENT  → PUBLIC Namespace:{DescID: 106 (crdb_internal_region-), Name: "crdb_internal_region", ReferencedDescID: 104 (multi_region_test_db-), IntValue: 105}
  │    │    │    ├── ABSENT  → PUBLIC Owner:{DescID: 106 (crdb_internal_region-)}
  │    │    │    ├── ABSENT  → PUBLIC UserPrivileges:{DescID: 106 (crdb_internal_region-), Name: "admin"}
@@ -212,11 +215,12 @@ Schema change plan for DROP DATABASE ‹multi_region_test_db› CASCADE;
  │    │    │    ├── ABSENT  → PUBLIC IndexColumn:{DescID: 108 (table_regional_by_table-), ColumnID: 1 (a-), IndexID: 1 (table_regional_by_table_pkey-)}
  │    │    │    ├── ABSENT  → PUBLIC PrimaryIndex:{DescID: 108 (table_regional_by_table-), IndexID: 1 (table_regional_by_table_pkey-), ConstraintID: 1}
  │    │    │    ├── ABSENT  → PUBLIC IndexName:{DescID: 108 (table_regional_by_table-), Name: "table_regional_by_table_pkey", IndexID: 1 (table_regional_by_table_pkey-)}
+ │    │    │    ├── ABSENT  → PUBLIC TableZoneConfig:{DescID: 108 (table_regional_by_table-), SeqNum: 0}
  │    │    │    └── ABSENT  → PUBLIC TableSchemaLocked:{DescID: 108 (table_regional_by_table-)}
  │    │    └── 1 Mutation operation
  │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
  │    └── Stage 2 of 2 in PreCommitPhase
- │         ├── 64 elements transitioning toward ABSENT
+ │         ├── 66 elements transitioning toward ABSENT
  │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 104 (multi_region_test_db-), Name: "multi_region_test_db", IntValue: 0}
  │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 104 (multi_region_test_db-)}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 104 (multi_region_test_db-), Name: "admin"}
@@ -225,6 +229,7 @@ Schema change plan for DROP DATABASE ‹multi_region_test_db› CASCADE;
  │         │    ├── PUBLIC → DROPPED Database:{DescID: 104 (multi_region_test_db-)}
  │         │    ├── PUBLIC → ABSENT  DatabaseRoleSetting:{DescID: 104 (multi_region_test_db-), Name: "__placeholder_role_name__"}
  │         │    ├── PUBLIC → ABSENT  DatabaseRegionConfig:{DescID: 104 (multi_region_test_db-), ReferencedDescID: 106 (crdb_internal_region-)}
+ │         │    ├── PUBLIC → ABSENT  DatabaseZoneConfig:{DescID: 104 (multi_region_test_db-), SeqNum: 0}
  │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 106 (crdb_internal_region-), Name: "crdb_internal_region", ReferencedDescID: 104 (multi_region_test_db-), IntValue: 105}
  │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 106 (crdb_internal_region-)}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 106 (crdb_internal_region-), Name: "admin"}
@@ -280,6 +285,7 @@ Schema change plan for DROP DATABASE ‹multi_region_test_db› CASCADE;
  │         │    ├── PUBLIC → ABSENT  IndexColumn:{DescID: 108 (table_regional_by_table-), ColumnID: 1 (a-), IndexID: 1 (table_regional_by_table_pkey-)}
  │         │    ├── PUBLIC → ABSENT  PrimaryIndex:{DescID: 108 (table_regional_by_table-), IndexID: 1 (table_regional_by_table_pkey-), ConstraintID: 1}
  │         │    ├── PUBLIC → ABSENT  IndexName:{DescID: 108 (table_regional_by_table-), Name: "table_regional_by_table_pkey", IndexID: 1 (table_regional_by_table_pkey-)}
+ │         │    ├── PUBLIC → ABSENT  TableZoneConfig:{DescID: 108 (table_regional_by_table-), SeqNum: 0}
  │         │    └── PUBLIC → ABSENT  TableSchemaLocked:{DescID: 108 (table_regional_by_table-)}
  │         └── 77 Mutation operations
  │              ├── MarkDescriptorAsDropped {"DescriptorID":106}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_table_multiregion/drop_table_multiregion.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_table_multiregion/drop_table_multiregion.explain
@@ -10,7 +10,7 @@ EXPLAIN (DDL) DROP TABLE multi_region_test_db.public.table_regional_by_row;
 Schema change plan for DROP TABLE ‹multi_region_test_db›.‹public›.‹table_regional_by_row›;
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
- │         ├── 41 elements transitioning toward ABSENT
+ │         ├── 45 elements transitioning toward ABSENT
  │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 108 (table_regional_by_row-), Name: "table_regional_by_row", ReferencedDescID: 104 (multi_region_test_db), IntValue: 105}
  │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 108 (table_regional_by_row-)}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 108 (table_regional_by_row-), Name: "admin"}
@@ -51,6 +51,10 @@ Schema change plan for DROP TABLE ‹multi_region_test_db›.‹public›.‹tab
  │         │    ├── PUBLIC → ABSENT  PrimaryIndex:{DescID: 108 (table_regional_by_row-), IndexID: 1 (table_regional_by_row_pkey-), ConstraintID: 1}
  │         │    ├── PUBLIC → ABSENT  IndexPartitioning:{DescID: 108 (table_regional_by_row-), IndexID: 1 (table_regional_by_row_pkey-)}
  │         │    ├── PUBLIC → ABSENT  IndexName:{DescID: 108 (table_regional_by_row-), Name: "table_regional_by_row_pkey", IndexID: 1 (table_regional_by_row_pkey-)}
+ │         │    ├── PUBLIC → ABSENT  TableZoneConfig:{DescID: 108 (table_regional_by_row-), SeqNum: 0}
+ │         │    ├── PUBLIC → ABSENT  PartitionZoneConfig:{DescID: 108 (table_regional_by_row-), IndexID: 1 (table_regional_by_row_pkey-), SeqNum: 0, PartitionName: "us-east1"}
+ │         │    ├── PUBLIC → ABSENT  PartitionZoneConfig:{DescID: 108 (table_regional_by_row-), IndexID: 1 (table_regional_by_row_pkey-), SeqNum: 0, PartitionName: "us-east2"}
+ │         │    ├── PUBLIC → ABSENT  PartitionZoneConfig:{DescID: 108 (table_regional_by_row-), IndexID: 1 (table_regional_by_row_pkey-), SeqNum: 0, PartitionName: "us-east3"}
  │         │    └── PUBLIC → ABSENT  TableSchemaLocked:{DescID: 108 (table_regional_by_row-)}
  │         └── 52 Mutation operations
  │              ├── MarkDescriptorAsDropped {"DescriptorID":108}
@@ -107,7 +111,7 @@ Schema change plan for DROP TABLE ‹multi_region_test_db›.‹public›.‹tab
  │              └── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":108}
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
- │    │    ├── 41 elements transitioning toward ABSENT
+ │    │    ├── 45 elements transitioning toward ABSENT
  │    │    │    ├── ABSENT  → PUBLIC Namespace:{DescID: 108 (table_regional_by_row-), Name: "table_regional_by_row", ReferencedDescID: 104 (multi_region_test_db), IntValue: 105}
  │    │    │    ├── ABSENT  → PUBLIC Owner:{DescID: 108 (table_regional_by_row-)}
  │    │    │    ├── ABSENT  → PUBLIC UserPrivileges:{DescID: 108 (table_regional_by_row-), Name: "admin"}
@@ -148,11 +152,15 @@ Schema change plan for DROP TABLE ‹multi_region_test_db›.‹public›.‹tab
  │    │    │    ├── ABSENT  → PUBLIC PrimaryIndex:{DescID: 108 (table_regional_by_row-), IndexID: 1 (table_regional_by_row_pkey-), ConstraintID: 1}
  │    │    │    ├── ABSENT  → PUBLIC IndexPartitioning:{DescID: 108 (table_regional_by_row-), IndexID: 1 (table_regional_by_row_pkey-)}
  │    │    │    ├── ABSENT  → PUBLIC IndexName:{DescID: 108 (table_regional_by_row-), Name: "table_regional_by_row_pkey", IndexID: 1 (table_regional_by_row_pkey-)}
+ │    │    │    ├── ABSENT  → PUBLIC TableZoneConfig:{DescID: 108 (table_regional_by_row-), SeqNum: 0}
+ │    │    │    ├── ABSENT  → PUBLIC PartitionZoneConfig:{DescID: 108 (table_regional_by_row-), IndexID: 1 (table_regional_by_row_pkey-), SeqNum: 0, PartitionName: "us-east1"}
+ │    │    │    ├── ABSENT  → PUBLIC PartitionZoneConfig:{DescID: 108 (table_regional_by_row-), IndexID: 1 (table_regional_by_row_pkey-), SeqNum: 0, PartitionName: "us-east2"}
+ │    │    │    ├── ABSENT  → PUBLIC PartitionZoneConfig:{DescID: 108 (table_regional_by_row-), IndexID: 1 (table_regional_by_row_pkey-), SeqNum: 0, PartitionName: "us-east3"}
  │    │    │    └── ABSENT  → PUBLIC TableSchemaLocked:{DescID: 108 (table_regional_by_row-)}
  │    │    └── 1 Mutation operation
  │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
  │    └── Stage 2 of 2 in PreCommitPhase
- │         ├── 41 elements transitioning toward ABSENT
+ │         ├── 45 elements transitioning toward ABSENT
  │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 108 (table_regional_by_row-), Name: "table_regional_by_row", ReferencedDescID: 104 (multi_region_test_db), IntValue: 105}
  │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 108 (table_regional_by_row-)}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 108 (table_regional_by_row-), Name: "admin"}
@@ -193,6 +201,10 @@ Schema change plan for DROP TABLE ‹multi_region_test_db›.‹public›.‹tab
  │         │    ├── PUBLIC → ABSENT  PrimaryIndex:{DescID: 108 (table_regional_by_row-), IndexID: 1 (table_regional_by_row_pkey-), ConstraintID: 1}
  │         │    ├── PUBLIC → ABSENT  IndexPartitioning:{DescID: 108 (table_regional_by_row-), IndexID: 1 (table_regional_by_row_pkey-)}
  │         │    ├── PUBLIC → ABSENT  IndexName:{DescID: 108 (table_regional_by_row-), Name: "table_regional_by_row_pkey", IndexID: 1 (table_regional_by_row_pkey-)}
+ │         │    ├── PUBLIC → ABSENT  TableZoneConfig:{DescID: 108 (table_regional_by_row-), SeqNum: 0}
+ │         │    ├── PUBLIC → ABSENT  PartitionZoneConfig:{DescID: 108 (table_regional_by_row-), IndexID: 1 (table_regional_by_row_pkey-), SeqNum: 0, PartitionName: "us-east1"}
+ │         │    ├── PUBLIC → ABSENT  PartitionZoneConfig:{DescID: 108 (table_regional_by_row-), IndexID: 1 (table_regional_by_row_pkey-), SeqNum: 0, PartitionName: "us-east2"}
+ │         │    ├── PUBLIC → ABSENT  PartitionZoneConfig:{DescID: 108 (table_regional_by_row-), IndexID: 1 (table_regional_by_row_pkey-), SeqNum: 0, PartitionName: "us-east3"}
  │         │    └── PUBLIC → ABSENT  TableSchemaLocked:{DescID: 108 (table_regional_by_row-)}
  │         └── 56 Mutation operations
  │              ├── MarkDescriptorAsDropped {"DescriptorID":108}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_table_multiregion_primary_region/drop_table_multiregion_primary_region.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_table_multiregion_primary_region/drop_table_multiregion_primary_region.explain
@@ -10,7 +10,7 @@ EXPLAIN (DDL) DROP TABLE multi_region_test_db.public.table_regional_by_table CAS
 Schema change plan for DROP TABLE ‹multi_region_test_db›.‹public›.‹table_regional_by_table› CASCADE;
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
- │         ├── 32 elements transitioning toward ABSENT
+ │         ├── 33 elements transitioning toward ABSENT
  │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 108 (table_regional_by_table-), Name: "table_regional_by_table", ReferencedDescID: 104 (multi_region_test_db), IntValue: 105}
  │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 108 (table_regional_by_table-)}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 108 (table_regional_by_table-), Name: "admin"}
@@ -42,6 +42,7 @@ Schema change plan for DROP TABLE ‹multi_region_test_db›.‹public›.‹tab
  │         │    ├── PUBLIC → ABSENT  IndexColumn:{DescID: 108 (table_regional_by_table-), ColumnID: 1 (a-), IndexID: 1 (table_regional_by_table_pkey-)}
  │         │    ├── PUBLIC → ABSENT  PrimaryIndex:{DescID: 108 (table_regional_by_table-), IndexID: 1 (table_regional_by_table_pkey-), ConstraintID: 1}
  │         │    ├── PUBLIC → ABSENT  IndexName:{DescID: 108 (table_regional_by_table-), Name: "table_regional_by_table_pkey", IndexID: 1 (table_regional_by_table_pkey-)}
+ │         │    ├── PUBLIC → ABSENT  TableZoneConfig:{DescID: 108 (table_regional_by_table-), SeqNum: 0}
  │         │    └── PUBLIC → ABSENT  TableSchemaLocked:{DescID: 108 (table_regional_by_table-)}
  │         └── 40 Mutation operations
  │              ├── MarkDescriptorAsDropped {"DescriptorID":108}
@@ -86,7 +87,7 @@ Schema change plan for DROP TABLE ‹multi_region_test_db›.‹public›.‹tab
  │              └── MakeDeleteOnlyColumnAbsent {"ColumnID":1,"TableID":108}
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
- │    │    ├── 32 elements transitioning toward ABSENT
+ │    │    ├── 33 elements transitioning toward ABSENT
  │    │    │    ├── ABSENT  → PUBLIC Namespace:{DescID: 108 (table_regional_by_table-), Name: "table_regional_by_table", ReferencedDescID: 104 (multi_region_test_db), IntValue: 105}
  │    │    │    ├── ABSENT  → PUBLIC Owner:{DescID: 108 (table_regional_by_table-)}
  │    │    │    ├── ABSENT  → PUBLIC UserPrivileges:{DescID: 108 (table_regional_by_table-), Name: "admin"}
@@ -118,11 +119,12 @@ Schema change plan for DROP TABLE ‹multi_region_test_db›.‹public›.‹tab
  │    │    │    ├── ABSENT  → PUBLIC IndexColumn:{DescID: 108 (table_regional_by_table-), ColumnID: 1 (a-), IndexID: 1 (table_regional_by_table_pkey-)}
  │    │    │    ├── ABSENT  → PUBLIC PrimaryIndex:{DescID: 108 (table_regional_by_table-), IndexID: 1 (table_regional_by_table_pkey-), ConstraintID: 1}
  │    │    │    ├── ABSENT  → PUBLIC IndexName:{DescID: 108 (table_regional_by_table-), Name: "table_regional_by_table_pkey", IndexID: 1 (table_regional_by_table_pkey-)}
+ │    │    │    ├── ABSENT  → PUBLIC TableZoneConfig:{DescID: 108 (table_regional_by_table-), SeqNum: 0}
  │    │    │    └── ABSENT  → PUBLIC TableSchemaLocked:{DescID: 108 (table_regional_by_table-)}
  │    │    └── 1 Mutation operation
  │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
  │    └── Stage 2 of 2 in PreCommitPhase
- │         ├── 32 elements transitioning toward ABSENT
+ │         ├── 33 elements transitioning toward ABSENT
  │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 108 (table_regional_by_table-), Name: "table_regional_by_table", ReferencedDescID: 104 (multi_region_test_db), IntValue: 105}
  │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 108 (table_regional_by_table-)}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 108 (table_regional_by_table-), Name: "admin"}
@@ -154,6 +156,7 @@ Schema change plan for DROP TABLE ‹multi_region_test_db›.‹public›.‹tab
  │         │    ├── PUBLIC → ABSENT  IndexColumn:{DescID: 108 (table_regional_by_table-), ColumnID: 1 (a-), IndexID: 1 (table_regional_by_table_pkey-)}
  │         │    ├── PUBLIC → ABSENT  PrimaryIndex:{DescID: 108 (table_regional_by_table-), IndexID: 1 (table_regional_by_table_pkey-), ConstraintID: 1}
  │         │    ├── PUBLIC → ABSENT  IndexName:{DescID: 108 (table_regional_by_table-), Name: "table_regional_by_table_pkey", IndexID: 1 (table_regional_by_table_pkey-)}
+ │         │    ├── PUBLIC → ABSENT  TableZoneConfig:{DescID: 108 (table_regional_by_table-), SeqNum: 0}
  │         │    └── PUBLIC → ABSENT  TableSchemaLocked:{DescID: 108 (table_regional_by_table-)}
  │         └── 43 Mutation operations
  │              ├── MarkDescriptorAsDropped {"DescriptorID":108}

--- a/pkg/sql/schemachanger/sctest/end_to_end.go
+++ b/pkg/sql/schemachanger/sctest/end_to_end.go
@@ -132,8 +132,9 @@ func EndToEndSideEffects(t *testing.T, relTestCaseDir string, factory TestServer
 				)
 				defer refFactoryCleanup()
 
+				allDescs := sctestdeps.ReadDescriptorsFromDB(ctx, t, tdb)
 				deps = sctestdeps.NewTestDependencies(
-					sctestdeps.WithDescriptors(sctestdeps.ReadDescriptorsFromDB(ctx, t, tdb).Catalog),
+					sctestdeps.WithDescriptors(allDescs.Catalog),
 					sctestdeps.WithSystemDatabaseDescriptor(),
 					sctestdeps.WithNamespace(sctestdeps.ReadNamespaceFromDB(t, tdb).Catalog),
 					sctestdeps.WithCurrentDatabase(sctestdeps.ReadCurrentDatabaseFromDB(t, tdb)),
@@ -160,6 +161,7 @@ func EndToEndSideEffects(t *testing.T, relTestCaseDir string, factory TestServer
 					sctestdeps.WithReferenceProviderFactory(refFactory),
 					sctestdeps.WithClusterSettings(s.ClusterSettings()),
 					sctestdeps.WithCodec(s.Codec()),
+					sctestdeps.WithZoneConfigs(sctestdeps.ReadZoneConfigsFromDB(t, tdb, allDescs.Catalog)),
 				)
 				stmtStates := execStatementWithTestDeps(ctx, t, deps, stmts...)
 				var fileNameSuffix string


### PR DESCRIPTION
Previously, end-to-end tests did not verify the side effects of adding or dropping zone config elements. This change, adds zone configs to end-to-end test dependencies to show and verify the side effects of zone configs mutations.

Informs: #150946

Release note: None