### PR TITLE
concurrency: print ts in intents to resolve

### DIFF
--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -828,8 +828,9 @@ func intentsToResolveToStr(toResolve []roachpb.LockUpdate, startOnNewLine bool) 
 	}
 	fmt.Fprintf(&buf, "Intents to resolve:")
 	for i := range toResolve {
-		fmt.Fprintf(&buf, "\n key=%s txn=%s status=%s", toResolve[i].Key,
-			toResolve[i].Txn.ID.Short(), toResolve[i].Status)
+		txn := toResolve[i].Txn
+		fmt.Fprintf(&buf, "\n key=%s txn=%s epoch=%d ts=%s status=%s", toResolve[i].Key,
+			txn.ID, txn.Epoch, txn.WriteTimestamp, toResolve[i].Status)
 	}
 	return buf.String()
 }

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/clear_finalized_txn_locks
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/clear_finalized_txn_locks
@@ -239,10 +239,10 @@ guard-state r=req1
 ----
 new: state=doneWaiting
 Intents to resolve:
- key="a" txn=00000000 status=ABORTED
- key="b" txn=00000000 status=ABORTED
- key="d" txn=00000000 status=COMMITTED
- key="e" txn=00000000 status=COMMITTED
+ key="a" txn=00000000-0000-0000-0000-000000000002 epoch=0 ts=10.000000000,1 status=ABORTED
+ key="b" txn=00000000-0000-0000-0000-000000000002 epoch=0 ts=10.000000000,1 status=ABORTED
+ key="d" txn=00000000-0000-0000-0000-000000000003 epoch=0 ts=11.000000000,1 status=COMMITTED
+ key="e" txn=00000000-0000-0000-0000-000000000003 epoch=0 ts=11.000000000,1 status=COMMITTED
 
 print
 ----
@@ -352,8 +352,8 @@ guard-state r=req3
 ----
 new: state=doneWaiting
 Intents to resolve:
- key="a" txn=00000000 status=ABORTED
- key="c" txn=00000000 status=ABORTED
+ key="a" txn=00000000-0000-0000-0000-000000000002 epoch=0 ts=11.000000000,1 status=ABORTED
+ key="c" txn=00000000-0000-0000-0000-000000000002 epoch=0 ts=11.000000000,1 status=ABORTED
 
 print
 ----
@@ -476,7 +476,7 @@ guard-state r=req5
 ----
 new: state=doneWaiting
 Intents to resolve:
- key="b" txn=00000000 status=ABORTED
+ key="b" txn=00000000-0000-0000-0000-000000000002 epoch=0 ts=11.000000000,1 status=ABORTED
 
 print
 ----
@@ -571,8 +571,8 @@ guard-state r=req8
 ----
 new: state=doneWaiting
 Intents to resolve:
- key="a" txn=00000000 status=ABORTED
- key="b" txn=00000000 status=ABORTED
+ key="a" txn=00000000-0000-0000-0000-000000000002 epoch=0 ts=11.000000000,1 status=ABORTED
+ key="b" txn=00000000-0000-0000-0000-000000000002 epoch=0 ts=11.000000000,1 status=ABORTED
 
 guard-state r=req7
 ----
@@ -685,8 +685,8 @@ guard-state r=req10
 ----
 new: state=doneWaiting
 Intents to resolve:
- key="a" txn=00000000 status=ABORTED
- key="b" txn=00000000 status=ABORTED
+ key="a" txn=00000000-0000-0000-0000-000000000003 epoch=0 ts=12.000000000,1 status=ABORTED
+ key="b" txn=00000000-0000-0000-0000-000000000003 epoch=0 ts=12.000000000,1 status=ABORTED
 
 pushed-txn-updated txn=txn4 status=aborted
 ----
@@ -701,7 +701,7 @@ guard-state r=req9
 ----
 new: state=doneWaiting
 Intents to resolve:
- key="d" txn=00000000 status=ABORTED
+ key="d" txn=00000000-0000-0000-0000-000000000004 epoch=0 ts=11.000000000,1 status=ABORTED
 
 print
 ----
@@ -744,7 +744,7 @@ guard-state r=req11
 ----
 new: state=doneWaiting
 Intents to resolve:
- key="a" txn=00000000 status=ABORTED
+ key="a" txn=00000000-0000-0000-0000-000000000002 epoch=0 ts=12.000000000,1 status=ABORTED
 
 dequeue r=req11
 ----
@@ -787,7 +787,7 @@ guard-state r=req12
 ----
 new: state=doneWaiting
 Intents to resolve:
- key="a" txn=00000000 status=ABORTED
+ key="a" txn=00000000-0000-0000-0000-000000000002 epoch=0 ts=12.000000000,1 status=ABORTED
 
 dequeue r=req12
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/discovered_locks_consults_txn_cache
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/discovered_locks_consults_txn_cache
@@ -57,7 +57,7 @@ guard-state r=req1
 ----
 new: state=doneWaiting
 Intents to resolve:
- key="a" txn=00000000 status=ABORTED
+ key="a" txn=00000000-0000-0000-0000-000000000002 epoch=0 ts=10.000000000,0 status=ABORTED
 
 print
 ----
@@ -105,8 +105,8 @@ num=2
 resolve-before-scanning r=req1
 ----
 Intents to resolve:
- key="b" txn=00000000 status=ABORTED
- key="c" txn=00000000 status=ABORTED
+ key="b" txn=00000000-0000-0000-0000-000000000003 epoch=0 ts=10.000000000,0 status=ABORTED
+ key="c" txn=00000000-0000-0000-0000-000000000003 epoch=0 ts=10.000000000,0 status=ABORTED
 
 scan r=req1
 ----
@@ -159,7 +159,7 @@ guard-state r=req2
 ----
 new: state=doneWaiting
 Intents to resolve:
- key="e" txn=00000000 status=PENDING
+ key="e" txn=00000000-0000-0000-0000-000000000005 epoch=0 ts=11.000000000,0 status=PENDING
 
 update txn=txn5 ts=11,1 epoch=0 span=e
 ----
@@ -193,8 +193,8 @@ num=1
 resolve-before-scanning r=req2
 ----
 Intents to resolve:
- key="f" txn=00000000 status=PENDING
- key="g" txn=00000000 status=ABORTED
+ key="f" txn=00000000-0000-0000-0000-000000000005 epoch=0 ts=11.000000000,0 status=PENDING
+ key="g" txn=00000000-0000-0000-0000-000000000006 epoch=0 ts=10.000000000,0 status=ABORTED
 
 scan r=req2
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/resolve_pushed_txn_locks
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/resolve_pushed_txn_locks
@@ -148,8 +148,8 @@ guard-state r=req4
 ----
 new: state=doneWaiting
 Intents to resolve:
- key="b" txn=00000000 status=PENDING
- key="c" txn=00000000 status=PENDING
+ key="b" txn=00000000-0000-0000-0000-000000000002 epoch=0 ts=11.000000000,1 status=PENDING
+ key="c" txn=00000000-0000-0000-0000-000000000002 epoch=0 ts=11.000000000,1 status=PENDING
 
 update txn=txn2 ts=11,1 epoch=0 span=b
 ----


### PR DESCRIPTION
We are about to add some tests where it will be a bit more important to verify the details of these intents.

Epic: none
Release note: None