### PR TITLE
sql: inspect import use synthetic descriptor

### DIFF
--- a/pkg/jobs/jobstest/logutils.go
+++ b/pkg/jobs/jobstest/logutils.go
@@ -67,7 +67,7 @@ func CheckEmittedEvents(
 				require.Equal(t, expectedJobType, ev.JobType)
 				require.Equal(t, jobID, ev.JobID)
 				if matchingEntryIndex >= len(expectedStatus) {
-					return errors.New("more events fround in log than expected")
+					return errors.New("more events found in log than expected")
 				}
 				require.Equal(t, expectedStatus[matchingEntryIndex], ev.Status)
 				matchingEntryIndex++

--- a/pkg/sql/importer/BUILD.bazel
+++ b/pkg/sql/importer/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
         "//pkg/jobs/joberror",
         "//pkg/jobs/jobspb",
         "//pkg/jobs/jobsprofiler",
+        "//pkg/keys",
         "//pkg/kv",
         "//pkg/kv/bulk",
         "//pkg/kv/kvpb",

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -12,6 +12,7 @@ import (
 	"math"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/ingeststopped"
 	"github.com/cockroachdb/cockroach/pkg/jobs/joberror"
@@ -368,15 +369,14 @@ func (r *importResumer) Resume(ctx context.Context, execCtx interface{}) error {
 			}
 			tableName = tblDesc.GetName()
 
-			// TODO(bghal): Get the initial row count so it can be included in the expected.
-			if !details.Table.WasEmpty {
-				log.Eventf(ctx, "skipping row count check on table %q: non-empty tables are not supported", tableName)
+			if creationVersion := r.job.Payload().CreationClusterVersion; !details.Table.WasEmpty && creationVersion.Less(clusterversion.V26_2.Version()) {
+				log.Eventf(ctx, "skipping row count on table %q: the table was not empty and the job was started in an unsupported version", tableName)
 
 				checks, err = inspect.ChecksForTable(ctx, nil /* p */, tblDesc, nil /* expectedRowCount */)
 				return err
 			}
 
-			expectedRowCount := uint64(r.res.Rows)
+			expectedRowCount := uint64(r.res.Rows) + table.InitialRowCount
 			checks, err = inspect.ChecksForTable(ctx, nil /* p */, tblDesc, &expectedRowCount)
 			return err
 		}); err != nil {

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -367,6 +367,15 @@ func (r *importResumer) Resume(ctx context.Context, execCtx interface{}) error {
 				return err
 			}
 			tableName = tblDesc.GetName()
+
+			// TODO(bghal): Get the initial row count so it can be included in the expected.
+			if !details.Table.WasEmpty {
+				log.Eventf(ctx, "skipping row count check on table %q: non-empty tables are not supported", tableName)
+
+				checks, err = inspect.ChecksForTable(ctx, nil /* p */, tblDesc, nil /* expectedRowCount */)
+				return err
+			}
+
 			expectedRowCount := uint64(r.res.Rows)
 			checks, err = inspect.ChecksForTable(ctx, nil /* p */, tblDesc, &expectedRowCount)
 			return err

--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -5397,7 +5397,11 @@ func TestImportJobEventLogging(t *testing.T) {
 	sqlDB.QueryRow(t, importQuery, simpleOcf).Scan(&jobID, &unused, &unused, &unused, &unused,
 		&unused)
 
-	expectedStatus := []string{string(jobs.StateSucceeded), string(jobs.StateRunning)}
+	expectedStatus := []string{
+		string(jobs.StateSucceeded),
+		string(jobs.StateRunning), // after row count check
+		string(jobs.StateRunning), // after prepare
+	}
 	expectedRecoveryEvent := eventpb.RecoveryEvent{
 		RecoveryType: importJobRecoveryEventType,
 		NumRows:      int64(1000),
@@ -5416,8 +5420,10 @@ func TestImportJobEventLogging(t *testing.T) {
 	row.Scan(&jobID)
 
 	expectedStatus = []string{
-		string(jobs.StateFailed), string(jobs.StateReverting),
-		string(jobs.StateRunning),
+		string(jobs.StateFailed),
+		string(jobs.StateReverting),
+		string(jobs.StateRunning), // after row count check
+		string(jobs.StateRunning), // after prepare
 	}
 	expectedRecoveryEvent = eventpb.RecoveryEvent{
 		RecoveryType: importJobRecoveryEventType,

--- a/pkg/sql/inspect/inspect_job_entry.go
+++ b/pkg/sql/inspect/inspect_job_entry.go
@@ -136,27 +136,11 @@ func ChecksForTable(
 	}
 
 	if expectedRowCount != nil {
-		var includesRowCounterCheck bool
-		for _, check := range checks {
-			switch check.Type {
-			case jobspb.InspectCheckIndexConsistency:
-				includesRowCounterCheck = true
-			}
-		}
-
-		// If none of the previous checks provide a row count, skip the check.
-		if includesRowCounterCheck {
-			checks = append(checks, &jobspb.InspectDetails_Check{
-				Type:     jobspb.InspectCheckRowCount,
-				TableID:  table.GetID(),
-				RowCount: *expectedRowCount,
-			})
-		} else {
-			if p != nil {
-				p.BufferClientNotice(ctx, pgnotice.Newf(
-					"skipping row count on table %q: no other checks provide a row count", table.GetName()))
-			}
-		}
+		checks = append(checks, &jobspb.InspectDetails_Check{
+			Type:     jobspb.InspectCheckRowCount,
+			TableID:  table.GetID(),
+			RowCount: *expectedRowCount,
+		})
 	}
 
 	return checks, nil

--- a/pkg/sql/inspect/row_count_check.go
+++ b/pkg/sql/inspect/row_count_check.go
@@ -7,14 +7,18 @@ package inspect
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/inspect/inspectpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
@@ -28,7 +32,7 @@ type inspectCheckRowCount interface {
 }
 
 // rowCountCheck verifies a table's row count matches the expected count.
-// It relies on other jobs to perform the row count.
+// It uses row counts exposed by other checks when possible.
 type rowCountCheck struct {
 	rowCountCheckApplicability
 
@@ -119,6 +123,7 @@ func (c *rowCountCheck) CheckSpan(
 	logger *inspectLoggerBundle,
 	data *inspectpb.InspectProcessorSpanCheckData,
 ) error {
+	// Find the row count among the registered checks.
 	for _, check := range checks {
 		// TODO(#160989): Handle inconsistency btwn checks on the same span.
 		if check, ok := check.(inspectCheckRowCount); ok {
@@ -127,7 +132,33 @@ func (c *rowCountCheck) CheckSpan(
 		}
 	}
 
-	return errors.AssertionFailedf("rowCountCheck requires an inspectCheckRowCount to be registered")
+	// If none of the checks provide a row count, do the count on the primary index.
+	tableDesc, err := loadTableDesc(ctx, c.execCfg, c.tableID, c.tableVersion, c.asOf)
+	if err != nil {
+		return err
+	}
+	c.tableDesc = tableDesc
+
+	predicate, queryArgs, err := getPredicateAndQueryArgs(
+		ctx,
+		&c.execCfg.DistSQLSrv.ServerConfig,
+		span,
+		c.tableDesc,
+		c.tableDesc.GetPrimaryIndex(),
+		c.asOf,
+		c.tableDesc.TableDesc().PrimaryIndex.KeyColumnNames,
+	)
+	if err != nil {
+		return err
+	}
+
+	rowCount, err := c.computeRowCount(ctx, predicate, queryArgs)
+	if err != nil {
+		return err
+	}
+	data.SpanRowCount = uint64(rowCount)
+
+	return nil
 }
 
 // StartedCluster implements the inspectClusterCheck interface.
@@ -185,4 +216,46 @@ func (c *rowCountCheck) DoneCluster(ctx context.Context) bool {
 // CloseCluster implements the inspectClusterCheck interface.
 func (c *rowCountCheck) CloseCluster(ctx context.Context) error {
 	return nil
+}
+
+// computeRowCount executes a row count query for the primary index and returns
+// the row count.
+func (c *rowCountCheck) computeRowCount(
+	ctx context.Context, predicate string, queryArgs []interface{},
+) (int64, error) {
+	query := c.buildRowCountQuery(c.tableDesc.GetID(), c.tableDesc.GetPrimaryIndex(), predicate)
+	queryWithAsOf := fmt.Sprintf("SELECT * FROM (%s) AS OF SYSTEM TIME %s", query, c.asOf.AsOfSystemTime())
+
+	qos := getInspectQoS(&c.execCfg.Settings.SV)
+	row, err := c.execCfg.DistSQLSrv.DB.Executor().QueryRowEx(
+		ctx, "inspect-row-count", nil, /* txn */
+		sessiondata.InternalExecutorOverride{
+			User:             username.NodeUserName(),
+			QualityOfService: &qos,
+		},
+		queryWithAsOf,
+		queryArgs...,
+	)
+	if err != nil {
+		return 0, err
+	}
+	if len(row) != 1 {
+		return 0, errors.AssertionFailedf("row count query returned unexpected column count: %d", len(row))
+	}
+	return int64(tree.MustBeDInt(row[0])), nil
+}
+
+// buildRowCountQuery constructs a query that computes row count for the specified index.
+func (c *rowCountCheck) buildRowCountQuery(
+	tableID descpb.ID, index catalog.Index, predicate string,
+) string {
+	whereClause := buildWhereClause(predicate, nil /* nullFilters */)
+	return fmt.Sprintf(`
+SELECT
+  count(*) AS row_count
+FROM [%d AS t]@{FORCE_INDEX=[%d]}%s`,
+		tableID,
+		index.GetID(),
+		whereClause,
+	)
 }

--- a/pkg/sql/logictest/testdata/logic_test/import
+++ b/pkg/sql/logictest/testdata/logic_test/import
@@ -1,0 +1,41 @@
+# LogicTest: local
+
+subtest import_into_non_empty_table
+
+statement ok
+CREATE DATABASE d
+
+statement ok
+CREATE TABLE d.t_for_import(
+  i INT PRIMARY KEY,
+  a INT NULL,
+  FAMILY f0 (i),
+  FAMILY f1 (a)
+)
+
+statement ok
+INSERT INTO d.t_for_import (i, a) VALUES (1, 100)
+
+statement ok
+INSERT INTO d.t_for_import (i, a)
+SELECT i, CASE WHEN i % 3 = 0 THEN NULL ELSE i * 10 END
+FROM generate_series(4, 22000) AS i;
+
+let $exp_file
+WITH cte AS (EXPORT INTO CSV 'nodelocal://1/import_test_data' WITH nullas = '' FROM SELECT 2 AS i, 200 AS a UNION ALL SELECT 3, NULL) SELECT filename FROM cte;
+
+statement ok
+IMPORT INTO d.t_for_import (i, a) CSV DATA ('nodelocal://1/import_test_data/$exp_file')
+
+query I rowsort
+SELECT count(*) FROM d.t_for_import
+----
+22000
+
+statement ok
+DROP TABLE d.t_for_import
+
+statement ok
+DROP DATABASE d
+
+subtest end

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -1137,6 +1137,13 @@ func TestLogic_hidden_columns(
 	runLogicTest(t, "hidden_columns")
 }
 
+func TestLogic_import(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "import")
+}
+
 func TestLogic_impure(
 	t *testing.T,
 ) {


### PR DESCRIPTION
### Draft WIP

Using the SQL interface is cleaner than the KV scan.

Epic: CRDB-58692

Part of: #161276
Part of: #155472
Part of: #161279

Release note: None