### PR TITLE
roachtest: add missing decimal array handling in float comparison

### DIFF
--- a/pkg/cmd/roachtest/tests/query_comparison_util.go
+++ b/pkg/cmd/roachtest/tests/query_comparison_util.go
@@ -768,6 +768,8 @@ func unsortedMatricesDiffWithFloatComp(
 					cmpFn = floatcmp.FloatArraysMatchApprox
 				case runtime.GOARCH == "s390x" && !isFloatOrDecimalArray:
 					cmpFn = floatcmp.FloatsMatchApprox
+				case isDecimalArray(colType):
+					cmpFn = floatcmp.FloatArraysMatch
 				case isFloatArray(colType):
 					cmpFn = floatcmp.FloatArraysMatchApprox
 				case isFloat(colType):


### PR DESCRIPTION
The previous commit omitted a case for decimal array types in the type switch. This adds handling for decimal arrays using FloatArraysMatch, consistent with the non-array decimal type handling.

Informs #150902

Release note: none

Epic: None