### PR TITLE
release-25.2.12-rc: pkg/cli: fix flaky TestZipIncludeAndExcludeFilesDataDriven test

### DIFF
--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -1432,6 +1432,12 @@ func trimNonDeterministicZipOutputFiles(out string) string {
 	out = re.ReplaceAllString(out, ``)
 	re = regexp.MustCompile(`(?m).*goroutine_dump.*\.txt\.gz$` + "\n")
 	out = re.ReplaceAllString(out, ``)
+	// CPU profiles are non-deterministic: stored profiles have timestamps in
+	// filenames, and live profile collection may fail producing error files.
+	re = regexp.MustCompile(`(?m).*cpuprof/cpuprof\..*\.pprof$` + "\n")
+	out = re.ReplaceAllString(out, ``)
+	re = regexp.MustCompile(`(?m).*cpu\.pprof\.err\.txt$` + "\n")
+	out = re.ReplaceAllString(out, ``)
 	return out
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #162526.

/cc @cockroachdb/release

---

The test was failing because the debug zip output now includes 
non-deterministic CPU profile files that weren't being filtered. 
Stored CPU profiles in the cpuprof/ directory have timestamped names 
like cpuprof.2026-01-27T08_53_56.910.67.pprof, and error files like 
cpu.pprof.err.txt are created when live CPU profiling fails during 
test execution.

The debug zip has two mechanisms for collecting CPU profiles. Live 
CPU profiles are collected via collectCPUProfiles and stored as 
cpu.pprof. Stored CPU profiles are collected via collectFileList 
with FileType_CPU from the cpuprof/ directory.

This fix adds regex patterns to trimNonDeterministicZipOutputFiles 
to filter out these files, similar to how other non-deterministic 
outputs like memprof, goroutine_dump, and job-related files are 
already handled.

Fixes: #161849
Part of: CRDB-59115
Epic: none
Release note: none

Release justification: fixing flaky test of TestZipIncludeAndExcludeFilesDataDriven
