### PR TITLE
release-25.4: kvclient/rangefeed: use larger machine for test runner

### DIFF
--- a/pkg/kv/kvclient/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvclient/rangefeed/BUILD.bazel
@@ -60,6 +60,10 @@ go_test(
         ":mock_rangefeed",  # keep
     ],
     embed = [":rangefeed"],
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "large"},
+        "//conditions:default": {"test.Pool": "default"},
+    }),
     deps = [
         "//pkg/base",
         "//pkg/keys",


### PR DESCRIPTION
Backport 1/1 commits from #155544 on behalf of @wenyihu6.

----

This commit updates kv/kvclient/rangefeed to use a larger machine for its test
runner under race, as TestRangefeedCatchupStarvation previously hit an OOM under
race and appears to be related to an infra flake.

Fixes: https://github.com/cockroachdb/cockroach/issues/155334
Epic: none
Release note: none

----

Release justification: Test-only change