### PR TITLE
concurrency: add kv.concurrency.push_pending_from_cache.enabled setting

### DIFF
--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -177,6 +177,16 @@ var VirtualIntentResolution = settings.RegisterBoolSetting(
 	}),
 )
 
+// PushUsingCachedClockObservation controls whether we allow intents from
+// PENDING transactions to be resolved by requests with uncertainty intervals by
+// using a cached clock observation from the original pusher.
+var PushUsingCachedClockObservation = settings.RegisterBoolSetting(
+	settings.SystemOnly,
+	"kv.concurrency.push_pending_from_cache.enabled",
+	"whether intents from pending transactions can be resolved using cached clock observations",
+	true,
+)
+
 // MaxLockFlushSize is the maximum number of lock bytes that we will attempt to
 // flush during merge and transfer operations.
 func GetMaxLockFlushSize(sv *settings.Values) int64 {

--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -90,6 +90,7 @@ import (
 // debug-advance-clock       ts=<secs>
 // debug-set-discovered-locks-threshold-to-consult-txn-status-cache n=<count>
 // debug-set-batch-pushed-lock-resolution-enabled ok=<enabled>
+// debug-set-push-using-cached-clock-observation-enabled ok=<enabled>
 // debug-set-max-locks n=<count>
 // reset [namespace|force]
 func TestConcurrencyManagerBasic(t *testing.T) {
@@ -604,6 +605,11 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 				c.setBatchPushedLockResolutionEnabled(ok)
 				return ""
 
+			case "debug-set-push-using-cached-clock-observation-enabled":
+				ok := dd.ScanArg[bool](t, d, "ok")
+				c.setPushUsingCachedClockObservationEnabled(ok)
+				return ""
+
 			case "debug-set-max-locks":
 				n := dd.ScanArg[int64](t, d, "n")
 				m.SetMaxLockTableSize(n)
@@ -1006,6 +1012,10 @@ func (c *cluster) setDiscoveredLocksThresholdToConsultTxnStatusCache(n int) {
 
 func (c *cluster) setBatchPushedLockResolutionEnabled(ok bool) {
 	concurrency.BatchPushedLockResolution.Override(context.Background(), &c.st.SV, ok)
+}
+
+func (c *cluster) setPushUsingCachedClockObservationEnabled(ok bool) {
+	concurrency.PushUsingCachedClockObservation.Override(context.Background(), &c.st.SV, ok)
 }
 
 // reset clears all request state in the cluster. This avoids portions of tests

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
@@ -1,3 +1,8 @@
+# Explicitly enable the push-using-cached-clock-observation setting so these
+# tests remain consistent regardless of any future default changes.
+debug-set-push-using-cached-clock-observation-enabled ok=true
+----
+
 # -------------------------------------------------------------
 # A transactional (txn2) read-only request runs into a replicated
 # intent below its read timestamp. It informs the lock table and
@@ -573,6 +578,88 @@ on-txn-updated txn=txn1 status=pending ts=15,2
 [3] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [3] sequence req1: pushing timestamp of txn 00000001 above 15.000000000,1
 [3] sequence req1: resolving intent ‹"b"› for txn 00000001 with PENDING status and clock observation {1 135.000000000,17}
+[3] sequence req1: lock wait-queue event: done waiting
+[3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"b"› for 0.000s
+[3] sequence req1: acquiring latches
+[3] sequence req1: scanning lock table for conflicting locks
+[3] sequence req1: sequencing complete, returned guard
+
+finish req=req1
+----
+[-] finish req1: finishing request
+
+reset namespace
+----
+
+# -------------------------------------------------------------
+# Same situation as the "cached push result" test above: txn2
+# has an uncertainty interval and an observed timestamp on this
+# node that would normally allow the optimization. However, the
+# push_pending_from_cache cluster setting is disabled, so the
+# cached clock observation cannot be used to resolve pending
+# intents. The request must wait and push again for each
+# subsequent intent.
+# -------------------------------------------------------------
+
+debug-set-push-using-cached-clock-observation-enabled ok=false
+----
+
+new-txn name=txn1 ts=10,1 epoch=0
+----
+
+# txn2 has the same setup as the optimization test: uncertainty interval
+# [12,1 to 15,1] and an observed timestamp on node 1 at 123,1.
+new-txn name=txn2 ts=12,1 epoch=0 uncertainty-limit=15,1 observed-ts=1@123,1
+----
+
+new-request name=req1 txn=txn2 ts=12,1
+  scan key=a endkey=z
+----
+
+sequence req=req1
+----
+[1] sequence req1: sequencing request
+[1] sequence req1: acquiring latches
+[1] sequence req1: scanning lock table for conflicting locks
+[1] sequence req1: sequencing complete, returned guard
+
+# Discover 2 intents from txn1 at keys a and b.
+handle-lock-conflict-error req=req1 lease-seq=1
+  lock txn=txn1 key=a
+  lock txn=txn1 key=b
+----
+[2] handle lock conflict error req1: added 2 discovered lock(s) to lock table: conflicting locks on ‹"a"›, ‹"b"›
+
+debug-lock-table
+----
+num=2
+ lock: "a"
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
+ lock: "b"
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
+
+sequence req=req1
+----
+[3] sequence req1: re-sequencing request
+[3] sequence req1: acquiring latches
+[3] sequence req1: scanning lock table for conflicting locks
+[3] sequence req1: waiting in lock wait-queues
+[3] sequence req1: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"a"› (queuedLockingRequests: 0, queuedReaders: 1)
+[3] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
+[3] sequence req1: pushing timestamp of txn 00000001 above 15.000000000,1
+[3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+# Because the setting is disabled, the cached clock observation
+# cannot be used to resolve the remaining intent after this push succeeds.
+on-txn-updated txn=txn1 status=pending ts=15,2
+----
+[-] update txn: increasing timestamp of txn1
+[3] sequence req1: resolving intent ‹"a"› for txn 00000001 with PENDING status and clock observation {1 135.000000000,19}
+[3] sequence req1: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"b"› (queuedLockingRequests: 0, queuedReaders: 1)
+[3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
+[3] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
+[3] sequence req1: pushing timestamp of txn 00000001 above 15.000000000,1
+[3] sequence req1: resolving intent ‹"b"› for txn 00000001 with PENDING status and clock observation {1 135.000000000,21}
 [3] sequence req1: lock wait-queue event: done waiting
 [3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"b"› for 0.000s
 [3] sequence req1: acquiring latches


### PR DESCRIPTION
We are putting this setting in place in case we want to back out the new push behaviour without reverting the original pull request since a lot of code might depend on it.

Release note: None
Epic: None