### PR TITLE
kvserver: bump node liveness suspect duration [backport release-24.3]

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_decommission.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_decommission.go
@@ -25,10 +25,9 @@ import (
 )
 
 func runDecommissionMixedVersions(ctx context.Context, t test.Test, c cluster.Cluster) {
-	// NB: The suspect duration must be at least 10s, as versions 23.2 and
-	// beyond will reset to the default of 30s if it fails validation, even if
-	// set by a previous version.
-	const suspectDuration = 10 * time.Second
+	// NB: The default value for both the store liveness and node liveness
+	// suspect duration settings is 1m.
+	const suspectDuration = time.Minute
 
 	mvt := mixedversion.NewTest(ctx, t, t.L(), c, c.All(),
 		// We test only upgrades from 23.2 in this test because it uses
@@ -44,16 +43,6 @@ func runDecommissionMixedVersions(ctx context.Context, t test.Test, c cluster.Cl
 	)
 	n1 := 1
 	n2 := 2
-
-	mvt.OnStartup(
-		"set suspect duration",
-		func(ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper) error {
-			return h.System.Exec(
-				rng,
-				"SET CLUSTER SETTING server.time_after_store_suspect = $1",
-				suspectDuration.String(),
-			)
-		})
 
 	mvt.OnStartup(
 		"preload data",

--- a/pkg/kv/kvserver/liveness/liveness.go
+++ b/pkg/kv/kvserver/liveness/liveness.go
@@ -74,7 +74,7 @@ var TimeAfterNodeSuspect = settings.RegisterDurationSetting(
 	timeAfterNodeSuspectSettingName,
 	"the amount of time we consider a node suspect for after it becomes unavailable."+
 		" A suspect node is typically treated the same as an unavailable node.",
-	30*time.Second,
+	time.Minute,
 	settings.DurationInRange(minTimeUntilNodeSuspect, maxTimeAfterNodeSuspect),
 )
 


### PR DESCRIPTION
Backport of node liveness suspect duration bump to release-24.3.

We've seen the previous default value, 30 seconds, to be a bit more optimistic than ideal recently. Bump this up to 1m.

Epic: none
Release note: None