### PR TITLE
release-26.1: sql/isession: deflake TestInternalSession

### DIFF
--- a/pkg/sql/isession/internal_session_test.go
+++ b/pkg/sql/isession/internal_session_test.go
@@ -213,6 +213,11 @@ func TestInternalSession(t *testing.T) {
 	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 
+	hostRunner := sqlutils.MakeSQLRunner(s.SystemLayer().SQLConn(t))
+	// If we have buffered writes enabled, we must have the split lock
+	// reliability enabled (which can be tweaked metamorphically, #161614).
+	hostRunner.Exec(t, "SET CLUSTER SETTING kv.lock_table.unreplicated_lock_reliability.split.enabled = true")
+
 	// This is a collection of tests that should all leave the internal session
 	// in a valid state. The order is randomized to ensure there is no accidental
 	// dependency on the order of operations. If the test fails, it is likely that


### PR DESCRIPTION
Backport 1/1 commits from #162507 on behalf of @yuzefovich.

----

This commit ensures that in `tcCancelQueryBlockedOnSQLLock` subtest we have the lock reliability with splits enabled for buffered writes (otherwise, it's possible for us to lose the lock that the test assumes is there).

Fixes: #161614.
Release note: None

----

Release justification: test-only change.