### PR TITLE
roachtest/mixedversion: use same node for backup dest and execution

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/helper.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/helper.go
@@ -219,6 +219,11 @@ func (h *Helper) AvailableNodes() option.NodeListOption {
 	return h.DefaultService().AvailableNodes()
 }
 
+func (h *Helper) RandomAvailableNode(rng *rand.Rand) int {
+	nodes := h.AvailableNodes()
+	return nodes.SeededRandNode(rng)[0]
+}
+
 func (h *Helper) Context() *ServiceContext {
 	return h.DefaultService().ServiceContext
 }

--- a/pkg/cmd/roachtest/tests/versionupgrade.go
+++ b/pkg/cmd/roachtest/tests/versionupgrade.go
@@ -123,8 +123,9 @@ func runVersionUpgrade(ctx context.Context, t test.Test, c cluster.Cluster) {
 				// Verify that backups can be created in various configurations. This is
 				// important to test because changes in system tables might cause backups to
 				// fail in mixed-version clusters.
-				dest := fmt.Sprintf("nodelocal://1/%d", timeutil.Now().UnixNano())
-				return h.Exec(rng, `BACKUP INTO $1`, dest)
+				gatewayNode := h.RandomAvailableNode(rng)
+				dest := fmt.Sprintf("nodelocal://%d/%d", gatewayNode, timeutil.Now().UnixNano())
+				return h.ExecWithGateway(rng, option.NodeListOption{gatewayNode}, `BACKUP INTO $1`, dest)
 			} else {
 				// Skip the backup step in separate-process deployments, since nodelocal
 				// is not supported in pods.


### PR DESCRIPTION
the `maybe run backup` hook in `runVersionUpgrade` test hardcoded `nodelocal://1/` in the backup destination while `h.Exec` picked a random available node for SQL execution. This caused flaky failures when n1 was just restarted and temporarily unavailable for gRPC connections, even though the SQL executed on a different node.

This change ensures the backup destination and SQL execution use the same randomly selected available node.

Fixes #160498

Release note: None

Epic: None