### PR TITLE
sql: foreign key should skip internal column in a hash-sharded pk

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_foreign_key
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_foreign_key
@@ -2303,3 +2303,111 @@ statement ok
 RESET create_table_with_schema_locked;
 
 subtest end
+
+# Test foreign keys with implicit column references on regional by row tables.
+# This verifies implicit FK references correctly skip the crdb_region column.
+subtest fk_implicit_rbr
+
+statement ok
+CREATE TABLE parent_rbr_implicit (
+  k INT PRIMARY KEY,
+  v INT
+) LOCALITY REGIONAL BY ROW
+
+statement ok
+INSERT INTO parent_rbr_implicit (k, v, crdb_region) VALUES
+  (1, 10, 'ca-central-1'),
+  (2, 20, 'ap-southeast-2'),
+  (3, 30, 'us-east-1')
+
+# FK without explicit column list should skip crdb_region implicit column
+statement ok
+CREATE TABLE child_rbr_implicit (
+  k INT PRIMARY KEY,
+  parent_k INT,
+  FOREIGN KEY (parent_k) REFERENCES parent_rbr_implicit
+) LOCALITY REGIONAL BY ROW
+
+statement ok
+INSERT INTO child_rbr_implicit (k, parent_k, crdb_region) VALUES
+  (1, 1, 'ca-central-1'),
+  (2, 2, 'ap-southeast-2')
+
+# Verify FK constraint enforcement
+statement error pq: insert on table "child_rbr_implicit" violates foreign key constraint
+INSERT INTO child_rbr_implicit (k, parent_k, crdb_region) VALUES (99, 99, 'ca-central-1')
+
+# Cleanup
+statement ok
+DROP TABLE child_rbr_implicit
+
+statement ok
+DROP TABLE parent_rbr_implicit
+
+subtest end
+
+# Test implicit keys with a combination of features that result in the
+# primary key index having internal/implicit columns.
+subtest fk_implicit_rbr_hash_sharded_combined
+
+# Parent table is regional by row with a hash-sharded primary key
+statement ok
+CREATE TABLE parent_combined (
+  k INT NOT NULL,
+  v INT NOT NULL,
+  data INT,
+  PRIMARY KEY (k, v) USING HASH
+) LOCALITY REGIONAL BY ROW
+
+statement ok
+INSERT INTO parent_combined (k, v, data, crdb_region) VALUES
+  (1, 1, 100, 'ca-central-1'),
+  (2, 2, 200, 'ap-southeast-2'),
+  (3, 3, 300, 'us-east-1')
+
+statement ok
+CREATE TABLE child_combined (
+  k INT,
+  v INT,
+  FOREIGN KEY (k, v) REFERENCES parent_combined
+) LOCALITY REGIONAL BY ROW
+
+statement ok
+INSERT INTO child_combined (k, v, crdb_region) VALUES
+  (1, 1, 'ca-central-1'),
+  (2, 2, 'ap-southeast-2')
+
+# Verify FK constraint enforcement
+statement error pq: insert on table "child_combined" violates foreign key constraint
+INSERT INTO child_combined (k, v, crdb_region) VALUES (99, 99, 'ca-central-1')
+
+# Verify this also works using ALTER TABLE
+statement ok
+CREATE TABLE child_combined2 (
+  k INT,
+  v INT
+) LOCALITY REGIONAL BY ROW
+
+statement ok
+ALTER TABLE child_combined2 ADD FOREIGN KEY (k, v) REFERENCES parent_combined
+
+statement ok
+INSERT INTO child_combined2 (k, v, crdb_region) VALUES
+  (1, 1, 'ca-central-1'),
+  (2, 2, 'ap-southeast-2')
+
+# Verify FK constraint enforcement
+statement error pq: insert on table "child_combined2" violates foreign key constraint
+INSERT INTO child_combined2 (k, v, crdb_region) VALUES (99, 99, 'ca-central-1')
+
+# Cleanup
+statement ok
+DROP TABLE child_combined
+
+statement ok
+DROP TABLE child_combined2
+
+statement ok
+DROP TABLE parent_combined
+
+subtest end

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -964,13 +964,14 @@ func ResolveFK(
 	referencedColNames := d.ToCols
 	// If no columns are specified, attempt to default to PK, ignoring implicit columns.
 	if len(referencedColNames) == 0 {
-		numImplicitCols := target.GetPrimaryIndex().ImplicitPartitioningColumnCount()
+		// Use ExplicitColumnStartIdx() to skip over all internal columns.
+		explicitColStartIdx := target.GetPrimaryIndex().ExplicitColumnStartIdx()
 		referencedColNames = make(
 			tree.NameList,
 			0,
-			target.GetPrimaryIndex().NumKeyColumns()-numImplicitCols,
+			target.GetPrimaryIndex().NumKeyColumns()-explicitColStartIdx,
 		)
-		for i := numImplicitCols; i < target.GetPrimaryIndex().NumKeyColumns(); i++ {
+		for i := explicitColStartIdx; i < target.GetPrimaryIndex().NumKeyColumns(); i++ {
 			referencedColNames = append(
 				referencedColNames,
 				tree.Name(target.GetPrimaryIndex().GetKeyColumnName(i)),

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -4843,3 +4843,64 @@ DROP TABLE t2_fk;
 DROP TABLE t1_fk;
 
 subtest end
+
+# Test foreign keys with implicit column references to hash-sharded primary keys
+subtest fk_implicit_hash_sharded
+
+# Parent table with hash-sharded primary key
+statement ok
+CREATE TABLE parent_hash_sharded (
+  c1 INT NOT NULL,
+  c2 INT NOT NULL,
+  c3 INT,
+  PRIMARY KEY (c1, c2) USING HASH
+)
+
+statement ok
+INSERT INTO parent_hash_sharded VALUES (1, 1, 1), (2, 2, 2), (3, 3, 3)
+
+# FK without explicit column list should skip the shard column
+statement ok
+CREATE TABLE child_implicit (
+  z INT,
+  y INT,
+  x INT,
+  FOREIGN KEY (z, y) REFERENCES parent_hash_sharded
+)
+
+statement ok
+INSERT INTO child_implicit VALUES (1, 1, 1), (2, 2, 2)
+
+# Verify FK constraint enforcement
+statement error pq: insert on table "child_implicit" violates foreign key constraint
+INSERT INTO child_implicit VALUES (99, 99, 99)
+
+# Verify this also works using ALTER TABLE
+statement ok
+CREATE TABLE child_implicit2 (
+  z INT,
+  y INT,
+  x INT
+)
+
+statement ok
+ALTER TABLE child_implicit2 ADD FOREIGN KEY (z, y) REFERENCES parent_hash_sharded
+
+statement ok
+INSERT INTO child_implicit2 VALUES (1, 1, 1), (2, 2, 2)
+
+# Verify FK constraint enforcement
+statement error pq: insert on table "child_implicit2" violates foreign key constraint
+INSERT INTO child_implicit2 VALUES (99, 99, 99)
+
+# Cleanup
+statement ok
+DROP TABLE child_implicit
+
+statement ok
+DROP TABLE child_implicit2
+
+statement ok
+DROP TABLE parent_hash_sharded
+
+subtest end


### PR DESCRIPTION
Previously, an error would occur when defining a foreign key which references a hash-sharded primary key without explicitly providing the primary key columns. The parser was incorrectly including the internal shard key column when identifying the columns to use from the primary index.

To address this, we now skip over the internal shard column when defining a foreign key.

Epic: CRDB-58150
Fixes: #161618

Release note (bug fix): Fixed a bug where an error would occur when defining a foreign key on a hash-sharded primary key without explicitly providing the primary key columns.