### PR TITLE
storage/disk: add instantaneous disk stats collection

### DIFF
--- a/pkg/kv/kvserver/stores.go
+++ b/pkg/kv/kvserver/stores.go
@@ -292,6 +292,7 @@ func (ls *Stores) updateBootstrapInfoLocked(bi *gossip.BootstrapInfo) error {
 
 // DiskStatsMonitor abstracts disk.Monitor for testing purposes.
 type DiskStatsMonitor interface {
+	DeviceID() disk.DeviceID
 	CumulativeStats() (disk.Stats, error)
 	Clone() *disk.Monitor
 	Close()

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -994,6 +994,10 @@ type testDiskStatsMonitor struct {
 	stats disk.Stats
 }
 
+func (t *testDiskStatsMonitor) DeviceID() disk.DeviceID {
+	return disk.DeviceID{}
+}
+
 func (t *testDiskStatsMonitor) CumulativeStats() (disk.Stats, error) {
 	return t.stats, nil
 }

--- a/pkg/storage/disk/linux_parse_test.go
+++ b/pkg/storage/disk/linux_parse_test.go
@@ -25,10 +25,10 @@ import (
 )
 
 func compareDeviceIDs(a, b DeviceID) int {
-	if v := cmp.Compare(a.major, b.major); v != 0 {
+	if v := cmp.Compare(a.Major, b.Major); v != 0 {
 		return v
 	}
-	return cmp.Compare(a.minor, b.minor)
+	return cmp.Compare(a.Minor, b.Minor)
 }
 
 func TestLinux_CollectDiskStats(t *testing.T) {
@@ -44,10 +44,10 @@ func TestLinux_CollectDiskStats(t *testing.T) {
 				var deviceID DeviceID
 				v, err := strconv.ParseUint(cmdArg.Vals[0], 10, 32)
 				require.NoError(t, err)
-				deviceID.major = uint32(v)
+				deviceID.Major = uint32(v)
 				v, err = strconv.ParseUint(cmdArg.Vals[1], 10, 32)
 				require.NoError(t, err)
-				deviceID.minor = uint32(v)
+				deviceID.Minor = uint32(v)
 				tracer := newMonitorTracer(1000)
 				disks = append(disks, &monitoredDisk{deviceID: deviceID, tracer: tracer})
 			}

--- a/pkg/storage/disk/platform_darwin.go
+++ b/pkg/storage/disk/platform_darwin.go
@@ -22,6 +22,12 @@ func (darwinCollector) collect(disks []*monitoredDisk, time time.Time) (int, err
 	return len(disks), nil
 }
 
+func (darwinCollector) collectInstantaneous(
+	disks []*monitoredDisk, now time.Time, recorder func(traceEvent), buf []byte,
+) (countCollected int, _ []byte, err error) {
+	return len(disks), buf, nil
+}
+
 func newStatsCollector(fs vfs.FS) (*darwinCollector, error) {
 	return &darwinCollector{}, nil
 }
@@ -29,8 +35,8 @@ func newStatsCollector(fs vfs.FS) (*darwinCollector, error) {
 func deviceIDFromFileInfo(finfo fs.FileInfo, path string) DeviceID {
 	statInfo := finfo.Sys().(*sysutil.StatT)
 	id := DeviceID{
-		major: unix.Major(uint64(statInfo.Dev)),
-		minor: unix.Minor(uint64(statInfo.Dev)),
+		Major: unix.Major(uint64(statInfo.Dev)),
+		Minor: unix.Minor(uint64(statInfo.Dev)),
 	}
 	return id
 }

--- a/pkg/storage/disk/platform_linux_test.go
+++ b/pkg/storage/disk/platform_linux_test.go
@@ -239,3 +239,28 @@ func TestLinux_parseDeviceID(t *testing.T) {
 		})
 	}
 }
+
+func TestEnsureMinSizeBuffer(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []byte
+	}{
+		{name: "nil buffer", input: nil},
+		{name: "empty buffer", input: []byte{}},
+		{name: "small buffer", input: make([]byte, 5)},
+		{name: "exact size buffer", input: make([]byte, 64)},
+		{name: "large buffer", input: make([]byte, 65)},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := ensureMinSizeBuffer(test.input)
+			require.NotNil(t, got)
+			if len(test.input) <= 64 {
+				require.Equal(t, len(got), 64)
+			} else {
+				require.Greater(t, len(got), 64)
+			}
+		})
+	}
+}

--- a/pkg/storage/disk/stats.go
+++ b/pkg/storage/disk/stats.go
@@ -15,6 +15,8 @@ const SectorSizeBytes = 512
 
 // Stats describes statistics for an individual disk or volume.
 type Stats struct {
+	DeviceID DeviceID
+
 	DeviceName string
 	// ReadsCount is the count of read operations completed successfully.
 	ReadsCount int


### PR DESCRIPTION
Add CollectInstantaneous() to MonitorManager which reads /proc/diskstats synchronously on-demand, bypassing the background polling tracer. This enables callers to get fresh disk stats at arbitrary intervals rather than relying on the 100ms background polling. This will eventually be used to enable 1ms error correction in the AC store grant coordinator.
    
Epic: CRDB-47073
Informs: #162214
Release note: None