### PR TITLE
release-26.1: roachtest: increase timeout for ChangeReplicasMixedVersion test

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_change_replicas.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_change_replicas.go
@@ -36,7 +36,7 @@ func registerChangeReplicasMixedVersion(r registry.Registry) {
 		Monitor:          true,
 		Randomized:       true,
 		Run:              runChangeReplicasMixedVersion,
-		Timeout:          60 * time.Minute,
+		Timeout:          3 * time.Hour,
 	})
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #159214 on behalf of @arulajmani.

----

We've increased the timeout for individual steps here recently:
- https://github.com/cockroachdb/cockroach/pull/149243
- https://github.com/cockroachdb/cockroach/pull/151199

The second PR there codifies the expectation that a single moveReplicas step may take upwards of 10 minutes, even though this isn't the common case scenario. Given we move replicas off all nodes, and we do a moveReplicas step on each binary upgrade, the previous 1 hour limit was a tad conservative. We bump this to 3 hours.

Closes https://github.com/cockroachdb/cockroach/issues/159138

Release note: None

----

Release justification: