### PR TITLE
authserver,ldapccl: enable ldap user provisioning for db console

### DIFF
--- a/pkg/server/authserver/BUILD.bazel
+++ b/pkg/server/authserver/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/roachpb",
         "//pkg/security",
         "//pkg/security/password",
+        "//pkg/security/provisioning",
         "//pkg/security/username",
         "//pkg/server/apiutil",
         "//pkg/server/serverpb",
@@ -54,6 +55,7 @@ go_library(
 
 go_test(
     name = "authserver_test",
+    size = "large",
     srcs = [
         "authentication_test.go",
         "main_test.go",

--- a/pkg/sql/pgwire/auth_methods.go
+++ b/pkg/sql/pgwire/auth_methods.go
@@ -1182,23 +1182,10 @@ func AuthLDAP(
 
 	b.SetProvisioner(func(ctx context.Context) error {
 		c.LogAuthInfof(ctx, "LDAP authentication succeeded; attempting to provision user")
-		telemetry.Inc(provisioning.BeginLDAPProvisionUseCounter)
-		// Provision the user in the system.
-		idpString := entry.Method.String() + ":" + entry.GetOption("ldapserver")
-		provisioningSource, err := provisioning.ParseProvisioningSource(idpString)
-		if err != nil {
-			err = errors.Wrapf(err, "LDAP provisioning: invalid provisioning source IDP %s", idpString)
+		if err := ProvisionLDAPHelper(ctx, execCfg, sessionUser, entry); err != nil {
 			c.LogAuthFailed(ctx, eventpb.AuthFailReason_PROVISIONING_ERROR, err)
 			return err
 		}
-
-		if err := sql.CreateRoleForProvisioning(ctx, execCfg, sessionUser, provisioningSource.String()); err != nil {
-			err = errors.Wrapf(err, "LDAP provisioning: error provisioning user %s", sessionUser)
-			c.LogAuthFailed(ctx, eventpb.AuthFailReason_PROVISIONING_ERROR, err)
-			return err
-		}
-
-		telemetry.Inc(provisioning.ProvisionLDAPSuccessCounter)
 		return nil
 	})
 
@@ -1284,4 +1271,28 @@ func AuthorizeLDAPHelper(
 		return redact.Sprint(detailedErr), clientErr
 	}
 	return "", nil
+}
+
+// ProvisionLDAPHelper provisions a user based on a successful LDAP
+// authentication. It creates the user if it doesn't exist and sets the
+// PROVISIONSRC role option. This function is used by both the SQL shell
+// and DB Console LDAP authentication paths.
+func ProvisionLDAPHelper(
+	ctx context.Context, execCfg *sql.ExecutorConfig, user username.SQLUsername, entry *hba.Entry,
+) error {
+	telemetry.Inc(provisioning.BeginLDAPProvisionUseCounter)
+	idpString := entry.Method.String() + ":" + entry.GetOption("ldapserver")
+	provisioningSource, err := provisioning.ParseProvisioningSource(idpString)
+	if err != nil {
+		return errors.Wrapf(err,
+			"LDAP provisioning: invalid provisioning source IDP %s", idpString)
+	}
+	if err := sql.CreateRoleForProvisioning(
+		ctx, execCfg, user, provisioningSource.String(),
+	); err != nil {
+		return errors.Wrapf(err,
+			"LDAP provisioning: error provisioning user %s", user)
+	}
+	telemetry.Inc(provisioning.ProvisionLDAPSuccessCounter)
+	return nil
 }


### PR DESCRIPTION
Previously, when a user who did not exist in CockroachDB attempted to log in to
the DB Console via LDAP, the login would fail immediately because the system
checked for user existence before attempting LDAP authentication. This meant
that LDAP user provisioning, which was already available for the SQL shell path,
could not be used for DB Console logins.

This commit restructures the DB Console login flow to attempt LDAP authentication
before rejecting non-existent users. When LDAP authentication succeeds for a
user that does not exist and the `security.provisioning.ldap.enabled` cluster
setting is enabled, the user is automatically provisioned with the `PROVISIONSRC`
role option set to the LDAP server. LDAP group-based role synchronization then
proceeds as normal for the newly provisioned user.

LDAP provisioning logic is now moved to a `ProvisionLDAPHelper` function in the
pgwire package, following the same pattern so both the SQL shell and DB Console
paths now delegates to this common utility.

Epic: CRDB-52460
Informs: #147602

Release note (security change): LDAP authentication for the DB Console now
supports automatic user provisioning. When the cluster setting
`security.provisioning.ldap.enabled` is set to true, users who authenticate
successfully via LDAP will be automatically created in CockroachDB if they do
not already exist.