### PR TITLE
ui: fix crash on debug hot ranges page

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/hotranges/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/hotranges/index.tsx
@@ -30,7 +30,7 @@ const HotRanges = (props: HotRangesProps) => {
 
   useEffect(() => {
     const request = new cockroach.server.serverpb.HotRangesRequest({
-      nodes: [nodeId],
+      nodes: nodeId ? [nodeId] : [],
       page_size: pageSize,
       page_token: pageToken,
     });


### PR DESCRIPTION
The debug hot ranges page at /#/debug/hotranges crashed on load with `TypeError: Cannot read properties of undefined (reading 'length')`. When no `node_id` URL parameter was present, `nodeId` was `undefined`, causing `nodes: [undefined]` to be passed to the HotRangesRequest protobuf constructor. The protobuf encoder then tried to compute the UTF-8 length of `undefined`, which has no `.length` property.

The fix filters out the undefined value by using an empty array when `nodeId` is not set, which correctly requests hot ranges for all nodes.

The top ranges page at /#/topranges does not have this bug because it guards with `if (filters.nodeIds.length > 0)` before constructing the request.

Fixes: #160556

Release note: None
Epic: None