### PR TITLE
mmaprototype: add more MMA related metrics

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -15554,6 +15554,62 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NONE
+    - name: mma.store.cpu.capacity
+      exported_name: mma_store_cpu_capacity
+      description: Logical CPU capacity estimated by MMA by extrapolating from the current load and system CPU utilization after accounting for CPU load that MMA cannot account for that scales with KV work (RPC, DistSender, etc.) and load that doesn't (SQL).
+      y_axis_label: Nanoseconds/Sec
+      type: GAUGE
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+    - name: mma.store.cpu.load
+      exported_name: mma_store_cpu_load
+      description: CPU load that is attributed to the replicas on this store. This includes reads (for leaseholder) and raft. Since CPU is shared across stores on a node, we approximate this by measuring the CPU usage on the node and then dividing this equally among all stores on the node.
+      y_axis_label: Nanoseconds/Sec
+      type: GAUGE
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+    - name: mma.store.cpu.utilization
+      exported_name: mma_store_cpu_utilization
+      description: Ratio of logical CPU load to capacity expressed as a percentage
+      y_axis_label: CPU Utilization
+      type: GAUGE
+      unit: PERCENT
+      aggregation: AVG
+      derivative: NONE
+    - name: mma.store.disk.capacity
+      exported_name: mma_store_disk_capacity
+      description: Logical disk capacity estimated by MMA by extrapolating from the logical bytes consumed by the replicas and the current used and free physical disk bytes.
+      y_axis_label: Bytes
+      type: GAUGE
+      unit: BYTES
+      aggregation: AVG
+      derivative: NONE
+    - name: mma.store.disk.logical
+      exported_name: mma_store_disk_logical
+      description: Logical bytes consumed by the replicas on this store as reported by MVCC statistics without accounting for any space amplification or compression.
+      y_axis_label: Bytes
+      type: GAUGE
+      unit: BYTES
+      aggregation: AVG
+      derivative: NONE
+    - name: mma.store.disk.utilization
+      exported_name: mma_store_disk_utilization
+      description: Ratio of logical disk usage to capacity expressed as a percentage
+      y_axis_label: Disk Utilization
+      type: GAUGE
+      unit: PERCENT
+      aggregation: AVG
+      derivative: NONE
+    - name: mma.store.write.bandwidth
+      exported_name: mma_store_write_bandwidth
+      description: Disk write bandwidth as observed by MMA corresponding to the store
+      y_axis_label: Bytes/Sec
+      type: GAUGE
+      unit: BYTES
+      aggregation: AVG
+      derivative: NONE
     - name: node-id
       exported_name: node_id
       description: node ID with labels for advertised RPC and HTTP addresses

--- a/pkg/kv/kvserver/allocator/mmaprototype/BUILD.bazel
+++ b/pkg/kv/kvserver/allocator/mmaprototype/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//pkg/util/metric",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
+        "@com_github_cockroachdb_crlib//crstrings",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_cockroachdb_redact//:redact",

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_test.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_test.go
@@ -543,7 +543,7 @@ func TestClusterState(t *testing.T) {
 					// Consider making it relative to ts.
 					for line := range strings.Lines(d.Input) {
 						msg := parseStoreLoadMsg(t, line)
-						cs.processStoreLoadMsg(context.Background(), &msg)
+						cs.processStoreLoadMsg(context.Background(), &msg, nil)
 					}
 					return ""
 

--- a/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
+++ b/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
@@ -1778,6 +1778,13 @@ mma_overloaded_store_short_dur_failure: mma.overloaded_store.short_dur.failure
 mma_overloaded_store_short_dur_success: mma.overloaded_store.short_dur.success
 mma_span_config_normalization_error: mma.span_config.normalization.error
 mma_span_config_normalization_soft_error: mma.span_config.normalization.soft_error
+mma_store_cpu_capacity: mma.store.cpu.capacity
+mma_store_cpu_load: mma.store.cpu.load
+mma_store_cpu_utilization: mma.store.cpu.utilization
+mma_store_disk_capacity: mma.store.disk.capacity
+mma_store_disk_logical: mma.store.disk.logical
+mma_store_disk_utilization: mma.store.disk.utilization
+mma_store_write_bandwidth: mma.store.write.bandwidth
 node_id: node_id
 obs_tablemetadata_update_job_duration: obs.tablemetadata.update_job.duration
 obs_tablemetadata_update_job_duration_bucket: obs.tablemetadata.update_job.duration.bucket


### PR DESCRIPTION
Add load and capacity related metrics to observe exactly what MMA sees instead of having to perform backwards calculations from raw data.

Fixes: #158681
Epic: CRDB-56265
Release note: None