### PR TITLE
release-24.3: logictest: skip `optimizer_timeout` under race

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/optimizer_timeout
+++ b/pkg/sql/logictest/testdata/logic_test/optimizer_timeout
@@ -1,3 +1,5 @@
+skip under race
+
 statement ok
 CREATE TABLE table1
 (


### PR DESCRIPTION
Backport 1/1 commits from #162475 on behalf of @yuzefovich.

----

Backport 1/1 commits from #162363.

/cc @cockroachdb/release

---

We've seen 3 failures on this test under race where `RESET statement_timeout` failed due to 0.1 stmt timeout. I don't think we're getting any value from running this test under race, so let's just skip it.

Fixes: #162089.
Release note: None

Release justification: test-only change.