### PR TITLE
sem/builtins: fix nil pointer in aggregate benchmarks

### DIFF
--- a/pkg/sql/sem/builtins/aggregate_builtins_test.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins_test.go
@@ -573,6 +573,9 @@ func runBenchmarkAggregate(
 ) {
 	evalCtx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(context.Background())
+	acc := evalCtx.TestingMon.MakeBoundAccount()
+	defer acc.Close(context.Background())
+	evalCtx.SingleDatumAggMemAccount = &acc
 	argTypes := []*types.T{firstArgs[0].ResolvedType()}
 	otherArgs = flattenArgs(otherArgs...)
 	if len(otherArgs) == 0 {


### PR DESCRIPTION
The `runBenchmarkAggregate` test helper was missing the `SingleDatumAggMemAccount` setup on the eval context. After 6b342aee52e simplified `singleDatumAggregateBase` to unconditionally use this field (removing the nil fallback), all aggregate benchmarks started panicking with a nil pointer dereference.

Set up a `BoundAccount` from `TestingMon`, matching the pattern already used by `testAggregateResultDeepCopy` in the same file.

Resolves: #163160
Resolves: #163161
Resolves: #163162
Resolves: #163163
Resolves: #163164
Resolves: #163165
Resolves: #163166
Resolves: #163167
Resolves: #163168
Resolves: #163169
Resolves: #163170
Resolves: #163171
Resolves: #163172
Resolves: #163173
Resolves: #163174
Resolves: #163175
Resolves: #163176
Resolves: #163177
Resolves: #163178
Resolves: #163179
Resolves: #163180
Resolves: #163181
Resolves: #163182
Resolves: #163183
Resolves: #163184
Resolves: #163185
Resolves: #163186
Resolves: #163187
Resolves: #163188
Resolves: #163189
Resolves: #163190

Release note: None