### PR TITLE
sql: refactor ValidateZoneConfigForMultiRegionDatabase

### DIFF
--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -177,119 +177,6 @@ func zoneConfigForMultiRegionDatabase(
 	return regionConfig.ExtendZoneConfigWithRegionalIn(zc, regionConfig.PrimaryRegion())
 }
 
-// zoneConfigForMultiRegionTable generates a ZoneConfig stub for a
-// regional-by-table or global table in a multi-region database.
-//
-// At the table/partition level, the only attributes that are set are
-// `num_voters`, `voter_constraints`, and `lease_preferences`. We expect that
-// the attributes `num_replicas` and `constraints` will be inherited from the
-// database level zone config.
-//
-// This function can return a nil zonepb.ZoneConfig, meaning no table level zone
-// configuration is required.
-//
-// Relevant multi-region configured fields (as defined in
-// `zonepb.MultiRegionZoneConfigFields`) will be overwritten by the calling function
-// into an existing ZoneConfig.
-func zoneConfigForMultiRegionTable(
-	localityConfig catpb.LocalityConfig, regionConfig multiregion.RegionConfig,
-) (zonepb.ZoneConfig, error) {
-	zc := *zonepb.NewZoneConfig()
-
-	switch l := localityConfig.Locality.(type) {
-	case *catpb.LocalityConfig_Global_:
-		// Enable non-blocking transactions.
-		zc.GlobalReads = proto.Bool(true)
-
-		if !regionConfig.GlobalTablesInheritDatabaseConstraints() {
-			// For GLOBAL tables, we want non-voters in all regions for fast reads, so
-			// we always use a DEFAULT placement config, even if the database is using
-			// RESTRICTED placement.
-			regionConfig = regionConfig.WithPlacementDefault()
-
-			numVoters, numReplicas := regions.GetNumVotersAndNumReplicas(regionConfig)
-			zc.NumVoters = &numVoters
-			zc.NumReplicas = &numReplicas
-
-			constraints, err := regions.SynthesizeReplicaConstraints(regionConfig.Regions(), regionConfig.Placement())
-			if err != nil {
-				return zonepb.ZoneConfig{}, err
-			}
-			zc.Constraints = constraints
-			zc.InheritedConstraints = false
-
-			voterConstraints, err := regions.SynthesizeVoterConstraints(regionConfig.PrimaryRegion(), regionConfig)
-			if err != nil {
-				return zonepb.ZoneConfig{}, err
-			}
-			zc.VoterConstraints = voterConstraints
-			zc.NullVoterConstraintsIsEmpty = true
-			zc.LeasePreferences = regions.SynthesizeLeasePreferences(regionConfig.PrimaryRegion(), "" /* secondaryRegion */)
-			zc.InheritedLeasePreferences = false
-
-			zc, err = regionConfig.ExtendZoneConfigWithGlobal(zc)
-			if err != nil {
-				return zonepb.ZoneConfig{}, err
-			}
-		}
-		// Inherit lease preference from the database. We do
-		// nothing here because `NewZoneConfig()` already marks the field as
-		// 'inherited'.
-		return zc, nil
-	case *catpb.LocalityConfig_RegionalByTable_:
-		affinityRegion := regionConfig.PrimaryRegion()
-		if l.RegionalByTable.Region != nil {
-			affinityRegion = *l.RegionalByTable.Region
-		}
-		if l.RegionalByTable.Region == nil && !regionConfig.IsMemberOfSuperRegion(affinityRegion) {
-			// If we don't have an explicit affinity region, use the same
-			// configuration as the database and return a blank zcfg here.
-			return zc, nil
-		}
-
-		numVoters, numReplicas := regions.GetNumVotersAndNumReplicas(regionConfig)
-		zc.NumVoters = &numVoters
-
-		if regionConfig.IsMemberOfSuperRegion(affinityRegion) {
-			err := regions.AddConstraintsForSuperRegion(&zc, regionConfig, affinityRegion)
-			if err != nil {
-				return zonepb.ZoneConfig{}, err
-			}
-		} else if !regionConfig.RegionalInTablesInheritDatabaseConstraints(affinityRegion) {
-			// If the database constraints can't be inherited to serve as the
-			// constraints for this table, define the constraints ourselves.
-			zc.NumReplicas = &numReplicas
-
-			constraints, err := regions.SynthesizeReplicaConstraints(regionConfig.Regions(), regionConfig.Placement())
-			if err != nil {
-				return zonepb.ZoneConfig{}, err
-			}
-			zc.Constraints = constraints
-			zc.InheritedConstraints = false
-		}
-
-		// If the table has a user-specified affinity region, use it.
-		voterConstraints, err := regions.SynthesizeVoterConstraints(affinityRegion, regionConfig)
-		if err != nil {
-			return zonepb.ZoneConfig{}, err
-		}
-		zc.VoterConstraints = voterConstraints
-		zc.NullVoterConstraintsIsEmpty = true
-		zc.LeasePreferences = regions.SynthesizeLeasePreferences(affinityRegion, "" /* secondaryRegion */)
-		zc.InheritedLeasePreferences = false
-
-		return regionConfig.ExtendZoneConfigWithRegionalIn(zc, affinityRegion)
-
-	case *catpb.LocalityConfig_RegionalByRow_:
-		// We purposely do not set anything here at table level - this should be done at
-		// partition level instead.
-		return zc, nil
-	default:
-		return zonepb.ZoneConfig{}, errors.AssertionFailedf(
-			"unexpected unknown locality type %T", localityConfig.Locality)
-	}
-}
-
 // applyZoneConfigForMultiRegionTableOption is an option that can be passed into
 // applyZoneConfigForMultiRegionTable.
 type applyZoneConfigForMultiRegionTableOption func(
@@ -359,7 +246,7 @@ func applyZoneConfigForMultiRegionTableOptionTableNewConfig(
 		regionConfig multiregion.RegionConfig,
 		table catalog.TableDescriptor,
 	) (bool, zonepb.ZoneConfig, error) {
-		localityZoneConfig, err := zoneConfigForMultiRegionTable(
+		localityZoneConfig, err := regions.ZoneConfigForMultiRegionTable(
 			newConfig,
 			regionConfig,
 		)
@@ -380,7 +267,7 @@ var ApplyZoneConfigForMultiRegionTableOptionTableAndIndexes = func(
 	table catalog.TableDescriptor,
 ) (bool, zonepb.ZoneConfig, error) {
 	localityConfig := *table.GetLocalityConfig()
-	localityZoneConfig, err := zoneConfigForMultiRegionTable(
+	localityZoneConfig, err := regions.ZoneConfigForMultiRegionTable(
 		localityConfig,
 		regionConfig,
 	)
@@ -1326,15 +1213,12 @@ func (p *planner) CheckZoneConfigChangePermittedForMultiRegion(
 
 // zoneConfigForMultiRegionValidator is an interface representing
 // actions to take when validating a zone config for multi-region
-// purposes.
+// purposes. This extends the shared regions.ZoneConfigForMultiRegionValidator
+// with legacy-schema-changer-specific methods.
 type zoneConfigForMultiRegionValidator interface {
+	regions.ZoneConfigForMultiRegionValidator
 	getExpectedDatabaseZoneConfig() (zonepb.ZoneConfig, error)
 	getExpectedTableZoneConfig(desc catalog.TableDescriptor) (zonepb.ZoneConfig, error)
-	transitioningRegions() catpb.RegionNames
-
-	newMismatchFieldError(descType string, descName string, mismatch zonepb.DiffWithZoneMismatch) error
-	newMissingSubzoneError(descType string, descName string, mismatch zonepb.DiffWithZoneMismatch) error
-	newExtraSubzoneError(descType string, descName string, mismatch zonepb.DiffWithZoneMismatch) error
 }
 
 // zoneConfigForMultiRegionValidatorSetInitialRegion implements
@@ -1351,7 +1235,7 @@ func (v *zoneConfigForMultiRegionValidatorSetInitialRegion) getExpectedDatabaseZ
 	return *zonepb.NewZoneConfig(), nil
 }
 
-func (v *zoneConfigForMultiRegionValidatorSetInitialRegion) transitioningRegions() catpb.RegionNames {
+func (v *zoneConfigForMultiRegionValidatorSetInitialRegion) TransitioningRegions() catpb.RegionNames {
 	// There are no transitioning regions at setup time.
 	return nil
 }
@@ -1375,7 +1259,7 @@ func (v *zoneConfigForMultiRegionValidatorSetInitialRegion) wrapErr(err error) e
 	)
 }
 
-func (v *zoneConfigForMultiRegionValidatorSetInitialRegion) newMismatchFieldError(
+func (v *zoneConfigForMultiRegionValidatorSetInitialRegion) NewMismatchFieldError(
 	descType string, descName string, mismatch zonepb.DiffWithZoneMismatch,
 ) error {
 	return v.wrapErr(
@@ -1391,7 +1275,7 @@ func (v *zoneConfigForMultiRegionValidatorSetInitialRegion) newMismatchFieldErro
 	)
 }
 
-func (v *zoneConfigForMultiRegionValidatorSetInitialRegion) newMissingSubzoneError(
+func (v *zoneConfigForMultiRegionValidatorSetInitialRegion) NewMissingSubzoneError(
 	descType string, descName string, _ zonepb.DiffWithZoneMismatch,
 ) error {
 	// There can never be a missing subzone as we only compare against
@@ -1403,7 +1287,7 @@ func (v *zoneConfigForMultiRegionValidatorSetInitialRegion) newMissingSubzoneErr
 	)
 }
 
-func (v *zoneConfigForMultiRegionValidatorSetInitialRegion) newExtraSubzoneError(
+func (v *zoneConfigForMultiRegionValidatorSetInitialRegion) NewExtraSubzoneError(
 	descType string, descName string, mismatch zonepb.DiffWithZoneMismatch,
 ) error {
 	return v.wrapErr(
@@ -1446,7 +1330,7 @@ func (v *zoneConfigForMultiRegionValidatorExistingMultiRegionObject) getExpected
 	return expectedZoneConfig, err
 }
 
-func (v *zoneConfigForMultiRegionValidatorExistingMultiRegionObject) transitioningRegions() catpb.RegionNames {
+func (v *zoneConfigForMultiRegionValidatorExistingMultiRegionObject) TransitioningRegions() catpb.RegionNames {
 	return v.regionConfig.TransitioningRegions()
 }
 
@@ -1458,7 +1342,7 @@ type zoneConfigForMultiRegionValidatorModifiedByUser struct {
 
 var _ zoneConfigForMultiRegionValidator = (*zoneConfigForMultiRegionValidatorModifiedByUser)(nil)
 
-func (v *zoneConfigForMultiRegionValidatorModifiedByUser) newMismatchFieldError(
+func (v *zoneConfigForMultiRegionValidatorModifiedByUser) NewMismatchFieldError(
 	descType string, descName string, mismatch zonepb.DiffWithZoneMismatch,
 ) error {
 	return v.wrapErr(
@@ -1486,7 +1370,7 @@ func (v *zoneConfigForMultiRegionValidatorModifiedByUser) wrapErr(err error) err
 	)
 }
 
-func (v *zoneConfigForMultiRegionValidatorModifiedByUser) newMissingSubzoneError(
+func (v *zoneConfigForMultiRegionValidatorModifiedByUser) NewMissingSubzoneError(
 	descType string, descName string, _ zonepb.DiffWithZoneMismatch,
 ) error {
 	return v.wrapErr(
@@ -1499,7 +1383,7 @@ func (v *zoneConfigForMultiRegionValidatorModifiedByUser) newMissingSubzoneError
 	)
 }
 
-func (v *zoneConfigForMultiRegionValidatorModifiedByUser) newExtraSubzoneError(
+func (v *zoneConfigForMultiRegionValidatorModifiedByUser) NewExtraSubzoneError(
 	descType string, descName string, mismatch zonepb.DiffWithZoneMismatch,
 ) error {
 	return v.wrapErr(
@@ -1523,7 +1407,7 @@ type zoneConfigForMultiRegionValidatorValidation struct {
 
 var _ zoneConfigForMultiRegionValidator = (*zoneConfigForMultiRegionValidatorValidation)(nil)
 
-func (v *zoneConfigForMultiRegionValidatorValidation) newMismatchFieldError(
+func (v *zoneConfigForMultiRegionValidatorValidation) NewMismatchFieldError(
 	descType string, descName string, mismatch zonepb.DiffWithZoneMismatch,
 ) error {
 	return pgerror.Newf(
@@ -1537,7 +1421,7 @@ func (v *zoneConfigForMultiRegionValidatorValidation) newMismatchFieldError(
 	)
 }
 
-func (v *zoneConfigForMultiRegionValidatorValidation) newMissingSubzoneError(
+func (v *zoneConfigForMultiRegionValidatorValidation) NewMissingSubzoneError(
 	descType string, descName string, _ zonepb.DiffWithZoneMismatch,
 ) error {
 	return pgerror.Newf(
@@ -1548,7 +1432,7 @@ func (v *zoneConfigForMultiRegionValidatorValidation) newMissingSubzoneError(
 	)
 }
 
-func (v *zoneConfigForMultiRegionValidatorValidation) newExtraSubzoneError(
+func (v *zoneConfigForMultiRegionValidatorValidation) NewExtraSubzoneError(
 	descType string, descName string, mismatch zonepb.DiffWithZoneMismatch,
 ) error {
 	return pgerror.Newf(
@@ -1634,7 +1518,7 @@ func (p *planner) validateZoneConfigForMultiRegionDatabase(
 	}
 	if !same {
 		dbName := tree.Name(dbDesc.GetName())
-		return zoneConfigForMultiRegionValidator.newMismatchFieldError(
+		return zoneConfigForMultiRegionValidator.NewMismatchFieldError(
 			"database",
 			dbName.String(),
 			mismatch,
@@ -1689,6 +1573,84 @@ func (p *planner) validateZoneConfigForMultiRegionTableWasNotModifiedByUser(
 	)
 }
 
+// multiRegionTableValidatorData implements zoneconfig.MultiRegionTableValidatorData for legacy schema changer.
+type multiRegionTableValidatorData struct {
+	desc   catalog.TableDescriptor
+	dbDesc catalog.DatabaseDescriptor
+}
+
+var _ regions.MultiRegionTableValidatorData = (*multiRegionTableValidatorData)(nil)
+
+func (v *multiRegionTableValidatorData) GetTransitioningRBRIndexes() map[uint32]struct{} {
+	// When there is a transition to/from REGIONAL BY ROW, the new indexes
+	// being set up will have zone configs which mismatch with the old
+	// table locality config. As we validate against the old table locality
+	// config (as the new indexes are not swapped in yet), exclude these
+	// indexes from any zone configuration validation.
+	regionalByRowNewIndexes := make(map[uint32]struct{})
+	for _, mut := range v.desc.AllMutations() {
+		if pkSwap := mut.AsPrimaryKeySwap(); pkSwap != nil {
+			if pkSwap.HasLocalityConfig() {
+				_ = pkSwap.ForEachNewIndexIDs(func(id descpb.IndexID) error {
+					regionalByRowNewIndexes[uint32(id)] = struct{}{}
+					if idx := catalog.FindCorrespondingTemporaryIndexByID(v.desc, id); idx != nil {
+						regionalByRowNewIndexes[uint32(idx.GetID())] = struct{}{}
+					}
+					return nil
+				})
+
+			}
+			// There can only be one pkSwap at a time, so break now.
+			break
+		}
+	}
+	return regionalByRowNewIndexes
+}
+
+func (v *multiRegionTableValidatorData) GetNonDropIndexes() map[uint32]tree.Name {
+	// Build map excluding RBR transitioning indexes
+	// Some transitioning subzones may remain on the zone configuration until it is cleaned up
+	// at a later step. Remove these as well as the regional by row new indexes.
+	regionalByRowNewIndexes := v.GetTransitioningRBRIndexes()
+	subzoneIndexIDsToDiff := make(map[uint32]tree.Name)
+	for _, idx := range v.desc.NonDropIndexes() {
+		if _, skip := regionalByRowNewIndexes[uint32(idx.GetID())]; !skip {
+			subzoneIndexIDsToDiff[uint32(idx.GetID())] = tree.Name(idx.GetName())
+		}
+	}
+	return subzoneIndexIDsToDiff
+}
+
+func (v *multiRegionTableValidatorData) GetDatabasePrimaryRegion() catpb.RegionName {
+	regionConfig := v.dbDesc.GetRegionConfig()
+	if regionConfig == nil {
+		return ""
+	}
+	return regionConfig.PrimaryRegion
+}
+
+func (v *multiRegionTableValidatorData) GetDatabaseSecondaryRegion() catpb.RegionName {
+	regionConfig := v.dbDesc.GetRegionConfig()
+	if regionConfig == nil {
+		return ""
+	}
+	return regionConfig.SecondaryRegion
+}
+
+func (v *multiRegionTableValidatorData) GetTableLocalitySecondaryRegion() *catpb.RegionName {
+	regionConfig := v.dbDesc.GetRegionConfig()
+	if regionConfig == nil || regionConfig.SecondaryRegion == "" {
+		return nil
+	}
+	if v.desc.IsLocalityRegionalByTable() {
+		rbt := v.desc.GetLocalityConfig().GetRegionalByTable()
+		if rbt.Region != nil {
+			return rbt.Region
+		}
+	}
+	return nil
+}
+
 // validateZoneConfigForMultiRegionTableOptions validates that
 // the multi-region fields of the table's zone configuration
 // matches what is expected for the given table.
@@ -1711,182 +1673,18 @@ func (p *planner) validateZoneConfigForMultiRegionTable(
 		return err
 	}
 
-	// When there is a transition to/from REGIONAL BY ROW, the new indexes
-	// being set up will have zone configs which mismatch with the old
-	// table locality config. As we validate against the old table locality
-	// config (as the new indexes are not swapped in yet), exclude these
-	// indexes from any zone configuration validation.
-	regionalByRowNewIndexes := make(map[uint32]struct{})
-	for _, mut := range desc.AllMutations() {
-		if pkSwap := mut.AsPrimaryKeySwap(); pkSwap != nil {
-			if pkSwap.HasLocalityConfig() {
-				_ = pkSwap.ForEachNewIndexIDs(func(id descpb.IndexID) error {
-					regionalByRowNewIndexes[uint32(id)] = struct{}{}
-					if idx := catalog.FindCorrespondingTemporaryIndexByID(desc, id); idx != nil {
-						regionalByRowNewIndexes[uint32(idx.GetID())] = struct{}{}
-					}
-					return nil
-				})
-
-			}
-			// There can only be one pkSwap at a time, so break now.
-			break
-		}
+	validatorData := multiRegionTableValidatorData{
+		desc:   desc,
+		dbDesc: dbDesc,
 	}
 
-	// Some transitioning subzones may remain on the zone configuration until it is cleaned up
-	// at a later step. Remove these as well as the regional by row new indexes.
-	subzoneIndexIDsToDiff := make(map[uint32]tree.Name, len(desc.NonDropIndexes()))
-	for _, idx := range desc.NonDropIndexes() {
-		if _, ok := regionalByRowNewIndexes[uint32(idx.GetID())]; !ok {
-			subzoneIndexIDsToDiff[uint32(idx.GetID())] = tree.Name(idx.GetName())
-		}
-	}
-
-	// Do not compare partitioning for these regions, as they may be in a
-	// transitioning state.
-	transitioningRegions := make(map[string]struct{}, len(zoneConfigForMultiRegionValidator.transitioningRegions()))
-	for _, transitioningRegion := range zoneConfigForMultiRegionValidator.transitioningRegions() {
-		transitioningRegions[string(transitioningRegion)] = struct{}{}
-	}
-
-	// We only want to compare against the list of subzones on active indexes
-	// and partitions, so filter the subzone list based on the
-	// subzoneIndexIDsToDiff computed above.
-	filteredCurrentZoneConfigSubzones := currentZoneConfig.Subzones[:0]
-	for _, c := range currentZoneConfig.Subzones {
-		if c.PartitionName != "" {
-			if _, ok := transitioningRegions[c.PartitionName]; ok {
-				continue
-			}
-		}
-		if _, ok := subzoneIndexIDsToDiff[c.IndexID]; !ok {
-			continue
-		}
-		filteredCurrentZoneConfigSubzones = append(filteredCurrentZoneConfigSubzones, c)
-	}
-	currentZoneConfig.Subzones = filteredCurrentZoneConfigSubzones
-	// Strip the placeholder status if there are no active subzones on the current
-	// zone config.
-	if len(filteredCurrentZoneConfigSubzones) == 0 && currentZoneConfig.IsSubzonePlaceholder() {
-		currentZoneConfig.NumReplicas = nil
-	}
-
-	// Remove regional by row new indexes and transitioning partitions from the expected zone config.
-	// These will be incorrect as ApplyZoneConfigForMultiRegionTableOptionTableAndIndexes
-	// will apply the existing locality config on them instead of the
-	// new locality config.
-	filteredExpectedZoneConfigSubzones := expectedZoneConfig.Subzones[:0]
-	for _, c := range expectedZoneConfig.Subzones {
-		if c.PartitionName != "" {
-			if _, ok := transitioningRegions[c.PartitionName]; ok {
-				continue
-			}
-		}
-		if _, ok := regionalByRowNewIndexes[c.IndexID]; ok {
-			continue
-		}
-		filteredExpectedZoneConfigSubzones = append(
-			filteredExpectedZoneConfigSubzones,
-			c,
-		)
-	}
-	expectedZoneConfig.Subzones = filteredExpectedZoneConfigSubzones
-
-	// Mark the expected NumReplicas as 0 if we have a placeholder
-	// and the current zone config is also a placeholder.
-	// The latter check is required as in cases where non-multiregion fields
-	// are set on the current zone config, the expected zone config needs
-	// the placeholder marked so that DiffWithZone does not error when
-	// num_replicas is expectedly different.
-	// e.g. if current zone config has gc.ttlseconds set, then we
-	// do not fudge num replicas to be equal to 0 -- otherwise the
-	// check fails when num_replicas is different, but that is
-	// expected as the current zone config is no longer a placeholder.
-	if currentZoneConfig.IsSubzonePlaceholder() && regions.IsPlaceholderZoneConfigForMultiRegion(expectedZoneConfig) {
-		expectedZoneConfig.NumReplicas = proto.Int32(0)
-	}
-
-	regionConfig := dbDesc.GetRegionConfig()
-	var leasePreferences []zonepb.LeasePreference
-	if regionConfig != nil {
-		if regionConfig.SecondaryRegion != "" {
-			switch {
-			case desc.IsLocalityRegionalByTable():
-				rbt := desc.GetLocalityConfig().GetRegionalByTable()
-				if rbt.Region != nil {
-					leasePreferences = regions.SynthesizeLeasePreferences(*rbt.Region, regionConfig.SecondaryRegion)
-				} else {
-					leasePreferences = regions.SynthesizeLeasePreferences(regionConfig.PrimaryRegion, regionConfig.SecondaryRegion)
-				}
-			default:
-				leasePreferences = regions.SynthesizeLeasePreferences(regionConfig.PrimaryRegion, regionConfig.SecondaryRegion)
-			}
-
-			expectedZoneConfig.LeasePreferences = leasePreferences
-		}
-	}
-
-	// Compare the two zone configs to see if anything is amiss.
-	same, mismatch, err := currentZoneConfig.DiffWithZone(
+	return regions.ValidateZoneConfigForMultiRegionTable(
+		tableName,
+		currentZoneConfig,
 		expectedZoneConfig,
-		zonepb.MultiRegionZoneConfigFields,
+		&validatorData,
+		zoneConfigForMultiRegionValidator,
 	)
-	if err != nil {
-		return err
-	}
-	if !same {
-		descType := "table"
-		name := tableName.String()
-		if mismatch.IndexID != 0 {
-			indexName, ok := subzoneIndexIDsToDiff[mismatch.IndexID]
-			if !ok {
-				return errors.AssertionFailedf(
-					"unexpected unknown index id %d on table %s (mismatch %#v)",
-					mismatch.IndexID,
-					tableName,
-					mismatch,
-				)
-			}
-
-			if mismatch.PartitionName != "" {
-				descType = "partition"
-				partitionName := tree.Name(mismatch.PartitionName)
-				name = fmt.Sprintf(
-					"%s of %s@%s",
-					partitionName.String(),
-					tableName.String(),
-					indexName.String(),
-				)
-			} else {
-				descType = "index"
-				name = fmt.Sprintf("%s@%s", tableName.String(), indexName.String())
-			}
-		}
-
-		if mismatch.IsMissingSubzone {
-			return zoneConfigForMultiRegionValidator.newMissingSubzoneError(
-				descType,
-				name,
-				mismatch,
-			)
-		}
-		if mismatch.IsExtraSubzone {
-			return zoneConfigForMultiRegionValidator.newExtraSubzoneError(
-				descType,
-				name,
-				mismatch,
-			)
-		}
-
-		return zoneConfigForMultiRegionValidator.newMismatchFieldError(
-			descType,
-			name,
-			mismatch,
-		)
-	}
-
-	return nil
 }
 
 // checkNoRegionalByRowChangeUnderway checks that no REGIONAL BY ROW

--- a/pkg/sql/region_util_test.go
+++ b/pkg/sql/region_util_test.go
@@ -1548,7 +1548,7 @@ func TestZoneConfigForMultiRegionTable(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			zc, err := zoneConfigForMultiRegionTable(tc.localityConfig, tc.regionConfig)
+			zc, err := regions.ZoneConfigForMultiRegionTable(tc.localityConfig, tc.regionConfig)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, zc)
 		})

--- a/pkg/sql/regions/BUILD.bazel
+++ b/pkg/sql/regions/BUILD.bazel
@@ -22,8 +22,10 @@ go_library(
         "//pkg/sql/catalog/descs",
         "//pkg/sql/catalog/lease",
         "//pkg/sql/catalog/multiregion",
+        "//pkg/sql/sem/tree",
         "//pkg/util/hlc",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_gogo_protobuf//proto",
     ],
 )
 

--- a/pkg/sql/regions/region_util.go
+++ b/pkg/sql/regions/region_util.go
@@ -6,12 +6,129 @@
 package regions
 
 import (
+	"fmt"
+
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/multiregion"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/errors"
+	"github.com/gogo/protobuf/proto"
 )
+
+// ZoneConfigForMultiRegionTable generates a ZoneConfig stub for a
+// regional-by-table or global table in a multi-region database.
+//
+// At the table/partition level, the only attributes that are set are
+// `num_voters`, `voter_constraints`, and `lease_preferences`. We expect that
+// the attributes `num_replicas` and `constraints` will be inherited from the
+// database level zone config.
+//
+// This function can return a nil zonepb.ZoneConfig, meaning no table level zone
+// configuration is required.
+//
+// Relevant multi-region configured fields (as defined in
+// `zonepb.MultiRegionZoneConfigFields`) will be overwritten by the calling function
+// into an existing ZoneConfig.
+func ZoneConfigForMultiRegionTable(
+	localityConfig catpb.LocalityConfig, regionConfig multiregion.RegionConfig,
+) (zonepb.ZoneConfig, error) {
+	zc := *zonepb.NewZoneConfig()
+
+	switch l := localityConfig.Locality.(type) {
+	case *catpb.LocalityConfig_Global_:
+		// Enable non-blocking transactions.
+		zc.GlobalReads = proto.Bool(true)
+
+		if !regionConfig.GlobalTablesInheritDatabaseConstraints() {
+			// For GLOBAL tables, we want non-voters in all regions for fast reads, so
+			// we always use a DEFAULT placement config, even if the database is using
+			// RESTRICTED placement.
+			regionConfig = regionConfig.WithPlacementDefault()
+
+			numVoters, numReplicas := GetNumVotersAndNumReplicas(regionConfig)
+			zc.NumVoters = &numVoters
+			zc.NumReplicas = &numReplicas
+
+			constraints, err := SynthesizeReplicaConstraints(regionConfig.Regions(), regionConfig.Placement())
+			if err != nil {
+				return zonepb.ZoneConfig{}, err
+			}
+			zc.Constraints = constraints
+			zc.InheritedConstraints = false
+
+			voterConstraints, err := SynthesizeVoterConstraints(regionConfig.PrimaryRegion(), regionConfig)
+			if err != nil {
+				return zonepb.ZoneConfig{}, err
+			}
+			zc.VoterConstraints = voterConstraints
+			zc.NullVoterConstraintsIsEmpty = true
+			zc.LeasePreferences = SynthesizeLeasePreferences(regionConfig.PrimaryRegion(), "" /* secondaryRegion */)
+			zc.InheritedLeasePreferences = false
+
+			zc, err = regionConfig.ExtendZoneConfigWithGlobal(zc)
+			if err != nil {
+				return zonepb.ZoneConfig{}, err
+			}
+		}
+		// Inherit lease preference from the database. We do
+		// nothing here because `NewZoneConfig()` already marks the field as
+		// 'inherited'.
+		return zc, nil
+	case *catpb.LocalityConfig_RegionalByTable_:
+		affinityRegion := regionConfig.PrimaryRegion()
+		if l.RegionalByTable.Region != nil {
+			affinityRegion = *l.RegionalByTable.Region
+		}
+		if l.RegionalByTable.Region == nil && !regionConfig.IsMemberOfSuperRegion(affinityRegion) {
+			// If we don't have an explicit affinity region, use the same
+			// configuration as the database and return a blank zcfg here.
+			return zc, nil
+		}
+
+		numVoters, numReplicas := GetNumVotersAndNumReplicas(regionConfig)
+		zc.NumVoters = &numVoters
+
+		if regionConfig.IsMemberOfSuperRegion(affinityRegion) {
+			err := AddConstraintsForSuperRegion(&zc, regionConfig, affinityRegion)
+			if err != nil {
+				return zonepb.ZoneConfig{}, err
+			}
+		} else if !regionConfig.RegionalInTablesInheritDatabaseConstraints(affinityRegion) {
+			// If the database constraints can't be inherited to serve as the
+			// constraints for this table, define the constraints ourselves.
+			zc.NumReplicas = &numReplicas
+
+			constraints, err := SynthesizeReplicaConstraints(regionConfig.Regions(), regionConfig.Placement())
+			if err != nil {
+				return zonepb.ZoneConfig{}, err
+			}
+			zc.Constraints = constraints
+			zc.InheritedConstraints = false
+		}
+
+		// If the table has a user-specified affinity region, use it.
+		voterConstraints, err := SynthesizeVoterConstraints(affinityRegion, regionConfig)
+		if err != nil {
+			return zonepb.ZoneConfig{}, err
+		}
+		zc.VoterConstraints = voterConstraints
+		zc.NullVoterConstraintsIsEmpty = true
+		zc.LeasePreferences = SynthesizeLeasePreferences(affinityRegion, "" /* secondaryRegion */)
+		zc.InheritedLeasePreferences = false
+
+		return regionConfig.ExtendZoneConfigWithRegionalIn(zc, affinityRegion)
+
+	case *catpb.LocalityConfig_RegionalByRow_:
+		// We purposely do not set anything here at table level - this should be done at
+		// partition level instead.
+		return zc, nil
+	default:
+		return zonepb.ZoneConfig{}, errors.AssertionFailedf(
+			"unexpected unknown locality type %T", localityConfig.Locality)
+	}
+}
 
 // ZoneConfigForMultiRegionPartition generates a ZoneConfig stub for a partition
 // that belongs to a regional by row table in a multi-region database.
@@ -303,6 +420,225 @@ func MakeRequiredConstraintForRegion(r catpb.RegionName) zonepb.Constraint {
 		Key:   "region",
 		Value: string(r),
 	}
+}
+
+// ZoneConfigForMultiRegionValidator is an interface that both schema changers
+// must implement to provide error reporting and state information during
+// multi-region zone config validation.
+type ZoneConfigForMultiRegionValidator interface {
+	// TransitioningRegions returns the regions currently being added or removed
+	TransitioningRegions() catpb.RegionNames
+
+	// NewMismatchFieldError creates an error for when a zone config field doesn't match
+	NewMismatchFieldError(descType, name string, mismatch zonepb.DiffWithZoneMismatch) error
+
+	// NewMissingSubzoneError creates an error for when an expected subzone is missing
+	NewMissingSubzoneError(descType, name string, mismatch zonepb.DiffWithZoneMismatch) error
+
+	// NewExtraSubzoneError creates an error for when an unexpected subzone is present
+	NewExtraSubzoneError(descType, name string, mismatch zonepb.DiffWithZoneMismatch) error
+}
+
+// MultiRegionTableValidatorData provides an abstraction for reading table metadata
+// that works with both legacy and declarative schema changers.
+type MultiRegionTableValidatorData interface {
+	// GetNonDropIndexes returns a map of index ID to index name for all non-drop indexes
+	GetNonDropIndexes() map[uint32]tree.Name
+
+	// GetTransitioningRBRIndexes returns index IDs that are transitioning to/from RBR
+	// (only relevant for legacy schema changer with mutations)
+	GetTransitioningRBRIndexes() map[uint32]struct{}
+
+	// GetTableLocalitySecondaryRegion returns the secondary region for REGIONAL BY TABLE
+	// Returns nil if not a secondary region table
+	GetTableLocalitySecondaryRegion() *catpb.RegionName
+
+	// GetDatabasePrimaryRegion returns the database primary region name
+	GetDatabasePrimaryRegion() catpb.RegionName
+
+	// GetDatabaseSecondaryRegion returns the database secondary region name
+	GetDatabaseSecondaryRegion() catpb.RegionName
+}
+
+// ValidateZoneConfigForMultiRegionTable validates that the multi-region fields
+// of a table's zone configuration match what is expected.
+// This is the shared core validation logic used by both schema changers.
+func ValidateZoneConfigForMultiRegionTable(
+	tableName tree.Name,
+	currentZoneConfig *zonepb.ZoneConfig,
+	expectedZoneConfig zonepb.ZoneConfig,
+	tableData MultiRegionTableValidatorData,
+	validator ZoneConfigForMultiRegionValidator,
+) error {
+	if currentZoneConfig == nil {
+		currentZoneConfig = zonepb.NewZoneConfig()
+	}
+
+	regionalByRowNewIndexes := tableData.GetTransitioningRBRIndexes()
+	subzoneIndexIDsToDiff := tableData.GetNonDropIndexes()
+
+	// Build transitioning regions map
+	// Do not compare partitioning for these regions, as they may be in a
+	// transitioning state.
+	transitioningRegions := make(map[string]struct{}, len(validator.TransitioningRegions()))
+	for _, region := range validator.TransitioningRegions() {
+		transitioningRegions[string(region)] = struct{}{}
+	}
+
+	// We only want to compare against the list of subzones on active indexes
+	// and partitions, so filter the subzone list based on the
+	// subzoneIndexIDsToDiff computed above.
+	// No need to pass regionalByRowNewIndexes to filter because they are
+	// already excluded from subzoneIndexIDsToDiff.
+	filteredCurrentSubzones := filterSubzones(
+		currentZoneConfig.Subzones,
+		subzoneIndexIDsToDiff,
+		nil, /* skipRBRIndexes */
+		transitioningRegions,
+	)
+	currentZoneConfig.Subzones = filteredCurrentSubzones
+
+	// Strip placeholder if no subzones
+	if len(filteredCurrentSubzones) == 0 && currentZoneConfig.IsSubzonePlaceholder() {
+		currentZoneConfig.NumReplicas = nil
+	}
+
+	// Remove regional by row new indexes and transitioning partitions from the expected zone config.
+	// These will be incorrect as ApplyZoneConfigForMultiRegionTableOptionTableAndIndexes
+	// will apply the existing locality config on them instead of the new locality config.
+	filteredExpectedSubzones := filterSubzones(
+		expectedZoneConfig.Subzones,
+		nil,                     /* validIndexIDs */
+		regionalByRowNewIndexes, // don't filter RBR indexes from expected
+		transitioningRegions,
+	)
+	expectedZoneConfig.Subzones = filteredExpectedSubzones
+
+	// Mark the expected NumReplicas as 0 if we have a placeholder
+	// and the current zone config is also a placeholder.
+	// The latter check is required as in cases where non-multiregion fields
+	// are set on the current zone config, the expected zone config needs
+	// the placeholder marked so that DiffWithZone does not error when
+	// num_replicas is expectedly different.
+	// e.g. if current zone config has gc.ttlseconds set, then we
+	// do not fudge num replicas to be equal to 0 -- otherwise the
+	// check fails when num_replicas is different, but that is
+	// expected as the current zone config is no longer a placeholder.
+	if currentZoneConfig.IsSubzonePlaceholder() && IsPlaceholderZoneConfigForMultiRegion(expectedZoneConfig) {
+		expectedZoneConfig.NumReplicas = proto.Int32(0)
+	}
+
+	// Synthesize lease preferences if secondary region exists
+	if tableData.GetDatabaseSecondaryRegion() != "" {
+		expectedZoneConfig.LeasePreferences = synthesizeLeasePreferencesForTable(
+			tableData,
+		)
+	}
+
+	// Compare the two zone configs to see if anything is amiss.
+	same, mismatch, err := currentZoneConfig.DiffWithZone(
+		expectedZoneConfig,
+		zonepb.MultiRegionZoneConfigFields,
+	)
+	if err != nil {
+		return err
+	}
+
+	if !same {
+		return buildValidationError(
+			tableName,
+			mismatch,
+			subzoneIndexIDsToDiff,
+			validator,
+		)
+	}
+
+	return nil
+}
+
+// filterSubzones filters subzones based on index IDs and regions
+func filterSubzones(
+	subzones []zonepb.Subzone,
+	validIndexIDs map[uint32]tree.Name,
+	skipRBRIndexes map[uint32]struct{},
+	skipRegions map[string]struct{},
+) []zonepb.Subzone {
+	filtered := subzones[:0]
+	for _, subzone := range subzones {
+		// Skip transitioning regions
+		if subzone.PartitionName != "" {
+			if _, skip := skipRegions[subzone.PartitionName]; skip {
+				continue
+			}
+		}
+		// Skip RBR transitioning indexes
+		if skipRBRIndexes != nil {
+			if _, skip := skipRBRIndexes[subzone.IndexID]; skip {
+				continue
+			}
+		}
+		// Skip indexes not in valid set
+		if validIndexIDs != nil {
+			if _, valid := validIndexIDs[subzone.IndexID]; !valid {
+				continue
+			}
+		}
+		filtered = append(filtered, subzone)
+	}
+	return filtered
+}
+
+// buildValidationError constructs the appropriate error based on mismatch type
+func buildValidationError(
+	tableName tree.Name,
+	mismatch zonepb.DiffWithZoneMismatch,
+	indexMap map[uint32]tree.Name,
+	validator ZoneConfigForMultiRegionValidator,
+) error {
+	descType := "table"
+	name := tableName.String()
+
+	if mismatch.IndexID != 0 {
+		indexName, ok := indexMap[mismatch.IndexID]
+		if !ok {
+			return errors.AssertionFailedf(
+				"unexpected unknown index id %d on table %s (mismatch %#v)",
+				mismatch.IndexID,
+				tableName,
+				mismatch,
+			)
+		}
+
+		if mismatch.PartitionName != "" {
+			descType = "partition"
+			partitionName := tree.Name(mismatch.PartitionName)
+			name = fmt.Sprintf("%s of %s@%s",
+				partitionName.String(),
+				tableName.String(),
+				indexName.String(),
+			)
+		} else {
+			descType = "index"
+			name = fmt.Sprintf("%s@%s", tableName.String(), indexName.String())
+		}
+	}
+
+	if mismatch.IsMissingSubzone {
+		return validator.NewMissingSubzoneError(descType, name, mismatch)
+	}
+	if mismatch.IsExtraSubzone {
+		return validator.NewExtraSubzoneError(descType, name, mismatch)
+	}
+	return validator.NewMismatchFieldError(descType, name, mismatch)
+}
+
+func synthesizeLeasePreferencesForTable(
+	tableData MultiRegionTableValidatorData,
+) []zonepb.LeasePreference {
+	if rbtSecondaryRegion := tableData.GetTableLocalitySecondaryRegion(); rbtSecondaryRegion != nil {
+		return SynthesizeLeasePreferences(*rbtSecondaryRegion, tableData.GetDatabaseSecondaryRegion())
+	}
+	return SynthesizeLeasePreferences(tableData.GetDatabasePrimaryRegion(), tableData.GetDatabaseSecondaryRegion())
 }
 
 // AddConstraintsForSuperRegion updates the ZoneConfig.Constraints field such


### PR DESCRIPTION
Previously, this logic was placed in the `sql` package because it was only used by the legacy schema changer. This change moves the main logic to the `regions` package so that it can be shared with the declarative schema changer. A new interface was designed to be shared between the legacy and the declarative schema changer.

Informs: #150946

Release note: None