### PR TITLE
evalcatalog: update Txn used by Builtins when flow switches to LeafTxn

### DIFF
--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -321,6 +321,9 @@ func (ds *ServerImpl) setupFlow(
 			// Update the Txn field early (before f.SetTxn() below) since some
 			// processors capture the field in their constructor (see #41992).
 			localEvalCtx.Txn = leafTxn
+			if localEvalCtx.CatalogBuiltins != nil {
+				localEvalCtx.CatalogBuiltins.SetTxn(leafTxn)
+			}
 		} else {
 			onFlowCleanupEnd = func(ctx context.Context) {
 				reserved.Close(ctx)

--- a/pkg/sql/evalcatalog/eval_catalog.go
+++ b/pkg/sql/evalcatalog/eval_catalog.go
@@ -54,3 +54,8 @@ func (ec *Builtins) Init(
 	ec.dc = descriptors
 	ec.authzAccessor = authzAccessor
 }
+
+// SetTxn updates the kv.Txn used by the Builtins.
+func (ec *Builtins) SetTxn(txn *kv.Txn) {
+	ec.txn = txn
+}

--- a/pkg/sql/flowinfra/flow.go
+++ b/pkg/sql/flowinfra/flow.go
@@ -281,6 +281,7 @@ func (f *FlowBase) Setup(
 func (f *FlowBase) SetTxn(txn *kv.Txn) {
 	f.FlowCtx.Txn = txn
 	f.EvalCtx.Txn = txn
+	f.EvalCtx.CatalogBuiltins.SetTxn(txn)
 }
 
 // ConcurrentTxnUse is part of the Flow interface.

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -84,6 +85,9 @@ type CastFunc = func(context.Context, tree.Datum, *types.T) (tree.Datum, error)
 // of the Planner interface as we subsume its privilege checking into an
 // intermediate layer.
 type CatalogBuiltins interface {
+	// SetTxn updates the kv.Txn used by the builtins.
+	SetTxn(txn *kv.Txn)
+
 	// EncodeTableIndexKey constructs a deterministic and immutable encoding of
 	// a table index key from a tuple of datums. It is leveraged as the
 	// input to a hash function for hash-sharded indexes.


### PR DESCRIPTION
The `Builtins` struct captures a kv.Txn reference during initialization,
either when resetting the planner or when creating a FlowContext on a
remote node. When a distributed flow later creates a LeafTxn for better
concurrency control, the flow's transaction references are updated via
`FlowBase.SetTxn()`. However, the Builtins struct was not being updated,
leaving it with a stale reference to the original RootTxn while the rest
of the execution context switched to the LeafTxn.

This commit adds a `SetTxn()` method to the Builtins struct and calls it
from `FlowBase.SetTxn()`, ensuring all transaction references in the
evaluation context remain consistent.

Note: This addresses the symptom but not the root cause - there remains
a broader architectural issue where components capture transaction
references too early in their lifecycle.

Touches: #41992
Epic: None
Release note: None