### PR TITLE
sql/schemachanger: implement CREATE OR REPLACE TRIGGER

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/triggers
+++ b/pkg/ccl/logictestccl/testdata/logic_test/triggers
@@ -4211,8 +4211,30 @@ DROP FUNCTION g;
 
 subtest unsupported
 
-statement error pgcode 0A000 pq: unimplemented: CREATE OR REPLACE TRIGGER is not supported
-CREATE OR REPLACE TRIGGER foo AFTER INSERT ON xy FOR EACH ROW EXECUTE FUNCTION f();
+# CREATE OR REPLACE TRIGGER when the trigger does not exist yet creates it.
+statement ok
+CREATE OR REPLACE TRIGGER replace_test BEFORE INSERT ON xy FOR EACH ROW EXECUTE FUNCTION f();
+
+query TT
+SHOW CREATE TRIGGER replace_test ON xy;
+----
+replace_test  CREATE TRIGGER replace_test BEFORE INSERT ON test.public.xy FOR EACH ROW EXECUTE FUNCTION test.public.f()
+
+# CREATE OR REPLACE TRIGGER when the trigger already exists replaces it.
+statement ok
+CREATE OR REPLACE TRIGGER replace_test AFTER UPDATE ON xy FOR EACH ROW EXECUTE FUNCTION f();
+
+query TT
+SHOW CREATE TRIGGER replace_test ON xy;
+----
+replace_test  CREATE TRIGGER replace_test AFTER UPDATE ON test.public.xy FOR EACH ROW EXECUTE FUNCTION test.public.f()
+
+# CREATE TRIGGER (without REPLACE) still errors on duplicate.
+statement error pgcode 42710 pq: trigger "replace_test" for relation "xy" already exists
+CREATE TRIGGER replace_test AFTER INSERT ON xy FOR EACH ROW EXECUTE FUNCTION f();
+
+statement ok
+DROP TRIGGER replace_test ON xy;
 
 statement error pgcode 0A000 pq: unimplemented: statement-level triggers are not yet supported
 CREATE TRIGGER foo AFTER INSERT ON xy FOR EACH STATEMENT EXECUTE FUNCTION f();

--- a/pkg/sql/schemachanger/scbuild/testdata/create_trigger
+++ b/pkg/sql/schemachanger/scbuild/testdata/create_trigger
@@ -37,6 +37,60 @@ CREATE TRIGGER tr BEFORE INSERT OR UPDATE ON xy FOR EACH ROW EXECUTE FUNCTION f(
 - [[TriggerDeps:{DescID: 104, ReferencedTypeIDs: [106 107], TriggerID: 1, ReferencedFunctionIDs: [109 110]}, PUBLIC], ABSENT]
   {tableId: 104, triggerId: 1, usesRelations: [{columnIds: [1, 2], id: 105}, {id: 108}], usesRoutineIds: [109, 110], usesTypeIds: [106, 107]}
 
+# CREATE OR REPLACE when no existing trigger exists creates a new trigger.
+build
+CREATE OR REPLACE TRIGGER tr2 BEFORE INSERT ON xy FOR EACH ROW EXECUTE FUNCTION f();
+----
+- [[IndexData:{DescID: 104, IndexID: 1}, PUBLIC], PUBLIC]
+  {indexId: 1, tableId: 104}
+- [[TableData:{DescID: 104, ReferencedDescID: 100}, PUBLIC], PUBLIC]
+  {databaseId: 100, tableId: 104}
+- [[Trigger:{DescID: 104, TriggerID: 1}, PUBLIC], ABSENT]
+  {tableId: 104, triggerId: 1}
+- [[TriggerName:{DescID: 104, TriggerID: 1}, PUBLIC], ABSENT]
+  {name: tr2, tableId: 104, triggerId: 1}
+- [[TriggerEnabled:{DescID: 104, TriggerID: 1}, PUBLIC], ABSENT]
+  {tableId: 104, triggerId: 1}
+- [[TriggerTiming:{DescID: 104, TriggerID: 1}, PUBLIC], ABSENT]
+  {actionTime: BEFORE, forEachRow: true, tableId: 104, triggerId: 1}
+- [[TriggerEvents:{DescID: 104, TriggerID: 1}, PUBLIC], ABSENT]
+  {events: [{columnNames: [], type: INSERT}], tableId: 104, triggerId: 1}
+- [[TriggerFunctionCall:{DescID: 104, TriggerID: 1}, PUBLIC], ABSENT]
+  {funcArgs: [], funcBody: "DECLARE\nfoo @100106 := 'a';\nBEGIN\nINSERT INTO defaultdb.public.ab VALUES ((new).x, (new).y);\nRAISE NOTICE '% %', public.g(), nextval(108:::REGCLASS);\nRETURN new;\nEND;\n", funcId: 110, tableId: 104, triggerId: 1}
+- [[TriggerDeps:{DescID: 104, ReferencedTypeIDs: [106 107], TriggerID: 1, ReferencedFunctionIDs: [109 110]}, PUBLIC], ABSENT]
+  {tableId: 104, triggerId: 1, usesRelations: [{columnIds: [1, 2], id: 105}, {id: 108}], usesRoutineIds: [109, 110], usesTypeIds: [106, 107]}
+
+# CREATE OR REPLACE when trigger already exists drops old and creates new.
+setup
+CREATE TRIGGER tr BEFORE INSERT OR UPDATE ON xy FOR EACH ROW EXECUTE FUNCTION f();
+----
+
+build
+CREATE OR REPLACE TRIGGER tr AFTER DELETE ON xy FOR EACH ROW EXECUTE FUNCTION f();
+----
+- [[IndexData:{DescID: 104, IndexID: 1}, PUBLIC], PUBLIC]
+  {indexId: 1, tableId: 104}
+- [[Trigger:{DescID: 104, TriggerID: 1}, ABSENT], PUBLIC]
+  {tableId: 104, triggerId: 1}
+- [[TriggerDeps:{DescID: 104, ReferencedTypeIDs: [106 107], TriggerID: 1, ReferencedFunctionIDs: [109 110]}, ABSENT], PUBLIC]
+  {tableId: 104, triggerId: 1, usesRelations: [{columnIds: [1, 2], id: 105}, {id: 108}], usesRoutineIds: [109, 110], usesTypeIds: [106, 107]}
+- [[TableData:{DescID: 104, ReferencedDescID: 100}, PUBLIC], PUBLIC]
+  {databaseId: 100, tableId: 104}
+- [[Trigger:{DescID: 104, TriggerID: 2}, PUBLIC], ABSENT]
+  {tableId: 104, triggerId: 2}
+- [[TriggerName:{DescID: 104, TriggerID: 2}, PUBLIC], ABSENT]
+  {name: tr, tableId: 104, triggerId: 2}
+- [[TriggerEnabled:{DescID: 104, TriggerID: 2}, PUBLIC], ABSENT]
+  {tableId: 104, triggerId: 2}
+- [[TriggerTiming:{DescID: 104, TriggerID: 2}, PUBLIC], ABSENT]
+  {actionTime: AFTER, forEachRow: true, tableId: 104, triggerId: 2}
+- [[TriggerEvents:{DescID: 104, TriggerID: 2}, PUBLIC], ABSENT]
+  {events: [{columnNames: [], type: DELETE}], tableId: 104, triggerId: 2}
+- [[TriggerFunctionCall:{DescID: 104, TriggerID: 2}, PUBLIC], ABSENT]
+  {funcArgs: [], funcBody: "DECLARE\nfoo @100106 := 'a';\nBEGIN\nINSERT INTO defaultdb.public.ab VALUES ((new).x, (new).y);\nRAISE NOTICE '% %', public.g(), nextval(108:::REGCLASS);\nRETURN new;\nEND;\n", funcId: 110, tableId: 104, triggerId: 2}
+- [[TriggerDeps:{DescID: 104, ReferencedTypeIDs: [106 107], TriggerID: 2, ReferencedFunctionIDs: [109 110]}, PUBLIC], ABSENT]
+  {tableId: 104, triggerId: 2, usesRelations: [{columnIds: [1, 2], id: 105}, {id: 108}], usesRoutineIds: [109, 110], usesTypeIds: [106, 107]}
+
 # TODO(#126362, #135655): uncomment this test case.
 # build
 # CREATE TRIGGER tr AFTER DELETE ON xy REFERENCING OLD TABLE AS foo WHEN (1 = 1) EXECUTE FUNCTION f('a', 'bc');

--- a/pkg/sql/schemachanger/scplan/testdata/create_trigger
+++ b/pkg/sql/schemachanger/scplan/testdata/create_trigger
@@ -197,3 +197,232 @@ CREATE TRIGGER t1_tg BEFORE INSERT OR UPDATE OR DELETE ON defaultdb.t1 FOR EACH 
   to:   [TriggerTiming:{DescID: 104, TriggerID: 1}, PUBLIC]
   kind: Precedence
   rule: trigger public before its dependents
+
+# CREATE OR REPLACE TRIGGER when the trigger already exists.
+setup
+CREATE TRIGGER t1_tg BEFORE INSERT OR UPDATE OR DELETE ON defaultdb.t1 FOR EACH ROW EXECUTE FUNCTION g();
+----
+
+ops
+CREATE OR REPLACE TRIGGER t1_tg AFTER INSERT ON defaultdb.t1 FOR EACH ROW EXECUTE FUNCTION g();
+----
+StatementPhase stage 1 of 1 with 12 MutationType ops
+  transitions:
+    [[Trigger:{DescID: 104, TriggerID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[TriggerDeps:{DescID: 104, TriggerID: 1, ReferencedFunctionIDs: [105]}, ABSENT], PUBLIC] -> ABSENT
+    [[Trigger:{DescID: 104, TriggerID: 2}, PUBLIC], ABSENT] -> PUBLIC
+    [[TriggerName:{DescID: 104, TriggerID: 2}, PUBLIC], ABSENT] -> PUBLIC
+    [[TriggerEnabled:{DescID: 104, TriggerID: 2}, PUBLIC], ABSENT] -> PUBLIC
+    [[TriggerTiming:{DescID: 104, TriggerID: 2}, PUBLIC], ABSENT] -> PUBLIC
+    [[TriggerEvents:{DescID: 104, TriggerID: 2}, PUBLIC], ABSENT] -> PUBLIC
+    [[TriggerFunctionCall:{DescID: 104, TriggerID: 2}, PUBLIC], ABSENT] -> PUBLIC
+    [[TriggerDeps:{DescID: 104, TriggerID: 2, ReferencedFunctionIDs: [105]}, PUBLIC], ABSENT] -> PUBLIC
+  ops:
+    *scop.RemoveTrigger
+      Trigger:
+        TableID: 104
+        TriggerID: 1
+    *scop.UpdateTriggerBackReferencesInRelations
+      RelationReferences:
+      - id: 104
+        columnids: []
+        indexid: 0
+      TableID: 104
+      TriggerID: 1
+    *scop.RemoveTriggerBackReferencesInRoutines
+      BackReferencedTableID: 104
+      BackReferencedTriggerID: 1
+      RoutineIDs:
+      - 105
+    *scop.AddTrigger
+      Trigger:
+        TableID: 104
+        TriggerID: 2
+    *scop.SetTriggerName
+      Name:
+        Name: t1_tg
+        TableID: 104
+        TriggerID: 2
+    *scop.SetTriggerEnabled
+      Enabled: true
+      TableID: 104
+      TriggerID: 2
+    *scop.SetTriggerTiming
+      Timing:
+        ActionTime: 2
+        ForEachRow: true
+        TableID: 104
+        TriggerID: 2
+    *scop.SetTriggerEvents
+      Events:
+        Events:
+        - type: 1
+          columnnames: []
+        TableID: 104
+        TriggerID: 2
+    *scop.SetTriggerFunctionCall
+      FunctionCall:
+        FuncArgs: []
+        FuncBody: |
+          BEGIN
+          RAISE NOTICE '%: old: %, new: %', tg_op, old, new;
+          RETURN COALESCE(new, old);
+          END;
+        FuncID: 105
+        TableID: 104
+        TriggerID: 2
+    *scop.SetTriggerForwardReferences
+      Deps:
+        TableID: 104
+        TriggerID: 2
+        UsesRelations:
+        - id: 104
+          columnids: []
+          indexid: 0
+        UsesRoutineIDs:
+        - 105
+    *scop.UpdateTriggerBackReferencesInRelations
+      RelationReferences:
+      - id: 104
+        columnids: []
+        indexid: 0
+      TableID: 104
+      TriggerID: 2
+    *scop.AddTriggerBackReferencesInRoutines
+      BackReferencedTableID: 104
+      BackReferencedTriggerID: 2
+      RoutineIDs:
+      - 105
+PreCommitPhase stage 1 of 2 with 1 MutationType op
+  transitions:
+    [[Trigger:{DescID: 104, TriggerID: 1}, ABSENT], ABSENT] -> PUBLIC
+    [[TriggerDeps:{DescID: 104, TriggerID: 1, ReferencedFunctionIDs: [105]}, ABSENT], ABSENT] -> PUBLIC
+    [[Trigger:{DescID: 104, TriggerID: 2}, PUBLIC], PUBLIC] -> ABSENT
+    [[TriggerName:{DescID: 104, TriggerID: 2}, PUBLIC], PUBLIC] -> ABSENT
+    [[TriggerEnabled:{DescID: 104, TriggerID: 2}, PUBLIC], PUBLIC] -> ABSENT
+    [[TriggerTiming:{DescID: 104, TriggerID: 2}, PUBLIC], PUBLIC] -> ABSENT
+    [[TriggerEvents:{DescID: 104, TriggerID: 2}, PUBLIC], PUBLIC] -> ABSENT
+    [[TriggerFunctionCall:{DescID: 104, TriggerID: 2}, PUBLIC], PUBLIC] -> ABSENT
+    [[TriggerDeps:{DescID: 104, TriggerID: 2, ReferencedFunctionIDs: [105]}, PUBLIC], PUBLIC] -> ABSENT
+  ops:
+    *scop.UndoAllInTxnImmediateMutationOpSideEffects
+      {}
+PreCommitPhase stage 2 of 2 with 12 MutationType ops
+  transitions:
+    [[Trigger:{DescID: 104, TriggerID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[TriggerDeps:{DescID: 104, TriggerID: 1, ReferencedFunctionIDs: [105]}, ABSENT], PUBLIC] -> ABSENT
+    [[Trigger:{DescID: 104, TriggerID: 2}, PUBLIC], ABSENT] -> PUBLIC
+    [[TriggerName:{DescID: 104, TriggerID: 2}, PUBLIC], ABSENT] -> PUBLIC
+    [[TriggerEnabled:{DescID: 104, TriggerID: 2}, PUBLIC], ABSENT] -> PUBLIC
+    [[TriggerTiming:{DescID: 104, TriggerID: 2}, PUBLIC], ABSENT] -> PUBLIC
+    [[TriggerEvents:{DescID: 104, TriggerID: 2}, PUBLIC], ABSENT] -> PUBLIC
+    [[TriggerFunctionCall:{DescID: 104, TriggerID: 2}, PUBLIC], ABSENT] -> PUBLIC
+    [[TriggerDeps:{DescID: 104, TriggerID: 2, ReferencedFunctionIDs: [105]}, PUBLIC], ABSENT] -> PUBLIC
+  ops:
+    *scop.RemoveTrigger
+      Trigger:
+        TableID: 104
+        TriggerID: 1
+    *scop.UpdateTriggerBackReferencesInRelations
+      RelationReferences:
+      - id: 104
+        columnids: []
+        indexid: 0
+      TableID: 104
+      TriggerID: 1
+    *scop.RemoveTriggerBackReferencesInRoutines
+      BackReferencedTableID: 104
+      BackReferencedTriggerID: 1
+      RoutineIDs:
+      - 105
+    *scop.AddTrigger
+      Trigger:
+        TableID: 104
+        TriggerID: 2
+    *scop.SetTriggerName
+      Name:
+        Name: t1_tg
+        TableID: 104
+        TriggerID: 2
+    *scop.SetTriggerEnabled
+      Enabled: true
+      TableID: 104
+      TriggerID: 2
+    *scop.SetTriggerTiming
+      Timing:
+        ActionTime: 2
+        ForEachRow: true
+        TableID: 104
+        TriggerID: 2
+    *scop.SetTriggerEvents
+      Events:
+        Events:
+        - type: 1
+          columnnames: []
+        TableID: 104
+        TriggerID: 2
+    *scop.SetTriggerFunctionCall
+      FunctionCall:
+        FuncArgs: []
+        FuncBody: |
+          BEGIN
+          RAISE NOTICE '%: old: %, new: %', tg_op, old, new;
+          RETURN COALESCE(new, old);
+          END;
+        FuncID: 105
+        TableID: 104
+        TriggerID: 2
+    *scop.SetTriggerForwardReferences
+      Deps:
+        TableID: 104
+        TriggerID: 2
+        UsesRelations:
+        - id: 104
+          columnids: []
+          indexid: 0
+        UsesRoutineIDs:
+        - 105
+    *scop.UpdateTriggerBackReferencesInRelations
+      RelationReferences:
+      - id: 104
+        columnids: []
+        indexid: 0
+      TableID: 104
+      TriggerID: 2
+    *scop.AddTriggerBackReferencesInRoutines
+      BackReferencedTableID: 104
+      BackReferencedTriggerID: 2
+      RoutineIDs:
+      - 105
+
+deps
+CREATE OR REPLACE TRIGGER t1_tg AFTER INSERT ON defaultdb.t1 FOR EACH ROW EXECUTE FUNCTION g();
+----
+- from: [Trigger:{DescID: 104, TriggerID: 2}, PUBLIC]
+  to:   [TriggerDeps:{DescID: 104, TriggerID: 2, ReferencedFunctionIDs: [105]}, PUBLIC]
+  kind: Precedence
+  rule: trigger public before its dependents
+- from: [Trigger:{DescID: 104, TriggerID: 2}, PUBLIC]
+  to:   [TriggerEnabled:{DescID: 104, TriggerID: 2}, PUBLIC]
+  kind: Precedence
+  rule: trigger public before its dependents
+- from: [Trigger:{DescID: 104, TriggerID: 2}, PUBLIC]
+  to:   [TriggerEvents:{DescID: 104, TriggerID: 2}, PUBLIC]
+  kind: Precedence
+  rule: trigger public before its dependents
+- from: [Trigger:{DescID: 104, TriggerID: 2}, PUBLIC]
+  to:   [TriggerFunctionCall:{DescID: 104, TriggerID: 2}, PUBLIC]
+  kind: Precedence
+  rule: trigger public before its dependents
+- from: [Trigger:{DescID: 104, TriggerID: 2}, PUBLIC]
+  to:   [TriggerName:{DescID: 104, TriggerID: 2}, PUBLIC]
+  kind: Precedence
+  rule: trigger public before its dependents
+- from: [Trigger:{DescID: 104, TriggerID: 2}, PUBLIC]
+  to:   [TriggerTiming:{DescID: 104, TriggerID: 2}, PUBLIC]
+  kind: Precedence
+  rule: trigger public before its dependents
+- from: [TriggerDeps:{DescID: 104, TriggerID: 1, ReferencedFunctionIDs: [105]}, ABSENT]
+  to:   [Trigger:{DescID: 104, TriggerID: 1}, PUBLIC]
+  kind: Precedence
+  rule: trigger removed before dependents


### PR DESCRIPTION
Previously, CREATE OR REPLACE TRIGGER returned an unimplemented error. This commit implements the feature by resolving any existing trigger with the same name on the table and dropping it before creating the replacement trigger with a new trigger ID.

The approach follows the same pattern as DropTrigger: only the Trigger and TriggerDeps elements are explicitly dropped, and the dependent elements (TriggerName, TriggerEnabled, TriggerTiming, etc.) are cleaned up by the existing dependency rules. A new trigger ID is allocated for the replacement because the declarative schema changer does not allow re-adding an element with the same key as one dropped in the same transaction.

The intermediate drop is safe because triggers cannot have dependents (nothing depends on a trigger), so there is no cascade concern.

Fixes: #128422

Release note (sql change): CREATE OR REPLACE TRIGGER is now supported. If a trigger with the same name already exists on the same table, it is replaced with the new definition. If no trigger with that name exists, a new trigger is created.