### PR TITLE
changefeedccl: emit max_behind_nanos during initial scans

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -456,6 +456,11 @@ func (ca *changeAggregator) Start(ctx context.Context) {
 		kvFeedHighWater = ca.spec.Feed.StatementTime
 	}
 
+	// Initialize the resolved timestamp metric for our aggregator with the initial
+	// high water. This allows max_behind_nanos to have a reasonable value during
+	// initial scans, which don't emit resolved timestamps.
+	ca.sliMetrics.setResolved(ca.sliMetricsID, kvFeedHighWater)
+
 	// TODO(yevgeniy): Introduce separate changefeed monitor that's a parent
 	// for all changefeeds to control memory allocated to all changefeeds.
 	pool := ca.FlowCtx.Cfg.BackfillerMonitor


### PR DESCRIPTION
This change initializes the resolved timestamp to the statement time on aggregator startup. This allows max_behind_nanos to report a reasonable value even during intial scans where resolved timestamps aren't emitted.

Release note (ops change): emit max_behind_nanos during initial scans
Fixes: https://github.com/cockroachdb/cockroach/issues/158075