### PR TITLE
security: Added post-quantum TLS validation tests

### DIFF
--- a/pkg/security/BUILD.bazel
+++ b/pkg/security/BUILD.bazel
@@ -95,6 +95,7 @@ go_test(
         "//pkg/server",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/util/envutil",
         "//pkg/util/leaktest",
         "//pkg/util/log",

--- a/pkg/security/tls.go
+++ b/pkg/security/tls.go
@@ -13,6 +13,13 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// CurvePreferencesOverride when non-nil, overrides the TLS curve preferences
+// for all TLS configs created by this package. Tests can use
+// testutils.TestingHook(&security.CurvePreferencesOverride, ...) to control
+// curve negotiation.
+// currently this is only used for testing purpose.
+var CurvePreferencesOverride []tls.CurveID
+
 // newServerTLSConfig creates a server TLSConfig from the supplied byte strings containing
 // - the certificate of this node (should be signed by the CA),
 // - the private key of this node.
@@ -134,6 +141,11 @@ func newBaseTLSConfig(settings TLSSettings, caPEM []byte) (*tls.Config, error) {
 	// mode.
 	if fips140.Enabled() {
 		baseCfg.CurvePreferences = []tls.CurveID{tls.CurveP256}
+	}
+
+	// Allow tests to override curve preferences.
+	if CurvePreferencesOverride != nil {
+		baseCfg.CurvePreferences = CurvePreferencesOverride
 	}
 
 	return baseCfg, nil

--- a/pkg/security/tls_test.go
+++ b/pkg/security/tls_test.go
@@ -7,8 +7,10 @@ package security_test
 
 import (
 	"context"
+	"crypto/fips140"
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -22,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -169,6 +172,11 @@ func TestTLSCipherRestrict(t *testing.T) {
 			err := security.SetTLSCipherSuitesConfigured(tt.ciphers)
 			require.NoError(t, err)
 
+			// Reset at end of subtest, to avoid global state pollution.
+			defer func() {
+				_ = security.SetTLSCipherSuitesConfigured([]string{})
+			}()
+
 			// setup for db console tests
 			httpClient, transport, err := s.ApplicationLayer().GetUnauthenticatedHTTPClientWithTransport()
 			require.NoError(t, err)
@@ -264,4 +272,300 @@ func TestTLSCipherRestrict(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestPostQuantumTLSIntegration tests complete integration of post-quantum
+// TLS in CockroachDB server configuration across all connection types.
+// PQC is supported by Go 1.24+ via the X25519MLKEM768 curve.
+// There is no need to make explicit TLS changes to support PQC as
+// it's natively supported by golang.
+// The test runs with both DRPC enabled and disabled to ensure PQC key
+// exchange works regardless of the RPC transport.
+func TestPostQuantumTLSIntegration(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	if fips140.Enabled() {
+		skip.IgnoreLint(t, "ML-KEM (X25519MLKEM768) is not FIPS-approved in go 1.25")
+	}
+
+	for _, drpcOption := range []base.DefaultTestDRPCOption{
+		base.TestDRPCDisabled,
+		base.TestDRPCEnabled,
+	} {
+		t.Run(fmt.Sprintf("DRPC_%s", drpcOption), func(t *testing.T) {
+			testPostQuantumTLSIntegration(t, drpcOption)
+		})
+	}
+}
+
+func testPostQuantumTLSIntegration(t *testing.T, drpcOption base.DefaultTestDRPCOption) {
+	type connectionInfo struct {
+		connType string
+		state    tls.ConnectionState
+	}
+
+	// Capture TLS connection details via the TLSCipherRestrict hook.
+	// We reuse this existing hook rather than adding a new dedicated inspection hook
+	// to keep the implementation simple. This is primarily necessary for RPC connections,
+	// as HTTP and SQL connections already expose TLS state through their respective APIs
+	// (resp.TLS and pgConn.Conn()). Note: this hook is being used here for TLS curve
+	// validation (X25519MLKEM768), not for cipher suite enforcement.
+	var connections []connectionInfo
+	var connMutex syncutil.Mutex
+	tlsInspectionHook := security.TLSCipherRestrict
+	defer testutils.TestingHook(&security.TLSCipherRestrict, func(conn net.Conn) (err net.Error) {
+		if tlsConn, ok := conn.(*tls.Conn); ok {
+			if !tlsConn.ConnectionState().HandshakeComplete {
+				_ = tlsConn.Handshake()
+			}
+			state := tlsConn.ConnectionState()
+
+			connMutex.Lock()
+			connections = append(connections, connectionInfo{
+				connType: "captured",
+				state:    state,
+			})
+			connMutex.Unlock()
+		}
+		return tlsInspectionHook(conn)
+	})()
+
+	ctx := context.Background()
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
+		DefaultDRPCOption: drpcOption,
+	})
+	defer s.Stopper().Stop(ctx)
+
+	// Test HTTP/Admin UI connections
+	t.Run("HTTP_Connection", func(t *testing.T) {
+		httpClient, _, err := s.ApplicationLayer().GetUnauthenticatedHTTPClientWithTransport()
+		require.NoError(t, err)
+		defer httpClient.CloseIdleConnections()
+
+		var connState tls.ConnectionState
+		resp, err := httpClient.Get(s.AdminURL().String() + "/_status/vars")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		if resp.TLS != nil {
+			connState = *resp.TLS
+		}
+
+		validateConnection(t, connState, "HTTP")
+	})
+
+	// Test PostgreSQL connections
+	t.Run("SQL_Connection", func(t *testing.T) {
+		pgURL, cleanup := s.PGUrl(t, serverutils.User(username.RootUser), serverutils.ClientCerts(true))
+		defer cleanup()
+
+		conn, err := pgx.Connect(ctx, pgURL.String())
+		require.NoError(t, err)
+		defer func() { _ = conn.Close(ctx) }()
+
+		var result int
+		err = conn.QueryRow(ctx, "SELECT 1").Scan(&result)
+		require.NoError(t, err)
+		require.Equal(t, 1, result)
+
+		var connState tls.ConnectionState
+		if pgConn := conn.PgConn(); pgConn != nil {
+			if tlsConn, ok := pgConn.Conn().(*tls.Conn); ok {
+				connState = tlsConn.ConnectionState()
+			}
+		}
+
+		validateConnection(t, connState, "SQL")
+	})
+
+	// Test RPC connections. Snapshot captured connections before making the
+	// RPC call so we only inspect connections established by our call, not
+	// background heartbeats or internal RPCs.
+	t.Run("RPC_Connection", func(t *testing.T) {
+		connMutex.Lock()
+		baselineCount := len(connections)
+		connMutex.Unlock()
+
+		_, err := s.RPCClientConnE(username.RootUserName())
+		require.NoError(t, err)
+
+		connMutex.Lock()
+		newConns := connections[baselineCount:]
+		connMutex.Unlock()
+
+		require.NotEmpty(t, newConns, "Should have captured new RPC connection states")
+		validateConnection(t, newConns[0].state, "RPC")
+	})
+}
+
+// validateConnection checks if the TLS connection matches expected PQC configuration
+func validateConnection(t *testing.T, state tls.ConnectionState, connType string) {
+	require.True(t, state.HandshakeComplete, "%s: TLS handshake should be complete", connType)
+
+	require.GreaterOrEqual(t, state.Version, uint16(tls.VersionTLS13),
+		"%s: Expected TLS 1.3 or higher when PQC enabled", connType)
+
+	// Verify cipher suite is appropriate for TLS version
+	validTLS13Ciphers := []uint16{
+		tls.TLS_AES_128_GCM_SHA256,
+		tls.TLS_AES_256_GCM_SHA384,
+		tls.TLS_CHACHA20_POLY1305_SHA256,
+	}
+	require.Contains(t, validTLS13Ciphers, state.CipherSuite,
+		"%s: Should use valid TLS 1.3 cipher suite", connType)
+
+	require.Equal(t, state.CurveID, tls.X25519MLKEM768)
+}
+
+// TestMLKEMCompatibility tests compatibility between ML-KEM and classical clients
+func TestMLKEMCompatibility(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	if fips140.Enabled() {
+		skip.IgnoreLint(t, "ML-KEM (X25519MLKEM768) is not FIPS-approved in go 1.25")
+	}
+
+	ctx := context.Background()
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	t.Run("ClassicalClientToMLKEMServer", func(t *testing.T) {
+		// Test that classical clients can still connect to ML-KEM enabled server
+		httpClient, transport, err := s.ApplicationLayer().GetUnauthenticatedHTTPClientWithTransport()
+		require.NoError(t, err)
+		defer httpClient.CloseIdleConnections()
+
+		// Force classical key exchange only
+		transport.TLSClientConfig.CurvePreferences = []tls.CurveID{
+			tls.X25519,
+			tls.CurveP256,
+			tls.CurveP384,
+		}
+		transport.TLSClientConfig.MinVersion = tls.VersionTLS13
+
+		resp, err := httpClient.Get(s.AdminURL().String() + "/_status/vars")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.NotNil(t, resp.TLS)
+		require.Equal(t, tls.X25519, resp.TLS.CurveID,
+			"Classical client should negotiate X25519, not ML-KEM")
+	})
+
+	t.Run("MLKEMClientToMLKEMServer", func(t *testing.T) {
+		// Test that ML-KEM clients can connect to ML-KEM enabled server
+		httpClient, transport, err := s.ApplicationLayer().GetUnauthenticatedHTTPClientWithTransport()
+		require.NoError(t, err)
+		defer httpClient.CloseIdleConnections()
+
+		// Prefer ML-KEM with classical fallback
+		transport.TLSClientConfig.CurvePreferences = []tls.CurveID{
+			tls.X25519MLKEM768,
+		}
+		transport.TLSClientConfig.MinVersion = tls.VersionTLS13
+
+		resp, err := httpClient.Get(s.AdminURL().String() + "/_status/vars")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.NotNil(t, resp.TLS)
+		require.Equal(t, tls.X25519MLKEM768, resp.TLS.CurveID,
+			"ML-KEM client should negotiate X25519MLKEM768")
+	})
+}
+
+// TestServerCurveNegotiation tests that a server constrained to specific TLS
+// curves correctly negotiates those curves with clients. This validates that
+// CurvePreferencesOverride works and that curve negotiation behaves as expected
+// when the server is pinned (e.g. in a FIPS-like configuration).
+func TestServerCurveNegotiation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	tests := []struct {
+		name            string
+		serverCurves    []tls.CurveID
+		clientCurves    []tls.CurveID
+		expectedCurveID tls.CurveID
+	}{
+		{
+			name:            "P256ServerWithMLKEMClient",
+			serverCurves:    []tls.CurveID{tls.CurveP256},
+			clientCurves:    []tls.CurveID{tls.X25519MLKEM768, tls.X25519, tls.CurveP256},
+			expectedCurveID: tls.CurveP256,
+		},
+		{
+			name:            "P256ServerWithP256Client",
+			serverCurves:    []tls.CurveID{tls.CurveP256},
+			clientCurves:    []tls.CurveID{tls.CurveP256, tls.CurveP384},
+			expectedCurveID: tls.CurveP256,
+		},
+		{
+			name:            "X25519ServerWithMLKEMClient",
+			serverCurves:    []tls.CurveID{tls.X25519},
+			clientCurves:    []tls.CurveID{tls.X25519MLKEM768, tls.X25519},
+			expectedCurveID: tls.X25519,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Pin the server's curve preferences before starting the server so
+			// the cached TLS config picks up the override.
+			defer testutils.TestingHook(
+				&security.CurvePreferencesOverride, tt.serverCurves,
+			)()
+
+			ctx := context.Background()
+			s := serverutils.StartServerOnly(t, base.TestServerArgs{})
+			defer s.Stopper().Stop(ctx)
+
+			httpClient, transport, err := s.ApplicationLayer().GetUnauthenticatedHTTPClientWithTransport()
+			require.NoError(t, err)
+			defer httpClient.CloseIdleConnections()
+
+			transport.TLSClientConfig.CurvePreferences = tt.clientCurves
+			transport.TLSClientConfig.MinVersion = tls.VersionTLS13
+
+			resp, err := httpClient.Get(s.AdminURL().String() + "/_status/vars")
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+			require.NotNil(t, resp.TLS)
+			require.Equal(t, tt.expectedCurveID, resp.TLS.CurveID)
+		})
+	}
+
+	// Test that a connection fails when the client and server have no
+	// overlapping curves.
+	t.Run("NoCommonCurves", func(t *testing.T) {
+		defer testutils.TestingHook(
+			&security.CurvePreferencesOverride,
+			[]tls.CurveID{tls.CurveP256},
+		)()
+
+		ctx := context.Background()
+		s := serverutils.StartServerOnly(t, base.TestServerArgs{})
+		defer s.Stopper().Stop(ctx)
+
+		httpClient, transport, err := s.ApplicationLayer().GetUnauthenticatedHTTPClientWithTransport()
+		require.NoError(t, err)
+		defer httpClient.CloseIdleConnections()
+
+		transport.TLSClientConfig.CurvePreferences = []tls.CurveID{
+			tls.X25519MLKEM768,
+			tls.X25519,
+		}
+		transport.TLSClientConfig.MinVersion = tls.VersionTLS13
+
+		_, err = httpClient.Get(s.AdminURL().String() + "/_status/vars")
+		require.ErrorContains(t, err, "tls: handshake failure",
+			"expected TLS handshake failure when client and server have no common curves")
+	})
 }


### PR DESCRIPTION
* this PR adds tests that validate hybrid post-quantum key exchange (X25519MLKEM768) support across all
connection types.
* These tests leverage Go 1.24+'s built-in support for ML-KEM, which is included in Go's default TLS
curve preferences.
* The tests verify:
- Post-quantum TLS negotiation works for HTTP, SQL, and RPC connections
- TLS 1.3 is properly negotiated when PQC is enabled
- X25519MLKEM768 hybrid curve is used for quantum-resistant connections
- Backward compatibility is maintained for classical clients using X25519

Release note: None

Epic: CRDB-59315