### PR TITLE
roachtest: add rust-sqlx ORM compatibility test

### DIFF
--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -181,6 +181,8 @@ go_library(
         "ruby_pg_blocklist.go",
         "rust_postgres.go",
         "rust_postgres_blocklist.go",
+        "rust_sqlx.go",
+        "rust_sqlx_blocklist.go",
         "s3_clone_backup_restore.go",
         "s3_microceph.go",
         "s3_minio.go",

--- a/pkg/cmd/roachtest/tests/parsing_helpers.go
+++ b/pkg/cmd/roachtest/tests/parsing_helpers.go
@@ -12,7 +12,9 @@ import (
 	"regexp"
 )
 
-var rustUnitTestOutputRegex = regexp.MustCompile(`(?P<type>.*) (?P<class>.*)::(?P<name>.*) \.\.\. (?P<result>.*)`)
+var rustUnitTestOutputRegex = regexp.MustCompile(
+	`(?P<type>test) (?:(?P<class>\S+)::)?(?P<name>\S+) \.\.\. (?P<result>.+)`,
+)
 var pythonUnitTestOutputRegex = regexp.MustCompile(`(?P<name>.*) \((?P<class>.*)\) \.\.\. (?P<result>[^'"]*?)(?: u?['"](?P<reason>.*)['"])?$`)
 
 func (r *ormTestsResults) parsePythonUnitTestOutput(

--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -184,4 +184,5 @@ func RegisterTests(r registry.Registry) {
 	registerDBConsoleEndpointsMixedVersion(r)
 	registerTTLRestart(r)
 	perturbation.RegisterTests(r)
+	registerRustSqlx(r)
 }

--- a/pkg/cmd/roachtest/tests/rust_sqlx.go
+++ b/pkg/cmd/roachtest/tests/rust_sqlx.go
@@ -1,0 +1,209 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachprod"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+)
+
+func registerRustSqlx(r registry.Registry) {
+	runRustSqlx := func(ctx context.Context, t test.Test, c cluster.Cluster) {
+		node := c.Node(1)
+		t.Status("setting up cockroach")
+
+		// Start CockroachDB in insecure mode with an in-memory store.
+		// sqlx connects via DATABASE_URL, so we use the default SQL port.
+		c.Start(ctx, t.L(), option.NewStartOpts(sqlClientsInMemoryDB),
+			install.MakeClusterSettings(install.SimpleSecureOption(false)), c.All())
+
+		db := c.Conn(ctx, t.L(), 1)
+		if _, err := db.Exec("CREATE DATABASE IF NOT EXISTS sqlx"); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := db.Exec(
+			"CREATE USER IF NOT EXISTS postgres WITH CREATEDB CREATELOGIN CREATEROLE CANCELQUERY",
+		); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := db.Exec("GRANT ALL ON DATABASE sqlx TO postgres"); err != nil {
+			t.Fatal(err)
+		}
+		// Match PostgreSQL's default integer size (INT4) so that sqlx's
+		// type expectations align with CockroachDB's inferred types.
+		if _, err := db.Exec("SET CLUSTER SETTING sql.defaults.default_int_size = 4"); err != nil {
+			t.Fatal(err)
+		}
+
+		version, err := fetchCockroachVersion(ctx, t.L(), c, node[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := alterZoneConfigAndClusterSettings(ctx, t, version, c, node[0]); err != nil {
+			t.Fatal(err)
+		}
+
+		t.Status("cloning rust-sqlx and installing prerequisites")
+
+		latestTag := "v0.8.6"
+		t.L().Printf("Using sqlx release %s.", latestTag)
+
+		// Use /tmp for local runs, /mnt/data1 for remote.
+		sqlxDir := "/mnt/data1/sqlx"
+		cargoPath := "/home/ubuntu/.cargo/bin/cargo"
+		if c.IsLocal() {
+			sqlxDir = "/tmp/sqlx"
+			cargoPath = "cargo"
+		}
+
+		if err := repeatRunE(
+			ctx, t, c, node,
+			"remove old rust-sqlx",
+			fmt.Sprintf(`rm -rf %s`, sqlxDir),
+		); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repeatGitCloneE(
+			ctx, t, c,
+			"https://github.com/launchbadge/sqlx.git",
+			sqlxDir,
+			latestTag,
+			node,
+		); err != nil {
+			t.Fatal(err)
+		}
+
+		// Skip system dependency installation for local runs (assumes
+		// rust, cargo, and build tools are already installed).
+		if !c.IsLocal() {
+			if err := repeatRunE(
+				ctx, t, c, node,
+				"install rust and cargo",
+				`curl https://sh.rustup.rs -sSf | sh -s -- -y`,
+			); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := repeatRunE(
+				ctx, t, c, node,
+				"install C linker",
+				"sudo apt-get install build-essential -y",
+			); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := repeatRunE(
+				ctx, t, c, node,
+				"install build dependencies",
+				"sudo apt-get install -y pkg-config libssl-dev",
+			); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		// Build the DATABASE_URL from the cluster's external PG URL.
+		urls, err := c.ExternalPGUrl(ctx, t.L(), node, roachprod.PGURLOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		pgURL, err := url.Parse(urls[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+		pgURL.Path = "/sqlx"
+		q := pgURL.Query()
+		q.Set("sslmode", "disable")
+		pgURL.RawQuery = q.Encode()
+		databaseURL := pgURL.String()
+
+		blocklistName := "rustSqlxBlockList"
+		ignorelistName := "rustSqlxIgnoreList"
+		expectedFailures := rustSqlxBlocklist
+		ignorelist := rustSqlxIgnoreList
+
+		status := fmt.Sprintf("running cockroach version %s, using blocklist %s",
+			version, blocklistName)
+		if ignorelist != nil {
+			status = fmt.Sprintf(
+				"running cockroach %s, using blocklist %s, using ignorelist %s",
+				version, blocklistName, ignorelistName)
+		}
+		t.L().Printf("%s", status)
+
+		t.Status("running rust-sqlx test suite")
+
+		// We run only test targets that do not use sqlx::query!()
+		// compile-time macros. Those macros connect to the database at
+		// compile time; CockroachDB's INT8 default and missing setup
+		// tables cause type mismatches and missing-relation errors that
+		// prevent compilation. The targets below exercise sqlx's runtime
+		// query and type layer without compile-time checking.
+		result, err := c.RunWithDetailsSingleNode(
+			ctx, t.L(),
+			option.WithNodes(node),
+			fmt.Sprintf(
+				`cd %s && DATABASE_URL='%s' `+
+					`%s test `+
+					`--features postgres,runtime-tokio,tls-none,_unstable-all-types `+
+					`--test postgres `+
+					`--test postgres-types `+
+					`--test postgres-describe `+
+					`--test postgres-error `+
+					`--test postgres-query-builder `+
+					`--no-fail-fast > rustsqlx.stdout 2>&1`,
+				sqlxDir, databaseURL, cargoPath))
+		if err != nil {
+			t.L().Printf("error during rust-sqlx run (may be ok): %v\n", err)
+		}
+		_ = result
+
+		t.L().Printf("Test stdout for rust-sqlx")
+		result, err = c.RunWithDetailsSingleNode(
+			ctx, t.L(), option.WithNodes(node),
+			fmt.Sprintf("cd %s && cat rustsqlx.stdout", sqlxDir),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		t.L().Printf("Test results for rust-sqlx: %s", result.Stdout+result.Stderr)
+		t.Status("collating the test results")
+
+		results := newORMTestsResults()
+		results.parseRustUnitTestOutput(
+			[]byte(result.Stdout+result.Stderr), expectedFailures, ignorelist,
+		)
+		t.L().Printf("Test pass for rust-sqlx: %d, Test fail for rust-sqlx: %d",
+			results.passExpectedCount, results.failUnexpectedCount)
+		results.summarizeAll(
+			t, "rust-sqlx" /* ormName */, blocklistName,
+			expectedFailures, version, latestTag,
+		)
+	}
+
+	r.Add(registry.TestSpec{
+		Name:             "rust-sqlx",
+		Owner:            registry.OwnerSQLFoundations,
+		Cluster:          r.MakeClusterSpec(1, spec.CPU(16)),
+		Leases:           registry.MetamorphicLeases,
+		CompatibleClouds: registry.Clouds(spec.GCE, spec.Local),
+		Suites:           registry.Suites(registry.Nightly, registry.ORM),
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			runRustSqlx(ctx, t, c)
+		},
+	})
+}

--- a/pkg/cmd/roachtest/tests/rust_sqlx_blocklist.go
+++ b/pkg/cmd/roachtest/tests/rust_sqlx_blocklist.go
@@ -1,0 +1,80 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package tests
+
+// These are lists of known rust-sqlx test errors and failures.
+// When the rust-sqlx test suite is run, the results are compared to this list.
+// Any failed test that is on this list is reported as FAIL - expected.
+// Any failed test that is not on this list is reported as FAIL - unexpected.
+//
+// Please keep these lists alphabetized for easy diffing.
+// After a failed run, an updated version of this blocklist should be available
+// in the test log.
+var rustSqlxBlocklist = blocklist{
+	`copy_can_work_with_failed_transactions`:              "test is #[ignore]d in sqlx source",
+	`it_can_abort_copy_in`:                                "default int size: expressions return INT8 instead of INT4",
+	`it_can_copy_in`:                                      "default int size: expressions return INT8 instead of INT4",
+	`it_can_copy_out`:                                     "default int size: expressions return INT8 instead of INT4",
+	`it_can_inspect_constraint_errors`:                    "missing fixture: relation \"products\" does not exist",
+	`it_can_inspect_errors`:                               "error position field not populated by CockroachDB",
+	`it_can_nest_map`:                                     "default int size: expressions return INT8 instead of INT4",
+	`it_can_prepare_then_execute`:                         "missing fixture: relation \"tweet\" does not exist",
+	`it_can_query_scalar`:                                 "default int size: expressions return INT8 instead of INT4",
+	`it_can_recover_from_copy_in_empty_query`:             "default int size: expressions return INT8 instead of INT4",
+	`it_can_recover_from_copy_in_invalid_params`:          "default int size: expressions return INT8 instead of INT4",
+	`it_can_recover_from_copy_in_syntax_error`:            "default int size: expressions return INT8 instead of INT4",
+	`it_can_recover_from_copy_in_to_missing_table`:        "default int size: expressions return INT8 instead of INT4",
+	`it_can_select_void`:                                  "unsupported function: pg_notify()",
+	`it_can_work_with_failed_transactions`:                "default int size: expressions return INT8 instead of INT4",
+	`it_closes_statements_when_not_persistent_issue_3850`: "prepared statement lifecycle differs from PostgreSQL",
+	`it_connects`:                                         "default int size: expressions return INT8 instead of INT4",
+	`it_describes_composite`:                              "missing fixture: type \"inventory_item\" does not exist",
+	`it_describes_enum`:                                   "missing fixture: type \"status\" does not exist",
+	`it_describes_simple`:                                 "missing fixture: relation \"tweet\" does not exist",
+	`it_fails_with_begin_failed`:                          "missing fixture: relation \"tweet\" does not exist",
+	`it_fails_with_check_violation`:                       "constraint violation error classification differs from PostgreSQL",
+	`it_fails_with_foreign_key_violation`:                 "constraint violation error classification differs from PostgreSQL",
+	`it_fails_with_not_null_violation`:                    "constraint violation error classification differs from PostgreSQL",
+	`it_fails_with_unique_violation`:                      "missing fixture: relation \"tweet\" does not exist",
+	`it_maths`:                                            "default int size: expressions return INT8 instead of INT4",
+	`it_resolves_custom_types_in_anonymous_records`:       "error message text differs from PostgreSQL",
+	`it_supports_domain_types_in_composite_domain_types`:  "unsupported PL/pgSQL syntax: DO $$ IF NOT EXISTS ... $$",
+	`pool_smoke_test`:                                     "test is #[ignore]d in sqlx source",
+	`test_advisory_locks`:                                 "unsupported function: pg_advisory_lock()",
+	`test_describe_outer_join_nullable`:                   "missing fixture: relation \"tweet\" does not exist",
+	`test_error_handling_with_deferred_constraints`:       "unsupported feature: DEFERRABLE constraints",
+	`test_invalid_query`:                                  "default int size: expressions return INT8 instead of INT4",
+	`test_listener_cleanup`:                               "unsupported feature: LISTEN/NOTIFY",
+	`test_listener_try_recv_buffered`:                     "unsupported feature: LISTEN/NOTIFY",
+	`test_multi_read_write`:                               "unique_rowid() produces different values than PostgreSQL SERIAL",
+	`test_pg_copy_chunked`:                                "missing fixture: relation \"products\" does not exist",
+	`test_pg_listener_implements_acquire`:                 "unsupported feature: LISTEN/NOTIFY",
+	`test_prepared_decode_type_num_tuple`:                 "default int size: expressions return INT8 instead of INT4",
+	`test_prepared_type_f32`:                              "REAL (float4) round-trip precision differs from PostgreSQL",
+	`test_prepared_type_i16`:                              "default int size: expressions return INT8 instead of INT2",
+	`test_prepared_type_i32`:                              "default int size: expressions return INT8 instead of INT4",
+	`test_prepared_type_int4range`:                        "unsupported type: INT4RANGE (unknown oid 3904)",
+	`test_prepared_type_ipnet`:                            "unsupported: CIDR IS NOT DISTINCT FROM",
+	`test_prepared_type_ipnetwork`:                        "unsupported: CIDR IS NOT DISTINCT FROM",
+	`test_prepared_type_mac_address`:                      "unsupported type: MACADDR",
+	`test_prepared_type_mac_address_vec`:                  "unsupported type: MACADDR[]",
+	`test_prepared_type_money`:                            "unsupported type: MONEY",
+	`test_prepared_type_money_vec`:                        "unsupported type: MONEY[]",
+	`test_prepared_type_numrange_bigdecimal`:              "unsupported type: NUMRANGE (unknown oid 3906)",
+	`test_prepared_type_numrange_decimal`:                 "unsupported type: NUMRANGE (unknown oid 3906)",
+	`test_select_expression`:                              "default int size: expressions return INT8 instead of INT4",
+	`test_unprepared_type_i16`:                            "default int size: expressions return INT8 instead of INT2",
+	`test_unprepared_type_i32`:                            "default int size: expressions return INT8 instead of INT4",
+	`test_unprepared_type_int4range`:                      "unsupported type: INT4RANGE",
+	`test_unprepared_type_ipnet`:                          "unsupported: CIDR IS NOT DISTINCT FROM",
+	`test_unprepared_type_ipnetwork`:                      "unsupported: CIDR IS NOT DISTINCT FROM",
+	`test_unprepared_type_mac_address`:                    "unsupported type: MACADDR",
+	`test_unprepared_type_mac_address_vec`:                "unsupported type: MACADDR[]",
+	`test_unprepared_type_numrange_bigdecimal`:            "unsupported type: NUMRANGE",
+	`test_unprepared_type_numrange_decimal`:               "unsupported type: NUMRANGE",
+}
+
+var rustSqlxIgnoreList = blocklist{}


### PR DESCRIPTION
Add a new roachtest that runs the sqlx Rust driver's test suite (v0.8.6)
against CockroachDB. This follows the same pattern as the existing
rust-postgres roachtest: start a single-node cluster, clone the sqlx
repo, run cargo test for the runtime (non-compile-time-macro) test
targets, and compare results against a known blocklist.

The shared rustUnitTestOutputRegex is updated to handle sqlx's test
output format, where integration tests emit flat names without a module
prefix (e.g. "test it_connects ... ok" rather than
"test module::test_name ... ok"). The regex now anchors the type group
to the literal "test", makes the class group optional, and uses \S+
instead of .* to prevent over-matching. This remains compatible with
the existing rust-postgres test output.

Resolves: #58074
Epic: CRDB-19024

Release note: None

fixes https://github.com/cockroachdb/cockroach/issues/58074
Epic CRDB-19024