### PR TITLE
sql/schemachanger: add ALTER SEQUENCE to declarative schema changer

### DIFF
--- a/pkg/sql/schemachanger/scbuild/event_log.go
+++ b/pkg/sql/schemachanger/scbuild/event_log.go
@@ -549,5 +549,14 @@ func (pb payloadBuilder) build(b buildCtx) logpb.EventPayload {
 			CascadeDroppedViews: pb.cascadeDroppedViews(b),
 		}
 	}
+	if _, _, seq := scpb.FindSequence(b.QueryByID(screl.GetDescID(pb.Element()))); seq != nil {
+		// If the sequence has a payload attached use that instead of ALTER SEQUENCE.
+		if pb.maybePayload != nil {
+			return pb.maybePayload
+		}
+		return &eventpb.AlterSequence{
+			SequenceName: fullyQualifiedName(b, seq),
+		}
+	}
 	return nil
 }

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     name = "scbuildstmt",
     srcs = [
         "alter_policy.go",
+        "alter_sequence.go",
         "alter_table.go",
         "alter_table_add_column.go",
         "alter_table_add_constraint.go",

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_sequence.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_sequence.go
@@ -1,0 +1,289 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package scbuildstmt
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
+	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
+	"github.com/cockroachdb/errors"
+)
+
+// AlterSequence implements ALTER SEQUENCE.
+func AlterSequence(b BuildCtx, n *tree.AlterSequence) {
+	elts := b.ResolveSequence(n.Name, ResolveParams{
+		IsExistenceOptional: n.IfExists,
+		RequiredPrivilege:   privilege.CREATE,
+	})
+	seq := elts.FilterSequence().MustGetZeroOrOneElement()
+	if seq == nil {
+		tn := n.Name.ToTableName()
+		b.MarkNameAsNonExistent(&tn)
+		return
+	}
+	// Annotate the AST with the fully resolved name.
+	tn := n.Name.ToTableName()
+	tn.ObjectNamePrefix = b.NamePrefix(seq)
+	b.SetUnresolvedNameAnnotation(n.Name, &tn)
+	b.IncrementSchemaChangeAlterCounter("sequence")
+
+	sequenceID := seq.SequenceID
+
+	// Handle OWNED BY separately, since AssignSequenceOptions does not handle it.
+	// SequenceOwner elements are stored on the owning table's descriptor, so we
+	// find them via back-references from the sequence.
+	for _, opt := range n.Options {
+		if opt.Name == tree.SeqOptOwnedBy {
+			// Drop the existing SequenceOwner element for this sequence.
+			// We filter by SequenceID because BackReferences returns all
+			// elements from the owning table, which may own other sequences,
+			// and by target status to skip elements already being dropped.
+			b.BackReferences(sequenceID).FilterSequenceOwner().Filter(
+				func(_ scpb.Status, target scpb.TargetStatus, e *scpb.SequenceOwner) bool {
+					return target == scpb.ToPublic && e.SequenceID == sequenceID
+				},
+			).ForEach(
+				func(_ scpb.Status, _ scpb.TargetStatus, e *scpb.SequenceOwner) {
+					b.Drop(e)
+				},
+			)
+			if opt.ColumnItemVal != nil {
+				// OWNED BY table.column: add a new owner.
+				seqNamespace := b.QueryByID(sequenceID).FilterNamespace().MustGetOneElement()
+				maybeAssignSequenceOwner(b, seqNamespace, opt.ColumnItemVal)
+			}
+			// If ColumnItemVal is nil, this is OWNED BY NONE — dropping is sufficient.
+		}
+	}
+
+	// Get the current sequence options from elements and defaults.
+	currentOpts := schemaexpr.DefaultSequenceOptions()
+	b.QueryByID(sequenceID).FilterSequenceOption().ForEach(
+		func(_ scpb.Status, _ scpb.TargetStatus, e *scpb.SequenceOption) {
+			var err error
+			switch name := e.Key; name {
+			case tree.SeqOptAs:
+				currentOpts.AsIntegerType = e.Value
+			case tree.SeqOptCacheNode:
+				currentOpts.NodeCacheSize, err = strconv.ParseInt(e.Value, 10, 64)
+				if err != nil {
+					panic(pgerror.Wrapf(err, pgcode.Internal, "invalid sequence option value for %q", name))
+				}
+			case tree.SeqOptCacheSession:
+				currentOpts.SessionCacheSize, err = strconv.ParseInt(e.Value, 10, 64)
+				if err != nil {
+					panic(pgerror.Wrapf(err, pgcode.Internal, "invalid sequence option value for %q", name))
+				}
+			case tree.SeqOptIncrement:
+				currentOpts.Increment, err = strconv.ParseInt(e.Value, 10, 64)
+				if err != nil {
+					panic(pgerror.Wrapf(err, pgcode.Internal, "invalid sequence option value for %q", name))
+				}
+			case tree.SeqOptMinValue:
+				currentOpts.MinValue, err = strconv.ParseInt(e.Value, 10, 64)
+				if err != nil {
+					panic(pgerror.Wrapf(err, pgcode.Internal, "invalid sequence option value for %q", name))
+				}
+			case tree.SeqOptMaxValue:
+				currentOpts.MaxValue, err = strconv.ParseInt(e.Value, 10, 64)
+				if err != nil {
+					panic(pgerror.Wrapf(err, pgcode.Internal, "invalid sequence option value for %q", name))
+				}
+			case tree.SeqOptStart:
+				currentOpts.Start, err = strconv.ParseInt(e.Value, 10, 64)
+				if err != nil {
+					panic(pgerror.Wrapf(err, pgcode.Internal, "invalid sequence option value for %q", name))
+				}
+			case tree.SeqOptVirtual:
+				currentOpts.Virtual, err = strconv.ParseBool(e.Value)
+				if err != nil {
+					panic(pgerror.Wrapf(err, pgcode.Internal, "invalid sequence option value for %q", name))
+				}
+			default:
+				panic(pgerror.Newf(pgcode.Internal, "unexpected sequence option %q", name))
+			}
+		},
+	)
+
+	// Determine the existing integer type for proper bounds adjustment when
+	// the AS type changes.
+	existingType := types.Int
+	if currentOpts.AsIntegerType != "" {
+		switch currentOpts.AsIntegerType {
+		case types.Int2.SQLString():
+			existingType = types.Int2
+		case types.Int4.SQLString():
+			existingType = types.Int4
+		case types.Int.SQLString():
+			existingType = types.Int
+		default:
+			panic(errors.AssertionFailedf(
+				"sequence has unexpected type %s", currentOpts.AsIntegerType,
+			))
+		}
+	}
+
+	// Compute the updated sequence options.
+	updatedOpts := currentOpts
+	if err := schemaexpr.AssignSequenceOptions(
+		&updatedOpts,
+		n.Options,
+		b.SessionData().DefaultIntSize,
+		false,        /* setDefaults */
+		existingType, /* existingType */
+	); err != nil {
+		panic(pgerror.Wrap(err, pgcode.FeatureNotSupported, ""))
+	}
+
+	defaultOpts := schemaexpr.DefaultSequenceOptions()
+
+	// alteredElement tracks a SequenceOption that was modified (added or
+	// dropped) during this ALTER SEQUENCE, used for event logging.
+	var alteredElement scpb.Element
+
+	// updateElement adds or drops elements to effect the changed option.
+	// isDefault indicates whether the new value equals the sequence default,
+	// in which case no element is added (defaults are implicit).
+	// Returns true if a sequence value update may be needed.
+	updateElement := func(key, value string, isDefault bool) bool {
+		newSeqOption := scpb.SequenceOption{
+			SequenceID: sequenceID,
+			Key:        key,
+			Value:      value,
+		}
+
+		oldSeqOption := b.QueryByID(sequenceID).FilterSequenceOption().Filter(
+			func(_ scpb.Status, _ scpb.TargetStatus, e *scpb.SequenceOption) bool {
+				return e.Key == key
+			},
+		).MustGetZeroOrOneElement()
+		if oldSeqOption != nil {
+			if oldSeqOption.Value == newSeqOption.Value {
+				return false
+			}
+			b.Drop(oldSeqOption)
+			if alteredElement == nil {
+				alteredElement = oldSeqOption
+			}
+		}
+
+		// Skip setting to default values.
+		if isDefault {
+			return true
+		}
+
+		b.Add(&newSeqOption)
+		if alteredElement == nil {
+			alteredElement = &newSeqOption
+		}
+		return true
+	}
+
+	fmtInt := func(v int64) string { return strconv.FormatInt(v, 10) }
+	fmtBool := func(v bool) string { return strconv.FormatBool(v) }
+
+	var updateSequenceValue bool
+	var restartWith *int64
+	optionsSeen := make(map[string]bool)
+	for _, opt := range n.Options {
+		optionsSeen[opt.Name] = true
+		switch name := opt.Name; name {
+		case tree.SeqOptAs:
+			_ = updateElement(name, updatedOpts.AsIntegerType, updatedOpts.AsIntegerType == defaultOpts.AsIntegerType)
+		case tree.SeqOptCycle:
+			panic(unimplemented.NewWithIssue(20961, "CYCLE option is not supported"))
+		case tree.SeqOptNoCycle:
+			// Noop for a default that can't be modified.
+		case tree.SeqOptCacheNode:
+			_ = updateElement(name, fmtInt(updatedOpts.NodeCacheSize), updatedOpts.NodeCacheSize == defaultOpts.NodeCacheSize)
+		case tree.SeqOptCacheSession:
+			_ = updateElement(name, fmtInt(updatedOpts.SessionCacheSize), updatedOpts.SessionCacheSize == defaultOpts.SessionCacheSize)
+		case tree.SeqOptIncrement:
+			updated := updateElement(name, fmtInt(updatedOpts.Increment), updatedOpts.Increment == defaultOpts.Increment)
+			updateSequenceValue = updateSequenceValue || updated
+		case tree.SeqOptMinValue:
+			updated := updateElement(name, fmtInt(updatedOpts.MinValue), updatedOpts.MinValue == defaultOpts.MinValue)
+			updateSequenceValue = updateSequenceValue || updated
+		case tree.SeqOptMaxValue:
+			updated := updateElement(name, fmtInt(updatedOpts.MaxValue), updatedOpts.MaxValue == defaultOpts.MaxValue)
+			updateSequenceValue = updateSequenceValue || updated
+		case tree.SeqOptStart:
+			updated := updateElement(name, fmtInt(updatedOpts.Start), updatedOpts.Start == defaultOpts.Start)
+			updateSequenceValue = updateSequenceValue || updated
+		case tree.SeqOptRestart:
+			if opt.IntVal != nil {
+				restartWith = opt.IntVal
+			} else {
+				restartWith = &updatedOpts.Start
+			}
+		case tree.SeqOptVirtual:
+			_ = updateElement(name, fmtBool(updatedOpts.Virtual), updatedOpts.Virtual == defaultOpts.Virtual)
+		case tree.SeqOptOwnedBy:
+			// Already handled above.
+		default:
+			panic(fmt.Sprintf("unexpected sequence option: %q", name))
+		}
+	}
+
+	// Handle implicit changes from AS type changes. AssignSequenceOptions may
+	// have adjusted MinValue/MaxValue/Start even if the user didn't explicitly
+	// set them (e.g., when changing AS INT2 to AS INT4, the bounds expand).
+	// Only apply if the option wasn't already handled in the loop above.
+	if !optionsSeen[tree.SeqOptMinValue] && currentOpts.MinValue != updatedOpts.MinValue {
+		updated := updateElement(tree.SeqOptMinValue, fmtInt(updatedOpts.MinValue), updatedOpts.MinValue == defaultOpts.MinValue)
+		updateSequenceValue = updateSequenceValue || updated
+	}
+	if !optionsSeen[tree.SeqOptMaxValue] && currentOpts.MaxValue != updatedOpts.MaxValue {
+		updated := updateElement(tree.SeqOptMaxValue, fmtInt(updatedOpts.MaxValue), updatedOpts.MaxValue == defaultOpts.MaxValue)
+		updateSequenceValue = updateSequenceValue || updated
+	}
+	if !optionsSeen[tree.SeqOptStart] && currentOpts.Start != updatedOpts.Start {
+		updated := updateElement(tree.SeqOptStart, fmtInt(updatedOpts.Start), updatedOpts.Start == defaultOpts.Start)
+		updateSequenceValue = updateSequenceValue || updated
+	}
+
+	if restartWith != nil {
+		restartSeqOption := scpb.SequenceOption{
+			SequenceID: sequenceID,
+			Key:        tree.SeqOptRestart,
+			Value:      fmtInt((*restartWith) - updatedOpts.Increment),
+		}
+		b.AddTransient(&restartSeqOption)
+	} else if updateSequenceValue {
+		seqValue := scpb.SequenceValue{
+			SequenceID:       sequenceID,
+			PrevIncrement:    currentOpts.Increment,
+			UpdatedIncrement: updatedOpts.Increment,
+			PrevMinValue:     currentOpts.MinValue,
+			UpdatedMinValue:  updatedOpts.MinValue,
+			PrevMaxValue:     currentOpts.MaxValue,
+			UpdatedMaxValue:  updatedOpts.MaxValue,
+			PrevStart:        currentOpts.Start,
+			UpdatedStart:     updatedOpts.Start,
+		}
+		b.AddTransient(&seqValue)
+	}
+
+	// Log the alter_sequence event. We log on a modified child element
+	// (SequenceOption) rather than the Sequence element itself, because
+	// the Sequence element wasn't directly modified (b.Add/b.Drop) and
+	// thus wouldn't be retained in the schema change output. This follows
+	// the same pattern as ALTER TABLE, which logs on child elements.
+	if alteredElement != nil {
+		b.LogEventForExistingPayload(alteredElement, &eventpb.AlterSequence{
+			SequenceName: tn.FQString(),
+		})
+	}
+}

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
@@ -45,6 +45,7 @@ var supportedStatements = map[reflect.Type]supportedStatement{
 	// here.
 	reflect.TypeOf((*tree.AlterTable)(nil)):          {fn: AlterTable, statementTags: []string{tree.AlterTableTag}, on: true, checks: alterTableChecks},
 	reflect.TypeOf((*tree.AlterPolicy)(nil)):         {fn: AlterPolicy, statementTags: []string{tree.AlterPolicyTag}, on: true, checks: isV251Active},
+	reflect.TypeOf((*tree.AlterSequence)(nil)):       {fn: AlterSequence, statementTags: []string{tree.AlterSequenceTag}, on: true, checks: isV262Active},
 	reflect.TypeOf((*tree.CommentOnColumn)(nil)):     {fn: CommentOnColumn, statementTags: []string{tree.CommentOnColumnTag}, on: true, checks: nil},
 	reflect.TypeOf((*tree.CommentOnConstraint)(nil)): {fn: CommentOnConstraint, statementTags: []string{tree.CommentOnConstraintTag}, on: true, checks: nil},
 	reflect.TypeOf((*tree.CommentOnDatabase)(nil)):   {fn: CommentOnDatabase, statementTags: []string{tree.CommentOnDatabaseTag}, on: true, checks: nil},

--- a/pkg/sql/schemachanger/scbuild/testdata/alter_sequence
+++ b/pkg/sql/schemachanger/scbuild/testdata/alter_sequence
@@ -1,0 +1,87 @@
+setup
+CREATE SEQUENCE defaultdb.sq1;
+----
+
+build
+ALTER SEQUENCE defaultdb.sq1 INCREMENT BY 2
+----
+- [[TableData:{DescID: 104, ReferencedDescID: 100}, PUBLIC], PUBLIC]
+  {databaseId: 100, tableId: 104}
+- [[SequenceOption:{DescID: 104, Name: INCREMENT, Value: 2}, PUBLIC], ABSENT]
+  {key: INCREMENT, sequenceId: 104, value: "2"}
+- [[SequenceValue:{DescID: 104}, TRANSIENT_ABSENT], ABSENT]
+  {prevIncrement: "1", prevMaxValue: "9223372036854775807", prevMinValue: "1", prevStart: "1", sequenceId: 104, updatedIncrement: "2", updatedMaxValue: "9223372036854775807", updatedMinValue: "1", updatedStart: "1"}
+
+build
+ALTER SEQUENCE defaultdb.sq1 MINVALUE 10 MAXVALUE 1000 START WITH 50
+----
+- [[TableData:{DescID: 104, ReferencedDescID: 100}, PUBLIC], PUBLIC]
+  {databaseId: 100, tableId: 104}
+- [[SequenceOption:{DescID: 104, Name: MINVALUE, Value: 10}, PUBLIC], ABSENT]
+  {key: MINVALUE, sequenceId: 104, value: "10"}
+- [[SequenceOption:{DescID: 104, Name: MAXVALUE, Value: 1000}, PUBLIC], ABSENT]
+  {key: MAXVALUE, sequenceId: 104, value: "1000"}
+- [[SequenceOption:{DescID: 104, Name: START, Value: 50}, PUBLIC], ABSENT]
+  {key: START, sequenceId: 104, value: "50"}
+- [[SequenceValue:{DescID: 104}, TRANSIENT_ABSENT], ABSENT]
+  {prevIncrement: "1", prevMaxValue: "9223372036854775807", prevMinValue: "1", prevStart: "1", sequenceId: 104, updatedIncrement: "1", updatedMaxValue: "1000", updatedMinValue: "10", updatedStart: "50"}
+
+build
+ALTER SEQUENCE defaultdb.sq1 RESTART WITH 100
+----
+- [[TableData:{DescID: 104, ReferencedDescID: 100}, PUBLIC], PUBLIC]
+  {databaseId: 100, tableId: 104}
+- [[SequenceOption:{DescID: 104, Name: RESTART, Value: 99}, TRANSIENT_ABSENT], ABSENT]
+  {key: RESTART, sequenceId: 104, value: "99"}
+
+build
+ALTER SEQUENCE defaultdb.sq1 CACHE 10
+----
+- [[TableData:{DescID: 104, ReferencedDescID: 100}, PUBLIC], PUBLIC]
+  {databaseId: 100, tableId: 104}
+- [[SequenceOption:{DescID: 104, Name: PER NODE CACHE, Value: 10}, PUBLIC], ABSENT]
+  {key: PER NODE CACHE, sequenceId: 104, value: "10"}
+
+build
+ALTER SEQUENCE IF EXISTS defaultdb.sq1 INCREMENT BY 3
+----
+- [[TableData:{DescID: 104, ReferencedDescID: 100}, PUBLIC], PUBLIC]
+  {databaseId: 100, tableId: 104}
+- [[SequenceOption:{DescID: 104, Name: INCREMENT, Value: 3}, PUBLIC], ABSENT]
+  {key: INCREMENT, sequenceId: 104, value: "3"}
+- [[SequenceValue:{DescID: 104}, TRANSIENT_ABSENT], ABSENT]
+  {prevIncrement: "1", prevMaxValue: "9223372036854775807", prevMinValue: "1", prevStart: "1", sequenceId: 104, updatedIncrement: "3", updatedMaxValue: "9223372036854775807", updatedMinValue: "1", updatedStart: "1"}
+
+build
+ALTER SEQUENCE IF EXISTS nonexistent INCREMENT BY 5
+----
+
+setup
+CREATE TABLE defaultdb.t1 (id INT PRIMARY KEY, val INT);
+----
+
+build
+ALTER SEQUENCE defaultdb.sq1 OWNED BY defaultdb.t1.val
+----
+- [[IndexData:{DescID: 105, IndexID: 1}, PUBLIC], PUBLIC]
+  {indexId: 1, tableId: 105}
+- [[TableData:{DescID: 105, ReferencedDescID: 100}, PUBLIC], PUBLIC]
+  {databaseId: 100, tableId: 105}
+- [[SequenceOwner:{DescID: 105, ColumnID: 2, ReferencedDescID: 104}, PUBLIC], ABSENT]
+  {columnId: 2, sequenceId: 104, tableId: 105}
+
+build
+ALTER SEQUENCE defaultdb.sq1 OWNED BY NONE
+----
+
+build
+ALTER SEQUENCE defaultdb.sq1 AS INT2
+----
+- [[TableData:{DescID: 104, ReferencedDescID: 100}, PUBLIC], PUBLIC]
+  {databaseId: 100, tableId: 104}
+- [[SequenceOption:{DescID: 104, Name: AS, Value: INT2}, PUBLIC], ABSENT]
+  {key: AS, sequenceId: 104, value: INT2}
+- [[SequenceOption:{DescID: 104, Name: MAXVALUE, Value: 32767}, PUBLIC], ABSENT]
+  {key: MAXVALUE, sequenceId: 104, value: "32767"}
+- [[SequenceValue:{DescID: 104}, TRANSIENT_ABSENT], ABSENT]
+  {prevIncrement: "1", prevMaxValue: "9223372036854775807", prevMinValue: "1", prevStart: "1", sequenceId: 104, updatedIncrement: "1", updatedMaxValue: "32767", updatedMinValue: "1", updatedStart: "1"}

--- a/pkg/sql/schemachanger/scplan/testdata/alter_sequence
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_sequence
@@ -1,0 +1,284 @@
+setup
+CREATE SEQUENCE defaultdb.sq1;
+----
+
+ops
+ALTER SEQUENCE defaultdb.sq1 INCREMENT BY 2;
+----
+StatementPhase stage 1 of 1 with 2 MutationType ops
+  transitions:
+    [[SequenceOption:{DescID: 104, Name: INCREMENT, Value: 2}, PUBLIC], ABSENT] -> PUBLIC
+    [[SequenceValue:{DescID: 104}, TRANSIENT_ABSENT], ABSENT] -> TRANSIENT_ABSENT
+  ops:
+    *scop.SetSequenceOption
+      Key: INCREMENT
+      SequenceID: 104
+      Value: "2"
+    *scop.MaybeUpdateSequenceValue
+      PrevIncrement: 1
+      PrevMaxValue: 9223372036854775807
+      PrevMinValue: 1
+      PrevStart: 1
+      SequenceID: 104
+      UpdatedIncrement: 2
+      UpdatedMaxValue: 9223372036854775807
+      UpdatedMinValue: 1
+      UpdatedStart: 1
+PreCommitPhase stage 1 of 2 with 1 MutationType op
+  transitions:
+    [[SequenceOption:{DescID: 104, Name: INCREMENT, Value: 2}, PUBLIC], PUBLIC] -> ABSENT
+    [[SequenceValue:{DescID: 104}, TRANSIENT_ABSENT], TRANSIENT_ABSENT] -> ABSENT
+  ops:
+    *scop.UndoAllInTxnImmediateMutationOpSideEffects
+      {}
+PreCommitPhase stage 2 of 2 with 2 MutationType ops
+  transitions:
+    [[SequenceOption:{DescID: 104, Name: INCREMENT, Value: 2}, PUBLIC], ABSENT] -> PUBLIC
+    [[SequenceValue:{DescID: 104}, TRANSIENT_ABSENT], ABSENT] -> TRANSIENT_ABSENT
+  ops:
+    *scop.SetSequenceOption
+      Key: INCREMENT
+      SequenceID: 104
+      Value: "2"
+    *scop.MaybeUpdateSequenceValue
+      PrevIncrement: 1
+      PrevMaxValue: 9223372036854775807
+      PrevMinValue: 1
+      PrevStart: 1
+      SequenceID: 104
+      UpdatedIncrement: 2
+      UpdatedMaxValue: 9223372036854775807
+      UpdatedMinValue: 1
+      UpdatedStart: 1
+
+ops
+ALTER SEQUENCE defaultdb.sq1 MINVALUE 10 MAXVALUE 1000 START WITH 50;
+----
+StatementPhase stage 1 of 1 with 4 MutationType ops
+  transitions:
+    [[SequenceOption:{DescID: 104, Name: MINVALUE, Value: 10}, PUBLIC], ABSENT] -> PUBLIC
+    [[SequenceOption:{DescID: 104, Name: MAXVALUE, Value: 1000}, PUBLIC], ABSENT] -> PUBLIC
+    [[SequenceOption:{DescID: 104, Name: START, Value: 50}, PUBLIC], ABSENT] -> PUBLIC
+    [[SequenceValue:{DescID: 104}, TRANSIENT_ABSENT], ABSENT] -> TRANSIENT_ABSENT
+  ops:
+    *scop.SetSequenceOption
+      Key: MINVALUE
+      SequenceID: 104
+      Value: "10"
+    *scop.SetSequenceOption
+      Key: MAXVALUE
+      SequenceID: 104
+      Value: "1000"
+    *scop.SetSequenceOption
+      Key: START
+      SequenceID: 104
+      Value: "50"
+    *scop.MaybeUpdateSequenceValue
+      PrevIncrement: 1
+      PrevMaxValue: 9223372036854775807
+      PrevMinValue: 1
+      PrevStart: 1
+      SequenceID: 104
+      UpdatedIncrement: 1
+      UpdatedMaxValue: 1000
+      UpdatedMinValue: 10
+      UpdatedStart: 50
+PreCommitPhase stage 1 of 2 with 1 MutationType op
+  transitions:
+    [[SequenceOption:{DescID: 104, Name: MINVALUE, Value: 10}, PUBLIC], PUBLIC] -> ABSENT
+    [[SequenceOption:{DescID: 104, Name: MAXVALUE, Value: 1000}, PUBLIC], PUBLIC] -> ABSENT
+    [[SequenceOption:{DescID: 104, Name: START, Value: 50}, PUBLIC], PUBLIC] -> ABSENT
+    [[SequenceValue:{DescID: 104}, TRANSIENT_ABSENT], TRANSIENT_ABSENT] -> ABSENT
+  ops:
+    *scop.UndoAllInTxnImmediateMutationOpSideEffects
+      {}
+PreCommitPhase stage 2 of 2 with 4 MutationType ops
+  transitions:
+    [[SequenceOption:{DescID: 104, Name: MINVALUE, Value: 10}, PUBLIC], ABSENT] -> PUBLIC
+    [[SequenceOption:{DescID: 104, Name: MAXVALUE, Value: 1000}, PUBLIC], ABSENT] -> PUBLIC
+    [[SequenceOption:{DescID: 104, Name: START, Value: 50}, PUBLIC], ABSENT] -> PUBLIC
+    [[SequenceValue:{DescID: 104}, TRANSIENT_ABSENT], ABSENT] -> TRANSIENT_ABSENT
+  ops:
+    *scop.SetSequenceOption
+      Key: MINVALUE
+      SequenceID: 104
+      Value: "10"
+    *scop.SetSequenceOption
+      Key: MAXVALUE
+      SequenceID: 104
+      Value: "1000"
+    *scop.SetSequenceOption
+      Key: START
+      SequenceID: 104
+      Value: "50"
+    *scop.MaybeUpdateSequenceValue
+      PrevIncrement: 1
+      PrevMaxValue: 9223372036854775807
+      PrevMinValue: 1
+      PrevStart: 1
+      SequenceID: 104
+      UpdatedIncrement: 1
+      UpdatedMaxValue: 1000
+      UpdatedMinValue: 10
+      UpdatedStart: 50
+
+ops
+ALTER SEQUENCE defaultdb.sq1 RESTART WITH 100;
+----
+StatementPhase stage 1 of 1 with 2 MutationType ops
+  transitions:
+    [[SequenceOption:{DescID: 104, Name: RESTART, Value: 99}, TRANSIENT_ABSENT], ABSENT] -> TRANSIENT_ABSENT
+  ops:
+    *scop.SetSequenceOption
+      Key: RESTART
+      SequenceID: 104
+      Value: "99"
+    *scop.UnsetSequenceOption
+      Key: RESTART
+      SequenceID: 104
+PreCommitPhase stage 1 of 2 with 1 MutationType op
+  transitions:
+    [[SequenceOption:{DescID: 104, Name: RESTART, Value: 99}, TRANSIENT_ABSENT], TRANSIENT_ABSENT] -> ABSENT
+  ops:
+    *scop.UndoAllInTxnImmediateMutationOpSideEffects
+      {}
+PreCommitPhase stage 2 of 2 with 2 MutationType ops
+  transitions:
+    [[SequenceOption:{DescID: 104, Name: RESTART, Value: 99}, TRANSIENT_ABSENT], ABSENT] -> TRANSIENT_ABSENT
+  ops:
+    *scop.SetSequenceOption
+      Key: RESTART
+      SequenceID: 104
+      Value: "99"
+    *scop.UnsetSequenceOption
+      Key: RESTART
+      SequenceID: 104
+
+ops
+ALTER SEQUENCE defaultdb.sq1 CACHE 10;
+----
+StatementPhase stage 1 of 1 with 1 MutationType op
+  transitions:
+    [[SequenceOption:{DescID: 104, Name: PER NODE CACHE, Value: 10}, PUBLIC], ABSENT] -> PUBLIC
+  ops:
+    *scop.SetSequenceOption
+      Key: PER NODE CACHE
+      SequenceID: 104
+      Value: "10"
+PreCommitPhase stage 1 of 2 with 1 MutationType op
+  transitions:
+    [[SequenceOption:{DescID: 104, Name: PER NODE CACHE, Value: 10}, PUBLIC], PUBLIC] -> ABSENT
+  ops:
+    *scop.UndoAllInTxnImmediateMutationOpSideEffects
+      {}
+PreCommitPhase stage 2 of 2 with 1 MutationType op
+  transitions:
+    [[SequenceOption:{DescID: 104, Name: PER NODE CACHE, Value: 10}, PUBLIC], ABSENT] -> PUBLIC
+  ops:
+    *scop.SetSequenceOption
+      Key: PER NODE CACHE
+      SequenceID: 104
+      Value: "10"
+
+setup
+CREATE TABLE defaultdb.t1 (id INT PRIMARY KEY, val INT);
+----
+
+ops
+ALTER SEQUENCE defaultdb.sq1 OWNED BY defaultdb.t1.val;
+----
+StatementPhase stage 1 of 1 with 2 MutationType ops
+  transitions:
+    [[SequenceOwner:{DescID: 105, ColumnID: 2, ReferencedDescID: 104}, PUBLIC], ABSENT] -> PUBLIC
+  ops:
+    *scop.AddSequenceOwner
+      ColumnID: 2
+      OwnedSequenceID: 104
+      TableID: 105
+    *scop.AddOwnerBackReferenceInSequence
+      ColumnID: 2
+      SequenceID: 104
+      TableID: 105
+PreCommitPhase stage 1 of 2 with 1 MutationType op
+  transitions:
+    [[SequenceOwner:{DescID: 105, ColumnID: 2, ReferencedDescID: 104}, PUBLIC], PUBLIC] -> ABSENT
+  ops:
+    *scop.UndoAllInTxnImmediateMutationOpSideEffects
+      {}
+PreCommitPhase stage 2 of 2 with 2 MutationType ops
+  transitions:
+    [[SequenceOwner:{DescID: 105, ColumnID: 2, ReferencedDescID: 104}, PUBLIC], ABSENT] -> PUBLIC
+  ops:
+    *scop.AddSequenceOwner
+      ColumnID: 2
+      OwnedSequenceID: 104
+      TableID: 105
+    *scop.AddOwnerBackReferenceInSequence
+      ColumnID: 2
+      SequenceID: 104
+      TableID: 105
+
+ops
+ALTER SEQUENCE defaultdb.sq1 OWNED BY NONE;
+----
+StatementPhase stage 1 of 1 with no ops
+  transitions:
+  no ops
+PreCommitPhase stage 1 of 1 with 1 MutationType op
+  transitions:
+  ops:
+    *scop.UndoAllInTxnImmediateMutationOpSideEffects
+      {}
+
+setup
+CREATE SEQUENCE defaultdb.sq2 OWNED BY defaultdb.t1.id;
+----
+
+ops
+ALTER SEQUENCE defaultdb.sq2 OWNED BY defaultdb.t1.val;
+----
+StatementPhase stage 1 of 1 with 4 MutationType ops
+  transitions:
+    [[SequenceOwner:{DescID: 105, ColumnID: 1, ReferencedDescID: 106}, ABSENT], PUBLIC] -> ABSENT
+    [[SequenceOwner:{DescID: 105, ColumnID: 2, ReferencedDescID: 106}, PUBLIC], ABSENT] -> PUBLIC
+  ops:
+    *scop.RemoveSequenceOwner
+      ColumnID: 1
+      OwnedSequenceID: 106
+      TableID: 105
+    *scop.RemoveOwnerBackReferenceInSequence
+      SequenceID: 106
+    *scop.AddSequenceOwner
+      ColumnID: 2
+      OwnedSequenceID: 106
+      TableID: 105
+    *scop.AddOwnerBackReferenceInSequence
+      ColumnID: 2
+      SequenceID: 106
+      TableID: 105
+PreCommitPhase stage 1 of 2 with 1 MutationType op
+  transitions:
+    [[SequenceOwner:{DescID: 105, ColumnID: 1, ReferencedDescID: 106}, ABSENT], ABSENT] -> PUBLIC
+    [[SequenceOwner:{DescID: 105, ColumnID: 2, ReferencedDescID: 106}, PUBLIC], PUBLIC] -> ABSENT
+  ops:
+    *scop.UndoAllInTxnImmediateMutationOpSideEffects
+      {}
+PreCommitPhase stage 2 of 2 with 4 MutationType ops
+  transitions:
+    [[SequenceOwner:{DescID: 105, ColumnID: 1, ReferencedDescID: 106}, ABSENT], PUBLIC] -> ABSENT
+    [[SequenceOwner:{DescID: 105, ColumnID: 2, ReferencedDescID: 106}, PUBLIC], ABSENT] -> PUBLIC
+  ops:
+    *scop.RemoveSequenceOwner
+      ColumnID: 1
+      OwnedSequenceID: 106
+      TableID: 105
+    *scop.RemoveOwnerBackReferenceInSequence
+      SequenceID: 106
+    *scop.AddSequenceOwner
+      ColumnID: 2
+      OwnedSequenceID: 106
+      TableID: 105
+    *scop.AddOwnerBackReferenceInSequence
+      ColumnID: 2
+      SequenceID: 106
+      TableID: 105

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -88,6 +88,7 @@ const (
 )
 
 const (
+	AlterSequenceTag       = "ALTER SEQUENCE"
 	AlterTableTag          = "ALTER TABLE"
 	AlterPolicyTag         = "ALTER POLICY"
 	BackupTag              = "BACKUP"
@@ -650,7 +651,7 @@ func (*AlterSequence) StatementReturnType() StatementReturnType { return DDL }
 func (*AlterSequence) StatementType() StatementType { return TypeDDL }
 
 // StatementTag returns a short string identifying the type of statement.
-func (*AlterSequence) StatementTag() string { return "ALTER SEQUENCE" }
+func (*AlterSequence) StatementTag() string { return AlterSequenceTag }
 
 // StatementReturnType implements the Statement interface.
 func (*AlterRole) StatementReturnType() StatementReturnType { return DDL }

--- a/pkg/sql/sequence_test.go
+++ b/pkg/sql/sequence_test.go
@@ -215,6 +215,7 @@ func assertColumnOwnsSequences(
 	colIdx int,
 	seqNames []string,
 ) {
+	t.Helper()
 	tableDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, codec, dbName, tbName)
 	col := tableDesc.PublicColumns()[colIdx]
 	var seqDescs []catalog.TableDescriptor


### PR DESCRIPTION
This commit adds ALTER SEQUENCE support to the declarative schema changer. The implementation follows the same pattern as ALTER TABLE ALTER COLUMN ... SET/DROP IDENTITY, which already manipulates SequenceOption, SequenceValue, and SequenceOwner elements for identity-backing sequences. All existing elements and operations are reused - no new proto definitions are needed.

The builder handles all ALTER SEQUENCE options: INCREMENT, MINVALUE, MAXVALUE, START, RESTART, CACHE (node and session), AS type changes (with implicit bounds adjustment), VIRTUAL, OWNED BY, OWNED BY NONE, and IF EXISTS. It is gated behind the V26_2 version check to ensure mixed-version compatibility.

Epic: CRDB-31169
Release note: None