### PR TITLE
release-25.4: kvcoord: more tracing for leaseholder backoffs

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -370,6 +370,9 @@ const (
 	// The maximum number of times a replica is retried when it repeatedly returns
 	// stale lease info.
 	sameReplicaRetryLimit = 10
+	// InLeaseTransferBackoffTraceMessage is traced when DistSender backs off as a
+	// result of a NotLeaseholderError. It is exported for testing.
+	InLeaseTransferBackoffTraceMessage = "backing off due to NotLeaseHolderErr with stale info"
 )
 
 var rangeDescriptorCacheSize = settings.RegisterIntSetting(
@@ -3108,8 +3111,8 @@ func (ds *DistSender) sendToReplicas(
 					if shouldBackoff {
 						ds.metrics.InLeaseTransferBackoffs.Inc(1)
 						log.VErrEventf(ctx, 2,
-							"backing off due to NotLeaseHolderErr with stale info "+
-								"(updatedLH=%t intentionallySentToFollower=%t leaseholderUnavailable=%t)",
+							InLeaseTransferBackoffTraceMessage+
+								" (updatedLH=%t intentionallySentToFollower=%t leaseholderUnavailable=%t)",
 							updatedLeaseholder, intentionallySentToFollower, leaseholderUnavailable)
 					} else {
 						inTransferRetry.Reset() // The following Next() call will not block.

--- a/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
+++ b/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
@@ -866,7 +866,6 @@ func TestReplicaCircuitBreaker_Partial_Retry(t *testing.T) {
 			requireRUEs := func(t *testing.T, dbs []*kv.DB) {
 				t.Helper()
 				for _, db := range dbs {
-					backoffMetric := (db.NonTransactionalSender().(*kv.CrossRangeTxnWrapperSender)).Wrapped().(*kvcoord.DistSender).Metrics().InLeaseTransferBackoffs
 					ctx, finishAndGetRec := tracing.ContextWithRecordingSpan(context.Background(), db.Tracer, "requireRUEs")
 					defer func() {
 						rec := finishAndGetRec()
@@ -875,13 +874,12 @@ func TestReplicaCircuitBreaker_Partial_Retry(t *testing.T) {
 						}
 						t.Logf("failure trace:\n%s", rec)
 					}()
-					initialBackoff := backoffMetric.Count()
 					err := db.Put(ctx, key, value)
-					// Verify that we did not perform any backoff while executing this request.
-					require.EqualValues(t, 0, backoffMetric.Count()-initialBackoff)
 					require.Error(t, err)
 					require.True(t, errors.HasType(err, (*kvpb.ReplicaUnavailableError)(nil)),
 						"expected ReplicaUnavailableError, got %v", err)
+					// Verify that we did not perform any backoff while executing this request.
+					require.NotContains(t, finishAndGetRec(), kvcoord.InLeaseTransferBackoffTraceMessage)
 				}
 				t.Logf("writes failed with ReplicaUnavailableError")
 			}

--- a/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
+++ b/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
@@ -867,6 +867,14 @@ func TestReplicaCircuitBreaker_Partial_Retry(t *testing.T) {
 				t.Helper()
 				for _, db := range dbs {
 					backoffMetric := (db.NonTransactionalSender().(*kv.CrossRangeTxnWrapperSender)).Wrapped().(*kvcoord.DistSender).Metrics().InLeaseTransferBackoffs
+					ctx, finishAndGetRec := tracing.ContextWithRecordingSpan(context.Background(), db.Tracer, "requireRUEs")
+					defer func() {
+						rec := finishAndGetRec()
+						if !t.Failed() {
+							return
+						}
+						t.Logf("failure trace:\n%s", rec)
+					}()
 					initialBackoff := backoffMetric.Count()
 					err := db.Put(ctx, key, value)
 					// Verify that we did not perform any backoff while executing this request.
@@ -924,7 +932,7 @@ func TestReplicaCircuitBreaker_Partial_Retry(t *testing.T) {
 			// and it will return RUE.
 			lease, _ := repl3.GetLease()
 			manualClock.Increment(tc.Servers[0].RaftConfig().RangeLeaseDuration.Nanoseconds())
-			t.Logf("expired n%d lease", lease.Replica.ReplicaID)
+			t.Logf("expired first lease (n%d)", lease.Replica.ReplicaID) // always n3
 
 			requireRUEs(t, dbs)
 
@@ -971,7 +979,7 @@ func TestReplicaCircuitBreaker_Partial_Retry(t *testing.T) {
 			// because the leader's circuit breaker is tripped.
 			lease, _ = repl1.GetLease()
 			manualClock.Increment(tc.Servers[0].RaftConfig().RangeLeaseDuration.Nanoseconds())
-			t.Logf("expired n%d lease", lease.Replica.ReplicaID)
+			t.Logf("expired second lease (n%d)", lease.Replica.ReplicaID)
 
 			requireRUEs(t, dbs)
 
@@ -985,7 +993,7 @@ func TestReplicaCircuitBreaker_Partial_Retry(t *testing.T) {
 				}
 				return true
 			}, 10*time.Second, 100*time.Millisecond)
-			t.Logf("no raft leader")
+			t.Logf("expired raft leader")
 
 			requireRUEs(t, dbs)
 


### PR DESCRIPTION
Backport 3/3 commits from #156368 on behalf of @tbg.

----

Informs #156284.

Epic: none

----

Release justification: some logging + flaky test fix.