### PR TITLE
admission: dynamically determine burstQualification

### DIFF
--- a/pkg/util/admission/BUILD.bazel
+++ b/pkg/util/admission/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "admission",
     srcs = [
         "admission.go",
+        "cpu_time_token_burst.go",
         "cpu_time_token_estimation.go",
         "cpu_time_token_filler.go",
         "cpu_time_token_grant_coordinator.go",

--- a/pkg/util/admission/admission.go
+++ b/pkg/util/admission/admission.go
@@ -139,6 +139,9 @@ import (
 type burstQualification uint8
 
 const (
+	// Order matters here. A higher priority burstQualification must use a
+	// lower ordinal than a lower priority burstQualification (see
+	// tenantHeap.Less for a place where this invariant is relied on).
 	canBurst burstQualification = iota
 	noBurst
 	numBurstQualifications

--- a/pkg/util/admission/cpu_time_token_burst.go
+++ b/pkg/util/admission/cpu_time_token_burst.go
@@ -1,0 +1,106 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package admission
+
+import "github.com/cockroachdb/redact"
+
+// cpuTimeBurstBucket is a per-tenant token bucket that determines whether a
+// tenant qualifies for burst priority. If a tenant qualifies, two things
+// happen:
+//
+//  1. In the WorkQueue, its work sorts above the work of tenants that don't
+//     qualify for burst priority.
+//  2. It has access to more CPU time tokens than tenants that don't qualify
+//     (see cpu_time_token_granter.go for more).
+//
+// These two things are related. Since canBurst tenants have access to more
+// CPU time than noBurst tenants, it is important that work from a
+// canBurst tenant always sorts before work from a noBurst tenant -- else
+// available capacity is left on the table.
+//
+// The bucket works as follows:
+//   - Tokens are added periodically via refill(), called by
+//     cpuTimeTokenAllocator.
+//   - Tokens are deducted when work is admitted, etc. via adjust().
+//   - A tenant qualifies for burst (canBurst) when bucket is > 90% full.
+//   - The bucket can go negative (down to -capacity/4) to allow recovery.
+//
+// The bucket capacity is derived from the noBurst refill rate in
+// cpuTimeTokenAllocator (capacity = noBurst_refill_rate / 4).
+// With cluster settings at their default values, this implies that
+// an application tenant can burst, if they are using roughly less
+// than 20% of the CPU on a CRDB node (0.8 * 0.25 = 0.2).
+type cpuTimeBurstBucket struct {
+	tokens   int64
+	capacity int64
+	// disabled is true when mode != usesCPUTimeTokens, causing
+	// burstQualification to always return noBurst. This effectively
+	// disables the burstQualification functionality.
+	disabled bool
+}
+
+func (m *cpuTimeBurstBucket) init(capacity int64, disabled bool) {
+	// The bucket of a new tenant is inited full. This implies that
+	// a tenant can burst when its work first appears on a KV node.
+	// After <= 1s, the bucket state should track the usage of the
+	// tenant accurately.
+	*m = cpuTimeBurstBucket{tokens: capacity, capacity: capacity, disabled: disabled}
+}
+
+// burstQualification returns whether this tenant qualifies for burst
+// priority. See the comments above cpuTimeBurstBucket for more.
+func (m *cpuTimeBurstBucket) burstQualification() burstQualification {
+	if m.disabled {
+		return noBurst
+	}
+	// Note that at CRDB startup time, the capacity that is passed into
+	// cpuTimeBurstBucket.init will be zero, until 1ms passes, and the
+	// first call to refillBurstBuckets is made by cpuTimeTokenAllocator.
+	// So it is important that this code does not assume that m.capacity
+	// is non-zero. (There is a test for this case in
+	// TestCPUTimeTokenBurst.)
+	if m.tokens > (m.capacity*9)/10 {
+		return canBurst
+	}
+	return noBurst
+}
+
+// adjust modifies the token count by delta. A positive delta adds tokens
+// (e.g., when returning unused resources), while a negative delta removes
+// tokens (e.g., when work is admitted). The token count is capped at
+// capacity but has no floor here. The floor is enforced in refill, which
+// is called every 1ms. There is no need to enforce the floor more
+// frequently than that.
+func (m *cpuTimeBurstBucket) adjust(delta int64) {
+	m.tokens += delta
+	m.tokens = min(m.tokens, m.capacity)
+}
+
+// refill adds tokens to the bucket and updates capacity. This is called
+// periodically by cpuTimeTokenAllocator (every 1ms). The token count is capped
+// at capacity and floored at -capacity/4. The negative floor allows tenants
+// that have gone into debt (consumed more than their share) to recover over
+// time rather than being disqualified from bursting for arbitrarily long periods
+// of time.
+func (m *cpuTimeBurstBucket) refill(toAdd int64, capacity int64) {
+	m.capacity = capacity
+	m.adjust(toAdd)
+	m.tokens = max(m.tokens, -m.capacity/4)
+}
+
+func (m *cpuTimeBurstBucket) String() string {
+	return redact.StringWithoutMarkers(m)
+}
+
+// SafeFormat implements the redact.SafeFormatter interface.
+func (m *cpuTimeBurstBucket) SafeFormat(s redact.SafePrinter, _ rune) {
+	var fullness float64
+	if m.capacity > 0 {
+		fullness = float64(m.tokens) / float64(m.capacity) * 100
+	}
+	s.Printf("fullness=%.1f%% tokens=%d capacity=%d qual=%s",
+		fullness, m.tokens, m.capacity, m.burstQualification())
+}

--- a/pkg/util/admission/cpu_time_token_grant_coordinator.go
+++ b/pkg/util/admission/cpu_time_token_grant_coordinator.go
@@ -130,6 +130,9 @@ func makeCPUTimeTokenGrantCoordinator(
 		requesters[tier] = makeWorkQueue(
 			ambientCtx, KVWork, &childGranters[tier], settings, wqMetrics, opts)
 		granter.requester[tier] = requesters[tier]
+		// This type assertion is always valid, since makeWorkQueue always
+		// returns a *WorkQueue.
+		allocator.queues[tier] = requesters[tier].(*WorkQueue)
 	}
 
 	coordinator := &cpuTimeTokenGrantCoordinator{

--- a/pkg/util/admission/snapshot_queue_test.go
+++ b/pkg/util/admission/snapshot_queue_test.go
@@ -88,7 +88,9 @@ func TestSnapshotQueue(t *testing.T) {
 			case "set-try-get-return-value":
 				var v bool
 				d.ScanArgs(t, "v", &v)
-				tg.returnValueFromTryGet = v
+				tg.mu.Lock()
+				tg.mu.returnValueFromTryGet = v
+				tg.mu.Unlock()
 				return ""
 
 			case "granted":

--- a/pkg/util/admission/testdata/cpu_time_token_allocator
+++ b/pkg/util/admission/testdata/cpu_time_token_allocator
@@ -20,6 +20,9 @@ fit(
 cpuTTG canBurst noBurst
 tier0  5000     4000
 tier1  3000     2000
+burstM
+tier0  1000
+tier1  500
 
 # clear simulates tokens being taken due to admitted work.
 clear
@@ -27,6 +30,9 @@ clear
 cpuTTG canBurst noBurst
 tier0  0        0
 tier1  0        0
+burstM
+tier0  0
+tier1  0
 
 # Over an interval (between calls to resetInterval), the refill rate should
 # be added to each bucket. Again, here are the refill rates:
@@ -43,35 +49,55 @@ tier1  0        0
 #        canBurst noBurst
 # tier0  1000     800
 # tier1  600      400
+#
+# Burst bucket state is also printed. The burst bucket refill rate and
+# capacity should be 1/4th of the noBurst refill rate and capacity
+# (for the corresponding resource tier). See cpu_time_token_burst.go for
+# context on the idea of burst buckets in general.
 allocate remaining=5
 ----
 cpuTTG canBurst noBurst
 tier0  1000     800
 tier1  600      400
+burstM
+tier0  200
+tier1  100
 
 allocate remaining=4
 ----
 cpuTTG canBurst noBurst
 tier0  2000     1600
 tier1  1200     800
+burstM
+tier0  400
+tier1  200
 
 allocate remaining=3
 ----
 cpuTTG canBurst noBurst
 tier0  3000     2400
 tier1  1800     1200
+burstM
+tier0  600
+tier1  300
 
 allocate remaining=2
 ----
 cpuTTG canBurst noBurst
 tier0  4000     3200
 tier1  2400     1600
+burstM
+tier0  800
+tier1  400
 
 allocate remaining=1
 ----
 cpuTTG canBurst noBurst
 tier0  5000     4000
 tier1  3000     2000
+burstM
+tier0  1000
+tier1  500
 
 resetInterval
 ----
@@ -84,6 +110,9 @@ fit(
 cpuTTG canBurst noBurst
 tier0  5000     4000
 tier1  3000     2000
+burstM
+tier0  1000
+tier1  500
 
 # resetInterval has been called, so a new interval has started.
 # So in theory more tokens can be added. But in this case the
@@ -95,12 +124,18 @@ allocate remaining=5
 cpuTTG canBurst noBurst
 tier0  5000     4000
 tier1  3000     2000
+burstM
+tier0  1000
+tier1  500
 
 clear
 ----
 cpuTTG canBurst noBurst
 tier0  0        0
 tier1  0        0
+burstM
+tier0  0
+tier1  0
 
 # In the interval, one call to allocateTokens was made already.
 # So we do not expect the full rates to end up in the buckets.
@@ -126,6 +161,9 @@ allocate remaining=1
 cpuTTG canBurst noBurst
 tier0  4000     3200
 tier1  2400     1600
+burstM
+tier0  800
+tier1  400
 
 resetInterval
 ----
@@ -138,12 +176,18 @@ fit(
 cpuTTG canBurst noBurst
 tier0  4000     3200
 tier1  2400     1600
+burstM
+tier0  800
+tier1  400
 
 clear
 ----
 cpuTTG canBurst noBurst
 tier0  0        0
 tier1  0        0
+burstM
+tier0  0
+tier1  0
 
 # In this interval, no call to allocateTokens so far, so we do
 # expect the full rates to end up in the bucket, again in a single
@@ -153,6 +197,9 @@ allocate remaining=1
 cpuTTG canBurst noBurst
 tier0  5000     4000
 tier1  3000     2000
+burstM
+tier0  1000
+tier1  500
 
 resetInterval
 ----
@@ -165,12 +212,18 @@ fit(
 cpuTTG canBurst noBurst
 tier0  5000     4000
 tier1  3000     2000
+burstM
+tier0  1000
+tier1  500
 
 clear
 ----
 cpuTTG canBurst noBurst
 tier0  0        0
 tier1  0        0
+burstM
+tier0  0
+tier1  0
 
 # In this interval, two ticks, so half of the tokens should be added
 # on the first call to allocate, and the other half on the second call.
@@ -179,12 +232,18 @@ allocate remaining=2
 cpuTTG canBurst noBurst
 tier0  2500     2000
 tier1  1500     1000
+burstM
+tier0  500
+tier1  250
 
 allocate remaining=1
 ----
 cpuTTG canBurst noBurst
 tier0  5000     4000
 tier1  3000     2000
+burstM
+tier0  1000
+tier1  500
 
 # These final cases test how cpuTimeTokenAllocator handles changes to
 # refillRates. See the comment above deltaRefillRates for a full explanation
@@ -203,12 +262,18 @@ fit(
 cpuTTG canBurst noBurst
 tier0  5001     4001
 tier1  3001     2001
+burstM
+tier0  1000
+tier1  500
 
 clear
 ----
 cpuTTG canBurst noBurst
 tier0  0        0
 tier1  0        0
+burstM
+tier0  0
+tier1  0
 
 # The updated refillRate is added to the buckets (in one tick for simplicity,
 # since remaining=1).
@@ -217,6 +282,9 @@ allocate remaining=1
 cpuTTG canBurst noBurst
 tier0  5001     4001
 tier1  3001     2001
+burstM
+tier0  1000
+tier1  500
 
 # Another test of a change to refillRates. If we decrease refillRates by two
 # (on all buckets), we expect two tokens to be removed from all buckets, as
@@ -232,12 +300,18 @@ fit(
 cpuTTG canBurst noBurst
 tier0  4999     3999
 tier1  2999     1999
+burstM
+tier0  999
+tier1  499
 
 clear
 ----
 cpuTTG canBurst noBurst
 tier0  0        0
 tier1  0        0
+burstM
+tier0  0
+tier1  0
 
 # The updated refillRate is added to the buckets (in one tick for simplicity,
 # since remaining=1).
@@ -246,12 +320,18 @@ allocate remaining=1
 cpuTTG canBurst noBurst
 tier0  4999     3999
 tier1  2999     1999
+burstM
+tier0  999
+tier1  499
 
 clear
 ----
 cpuTTG canBurst noBurst
 tier0  0        0
 tier1  0        0
+burstM
+tier0  0
+tier1  0
 
 # Test of computation of target CPU utilizations from overridden cluster
 # settings. The noBurst targets are configurable by cluster settings, which
@@ -266,6 +346,9 @@ SET CLUSTER SETTING admission.cpu_time_tokens.target_util.burst_delta = 0.1
 cpuTTG canBurst noBurst
 tier0  0        0
 tier1  0        0
+burstM
+tier0  0
+tier1  0
 
 resetInterval
 ----
@@ -278,3 +361,6 @@ fit(
 cpuTTG canBurst noBurst
 tier0  0        0
 tier1  0        0
+burstM
+tier0  0
+tier1  0

--- a/pkg/util/admission/testdata/cpu_time_token_work_queue
+++ b/pkg/util/admission/testdata/cpu_time_token_work_queue
@@ -1,19 +1,23 @@
+###
+# The first test here is mostly a test of AdmittedWorkDone (work-done).
+# So AC admits requests, one to tenant ID 53 and another to tenant ID
+# 54. The test granter has been set up to allow granting of all requests.
+# This is just test setup.
+###
 init
 ----
 
-# See comment above TestCPUTimeTokenWorkQueue for background. This is
-# mostly a test of AdmittedWorkDone (work-done). So AC admits requests,
-# one to tenant ID 53 and another to tenant ID 54. The test granter
-# has been set up to allow granting of all requests. This is just test
-# setup.
+set-try-get-return-value v=true
+----
+
 admit id=1 tenant=53 requested-count=3
 ----
-tryGet: returning true
+tryGet: input noBurst, returning true
 id 1: admit succeeded
 
 admit id=2 tenant=54 requested-count=8
 ----
-tryGet: returning true
+tryGet: input noBurst, returning true
 id 2: admit succeeded
 
 print
@@ -21,6 +25,7 @@ print
 closed epoch: 0 tenantHeap len: 0
  tenant-id: 53 used: 3, w: 1, fifo: -128
  tenant-id: 54 used: 8, w: 1, fifo: -128
+burst-buckets: t53=fullness=0.0% tokens=-3 capacity=0 qual=noBurst t54=fullness=0.0% tokens=-8 capacity=0 qual=noBurst
 
 # requested-count at admit time was 3. cpu-time below is 1. This
 # simulates a situation where at admit time, the predicted CPU usage
@@ -40,6 +45,7 @@ print
 closed epoch: 0 tenantHeap len: 0
  tenant-id: 53 used: 1, w: 1, fifo: -128
  tenant-id: 54 used: 8, w: 1, fifo: -128
+burst-buckets: t53=fullness=0.0% tokens=-1 capacity=0 qual=noBurst t54=fullness=0.0% tokens=-8 capacity=0 qual=noBurst
 
 # In this case, measured CPU usage was more than predicted CPU usage.
 # So, we should take additional tokens from the granter this time.
@@ -53,3 +59,523 @@ print
 closed epoch: 0 tenantHeap len: 0
  tenant-id: 53 used: 1, w: 1, fifo: -128
  tenant-id: 54 used: 15, w: 1, fifo: -128
+burst-buckets: t53=fullness=0.0% tokens=-1 capacity=0 qual=noBurst t54=fullness=0.0% tokens=-15 capacity=0 qual=noBurst
+
+###
+# This test is of the integration of burstQualification with the tenant
+# heap sorting in WorkQueue. That is, we check that work associated with
+# canBurst tenants sort to the top of the heap. See
+# cpu_time_token_burst.go for more.
+###
+init
+----
+
+set-try-get-return-value v=true
+----
+
+admit id=1 tenant=53 requested-count=1
+----
+tryGet: input noBurst, returning true
+id 1: admit succeeded
+
+admit id=2 tenant=54 requested-count=1
+----
+tryGet: input noBurst, returning true
+id 2: admit succeeded
+
+# Set up buckets so that tenant 53 can burst, while tenant
+# 54 cannot burst (call to Admit below empties 54's token
+# bucket).
+refill-burst-buckets to-add=100 capacity=100
+----
+
+admit id=1000 tenant=54 requested-count=100
+----
+tryGet: input canBurst, returning true
+id 1000: admit succeeded
+
+print
+----
+closed epoch: 0 tenantHeap len: 0
+ tenant-id: 53 used: 1, w: 1, fifo: -128
+ tenant-id: 54 used: 101, w: 1, fifo: -128
+burst-buckets: t53=fullness=99.0% tokens=99 capacity=100 qual=canBurst t54=fullness=-1.0% tokens=-1 capacity=100 qual=noBurst
+
+set-try-get-return-value v=false
+----
+
+# Some work from 54 is queued this time. Then some work from 53
+# tries to admit. The work from 53 is admitted, since 53 can
+# burst, and the backlog is all for work that cannot burst, and
+# since the granter says the work from 53 can proceed (there are
+# available canBurst CPU time tokens in the granter).
+admit id=5 tenant=54 requested-count=15
+----
+tryGet: input noBurst, returning false
+
+set-try-get-return-value v=true
+----
+
+admit id=6 tenant=53 requested-count=1
+----
+tryGet: input canBurst, returning true
+id 6: admit succeeded
+
+granted chain-id=1
+----
+continueGrantChain 1
+id 5: admit succeeded
+granted: returned 15
+
+set-try-get-return-value v=false
+----
+
+# Work from 54 is queued before work from 53. Still, the work
+# from 53 is granted admission before the work from 54, since
+# 53 can burst.
+admit id=7 tenant=54 requested-count=15
+----
+tryGet: input noBurst, returning false
+
+admit id=8 tenant=53 requested-count=1
+----
+tryGet: input canBurst, returning false
+
+# See Less implementation in WorkQueue. We clear used to be sure
+# that the reason the WorkQueue sorts the heap the way it does below
+# is the burstQualifications.
+gc-tenants-and-reset-used
+----
+
+granted chain-id=1
+----
+continueGrantChain 1
+id 8: admit succeeded
+granted: returned 1
+
+granted chain-id=1
+----
+continueGrantChain 1
+id 7: admit succeeded
+granted: returned 15
+
+###
+# This test exercises the burst qualification logic. It verifies that
+# the correct burstQualification is passed to the granter's tryGet
+# method based on the tenant's burst bucket state. It tests the 90%
+# fullness threshold, the capacity cap, negative bucket recovery,
+# AdmittedWorkDone token refunds, and capacity changes.
+###
+init
+----
+
+set-try-get-return-value v=true
+----
+
+# Init tenant 1 before refillBurstBuckets has been called. The bucket
+# does not have a capacity set yet. It is important to test that a
+# zero-valued capacity does not cause bad behavior, such as a panic.
+# refillBurstBuckets is called every 1ms, so AC does not stay in this
+# state for long.
+admit id=1 tenant=1 requested-count=1
+----
+tryGet: input noBurst, returning true
+id 1: admit succeeded
+
+# Fill tenant 1's burst bucket to the top with 100 tokens.
+refill-burst-buckets to-add=100 capacity=100
+----
+
+# Tenant 2 is inited after the first call to refillBurstBuckets. Burst
+# buckets start full, so on the first call to Admit, it can burst.
+admit id=2 tenant=2 requested-count=1
+----
+tryGet: input canBurst, returning true
+id 2: admit succeeded
+
+# Call refillBurstBuckets again. Since both buckets are already full,
+# the cap on tokens is tested here. That is, at the end of this call,
+# the buckets should each have 100 tokens, not more than 100 tokens.
+refill-burst-buckets to-add=100 capacity=100
+----
+
+print
+----
+closed epoch: 0 tenantHeap len: 0
+ tenant-id: 1 used: 1, w: 1, fifo: -128
+ tenant-id: 2 used: 1, w: 1, fifo: -128
+burst-buckets: t1=fullness=100.0% tokens=100 capacity=100 qual=canBurst t2=fullness=100.0% tokens=100 capacity=100 qual=canBurst
+
+# Since both burst buckets are full, both tenants can burst.
+admit id=3 tenant=1 requested-count=1
+----
+tryGet: input canBurst, returning true
+id 3: admit succeeded
+
+print
+----
+closed epoch: 0 tenantHeap len: 0
+ tenant-id: 1 used: 2, w: 1, fifo: -128
+ tenant-id: 2 used: 1, w: 1, fifo: -128
+burst-buckets: t1=fullness=99.0% tokens=99 capacity=100 qual=canBurst t2=fullness=100.0% tokens=100 capacity=100 qual=canBurst
+
+admit id=4 tenant=2 requested-count=1
+----
+tryGet: input canBurst, returning true
+id 4: admit succeeded
+
+print
+----
+closed epoch: 0 tenantHeap len: 0
+ tenant-id: 1 used: 2, w: 1, fifo: -128
+ tenant-id: 2 used: 2, w: 1, fifo: -128
+burst-buckets: t1=fullness=99.0% tokens=99 capacity=100 qual=canBurst t2=fullness=99.0% tokens=99 capacity=100 qual=canBurst
+
+# Bucket started at 100 tokens. First call to Admit removed 1 token.
+# This call to Admit removes 7 tokens. 100-1-7 = 92 tokens in bucket.
+# So tenant 1 can burst still, since bucket is more than 90% full.
+admit id=5 tenant=1 requested-count=7
+----
+tryGet: input canBurst, returning true
+id 5: admit succeeded
+
+print
+----
+closed epoch: 0 tenantHeap len: 0
+ tenant-id: 1 used: 9, w: 1, fifo: -128
+ tenant-id: 2 used: 2, w: 1, fifo: -128
+burst-buckets: t1=fullness=92.0% tokens=92 capacity=100 qual=canBurst t2=fullness=99.0% tokens=99 capacity=100 qual=canBurst
+
+# Bucket started at 100 tokens. First call to Admit removed 1 token.
+# This call to Admit removes 10 tokens. 100-1-10 = 89 tokens in bucket.
+# Tenant 2 can burst this time, but won't be able to the next call to
+# admit.
+admit id=6 tenant=2 requested-count=10
+----
+tryGet: input canBurst, returning true
+id 6: admit succeeded
+
+print
+----
+closed epoch: 0 tenantHeap len: 0
+ tenant-id: 1 used: 9, w: 1, fifo: -128
+ tenant-id: 2 used: 12, w: 1, fifo: -128
+burst-buckets: t1=fullness=92.0% tokens=92 capacity=100 qual=canBurst t2=fullness=89.0% tokens=89 capacity=100 qual=noBurst
+
+# 100-1-7-1 = 91 tokens in the bucket. So tenant 1 can burst still.
+admit id=7 tenant=1 requested-count=1
+----
+tryGet: input canBurst, returning true
+id 7: admit succeeded
+
+print
+----
+closed epoch: 0 tenantHeap len: 0
+ tenant-id: 1 used: 10, w: 1, fifo: -128
+ tenant-id: 2 used: 12, w: 1, fifo: -128
+burst-buckets: t1=fullness=91.0% tokens=91 capacity=100 qual=canBurst t2=fullness=89.0% tokens=89 capacity=100 qual=noBurst
+
+# 100-1-10-1 = 88. Tenant 2 cannot burst this time.
+admit id=8 tenant=2 requested-count=1
+----
+tryGet: input noBurst, returning true
+id 8: admit succeeded
+
+print
+----
+closed epoch: 0 tenantHeap len: 0
+ tenant-id: 1 used: 10, w: 1, fifo: -128
+ tenant-id: 2 used: 13, w: 1, fifo: -128
+burst-buckets: t1=fullness=91.0% tokens=91 capacity=100 qual=canBurst t2=fullness=88.0% tokens=88 capacity=100 qual=noBurst
+
+# 100-1-7-1-1 = 90. So this call to Admit, tenant 1 can burst, but
+# the next call, tenant 1 cannot burst.
+admit id=9 tenant=1 requested-count=1
+----
+tryGet: input canBurst, returning true
+id 9: admit succeeded
+
+print
+----
+closed epoch: 0 tenantHeap len: 0
+ tenant-id: 1 used: 11, w: 1, fifo: -128
+ tenant-id: 2 used: 13, w: 1, fifo: -128
+burst-buckets: t1=fullness=90.0% tokens=90 capacity=100 qual=noBurst t2=fullness=88.0% tokens=88 capacity=100 qual=noBurst
+
+admit id=10 tenant=1 requested-count=1
+----
+tryGet: input noBurst, returning true
+id 10: admit succeeded
+
+print
+----
+closed epoch: 0 tenantHeap len: 0
+ tenant-id: 1 used: 12, w: 1, fifo: -128
+ tenant-id: 2 used: 13, w: 1, fifo: -128
+burst-buckets: t1=fullness=89.0% tokens=89 capacity=100 qual=noBurst t2=fullness=88.0% tokens=88 capacity=100 qual=noBurst
+
+# Fill to full again. Both tenants thus can burst.
+refill-burst-buckets to-add=100 capacity=100
+----
+
+admit id=11 tenant=1 requested-count=1
+----
+tryGet: input canBurst, returning true
+id 11: admit succeeded
+
+admit id=12 tenant=2 requested-count=1
+----
+tryGet: input canBurst, returning true
+id 12: admit succeeded
+
+# Deduct huge number of tokens from tenant 1's bucket. Can
+# burst, since bucket is mostly full before this call.
+admit id=13 tenant=1 requested-count=100000000
+----
+tryGet: input canBurst, returning true
+id 13: admit succeeded
+
+# First refill will cap tenant 1 bucket at the min, which is
+# -bucketCapacity/4 = -100/4 = -25. Second refill adds 116, so
+# bucket is just barely 90% full after second refill. So can
+# burst.
+refill-burst-buckets to-add=10 capacity=100
+----
+
+print
+----
+closed epoch: 0 tenantHeap len: 0
+ tenant-id: 1 used: 100000013, w: 1, fifo: -128
+ tenant-id: 2 used: 14, w: 1, fifo: -128
+burst-buckets: t1=fullness=-25.0% tokens=-25 capacity=100 qual=noBurst t2=fullness=100.0% tokens=100 capacity=100 qual=canBurst
+
+refill-burst-buckets to-add=116 capacity=100
+----
+
+print
+----
+closed epoch: 0 tenantHeap len: 0
+ tenant-id: 1 used: 100000013, w: 1, fifo: -128
+ tenant-id: 2 used: 14, w: 1, fifo: -128
+burst-buckets: t1=fullness=91.0% tokens=91 capacity=100 qual=canBurst t2=fullness=100.0% tokens=100 capacity=100 qual=canBurst
+
+admit id=14 tenant=1 requested-count=1
+----
+tryGet: input canBurst, returning true
+id 14: admit succeeded
+
+# Since bucket was only barely 90% full, after one more call to
+# Admit, it is below 90% full. No burst.
+admit id=15 tenant=1 requested-count=1
+----
+tryGet: input noBurst, returning true
+id 15: admit succeeded
+
+# In production, requestedCount is a prediction of the CPU time
+# used by a request. Actual usage is measured by grunning and passed
+# to AdmittedWorkDone. In this test case, actual usage is way way
+# lower than the predicted usage. AdmittedWorkDone will thus add
+# tokens to the bucket. We refill to full first, then admit with a
+# large requested-count and complete with small cpu-time. The admit
+# deducts 1000000 tokens and work-done refunds 999999 (1000000-1),
+# so the net effect is -1 token on the burst bucket (99 after).
+# The first subsequent Admit puts bucket below 90% full, and the
+# second confirms noBurst.
+refill-burst-buckets to-add=100 capacity=100
+----
+
+admit id=16 tenant=1 requested-count=1000000
+----
+tryGet: input canBurst, returning true
+id 16: admit succeeded
+
+print
+----
+closed epoch: 0 tenantHeap len: 0
+ tenant-id: 1 used: 101000015, w: 1, fifo: -128
+ tenant-id: 2 used: 14, w: 1, fifo: -128
+burst-buckets: t1=fullness=-999900.0% tokens=-999900 capacity=100 qual=noBurst t2=fullness=100.0% tokens=100 capacity=100 qual=canBurst
+
+work-done id=16 cpu-time=1
+----
+returnGrant 999999
+
+print
+----
+closed epoch: 0 tenantHeap len: 0
+ tenant-id: 1 used: 100000016, w: 1, fifo: -128
+ tenant-id: 2 used: 14, w: 1, fifo: -128
+burst-buckets: t1=fullness=99.0% tokens=99 capacity=100 qual=canBurst t2=fullness=100.0% tokens=100 capacity=100 qual=canBurst
+
+admit id=17 tenant=1 requested-count=10
+----
+tryGet: input canBurst, returning true
+id 17: admit succeeded
+
+admit id=18 tenant=1 requested-count=1
+----
+tryGet: input noBurst, returning true
+id 18: admit succeeded
+
+# Test a bucket capacity change. On first call to Admit, bucket is
+# full. On second call, bucket is less than 90% full.
+refill-burst-buckets to-add=20 capacity=20
+----
+
+print
+----
+closed epoch: 0 tenantHeap len: 0
+ tenant-id: 1 used: 100000027, w: 1, fifo: -128
+ tenant-id: 2 used: 14, w: 1, fifo: -128
+burst-buckets: t1=fullness=100.0% tokens=20 capacity=20 qual=canBurst t2=fullness=100.0% tokens=20 capacity=20 qual=canBurst
+
+admit id=19 tenant=1 requested-count=2
+----
+tryGet: input canBurst, returning true
+id 19: admit succeeded
+
+admit id=20 tenant=1 requested-count=1
+----
+tryGet: input noBurst, returning true
+id 20: admit succeeded
+
+###
+# This is a test of WorkQueue deducting tokens from the burst buckets.
+# This test is an integration test. It ensures that the burst bucket
+# state correctly captures the usage seen by the WorkQueue, regardless
+# of exactly how the usage has flowed thru the WorkQueue. See the
+# earlier test in this file for a test focused on the burst qualification
+# logic in cpu_time_token_burst.go specifically.
+###
+init
+----
+
+set-try-get-return-value v=true
+----
+
+# Init a tenant, fill its burst bucket to the top.
+admit id=1 tenant=53 requested-count=1
+----
+tryGet: input noBurst, returning true
+id 1: admit succeeded
+
+refill-burst-buckets to-add=100 capacity=100
+----
+
+# The rest of this test is mostly of the burstBucket state
+# below. It starts at 99% full. The call to Admit put the
+# bucket at -1 tokens. The call to refill added 100 tokens.
+#
+# The rest of the test is self-explanatory, so I will not
+# add comments above every call to print. Calls to Admit
+# or AdmittedWorkDone are made, and they both adjust used
+# and adjust the burst bucket state.
+print
+----
+closed epoch: 0 tenantHeap len: 0
+ tenant-id: 53 used: 1, w: 1, fifo: -128
+burst-buckets: t53=fullness=99.0% tokens=99 capacity=100 qual=canBurst
+
+admit id=2 tenant=53 requested-count=5
+----
+tryGet: input canBurst, returning true
+id 2: admit succeeded
+
+print
+----
+closed epoch: 0 tenantHeap len: 0
+ tenant-id: 53 used: 6, w: 1, fifo: -128
+burst-buckets: t53=fullness=94.0% tokens=94 capacity=100 qual=canBurst
+
+set-try-get-return-value v=false
+----
+
+admit id=3 tenant=53 requested-count=1
+----
+tryGet: input canBurst, returning false
+
+print
+----
+closed epoch: 0 tenantHeap len: 1 top tenant: 53
+ tenant-id: 53 used: 6, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+burst-buckets: t53=fullness=94.0% tokens=94 capacity=100 qual=canBurst
+
+granted chain-id=1
+----
+continueGrantChain 1
+id 3: admit succeeded
+granted: returned 1
+
+print
+----
+closed epoch: 0 tenantHeap len: 0
+ tenant-id: 53 used: 7, w: 1, fifo: -128
+burst-buckets: t53=fullness=93.0% tokens=93 capacity=100 qual=canBurst
+
+work-done id=1 cpu-time=2
+----
+tookWithoutPermission 1
+
+print
+----
+closed epoch: 0 tenantHeap len: 0
+ tenant-id: 53 used: 8, w: 1, fifo: -128
+burst-buckets: t53=fullness=92.0% tokens=92 capacity=100 qual=canBurst
+
+work-done id=2 cpu-time=3
+----
+returnGrant 2
+
+print
+----
+closed epoch: 0 tenantHeap len: 0
+ tenant-id: 53 used: 6, w: 1, fifo: -128
+burst-buckets: t53=fullness=94.0% tokens=94 capacity=100 qual=canBurst
+
+admit id=4 tenant=53 requested-count=1 bypass
+----
+tookWithoutPermission 1
+id 4: admit succeeded
+
+print
+----
+closed epoch: 0 tenantHeap len: 0
+ tenant-id: 53 used: 7, w: 1, fifo: -128
+burst-buckets: t53=fullness=93.0% tokens=93 capacity=100 qual=canBurst
+
+set-try-get-return-value v=false
+----
+
+admit id=5 tenant=53 requested-count=1
+----
+tryGet: input canBurst, returning false
+
+cancel-work id=5
+----
+id 5: admit failed
+
+print
+----
+closed epoch: 0 tenantHeap len: 0
+ tenant-id: 53 used: 7, w: 1, fifo: -128
+burst-buckets: t53=fullness=93.0% tokens=93 capacity=100 qual=canBurst
+
+# Check the transition to no burst.
+set-try-get-return-value v=true
+----
+
+admit id=6 tenant=53 requested-count=5
+----
+tryGet: input canBurst, returning true
+id 6: admit succeeded
+
+admit id=7 tenant=53 requested-count=1
+----
+tryGet: input noBurst, returning true
+id 7: admit succeeded
+
+print
+----
+closed epoch: 0 tenantHeap len: 0
+ tenant-id: 53 used: 13, w: 1, fifo: -128
+burst-buckets: t53=fullness=87.0% tokens=87 capacity=100 qual=noBurst


### PR DESCRIPTION
**admission: dynamically determine burstQualification**

This commit introduces token buckets to CPU time token AC for dynamically determining the burstQualification of a tenant. If a tenant qualifies for burst, two things happen. First, in the WorkQueue, its work sorts above the work of tenants that don't qualify for burst priority. Second, it has access to more CPU time tokens than tenants that don't qualify (see cpu_time_token_granter.go for more). These two things are related: Since canBurst tenants have access to more CPU time than noBurst tenants, it is important that work from a canBurst tenant always sorts before work from a noBurst tenant -- else available capacity is left on the table.

Fixes: https://github.com/cockroachdb/cockroach/issues/155992

Release note: None.