### PR TITLE
server: *correctly* add store ID tag to ProcessStoreLoadMsg

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -930,7 +930,8 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 			}
 			storeLoadMsg := mmaintegration.MakeStoreLoadMsg(storeDesc, origTimestampNanos)
 			mmaAlloc.SetStore(state.StoreAttrAndLocFromDesc(storeDesc))
-			mmaAlloc.ProcessStoreLoadMsg(ctx, &storeLoadMsg)
+			sCtx := logtags.AddTag(ctx, "s", storeDesc.StoreID)
+			mmaAlloc.ProcessStoreLoadMsg(sCtx, &storeLoadMsg)
 		},
 	)
 


### PR DESCRIPTION
Add a store ID tag to the context passed to ProcessStoreLoadMsg call for better logging.

Release note: None
Informs: #162257
Epic: None