### PR TITLE
backup: deflake backupFixture/tpcc/warehouses=5000/incrementals=48 roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_fixtures.go
+++ b/pkg/cmd/roachtest/tests/backup_fixtures.go
@@ -611,9 +611,9 @@ func registerBackupFixtures(r registry.Registry) {
 			hardware: makeHardwareSpecs(hardwareSpecs{
 				workloadNode: true,
 			}),
-			// Fingerprinting is measured to take about 40 minutes on a 350 GB
-			// fixture on top of the allocated 2 hours for the test.
-			timeout: 3 * time.Hour,
+			// Fingerprinting is measured to take about 40 minutes, and occasionally longer than an hour,
+			// on a 350 GB fixture on top of the allocated 2 hours for the test.
+			timeout: 4 * time.Hour,
 			suites:  registry.Suites(registry.Nightly),
 			clouds:  []spec.Cloud{spec.AWS, spec.Azure, spec.GCE},
 		},


### PR DESCRIPTION
Previously, the timeout for this test was 3 hours, allocating 2 hours for the test itself, and additional time for fingerprinting. Fingerprinting has occasionally taken longer than an hour, leading to test flakes. This patch bumps the timeout to 4 hours.

Fixes: #162082

Release note: None