### PR TITLE
rpc: add protocol label to rpc peer and request metrics

### DIFF
--- a/pkg/rpc/drpc.go
+++ b/pkg/rpc/drpc.go
@@ -392,7 +392,7 @@ func (srv *drpcOffServer) Register(interface{}, drpc.Description) error {
 func newDRPCPeerOptions(
 	rpcCtx *Context, k peerKey, locality roachpb.Locality,
 ) *peerOptions[drpc.Conn] {
-	pm, _ := rpcCtx.metrics.acquire(k, locality)
+	pm, _ := rpcCtx.metrics.acquire(k, locality, rpcProtocolDRPC)
 	return &peerOptions[drpc.Conn]{
 		locality: locality,
 		peers:    &rpcCtx.drpcPeers,

--- a/pkg/rpc/grpc.go
+++ b/pkg/rpc/grpc.go
@@ -57,7 +57,7 @@ type GRPCConnection = Connection[*grpc.ClientConn]
 func newGRPCPeerOptions(
 	rpcCtx *Context, k peerKey, locality roachpb.Locality,
 ) *peerOptions[*grpc.ClientConn] {
-	pm, lm := rpcCtx.metrics.acquire(k, locality)
+	pm, lm := rpcCtx.metrics.acquire(k, locality, rpcProtocolGRPC)
 	return &peerOptions[*grpc.ClientConn]{
 		locality: locality,
 		peers:    &rpcCtx.peers,

--- a/pkg/rpc/metrics_test.go
+++ b/pkg/rpc/metrics_test.go
@@ -71,26 +71,31 @@ func TestMetricsRelease(t *testing.T) {
 	// added/deleted).
 	require.Equal(t, expectedCount, verifyAllFields(m, 0))
 	// Verify that a new peer's metrics all get registered.
-	pm, lm := m.acquire(k1, l1)
+	pm, lm := m.acquire(k1, l1, rpcProtocolGRPC)
 	require.Equal(t, expectedCount, verifyAllFields(m, 1))
 	// Acquire the same peer. The count remains at 1.
-	pm2, lm2 := m.acquire(k1, l1)
+	pm2, lm2 := m.acquire(k1, l1, rpcProtocolGRPC)
 	require.Equal(t, expectedCount, verifyAllFields(m, 1))
 	require.Equal(t, pm, pm2)
 	require.Equal(t, lm, lm2)
 
 	// Acquire a different peer but the same locality.
-	pm3, lm3 := m.acquire(k2, l1)
+	pm3, lm3 := m.acquire(k2, l1, rpcProtocolGRPC)
 	require.NotEqual(t, pm, pm3)
 	require.Equal(t, lm, lm3)
 
 	// Acquire a different locality but the same peer.
-	pm4, lm4 := m.acquire(k1, l2)
+	pm4, lm4 := m.acquire(k1, l2, rpcProtocolGRPC)
 	require.Equal(t, pm, pm4)
 	require.NotEqual(t, lm, lm4)
 
 	// We added one extra peer and one extra locality, verify counts.
 	require.Equal(t, expectedCount, verifyAllFields(m, 2))
+
+	// Acquire the same peer and locality with drpc protocol
+	pm5, lm5 := m.acquire(k1, l1, rpcProtocolDRPC)
+	require.NotEqual(t, pm, pm5)
+	require.Equal(t, lm, lm5)
 }
 
 func TestServerRequestInstrumentInterceptor(t *testing.T) {
@@ -105,39 +110,42 @@ func TestServerRequestInstrumentInterceptor(t *testing.T) {
 	testcase := []struct {
 		methodName   string
 		statusCode   codes.Code
+		rpcProtocol  string
 		shouldRecord bool
 	}{
-		{"rpc/test/method", codes.OK, true},
-		{"rpc/test/method", codes.Internal, true},
-		{"rpc/test/method", codes.Aborted, true},
-		{"rpc/test/notRecorded", codes.OK, false},
+		{"rpc/test/method", codes.OK, rpcProtocolGRPC, true},
+		{"rpc/test/method", codes.Internal, rpcProtocolGRPC, true},
+		{"rpc/test/method", codes.Aborted, rpcProtocolGRPC, true},
+		{"rpc/test/notRecorded", codes.OK, rpcProtocolGRPC, false},
 	}
 
 	for _, tc := range testcase {
-		t.Run(fmt.Sprintf("%s %s", tc.methodName, tc.statusCode), func(t *testing.T) {
-			info := &grpc.UnaryServerInfo{FullMethod: tc.methodName}
-			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-				if tc.statusCode == codes.OK {
-					time.Sleep(time.Millisecond)
-					return struct{}{}, nil
+		t.Run(fmt.Sprintf("%s %s %s", tc.methodName, tc.statusCode, tc.rpcProtocol),
+			func(t *testing.T) {
+				info := &grpc.UnaryServerInfo{FullMethod: tc.methodName}
+				handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+					if tc.statusCode == codes.OK {
+						time.Sleep(time.Millisecond)
+						return struct{}{}, nil
+					}
+					return nil, status.Error(tc.statusCode, tc.statusCode.String())
 				}
-				return nil, status.Error(tc.statusCode, tc.statusCode.String())
-			}
-			interceptor := NewRequestMetricsInterceptor(requestMetrics, func(fullMethodName string) bool {
-				return tc.shouldRecord
+				interceptor := NewRequestMetricsInterceptor(requestMetrics, func(fullMethodName string) bool {
+					return tc.shouldRecord
+				})
+				_, err := interceptor(ctx, req, info, handler)
+				if err != nil {
+					require.Equal(t, tc.statusCode, status.Code(err))
+				}
+				var expectedCount uint64
+				if tc.shouldRecord {
+					expectedCount = 1
+				}
+				assertRpcMetrics(t, requestMetrics.Duration.ToPrometheusMetrics(), map[string]uint64{
+					fmt.Sprintf("%s %s %s", tc.methodName, tc.statusCode,
+						tc.rpcProtocol): expectedCount,
+				})
 			})
-			_, err := interceptor(ctx, req, info, handler)
-			if err != nil {
-				require.Equal(t, tc.statusCode, status.Code(err))
-			}
-			var expectedCount uint64
-			if tc.shouldRecord {
-				expectedCount = 1
-			}
-			assertRpcMetrics(t, requestMetrics.Duration.ToPrometheusMetrics(), map[string]uint64{
-				fmt.Sprintf("%s %s", tc.methodName, tc.statusCode): expectedCount,
-			})
-		})
 	}
 }
 
@@ -215,18 +223,20 @@ func assertRpcMetrics(
 	t.Helper()
 	actual := map[string]*io_prometheus_client.Histogram{}
 	for _, m := range metrics {
-		var method, statusCode string
+		var method, statusCode, protocol string
 		for _, l := range m.Label {
 			switch *l.Name {
 			case RpcMethodLabel:
 				method = *l.Value
 			case RpcStatusCodeLabel:
 				statusCode = *l.Value
+			case RpcProtocolLabel:
+				protocol = *l.Value
 			}
 		}
 		histogram := m.Histogram
 		require.NotNil(t, histogram, "expected histogram")
-		key := fmt.Sprintf("%s %s", method, statusCode)
+		key := fmt.Sprintf("%s %s %s", method, statusCode, protocol)
 		actual[key] = histogram
 	}
 


### PR DESCRIPTION
This PR adds a new label `protocol` to peer metrics, where applicable and to rpc request metrics that are populated by grpc and drpc interceptors. This will enable us to provide non-disruptive observability to customers for these metrics during gRPC to DRPC migration. 
During the migration period, when a cluster is expected to have a mix of grpc and drpc traffic, existing customer dashboards and alerts that use these metrics will show an aggregate of grpc and drpc traffic. Customers can drill-down by the `protocol` label, to see the split. 
For more details, refer to: [DRPC migration: Changes to Essential RPC metrics](https://docs.google.com/document/d/1yhis6bKbYyh3Wwi8FZeqXgvIt9KJn7CCkDaCFQSn8kg/edit?tab=t.0) 

Epic: CRDB-48931
Fixes: #162513
Release note: With this change, customers of self-hosted cockroach clusters will see a new label "protocol" with the value "grpc" against child metrics of the following essential rpc metrics. 

```
rpc.connection.avg_round_trip_latency
rpc.connection.failures
rpc.connection.healthy
rpc.connection.healthy_nanos
rpc.connection.heartbeats
rpc.connection.tcp_rtt
rpc.connection.tcp_rtt_var
rpc.connection.unhealthy
rpc.connection.unhealthy_nanos
rpc.connection.inactive
```

Example:
`rpc_connection_healthy{node_id="1",remote_node_id="0",remote_addr="localhost:26258",class="system",protocol="grpc"} 1
`

---

Testing:
Tested on a local cockroach demo setup with 3 nodes. Screenshot below:

<img width="1080" height="152" alt="Screenshot 2026-02-09 at 6 22 19 PM" src="https://github.com/user-attachments/assets/a34a48c9-b50a-4c3b-9d6b-1537a4ebac58" />
