### PR TITLE
sql/opt: support subqueries in ORDER BY with NULLS FIRST/LAST

### DIFF
--- a/pkg/sql/explain_bundle_test.go
+++ b/pkg/sql/explain_bundle_test.go
@@ -215,9 +215,7 @@ CREATE TABLE users(id UUID DEFAULT gen_random_uuid() PRIMARY KEY, promo_id INT R
 			{"intervalstyle", "iso_8601"},
 			{"large_full_scan_rows", "2000"},
 			{"locality_optimized_partitioned_index_scan", "off"},
-			// TODO(#129956): Enable this once non-default NULLS ordering with
-			// subqueries is allowed in tests.
-			// {"null_ordered_last", "on"},
+			{"null_ordered_last", "on"},
 			{"on_update_rehome_row_enabled", "off"},
 			{"opt_split_scan_limit", "1000"},
 			{"optimizer_use_histograms", "off"},

--- a/pkg/sql/logictest/testdata/logic_test/order_by
+++ b/pkg/sql/logictest/testdata/logic_test/order_by
@@ -622,3 +622,183 @@ query II
 SELECT a, b FROM (SELECT a, b FROM t106678 ORDER BY a LIMIT 3) ORDER BY a, b LIMIT 1
 ----
 1  -1
+
+# ------------------------------------------------------------------------------
+# ORDER BY with subqueries and non-default NULLS ordering test cases.
+# These test the pre-projection logic for avoiding subquery duplication.
+# ------------------------------------------------------------------------------
+subtest subquery_nulls_ordering
+
+statement ok
+CREATE TABLE t_sub (id INT, val INT);
+INSERT INTO t_sub VALUES (1, 10), (2, NULL), (3, 30), (NULL, 40)
+
+statement ok
+CREATE TABLE t_lookup (k INT, v INT);
+INSERT INTO t_lookup VALUES (1, 100), (2, 200), (3, 300)
+
+# Test ORDER BY subquery with NULLS LAST (non-default for ASC).
+query II
+SELECT id, val FROM t_sub ORDER BY (SELECT v FROM t_lookup WHERE k = id) NULLS LAST
+----
+1     10
+2     NULL
+3     30
+NULL  40
+
+# Test ORDER BY subquery with NULLS FIRST (default for ASC).
+query II
+SELECT id, val FROM t_sub ORDER BY (SELECT v FROM t_lookup WHERE k = id) NULLS FIRST
+----
+NULL  40
+1     10
+2     NULL
+3     30
+
+# Test ORDER BY subquery with DESC NULLS FIRST (non-default for DESC).
+query II
+SELECT id, val FROM t_sub ORDER BY (SELECT v FROM t_lookup WHERE k = id) DESC NULLS FIRST
+----
+NULL  40
+3     30
+2     NULL
+1     10
+
+# Test ORDER BY subquery with DESC NULLS LAST (default for DESC).
+query II
+SELECT id, val FROM t_sub ORDER BY (SELECT v FROM t_lookup WHERE k = id) DESC NULLS LAST
+----
+3     30
+2     NULL
+1     10
+NULL  40
+
+# Test multiple ORDER BY columns, some with subqueries and non-default NULLS.
+query II
+SELECT id, val FROM t_sub ORDER BY id NULLS LAST, (SELECT v FROM t_lookup WHERE k = id) NULLS LAST
+----
+1     10
+2     NULL
+3     30
+NULL  40
+
+# Test complex subquery expression with NULLS LAST.
+query II
+SELECT id, val FROM t_sub ORDER BY (SELECT CASE WHEN v > 150 THEN v ELSE NULL END FROM t_lookup WHERE k = id) NULLS LAST, id NULLS FIRST
+----
+2     NULL
+3     30
+NULL  40
+1     10
+
+# Test subquery in SELECT list that matches ORDER BY expression.
+query III
+SELECT id, val, (SELECT v FROM t_lookup WHERE k = id) AS lookup_val
+FROM t_sub
+ORDER BY (SELECT v FROM t_lookup WHERE k = id) NULLS LAST
+----
+1     10    100
+2     NULL  200
+3     30    300
+NULL  40    NULL
+
+# Test correlated subquery with aggregation and NULLS LAST.
+statement ok
+CREATE TABLE t_orders (customer_id INT, amount DECIMAL);
+INSERT INTO t_orders VALUES (1, 25.50), (1, 75.00), (2, 150.75), (3, 10.25)
+
+# Test aggregation with subquery ORDER BY and NULLS LAST.
+query IT
+SELECT id, sum(val) FROM t_sub
+GROUP BY id
+ORDER BY (SELECT sum(amount) FROM t_orders WHERE customer_id = id) NULLS LAST
+----
+3     30
+1     10
+2     NULL
+NULL  40
+
+# Test VALUES clause with subquery ORDER BY and NULLS LAST.
+query II
+VALUES (1, 10), (2, NULL), (3, 30), (NULL, 40)
+ORDER BY (SELECT count(*) FROM t_lookup WHERE k = column1) NULLS LAST, column1 NULLS FIRST
+----
+NULL  40
+1     10
+2     NULL
+3     30
+
+# Regression test: side-effecting functions in ORDER BY with NULLS LAST
+# should not be evaluated twice per row. The pre-projection ensures the
+# expression is evaluated once, and IS NULL references the result by
+# column ID.
+statement ok
+CREATE TABLE side_effects (id SERIAL PRIMARY KEY, input_val INT)
+
+statement ok
+CREATE FUNCTION tracked_add(x INT) RETURNS INT LANGUAGE SQL AS $$
+  INSERT INTO side_effects (input_val) VALUES (x);
+  SELECT x + 1;
+$$
+
+# Baseline: without NULLS LAST, function is called once per row.
+statement ok
+TRUNCATE side_effects
+
+query I
+SELECT id FROM t_sub ORDER BY tracked_add(id)
+----
+NULL
+1
+2
+3
+
+query I
+SELECT count(*) FROM side_effects
+----
+4
+
+# With NULLS LAST: function should still be called once per row (not twice).
+statement ok
+TRUNCATE side_effects
+
+query I
+SELECT id FROM t_sub ORDER BY tracked_add(id) NULLS LAST
+----
+1
+2
+3
+NULL
+
+query I
+SELECT count(*) FROM side_effects
+----
+4
+
+statement ok
+DROP FUNCTION tracked_add
+
+statement ok
+DROP TABLE side_effects CASCADE
+
+# Regression test: when ORDER BY expression matches a SELECT list expression,
+# the existing projection should be reused (SQL99 rule 3).
+query III
+SELECT id, val, (SELECT v FROM t_lookup WHERE k = id) AS lookup_val
+FROM t_sub
+ORDER BY (SELECT v FROM t_lookup WHERE k = id) NULLS LAST
+----
+1     10    100
+2     NULL  200
+3     30    300
+NULL  40    NULL
+
+# Clean up
+statement ok
+DROP TABLE t_sub CASCADE
+
+statement ok
+DROP TABLE t_lookup CASCADE
+
+statement ok
+DROP TABLE t_orders CASCADE

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -421,7 +421,12 @@ func (mb *mutationBuilder) buildInputForUpdate(
 	projectionsScope.appendColumnsFromScope(mb.outScope)
 	orderByScope := mb.b.analyzeOrderBy(orderBy, mb.outScope, projectionsScope,
 		exprKindOrderByUpdate, tree.RejectGenerators|tree.RejectAggregates)
+	preProjectionScope := mb.b.buildOrderByPreProjection(mb.outScope, projectionsScope, orderByScope)
 	mb.b.buildOrderBy(mb.outScope, projectionsScope, orderByScope)
+	if preProjectionScope != nil {
+		mb.b.constructProjectForScope(mb.outScope, preProjectionScope)
+		mb.outScope.expr = preProjectionScope.expr
+	}
 	mb.b.constructProjectForScope(mb.outScope, projectionsScope)
 
 	// LIMIT
@@ -542,7 +547,12 @@ func (mb *mutationBuilder) buildInputForDelete(
 	projectionsScope.appendColumnsFromScope(mb.outScope)
 	orderByScope := mb.b.analyzeOrderBy(orderBy, mb.outScope, projectionsScope,
 		exprKindOrderByDelete, tree.RejectGenerators|tree.RejectAggregates)
+	preProjectionScope := mb.b.buildOrderByPreProjection(mb.outScope, projectionsScope, orderByScope)
 	mb.b.buildOrderBy(mb.outScope, projectionsScope, orderByScope)
+	if preProjectionScope != nil {
+		mb.b.constructProjectForScope(mb.outScope, preProjectionScope)
+		mb.outScope.expr = preProjectionScope.expr
+	}
 	mb.b.constructProjectForScope(mb.outScope, projectionsScope)
 
 	// LIMIT

--- a/pkg/sql/opt/optbuilder/orderby.go
+++ b/pkg/sql/opt/optbuilder/orderby.go
@@ -8,7 +8,6 @@ package optbuilder
 import (
 	"fmt"
 
-	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
@@ -19,8 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
-	"github.com/cockroachdb/errors"
 )
 
 // analyzeOrderBy analyzes an Ordering physical property from the ORDER BY
@@ -70,13 +67,63 @@ func (b *Builder) analyzeOrderBy(
 // columns to the projectionsScope and sets the ordering property on the
 // projectionsScope. This property later becomes part of the required physical
 // properties returned by Build.
+//
+// For columns with non-default NULLS ordering (e.g., NULLS LAST for ASC or
+// NULLS FIRST for DESC), an additional IS NULL column is generated and added
+// to the ordering before the main column. This implements the correct NULL
+// ordering semantics by first sorting by whether values are NULL, then by
+// the actual values.
 func (b *Builder) buildOrderBy(inScope, projectionsScope, orderByScope *scope) {
 	if orderByScope == nil {
 		return
 	}
 
+	nullsOrderingCount := 0
+	for i := range orderByScope.cols {
+		if orderByScope.cols[i].nonDefaultNullsOrder {
+			nullsOrderingCount++
+		}
+	}
+	if nullsOrderingCount > 0 {
+		// Pre-allocate space for the new columns list to avoid multiple
+		// allocations. We need space for original columns plus IS NULL
+		// columns for those with nonDefaultNullsOrder.
+		newCols := make([]scopeColumn, 0, len(orderByScope.cols)+nullsOrderingCount)
+
+		// Process each ORDER BY column, adding IS NULL columns for non-default NULLS ordering.
+		for i := range orderByScope.cols {
+			orderByCol := &orderByScope.cols[i]
+
+			// For non-default NULLS ordering, create an IS NULL column first.
+			if orderByCol.nonDefaultNullsOrder {
+				// Create the IS NULL expression using the ORDER BY column's expression.
+				isNullExpr := tree.NewTypedIsNullExpr(orderByCol.getExpr())
+
+				// Create the IS NULL column with a descriptive metadata
+				// name derived from the ORDER BY column's metadata alias.
+				orderByAlias := b.factory.Metadata().ColumnMeta(orderByCol.id).Alias
+				metadataName := fmt.Sprintf("nulls_ordering_%s", orderByAlias)
+				isNullCol := scopeColumn{
+					name:       scopeColName("").WithMetadataName(metadataName),
+					typ:        isNullExpr.ResolvedType(),
+					expr:       isNullExpr,
+					descending: orderByCol.descending,
+				}
+
+				// Add the IS NULL column first.
+				newCols = append(newCols, isNullCol)
+			}
+			// Add the main ORDER BY column.
+			newCols = append(newCols, *orderByCol)
+		}
+
+		// Replace the columns in orderByScope with the new list.
+		orderByScope.cols = newCols
+	}
+
 	orderByScope.ordering = make([]opt.OrderingColumn, 0, len(orderByScope.cols))
 
+	// Build all the columns and their ordering in the correct sequence.
 	for i := range orderByScope.cols {
 		b.buildOrderByArg(inScope, projectionsScope, orderByScope, &orderByScope.cols[i])
 	}
@@ -266,47 +313,93 @@ func (b *Builder) analyzeExtraArgument(
 	for _, e := range exprs {
 		// Ensure we can order on the given column(s).
 		ensureColumnOrderable(e)
-		if !nullsDefaultOrder {
-			if buildutil.CrdbTestBuild && containsSubquery(e) {
-				panic(errors.UnimplementedError(
-					errors.IssueLink{IssueURL: build.MakeIssueURL(129956)},
-					"subqueries in ORDER BY with non-default NULLS ordering is not supported"),
-				)
-			}
-			metadataName := fmt.Sprintf("nulls_ordering_%s", e.String())
-			extraColsScope.addColumn(
-				scopeColName("").WithMetadataName(metadataName),
-				tree.NewTypedIsNullExpr(e),
-			)
+		var name scopeColumnName
+		if idx != -1 {
+			name = projectionsScope.cols[idx].name
 		}
-		extraColsScope.addColumn(scopeColName(""), e)
+		col := extraColsScope.addColumn(name, e)
+		col.nonDefaultNullsOrder = !nullsDefaultOrder
 	}
 }
 
-func containsSubquery(expr tree.Expr) bool {
-	var v subqueryVisitor
-	tree.WalkExprConst(&v, expr)
-	return v.foundSubquery
-}
-
-type subqueryVisitor struct {
-	foundSubquery bool
-}
-
-var _ tree.Visitor = &subqueryVisitor{}
-
-func (s *subqueryVisitor) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
-	if s.foundSubquery {
-		return false, expr
+// buildOrderByPreProjection constructs a pre-projection when ORDER BY
+// expressions with non-default NULLS ordering need to avoid duplicating
+// the expression. Without pre-projection, the IS NULL column created
+// for NULLS ordering would duplicate the ORDER BY expression, causing
+// issues with subqueries and double-evaluation of side-effecting
+// functions.
+//
+// When pre-projection is built, matching expressions in projectionsScope
+// and orderByScope are updated to be passthrough columns referencing the
+// pre-projected columns.
+func (b *Builder) buildOrderByPreProjection(
+	inScope, projectionsScope, orderByScope *scope,
+) (preProjectionScope *scope) {
+	if orderByScope == nil {
+		return nil
 	}
-	if _, ok := expr.(*subquery); ok {
-		s.foundSubquery = true
-		return false, expr
-	}
-	return true, expr
-}
 
-func (s *subqueryVisitor) VisitPost(expr tree.Expr) tree.Expr { return expr }
+	// Check if any ORDER BY columns require pre-projection.
+	needPreProjection := false
+	for i := range orderByScope.cols {
+		if orderByScope.cols[i].nonDefaultNullsOrder {
+			needPreProjection = true
+			break
+		}
+	}
+	if !needPreProjection {
+		return nil
+	}
+
+	// Create a new scope for the pre-projection that will contain all
+	// projection columns plus ORDER BY expressions.
+	preProjectionScope = inScope.replace()
+	preProjectionScope.cols = make([]scopeColumn, 0, len(projectionsScope.cols)+len(orderByScope.cols))
+
+	// Copy all SELECT projection columns to the pre-projection scope.
+	// These are already built with column IDs set. They become passthrough
+	// columns referencing the pre-projected expressions.
+	for i := range projectionsScope.cols {
+		col := &projectionsScope.cols[i]
+		preProjectionScope.cols = append(preProjectionScope.cols, *col)
+		// Convert to passthrough column - clear expression fields since
+		// the column will reference the pre-projected result by ID.
+		// Also clear the cached exprStr so that findExistingCol in
+		// addOrderByOrDistinctOnColumn recomputes it from the
+		// now-nil expr (which returns the scopeColumn itself).
+		col.expr = nil
+		col.scalar = nil
+		col.exprStr = ""
+	}
+
+	// Build ORDER BY columns in the pre-projection scope. This ensures
+	// expressions are evaluated once rather than duplicated for both the
+	// main expression and IS NULL check. Reuse existing SELECT list
+	// projections when possible (SQL99 rule 3). We search
+	// preProjectionScope (not projectionsScope) because
+	// projectionsScope columns have had their expr fields cleared
+	// above.
+	for i := range orderByScope.cols {
+		orderCol := &orderByScope.cols[i]
+		if col := preProjectionScope.findExistingCol(
+			orderCol.getExpr(), true, /* allowSideEffects */
+		); col != nil {
+			orderCol.id = col.id
+		} else {
+			preProjectionScope.cols = append(preProjectionScope.cols, *orderCol)
+			preProjectedCol := &preProjectionScope.cols[len(preProjectionScope.cols)-1]
+			b.buildScalar(preProjectedCol.getExpr(), inScope, preProjectionScope, preProjectedCol, nil)
+			orderCol.id = preProjectedCol.id
+		}
+		// Clear expression so IS NULL references the column by ID
+		// rather than duplicating the expression. Also clear the
+		// cached exprStr to avoid stale matches.
+		orderCol.expr = nil
+		orderCol.scalar = nil
+		orderCol.exprStr = ""
+	}
+	return preProjectionScope
+}
 
 // hasDefaultNullsOrder returns whether the provided ordering uses the default
 // ordering for NULLs. The default order in Cockroach if null_ordered_last=False

--- a/pkg/sql/opt/optbuilder/scope_column.go
+++ b/pkg/sql/opt/optbuilder/scope_column.go
@@ -52,6 +52,13 @@ type scopeColumn struct {
 	// This field is only used for ordering columns.
 	descending bool
 
+	// nonDefaultNullsOrder is true when this ORDER BY column requires
+	// non-default NULLS ordering (e.g., NULLS LAST for ASC, or NULLS FIRST
+	// for DESC). When true, an additional IS NULL column will be generated
+	// to implement the correct NULL ordering semantics.
+	// This field is only used for ordering columns.
+	nonDefaultNullsOrder bool
+
 	// paramOrd is the 1-based ordinal of the parameter of the function that
 	// the column corresponds to. It is used to resolve placeholders (e.g., $1)
 	// in function bodies that are references to function arguments. If the

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -1165,7 +1165,15 @@ func (b *Builder) buildSelectStmtWithoutParens(
 		}
 		orderByScope := b.analyzeOrderBy(orderBy, outScope, projectionsScope, exprKindOrderBy,
 			tree.RejectGenerators|tree.RejectAggregates|tree.RejectWindowApplications)
+		preProjectionScope := b.buildOrderByPreProjection(outScope, projectionsScope, orderByScope)
 		b.buildOrderBy(outScope, projectionsScope, orderByScope)
+
+		// Construct the pre-projection for the ordering expressions.
+		if preProjectionScope != nil {
+			b.constructProjectForScope(outScope, preProjectionScope)
+			outScope.expr = preProjectionScope.expr
+		}
+
 		b.constructProjectForScope(outScope, projectionsScope)
 		outScope = projectionsScope
 	}
@@ -1240,6 +1248,7 @@ func (b *Builder) buildSelectClause(
 	}
 
 	b.buildProjectionList(fromScope, projectionsScope, nil /* colRefs */)
+	preProjectionScope := b.buildOrderByPreProjection(fromScope, projectionsScope, orderByScope)
 	b.buildOrderBy(fromScope, projectionsScope, orderByScope)
 	b.buildDistinctOnArgs(fromScope, projectionsScope, distinctOnScope)
 	b.buildLockArgs(fromScope, projectionsScope, lockScope)
@@ -1256,6 +1265,12 @@ func (b *Builder) buildSelectClause(
 
 	b.buildWindow(outScope, fromScope)
 	b.validateLockingInFrom(sel, lockCtx.locking, fromScope)
+
+	if preProjectionScope != nil {
+		// Construct the pre-projection for the ordering expressions.
+		b.constructProjectForScope(outScope, preProjectionScope)
+		outScope.expr = preProjectionScope.expr
+	}
 
 	// Construct the projection.
 	b.constructProjectForScope(outScope, projectionsScope)

--- a/pkg/sql/opt/optbuilder/testdata/delete
+++ b/pkg/sql/opt/optbuilder/testdata/delete
@@ -60,6 +60,38 @@ delete abcde
       │         └── a:9
       └── flags: avoid-full-scan
 
+# Use ORDER BY with NULLS LAST and LIMIT.
+build
+DELETE FROM abcde WHERE a>0 ORDER BY b NULLS LAST LIMIT 10
+----
+delete abcde
+ ├── columns: <none>
+ ├── fetch columns: a:9 b:10 c:11 d:12 e:13 rowid:14
+ └── limit
+      ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16 nulls_ordering_b:17!null
+      ├── internal-ordering: +17,+10
+      ├── sort
+      │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16 nulls_ordering_b:17!null
+      │    ├── ordering: +17,+10
+      │    ├── limit hint: 10.00
+      │    └── project
+      │         ├── columns: nulls_ordering_b:17!null a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
+      │         ├── select
+      │         │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
+      │         │    ├── scan abcde
+      │         │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
+      │         │    │    ├── computed column expressions
+      │         │    │    │    ├── d:12
+      │         │    │    │    │    └── (b:10 + c:11) + 1
+      │         │    │    │    └── e:13
+      │         │    │    │         └── a:9
+      │         │    │    └── flags: avoid-full-scan
+      │         │    └── filters
+      │         │         └── a:9 > 0
+      │         └── projections
+      │              └── b:10 IS NULL [as=nulls_ordering_b:17]
+      └── 10
+
 # Use WHERE, ORDER BY, LIMIT.
 build
 DELETE FROM abcde WHERE a>0 ORDER BY a LIMIT 10

--- a/pkg/sql/opt/optbuilder/testdata/distinct_on
+++ b/pkg/sql/opt/optbuilder/testdata/distinct_on
@@ -517,8 +517,10 @@ distinct-on
  │    ├── ordering: +6,+3,+7,+1
  │    └── project
  │         ├── columns: nulls_ordering_genre:6!null nulls_ordering_id:7!null id:1!null name:2 genre:3
- │         ├── scan author
- │         │    └── columns: id:1!null name:2 genre:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+ │         ├── project
+ │         │    ├── columns: id:1!null name:2 genre:3
+ │         │    └── scan author
+ │         │         └── columns: id:1!null name:2 genre:3 crdb_internal_mvcc_timestamp:4 tableoid:5
  │         └── projections
  │              ├── genre:3 IS NULL [as=nulls_ordering_genre:6]
  │              └── id:1 IS NULL [as=nulls_ordering_id:7]
@@ -554,14 +556,16 @@ sort
       ├── grouping columns: t2.id:6!null nulls_ordering_id:11!null
       ├── project
       │    ├── columns: nulls_ordering_id:11!null t1.id:1!null str:2 t2.id:6!null
-      │    ├── inner-join (hash)
-      │    │    ├── columns: t1.id:1!null str:2 t1.rowid:3!null t1.crdb_internal_mvcc_timestamp:4 t1.tableoid:5 t2.id:6!null num:7 t2.rowid:8!null t2.crdb_internal_mvcc_timestamp:9 t2.tableoid:10
-      │    │    ├── scan t1
-      │    │    │    └── columns: t1.id:1 str:2 t1.rowid:3!null t1.crdb_internal_mvcc_timestamp:4 t1.tableoid:5
-      │    │    ├── scan t2
-      │    │    │    └── columns: t2.id:6 num:7 t2.rowid:8!null t2.crdb_internal_mvcc_timestamp:9 t2.tableoid:10
-      │    │    └── filters
-      │    │         └── t1.id:1 = t2.id:6
+      │    ├── project
+      │    │    ├── columns: t1.id:1!null str:2 t2.id:6!null
+      │    │    └── inner-join (hash)
+      │    │         ├── columns: t1.id:1!null str:2 t1.rowid:3!null t1.crdb_internal_mvcc_timestamp:4 t1.tableoid:5 t2.id:6!null num:7 t2.rowid:8!null t2.crdb_internal_mvcc_timestamp:9 t2.tableoid:10
+      │    │         ├── scan t1
+      │    │         │    └── columns: t1.id:1 str:2 t1.rowid:3!null t1.crdb_internal_mvcc_timestamp:4 t1.tableoid:5
+      │    │         ├── scan t2
+      │    │         │    └── columns: t2.id:6 num:7 t2.rowid:8!null t2.crdb_internal_mvcc_timestamp:9 t2.tableoid:10
+      │    │         └── filters
+      │    │              └── t1.id:1 = t2.id:6
       │    └── projections
       │         └── t2.id:6 IS NULL [as=nulls_ordering_id:11]
       └── aggregations

--- a/pkg/sql/opt/optbuilder/testdata/orderby
+++ b/pkg/sql/opt/optbuilder/testdata/orderby
@@ -1079,8 +1079,10 @@ sort
  ├── ordering: +7,+2,+3
  └── project
       ├── columns: nulls_ordering_b:7!null a:1!null b:2 c:3
-      ├── scan abcd
-      │    └── columns: a:1!null b:2 c:3 d:4 crdb_internal_mvcc_timestamp:5 tableoid:6
+      ├── project
+      │    ├── columns: a:1!null b:2 c:3
+      │    └── scan abcd
+      │         └── columns: a:1!null b:2 c:3 d:4 crdb_internal_mvcc_timestamp:5 tableoid:6
       └── projections
            └── b:2 IS NULL [as=nulls_ordering_b:7]
 
@@ -1093,8 +1095,10 @@ sort
  ├── ordering: +7,+2,-8,-3
  └── project
       ├── columns: nulls_ordering_b:7!null nulls_ordering_c:8!null a:1!null b:2 c:3
-      ├── scan abcd
-      │    └── columns: a:1!null b:2 c:3 d:4 crdb_internal_mvcc_timestamp:5 tableoid:6
+      ├── project
+      │    ├── columns: a:1!null b:2 c:3
+      │    └── scan abcd
+      │         └── columns: a:1!null b:2 c:3 d:4 crdb_internal_mvcc_timestamp:5 tableoid:6
       └── projections
            ├── b:2 IS NULL [as=nulls_ordering_b:7]
            └── c:3 IS NULL [as=nulls_ordering_c:8]
@@ -1109,8 +1113,10 @@ sort
  ├── ordering: +7,+2,+8,+3
  └── project
       ├── columns: nulls_ordering_b:7!null nulls_ordering_c:8!null a:1!null b:2 c:3
-      ├── scan abcd
-      │    └── columns: a:1!null b:2 c:3 d:4 crdb_internal_mvcc_timestamp:5 tableoid:6
+      ├── project
+      │    ├── columns: a:1!null b:2 c:3
+      │    └── scan abcd
+      │         └── columns: a:1!null b:2 c:3 d:4 crdb_internal_mvcc_timestamp:5 tableoid:6
       └── projections
            ├── b:2 IS NULL [as=nulls_ordering_b:7]
            └── c:3 IS NULL [as=nulls_ordering_c:8]
@@ -1123,8 +1129,10 @@ sort
  ├── ordering: +7,+2,+8,+3
  └── project
       ├── columns: nulls_ordering_b:7!null nulls_ordering_c:8!null a:1!null b:2 c:3
-      ├── scan abcd
-      │    └── columns: a:1!null b:2 c:3 d:4 crdb_internal_mvcc_timestamp:5 tableoid:6
+      ├── project
+      │    ├── columns: a:1!null b:2 c:3
+      │    └── scan abcd
+      │         └── columns: a:1!null b:2 c:3 d:4 crdb_internal_mvcc_timestamp:5 tableoid:6
       └── projections
            ├── b:2 IS NULL [as=nulls_ordering_b:7]
            └── c:3 IS NULL [as=nulls_ordering_c:8]
@@ -1138,8 +1146,10 @@ sort
  ├── ordering: +2,+7,+3
  └── project
       ├── columns: nulls_ordering_c:7!null a:1!null b:2 c:3
-      ├── scan abcd
-      │    └── columns: a:1!null b:2 c:3 d:4 crdb_internal_mvcc_timestamp:5 tableoid:6
+      ├── project
+      │    ├── columns: a:1!null b:2 c:3
+      │    └── scan abcd
+      │         └── columns: a:1!null b:2 c:3 d:4 crdb_internal_mvcc_timestamp:5 tableoid:6
       └── projections
            └── c:3 IS NULL [as=nulls_ordering_c:7]
 
@@ -1221,8 +1231,10 @@ sort
  ├── ordering: -7,-2
  └── project
       ├── columns: nulls_ordering_b:7!null a:1!null b:2 c:3 d:4
-      ├── scan abcd
-      │    └── columns: a:1!null b:2 c:3 d:4 crdb_internal_mvcc_timestamp:5 tableoid:6
+      ├── project
+      │    ├── columns: a:1!null b:2 c:3 d:4
+      │    └── scan abcd
+      │         └── columns: a:1!null b:2 c:3 d:4 crdb_internal_mvcc_timestamp:5 tableoid:6
       └── projections
            └── b:2 IS NULL [as=nulls_ordering_b:7]
 
@@ -1236,8 +1248,10 @@ sort
  ├── ordering: -7,-2
  └── project
       ├── columns: nulls_ordering_b:7!null a:1!null b:2 c:3 d:4
-      ├── scan abcd
-      │    └── columns: a:1!null b:2 c:3 d:4 crdb_internal_mvcc_timestamp:5 tableoid:6
+      ├── project
+      │    ├── columns: a:1!null b:2 c:3 d:4
+      │    └── scan abcd
+      │         └── columns: a:1!null b:2 c:3 d:4 crdb_internal_mvcc_timestamp:5 tableoid:6
       └── projections
            └── b:2 IS NULL [as=nulls_ordering_b:7]
 
@@ -1249,8 +1263,10 @@ sort
  ├── ordering: -7,-2
  └── project
       ├── columns: nulls_ordering_b:7!null a:1!null b:2 c:3 d:4
-      ├── scan abcd
-      │    └── columns: a:1!null b:2 c:3 d:4 crdb_internal_mvcc_timestamp:5 tableoid:6
+      ├── project
+      │    ├── columns: a:1!null b:2 c:3 d:4
+      │    └── scan abcd
+      │         └── columns: a:1!null b:2 c:3 d:4 crdb_internal_mvcc_timestamp:5 tableoid:6
       └── projections
            └── b:2 IS NULL [as=nulls_ordering_b:7]
 
@@ -1266,8 +1282,8 @@ sort
       └── scan abcd
            └── columns: a:1!null b:2 c:3 d:4 crdb_internal_mvcc_timestamp:5 tableoid:6
 
-# TODO(#129956): Handle non-default NULL ordering that references a projected
-# expression that contains a subquery.
+# Regression #129956: Handle non-default NULL ordering that references a
+# projected expression that contains a subquery.
 exec-ddl
 CREATE TABLE t129956 (i INT)
 ----
@@ -1279,7 +1295,350 @@ WHERE EXISTS(
   ORDER BY tmp NULLS LAST
 )
 ----
-error (0A000): subqueries in ORDER BY with non-default NULLS ordering is not supported
+project
+ ├── columns: i:1
+ └── select
+      ├── columns: t0.i:1 t0.rowid:2!null t0.crdb_internal_mvcc_timestamp:3 t0.tableoid:4
+      ├── scan t129956 [as=t0]
+      │    └── columns: t0.i:1 t0.rowid:2!null t0.crdb_internal_mvcc_timestamp:3 t0.tableoid:4
+      └── filters
+           └── exists
+                └── project
+                     ├── columns: tmp:10
+                     └── project
+                          ├── columns: nulls_ordering_tmp:11!null tmp:10
+                          ├── project
+                          │    ├── columns: tmp:10
+                          │    ├── values
+                          │    │    └── ()
+                          │    └── projections
+                          │         └── subquery [as=tmp:10]
+                          │              └── max1-row
+                          │                   ├── columns: i:9
+                          │                   └── project
+                          │                        ├── columns: i:9
+                          │                        ├── scan t129956
+                          │                        │    └── columns: t129956.i:5 t129956.rowid:6!null t129956.crdb_internal_mvcc_timestamp:7 t129956.tableoid:8
+                          │                        └── projections
+                          │                             └── t0.i:1 [as=i:9]
+                          └── projections
+                               └── tmp:10 IS NULL [as=nulls_ordering_tmp:11]
+
+# Test subqueries in ORDER BY with NULLS FIRST/LAST (issue #129956).
+exec-ddl
+CREATE TABLE t_sub1 (id INT, val INT)
+----
+
+exec-ddl
+CREATE TABLE t_sub2 (id INT, val INT)
+----
+
+# Simple subquery with NULLS FIRST.
+build
+SELECT id FROM t_sub1 ORDER BY (SELECT val FROM t_sub2 WHERE t_sub2.id = t_sub1.id) NULLS FIRST
+----
+sort
+ ├── columns: id:1  [hidden: column11:11]
+ ├── ordering: +11
+ └── project
+      ├── columns: column11:11 t_sub1.id:1
+      ├── scan t_sub1
+      │    └── columns: t_sub1.id:1 t_sub1.val:2 t_sub1.rowid:3!null t_sub1.crdb_internal_mvcc_timestamp:4 t_sub1.tableoid:5
+      └── projections
+           └── subquery [as=column11:11]
+                └── max1-row
+                     ├── columns: t_sub2.val:7
+                     └── project
+                          ├── columns: t_sub2.val:7
+                          └── select
+                               ├── columns: t_sub2.id:6!null t_sub2.val:7 t_sub2.rowid:8!null t_sub2.crdb_internal_mvcc_timestamp:9 t_sub2.tableoid:10
+                               ├── scan t_sub2
+                               │    └── columns: t_sub2.id:6 t_sub2.val:7 t_sub2.rowid:8!null t_sub2.crdb_internal_mvcc_timestamp:9 t_sub2.tableoid:10
+                               └── filters
+                                    └── t_sub2.id:6 = t_sub1.id:1
+
+# Simple subquery with NULLS LAST.
+build
+SELECT id FROM t_sub1 ORDER BY (SELECT val FROM t_sub2 WHERE t_sub2.id = t_sub1.id) NULLS LAST
+----
+sort
+ ├── columns: id:1  [hidden: nulls_ordering_column11:12!null column13:13]
+ ├── ordering: +12,+13
+ └── project
+      ├── columns: nulls_ordering_column11:12!null column13:13 t_sub1.id:1
+      ├── project
+      │    ├── columns: column11:11 t_sub1.id:1
+      │    ├── scan t_sub1
+      │    │    └── columns: t_sub1.id:1 t_sub1.val:2 t_sub1.rowid:3!null t_sub1.crdb_internal_mvcc_timestamp:4 t_sub1.tableoid:5
+      │    └── projections
+      │         └── subquery [as=column11:11]
+      │              └── max1-row
+      │                   ├── columns: t_sub2.val:7
+      │                   └── project
+      │                        ├── columns: t_sub2.val:7
+      │                        └── select
+      │                             ├── columns: t_sub2.id:6!null t_sub2.val:7 t_sub2.rowid:8!null t_sub2.crdb_internal_mvcc_timestamp:9 t_sub2.tableoid:10
+      │                             ├── scan t_sub2
+      │                             │    └── columns: t_sub2.id:6 t_sub2.val:7 t_sub2.rowid:8!null t_sub2.crdb_internal_mvcc_timestamp:9 t_sub2.tableoid:10
+      │                             └── filters
+      │                                  └── t_sub2.id:6 = t_sub1.id:1
+      └── projections
+           ├── column11:11 IS NULL [as=nulls_ordering_column11:12]
+           └── column11:11 [as=column13:13]
+
+# Subquery with DESC and NULLS FIRST.
+build
+SELECT id FROM t_sub1 ORDER BY (SELECT val FROM t_sub2 WHERE t_sub2.id = t_sub1.id) DESC NULLS FIRST
+----
+sort
+ ├── columns: id:1  [hidden: nulls_ordering_column11:12!null column13:13]
+ ├── ordering: -12,-13
+ └── project
+      ├── columns: nulls_ordering_column11:12!null column13:13 t_sub1.id:1
+      ├── project
+      │    ├── columns: column11:11 t_sub1.id:1
+      │    ├── scan t_sub1
+      │    │    └── columns: t_sub1.id:1 t_sub1.val:2 t_sub1.rowid:3!null t_sub1.crdb_internal_mvcc_timestamp:4 t_sub1.tableoid:5
+      │    └── projections
+      │         └── subquery [as=column11:11]
+      │              └── max1-row
+      │                   ├── columns: t_sub2.val:7
+      │                   └── project
+      │                        ├── columns: t_sub2.val:7
+      │                        └── select
+      │                             ├── columns: t_sub2.id:6!null t_sub2.val:7 t_sub2.rowid:8!null t_sub2.crdb_internal_mvcc_timestamp:9 t_sub2.tableoid:10
+      │                             ├── scan t_sub2
+      │                             │    └── columns: t_sub2.id:6 t_sub2.val:7 t_sub2.rowid:8!null t_sub2.crdb_internal_mvcc_timestamp:9 t_sub2.tableoid:10
+      │                             └── filters
+      │                                  └── t_sub2.id:6 = t_sub1.id:1
+      └── projections
+           ├── column11:11 IS NULL [as=nulls_ordering_column11:12]
+           └── column11:11 [as=column13:13]
+
+# Subquery with DESC and NULLS LAST.
+build
+SELECT id FROM t_sub1 ORDER BY (SELECT val FROM t_sub2 WHERE t_sub2.id = t_sub1.id) DESC NULLS LAST
+----
+sort
+ ├── columns: id:1  [hidden: column11:11]
+ ├── ordering: -11
+ └── project
+      ├── columns: column11:11 t_sub1.id:1
+      ├── scan t_sub1
+      │    └── columns: t_sub1.id:1 t_sub1.val:2 t_sub1.rowid:3!null t_sub1.crdb_internal_mvcc_timestamp:4 t_sub1.tableoid:5
+      └── projections
+           └── subquery [as=column11:11]
+                └── max1-row
+                     ├── columns: t_sub2.val:7
+                     └── project
+                          ├── columns: t_sub2.val:7
+                          └── select
+                               ├── columns: t_sub2.id:6!null t_sub2.val:7 t_sub2.rowid:8!null t_sub2.crdb_internal_mvcc_timestamp:9 t_sub2.tableoid:10
+                               ├── scan t_sub2
+                               │    └── columns: t_sub2.id:6 t_sub2.val:7 t_sub2.rowid:8!null t_sub2.crdb_internal_mvcc_timestamp:9 t_sub2.tableoid:10
+                               └── filters
+                                    └── t_sub2.id:6 = t_sub1.id:1
+
+# VALUES clause ordered by subquery with NULLS LAST.
+build
+VALUES (1, 2), (3, 4), (NULL, 5) ORDER BY (SELECT column1 = ANY(SELECT id FROM t_sub1)) NULLS LAST
+----
+sort
+ ├── columns: column1:1 column2:2!null  [hidden: nulls_ordering_column9:10!null column11:11]
+ ├── ordering: +10,+11
+ └── project
+      ├── columns: nulls_ordering_column9:10!null column11:11 column1:1 column2:2!null
+      ├── project
+      │    ├── columns: column9:9 column1:1 column2:2!null
+      │    ├── values
+      │    │    ├── columns: column1:1 column2:2!null
+      │    │    ├── (1, 2)
+      │    │    ├── (3, 4)
+      │    │    └── (NULL::INT8, 5)
+      │    └── projections
+      │         └── subquery [as=column9:9]
+      │              └── max1-row
+      │                   ├── columns: "?column?":8
+      │                   └── project
+      │                        ├── columns: "?column?":8
+      │                        ├── values
+      │                        │    └── ()
+      │                        └── projections
+      │                             └── any: eq [as="?column?":8]
+      │                                  ├── project
+      │                                  │    ├── columns: id:3
+      │                                  │    └── scan t_sub1
+      │                                  │         └── columns: id:3 val:4 rowid:5!null crdb_internal_mvcc_timestamp:6 tableoid:7
+      │                                  └── column1:1
+      └── projections
+           ├── column9:9 IS NULL [as=nulls_ordering_column9:10]
+           └── column9:9 [as=column11:11]
+
+# Aggregation ordered by subquery with NULLS LAST.
+build
+SELECT id, sum(val) FROM t_sub1
+GROUP BY id
+ORDER BY (SELECT sum(val) FROM t_sub2 WHERE t_sub2.id = t_sub1.id) NULLS LAST
+----
+sort
+ ├── columns: id:1 sum:6  [hidden: nulls_ordering_column13:14!null column15:15]
+ ├── ordering: +14,+15
+ └── project
+      ├── columns: nulls_ordering_column13:14!null column15:15 t_sub1.id:1 sum:6
+      ├── project
+      │    ├── columns: column13:13 t_sub1.id:1 sum:6
+      │    ├── group-by (hash)
+      │    │    ├── columns: t_sub1.id:1 sum:6
+      │    │    ├── grouping columns: t_sub1.id:1
+      │    │    ├── project
+      │    │    │    ├── columns: t_sub1.id:1 t_sub1.val:2
+      │    │    │    └── scan t_sub1
+      │    │    │         └── columns: t_sub1.id:1 t_sub1.val:2 t_sub1.rowid:3!null t_sub1.crdb_internal_mvcc_timestamp:4 t_sub1.tableoid:5
+      │    │    └── aggregations
+      │    │         └── sum [as=sum:6]
+      │    │              └── t_sub1.val:2
+      │    └── projections
+      │         └── subquery [as=column13:13]
+      │              └── max1-row
+      │                   ├── columns: sum:12
+      │                   └── scalar-group-by
+      │                        ├── columns: sum:12
+      │                        ├── project
+      │                        │    ├── columns: t_sub2.val:8
+      │                        │    └── select
+      │                        │         ├── columns: t_sub2.id:7!null t_sub2.val:8 t_sub2.rowid:9!null t_sub2.crdb_internal_mvcc_timestamp:10 t_sub2.tableoid:11
+      │                        │         ├── scan t_sub2
+      │                        │         │    └── columns: t_sub2.id:7 t_sub2.val:8 t_sub2.rowid:9!null t_sub2.crdb_internal_mvcc_timestamp:10 t_sub2.tableoid:11
+      │                        │         └── filters
+      │                        │              └── t_sub2.id:7 = t_sub1.id:1
+      │                        └── aggregations
+      │                             └── sum [as=sum:12]
+      │                                  └── t_sub2.val:8
+      └── projections
+           ├── column13:13 IS NULL [as=nulls_ordering_column13:14]
+           └── column13:13 [as=column15:15]
+
+# Volatile function with NULLS LAST should use pre-projection to avoid
+# evaluating the function twice per row.
+exec-ddl
+CREATE FUNCTION volatile_fn(x INT) RETURNS INT VOLATILE LANGUAGE SQL AS 'SELECT x + 1'
+----
+
+build
+SELECT id FROM t_sub1 ORDER BY volatile_fn(id) NULLS LAST
+----
+sort
+ ├── columns: id:1  [hidden: nulls_ordering_column8:9!null column10:10]
+ ├── ordering: +9,+10
+ └── project
+      ├── columns: nulls_ordering_column8:9!null column10:10 id:1
+      ├── project
+      │    ├── columns: column8:8 id:1
+      │    ├── scan t_sub1
+      │    │    └── columns: id:1 val:2 rowid:3!null crdb_internal_mvcc_timestamp:4 tableoid:5
+      │    └── projections
+      │         └── volatile_fn(id:1) [as=column8:8]
+      └── projections
+           ├── column8:8 IS NULL [as=nulls_ordering_column8:9]
+           └── column8:8 [as=column10:10]
+
+# When ORDER BY expression matches a SELECT list expression, reuse the
+# existing projection column (SQL99 rule 3) instead of building a duplicate.
+build
+SELECT id, (SELECT val FROM t_sub2 WHERE t_sub2.id = t_sub1.id) AS lookup_val
+FROM t_sub1
+ORDER BY (SELECT val FROM t_sub2 WHERE t_sub2.id = t_sub1.id) NULLS LAST
+----
+sort
+ ├── columns: id:1 lookup_val:16  [hidden: nulls_ordering_lookup_val:17!null]
+ ├── ordering: +17,+16
+ └── project
+      ├── columns: nulls_ordering_lookup_val:17!null t_sub1.id:1 lookup_val:16
+      ├── project
+      │    ├── columns: lookup_val:16 t_sub1.id:1
+      │    ├── scan t_sub1
+      │    │    └── columns: t_sub1.id:1 t_sub1.val:2 t_sub1.rowid:3!null t_sub1.crdb_internal_mvcc_timestamp:4 t_sub1.tableoid:5
+      │    └── projections
+      │         └── subquery [as=lookup_val:16]
+      │              └── max1-row
+      │                   ├── columns: t_sub2.val:7
+      │                   └── project
+      │                        ├── columns: t_sub2.val:7
+      │                        └── select
+      │                             ├── columns: t_sub2.id:6!null t_sub2.val:7 t_sub2.rowid:8!null t_sub2.crdb_internal_mvcc_timestamp:9 t_sub2.tableoid:10
+      │                             ├── scan t_sub2
+      │                             │    └── columns: t_sub2.id:6 t_sub2.val:7 t_sub2.rowid:8!null t_sub2.crdb_internal_mvcc_timestamp:9 t_sub2.tableoid:10
+      │                             └── filters
+      │                                  └── t_sub2.id:6 = t_sub1.id:1
+      └── projections
+           └── lookup_val:16 IS NULL [as=nulls_ordering_lookup_val:17]
+
+# Two identical subqueries in ORDER BY, one with NULLS LAST. The subquery
+# should only be evaluated once.
+build
+SELECT id
+FROM t_sub1
+ORDER BY (SELECT val FROM t_sub2 WHERE t_sub2.id = t_sub1.id),
+(SELECT val FROM t_sub2 WHERE t_sub2.id = t_sub1.id) NULLS LAST
+----
+project
+ ├── columns: id:1  [hidden: column17:17 nulls_ordering_column16:18!null column19:19]
+ ├── ordering: +17,+18,+19
+ ├── sort
+ │    ├── columns: t_sub1.id:1 column16:16
+ │    ├── ordering: +16
+ │    └── project
+ │         ├── columns: column16:16 t_sub1.id:1
+ │         ├── scan t_sub1
+ │         │    └── columns: t_sub1.id:1 t_sub1.val:2 t_sub1.rowid:3!null t_sub1.crdb_internal_mvcc_timestamp:4 t_sub1.tableoid:5
+ │         └── projections
+ │              └── subquery [as=column16:16]
+ │                   └── max1-row
+ │                        ├── columns: t_sub2.val:7
+ │                        └── project
+ │                             ├── columns: t_sub2.val:7
+ │                             └── select
+ │                                  ├── columns: t_sub2.id:6!null t_sub2.val:7 t_sub2.rowid:8!null t_sub2.crdb_internal_mvcc_timestamp:9 t_sub2.tableoid:10
+ │                                  ├── scan t_sub2
+ │                                  │    └── columns: t_sub2.id:6 t_sub2.val:7 t_sub2.rowid:8!null t_sub2.crdb_internal_mvcc_timestamp:9 t_sub2.tableoid:10
+ │                                  └── filters
+ │                                       └── t_sub2.id:6 = t_sub1.id:1
+ └── projections
+      ├── column16:16 [as=column17:17]
+      ├── column16:16 IS NULL [as=nulls_ordering_column16:18]
+      └── column16:16 [as=column19:19]
+
+# SQL92 rule 1: ORDER BY column alias with NULLS LAST.
+build
+SELECT id, val AS v FROM t_sub1 ORDER BY v NULLS LAST
+----
+sort
+ ├── columns: id:1 v:2  [hidden: nulls_ordering_val:6!null]
+ ├── ordering: +6,+2
+ └── project
+      ├── columns: nulls_ordering_val:6!null id:1 val:2
+      ├── project
+      │    ├── columns: id:1 val:2
+      │    └── scan t_sub1
+      │         └── columns: id:1 val:2 rowid:3!null crdb_internal_mvcc_timestamp:4 tableoid:5
+      └── projections
+           └── val:2 IS NULL [as=nulls_ordering_val:6]
+
+# SQL92 rule 2: ORDER BY column ordinal with NULLS LAST.
+build
+SELECT id, val FROM t_sub1 ORDER BY 2 NULLS LAST
+----
+sort
+ ├── columns: id:1 val:2  [hidden: nulls_ordering_val:6!null]
+ ├── ordering: +6,+2
+ └── project
+      ├── columns: nulls_ordering_val:6!null id:1 val:2
+      ├── project
+      │    ├── columns: id:1 val:2
+      │    └── scan t_sub1
+      │         └── columns: id:1 val:2 rowid:3!null crdb_internal_mvcc_timestamp:4 tableoid:5
+      └── projections
+           └── val:2 IS NULL [as=nulls_ordering_val:6]
 
 # TODO(#92165): Allow ordering by VECTOR columns.
 exec-ddl

--- a/pkg/sql/opt/optbuilder/testdata/update
+++ b/pkg/sql/opt/optbuilder/testdata/update
@@ -290,6 +290,49 @@ update abcde [as=foo]
       └── projections
            └── (c:11 + c:11) + 1 [as=d_comp:17]
 
+# Use ORDER BY with NULLS LAST and LIMIT.
+build
+UPDATE abcde SET b=1 WHERE a>0 ORDER BY a NULLS LAST LIMIT 10
+----
+update abcde
+ ├── columns: <none>
+ ├── fetch columns: a:9 b:10 c:11 d:12 e:13 rowid:14
+ ├── update-mapping:
+ │    ├── b_new:18 => b:2
+ │    └── d_comp:19 => d:4
+ └── project
+      ├── columns: d_comp:19 a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16 b_new:18!null
+      ├── project
+      │    ├── columns: b_new:18!null a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
+      │    ├── limit
+      │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16 nulls_ordering_a:17!null
+      │    │    ├── internal-ordering: +17,+9
+      │    │    ├── sort
+      │    │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16 nulls_ordering_a:17!null
+      │    │    │    ├── ordering: +17,+9
+      │    │    │    ├── limit hint: 10.00
+      │    │    │    └── project
+      │    │    │         ├── columns: nulls_ordering_a:17!null a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
+      │    │    │         ├── select
+      │    │    │         │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
+      │    │    │         │    ├── scan abcde
+      │    │    │         │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
+      │    │    │         │    │    ├── computed column expressions
+      │    │    │         │    │    │    ├── d:12
+      │    │    │         │    │    │    │    └── (b:10 + c:11) + 1
+      │    │    │         │    │    │    └── e:13
+      │    │    │         │    │    │         └── a:9
+      │    │    │         │    │    └── flags: avoid-full-scan
+      │    │    │         │    └── filters
+      │    │    │         │         └── a:9 > 0
+      │    │    │         └── projections
+      │    │    │              └── a:9 IS NULL [as=nulls_ordering_a:17]
+      │    │    └── 10
+      │    └── projections
+      │         └── 1 [as=b_new:18]
+      └── projections
+           └── (b_new:18 + c:11) + 1 [as=d_comp:19]
+
 # Use WHERE, ORDER BY, LIMIT.
 build
 UPDATE abcde SET b=1 WHERE a>0 ORDER BY a LIMIT 10


### PR DESCRIPTION
Previously, `ORDER BY` expressions containing subqueries with non-default
NULLS ordering (e.g., `NULLS LAST` for `ASC`, `NULLS FIRST` for `DESC`) could
cause an error. This was because the optimizer needed to create `IS NULL`
columns to implement correct NULL ordering semantics, which would
duplicate any subqueries in the `ORDER BY` columns. Duplicating subqueries
in the optimizer can cause issues during planning (e.g., Issue #116022).

This change implements support for subqueries in `ORDER BY` with non-default
NULLS ordering by:

1. Adding a `nonDefaultNullsOrder` field to `scopeColumn` to track which
   `ORDER BY` columns require special NULL handling.

2. Implementing pre-projection logic in `buildOrderByPreProjection` that
   evaluates `ORDER BY` expressions once and creates passthrough columns
   to avoid duplication. This handles both subqueries and side-effecting
   functions that should not be evaluated twice.

3. Reusing existing `SELECT` list projections when possible (SQL99 rule 3)
   to avoid redundant expression evaluation.

4. Adding comprehensive tests covering subquery scenarios, volatile
   function side-effect avoidance, and `SELECT` list projection reuse
   with `NULLS FIRST`/`LAST` ordering.

Fixes #129956

Release note (bug fix): Fixed an issue where `ORDER BY` expressions
containing subqueries with non-default NULLS ordering (e.g., `NULLS LAST`
for `ASC`, `NULLS FIRST` for `DESC`) could cause an error during query
planning.