### PR TITLE
release-26.1: roachtest: refactor datadog upload flags

### DIFF
--- a/pkg/cmd/roachtest/roachtestflags/flags.go
+++ b/pkg/cmd/roachtest/roachtestflags/flags.go
@@ -342,11 +342,16 @@ var (
 		Usage: `flag to pass custom labels to pass to openmetrics for performance metrics,`,
 	})
 
-	DatadogAlwaysUpload bool = false
-	_                        = registerRunFlag(&DatadogAlwaysUpload, FlagInfo{
-		Name: "datadog-always-upload",
-		Usage: `Always upload roachtest run log data to Datadog. Logs from master and release branches are uploaded by
-				default.`,
+	DatadogSendLogsAnyBranch bool = false
+	_                             = registerRunFlag(&DatadogSendLogsAnyBranch, FlagInfo{
+		Name:  "datadog-send-logs-any-branch",
+		Usage: `Upload roachtest logs to Datadog from any branch. By default, only logs from master and release branches are uploaded.`,
+	})
+
+	DatadogSendLogsAnyResult bool = false
+	_                             = registerRunFlag(&DatadogSendLogsAnyResult, FlagInfo{
+		Name:  "datadog-send-logs-any-result",
+		Usage: `Upload roachtest logs to Datadog regardless of test result. By default, only failed test logs are uploaded.`,
 	})
 
 	DatadogSite string = "us5.datadoghq.com"

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1623,8 +1623,8 @@ func (r *testRunner) runTest(
 		l.PrintfCtx(ctx, "error during artifact inspection: %v", err)
 	}
 
-	//Upload test logs to Datadog if running on TeamCity on a release branch
-	if datadog.ShouldUploadLogs() {
+	// Upload test logs to Datadog for failed tests on master/release branches (configurable via flags)
+	if datadog.ShouldUploadLogs(t.Failed()) {
 		t.L().Printf("uploading %s to Datadog", "test.log")
 		logPath := filepath.Join(t.artifactsDir, "test.log")
 		m := datadog.NewLogMetadata(


### PR DESCRIPTION
Backport 1/1 commits from #162558 on behalf of @williamchoe3.

----

Previously, all test.log logs would be uploaded regardless of result status. 
Now test logs will only be uploaded for failed tests to help reduce overall volume. 
Added a flag to enable upload regardless of result `--datadog-send-logs-any-result`. Also renamed `--datadog-always-upload` to `--datadog-send-logs-any-branch` to avoid confusion with the new flag

----

Release justification: Test observability only change