### PR TITLE
release-25.2: revert: deflake TestRevertSpansFanout under race

### DIFF
--- a/pkg/revert/BUILD.bazel
+++ b/pkg/revert/BUILD.bazel
@@ -65,6 +65,7 @@ go_test(
         "//pkg/sql/sem/catid",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/hlc",

--- a/pkg/revert/revert_test.go
+++ b/pkg/revert/revert_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -38,6 +39,8 @@ import (
 func TestRevertSpansFanout(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	skip.UnderRace(t, "takes too long under race")
 
 	ctx := context.Background()
 


### PR DESCRIPTION
Backport 1/1 commits from #162474 on behalf of @kev-cao.

----

This test spins up a multi-node cluster, which is flaky when under race.

Fixes: #162132

Fixes: #162193

Fixes: #161164

Release note: None

----

Release justification: Test-only change.