### PR TITLE
changefeedccl: do not replace initial_scan option

### DIFF
--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -1294,30 +1294,20 @@ func maybeForceDBLevelChangefeed(
 	return create, args, nil
 }
 
-// isUsingDefaultInitialScan returns true if the changefeed is does not specify
+// isUsingDefaultInitialScan returns true if the changefeed does not specify
 // an initial scan type and does not have a cursor, resulting in the default
 // behavior of the initial scan.
 func isUsingDefaultInitialScan(opts []tree.KVOption) bool {
-	initialScanType := ""
-	hasCursor := false
 	for _, opt := range opts {
-		key := opt.Key.String()
-		if strings.EqualFold(key, "initial_scan") {
-			if opt.Value != nil {
-				initialScanType = opt.Value.String()
-			}
-		}
-		if strings.EqualFold(key, "no_initial_scan") {
-			initialScanType = "'no'"
-		}
-		if strings.EqualFold(key, "initial_scan_only") {
-			initialScanType = "'only'"
-		}
-		if strings.EqualFold(key, "cursor") {
-			hasCursor = true
+		switch strings.ToLower(opt.Key.String()) {
+		case "cursor":
+			return false
+		case "initial_scan", "no_initial_scan", "initial_scan_only":
+			return false
 		}
 	}
-	return initialScanType == "" && !hasCursor
+
+	return true
 }
 
 func maybeForceEnrichedEnvelope(


### PR DESCRIPTION
In DB-level feed metamorphic testing, we have always manually added "WITH initial_scan='yes'" to a changefeed statement that doesn't specify initial scan options when replacing it with an equivalent DB-level feed. This is needed because the DB-level feed default is to do no initial scan when no option is specified.

We were doing this replacement when we did not need to for changefeed statements that specified "WITH initial_scan". We now preserve those options for the equivalent db-level feed instead of replacing with "WITH initial_scan='yes'".

These options are equivalent. This should also not affect which changefeed tests are metamorphically tested.

Epic: none

Release note: None