### PR TITLE
backup: add progress tracking to backup compactions.

### DIFF
--- a/pkg/backup/backupsink/sst_sink_key_writer.go
+++ b/pkg/backup/backupsink/sst_sink_key_writer.go
@@ -110,6 +110,11 @@ func (s *SSTSinkKeyWriter) WriteKey(ctx context.Context, key storage.MVCCKey, va
 	return nil
 }
 
+// CompletedSpan manually increments the underlying FileSSTSink completedSpans field.
+func (s *SSTSinkKeyWriter) CompletedSpan() {
+	s.completedSpans += 1
+}
+
 // AssumeNotMidRow marks the last key written as not mid-row. This exists to
 // ensure that the caller explicitly is aware that SSTSinkKeyWriter is unable
 // to determine if the last key written in a span is mid-row and must enforce

--- a/pkg/backup/compaction_job.go
+++ b/pkg/backup/compaction_job.go
@@ -829,14 +829,15 @@ func getBackupChain(
 	return manifests, localityInfo, baseEncryptionInfo, allIters, nil
 }
 
-// processProgress processes progress updates from the bulk processor for a backup and updates
+// checkpointLoop processes progress updates from the bulk processor for a backup and updates
 // the associated manifest.
-func processProgress(
+func checkpointLoop(
 	ctx context.Context,
 	execCtx sql.JobExecContext,
 	details jobspb.BackupDetails,
 	manifest *backuppb.BackupManifest,
 	progCh <-chan *execinfrapb.RemoteProducerMetadata_BulkProcessorProgress,
+	chunkFinishedCh chan<- struct{},
 	kmsEnv cloud.KMSEnv,
 ) error {
 	var lastCheckpointTime time.Time
@@ -851,6 +852,9 @@ func processProgress(
 		for _, file := range progDetails.Files {
 			manifest.Files = append(manifest.Files, file)
 			manifest.EntryCounts.Add(file.EntryCounts)
+		}
+		for range progDetails.CompletedSpans {
+			chunkFinishedCh <- struct{}{}
 		}
 
 		// TODO (kev-cao): Add per node progress updates.
@@ -903,7 +907,7 @@ func doCompaction(
 	defaultStore cloud.ExternalStorage,
 	kmsEnv cloud.KMSEnv,
 ) error {
-	plan, planCtx, err := createCompactionPlan(
+	compactionPlan, err := createCompactionPlan(
 		ctx, execCtx, jobID, details, compactChain, manifest, defaultStore, kmsEnv,
 	)
 	if err != nil {
@@ -913,15 +917,45 @@ func doCompaction(
 	progCh := make(chan *execinfrapb.RemoteProducerMetadata_BulkProcessorProgress)
 	runDistCompaction := func(ctx context.Context) error {
 		defer close(progCh)
-		return runCompactionPlan(ctx, execCtx, jobID, planCtx, plan, progCh)
+		return runCompactionPlan(
+			ctx, execCtx, jobID, compactionPlan, progCh,
+		)
 	}
+
+	var totalEntriesLeft int
+	for _, set := range compactionPlan.localitySets {
+		totalEntriesLeft += set.totalEntries
+	}
+	chunkFinishedCh := make(chan struct{}, totalEntriesLeft)
 	checkpointLoop := func(ctx context.Context) error {
-		return processProgress(ctx, execCtx, details, manifest, progCh, kmsEnv)
+		defer close(chunkFinishedCh)
+		return checkpointLoop(
+			ctx, execCtx, details, manifest, progCh, chunkFinishedCh, kmsEnv,
+		)
 	}
+
+	var frac float64
+	if err := execCtx.ExecCfg().InternalDB.Txn(ctx, func(ctx context.Context, t isql.Txn) error {
+		var err error
+		frac, _, _, err = jobs.ProgressStorage(jobID).Get(ctx, t)
+		return err
+	}); err != nil {
+		return err
+	}
+	if math.IsNaN(frac) {
+		frac = 0
+	}
+	logger := jobs.NewChunkProgressLoggerForJob(
+		jobID, execCtx.ExecCfg().InternalDB, totalEntriesLeft, frac,
+	)
+	progressLoop := func(ctx context.Context) error {
+		return logger.Loop(ctx, chunkFinishedCh)
+	}
+
 	// TODO (kev-cao): Add trace aggregator loop.
 
 	if err := ctxgroup.GoAndWait(
-		ctx, runDistCompaction, checkpointLoop,
+		ctx, runDistCompaction, checkpointLoop, progressLoop,
 	); err != nil {
 		return err
 	}

--- a/pkg/backup/compaction_processor.go
+++ b/pkg/backup/compaction_processor.go
@@ -479,6 +479,7 @@ func compactSpanEntry(
 		}
 	}
 	sink.AssumeNotMidRow()
+	sink.CompletedSpan()
 	return nil
 }
 

--- a/pkg/jobs/progress.go
+++ b/pkg/jobs/progress.go
@@ -54,6 +54,9 @@ type ChunkProgressLogger struct {
 	batcher ProgressUpdateBatcher
 }
 
+// NewChunkProgressLoggerForJob returns a ChunkProgressLogger which updates a job's
+// fraction_completed via ProgressStorage. expectedChunks is the expected number of chunks left
+// for this job, and fraction_completed is calculated based on this number and startFraction.
 func NewChunkProgressLoggerForJob(
 	jobID jobspb.JobID, db isql.DB, expectedChunks int, startFraction float64,
 ) *ChunkProgressLogger {
@@ -67,8 +70,8 @@ func NewChunkProgressLoggerForJob(
 	)
 }
 
-// DeprecatedProgressUpdateOnly is for use with NewChunkProgressLogger to just update job
-// progress fraction (ie. when a custom func with side-effects is not needed).
+// DeprecatedProgressUpdateOnly is for use with DeprecatedNewChunkProgressLoggerForJob to just
+// update job progress fraction (ie. when a custom func with side-effects is not needed).
 var DeprecatedProgressUpdateOnly func(context.Context, jobspb.ProgressDetails)
 
 func DeprecatedNewChunkProgressLoggerForJob(


### PR DESCRIPTION
Previously, backup compactions took checkpoints, but did not report progress updates for use in `SHOW JOBS`. This patch adds these progress updates.

Fixes: #159428

Release note: None