### PR TITLE
sql/catalog: fallback to KV reads for inactive descriptors

### DIFF
--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -1370,7 +1370,8 @@ func (tc *Collection) aggregateAllLayers(
 	flags := defaultUnleasedFlags()
 	if getAllOptions.allowLeased {
 		flags.layerFilters.withoutLeased = false
-		flags.layerFilters.withAdding = true
+		flags.layerFilters.withAddingOrInactive = true
+		flags.descFilters.withAdding = true
 	}
 	if getAllOptions.withMetadata {
 		flags.layerFilters.withMetadata = true

--- a/pkg/sql/catalog/descs/getters.go
+++ b/pkg/sql/catalog/descs/getters.go
@@ -483,8 +483,10 @@ type layerFilters struct {
 	// This is always acquired for descriptors from storage, and may need an extra
 	// round trip.
 	withMetadata bool
-	// withAdding specifies that adding descriptors can be safely included.
-	withAdding bool
+	// withAddingOrInactive specifies that adding / inactive descriptors still
+	// need to be read. The leasing layer will return an error when these are
+	// encountered.
+	withAddingOrInactive bool
 }
 
 type descFilters struct {
@@ -504,6 +506,9 @@ type descFilters struct {
 	// be resolved at the current timestamp. This is to ensure caches
 	// are up to date.
 	withoutLockedTimestamp bool
+	// withAdding, specifies that adding descriptors should
+	// not be filtered.
+	withAdding bool
 }
 
 func defaultUnleasedFlags() (f getterFlags) {


### PR DESCRIPTION
Previously, descriptor GetAll functions used KV reads for individual descriptors, meaning that added, dropped, and offline descriptors were not excluded by default. When support was introduced to move these GetAll functions to use leased descriptors, we accidentally began blocking them whenever dropped or offline descriptors were encountered. While an earlier fix allowed added descriptors to be handled via a KV fallback, we now need to extend this support to include droppedand offline descriptors in the same manner.

Fixes: #159509
Informs: #161495

Release note (bug fix): Address an issue where information_schema and pg_catalog functions can intermittently fail on dropped or offline descriptors.