### PR TITLE
release-26.1: sql/importer: disable test tenant randomization in TestImportIntoCSV

### DIFF
--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -2198,6 +2198,10 @@ func TestImportIntoCSV(t *testing.T) {
 			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 		},
 		ExternalIODir: baseDir,
+		// This test can take very long time under both shared-process and
+		// external-process configs, so we abuse the "system tenant" option to
+		// only allow running in the single-tenant mode.
+		DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
 	}})
 	defer tc.Stopper().Stop(ctx)
 	conn := tc.ServerConn(0)


### PR DESCRIPTION
Backport 1/1 commits from #162618 on behalf of @yuzefovich.

----

We've seen this test be extremely slow occasionally resulting in the package-level timeout. Let's opt it out of the secondary tenant randomization.

Fixes: #161685.
Release note: None

----

Release justification: test-only change.