### PR TITLE
kvserver: cancel queue ops on quiesce

### DIFF
--- a/pkg/kv/kvserver/queue.go
+++ b/pkg/kv/kvserver/queue.go
@@ -1187,6 +1187,9 @@ func (bq *baseQueue) processOneAsyncAndReleaseSem(
 	taskName := bq.processOpName() + " [outer]"
 	if err := stopper.RunAsyncTaskEx(ctx, stop.TaskOpts{TaskName: taskName},
 		func(ctx context.Context) {
+			c, cancel := stopper.WithCancelOnQuiesce(ctx)
+			defer cancel()
+			ctx = c
 			// Release semaphore when finished processing.
 			defer func() { <-bq.processSem }()
 			start := timeutil.Now()


### PR DESCRIPTION
If a node is shutting down, any in-flight queue actions like rebalancing or computing checksums should be aborted promptly to prevent delaying shutdown.

Fixes https://github.com/cockroachdb/cockroach/issues/164944.

Release note: none.
Epic: none.