### PR TITLE
asim: add gateway-overload test for #162590

### DIFF
--- a/pkg/kv/kvserver/asim/tests/testdata/non_rand/sma/gateway_overload.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/non_rand/sma/gateway_overload.txt
@@ -1,0 +1,77 @@
+# Regression test for #162590: when SQL-only (gateway) nodes with no ranges
+# share a cluster with KV nodes, the cluster-wide load mean is diluted by the
+# idle gateway stores. This can cause the SMA store rebalancer to permanently
+# consider all KV nodes overloaded and churn leases needlessly. MMA avoids this
+# churn due to its tighter checks on targets.
+#
+# Topology: 5 KV nodes (region=kv) + 3 gateway nodes (region=gw) = 8 nodes.
+# All ranges are constrained to region=kv, so gateway nodes carry no replicas.
+# With rf=3 and 5 KV nodes, each range's replicas span a subset of KV nodes,
+# giving the store rebalancer room to attempt (unnecessary) lease transfers.
+#
+# We track lease_moves to observe whether the store rebalancer churns leases
+# between the (balanced) KV nodes.
+
+gen_cluster nodes=8 region=(kv,gw) nodes_per_region=(5,3)
+----
+
+gen_ranges ranges=20 repl_factor=3
+----
+
+# Constrain all replicas to the KV region.
+set_span_config
+[0,10000): num_replicas=3 num_voters=3 constraints={'+region=kv':3}
+----
+
+# Disable the split queue so the range count stays fixed. Use CPU objective.
+setting split_queue_enabled=false rebalance_objective=1
+----
+
+# Generate moderate CPU load across the keyspace. Target ~0.5 cores per KV node.
+gen_load rate=5000 rw_ratio=0.95 min_block=128 max_block=128 request_cpu_per_access=1000000 raft_cpu_per_write=200000
+----
+5.00 access-vcpus, 0.05 raft-vcpus, 31 KiB/s goodput
+
+# Assert that leases are stable (not bouncing) over the last 100 ticks.
+# SMA is expected to fail this due to the diluted-mean churn described above.
+assertion type=steady stat=leases ticks=100 upper_bound=0.15
+----
+asserting: |leases(t)/mean_{T}(leases) - 1| ≤ 0.15 ∀ t∈T and each store (T=last 100 ticks)
+
+eval duration=10m samples=1 seed=42 cfgs=(sma-count,mma-count) metrics=(cpu,cpu_util,leases,lease_moves,replica_moves)
+----
+sma-count:
+cpu#1: last:  [s1=1031735064, s2=528633298, s3=778685297, s4=778189140, s5=2025375171, s6=0, s7=0, s8=0] (stddev=647320358.34, mean=642827246.25, sum=5142617970)
+cpu#1: thrash_pct: [s1=362%, s2=312%, s3=403%, s4=489%, s5=258%, s6=0%, s7=0%, s8=1%]  (sum=1826%)
+cpu_util#1: last:  [s1=0.13, s2=0.07, s3=0.10, s4=0.10, s5=0.25, s6=0.00, s7=0.00, s8=0.00] (stddev=0.08, mean=0.08, sum=1)
+cpu_util#1: thrash_pct: [s1=362%, s2=312%, s3=403%, s4=489%, s5=258%, s6=0%, s7=0%, s8=1%]  (sum=1826%)
+lease_moves#1: last:  [s1=10, s2=6, s3=13, s4=13, s5=5, s6=0, s7=0, s8=0] (stddev=5.28, mean=5.88, sum=47)
+lease_moves#1: thrash_pct: [s1=0%, s2=0%, s3=0%, s4=0%, s5=0%, s6=0%, s7=0%, s8=0%]  (sum=0%)
+leases#1: first: [s1=3, s2=2, s3=2, s4=3, s5=2, s6=2, s7=3, s8=4] (stddev=0.70, mean=2.62, sum=21)
+leases#1: last:  [s1=4, s2=2, s3=3, s4=3, s5=8, s6=0, s7=0, s8=1] (stddev=2.45, mean=2.62, sum=21)
+leases#1: thrash_pct: [s1=302%, s2=260%, s3=322%, s4=460%, s5=210%, s6=0%, s7=0%, s8=0%]  (sum=1554%)
+replica_moves#1: last:  [s1=14, s2=13, s3=13, s4=22, s5=14, s6=2, s7=3, s8=5] (stddev=6.40, mean=10.75, sum=86)
+replica_moves#1: thrash_pct: [s1=0%, s2=0%, s3=0%, s4=0%, s5=0%, s6=0%, s7=0%, s8=0%]  (sum=0%)
+hash: 3b6ebc370a99142f
+failed assertion sample 1
+  steady state stat=leases threshold=(≤0.15) ticks=100
+	store=1 min/mean=0.23 max/mean=0.54
+	store=2 min/mean=0.11 max/mean=0.33
+	store=3 min/mean=0.08 max/mean=0.84
+	store=4 min/mean=0.05 max/mean=0.59
+	store=5 min/mean=0.87 max/mean=0.08
+==========================
+mma-count:
+cpu#1: last:  [s1=1030717382, s2=1034178068, s3=1028156073, s4=1028552503, s5=1027707110, s6=0, s7=0, s8=0] (stddev=498583495.61, mean=643663892.00, sum=5149311136)
+cpu#1: thrash_pct: [s1=12%, s2=11%, s3=13%, s4=80%, s5=19%, s6=0%, s7=0%, s8=2%]  (sum=137%)
+cpu_util#1: last:  [s1=0.13, s2=0.13, s3=0.13, s4=0.13, s5=0.13, s6=0.00, s7=0.00, s8=0.00] (stddev=0.06, mean=0.08, sum=1)
+cpu_util#1: thrash_pct: [s1=12%, s2=11%, s3=13%, s4=80%, s5=19%, s6=0%, s7=0%, s8=2%]  (sum=137%)
+lease_moves#1: last:  [s1=0, s2=0, s3=0, s4=2, s5=0, s6=0, s7=0, s8=0] (stddev=0.66, mean=0.25, sum=2)
+lease_moves#1: thrash_pct: [s1=0%, s2=0%, s3=0%, s4=0%, s5=0%, s6=0%, s7=0%, s8=0%]  (sum=0%)
+leases#1: first: [s1=3, s2=2, s3=2, s4=3, s5=2, s6=2, s7=3, s8=4] (stddev=0.70, mean=2.62, sum=21)
+leases#1: last:  [s1=4, s2=4, s3=4, s4=4, s5=4, s6=0, s7=0, s8=1] (stddev=1.80, mean=2.62, sum=21)
+leases#1: thrash_pct: [s1=0%, s2=0%, s3=0%, s4=69%, s5=0%, s6=0%, s7=0%, s8=0%]  (sum=69%)
+replica_moves#1: last:  [s1=1, s2=2, s3=3, s4=6, s5=2, s6=2, s7=3, s8=5] (stddev=1.58, mean=3.00, sum=24)
+replica_moves#1: thrash_pct: [s1=0%, s2=0%, s3=0%, s4=0%, s5=0%, s6=0%, s7=0%, s8=0%]  (sum=0%)
+hash: 9b1eb64c38ece3bf
+==========================


### PR DESCRIPTION
Add an allocator simulation test that reproduces the scenario where SQL-only (gateway) nodes dilute the cluster-wide load mean, causing the store rebalancer to permanently consider all KV nodes overloaded and churn leases unnecessarily.

The test sets up 5 KV nodes + 3 gateway nodes with all ranges constrained to the KV region. Under SMA, the rebalancer performs 47 lease moves in 10 minutes with massive lease thrashing (1554%), while MMA correctly recognizes the situation and performs only 2 lease moves with stable lease placement.

A steady-state assertion on lease counts confirms that SMA fails to maintain stability while MMA passes.

Informs: #162590
Epic: CRDB-56265
Release note: None