### PR TITLE
sql: deflake TestStatusAPIContentionEvents

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -1682,6 +1682,13 @@ func (r *DistSQLReceiver) pushMeta(meta *execinfrapb.ProducerMetadata) execinfra
 	}
 	if len(meta.TraceData) > 0 {
 		if span := tracing.SpanFromContext(r.ctx); span != nil {
+			// Note(davidh): I believe this import can be triggered multiple times
+			// during distsql execution and cause duplicate spans. This has only
+			// been triggered by test flakes so far. If we observe this in production
+			// we should consider adding some deduplication logic or accept that
+			// duplicate spans can occur. For now I'm leaving the behavior as-is
+			// because I don't introduce more allocation to the tracing logic.
+			// see also: exec_util.go:getMessagesForSubtrace which detects the dupe.
 			span.ImportRemoteRecording(meta.TraceData)
 		}
 	}

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3405,6 +3405,14 @@ func getMessagesForSubtrace(
 	span spanWithIndex, allSpans []tracingpb.RecordedSpan, seenSpans map[tracingpb.SpanID]struct{},
 ) ([]logRecordRow, error) {
 	if _, ok := seenSpans[span.SpanID]; ok {
+		// Note(davidh): If you're investigating a test flake that's
+		// triggering this error I believe it's triggered by behavior in
+		// DistSQLReceiver.pushMeta which calls span.ImportRemoteRecording.
+		// Consider changing this code to log the error and continue, or
+		// implement span deduplication on import. I've left this as-is for now
+		// since the problem occurs very rarely and only in tests and I think
+		// the consequences for a user would require tracing the same execution
+		// again, which can usually be done.
 		return nil, errors.Errorf("duplicate span %d", span.SpanID)
 	}
 	var allLogs []logRecordRow


### PR DESCRIPTION
Add detection for duplicate span errors to the test and ignore them since this test only cares about the contention information that's captured while tracing, and not the trace itself.

Also added notes to the two callsites I found that were causing this error to trigger. I confirmed that the test would stop flaking if I commented out the `ImportRemoteRecording` line in distsql_running.go.

I've chosen for now not to disrupt the application logic because even if I disabled duplicate span
detection, I'd still want it on during tests, and I haven't observed this error in production so it
doesn't seem to be urgent.

Resolves: #160544
Resolves: #160876
Epic: none
Release note: None