### PR TITLE
kvserver: bump node and store liveness suspect durations

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_decommission.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_decommission.go
@@ -26,8 +26,8 @@ import (
 
 func runDecommissionMixedVersions(ctx context.Context, t test.Test, c cluster.Cluster) {
 	// NB: The default value for both the store liveness and node liveness
-	// suspect duration settings is 30s.
-	const suspectDuration = 30 * time.Second
+	// suspect duration settings is 1m.
+	const suspectDuration = time.Minute
 
 	mvt := mixedversion.NewTest(ctx, t, t.L(), c, c.All(),
 		// We test only upgrades from 23.2 in this test because it uses

--- a/pkg/kv/kvserver/client_lease_test.go
+++ b/pkg/kv/kvserver/client_lease_test.go
@@ -1308,6 +1308,10 @@ func TestLeasesDontThrashWhenNodeBecomesSuspect(t *testing.T) {
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	kvserver.ExpirationLeasesOnly.Override(ctx, &st.SV, false) // override metamorphism
+	// Use a fixed suspect duration that the manual clock can easily exceed,
+	// rather than relying on the default (which may be too long for the
+	// SucceedsSoon timeout when combined with HybridManualClock wall time).
+	liveness.TimeAfterNodeSuspect.Override(ctx, &st.SV, 20*time.Second)
 
 	// Speed up lease transfers.
 	stickyRegistry := fs.NewStickyRegistry()

--- a/pkg/kv/kvserver/client_lease_test.go
+++ b/pkg/kv/kvserver/client_lease_test.go
@@ -1312,6 +1312,7 @@ func TestLeasesDontThrashWhenNodeBecomesSuspect(t *testing.T) {
 	// rather than relying on the default (which may be too long for the
 	// SucceedsSoon timeout when combined with HybridManualClock wall time).
 	liveness.TimeAfterNodeSuspect.Override(ctx, &st.SV, 20*time.Second)
+	liveness.TimeAfterStoreSuspectInStoreLiveness.Override(ctx, &st.SV, 20*time.Second)
 
 	// Speed up lease transfers.
 	stickyRegistry := fs.NewStickyRegistry()

--- a/pkg/kv/kvserver/liveness/liveness.go
+++ b/pkg/kv/kvserver/liveness/liveness.go
@@ -87,7 +87,7 @@ var TimeAfterStoreSuspectInStoreLiveness = settings.RegisterDurationSetting(
 	timeAfterStoreSuspectInStoreLivenessSettingName,
 	"the amount of time we consider a store suspect for after its support is withdrawn in StoreLiveness."+
 		" A suspect store is typically treated the same as an unavailable store.",
-	30*time.Second,
+	time.Minute,
 	settings.DurationInRange(minTimeUntilNodeSuspect, maxTimeAfterNodeSuspect),
 )
 

--- a/pkg/kv/kvserver/liveness/liveness.go
+++ b/pkg/kv/kvserver/liveness/liveness.go
@@ -76,7 +76,7 @@ var TimeAfterNodeSuspect = settings.RegisterDurationSetting(
 	timeAfterNodeSuspectSettingName,
 	"the amount of time we consider a node suspect for after it becomes unavailable."+
 		" A suspect node is typically treated the same as an unavailable node.",
-	30*time.Second,
+	time.Minute,
 	settings.DurationInRange(minTimeUntilNodeSuspect, maxTimeAfterNodeSuspect),
 )
 


### PR DESCRIPTION
See individual commits. I'll backport commits 1 and 3 to previous releases. 