### PR TITLE
release-24.3: kv: deflake TestReplicaCircuitBreaker_Partial_Retry

### DIFF
--- a/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
+++ b/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
@@ -887,9 +887,16 @@ func TestReplicaCircuitBreaker_Partial_Retry(t *testing.T) {
 	var leader raftpb.PeerID
 	require.Eventually(t, func() bool {
 		for _, repl := range repls {
-			if l := repl.RaftStatus().Lead; l == 3 {
+			l := repl.RaftStatus().Lead
+			if l == 3 {
 				return false
-			} else if l > 0 {
+			}
+			if repl.ReplicaID() != 3 && l == 0 {
+				// The old leader (3) steps down because of check quorum. A new leader
+				// should be elected amongst 1 and 2, and both of them should know who
+				// that is before we proceed with the test.
+				return false
+			} else if repl.ReplicaID() != 3 {
 				leader = l
 			}
 		}


### PR DESCRIPTION
Backport 1/1 commits from #134120 on behalf of @arulajmani.

----

The test expects a new leader to be elected, so that when we try a different replica upon receiving a RUE we're able to serve the request. The test was incorrectly assuming that this was the case, as evidenced by these log lines:

```
    client_replica_circuit_breaker_test.go:851: writes failed with ReplicaUnavailableError
    client_replica_circuit_breaker_test.go:868: raft leadership moved to n0
```

Fixes https://github.com/cockroachdb/cockroach/issues/133818

Release note: None

----

Release justification: test-only deflake.