### PR TITLE
opt: apply min_row_count to anti-joins

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_query_behavior
@@ -282,13 +282,13 @@ distribution: local
 │   └── • error if rows
 │       │
 │       └── • lookup join (anti)
-│           │ estimated row count: 0
+│           │ estimated row count: 1
 │           │ table: customer@primary
 │           │ equality cols are key
 │           │ lookup condition: (((crdb_region IN ('ca-central-1', 'us-east-1')) AND (column3 = c_w_id)) AND (column2 = c_d_id)) AND (column1 = c_id)
 │           │
 │           └── • lookup join (anti)
-│               │ estimated row count: 0
+│               │ estimated row count: 1
 │               │ table: customer@primary
 │               │ equality cols are key
 │               │ lookup condition: (((crdb_region = 'ap-southeast-2') AND (column3 = c_w_id)) AND (column2 = c_d_id)) AND (column1 = c_id)
@@ -302,13 +302,13 @@ distribution: local
     └── • error if rows
         │
         └── • lookup join (anti)
-            │ estimated row count: 0
+            │ estimated row count: 1
             │ table: district@primary
             │ equality cols are key
             │ lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (column5 = d_w_id)) AND (column4 = d_id)
             │
             └── • lookup join (anti)
-                │ estimated row count: 0
+                │ estimated row count: 1
                 │ table: district@primary
                 │ equality cols are key
                 │ lookup condition: ((crdb_region = 'ap-southeast-2') AND (column5 = d_w_id)) AND (column4 = d_id)

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_hash_sharded_index_query_plan
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_hash_sharded_index_query_plan
@@ -68,7 +68,7 @@ vectorized: true
             │
             └── • lookup join (anti)
                 │ columns: (crdb_internal_id_shard_16_eq, pid)
-                │ estimated row count: 0 (missing stats)
+                │ estimated row count: 1 (missing stats)
                 │ table: t_parent@t_parent_pkey
                 │ equality cols are key
                 │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (pid = id)
@@ -147,7 +147,7 @@ vectorized: true
             │
             └── • lookup join (anti)
                 │ columns: (crdb_internal_id_shard_16_eq, pid)
-                │ estimated row count: 0 (missing stats)
+                │ estimated row count: 1 (missing stats)
                 │ table: t_parent@t_parent_pkey
                 │ equality cols are key
                 │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (pid = id)
@@ -242,7 +242,7 @@ vectorized: true
         │
         └── • lookup join (anti)
             │ columns: (crdb_internal_user_id_shard_16_eq, crdb_internal_user_id_shard_16_comp, column2, val_cast, user_id_default)
-            │ estimated row count: 0 (missing stats)
+            │ estimated row count: 1 (missing stats)
             │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
             │ equality cols are key
             │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_user_id_shard_16_eq = crdb_internal_user_id_shard_16)) AND (user_id_default = user_id)
@@ -287,7 +287,7 @@ vectorized: true
     │
     └── • distinct
         │ columns: (column2, val_cast, user_id_default, crdb_internal_user_id_shard_16_comp)
-        │ estimated row count: 0 (missing stats)
+        │ estimated row count: 1 (missing stats)
         │ distinct on: user_id_default
         │ nulls are distinct
         │
@@ -296,7 +296,7 @@ vectorized: true
             │
             └── • lookup join (anti)
                 │ columns: (crdb_internal_user_id_shard_16_eq, crdb_internal_user_id_shard_16_comp, column2, val_cast, user_id_default)
-                │ estimated row count: 0 (missing stats)
+                │ estimated row count: 1 (missing stats)
                 │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
                 │ equality cols are key
                 │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_user_id_shard_16_eq = crdb_internal_user_id_shard_16)) AND (user_id_default = user_id)
@@ -420,7 +420,7 @@ vectorized: true
         │
         └── • lookup join (anti)
             │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, column1, column2)
-            │ estimated row count: 0 (missing stats)
+            │ estimated row count: 1 (missing stats)
             │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
             │ equality cols are key
             │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (column1 = id)
@@ -506,7 +506,7 @@ vectorized: true
         │
         └── • lookup join (anti)
             │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, column1, column2)
-            │ estimated row count: 0 (missing stats)
+            │ estimated row count: 1 (missing stats)
             │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
             │ equality cols are key
             │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (column1 = id)
@@ -960,7 +960,7 @@ vectorized: true
         │
         └── • lookup join (anti)
             │ columns: (crdb_internal_email_shard_16_eq, column1, column2, column3, crdb_internal_email_shard_16_comp)
-            │ estimated row count: 0 (missing stats)
+            │ estimated row count: 1 (missing stats)
             │ table: t_unique_hash_sec_key@idx_uniq_hash_email
             │ equality cols are key
             │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (column2 = email)
@@ -1023,7 +1023,7 @@ vectorized: true
         │
         └── • lookup join (anti)
             │ columns: (crdb_internal_email_shard_16_eq, column1, column2, column3, crdb_internal_email_shard_16_comp)
-            │ estimated row count: 0 (missing stats)
+            │ estimated row count: 1 (missing stats)
             │ table: t_unique_hash_sec_key@idx_uniq_hash_email
             │ equality cols are key
             │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (column2 = email)
@@ -1039,7 +1039,7 @@ vectorized: true
                 │
                 └── • lookup join (anti)
                     │ columns: (crdb_internal_email_shard_16_comp, column1, column2, column3)
-                    │ estimated row count: 0 (missing stats)
+                    │ estimated row count: 1 (missing stats)
                     │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
                     │ equality cols are key
                     │ lookup condition: (part IN ('new york', 'seattle')) AND (column1 = id)
@@ -1165,7 +1165,7 @@ vectorized: true
 │               │
 │               └── • lookup join (anti)
 │                   │ columns: (crdb_internal_email_shard_16_eq, crdb_internal_email_shard_16_comp, column1, column2, column3)
-│                   │ estimated row count: 0 (missing stats)
+│                   │ estimated row count: 1 (missing stats)
 │                   │ table: t_unique_hash_sec_key@idx_uniq_hash_email
 │                   │ equality cols are key
 │                   │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (column2 = email)

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_foreign_key
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_foreign_key
@@ -1761,7 +1761,7 @@ vectorized: true
         │
         └── • lookup join (anti)
             │ columns: (fk_lookup_crdb_region, column1)
-            │ estimated row count: 0 (missing stats)
+            │ estimated row count: 1 (missing stats)
             │ table: parent_rbr@parent_rbr_pkey
             │ equality: (fk_lookup_crdb_region, column1) = (crdb_region, k)
             │ equality cols are key
@@ -1847,7 +1847,7 @@ vectorized: true
         │
         └── • lookup join (anti)
             │ columns: (fk_lookup_crdb_region, k_new)
-            │ estimated row count: 0 (missing stats)
+            │ estimated row count: 1 (missing stats)
             │ table: parent_rbr@parent_rbr_pkey
             │ equality: (fk_lookup_crdb_region, k_new) = (crdb_region, k)
             │ equality cols are key
@@ -1973,7 +1973,7 @@ vectorized: true
         │
         └── • lookup join (anti)
             │ columns: (fk_lookup_crdb_region, column1, column2)
-            │ estimated row count: 0 (missing stats)
+            │ estimated row count: 1 (missing stats)
             │ table: parent_unique_nullable@parent_unique_nullable_x_y_key
             │ equality: (fk_lookup_crdb_region, column1, column2) = (crdb_region, x, y)
             │ equality cols are key
@@ -2101,7 +2101,7 @@ vectorized: true
         │
         └── • lookup join (anti)
             │ columns: (fk_lookup_crdb_region, x, y_new)
-            │ estimated row count: 0 (missing stats)
+            │ estimated row count: 1 (missing stats)
             │ table: parent_unique_nullable@parent_unique_nullable_x_y_key
             │ equality: (fk_lookup_crdb_region, x, y_new) = (crdb_region, x, y)
             │ equality cols are key

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index_query_plan
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index_query_plan
@@ -72,7 +72,7 @@ vectorized: true
             │
             └── • lookup join (anti)
                 │ columns: (crdb_internal_id_shard_16_eq, pid)
-                │ estimated row count: 0 (missing stats)
+                │ estimated row count: 1 (missing stats)
                 │ table: t_parent@t_parent_pkey
                 │ equality cols are key
                 │ lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (pid = id)
@@ -80,7 +80,7 @@ vectorized: true
                 │
                 └── • lookup join (anti)
                     │ columns: (crdb_internal_id_shard_16_eq, pid)
-                    │ estimated row count: 0 (missing stats)
+                    │ estimated row count: 1 (missing stats)
                     │ table: t_parent@t_parent_pkey
                     │ equality cols are key
                     │ lookup condition: ((crdb_region = 'ap-southeast-2') AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (pid = id)
@@ -159,7 +159,7 @@ vectorized: true
             │
             └── • lookup join (anti)
                 │ columns: (crdb_internal_id_shard_16_eq, pid)
-                │ estimated row count: 0 (missing stats)
+                │ estimated row count: 1 (missing stats)
                 │ table: t_parent@t_parent_pkey
                 │ equality cols are key
                 │ lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (pid = id)
@@ -167,7 +167,7 @@ vectorized: true
                 │
                 └── • lookup join (anti)
                     │ columns: (crdb_internal_id_shard_16_eq, pid)
-                    │ estimated row count: 0 (missing stats)
+                    │ estimated row count: 1 (missing stats)
                     │ table: t_parent@t_parent_pkey
                     │ equality cols are key
                     │ lookup condition: ((crdb_region = 'ap-southeast-2') AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (pid = id)
@@ -258,7 +258,7 @@ vectorized: true
         │
         └── • lookup join (anti)
             │ columns: (crdb_internal_user_id_shard_16_eq, crdb_internal_user_id_shard_16_comp, val_cast, user_id_default, crdb_region_default)
-            │ estimated row count: 0 (missing stats)
+            │ estimated row count: 1 (missing stats)
             │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
             │ equality cols are key
             │ lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_user_id_shard_16_eq = crdb_internal_user_id_shard_16)) AND (user_id_default = user_id)
@@ -266,7 +266,7 @@ vectorized: true
             │
             └── • lookup join (anti)
                 │ columns: (crdb_internal_user_id_shard_16_eq, crdb_internal_user_id_shard_16_comp, val_cast, user_id_default, crdb_region_default)
-                │ estimated row count: 0 (missing stats)
+                │ estimated row count: 1 (missing stats)
                 │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
                 │ equality cols are key
                 │ lookup condition: ((crdb_region = 'ap-southeast-2') AND (crdb_internal_user_id_shard_16_eq = crdb_internal_user_id_shard_16)) AND (user_id_default = user_id)
@@ -311,7 +311,7 @@ vectorized: true
     │
     └── • distinct
         │ columns: (val_cast, user_id_default, crdb_region_default, crdb_internal_user_id_shard_16_comp)
-        │ estimated row count: 0 (missing stats)
+        │ estimated row count: 1 (missing stats)
         │ distinct on: user_id_default
         │ nulls are distinct
         │
@@ -320,7 +320,7 @@ vectorized: true
             │
             └── • lookup join (anti)
                 │ columns: (crdb_internal_user_id_shard_16_eq, crdb_internal_user_id_shard_16_comp, val_cast, user_id_default, crdb_region_default)
-                │ estimated row count: 0 (missing stats)
+                │ estimated row count: 1 (missing stats)
                 │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
                 │ equality cols are key
                 │ lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_user_id_shard_16_eq = crdb_internal_user_id_shard_16)) AND (user_id_default = user_id)
@@ -456,7 +456,7 @@ vectorized: true
         │
         └── • lookup join (anti)
             │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, crdb_region_default, column1)
-            │ estimated row count: 0 (missing stats)
+            │ estimated row count: 1 (missing stats)
             │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
             │ equality cols are key
             │ lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (column1 = id)
@@ -559,7 +559,7 @@ vectorized: true
         │
         └── • lookup join (anti)
             │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, crdb_region_default, column1)
-            │ estimated row count: 0 (missing stats)
+            │ estimated row count: 1 (missing stats)
             │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
             │ equality cols are key
             │ lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (column1 = id)
@@ -1033,7 +1033,7 @@ vectorized: true
         │
         └── • lookup join (anti)
             │ columns: (crdb_internal_email_shard_16_eq, column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp)
-            │ estimated row count: 0 (missing stats)
+            │ estimated row count: 1 (missing stats)
             │ table: t_unique_hash_sec_key@idx_uniq_hash_email
             │ equality cols are key
             │ lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (column2 = email)
@@ -1041,7 +1041,7 @@ vectorized: true
             │
             └── • lookup join (anti)
                 │ columns: (crdb_internal_email_shard_16_eq, column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp)
-                │ estimated row count: 0 (missing stats)
+                │ estimated row count: 1 (missing stats)
                 │ table: t_unique_hash_sec_key@idx_uniq_hash_email
                 │ equality cols are key
                 │ lookup condition: ((crdb_region = 'ap-southeast-2') AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (column2 = email)
@@ -1110,63 +1110,56 @@ vectorized: true
     │ render crdb_region_default: crdb_region_default
     │ render crdb_internal_email_shard_16_comp: crdb_internal_email_shard_16_comp
     │
-    └── • project
+    └── • lookup join (anti)
         │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp)
+        │ estimated row count: 1 (missing stats)
+        │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+        │ equality cols are key
+        │ lookup condition: (crdb_region IN ('ca-central-1', 'us-east-1')) AND (column1 = id)
+        │ parallel
         │
         └── • lookup join (anti)
-            │ columns: (crdb_internal_email_shard_16_eq, column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp)
-            │ estimated row count: 0 (missing stats)
-            │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+            │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp)
+            │ estimated row count: 1 (missing stats)
+            │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
             │ equality cols are key
-            │ lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (column2 = email)
+            │ lookup condition: (crdb_region = 'ap-southeast-2') AND (column1 = id)
             │ parallel
             │
-            └── • lookup join (anti)
-                │ columns: (crdb_internal_email_shard_16_eq, column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp)
-                │ estimated row count: 0 (missing stats)
-                │ table: t_unique_hash_sec_key@idx_uniq_hash_email
-                │ equality cols are key
-                │ lookup condition: ((crdb_region = 'ap-southeast-2') AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (column2 = email)
-                │ parallel
+            └── • project
+                │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp)
                 │
-                └── • render
-                    │ columns: (crdb_internal_email_shard_16_eq, column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp)
-                    │ render crdb_internal_email_shard_16_eq: mod(fnv32(md5(crdb_internal.datums_to_bytes(column2))), 16)
-                    │ render column1: column1
-                    │ render column2: column2
-                    │ render crdb_region_default: crdb_region_default
-                    │ render crdb_internal_email_shard_16_comp: crdb_internal_email_shard_16_comp
+                └── • lookup join (anti)
+                    │ columns: (crdb_internal_email_shard_16_eq, crdb_internal_email_shard_16_comp, crdb_region_default, column1, column2)
+                    │ estimated row count: 1 (missing stats)
+                    │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+                    │ equality cols are key
+                    │ lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (column2 = email)
+                    │ parallel
                     │
                     └── • lookup join (anti)
-                        │ columns: (crdb_internal_email_shard_16_comp, crdb_region_default, column1, column2)
-                        │ estimated row count: 0 (missing stats)
-                        │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+                        │ columns: (crdb_internal_email_shard_16_eq, crdb_internal_email_shard_16_comp, crdb_region_default, column1, column2)
+                        │ estimated row count: 1 (missing stats)
+                        │ table: t_unique_hash_sec_key@idx_uniq_hash_email
                         │ equality cols are key
-                        │ lookup condition: (crdb_region IN ('ca-central-1', 'us-east-1')) AND (column1 = id)
+                        │ lookup condition: ((crdb_region = 'ap-southeast-2') AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (column2 = email)
                         │ parallel
                         │
-                        └── • lookup join (anti)
-                            │ columns: (crdb_internal_email_shard_16_comp, crdb_region_default, column1, column2)
-                            │ estimated row count: 1 (missing stats)
-                            │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
-                            │ equality cols are key
-                            │ lookup condition: (crdb_region = 'ap-southeast-2') AND (column1 = id)
-                            │ parallel
+                        └── • render
+                            │ columns: (crdb_internal_email_shard_16_eq, crdb_internal_email_shard_16_comp, crdb_region_default, column1, column2)
+                            │ render crdb_internal_email_shard_16_eq: mod(fnv32(md5(crdb_internal.datums_to_bytes(column2))), 16)
+                            │ render crdb_internal_email_shard_16_comp: mod(fnv32(md5(crdb_internal.datums_to_bytes(column2))), 16)
+                            │ render crdb_region_default: 'ap-southeast-2'
+                            │ render column1: column1
+                            │ render column2: column2
                             │
-                            └── • render
-                                │ columns: (crdb_internal_email_shard_16_comp, crdb_region_default, column1, column2)
-                                │ render crdb_internal_email_shard_16_comp: mod(fnv32(md5(crdb_internal.datums_to_bytes(column2))), 16)
-                                │ render crdb_region_default: 'ap-southeast-2'
-                                │ render column1: column1
-                                │ render column2: column2
-                                │
-                                └── • values
-                                      columns: (column1, column2)
-                                      size: 2 columns, 2 rows
-                                      row 0, expr 0: 4321
-                                      row 0, expr 1: 'some_email'
-                                      row 1, expr 0: 8765
-                                      row 1, expr 1: 'another_email'
+                            └── • values
+                                  columns: (column1, column2)
+                                  size: 2 columns, 2 rows
+                                  row 0, expr 0: 4321
+                                  row 0, expr 1: 'some_email'
+                                  row 1, expr 0: 8765
+                                  row 1, expr 1: 'another_email'
 
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email) VALUES (4321, 'some_email') ON CONFLICT (email) DO NOTHING;
@@ -1282,7 +1275,7 @@ vectorized: true
 │               │
 │               └── • lookup join (anti)
 │                   │ columns: (crdb_internal_email_shard_16_eq, crdb_internal_email_shard_16_comp, crdb_region_default, column1, column2)
-│                   │ estimated row count: 0 (missing stats)
+│                   │ estimated row count: 1 (missing stats)
 │                   │ table: t_unique_hash_sec_key@idx_uniq_hash_email
 │                   │ equality cols are key
 │                   │ lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (column2 = email)

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
@@ -354,24 +354,24 @@ SELECT * FROM [
 └── • render
     │
     └── • lookup join (anti)
-        │ table: regional_by_row_table@uniq_idx (partial index)
-        │ lookup condition: (crdb_region IN ('ca-central-1', 'us-east-1')) AND (column4 = a)
-        │ pred: column5 > 0
+        │ table: regional_by_row_table@regional_by_row_table_b_key
+        │ equality cols are key
+        │ lookup condition: (crdb_region IN ('ca-central-1', 'us-east-1')) AND (column5 = b)
         │
         └── • lookup join (anti)
-            │ table: regional_by_row_table@uniq_idx (partial index)
-            │ lookup condition: (crdb_region = 'ap-southeast-2') AND (column4 = a)
-            │ pred: column5 > 0
+            │ table: regional_by_row_table@regional_by_row_table_b_key
+            │ equality cols are key
+            │ lookup condition: (crdb_region = 'ap-southeast-2') AND (column5 = b)
             │
             └── • lookup join (anti)
-                │ table: regional_by_row_table@regional_by_row_table_b_key
-                │ equality cols are key
-                │ lookup condition: (crdb_region IN ('ca-central-1', 'us-east-1')) AND (column5 = b)
+                │ table: regional_by_row_table@uniq_idx (partial index)
+                │ lookup condition: (crdb_region IN ('ca-central-1', 'us-east-1')) AND (column4 = a)
+                │ pred: column5 > 0
                 │
                 └── • lookup join (anti)
-                    │ table: regional_by_row_table@regional_by_row_table_b_key
-                    │ equality cols are key
-                    │ lookup condition: (crdb_region = 'ap-southeast-2') AND (column5 = b)
+                    │ table: regional_by_row_table@uniq_idx (partial index)
+                    │ lookup condition: (crdb_region = 'ap-southeast-2') AND (column4 = a)
+                    │ pred: column5 > 0
                     │
                     └── • cross join (anti)
                         │

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -3910,7 +3910,7 @@ optimizer_use_lock_elision_multiple_families                     off
 optimizer_use_lock_op_for_serializable                           off
 optimizer_use_max_frequency_selectivity                          on
 optimizer_use_merged_partial_statistics                          on
-optimizer_use_min_row_count_anti_join_fix                        off
+optimizer_use_min_row_count_anti_join_fix                        on
 optimizer_use_multicol_stats                                     on
 optimizer_use_not_visible_indexes                                off
 optimizer_use_polymorphic_parameter_fix                          on

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -3910,6 +3910,7 @@ optimizer_use_lock_elision_multiple_families                     off
 optimizer_use_lock_op_for_serializable                           off
 optimizer_use_max_frequency_selectivity                          on
 optimizer_use_merged_partial_statistics                          on
+optimizer_use_min_row_count_anti_join_fix                        off
 optimizer_use_multicol_stats                                     on
 optimizer_use_not_visible_indexes                                off
 optimizer_use_polymorphic_parameter_fix                          on

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3201,7 +3201,7 @@ optimizer_use_lock_elision_multiple_families                     off            
 optimizer_use_lock_op_for_serializable                           off                 NULL      NULL        NULL        string
 optimizer_use_max_frequency_selectivity                          on                  NULL      NULL        NULL        string
 optimizer_use_merged_partial_statistics                          on                  NULL      NULL        NULL        string
-optimizer_use_min_row_count_anti_join_fix                        off                 NULL      NULL        NULL        string
+optimizer_use_min_row_count_anti_join_fix                        on                  NULL      NULL        NULL        string
 optimizer_use_multicol_stats                                     on                  NULL      NULL        NULL        string
 optimizer_use_not_visible_indexes                                off                 NULL      NULL        NULL        string
 optimizer_use_polymorphic_parameter_fix                          on                  NULL      NULL        NULL        string
@@ -3458,7 +3458,7 @@ optimizer_use_lock_elision_multiple_families                     off            
 optimizer_use_lock_op_for_serializable                           off                 NULL  user     NULL      off                 off
 optimizer_use_max_frequency_selectivity                          on                  NULL  user     NULL      on                  on
 optimizer_use_merged_partial_statistics                          on                  NULL  user     NULL      on                  on
-optimizer_use_min_row_count_anti_join_fix                        off                 NULL  user     NULL      off                 off
+optimizer_use_min_row_count_anti_join_fix                        on                  NULL  user     NULL      on                  on
 optimizer_use_multicol_stats                                     on                  NULL  user     NULL      on                  on
 optimizer_use_not_visible_indexes                                off                 NULL  user     NULL      off                 off
 optimizer_use_polymorphic_parameter_fix                          on                  NULL  user     NULL      on                  on

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3201,6 +3201,7 @@ optimizer_use_lock_elision_multiple_families                     off            
 optimizer_use_lock_op_for_serializable                           off                 NULL      NULL        NULL        string
 optimizer_use_max_frequency_selectivity                          on                  NULL      NULL        NULL        string
 optimizer_use_merged_partial_statistics                          on                  NULL      NULL        NULL        string
+optimizer_use_min_row_count_anti_join_fix                        off                 NULL      NULL        NULL        string
 optimizer_use_multicol_stats                                     on                  NULL      NULL        NULL        string
 optimizer_use_not_visible_indexes                                off                 NULL      NULL        NULL        string
 optimizer_use_polymorphic_parameter_fix                          on                  NULL      NULL        NULL        string
@@ -3457,6 +3458,7 @@ optimizer_use_lock_elision_multiple_families                     off            
 optimizer_use_lock_op_for_serializable                           off                 NULL  user     NULL      off                 off
 optimizer_use_max_frequency_selectivity                          on                  NULL  user     NULL      on                  on
 optimizer_use_merged_partial_statistics                          on                  NULL  user     NULL      on                  on
+optimizer_use_min_row_count_anti_join_fix                        off                 NULL  user     NULL      off                 off
 optimizer_use_multicol_stats                                     on                  NULL  user     NULL      on                  on
 optimizer_use_not_visible_indexes                                off                 NULL  user     NULL      off                 off
 optimizer_use_polymorphic_parameter_fix                          on                  NULL  user     NULL      on                  on
@@ -3704,6 +3706,7 @@ optimizer_use_lock_elision_multiple_families                     NULL    NULL   
 optimizer_use_lock_op_for_serializable                           NULL    NULL     NULL     NULL        NULL
 optimizer_use_max_frequency_selectivity                          NULL    NULL     NULL     NULL        NULL
 optimizer_use_merged_partial_statistics                          NULL    NULL     NULL     NULL        NULL
+optimizer_use_min_row_count_anti_join_fix                        NULL    NULL     NULL     NULL        NULL
 optimizer_use_multicol_stats                                     NULL    NULL     NULL     NULL        NULL
 optimizer_use_not_visible_indexes                                NULL    NULL     NULL     NULL        NULL
 optimizer_use_polymorphic_parameter_fix                          NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -186,7 +186,7 @@ optimizer_use_lock_elision_multiple_families                     off
 optimizer_use_lock_op_for_serializable                           off
 optimizer_use_max_frequency_selectivity                          on
 optimizer_use_merged_partial_statistics                          on
-optimizer_use_min_row_count_anti_join_fix                        off
+optimizer_use_min_row_count_anti_join_fix                        on
 optimizer_use_multicol_stats                                     on
 optimizer_use_not_visible_indexes                                off
 optimizer_use_polymorphic_parameter_fix                          on

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -186,6 +186,7 @@ optimizer_use_lock_elision_multiple_families                     off
 optimizer_use_lock_op_for_serializable                           off
 optimizer_use_max_frequency_selectivity                          on
 optimizer_use_merged_partial_statistics                          on
+optimizer_use_min_row_count_anti_join_fix                        off
 optimizer_use_multicol_stats                                     on
 optimizer_use_not_visible_indexes                                off
 optimizer_use_polymorphic_parameter_fix                          on

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk
@@ -2003,7 +2003,7 @@ distribution: local
     └── • error if rows
         │
         └── • lookup join (anti)
-            │ estimated row count: 0
+            │ estimated row count: 1
             │ table: small_parent@small_parent_pkey
             │ equality: (?column?) = (p)
             │ equality cols are key

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk_read_committed
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk_read_committed
@@ -176,7 +176,7 @@ vectorized: true
         │
         └── • lookup join (anti)
             │ columns: (j_new)
-            │ estimated row count: 0 (missing stats)
+            │ estimated row count: 1 (missing stats)
             │ table: jars@jars_pkey
             │ equality: (j_new) = (j)
             │ equality cols are key
@@ -299,7 +299,7 @@ vectorized: true
 │               │
 │               └── • lookup join (anti)
 │                   │ columns: (j_new)
-│                   │ estimated row count: 0 (missing stats)
+│                   │ estimated row count: 1 (missing stats)
 │                   │ table: jars@jars_pkey
 │                   │ equality: (j_new) = (j)
 │                   │ equality cols are key

--- a/pkg/sql/opt/exec/execbuilder/testdata/hash_sharded_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/hash_sharded_index
@@ -1141,7 +1141,7 @@ vectorized: true
         │
         └── • lookup join (anti)
             │ columns: (crdb_internal_b_shard_8_eq, column1, column2, crdb_internal_b_shard_8_comp)
-            │ estimated row count: 0 (missing stats)
+            │ estimated row count: 1 (missing stats)
             │ table: t_hash_indexed@idx_t_hash_indexed
             │ equality: (crdb_internal_b_shard_8_eq, column2) = (crdb_internal_b_shard_8, b)
             │ equality cols are key
@@ -1200,7 +1200,7 @@ vectorized: true
         │
         └── • lookup join (anti)
             │ columns: (crdb_internal_b_shard_8_eq, column1, column2, crdb_internal_b_shard_8_comp)
-            │ estimated row count: 0 (missing stats)
+            │ estimated row count: 1 (missing stats)
             │ table: t_hash_indexed@idx_t_hash_indexed
             │ equality: (crdb_internal_b_shard_8_eq, column2) = (crdb_internal_b_shard_8, b)
             │ equality cols are key
@@ -1215,7 +1215,7 @@ vectorized: true
                 │
                 └── • lookup join (anti)
                     │ columns: (crdb_internal_b_shard_8_comp, column1, column2)
-                    │ estimated row count: 0 (missing stats)
+                    │ estimated row count: 1 (missing stats)
                     │ table: t_hash_indexed@t_hash_indexed_pkey
                     │ equality: (column1) = (a)
                     │ equality cols are key
@@ -1300,7 +1300,7 @@ vectorized: true
         │
         └── • lookup join (anti)
             │ columns: (crdb_internal_b_shard_8_eq, crdb_internal_b_shard_8_comp, column1, column2)
-            │ estimated row count: 0 (missing stats)
+            │ estimated row count: 1 (missing stats)
             │ table: t_hash_indexed@idx_t_hash_indexed
             │ equality: (crdb_internal_b_shard_8_eq, column2) = (crdb_internal_b_shard_8, b)
             │ equality cols are key
@@ -1369,7 +1369,7 @@ vectorized: true
             │
             └── • lookup join (anti)
                 │ columns: (crdb_internal_id_shard_16_eq, pid)
-                │ estimated row count: 0 (missing stats)
+                │ estimated row count: 1 (missing stats)
                 │ table: t_parent_pk@t_parent_pk_pkey
                 │ equality: (crdb_internal_id_shard_16_eq, pid) = (crdb_internal_id_shard_16, id)
                 │ equality cols are key
@@ -1439,7 +1439,7 @@ vectorized: true
             │
             └── • lookup join (anti)
                 │ columns: (crdb_internal_real_id_shard_16_eq, pid)
-                │ estimated row count: 0 (missing stats)
+                │ estimated row count: 1 (missing stats)
                 │ table: t_parent_sec@idx_t_parent_sec_real_id
                 │ equality: (crdb_internal_real_id_shard_16_eq, pid) = (crdb_internal_real_id_shard_16, real_id)
                 │ equality cols are key

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -1110,7 +1110,7 @@ vectorized: true
 │
 └── • lookup join (anti)
     │ columns: (c, a, b, cont)
-    │ estimated row count: 0
+    │ estimated row count: 1
     │ table: large@large_pkey
     │ equality: (a, b) = (a, b)
     │ equality cols are key
@@ -1409,7 +1409,7 @@ vectorized: true
 ·
 • lookup join (anti)
 │ columns: (a, b, c)
-│ estimated row count: 0
+│ estimated row count: 1
 │ table: def@def_pkey
 │ equality: (a) = (f)
 │
@@ -1447,7 +1447,7 @@ vectorized: true
 ·
 • lookup join (anti)
 │ columns: (a, b, c)
-│ estimated row count: 0
+│ estimated row count: 1
 │ table: def@def_pkey
 │ equality: (a, c) = (f, e)
 │ equality cols are key
@@ -2108,14 +2108,14 @@ distribution: full
         │ pred: l_suppkey != l_suppkey
         │
         └── • lookup join
-            │ estimated row count: 0
+            │ estimated row count: 1
             │ table: orders@orders_pkey
             │ equality: (l_orderkey) = (o_orderkey)
             │ equality cols are key
             │ pred: o_orderstatus = 'F'
             │
             └── • lookup join (anti)
-                │ estimated row count: 0
+                │ estimated row count: 1
                 │ table: lineitem@lineitem_pkey
                 │ equality: (l_orderkey) = (l_orderkey)
                 │ pred: l_receiptdate > l_commitdate

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -346,7 +346,7 @@ vectorized: true
 ·
 • merge join (anti)
 │ columns: (x, y)
-│ estimated row count: 0 (missing stats)
+│ estimated row count: 1 (missing stats)
 │ equality: (x) = (x)
 │ left cols are key
 │ right cols are key
@@ -374,7 +374,7 @@ vectorized: true
 ·
 • hash join (anti)
 │ columns: (x, z)
-│ estimated row count: 0 (missing stats)
+│ estimated row count: 1 (missing stats)
 │ equality: (x) = (column14)
 │ left cols are key
 │

--- a/pkg/sql/opt/exec/execbuilder/testdata/tpch_vec
+++ b/pkg/sql/opt/exec/execbuilder/testdata/tpch_vec
@@ -20998,8 +20998,8 @@ EXPLAIN (VEC) SELECT cntrycode, count(*) AS numcust, sum(c_acctbal) AS totacctba
 ----
 │
 └ Node 1
-  └ *colexec.sortOp
-    └ *colexec.hashAggregator
+  └ *colexec.orderedAggregator
+    └ *colexec.sortOp
       └ *colexecbuiltins.substringInt64Int64Operator
         └ *colexecbase.constInt64Op
           └ *colexecbase.constInt64Op

--- a/pkg/sql/opt/exec/execbuilder/testdata/triggers
+++ b/pkg/sql/opt/exec/execbuilder/testdata/triggers
@@ -984,7 +984,7 @@ quality of service: regular
         │           │ MVCC step count (ext/int): 0/0
         │           │ MVCC seek count (ext/int): 0/0
         │           │ actual row count: 0
-        │           │ estimated row count: 0 (missing stats)
+        │           │ estimated row count: 1 (missing stats)
         │           │ table: parent@parent_pkey
         │           │ equality: (fk_new) = (k)
         │           │ equality cols are key

--- a/pkg/sql/opt/exec/execbuilder/testdata/unique
+++ b/pkg/sql/opt/exec/execbuilder/testdata/unique
@@ -358,54 +358,54 @@ vectorized: true
 │
 └── • hash join (right anti)
     │ columns: (column1, column2, column3, column4, column5)
-    │ estimated row count: 0 (missing stats)
-    │ equality: (x, y) = (column4, column5)
+    │ estimated row count: 1 (missing stats)
+    │ equality: (w) = (column3)
     │ right cols are key
     │
     ├── • scan
-    │     columns: (x, y)
+    │     columns: (w)
     │     estimated row count: 1,000 (missing stats)
     │     table: uniq@uniq_pkey
     │     spans: FULL SCAN
     │
-    └── • cross join (right anti)
+    └── • lookup join (anti)
         │ columns: (column1, column2, column3, column4, column5)
         │ estimated row count: 0 (missing stats)
+        │ table: uniq@uniq_v_key
+        │ equality: (column2) = (v)
+        │ equality cols are key
+        │ parallel
         │
-        ├── • scan
-        │     columns: (k)
-        │     estimated row count: 1 (missing stats)
-        │     table: uniq@uniq_pkey
-        │     spans: /1/0
-        │
-        └── • lookup join (anti)
+        └── • hash join (right anti)
             │ columns: (column1, column2, column3, column4, column5)
             │ estimated row count: 0 (missing stats)
-            │ table: uniq@uniq_v_key
-            │ equality: (column2) = (v)
-            │ equality cols are key
-            │ parallel
+            │ equality: (x, y) = (column4, column5)
+            │ right cols are key
             │
-            └── • hash join (right anti)
+            ├── • scan
+            │     columns: (x, y)
+            │     estimated row count: 1,000 (missing stats)
+            │     table: uniq@uniq_pkey
+            │     spans: FULL SCAN
+            │
+            └── • cross join (anti)
                 │ columns: (column1, column2, column3, column4, column5)
                 │ estimated row count: 0 (missing stats)
-                │ equality: (w) = (column3)
-                │ right cols are key
                 │
-                ├── • scan
-                │     columns: (w)
-                │     estimated row count: 1,000 (missing stats)
-                │     table: uniq@uniq_pkey
-                │     spans: FULL SCAN
+                ├── • values
+                │     columns: (column1, column2, column3, column4, column5)
+                │     size: 5 columns, 1 row
+                │     row 0, expr 0: 1
+                │     row 0, expr 1: 2
+                │     row 0, expr 2: 3
+                │     row 0, expr 3: 4
+                │     row 0, expr 4: 5
                 │
-                └── • values
-                      columns: (column1, column2, column3, column4, column5)
-                      size: 5 columns, 1 row
-                      row 0, expr 0: 1
-                      row 0, expr 1: 2
-                      row 0, expr 2: 3
-                      row 0, expr 3: 4
-                      row 0, expr 4: 5
+                └── • scan
+                      columns: (k)
+                      estimated row count: 1 (missing stats)
+                      table: uniq@uniq_pkey
+                      spans: /1/0
 
 # Insert with non-constant input.
 query T
@@ -1020,7 +1020,7 @@ vectorized: true
     │
     └── • lookup join (anti)
         │ columns: (column1, column2, column3, column4)
-        │ estimated row count: 0 (missing stats)
+        │ estimated row count: 1 (missing stats)
         │ table: uniq_enum@uniq_enum_pkey
         │ equality cols are key
         │ lookup condition: (r IN ('us-east', 'us-west', 'eu-west')) AND (column3 = i)
@@ -1028,7 +1028,7 @@ vectorized: true
         │
         └── • lookup join (anti)
             │ columns: (column1, column2, column3, column4)
-            │ estimated row count: 0 (missing stats)
+            │ estimated row count: 1 (missing stats)
             │ table: uniq_enum@uniq_enum_r_s_j_key
             │ equality cols are key
             │ lookup condition: ((r IN ('us-east', 'us-west', 'eu-west')) AND (column2 = s)) AND (column4 = j)
@@ -1170,17 +1170,18 @@ vectorized: true
 │
 └── • hash join (right anti)
     │ columns: (column1, column2, column3)
-    │ estimated row count: 0 (missing stats)
-    │ equality: (b) = (column3)
+    │ estimated row count: 1 (missing stats)
+    │ equality: (a) = (column2)
     │ right cols are key
+    │ pred: column3 > 0
     │
     ├── • filter
-    │   │ columns: (b)
+    │   │ columns: (a, b)
     │   │ estimated row count: 333 (missing stats)
     │   │ filter: b > 0
     │   │
     │   └── • scan
-    │         columns: (b)
+    │         columns: (a, b)
     │         estimated row count: 1,000 (missing stats)
     │         table: uniq_partial@uniq_partial_pkey
     │         spans: FULL SCAN
@@ -1188,17 +1189,16 @@ vectorized: true
     └── • hash join (right anti)
         │ columns: (column1, column2, column3)
         │ estimated row count: 0 (missing stats)
-        │ equality: (a) = (column2)
+        │ equality: (b) = (column3)
         │ right cols are key
-        │ pred: column3 > 0
         │
         ├── • filter
-        │   │ columns: (a, b)
+        │   │ columns: (b)
         │   │ estimated row count: 333 (missing stats)
         │   │ filter: b > 0
         │   │
         │   └── • scan
-        │         columns: (a, b)
+        │         columns: (b)
         │         estimated row count: 1,000 (missing stats)
         │         table: uniq_partial@uniq_partial_pkey
         │         spans: FULL SCAN
@@ -1435,7 +1435,7 @@ vectorized: true
     │
     └── • distinct
         │ columns: (arbiter_unique_b_distinct, column1, column2, column3, column4)
-        │ estimated row count: 0
+        │ estimated row count: 1
         │ distinct on: arbiter_unique_b_distinct, column3
         │ nulls are distinct
         │
@@ -1449,14 +1449,14 @@ vectorized: true
             │
             └── • lookup join (anti)
                 │ columns: (column1, column2, column3, column4)
-                │ estimated row count: 0
+                │ estimated row count: 1
                 │ table: uniq_partial_enum@uniq_partial_enum_r_b_idx (partial index)
                 │ lookup condition: (r IN ('us-east', 'us-west', 'eu-west')) AND (column3 = b)
                 │ pred: column4 IN ('bar', 'baz', 'foo')
                 │
                 └── • lookup join (anti)
                     │ columns: (column1, column2, column3, column4)
-                    │ estimated row count: 0
+                    │ estimated row count: 1
                     │ table: uniq_partial_enum@uniq_partial_enum_pkey
                     │ equality: (column1, column2) = (r, a)
                     │ equality cols are key

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -671,7 +671,7 @@ vectorized: true
     │
     └── • lookup join (anti)
         │ columns: (column1, column2, column3, d_comp)
-        │ estimated row count: 0 (missing stats)
+        │ estimated row count: 1 (missing stats)
         │ table: indexed@secondary
         │ equality: (d_comp, column2) = (d, b)
         │ equality cols are key

--- a/pkg/sql/opt/exec/execbuilder/testdata/virtual_columns
+++ b/pkg/sql/opt/exec/execbuilder/testdata/virtual_columns
@@ -791,14 +791,14 @@ vectorized: true
 │
 └── • insert
     │ columns: (a, v)
-    │ estimated row count: 0 (missing stats)
+    │ estimated row count: 1 (missing stats)
     │ into: t(a, b, v)
     │ auto commit
     │ arbiter indexes: t_pkey
     │
     └── • lookup join (anti)
         │ columns: (column1, column2, v_comp)
-        │ estimated row count: 0 (missing stats)
+        │ estimated row count: 1 (missing stats)
         │ table: t@t_pkey
         │ equality: (column1) = (a)
         │ equality cols are key
@@ -1083,20 +1083,20 @@ vectorized: true
 │
 └── • insert
     │ columns: (a, w)
-    │ estimated row count: 0 (missing stats)
+    │ estimated row count: 1 (missing stats)
     │ into: t_idx(a, b, c, v, w)
     │ auto commit
     │ arbiter indexes: t_idx_pkey, t_idx_w_key
     │
     └── • distinct
         │ columns: (column1, column2, column3, v_comp, w_comp)
-        │ estimated row count: 0 (missing stats)
+        │ estimated row count: 1 (missing stats)
         │ distinct on: w_comp
         │ nulls are distinct
         │
         └── • lookup join (anti)
             │ columns: (v_comp, w_comp, column1, column2, column3)
-            │ estimated row count: 0 (missing stats)
+            │ estimated row count: 1 (missing stats)
             │ table: t_idx@t_idx_pkey
             │ equality: (column1) = (a)
             │ equality cols are key
@@ -1104,7 +1104,7 @@ vectorized: true
             │
             └── • lookup join (anti)
                 │ columns: (v_comp, w_comp, column1, column2, column3)
-                │ estimated row count: 0 (missing stats)
+                │ estimated row count: 1 (missing stats)
                 │ table: t_idx@t_idx_w_key
                 │ equality: (w_comp) = (w)
                 │ equality cols are key

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -219,6 +219,7 @@ type Memo struct {
 	useSwapMutations                           bool
 	preventUpdateSetColumnDrop                 bool
 	useImprovedRoutineDepsTriggersComputedCols bool
+	inlineAnyUnnestSubquery                    bool
 
 	// txnIsoLevel is the isolation level under which the plan was created. This
 	// affects the planning of some locking operations, so it must be included in
@@ -338,6 +339,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		useSwapMutations:                           evalCtx.SessionData().UseSwapMutations,
 		preventUpdateSetColumnDrop:                 evalCtx.SessionData().PreventUpdateSetColumnDrop,
 		useImprovedRoutineDepsTriggersComputedCols: evalCtx.SessionData().UseImprovedRoutineDepsTriggersAndComputedCols,
+		inlineAnyUnnestSubquery:                    evalCtx.SessionData().OptimizerInlineAnyUnnestSubquery,
 		txnIsoLevel:                                evalCtx.TxnIsoLevel,
 	}
 	m.metadata.Init()
@@ -521,6 +523,7 @@ func (m *Memo) IsStale(
 		m.useSwapMutations != evalCtx.SessionData().UseSwapMutations ||
 		m.preventUpdateSetColumnDrop != evalCtx.SessionData().PreventUpdateSetColumnDrop ||
 		m.useImprovedRoutineDepsTriggersComputedCols != evalCtx.SessionData().UseImprovedRoutineDepsTriggersAndComputedCols ||
+		m.inlineAnyUnnestSubquery != evalCtx.SessionData().OptimizerInlineAnyUnnestSubquery ||
 		m.txnIsoLevel != evalCtx.TxnIsoLevel {
 		return true, nil
 	}

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -220,6 +220,7 @@ type Memo struct {
 	preventUpdateSetColumnDrop                 bool
 	useImprovedRoutineDepsTriggersComputedCols bool
 	inlineAnyUnnestSubquery                    bool
+	useMinRowCountAntiJoinFix                  bool
 
 	// txnIsoLevel is the isolation level under which the plan was created. This
 	// affects the planning of some locking operations, so it must be included in
@@ -340,6 +341,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		preventUpdateSetColumnDrop:                 evalCtx.SessionData().PreventUpdateSetColumnDrop,
 		useImprovedRoutineDepsTriggersComputedCols: evalCtx.SessionData().UseImprovedRoutineDepsTriggersAndComputedCols,
 		inlineAnyUnnestSubquery:                    evalCtx.SessionData().OptimizerInlineAnyUnnestSubquery,
+		useMinRowCountAntiJoinFix:                  evalCtx.SessionData().OptimizerUseMinRowCountAntiJoinFix,
 		txnIsoLevel:                                evalCtx.TxnIsoLevel,
 	}
 	m.metadata.Init()
@@ -524,6 +526,7 @@ func (m *Memo) IsStale(
 		m.preventUpdateSetColumnDrop != evalCtx.SessionData().PreventUpdateSetColumnDrop ||
 		m.useImprovedRoutineDepsTriggersComputedCols != evalCtx.SessionData().UseImprovedRoutineDepsTriggersAndComputedCols ||
 		m.inlineAnyUnnestSubquery != evalCtx.SessionData().OptimizerInlineAnyUnnestSubquery ||
+		m.useMinRowCountAntiJoinFix != evalCtx.SessionData().OptimizerUseMinRowCountAntiJoinFix ||
 		m.txnIsoLevel != evalCtx.TxnIsoLevel {
 		return true, nil
 	}

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -623,6 +623,12 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().UseImprovedRoutineDepsTriggersAndComputedCols = false
 	notStale()
 
+	// Stale optimizer_inline_any_unnest_subquery.
+	evalCtx.SessionData().OptimizerInlineAnyUnnestSubquery = true
+	stale()
+	evalCtx.SessionData().OptimizerInlineAnyUnnestSubquery = false
+	notStale()
+
 	// User no longer has access to view.
 	catalog.View(tree.NewTableNameWithSchema("t", catconstants.PublicSchemaName, "abcview")).Revoked = true
 	_, err = o.Memo().IsStale(ctx, &evalCtx, catalog)

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -629,6 +629,12 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().OptimizerInlineAnyUnnestSubquery = false
 	notStale()
 
+	// Stale optimizer_use_min_row_count_anti_join_fix.
+	evalCtx.SessionData().OptimizerUseMinRowCountAntiJoinFix = true
+	stale()
+	evalCtx.SessionData().OptimizerUseMinRowCountAntiJoinFix = false
+	notStale()
+
 	// User no longer has access to view.
 	catalog.View(tree.NewTableNameWithSchema("t", catconstants.PublicSchemaName, "abcview")).Revoked = true
 	_, err = o.Memo().IsStale(ctx, &evalCtx, catalog)

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -1548,8 +1548,17 @@ func (sb *statisticsBuilder) buildJoin(
 	// Fix the stats for anti join.
 	switch h.joinType {
 	case opt.AntiJoinOp, opt.AntiJoinApplyOp:
-		s.RowCount = max(leftStats.RowCount-s.RowCount, epsilon)
-		s.Selectivity = props.MakeSelectivity(1 - s.Selectivity.AsFloat())
+		if sb.evalCtx.SessionData().OptimizerUseMinRowCountAntiJoinFix {
+			// Make sure to use ApplySelectivity instead of setting the selectivity and
+			// row count directly so that min_row_count is respected.
+			originalSel := s.Selectivity
+			s.RowCount = leftStats.RowCount
+			s.Selectivity = props.OneSelectivity
+			s.ApplySelectivity(props.MakeSelectivity(1 - originalSel.AsFloat()))
+		} else {
+			s.RowCount = max(leftStats.RowCount-s.RowCount, epsilon)
+			s.Selectivity = props.MakeSelectivity(1 - s.Selectivity.AsFloat())
+		}
 
 		// Converting column stats is error-prone. If any column stats are needed,
 		// colStatJoin will use the selectivity calculated above to estimate the

--- a/pkg/sql/opt/memo/testdata/stats/insert
+++ b/pkg/sql/opt/memo/testdata/stats/insert
@@ -214,7 +214,7 @@ insert c137547
                 ├── key columns: [14 15] = [16 17]
                 ├── lookup columns are key
                 ├── cardinality: [0 - 1]
-                ├── stats: [rows=1e-10]
+                ├── stats: [rows=1]
                 ├── key: ()
                 ├── fd: ()-->(14,15)
                 ├── distribution: us

--- a/pkg/sql/opt/memo/testdata/stats/join
+++ b/pkg/sql/opt/memo/testdata/stats/join
@@ -1653,7 +1653,7 @@ expr format=show-all colstat=7 colstat=8 colstat=(7, 8) colstat=1 colstat=2 cols
 anti-join (lookup t.public.def)
  ├── columns: t.public.abc.a:1(int!null) t.public.abc.b:2(int!null) t.public.abc.c:3(int)
  ├── key columns: [1 2] = [6 7]
- ├── stats: [rows=1e-10, distinct(1)=1e-10, null(1)=0, distinct(2)=1e-10, null(2)=0, distinct(3)=1e-10, null(3)=1e-10, distinct(7)=1e-10, null(7)=0, distinct(8)=1e-10, null(8)=0, distinct(7,8)=1e-10, null(7,8)=0, distinct(1-3)=1e-10, null(1-3)=0]
+ ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(2)=0.956179, null(2)=0, distinct(3)=0.956179, null(3)=0.01, distinct(7)=0.633968, null(7)=0, distinct(8)=0.633968, null(8)=0, distinct(7,8)=0.633968, null(7,8)=0, distinct(1-3)=1, null(1-3)=0]
  ├── cost: 2137.95
  ├── cost-flags: unbounded-cardinality
  ├── key: (1,2)
@@ -2109,7 +2109,7 @@ SELECT * FROM classes WHERE NOT EXISTS (SELECT * FROM classRequest WHERE
 ----
 anti-join (cross)
  ├── columns: classid:1(int) description:2(varchar)
- ├── stats: [rows=1e-10]
+ ├── stats: [rows=1]
  ├── scan classes
  │    ├── columns: classid:1(int) description:2(varchar)
  │    └── stats: [rows=1000, distinct(1)=100, null(1)=10]

--- a/pkg/sql/opt/memo/testdata/stats/lookup-join
+++ b/pkg/sql/opt/memo/testdata/stats/lookup-join
@@ -359,7 +359,7 @@ SELECT * FROM u WHERE NOT EXISTS (SELECT * FROM t WHERE u.x=t.x AND u.y=t.y);
 anti-join (lookup t@xy_idx)
  ├── columns: x:1(int) y:2(int)
  ├── key columns: [1 2] = [6 7]
- ├── stats: [rows=1e-10]
+ ├── stats: [rows=1]
  ├── scan u
  │    ├── columns: u.x:1(int) u.y:2(int)
  │    └── stats: [rows=10, distinct(1)=2, null(1)=0, distinct(2)=2, null(2)=0]

--- a/pkg/sql/opt/memo/testdata/stats/update
+++ b/pkg/sql/opt/memo/testdata/stats/update
@@ -222,7 +222,7 @@ with &2 (q)
  │              └── f-k-checks-item: child(c) -> parent(p)
  │                   └── anti-join (hash)
  │                        ├── columns: c:14(int!null)
- │                        ├── stats: [rows=1e-10]
+ │                        ├── stats: [rows=1]
  │                        ├── fd: ()-->(14)
  │                        ├── with-scan &1
  │                        │    ├── columns: c:14(int!null)

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q22
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q22
@@ -54,159 +54,156 @@ ORDER BY
     cntrycode;
 ----
 ----
-sort
- ├── save-table-name: q22_sort_1
+group-by (streaming)
+ ├── save-table-name: q22_group_by_1
  ├── columns: cntrycode:34(string) numcust:35(int!null) totacctbal:36(float!null)
+ ├── grouping columns: cntrycode:34(string)
  ├── immutable
- ├── stats: [rows=1e-10, distinct(34)=1e-10, null(34)=0, distinct(35)=1e-10, null(35)=0, distinct(36)=1e-10, null(36)=0]
+ ├── stats: [rows=1, distinct(34)=1, null(34)=0, distinct(35)=1, null(35)=0, distinct(36)=1, null(36)=0]
  ├── key: (34)
  ├── fd: (34)-->(35,36)
  ├── ordering: +34
- └── group-by (hash)
-      ├── save-table-name: q22_group_by_2
-      ├── columns: cntrycode:34(string) count_rows:35(int!null) sum:36(float!null)
-      ├── grouping columns: cntrycode:34(string)
-      ├── immutable
-      ├── stats: [rows=1e-10, distinct(34)=1e-10, null(34)=0, distinct(35)=1e-10, null(35)=0, distinct(36)=1e-10, null(36)=0]
-      ├── key: (34)
-      ├── fd: (34)-->(35,36)
-      ├── project
-      │    ├── save-table-name: q22_project_3
-      │    ├── columns: cntrycode:34(string) c_acctbal:6(float!null)
-      │    ├── immutable
-      │    ├── stats: [rows=1e-10, distinct(6)=1e-10, null(6)=0, distinct(34)=1e-10, null(34)=0]
-      │    ├── anti-join (lookup orders@o_ck)
-      │    │    ├── save-table-name: q22_lookup_join_4
-      │    │    ├── columns: c_custkey:1(int!null) c_phone:5(char!null) c_acctbal:6(float!null)
-      │    │    ├── key columns: [1] = [23]
-      │    │    ├── immutable
-      │    │    ├── stats: [rows=1e-10, distinct(1)=1e-10, null(1)=0, distinct(5)=1e-10, null(5)=0, distinct(6)=1e-10, null(6)=0]
-      │    │    ├── key: (1)
-      │    │    ├── fd: (1)-->(5,6)
-      │    │    ├── select
-      │    │    │    ├── save-table-name: q22_select_5
-      │    │    │    ├── columns: c_custkey:1(int!null) c_phone:5(char!null) c_acctbal:6(float!null)
-      │    │    │    ├── immutable
-      │    │    │    ├── stats: [rows=16666.7, distinct(1)=16659, null(1)=0, distinct(5)=16666.7, null(5)=0, distinct(6)=16666.7, null(6)=0]
-      │    │    │    ├── key: (1)
-      │    │    │    ├── fd: (1)-->(5,6)
-      │    │    │    ├── scan customer
-      │    │    │    │    ├── save-table-name: q22_scan_6
-      │    │    │    │    ├── columns: c_custkey:1(int!null) c_phone:5(char!null) c_acctbal:6(float!null)
-      │    │    │    │    ├── stats: [rows=150000, distinct(1)=148813, null(1)=0, distinct(5)=150000, null(5)=0, distinct(6)=140628, null(6)=0]
-      │    │    │    │    │   histogram(1)=  0           0            0  5   745   5   746   5    711   5    780   5    738   5    835   5    697   5    757   5    704   5    696   5    753   5    678   5    813   5    873    5    736    5    840    5    703    5    745    5    710    5    763    5    742    5    673    5    702    5    793    5    732    5    752    5    707    5    751    5    722    5    814    5    789    5    671    5    643    5    706    5    723    5    757    5    713    5    760    5    766    5    711    5    858    5    702    5    695    5    697    5    823    5    857    5    712    5    808    5    754    5    739    5    694    5    782    5    792    5    751    5    758    5    749    5    798    5    685    5    692    5    792    5    710    5    771    5    724    5    853    5    713    5    823    5    772    5    656    5    763    5    672    5    735    5    810    5    786    5    709    5    731    5    702    5    708    5    669    5    733    5    744    5    758    5    800    5    682    5    716    5    716    5    729    5    778    5    721    5    766    5    820    5    757    5    739    5    799    5    780    5    710    5    749    5    754    5    750    5    699    5    821    5    759    5    818    5    763    5    854    5    779    5    810    5    783    5    686    5    703    5    776    5    675    5    812    5    745    5    759    5    793    5    751    5    761    5    798    5    794    5    729    5    696    5    699    5    831    5    709    5    747    5    722    5    768    5    729    5    702    5    729    5    698    5    767    5    792    5     726    5     737    5     671    5     721    5     842    5     701    5     704    5     708    5     726    5     695    5     665    5     688    5     653    5     690    5     734    5     789    5     659    5     785    5     733    5     740    5     826    5     745    5     929    5     899    5     743    5     790    5     825    5     779    5     677    5     697    5     756    5     693    5     862    5     772    5     783    5     757    5     799    5     778    5     752    5     715    5     709    5     790    5     789    5     865    5     808    5     772    5     743    5     751    5     742    5     676    5     684    5     744    5     709    5     679    5     817    5     755    5     754    5     797    5     709    5     748    5     679    5     751    5     775    5     736    5     790    5     714    5     0           0
-      │    │    │    │    │                <--- -9223372036854775808 --- 59 ----- 811 ----- 1565 ----- 2252 ----- 3068 ----- 3807 ----- 4720 ----- 5381 ----- 6155 ----- 6829 ----- 7487 ----- 8254 ----- 8876 ----- 9751 ----- 10728 ----- 11463 ----- 12385 ----- 13057 ----- 13810 ----- 14495 ----- 15281 ----- 16028 ----- 16640 ----- 17311 ----- 18151 ----- 18880 ----- 19645 ----- 20325 ----- 21088 ----- 21798 ----- 22674 ----- 23507 ----- 24115 ----- 24661 ----- 25340 ----- 26052 ----- 26827 ----- 27518 ----- 28298 ----- 29089 ----- 29777 ----- 30730 ----- 31401 ----- 32057 ----- 32718 ----- 33611 ----- 34562 ----- 35251 ----- 36117 ----- 36887 ----- 37629 ----- 38283 ----- 39104 ----- 39942 ----- 40705 ----- 41481 ----- 42241 ----- 43089 ----- 43725 ----- 44376 ----- 45214 ----- 45899 ----- 46700 ----- 47413 ----- 48356 ----- 49047 ----- 49939 ----- 50742 ----- 51316 ----- 52101 ----- 52710 ----- 53444 ----- 54313 ----- 55140 ----- 55823 ----- 56549 ----- 57219 ----- 57901 ----- 58503 ----- 59234 ----- 59984 ----- 60760 ----- 61613 ----- 62243 ----- 62941 ----- 63638 ----- 64360 ----- 65173 ----- 65880 ----- 66672 ----- 67560 ----- 68334 ----- 69075 ----- 69925 ----- 70742 ----- 71428 ----- 72189 ----- 72958 ----- 73720 ----- 74385 ----- 75274 ----- 76053 ----- 76936 ----- 77721 ----- 78666 ----- 79480 ----- 80349 ----- 81171 ----- 81810 ----- 82482 ----- 83292 ----- 83907 ----- 84780 ----- 85532 ----- 86310 ----- 87149 ----- 87912 ----- 88694 ----- 89543 ----- 90384 ----- 91106 ----- 91764 ----- 92428 ----- 93335 ----- 94018 ----- 94775 ----- 95484 ----- 96279 ----- 97001 ----- 97672 ----- 98394 ----- 99056 ----- 99850 ----- 100688 ----- 101405 ----- 102143 ----- 102751 ----- 103459 ----- 104384 ----- 105052 ----- 105727 ----- 106409 ----- 107125 ----- 107782 ----- 108377 ----- 109020 ----- 109588 ----- 110235 ----- 110967 ----- 111800 ----- 112382 ----- 113196 ----- 113913 ----- 114643 ----- 115529 ----- 116268 ----- 117329 ----- 118341 ----- 119076 ----- 119898 ----- 120782 ----- 121584 ----- 122186 ----- 122830 ----- 123591 ----- 124227 ----- 125175 ----- 125964 ----- 126773 ----- 127535 ----- 128374 ----- 129175 ----- 129928 ----- 130609 ----- 131279 ----- 132102 ----- 132923 ----- 133877 ----- 134732 ----- 135521 ----- 136257 ----- 137007 ----- 137740 ----- 138341 ----- 138958 ----- 139695 ----- 140364 ----- 140971 ----- 141841 ----- 142600 ----- 143356 ----- 144192 ----- 144861 ----- 145607 ----- 146214 ----- 146965 ----- 147761 ----- 148483 ----- 149306 ----- 149986 --- 9223372036854775807
-      │    │    │    │    │   histogram(5)=  0          1          1.5e+05          1
-      │    │    │    │    │                <--- '10-100-106-1617' --------- '34-999-618-6881'
-      │    │    │    │    │   histogram(6)=  0    15     1.4997e+05    15
-      │    │    │    │    │                <--- -997.51 ------------ 9998.32
-      │    │    │    │    ├── key: (1)
-      │    │    │    │    └── fd: (1)-->(5,6)
-      │    │    │    └── filters
-      │    │    │         ├── substring(c_phone:5, 1, 2) IN ('13', '17', '18', '23', '29', '30', '31') [type=bool, outer=(5), immutable]
-      │    │    │         └── gt [type=bool, outer=(6), immutable, subquery, constraints=(/6: (/NULL - ])]
-      │    │    │              ├── c_acctbal:6 [type=float]
-      │    │    │              └── subquery [type=float]
-      │    │    │                   └── scalar-group-by
-      │    │    │                        ├── save-table-name: q22_scalar_group_by_7
-      │    │    │                        ├── columns: avg:21(float)
-      │    │    │                        ├── cardinality: [1 - 1]
-      │    │    │                        ├── immutable
-      │    │    │                        ├── stats: [rows=1, distinct(21)=1, null(21)=0]
-      │    │    │                        ├── key: ()
-      │    │    │                        ├── fd: ()-->(21)
-      │    │    │                        ├── select
-      │    │    │                        │    ├── save-table-name: q22_select_8
-      │    │    │                        │    ├── columns: c_phone:15(char!null) c_acctbal:16(float!null)
-      │    │    │                        │    ├── immutable
-      │    │    │                        │    ├── stats: [rows=45460.1, distinct(15)=45460.1, null(15)=0, distinct(16)=45460.1, null(16)=0]
-      │    │    │                        │    │   histogram(16)=  0   0   45455     5
-      │    │    │                        │    │                 <--- 0.0 ------- 9998.32
-      │    │    │                        │    ├── scan customer
-      │    │    │                        │    │    ├── save-table-name: q22_scan_9
-      │    │    │                        │    │    ├── columns: c_phone:15(char!null) c_acctbal:16(float!null)
-      │    │    │                        │    │    └── stats: [rows=150000, distinct(15)=150000, null(15)=0, distinct(16)=140628, null(16)=0]
-      │    │    │                        │    │        histogram(15)=  0          1          1.5e+05          1
-      │    │    │                        │    │                      <--- '10-100-106-1617' --------- '34-999-618-6881'
-      │    │    │                        │    │        histogram(16)=  0    15     1.4997e+05    15
-      │    │    │                        │    │                      <--- -997.51 ------------ 9998.32
-      │    │    │                        │    └── filters
-      │    │    │                        │         ├── c_acctbal:16 > 0.0 [type=bool, outer=(16), constraints=(/16: [/5e-324 - ]; tight)]
-      │    │    │                        │         └── substring(c_phone:15, 1, 2) IN ('13', '17', '18', '23', '29', '30', '31') [type=bool, outer=(15), immutable]
-      │    │    │                        └── aggregations
-      │    │    │                             └── avg [as=avg:21, type=float, outer=(16)]
-      │    │    │                                  └── c_acctbal:16 [type=float]
-      │    │    └── filters (true)
-      │    └── projections
-      │         └── substring(c_phone:5, 1, 2) [as=cntrycode:34, type=string, outer=(5), immutable]
-      └── aggregations
-           ├── count-rows [as=count_rows:35, type=int]
-           └── sum [as=sum:36, type=float, outer=(6)]
-                └── c_acctbal:6 [type=float]
+ ├── sort
+ │    ├── save-table-name: q22_sort_2
+ │    ├── columns: c_acctbal:6(float!null) cntrycode:34(string)
+ │    ├── immutable
+ │    ├── stats: [rows=1, distinct(6)=1, null(6)=0, distinct(34)=1, null(34)=0]
+ │    ├── ordering: +34
+ │    └── project
+ │         ├── save-table-name: q22_project_3
+ │         ├── columns: cntrycode:34(string) c_acctbal:6(float!null)
+ │         ├── immutable
+ │         ├── stats: [rows=1, distinct(6)=1, null(6)=0, distinct(34)=1, null(34)=0]
+ │         ├── anti-join (lookup orders@o_ck)
+ │         │    ├── save-table-name: q22_lookup_join_4
+ │         │    ├── columns: c_custkey:1(int!null) c_phone:5(char!null) c_acctbal:6(float!null)
+ │         │    ├── key columns: [1] = [23]
+ │         │    ├── immutable
+ │         │    ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(5)=1, null(5)=0, distinct(6)=1, null(6)=0]
+ │         │    ├── key: (1)
+ │         │    ├── fd: (1)-->(5,6)
+ │         │    ├── select
+ │         │    │    ├── save-table-name: q22_select_5
+ │         │    │    ├── columns: c_custkey:1(int!null) c_phone:5(char!null) c_acctbal:6(float!null)
+ │         │    │    ├── immutable
+ │         │    │    ├── stats: [rows=16666.7, distinct(1)=16659, null(1)=0, distinct(5)=16666.7, null(5)=0, distinct(6)=16666.7, null(6)=0]
+ │         │    │    ├── key: (1)
+ │         │    │    ├── fd: (1)-->(5,6)
+ │         │    │    ├── scan customer
+ │         │    │    │    ├── save-table-name: q22_scan_6
+ │         │    │    │    ├── columns: c_custkey:1(int!null) c_phone:5(char!null) c_acctbal:6(float!null)
+ │         │    │    │    ├── stats: [rows=150000, distinct(1)=148813, null(1)=0, distinct(5)=150000, null(5)=0, distinct(6)=140628, null(6)=0]
+ │         │    │    │    │   histogram(1)=  0           0            0  5   745   5   746   5    711   5    780   5    738   5    835   5    697   5    757   5    704   5    696   5    753   5    678   5    813   5    873    5    736    5    840    5    703    5    745    5    710    5    763    5    742    5    673    5    702    5    793    5    732    5    752    5    707    5    751    5    722    5    814    5    789    5    671    5    643    5    706    5    723    5    757    5    713    5    760    5    766    5    711    5    858    5    702    5    695    5    697    5    823    5    857    5    712    5    808    5    754    5    739    5    694    5    782    5    792    5    751    5    758    5    749    5    798    5    685    5    692    5    792    5    710    5    771    5    724    5    853    5    713    5    823    5    772    5    656    5    763    5    672    5    735    5    810    5    786    5    709    5    731    5    702    5    708    5    669    5    733    5    744    5    758    5    800    5    682    5    716    5    716    5    729    5    778    5    721    5    766    5    820    5    757    5    739    5    799    5    780    5    710    5    749    5    754    5    750    5    699    5    821    5    759    5    818    5    763    5    854    5    779    5    810    5    783    5    686    5    703    5    776    5    675    5    812    5    745    5    759    5    793    5    751    5    761    5    798    5    794    5    729    5    696    5    699    5    831    5    709    5    747    5    722    5    768    5    729    5    702    5    729    5    698    5    767    5    792    5     726    5     737    5     671    5     721    5     842    5     701    5     704    5     708    5     726    5     695    5     665    5     688    5     653    5     690    5     734    5     789    5     659    5     785    5     733    5     740    5     826    5     745    5     929    5     899    5     743    5     790    5     825    5     779    5     677    5     697    5     756    5     693    5     862    5     772    5     783    5     757    5     799    5     778    5     752    5     715    5     709    5     790    5     789    5     865    5     808    5     772    5     743    5     751    5     742    5     676    5     684    5     744    5     709    5     679    5     817    5     755    5     754    5     797    5     709    5     748    5     679    5     751    5     775    5     736    5     790    5     714    5     0           0
+ │         │    │    │    │                <--- -9223372036854775808 --- 59 ----- 811 ----- 1565 ----- 2252 ----- 3068 ----- 3807 ----- 4720 ----- 5381 ----- 6155 ----- 6829 ----- 7487 ----- 8254 ----- 8876 ----- 9751 ----- 10728 ----- 11463 ----- 12385 ----- 13057 ----- 13810 ----- 14495 ----- 15281 ----- 16028 ----- 16640 ----- 17311 ----- 18151 ----- 18880 ----- 19645 ----- 20325 ----- 21088 ----- 21798 ----- 22674 ----- 23507 ----- 24115 ----- 24661 ----- 25340 ----- 26052 ----- 26827 ----- 27518 ----- 28298 ----- 29089 ----- 29777 ----- 30730 ----- 31401 ----- 32057 ----- 32718 ----- 33611 ----- 34562 ----- 35251 ----- 36117 ----- 36887 ----- 37629 ----- 38283 ----- 39104 ----- 39942 ----- 40705 ----- 41481 ----- 42241 ----- 43089 ----- 43725 ----- 44376 ----- 45214 ----- 45899 ----- 46700 ----- 47413 ----- 48356 ----- 49047 ----- 49939 ----- 50742 ----- 51316 ----- 52101 ----- 52710 ----- 53444 ----- 54313 ----- 55140 ----- 55823 ----- 56549 ----- 57219 ----- 57901 ----- 58503 ----- 59234 ----- 59984 ----- 60760 ----- 61613 ----- 62243 ----- 62941 ----- 63638 ----- 64360 ----- 65173 ----- 65880 ----- 66672 ----- 67560 ----- 68334 ----- 69075 ----- 69925 ----- 70742 ----- 71428 ----- 72189 ----- 72958 ----- 73720 ----- 74385 ----- 75274 ----- 76053 ----- 76936 ----- 77721 ----- 78666 ----- 79480 ----- 80349 ----- 81171 ----- 81810 ----- 82482 ----- 83292 ----- 83907 ----- 84780 ----- 85532 ----- 86310 ----- 87149 ----- 87912 ----- 88694 ----- 89543 ----- 90384 ----- 91106 ----- 91764 ----- 92428 ----- 93335 ----- 94018 ----- 94775 ----- 95484 ----- 96279 ----- 97001 ----- 97672 ----- 98394 ----- 99056 ----- 99850 ----- 100688 ----- 101405 ----- 102143 ----- 102751 ----- 103459 ----- 104384 ----- 105052 ----- 105727 ----- 106409 ----- 107125 ----- 107782 ----- 108377 ----- 109020 ----- 109588 ----- 110235 ----- 110967 ----- 111800 ----- 112382 ----- 113196 ----- 113913 ----- 114643 ----- 115529 ----- 116268 ----- 117329 ----- 118341 ----- 119076 ----- 119898 ----- 120782 ----- 121584 ----- 122186 ----- 122830 ----- 123591 ----- 124227 ----- 125175 ----- 125964 ----- 126773 ----- 127535 ----- 128374 ----- 129175 ----- 129928 ----- 130609 ----- 131279 ----- 132102 ----- 132923 ----- 133877 ----- 134732 ----- 135521 ----- 136257 ----- 137007 ----- 137740 ----- 138341 ----- 138958 ----- 139695 ----- 140364 ----- 140971 ----- 141841 ----- 142600 ----- 143356 ----- 144192 ----- 144861 ----- 145607 ----- 146214 ----- 146965 ----- 147761 ----- 148483 ----- 149306 ----- 149986 --- 9223372036854775807
+ │         │    │    │    │   histogram(5)=  0          1          1.5e+05          1
+ │         │    │    │    │                <--- '10-100-106-1617' --------- '34-999-618-6881'
+ │         │    │    │    │   histogram(6)=  0    15     1.4997e+05    15
+ │         │    │    │    │                <--- -997.51 ------------ 9998.32
+ │         │    │    │    ├── key: (1)
+ │         │    │    │    └── fd: (1)-->(5,6)
+ │         │    │    └── filters
+ │         │    │         ├── substring(c_phone:5, 1, 2) IN ('13', '17', '18', '23', '29', '30', '31') [type=bool, outer=(5), immutable]
+ │         │    │         └── gt [type=bool, outer=(6), immutable, subquery, constraints=(/6: (/NULL - ])]
+ │         │    │              ├── c_acctbal:6 [type=float]
+ │         │    │              └── subquery [type=float]
+ │         │    │                   └── scalar-group-by
+ │         │    │                        ├── save-table-name: q22_scalar_group_by_7
+ │         │    │                        ├── columns: avg:21(float)
+ │         │    │                        ├── cardinality: [1 - 1]
+ │         │    │                        ├── immutable
+ │         │    │                        ├── stats: [rows=1, distinct(21)=1, null(21)=0]
+ │         │    │                        ├── key: ()
+ │         │    │                        ├── fd: ()-->(21)
+ │         │    │                        ├── select
+ │         │    │                        │    ├── save-table-name: q22_select_8
+ │         │    │                        │    ├── columns: c_phone:15(char!null) c_acctbal:16(float!null)
+ │         │    │                        │    ├── immutable
+ │         │    │                        │    ├── stats: [rows=45460.1, distinct(15)=45460.1, null(15)=0, distinct(16)=45460.1, null(16)=0]
+ │         │    │                        │    │   histogram(16)=  0   0   45455     5
+ │         │    │                        │    │                 <--- 0.0 ------- 9998.32
+ │         │    │                        │    ├── scan customer
+ │         │    │                        │    │    ├── save-table-name: q22_scan_9
+ │         │    │                        │    │    ├── columns: c_phone:15(char!null) c_acctbal:16(float!null)
+ │         │    │                        │    │    └── stats: [rows=150000, distinct(15)=150000, null(15)=0, distinct(16)=140628, null(16)=0]
+ │         │    │                        │    │        histogram(15)=  0          1          1.5e+05          1
+ │         │    │                        │    │                      <--- '10-100-106-1617' --------- '34-999-618-6881'
+ │         │    │                        │    │        histogram(16)=  0    15     1.4997e+05    15
+ │         │    │                        │    │                      <--- -997.51 ------------ 9998.32
+ │         │    │                        │    └── filters
+ │         │    │                        │         ├── c_acctbal:16 > 0.0 [type=bool, outer=(16), constraints=(/16: [/5e-324 - ]; tight)]
+ │         │    │                        │         └── substring(c_phone:15, 1, 2) IN ('13', '17', '18', '23', '29', '30', '31') [type=bool, outer=(15), immutable]
+ │         │    │                        └── aggregations
+ │         │    │                             └── avg [as=avg:21, type=float, outer=(16)]
+ │         │    │                                  └── c_acctbal:16 [type=float]
+ │         │    └── filters (true)
+ │         └── projections
+ │              └── substring(c_phone:5, 1, 2) [as=cntrycode:34, type=string, outer=(5), immutable]
+ └── aggregations
+      ├── count-rows [as=count_rows:35, type=int]
+      └── sum [as=sum:36, type=float, outer=(6)]
+           └── c_acctbal:6 [type=float]
 
-----Stats for q22_sort_1----
+----Stats for q22_group_by_1----
 column_names  row_count  distinct_count  null_count
 {cntrycode}   7          7               0
-{numcust}     7          7               0
+{numcust}     7          6               0
 {totacctbal}  7          7               0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{cntrycode}   0.00           +Inf <==       0.00                +Inf <==            0.00            1.00
-{numcust}     0.00           +Inf <==       0.00                +Inf <==            0.00            1.00
-{totacctbal}  0.00           +Inf <==       0.00                +Inf <==            0.00            1.00
+{cntrycode}   1.00           7.00 <==       1.00                7.00 <==            0.00            1.00
+{numcust}     1.00           7.00 <==       1.00                6.00 <==            0.00            1.00
+{totacctbal}  1.00           7.00 <==       1.00                7.00 <==            0.00            1.00
 
-----Stats for q22_group_by_2----
+----Stats for q22_sort_2----
 column_names  row_count  distinct_count  null_count
-{cntrycode}   7          7               0
-{count_rows}  7          7               0
-{sum}         7          7               0
+{c_acctbal}   6333       6291            0
+{cntrycode}   6333       7               0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{cntrycode}   0.00           +Inf <==       0.00                +Inf <==            0.00            1.00
-{count_rows}  0.00           +Inf <==       0.00                +Inf <==            0.00            1.00
-{sum}         0.00           +Inf <==       0.00                +Inf <==            0.00            1.00
+{c_acctbal}   1.00           6333.00 <==    1.00                6291.00 <==         0.00            1.00
+{cntrycode}   1.00           6333.00 <==    1.00                7.00 <==            0.00            1.00
 
 ----Stats for q22_project_3----
 column_names  row_count  distinct_count  null_count
-{c_acctbal}   6384       6304            0
-{cntrycode}   6384       7               0
+{c_acctbal}   6333       6291            0
+{cntrycode}   6333       7               0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{c_acctbal}   0.00           +Inf <==       0.00                +Inf <==            0.00            1.00
-{cntrycode}   0.00           +Inf <==       0.00                +Inf <==            0.00            1.00
+{c_acctbal}   1.00           6333.00 <==    1.00                6291.00 <==         0.00            1.00
+{cntrycode}   1.00           6333.00 <==    1.00                7.00 <==            0.00            1.00
 
 ----Stats for q22_lookup_join_4----
 column_names  row_count  distinct_count  null_count
-{c_acctbal}   6384       6304            0
-{c_custkey}   6384       6359            0
-{c_phone}     6384       6384            0
+{c_acctbal}   6333       6291            0
+{c_custkey}   6333       6332            0
+{c_phone}     6333       6333            0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{c_acctbal}   0.00           +Inf <==       0.00                +Inf <==            0.00            1.00
-{c_custkey}   0.00           +Inf <==       0.00                +Inf <==            0.00            1.00
-{c_phone}     0.00           +Inf <==       0.00                +Inf <==            0.00            1.00
+{c_acctbal}   1.00           6333.00 <==    1.00                6291.00 <==         0.00            1.00
+{c_custkey}   1.00           6333.00 <==    1.00                6332.00 <==         0.00            1.00
+{c_phone}     1.00           6333.00 <==    1.00                6333.00 <==         0.00            1.00
 
 ----Stats for q22_select_5----
 column_names  row_count  distinct_count  null_count
-{c_acctbal}   19000      18527           0
-{c_custkey}   19000      19000           0
-{c_phone}     19000      19000           0
+{c_acctbal}   19008      18673           0
+{c_custkey}   19008      18864           0
+{c_phone}     19008      18881           0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{c_acctbal}   16667.00       1.14           16667.00            1.11                0.00            1.00
-{c_custkey}   16667.00       1.14           16659.00            1.14                0.00            1.00
-{c_phone}     16667.00       1.14           16667.00            1.14                0.00            1.00
+{c_acctbal}   16667.00       1.14           16667.00            1.12                0.00            1.00
+{c_custkey}   16667.00       1.14           16659.00            1.13                0.00            1.00
+{c_phone}     16667.00       1.14           16667.00            1.13                0.00            1.00
 
 ----Stats for q22_scan_6----
 column_names  row_count  distinct_count  null_count
-{c_acctbal}   150000     140628          0
-{c_custkey}   150000     148813          0
-{c_phone}     150000     150000          0
+{c_acctbal}   150000     141883          0
+{c_custkey}   150000     150000          0
+{c_phone}     150000     148908          0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{c_acctbal}   150000.00      1.00           140628.00           1.00                0.00            1.00
-{c_custkey}   150000.00      1.00           148813.00           1.00                0.00            1.00
-{c_phone}     150000.00      1.00           150000.00           1.00                0.00            1.00
+{c_acctbal}   150000.00      1.00           140628.00           1.01                0.00            1.00
+{c_custkey}   150000.00      1.00           148813.00           1.01                0.00            1.00
+{c_phone}     150000.00      1.00           150000.00           1.01                0.00            1.00
 
 ----Stats for q22_scalar_group_by_7----
 column_names  row_count  distinct_count  null_count
@@ -217,20 +214,20 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 
 ----Stats for q22_select_8----
 column_names  row_count  distinct_count  null_count
-{c_acctbal}   38120      37172           0
-{c_phone}     38120      38046           0
+{c_acctbal}   38150      37600           0
+{c_phone}     38150      38093           0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{c_acctbal}   45460.00       1.19           45460.00            1.22                0.00            1.00
+{c_acctbal}   45460.00       1.19           45460.00            1.21                0.00            1.00
 {c_phone}     45460.00       1.19           45460.00            1.19                0.00            1.00
 
 ----Stats for q22_scan_9----
 column_names  row_count  distinct_count  null_count
-{c_acctbal}   150000     140628          0
-{c_phone}     150000     150000          0
+{c_acctbal}   150000     141883          0
+{c_phone}     150000     148908          0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{c_acctbal}   150000.00      1.00           140628.00           1.00                0.00            1.00
-{c_phone}     150000.00      1.00           150000.00           1.00                0.00            1.00
+{c_acctbal}   150000.00      1.00           140628.00           1.01                0.00            1.00
+{c_phone}     150000.00      1.00           150000.00           1.01                0.00            1.00
 ----
 ----

--- a/pkg/sql/opt/norm/testdata/rules/with
+++ b/pkg/sql/opt/norm/testdata/rules/with
@@ -673,7 +673,7 @@ with &2 (cte)
  │              └── anti-join (hash)
  │                   ├── columns: p:7(int!null)
  │                   ├── cardinality: [0 - 1]
- │                   ├── stats: [rows=1e-10]
+ │                   ├── stats: [rows=1]
  │                   ├── cost: 1060.7675
  │                   ├── cost-flags: full-scan-penalty unbounded-cardinality
  │                   ├── key: ()

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-update-cascade
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-update-cascade
@@ -1619,7 +1619,7 @@ root
                 └── f-k-checks-item: child_diff_type(p) -> parent_diff_type(p)
                      └── anti-join (hash)
                           ├── columns: p:19(int2!null)
-                          ├── stats: [rows=1e-10]
+                          ├── stats: [rows=1]
                           ├── fd: ()-->(19)
                           ├── cte-uses
                           │    └── &2: count=1 used-columns=(18)

--- a/pkg/sql/opt/xform/testdata/coster/join
+++ b/pkg/sql/opt/xform/testdata/coster/join
@@ -929,7 +929,7 @@ insert c
                 ├── key columns: [7] = [8]
                 ├── lookup columns are key
                 ├── cardinality: [0 - 2]
-                ├── stats: [rows=1e-10]
+                ├── stats: [rows=1]
                 ├── cost: 16.08
                 ├── with-scan &1
                 │    ├── columns: p:7!null
@@ -969,7 +969,7 @@ insert c
                 ├── key columns: [7] = [8]
                 ├── lookup columns are key
                 ├── cardinality: [0 - 2]
-                ├── stats: [rows=1e-10]
+                ├── stats: [rows=1]
                 ├── cost: 4.02001206
                 ├── with-scan &1
                 │    ├── columns: p:7!null
@@ -1021,7 +1021,7 @@ insert c
                 ├── key columns: [7] = [8]
                 ├── lookup columns are key
                 ├── cardinality: [0 - 1]
-                ├── stats: [rows=1e-10]
+                ├── stats: [rows=1]
                 ├── cost: 10.05
                 ├── key: ()
                 ├── fd: ()-->(7)

--- a/pkg/sql/opt/xform/testdata/coster/zone
+++ b/pkg/sql/opt/xform/testdata/coster/zone
@@ -891,8 +891,8 @@ anti-join (lookup abc_part@bc_idx [as=a2])
  │         ├── a2.r:7 = 'west' [outer=(7), constraints=(/7: [/'west' - /'west']; tight), fd=()-->(7)]
  │         └── a1.a:2 = a2.b:9 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
  ├── cardinality: [0 - 1]
- ├── stats: [rows=1e-10]
- ├── cost: 15.4398
+ ├── stats: [rows=1]
+ ├── cost: 23.4486
  ├── key: ()
  ├── fd: ()-->(1-4)
  ├── distribution: east
@@ -903,7 +903,7 @@ anti-join (lookup abc_part@bc_idx [as=a2])
  │    │         ├── a2.r:7 = 'east' [outer=(7), constraints=(/7: [/'east' - /'east']; tight), fd=()-->(7)]
  │    │         └── a1.a:2 = a2.b:9 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
  │    ├── cardinality: [0 - 1]
- │    ├── stats: [rows=1e-10, distinct(2)=1e-10, null(2)=0]
+ │    ├── stats: [rows=1, distinct(2)=1, null(2)=0]
  │    ├── cost: 14.5778
  │    ├── key: ()
  │    ├── fd: ()-->(1-4)

--- a/pkg/sql/opt/xform/testdata/external/tpcds/q61-q70
+++ b/pkg/sql/opt/xform/testdata/external/tpcds/q61-q70
@@ -2493,123 +2493,115 @@ opt
 	LIMIT
 		100;
 ----
-limit
+top-k
  ├── columns: cd_gender:37 cd_marital_status:38 cd_education_status:39 cnt1:237!null cd_purchase_estimate:40 cnt2:237!null cd_credit_rating:41 cnt3:237!null
  ├── internal-ordering: +37,+38,+39,+40,+41
+ ├── k: 100
  ├── cardinality: [0 - 100]
  ├── key: (37-41)
  ├── fd: (37-41)-->(237)
  ├── ordering: +37,+38,+39,+40,+41
- ├── group-by (streaming)
- │    ├── columns: cd_gender:37 cd_marital_status:38 cd_education_status:39 cd_purchase_estimate:40 cd_credit_rating:41 count_rows:237!null
- │    ├── grouping columns: cd_gender:37 cd_marital_status:38 cd_education_status:39 cd_purchase_estimate:40 cd_credit_rating:41
- │    ├── key: (37-41)
- │    ├── fd: (37-41)-->(237)
- │    ├── ordering: +37,+38,+39,+40,+41
- │    ├── limit hint: 100.00
- │    ├── inner-join (lookup customer_address [as=ca])
- │    │    ├── columns: c_customer_sk:1!null c_current_cdemo_sk:3!null c_current_addr_sk:5!null ca_address_sk:21!null ca_state:29!null cd_demo_sk:36!null cd_gender:37 cd_marital_status:38 cd_education_status:39 cd_purchase_estimate:40 cd_credit_rating:41
- │    │    ├── key columns: [5] = [21]
- │    │    ├── lookup columns are key
- │    │    ├── key: (1)
- │    │    ├── fd: (1)-->(3,5), (21)-->(29), (36)-->(37-41), (5)==(21), (21)==(5), (3)==(36), (36)==(3)
- │    │    ├── ordering: +37,+38,+39,+40,+41
- │    │    ├── sort
- │    │    │    ├── columns: c_customer_sk:1!null c_current_cdemo_sk:3!null c_current_addr_sk:5 cd_demo_sk:36!null cd_gender:37 cd_marital_status:38 cd_education_status:39 cd_purchase_estimate:40 cd_credit_rating:41
- │    │    │    ├── key: (1)
- │    │    │    ├── fd: (1)-->(3,5), (36)-->(37-41), (3)==(36), (36)==(3)
- │    │    │    ├── ordering: +37,+38,+39,+40,+41
- │    │    │    └── semi-join (hash)
- │    │    │         ├── columns: c_customer_sk:1!null c_current_cdemo_sk:3!null c_current_addr_sk:5 cd_demo_sk:36!null cd_gender:37 cd_marital_status:38 cd_education_status:39 cd_purchase_estimate:40 cd_credit_rating:41
- │    │    │         ├── key: (1)
- │    │    │         ├── fd: (1)-->(3,5), (36)-->(37-41), (3)==(36), (36)==(3)
- │    │    │         ├── inner-join (lookup customer_demographics)
- │    │    │         │    ├── columns: c_customer_sk:1!null c_current_cdemo_sk:3!null c_current_addr_sk:5 cd_demo_sk:36!null cd_gender:37 cd_marital_status:38 cd_education_status:39 cd_purchase_estimate:40 cd_credit_rating:41
- │    │    │         │    ├── key columns: [3] = [36]
- │    │    │         │    ├── lookup columns are key
- │    │    │         │    ├── key: (1)
- │    │    │         │    ├── fd: (1)-->(3,5), (36)-->(37-41), (3)==(36), (36)==(3)
- │    │    │         │    ├── anti-join (hash)
- │    │    │         │    │    ├── columns: c_customer_sk:1!null c_current_cdemo_sk:3 c_current_addr_sk:5
- │    │    │         │    │    ├── key: (1)
- │    │    │         │    │    ├── fd: (1)-->(3,5)
- │    │    │         │    │    ├── anti-join (hash)
- │    │    │         │    │    │    ├── columns: c_customer_sk:1!null c_current_cdemo_sk:3 c_current_addr_sk:5
- │    │    │         │    │    │    ├── key: (1)
- │    │    │         │    │    │    ├── fd: (1)-->(3,5)
- │    │    │         │    │    │    ├── scan customer [as=c]
- │    │    │         │    │    │    │    ├── columns: c_customer_sk:1!null c_current_cdemo_sk:3 c_current_addr_sk:5
- │    │    │         │    │    │    │    ├── key: (1)
- │    │    │         │    │    │    │    └── fd: (1)-->(3,5)
- │    │    │         │    │    │    ├── inner-join (hash)
- │    │    │         │    │    │    │    ├── columns: ws_sold_date_sk:102!null ws_bill_customer_sk:106 d_date_sk:138!null d_year:144!null d_moy:146!null
- │    │    │         │    │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
- │    │    │         │    │    │    │    ├── fd: ()-->(144), (138)-->(146), (102)==(138), (138)==(102)
- │    │    │         │    │    │    │    ├── scan web_sales
- │    │    │         │    │    │    │    │    └── columns: ws_sold_date_sk:102 ws_bill_customer_sk:106
- │    │    │         │    │    │    │    ├── select
- │    │    │         │    │    │    │    │    ├── columns: d_date_sk:138!null d_year:144!null d_moy:146!null
- │    │    │         │    │    │    │    │    ├── key: (138)
- │    │    │         │    │    │    │    │    ├── fd: ()-->(144), (138)-->(146)
- │    │    │         │    │    │    │    │    ├── scan date_dim
- │    │    │         │    │    │    │    │    │    ├── columns: d_date_sk:138!null d_year:144 d_moy:146
- │    │    │         │    │    │    │    │    │    ├── key: (138)
- │    │    │         │    │    │    │    │    │    └── fd: (138)-->(144,146)
- │    │    │         │    │    │    │    │    └── filters
- │    │    │         │    │    │    │    │         ├── (d_moy:146 >= 1) AND (d_moy:146 <= 3) [outer=(146), constraints=(/146: [/1 - /3]; tight)]
- │    │    │         │    │    │    │    │         └── d_year:144 = 2002 [outer=(144), constraints=(/144: [/2002 - /2002]; tight), fd=()-->(144)]
- │    │    │         │    │    │    │    └── filters
- │    │    │         │    │    │    │         └── ws_sold_date_sk:102 = d_date_sk:138 [outer=(102,138), constraints=(/102: (/NULL - ]; /138: (/NULL - ]), fd=(102)==(138), (138)==(102)]
- │    │    │         │    │    │    └── filters
- │    │    │         │    │    │         └── c_customer_sk:1 = ws_bill_customer_sk:106 [outer=(1,106), constraints=(/1: (/NULL - ]; /106: (/NULL - ]), fd=(1)==(106), (106)==(1)]
- │    │    │         │    │    ├── inner-join (hash)
- │    │    │         │    │    │    ├── columns: cs_sold_date_sk:168!null cs_ship_customer_sk:175 d_date_sk:204!null d_year:210!null d_moy:212!null
- │    │    │         │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
- │    │    │         │    │    │    ├── fd: ()-->(210), (204)-->(212), (168)==(204), (204)==(168)
- │    │    │         │    │    │    ├── scan catalog_sales
- │    │    │         │    │    │    │    └── columns: cs_sold_date_sk:168 cs_ship_customer_sk:175
- │    │    │         │    │    │    ├── select
- │    │    │         │    │    │    │    ├── columns: d_date_sk:204!null d_year:210!null d_moy:212!null
- │    │    │         │    │    │    │    ├── key: (204)
- │    │    │         │    │    │    │    ├── fd: ()-->(210), (204)-->(212)
- │    │    │         │    │    │    │    ├── scan date_dim
- │    │    │         │    │    │    │    │    ├── columns: d_date_sk:204!null d_year:210 d_moy:212
- │    │    │         │    │    │    │    │    ├── key: (204)
- │    │    │         │    │    │    │    │    └── fd: (204)-->(210,212)
- │    │    │         │    │    │    │    └── filters
- │    │    │         │    │    │    │         ├── (d_moy:212 >= 1) AND (d_moy:212 <= 3) [outer=(212), constraints=(/212: [/1 - /3]; tight)]
- │    │    │         │    │    │    │         └── d_year:210 = 2002 [outer=(210), constraints=(/210: [/2002 - /2002]; tight), fd=()-->(210)]
- │    │    │         │    │    │    └── filters
- │    │    │         │    │    │         └── cs_sold_date_sk:168 = d_date_sk:204 [outer=(168,204), constraints=(/168: (/NULL - ]; /204: (/NULL - ]), fd=(168)==(204), (204)==(168)]
- │    │    │         │    │    └── filters
- │    │    │         │    │         └── c_customer_sk:1 = cs_ship_customer_sk:175 [outer=(1,175), constraints=(/1: (/NULL - ]; /175: (/NULL - ]), fd=(1)==(175), (175)==(1)]
- │    │    │         │    └── filters (true)
- │    │    │         ├── inner-join (hash)
- │    │    │         │    ├── columns: ss_sold_date_sk:47!null ss_customer_sk:50 d_date_sk:72!null d_year:78!null d_moy:80!null
- │    │    │         │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
- │    │    │         │    ├── fd: ()-->(78), (72)-->(80), (47)==(72), (72)==(47)
- │    │    │         │    ├── scan store_sales
- │    │    │         │    │    └── columns: ss_sold_date_sk:47 ss_customer_sk:50
- │    │    │         │    ├── select
- │    │    │         │    │    ├── columns: d_date_sk:72!null d_year:78!null d_moy:80!null
- │    │    │         │    │    ├── key: (72)
- │    │    │         │    │    ├── fd: ()-->(78), (72)-->(80)
- │    │    │         │    │    ├── scan date_dim
- │    │    │         │    │    │    ├── columns: d_date_sk:72!null d_year:78 d_moy:80
- │    │    │         │    │    │    ├── key: (72)
- │    │    │         │    │    │    └── fd: (72)-->(78,80)
- │    │    │         │    │    └── filters
- │    │    │         │    │         ├── (d_moy:80 >= 1) AND (d_moy:80 <= 3) [outer=(80), constraints=(/80: [/1 - /3]; tight)]
- │    │    │         │    │         └── d_year:78 = 2002 [outer=(78), constraints=(/78: [/2002 - /2002]; tight), fd=()-->(78)]
- │    │    │         │    └── filters
- │    │    │         │         └── ss_sold_date_sk:47 = d_date_sk:72 [outer=(47,72), constraints=(/47: (/NULL - ]; /72: (/NULL - ]), fd=(47)==(72), (72)==(47)]
- │    │    │         └── filters
- │    │    │              └── c_customer_sk:1 = ss_customer_sk:50 [outer=(1,50), constraints=(/1: (/NULL - ]; /50: (/NULL - ]), fd=(1)==(50), (50)==(1)]
- │    │    └── filters
- │    │         └── ca_state:29 IN ('IL', 'ME', 'TX') [outer=(29), constraints=(/29: [/'IL' - /'IL'] [/'ME' - /'ME'] [/'TX' - /'TX']; tight)]
- │    └── aggregations
- │         └── count-rows [as=count_rows:237]
- └── 100
+ └── group-by (hash)
+      ├── columns: cd_gender:37 cd_marital_status:38 cd_education_status:39 cd_purchase_estimate:40 cd_credit_rating:41 count_rows:237!null
+      ├── grouping columns: cd_gender:37 cd_marital_status:38 cd_education_status:39 cd_purchase_estimate:40 cd_credit_rating:41
+      ├── key: (37-41)
+      ├── fd: (37-41)-->(237)
+      ├── semi-join (hash)
+      │    ├── columns: c_customer_sk:1!null c_current_cdemo_sk:3!null c_current_addr_sk:5!null ca_address_sk:21!null ca_state:29!null cd_demo_sk:36!null cd_gender:37 cd_marital_status:38 cd_education_status:39 cd_purchase_estimate:40 cd_credit_rating:41
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(3,5), (21)-->(29), (36)-->(37-41), (5)==(21), (21)==(5), (3)==(36), (36)==(3)
+      │    ├── inner-join (lookup customer_address [as=ca])
+      │    │    ├── columns: c_customer_sk:1!null c_current_cdemo_sk:3!null c_current_addr_sk:5!null ca_address_sk:21!null ca_state:29!null cd_demo_sk:36!null cd_gender:37 cd_marital_status:38 cd_education_status:39 cd_purchase_estimate:40 cd_credit_rating:41
+      │    │    ├── key columns: [5] = [21]
+      │    │    ├── lookup columns are key
+      │    │    ├── key: (1)
+      │    │    ├── fd: (21)-->(29), (1)-->(3,5), (36)-->(37-41), (3)==(36), (36)==(3), (5)==(21), (21)==(5)
+      │    │    ├── inner-join (lookup customer_demographics)
+      │    │    │    ├── columns: c_customer_sk:1!null c_current_cdemo_sk:3!null c_current_addr_sk:5 cd_demo_sk:36!null cd_gender:37 cd_marital_status:38 cd_education_status:39 cd_purchase_estimate:40 cd_credit_rating:41
+      │    │    │    ├── key columns: [3] = [36]
+      │    │    │    ├── lookup columns are key
+      │    │    │    ├── key: (1)
+      │    │    │    ├── fd: (1)-->(3,5), (36)-->(37-41), (3)==(36), (36)==(3)
+      │    │    │    ├── anti-join (hash)
+      │    │    │    │    ├── columns: c_customer_sk:1!null c_current_cdemo_sk:3 c_current_addr_sk:5
+      │    │    │    │    ├── key: (1)
+      │    │    │    │    ├── fd: (1)-->(3,5)
+      │    │    │    │    ├── anti-join (hash)
+      │    │    │    │    │    ├── columns: c_customer_sk:1!null c_current_cdemo_sk:3 c_current_addr_sk:5
+      │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    ├── fd: (1)-->(3,5)
+      │    │    │    │    │    ├── scan customer [as=c]
+      │    │    │    │    │    │    ├── columns: c_customer_sk:1!null c_current_cdemo_sk:3 c_current_addr_sk:5
+      │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    └── fd: (1)-->(3,5)
+      │    │    │    │    │    ├── inner-join (hash)
+      │    │    │    │    │    │    ├── columns: ws_sold_date_sk:102!null ws_bill_customer_sk:106 d_date_sk:138!null d_year:144!null d_moy:146!null
+      │    │    │    │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+      │    │    │    │    │    │    ├── fd: ()-->(144), (138)-->(146), (102)==(138), (138)==(102)
+      │    │    │    │    │    │    ├── scan web_sales
+      │    │    │    │    │    │    │    └── columns: ws_sold_date_sk:102 ws_bill_customer_sk:106
+      │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    │    ├── columns: d_date_sk:138!null d_year:144!null d_moy:146!null
+      │    │    │    │    │    │    │    ├── key: (138)
+      │    │    │    │    │    │    │    ├── fd: ()-->(144), (138)-->(146)
+      │    │    │    │    │    │    │    ├── scan date_dim
+      │    │    │    │    │    │    │    │    ├── columns: d_date_sk:138!null d_year:144 d_moy:146
+      │    │    │    │    │    │    │    │    ├── key: (138)
+      │    │    │    │    │    │    │    │    └── fd: (138)-->(144,146)
+      │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │         ├── (d_moy:146 >= 1) AND (d_moy:146 <= 3) [outer=(146), constraints=(/146: [/1 - /3]; tight)]
+      │    │    │    │    │    │    │         └── d_year:144 = 2002 [outer=(144), constraints=(/144: [/2002 - /2002]; tight), fd=()-->(144)]
+      │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │         └── ws_sold_date_sk:102 = d_date_sk:138 [outer=(102,138), constraints=(/102: (/NULL - ]; /138: (/NULL - ]), fd=(102)==(138), (138)==(102)]
+      │    │    │    │    │    └── filters
+      │    │    │    │    │         └── c_customer_sk:1 = ws_bill_customer_sk:106 [outer=(1,106), constraints=(/1: (/NULL - ]; /106: (/NULL - ]), fd=(1)==(106), (106)==(1)]
+      │    │    │    │    ├── inner-join (hash)
+      │    │    │    │    │    ├── columns: cs_sold_date_sk:168!null cs_ship_customer_sk:175 d_date_sk:204!null d_year:210!null d_moy:212!null
+      │    │    │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+      │    │    │    │    │    ├── fd: ()-->(210), (204)-->(212), (168)==(204), (204)==(168)
+      │    │    │    │    │    ├── scan catalog_sales
+      │    │    │    │    │    │    └── columns: cs_sold_date_sk:168 cs_ship_customer_sk:175
+      │    │    │    │    │    ├── select
+      │    │    │    │    │    │    ├── columns: d_date_sk:204!null d_year:210!null d_moy:212!null
+      │    │    │    │    │    │    ├── key: (204)
+      │    │    │    │    │    │    ├── fd: ()-->(210), (204)-->(212)
+      │    │    │    │    │    │    ├── scan date_dim
+      │    │    │    │    │    │    │    ├── columns: d_date_sk:204!null d_year:210 d_moy:212
+      │    │    │    │    │    │    │    ├── key: (204)
+      │    │    │    │    │    │    │    └── fd: (204)-->(210,212)
+      │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │         ├── (d_moy:212 >= 1) AND (d_moy:212 <= 3) [outer=(212), constraints=(/212: [/1 - /3]; tight)]
+      │    │    │    │    │    │         └── d_year:210 = 2002 [outer=(210), constraints=(/210: [/2002 - /2002]; tight), fd=()-->(210)]
+      │    │    │    │    │    └── filters
+      │    │    │    │    │         └── cs_sold_date_sk:168 = d_date_sk:204 [outer=(168,204), constraints=(/168: (/NULL - ]; /204: (/NULL - ]), fd=(168)==(204), (204)==(168)]
+      │    │    │    │    └── filters
+      │    │    │    │         └── c_customer_sk:1 = cs_ship_customer_sk:175 [outer=(1,175), constraints=(/1: (/NULL - ]; /175: (/NULL - ]), fd=(1)==(175), (175)==(1)]
+      │    │    │    └── filters (true)
+      │    │    └── filters
+      │    │         └── ca_state:29 IN ('IL', 'ME', 'TX') [outer=(29), constraints=(/29: [/'IL' - /'IL'] [/'ME' - /'ME'] [/'TX' - /'TX']; tight)]
+      │    ├── inner-join (hash)
+      │    │    ├── columns: ss_sold_date_sk:47!null ss_customer_sk:50 d_date_sk:72!null d_year:78!null d_moy:80!null
+      │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+      │    │    ├── fd: ()-->(78), (72)-->(80), (47)==(72), (72)==(47)
+      │    │    ├── scan store_sales
+      │    │    │    └── columns: ss_sold_date_sk:47 ss_customer_sk:50
+      │    │    ├── select
+      │    │    │    ├── columns: d_date_sk:72!null d_year:78!null d_moy:80!null
+      │    │    │    ├── key: (72)
+      │    │    │    ├── fd: ()-->(78), (72)-->(80)
+      │    │    │    ├── scan date_dim
+      │    │    │    │    ├── columns: d_date_sk:72!null d_year:78 d_moy:80
+      │    │    │    │    ├── key: (72)
+      │    │    │    │    └── fd: (72)-->(78,80)
+      │    │    │    └── filters
+      │    │    │         ├── (d_moy:80 >= 1) AND (d_moy:80 <= 3) [outer=(80), constraints=(/80: [/1 - /3]; tight)]
+      │    │    │         └── d_year:78 = 2002 [outer=(78), constraints=(/78: [/2002 - /2002]; tight), fd=()-->(78)]
+      │    │    └── filters
+      │    │         └── ss_sold_date_sk:47 = d_date_sk:72 [outer=(47,72), constraints=(/47: (/NULL - ]; /72: (/NULL - ]), fd=(47)==(72), (72)==(47)]
+      │    └── filters
+      │         └── c_customer_sk:1 = ss_customer_sk:50 [outer=(1,50), constraints=(/1: (/NULL - ]; /50: (/NULL - ]), fd=(1)==(50), (50)==(1)]
+      └── aggregations
+           └── count-rows [as=count_rows:237]
 
 # --------------------------------------------------
 # Q70

--- a/pkg/sql/opt/xform/testdata/external/tpch
+++ b/pkg/sql/opt/xform/testdata/external/tpch
@@ -2503,62 +2503,61 @@ GROUP BY
 ORDER BY
     cntrycode;
 ----
-sort
+group-by (streaming)
  ├── columns: cntrycode:34 numcust:35!null totacctbal:36!null
+ ├── grouping columns: cntrycode:34
  ├── immutable
  ├── key: (34)
  ├── fd: (34)-->(35,36)
  ├── ordering: +34
- └── group-by (hash)
-      ├── columns: cntrycode:34 count_rows:35!null sum:36!null
-      ├── grouping columns: cntrycode:34
-      ├── immutable
-      ├── key: (34)
-      ├── fd: (34)-->(35,36)
-      ├── project
-      │    ├── columns: cntrycode:34 c_acctbal:6!null
-      │    ├── immutable
-      │    ├── anti-join (lookup orders@o_ck)
-      │    │    ├── columns: c_custkey:1!null c_phone:5!null c_acctbal:6!null
-      │    │    ├── key columns: [1] = [23]
-      │    │    ├── immutable
-      │    │    ├── key: (1)
-      │    │    ├── fd: (1)-->(5,6)
-      │    │    ├── select
-      │    │    │    ├── columns: c_custkey:1!null c_phone:5!null c_acctbal:6!null
-      │    │    │    ├── immutable
-      │    │    │    ├── key: (1)
-      │    │    │    ├── fd: (1)-->(5,6)
-      │    │    │    ├── scan customer
-      │    │    │    │    ├── columns: c_custkey:1!null c_phone:5!null c_acctbal:6!null
-      │    │    │    │    ├── key: (1)
-      │    │    │    │    └── fd: (1)-->(5,6)
-      │    │    │    └── filters
-      │    │    │         ├── substring(c_phone:5, 1, 2) IN ('13', '17', '18', '23', '29', '30', '31') [outer=(5), immutable]
-      │    │    │         └── gt [outer=(6), immutable, subquery, constraints=(/6: (/NULL - ])]
-      │    │    │              ├── c_acctbal:6
-      │    │    │              └── subquery
-      │    │    │                   └── scalar-group-by
-      │    │    │                        ├── columns: avg:21
-      │    │    │                        ├── cardinality: [1 - 1]
-      │    │    │                        ├── immutable
-      │    │    │                        ├── key: ()
-      │    │    │                        ├── fd: ()-->(21)
-      │    │    │                        ├── select
-      │    │    │                        │    ├── columns: c_phone:15!null c_acctbal:16!null
-      │    │    │                        │    ├── immutable
-      │    │    │                        │    ├── scan customer
-      │    │    │                        │    │    └── columns: c_phone:15!null c_acctbal:16!null
-      │    │    │                        │    └── filters
-      │    │    │                        │         ├── c_acctbal:16 > 0.0 [outer=(16), constraints=(/16: [/5e-324 - ]; tight)]
-      │    │    │                        │         └── substring(c_phone:15, 1, 2) IN ('13', '17', '18', '23', '29', '30', '31') [outer=(15), immutable]
-      │    │    │                        └── aggregations
-      │    │    │                             └── avg [as=avg:21, outer=(16)]
-      │    │    │                                  └── c_acctbal:16
-      │    │    └── filters (true)
-      │    └── projections
-      │         └── substring(c_phone:5, 1, 2) [as=cntrycode:34, outer=(5), immutable]
-      └── aggregations
-           ├── count-rows [as=count_rows:35]
-           └── sum [as=sum:36, outer=(6)]
-                └── c_acctbal:6
+ ├── sort
+ │    ├── columns: c_acctbal:6!null cntrycode:34
+ │    ├── immutable
+ │    ├── ordering: +34
+ │    └── project
+ │         ├── columns: cntrycode:34 c_acctbal:6!null
+ │         ├── immutable
+ │         ├── anti-join (lookup orders@o_ck)
+ │         │    ├── columns: c_custkey:1!null c_phone:5!null c_acctbal:6!null
+ │         │    ├── key columns: [1] = [23]
+ │         │    ├── immutable
+ │         │    ├── key: (1)
+ │         │    ├── fd: (1)-->(5,6)
+ │         │    ├── select
+ │         │    │    ├── columns: c_custkey:1!null c_phone:5!null c_acctbal:6!null
+ │         │    │    ├── immutable
+ │         │    │    ├── key: (1)
+ │         │    │    ├── fd: (1)-->(5,6)
+ │         │    │    ├── scan customer
+ │         │    │    │    ├── columns: c_custkey:1!null c_phone:5!null c_acctbal:6!null
+ │         │    │    │    ├── key: (1)
+ │         │    │    │    └── fd: (1)-->(5,6)
+ │         │    │    └── filters
+ │         │    │         ├── substring(c_phone:5, 1, 2) IN ('13', '17', '18', '23', '29', '30', '31') [outer=(5), immutable]
+ │         │    │         └── gt [outer=(6), immutable, subquery, constraints=(/6: (/NULL - ])]
+ │         │    │              ├── c_acctbal:6
+ │         │    │              └── subquery
+ │         │    │                   └── scalar-group-by
+ │         │    │                        ├── columns: avg:21
+ │         │    │                        ├── cardinality: [1 - 1]
+ │         │    │                        ├── immutable
+ │         │    │                        ├── key: ()
+ │         │    │                        ├── fd: ()-->(21)
+ │         │    │                        ├── select
+ │         │    │                        │    ├── columns: c_phone:15!null c_acctbal:16!null
+ │         │    │                        │    ├── immutable
+ │         │    │                        │    ├── scan customer
+ │         │    │                        │    │    └── columns: c_phone:15!null c_acctbal:16!null
+ │         │    │                        │    └── filters
+ │         │    │                        │         ├── c_acctbal:16 > 0.0 [outer=(16), constraints=(/16: [/5e-324 - ]; tight)]
+ │         │    │                        │         └── substring(c_phone:15, 1, 2) IN ('13', '17', '18', '23', '29', '30', '31') [outer=(15), immutable]
+ │         │    │                        └── aggregations
+ │         │    │                             └── avg [as=avg:21, outer=(16)]
+ │         │    │                                  └── c_acctbal:16
+ │         │    └── filters (true)
+ │         └── projections
+ │              └── substring(c_phone:5, 1, 2) [as=cntrycode:34, outer=(5), immutable]
+ └── aggregations
+      ├── count-rows [as=count_rows:35]
+      └── sum [as=sum:36, outer=(6)]
+           └── c_acctbal:6

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -2369,11 +2369,11 @@ memo (optimized, ~29KB, required=[])
  ├── G1: (insert G2 G3 G4 G5 xyz)
  │    └── []
  │         ├── best: (insert G2 G3 G4 G5 xyz)
- │         └── cost: 7132.30
+ │         └── cost: 7132.34
  ├── G2: (upsert-distinct-on G6 G7 cols=(8)) (upsert-distinct-on G6 G7 cols=(8),ordering=+8 opt(12))
  │    └── []
- │         ├── best: (upsert-distinct-on G6 G7 cols=(8))
- │         └── cost: 7132.29
+ │         ├── best: (upsert-distinct-on G6="[ordering: +8 opt(12)]" G7 cols=(8),ordering=+8 opt(12))
+ │         └── cost: 7132.33
  ├── G3: (unique-checks)
  ├── G4: (fast-path-unique-checks)
  ├── G5: (f-k-checks)

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -1825,9 +1825,9 @@ Joins Considered: 12
 ================================================================================
 Final Plan
 ================================================================================
-semi-join (lookup dz)
+left-join (lookup cy)
  ├── lookup columns are key
- ├── left-join (lookup cy)
+ ├── semi-join (lookup dz)
  │    ├── lookup columns are key
  │    ├── anti-join (merge)
  │    │    ├── scan bx

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -773,27 +773,25 @@ message LocalOnlySessionData {
   // OptimizerInlineAnyUnnestSubquery, when true, enables the InlineAnyProjectSet
   // normalization rule that inlines unnest subqueries in ANY comparisons.
   bool optimizer_inline_any_unnest_subquery = 198;
-
   // TcpKeepalivesIdle is the time (in seconds) with no network activity before
   // sending a TCP keepalive probe. 0 means use the cluster setting default.
   // Corresponds to PostgreSQL's tcp_keepalives_idle.
   int32 tcp_keepalives_idle = 199;
-
   // TcpKeepalivesInterval is the time (in seconds) between TCP keepalive
   // retransmissions. 0 means use the cluster setting default.
   // Corresponds to PostgreSQL's tcp_keepalives_interval.
   int32 tcp_keepalives_interval = 200;
-
   // TcpKeepalivesCount is the maximum number of TCP keepalive probes before
   // the connection is dropped. 0 means use the cluster setting default.
   // Corresponds to PostgreSQL's tcp_keepalives_count.
   int32 tcp_keepalives_count = 201;
-
   // TcpUserTimeout is the maximum time (in milliseconds) that transmitted data
   // may remain unacknowledged before the connection is dropped. 0 means use the
   // cluster setting default. Corresponds to PostgreSQL's tcp_user_timeout.
   int32 tcp_user_timeout = 202;
-
+  // OptimizerUseMinRowCountAntiJoinFix, when true, causes the
+  // optimizer_min_row_count setting to be applied correctly to anti-joins.
+  bool optimizer_use_min_row_count_anti_join_fix = 203;
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //
   // be propagated to the remote nodes. If so, that parameter should live  //

--- a/pkg/sql/sessionmutator/mutator.go
+++ b/pkg/sql/sessionmutator/mutator.go
@@ -1160,3 +1160,7 @@ func (m *SessionDataMutator) notifyTCPKeepAliveChange() {
 		)
 	}
 }
+
+func (m *SessionDataMutator) SetOptimizerUseMinRowCountAntiJoinFix(val bool) {
+	m.Data.OptimizerUseMinRowCountAntiJoinFix = val
+}

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -4673,7 +4673,7 @@ var varGen = map[string]sessionVar{
 		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
 			return formatBoolAsPostgresSetting(evalCtx.SessionData().OptimizerUseMinRowCountAntiJoinFix), nil
 		},
-		GlobalDefault: globalFalse,
+		GlobalDefault: globalTrue,
 	},
 }
 

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -4658,6 +4658,23 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalTrue,
 	},
+
+	// CockroachDB extension.
+	`optimizer_use_min_row_count_anti_join_fix`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`optimizer_use_min_row_count_anti_join_fix`),
+		Set: func(_ context.Context, m sessionmutator.SessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("optimizer_use_min_row_count_anti_join_fix", s)
+			if err != nil {
+				return err
+			}
+			m.SetOptimizerUseMinRowCountAntiJoinFix(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().OptimizerUseMinRowCountAntiJoinFix), nil
+		},
+		GlobalDefault: globalFalse,
+	},
 }
 
 func ReplicationModeFromString(s string) (sessiondatapb.ReplicationMode, error) {


### PR DESCRIPTION
#### opt: add staleness check for recently introduced session setting

This commit adds a memo staleness check that I forgot to add when
introducing the `optimizer_inline_any_unnest_subquery` setting.
There is no release note since the setting hasn't made it into a
release.

Informs #161871
Release note: None

#### opt: apply min_row_count to anti-joins

Previously, the `optimizer_min_row_count` setting did not apply to the
final selectivity calculated for AntiJoin expressions. This meant that
the setting was applied asymmetrically, which could cause the optimizer
to choose bad plans. This commit fixes the issue, gated behind a session
setting `optimizer_use_min_row_count_anti_join_fix`.

Fixes #162258

Release note (bug fix): Fixed a bug that prevented the optimizer_min_row_count
setting from applying to anti-join expressions, which could lead to bad query
plans. The fix is gated behind `optimizer_use_min_row_count_anti_join_fix`, and
will be on by default on 26.2+, and off by default in prior versions.

#### opt: turn on new session setting

This commit turns the `optimizer_use_min_row_count_anti_join_fix` session
setting on by default. This will cause the `optimizer_min_row_count`
setting to apply to anti-joins.

Informs #162258

Release note: None