### PR TITLE
backup: add two-phase retry mechanism

### DIFF
--- a/pkg/backup/BUILD.bazel
+++ b/pkg/backup/BUILD.bazel
@@ -51,6 +51,7 @@ go_library(
         "//pkg/backup/backuputils",
         "//pkg/base",
         "//pkg/build",
+        "//pkg/build/bazel",
         "//pkg/cloud",
         "//pkg/cloud/cloudpb",
         "//pkg/cloud/externalconn",

--- a/pkg/backup/backup_job.go
+++ b/pkg/backup/backup_job.go
@@ -21,9 +21,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/backup/backuppb"
 	"github.com/cockroachdb/cockroach/pkg/backup/backuputils"
 	"github.com/cockroachdb/cockroach/pkg/build"
+	"github.com/cockroachdb/cockroach/pkg/build/bazel"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
-	"github.com/cockroachdb/cockroach/pkg/jobs/joberror"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobsprofiler"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobsprotectedts"
@@ -105,6 +105,141 @@ func filterSpans(includes []roachpb.Span, excludes []roachpb.Span) []roachpb.Spa
 	return cov.Slice()
 }
 
+func backupWithRetry(
+	ctx context.Context,
+	execCtx sql.JobExecContext,
+	mem *mon.BoundAccount,
+	kmsEnv cloud.KMSEnv,
+	details jobspb.BackupDetails,
+	settings *cluster.Settings,
+	defaultStore cloud.ExternalStorage,
+	resumer *backupResumer,
+	backupManifest *backuppb.BackupManifest,
+) (
+	latestManifest *backuppb.BackupManifest,
+	memSize int64,
+	rowCount roachpb.RowCount,
+	numBackupInstances int,
+	err error,
+) {
+	type retryState string
+	const (
+		initialState   retryState = "initial"
+		secondaryState retryState = "secondary"
+	)
+
+	currState := initialState
+	initialPolicy, secondaryPolicy := getBackupRetryPolicies(execCtx.ExecCfg())
+	latestManifest = backupManifest
+
+	prevTotalProg := resumer.job.FractionCompleted()
+	var attempts int
+	testKnobs := execCtx.ExecCfg().BackupRestoreTestingKnobs
+	for r := retry.StartWithCtx(ctx, initialPolicy); r.Next(); {
+		attempts++
+		var rowCount roachpb.RowCount
+		var progress map[execinfrapb.ComponentID]float32
+		var numInstances int
+		rowCount, progress, numInstances, err = backup(
+			ctx, execCtx, details, settings, defaultStore, resumer, latestManifest,
+		)
+		if err == nil {
+			return latestManifest, memSize, rowCount, numInstances, nil
+		}
+
+		if bazel.InBazelTest() && (testKnobs == nil || !testKnobs.EnableBackupRetriesUnderTest) {
+			break
+		}
+
+		// If we are draining, it is unlikely we can start a new DistSQL flow.
+		// Exit with a retryable error so that another node can pick up the job.
+		if execCtx.ExecCfg().JobRegistry.IsDraining() {
+			return nil, 0, roachpb.RowCount{}, 0, jobs.MarkAsRetryJobError(
+				errors.Wrapf(err, "backup job encountered retryable error on draining node"),
+			)
+		}
+
+		log.Dev.Warningf(ctx, "backup attempt %d failed with error: %+v", attempts, err)
+
+		mem.Shrink(ctx, memSize)
+		var readErr error
+		// Reload the backup manifest to pick up any spans we may have completed on
+		// previous attempts.
+		latestManifest, memSize, readErr = resumer.readManifestOnResume(
+			ctx, mem, execCtx.ExecCfg(), defaultStore, details, execCtx.User(), kmsEnv,
+		)
+		if readErr != nil {
+			return nil, 0, roachpb.RowCount{}, 0, errors.Wrapf(readErr, "reading backup manifest on retry")
+		}
+
+		switch currState {
+		case initialState:
+			// In the initial state, we are still waiting for all nodes to return
+			// progress.
+			var numProgressedNodes int
+			for _, v := range progress {
+				if v > 0 {
+					numProgressedNodes++
+				}
+			}
+			if numProgressedNodes == numInstances && numProgressedNodes > 0 {
+				log.Dev.Infof(
+					ctx, "backup made progress on all nodes, switching to secondary retry policy",
+				)
+				currState = secondaryState
+				r = retry.StartWithCtx(ctx, secondaryPolicy)
+			}
+		case secondaryState:
+			// In the secondary state, we reset our retry mechanism as long as there
+			// has been some progress since the last attempt.
+			jobID := resumer.job.ID()
+			job, reloadErr := execCtx.ExecCfg().JobRegistry.LoadClaimedJob(ctx, jobID)
+			if reloadErr != nil {
+				log.Dev.Warningf(
+					ctx, "backup job %d could not reload job progress when retrying: %+v",
+					jobID, reloadErr,
+				)
+				continue
+			}
+			currProg := job.FractionCompleted()
+			if madeProgress := currProg - prevTotalProg; madeProgress >= 0.01 {
+				log.Dev.Infof(
+					ctx,
+					"backup made %d%% additional progress, resetting retry",
+					int(math.Round(float64(100*madeProgress))),
+				)
+				prevTotalProg = currProg
+				r.Reset()
+			}
+		}
+	}
+
+	return nil, 0, roachpb.RowCount{}, 0, errors.Wrapf(
+		err, "backup exhausted retries in %s state", currState,
+	)
+}
+
+func getBackupRetryPolicies(execCfg *sql.ExecutorConfig) (initial, secondary retry.Options) {
+	initial = retry.Options{
+		MaxBackoff: time.Second,
+		MaxRetries: 5,
+	}
+	secondary = retry.Options{
+		MaxBackoff:  time.Second,
+		MaxDuration: 5 * time.Minute,
+	}
+
+	if execCfg.BackupRestoreTestingKnobs != nil {
+		if execCfg.BackupRestoreTestingKnobs.BackupDistSQLInitialRetryPolicy != nil {
+			initial = *execCfg.BackupRestoreTestingKnobs.BackupDistSQLInitialRetryPolicy
+		}
+		if execCfg.BackupRestoreTestingKnobs.BackupDistSQLSecondaryRetryPolicy != nil {
+			secondary = *execCfg.BackupRestoreTestingKnobs.BackupDistSQLSecondaryRetryPolicy
+		}
+	}
+	return initial, secondary
+}
+
 // backup exports a snapshot of every kv entry into ranged sstables.
 //
 // The output is an sstable per range with files in the following locations:
@@ -112,6 +247,9 @@ func filterSpans(includes []roachpb.Span, excludes []roachpb.Span) []roachpb.Spa
 //   - <dir> is given by the user and may be cloud storage
 //   - Each file contains data for a key range that doesn't overlap with any other
 //     file.
+//
+// - trackedProgress maps nodes to the fraction of backup spans that they have
+// completed.
 //
 // - numBackupInstances indicates the number of SQL instances that were used to
 // execute the backup.
@@ -123,7 +261,12 @@ func backup(
 	defaultStore cloud.ExternalStorage,
 	resumer *backupResumer,
 	backupManifest *backuppb.BackupManifest,
-) (_ roachpb.RowCount, numBackupInstances int, _ error) {
+) (
+	_ roachpb.RowCount,
+	trackedProgress map[execinfrapb.ComponentID]float32,
+	numBackupInstances int,
+	_ error,
+) {
 	resumerSpan := tracing.SpanFromContext(ctx)
 	var lastCheckpoint time.Time
 	encryption := details.EncryptionOptions
@@ -138,7 +281,7 @@ func backup(
 		ctx, execCtx, backupManifest, defaultStore, encryption, &kmsEnv,
 	)
 	if err != nil {
-		return roachpb.RowCount{}, 0, err
+		return roachpb.RowCount{}, nil, 0, err
 	}
 
 	// Subtract out any completed spans.
@@ -156,7 +299,7 @@ func backup(
 	dsp := execCtx.DistSQLPlanner()
 
 	if details.ExecutionLocality.NonEmpty() && details.StrictLocalityFiltering {
-		return roachpb.RowCount{}, 0, errors.AssertionFailedf("cannot set both ExecutionLocality and StrictLocalityFiltering")
+		return roachpb.RowCount{}, nil, 0, errors.AssertionFailedf("cannot set both ExecutionLocality and StrictLocalityFiltering")
 	}
 
 	locFilter := sql.SingleLocalityFilter(details.ExecutionLocality)
@@ -165,7 +308,7 @@ func backup(
 		for kv := range details.URIsByLocalityKV {
 			kvLoc := roachpb.Locality{}
 			if err := kvLoc.Set(kv); err != nil {
-				return roachpb.RowCount{}, 0, errors.Wrapf(err, "parsing locality from key value %s", kv)
+				return roachpb.RowCount{}, nil, 0, errors.Wrapf(err, "parsing locality from key value %s", kv)
 			}
 			locFilter = append(locFilter, kvLoc)
 		}
@@ -178,7 +321,7 @@ func backup(
 			locFilter,
 		)
 		if err != nil {
-			return roachpb.RowCount{}, 0, errors.Wrap(err, "failed to create locality filtering bulk oracle")
+			return roachpb.RowCount{}, nil, 0, errors.Wrap(err, "failed to create locality filtering bulk oracle")
 		}
 	}
 
@@ -188,7 +331,7 @@ func backup(
 		ctx, evalCtx, execCtx.ExecCfg(), oracle, locFilter, details.StrictLocalityFiltering,
 	)
 	if err != nil {
-		return roachpb.RowCount{}, 0, errors.Wrap(err, "failed to determine nodes on which to run")
+		return roachpb.RowCount{}, nil, 0, errors.Wrap(err, "failed to determine nodes on which to run")
 	}
 
 	job := resumer.job
@@ -212,7 +355,7 @@ func backup(
 		backupManifest.ElidedPrefix,
 	)
 	if err != nil {
-		return roachpb.RowCount{}, 0, err
+		return roachpb.RowCount{}, nil, 0, err
 	}
 
 	numBackupInstances = len(backupSpecs)
@@ -236,10 +379,11 @@ func backup(
 
 	// Create a channel with a little buffering, but plan on dropping if blocked.
 	perNodeProgressCh := make(chan map[execinfrapb.ComponentID]float32, len(backupSpecs))
+	trackedProgress = make(map[execinfrapb.ComponentID]float32)
 	storePerNodeProgressLoop := func(ctx context.Context) error {
 		// track the last progress per component, periodically flushing those that
 		// have changed to info rows.
-		current, persisted := make(map[execinfrapb.ComponentID]float32), make(map[execinfrapb.ComponentID]float32)
+		persisted := make(map[execinfrapb.ComponentID]float32)
 		lastSaved := timeutil.Now()
 
 		for {
@@ -249,15 +393,15 @@ func backup(
 					return nil
 				}
 				for k, v := range prog {
-					current[k] = v
+					trackedProgress[k] = v
 				}
 				if timeutil.Since(lastSaved) > time.Second*15 {
 					lastSaved = timeutil.Now()
 					updates := make(map[execinfrapb.ComponentID]float32)
-					for k := range current {
-						if current[k] != persisted[k] {
-							persisted[k] = current[k]
-							updates[k] = current[k]
+					for k := range trackedProgress {
+						if trackedProgress[k] != persisted[k] {
+							persisted[k] = trackedProgress[k]
+							updates[k] = trackedProgress[k]
 						}
 					}
 					jobsprofiler.StorePerNodeProcessorProgressFraction(
@@ -376,7 +520,7 @@ func backup(
 	testingKnobs := execCtx.ExecCfg().BackupRestoreTestingKnobs
 	if testingKnobs != nil && testingKnobs.RunBeforeBackupFlow != nil {
 		if err := testingKnobs.RunBeforeBackupFlow(); err != nil {
-			return roachpb.RowCount{}, 0, err
+			return roachpb.RowCount{}, nil, 0, err
 		}
 	}
 
@@ -388,21 +532,21 @@ func backup(
 		tracingAggLoop,
 		runBackup,
 	); err != nil {
-		return roachpb.RowCount{}, 0, err
+		return roachpb.RowCount{}, trackedProgress, numBackupInstances, err
 	}
 
 	if testingKnobs != nil && testingKnobs.RunAfterBackupFlow != nil {
 		if err := testingKnobs.RunAfterBackupFlow(); err != nil {
-			return roachpb.RowCount{}, 0, err
+			return roachpb.RowCount{}, trackedProgress, numBackupInstances, err
 		}
 	}
 
 	statsTable := getTableStatsForBackup(ctx, execCtx.ExecCfg().InternalDB.Executor(), execCtx.ExecCfg().Settings, backupManifest.Descriptors)
 	if err := backupinfo.WriteBackupMetadata(ctx, execCtx, defaultStore, details, &kmsEnv, backupManifest, statsTable); err != nil {
-		return roachpb.RowCount{}, 0, err
+		return roachpb.RowCount{}, trackedProgress, numBackupInstances, err
 	}
 
-	return backupManifest.EntryCounts, numBackupInstances, nil
+	return backupManifest.EntryCounts, trackedProgress, numBackupInstances, nil
 }
 
 func releaseProtectedTimestamp(
@@ -642,6 +786,9 @@ func (b *backupResumer) Resume(ctx context.Context, execCtx interface{}) error {
 	mem := p.ExecCfg().RootMemoryMonitor.MakeBoundAccount()
 	defer mem.Close(ctx)
 	var memSize int64
+	defer func() {
+		mem.Shrink(ctx, memSize)
+	}()
 
 	if backupManifest == nil {
 		backupManifest, memSize, err = b.readManifestOnResume(ctx, &mem, p.ExecCfg(), defaultStore,
@@ -651,91 +798,15 @@ func (b *backupResumer) Resume(ctx context.Context, execCtx interface{}) error {
 		}
 	}
 
-	// We retry on pretty generic failures -- any rpc error. If a worker node were
-	// to restart, it would produce this kind of error, but there may be other
-	// errors that are also rpc errors. Don't retry too aggressively.
-	retryOpts := retry.Options{
-		MaxBackoff: 1 * time.Second,
-		MaxRetries: 5,
-	}
-
-	if p.ExecCfg().BackupRestoreTestingKnobs != nil &&
-		p.ExecCfg().BackupRestoreTestingKnobs.BackupDistSQLRetryPolicy != nil {
-		retryOpts = *p.ExecCfg().BackupRestoreTestingKnobs.BackupDistSQLRetryPolicy
-	}
-
 	if err := p.ExecCfg().JobRegistry.CheckPausepoint("backup.before.flow"); err != nil {
 		return err
 	}
 
-	// We want to retry a backup if there are transient failures (i.e. worker nodes
-	// dying), so if we receive a retryable error, re-plan and retry the backup.
-	var res roachpb.RowCount
-	var lastProgress float32
-	var numBackupInstances int
-	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
-		res, numBackupInstances, err = backup(
-			ctx,
-			p,
-			details,
-			p.ExecCfg().Settings,
-			defaultStore,
-			b,
-			backupManifest,
-		)
-		if err == nil {
-			break
-		}
-
-		if joberror.IsPermanentBulkJobError(err) {
-			return errors.Wrap(err, "failed to run backup")
-		}
-
-		// If we are draining, it is unlikely we can start a
-		// new DistSQL flow. Exit with a retryable error so
-		// that another node can pick up the job.
-		if p.ExecCfg().JobRegistry.IsDraining() {
-			return jobs.MarkAsRetryJobError(errors.Wrapf(err, "job encountered retryable error on draining node"))
-		}
-
-		log.Dev.Warningf(ctx, "encountered retryable error: %+v", err)
-
-		// Reload the backup manifest to pick up any spans we may have completed on
-		// previous attempts.
-		var reloadBackupErr error
-		mem.Shrink(ctx, memSize)
-		backupManifest, memSize, reloadBackupErr = b.readManifestOnResume(ctx, &mem, p.ExecCfg(),
-			defaultStore, details, p.User(), &kmsEnv)
-		if reloadBackupErr != nil {
-			return errors.Wrap(reloadBackupErr, "could not reload backup manifest when retrying")
-		}
-		// Re-load the job in order to update our progress object, which
-		// may have been updated since the flow started.
-		reloadedJob, reloadErr := p.ExecCfg().JobRegistry.LoadClaimedJob(ctx, b.job.ID())
-		if reloadErr != nil {
-			if ctx.Err() != nil {
-				return ctx.Err()
-			}
-			log.Dev.Warningf(ctx, "BACKUP job %d could not reload job progress when retrying: %+v",
-				b.job.ID(), reloadErr)
-		} else {
-			curProgress := reloadedJob.FractionCompleted()
-			// If we made decent progress with the BACKUP, reset the last
-			// progress state.
-			if madeProgress := curProgress - lastProgress; madeProgress >= 0.01 {
-				log.Dev.Infof(ctx, "backport made %d%% progress, resetting retry duration", int(math.Round(float64(100*madeProgress))))
-				lastProgress = curProgress
-				r.Reset()
-			}
-		}
-	}
-
-	// We have exhausted retries without getting a "PermanentBulkJobError", but
-	// something must be wrong if we keep seeing errors so give up and fail to
-	// ensure that any alerting on failures is triggered and that any subsequent
-	// schedule runs are not blocked.
+	backupManifest, memSize, res, numBackupInstances, err := backupWithRetry(
+		ctx, p, &mem, &kmsEnv, details, p.ExecCfg().Settings, defaultStore, b, backupManifest,
+	)
 	if err != nil {
-		return errors.Wrap(err, "exhausted retries")
+		return err
 	}
 
 	var jobDetails jobspb.BackupDetails

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -1612,36 +1612,38 @@ func TestBackupJobRetryReset(t *testing.T) {
 		syncutil.Mutex
 		retryCount int
 	}{}
-	waitForProgress := make(chan struct{})
-	maxRetries := 4
+	initialMaxRetries := 3
+	secondaryMaxRetries := 6
 
+	var runBeforeBackupFlow func() error
+	var runAfterBackupFlow func() error
 	params := base.TestClusterArgs{}
 	knobs := base.TestingKnobs{
 		BackupRestore: &sql.BackupRestoreTestingKnobs{
-			BackupDistSQLRetryPolicy: &retry.Options{
+			EnableBackupRetriesUnderTest: true,
+			BackupDistSQLInitialRetryPolicy: &retry.Options{
 				InitialBackoff: time.Microsecond,
 				Multiplier:     2,
 				MaxBackoff:     2 * time.Microsecond,
-				MaxRetries:     maxRetries,
+				MaxRetries:     initialMaxRetries,
+			},
+			BackupDistSQLSecondaryRetryPolicy: &retry.Options{
+				InitialBackoff: time.Microsecond,
+				Multiplier:     2,
+				MaxBackoff:     2 * time.Microsecond,
+				MaxRetries:     secondaryMaxRetries,
 			},
 			RunBeforeBackupFlow: func() error {
-				mu.Lock()
-				defer mu.Unlock()
-				if mu.retryCount >= maxRetries-1 {
-					return nil
+				if runBeforeBackupFlow != nil {
+					return runBeforeBackupFlow()
 				}
-				mu.retryCount++
-				// Send a retryable error
-				return syscall.ECONNRESET
+				return nil
 			},
 			RunAfterBackupFlow: func() error {
-				mu.Lock()
-				defer mu.Unlock()
-				// Wait for at least 1% backup job progress, then continue sending retryable errors
-				<-waitForProgress
-				mu.retryCount++
-				// Send a retryable error
-				return syscall.ECONNRESET
+				if runAfterBackupFlow != nil {
+					return runAfterBackupFlow()
+				}
+				return nil
 			},
 		},
 		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
@@ -1653,19 +1655,68 @@ func TestBackupJobRetryReset(t *testing.T) {
 		sqlDB.Exec(t, fmt.Sprintf(`CREATE TABLE %s AS (SELECT * FROM bank)`, "bank"+strconv.Itoa(i)))
 	}
 	defer cleanupFn()
-	var backupJobId jobspb.JobID
-	sqlDB.QueryRow(t, `BACKUP DATABASE data INTO $1 WITH DETACHED`, localFoo).Scan(&backupJobId)
-	testutils.SucceedsSoon(t, func() error {
-		jobProgress := jobutils.GetJobProgress(t, sqlDB, backupJobId)
-		if jobProgress.GetFractionCompleted() < 0.01 {
-			return errors.Newf("backup has not made progress yet")
-		}
-		return nil
-	})
-	close(waitForProgress)
-	// Job will fail with exhausted retries: connection reset by peer
-	jobutils.WaitForJobToFail(t, sqlDB, backupJobId)
-	require.Greater(t, mu.retryCount, maxRetries+2)
+
+	testcases := []struct {
+		name             string
+		beforeFlow       func() error
+		afterFlow        func() error
+		expectedAttempts int
+	}{
+		{
+			name: "fail before any progress is made on nodes",
+			beforeFlow: func() error {
+				mu.Lock()
+				defer mu.Unlock()
+				mu.retryCount++
+				return syscall.ECONNRESET
+			},
+			expectedAttempts: initialMaxRetries + 1,
+		},
+		{
+			name: "fail after all nodes have reported progress",
+			beforeFlow: func() error {
+				mu.Lock()
+				defer mu.Unlock()
+				if mu.retryCount >= initialMaxRetries {
+					return nil
+				}
+				mu.retryCount++
+				return syscall.ECONNRESET
+			},
+			afterFlow: func() error {
+				mu.Lock()
+				defer mu.Unlock()
+				mu.retryCount++
+				return syscall.ECONNRESET
+			},
+			// We include 1 additional attempt because the job will make progress,
+			// which adds one additional reset. And because a retry policy with n max
+			// retries makes n + 1 attempts, and we go through two retry policies, we
+			// +2.
+			expectedAttempts: initialMaxRetries + secondaryMaxRetries + 2 + 1,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Reset test environment before each test case
+			defer func() {
+				mu.Lock()
+				defer mu.Unlock()
+				mu.retryCount = 0
+				runBeforeBackupFlow = nil
+				runAfterBackupFlow = nil
+			}()
+
+			runBeforeBackupFlow = tc.beforeFlow
+			runAfterBackupFlow = tc.afterFlow
+			var jobID jobspb.JobID
+			sqlDB.QueryRow(t, `BACKUP DATABASE data INTO $1 WITH DETACHED`, localFoo).Scan(&jobID)
+			jobutils.WaitForJobToFail(t, sqlDB, jobID)
+
+			require.Equal(t, tc.expectedAttempts, mu.retryCount, "unexpected number of attempts")
+		})
+	}
 }
 
 func createAndWaitForJob(
@@ -7539,6 +7590,7 @@ func TestBackupExportRequestTimeout(t *testing.T) {
 	// export request but since the intent was laid by a high priority txn it
 	// should hang. The timeout should save us in this case.
 	_, err := sqlSessions[1].DB.ExecContext(ctx, "BACKUP TABLE data.bank INTO 'nodelocal://1/timeout'")
+	require.Error(t, err)
 	require.Regexp(t,
 		`running distributed backup to export.*/Table/\d+/.*\: context deadline exceeded`,
 		err.Error())

--- a/pkg/backup/compaction_job.go
+++ b/pkg/backup/compaction_job.go
@@ -420,8 +420,8 @@ func (b *backupResumer) ResumeCompaction(
 		MaxRetries: 5,
 	}
 
-	if testingKnobs != nil && testingKnobs.BackupDistSQLRetryPolicy != nil {
-		retryOpts = *testingKnobs.BackupDistSQLRetryPolicy
+	if testingKnobs != nil && testingKnobs.BackupDistSQLInitialRetryPolicy != nil {
+		retryOpts = *testingKnobs.BackupDistSQLInitialRetryPolicy
 	}
 
 	// We want to retry a backup if there are transient failures (i.e. worker nodes

--- a/pkg/sql/exec_util_backup.go
+++ b/pkg/sql/exec_util_backup.go
@@ -67,7 +67,11 @@ type BackupRestoreTestingKnobs struct {
 
 	RunAfterRestoreFlow func() error
 
-	BackupDistSQLRetryPolicy *retry.Options
+	EnableBackupRetriesUnderTest bool
+
+	BackupDistSQLInitialRetryPolicy *retry.Options
+
+	BackupDistSQLSecondaryRetryPolicy *retry.Options
 
 	RunBeforeBackupFlow func() error
 


### PR DESCRIPTION
This commit teaches backup to use a two-phase retry raather than the attempt-based retry we use today. Under this new retry mechanism, backup will use an attempt based retry until all nodes have reported progress. After all nodes have done so, we switch to a short duration based policy that is reset each time progress is made.

Resolves: #159388

Release note: None