### PR TITLE
rpc: add SAN-based authentication for root and node users

### DIFF
--- a/pkg/rpc/auth.go
+++ b/pkg/rpc/auth.go
@@ -398,41 +398,96 @@ func (a kvAuth) authenticateNetworkRequest(ctx context.Context) (authnResult, er
 	}
 
 	// We are using TLS, but the peer is not using a client tenant cert.
-	// In that case, we only allow RPCs if the principal is 'node' or
-	// 'root' and the tenant scope in the cert matches this server
-	// (either the cert has scope "global" or its scope tenant ID
-	// matches our own). The client could also present a certificate with subject
-	// DN equalling rootSubject or nodeSubject set using
-	// root-cert-distinguished-name and node-cert-distinguished-name cli flags
-	// respectively. Additionally if subject_required cluster setting is set, both
-	// root and node users must have a valid DN set.
+	// In that case, we only allow RPCs if the client presents a valid root or
+	// node certificate. Identity is validated using one of:
+	//
+	// 1. SAN validation (if ClientCertSANRequired is enabled): validates against
+	//    root-cert-san or node-cert-san CLI flags. If SAN fails and
+	//    ClientCertSubjectRequired is also enabled, falls back to DN.
+	// 2. DN validation: validates against root-cert-distinguished-name or
+	//    node-cert-distinguished-name CLI flags.
+	// 3. Scope-based validation: validates that the principal is 'root' or
+	//    'node' and the tenant scope matches this server. Used when neither
+	//    SAN nor DN is configured.
+	//
+	// In all cases, the cert's tenant scope is verified to ensure the
+	// principal is authorized for this server's tenant.
 	//
 	// TODO(benesch): the vast majority of RPCs should be limited to
 	// just NodeUser. This is not a security concern, as RootUser has
 	// access to read and write all data, merely good hygiene. For
 	// example, there is no reason to permit the root user to send raw
 	// Raft RPCs.
-	rootOrNodeDNSet, certDNMatchesRootOrNodeDN := security.CheckCertDNMatchesRootDNorNodeDN(clientCert)
-	if rootOrNodeDNSet && !certDNMatchesRootOrNodeDN {
-		return nil, authErrorf(
-			"need root or node client cert to perform RPCs on this server: cert dn did not match set root or node dn",
-		)
-	}
-	if !rootOrNodeDNSet {
-		if security.ClientCertSubjectRequired.Get(a.sv) {
-			return nil, authErrorf(
-				"root and node roles do not have valid DNs set which subject_required cluster setting mandates",
-			)
-		}
-		if err := checkRootOrNodeInScope(clientCert, a.tenant.tenantID); err != nil {
-			return nil, err
-		}
+	if err := a.validateRootOrNodeClientCert(clientCert); err != nil {
+		return nil, err
 	}
 
 	if tenantIDFromMetadata.IsSet() {
 		return authnSuccessPeerIsTenantServer(tenantIDFromMetadata), nil
 	}
 	return authnSuccessPeerIsPrivileged{}, nil
+}
+
+// validateRootOrNodeClientCert validates that clientCert is authorized for
+// privileged RPC access as a root or node user. Identity is validated via
+// SAN (if ClientCertSANRequired is enabled), DN, or certificate scope.
+// In all paths, the cert's tenant scope is checked to ensure the principal
+// is authorized for this server's tenant. Returns an error if validation
+// fails.
+func (a kvAuth) validateRootOrNodeClientCert(clientCert *x509.Certificate) error {
+	if security.ClientCertSANRequired.Get(a.sv) {
+		// SAN validation is enabled - try SAN first, then fallback to DN.
+		certSANMatchesRootOrNodeSAN := security.CheckCertSANMatchesRootOrNodeSAN(clientCert)
+		if certSANMatchesRootOrNodeSAN {
+			// Check for root or node in tenant scope if SAN matching is enabled.
+			if err := checkRootOrNodeInScope(clientCert, a.tenant.tenantID); err != nil {
+				return err
+			}
+			return nil
+		}
+
+		// DN not configured
+		if !security.ClientCertSubjectRequired.Get(a.sv) {
+			return authErrorf(
+				"root and node roles do not have valid SANs set and subject_required cluster setting is not enabled",
+			)
+		}
+
+		// SAN didn't match, try DN as fallback
+		_, certDNMatchesRootOrNodeDN := security.CheckCertDNMatchesRootDNorNodeDN(clientCert)
+		if certDNMatchesRootOrNodeDN {
+			// Check for root or node in tenant scope if Subject matching is enabled.
+			if err := checkRootOrNodeInScope(clientCert, a.tenant.tenantID); err != nil {
+				return err
+			}
+			return nil
+		}
+
+		// When SAN is explicitly enabled, we don't fall back to scope-based validation
+		// as scope alone doesn't confirm identity
+		return authErrorf(
+			"need root or node client cert to perform RPCs on this server: SAN and DN validation failed",
+		)
+	}
+
+	// SAN not enabled, use DN-based validation with scope fallback
+	rootOrNodeDNSet, certDNMatchesRootOrNodeDN := security.CheckCertDNMatchesRootDNorNodeDN(clientCert)
+	if rootOrNodeDNSet && !certDNMatchesRootOrNodeDN {
+		return authErrorf(
+			"need root or node client cert to perform RPCs on this server: cert dn did not match set root or node dn",
+		)
+	}
+	if !rootOrNodeDNSet {
+		if security.ClientCertSubjectRequired.Get(a.sv) {
+			return authErrorf(
+				"root and node roles do not have valid DNs set which subject_required cluster setting mandates",
+			)
+		}
+		if err := checkRootOrNodeInScope(clientCert, a.tenant.tenantID); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // requiredAuthzMethod is a sum type that describes which authorization

--- a/pkg/rpc/auth_test.go
+++ b/pkg/rpc/auth_test.go
@@ -13,6 +13,8 @@ import (
 	"encoding/asn1"
 	"fmt"
 	"io"
+	"net"
+	"net/url"
 	"strconv"
 	"strings"
 	"testing"
@@ -121,6 +123,12 @@ func testAuthenticateTenant(t *testing.T, enableDRPC bool) {
 		certPrincipalMap string
 		certDNSName      string
 		allowDebugUser   bool
+		certDNSSANs      []string
+		certURISANs      []string
+		certIPSANs       []string
+		rootSAN          string
+		nodeSAN          string
+		sanRequired      bool
 	}{
 		{systemID: stid, ous: correctOU, commonName: "10", expTenID: tenTen},
 		{systemID: stid, ous: correctOU, commonName: roachpb.MinTenantID.String(), expTenID: roachpb.MinTenantID},
@@ -219,6 +227,61 @@ func testAuthenticateTenant(t *testing.T, enableDRPC bool) {
 		// Test cases for allow debug user functionality
 		{systemID: stid, ous: nil, commonName: "debug_user", expErr: "debug_user login is not allowed"},
 		{systemID: stid, ous: nil, commonName: "foo", certDNSName: "debug_user", expErr: "debug_user login is not allowed"},
+
+		// SAN-based authentication tests
+		// SAN validation succeeds with correct cert scope
+		{systemID: stid, ous: nil, commonName: "root", certURISANs: []string{"spiffe://example.com/root"},
+			rootSAN: "URI=spiffe://example.com/root", sanRequired: true},
+		{systemID: stid, ous: nil, commonName: "node", certDNSSANs: []string{"node.example.com"},
+			nodeSAN: "DNS=node.example.com", sanRequired: true},
+		// SAN fails, DN fallback succeeds
+		{systemID: stid, ous: nil, commonName: "root", subjectRequired: true, certURISANs: []string{"spiffe://example.com/wrong"},
+			rootSAN: "URI=spiffe://example.com/root", rootDNString: "CN=root", sanRequired: true},
+		{systemID: stid, ous: nil, commonName: "node", subjectRequired: true, certDNSSANs: []string{"wrong.example.com"},
+			nodeSAN: "DNS=node.example.com", nodeDNString: "CN=node", sanRequired: true},
+		// Both SAN and DN fail
+		{systemID: stid, ous: nil, commonName: "foo", subjectRequired: true, certURISANs: []string{"spiffe://example.com/wrong"},
+			rootSAN: "URI=spiffe://example.com/root", rootDNString: "CN=bar", sanRequired: true,
+			expErr: "need root or node client cert to perform RPCs on this server: SAN and DN validation failed"},
+		// SAN fails, DN not configured
+		{systemID: stid, ous: nil, commonName: "foo", certURISANs: []string{"spiffe://example.com/wrong"},
+			rootSAN: "URI=spiffe://example.com/root", sanRequired: true, subjectRequired: true,
+			expErr: "need root or node client cert to perform RPCs on this server: SAN and DN validation failed"},
+		// Both SAN and DN not configured, both cluster settings enabled
+		{systemID: stid, ous: nil, commonName: "root", sanRequired: true, subjectRequired: true,
+			expErr: "need root or node client cert to perform RPCs on this server: SAN and DN validation failed"},
+		// SAN fails, DN cluster setting not enabled
+		{systemID: stid, ous: nil, commonName: "root", certURISANs: []string{"spiffe://example.com/wrong"},
+			rootSAN: "URI=spiffe://example.com/root", rootDNString: "CN=root", sanRequired: true,
+			expErr: "root and node roles do not have valid SANs set and subject_required cluster setting is not enabled"},
+		// Multiple SAN attributes
+		{systemID: stid, ous: nil, commonName: "root",
+			certURISANs: []string{"spiffe://example.com/root"}, certDNSSANs: []string{"node.example.com"},
+			certIPSANs: []string{"192.168.1.1"}, rootSAN: "URI=spiffe://example.com/root", sanRequired: true},
+		{systemID: stid, ous: nil, commonName: "foo", certURISANs: []string{"spiffe://example.com/root"},
+			rootSAN: "URI=spiffe://example.com/root,DNS=missing.example.com", sanRequired: true,
+			expErr: "root and node roles do not have valid SANs set and subject_required cluster setting is not enabled"},
+		// Both root and node SANs configured
+		{systemID: stid, ous: nil, commonName: "root", certURISANs: []string{"spiffe://example.com/root"},
+			rootSAN: "URI=spiffe://example.com/root", nodeSAN: "DNS=node.example.com", sanRequired: true},
+		{systemID: stid, ous: nil, commonName: "node", certDNSSANs: []string{"node.example.com"},
+			rootSAN: "URI=spiffe://example.com/root", nodeSAN: "DNS=node.example.com", sanRequired: true},
+		// SAN matches but cert has wrong tenant scope - reject
+		{systemID: stid, ous: nil, commonName: "root", certURISANs: []string{"spiffe://example.com/root"},
+			rootSAN: "URI=spiffe://example.com/root", sanRequired: true, tenantScope: 10,
+			expErr: `need root or node client cert to perform RPCs on this server \(this is tenant system; cert is valid for "root" on tenantID 10\)`},
+		// SAN matches and cert has correct tenant scope - accept
+		{systemID: tenTen, ous: nil, commonName: "root", certURISANs: []string{"spiffe://example.com/root"},
+			rootSAN: "URI=spiffe://example.com/root", sanRequired: true, tenantScope: 10},
+		// SAN fails, DN fallback matches, but cert has wrong tenant scope - reject
+		{systemID: stid, ous: nil, commonName: "root", subjectRequired: true,
+			certURISANs: []string{"spiffe://example.com/wrong"},
+			rootSAN:     "URI=spiffe://example.com/root", rootDNString: "CN=root", sanRequired: true, tenantScope: 10,
+			expErr: `need root or node client cert to perform RPCs on this server \(this is tenant system; cert is valid for "root" on tenantID 10\)`},
+		// SAN matches with tenant ID in metadata - expect tenant authorization
+		{clientTenantInMD: "10",
+			systemID: stid, ous: nil, commonName: "root", certURISANs: []string{"spiffe://example.com/root"},
+			rootSAN: "URI=spiffe://example.com/root", sanRequired: true, expTenID: tenTen},
 	} {
 		t.Run(fmt.Sprintf("from %v to %v (md %q)", tc.commonName, tc.systemID, tc.clientTenantInMD), func(t *testing.T) {
 			// Enable root login blocking for the specific test case
@@ -254,9 +317,19 @@ func testAuthenticateTenant(t *testing.T, enableDRPC bool) {
 					t.Fatalf("could not set node subject DN, err: %v", err)
 				}
 			}
+			if tc.rootSAN != "" {
+				err = security.SetRootSAN(tc.rootSAN)
+				require.NoError(t, err)
+			}
+			if tc.nodeSAN != "" {
+				err = security.SetNodeSAN(tc.nodeSAN)
+				require.NoError(t, err)
+			}
 			defer func() {
 				security.UnsetRootSubject()
 				security.UnsetNodeSubject()
+				security.UnsetRootSAN()
+				security.UnsetNodeSAN()
 			}()
 
 			cert := &x509.Certificate{
@@ -271,6 +344,26 @@ func testAuthenticateTenant(t *testing.T, enableDRPC bool) {
 			}
 			if tc.certDNSName != "" {
 				cert.DNSNames = append(cert.DNSNames, tc.certDNSName)
+			}
+			// Add DNS SANs
+			if len(tc.certDNSSANs) > 0 {
+				cert.DNSNames = append(cert.DNSNames, tc.certDNSSANs...)
+			}
+			// Add URI SANs
+			if len(tc.certURISANs) > 0 {
+				for _, uriStr := range tc.certURISANs {
+					uri, err := url.Parse(uriStr)
+					require.NoError(t, err)
+					cert.URIs = append(cert.URIs, uri)
+				}
+			}
+			// Add IP SANs
+			if len(tc.certIPSANs) > 0 {
+				for _, ipStr := range tc.certIPSANs {
+					ip := net.ParseIP(ipStr)
+					require.NotNil(t, ip)
+					cert.IPAddresses = append(cert.IPAddresses, ip)
+				}
 			}
 			if tc.tenantScope > 0 {
 				tenantSANs, err := security.MakeTenantURISANs(
@@ -302,6 +395,9 @@ func testAuthenticateTenant(t *testing.T, enableDRPC bool) {
 			u := settings.NewUpdater(sv)
 			err = u.Set(ctx, security.ClientCertSubjectRequiredSettingName,
 				settings.EncodedValue{Value: strconv.FormatBool(tc.subjectRequired), Type: "b"})
+			require.NoError(t, err)
+			err = u.Set(ctx, security.ClientCertSANRequiredSettingName,
+				settings.EncodedValue{Value: strconv.FormatBool(tc.sanRequired), Type: "b"})
 			require.NoError(t, err)
 
 			tenID, err := rpc.TestingAuthenticateTenant(ctx, tc.systemID, sv, enableDRPC)

--- a/pkg/security/auth.go
+++ b/pkg/security/auth.go
@@ -366,21 +366,18 @@ func sanListIsSubset(sanSubset, sanSuperset []string) bool {
 	return true
 }
 
-// checkCertSANMatchesRootSANorNodeSAN returns `rootOrNodeSANSet` which validates
-// whether rootSAN or nodeSAN is currently set using their respective CLI flags
-// *-cert-san. It also returns `certSANMatchesRootOrNodeSAN` which
-// validates whether SANs contained in cert being presented contain all the
-// configured rootSAN or nodeSAN entries for the specific user type
+// checkCertSANMatchesUserSpecificSAN returns `certSANMatchesRootOrNodeSAN`
+// which validates whether SANs contained in cert being presented contain
+// all the configured rootSAN or nodeSAN entries for the specific user type
 // (i.e., configured SANs are a subset of cert SANs).
-func checkCertSANMatchesRootSANorNodeSAN(
+func checkCertSANMatchesUserSpecificSAN(
 	certSANs []string, user string,
-) (rootOrNodeSANSet bool, certSANMatchesRootOrNodeSAN bool) {
+) (certSANMatchesRootOrNodeSAN bool) {
 	// Check user-specific SANs based on username
 	switch user {
 	case username.RootUser:
 		rootSANs := rootSANMu.getSANs()
 		if len(rootSANs) > 0 {
-			rootOrNodeSANSet = true
 			// For root user, only check root SANs
 			if sanListIsSubset(rootSANs, certSANs) {
 				certSANMatchesRootOrNodeSAN = true
@@ -389,21 +386,20 @@ func checkCertSANMatchesRootSANorNodeSAN(
 	case username.NodeUser:
 		nodeSANs := nodeSANMu.getSANs()
 		if len(nodeSANs) > 0 {
-			rootOrNodeSANSet = true
 			// For node user, only check node SANs
 			if sanListIsSubset(nodeSANs, certSANs) {
 				certSANMatchesRootOrNodeSAN = true
 			}
 		}
 	}
-	return rootOrNodeSANSet, certSANMatchesRootOrNodeSAN
+	return certSANMatchesRootOrNodeSAN
 }
 
 func isRootOrNodeUser(user string) bool {
 	return user == username.RootUser || user == username.NodeUser
 }
 
-// Helper function to validate SAN for specific users
+// validateSANMatchForUser validates SAN for specific users
 // For root and node users, performs actual SAN validation
 // For all other users SAN is only used to map to a
 // SQL user using identity mapping and not validate the
@@ -415,8 +411,24 @@ func validateSANMatchForUser(certSANs []string, user string) bool {
 	}
 
 	// For root/node users, perform actual validation
-	_, match := checkCertSANMatchesRootSANorNodeSAN(certSANs, user)
-	return match
+	return checkCertSANMatchesUserSpecificSAN(certSANs, user)
+}
+
+// CheckCertSANMatchesRootOrNodeSAN returns `certSANMatchesRootOrNodeSAN`
+// which validates whether SAN contained in cert being presented is a
+// superset of rootSAN or nodeSAN (provided they are set via start-up flag).
+func CheckCertSANMatchesRootOrNodeSAN(cert *x509.Certificate) (certSANMatchesRootOrNodeSAN bool) {
+	rootSANs := rootSANMu.getSANs()
+	nodeSANs := nodeSANMu.getSANs()
+
+	if len(rootSANs) != 0 || len(nodeSANs) != 0 {
+		certSANs := ExtractSANsFromCertificate(cert)
+		// certSANMatchesRootOrNodeSAN is true if certSANs contains all configured rootSANs or nodeSANs
+		if (len(rootSANs) != 0 && sanListIsSubset(rootSANs, certSANs)) || (len(nodeSANs) != 0 && sanListIsSubset(nodeSANs, certSANs)) {
+			certSANMatchesRootOrNodeSAN = true
+		}
+	}
+	return certSANMatchesRootOrNodeSAN
 }
 
 // SetCertPrincipalMap sets the global principal map. Each entry in the mapping

--- a/pkg/sql/pgwire/auth_behaviors.go
+++ b/pkg/sql/pgwire/auth_behaviors.go
@@ -125,7 +125,7 @@ func (b *AuthBehaviors) EnhancedMapRole(
 	if found := b.enhancedRoleMapper; found != nil {
 		return found(ctx, systemIdentities)
 	}
-	return nil, errors.New("no SAN RoleMapper provided to AuthBehaviors.")
+	return nil, errors.New("no SAN RoleMapper provided to AuthBehaviors")
 }
 
 // SetRoleMapper updates the RoleMapper to be used.
@@ -135,13 +135,13 @@ func (b *AuthBehaviors) SetRoleMapper(m RoleMapper) {
 
 // SetEnhancedRoleMapper sets the enhanced mapper that returns identity associations.
 // This is used when multiple system identities exist (e.g., certificate SANs).
-func (a *AuthBehaviors) SetEnhancedRoleMapper(fn EnhancedRoleMapper) {
-	a.enhancedRoleMapper = fn
-	a.enhancedRoleMapperSet = true
+func (b *AuthBehaviors) SetEnhancedRoleMapper(fn EnhancedRoleMapper) {
+	b.enhancedRoleMapper = fn
+	b.enhancedRoleMapperSet = true
 }
 
-func (a *AuthBehaviors) IsEnhancedRoleMapperSet() bool {
-	return a.enhancedRoleMapperSet
+func (b *AuthBehaviors) IsEnhancedRoleMapperSet() bool {
+	return b.enhancedRoleMapperSet
 }
 
 // SetAuthorizer updates the SetAuthorizer to be used.

--- a/pkg/sql/pgwire/auth_methods.go
+++ b/pkg/sql/pgwire/auth_methods.go
@@ -477,6 +477,9 @@ func authCert(
 	if len(tlsState.PeerCertificates) > 0 && hbaEntry.GetOption("map") != "" {
 		if clientCertSANRequired {
 			identityList := security.ExtractSANsFromCertificate(tlsState.PeerCertificates[0])
+			if len(identityList) == 0 {
+				return nil, errors.New("client certificate SAN is required, but no SAN found in the certificate")
+			}
 			b.SetSANIdentities(identityList)
 		} else {
 			// The common name in the certificate is set as the system identity in case we have an HBAEntry for db user.


### PR DESCRIPTION
* Previously, RPC authentication for root and node users relied solely on Distinguished Name (DN) validation when configured, falling back to username and tenant scope checks from the certificate's Common Name and SAN fields.
* This approach did not leverage Subject Alternative Name identities for authenticating these privileged system users, even when the client_cert_san_required cluster setting was enabled.
* To address this, this patch adds SAN-based authentication support for root and node users in RPC authentication. When client_cert_san_required is enabled, the validateRootOrNodeClientCert function now:
    1. First attempts SAN validation using CheckCertSANMatchesRootOrNodeSAN
    2. Falls back to DN validation if SAN validation fails
    3. Does NOT fall back to the legacy scope-based validation
         (checkRootOrNodeInScope) when SAN is explicitly enabled.
    
Release note: None
    
Resolves: #164135
    
Epic: [CRDB-58929](https://cockroachlabs.atlassian.net/browse/CRDB-58929)