### PR TITLE
ui: fix custom time interval picker after antd upgrade

### DIFF
--- a/pkg/ui/pnpm-lock.yaml
+++ b/pkg/ui/pnpm-lock.yaml
@@ -149,8 +149,8 @@ importers:
         specifier: ~3.5.0
         version: 3.5.0(react-dom@16.12.0(react@16.12.0))(react@16.12.0)
       rc-picker:
-        specifier: 3.8.1
-        version: 3.8.1(dayjs@1.11.19)(luxon@3.5.0)(moment@2.29.4)(react-dom@16.12.0(react@16.12.0))(react@16.12.0)
+        specifier: 4.6.15
+        version: 4.6.15(dayjs@1.11.19)(luxon@3.5.0)(moment@2.29.4)(react-dom@16.12.0(react@16.12.0))(react@16.12.0)
       rc-progress:
         specifier: 2.5.3
         version: 2.5.3(react-dom@16.12.0(react@16.12.0))(react@16.12.0)
@@ -9671,26 +9671,6 @@ packages:
       react: 16.12.0
       react-dom: 16.12.0
 
-  rc-picker@3.8.1:
-    resolution: {integrity: sha512-Td63/F/V+36dXMEvjuqCNEahBR8S4yocgH7XXY+NrJh6+8dJM+X+5w0PgEjYo0LKkDvfGcu5CpdLG0gobnyLWA==}
-    engines: {node: '>=8.x'}
-    peerDependencies:
-      date-fns: '>= 2.x'
-      dayjs: '>= 1.x'
-      luxon: '>= 3.x'
-      moment: '>= 2.x'
-      react: 16.12.0
-      react-dom: 16.12.0
-    peerDependenciesMeta:
-      date-fns:
-        optional: true
-      dayjs:
-        optional: true
-      luxon:
-        optional: true
-      moment:
-        optional: true
-
   rc-picker@4.6.15:
     resolution: {integrity: sha512-OWZ1yrMie+KN2uEUfYCfS4b2Vu6RC1FWwNI0s+qypsc3wRt7g+peuZKVIzXCTaJwyyZruo80+akPg2+GmyiJjw==}
     engines: {node: '>=8.x'}
@@ -14860,7 +14840,7 @@ snapshots:
   '@emotion/babel-plugin@11.11.0':
     dependencies:
       '@babel/helper-module-imports': 7.22.5
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.28.6
       '@emotion/hash': 0.9.1
       '@emotion/memoize': 0.8.1
       '@emotion/serialize': 1.1.2
@@ -19729,7 +19709,7 @@ snapshots:
 
   downshift@6.1.12(react@16.12.0):
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.28.6
       compute-scroll-into-view: 1.0.20
       prop-types: 15.8.1
       react: 16.12.0
@@ -24682,19 +24662,6 @@ snapshots:
       react: 16.12.0
       react-dom: 16.12.0(react@16.12.0)
 
-  rc-picker@3.8.1(dayjs@1.11.19)(luxon@3.5.0)(moment@2.29.4)(react-dom@16.12.0(react@16.12.0))(react@16.12.0):
-    dependencies:
-      '@babel/runtime': 7.12.13
-      '@rc-component/trigger': 1.18.3(react-dom@16.12.0(react@16.12.0))(react@16.12.0)
-      classnames: 2.3.2
-      rc-util: 5.39.3(react-dom@16.12.0(react@16.12.0))(react@16.12.0)
-      react: 16.12.0
-      react-dom: 16.12.0(react@16.12.0)
-    optionalDependencies:
-      dayjs: 1.11.19
-      luxon: 3.5.0
-      moment: 2.29.4
-
   rc-picker@4.6.15(dayjs@1.11.19)(luxon@3.5.0)(moment@2.29.4)(react-dom@16.12.0(react@16.12.0))(react@16.12.0):
     dependencies:
       '@babel/runtime': 7.28.6
@@ -25205,7 +25172,7 @@ snapshots:
 
   react-textarea-autosize@8.5.2(@types/react@16.14.8)(react@16.12.0):
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.28.6
       react: 16.12.0
       use-composed-ref: 1.3.0(react@16.12.0)
       use-latest: 1.2.1(@types/react@16.14.8)(react@16.12.0)

--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -63,7 +63,7 @@
     "moment-timezone-data-webpack-plugin": "^1.5.1",
     "path-browserify": "^1.0.1",
     "protobufjs": "6.8.6",
-    "rc-picker": "3.8.1",
+    "rc-picker": "4.6.15",
     "rc-progress": "2.5.3",
     "react": ">=16.12.0",
     "react-dom": ">=16.12.0",

--- a/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/rangeSelector.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/rangeSelector.module.scss
@@ -40,6 +40,7 @@
     height: 100%;
     padding-top: 0;
     padding-bottom: 0;
+    justify-content: flex-start; // text-align no longer works with antd 5.18+
   }
 }
 
@@ -72,6 +73,7 @@
 
   ._time-button {
     text-align: left;
+    justify-content: flex-start; // text-align no longer works with antd 5.18+
     padding: 0;
     margin: 0;
 
@@ -112,6 +114,7 @@
 .Select {
   display: flex;
   justify-content: space-between;
+  width: 100%; // need space inside antd 5.18+ inline-flex button
   .Select-value-label {
     margin-right: 10px;
     font-family: $font-family--base;


### PR DESCRIPTION
The antd package upgrade caused two issues:
1. the "Custom timer interval" picker causes an error
3. the alignment of the time picker dropdown changed

The first was because antd 5.20 uses rc-picker 4.6, while we explicitly import rc-picker 3.8.
rc-picker had a breaking change from version 3 to 4 which is the reason for this failure.

The second was because antd 5.18+ defaulted to flex center.

This change resolves the first by explicitly updating rc-picker to 4.6 and fixing the type definition.
This change also fixes the second by explicitly aligning the necessary items.

Fixes: https://github.com/cockroachdb/cockroach/issues/161892

Epic: None
Release Note: None