### PR TITLE
backup: fix table-level restore of tables with trigger function references

### DIFF
--- a/pkg/backup/restore_job.go
+++ b/pkg/backup/restore_job.go
@@ -1711,20 +1711,20 @@ func createImportingDescriptors(
 		return err
 	}
 
-	// Functions are only restored as part of full database restores and are not
-	// yet referenced by other object types in ways that would require remapping.
-	// This avoids the need for collision resolution between restored functions
-	// and existing ones in the target database.
-	//
-	// For table-level restores, function dependencies are handled by existing
-	// safeguards: if the target DB already has the function, the dependent table
-	// must be dropped before restore; if the function is missing, restore fails
-	// unless skip_missing_udfs is set, in which case the function is omitted.
-	functionsToWrite := make([]*funcdesc.Mutable, len(functions))
-	writtenFunctions := make([]catalog.FunctionDescriptor, len(functions))
-	for i, fn := range functions {
-		functionsToWrite[i] = fn
-		writtenFunctions[i] = fn
+	// Filter out functions that are remapped to existing descriptors (e.g.,
+	// when restoring into a schema that already has a function with the same
+	// name and signature).
+	var functionsToWrite []*funcdesc.Mutable
+	var writtenFunctions []catalog.FunctionDescriptor
+	existingFunctionIDs := make(map[descpb.ID]struct{})
+	for _, fn := range functions {
+		fnRewrite := details.DescriptorRewrites[fn.GetID()]
+		if fnRewrite.ToExisting {
+			existingFunctionIDs[fnRewrite.ID] = struct{}{}
+			continue
+		}
+		functionsToWrite = append(functionsToWrite, fn)
+		writtenFunctions = append(writtenFunctions, fn)
 	}
 	if err := rewrite.FunctionDescs(functions, details.DescriptorRewrites, details.OverrideDB); err != nil {
 		return err
@@ -1841,6 +1841,49 @@ func createImportingDescriptors(
 			}
 		}
 
+		// We could be restoring new functions into existing schemas (e.g., when
+		// a table-level restore brings in a trigger function that doesn't have
+		// a matching signature in the target schema). The existing schema's
+		// Functions map needs to be updated with the new function's signature.
+		writtenSchemaIDs := make(map[descpb.ID]struct{}, len(writtenSchemas))
+		for _, sc := range writtenSchemas {
+			writtenSchemaIDs[sc.GetID()] = struct{}{}
+		}
+		updatedSchemas := make(map[descpb.ID]*schemadesc.Mutable)
+		for _, fn := range functionsToWrite {
+			schemaID := fn.GetParentSchemaID()
+			// Skip if the schema is being created as part of this restore
+			// (it will already have the function registered).
+			if _, ok := writtenSchemaIDs[schemaID]; ok {
+				continue
+			}
+			scDesc, ok := updatedSchemas[schemaID]
+			if !ok {
+				scDesc, err = descsCol.MutableByID(txn.KV()).Schema(ctx, schemaID)
+				if err != nil {
+					return err
+				}
+				updatedSchemas[schemaID] = scDesc
+			}
+			sig := descpb.SchemaDescriptor_FunctionSignature{
+				ID:         fn.GetID(),
+				ReturnType: fn.ReturnType.Type,
+				ReturnSet:  fn.ReturnType.ReturnSet,
+			}
+			for _, param := range fn.Params {
+				class := funcdesc.ToTreeRoutineParamClass(param.Class)
+				if tree.IsInParamClass(class) {
+					sig.ArgTypes = append(sig.ArgTypes, param.Type)
+				}
+			}
+			scDesc.AddFunction(fn.GetName(), sig)
+		}
+		for _, scDesc := range updatedSchemas {
+			if err := descsCol.WriteDescToBatch(ctx, kvTrace, scDesc, b); err != nil {
+				return err
+			}
+		}
+
 		// We could be restoring tables that point to existing types. We need to
 		// ensure that those existing types are updated with back references pointing
 		// to the new tables being restored.
@@ -1876,6 +1919,34 @@ func createImportingDescriptors(
 					ctx, kvTrace, typDesc, b,
 				); err != nil {
 					return err
+				}
+			}
+		}
+
+		// We could be restoring tables with triggers that reference existing
+		// functions. We need to ensure that those existing functions are updated
+		// with back references pointing to the new tables being restored.
+		for _, table := range mutableTables {
+			for i := range table.Triggers {
+				trigger := &table.Triggers[i]
+				for _, routineID := range trigger.DependsOnRoutines {
+					if _, ok := existingFunctionIDs[routineID]; !ok {
+						continue
+					}
+					// The function already exists in the cluster, so we need to
+					// add a back-reference to the restored table.
+					fnDesc, err := descsCol.MutableByID(txn.KV()).Function(ctx, routineID)
+					if err != nil {
+						return err
+					}
+					if err := fnDesc.AddTriggerReference(table.GetID(), trigger.ID); err != nil {
+						return err
+					}
+					if err := descsCol.WriteDescToBatch(
+						ctx, kvTrace, fnDesc, b,
+					); err != nil {
+						return err
+					}
 				}
 			}
 		}

--- a/pkg/backup/testdata/backup-restore/triggers
+++ b/pkg/backup/testdata/backup-restore/triggers
@@ -675,11 +675,11 @@ DROP DATABASE db4_new;
 # ==============================================================================
 
 exec-sql
-CREATE DATABASE db3;
+CREATE DATABASE db5;
 ----
 
 exec-sql
-USE db3;
+USE db5;
 ----
 
 exec-sql
@@ -743,7 +743,7 @@ tbl1 "tr1"
 tbl1 "tr2"
 
 exec-sql
-BACKUP DATABASE db3 INTO 'nodelocal://1/test_schema_restore/'
+BACKUP DATABASE db5 INTO 'nodelocal://1/test_schema_restore/'
 ----
 
 # Drop and recreate the schemas to set up for the restore.
@@ -759,7 +759,7 @@ DROP FUNCTION sc_drop.f2;
 # This should work: tr1 should be kept (its function f1 is restored),
 # tr2 should be dropped (its function f2 is missing).
 exec-sql
-RESTORE TABLE db3.sc_keep.* FROM LATEST IN 'nodelocal://1/test_schema_restore/' WITH skip_missing_udfs;
+RESTORE TABLE db5.sc_keep.* FROM LATEST IN 'nodelocal://1/test_schema_restore/' WITH skip_missing_udfs;
 ----
 
 # Verify that tr1 is present (function was restored) and tr2 is dropped
@@ -794,5 +794,428 @@ DROP FUNCTION sc_keep.f1;
 ----
 
 exec-sql
-DROP DATABASE db3;
+DROP DATABASE db5;
+----
+
+# ==============================================================================
+# Test function collision detection during table-level restore. When restoring
+# a schema's objects into a schema that already has the trigger's function, the
+# restore should detect the collision and remap the function to the existing one
+# rather than creating a duplicate.
+# ==============================================================================
+
+exec-sql
+CREATE DATABASE db6;
+----
+
+exec-sql
+USE db6;
+----
+
+exec-sql
+CREATE SCHEMA sc;
+----
+
+exec-sql
+CREATE TABLE sc.tbl1(a INT PRIMARY KEY);
+----
+
+exec-sql
+CREATE FUNCTION sc.f1() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RAISE NOTICE 'trigger fired';
+    RETURN NEW;
+  END
+$$;
+----
+
+exec-sql
+CREATE TRIGGER tr1 AFTER INSERT ON sc.tbl1 FOR EACH ROW EXECUTE FUNCTION sc.f1();
+----
+
+exec-sql
+BACKUP DATABASE db6 INTO 'nodelocal://1/test_func_collision/';
+----
+
+# Drop the schema and recreate it with just the function. This means the schema
+# exists (with a new ID) and the function exists (with a new ID), but the table
+# is missing.
+exec-sql
+DROP SCHEMA sc CASCADE;
+----
+
+exec-sql
+CREATE SCHEMA sc;
+----
+
+exec-sql
+CREATE FUNCTION sc.f1() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RAISE NOTICE 'trigger fired';
+    RETURN NEW;
+  END
+$$;
+----
+
+# Restore all objects from sc. The schema and function f1 already exist in the
+# target, so the restore should detect the collision and remap the function to
+# the existing descriptor.
+exec-sql
+RESTORE TABLE db6.sc.* FROM LATEST IN 'nodelocal://1/test_func_collision/';
+----
+
+# Verify the trigger is present on the restored table.
+query-sql
+WITH descs AS (
+  SELECT relname, tab->'table'->'triggers' AS triggers FROM (
+    SELECT relname, crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', descriptor, false) AS tab
+    FROM system.descriptor d INNER JOIN pg_class c ON d.id = c.oid::INT
+    WHERE relname = 'tbl1'
+  )
+)
+SELECT relname, t.name FROM descs, LATERAL (
+  SELECT value->'name' FROM jsonb_array_elements(descs.triggers)
+) AS t(name)
+ORDER BY relname, t.name
+----
+tbl1 "tr1"
+
+# Verify the trigger fires correctly (the function is correctly linked).
+exec-sql
+INSERT INTO sc.tbl1 VALUES (1);
+----
+NOTICE: trigger fired
+
+# Verify that the function can be dropped only after removing its dependents.
+exec-sql
+DROP FUNCTION sc.f1;
+----
+pq: cannot drop function "f1" because other objects ([db6.sc.tbl1]) still depend on it
+
+# Clean up.
+exec-sql
+DROP TRIGGER tr1 ON sc.tbl1;
+----
+
+exec-sql
+DROP FUNCTION sc.f1;
+----
+
+exec-sql
+DROP DATABASE db6;
+----
+
+# ==============================================================================
+# Test function collision detection with overloaded function names. When the
+# target schema has both f1() (trigger function) and f1(my_enum) (regular
+# function with a UDT parameter), restoring a table with a trigger calling f1()
+# should correctly match to the existing f1() overload and not be confused by
+# f1(my_enum).
+# ==============================================================================
+
+exec-sql
+CREATE DATABASE db7;
+----
+
+exec-sql
+USE db7;
+----
+
+exec-sql
+CREATE SCHEMA sc;
+----
+
+exec-sql
+CREATE TABLE sc.tbl1(a INT PRIMARY KEY);
+----
+
+exec-sql
+CREATE FUNCTION sc.f1() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RAISE NOTICE 'trigger fired';
+    RETURN NEW;
+  END
+$$;
+----
+
+exec-sql
+CREATE TRIGGER tr1 AFTER INSERT ON sc.tbl1 FOR EACH ROW EXECUTE FUNCTION sc.f1();
+----
+
+exec-sql
+BACKUP DATABASE db7 INTO 'nodelocal://1/test_func_overload_match/';
+----
+
+# Drop the schema and recreate it with f1() (trigger) AND f1(my_enum) (regular
+# function with a user-defined enum parameter). The restore should match to
+# the existing f1() and ignore f1(my_enum).
+exec-sql
+DROP SCHEMA sc CASCADE;
+----
+
+exec-sql
+CREATE SCHEMA sc;
+----
+
+exec-sql
+CREATE TYPE sc.my_enum AS ENUM ('a', 'b', 'c');
+----
+
+exec-sql
+CREATE FUNCTION sc.f1() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RAISE NOTICE 'trigger fired';
+    RETURN NEW;
+  END
+$$;
+----
+
+exec-sql
+CREATE FUNCTION sc.f1(a sc.my_enum) RETURNS TEXT LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RETURN a::TEXT;
+  END
+$$;
+----
+
+exec-sql
+RESTORE TABLE db7.sc.* FROM LATEST IN 'nodelocal://1/test_func_overload_match/';
+----
+
+# Verify the trigger is present on the restored table.
+query-sql
+WITH descs AS (
+  SELECT relname, tab->'table'->'triggers' AS triggers FROM (
+    SELECT relname, crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', descriptor, false) AS tab
+    FROM system.descriptor d INNER JOIN pg_class c ON d.id = c.oid::INT
+    WHERE relname = 'tbl1'
+  )
+)
+SELECT relname, t.name FROM descs, LATERAL (
+  SELECT value->'name' FROM jsonb_array_elements(descs.triggers)
+) AS t(name)
+ORDER BY relname, t.name
+----
+tbl1 "tr1"
+
+# Verify the trigger fires correctly.
+exec-sql
+INSERT INTO sc.tbl1 VALUES (1);
+----
+NOTICE: trigger fired
+
+# Verify both function overloads exist in the schema descriptor: f1() and
+# f1(my_enum). We query the schema descriptor's functions map and check the
+# number of arguments for each overload.
+let $db7_sc_id
+WITH db_id AS (
+  SELECT id FROM system.namespace WHERE name = 'db7'
+),
+schema_id AS (
+  SELECT ns.id
+  FROM system.namespace AS ns
+  JOIN db_id ON ns."parentID" = db_id.id
+  WHERE ns.name = 'sc'
+)
+SELECT id FROM schema_id;
+----
+
+query-sql
+WITH to_json AS (
+    SELECT
+      crdb_internal.pb_to_json(
+        'cockroach.sql.sqlbase.Descriptor',
+        descriptor,
+        false
+      ) AS d
+    FROM system.descriptor
+    WHERE id = $db7_sc_id
+),
+sigs AS (
+  SELECT jsonb_array_elements(d->'schema'->'functions'->'f1'->'signatures') AS sig
+  FROM to_json
+)
+SELECT
+  COALESCE(jsonb_array_length(sig->'argTypes'), 0) AS num_args
+FROM sigs
+ORDER BY num_args;
+----
+0
+1
+
+# The f1() trigger function can't be dropped while the trigger depends on it.
+exec-sql
+DROP FUNCTION sc.f1();
+----
+pq: cannot drop function "f1" because other objects ([db7.sc.tbl1]) still depend on it
+
+# The f1(my_enum) overload can be dropped independently.
+exec-sql
+DROP FUNCTION sc.f1(sc.my_enum);
+----
+
+# Clean up.
+exec-sql
+DROP TRIGGER tr1 ON sc.tbl1;
+----
+
+exec-sql
+DROP FUNCTION sc.f1;
+----
+
+exec-sql
+DROP DATABASE db7;
+----
+
+# ==============================================================================
+# Test that when the target schema has a function with the same name but a
+# different signature (f1(int) but not f1()), restoring a table with a trigger
+# calling f1() should NOT match the existing f1(int). Instead, it should create
+# a new f1() overload.
+# ==============================================================================
+
+exec-sql
+CREATE DATABASE db8;
+----
+
+exec-sql
+USE db8;
+----
+
+exec-sql
+CREATE SCHEMA sc;
+----
+
+exec-sql
+CREATE TABLE sc.tbl1(a INT PRIMARY KEY);
+----
+
+exec-sql
+CREATE FUNCTION sc.f1() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RAISE NOTICE 'trigger fired';
+    RETURN NEW;
+  END
+$$;
+----
+
+exec-sql
+CREATE TRIGGER tr1 AFTER INSERT ON sc.tbl1 FOR EACH ROW EXECUTE FUNCTION sc.f1();
+----
+
+exec-sql
+BACKUP DATABASE db8 INTO 'nodelocal://1/test_func_no_sig_match/';
+----
+
+# Drop the schema and recreate it with only f1(int) (a regular function, not a
+# trigger function). The restore should see "f1" in the schema's function map
+# but find no matching signature, so it should create the trigger function f1()
+# as a new overload.
+exec-sql
+DROP SCHEMA sc CASCADE;
+----
+
+exec-sql
+CREATE SCHEMA sc;
+----
+
+exec-sql
+CREATE FUNCTION sc.f1(a INT) RETURNS INT LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RETURN a + 1;
+  END
+$$;
+----
+
+exec-sql
+RESTORE TABLE db8.sc.* FROM LATEST IN 'nodelocal://1/test_func_no_sig_match/';
+----
+
+# Verify the trigger is present on the restored table.
+query-sql
+WITH descs AS (
+  SELECT relname, tab->'table'->'triggers' AS triggers FROM (
+    SELECT relname, crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', descriptor, false) AS tab
+    FROM system.descriptor d INNER JOIN pg_class c ON d.id = c.oid::INT
+    WHERE relname = 'tbl1'
+  )
+)
+SELECT relname, t.name FROM descs, LATERAL (
+  SELECT value->'name' FROM jsonb_array_elements(descs.triggers)
+) AS t(name)
+ORDER BY relname, t.name
+----
+tbl1 "tr1"
+
+# Verify the trigger fires correctly.
+exec-sql
+INSERT INTO sc.tbl1 VALUES (1);
+----
+NOTICE: trigger fired
+
+# Verify both overloads exist in the schema descriptor: the restored f1() and
+# the pre-existing f1(int).
+let $db8_sc_id
+WITH db_id AS (
+  SELECT id FROM system.namespace WHERE name = 'db8'
+),
+schema_id AS (
+  SELECT ns.id
+  FROM system.namespace AS ns
+  JOIN db_id ON ns."parentID" = db_id.id
+  WHERE ns.name = 'sc'
+)
+SELECT id FROM schema_id;
+----
+
+query-sql
+WITH to_json AS (
+    SELECT
+      crdb_internal.pb_to_json(
+        'cockroach.sql.sqlbase.Descriptor',
+        descriptor,
+        false
+      ) AS d
+    FROM system.descriptor
+    WHERE id = $db8_sc_id
+),
+sigs AS (
+  SELECT jsonb_array_elements(d->'schema'->'functions'->'f1'->'signatures') AS sig
+  FROM to_json
+)
+SELECT
+  COALESCE(jsonb_array_length(sig->'argTypes'), 0) AS num_args,
+  CASE
+    WHEN jsonb_array_length(sig->'argTypes') > 0
+    THEN (SELECT string_agg(elem->>'oid', ', ' ORDER BY ordinality) FROM jsonb_array_elements(sig->'argTypes') WITH ORDINALITY AS t(elem, ordinality))
+    ELSE 'none'
+  END AS arg_oids
+FROM sigs
+ORDER BY num_args;
+----
+0 none
+1 20
+
+# The restored f1() can't be dropped while the trigger depends on it.
+exec-sql
+DROP FUNCTION sc.f1();
+----
+pq: cannot drop function "f1" because other objects ([db8.sc.tbl1]) still depend on it
+
+# The pre-existing f1(int) can be dropped independently.
+exec-sql
+DROP FUNCTION sc.f1(INT);
+----
+
+# Clean up.
+exec-sql
+DROP TRIGGER tr1 ON sc.tbl1;
+----
+
+exec-sql
+DROP FUNCTION sc.f1;
+----
+
+exec-sql
+DROP DATABASE db8;
 ----

--- a/pkg/backup/testdata/backup-restore/triggers
+++ b/pkg/backup/testdata/backup-restore/triggers
@@ -666,3 +666,133 @@ ORDER BY trigger_id
 exec-sql
 DROP DATABASE db4_new;
 ----
+
+# ==============================================================================
+# Regression test for restoring a schema that contains both a table with
+# triggers and the function referenced by one of the triggers. This is a
+# table-level restore where some trigger functions ARE present in the restore
+# target.
+# ==============================================================================
+
+exec-sql
+CREATE DATABASE db3;
+----
+
+exec-sql
+USE db3;
+----
+
+exec-sql
+CREATE SCHEMA sc_keep;
+----
+
+exec-sql
+CREATE SCHEMA sc_drop;
+----
+
+exec-sql
+CREATE TABLE sc_keep.tbl1(a INT PRIMARY KEY, b INT);
+----
+
+exec-sql
+CREATE TABLE sc_keep.tbl2(a INT, b INT);
+----
+
+exec-sql
+CREATE FUNCTION sc_keep.f1() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$
+  BEGIN
+    SELECT a FROM sc_keep.tbl2;
+    RETURN NEW;
+  END
+$$;
+----
+
+exec-sql
+CREATE FUNCTION sc_drop.f2() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$
+  BEGIN
+    SELECT b FROM sc_keep.tbl2;
+    RETURN NEW;
+  END
+$$;
+----
+
+# Create two triggers on the same table, each referencing a function in a
+# different schema.
+exec-sql
+CREATE TRIGGER tr1 AFTER INSERT ON sc_keep.tbl1 FOR EACH ROW EXECUTE FUNCTION sc_keep.f1();
+----
+
+exec-sql
+CREATE TRIGGER tr2 AFTER INSERT ON sc_keep.tbl1 FOR EACH ROW EXECUTE FUNCTION sc_drop.f2();
+----
+
+query-sql
+WITH descs AS (
+  SELECT relname, tab->'table'->'triggers' AS triggers FROM (
+    SELECT relname, crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', descriptor, false) AS tab
+    FROM system.descriptor d INNER JOIN pg_class c ON d.id = c.oid::INT
+    WHERE relname = 'tbl1'
+  )
+)
+SELECT relname, t.name FROM descs, LATERAL (
+  SELECT value->'name' FROM jsonb_array_elements(descs.triggers)
+) AS t(name)
+ORDER BY relname, t.name
+----
+tbl1 "tr1"
+tbl1 "tr2"
+
+exec-sql
+BACKUP DATABASE db3 INTO 'nodelocal://1/test_schema_restore/'
+----
+
+# Drop and recreate the schemas to set up for the restore.
+exec-sql
+DROP SCHEMA sc_keep CASCADE;
+----
+
+exec-sql
+DROP FUNCTION sc_drop.f2;
+----
+
+# Restore only sc_keep.* which includes f1 but NOT f2.
+# This should work: tr1 should be kept (its function f1 is restored),
+# tr2 should be dropped (its function f2 is missing).
+exec-sql
+RESTORE TABLE db3.sc_keep.* FROM LATEST IN 'nodelocal://1/test_schema_restore/' WITH skip_missing_udfs;
+----
+
+# Verify that tr1 is present (function was restored) and tr2 is dropped
+# (function was missing).
+query-sql
+WITH descs AS (
+  SELECT relname, tab->'table'->'triggers' AS triggers FROM (
+    SELECT relname, crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', descriptor, false) AS tab
+    FROM system.descriptor d INNER JOIN pg_class c ON d.id = c.oid::INT
+    WHERE relname = 'tbl1'
+  )
+)
+SELECT relname, t.name FROM descs, LATERAL (
+  SELECT value->'name' FROM jsonb_array_elements(descs.triggers)
+) AS t(name)
+ORDER BY relname, t.name
+----
+tbl1 "tr1"
+
+# Verify that the trigger and function work correctly.
+exec-sql
+INSERT INTO sc_keep.tbl1 VALUES (1, 1);
+----
+
+# Clean up.
+exec-sql
+DROP TRIGGER tr1 ON sc_keep.tbl1;
+----
+
+exec-sql
+DROP FUNCTION sc_keep.f1;
+----
+
+exec-sql
+DROP DATABASE db3;
+----


### PR DESCRIPTION
### backup: fix table-level restore of tables with trigger function references

Previously, `remapFunctions` in restore planning assumed that function
descriptors could never appear in table-level restores, since UDFs were
not directly referenced by tables. This assumption became invalid when
triggers were introduced, as triggers on a table can reference UDFs.
Attempting a table-level restore (e.g., `RESTORE TABLE db.schema.*`)
that included a trigger function would hit an assertion failure:
"function descriptor seen when restoring tables".

Additionally, the backref cleanup logic in 
`rewrite.TableDescs` was too
aggressive when dropping triggers with missing dependencies. If two
triggers on the same table both referenced the same relation, dropping
one trigger would remove all backrefs from the referenced relation to
the table, even though the other trigger still maintained a valid
forward reference. This caused descriptor validation failures.

This patch fixes both issues:

1. Updates `remapFunctions` to handle table-level restores by looking up
   the target database and creating proper rewrite entries, following the
   same pattern as `remapTables` and `remapTypes`.

2. Makes the backref cleanup in the second pass of `rewrite.TableDescs`
   trigger-ID-aware: when a backref has a non-zero TriggerID, the code
   now checks whether that specific trigger still exists on the
   referencing table before removing the backref.

###  backup: add function collision detection for table-level restore

Previously, table-level restores of tables with triggers would fail when
the target schema already contained the trigger's function. The restore
had a TODO for implementing function collision detection (similar to
tables and types), but it was not yet implemented.

This change adds collision detection for functions during restore
planning. Unlike tables and types, functions don't have namespace
entries, so collision detection works by looking up the function by name
in the schema descriptor's Functions map, then comparing input parameter
types to find a matching overload. Type comparison accounts for
descriptor rewrites on user-defined types.

When a collision is detected, the function is marked as ToExisting and
filtered out of the write set. Additionally, existing functions that are
referenced by restored tables' triggers are updated with back-references
(DependedOnBy) to maintain correct dependency tracking.

---

fixes https://github.com/cockroachdb/cockroach/issues/162557
Epic: CRDB-42942
Release note: None