### PR TITLE
release-25.4: kvserver: deflake TestClosedTimestampFrozenAfterSubsumption

### DIFF
--- a/pkg/kv/kvserver/closed_timestamp_test.go
+++ b/pkg/kv/kvserver/closed_timestamp_test.go
@@ -733,13 +733,13 @@ func TestClosedTimestampFrozenAfterSubsumption(t *testing.T) {
 			//
 			// NB: We want to ensure that the closed timestamp on the LHS is less than
 			// the lease start time for the RHS after the lease transfer. To ensure
-			// this holds and doesn't flake, we increase the target duration to 10
+			// this holds and doesn't flake, we increase the target duration to 30
 			// seconds.
 			tc, _, _ := setupClusterForClosedTSTesting(ctx, t, 5*time.Second, 100*time.Millisecond, clusterArgs, "cttest", "kv")
 			defer tc.Stopper().Stop(ctx)
 			sqlDB := sqlutils.MakeSQLRunner(tc.ServerConn(0))
 			sqlDB.ExecMultiple(t, strings.Split(`
-SET CLUSTER SETTING kv.closed_timestamp.target_duration = '10s';
+SET CLUSTER SETTING kv.closed_timestamp.target_duration = '30s';
 SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '100ms';
 SET CLUSTER SETTING kv.rangefeed.closed_timestamp_refresh_interval = '100ms';
 SET CLUSTER SETTING kv.closed_timestamp.follower_reads.enabled = true;


### PR DESCRIPTION
Backport 1/1 commits from #161805 on behalf of @stevendanna.

----

This test depends on the closed timestamp not having advanced past the merge timestamp by the time of a post-merge write. The only thing making this true is that we set the target duration to a high value.

We've seen this failing recently because that high value was not high enough. In this PR, we move the target duration from 10s to 30s.

It's an open question about why this is failing more often recently.

Fixes #160181

Release note: None

----

Release justification: Test only change