### PR TITLE
release-26.1: restore: log restore perf as a structured event

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -3620,6 +3620,37 @@ Note that because stats are scoped to the lifetime of the process, counters
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
 
+## TELEMETRY
+
+Events in this file are related to bulk ingest operations performance metrics.
+
+Events in this category are logged to the `TELEMETRY` channel.
+
+
+### `bulk_ingest_completed`
+
+An event of type `bulk_ingest_completed` is an event that is logged when a bulk ingest job
+(restore, import, etc.) completes successfully.
+It captures key performance metrics for the operation.
+
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `JobID` | JobID is the ID of the bulk ingest job. | no |
+| `JobType` | JobType identifies the type of bulk ingest job (e.g., "restore", "import"). | no |
+| `NumRows` | NumRows is the number of rows successfully ingested. | no |
+| `DurationSeconds` | Duration of the ingest operation in seconds. | no |
+| `DataSizeMb` | Total logical size of data ingested in megabytes. | no |
+| `NodeCount` | Number of nodes that participated in the ingest operation. | no |
+
+
+#### Common fields
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
+| `EventType` | The type of the event. | no |
+
 ## Telemetry events
 
 

--- a/pkg/util/log/eventpb/BUILD.bazel
+++ b/pkg/util/log/eventpb/BUILD.bazel
@@ -47,6 +47,7 @@ go_test(
 proto_library(
     name = "eventpb_proto",
     srcs = [
+        "bulk_ingest_perf.proto",
         "changefeed_events.proto",
         "cluster_events.proto",
         "contention_events.proto",

--- a/pkg/util/log/eventpb/PROTOS.bzl
+++ b/pkg/util/log/eventpb/PROTOS.bzl
@@ -21,6 +21,7 @@ EVENTPB_PROTOS = [
     "telemetry.proto",
     "changefeed_events.proto",
     "contention_events.proto",
+    "bulk_ingest_perf.proto",
 ]
 
 EVENTPB_PROTO_DEPS = [ "//pkg/util/log/logpb:event.proto", ] + EVENTPB_PROTOS

--- a/pkg/util/log/eventpb/bulk_ingest_perf.proto
+++ b/pkg/util/log/eventpb/bulk_ingest_perf.proto
@@ -1,0 +1,43 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+syntax = "proto3";
+package cockroach.util.log.eventpb;
+option go_package = "github.com/cockroachdb/cockroach/pkg/util/log/eventpb";
+
+import "gogoproto/gogo.proto";
+import "util/log/eventpb/events.proto";
+import "util/log/logpb/event.proto";
+
+// Category: TELEMETRY
+// Channel: TELEMETRY
+//
+// Events in this file are related to bulk ingest operations performance metrics.
+
+// BulkIngestCompleted is an event that is logged when a bulk ingest job
+// (restore, import, etc.) completes successfully.
+// It captures key performance metrics for the operation.
+message BulkIngestCompleted {
+  // Common fields for all events.
+  CommonEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+
+  // JobID is the ID of the bulk ingest job.
+  uint64 job_id = 2 [(gogoproto.jsontag) = ",omitempty", (gogoproto.customname) = "JobID"];
+
+  // JobType identifies the type of bulk ingest job (e.g., "restore", "import").
+  string job_type = 3 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+  // NumRows is the number of rows successfully ingested.
+  int64 num_rows = 4 [(gogoproto.jsontag) = ",omitempty"];
+
+  // Duration of the ingest operation in seconds.
+  int64 duration_seconds = 5 [(gogoproto.jsontag) = ",omitempty"];
+
+  // Total logical size of data ingested in megabytes.
+  int64 data_size_mb = 6 [(gogoproto.jsontag) = ",omitempty"];
+
+  // Number of nodes that participated in the ingest operation.
+  int32 node_count = 7 [(gogoproto.jsontag) = ",omitempty"];
+}

--- a/pkg/util/log/eventpb/eventlog_channels_generated.go
+++ b/pkg/util/log/eventpb/eventlog_channels_generated.go
@@ -393,6 +393,9 @@ func (m *LevelStats) LoggingChannel() logpb.Channel { return logpb.Channel_TELEM
 func (m *StoreStats) LoggingChannel() logpb.Channel { return logpb.Channel_TELEMETRY }
 
 // LoggingChannel implements the EventPayload interface.
+func (m *BulkIngestCompleted) LoggingChannel() logpb.Channel { return logpb.Channel_TELEMETRY }
+
+// LoggingChannel implements the EventPayload interface.
 func (m *CapturedIndexUsageStats) LoggingChannel() logpb.Channel { return logpb.Channel_TELEMETRY }
 
 // LoggingChannel implements the EventPayload interface.

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -743,6 +743,69 @@ func (m *AlterTypeOwner) AppendJSONFields(printComma bool, b redact.RedactableBy
 }
 
 // AppendJSONFields implements the EventPayload interface.
+func (m *BulkIngestCompleted) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
+
+	printComma, b = m.CommonEventDetails.AppendJSONFields(printComma, b)
+
+	if m.JobID != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"JobID\":"...)
+		b = strconv.AppendUint(b, uint64(m.JobID), 10)
+	}
+
+	if m.JobType != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"JobType\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.JobType)))
+		b = append(b, '"')
+	}
+
+	if m.NumRows != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"NumRows\":"...)
+		b = strconv.AppendInt(b, int64(m.NumRows), 10)
+	}
+
+	if m.DurationSeconds != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"DurationSeconds\":"...)
+		b = strconv.AppendInt(b, int64(m.DurationSeconds), 10)
+	}
+
+	if m.DataSizeMb != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"DataSizeMb\":"...)
+		b = strconv.AppendInt(b, int64(m.DataSizeMb), 10)
+	}
+
+	if m.NodeCount != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"NodeCount\":"...)
+		b = strconv.AppendInt(b, int64(m.NodeCount), 10)
+	}
+
+	return printComma, b
+}
+
+// AppendJSONFields implements the EventPayload interface.
 func (m *CapturedIndexUsageStats) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
 
 	printComma, b = m.CommonEventDetails.AppendJSONFields(printComma, b)


### PR DESCRIPTION
Backport 1/1 commits from #162092 on behalf of @msbutler.

----

On restore completion, we now admit a structured telemetry event that contains data to construct per node logical throughput. This event could also be used by import. This event also removes some telemetry metrics we don't use.

Epic: none

Release note: none

----

Release justification: