### PR TITLE
release-25.2: sql: TestRelocateNonVoters clean up learners before disabling all queues

### DIFF
--- a/pkg/sql/multitenant_admin_function_test.go
+++ b/pkg/sql/multitenant_admin_function_test.go
@@ -932,6 +932,27 @@ func TestRelocateNonVoters(t *testing.T) {
 					require.NoErrorf(t, err, message)
 					err = testCluster.WaitForFullReplication()
 					require.NoErrorf(t, err, message)
+					testutils.SucceedsSoon(t, func() error {
+						// Check for learners before disabling the replicate queues to
+						// allow cleanup of learners
+						rows, err := db.QueryContext(ctx,
+							`SELECT learner_replicas FROM [SHOW RANGES FROM INDEX t@primary WITH DETAILS]`)
+						if err != nil {
+							return err
+						}
+						defer rows.Close()
+						if rows.Next() {
+							var learners string
+							err = rows.Scan(&learners)
+							if err != nil {
+								return err
+							}
+							if learners != "{}" && learners != "" {
+								return errors.Newf("waiting for LEARNER replicas: %s", learners)
+							}
+						}
+						return nil
+					})
 					testCluster.ToggleLeaseQueues(false)
 					testCluster.ToggleReplicateQueues(false)
 					testCluster.ToggleSplitQueues(false)


### PR DESCRIPTION
Backport 1/1 commits from #162342 on behalf of @shghasemi.

----

There are a couple of ways a learner can be left behind before this test disables all queues. Previously, the test would disable all queues without checking on the learners. This changes, allows for the test to wait for learners to be cleaned up.

Fixes: #161363

Release note: None

----

Release justification: test-only change.