### PR TITLE
server: add store ID tag to MMA ProcessStoreLoadMsg context

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -930,6 +930,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 			}
 			storeLoadMsg := mmaintegration.MakeStoreLoadMsg(storeDesc, origTimestampNanos)
 			mmaAlloc.SetStore(state.StoreAttrAndLocFromDesc(storeDesc))
+			ctx = logtags.AddTag(ctx, "s", storeDesc.StoreID)
 			mmaAlloc.ProcessStoreLoadMsg(ctx, &storeLoadMsg)
 		},
 	)


### PR DESCRIPTION
Adds the store ID tag to context passed to ProcessStoreLoadMsg for better logging and observability.

Fixes: #162257
Epic: CRDB-56265
Release note: None