### PR TITLE
sql/schemachanger: add bool and int32 attr support to rel package

### DIFF
--- a/pkg/sql/schemachanger/rel/compare.go
+++ b/pkg/sql/schemachanger/rel/compare.go
@@ -87,6 +87,13 @@ func compareNotNil(a, b interface{}) (less, eq bool) {
 			return true, false
 		}
 		return false, *a == *b
+	case *bool:
+		b := b.(*bool)
+		// false < true
+		if !*a && *b {
+			return true, false
+		}
+		return false, *a == *b
 	case reflect.Type:
 		return compareTypes(a, b.(reflect.Type))
 
@@ -138,8 +145,9 @@ var (
 	}
 
 	kindTypeMap = func() kindMap {
-		m := make(kindMap, len(intKindMap)+len(uintKindMap)+1)
+		m := make(kindMap, len(intKindMap)+len(uintKindMap)+2)
 		m[reflect.String] = reflect.TypeOf((*string)(nil)).Elem()
+		m[reflect.Bool] = reflect.TypeOf((*bool)(nil)).Elem()
 		for _, src := range []kindMap{uintKindMap, intKindMap} {
 			for k, t := range src {
 				m[k] = t

--- a/pkg/sql/schemachanger/rel/database_entity_set.go
+++ b/pkg/sql/schemachanger/rel/database_entity_set.go
@@ -97,6 +97,12 @@ func (t *entitySet) insert(v interface{}, es entityStore) (int, error) {
 			if !ok {
 				continue
 			}
+		case field.isBool():
+			var ok bool
+			val, ok = field.inline(vp)
+			if !ok {
+				continue
+			}
 		case field.isString():
 			s, ok := field.comparableValue(vp).(*string)
 			if !ok {

--- a/pkg/sql/schemachanger/rel/schema_value.go
+++ b/pkg/sql/schemachanger/rel/schema_value.go
@@ -38,9 +38,23 @@ func makeComparableValue(val interface{}) (typedValue, error) {
 			typ:   vv.Type(),
 			value: vvNew.Convert(reflect.PointerTo(compType)).Interface(),
 		}, nil
+	case typ.Kind() == reflect.Bool:
+		compType := getComparableType(typ)
+		vvNew := reflect.New(vv.Type())
+		vvNew.Elem().Set(vv)
+		return typedValue{
+			typ:   vv.Type(),
+			value: vvNew.Convert(reflect.PointerTo(compType)).Interface(),
+		}, nil
 	case typ.Kind() == reflect.Ptr:
 		switch {
 		case isIntKind(typ.Elem().Kind()), isUintKind(typ.Elem().Kind()):
+			compType := getComparableType(typ.Elem())
+			return typedValue{
+				typ:   vv.Type().Elem(),
+				value: vv.Convert(reflect.PointerTo(compType)).Interface(),
+			}, nil
+		case typ.Elem().Kind() == reflect.Bool:
 			compType := getComparableType(typ.Elem())
 			return typedValue{
 				typ:   vv.Type().Elem(),

--- a/pkg/sql/schemachanger/scbuild/testdata/alter_table_add_column
+++ b/pkg/sql/schemachanger/scbuild/testdata/alter_table_add_column
@@ -325,7 +325,7 @@ ALTER TABLE defaultdb.foo ADD COLUMN j INT GENERATED ALWAYS AS IDENTITY
   {databaseId: 100, tableId: 104}
 - [[Sequence:{DescID: 107}, PUBLIC], ABSENT]
   {sequenceId: 107}
-- [[Namespace:{DescID: 107, Name: foo_j_seq, ReferencedDescID: 100, IntValue: 101}, PUBLIC], ABSENT]
+- [[Namespace:{DescID: 107, Name: foo_j_seq, ReferencedDescID: 100, UInt32Value: 101}, PUBLIC], ABSENT]
   {databaseId: 100, descriptorId: 107, name: foo_j_seq, schemaId: 101}
 - [[SchemaChild:{DescID: 107, ReferencedDescID: 101}, PUBLIC], ABSENT]
   {childObjectId: 107, schemaId: 101}

--- a/pkg/sql/schemachanger/scbuild/testdata/alter_table_drop_column
+++ b/pkg/sql/schemachanger/scbuild/testdata/alter_table_drop_column
@@ -158,7 +158,7 @@ ALTER TABLE defaultdb.t DROP COLUMN k, DROP COLUMN l
   {columnId: 2, indexId: 5, kind: STORED, tableId: 104}
 - [[IndexData:{DescID: 104, IndexID: 5}, TRANSIENT_ABSENT], ABSENT]
   {indexId: 5, tableId: 104}
-- [[Namespace:{DescID: 105, Name: t_l_seq, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 105, Name: t_l_seq, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 105, name: t_l_seq, schemaId: 101}
 - [[Owner:{DescID: 105}, ABSENT], PUBLIC]
   {descriptorId: 105, owner: root}
@@ -208,7 +208,7 @@ ALTER TABLE defaultdb.t DROP COLUMN l
   {indexId: 3, tableId: 104}
 - [[TableData:{DescID: 104, ReferencedDescID: 100}, PUBLIC], PUBLIC]
   {databaseId: 100, tableId: 104}
-- [[Namespace:{DescID: 105, Name: t_l_seq, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 105, Name: t_l_seq, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 105, name: t_l_seq, schemaId: 101}
 - [[Owner:{DescID: 105}, ABSENT], PUBLIC]
   {descriptorId: 105, owner: root}

--- a/pkg/sql/schemachanger/scbuild/testdata/create_database
+++ b/pkg/sql/schemachanger/scbuild/testdata/create_database
@@ -7,7 +7,7 @@ CREATE DATABASE db OWNER roacher;
 ----
 - [[Database:{DescID: 104}, PUBLIC], ABSENT]
   {databaseId: 104}
-- [[Namespace:{DescID: 104, Name: db, ReferencedDescID: 0, IntValue: 0}, PUBLIC], ABSENT]
+- [[Namespace:{DescID: 104, Name: db, ReferencedDescID: 0, UInt32Value: 0}, PUBLIC], ABSENT]
   {descriptorId: 104, name: db}
 - [[DatabaseData:{DescID: 104}, PUBLIC], ABSENT]
   {databaseId: 104}
@@ -21,7 +21,7 @@ CREATE DATABASE db OWNER roacher;
   {descriptorId: 104, privileges: "2", userName: root, withGrantOption: "2"}
 - [[Schema:{DescID: 105}, PUBLIC], ABSENT]
   {isPublic: true, schemaId: 105}
-- [[Namespace:{DescID: 105, Name: public, ReferencedDescID: 104, IntValue: 0}, PUBLIC], ABSENT]
+- [[Namespace:{DescID: 105, Name: public, ReferencedDescID: 104, UInt32Value: 0}, PUBLIC], ABSENT]
   {databaseId: 104, descriptorId: 105, name: public}
 - [[SchemaParent:{DescID: 105, ReferencedDescID: 104}, PUBLIC], ABSENT]
   {parentDatabaseId: 104, schemaId: 105}

--- a/pkg/sql/schemachanger/scbuild/testdata/create_function
+++ b/pkg/sql/schemachanger/scbuild/testdata/create_function
@@ -28,7 +28,7 @@ $$;
   {childObjectId: 110, schemaId: 101}
 - [[FunctionName:{DescID: 110}, PUBLIC], ABSENT]
   {functionId: 110, name: f}
-- [[FunctionVolatility:{DescID: 110}, PUBLIC], ABSENT]
+- [[FunctionVolatility:{DescID: 110, Int32Value: VOLATILE}, PUBLIC], ABSENT]
   {functionId: 110, volatility: {volatility: VOLATILE}}
 - [[Owner:{DescID: 110}, PUBLIC], ABSENT]
   {descriptorId: 110, owner: root}
@@ -38,7 +38,12 @@ $$;
   {descriptorId: 110, privileges: "1048576", userName: public}
 - [[UserPrivileges:{DescID: 110, Name: root}, PUBLIC], ABSENT]
   {descriptorId: 110, privileges: "2", userName: root, withGrantOption: "2"}
-- [[FunctionBody:{DescID: 110}, PUBLIC], ABSENT]
+- [[FunctionBody:{DescID: 110, Value: SELECT a FROM t;
+SELECT b FROM t@t_idx_b;
+SELECT c FROM t@t_idx_c;
+SELECT a FROM v;
+SELECT b'@':::@100108;
+SELECT nextval(105:::REGCLASS);}, PUBLIC], ABSENT]
   {body: "SELECT a FROM t;\nSELECT b FROM t@t_idx_b;\nSELECT c FROM t@t_idx_c;\nSELECT a FROM v;\nSELECT b'@':::@100108;\nSELECT nextval(105:::REGCLASS);", functionId: 110, lang: {lang: SQL}, usesSequenceIds: [105], usesTables: [{columnIds: [1], tableId: 104}, {columnIds: [2], indexId: 2, tableId: 104}, {columnIds: [3], indexId: 3, tableId: 104}], usesTypeIds: [108, 109], usesViews: [{columnIds: [1], viewId: 107}]}
 
 build
@@ -59,7 +64,7 @@ $$;
   {childObjectId: 111, schemaId: 101}
 - [[FunctionName:{DescID: 111}, PUBLIC], ABSENT]
   {functionId: 111, name: f}
-- [[FunctionVolatility:{DescID: 111}, PUBLIC], ABSENT]
+- [[FunctionVolatility:{DescID: 111, Int32Value: VOLATILE}, PUBLIC], ABSENT]
   {functionId: 111, volatility: {volatility: VOLATILE}}
 - [[Owner:{DescID: 111}, PUBLIC], ABSENT]
   {descriptorId: 111, owner: root}
@@ -69,5 +74,13 @@ $$;
   {descriptorId: 111, privileges: "1048576", userName: public}
 - [[UserPrivileges:{DescID: 111, Name: root}, PUBLIC], ABSENT]
   {descriptorId: 111, privileges: "2", userName: root, withGrantOption: "2"}
-- [[FunctionBody:{DescID: 111}, PUBLIC], ABSENT]
+- [[FunctionBody:{DescID: 111, Value: BEGIN
+SELECT a FROM t;
+SELECT b FROM t@t_idx_b;
+SELECT c FROM t@t_idx_c;
+SELECT a FROM v;
+SELECT b'@':::@100108;
+RETURN nextval(105:::REGCLASS);
+END;
+}, PUBLIC], ABSENT]
   {body: "BEGIN\nSELECT a FROM t;\nSELECT b FROM t@t_idx_b;\nSELECT c FROM t@t_idx_c;\nSELECT a FROM v;\nSELECT b'@':::@100108;\nRETURN nextval(105:::REGCLASS);\nEND;\n", functionId: 111, lang: {lang: PLPGSQL}, usesSequenceIds: [105], usesTables: [{columnIds: [1], tableId: 104}, {columnIds: [2], indexId: 2, tableId: 104}, {columnIds: [3], indexId: 3, tableId: 104}], usesTypeIds: [108, 109], usesViews: [{columnIds: [1], viewId: 107}]}

--- a/pkg/sql/schemachanger/scbuild/testdata/create_procedure
+++ b/pkg/sql/schemachanger/scbuild/testdata/create_procedure
@@ -36,7 +36,12 @@ $$;
   {descriptorId: 110, privileges: "1048576", userName: public}
 - [[UserPrivileges:{DescID: 110, Name: root}, PUBLIC], ABSENT]
   {descriptorId: 110, privileges: "2", userName: root, withGrantOption: "2"}
-- [[FunctionBody:{DescID: 110}, PUBLIC], ABSENT]
+- [[FunctionBody:{DescID: 110, Value: SELECT a FROM t;
+SELECT b FROM t@t_idx_b;
+SELECT c FROM t@t_idx_c;
+SELECT a FROM v;
+SELECT b'@':::@100108;
+SELECT nextval(105:::REGCLASS);}, PUBLIC], ABSENT]
   {body: "SELECT a FROM t;\nSELECT b FROM t@t_idx_b;\nSELECT c FROM t@t_idx_c;\nSELECT a FROM v;\nSELECT b'@':::@100108;\nSELECT nextval(105:::REGCLASS);", functionId: 110, lang: {lang: SQL}, usesSequenceIds: [105], usesTables: [{columnIds: [1], tableId: 104}, {columnIds: [2], indexId: 2, tableId: 104}, {columnIds: [3], indexId: 3, tableId: 104}], usesTypeIds: [108, 109], usesViews: [{columnIds: [1], viewId: 107}]}
 
 build
@@ -65,5 +70,13 @@ $$;
   {descriptorId: 111, privileges: "1048576", userName: public}
 - [[UserPrivileges:{DescID: 111, Name: root}, PUBLIC], ABSENT]
   {descriptorId: 111, privileges: "2", userName: root, withGrantOption: "2"}
-- [[FunctionBody:{DescID: 111}, PUBLIC], ABSENT]
+- [[FunctionBody:{DescID: 111, Value: BEGIN
+SELECT a FROM t;
+SELECT b FROM t@t_idx_b;
+SELECT c FROM t@t_idx_c;
+SELECT a FROM v;
+SELECT b'@':::@100108;
+SELECT nextval(105:::REGCLASS);
+END;
+}, PUBLIC], ABSENT]
   {body: "BEGIN\nSELECT a FROM t;\nSELECT b FROM t@t_idx_b;\nSELECT c FROM t@t_idx_c;\nSELECT a FROM v;\nSELECT b'@':::@100108;\nSELECT nextval(105:::REGCLASS);\nEND;\n", functionId: 111, lang: {lang: PLPGSQL}, usesSequenceIds: [105], usesTables: [{columnIds: [1], tableId: 104}, {columnIds: [2], indexId: 2, tableId: 104}, {columnIds: [3], indexId: 3, tableId: 104}], usesTypeIds: [108, 109], usesViews: [{columnIds: [1], viewId: 107}]}

--- a/pkg/sql/schemachanger/scbuild/testdata/create_schema
+++ b/pkg/sql/schemachanger/scbuild/testdata/create_schema
@@ -3,7 +3,7 @@ CREATE SCHEMA testsc
 ----
 - [[Schema:{DescID: 104}, PUBLIC], ABSENT]
   {schemaId: 104}
-- [[Namespace:{DescID: 104, Name: testsc, ReferencedDescID: 100, IntValue: 0}, PUBLIC], ABSENT]
+- [[Namespace:{DescID: 104, Name: testsc, ReferencedDescID: 100, UInt32Value: 0}, PUBLIC], ABSENT]
   {databaseId: 100, descriptorId: 104, name: testsc}
 - [[SchemaParent:{DescID: 104, ReferencedDescID: 100}, PUBLIC], ABSENT]
   {parentDatabaseId: 100, schemaId: 104}

--- a/pkg/sql/schemachanger/scbuild/testdata/create_sequence
+++ b/pkg/sql/schemachanger/scbuild/testdata/create_sequence
@@ -8,7 +8,7 @@ CREATE SEQUENCE db.public.sq1 MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 
 ----
 - [[Sequence:{DescID: 107}, PUBLIC], ABSENT]
   {sequenceId: 107}
-- [[Namespace:{DescID: 107, Name: sq1, ReferencedDescID: 104, IntValue: 105}, PUBLIC], ABSENT]
+- [[Namespace:{DescID: 107, Name: sq1, ReferencedDescID: 104, UInt32Value: 105}, PUBLIC], ABSENT]
   {databaseId: 104, descriptorId: 107, name: sq1, schemaId: 105}
 - [[SchemaChild:{DescID: 107, ReferencedDescID: 105}, PUBLIC], ABSENT]
   {childObjectId: 107, schemaId: 105}

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_database
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_database
@@ -21,7 +21,7 @@ COMMENT ON INDEX db1.sc1.t1@t1_pkey IS 't1_pkey is good';
 build
 DROP DATABASE db1 CASCADE
 ----
-- [[Namespace:{DescID: 104, Name: db1, ReferencedDescID: 0, IntValue: 0}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 104, Name: db1, ReferencedDescID: 0, UInt32Value: 0}, ABSENT], PUBLIC]
   {descriptorId: 104, name: db1}
 - [[Owner:{DescID: 104}, ABSENT], PUBLIC]
   {descriptorId: 104, owner: root}
@@ -39,7 +39,7 @@ DROP DATABASE db1 CASCADE
   {comment: db1 is good, databaseId: 104}
 - [[DatabaseData:{DescID: 104}, ABSENT], PUBLIC]
   {databaseId: 104}
-- [[Namespace:{DescID: 105, Name: public, ReferencedDescID: 104, IntValue: 0}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 105, Name: public, ReferencedDescID: 104, UInt32Value: 0}, ABSENT], PUBLIC]
   {databaseId: 104, descriptorId: 105, name: public}
 - [[Owner:{DescID: 105}, ABSENT], PUBLIC]
   {descriptorId: 105, owner: root}
@@ -53,7 +53,7 @@ DROP DATABASE db1 CASCADE
   {isPublic: true, schemaId: 105}
 - [[SchemaParent:{DescID: 105, ReferencedDescID: 104}, ABSENT], PUBLIC]
   {parentDatabaseId: 104, schemaId: 105}
-- [[Namespace:{DescID: 106, Name: sc1, ReferencedDescID: 104, IntValue: 0}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 106, Name: sc1, ReferencedDescID: 104, UInt32Value: 0}, ABSENT], PUBLIC]
   {databaseId: 104, descriptorId: 106, name: sc1}
 - [[Owner:{DescID: 106}, ABSENT], PUBLIC]
   {descriptorId: 106, owner: root}
@@ -67,7 +67,7 @@ DROP DATABASE db1 CASCADE
   {parentDatabaseId: 104, schemaId: 106}
 - [[SchemaComment:{DescID: 106, Value: sc1 is good}, ABSENT], PUBLIC]
   {comment: sc1 is good, schemaId: 106}
-- [[Namespace:{DescID: 107, Name: sq1, ReferencedDescID: 104, IntValue: 105}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 107, Name: sq1, ReferencedDescID: 104, UInt32Value: 105}, ABSENT], PUBLIC]
   {databaseId: 104, descriptorId: 107, name: sq1, schemaId: 105}
 - [[Owner:{DescID: 107}, ABSENT], PUBLIC]
   {descriptorId: 107, owner: root}
@@ -81,7 +81,7 @@ DROP DATABASE db1 CASCADE
   {childObjectId: 107, schemaId: 105}
 - [[TableData:{DescID: 107, ReferencedDescID: 104}, ABSENT], PUBLIC]
   {databaseId: 104, tableId: 107}
-- [[Namespace:{DescID: 110, Name: t1, ReferencedDescID: 104, IntValue: 105}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 110, Name: t1, ReferencedDescID: 104, UInt32Value: 105}, ABSENT], PUBLIC]
   {databaseId: 104, descriptorId: 110, name: t1, schemaId: 105}
 - [[Owner:{DescID: 110}, ABSENT], PUBLIC]
   {descriptorId: 110, owner: root}
@@ -163,7 +163,7 @@ DROP DATABASE db1 CASCADE
   {indexId: 1, tableId: 110}
 - [[TableData:{DescID: 110, ReferencedDescID: 104}, ABSENT], PUBLIC]
   {databaseId: 104, tableId: 110}
-- [[Namespace:{DescID: 108, Name: sq1, ReferencedDescID: 104, IntValue: 106}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 108, Name: sq1, ReferencedDescID: 104, UInt32Value: 106}, ABSENT], PUBLIC]
   {databaseId: 104, descriptorId: 108, name: sq1, schemaId: 106}
 - [[Owner:{DescID: 108}, ABSENT], PUBLIC]
   {descriptorId: 108, owner: root}
@@ -177,7 +177,7 @@ DROP DATABASE db1 CASCADE
   {childObjectId: 108, schemaId: 106}
 - [[TableData:{DescID: 108, ReferencedDescID: 104}, ABSENT], PUBLIC]
   {databaseId: 104, tableId: 108}
-- [[Namespace:{DescID: 109, Name: t1, ReferencedDescID: 104, IntValue: 106}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 109, Name: t1, ReferencedDescID: 104, UInt32Value: 106}, ABSENT], PUBLIC]
   {databaseId: 104, descriptorId: 109, name: t1, schemaId: 106}
 - [[Owner:{DescID: 109}, ABSENT], PUBLIC]
   {descriptorId: 109, owner: root}
@@ -265,7 +265,7 @@ DROP DATABASE db1 CASCADE
   {indexId: 1, tableId: 109}
 - [[TableData:{DescID: 109, ReferencedDescID: 104}, ABSENT], PUBLIC]
   {databaseId: 104, tableId: 109}
-- [[Namespace:{DescID: 111, Name: v1, ReferencedDescID: 104, IntValue: 106}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 111, Name: v1, ReferencedDescID: 104, UInt32Value: 106}, ABSENT], PUBLIC]
   {databaseId: 104, descriptorId: 111, name: v1, schemaId: 106}
 - [[Owner:{DescID: 111}, ABSENT], PUBLIC]
   {descriptorId: 111, owner: root}
@@ -315,7 +315,7 @@ DROP DATABASE db1 CASCADE
   {columnId: 4.294967292e+09, elementCreationMetadata: {in261OrLater: true}, tableId: 111, type: {family: DecimalFamily, oid: 1700}, typeName: DECIMAL}
 - [[ColumnHidden:{DescID: 111, ColumnID: 4294967292}, ABSENT], PUBLIC]
   {columnId: 4.294967292e+09, tableId: 111}
-- [[Namespace:{DescID: 112, Name: v2, ReferencedDescID: 104, IntValue: 106}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 112, Name: v2, ReferencedDescID: 104, UInt32Value: 106}, ABSENT], PUBLIC]
   {databaseId: 104, descriptorId: 112, name: v2, schemaId: 106}
 - [[Owner:{DescID: 112}, ABSENT], PUBLIC]
   {descriptorId: 112, owner: root}
@@ -371,7 +371,7 @@ DROP DATABASE db1 CASCADE
   {columnId: 4.294967292e+09, elementCreationMetadata: {in261OrLater: true}, tableId: 112, type: {family: DecimalFamily, oid: 1700}, typeName: DECIMAL}
 - [[ColumnHidden:{DescID: 112, ColumnID: 4294967292}, ABSENT], PUBLIC]
   {columnId: 4.294967292e+09, tableId: 112}
-- [[Namespace:{DescID: 113, Name: v3, ReferencedDescID: 104, IntValue: 106}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 113, Name: v3, ReferencedDescID: 104, UInt32Value: 106}, ABSENT], PUBLIC]
   {databaseId: 104, descriptorId: 113, name: v3, schemaId: 106}
 - [[Owner:{DescID: 113}, ABSENT], PUBLIC]
   {descriptorId: 113, owner: root}
@@ -427,7 +427,7 @@ DROP DATABASE db1 CASCADE
   {columnId: 4.294967292e+09, elementCreationMetadata: {in261OrLater: true}, tableId: 113, type: {family: DecimalFamily, oid: 1700}, typeName: DECIMAL}
 - [[ColumnHidden:{DescID: 113, ColumnID: 4294967292}, ABSENT], PUBLIC]
   {columnId: 4.294967292e+09, tableId: 113}
-- [[Namespace:{DescID: 114, Name: v4, ReferencedDescID: 104, IntValue: 106}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 114, Name: v4, ReferencedDescID: 104, UInt32Value: 106}, ABSENT], PUBLIC]
   {databaseId: 104, descriptorId: 114, name: v4, schemaId: 106}
 - [[Owner:{DescID: 114}, ABSENT], PUBLIC]
   {descriptorId: 114, owner: root}
@@ -483,7 +483,7 @@ DROP DATABASE db1 CASCADE
   {columnId: 4.294967292e+09, elementCreationMetadata: {in261OrLater: true}, tableId: 114, type: {family: DecimalFamily, oid: 1700}, typeName: DECIMAL}
 - [[ColumnHidden:{DescID: 114, ColumnID: 4294967292}, ABSENT], PUBLIC]
   {columnId: 4.294967292e+09, tableId: 114}
-- [[Namespace:{DescID: 115, Name: typ, ReferencedDescID: 104, IntValue: 106}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 115, Name: typ, ReferencedDescID: 104, UInt32Value: 106}, ABSENT], PUBLIC]
   {databaseId: 104, descriptorId: 115, name: typ, schemaId: 106}
 - [[Owner:{DescID: 115}, ABSENT], PUBLIC]
   {descriptorId: 115, owner: root}
@@ -499,7 +499,7 @@ DROP DATABASE db1 CASCADE
   {logicalRepresentation: a, physicalRepresentation: gA==, typeId: 115}
 - [[SchemaChild:{DescID: 115, ReferencedDescID: 106}, ABSENT], PUBLIC]
   {childObjectId: 115, schemaId: 106}
-- [[Namespace:{DescID: 116, Name: _typ, ReferencedDescID: 104, IntValue: 106}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 116, Name: _typ, ReferencedDescID: 104, UInt32Value: 106}, ABSENT], PUBLIC]
   {databaseId: 104, descriptorId: 116, name: _typ, schemaId: 106}
 - [[Owner:{DescID: 116}, ABSENT], PUBLIC]
   {descriptorId: 116, owner: root}
@@ -513,7 +513,7 @@ DROP DATABASE db1 CASCADE
   {closedTypeIds: [115, 116], type: {arrayContents: {family: EnumFamily, oid: 100115, udtMetadata: {arrayTypeOid: 100116}}, family: ArrayFamily, oid: 100116}, typeId: 116, typeName: 'sc1.typ[]'}
 - [[SchemaChild:{DescID: 116, ReferencedDescID: 106}, ABSENT], PUBLIC]
   {childObjectId: 116, schemaId: 106}
-- [[Namespace:{DescID: 117, Name: v5, ReferencedDescID: 104, IntValue: 106}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 117, Name: v5, ReferencedDescID: 104, UInt32Value: 106}, ABSENT], PUBLIC]
   {databaseId: 104, descriptorId: 117, name: v5, schemaId: 106}
 - [[Owner:{DescID: 117}, ABSENT], PUBLIC]
   {descriptorId: 117, owner: root}

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_function
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_function
@@ -35,13 +35,17 @@ DROP FUNCTION f;
   {childObjectId: 109, schemaId: 101}
 - [[FunctionName:{DescID: 109}, ABSENT], PUBLIC]
   {functionId: 109, name: f}
-- [[FunctionVolatility:{DescID: 109}, ABSENT], PUBLIC]
+- [[FunctionVolatility:{DescID: 109, Int32Value: VOLATILE}, ABSENT], PUBLIC]
   {functionId: 109, volatility: {volatility: VOLATILE}}
-- [[FunctionLeakProof:{DescID: 109}, ABSENT], PUBLIC]
+- [[FunctionLeakProof:{DescID: 109, BoolValue: false}, ABSENT], PUBLIC]
   {functionId: 109}
-- [[FunctionNullInputBehavior:{DescID: 109}, ABSENT], PUBLIC]
+- [[FunctionNullInputBehavior:{DescID: 109, Int32Value: CALLED_ON_NULL_INPUT}, ABSENT], PUBLIC]
   {functionId: 109, nullInputBehavior: {nullInputBehavior: CALLED_ON_NULL_INPUT}}
-- [[FunctionSecurity:{DescID: 109}, ABSENT], PUBLIC]
+- [[FunctionSecurity:{DescID: 109, Int32Value: INVOKER}, ABSENT], PUBLIC]
   {functionId: 109, security: {}}
-- [[FunctionBody:{DescID: 109}, ABSENT], PUBLIC]
+- [[FunctionBody:{DescID: 109, Value: SELECT a FROM defaultdb.public.t;
+SELECT b FROM defaultdb.public.t@t_idx_b;
+SELECT c FROM defaultdb.public.t@t_idx_c;
+SELECT a FROM defaultdb.public.v;
+SELECT nextval(105:::REGCLASS);}, ABSENT], PUBLIC]
   {body: "SELECT a FROM defaultdb.public.t;\nSELECT b FROM defaultdb.public.t@t_idx_b;\nSELECT c FROM defaultdb.public.t@t_idx_c;\nSELECT a FROM defaultdb.public.v;\nSELECT nextval(105:::REGCLASS);", functionId: 109, lang: {lang: SQL}, usesSequenceIds: [105], usesTables: [{columnIds: [1], tableId: 104}, {columnIds: [2], indexId: 2, tableId: 104}, {columnIds: [3], indexId: 3, tableId: 104}], usesTypeIds: [107, 108], usesViews: [{columnIds: [1], viewId: 106}]}

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_index
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_index
@@ -105,7 +105,7 @@ DROP INDEX idx3 CASCADE
   {constraintId: 3, name: check_crdb_internal_i_shard_16, tableId: 104}
 - [[TableData:{DescID: 104, ReferencedDescID: 100}, PUBLIC], PUBLIC]
   {databaseId: 100, tableId: 104}
-- [[Namespace:{DescID: 105, Name: v, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 105, Name: v, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 105, name: v, schemaId: 101}
 - [[Owner:{DescID: 105}, ABSENT], PUBLIC]
   {descriptorId: 105, owner: root}
@@ -173,7 +173,7 @@ DROP INDEX v2@idx CASCADE
   {indexId: 2, tableId: 106}
 - [[TableData:{DescID: 106, ReferencedDescID: 100}, PUBLIC], PUBLIC]
   {databaseId: 100, tableId: 106}
-- [[Namespace:{DescID: 107, Name: v3, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 107, Name: v3, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 107, name: v3, schemaId: 101}
 - [[Owner:{DescID: 107}, ABSENT], PUBLIC]
   {descriptorId: 107, owner: root}

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_owned_by
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_owned_by
@@ -20,7 +20,7 @@ DROP OWNED BY r
 ----
 - [[UserPrivileges:{DescID: 100, Name: r}, ABSENT], PUBLIC]
   {descriptorId: 100, privileges: "4", userName: r, withGrantOption: "4"}
-- [[Namespace:{DescID: 105, Name: s, ReferencedDescID: 100, IntValue: 0}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 105, Name: s, ReferencedDescID: 100, UInt32Value: 0}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 105, name: s}
 - [[Owner:{DescID: 105}, ABSENT], PUBLIC]
   {descriptorId: 105, owner: r}
@@ -38,7 +38,7 @@ DROP OWNED BY r
   {indexId: 1, tableId: 104}
 - [[TableData:{DescID: 104, ReferencedDescID: 100}, PUBLIC], PUBLIC]
   {databaseId: 100, tableId: 104}
-- [[Namespace:{DescID: 106, Name: sq, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 106, Name: sq, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 106, name: sq, schemaId: 101}
 - [[Owner:{DescID: 106}, ABSENT], PUBLIC]
   {descriptorId: 106, owner: r}
@@ -52,7 +52,7 @@ DROP OWNED BY r
   {childObjectId: 106, schemaId: 101}
 - [[TableData:{DescID: 106, ReferencedDescID: 100}, ABSENT], PUBLIC]
   {databaseId: 100, tableId: 106}
-- [[Namespace:{DescID: 109, Name: t, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 109, Name: t, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 109, name: t, schemaId: 101}
 - [[Owner:{DescID: 109}, ABSENT], PUBLIC]
   {descriptorId: 109, owner: r}
@@ -134,7 +134,7 @@ DROP OWNED BY r
   {indexId: 1, tableId: 109}
 - [[TableData:{DescID: 109, ReferencedDescID: 100}, ABSENT], PUBLIC]
   {databaseId: 100, tableId: 109}
-- [[Namespace:{DescID: 107, Name: sq, ReferencedDescID: 100, IntValue: 105}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 107, Name: sq, ReferencedDescID: 100, UInt32Value: 105}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 107, name: sq, schemaId: 105}
 - [[Owner:{DescID: 107}, ABSENT], PUBLIC]
   {descriptorId: 107, owner: r}
@@ -148,7 +148,7 @@ DROP OWNED BY r
   {childObjectId: 107, schemaId: 105}
 - [[TableData:{DescID: 107, ReferencedDescID: 100}, ABSENT], PUBLIC]
   {databaseId: 100, tableId: 107}
-- [[Namespace:{DescID: 108, Name: t, ReferencedDescID: 100, IntValue: 105}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 108, Name: t, ReferencedDescID: 100, UInt32Value: 105}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 108, name: t, schemaId: 105}
 - [[Owner:{DescID: 108}, ABSENT], PUBLIC]
   {descriptorId: 108, owner: r}
@@ -230,7 +230,7 @@ DROP OWNED BY r
   {indexId: 1, tableId: 108}
 - [[TableData:{DescID: 108, ReferencedDescID: 100}, ABSENT], PUBLIC]
   {databaseId: 100, tableId: 108}
-- [[Namespace:{DescID: 110, Name: v1, ReferencedDescID: 100, IntValue: 105}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 110, Name: v1, ReferencedDescID: 100, UInt32Value: 105}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 110, name: v1, schemaId: 105}
 - [[Owner:{DescID: 110}, ABSENT], PUBLIC]
   {descriptorId: 110, owner: r}
@@ -280,7 +280,7 @@ DROP OWNED BY r
   {columnId: 4.294967292e+09, elementCreationMetadata: {in261OrLater: true}, tableId: 110, type: {family: DecimalFamily, oid: 1700}, typeName: DECIMAL}
 - [[ColumnHidden:{DescID: 110, ColumnID: 4294967292}, ABSENT], PUBLIC]
   {columnId: 4.294967292e+09, tableId: 110}
-- [[Namespace:{DescID: 111, Name: typ, ReferencedDescID: 100, IntValue: 105}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 111, Name: typ, ReferencedDescID: 100, UInt32Value: 105}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 111, name: typ, schemaId: 105}
 - [[Owner:{DescID: 111}, ABSENT], PUBLIC]
   {descriptorId: 111, owner: r}
@@ -296,7 +296,7 @@ DROP OWNED BY r
   {logicalRepresentation: a, physicalRepresentation: gA==, typeId: 111}
 - [[SchemaChild:{DescID: 111, ReferencedDescID: 105}, ABSENT], PUBLIC]
   {childObjectId: 111, schemaId: 105}
-- [[Namespace:{DescID: 112, Name: _typ, ReferencedDescID: 100, IntValue: 105}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 112, Name: _typ, ReferencedDescID: 100, UInt32Value: 105}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 112, name: _typ, schemaId: 105}
 - [[Owner:{DescID: 112}, ABSENT], PUBLIC]
   {descriptorId: 112, owner: r}
@@ -310,7 +310,7 @@ DROP OWNED BY r
   {closedTypeIds: [111, 112], type: {arrayContents: {family: EnumFamily, oid: 100111, udtMetadata: {arrayTypeOid: 100112}}, family: ArrayFamily, oid: 100112}, typeId: 112, typeName: 's.typ[]'}
 - [[SchemaChild:{DescID: 112, ReferencedDescID: 105}, ABSENT], PUBLIC]
   {childObjectId: 112, schemaId: 105}
-- [[Namespace:{DescID: 113, Name: v2, ReferencedDescID: 100, IntValue: 105}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 113, Name: v2, ReferencedDescID: 100, UInt32Value: 105}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 113, name: v2, schemaId: 105}
 - [[Owner:{DescID: 113}, ABSENT], PUBLIC]
   {descriptorId: 113, owner: r}

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_schema
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_schema
@@ -19,7 +19,7 @@ COMMENT ON INDEX sc1.t1@t1_pkey IS 't1_pkey is good';
 build
 DROP SCHEMA defaultdb.SC1 CASCADE
 ----
-- [[Namespace:{DescID: 104, Name: sc1, ReferencedDescID: 100, IntValue: 0}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 104, Name: sc1, ReferencedDescID: 100, UInt32Value: 0}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 104, name: sc1}
 - [[Owner:{DescID: 104}, ABSENT], PUBLIC]
   {descriptorId: 104, owner: root}
@@ -33,7 +33,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   {parentDatabaseId: 100, schemaId: 104}
 - [[SchemaComment:{DescID: 104, Value: sc1 is good}, ABSENT], PUBLIC]
   {comment: sc1 is good, schemaId: 104}
-- [[Namespace:{DescID: 106, Name: sq1, ReferencedDescID: 100, IntValue: 104}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 106, Name: sq1, ReferencedDescID: 100, UInt32Value: 104}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 106, name: sq1, schemaId: 104}
 - [[Owner:{DescID: 106}, ABSENT], PUBLIC]
   {descriptorId: 106, owner: root}
@@ -47,7 +47,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   {childObjectId: 106, schemaId: 104}
 - [[TableData:{DescID: 106, ReferencedDescID: 100}, ABSENT], PUBLIC]
   {databaseId: 100, tableId: 106}
-- [[Namespace:{DescID: 107, Name: t1, ReferencedDescID: 100, IntValue: 104}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 107, Name: t1, ReferencedDescID: 100, UInt32Value: 104}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 107, name: t1, schemaId: 104}
 - [[Owner:{DescID: 107}, ABSENT], PUBLIC]
   {descriptorId: 107, owner: root}
@@ -135,7 +135,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   {indexId: 1, tableId: 107}
 - [[TableData:{DescID: 107, ReferencedDescID: 100}, ABSENT], PUBLIC]
   {databaseId: 100, tableId: 107}
-- [[Namespace:{DescID: 108, Name: v1, ReferencedDescID: 100, IntValue: 104}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 108, Name: v1, ReferencedDescID: 100, UInt32Value: 104}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 108, name: v1, schemaId: 104}
 - [[Owner:{DescID: 108}, ABSENT], PUBLIC]
   {descriptorId: 108, owner: root}
@@ -185,7 +185,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   {columnId: 4.294967292e+09, elementCreationMetadata: {in261OrLater: true}, tableId: 108, type: {family: DecimalFamily, oid: 1700}, typeName: DECIMAL}
 - [[ColumnHidden:{DescID: 108, ColumnID: 4294967292}, ABSENT], PUBLIC]
   {columnId: 4.294967292e+09, tableId: 108}
-- [[Namespace:{DescID: 109, Name: v2, ReferencedDescID: 100, IntValue: 104}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 109, Name: v2, ReferencedDescID: 100, UInt32Value: 104}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 109, name: v2, schemaId: 104}
 - [[Owner:{DescID: 109}, ABSENT], PUBLIC]
   {descriptorId: 109, owner: root}
@@ -241,7 +241,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   {columnId: 4.294967292e+09, elementCreationMetadata: {in261OrLater: true}, tableId: 109, type: {family: DecimalFamily, oid: 1700}, typeName: DECIMAL}
 - [[ColumnHidden:{DescID: 109, ColumnID: 4294967292}, ABSENT], PUBLIC]
   {columnId: 4.294967292e+09, tableId: 109}
-- [[Namespace:{DescID: 110, Name: v3, ReferencedDescID: 100, IntValue: 104}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 110, Name: v3, ReferencedDescID: 100, UInt32Value: 104}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 110, name: v3, schemaId: 104}
 - [[Owner:{DescID: 110}, ABSENT], PUBLIC]
   {descriptorId: 110, owner: root}
@@ -297,7 +297,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   {columnId: 4.294967292e+09, elementCreationMetadata: {in261OrLater: true}, tableId: 110, type: {family: DecimalFamily, oid: 1700}, typeName: DECIMAL}
 - [[ColumnHidden:{DescID: 110, ColumnID: 4294967292}, ABSENT], PUBLIC]
   {columnId: 4.294967292e+09, tableId: 110}
-- [[Namespace:{DescID: 111, Name: v4, ReferencedDescID: 100, IntValue: 104}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 111, Name: v4, ReferencedDescID: 100, UInt32Value: 104}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 111, name: v4, schemaId: 104}
 - [[Owner:{DescID: 111}, ABSENT], PUBLIC]
   {descriptorId: 111, owner: root}
@@ -353,7 +353,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   {columnId: 4.294967292e+09, elementCreationMetadata: {in261OrLater: true}, tableId: 111, type: {family: DecimalFamily, oid: 1700}, typeName: DECIMAL}
 - [[ColumnHidden:{DescID: 111, ColumnID: 4294967292}, ABSENT], PUBLIC]
   {columnId: 4.294967292e+09, tableId: 111}
-- [[Namespace:{DescID: 112, Name: typ, ReferencedDescID: 100, IntValue: 104}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 112, Name: typ, ReferencedDescID: 100, UInt32Value: 104}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 112, name: typ, schemaId: 104}
 - [[Owner:{DescID: 112}, ABSENT], PUBLIC]
   {descriptorId: 112, owner: root}
@@ -369,7 +369,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   {logicalRepresentation: a, physicalRepresentation: gA==, typeId: 112}
 - [[SchemaChild:{DescID: 112, ReferencedDescID: 104}, ABSENT], PUBLIC]
   {childObjectId: 112, schemaId: 104}
-- [[Namespace:{DescID: 113, Name: _typ, ReferencedDescID: 100, IntValue: 104}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 113, Name: _typ, ReferencedDescID: 100, UInt32Value: 104}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 113, name: _typ, schemaId: 104}
 - [[Owner:{DescID: 113}, ABSENT], PUBLIC]
   {descriptorId: 113, owner: root}
@@ -383,7 +383,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   {closedTypeIds: [112, 113], type: {arrayContents: {family: EnumFamily, oid: 100112, udtMetadata: {arrayTypeOid: 100113}}, family: ArrayFamily, oid: 100113}, typeId: 113, typeName: 'sc1.typ[]'}
 - [[SchemaChild:{DescID: 113, ReferencedDescID: 104}, ABSENT], PUBLIC]
   {childObjectId: 113, schemaId: 104}
-- [[Namespace:{DescID: 114, Name: v5, ReferencedDescID: 100, IntValue: 104}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 114, Name: v5, ReferencedDescID: 100, UInt32Value: 104}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 114, name: v5, schemaId: 104}
 - [[Owner:{DescID: 114}, ABSENT], PUBLIC]
   {descriptorId: 114, owner: root}
@@ -445,7 +445,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   {columnId: 4.294967292e+09, elementCreationMetadata: {in261OrLater: true}, tableId: 114, type: {family: DecimalFamily, oid: 1700}, typeName: DECIMAL}
 - [[ColumnHidden:{DescID: 114, ColumnID: 4294967292}, ABSENT], PUBLIC]
   {columnId: 4.294967292e+09, tableId: 114}
-- [[Namespace:{DescID: 115, Name: v6, ReferencedDescID: 100, IntValue: 105}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 115, Name: v6, ReferencedDescID: 100, UInt32Value: 105}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 115, name: v6, schemaId: 105}
 - [[Owner:{DescID: 115}, ABSENT], PUBLIC]
   {descriptorId: 115, owner: root}

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_sequence
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_sequence
@@ -5,7 +5,7 @@ CREATE SEQUENCE defaultdb.SQ1
 build
 DROP SEQUENCE defaultdb.SQ1 CASCADE
 ----
-- [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 104, name: sq1, schemaId: 101}
 - [[Owner:{DescID: 104}, ABSENT], PUBLIC]
   {descriptorId: 104, owner: root}
@@ -30,7 +30,7 @@ CREATE TABLE defaultdb.blog_posts3 (id INT PRIMARY KEY, val typ DEFAULT CAST(chr
 build
 DROP SEQUENCE defaultdb.SQ1 CASCADE
 ----
-- [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 104, name: sq1, schemaId: 101}
 - [[Owner:{DescID: 104}, ABSENT], PUBLIC]
   {descriptorId: 104, owner: root}
@@ -71,7 +71,7 @@ CREATE SEQUENCE defaultdb.ownedseq OWNED BY defaultdb.ownertbl.id;
 build
 DROP SEQUENCE defaultdb.ownedseq CASCADE
 ----
-- [[Namespace:{DescID: 111, Name: ownedseq, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 111, Name: ownedseq, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 111, name: ownedseq, schemaId: 101}
 - [[Owner:{DescID: 111}, ABSENT], PUBLIC]
   {descriptorId: 111, owner: root}

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_table
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_table
@@ -29,7 +29,7 @@ COMMENT ON CONSTRAINT fk_customers ON defaultdb.shipments IS 'customer is import
 build
 DROP TABLE defaultdb.shipments CASCADE;
 ----
-- [[Namespace:{DescID: 109, Name: shipments, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 109, Name: shipments, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 109, name: shipments, schemaId: 101}
 - [[Owner:{DescID: 109}, ABSENT], PUBLIC]
   {descriptorId: 109, owner: root}
@@ -157,7 +157,7 @@ DROP TABLE defaultdb.shipments CASCADE;
   {constraintId: 3, name: fk_orders, tableId: 109}
 - [[TableData:{DescID: 109, ReferencedDescID: 100}, ABSENT], PUBLIC]
   {databaseId: 100, tableId: 109}
-- [[Namespace:{DescID: 110, Name: sq1, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 110, Name: sq1, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 110, name: sq1, schemaId: 101}
 - [[Owner:{DescID: 110}, ABSENT], PUBLIC]
   {descriptorId: 110, owner: root}
@@ -171,7 +171,7 @@ DROP TABLE defaultdb.shipments CASCADE;
   {childObjectId: 110, schemaId: 101}
 - [[TableData:{DescID: 110, ReferencedDescID: 100}, ABSENT], PUBLIC]
   {databaseId: 100, tableId: 110}
-- [[Namespace:{DescID: 111, Name: v1, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 111, Name: v1, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 111, name: v1, schemaId: 101}
 - [[Owner:{DescID: 111}, ABSENT], PUBLIC]
   {descriptorId: 111, owner: root}

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_type
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_type
@@ -6,7 +6,7 @@ CREATE TYPE defaultdb.ctyp AS (a INT, b INT)
 build
 DROP TYPE defaultdb.typ
 ----
-- [[Namespace:{DescID: 104, Name: typ, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 104, Name: typ, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 104, name: typ, schemaId: 101}
 - [[Owner:{DescID: 104}, ABSENT], PUBLIC]
   {descriptorId: 104, owner: root}
@@ -22,7 +22,7 @@ DROP TYPE defaultdb.typ
   {logicalRepresentation: a, physicalRepresentation: gA==, typeId: 104}
 - [[SchemaChild:{DescID: 104, ReferencedDescID: 101}, ABSENT], PUBLIC]
   {childObjectId: 104, schemaId: 101}
-- [[Namespace:{DescID: 105, Name: _typ, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 105, Name: _typ, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 105, name: _typ, schemaId: 101}
 - [[Owner:{DescID: 105}, ABSENT], PUBLIC]
   {descriptorId: 105, owner: root}
@@ -40,7 +40,7 @@ DROP TYPE defaultdb.typ
 build
 DROP TYPE defaultdb.ctyp
 ----
-- [[Namespace:{DescID: 106, Name: ctyp, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 106, Name: ctyp, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 106, name: ctyp, schemaId: 101}
 - [[Owner:{DescID: 106}, ABSENT], PUBLIC]
   {descriptorId: 106, owner: root}
@@ -60,7 +60,7 @@ DROP TYPE defaultdb.ctyp
   {compositeTypeId: 106, name: b}
 - [[SchemaChild:{DescID: 106, ReferencedDescID: 101}, ABSENT], PUBLIC]
   {childObjectId: 106, schemaId: 101}
-- [[Namespace:{DescID: 107, Name: _ctyp, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 107, Name: _ctyp, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 107, name: _ctyp, schemaId: 101}
 - [[Owner:{DescID: 107}, ABSENT], PUBLIC]
   {descriptorId: 107, owner: root}

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_view
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_view
@@ -6,7 +6,7 @@ CREATE VIEW defaultdb.v1 AS (SELECT name FROM defaultdb.t1);
 build
 DROP VIEW defaultdb.v1
 ----
-- [[Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 105, name: v1, schemaId: 101}
 - [[Owner:{DescID: 105}, ABSENT], PUBLIC]
   {descriptorId: 105, owner: root}
@@ -68,7 +68,7 @@ CREATE VIEW v5 AS (SELECT 'a'::defaultdb.typ::string AS k, n2, n1 from defaultdb
 build
 DROP VIEW defaultdb.v1 CASCADE
 ----
-- [[Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 105, name: v1, schemaId: 101}
 - [[Owner:{DescID: 105}, ABSENT], PUBLIC]
   {descriptorId: 105, owner: root}
@@ -118,7 +118,7 @@ DROP VIEW defaultdb.v1 CASCADE
   {columnId: 4.294967292e+09, elementCreationMetadata: {in261OrLater: true}, tableId: 105, type: {family: DecimalFamily, oid: 1700}, typeName: DECIMAL}
 - [[ColumnHidden:{DescID: 105, ColumnID: 4294967292}, ABSENT], PUBLIC]
   {columnId: 4.294967292e+09, tableId: 105}
-- [[Namespace:{DescID: 106, Name: v2, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 106, Name: v2, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 106, name: v2, schemaId: 101}
 - [[Owner:{DescID: 106}, ABSENT], PUBLIC]
   {descriptorId: 106, owner: root}
@@ -174,7 +174,7 @@ DROP VIEW defaultdb.v1 CASCADE
   {columnId: 4.294967292e+09, elementCreationMetadata: {in261OrLater: true}, tableId: 106, type: {family: DecimalFamily, oid: 1700}, typeName: DECIMAL}
 - [[ColumnHidden:{DescID: 106, ColumnID: 4294967292}, ABSENT], PUBLIC]
   {columnId: 4.294967292e+09, tableId: 106}
-- [[Namespace:{DescID: 107, Name: v3, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 107, Name: v3, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 107, name: v3, schemaId: 101}
 - [[Owner:{DescID: 107}, ABSENT], PUBLIC]
   {descriptorId: 107, owner: root}
@@ -230,7 +230,7 @@ DROP VIEW defaultdb.v1 CASCADE
   {columnId: 4.294967292e+09, elementCreationMetadata: {in261OrLater: true}, tableId: 107, type: {family: DecimalFamily, oid: 1700}, typeName: DECIMAL}
 - [[ColumnHidden:{DescID: 107, ColumnID: 4294967292}, ABSENT], PUBLIC]
   {columnId: 4.294967292e+09, tableId: 107}
-- [[Namespace:{DescID: 108, Name: v4, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 108, Name: v4, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 108, name: v4, schemaId: 101}
 - [[Owner:{DescID: 108}, ABSENT], PUBLIC]
   {descriptorId: 108, owner: root}
@@ -286,7 +286,7 @@ DROP VIEW defaultdb.v1 CASCADE
   {columnId: 4.294967292e+09, elementCreationMetadata: {in261OrLater: true}, tableId: 108, type: {family: DecimalFamily, oid: 1700}, typeName: DECIMAL}
 - [[ColumnHidden:{DescID: 108, ColumnID: 4294967292}, ABSENT], PUBLIC]
   {columnId: 4.294967292e+09, tableId: 108}
-- [[Namespace:{DescID: 111, Name: v5, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 111, Name: v5, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 111, name: v5, schemaId: 101}
 - [[Owner:{DescID: 111}, ABSENT], PUBLIC]
   {descriptorId: 111, owner: root}

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_add_column_generated
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_add_column_generated
@@ -8,7 +8,7 @@ ALTER TABLE defaultdb.foo ADD COLUMN j INT GENERATED ALWAYS AS IDENTITY
 StatementPhase stage 1 of 1 with 37 MutationType ops
   transitions:
     [[Sequence:{DescID: 105}, PUBLIC], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 105, Name: foo_j_seq, ReferencedDescID: 100, IntValue: 101}, PUBLIC], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 105, Name: foo_j_seq, ReferencedDescID: 100, UInt32Value: 101}, PUBLIC], ABSENT] -> PUBLIC
     [[SchemaChild:{DescID: 105, ReferencedDescID: 101}, PUBLIC], ABSENT] -> PUBLIC
     [[TableData:{DescID: 105, ReferencedDescID: 100}, PUBLIC], ABSENT] -> PUBLIC
     [[Column:{DescID: 105, ColumnID: 1}, PUBLIC], ABSENT] -> PUBLIC
@@ -209,7 +209,7 @@ StatementPhase stage 1 of 1 with 37 MutationType ops
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
     [[Sequence:{DescID: 105}, PUBLIC], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 105, Name: foo_j_seq, ReferencedDescID: 100, IntValue: 101}, PUBLIC], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 105, Name: foo_j_seq, ReferencedDescID: 100, UInt32Value: 101}, PUBLIC], PUBLIC] -> ABSENT
     [[SchemaChild:{DescID: 105, ReferencedDescID: 101}, PUBLIC], PUBLIC] -> ABSENT
     [[TableData:{DescID: 105, ReferencedDescID: 100}, PUBLIC], PUBLIC] -> ABSENT
     [[Column:{DescID: 105, ColumnID: 1}, PUBLIC], PUBLIC] -> ABSENT
@@ -241,7 +241,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
 PreCommitPhase stage 2 of 2 with 43 MutationType ops
   transitions:
     [[Sequence:{DescID: 105}, PUBLIC], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 105, Name: foo_j_seq, ReferencedDescID: 100, IntValue: 101}, PUBLIC], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 105, Name: foo_j_seq, ReferencedDescID: 100, UInt32Value: 101}, PUBLIC], ABSENT] -> PUBLIC
     [[SchemaChild:{DescID: 105, ReferencedDescID: 101}, PUBLIC], ABSENT] -> PUBLIC
     [[TableData:{DescID: 105, ReferencedDescID: 100}, PUBLIC], ABSENT] -> PUBLIC
     [[Column:{DescID: 105, ColumnID: 1}, PUBLIC], ABSENT] -> PUBLIC

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_drop_column
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_drop_column
@@ -22,7 +22,7 @@ StatementPhase stage 1 of 1 with 53 MutationType ops
     [[Column:{DescID: 107, ColumnID: 2}, ABSENT], PUBLIC] -> WRITE_ONLY
     [[ColumnName:{DescID: 107, Name: v1, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
     [[SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 1, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, ABSENT], PUBLIC] -> VALIDATED
-    [[Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 108}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -262,7 +262,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[Column:{DescID: 107, ColumnID: 2}, ABSENT], WRITE_ONLY] -> PUBLIC
     [[ColumnName:{DescID: 107, Name: v1, ColumnID: 2}, ABSENT], ABSENT] -> PUBLIC
     [[SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 1, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, ABSENT], VALIDATED] -> PUBLIC
-    [[Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 100, IntValue: 101}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 108}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -514,7 +514,7 @@ PostCommitNonRevertiblePhase stage 1 of 3 with 61 MutationType ops
     [[IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 2}, ABSENT], PUBLIC] -> ABSENT
     [[SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 1, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, ABSENT], VALIDATED] -> DELETE_ONLY
     [[IndexName:{DescID: 107, Name: foo_v2_key, IndexID: 2}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 108}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -1270,7 +1270,7 @@ ALTER TABLE defaultdb.foo DROP COLUMN v1 CASCADE;
   to:   [SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 1, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, ABSENT]
   kind: Precedence
   rule: dependents removed before index
-- from: [Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 100, IntValue: 101}, ABSENT]
+- from: [Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 100, UInt32Value: 101}, ABSENT]
   to:   [View:{DescID: 108}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
@@ -1587,7 +1587,7 @@ ALTER TABLE defaultdb.foo DROP COLUMN v1 CASCADE;
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 108}, DROPPED]
-  to:   [Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 100, IntValue: 101}, ABSENT]
+  to:   [Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 100, UInt32Value: 101}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 108}, DROPPED]
@@ -1618,7 +1618,7 @@ StatementPhase stage 1 of 1 with 52 MutationType ops
   transitions:
     [[ColumnNotNull:{DescID: 107, ColumnID: 3, IndexID: 0}, ABSENT], PUBLIC] -> VALIDATED
     [[SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 1, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, ABSENT], PUBLIC] -> VALIDATED
-    [[Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 108}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -1853,7 +1853,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
     [[ColumnNotNull:{DescID: 107, ColumnID: 3, IndexID: 0}, ABSENT], VALIDATED] -> PUBLIC
     [[SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 1, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, ABSENT], VALIDATED] -> PUBLIC
-    [[Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 100, IntValue: 101}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 108}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -2114,7 +2114,7 @@ PostCommitNonRevertiblePhase stage 1 of 3 with 64 MutationType ops
     [[IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 2}, ABSENT], PUBLIC] -> ABSENT
     [[SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 1, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, ABSENT], VALIDATED] -> DELETE_ONLY
     [[IndexName:{DescID: 107, Name: foo_v2_key, IndexID: 2}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 108}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -2918,7 +2918,7 @@ ALTER TABLE defaultdb.foo DROP COLUMN v2 CASCADE;
   to:   [SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 1, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, ABSENT]
   kind: Precedence
   rule: dependents removed before index
-- from: [Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 100, IntValue: 101}, ABSENT]
+- from: [Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 100, UInt32Value: 101}, ABSENT]
   to:   [View:{DescID: 108}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
@@ -3239,7 +3239,7 @@ ALTER TABLE defaultdb.foo DROP COLUMN v2 CASCADE;
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 108}, DROPPED]
-  to:   [Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 100, IntValue: 101}, ABSENT]
+  to:   [Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 100, UInt32Value: 101}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 108}, DROPPED]

--- a/pkg/sql/schemachanger/scplan/testdata/create_database
+++ b/pkg/sql/schemachanger/scplan/testdata/create_database
@@ -4,14 +4,14 @@ CREATE DATABASE db;
 StatementPhase stage 1 of 1 with 17 MutationType ops
   transitions:
     [[Database:{DescID: 104}, PUBLIC], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 104, Name: db, ReferencedDescID: 0, IntValue: 0}, PUBLIC], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 104, Name: db, ReferencedDescID: 0, UInt32Value: 0}, PUBLIC], ABSENT] -> PUBLIC
     [[DatabaseData:{DescID: 104}, PUBLIC], ABSENT] -> PUBLIC
     [[Owner:{DescID: 104}, PUBLIC], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 104, Name: admin}, PUBLIC], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 104, Name: public}, PUBLIC], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 104, Name: root}, PUBLIC], ABSENT] -> PUBLIC
     [[Schema:{DescID: 105}, PUBLIC], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 105, Name: public, ReferencedDescID: 104, IntValue: 0}, PUBLIC], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 105, Name: public, ReferencedDescID: 104, UInt32Value: 0}, PUBLIC], ABSENT] -> PUBLIC
     [[SchemaParent:{DescID: 105, ReferencedDescID: 104}, PUBLIC], ABSENT] -> PUBLIC
     [[Owner:{DescID: 105}, PUBLIC], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 105, Name: admin}, PUBLIC], ABSENT] -> PUBLIC
@@ -90,14 +90,14 @@ StatementPhase stage 1 of 1 with 17 MutationType ops
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
     [[Database:{DescID: 104}, PUBLIC], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 104, Name: db, ReferencedDescID: 0, IntValue: 0}, PUBLIC], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 104, Name: db, ReferencedDescID: 0, UInt32Value: 0}, PUBLIC], PUBLIC] -> ABSENT
     [[DatabaseData:{DescID: 104}, PUBLIC], PUBLIC] -> ABSENT
     [[Owner:{DescID: 104}, PUBLIC], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: admin}, PUBLIC], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: public}, PUBLIC], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: root}, PUBLIC], PUBLIC] -> ABSENT
     [[Schema:{DescID: 105}, PUBLIC], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 105, Name: public, ReferencedDescID: 104, IntValue: 0}, PUBLIC], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 105, Name: public, ReferencedDescID: 104, UInt32Value: 0}, PUBLIC], PUBLIC] -> ABSENT
     [[SchemaParent:{DescID: 105, ReferencedDescID: 104}, PUBLIC], PUBLIC] -> ABSENT
     [[Owner:{DescID: 105}, PUBLIC], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: admin}, PUBLIC], PUBLIC] -> ABSENT
@@ -109,14 +109,14 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
 PreCommitPhase stage 2 of 2 with 17 MutationType ops
   transitions:
     [[Database:{DescID: 104}, PUBLIC], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 104, Name: db, ReferencedDescID: 0, IntValue: 0}, PUBLIC], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 104, Name: db, ReferencedDescID: 0, UInt32Value: 0}, PUBLIC], ABSENT] -> PUBLIC
     [[DatabaseData:{DescID: 104}, PUBLIC], ABSENT] -> PUBLIC
     [[Owner:{DescID: 104}, PUBLIC], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 104, Name: admin}, PUBLIC], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 104, Name: public}, PUBLIC], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 104, Name: root}, PUBLIC], ABSENT] -> PUBLIC
     [[Schema:{DescID: 105}, PUBLIC], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 105, Name: public, ReferencedDescID: 104, IntValue: 0}, PUBLIC], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 105, Name: public, ReferencedDescID: 104, UInt32Value: 0}, PUBLIC], ABSENT] -> PUBLIC
     [[SchemaParent:{DescID: 105, ReferencedDescID: 104}, PUBLIC], ABSENT] -> PUBLIC
     [[Owner:{DescID: 105}, PUBLIC], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 105, Name: admin}, PUBLIC], ABSENT] -> PUBLIC
@@ -201,7 +201,7 @@ CREATE DATABASE db;
   kind: Precedence
   rule: descriptor existence precedes dependents
 - from: [Database:{DescID: 106}, DESCRIPTOR_ADDED]
-  to:   [Namespace:{DescID: 106, Name: db, ReferencedDescID: 0, IntValue: 0}, PUBLIC]
+  to:   [Namespace:{DescID: 106, Name: db, ReferencedDescID: 0, UInt32Value: 0}, PUBLIC]
   kind: Precedence
   rule: descriptor existence precedes dependents
 - from: [Database:{DescID: 106}, DESCRIPTOR_ADDED]
@@ -224,15 +224,15 @@ CREATE DATABASE db;
   to:   [DatabaseData:{DescID: 106}, PUBLIC]
   kind: Precedence
   rule: table added right before data element
-- from: [Namespace:{DescID: 106, Name: db, ReferencedDescID: 0, IntValue: 0}, PUBLIC]
+- from: [Namespace:{DescID: 106, Name: db, ReferencedDescID: 0, UInt32Value: 0}, PUBLIC]
   to:   [Database:{DescID: 106}, PUBLIC]
   kind: Precedence
   rule: dependents exist before descriptor becomes public
-- from: [Namespace:{DescID: 107, Name: public, ReferencedDescID: 106, IntValue: 0}, PUBLIC]
+- from: [Namespace:{DescID: 107, Name: public, ReferencedDescID: 106, UInt32Value: 0}, PUBLIC]
   to:   [Schema:{DescID: 107}, PUBLIC]
   kind: Precedence
   rule: dependents exist before descriptor becomes public
-- from: [Namespace:{DescID: 107, Name: public, ReferencedDescID: 106, IntValue: 0}, PUBLIC]
+- from: [Namespace:{DescID: 107, Name: public, ReferencedDescID: 106, UInt32Value: 0}, PUBLIC]
   to:   [SchemaParent:{DescID: 107, ReferencedDescID: 106}, PUBLIC]
   kind: Precedence
   rule: namespace exist before schema parent
@@ -245,7 +245,7 @@ CREATE DATABASE db;
   kind: Precedence
   rule: dependents exist before descriptor becomes public
 - from: [Schema:{DescID: 107}, DESCRIPTOR_ADDED]
-  to:   [Namespace:{DescID: 107, Name: public, ReferencedDescID: 106, IntValue: 0}, PUBLIC]
+  to:   [Namespace:{DescID: 107, Name: public, ReferencedDescID: 106, UInt32Value: 0}, PUBLIC]
   kind: Precedence
   rule: descriptor existence precedes dependents
 - from: [Schema:{DescID: 107}, DESCRIPTOR_ADDED]

--- a/pkg/sql/schemachanger/scplan/testdata/create_function
+++ b/pkg/sql/schemachanger/scplan/testdata/create_function
@@ -26,12 +26,17 @@ StatementPhase stage 1 of 1 with 12 MutationType ops
     [[Function:{DescID: 109}, PUBLIC], ABSENT] -> PUBLIC
     [[SchemaChild:{DescID: 109, ReferencedDescID: 101}, PUBLIC], ABSENT] -> PUBLIC
     [[FunctionName:{DescID: 109}, PUBLIC], ABSENT] -> PUBLIC
-    [[FunctionVolatility:{DescID: 109}, PUBLIC], ABSENT] -> PUBLIC
+    [[FunctionVolatility:{DescID: 109, Int32Value: VOLATILE}, PUBLIC], ABSENT] -> PUBLIC
     [[Owner:{DescID: 109}, PUBLIC], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 109, Name: admin}, PUBLIC], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 109, Name: public}, PUBLIC], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 109, Name: root}, PUBLIC], ABSENT] -> PUBLIC
-    [[FunctionBody:{DescID: 109}, PUBLIC], ABSENT] -> PUBLIC
+    [[FunctionBody:{DescID: 109, Value: SELECT a FROM t;
+    SELECT b FROM t@t_idx_b;
+    SELECT c FROM t@t_idx_c;
+    SELECT a FROM v;
+    SELECT b'@':::@100107;
+    SELECT nextval(105:::REGCLASS);}, PUBLIC], ABSENT] -> PUBLIC
   ops:
     *scop.CreateFunctionDescriptor
       Function:
@@ -161,12 +166,17 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[Function:{DescID: 109}, PUBLIC], PUBLIC] -> ABSENT
     [[SchemaChild:{DescID: 109, ReferencedDescID: 101}, PUBLIC], PUBLIC] -> ABSENT
     [[FunctionName:{DescID: 109}, PUBLIC], PUBLIC] -> ABSENT
-    [[FunctionVolatility:{DescID: 109}, PUBLIC], PUBLIC] -> ABSENT
+    [[FunctionVolatility:{DescID: 109, Int32Value: VOLATILE}, PUBLIC], PUBLIC] -> ABSENT
     [[Owner:{DescID: 109}, PUBLIC], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 109, Name: admin}, PUBLIC], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 109, Name: public}, PUBLIC], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 109, Name: root}, PUBLIC], PUBLIC] -> ABSENT
-    [[FunctionBody:{DescID: 109}, PUBLIC], PUBLIC] -> ABSENT
+    [[FunctionBody:{DescID: 109, Value: SELECT a FROM t;
+    SELECT b FROM t@t_idx_b;
+    SELECT c FROM t@t_idx_c;
+    SELECT a FROM v;
+    SELECT b'@':::@100107;
+    SELECT nextval(105:::REGCLASS);}, PUBLIC], PUBLIC] -> ABSENT
   ops:
     *scop.UndoAllInTxnImmediateMutationOpSideEffects
       {}
@@ -175,12 +185,17 @@ PreCommitPhase stage 2 of 2 with 12 MutationType ops
     [[Function:{DescID: 109}, PUBLIC], ABSENT] -> PUBLIC
     [[SchemaChild:{DescID: 109, ReferencedDescID: 101}, PUBLIC], ABSENT] -> PUBLIC
     [[FunctionName:{DescID: 109}, PUBLIC], ABSENT] -> PUBLIC
-    [[FunctionVolatility:{DescID: 109}, PUBLIC], ABSENT] -> PUBLIC
+    [[FunctionVolatility:{DescID: 109, Int32Value: VOLATILE}, PUBLIC], ABSENT] -> PUBLIC
     [[Owner:{DescID: 109}, PUBLIC], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 109, Name: admin}, PUBLIC], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 109, Name: public}, PUBLIC], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 109, Name: root}, PUBLIC], ABSENT] -> PUBLIC
-    [[FunctionBody:{DescID: 109}, PUBLIC], ABSENT] -> PUBLIC
+    [[FunctionBody:{DescID: 109, Value: SELECT a FROM t;
+    SELECT b FROM t@t_idx_b;
+    SELECT c FROM t@t_idx_c;
+    SELECT a FROM v;
+    SELECT b'@':::@100107;
+    SELECT nextval(105:::REGCLASS);}, PUBLIC], ABSENT] -> PUBLIC
   ops:
     *scop.CreateFunctionDescriptor
       Function:
@@ -317,7 +332,12 @@ CREATE FUNCTION f(a notmyworkday) RETURNS INT VOLATILE LANGUAGE SQL AS $$
 $$;
 ----
 - from: [Function:{DescID: 110}, DESCRIPTOR_ADDED]
-  to:   [FunctionBody:{DescID: 110}, PUBLIC]
+  to:   [FunctionBody:{DescID: 110, Value: SELECT a FROM t;
+SELECT b FROM t@t_idx_b;
+SELECT c FROM t@t_idx_c;
+SELECT a FROM v;
+SELECT b'@':::@100107;
+SELECT nextval(105:::REGCLASS);}, PUBLIC]
   kind: Precedence
   rule: descriptor existence precedes dependents
 - from: [Function:{DescID: 110}, DESCRIPTOR_ADDED]
@@ -325,7 +345,7 @@ $$;
   kind: Precedence
   rule: descriptor existence precedes dependents
 - from: [Function:{DescID: 110}, DESCRIPTOR_ADDED]
-  to:   [FunctionVolatility:{DescID: 110}, PUBLIC]
+  to:   [FunctionVolatility:{DescID: 110, Int32Value: VOLATILE}, PUBLIC]
   kind: Precedence
   rule: descriptor existence precedes dependents
 - from: [Function:{DescID: 110}, DESCRIPTOR_ADDED]
@@ -348,7 +368,12 @@ $$;
   to:   [UserPrivileges:{DescID: 110, Name: root}, PUBLIC]
   kind: Precedence
   rule: descriptor existence precedes dependents
-- from: [FunctionBody:{DescID: 110}, PUBLIC]
+- from: [FunctionBody:{DescID: 110, Value: SELECT a FROM t;
+SELECT b FROM t@t_idx_b;
+SELECT c FROM t@t_idx_c;
+SELECT a FROM v;
+SELECT b'@':::@100107;
+SELECT nextval(105:::REGCLASS);}, PUBLIC]
   to:   [Function:{DescID: 110}, PUBLIC]
   kind: Precedence
   rule: dependents exist before descriptor becomes public
@@ -360,7 +385,7 @@ $$;
   to:   [SchemaChild:{DescID: 110, ReferencedDescID: 101}, PUBLIC]
   kind: Precedence
   rule: function name should be set before parent ids
-- from: [FunctionVolatility:{DescID: 110}, PUBLIC]
+- from: [FunctionVolatility:{DescID: 110, Int32Value: VOLATILE}, PUBLIC]
   to:   [Function:{DescID: 110}, PUBLIC]
   kind: Precedence
   rule: dependents exist before descriptor becomes public
@@ -402,12 +427,20 @@ StatementPhase stage 1 of 1 with 12 MutationType ops
     [[Function:{DescID: 111}, PUBLIC], ABSENT] -> PUBLIC
     [[SchemaChild:{DescID: 111, ReferencedDescID: 101}, PUBLIC], ABSENT] -> PUBLIC
     [[FunctionName:{DescID: 111}, PUBLIC], ABSENT] -> PUBLIC
-    [[FunctionVolatility:{DescID: 111}, PUBLIC], ABSENT] -> PUBLIC
+    [[FunctionVolatility:{DescID: 111, Int32Value: VOLATILE}, PUBLIC], ABSENT] -> PUBLIC
     [[Owner:{DescID: 111}, PUBLIC], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 111, Name: admin}, PUBLIC], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 111, Name: public}, PUBLIC], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 111, Name: root}, PUBLIC], ABSENT] -> PUBLIC
-    [[FunctionBody:{DescID: 111}, PUBLIC], ABSENT] -> PUBLIC
+    [[FunctionBody:{DescID: 111, Value: BEGIN
+    SELECT a FROM t;
+    SELECT b FROM t@t_idx_b;
+    SELECT c FROM t@t_idx_c;
+    SELECT a FROM v;
+    SELECT b'@':::@100107;
+    RETURN nextval(105:::REGCLASS);
+    END;
+    }, PUBLIC], ABSENT] -> PUBLIC
   ops:
     *scop.CreateFunctionDescriptor
       Function:
@@ -539,12 +572,20 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[Function:{DescID: 111}, PUBLIC], PUBLIC] -> ABSENT
     [[SchemaChild:{DescID: 111, ReferencedDescID: 101}, PUBLIC], PUBLIC] -> ABSENT
     [[FunctionName:{DescID: 111}, PUBLIC], PUBLIC] -> ABSENT
-    [[FunctionVolatility:{DescID: 111}, PUBLIC], PUBLIC] -> ABSENT
+    [[FunctionVolatility:{DescID: 111, Int32Value: VOLATILE}, PUBLIC], PUBLIC] -> ABSENT
     [[Owner:{DescID: 111}, PUBLIC], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: admin}, PUBLIC], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: public}, PUBLIC], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: root}, PUBLIC], PUBLIC] -> ABSENT
-    [[FunctionBody:{DescID: 111}, PUBLIC], PUBLIC] -> ABSENT
+    [[FunctionBody:{DescID: 111, Value: BEGIN
+    SELECT a FROM t;
+    SELECT b FROM t@t_idx_b;
+    SELECT c FROM t@t_idx_c;
+    SELECT a FROM v;
+    SELECT b'@':::@100107;
+    RETURN nextval(105:::REGCLASS);
+    END;
+    }, PUBLIC], PUBLIC] -> ABSENT
   ops:
     *scop.UndoAllInTxnImmediateMutationOpSideEffects
       {}
@@ -553,12 +594,20 @@ PreCommitPhase stage 2 of 2 with 12 MutationType ops
     [[Function:{DescID: 111}, PUBLIC], ABSENT] -> PUBLIC
     [[SchemaChild:{DescID: 111, ReferencedDescID: 101}, PUBLIC], ABSENT] -> PUBLIC
     [[FunctionName:{DescID: 111}, PUBLIC], ABSENT] -> PUBLIC
-    [[FunctionVolatility:{DescID: 111}, PUBLIC], ABSENT] -> PUBLIC
+    [[FunctionVolatility:{DescID: 111, Int32Value: VOLATILE}, PUBLIC], ABSENT] -> PUBLIC
     [[Owner:{DescID: 111}, PUBLIC], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 111, Name: admin}, PUBLIC], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 111, Name: public}, PUBLIC], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 111, Name: root}, PUBLIC], ABSENT] -> PUBLIC
-    [[FunctionBody:{DescID: 111}, PUBLIC], ABSENT] -> PUBLIC
+    [[FunctionBody:{DescID: 111, Value: BEGIN
+    SELECT a FROM t;
+    SELECT b FROM t@t_idx_b;
+    SELECT c FROM t@t_idx_c;
+    SELECT a FROM v;
+    SELECT b'@':::@100107;
+    RETURN nextval(105:::REGCLASS);
+    END;
+    }, PUBLIC], ABSENT] -> PUBLIC
   ops:
     *scop.CreateFunctionDescriptor
       Function:
@@ -699,7 +748,15 @@ CREATE FUNCTION f(a notmyworkday) RETURNS INT VOLATILE LANGUAGE PLpgSQL AS $$
 $$;
 ----
 - from: [Function:{DescID: 112}, DESCRIPTOR_ADDED]
-  to:   [FunctionBody:{DescID: 112}, PUBLIC]
+  to:   [FunctionBody:{DescID: 112, Value: BEGIN
+SELECT a FROM t;
+SELECT b FROM t@t_idx_b;
+SELECT c FROM t@t_idx_c;
+SELECT a FROM v;
+SELECT b'@':::@100107;
+RETURN nextval(105:::REGCLASS);
+END;
+}, PUBLIC]
   kind: Precedence
   rule: descriptor existence precedes dependents
 - from: [Function:{DescID: 112}, DESCRIPTOR_ADDED]
@@ -707,7 +764,7 @@ $$;
   kind: Precedence
   rule: descriptor existence precedes dependents
 - from: [Function:{DescID: 112}, DESCRIPTOR_ADDED]
-  to:   [FunctionVolatility:{DescID: 112}, PUBLIC]
+  to:   [FunctionVolatility:{DescID: 112, Int32Value: VOLATILE}, PUBLIC]
   kind: Precedence
   rule: descriptor existence precedes dependents
 - from: [Function:{DescID: 112}, DESCRIPTOR_ADDED]
@@ -730,7 +787,15 @@ $$;
   to:   [UserPrivileges:{DescID: 112, Name: root}, PUBLIC]
   kind: Precedence
   rule: descriptor existence precedes dependents
-- from: [FunctionBody:{DescID: 112}, PUBLIC]
+- from: [FunctionBody:{DescID: 112, Value: BEGIN
+SELECT a FROM t;
+SELECT b FROM t@t_idx_b;
+SELECT c FROM t@t_idx_c;
+SELECT a FROM v;
+SELECT b'@':::@100107;
+RETURN nextval(105:::REGCLASS);
+END;
+}, PUBLIC]
   to:   [Function:{DescID: 112}, PUBLIC]
   kind: Precedence
   rule: dependents exist before descriptor becomes public
@@ -742,7 +807,7 @@ $$;
   to:   [SchemaChild:{DescID: 112, ReferencedDescID: 101}, PUBLIC]
   kind: Precedence
   rule: function name should be set before parent ids
-- from: [FunctionVolatility:{DescID: 112}, PUBLIC]
+- from: [FunctionVolatility:{DescID: 112, Int32Value: VOLATILE}, PUBLIC]
   to:   [Function:{DescID: 112}, PUBLIC]
   kind: Precedence
   rule: dependents exist before descriptor becomes public

--- a/pkg/sql/schemachanger/scplan/testdata/create_procedure
+++ b/pkg/sql/schemachanger/scplan/testdata/create_procedure
@@ -30,7 +30,12 @@ StatementPhase stage 1 of 1 with 11 MutationType ops
     [[UserPrivileges:{DescID: 109, Name: admin}, PUBLIC], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 109, Name: public}, PUBLIC], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 109, Name: root}, PUBLIC], ABSENT] -> PUBLIC
-    [[FunctionBody:{DescID: 109}, PUBLIC], ABSENT] -> PUBLIC
+    [[FunctionBody:{DescID: 109, Value: SELECT a FROM t;
+    SELECT b FROM t@t_idx_b;
+    SELECT c FROM t@t_idx_c;
+    SELECT a FROM v;
+    SELECT b'@':::@100107;
+    SELECT nextval(105:::REGCLASS);}, PUBLIC], ABSENT] -> PUBLIC
   ops:
     *scop.CreateFunctionDescriptor
       Function:
@@ -161,7 +166,12 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[UserPrivileges:{DescID: 109, Name: admin}, PUBLIC], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 109, Name: public}, PUBLIC], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 109, Name: root}, PUBLIC], PUBLIC] -> ABSENT
-    [[FunctionBody:{DescID: 109}, PUBLIC], PUBLIC] -> ABSENT
+    [[FunctionBody:{DescID: 109, Value: SELECT a FROM t;
+    SELECT b FROM t@t_idx_b;
+    SELECT c FROM t@t_idx_c;
+    SELECT a FROM v;
+    SELECT b'@':::@100107;
+    SELECT nextval(105:::REGCLASS);}, PUBLIC], PUBLIC] -> ABSENT
   ops:
     *scop.UndoAllInTxnImmediateMutationOpSideEffects
       {}
@@ -174,7 +184,12 @@ PreCommitPhase stage 2 of 2 with 11 MutationType ops
     [[UserPrivileges:{DescID: 109, Name: admin}, PUBLIC], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 109, Name: public}, PUBLIC], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 109, Name: root}, PUBLIC], ABSENT] -> PUBLIC
-    [[FunctionBody:{DescID: 109}, PUBLIC], ABSENT] -> PUBLIC
+    [[FunctionBody:{DescID: 109, Value: SELECT a FROM t;
+    SELECT b FROM t@t_idx_b;
+    SELECT c FROM t@t_idx_c;
+    SELECT a FROM v;
+    SELECT b'@':::@100107;
+    SELECT nextval(105:::REGCLASS);}, PUBLIC], ABSENT] -> PUBLIC
   ops:
     *scop.CreateFunctionDescriptor
       Function:
@@ -308,7 +323,12 @@ CREATE PROCEDURE p(a notmyworkday) LANGUAGE SQL AS $$
 $$;
 ----
 - from: [Function:{DescID: 110}, DESCRIPTOR_ADDED]
-  to:   [FunctionBody:{DescID: 110}, PUBLIC]
+  to:   [FunctionBody:{DescID: 110, Value: SELECT a FROM t;
+SELECT b FROM t@t_idx_b;
+SELECT c FROM t@t_idx_c;
+SELECT a FROM v;
+SELECT b'@':::@100107;
+SELECT nextval(105:::REGCLASS);}, PUBLIC]
   kind: Precedence
   rule: descriptor existence precedes dependents
 - from: [Function:{DescID: 110}, DESCRIPTOR_ADDED]
@@ -335,7 +355,12 @@ $$;
   to:   [UserPrivileges:{DescID: 110, Name: root}, PUBLIC]
   kind: Precedence
   rule: descriptor existence precedes dependents
-- from: [FunctionBody:{DescID: 110}, PUBLIC]
+- from: [FunctionBody:{DescID: 110, Value: SELECT a FROM t;
+SELECT b FROM t@t_idx_b;
+SELECT c FROM t@t_idx_c;
+SELECT a FROM v;
+SELECT b'@':::@100107;
+SELECT nextval(105:::REGCLASS);}, PUBLIC]
   to:   [Function:{DescID: 110}, PUBLIC]
   kind: Precedence
   rule: dependents exist before descriptor becomes public
@@ -389,7 +414,15 @@ StatementPhase stage 1 of 1 with 11 MutationType ops
     [[UserPrivileges:{DescID: 111, Name: admin}, PUBLIC], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 111, Name: public}, PUBLIC], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 111, Name: root}, PUBLIC], ABSENT] -> PUBLIC
-    [[FunctionBody:{DescID: 111}, PUBLIC], ABSENT] -> PUBLIC
+    [[FunctionBody:{DescID: 111, Value: BEGIN
+    SELECT a FROM t;
+    SELECT b FROM t@t_idx_b;
+    SELECT c FROM t@t_idx_c;
+    SELECT a FROM v;
+    SELECT b'@':::@100107;
+    SELECT nextval(105:::REGCLASS);
+    END;
+    }, PUBLIC], ABSENT] -> PUBLIC
   ops:
     *scop.CreateFunctionDescriptor
       Function:
@@ -522,7 +555,15 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[UserPrivileges:{DescID: 111, Name: admin}, PUBLIC], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: public}, PUBLIC], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: root}, PUBLIC], PUBLIC] -> ABSENT
-    [[FunctionBody:{DescID: 111}, PUBLIC], PUBLIC] -> ABSENT
+    [[FunctionBody:{DescID: 111, Value: BEGIN
+    SELECT a FROM t;
+    SELECT b FROM t@t_idx_b;
+    SELECT c FROM t@t_idx_c;
+    SELECT a FROM v;
+    SELECT b'@':::@100107;
+    SELECT nextval(105:::REGCLASS);
+    END;
+    }, PUBLIC], PUBLIC] -> ABSENT
   ops:
     *scop.UndoAllInTxnImmediateMutationOpSideEffects
       {}
@@ -535,7 +576,15 @@ PreCommitPhase stage 2 of 2 with 11 MutationType ops
     [[UserPrivileges:{DescID: 111, Name: admin}, PUBLIC], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 111, Name: public}, PUBLIC], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 111, Name: root}, PUBLIC], ABSENT] -> PUBLIC
-    [[FunctionBody:{DescID: 111}, PUBLIC], ABSENT] -> PUBLIC
+    [[FunctionBody:{DescID: 111, Value: BEGIN
+    SELECT a FROM t;
+    SELECT b FROM t@t_idx_b;
+    SELECT c FROM t@t_idx_c;
+    SELECT a FROM v;
+    SELECT b'@':::@100107;
+    SELECT nextval(105:::REGCLASS);
+    END;
+    }, PUBLIC], ABSENT] -> PUBLIC
   ops:
     *scop.CreateFunctionDescriptor
       Function:
@@ -673,7 +722,15 @@ CREATE PROCEDURE p(a notmyworkday) LANGUAGE PLpgSQL AS $$
 $$;
 ----
 - from: [Function:{DescID: 112}, DESCRIPTOR_ADDED]
-  to:   [FunctionBody:{DescID: 112}, PUBLIC]
+  to:   [FunctionBody:{DescID: 112, Value: BEGIN
+SELECT a FROM t;
+SELECT b FROM t@t_idx_b;
+SELECT c FROM t@t_idx_c;
+SELECT a FROM v;
+SELECT b'@':::@100107;
+SELECT nextval(105:::REGCLASS);
+END;
+}, PUBLIC]
   kind: Precedence
   rule: descriptor existence precedes dependents
 - from: [Function:{DescID: 112}, DESCRIPTOR_ADDED]
@@ -700,7 +757,15 @@ $$;
   to:   [UserPrivileges:{DescID: 112, Name: root}, PUBLIC]
   kind: Precedence
   rule: descriptor existence precedes dependents
-- from: [FunctionBody:{DescID: 112}, PUBLIC]
+- from: [FunctionBody:{DescID: 112, Value: BEGIN
+SELECT a FROM t;
+SELECT b FROM t@t_idx_b;
+SELECT c FROM t@t_idx_c;
+SELECT a FROM v;
+SELECT b'@':::@100107;
+SELECT nextval(105:::REGCLASS);
+END;
+}, PUBLIC]
   to:   [Function:{DescID: 112}, PUBLIC]
   kind: Precedence
   rule: dependents exist before descriptor becomes public

--- a/pkg/sql/schemachanger/scplan/testdata/create_schema
+++ b/pkg/sql/schemachanger/scplan/testdata/create_schema
@@ -4,7 +4,7 @@ CREATE SCHEMA sc;
 StatementPhase stage 1 of 1 with 8 MutationType ops
   transitions:
     [[Schema:{DescID: 104}, PUBLIC], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 104, Name: sc, ReferencedDescID: 100, IntValue: 0}, PUBLIC], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 104, Name: sc, ReferencedDescID: 100, UInt32Value: 0}, PUBLIC], ABSENT] -> PUBLIC
     [[SchemaParent:{DescID: 104, ReferencedDescID: 100}, PUBLIC], ABSENT] -> PUBLIC
     [[Owner:{DescID: 104}, PUBLIC], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 104, Name: admin}, PUBLIC], ABSENT] -> PUBLIC
@@ -45,7 +45,7 @@ StatementPhase stage 1 of 1 with 8 MutationType ops
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
     [[Schema:{DescID: 104}, PUBLIC], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 104, Name: sc, ReferencedDescID: 100, IntValue: 0}, PUBLIC], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 104, Name: sc, ReferencedDescID: 100, UInt32Value: 0}, PUBLIC], PUBLIC] -> ABSENT
     [[SchemaParent:{DescID: 104, ReferencedDescID: 100}, PUBLIC], PUBLIC] -> ABSENT
     [[Owner:{DescID: 104}, PUBLIC], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: admin}, PUBLIC], PUBLIC] -> ABSENT
@@ -56,7 +56,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
 PreCommitPhase stage 2 of 2 with 8 MutationType ops
   transitions:
     [[Schema:{DescID: 104}, PUBLIC], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 104, Name: sc, ReferencedDescID: 100, IntValue: 0}, PUBLIC], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 104, Name: sc, ReferencedDescID: 100, UInt32Value: 0}, PUBLIC], ABSENT] -> PUBLIC
     [[SchemaParent:{DescID: 104, ReferencedDescID: 100}, PUBLIC], ABSENT] -> PUBLIC
     [[Owner:{DescID: 104}, PUBLIC], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 104, Name: admin}, PUBLIC], ABSENT] -> PUBLIC
@@ -98,11 +98,11 @@ PreCommitPhase stage 2 of 2 with 8 MutationType ops
 deps
 CREATE SCHEMA sc;
 ----
-- from: [Namespace:{DescID: 105, Name: sc, ReferencedDescID: 100, IntValue: 0}, PUBLIC]
+- from: [Namespace:{DescID: 105, Name: sc, ReferencedDescID: 100, UInt32Value: 0}, PUBLIC]
   to:   [Schema:{DescID: 105}, PUBLIC]
   kind: Precedence
   rule: dependents exist before descriptor becomes public
-- from: [Namespace:{DescID: 105, Name: sc, ReferencedDescID: 100, IntValue: 0}, PUBLIC]
+- from: [Namespace:{DescID: 105, Name: sc, ReferencedDescID: 100, UInt32Value: 0}, PUBLIC]
   to:   [SchemaParent:{DescID: 105, ReferencedDescID: 100}, PUBLIC]
   kind: Precedence
   rule: namespace exist before schema parent
@@ -111,7 +111,7 @@ CREATE SCHEMA sc;
   kind: Precedence
   rule: dependents exist before descriptor becomes public
 - from: [Schema:{DescID: 105}, DESCRIPTOR_ADDED]
-  to:   [Namespace:{DescID: 105, Name: sc, ReferencedDescID: 100, IntValue: 0}, PUBLIC]
+  to:   [Namespace:{DescID: 105, Name: sc, ReferencedDescID: 100, UInt32Value: 0}, PUBLIC]
   kind: Precedence
   rule: descriptor existence precedes dependents
 - from: [Schema:{DescID: 105}, DESCRIPTOR_ADDED]

--- a/pkg/sql/schemachanger/scplan/testdata/create_sequence
+++ b/pkg/sql/schemachanger/scplan/testdata/create_sequence
@@ -4,7 +4,7 @@ CREATE SEQUENCE sq1 MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 32
 StatementPhase stage 1 of 1 with 24 MutationType ops
   transitions:
     [[Sequence:{DescID: 104}, PUBLIC], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 100, IntValue: 101}, PUBLIC], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 100, UInt32Value: 101}, PUBLIC], ABSENT] -> PUBLIC
     [[SchemaChild:{DescID: 104, ReferencedDescID: 101}, PUBLIC], ABSENT] -> PUBLIC
     [[TableData:{DescID: 104, ReferencedDescID: 100}, PUBLIC], ABSENT] -> PUBLIC
     [[SequenceOption:{DescID: 104, Name: START, Value: 32}, PUBLIC], ABSENT] -> PUBLIC
@@ -118,7 +118,7 @@ StatementPhase stage 1 of 1 with 24 MutationType ops
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
     [[Sequence:{DescID: 104}, PUBLIC], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 100, IntValue: 101}, PUBLIC], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 100, UInt32Value: 101}, PUBLIC], PUBLIC] -> ABSENT
     [[SchemaChild:{DescID: 104, ReferencedDescID: 101}, PUBLIC], PUBLIC] -> ABSENT
     [[TableData:{DescID: 104, ReferencedDescID: 100}, PUBLIC], PUBLIC] -> ABSENT
     [[SequenceOption:{DescID: 104, Name: START, Value: 32}, PUBLIC], PUBLIC] -> ABSENT
@@ -138,7 +138,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
 PreCommitPhase stage 2 of 2 with 25 MutationType ops
   transitions:
     [[Sequence:{DescID: 104}, PUBLIC], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 100, IntValue: 101}, PUBLIC], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 100, UInt32Value: 101}, PUBLIC], ABSENT] -> PUBLIC
     [[SchemaChild:{DescID: 104, ReferencedDescID: 101}, PUBLIC], ABSENT] -> PUBLIC
     [[TableData:{DescID: 104, ReferencedDescID: 100}, PUBLIC], ABSENT] -> PUBLIC
     [[SequenceOption:{DescID: 104, Name: START, Value: 32}, PUBLIC], ABSENT] -> PUBLIC
@@ -333,7 +333,7 @@ CREATE SEQUENCE sq1  MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 3
   to:   [Sequence:{DescID: 105}, PUBLIC]
   kind: Precedence
   rule: dependents exist before descriptor becomes public
-- from: [Namespace:{DescID: 105, Name: sq1, ReferencedDescID: 100, IntValue: 101}, PUBLIC]
+- from: [Namespace:{DescID: 105, Name: sq1, ReferencedDescID: 100, UInt32Value: 101}, PUBLIC]
   to:   [Sequence:{DescID: 105}, PUBLIC]
   kind: Precedence
   rule: dependents exist before descriptor becomes public
@@ -382,7 +382,7 @@ CREATE SEQUENCE sq1  MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 3
   kind: Precedence
   rule: descriptor existence precedes dependents
 - from: [Sequence:{DescID: 105}, DESCRIPTOR_ADDED]
-  to:   [Namespace:{DescID: 105, Name: sq1, ReferencedDescID: 100, IntValue: 101}, PUBLIC]
+  to:   [Namespace:{DescID: 105, Name: sq1, ReferencedDescID: 100, UInt32Value: 101}, PUBLIC]
   kind: Precedence
   rule: descriptor existence precedes dependents
 - from: [Sequence:{DescID: 105}, DESCRIPTOR_ADDED]

--- a/pkg/sql/schemachanger/scplan/testdata/drop_database
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_database
@@ -21,7 +21,7 @@ DROP DATABASE db1 CASCADE
 ----
 StatementPhase stage 1 of 1 with 325 MutationType ops
   transitions:
-    [[Namespace:{DescID: 104, Name: db1, ReferencedDescID: 0, IntValue: 0}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 104, Name: db1, ReferencedDescID: 0, UInt32Value: 0}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: public}, ABSENT], PUBLIC] -> ABSENT
@@ -29,27 +29,27 @@ StatementPhase stage 1 of 1 with 325 MutationType ops
     [[Database:{DescID: 104}, ABSENT], PUBLIC] -> DROPPED
     [[DatabaseRoleSetting:{DescID: 104, Name: __placeholder_role_name__}, ABSENT], PUBLIC] -> ABSENT
     [[DatabaseComment:{DescID: 104, Value: db1 is good}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 105, Name: public, ReferencedDescID: 104, IntValue: 0}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 105, Name: public, ReferencedDescID: 104, UInt32Value: 0}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: public}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Schema:{DescID: 105}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaParent:{DescID: 105, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 106, Name: sc1, ReferencedDescID: 104, IntValue: 0}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 106, Name: sc1, ReferencedDescID: 104, UInt32Value: 0}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Schema:{DescID: 106}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaParent:{DescID: 106, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[SchemaComment:{DescID: 106, Value: sc1 is good}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 107, Name: sq1, ReferencedDescID: 104, IntValue: 105}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 107, Name: sq1, ReferencedDescID: 104, UInt32Value: 105}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 107}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Sequence:{DescID: 107}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaChild:{DescID: 107, ReferencedDescID: 105}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 110, Name: t1, ReferencedDescID: 104, IntValue: 105}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 110, Name: t1, ReferencedDescID: 104, UInt32Value: 105}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 110}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 110, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 110, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -88,13 +88,13 @@ StatementPhase stage 1 of 1 with 325 MutationType ops
     [[IndexColumn:{DescID: 110, ColumnID: 3, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[PrimaryIndex:{DescID: 110, IndexID: 1, ConstraintID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[IndexName:{DescID: 110, Name: t1_pkey, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 108, Name: sq1, ReferencedDescID: 104, IntValue: 106}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 108, Name: sq1, ReferencedDescID: 104, UInt32Value: 106}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 108}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Sequence:{DescID: 108}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaChild:{DescID: 108, ReferencedDescID: 106}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 109, Name: t1, ReferencedDescID: 104, IntValue: 106}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 109, Name: t1, ReferencedDescID: 104, UInt32Value: 106}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 109}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 109, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 109, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -134,7 +134,7 @@ StatementPhase stage 1 of 1 with 325 MutationType ops
     [[IndexColumn:{DescID: 109, ColumnID: 3, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[PrimaryIndex:{DescID: 109, IndexID: 1, ConstraintID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[IndexName:{DescID: 109, Name: t1_pkey, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 111, Name: v1, ReferencedDescID: 104, IntValue: 106}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 111, Name: v1, ReferencedDescID: 104, UInt32Value: 106}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 111}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -159,7 +159,7 @@ StatementPhase stage 1 of 1 with 325 MutationType ops
     [[ColumnName:{DescID: 111, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 111, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 112, Name: v2, ReferencedDescID: 104, IntValue: 106}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 112, Name: v2, ReferencedDescID: 104, UInt32Value: 106}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 112}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 112, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 112, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -187,7 +187,7 @@ StatementPhase stage 1 of 1 with 325 MutationType ops
     [[ColumnName:{DescID: 112, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 112, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 112, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 113, Name: v3, ReferencedDescID: 104, IntValue: 106}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 113, Name: v3, ReferencedDescID: 104, UInt32Value: 106}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 113}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 113, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 113, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -215,7 +215,7 @@ StatementPhase stage 1 of 1 with 325 MutationType ops
     [[ColumnName:{DescID: 113, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 113, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 113, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 114, Name: v4, ReferencedDescID: 104, IntValue: 106}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 114, Name: v4, ReferencedDescID: 104, UInt32Value: 106}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 114}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 114, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 114, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -243,7 +243,7 @@ StatementPhase stage 1 of 1 with 325 MutationType ops
     [[ColumnName:{DescID: 114, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 114, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 114, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 115, Name: typ, ReferencedDescID: 104, IntValue: 106}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 115, Name: typ, ReferencedDescID: 104, UInt32Value: 106}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 115}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 115, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 115, Name: public}, ABSENT], PUBLIC] -> ABSENT
@@ -251,14 +251,14 @@ StatementPhase stage 1 of 1 with 325 MutationType ops
     [[EnumType:{DescID: 115}, ABSENT], PUBLIC] -> DROPPED
     [[EnumTypeValue:{DescID: 115, Name: a}, ABSENT], PUBLIC] -> ABSENT
     [[SchemaChild:{DescID: 115, ReferencedDescID: 106}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 116, Name: _typ, ReferencedDescID: 104, IntValue: 106}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 116, Name: _typ, ReferencedDescID: 104, UInt32Value: 106}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 116}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 116, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 116, Name: public}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 116, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[AliasType:{DescID: 116, ReferencedTypeIDs: [115 116]}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaChild:{DescID: 116, ReferencedDescID: 106}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 117, Name: v5, ReferencedDescID: 104, IntValue: 106}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 117, Name: v5, ReferencedDescID: 104, UInt32Value: 106}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 117}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 117, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 117, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -1358,7 +1358,7 @@ StatementPhase stage 1 of 1 with 325 MutationType ops
       TableID: 109
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
-    [[Namespace:{DescID: 104, Name: db1, ReferencedDescID: 0, IntValue: 0}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 104, Name: db1, ReferencedDescID: 0, UInt32Value: 0}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 104}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 104, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 104, Name: public}, ABSENT], ABSENT] -> PUBLIC
@@ -1366,27 +1366,27 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[Database:{DescID: 104}, ABSENT], DROPPED] -> PUBLIC
     [[DatabaseRoleSetting:{DescID: 104, Name: __placeholder_role_name__}, ABSENT], ABSENT] -> PUBLIC
     [[DatabaseComment:{DescID: 104, Value: db1 is good}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 105, Name: public, ReferencedDescID: 104, IntValue: 0}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 105, Name: public, ReferencedDescID: 104, UInt32Value: 0}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 105}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 105, Name: public}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], ABSENT] -> PUBLIC
     [[Schema:{DescID: 105}, ABSENT], DROPPED] -> PUBLIC
     [[SchemaParent:{DescID: 105, ReferencedDescID: 104}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 106, Name: sc1, ReferencedDescID: 104, IntValue: 0}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 106, Name: sc1, ReferencedDescID: 104, UInt32Value: 0}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 106}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 106, Name: root}, ABSENT], ABSENT] -> PUBLIC
     [[Schema:{DescID: 106}, ABSENT], DROPPED] -> PUBLIC
     [[SchemaParent:{DescID: 106, ReferencedDescID: 104}, ABSENT], ABSENT] -> PUBLIC
     [[SchemaComment:{DescID: 106, Value: sc1 is good}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 107, Name: sq1, ReferencedDescID: 104, IntValue: 105}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 107, Name: sq1, ReferencedDescID: 104, UInt32Value: 105}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 107}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 107, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 107, Name: root}, ABSENT], ABSENT] -> PUBLIC
     [[Sequence:{DescID: 107}, ABSENT], DROPPED] -> PUBLIC
     [[SchemaChild:{DescID: 107, ReferencedDescID: 105}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 110, Name: t1, ReferencedDescID: 104, IntValue: 105}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 110, Name: t1, ReferencedDescID: 104, UInt32Value: 105}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 110}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 110, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 110, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -1425,13 +1425,13 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[IndexColumn:{DescID: 110, ColumnID: 3, IndexID: 1}, ABSENT], ABSENT] -> PUBLIC
     [[PrimaryIndex:{DescID: 110, IndexID: 1, ConstraintID: 1}, ABSENT], ABSENT] -> PUBLIC
     [[IndexName:{DescID: 110, Name: t1_pkey, IndexID: 1}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 108, Name: sq1, ReferencedDescID: 104, IntValue: 106}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 108, Name: sq1, ReferencedDescID: 104, UInt32Value: 106}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 108}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], ABSENT] -> PUBLIC
     [[Sequence:{DescID: 108}, ABSENT], DROPPED] -> PUBLIC
     [[SchemaChild:{DescID: 108, ReferencedDescID: 106}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 109, Name: t1, ReferencedDescID: 104, IntValue: 106}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 109, Name: t1, ReferencedDescID: 104, UInt32Value: 106}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 109}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 109, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 109, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -1471,7 +1471,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[IndexColumn:{DescID: 109, ColumnID: 3, IndexID: 1}, ABSENT], ABSENT] -> PUBLIC
     [[PrimaryIndex:{DescID: 109, IndexID: 1, ConstraintID: 1}, ABSENT], ABSENT] -> PUBLIC
     [[IndexName:{DescID: 109, Name: t1_pkey, IndexID: 1}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 111, Name: v1, ReferencedDescID: 104, IntValue: 106}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 111, Name: v1, ReferencedDescID: 104, UInt32Value: 106}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 111}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 111, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 111, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -1496,7 +1496,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[ColumnName:{DescID: 111, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnHidden:{DescID: 111, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 112, Name: v2, ReferencedDescID: 104, IntValue: 106}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 112, Name: v2, ReferencedDescID: 104, UInt32Value: 106}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 112}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 112, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 112, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -1524,7 +1524,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[ColumnName:{DescID: 112, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnType:{DescID: 112, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnHidden:{DescID: 112, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 113, Name: v3, ReferencedDescID: 104, IntValue: 106}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 113, Name: v3, ReferencedDescID: 104, UInt32Value: 106}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 113}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 113, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 113, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -1552,7 +1552,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[ColumnName:{DescID: 113, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnType:{DescID: 113, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnHidden:{DescID: 113, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 114, Name: v4, ReferencedDescID: 104, IntValue: 106}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 114, Name: v4, ReferencedDescID: 104, UInt32Value: 106}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 114}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 114, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 114, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -1580,7 +1580,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[ColumnName:{DescID: 114, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnType:{DescID: 114, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnHidden:{DescID: 114, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 115, Name: typ, ReferencedDescID: 104, IntValue: 106}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 115, Name: typ, ReferencedDescID: 104, UInt32Value: 106}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 115}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 115, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 115, Name: public}, ABSENT], ABSENT] -> PUBLIC
@@ -1588,14 +1588,14 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[EnumType:{DescID: 115}, ABSENT], DROPPED] -> PUBLIC
     [[EnumTypeValue:{DescID: 115, Name: a}, ABSENT], ABSENT] -> PUBLIC
     [[SchemaChild:{DescID: 115, ReferencedDescID: 106}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 116, Name: _typ, ReferencedDescID: 104, IntValue: 106}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 116, Name: _typ, ReferencedDescID: 104, UInt32Value: 106}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 116}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 116, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 116, Name: public}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 116, Name: root}, ABSENT], ABSENT] -> PUBLIC
     [[AliasType:{DescID: 116, ReferencedTypeIDs: [115 116]}, ABSENT], DROPPED] -> PUBLIC
     [[SchemaChild:{DescID: 116, ReferencedDescID: 106}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 117, Name: v5, ReferencedDescID: 104, IntValue: 106}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 117, Name: v5, ReferencedDescID: 104, UInt32Value: 106}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 117}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 117, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 117, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -1631,7 +1631,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
       {}
 PreCommitPhase stage 2 of 2 with 341 MutationType ops
   transitions:
-    [[Namespace:{DescID: 104, Name: db1, ReferencedDescID: 0, IntValue: 0}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 104, Name: db1, ReferencedDescID: 0, UInt32Value: 0}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: public}, ABSENT], PUBLIC] -> ABSENT
@@ -1639,27 +1639,27 @@ PreCommitPhase stage 2 of 2 with 341 MutationType ops
     [[Database:{DescID: 104}, ABSENT], PUBLIC] -> DROPPED
     [[DatabaseRoleSetting:{DescID: 104, Name: __placeholder_role_name__}, ABSENT], PUBLIC] -> ABSENT
     [[DatabaseComment:{DescID: 104, Value: db1 is good}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 105, Name: public, ReferencedDescID: 104, IntValue: 0}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 105, Name: public, ReferencedDescID: 104, UInt32Value: 0}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: public}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Schema:{DescID: 105}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaParent:{DescID: 105, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 106, Name: sc1, ReferencedDescID: 104, IntValue: 0}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 106, Name: sc1, ReferencedDescID: 104, UInt32Value: 0}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Schema:{DescID: 106}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaParent:{DescID: 106, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[SchemaComment:{DescID: 106, Value: sc1 is good}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 107, Name: sq1, ReferencedDescID: 104, IntValue: 105}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 107, Name: sq1, ReferencedDescID: 104, UInt32Value: 105}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 107}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Sequence:{DescID: 107}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaChild:{DescID: 107, ReferencedDescID: 105}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 110, Name: t1, ReferencedDescID: 104, IntValue: 105}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 110, Name: t1, ReferencedDescID: 104, UInt32Value: 105}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 110}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 110, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 110, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -1698,13 +1698,13 @@ PreCommitPhase stage 2 of 2 with 341 MutationType ops
     [[IndexColumn:{DescID: 110, ColumnID: 3, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[PrimaryIndex:{DescID: 110, IndexID: 1, ConstraintID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[IndexName:{DescID: 110, Name: t1_pkey, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 108, Name: sq1, ReferencedDescID: 104, IntValue: 106}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 108, Name: sq1, ReferencedDescID: 104, UInt32Value: 106}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 108}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Sequence:{DescID: 108}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaChild:{DescID: 108, ReferencedDescID: 106}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 109, Name: t1, ReferencedDescID: 104, IntValue: 106}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 109, Name: t1, ReferencedDescID: 104, UInt32Value: 106}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 109}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 109, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 109, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -1744,7 +1744,7 @@ PreCommitPhase stage 2 of 2 with 341 MutationType ops
     [[IndexColumn:{DescID: 109, ColumnID: 3, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[PrimaryIndex:{DescID: 109, IndexID: 1, ConstraintID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[IndexName:{DescID: 109, Name: t1_pkey, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 111, Name: v1, ReferencedDescID: 104, IntValue: 106}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 111, Name: v1, ReferencedDescID: 104, UInt32Value: 106}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 111}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -1769,7 +1769,7 @@ PreCommitPhase stage 2 of 2 with 341 MutationType ops
     [[ColumnName:{DescID: 111, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 111, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 112, Name: v2, ReferencedDescID: 104, IntValue: 106}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 112, Name: v2, ReferencedDescID: 104, UInt32Value: 106}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 112}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 112, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 112, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -1797,7 +1797,7 @@ PreCommitPhase stage 2 of 2 with 341 MutationType ops
     [[ColumnName:{DescID: 112, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 112, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 112, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 113, Name: v3, ReferencedDescID: 104, IntValue: 106}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 113, Name: v3, ReferencedDescID: 104, UInt32Value: 106}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 113}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 113, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 113, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -1825,7 +1825,7 @@ PreCommitPhase stage 2 of 2 with 341 MutationType ops
     [[ColumnName:{DescID: 113, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 113, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 113, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 114, Name: v4, ReferencedDescID: 104, IntValue: 106}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 114, Name: v4, ReferencedDescID: 104, UInt32Value: 106}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 114}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 114, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 114, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -1853,7 +1853,7 @@ PreCommitPhase stage 2 of 2 with 341 MutationType ops
     [[ColumnName:{DescID: 114, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 114, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 114, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 115, Name: typ, ReferencedDescID: 104, IntValue: 106}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 115, Name: typ, ReferencedDescID: 104, UInt32Value: 106}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 115}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 115, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 115, Name: public}, ABSENT], PUBLIC] -> ABSENT
@@ -1861,14 +1861,14 @@ PreCommitPhase stage 2 of 2 with 341 MutationType ops
     [[EnumType:{DescID: 115}, ABSENT], PUBLIC] -> DROPPED
     [[EnumTypeValue:{DescID: 115, Name: a}, ABSENT], PUBLIC] -> ABSENT
     [[SchemaChild:{DescID: 115, ReferencedDescID: 106}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 116, Name: _typ, ReferencedDescID: 104, IntValue: 106}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 116, Name: _typ, ReferencedDescID: 104, UInt32Value: 106}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 116}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 116, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 116, Name: public}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 116, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[AliasType:{DescID: 116, ReferencedTypeIDs: [115 116]}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaChild:{DescID: 116, ReferencedDescID: 106}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 117, Name: v5, ReferencedDescID: 104, IntValue: 106}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 117, Name: v5, ReferencedDescID: 104, UInt32Value: 106}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 117}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 117, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 117, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -3183,7 +3183,7 @@ DROP DATABASE db1 CASCADE
   kind: PreviousTransactionPrecedence
   rule: descriptor dropped in transaction before removal
 - from: [AliasType:{DescID: 116, ReferencedTypeIDs: [115 116]}, DROPPED]
-  to:   [Namespace:{DescID: 116, Name: _typ, ReferencedDescID: 104, IntValue: 106}, ABSENT]
+  to:   [Namespace:{DescID: 116, Name: _typ, ReferencedDescID: 104, UInt32Value: 106}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [AliasType:{DescID: 116, ReferencedTypeIDs: [115 116]}, DROPPED]
@@ -4935,59 +4935,59 @@ DROP DATABASE db1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [Database:{DescID: 104}, DROPPED]
-  to:   [Namespace:{DescID: 104, Name: db1, ReferencedDescID: 0, IntValue: 0}, ABSENT]
+  to:   [Namespace:{DescID: 104, Name: db1, ReferencedDescID: 0, UInt32Value: 0}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [Database:{DescID: 104}, DROPPED]
-  to:   [Namespace:{DescID: 105, Name: public, ReferencedDescID: 104, IntValue: 0}, ABSENT]
+  to:   [Namespace:{DescID: 105, Name: public, ReferencedDescID: 104, UInt32Value: 0}, ABSENT]
   kind: SameStagePrecedence
   rule: descriptor drop right before removing dependent with attr ref
 - from: [Database:{DescID: 104}, DROPPED]
-  to:   [Namespace:{DescID: 106, Name: sc1, ReferencedDescID: 104, IntValue: 0}, ABSENT]
+  to:   [Namespace:{DescID: 106, Name: sc1, ReferencedDescID: 104, UInt32Value: 0}, ABSENT]
   kind: SameStagePrecedence
   rule: descriptor drop right before removing dependent with attr ref
 - from: [Database:{DescID: 104}, DROPPED]
-  to:   [Namespace:{DescID: 107, Name: sq1, ReferencedDescID: 104, IntValue: 105}, ABSENT]
+  to:   [Namespace:{DescID: 107, Name: sq1, ReferencedDescID: 104, UInt32Value: 105}, ABSENT]
   kind: SameStagePrecedence
   rule: descriptor drop right before removing dependent with attr ref
 - from: [Database:{DescID: 104}, DROPPED]
-  to:   [Namespace:{DescID: 108, Name: sq1, ReferencedDescID: 104, IntValue: 106}, ABSENT]
+  to:   [Namespace:{DescID: 108, Name: sq1, ReferencedDescID: 104, UInt32Value: 106}, ABSENT]
   kind: SameStagePrecedence
   rule: descriptor drop right before removing dependent with attr ref
 - from: [Database:{DescID: 104}, DROPPED]
-  to:   [Namespace:{DescID: 109, Name: t1, ReferencedDescID: 104, IntValue: 106}, ABSENT]
+  to:   [Namespace:{DescID: 109, Name: t1, ReferencedDescID: 104, UInt32Value: 106}, ABSENT]
   kind: SameStagePrecedence
   rule: descriptor drop right before removing dependent with attr ref
 - from: [Database:{DescID: 104}, DROPPED]
-  to:   [Namespace:{DescID: 110, Name: t1, ReferencedDescID: 104, IntValue: 105}, ABSENT]
+  to:   [Namespace:{DescID: 110, Name: t1, ReferencedDescID: 104, UInt32Value: 105}, ABSENT]
   kind: SameStagePrecedence
   rule: descriptor drop right before removing dependent with attr ref
 - from: [Database:{DescID: 104}, DROPPED]
-  to:   [Namespace:{DescID: 111, Name: v1, ReferencedDescID: 104, IntValue: 106}, ABSENT]
+  to:   [Namespace:{DescID: 111, Name: v1, ReferencedDescID: 104, UInt32Value: 106}, ABSENT]
   kind: SameStagePrecedence
   rule: descriptor drop right before removing dependent with attr ref
 - from: [Database:{DescID: 104}, DROPPED]
-  to:   [Namespace:{DescID: 112, Name: v2, ReferencedDescID: 104, IntValue: 106}, ABSENT]
+  to:   [Namespace:{DescID: 112, Name: v2, ReferencedDescID: 104, UInt32Value: 106}, ABSENT]
   kind: SameStagePrecedence
   rule: descriptor drop right before removing dependent with attr ref
 - from: [Database:{DescID: 104}, DROPPED]
-  to:   [Namespace:{DescID: 113, Name: v3, ReferencedDescID: 104, IntValue: 106}, ABSENT]
+  to:   [Namespace:{DescID: 113, Name: v3, ReferencedDescID: 104, UInt32Value: 106}, ABSENT]
   kind: SameStagePrecedence
   rule: descriptor drop right before removing dependent with attr ref
 - from: [Database:{DescID: 104}, DROPPED]
-  to:   [Namespace:{DescID: 114, Name: v4, ReferencedDescID: 104, IntValue: 106}, ABSENT]
+  to:   [Namespace:{DescID: 114, Name: v4, ReferencedDescID: 104, UInt32Value: 106}, ABSENT]
   kind: SameStagePrecedence
   rule: descriptor drop right before removing dependent with attr ref
 - from: [Database:{DescID: 104}, DROPPED]
-  to:   [Namespace:{DescID: 115, Name: typ, ReferencedDescID: 104, IntValue: 106}, ABSENT]
+  to:   [Namespace:{DescID: 115, Name: typ, ReferencedDescID: 104, UInt32Value: 106}, ABSENT]
   kind: SameStagePrecedence
   rule: descriptor drop right before removing dependent with attr ref
 - from: [Database:{DescID: 104}, DROPPED]
-  to:   [Namespace:{DescID: 116, Name: _typ, ReferencedDescID: 104, IntValue: 106}, ABSENT]
+  to:   [Namespace:{DescID: 116, Name: _typ, ReferencedDescID: 104, UInt32Value: 106}, ABSENT]
   kind: SameStagePrecedence
   rule: descriptor drop right before removing dependent with attr ref
 - from: [Database:{DescID: 104}, DROPPED]
-  to:   [Namespace:{DescID: 117, Name: v5, ReferencedDescID: 104, IntValue: 106}, ABSENT]
+  to:   [Namespace:{DescID: 117, Name: v5, ReferencedDescID: 104, UInt32Value: 106}, ABSENT]
   kind: SameStagePrecedence
   rule: descriptor drop right before removing dependent with attr ref
 - from: [Database:{DescID: 104}, DROPPED]
@@ -5023,7 +5023,7 @@ DROP DATABASE db1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [EnumType:{DescID: 115}, DROPPED]
-  to:   [Namespace:{DescID: 115, Name: typ, ReferencedDescID: 104, IntValue: 106}, ABSENT]
+  to:   [Namespace:{DescID: 115, Name: typ, ReferencedDescID: 104, UInt32Value: 106}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [EnumType:{DescID: 115}, DROPPED]
@@ -5138,59 +5138,59 @@ DROP DATABASE db1 CASCADE
   to:   [Table:{DescID: 110}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 104, Name: db1, ReferencedDescID: 0, IntValue: 0}, ABSENT]
+- from: [Namespace:{DescID: 104, Name: db1, ReferencedDescID: 0, UInt32Value: 0}, ABSENT]
   to:   [Database:{DescID: 104}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 105, Name: public, ReferencedDescID: 104, IntValue: 0}, ABSENT]
+- from: [Namespace:{DescID: 105, Name: public, ReferencedDescID: 104, UInt32Value: 0}, ABSENT]
   to:   [Schema:{DescID: 105}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 106, Name: sc1, ReferencedDescID: 104, IntValue: 0}, ABSENT]
+- from: [Namespace:{DescID: 106, Name: sc1, ReferencedDescID: 104, UInt32Value: 0}, ABSENT]
   to:   [Schema:{DescID: 106}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 107, Name: sq1, ReferencedDescID: 104, IntValue: 105}, ABSENT]
+- from: [Namespace:{DescID: 107, Name: sq1, ReferencedDescID: 104, UInt32Value: 105}, ABSENT]
   to:   [Sequence:{DescID: 107}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 108, Name: sq1, ReferencedDescID: 104, IntValue: 106}, ABSENT]
+- from: [Namespace:{DescID: 108, Name: sq1, ReferencedDescID: 104, UInt32Value: 106}, ABSENT]
   to:   [Sequence:{DescID: 108}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 109, Name: t1, ReferencedDescID: 104, IntValue: 106}, ABSENT]
+- from: [Namespace:{DescID: 109, Name: t1, ReferencedDescID: 104, UInt32Value: 106}, ABSENT]
   to:   [Table:{DescID: 109}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 110, Name: t1, ReferencedDescID: 104, IntValue: 105}, ABSENT]
+- from: [Namespace:{DescID: 110, Name: t1, ReferencedDescID: 104, UInt32Value: 105}, ABSENT]
   to:   [Table:{DescID: 110}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 111, Name: v1, ReferencedDescID: 104, IntValue: 106}, ABSENT]
+- from: [Namespace:{DescID: 111, Name: v1, ReferencedDescID: 104, UInt32Value: 106}, ABSENT]
   to:   [View:{DescID: 111}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 112, Name: v2, ReferencedDescID: 104, IntValue: 106}, ABSENT]
+- from: [Namespace:{DescID: 112, Name: v2, ReferencedDescID: 104, UInt32Value: 106}, ABSENT]
   to:   [View:{DescID: 112}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 113, Name: v3, ReferencedDescID: 104, IntValue: 106}, ABSENT]
+- from: [Namespace:{DescID: 113, Name: v3, ReferencedDescID: 104, UInt32Value: 106}, ABSENT]
   to:   [View:{DescID: 113}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 114, Name: v4, ReferencedDescID: 104, IntValue: 106}, ABSENT]
+- from: [Namespace:{DescID: 114, Name: v4, ReferencedDescID: 104, UInt32Value: 106}, ABSENT]
   to:   [View:{DescID: 114}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 115, Name: typ, ReferencedDescID: 104, IntValue: 106}, ABSENT]
+- from: [Namespace:{DescID: 115, Name: typ, ReferencedDescID: 104, UInt32Value: 106}, ABSENT]
   to:   [EnumType:{DescID: 115}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 116, Name: _typ, ReferencedDescID: 104, IntValue: 106}, ABSENT]
+- from: [Namespace:{DescID: 116, Name: _typ, ReferencedDescID: 104, UInt32Value: 106}, ABSENT]
   to:   [AliasType:{DescID: 116, ReferencedTypeIDs: [115 116]}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 117, Name: v5, ReferencedDescID: 104, IntValue: 106}, ABSENT]
+- from: [Namespace:{DescID: 117, Name: v5, ReferencedDescID: 104, UInt32Value: 106}, ABSENT]
   to:   [View:{DescID: 117}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
@@ -5299,7 +5299,7 @@ DROP DATABASE db1 CASCADE
   kind: Precedence
   rule: index no longer public before dependents, excluding columns
 - from: [Schema:{DescID: 105}, DROPPED]
-  to:   [Namespace:{DescID: 105, Name: public, ReferencedDescID: 104, IntValue: 0}, ABSENT]
+  to:   [Namespace:{DescID: 105, Name: public, ReferencedDescID: 104, UInt32Value: 0}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [Schema:{DescID: 105}, DROPPED]
@@ -5327,7 +5327,7 @@ DROP DATABASE db1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [Schema:{DescID: 106}, DROPPED]
-  to:   [Namespace:{DescID: 106, Name: sc1, ReferencedDescID: 104, IntValue: 0}, ABSENT]
+  to:   [Namespace:{DescID: 106, Name: sc1, ReferencedDescID: 104, UInt32Value: 0}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [Schema:{DescID: 106}, DROPPED]
@@ -5471,7 +5471,7 @@ DROP DATABASE db1 CASCADE
   kind: SameStagePrecedence
   rule: descriptor drop right before removing dependent with expr ref to sequence
 - from: [Sequence:{DescID: 107}, DROPPED]
-  to:   [Namespace:{DescID: 107, Name: sq1, ReferencedDescID: 104, IntValue: 105}, ABSENT]
+  to:   [Namespace:{DescID: 107, Name: sq1, ReferencedDescID: 104, UInt32Value: 105}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [Sequence:{DescID: 107}, DROPPED]
@@ -5503,7 +5503,7 @@ DROP DATABASE db1 CASCADE
   kind: SameStagePrecedence
   rule: descriptor drop right before removing dependent with expr ref to sequence
 - from: [Sequence:{DescID: 108}, DROPPED]
-  to:   [Namespace:{DescID: 108, Name: sq1, ReferencedDescID: 104, IntValue: 106}, ABSENT]
+  to:   [Namespace:{DescID: 108, Name: sq1, ReferencedDescID: 104, UInt32Value: 106}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [Sequence:{DescID: 108}, DROPPED]
@@ -5659,7 +5659,7 @@ DROP DATABASE db1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [Table:{DescID: 109}, DROPPED]
-  to:   [Namespace:{DescID: 109, Name: t1, ReferencedDescID: 104, IntValue: 106}, ABSENT]
+  to:   [Namespace:{DescID: 109, Name: t1, ReferencedDescID: 104, UInt32Value: 106}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [Table:{DescID: 109}, DROPPED]
@@ -5823,7 +5823,7 @@ DROP DATABASE db1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [Table:{DescID: 110}, DROPPED]
-  to:   [Namespace:{DescID: 110, Name: t1, ReferencedDescID: 104, IntValue: 105}, ABSENT]
+  to:   [Namespace:{DescID: 110, Name: t1, ReferencedDescID: 104, UInt32Value: 105}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [Table:{DescID: 110}, DROPPED]
@@ -6067,7 +6067,7 @@ DROP DATABASE db1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 111}, DROPPED]
-  to:   [Namespace:{DescID: 111, Name: v1, ReferencedDescID: 104, IntValue: 106}, ABSENT]
+  to:   [Namespace:{DescID: 111, Name: v1, ReferencedDescID: 104, UInt32Value: 106}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 111}, DROPPED]
@@ -6179,7 +6179,7 @@ DROP DATABASE db1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 112}, DROPPED]
-  to:   [Namespace:{DescID: 112, Name: v2, ReferencedDescID: 104, IntValue: 106}, ABSENT]
+  to:   [Namespace:{DescID: 112, Name: v2, ReferencedDescID: 104, UInt32Value: 106}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 112}, DROPPED]
@@ -6291,7 +6291,7 @@ DROP DATABASE db1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 113}, DROPPED]
-  to:   [Namespace:{DescID: 113, Name: v3, ReferencedDescID: 104, IntValue: 106}, ABSENT]
+  to:   [Namespace:{DescID: 113, Name: v3, ReferencedDescID: 104, UInt32Value: 106}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 113}, DROPPED]
@@ -6403,7 +6403,7 @@ DROP DATABASE db1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 114}, DROPPED]
-  to:   [Namespace:{DescID: 114, Name: v4, ReferencedDescID: 104, IntValue: 106}, ABSENT]
+  to:   [Namespace:{DescID: 114, Name: v4, ReferencedDescID: 104, UInt32Value: 106}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 114}, DROPPED]
@@ -6527,7 +6527,7 @@ DROP DATABASE db1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 117}, DROPPED]
-  to:   [Namespace:{DescID: 117, Name: v5, ReferencedDescID: 104, IntValue: 106}, ABSENT]
+  to:   [Namespace:{DescID: 117, Name: v5, ReferencedDescID: 104, UInt32Value: 106}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 117}, DROPPED]

--- a/pkg/sql/schemachanger/scplan/testdata/drop_function
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_function
@@ -30,11 +30,15 @@ StatementPhase stage 1 of 1 with 14 MutationType ops
     [[Function:{DescID: 109}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaChild:{DescID: 109, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[FunctionName:{DescID: 109}, ABSENT], PUBLIC] -> ABSENT
-    [[FunctionVolatility:{DescID: 109}, ABSENT], PUBLIC] -> ABSENT
-    [[FunctionLeakProof:{DescID: 109}, ABSENT], PUBLIC] -> ABSENT
-    [[FunctionNullInputBehavior:{DescID: 109}, ABSENT], PUBLIC] -> ABSENT
-    [[FunctionSecurity:{DescID: 109}, ABSENT], PUBLIC] -> ABSENT
-    [[FunctionBody:{DescID: 109}, ABSENT], PUBLIC] -> ABSENT
+    [[FunctionVolatility:{DescID: 109, Int32Value: VOLATILE}, ABSENT], PUBLIC] -> ABSENT
+    [[FunctionLeakProof:{DescID: 109, BoolValue: false}, ABSENT], PUBLIC] -> ABSENT
+    [[FunctionNullInputBehavior:{DescID: 109, Int32Value: CALLED_ON_NULL_INPUT}, ABSENT], PUBLIC] -> ABSENT
+    [[FunctionSecurity:{DescID: 109, Int32Value: INVOKER}, ABSENT], PUBLIC] -> ABSENT
+    [[FunctionBody:{DescID: 109, Value: SELECT a FROM defaultdb.public.t;
+    SELECT b FROM defaultdb.public.t@t_idx_b;
+    SELECT c FROM defaultdb.public.t@t_idx_c;
+    SELECT a FROM defaultdb.public.v;
+    SELECT nextval(105:::REGCLASS);}, ABSENT], PUBLIC] -> ABSENT
   ops:
     *scop.MarkDescriptorAsDropped
       DescriptorID: 109
@@ -92,11 +96,15 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[Function:{DescID: 109}, ABSENT], DROPPED] -> PUBLIC
     [[SchemaChild:{DescID: 109, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
     [[FunctionName:{DescID: 109}, ABSENT], ABSENT] -> PUBLIC
-    [[FunctionVolatility:{DescID: 109}, ABSENT], ABSENT] -> PUBLIC
-    [[FunctionLeakProof:{DescID: 109}, ABSENT], ABSENT] -> PUBLIC
-    [[FunctionNullInputBehavior:{DescID: 109}, ABSENT], ABSENT] -> PUBLIC
-    [[FunctionSecurity:{DescID: 109}, ABSENT], ABSENT] -> PUBLIC
-    [[FunctionBody:{DescID: 109}, ABSENT], ABSENT] -> PUBLIC
+    [[FunctionVolatility:{DescID: 109, Int32Value: VOLATILE}, ABSENT], ABSENT] -> PUBLIC
+    [[FunctionLeakProof:{DescID: 109, BoolValue: false}, ABSENT], ABSENT] -> PUBLIC
+    [[FunctionNullInputBehavior:{DescID: 109, Int32Value: CALLED_ON_NULL_INPUT}, ABSENT], ABSENT] -> PUBLIC
+    [[FunctionSecurity:{DescID: 109, Int32Value: INVOKER}, ABSENT], ABSENT] -> PUBLIC
+    [[FunctionBody:{DescID: 109, Value: SELECT a FROM defaultdb.public.t;
+    SELECT b FROM defaultdb.public.t@t_idx_b;
+    SELECT c FROM defaultdb.public.t@t_idx_c;
+    SELECT a FROM defaultdb.public.v;
+    SELECT nextval(105:::REGCLASS);}, ABSENT], ABSENT] -> PUBLIC
   ops:
     *scop.UndoAllInTxnImmediateMutationOpSideEffects
       {}
@@ -109,11 +117,15 @@ PreCommitPhase stage 2 of 2 with 21 MutationType ops
     [[Function:{DescID: 109}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaChild:{DescID: 109, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[FunctionName:{DescID: 109}, ABSENT], PUBLIC] -> ABSENT
-    [[FunctionVolatility:{DescID: 109}, ABSENT], PUBLIC] -> ABSENT
-    [[FunctionLeakProof:{DescID: 109}, ABSENT], PUBLIC] -> ABSENT
-    [[FunctionNullInputBehavior:{DescID: 109}, ABSENT], PUBLIC] -> ABSENT
-    [[FunctionSecurity:{DescID: 109}, ABSENT], PUBLIC] -> ABSENT
-    [[FunctionBody:{DescID: 109}, ABSENT], PUBLIC] -> ABSENT
+    [[FunctionVolatility:{DescID: 109, Int32Value: VOLATILE}, ABSENT], PUBLIC] -> ABSENT
+    [[FunctionLeakProof:{DescID: 109, BoolValue: false}, ABSENT], PUBLIC] -> ABSENT
+    [[FunctionNullInputBehavior:{DescID: 109, Int32Value: CALLED_ON_NULL_INPUT}, ABSENT], PUBLIC] -> ABSENT
+    [[FunctionSecurity:{DescID: 109, Int32Value: INVOKER}, ABSENT], PUBLIC] -> ABSENT
+    [[FunctionBody:{DescID: 109, Value: SELECT a FROM defaultdb.public.t;
+    SELECT b FROM defaultdb.public.t@t_idx_b;
+    SELECT c FROM defaultdb.public.t@t_idx_c;
+    SELECT a FROM defaultdb.public.v;
+    SELECT nextval(105:::REGCLASS);}, ABSENT], PUBLIC] -> ABSENT
   ops:
     *scop.MarkDescriptorAsDropped
       DescriptorID: 109

--- a/pkg/sql/schemachanger/scplan/testdata/drop_index
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_index
@@ -708,7 +708,7 @@ DROP INDEX idx4 CASCADE
 StatementPhase stage 1 of 1 with 32 MutationType ops
   transitions:
     [[SecondaryIndex:{DescID: 105, IndexID: 8, ConstraintID: 4, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, ABSENT], PUBLIC] -> VALIDATED
-    [[Namespace:{DescID: 106, Name: v, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 106, Name: v, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -841,7 +841,7 @@ StatementPhase stage 1 of 1 with 32 MutationType ops
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
     [[SecondaryIndex:{DescID: 105, IndexID: 8, ConstraintID: 4, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, ABSENT], VALIDATED] -> PUBLIC
-    [[Namespace:{DescID: 106, Name: v, ReferencedDescID: 100, IntValue: 101}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 106, Name: v, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 106}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 106, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -872,7 +872,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
 PreCommitPhase stage 2 of 2 with 35 MutationType ops
   transitions:
     [[SecondaryIndex:{DescID: 105, IndexID: 8, ConstraintID: 4, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, ABSENT], PUBLIC] -> VALIDATED
-    [[Namespace:{DescID: 106, Name: v, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 106, Name: v, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -1280,7 +1280,7 @@ DROP INDEX idx4 CASCADE
   to:   [SecondaryIndex:{DescID: 105, IndexID: 8, ConstraintID: 4, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, ABSENT]
   kind: Precedence
   rule: dependents removed before index
-- from: [Namespace:{DescID: 106, Name: v, ReferencedDescID: 100, IntValue: 101}, ABSENT]
+- from: [Namespace:{DescID: 106, Name: v, ReferencedDescID: 100, UInt32Value: 101}, ABSENT]
   to:   [View:{DescID: 106}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
@@ -1417,7 +1417,7 @@ DROP INDEX idx4 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 106}, DROPPED]
-  to:   [Namespace:{DescID: 106, Name: v, ReferencedDescID: 100, IntValue: 101}, ABSENT]
+  to:   [Namespace:{DescID: 106, Name: v, ReferencedDescID: 100, UInt32Value: 101}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 106}, DROPPED]
@@ -1451,7 +1451,7 @@ DROP INDEX v2@idx CASCADE;
 StatementPhase stage 1 of 1 with 47 MutationType ops
   transitions:
     [[SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, ABSENT], PUBLIC] -> VALIDATED
-    [[Namespace:{DescID: 108, Name: v3, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 108, Name: v3, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 108}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -1644,7 +1644,7 @@ StatementPhase stage 1 of 1 with 47 MutationType ops
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
     [[SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, ABSENT], VALIDATED] -> PUBLIC
-    [[Namespace:{DescID: 108, Name: v3, ReferencedDescID: 100, IntValue: 101}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 108, Name: v3, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 108}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -1686,7 +1686,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
 PreCommitPhase stage 2 of 2 with 50 MutationType ops
   transitions:
     [[SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, ABSENT], PUBLIC] -> VALIDATED
-    [[Namespace:{DescID: 108, Name: v3, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 108, Name: v3, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 108}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], PUBLIC] -> ABSENT

--- a/pkg/sql/schemachanger/scplan/testdata/drop_owned_by
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_owned_by
@@ -20,20 +20,20 @@ DROP OWNED BY r
 StatementPhase stage 1 of 1 with 202 MutationType ops
   transitions:
     [[UserPrivileges:{DescID: 100, Name: r}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 105, Name: s, ReferencedDescID: 100, IntValue: 0}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 105, Name: s, ReferencedDescID: 100, UInt32Value: 0}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Schema:{DescID: 105}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaParent:{DescID: 105, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: r}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 106, Name: sq, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 106, Name: sq, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Sequence:{DescID: 106}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaChild:{DescID: 106, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 109, Name: t, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 109, Name: t, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 109}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 109, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 109, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -72,13 +72,13 @@ StatementPhase stage 1 of 1 with 202 MutationType ops
     [[IndexColumn:{DescID: 109, ColumnID: 3, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[PrimaryIndex:{DescID: 109, IndexID: 1, ConstraintID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[IndexName:{DescID: 109, Name: t_pkey, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 107, Name: sq, ReferencedDescID: 100, IntValue: 105}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 107, Name: sq, ReferencedDescID: 100, UInt32Value: 105}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 107}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Sequence:{DescID: 107}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaChild:{DescID: 107, ReferencedDescID: 105}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 108, Name: t, ReferencedDescID: 100, IntValue: 105}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 108, Name: t, ReferencedDescID: 100, UInt32Value: 105}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 108}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -117,7 +117,7 @@ StatementPhase stage 1 of 1 with 202 MutationType ops
     [[IndexColumn:{DescID: 108, ColumnID: 3, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[PrimaryIndex:{DescID: 108, IndexID: 1, ConstraintID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[IndexName:{DescID: 108, Name: t_pkey, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 110, Name: v1, ReferencedDescID: 100, IntValue: 105}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 110, Name: v1, ReferencedDescID: 100, UInt32Value: 105}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 110}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 110, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 110, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -142,7 +142,7 @@ StatementPhase stage 1 of 1 with 202 MutationType ops
     [[ColumnName:{DescID: 110, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 110, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 110, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 111, Name: typ, ReferencedDescID: 100, IntValue: 105}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 111, Name: typ, ReferencedDescID: 100, UInt32Value: 105}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 111}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: public}, ABSENT], PUBLIC] -> ABSENT
@@ -150,14 +150,14 @@ StatementPhase stage 1 of 1 with 202 MutationType ops
     [[EnumType:{DescID: 111}, ABSENT], PUBLIC] -> DROPPED
     [[EnumTypeValue:{DescID: 111, Name: a}, ABSENT], PUBLIC] -> ABSENT
     [[SchemaChild:{DescID: 111, ReferencedDescID: 105}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 112, Name: _typ, ReferencedDescID: 100, IntValue: 105}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 112, Name: _typ, ReferencedDescID: 100, UInt32Value: 105}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 112}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 112, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 112, Name: public}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 112, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[AliasType:{DescID: 112, ReferencedTypeIDs: [111 112]}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaChild:{DescID: 112, ReferencedDescID: 105}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 113, Name: v2, ReferencedDescID: 100, IntValue: 105}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 113, Name: v2, ReferencedDescID: 100, UInt32Value: 105}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 113}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 113, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 113, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -858,20 +858,20 @@ StatementPhase stage 1 of 1 with 202 MutationType ops
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
     [[UserPrivileges:{DescID: 100, Name: r}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 105, Name: s, ReferencedDescID: 100, IntValue: 0}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 105, Name: s, ReferencedDescID: 100, UInt32Value: 0}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 105}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], ABSENT] -> PUBLIC
     [[Schema:{DescID: 105}, ABSENT], DROPPED] -> PUBLIC
     [[SchemaParent:{DescID: 105, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 104, Name: r}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 106, Name: sq, ReferencedDescID: 100, IntValue: 101}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 106, Name: sq, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 106}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 106, Name: root}, ABSENT], ABSENT] -> PUBLIC
     [[Sequence:{DescID: 106}, ABSENT], DROPPED] -> PUBLIC
     [[SchemaChild:{DescID: 106, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 109, Name: t, ReferencedDescID: 100, IntValue: 101}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 109, Name: t, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 109}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 109, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 109, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -910,13 +910,13 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[IndexColumn:{DescID: 109, ColumnID: 3, IndexID: 1}, ABSENT], ABSENT] -> PUBLIC
     [[PrimaryIndex:{DescID: 109, IndexID: 1, ConstraintID: 1}, ABSENT], ABSENT] -> PUBLIC
     [[IndexName:{DescID: 109, Name: t_pkey, IndexID: 1}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 107, Name: sq, ReferencedDescID: 100, IntValue: 105}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 107, Name: sq, ReferencedDescID: 100, UInt32Value: 105}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 107}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 107, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 107, Name: root}, ABSENT], ABSENT] -> PUBLIC
     [[Sequence:{DescID: 107}, ABSENT], DROPPED] -> PUBLIC
     [[SchemaChild:{DescID: 107, ReferencedDescID: 105}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 108, Name: t, ReferencedDescID: 100, IntValue: 105}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 108, Name: t, ReferencedDescID: 100, UInt32Value: 105}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 108}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -955,7 +955,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[IndexColumn:{DescID: 108, ColumnID: 3, IndexID: 1}, ABSENT], ABSENT] -> PUBLIC
     [[PrimaryIndex:{DescID: 108, IndexID: 1, ConstraintID: 1}, ABSENT], ABSENT] -> PUBLIC
     [[IndexName:{DescID: 108, Name: t_pkey, IndexID: 1}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 110, Name: v1, ReferencedDescID: 100, IntValue: 105}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 110, Name: v1, ReferencedDescID: 100, UInt32Value: 105}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 110}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 110, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 110, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -980,7 +980,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[ColumnName:{DescID: 110, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnType:{DescID: 110, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnHidden:{DescID: 110, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 111, Name: typ, ReferencedDescID: 100, IntValue: 105}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 111, Name: typ, ReferencedDescID: 100, UInt32Value: 105}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 111}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 111, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 111, Name: public}, ABSENT], ABSENT] -> PUBLIC
@@ -988,14 +988,14 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[EnumType:{DescID: 111}, ABSENT], DROPPED] -> PUBLIC
     [[EnumTypeValue:{DescID: 111, Name: a}, ABSENT], ABSENT] -> PUBLIC
     [[SchemaChild:{DescID: 111, ReferencedDescID: 105}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 112, Name: _typ, ReferencedDescID: 100, IntValue: 105}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 112, Name: _typ, ReferencedDescID: 100, UInt32Value: 105}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 112}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 112, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 112, Name: public}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 112, Name: root}, ABSENT], ABSENT] -> PUBLIC
     [[AliasType:{DescID: 112, ReferencedTypeIDs: [111 112]}, ABSENT], DROPPED] -> PUBLIC
     [[SchemaChild:{DescID: 112, ReferencedDescID: 105}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 113, Name: v2, ReferencedDescID: 100, IntValue: 105}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 113, Name: v2, ReferencedDescID: 100, UInt32Value: 105}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 113}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 113, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 113, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -1029,20 +1029,20 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
 PreCommitPhase stage 2 of 2 with 214 MutationType ops
   transitions:
     [[UserPrivileges:{DescID: 100, Name: r}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 105, Name: s, ReferencedDescID: 100, IntValue: 0}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 105, Name: s, ReferencedDescID: 100, UInt32Value: 0}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Schema:{DescID: 105}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaParent:{DescID: 105, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: r}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 106, Name: sq, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 106, Name: sq, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Sequence:{DescID: 106}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaChild:{DescID: 106, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 109, Name: t, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 109, Name: t, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 109}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 109, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 109, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -1081,13 +1081,13 @@ PreCommitPhase stage 2 of 2 with 214 MutationType ops
     [[IndexColumn:{DescID: 109, ColumnID: 3, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[PrimaryIndex:{DescID: 109, IndexID: 1, ConstraintID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[IndexName:{DescID: 109, Name: t_pkey, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 107, Name: sq, ReferencedDescID: 100, IntValue: 105}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 107, Name: sq, ReferencedDescID: 100, UInt32Value: 105}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 107}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Sequence:{DescID: 107}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaChild:{DescID: 107, ReferencedDescID: 105}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 108, Name: t, ReferencedDescID: 100, IntValue: 105}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 108, Name: t, ReferencedDescID: 100, UInt32Value: 105}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 108}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -1126,7 +1126,7 @@ PreCommitPhase stage 2 of 2 with 214 MutationType ops
     [[IndexColumn:{DescID: 108, ColumnID: 3, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[PrimaryIndex:{DescID: 108, IndexID: 1, ConstraintID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[IndexName:{DescID: 108, Name: t_pkey, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 110, Name: v1, ReferencedDescID: 100, IntValue: 105}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 110, Name: v1, ReferencedDescID: 100, UInt32Value: 105}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 110}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 110, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 110, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -1151,7 +1151,7 @@ PreCommitPhase stage 2 of 2 with 214 MutationType ops
     [[ColumnName:{DescID: 110, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 110, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 110, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 111, Name: typ, ReferencedDescID: 100, IntValue: 105}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 111, Name: typ, ReferencedDescID: 100, UInt32Value: 105}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 111}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: public}, ABSENT], PUBLIC] -> ABSENT
@@ -1159,14 +1159,14 @@ PreCommitPhase stage 2 of 2 with 214 MutationType ops
     [[EnumType:{DescID: 111}, ABSENT], PUBLIC] -> DROPPED
     [[EnumTypeValue:{DescID: 111, Name: a}, ABSENT], PUBLIC] -> ABSENT
     [[SchemaChild:{DescID: 111, ReferencedDescID: 105}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 112, Name: _typ, ReferencedDescID: 100, IntValue: 105}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 112, Name: _typ, ReferencedDescID: 100, UInt32Value: 105}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 112}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 112, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 112, Name: public}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 112, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[AliasType:{DescID: 112, ReferencedTypeIDs: [111 112]}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaChild:{DescID: 112, ReferencedDescID: 105}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 113, Name: v2, ReferencedDescID: 100, IntValue: 105}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 113, Name: v2, ReferencedDescID: 100, UInt32Value: 105}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 113}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 113, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 113, Name: root}, ABSENT], PUBLIC] -> ABSENT

--- a/pkg/sql/schemachanger/scplan/testdata/drop_schema
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_schema
@@ -20,7 +20,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   kind: PreviousTransactionPrecedence
   rule: descriptor dropped in transaction before removal
 - from: [AliasType:{DescID: 112, ReferencedTypeIDs: [111 112]}, DROPPED]
-  to:   [Namespace:{DescID: 112, Name: _typ, ReferencedDescID: 100, IntValue: 104}, ABSENT]
+  to:   [Namespace:{DescID: 112, Name: _typ, ReferencedDescID: 100, UInt32Value: 104}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [AliasType:{DescID: 112, ReferencedTypeIDs: [111 112]}, DROPPED]
@@ -1448,7 +1448,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [EnumType:{DescID: 111}, DROPPED]
-  to:   [Namespace:{DescID: 111, Name: typ, ReferencedDescID: 100, IntValue: 104}, ABSENT]
+  to:   [Namespace:{DescID: 111, Name: typ, ReferencedDescID: 100, UInt32Value: 104}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [EnumType:{DescID: 111}, DROPPED]
@@ -1519,43 +1519,43 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   to:   [Table:{DescID: 106}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 104, Name: sc1, ReferencedDescID: 100, IntValue: 0}, ABSENT]
+- from: [Namespace:{DescID: 104, Name: sc1, ReferencedDescID: 100, UInt32Value: 0}, ABSENT]
   to:   [Schema:{DescID: 104}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 105, Name: sq1, ReferencedDescID: 100, IntValue: 104}, ABSENT]
+- from: [Namespace:{DescID: 105, Name: sq1, ReferencedDescID: 100, UInt32Value: 104}, ABSENT]
   to:   [Sequence:{DescID: 105}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 106, Name: t1, ReferencedDescID: 100, IntValue: 104}, ABSENT]
+- from: [Namespace:{DescID: 106, Name: t1, ReferencedDescID: 100, UInt32Value: 104}, ABSENT]
   to:   [Table:{DescID: 106}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 107, Name: v1, ReferencedDescID: 100, IntValue: 104}, ABSENT]
+- from: [Namespace:{DescID: 107, Name: v1, ReferencedDescID: 100, UInt32Value: 104}, ABSENT]
   to:   [View:{DescID: 107}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 108, Name: v2, ReferencedDescID: 100, IntValue: 104}, ABSENT]
+- from: [Namespace:{DescID: 108, Name: v2, ReferencedDescID: 100, UInt32Value: 104}, ABSENT]
   to:   [View:{DescID: 108}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 109, Name: v3, ReferencedDescID: 100, IntValue: 104}, ABSENT]
+- from: [Namespace:{DescID: 109, Name: v3, ReferencedDescID: 100, UInt32Value: 104}, ABSENT]
   to:   [View:{DescID: 109}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 110, Name: v4, ReferencedDescID: 100, IntValue: 104}, ABSENT]
+- from: [Namespace:{DescID: 110, Name: v4, ReferencedDescID: 100, UInt32Value: 104}, ABSENT]
   to:   [View:{DescID: 110}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 111, Name: typ, ReferencedDescID: 100, IntValue: 104}, ABSENT]
+- from: [Namespace:{DescID: 111, Name: typ, ReferencedDescID: 100, UInt32Value: 104}, ABSENT]
   to:   [EnumType:{DescID: 111}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 112, Name: _typ, ReferencedDescID: 100, IntValue: 104}, ABSENT]
+- from: [Namespace:{DescID: 112, Name: _typ, ReferencedDescID: 100, UInt32Value: 104}, ABSENT]
   to:   [AliasType:{DescID: 112, ReferencedTypeIDs: [111 112]}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 113, Name: v5, ReferencedDescID: 100, IntValue: 104}, ABSENT]
+- from: [Namespace:{DescID: 113, Name: v5, ReferencedDescID: 100, UInt32Value: 104}, ABSENT]
   to:   [View:{DescID: 113}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
@@ -1624,7 +1624,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   kind: Precedence
   rule: index no longer public before dependents, excluding columns
 - from: [Schema:{DescID: 104}, DROPPED]
-  to:   [Namespace:{DescID: 104, Name: sc1, ReferencedDescID: 100, IntValue: 0}, ABSENT]
+  to:   [Namespace:{DescID: 104, Name: sc1, ReferencedDescID: 100, UInt32Value: 0}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [Schema:{DescID: 104}, DROPPED]
@@ -1740,7 +1740,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   kind: SameStagePrecedence
   rule: descriptor drop right before removing dependent with expr ref to sequence
 - from: [Sequence:{DescID: 105}, DROPPED]
-  to:   [Namespace:{DescID: 105, Name: sq1, ReferencedDescID: 100, IntValue: 104}, ABSENT]
+  to:   [Namespace:{DescID: 105, Name: sq1, ReferencedDescID: 100, UInt32Value: 104}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [Sequence:{DescID: 105}, DROPPED]
@@ -1896,7 +1896,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [Table:{DescID: 106}, DROPPED]
-  to:   [Namespace:{DescID: 106, Name: t1, ReferencedDescID: 100, IntValue: 104}, ABSENT]
+  to:   [Namespace:{DescID: 106, Name: t1, ReferencedDescID: 100, UInt32Value: 104}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [Table:{DescID: 106}, DROPPED]
@@ -2100,7 +2100,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 107}, DROPPED]
-  to:   [Namespace:{DescID: 107, Name: v1, ReferencedDescID: 100, IntValue: 104}, ABSENT]
+  to:   [Namespace:{DescID: 107, Name: v1, ReferencedDescID: 100, UInt32Value: 104}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 107}, DROPPED]
@@ -2212,7 +2212,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 108}, DROPPED]
-  to:   [Namespace:{DescID: 108, Name: v2, ReferencedDescID: 100, IntValue: 104}, ABSENT]
+  to:   [Namespace:{DescID: 108, Name: v2, ReferencedDescID: 100, UInt32Value: 104}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 108}, DROPPED]
@@ -2324,7 +2324,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 109}, DROPPED]
-  to:   [Namespace:{DescID: 109, Name: v3, ReferencedDescID: 100, IntValue: 104}, ABSENT]
+  to:   [Namespace:{DescID: 109, Name: v3, ReferencedDescID: 100, UInt32Value: 104}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 109}, DROPPED]
@@ -2436,7 +2436,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 110}, DROPPED]
-  to:   [Namespace:{DescID: 110, Name: v4, ReferencedDescID: 100, IntValue: 104}, ABSENT]
+  to:   [Namespace:{DescID: 110, Name: v4, ReferencedDescID: 100, UInt32Value: 104}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 110}, DROPPED]
@@ -2560,7 +2560,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 113}, DROPPED]
-  to:   [Namespace:{DescID: 113, Name: v5, ReferencedDescID: 100, IntValue: 104}, ABSENT]
+  to:   [Namespace:{DescID: 113, Name: v5, ReferencedDescID: 100, UInt32Value: 104}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 113}, DROPPED]
@@ -2589,20 +2589,20 @@ DROP SCHEMA defaultdb.SC1 CASCADE
 ----
 StatementPhase stage 1 of 1 with 255 MutationType ops
   transitions:
-    [[Namespace:{DescID: 104, Name: sc1, ReferencedDescID: 100, IntValue: 0}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 104, Name: sc1, ReferencedDescID: 100, UInt32Value: 0}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Schema:{DescID: 104}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaParent:{DescID: 104, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
     [[SchemaComment:{DescID: 104, Value: sc1 is good schema}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 105, Name: sq1, ReferencedDescID: 100, IntValue: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 105, Name: sq1, ReferencedDescID: 100, UInt32Value: 104}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Sequence:{DescID: 105}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaChild:{DescID: 105, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 106, Name: t1, ReferencedDescID: 100, IntValue: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 106, Name: t1, ReferencedDescID: 100, UInt32Value: 104}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -2642,7 +2642,7 @@ StatementPhase stage 1 of 1 with 255 MutationType ops
     [[IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[IndexName:{DescID: 106, Name: t1_pkey, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 107, Name: v1, ReferencedDescID: 100, IntValue: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 107, Name: v1, ReferencedDescID: 100, UInt32Value: 104}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 107}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -2667,7 +2667,7 @@ StatementPhase stage 1 of 1 with 255 MutationType ops
     [[ColumnName:{DescID: 107, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 107, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 108, Name: v2, ReferencedDescID: 100, IntValue: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 108, Name: v2, ReferencedDescID: 100, UInt32Value: 104}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 108}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -2695,7 +2695,7 @@ StatementPhase stage 1 of 1 with 255 MutationType ops
     [[ColumnName:{DescID: 108, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 108, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 109, Name: v3, ReferencedDescID: 100, IntValue: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 109, Name: v3, ReferencedDescID: 100, UInt32Value: 104}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 109}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 109, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 109, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -2723,7 +2723,7 @@ StatementPhase stage 1 of 1 with 255 MutationType ops
     [[ColumnName:{DescID: 109, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 109, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 110, Name: v4, ReferencedDescID: 100, IntValue: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 110, Name: v4, ReferencedDescID: 100, UInt32Value: 104}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 110}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 110, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 110, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -2751,7 +2751,7 @@ StatementPhase stage 1 of 1 with 255 MutationType ops
     [[ColumnName:{DescID: 110, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 110, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 110, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 111, Name: typ, ReferencedDescID: 100, IntValue: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 111, Name: typ, ReferencedDescID: 100, UInt32Value: 104}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 111}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: public}, ABSENT], PUBLIC] -> ABSENT
@@ -2759,14 +2759,14 @@ StatementPhase stage 1 of 1 with 255 MutationType ops
     [[EnumType:{DescID: 111}, ABSENT], PUBLIC] -> DROPPED
     [[EnumTypeValue:{DescID: 111, Name: a}, ABSENT], PUBLIC] -> ABSENT
     [[SchemaChild:{DescID: 111, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 112, Name: _typ, ReferencedDescID: 100, IntValue: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 112, Name: _typ, ReferencedDescID: 100, UInt32Value: 104}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 112}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 112, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 112, Name: public}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 112, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[AliasType:{DescID: 112, ReferencedTypeIDs: [111 112]}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaChild:{DescID: 112, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 113, Name: v5, ReferencedDescID: 100, IntValue: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 113, Name: v5, ReferencedDescID: 100, UInt32Value: 104}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 113}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 113, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 113, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -3636,20 +3636,20 @@ StatementPhase stage 1 of 1 with 255 MutationType ops
       TableID: 106
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
-    [[Namespace:{DescID: 104, Name: sc1, ReferencedDescID: 100, IntValue: 0}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 104, Name: sc1, ReferencedDescID: 100, UInt32Value: 0}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 104}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 104, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 104, Name: root}, ABSENT], ABSENT] -> PUBLIC
     [[Schema:{DescID: 104}, ABSENT], DROPPED] -> PUBLIC
     [[SchemaParent:{DescID: 104, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
     [[SchemaComment:{DescID: 104, Value: sc1 is good schema}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 105, Name: sq1, ReferencedDescID: 100, IntValue: 104}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 105, Name: sq1, ReferencedDescID: 100, UInt32Value: 104}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 105}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], ABSENT] -> PUBLIC
     [[Sequence:{DescID: 105}, ABSENT], DROPPED] -> PUBLIC
     [[SchemaChild:{DescID: 105, ReferencedDescID: 104}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 106, Name: t1, ReferencedDescID: 100, IntValue: 104}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 106, Name: t1, ReferencedDescID: 100, UInt32Value: 104}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 106}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 106, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -3689,7 +3689,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 1}, ABSENT], ABSENT] -> PUBLIC
     [[PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}, ABSENT], ABSENT] -> PUBLIC
     [[IndexName:{DescID: 106, Name: t1_pkey, IndexID: 1}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 107, Name: v1, ReferencedDescID: 100, IntValue: 104}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 107, Name: v1, ReferencedDescID: 100, UInt32Value: 104}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 107}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 107, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 107, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -3714,7 +3714,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[ColumnName:{DescID: 107, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnHidden:{DescID: 107, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 108, Name: v2, ReferencedDescID: 100, IntValue: 104}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 108, Name: v2, ReferencedDescID: 100, UInt32Value: 104}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 108}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -3742,7 +3742,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[ColumnName:{DescID: 108, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnHidden:{DescID: 108, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 109, Name: v3, ReferencedDescID: 100, IntValue: 104}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 109, Name: v3, ReferencedDescID: 100, UInt32Value: 104}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 109}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 109, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 109, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -3770,7 +3770,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[ColumnName:{DescID: 109, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnHidden:{DescID: 109, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 110, Name: v4, ReferencedDescID: 100, IntValue: 104}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 110, Name: v4, ReferencedDescID: 100, UInt32Value: 104}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 110}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 110, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 110, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -3798,7 +3798,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[ColumnName:{DescID: 110, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnType:{DescID: 110, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnHidden:{DescID: 110, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 111, Name: typ, ReferencedDescID: 100, IntValue: 104}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 111, Name: typ, ReferencedDescID: 100, UInt32Value: 104}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 111}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 111, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 111, Name: public}, ABSENT], ABSENT] -> PUBLIC
@@ -3806,14 +3806,14 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[EnumType:{DescID: 111}, ABSENT], DROPPED] -> PUBLIC
     [[EnumTypeValue:{DescID: 111, Name: a}, ABSENT], ABSENT] -> PUBLIC
     [[SchemaChild:{DescID: 111, ReferencedDescID: 104}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 112, Name: _typ, ReferencedDescID: 100, IntValue: 104}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 112, Name: _typ, ReferencedDescID: 100, UInt32Value: 104}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 112}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 112, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 112, Name: public}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 112, Name: root}, ABSENT], ABSENT] -> PUBLIC
     [[AliasType:{DescID: 112, ReferencedTypeIDs: [111 112]}, ABSENT], DROPPED] -> PUBLIC
     [[SchemaChild:{DescID: 112, ReferencedDescID: 104}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 113, Name: v5, ReferencedDescID: 100, IntValue: 104}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 113, Name: v5, ReferencedDescID: 100, UInt32Value: 104}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 113}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 113, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 113, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -3849,20 +3849,20 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
       {}
 PreCommitPhase stage 2 of 2 with 267 MutationType ops
   transitions:
-    [[Namespace:{DescID: 104, Name: sc1, ReferencedDescID: 100, IntValue: 0}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 104, Name: sc1, ReferencedDescID: 100, UInt32Value: 0}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Schema:{DescID: 104}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaParent:{DescID: 104, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
     [[SchemaComment:{DescID: 104, Value: sc1 is good schema}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 105, Name: sq1, ReferencedDescID: 100, IntValue: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 105, Name: sq1, ReferencedDescID: 100, UInt32Value: 104}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Sequence:{DescID: 105}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaChild:{DescID: 105, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 106, Name: t1, ReferencedDescID: 100, IntValue: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 106, Name: t1, ReferencedDescID: 100, UInt32Value: 104}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -3902,7 +3902,7 @@ PreCommitPhase stage 2 of 2 with 267 MutationType ops
     [[IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[IndexName:{DescID: 106, Name: t1_pkey, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 107, Name: v1, ReferencedDescID: 100, IntValue: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 107, Name: v1, ReferencedDescID: 100, UInt32Value: 104}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 107}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -3927,7 +3927,7 @@ PreCommitPhase stage 2 of 2 with 267 MutationType ops
     [[ColumnName:{DescID: 107, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 107, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 108, Name: v2, ReferencedDescID: 100, IntValue: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 108, Name: v2, ReferencedDescID: 100, UInt32Value: 104}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 108}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -3955,7 +3955,7 @@ PreCommitPhase stage 2 of 2 with 267 MutationType ops
     [[ColumnName:{DescID: 108, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 108, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 109, Name: v3, ReferencedDescID: 100, IntValue: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 109, Name: v3, ReferencedDescID: 100, UInt32Value: 104}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 109}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 109, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 109, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -3983,7 +3983,7 @@ PreCommitPhase stage 2 of 2 with 267 MutationType ops
     [[ColumnName:{DescID: 109, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 109, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 110, Name: v4, ReferencedDescID: 100, IntValue: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 110, Name: v4, ReferencedDescID: 100, UInt32Value: 104}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 110}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 110, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 110, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -4011,7 +4011,7 @@ PreCommitPhase stage 2 of 2 with 267 MutationType ops
     [[ColumnName:{DescID: 110, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 110, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 110, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 111, Name: typ, ReferencedDescID: 100, IntValue: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 111, Name: typ, ReferencedDescID: 100, UInt32Value: 104}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 111}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: public}, ABSENT], PUBLIC] -> ABSENT
@@ -4019,14 +4019,14 @@ PreCommitPhase stage 2 of 2 with 267 MutationType ops
     [[EnumType:{DescID: 111}, ABSENT], PUBLIC] -> DROPPED
     [[EnumTypeValue:{DescID: 111, Name: a}, ABSENT], PUBLIC] -> ABSENT
     [[SchemaChild:{DescID: 111, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 112, Name: _typ, ReferencedDescID: 100, IntValue: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 112, Name: _typ, ReferencedDescID: 100, UInt32Value: 104}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 112}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 112, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 112, Name: public}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 112, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[AliasType:{DescID: 112, ReferencedTypeIDs: [111 112]}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaChild:{DescID: 112, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 113, Name: v5, ReferencedDescID: 100, IntValue: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 113, Name: v5, ReferencedDescID: 100, UInt32Value: 104}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 113}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 113, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 113, Name: root}, ABSENT], PUBLIC] -> ABSENT

--- a/pkg/sql/schemachanger/scplan/testdata/drop_sequence
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_sequence
@@ -7,7 +7,7 @@ DROP SEQUENCE defaultdb.SQ1
 ----
 StatementPhase stage 1 of 1 with 6 MutationType ops
   transitions:
-    [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -36,7 +36,7 @@ StatementPhase stage 1 of 1 with 6 MutationType ops
       User: root
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
-    [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 100, IntValue: 101}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 104}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 104, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 104, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -47,7 +47,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
       {}
 PreCommitPhase stage 2 of 2 with 8 MutationType ops
   transitions:
-    [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -119,7 +119,7 @@ DROP SEQUENCE defaultdb.SQ1 CASCADE
 ----
 StatementPhase stage 1 of 1 with 10 MutationType ops
   transitions:
-    [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -166,7 +166,7 @@ StatementPhase stage 1 of 1 with 10 MutationType ops
       User: root
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
-    [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 100, IntValue: 101}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 104}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 104, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 104, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -179,7 +179,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
       {}
 PreCommitPhase stage 2 of 2 with 14 MutationType ops
   transitions:
-    [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -279,7 +279,7 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 5 MutationType ops
 deps
 DROP SEQUENCE defaultdb.SQ1 CASCADE
 ----
-- from: [Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 100, IntValue: 101}, ABSENT]
+- from: [Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 100, UInt32Value: 101}, ABSENT]
   to:   [Sequence:{DescID: 104}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
@@ -304,7 +304,7 @@ DROP SEQUENCE defaultdb.SQ1 CASCADE
   kind: SameStagePrecedence
   rule: descriptor drop right before removing dependent with expr ref to sequence
 - from: [Sequence:{DescID: 104}, DROPPED]
-  to:   [Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 100, IntValue: 101}, ABSENT]
+  to:   [Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 100, UInt32Value: 101}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [Sequence:{DescID: 104}, DROPPED]

--- a/pkg/sql/schemachanger/scplan/testdata/drop_table
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_table
@@ -44,7 +44,7 @@ DROP TABLE defaultdb.shipments CASCADE;
 ----
 StatementPhase stage 1 of 1 with 150 MutationType ops
   transitions:
-    [[Namespace:{DescID: 109, Name: shipments, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 109, Name: shipments, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 109}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 109, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 109, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -122,13 +122,13 @@ StatementPhase stage 1 of 1 with 150 MutationType ops
     [[TriggerEvents:{DescID: 109, TriggerID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[TriggerFunctionCall:{DescID: 109, TriggerID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[TriggerDeps:{DescID: 109, ReferencedTypeIDs: [107 108], TriggerID: 1, ReferencedFunctionIDs: [113]}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 110, Name: sq1, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 110, Name: sq1, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 110}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 110, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 110, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Sequence:{DescID: 110}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaChild:{DescID: 110, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 111, Name: v1, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 111, Name: v1, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 111}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -681,7 +681,7 @@ StatementPhase stage 1 of 1 with 150 MutationType ops
       TableID: 109
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
-    [[Namespace:{DescID: 109, Name: shipments, ReferencedDescID: 100, IntValue: 101}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 109, Name: shipments, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 109}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 109, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 109, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -759,13 +759,13 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[TriggerEvents:{DescID: 109, TriggerID: 1}, ABSENT], ABSENT] -> PUBLIC
     [[TriggerFunctionCall:{DescID: 109, TriggerID: 1}, ABSENT], ABSENT] -> PUBLIC
     [[TriggerDeps:{DescID: 109, ReferencedTypeIDs: [107 108], TriggerID: 1, ReferencedFunctionIDs: [113]}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 110, Name: sq1, ReferencedDescID: 100, IntValue: 101}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 110, Name: sq1, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 110}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 110, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 110, Name: root}, ABSENT], ABSENT] -> PUBLIC
     [[Sequence:{DescID: 110}, ABSENT], DROPPED] -> PUBLIC
     [[SchemaChild:{DescID: 110, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 111, Name: v1, ReferencedDescID: 100, IntValue: 101}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 111, Name: v1, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 111}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 111, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 111, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -798,7 +798,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
       {}
 PreCommitPhase stage 2 of 2 with 161 MutationType ops
   transitions:
-    [[Namespace:{DescID: 109, Name: shipments, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 109, Name: shipments, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 109}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 109, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 109, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -876,13 +876,13 @@ PreCommitPhase stage 2 of 2 with 161 MutationType ops
     [[TriggerEvents:{DescID: 109, TriggerID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[TriggerFunctionCall:{DescID: 109, TriggerID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[TriggerDeps:{DescID: 109, ReferencedTypeIDs: [107 108], TriggerID: 1, ReferencedFunctionIDs: [113]}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 110, Name: sq1, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 110, Name: sq1, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 110}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 110, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 110, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Sequence:{DescID: 110}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaChild:{DescID: 110, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 111, Name: v1, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 111, Name: v1, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 111}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -2485,15 +2485,15 @@ DROP TABLE defaultdb.shipments CASCADE;
   to:   [Table:{DescID: 109}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 109, Name: shipments, ReferencedDescID: 100, IntValue: 101}, ABSENT]
+- from: [Namespace:{DescID: 109, Name: shipments, ReferencedDescID: 100, UInt32Value: 101}, ABSENT]
   to:   [Table:{DescID: 109}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 110, Name: sq1, ReferencedDescID: 100, IntValue: 101}, ABSENT]
+- from: [Namespace:{DescID: 110, Name: sq1, ReferencedDescID: 100, UInt32Value: 101}, ABSENT]
   to:   [Sequence:{DescID: 110}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 111, Name: v1, ReferencedDescID: 100, IntValue: 101}, ABSENT]
+- from: [Namespace:{DescID: 111, Name: v1, ReferencedDescID: 100, UInt32Value: 101}, ABSENT]
   to:   [View:{DescID: 111}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
@@ -2594,7 +2594,7 @@ DROP TABLE defaultdb.shipments CASCADE;
   kind: SameStagePrecedence
   rule: table removed right before garbage collection
 - from: [Sequence:{DescID: 110}, DROPPED]
-  to:   [Namespace:{DescID: 110, Name: sq1, ReferencedDescID: 100, IntValue: 101}, ABSENT]
+  to:   [Namespace:{DescID: 110, Name: sq1, ReferencedDescID: 100, UInt32Value: 101}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [Sequence:{DescID: 110}, DROPPED]
@@ -2850,7 +2850,7 @@ DROP TABLE defaultdb.shipments CASCADE;
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [Table:{DescID: 109}, DROPPED]
-  to:   [Namespace:{DescID: 109, Name: shipments, ReferencedDescID: 100, IntValue: 101}, ABSENT]
+  to:   [Namespace:{DescID: 109, Name: shipments, ReferencedDescID: 100, UInt32Value: 101}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [Table:{DescID: 109}, DROPPED]
@@ -3094,7 +3094,7 @@ DROP TABLE defaultdb.shipments CASCADE;
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 111}, DROPPED]
-  to:   [Namespace:{DescID: 111, Name: v1, ReferencedDescID: 100, IntValue: 101}, ABSENT]
+  to:   [Namespace:{DescID: 111, Name: v1, ReferencedDescID: 100, UInt32Value: 101}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 111}, DROPPED]
@@ -3185,7 +3185,7 @@ PreCommitPhase stage 2 of 2 with 7 MutationType ops
         statementtag: DROP TABLE
 PostCommitNonRevertiblePhase stage 1 of 2 with 59 MutationType ops
   transitions:
-    [[Namespace:{DescID: 104, Name: customers, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 104, Name: customers, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -3837,7 +3837,7 @@ DROP TABLE defaultdb.customers CASCADE;
   to:   [Table:{DescID: 104}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 104, Name: customers, ReferencedDescID: 100, IntValue: 101}, ABSENT]
+- from: [Namespace:{DescID: 104, Name: customers, ReferencedDescID: 100, UInt32Value: 101}, ABSENT]
   to:   [Table:{DescID: 104}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
@@ -4018,7 +4018,7 @@ DROP TABLE defaultdb.customers CASCADE;
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [Table:{DescID: 104}, DROPPED]
-  to:   [Namespace:{DescID: 104, Name: customers, ReferencedDescID: 100, IntValue: 101}, ABSENT]
+  to:   [Namespace:{DescID: 104, Name: customers, ReferencedDescID: 100, UInt32Value: 101}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [Table:{DescID: 104}, DROPPED]
@@ -4081,7 +4081,7 @@ DROP TABLE defaultdb.greeter
 ----
 StatementPhase stage 1 of 1 with 68 MutationType ops
   transitions:
-    [[Namespace:{DescID: 116, Name: greeter, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 116, Name: greeter, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 116}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 116, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 116, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -4364,7 +4364,7 @@ StatementPhase stage 1 of 1 with 68 MutationType ops
       TableID: 116
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
-    [[Namespace:{DescID: 116, Name: greeter, ReferencedDescID: 100, IntValue: 101}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 116, Name: greeter, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 116}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 116, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 116, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -4417,7 +4417,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
       {}
 PreCommitPhase stage 2 of 2 with 72 MutationType ops
   transitions:
-    [[Namespace:{DescID: 116, Name: greeter, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 116, Name: greeter, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 116}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 116, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 116, Name: root}, ABSENT], PUBLIC] -> ABSENT

--- a/pkg/sql/schemachanger/scplan/testdata/drop_type
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_type
@@ -8,7 +8,7 @@ DROP TYPE defaultdb.typ
 ----
 StatementPhase stage 1 of 1 with 15 MutationType ops
   transitions:
-    [[Namespace:{DescID: 104, Name: typ, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 104, Name: typ, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: public}, ABSENT], PUBLIC] -> ABSENT
@@ -16,7 +16,7 @@ StatementPhase stage 1 of 1 with 15 MutationType ops
     [[EnumType:{DescID: 104}, ABSENT], PUBLIC] -> DROPPED
     [[EnumTypeValue:{DescID: 104, Name: a}, ABSENT], PUBLIC] -> ABSENT
     [[SchemaChild:{DescID: 104, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 105, Name: _typ, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 105, Name: _typ, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: public}, ABSENT], PUBLIC] -> ABSENT
@@ -75,7 +75,7 @@ StatementPhase stage 1 of 1 with 15 MutationType ops
       User: root
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
-    [[Namespace:{DescID: 104, Name: typ, ReferencedDescID: 100, IntValue: 101}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 104, Name: typ, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 104}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 104, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 104, Name: public}, ABSENT], ABSENT] -> PUBLIC
@@ -83,7 +83,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[EnumType:{DescID: 104}, ABSENT], DROPPED] -> PUBLIC
     [[EnumTypeValue:{DescID: 104, Name: a}, ABSENT], ABSENT] -> PUBLIC
     [[SchemaChild:{DescID: 104, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 105, Name: _typ, ReferencedDescID: 100, IntValue: 101}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 105, Name: _typ, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 105}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 105, Name: public}, ABSENT], ABSENT] -> PUBLIC
@@ -95,7 +95,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
       {}
 PreCommitPhase stage 2 of 2 with 18 MutationType ops
   transitions:
-    [[Namespace:{DescID: 104, Name: typ, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 104, Name: typ, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: public}, ABSENT], PUBLIC] -> ABSENT
@@ -103,7 +103,7 @@ PreCommitPhase stage 2 of 2 with 18 MutationType ops
     [[EnumType:{DescID: 104}, ABSENT], PUBLIC] -> DROPPED
     [[EnumTypeValue:{DescID: 104, Name: a}, ABSENT], PUBLIC] -> ABSENT
     [[SchemaChild:{DescID: 104, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 105, Name: _typ, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 105, Name: _typ, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: public}, ABSENT], PUBLIC] -> ABSENT
@@ -210,7 +210,7 @@ DROP TYPE defaultdb.typ
   kind: PreviousTransactionPrecedence
   rule: descriptor dropped in transaction before removal
 - from: [AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}, DROPPED]
-  to:   [Namespace:{DescID: 105, Name: _typ, ReferencedDescID: 100, IntValue: 101}, ABSENT]
+  to:   [Namespace:{DescID: 105, Name: _typ, ReferencedDescID: 100, UInt32Value: 101}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}, DROPPED]
@@ -242,7 +242,7 @@ DROP TYPE defaultdb.typ
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [EnumType:{DescID: 104}, DROPPED]
-  to:   [Namespace:{DescID: 104, Name: typ, ReferencedDescID: 100, IntValue: 101}, ABSENT]
+  to:   [Namespace:{DescID: 104, Name: typ, ReferencedDescID: 100, UInt32Value: 101}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [EnumType:{DescID: 104}, DROPPED]
@@ -269,11 +269,11 @@ DROP TYPE defaultdb.typ
   to:   [EnumType:{DescID: 104}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 104, Name: typ, ReferencedDescID: 100, IntValue: 101}, ABSENT]
+- from: [Namespace:{DescID: 104, Name: typ, ReferencedDescID: 100, UInt32Value: 101}, ABSENT]
   to:   [EnumType:{DescID: 104}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 105, Name: _typ, ReferencedDescID: 100, IntValue: 101}, ABSENT]
+- from: [Namespace:{DescID: 105, Name: _typ, ReferencedDescID: 100, UInt32Value: 101}, ABSENT]
   to:   [AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
@@ -323,7 +323,7 @@ DROP TYPE defaultdb.ctyp
 ----
 StatementPhase stage 1 of 1 with 16 MutationType ops
   transitions:
-    [[Namespace:{DescID: 106, Name: ctyp, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 106, Name: ctyp, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: public}, ABSENT], PUBLIC] -> ABSENT
@@ -333,7 +333,7 @@ StatementPhase stage 1 of 1 with 16 MutationType ops
     [[CompositeTypeAttrType:{DescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[CompositeTypeAttrName:{DescID: 106, Name: b}, ABSENT], PUBLIC] -> ABSENT
     [[SchemaChild:{DescID: 106, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 107, Name: _ctyp, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 107, Name: _ctyp, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 107}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: public}, ABSENT], PUBLIC] -> ABSENT
@@ -395,7 +395,7 @@ StatementPhase stage 1 of 1 with 16 MutationType ops
       User: root
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
-    [[Namespace:{DescID: 106, Name: ctyp, ReferencedDescID: 100, IntValue: 101}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 106, Name: ctyp, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 106}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 106, Name: public}, ABSENT], ABSENT] -> PUBLIC
@@ -405,7 +405,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[CompositeTypeAttrType:{DescID: 106}, ABSENT], ABSENT] -> PUBLIC
     [[CompositeTypeAttrName:{DescID: 106, Name: b}, ABSENT], ABSENT] -> PUBLIC
     [[SchemaChild:{DescID: 106, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 107, Name: _ctyp, ReferencedDescID: 100, IntValue: 101}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 107, Name: _ctyp, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 107}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 107, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 107, Name: public}, ABSENT], ABSENT] -> PUBLIC
@@ -417,7 +417,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
       {}
 PreCommitPhase stage 2 of 2 with 19 MutationType ops
   transitions:
-    [[Namespace:{DescID: 106, Name: ctyp, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 106, Name: ctyp, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: public}, ABSENT], PUBLIC] -> ABSENT
@@ -427,7 +427,7 @@ PreCommitPhase stage 2 of 2 with 19 MutationType ops
     [[CompositeTypeAttrType:{DescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[CompositeTypeAttrName:{DescID: 106, Name: b}, ABSENT], PUBLIC] -> ABSENT
     [[SchemaChild:{DescID: 106, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 107, Name: _ctyp, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 107, Name: _ctyp, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 107}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: public}, ABSENT], PUBLIC] -> ABSENT
@@ -537,7 +537,7 @@ DROP TYPE defaultdb.ctyp
   kind: PreviousTransactionPrecedence
   rule: descriptor dropped in transaction before removal
 - from: [AliasType:{DescID: 107, ReferencedTypeIDs: [106 107]}, DROPPED]
-  to:   [Namespace:{DescID: 107, Name: _ctyp, ReferencedDescID: 100, IntValue: 101}, ABSENT]
+  to:   [Namespace:{DescID: 107, Name: _ctyp, ReferencedDescID: 100, UInt32Value: 101}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [AliasType:{DescID: 107, ReferencedTypeIDs: [106 107]}, DROPPED]
@@ -577,7 +577,7 @@ DROP TYPE defaultdb.ctyp
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [CompositeType:{DescID: 106}, DROPPED]
-  to:   [Namespace:{DescID: 106, Name: ctyp, ReferencedDescID: 100, IntValue: 101}, ABSENT]
+  to:   [Namespace:{DescID: 106, Name: ctyp, ReferencedDescID: 100, UInt32Value: 101}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [CompositeType:{DescID: 106}, DROPPED]
@@ -612,11 +612,11 @@ DROP TYPE defaultdb.ctyp
   to:   [CompositeType:{DescID: 106}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 106, Name: ctyp, ReferencedDescID: 100, IntValue: 101}, ABSENT]
+- from: [Namespace:{DescID: 106, Name: ctyp, ReferencedDescID: 100, UInt32Value: 101}, ABSENT]
   to:   [CompositeType:{DescID: 106}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 107, Name: _ctyp, ReferencedDescID: 100, IntValue: 101}, ABSENT]
+- from: [Namespace:{DescID: 107, Name: _ctyp, ReferencedDescID: 100, UInt32Value: 101}, ABSENT]
   to:   [AliasType:{DescID: 107, ReferencedTypeIDs: [106 107]}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor

--- a/pkg/sql/schemachanger/scplan/testdata/drop_view
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_view
@@ -8,7 +8,7 @@ DROP VIEW defaultdb.v1
 ----
 StatementPhase stage 1 of 1 with 31 MutationType ops
   transitions:
-    [[Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -137,7 +137,7 @@ StatementPhase stage 1 of 1 with 31 MutationType ops
       TableID: 105
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
-    [[Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100, IntValue: 101}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 105}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -167,7 +167,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
       {}
 PreCommitPhase stage 2 of 2 with 34 MutationType ops
   transitions:
-    [[Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -524,7 +524,7 @@ DROP VIEW defaultdb.v1
   to:   [View:{DescID: 105}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100, IntValue: 101}, ABSENT]
+- from: [Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100, UInt32Value: 101}, ABSENT]
   to:   [View:{DescID: 105}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
@@ -621,7 +621,7 @@ DROP VIEW defaultdb.v1
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 105}, DROPPED]
-  to:   [Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100, IntValue: 101}, ABSENT]
+  to:   [Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100, UInt32Value: 101}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 105}, DROPPED]
@@ -658,7 +658,7 @@ DROP VIEW defaultdb.v1 CASCADE
 ----
 StatementPhase stage 1 of 1 with 176 MutationType ops
   transitions:
-    [[Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -683,7 +683,7 @@ StatementPhase stage 1 of 1 with 176 MutationType ops
     [[ColumnName:{DescID: 105, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 105, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 106, Name: v2, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 106, Name: v2, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -711,7 +711,7 @@ StatementPhase stage 1 of 1 with 176 MutationType ops
     [[ColumnName:{DescID: 106, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 106, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 107, Name: v3, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 107, Name: v3, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 107}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -739,7 +739,7 @@ StatementPhase stage 1 of 1 with 176 MutationType ops
     [[ColumnName:{DescID: 107, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 107, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 108, Name: v4, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 108, Name: v4, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 108}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -767,7 +767,7 @@ StatementPhase stage 1 of 1 with 176 MutationType ops
     [[ColumnName:{DescID: 108, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 108, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 111, Name: v5, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 111, Name: v5, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 111}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -1377,7 +1377,7 @@ StatementPhase stage 1 of 1 with 176 MutationType ops
       TableID: 111
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
-    [[Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100, IntValue: 101}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 105}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -1402,7 +1402,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[ColumnName:{DescID: 105, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnHidden:{DescID: 105, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 106, Name: v2, ReferencedDescID: 100, IntValue: 101}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 106, Name: v2, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 106}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 106, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -1430,7 +1430,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[ColumnName:{DescID: 106, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnHidden:{DescID: 106, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 107, Name: v3, ReferencedDescID: 100, IntValue: 101}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 107, Name: v3, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 107}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 107, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 107, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -1458,7 +1458,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[ColumnName:{DescID: 107, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnHidden:{DescID: 107, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 108, Name: v4, ReferencedDescID: 100, IntValue: 101}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 108, Name: v4, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 108}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -1486,7 +1486,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[ColumnName:{DescID: 108, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnHidden:{DescID: 108, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 111, Name: v5, ReferencedDescID: 100, IntValue: 101}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 111, Name: v5, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 111}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 111, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 111, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -1522,7 +1522,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
       {}
 PreCommitPhase stage 2 of 2 with 185 MutationType ops
   transitions:
-    [[Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -1547,7 +1547,7 @@ PreCommitPhase stage 2 of 2 with 185 MutationType ops
     [[ColumnName:{DescID: 105, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 105, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 106, Name: v2, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 106, Name: v2, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -1575,7 +1575,7 @@ PreCommitPhase stage 2 of 2 with 185 MutationType ops
     [[ColumnName:{DescID: 106, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 106, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 107, Name: v3, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 107, Name: v3, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 107}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -1603,7 +1603,7 @@ PreCommitPhase stage 2 of 2 with 185 MutationType ops
     [[ColumnName:{DescID: 107, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 107, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 108, Name: v4, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 108, Name: v4, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 108}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -1631,7 +1631,7 @@ PreCommitPhase stage 2 of 2 with 185 MutationType ops
     [[ColumnName:{DescID: 108, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 108, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 111, Name: v5, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 111, Name: v5, ReferencedDescID: 100, UInt32Value: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 111}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -3421,23 +3421,23 @@ DROP VIEW defaultdb.v1 CASCADE
   to:   [View:{DescID: 111}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100, IntValue: 101}, ABSENT]
+- from: [Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100, UInt32Value: 101}, ABSENT]
   to:   [View:{DescID: 105}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 106, Name: v2, ReferencedDescID: 100, IntValue: 101}, ABSENT]
+- from: [Namespace:{DescID: 106, Name: v2, ReferencedDescID: 100, UInt32Value: 101}, ABSENT]
   to:   [View:{DescID: 106}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 107, Name: v3, ReferencedDescID: 100, IntValue: 101}, ABSENT]
+- from: [Namespace:{DescID: 107, Name: v3, ReferencedDescID: 100, UInt32Value: 101}, ABSENT]
   to:   [View:{DescID: 107}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 108, Name: v4, ReferencedDescID: 100, IntValue: 101}, ABSENT]
+- from: [Namespace:{DescID: 108, Name: v4, ReferencedDescID: 100, UInt32Value: 101}, ABSENT]
   to:   [View:{DescID: 108}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 111, Name: v5, ReferencedDescID: 100, IntValue: 101}, ABSENT]
+- from: [Namespace:{DescID: 111, Name: v5, ReferencedDescID: 100, UInt32Value: 101}, ABSENT]
   to:   [View:{DescID: 111}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
@@ -3598,7 +3598,7 @@ DROP VIEW defaultdb.v1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 105}, DROPPED]
-  to:   [Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100, IntValue: 101}, ABSENT]
+  to:   [Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100, UInt32Value: 101}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 105}, DROPPED]
@@ -3710,7 +3710,7 @@ DROP VIEW defaultdb.v1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 106}, DROPPED]
-  to:   [Namespace:{DescID: 106, Name: v2, ReferencedDescID: 100, IntValue: 101}, ABSENT]
+  to:   [Namespace:{DescID: 106, Name: v2, ReferencedDescID: 100, UInt32Value: 101}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 106}, DROPPED]
@@ -3822,7 +3822,7 @@ DROP VIEW defaultdb.v1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 107}, DROPPED]
-  to:   [Namespace:{DescID: 107, Name: v3, ReferencedDescID: 100, IntValue: 101}, ABSENT]
+  to:   [Namespace:{DescID: 107, Name: v3, ReferencedDescID: 100, UInt32Value: 101}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 107}, DROPPED]
@@ -3934,7 +3934,7 @@ DROP VIEW defaultdb.v1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 108}, DROPPED]
-  to:   [Namespace:{DescID: 108, Name: v4, ReferencedDescID: 100, IntValue: 101}, ABSENT]
+  to:   [Namespace:{DescID: 108, Name: v4, ReferencedDescID: 100, UInt32Value: 101}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 108}, DROPPED]
@@ -4058,7 +4058,7 @@ DROP VIEW defaultdb.v1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 111}, DROPPED]
-  to:   [Namespace:{DescID: 111, Name: v5, ReferencedDescID: 100, IntValue: 101}, ABSENT]
+  to:   [Namespace:{DescID: 111, Name: v5, ReferencedDescID: 100, UInt32Value: 101}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 111}, DROPPED]

--- a/pkg/sql/schemachanger/screl/attr.go
+++ b/pkg/sql/schemachanger/screl/attr.go
@@ -124,13 +124,22 @@ const (
 	// It's value must be in catpb.GeneratedAsIdentityType.
 	GeneratedAsIdentityType
 
-	// IntValue A int64 used only for element uniqueness, and this can map out
-	// to any int64 attribute. It is currently used for:
+	// UInt32Value is an unsigned 32-bit integer used only for element uniqueness.
+	// It is currently used for:
 	// 1) SchemaID in the namespace element.
-	IntValue
-
+	UInt32Value
+	// BoolValue is a bool used only for element uniqueness. It is
+	// currently used for:
+	// 1) LeakProof in FunctionLeakProof.
+	BoolValue
+	// Int32Value is a 32-bit integer used only for element uniqueness.
+	// It is currently used for:
+	// 1) Volatility in FunctionVolatility.
+	// 2) NullInputBehavior in FunctionNullInputBehavior.
+	// 3) Security in FunctionSecurity.
+	Int32Value
 	// AttrMax is the largest possible Attr value.
-	// Note: add any new enum values before IntValue, leave these at the end.
+	// Note: add any new enum values before UInt32Value, leave these at the end.
 	AttrMax = iota - 1
 )
 
@@ -440,7 +449,7 @@ var elementSchemaOptions = []rel.SchemaOption{
 	rel.EntityMapping(t((*scpb.Namespace)(nil)),
 		rel.EntityAttr(DescID, "DescriptorID"),
 		rel.EntityAttr(ReferencedDescID, "DatabaseID"),
-		rel.EntityAttr(IntValue, "SchemaID"),
+		rel.EntityAttr(UInt32Value, "SchemaID"),
 		rel.EntityAttr(Name, "Name"),
 	),
 	rel.EntityMapping(t((*scpb.Owner)(nil)),
@@ -567,18 +576,23 @@ var elementSchemaOptions = []rel.SchemaOption{
 	),
 	rel.EntityMapping(t((*scpb.FunctionVolatility)(nil)),
 		rel.EntityAttr(DescID, "FunctionID"),
+		rel.EntityAttr(Int32Value, "Volatility.Volatility"),
 	),
 	rel.EntityMapping(t((*scpb.FunctionLeakProof)(nil)),
 		rel.EntityAttr(DescID, "FunctionID"),
+		rel.EntityAttr(BoolValue, "LeakProof"),
 	),
 	rel.EntityMapping(t((*scpb.FunctionNullInputBehavior)(nil)),
 		rel.EntityAttr(DescID, "FunctionID"),
+		rel.EntityAttr(Int32Value, "NullInputBehavior.NullInputBehavior"),
 	),
 	rel.EntityMapping(t((*scpb.FunctionBody)(nil)),
 		rel.EntityAttr(DescID, "FunctionID"),
+		rel.EntityAttr(Value, "Body"),
 	),
 	rel.EntityMapping(t((*scpb.FunctionSecurity)(nil)),
 		rel.EntityAttr(DescID, "FunctionID"),
+		rel.EntityAttr(Int32Value, "Security.Security"),
 	),
 }
 

--- a/pkg/sql/schemachanger/screl/attr_string.go
+++ b/pkg/sql/schemachanger/screl/attr_string.go
@@ -41,8 +41,10 @@ func _() {
 	_ = x[Usage-26]
 	_ = x[PolicyID-27]
 	_ = x[GeneratedAsIdentityType-28]
-	_ = x[IntValue-29]
-	_ = x[AttrMax-29]
+	_ = x[BoolValue-29]
+	_ = x[Int32Value-30]
+	_ = x[UInt32Value-31]
+	_ = x[AttrMax-31]
 }
 
 func (i Attr) String() string {
@@ -103,8 +105,12 @@ func (i Attr) String() string {
 		return "PolicyID"
 	case GeneratedAsIdentityType:
 		return "GeneratedAsIdentityType"
-	case IntValue:
-		return "IntValue"
+	case BoolValue:
+		return "BoolValue"
+	case Int32Value:
+		return "Int32Value"
+	case UInt32Value:
+		return "UInt32Value"
 	default:
 		return "Attr(" + strconv.FormatInt(int64(i), 10) + ")"
 	}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_generated/add_column_generated.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_generated/add_column_generated.explain
@@ -10,7 +10,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 27 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC        Sequence:{DescID: 107 (tbl_serial_id_seq+)}
- │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db), IntValue: 105}
+ │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db), UInt32Value: 105}
  │         │    ├── ABSENT → PUBLIC        SchemaChild:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 105 (public)}
  │         │    ├── ABSENT → PUBLIC        TableData:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 104 (db)}
  │         │    ├── ABSENT → PUBLIC        SequenceOption:{DescID: 107 (tbl_serial_id_seq+), Name: "INCREMENT", Value: "32"}
@@ -88,7 +88,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │    ├── Stage 1 of 2 in PreCommitPhase
  │    │    ├── 27 elements transitioning toward PUBLIC
  │    │    │    ├── PUBLIC        → ABSENT Sequence:{DescID: 107 (tbl_serial_id_seq+)}
- │    │    │    ├── PUBLIC        → ABSENT Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db), IntValue: 105}
+ │    │    │    ├── PUBLIC        → ABSENT Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db), UInt32Value: 105}
  │    │    │    ├── PUBLIC        → ABSENT SchemaChild:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 105 (public)}
  │    │    │    ├── PUBLIC        → ABSENT TableData:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 104 (db)}
  │    │    │    ├── PUBLIC        → ABSENT SequenceOption:{DescID: 107 (tbl_serial_id_seq+), Name: "INCREMENT", Value: "32"}
@@ -125,7 +125,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │    └── Stage 2 of 2 in PreCommitPhase
  │         ├── 27 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC        Sequence:{DescID: 107 (tbl_serial_id_seq+)}
- │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db), IntValue: 105}
+ │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db), UInt32Value: 105}
  │         │    ├── ABSENT → PUBLIC        SchemaChild:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 105 (public)}
  │         │    ├── ABSENT → PUBLIC        TableData:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 104 (db)}
  │         │    ├── ABSENT → PUBLIC        SequenceOption:{DescID: 107 (tbl_serial_id_seq+), Name: "INCREMENT", Value: "32"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_generated/add_column_generated__rollback_1_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_generated/add_column_generated__rollback_1_of_7.explain
@@ -11,7 +11,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
       │    ├── 29 elements transitioning toward ABSENT
       │    │    ├── PUBLIC        → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC        → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), IntValue: 105}
+      │    │    ├── PUBLIC        → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), UInt32Value: 105}
       │    │    ├── PUBLIC        → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC        → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "INCREMENT", Value: "32"}
       │    │    ├── PUBLIC        → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "MINVALUE", Value: "0"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_generated/add_column_generated__rollback_2_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_generated/add_column_generated__rollback_2_of_7.explain
@@ -43,7 +43,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 22 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), IntValue: 105}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), UInt32Value: 105}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "INCREMENT", Value: "32"}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "MINVALUE", Value: "0"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_generated/add_column_generated__rollback_3_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_generated/add_column_generated__rollback_3_of_7.explain
@@ -43,7 +43,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 22 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), IntValue: 105}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), UInt32Value: 105}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "INCREMENT", Value: "32"}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "MINVALUE", Value: "0"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_generated/add_column_generated__rollback_4_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_generated/add_column_generated__rollback_4_of_7.explain
@@ -43,7 +43,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 22 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), IntValue: 105}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), UInt32Value: 105}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "INCREMENT", Value: "32"}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "MINVALUE", Value: "0"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_generated/add_column_generated__rollback_5_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_generated/add_column_generated__rollback_5_of_7.explain
@@ -43,7 +43,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 23 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), IntValue: 105}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), UInt32Value: 105}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "INCREMENT", Value: "32"}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "MINVALUE", Value: "0"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_generated/add_column_generated__rollback_6_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_generated/add_column_generated__rollback_6_of_7.explain
@@ -43,7 +43,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 23 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), IntValue: 105}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), UInt32Value: 105}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "INCREMENT", Value: "32"}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "MINVALUE", Value: "0"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_generated/add_column_generated__rollback_7_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_generated/add_column_generated__rollback_7_of_7.explain
@@ -43,7 +43,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 22 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), IntValue: 105}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), UInt32Value: 105}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "INCREMENT", Value: "32"}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "MINVALUE", Value: "0"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence/add_column_serial_simple_sequence.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence/add_column_serial_simple_sequence.explain
@@ -11,7 +11,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 23 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC        Sequence:{DescID: 107 (tbl_serial_id_seq+)}
- │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db), IntValue: 105}
+ │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db), UInt32Value: 105}
  │         │    ├── ABSENT → PUBLIC        SchemaChild:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 105 (public)}
  │         │    ├── ABSENT → PUBLIC        TableData:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 104 (db)}
  │         │    ├── ABSENT → PUBLIC        Column:{DescID: 107 (tbl_serial_id_seq+), ColumnID: 1 (value+)}
@@ -81,7 +81,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │    ├── Stage 1 of 2 in PreCommitPhase
  │    │    ├── 23 elements transitioning toward PUBLIC
  │    │    │    ├── PUBLIC        → ABSENT Sequence:{DescID: 107 (tbl_serial_id_seq+)}
- │    │    │    ├── PUBLIC        → ABSENT Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db), IntValue: 105}
+ │    │    │    ├── PUBLIC        → ABSENT Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db), UInt32Value: 105}
  │    │    │    ├── PUBLIC        → ABSENT SchemaChild:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 105 (public)}
  │    │    │    ├── PUBLIC        → ABSENT TableData:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 104 (db)}
  │    │    │    ├── PUBLIC        → ABSENT Column:{DescID: 107 (tbl_serial_id_seq+), ColumnID: 1 (value+)}
@@ -114,7 +114,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │    └── Stage 2 of 2 in PreCommitPhase
  │         ├── 23 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC        Sequence:{DescID: 107 (tbl_serial_id_seq+)}
- │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db), IntValue: 105}
+ │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db), UInt32Value: 105}
  │         │    ├── ABSENT → PUBLIC        SchemaChild:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 105 (public)}
  │         │    ├── ABSENT → PUBLIC        TableData:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 104 (db)}
  │         │    ├── ABSENT → PUBLIC        Column:{DescID: 107 (tbl_serial_id_seq+), ColumnID: 1 (value+)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence/add_column_serial_simple_sequence__rollback_1_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence/add_column_serial_simple_sequence__rollback_1_of_7.explain
@@ -12,7 +12,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
       │    ├── 25 elements transitioning toward ABSENT
       │    │    ├── PUBLIC        → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC        → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), IntValue: 105}
+      │    │    ├── PUBLIC        → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), UInt32Value: 105}
       │    │    ├── PUBLIC        → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC        → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}
       │    │    ├── PUBLIC        → ABSENT  ColumnType:{DescID: 107 (tbl_serial_id_seq-), ColumnFamilyID: 0, ColumnID: 1 (value-), TypeName: "INT8"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence/add_column_serial_simple_sequence__rollback_2_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence/add_column_serial_simple_sequence__rollback_2_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 19 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), IntValue: 105}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), UInt32Value: 105}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}
       │    │    ├── PUBLIC      → ABSENT  ColumnType:{DescID: 107 (tbl_serial_id_seq-), ColumnFamilyID: 0, ColumnID: 1 (value-), TypeName: "INT8"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence/add_column_serial_simple_sequence__rollback_3_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence/add_column_serial_simple_sequence__rollback_3_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 19 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), IntValue: 105}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), UInt32Value: 105}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}
       │    │    ├── PUBLIC      → ABSENT  ColumnType:{DescID: 107 (tbl_serial_id_seq-), ColumnFamilyID: 0, ColumnID: 1 (value-), TypeName: "INT8"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence/add_column_serial_simple_sequence__rollback_4_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence/add_column_serial_simple_sequence__rollback_4_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 19 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), IntValue: 105}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), UInt32Value: 105}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}
       │    │    ├── PUBLIC      → ABSENT  ColumnType:{DescID: 107 (tbl_serial_id_seq-), ColumnFamilyID: 0, ColumnID: 1 (value-), TypeName: "INT8"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence/add_column_serial_simple_sequence__rollback_5_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence/add_column_serial_simple_sequence__rollback_5_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 20 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), IntValue: 105}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), UInt32Value: 105}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}
       │    │    ├── PUBLIC      → ABSENT  ColumnType:{DescID: 107 (tbl_serial_id_seq-), ColumnFamilyID: 0, ColumnID: 1 (value-), TypeName: "INT8"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence/add_column_serial_simple_sequence__rollback_6_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence/add_column_serial_simple_sequence__rollback_6_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 20 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), IntValue: 105}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), UInt32Value: 105}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}
       │    │    ├── PUBLIC      → ABSENT  ColumnType:{DescID: 107 (tbl_serial_id_seq-), ColumnFamilyID: 0, ColumnID: 1 (value-), TypeName: "INT8"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence/add_column_serial_simple_sequence__rollback_7_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence/add_column_serial_simple_sequence__rollback_7_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 19 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), IntValue: 105}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), UInt32Value: 105}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}
       │    │    ├── PUBLIC      → ABSENT  ColumnType:{DescID: 107 (tbl_serial_id_seq-), ColumnFamilyID: 0, ColumnID: 1 (value-), TypeName: "INT8"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached/add_column_serial_simple_sequence_cached.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached/add_column_serial_simple_sequence_cached.explain
@@ -11,7 +11,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 24 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC        Sequence:{DescID: 107 (tbl_serial_id_seq+)}
- │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db), IntValue: 105}
+ │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db), UInt32Value: 105}
  │         │    ├── ABSENT → PUBLIC        SchemaChild:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 105 (public)}
  │         │    ├── ABSENT → PUBLIC        TableData:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 104 (db)}
  │         │    ├── ABSENT → PUBLIC        SequenceOption:{DescID: 107 (tbl_serial_id_seq+), Name: "PER SESSION CACHE", Value: "256"}
@@ -83,7 +83,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │    ├── Stage 1 of 2 in PreCommitPhase
  │    │    ├── 24 elements transitioning toward PUBLIC
  │    │    │    ├── PUBLIC        → ABSENT Sequence:{DescID: 107 (tbl_serial_id_seq+)}
- │    │    │    ├── PUBLIC        → ABSENT Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db), IntValue: 105}
+ │    │    │    ├── PUBLIC        → ABSENT Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db), UInt32Value: 105}
  │    │    │    ├── PUBLIC        → ABSENT SchemaChild:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 105 (public)}
  │    │    │    ├── PUBLIC        → ABSENT TableData:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 104 (db)}
  │    │    │    ├── PUBLIC        → ABSENT SequenceOption:{DescID: 107 (tbl_serial_id_seq+), Name: "PER SESSION CACHE", Value: "256"}
@@ -117,7 +117,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │    └── Stage 2 of 2 in PreCommitPhase
  │         ├── 24 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC        Sequence:{DescID: 107 (tbl_serial_id_seq+)}
- │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db), IntValue: 105}
+ │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db), UInt32Value: 105}
  │         │    ├── ABSENT → PUBLIC        SchemaChild:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 105 (public)}
  │         │    ├── ABSENT → PUBLIC        TableData:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 104 (db)}
  │         │    ├── ABSENT → PUBLIC        SequenceOption:{DescID: 107 (tbl_serial_id_seq+), Name: "PER SESSION CACHE", Value: "256"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached/add_column_serial_simple_sequence_cached__rollback_1_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached/add_column_serial_simple_sequence_cached__rollback_1_of_7.explain
@@ -12,7 +12,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
       │    ├── 26 elements transitioning toward ABSENT
       │    │    ├── PUBLIC        → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC        → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), IntValue: 105}
+      │    │    ├── PUBLIC        → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), UInt32Value: 105}
       │    │    ├── PUBLIC        → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC        → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "PER SESSION CACHE", Value: "256"}
       │    │    ├── PUBLIC        → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached/add_column_serial_simple_sequence_cached__rollback_2_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached/add_column_serial_simple_sequence_cached__rollback_2_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 20 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), IntValue: 105}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), UInt32Value: 105}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "PER SESSION CACHE", Value: "256"}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached/add_column_serial_simple_sequence_cached__rollback_3_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached/add_column_serial_simple_sequence_cached__rollback_3_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 20 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), IntValue: 105}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), UInt32Value: 105}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "PER SESSION CACHE", Value: "256"}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached/add_column_serial_simple_sequence_cached__rollback_4_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached/add_column_serial_simple_sequence_cached__rollback_4_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 20 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), IntValue: 105}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), UInt32Value: 105}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "PER SESSION CACHE", Value: "256"}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached/add_column_serial_simple_sequence_cached__rollback_5_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached/add_column_serial_simple_sequence_cached__rollback_5_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 21 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), IntValue: 105}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), UInt32Value: 105}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "PER SESSION CACHE", Value: "256"}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached/add_column_serial_simple_sequence_cached__rollback_6_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached/add_column_serial_simple_sequence_cached__rollback_6_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 21 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), IntValue: 105}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), UInt32Value: 105}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "PER SESSION CACHE", Value: "256"}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached/add_column_serial_simple_sequence_cached__rollback_7_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached/add_column_serial_simple_sequence_cached__rollback_7_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 20 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), IntValue: 105}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), UInt32Value: 105}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "PER SESSION CACHE", Value: "256"}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached_node/add_column_serial_simple_sequence_cached_node.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached_node/add_column_serial_simple_sequence_cached_node.explain
@@ -11,7 +11,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 24 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC        Sequence:{DescID: 107 (tbl_serial_id_seq+)}
- │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db), IntValue: 105}
+ │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db), UInt32Value: 105}
  │         │    ├── ABSENT → PUBLIC        SchemaChild:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 105 (public)}
  │         │    ├── ABSENT → PUBLIC        TableData:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 104 (db)}
  │         │    ├── ABSENT → PUBLIC        SequenceOption:{DescID: 107 (tbl_serial_id_seq+), Name: "PER NODE CACHE", Value: "256"}
@@ -83,7 +83,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │    ├── Stage 1 of 2 in PreCommitPhase
  │    │    ├── 24 elements transitioning toward PUBLIC
  │    │    │    ├── PUBLIC        → ABSENT Sequence:{DescID: 107 (tbl_serial_id_seq+)}
- │    │    │    ├── PUBLIC        → ABSENT Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db), IntValue: 105}
+ │    │    │    ├── PUBLIC        → ABSENT Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db), UInt32Value: 105}
  │    │    │    ├── PUBLIC        → ABSENT SchemaChild:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 105 (public)}
  │    │    │    ├── PUBLIC        → ABSENT TableData:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 104 (db)}
  │    │    │    ├── PUBLIC        → ABSENT SequenceOption:{DescID: 107 (tbl_serial_id_seq+), Name: "PER NODE CACHE", Value: "256"}
@@ -117,7 +117,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │    └── Stage 2 of 2 in PreCommitPhase
  │         ├── 24 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC        Sequence:{DescID: 107 (tbl_serial_id_seq+)}
- │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db), IntValue: 105}
+ │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db), UInt32Value: 105}
  │         │    ├── ABSENT → PUBLIC        SchemaChild:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 105 (public)}
  │         │    ├── ABSENT → PUBLIC        TableData:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 104 (db)}
  │         │    ├── ABSENT → PUBLIC        SequenceOption:{DescID: 107 (tbl_serial_id_seq+), Name: "PER NODE CACHE", Value: "256"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached_node/add_column_serial_simple_sequence_cached_node__rollback_1_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached_node/add_column_serial_simple_sequence_cached_node__rollback_1_of_7.explain
@@ -12,7 +12,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
       │    ├── 26 elements transitioning toward ABSENT
       │    │    ├── PUBLIC        → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC        → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), IntValue: 105}
+      │    │    ├── PUBLIC        → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), UInt32Value: 105}
       │    │    ├── PUBLIC        → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC        → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "PER NODE CACHE", Value: "256"}
       │    │    ├── PUBLIC        → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached_node/add_column_serial_simple_sequence_cached_node__rollback_2_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached_node/add_column_serial_simple_sequence_cached_node__rollback_2_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 20 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), IntValue: 105}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), UInt32Value: 105}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "PER NODE CACHE", Value: "256"}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached_node/add_column_serial_simple_sequence_cached_node__rollback_3_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached_node/add_column_serial_simple_sequence_cached_node__rollback_3_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 20 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), IntValue: 105}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), UInt32Value: 105}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "PER NODE CACHE", Value: "256"}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached_node/add_column_serial_simple_sequence_cached_node__rollback_4_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached_node/add_column_serial_simple_sequence_cached_node__rollback_4_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 20 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), IntValue: 105}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), UInt32Value: 105}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "PER NODE CACHE", Value: "256"}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached_node/add_column_serial_simple_sequence_cached_node__rollback_5_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached_node/add_column_serial_simple_sequence_cached_node__rollback_5_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 21 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), IntValue: 105}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), UInt32Value: 105}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "PER NODE CACHE", Value: "256"}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached_node/add_column_serial_simple_sequence_cached_node__rollback_6_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached_node/add_column_serial_simple_sequence_cached_node__rollback_6_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 21 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), IntValue: 105}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), UInt32Value: 105}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "PER NODE CACHE", Value: "256"}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached_node/add_column_serial_simple_sequence_cached_node__rollback_7_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached_node/add_column_serial_simple_sequence_cached_node__rollback_7_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 20 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), IntValue: 105}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), UInt32Value: 105}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "PER NODE CACHE", Value: "256"}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_virtual/add_column_serial_simple_sequence_virtual.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_virtual/add_column_serial_simple_sequence_virtual.explain
@@ -11,7 +11,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 24 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC        Sequence:{DescID: 107 (tbl_serial_id_seq+)}
- │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db), IntValue: 105}
+ │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db), UInt32Value: 105}
  │         │    ├── ABSENT → PUBLIC        SchemaChild:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 105 (public)}
  │         │    ├── ABSENT → PUBLIC        TableData:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 104 (db)}
  │         │    ├── ABSENT → PUBLIC        SequenceOption:{DescID: 107 (tbl_serial_id_seq+), Name: "VIRTUAL", Value: "true"}
@@ -83,7 +83,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │    ├── Stage 1 of 2 in PreCommitPhase
  │    │    ├── 24 elements transitioning toward PUBLIC
  │    │    │    ├── PUBLIC        → ABSENT Sequence:{DescID: 107 (tbl_serial_id_seq+)}
- │    │    │    ├── PUBLIC        → ABSENT Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db), IntValue: 105}
+ │    │    │    ├── PUBLIC        → ABSENT Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db), UInt32Value: 105}
  │    │    │    ├── PUBLIC        → ABSENT SchemaChild:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 105 (public)}
  │    │    │    ├── PUBLIC        → ABSENT TableData:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 104 (db)}
  │    │    │    ├── PUBLIC        → ABSENT SequenceOption:{DescID: 107 (tbl_serial_id_seq+), Name: "VIRTUAL", Value: "true"}
@@ -117,7 +117,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │    └── Stage 2 of 2 in PreCommitPhase
  │         ├── 24 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC        Sequence:{DescID: 107 (tbl_serial_id_seq+)}
- │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db), IntValue: 105}
+ │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db), UInt32Value: 105}
  │         │    ├── ABSENT → PUBLIC        SchemaChild:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 105 (public)}
  │         │    ├── ABSENT → PUBLIC        TableData:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 104 (db)}
  │         │    ├── ABSENT → PUBLIC        SequenceOption:{DescID: 107 (tbl_serial_id_seq+), Name: "VIRTUAL", Value: "true"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_virtual/add_column_serial_simple_sequence_virtual__rollback_1_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_virtual/add_column_serial_simple_sequence_virtual__rollback_1_of_7.explain
@@ -12,7 +12,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
       │    ├── 26 elements transitioning toward ABSENT
       │    │    ├── PUBLIC        → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC        → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), IntValue: 105}
+      │    │    ├── PUBLIC        → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), UInt32Value: 105}
       │    │    ├── PUBLIC        → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC        → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "VIRTUAL", Value: "true"}
       │    │    ├── PUBLIC        → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_virtual/add_column_serial_simple_sequence_virtual__rollback_2_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_virtual/add_column_serial_simple_sequence_virtual__rollback_2_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 20 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), IntValue: 105}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), UInt32Value: 105}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "VIRTUAL", Value: "true"}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_virtual/add_column_serial_simple_sequence_virtual__rollback_3_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_virtual/add_column_serial_simple_sequence_virtual__rollback_3_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 20 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), IntValue: 105}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), UInt32Value: 105}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "VIRTUAL", Value: "true"}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_virtual/add_column_serial_simple_sequence_virtual__rollback_4_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_virtual/add_column_serial_simple_sequence_virtual__rollback_4_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 20 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), IntValue: 105}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), UInt32Value: 105}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "VIRTUAL", Value: "true"}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_virtual/add_column_serial_simple_sequence_virtual__rollback_5_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_virtual/add_column_serial_simple_sequence_virtual__rollback_5_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 21 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), IntValue: 105}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), UInt32Value: 105}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "VIRTUAL", Value: "true"}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_virtual/add_column_serial_simple_sequence_virtual__rollback_6_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_virtual/add_column_serial_simple_sequence_virtual__rollback_6_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 21 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), IntValue: 105}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), UInt32Value: 105}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "VIRTUAL", Value: "true"}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_virtual/add_column_serial_simple_sequence_virtual__rollback_7_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_virtual/add_column_serial_simple_sequence_virtual__rollback_7_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 20 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), IntValue: 105}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104), UInt32Value: 105}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "VIRTUAL", Value: "true"}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_add_identity/alter_table_alter_column_add_identity.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_add_identity/alter_table_alter_column_add_identity.explain
@@ -12,7 +12,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER CO
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 17 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC Sequence:{DescID: 105 (t_j_seq+)}
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (t_j_seq+), Name: "t_j_seq", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (t_j_seq+), Name: "t_j_seq", ReferencedDescID: 100 (defaultdb), UInt32Value: 101}
  │         │    ├── ABSENT → PUBLIC SchemaChild:{DescID: 105 (t_j_seq+), ReferencedDescID: 101 (public)}
  │         │    ├── ABSENT → PUBLIC TableData:{DescID: 105 (t_j_seq+), ReferencedDescID: 100 (defaultdb)}
  │         │    ├── ABSENT → PUBLIC Column:{DescID: 105 (t_j_seq+), ColumnID: 1 (value+)}
@@ -64,7 +64,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER CO
  │    ├── Stage 1 of 2 in PreCommitPhase
  │    │    ├── 17 elements transitioning toward PUBLIC
  │    │    │    ├── PUBLIC → ABSENT Sequence:{DescID: 105 (t_j_seq+)}
- │    │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 105 (t_j_seq+), Name: "t_j_seq", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+ │    │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 105 (t_j_seq+), Name: "t_j_seq", ReferencedDescID: 100 (defaultdb), UInt32Value: 101}
  │    │    │    ├── PUBLIC → ABSENT SchemaChild:{DescID: 105 (t_j_seq+), ReferencedDescID: 101 (public)}
  │    │    │    ├── PUBLIC → ABSENT TableData:{DescID: 105 (t_j_seq+), ReferencedDescID: 100 (defaultdb)}
  │    │    │    ├── PUBLIC → ABSENT Column:{DescID: 105 (t_j_seq+), ColumnID: 1 (value+)}
@@ -87,7 +87,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER CO
  │    └── Stage 2 of 2 in PreCommitPhase
  │         ├── 17 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC Sequence:{DescID: 105 (t_j_seq+)}
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (t_j_seq+), Name: "t_j_seq", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (t_j_seq+), Name: "t_j_seq", ReferencedDescID: 100 (defaultdb), UInt32Value: 101}
  │         │    ├── ABSENT → PUBLIC SchemaChild:{DescID: 105 (t_j_seq+), ReferencedDescID: 101 (public)}
  │         │    ├── ABSENT → PUBLIC TableData:{DescID: 105 (t_j_seq+), ReferencedDescID: 100 (defaultdb)}
  │         │    ├── ABSENT → PUBLIC Column:{DescID: 105 (t_j_seq+), ColumnID: 1 (value+)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_add_identity/alter_table_alter_column_add_identity__rollback_1_of_1.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_add_identity/alter_table_alter_column_add_identity__rollback_1_of_1.explain
@@ -13,7 +13,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER COLUMN 
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
       │    ├── 16 elements transitioning toward ABSENT
       │    │    ├── PUBLIC → DROPPED Sequence:{DescID: 105 (t_j_seq-)}
-      │    │    ├── PUBLIC → ABSENT  Namespace:{DescID: 105 (t_j_seq-), Name: "t_j_seq", ReferencedDescID: 100 (#100), IntValue: 101}
+      │    │    ├── PUBLIC → ABSENT  Namespace:{DescID: 105 (t_j_seq-), Name: "t_j_seq", ReferencedDescID: 100 (#100), UInt32Value: 101}
       │    │    ├── PUBLIC → ABSENT  SchemaChild:{DescID: 105 (t_j_seq-), ReferencedDescID: 101 (#101)}
       │    │    ├── PUBLIC → ABSENT  Column:{DescID: 105 (t_j_seq-), ColumnID: 1 (value-)}
       │    │    ├── PUBLIC → ABSENT  ColumnType:{DescID: 105 (t_j_seq-), ColumnFamilyID: 0, ColumnID: 1 (value-), TypeName: "INT8"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename/alter_table_rename.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename/alter_table_rename.explain
@@ -8,9 +8,9 @@ Schema change plan for ALTER TABLE ‹t1› RENAME TO ‹t1_renamed›;
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 1 element transitioning toward PUBLIC
- │         │    └── ABSENT → PUBLIC Namespace:{DescID: 104 (t1-t1_renamed+), Name: "t1_renamed", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+ │         │    └── ABSENT → PUBLIC Namespace:{DescID: 104 (t1-t1_renamed+), Name: "t1_renamed", ReferencedDescID: 100 (defaultdb), UInt32Value: 101}
  │         ├── 1 element transitioning toward ABSENT
- │         │    └── PUBLIC → ABSENT Namespace:{DescID: 104 (t1-t1_renamed+), Name: "t1", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+ │         │    └── PUBLIC → ABSENT Namespace:{DescID: 104 (t1-t1_renamed+), Name: "t1", ReferencedDescID: 100 (defaultdb), UInt32Value: 101}
  │         └── 3 Mutation operations
  │              ├── DrainDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"t1","SchemaID":101}}
  │              ├── SetNameInDescriptor {"DescriptorID":104,"Name":"t1_renamed"}
@@ -18,16 +18,16 @@ Schema change plan for ALTER TABLE ‹t1› RENAME TO ‹t1_renamed›;
  └── PreCommitPhase
       ├── Stage 1 of 2 in PreCommitPhase
       │    ├── 1 element transitioning toward PUBLIC
-      │    │    └── PUBLIC → ABSENT Namespace:{DescID: 104 (t1-t1_renamed+), Name: "t1_renamed", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+      │    │    └── PUBLIC → ABSENT Namespace:{DescID: 104 (t1-t1_renamed+), Name: "t1_renamed", ReferencedDescID: 100 (defaultdb), UInt32Value: 101}
       │    ├── 1 element transitioning toward ABSENT
-      │    │    └── ABSENT → PUBLIC Namespace:{DescID: 104 (t1-t1_renamed+), Name: "t1", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+      │    │    └── ABSENT → PUBLIC Namespace:{DescID: 104 (t1-t1_renamed+), Name: "t1", ReferencedDescID: 100 (defaultdb), UInt32Value: 101}
       │    └── 1 Mutation operation
       │         └── UndoAllInTxnImmediateMutationOpSideEffects
       └── Stage 2 of 2 in PreCommitPhase
            ├── 1 element transitioning toward PUBLIC
-           │    └── ABSENT → PUBLIC Namespace:{DescID: 104 (t1-t1_renamed+), Name: "t1_renamed", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+           │    └── ABSENT → PUBLIC Namespace:{DescID: 104 (t1-t1_renamed+), Name: "t1_renamed", ReferencedDescID: 100 (defaultdb), UInt32Value: 101}
            ├── 1 element transitioning toward ABSENT
-           │    └── PUBLIC → ABSENT Namespace:{DescID: 104 (t1-t1_renamed+), Name: "t1", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+           │    └── PUBLIC → ABSENT Namespace:{DescID: 104 (t1-t1_renamed+), Name: "t1", ReferencedDescID: 100 (defaultdb), UInt32Value: 101}
            └── 4 Mutation operations
                 ├── DrainDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"t1","SchemaID":101}}
                 ├── SetNameInDescriptor {"DescriptorID":104,"Name":"t1_renamed"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_set_schema/alter_table_set_schema.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_set_schema/alter_table_set_schema.explain
@@ -9,10 +9,10 @@ Schema change plan for ALTER TABLE ‹t› SET SCHEMA ‹sc›;
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 2 elements transitioning toward PUBLIC
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (t-t+), Name: "t", ReferencedDescID: 100 (defaultdb), IntValue: 105}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (t-t+), Name: "t", ReferencedDescID: 100 (defaultdb), UInt32Value: 105}
  │         │    └── ABSENT → PUBLIC SchemaChild:{DescID: 104 (t-t+), ReferencedDescID: 105 (sc)}
  │         ├── 2 elements transitioning toward ABSENT
- │         │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (t-t+), Name: "t", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+ │         │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (t-t+), Name: "t", ReferencedDescID: 100 (defaultdb), UInt32Value: 101}
  │         │    └── PUBLIC → ABSENT SchemaChild:{DescID: 104 (t-t+), ReferencedDescID: 101 (public)}
  │         └── 5 Mutation operations
  │              ├── DrainDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"t","SchemaID":101}}
@@ -23,19 +23,19 @@ Schema change plan for ALTER TABLE ‹t› SET SCHEMA ‹sc›;
  └── PreCommitPhase
       ├── Stage 1 of 2 in PreCommitPhase
       │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (t-t+), Name: "t", ReferencedDescID: 100 (defaultdb), IntValue: 105}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (t-t+), Name: "t", ReferencedDescID: 100 (defaultdb), UInt32Value: 105}
       │    │    └── PUBLIC → ABSENT SchemaChild:{DescID: 104 (t-t+), ReferencedDescID: 105 (sc)}
       │    ├── 2 elements transitioning toward ABSENT
-      │    │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (t-t+), Name: "t", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+      │    │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (t-t+), Name: "t", ReferencedDescID: 100 (defaultdb), UInt32Value: 101}
       │    │    └── ABSENT → PUBLIC SchemaChild:{DescID: 104 (t-t+), ReferencedDescID: 101 (public)}
       │    └── 1 Mutation operation
       │         └── UndoAllInTxnImmediateMutationOpSideEffects
       └── Stage 2 of 2 in PreCommitPhase
            ├── 2 elements transitioning toward PUBLIC
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (t-t+), Name: "t", ReferencedDescID: 100 (defaultdb), IntValue: 105}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (t-t+), Name: "t", ReferencedDescID: 100 (defaultdb), UInt32Value: 105}
            │    └── ABSENT → PUBLIC SchemaChild:{DescID: 104 (t-t+), ReferencedDescID: 105 (sc)}
            ├── 2 elements transitioning toward ABSENT
-           │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (t-t+), Name: "t", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+           │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (t-t+), Name: "t", ReferencedDescID: 100 (defaultdb), UInt32Value: 101}
            │    └── PUBLIC → ABSENT SchemaChild:{DescID: 104 (t-t+), ReferencedDescID: 101 (public)}
            └── 6 Mutation operations
                 ├── DrainDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"t","SchemaID":101}}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_complex/create_complex__statement_1_of_4.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_complex/create_complex__statement_1_of_4.explain
@@ -9,14 +9,14 @@ Schema change plan for CREATE DATABASE ‹db›;
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 14 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC Database:{DescID: 104 (db+)}
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (db+), Name: "db", IntValue: 0}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (db+), Name: "db", UInt32Value: 0}
  │         │    ├── ABSENT → PUBLIC DatabaseData:{DescID: 104 (db+)}
  │         │    ├── ABSENT → PUBLIC Owner:{DescID: 104 (db+)}
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "admin"}
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "public"}
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "root"}
  │         │    ├── ABSENT → PUBLIC Schema:{DescID: 105 (public+)}
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+), IntValue: 0}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+), UInt32Value: 0}
  │         │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 105 (public+), ReferencedDescID: 104 (db+)}
  │         │    ├── ABSENT → PUBLIC Owner:{DescID: 105 (public+)}
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (public+), Name: "admin"}
@@ -44,14 +44,14 @@ Schema change plan for CREATE DATABASE ‹db›;
       ├── Stage 1 of 2 in PreCommitPhase
       │    ├── 14 elements transitioning toward PUBLIC
       │    │    ├── PUBLIC → ABSENT Database:{DescID: 104 (db+)}
-      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (db+), Name: "db", IntValue: 0}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (db+), Name: "db", UInt32Value: 0}
       │    │    ├── PUBLIC → ABSENT DatabaseData:{DescID: 104 (db+)}
       │    │    ├── PUBLIC → ABSENT Owner:{DescID: 104 (db+)}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 104 (db+), Name: "admin"}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 104 (db+), Name: "public"}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 104 (db+), Name: "root"}
       │    │    ├── PUBLIC → ABSENT Schema:{DescID: 105 (public+)}
-      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+), IntValue: 0}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+), UInt32Value: 0}
       │    │    ├── PUBLIC → ABSENT SchemaParent:{DescID: 105 (public+), ReferencedDescID: 104 (db+)}
       │    │    ├── PUBLIC → ABSENT Owner:{DescID: 105 (public+)}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 105 (public+), Name: "admin"}
@@ -62,14 +62,14 @@ Schema change plan for CREATE DATABASE ‹db›;
       └── Stage 2 of 2 in PreCommitPhase
            ├── 14 elements transitioning toward PUBLIC
            │    ├── ABSENT → PUBLIC Database:{DescID: 104 (db+)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (db+), Name: "db", IntValue: 0}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (db+), Name: "db", UInt32Value: 0}
            │    ├── ABSENT → PUBLIC DatabaseData:{DescID: 104 (db+)}
            │    ├── ABSENT → PUBLIC Owner:{DescID: 104 (db+)}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "admin"}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "public"}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "root"}
            │    ├── ABSENT → PUBLIC Schema:{DescID: 105 (public+)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+), IntValue: 0}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+), UInt32Value: 0}
            │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 105 (public+), ReferencedDescID: 104 (db+)}
            │    ├── ABSENT → PUBLIC Owner:{DescID: 105 (public+)}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (public+), Name: "admin"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_complex/create_complex__statement_2_of_4.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_complex/create_complex__statement_2_of_4.explain
@@ -10,7 +10,7 @@ Schema change plan for CREATE SCHEMA ‹db›.‹sc› AUTHORIZATION foo; follow
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 6 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC Schema:{DescID: 106 (sc+)}
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 106 (sc+), Name: "sc", ReferencedDescID: 104 (db+), IntValue: 0}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 106 (sc+), Name: "sc", ReferencedDescID: 104 (db+), UInt32Value: 0}
  │         │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 106 (sc+), ReferencedDescID: 104 (db+)}
  │         │    ├── ABSENT → PUBLIC Owner:{DescID: 106 (sc+)}
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 106 (sc+), Name: "admin"}
@@ -27,14 +27,14 @@ Schema change plan for CREATE SCHEMA ‹db›.‹sc› AUTHORIZATION foo; follow
  └── PreCommitPhase
       ├── Stage 1 of 2 in PreCommitPhase
       │    ├── 20 elements transitioning toward PUBLIC
-      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (db+), Name: "db", IntValue: 0}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (db+), Name: "db", UInt32Value: 0}
       │    │    ├── PUBLIC → ABSENT Owner:{DescID: 104 (db+)}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 104 (db+), Name: "admin"}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 104 (db+), Name: "public"}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 104 (db+), Name: "root"}
       │    │    ├── PUBLIC → ABSENT Database:{DescID: 104 (db+)}
       │    │    ├── PUBLIC → ABSENT DatabaseData:{DescID: 104 (db+)}
-      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+), IntValue: 0}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+), UInt32Value: 0}
       │    │    ├── PUBLIC → ABSENT Owner:{DescID: 105 (public+)}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 105 (public+), Name: "admin"}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 105 (public+), Name: "public"}
@@ -42,7 +42,7 @@ Schema change plan for CREATE SCHEMA ‹db›.‹sc› AUTHORIZATION foo; follow
       │    │    ├── PUBLIC → ABSENT Schema:{DescID: 105 (public+)}
       │    │    ├── PUBLIC → ABSENT SchemaParent:{DescID: 105 (public+), ReferencedDescID: 104 (db+)}
       │    │    ├── PUBLIC → ABSENT Schema:{DescID: 106 (sc+)}
-      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 106 (sc+), Name: "sc", ReferencedDescID: 104 (db+), IntValue: 0}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 106 (sc+), Name: "sc", ReferencedDescID: 104 (db+), UInt32Value: 0}
       │    │    ├── PUBLIC → ABSENT SchemaParent:{DescID: 106 (sc+), ReferencedDescID: 104 (db+)}
       │    │    ├── PUBLIC → ABSENT Owner:{DescID: 106 (sc+)}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 106 (sc+), Name: "admin"}
@@ -51,14 +51,14 @@ Schema change plan for CREATE SCHEMA ‹db›.‹sc› AUTHORIZATION foo; follow
       │         └── UndoAllInTxnImmediateMutationOpSideEffects
       └── Stage 2 of 2 in PreCommitPhase
            ├── 20 elements transitioning toward PUBLIC
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (db+), Name: "db", IntValue: 0}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (db+), Name: "db", UInt32Value: 0}
            │    ├── ABSENT → PUBLIC Owner:{DescID: 104 (db+)}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "admin"}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "public"}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "root"}
            │    ├── ABSENT → PUBLIC Database:{DescID: 104 (db+)}
            │    ├── ABSENT → PUBLIC DatabaseData:{DescID: 104 (db+)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+), IntValue: 0}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+), UInt32Value: 0}
            │    ├── ABSENT → PUBLIC Owner:{DescID: 105 (public+)}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (public+), Name: "admin"}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (public+), Name: "public"}
@@ -66,7 +66,7 @@ Schema change plan for CREATE SCHEMA ‹db›.‹sc› AUTHORIZATION foo; follow
            │    ├── ABSENT → PUBLIC Schema:{DescID: 105 (public+)}
            │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 105 (public+), ReferencedDescID: 104 (db+)}
            │    ├── ABSENT → PUBLIC Schema:{DescID: 106 (sc+)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 106 (sc+), Name: "sc", ReferencedDescID: 104 (db+), IntValue: 0}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 106 (sc+), Name: "sc", ReferencedDescID: 104 (db+), UInt32Value: 0}
            │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 106 (sc+), ReferencedDescID: 104 (db+)}
            │    ├── ABSENT → PUBLIC Owner:{DescID: 106 (sc+)}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 106 (sc+), Name: "admin"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_complex/create_complex__statement_3_of_4.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_complex/create_complex__statement_3_of_4.explain
@@ -36,21 +36,21 @@ Schema change plan for CREATE FUNCTION ‹defaultdb›.‹public›.‹t›()
  └── PreCommitPhase
       ├── Stage 1 of 2 in PreCommitPhase
       │    ├── 28 elements transitioning toward PUBLIC
-      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (db+), Name: "db", IntValue: 0}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (db+), Name: "db", UInt32Value: 0}
       │    │    ├── PUBLIC → ABSENT Owner:{DescID: 104 (db+)}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 104 (db+), Name: "admin"}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 104 (db+), Name: "public"}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 104 (db+), Name: "root"}
       │    │    ├── PUBLIC → ABSENT Database:{DescID: 104 (db+)}
       │    │    ├── PUBLIC → ABSENT DatabaseData:{DescID: 104 (db+)}
-      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+), IntValue: 0}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+), UInt32Value: 0}
       │    │    ├── PUBLIC → ABSENT Owner:{DescID: 105 (public+)}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 105 (public+), Name: "admin"}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 105 (public+), Name: "public"}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 105 (public+), Name: "root"}
       │    │    ├── PUBLIC → ABSENT Schema:{DescID: 105 (public+)}
       │    │    ├── PUBLIC → ABSENT SchemaParent:{DescID: 105 (public+), ReferencedDescID: 104 (db+)}
-      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 106 (sc+), Name: "sc", ReferencedDescID: 104 (db+), IntValue: 0}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 106 (sc+), Name: "sc", ReferencedDescID: 104 (db+), UInt32Value: 0}
       │    │    ├── PUBLIC → ABSENT Owner:{DescID: 106 (sc+)}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 106 (sc+), Name: "admin"}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 106 (sc+), Name: "root"}
@@ -68,21 +68,21 @@ Schema change plan for CREATE FUNCTION ‹defaultdb›.‹public›.‹t›()
       │         └── UndoAllInTxnImmediateMutationOpSideEffects
       └── Stage 2 of 2 in PreCommitPhase
            ├── 28 elements transitioning toward PUBLIC
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (db+), Name: "db", IntValue: 0}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (db+), Name: "db", UInt32Value: 0}
            │    ├── ABSENT → PUBLIC Owner:{DescID: 104 (db+)}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "admin"}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "public"}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "root"}
            │    ├── ABSENT → PUBLIC Database:{DescID: 104 (db+)}
            │    ├── ABSENT → PUBLIC DatabaseData:{DescID: 104 (db+)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+), IntValue: 0}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+), UInt32Value: 0}
            │    ├── ABSENT → PUBLIC Owner:{DescID: 105 (public+)}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (public+), Name: "admin"}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (public+), Name: "public"}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (public+), Name: "root"}
            │    ├── ABSENT → PUBLIC Schema:{DescID: 105 (public+)}
            │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 105 (public+), ReferencedDescID: 104 (db+)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 106 (sc+), Name: "sc", ReferencedDescID: 104 (db+), IntValue: 0}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 106 (sc+), Name: "sc", ReferencedDescID: 104 (db+), UInt32Value: 0}
            │    ├── ABSENT → PUBLIC Owner:{DescID: 106 (sc+)}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 106 (sc+), Name: "admin"}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 106 (sc+), Name: "root"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_complex/create_complex__statement_4_of_4.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_complex/create_complex__statement_4_of_4.explain
@@ -15,7 +15,7 @@ Schema change plan for CREATE SEQUENCE ‹db›.‹sc›.‹sq1› MINVALUE 1 MA
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 15 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC Sequence:{DescID: 108 (sq1+)}
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 108 (sq1+), Name: "sq1", ReferencedDescID: 104 (db+), IntValue: 106}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 108 (sq1+), Name: "sq1", ReferencedDescID: 104 (db+), UInt32Value: 106}
  │         │    ├── ABSENT → PUBLIC SchemaChild:{DescID: 108 (sq1+), ReferencedDescID: 106 (sc+)}
  │         │    ├── ABSENT → PUBLIC TableData:{DescID: 108 (sq1+), ReferencedDescID: 104 (db+)}
  │         │    ├── ABSENT → PUBLIC SequenceOption:{DescID: 108 (sq1+), Name: "START", Value: "32"}
@@ -57,21 +57,21 @@ Schema change plan for CREATE SEQUENCE ‹db›.‹sc›.‹sq1› MINVALUE 1 MA
  └── PreCommitPhase
       ├── Stage 1 of 2 in PreCommitPhase
       │    ├── 43 elements transitioning toward PUBLIC
-      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (db+), Name: "db", IntValue: 0}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (db+), Name: "db", UInt32Value: 0}
       │    │    ├── PUBLIC → ABSENT Owner:{DescID: 104 (db+)}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 104 (db+), Name: "admin"}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 104 (db+), Name: "public"}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 104 (db+), Name: "root"}
       │    │    ├── PUBLIC → ABSENT Database:{DescID: 104 (db+)}
       │    │    ├── PUBLIC → ABSENT DatabaseData:{DescID: 104 (db+)}
-      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+), IntValue: 0}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+), UInt32Value: 0}
       │    │    ├── PUBLIC → ABSENT Owner:{DescID: 105 (public+)}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 105 (public+), Name: "admin"}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 105 (public+), Name: "public"}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 105 (public+), Name: "root"}
       │    │    ├── PUBLIC → ABSENT Schema:{DescID: 105 (public+)}
       │    │    ├── PUBLIC → ABSENT SchemaParent:{DescID: 105 (public+), ReferencedDescID: 104 (db+)}
-      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 106 (sc+), Name: "sc", ReferencedDescID: 104 (db+), IntValue: 0}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 106 (sc+), Name: "sc", ReferencedDescID: 104 (db+), UInt32Value: 0}
       │    │    ├── PUBLIC → ABSENT Owner:{DescID: 106 (sc+)}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 106 (sc+), Name: "admin"}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 106 (sc+), Name: "root"}
@@ -86,7 +86,7 @@ Schema change plan for CREATE SEQUENCE ‹db›.‹sc›.‹sq1› MINVALUE 1 MA
       │    │    ├── PUBLIC → ABSENT FunctionName:{DescID: 107 (t+)}
       │    │    ├── PUBLIC → ABSENT FunctionBody:{DescID: 107 (t+)}
       │    │    ├── PUBLIC → ABSENT Sequence:{DescID: 108 (sq1+)}
-      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 108 (sq1+), Name: "sq1", ReferencedDescID: 104 (db+), IntValue: 106}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 108 (sq1+), Name: "sq1", ReferencedDescID: 104 (db+), UInt32Value: 106}
       │    │    ├── PUBLIC → ABSENT SchemaChild:{DescID: 108 (sq1+), ReferencedDescID: 106 (sc+)}
       │    │    ├── PUBLIC → ABSENT TableData:{DescID: 108 (sq1+), ReferencedDescID: 104 (db+)}
       │    │    ├── PUBLIC → ABSENT SequenceOption:{DescID: 108 (sq1+), Name: "START", Value: "32"}
@@ -104,21 +104,21 @@ Schema change plan for CREATE SEQUENCE ‹db›.‹sc›.‹sq1› MINVALUE 1 MA
       │         └── UndoAllInTxnImmediateMutationOpSideEffects
       └── Stage 2 of 2 in PreCommitPhase
            ├── 43 elements transitioning toward PUBLIC
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (db+), Name: "db", IntValue: 0}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (db+), Name: "db", UInt32Value: 0}
            │    ├── ABSENT → PUBLIC Owner:{DescID: 104 (db+)}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "admin"}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "public"}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "root"}
            │    ├── ABSENT → PUBLIC Database:{DescID: 104 (db+)}
            │    ├── ABSENT → PUBLIC DatabaseData:{DescID: 104 (db+)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+), IntValue: 0}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+), UInt32Value: 0}
            │    ├── ABSENT → PUBLIC Owner:{DescID: 105 (public+)}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (public+), Name: "admin"}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (public+), Name: "public"}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (public+), Name: "root"}
            │    ├── ABSENT → PUBLIC Schema:{DescID: 105 (public+)}
            │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 105 (public+), ReferencedDescID: 104 (db+)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 106 (sc+), Name: "sc", ReferencedDescID: 104 (db+), IntValue: 0}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 106 (sc+), Name: "sc", ReferencedDescID: 104 (db+), UInt32Value: 0}
            │    ├── ABSENT → PUBLIC Owner:{DescID: 106 (sc+)}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 106 (sc+), Name: "admin"}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 106 (sc+), Name: "root"}
@@ -133,7 +133,7 @@ Schema change plan for CREATE SEQUENCE ‹db›.‹sc›.‹sq1› MINVALUE 1 MA
            │    ├── ABSENT → PUBLIC FunctionName:{DescID: 107 (t+)}
            │    ├── ABSENT → PUBLIC FunctionBody:{DescID: 107 (t+)}
            │    ├── ABSENT → PUBLIC Sequence:{DescID: 108 (sq1+)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 108 (sq1+), Name: "sq1", ReferencedDescID: 104 (db+), IntValue: 106}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 108 (sq1+), Name: "sq1", ReferencedDescID: 104 (db+), UInt32Value: 106}
            │    ├── ABSENT → PUBLIC SchemaChild:{DescID: 108 (sq1+), ReferencedDescID: 106 (sc+)}
            │    ├── ABSENT → PUBLIC TableData:{DescID: 108 (sq1+), ReferencedDescID: 104 (db+)}
            │    ├── ABSENT → PUBLIC SequenceOption:{DescID: 108 (sq1+), Name: "START", Value: "32"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_database/create_database.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_database/create_database.explain
@@ -8,14 +8,14 @@ Schema change plan for CREATE DATABASE ‹db›;
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 14 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC Database:{DescID: 104 (db+)}
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (db+), Name: "db", IntValue: 0}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (db+), Name: "db", UInt32Value: 0}
  │         │    ├── ABSENT → PUBLIC DatabaseData:{DescID: 104 (db+)}
  │         │    ├── ABSENT → PUBLIC Owner:{DescID: 104 (db+)}
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "admin"}
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "public"}
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "root"}
  │         │    ├── ABSENT → PUBLIC Schema:{DescID: 105 (public+)}
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+), IntValue: 0}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+), UInt32Value: 0}
  │         │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 105 (public+), ReferencedDescID: 104 (db+)}
  │         │    ├── ABSENT → PUBLIC Owner:{DescID: 105 (public+)}
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (public+), Name: "admin"}
@@ -43,14 +43,14 @@ Schema change plan for CREATE DATABASE ‹db›;
       ├── Stage 1 of 2 in PreCommitPhase
       │    ├── 14 elements transitioning toward PUBLIC
       │    │    ├── PUBLIC → ABSENT Database:{DescID: 104 (db+)}
-      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (db+), Name: "db", IntValue: 0}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (db+), Name: "db", UInt32Value: 0}
       │    │    ├── PUBLIC → ABSENT DatabaseData:{DescID: 104 (db+)}
       │    │    ├── PUBLIC → ABSENT Owner:{DescID: 104 (db+)}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 104 (db+), Name: "admin"}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 104 (db+), Name: "public"}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 104 (db+), Name: "root"}
       │    │    ├── PUBLIC → ABSENT Schema:{DescID: 105 (public+)}
-      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+), IntValue: 0}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+), UInt32Value: 0}
       │    │    ├── PUBLIC → ABSENT SchemaParent:{DescID: 105 (public+), ReferencedDescID: 104 (db+)}
       │    │    ├── PUBLIC → ABSENT Owner:{DescID: 105 (public+)}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 105 (public+), Name: "admin"}
@@ -61,14 +61,14 @@ Schema change plan for CREATE DATABASE ‹db›;
       └── Stage 2 of 2 in PreCommitPhase
            ├── 14 elements transitioning toward PUBLIC
            │    ├── ABSENT → PUBLIC Database:{DescID: 104 (db+)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (db+), Name: "db", IntValue: 0}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (db+), Name: "db", UInt32Value: 0}
            │    ├── ABSENT → PUBLIC DatabaseData:{DescID: 104 (db+)}
            │    ├── ABSENT → PUBLIC Owner:{DescID: 104 (db+)}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "admin"}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "public"}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "root"}
            │    ├── ABSENT → PUBLIC Schema:{DescID: 105 (public+)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+), IntValue: 0}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+), UInt32Value: 0}
            │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 105 (public+), ReferencedDescID: 104 (db+)}
            │    ├── ABSENT → PUBLIC Owner:{DescID: 105 (public+)}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (public+), Name: "admin"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_database_drop_database_separate_statements/create_database_drop_database_separate_statements__statement_1_of_3.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_database_drop_database_separate_statements/create_database_drop_database_separate_statements__statement_1_of_3.explain
@@ -8,14 +8,14 @@ Schema change plan for CREATE DATABASE ‹db›;
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 14 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC Database:{DescID: 104 (db+)}
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (db+), Name: "db", IntValue: 0}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (db+), Name: "db", UInt32Value: 0}
  │         │    ├── ABSENT → PUBLIC DatabaseData:{DescID: 104 (db+)}
  │         │    ├── ABSENT → PUBLIC Owner:{DescID: 104 (db+)}
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "admin"}
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "public"}
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "root"}
  │         │    ├── ABSENT → PUBLIC Schema:{DescID: 105 (public+)}
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+), IntValue: 0}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+), UInt32Value: 0}
  │         │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 105 (public+), ReferencedDescID: 104 (db+)}
  │         │    ├── ABSENT → PUBLIC Owner:{DescID: 105 (public+)}
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (public+), Name: "admin"}
@@ -43,14 +43,14 @@ Schema change plan for CREATE DATABASE ‹db›;
       ├── Stage 1 of 2 in PreCommitPhase
       │    ├── 14 elements transitioning toward PUBLIC
       │    │    ├── PUBLIC → ABSENT Database:{DescID: 104 (db+)}
-      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (db+), Name: "db", IntValue: 0}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (db+), Name: "db", UInt32Value: 0}
       │    │    ├── PUBLIC → ABSENT DatabaseData:{DescID: 104 (db+)}
       │    │    ├── PUBLIC → ABSENT Owner:{DescID: 104 (db+)}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 104 (db+), Name: "admin"}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 104 (db+), Name: "public"}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 104 (db+), Name: "root"}
       │    │    ├── PUBLIC → ABSENT Schema:{DescID: 105 (public+)}
-      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+), IntValue: 0}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+), UInt32Value: 0}
       │    │    ├── PUBLIC → ABSENT SchemaParent:{DescID: 105 (public+), ReferencedDescID: 104 (db+)}
       │    │    ├── PUBLIC → ABSENT Owner:{DescID: 105 (public+)}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 105 (public+), Name: "admin"}
@@ -61,14 +61,14 @@ Schema change plan for CREATE DATABASE ‹db›;
       └── Stage 2 of 2 in PreCommitPhase
            ├── 14 elements transitioning toward PUBLIC
            │    ├── ABSENT → PUBLIC Database:{DescID: 104 (db+)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (db+), Name: "db", IntValue: 0}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (db+), Name: "db", UInt32Value: 0}
            │    ├── ABSENT → PUBLIC DatabaseData:{DescID: 104 (db+)}
            │    ├── ABSENT → PUBLIC Owner:{DescID: 104 (db+)}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "admin"}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "public"}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "root"}
            │    ├── ABSENT → PUBLIC Schema:{DescID: 105 (public+)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+), IntValue: 0}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+), UInt32Value: 0}
            │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 105 (public+), ReferencedDescID: 104 (db+)}
            │    ├── ABSENT → PUBLIC Owner:{DescID: 105 (public+)}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (public+), Name: "admin"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_database_drop_database_separate_statements/create_database_drop_database_separate_statements__statement_2_of_3.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_database_drop_database_separate_statements/create_database_drop_database_separate_statements__statement_2_of_3.explain
@@ -8,14 +8,14 @@ Schema change plan for DROP DATABASE ‹db›; following CREATE DATABASE ‹db�
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 14 elements transitioning toward ABSENT
- │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 104 (db-), Name: "db", IntValue: 0}
+ │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 104 (db-), Name: "db", UInt32Value: 0}
  │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 104 (db-)}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 104 (db-), Name: "admin"}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 104 (db-), Name: "public"}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 104 (db-), Name: "root"}
  │         │    ├── PUBLIC → DROPPED Database:{DescID: 104 (db-)}
  │         │    ├── PUBLIC → ABSENT  DatabaseRoleSetting:{DescID: 104 (db-), Name: "__placeholder_role_name__"}
- │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 105 (public-), Name: "public", ReferencedDescID: 104 (db-), IntValue: 0}
+ │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 105 (public-), Name: "public", ReferencedDescID: 104 (db-), UInt32Value: 0}
  │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 105 (public-)}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 105 (public-), Name: "admin"}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 105 (public-), Name: "public"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_database_drop_database_separate_statements/create_database_drop_database_separate_statements__statement_3_of_3.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_database_drop_database_separate_statements/create_database_drop_database_separate_statements__statement_3_of_3.explain
@@ -10,14 +10,14 @@ Schema change plan for CREATE DATABASE ‹db›; following CREATE DATABASE ‹db
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 14 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC Database:{DescID: 106 (db+)}
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 106 (db+), Name: "db", IntValue: 0}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 106 (db+), Name: "db", UInt32Value: 0}
  │         │    ├── ABSENT → PUBLIC DatabaseData:{DescID: 106 (db+)}
  │         │    ├── ABSENT → PUBLIC Owner:{DescID: 106 (db+)}
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 106 (db+), Name: "admin"}
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 106 (db+), Name: "public"}
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 106 (db+), Name: "root"}
  │         │    ├── ABSENT → PUBLIC Schema:{DescID: 107 (public+)}
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 107 (public+), Name: "public", ReferencedDescID: 106 (db+), IntValue: 0}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 107 (public+), Name: "public", ReferencedDescID: 106 (db+), UInt32Value: 0}
  │         │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 107 (public+), ReferencedDescID: 106 (db+)}
  │         │    ├── ABSENT → PUBLIC Owner:{DescID: 107 (public+)}
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 107 (public+), Name: "admin"}
@@ -45,14 +45,14 @@ Schema change plan for CREATE DATABASE ‹db›; following CREATE DATABASE ‹db
       ├── Stage 1 of 2 in PreCommitPhase
       │    ├── 14 elements transitioning toward PUBLIC
       │    │    ├── PUBLIC  → ABSENT Database:{DescID: 106 (db+)}
-      │    │    ├── PUBLIC  → ABSENT Namespace:{DescID: 106 (db+), Name: "db", IntValue: 0}
+      │    │    ├── PUBLIC  → ABSENT Namespace:{DescID: 106 (db+), Name: "db", UInt32Value: 0}
       │    │    ├── PUBLIC  → ABSENT DatabaseData:{DescID: 106 (db+)}
       │    │    ├── PUBLIC  → ABSENT Owner:{DescID: 106 (db+)}
       │    │    ├── PUBLIC  → ABSENT UserPrivileges:{DescID: 106 (db+), Name: "admin"}
       │    │    ├── PUBLIC  → ABSENT UserPrivileges:{DescID: 106 (db+), Name: "public"}
       │    │    ├── PUBLIC  → ABSENT UserPrivileges:{DescID: 106 (db+), Name: "root"}
       │    │    ├── PUBLIC  → ABSENT Schema:{DescID: 107 (public+)}
-      │    │    ├── PUBLIC  → ABSENT Namespace:{DescID: 107 (public+), Name: "public", ReferencedDescID: 106 (db+), IntValue: 0}
+      │    │    ├── PUBLIC  → ABSENT Namespace:{DescID: 107 (public+), Name: "public", ReferencedDescID: 106 (db+), UInt32Value: 0}
       │    │    ├── PUBLIC  → ABSENT SchemaParent:{DescID: 107 (public+), ReferencedDescID: 106 (db+)}
       │    │    ├── PUBLIC  → ABSENT Owner:{DescID: 107 (public+)}
       │    │    ├── PUBLIC  → ABSENT UserPrivileges:{DescID: 107 (public+), Name: "admin"}
@@ -68,14 +68,14 @@ Schema change plan for CREATE DATABASE ‹db›; following CREATE DATABASE ‹db
       └── Stage 2 of 2 in PreCommitPhase
            ├── 14 elements transitioning toward PUBLIC
            │    ├── ABSENT → PUBLIC Database:{DescID: 106 (db+)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 106 (db+), Name: "db", IntValue: 0}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 106 (db+), Name: "db", UInt32Value: 0}
            │    ├── ABSENT → PUBLIC DatabaseData:{DescID: 106 (db+)}
            │    ├── ABSENT → PUBLIC Owner:{DescID: 106 (db+)}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 106 (db+), Name: "admin"}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 106 (db+), Name: "public"}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 106 (db+), Name: "root"}
            │    ├── ABSENT → PUBLIC Schema:{DescID: 107 (public+)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 107 (public+), Name: "public", ReferencedDescID: 106 (db+), IntValue: 0}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 107 (public+), Name: "public", ReferencedDescID: 106 (db+), UInt32Value: 0}
            │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 107 (public+), ReferencedDescID: 106 (db+)}
            │    ├── ABSENT → PUBLIC Owner:{DescID: 107 (public+)}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 107 (public+), Name: "admin"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_index_create_database_separate_statements/create_index_create_database_separate_statements__statement_2_of_2.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_index_create_database_separate_statements/create_index_create_database_separate_statements__statement_2_of_2.explain
@@ -11,14 +11,14 @@ Schema change plan for CREATE DATABASE ‹db›; following CREATE UNIQUE INDEX �
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 14 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC Database:{DescID: 105 (db+)}
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (db+), Name: "db", IntValue: 0}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (db+), Name: "db", UInt32Value: 0}
  │         │    ├── ABSENT → PUBLIC DatabaseData:{DescID: 105 (db+)}
  │         │    ├── ABSENT → PUBLIC Owner:{DescID: 105 (db+)}
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (db+), Name: "admin"}
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (db+), Name: "public"}
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (db+), Name: "root"}
  │         │    ├── ABSENT → PUBLIC Schema:{DescID: 106 (public+)}
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 106 (public+), Name: "public", ReferencedDescID: 105 (db+), IntValue: 0}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 106 (public+), Name: "public", ReferencedDescID: 105 (db+), UInt32Value: 0}
  │         │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 106 (public+), ReferencedDescID: 105 (db+)}
  │         │    ├── ABSENT → PUBLIC Owner:{DescID: 106 (public+)}
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 106 (public+), Name: "admin"}
@@ -51,14 +51,14 @@ Schema change plan for CREATE DATABASE ‹db›; following CREATE UNIQUE INDEX �
  │    │    │    ├── PUBLIC        → ABSENT IndexData:{DescID: 104 (t), IndexID: 2 (idx+)}
  │    │    │    ├── BACKFILL_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx+), ConstraintID: 2, TemporaryIndexID: 3 (crdb_internal_index_3_name_placeholder), SourceIndexID: 1 (t_pkey), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
  │    │    │    ├── PUBLIC        → ABSENT Database:{DescID: 105 (db+)}
- │    │    │    ├── PUBLIC        → ABSENT Namespace:{DescID: 105 (db+), Name: "db", IntValue: 0}
+ │    │    │    ├── PUBLIC        → ABSENT Namespace:{DescID: 105 (db+), Name: "db", UInt32Value: 0}
  │    │    │    ├── PUBLIC        → ABSENT DatabaseData:{DescID: 105 (db+)}
  │    │    │    ├── PUBLIC        → ABSENT Owner:{DescID: 105 (db+)}
  │    │    │    ├── PUBLIC        → ABSENT UserPrivileges:{DescID: 105 (db+), Name: "admin"}
  │    │    │    ├── PUBLIC        → ABSENT UserPrivileges:{DescID: 105 (db+), Name: "public"}
  │    │    │    ├── PUBLIC        → ABSENT UserPrivileges:{DescID: 105 (db+), Name: "root"}
  │    │    │    ├── PUBLIC        → ABSENT Schema:{DescID: 106 (public+)}
- │    │    │    ├── PUBLIC        → ABSENT Namespace:{DescID: 106 (public+), Name: "public", ReferencedDescID: 105 (db+), IntValue: 0}
+ │    │    │    ├── PUBLIC        → ABSENT Namespace:{DescID: 106 (public+), Name: "public", ReferencedDescID: 105 (db+), UInt32Value: 0}
  │    │    │    ├── PUBLIC        → ABSENT SchemaParent:{DescID: 106 (public+), ReferencedDescID: 105 (db+)}
  │    │    │    ├── PUBLIC        → ABSENT Owner:{DescID: 106 (public+)}
  │    │    │    ├── PUBLIC        → ABSENT UserPrivileges:{DescID: 106 (public+), Name: "admin"}
@@ -80,13 +80,13 @@ Schema change plan for CREATE DATABASE ‹db›; following CREATE UNIQUE INDEX �
  │         │    ├── ABSENT → PUBLIC           IndexData:{DescID: 104 (t), IndexID: 2 (idx+)}
  │         │    ├── ABSENT → BACKFILL_ONLY    SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx+), ConstraintID: 2, TemporaryIndexID: 3 (crdb_internal_index_3_name_placeholder), SourceIndexID: 1 (t_pkey), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
  │         │    ├── ABSENT → DESCRIPTOR_ADDED Database:{DescID: 105 (db+)}
- │         │    ├── ABSENT → PUBLIC           Namespace:{DescID: 105 (db+), Name: "db", IntValue: 0}
+ │         │    ├── ABSENT → PUBLIC           Namespace:{DescID: 105 (db+), Name: "db", UInt32Value: 0}
  │         │    ├── ABSENT → PUBLIC           Owner:{DescID: 105 (db+)}
  │         │    ├── ABSENT → PUBLIC           UserPrivileges:{DescID: 105 (db+), Name: "admin"}
  │         │    ├── ABSENT → PUBLIC           UserPrivileges:{DescID: 105 (db+), Name: "public"}
  │         │    ├── ABSENT → PUBLIC           UserPrivileges:{DescID: 105 (db+), Name: "root"}
  │         │    ├── ABSENT → DESCRIPTOR_ADDED Schema:{DescID: 106 (public+)}
- │         │    ├── ABSENT → PUBLIC           Namespace:{DescID: 106 (public+), Name: "public", ReferencedDescID: 105 (db+), IntValue: 0}
+ │         │    ├── ABSENT → PUBLIC           Namespace:{DescID: 106 (public+), Name: "public", ReferencedDescID: 105 (db+), UInt32Value: 0}
  │         │    ├── ABSENT → PUBLIC           SchemaParent:{DescID: 106 (public+), ReferencedDescID: 105 (db+)}
  │         │    ├── ABSENT → PUBLIC           Owner:{DescID: 106 (public+)}
  │         │    ├── ABSENT → PUBLIC           UserPrivileges:{DescID: 106 (public+), Name: "admin"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_index_create_schema_separate_statements/create_index_create_schema_separate_statements__rollback_1_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_index_create_schema_separate_statements/create_index_create_schema_separate_statements__rollback_1_of_7.explain
@@ -20,7 +20,7 @@ Schema change plan for rolling back CREATE SCHEMA defaultdb.sc; following CREATE
       │    │    ├── BACKFILL_ONLY    → ABSENT  SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx-), ConstraintID: 2, TemporaryIndexID: 3 (crdb_internal_index_3_name_placeholder), SourceIndexID: 1 (t_pkey), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
       │    │    ├── DELETE_ONLY      → ABSENT  TemporaryIndex:{DescID: 104 (t), IndexID: 3 (crdb_internal_index_3_name_placeholder), ConstraintID: 3, SourceIndexID: 1 (t_pkey)}
       │    │    ├── DESCRIPTOR_ADDED → DROPPED Schema:{DescID: 105 (sc-)}
-      │    │    ├── PUBLIC           → ABSENT  Namespace:{DescID: 105 (sc-), Name: "sc", ReferencedDescID: 100 (defaultdb), IntValue: 0}
+      │    │    ├── PUBLIC           → ABSENT  Namespace:{DescID: 105 (sc-), Name: "sc", ReferencedDescID: 100 (defaultdb), UInt32Value: 0}
       │    │    ├── PUBLIC           → ABSENT  SchemaParent:{DescID: 105 (sc-), ReferencedDescID: 100 (defaultdb)}
       │    │    ├── PUBLIC           → ABSENT  Owner:{DescID: 105 (sc-)}
       │    │    ├── PUBLIC           → ABSENT  UserPrivileges:{DescID: 105 (sc-), Name: "admin"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_index_create_schema_separate_statements/create_index_create_schema_separate_statements__rollback_2_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_index_create_schema_separate_statements/create_index_create_schema_separate_statements__rollback_2_of_7.explain
@@ -19,7 +19,7 @@ Schema change plan for rolling back CREATE SCHEMA defaultdb.sc; following CREATE
       │    │    ├── BACKFILL_ONLY    → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx-), ConstraintID: 2, TemporaryIndexID: 3 (crdb_internal_index_3_name_placeholder), SourceIndexID: 1 (t_pkey), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
       │    │    ├── WRITE_ONLY       → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3 (crdb_internal_index_3_name_placeholder), ConstraintID: 3, SourceIndexID: 1 (t_pkey)}
       │    │    ├── DESCRIPTOR_ADDED → DROPPED     Schema:{DescID: 105 (sc-)}
-      │    │    ├── PUBLIC           → ABSENT      Namespace:{DescID: 105 (sc-), Name: "sc", ReferencedDescID: 100 (defaultdb), IntValue: 0}
+      │    │    ├── PUBLIC           → ABSENT      Namespace:{DescID: 105 (sc-), Name: "sc", ReferencedDescID: 100 (defaultdb), UInt32Value: 0}
       │    │    ├── PUBLIC           → ABSENT      SchemaParent:{DescID: 105 (sc-), ReferencedDescID: 100 (defaultdb)}
       │    │    ├── PUBLIC           → ABSENT      Owner:{DescID: 105 (sc-)}
       │    │    ├── PUBLIC           → ABSENT      UserPrivileges:{DescID: 105 (sc-), Name: "admin"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_index_create_schema_separate_statements/create_index_create_schema_separate_statements__rollback_3_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_index_create_schema_separate_statements/create_index_create_schema_separate_statements__rollback_3_of_7.explain
@@ -19,7 +19,7 @@ Schema change plan for rolling back CREATE SCHEMA defaultdb.sc; following CREATE
       │    │    ├── BACKFILL_ONLY    → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx-), ConstraintID: 2, TemporaryIndexID: 3 (crdb_internal_index_3_name_placeholder), SourceIndexID: 1 (t_pkey), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
       │    │    ├── WRITE_ONLY       → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3 (crdb_internal_index_3_name_placeholder), ConstraintID: 3, SourceIndexID: 1 (t_pkey)}
       │    │    ├── DESCRIPTOR_ADDED → DROPPED     Schema:{DescID: 105 (sc-)}
-      │    │    ├── PUBLIC           → ABSENT      Namespace:{DescID: 105 (sc-), Name: "sc", ReferencedDescID: 100 (defaultdb), IntValue: 0}
+      │    │    ├── PUBLIC           → ABSENT      Namespace:{DescID: 105 (sc-), Name: "sc", ReferencedDescID: 100 (defaultdb), UInt32Value: 0}
       │    │    ├── PUBLIC           → ABSENT      SchemaParent:{DescID: 105 (sc-), ReferencedDescID: 100 (defaultdb)}
       │    │    ├── PUBLIC           → ABSENT      Owner:{DescID: 105 (sc-)}
       │    │    ├── PUBLIC           → ABSENT      UserPrivileges:{DescID: 105 (sc-), Name: "admin"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_index_create_schema_separate_statements/create_index_create_schema_separate_statements__rollback_4_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_index_create_schema_separate_statements/create_index_create_schema_separate_statements__rollback_4_of_7.explain
@@ -19,7 +19,7 @@ Schema change plan for rolling back CREATE SCHEMA defaultdb.sc; following CREATE
       │    │    ├── DELETE_ONLY      → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx-), ConstraintID: 2, TemporaryIndexID: 3 (crdb_internal_index_3_name_placeholder), SourceIndexID: 1 (t_pkey), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
       │    │    ├── WRITE_ONLY       → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3 (crdb_internal_index_3_name_placeholder), ConstraintID: 3, SourceIndexID: 1 (t_pkey)}
       │    │    ├── DESCRIPTOR_ADDED → DROPPED     Schema:{DescID: 105 (sc-)}
-      │    │    ├── PUBLIC           → ABSENT      Namespace:{DescID: 105 (sc-), Name: "sc", ReferencedDescID: 100 (defaultdb), IntValue: 0}
+      │    │    ├── PUBLIC           → ABSENT      Namespace:{DescID: 105 (sc-), Name: "sc", ReferencedDescID: 100 (defaultdb), UInt32Value: 0}
       │    │    ├── PUBLIC           → ABSENT      SchemaParent:{DescID: 105 (sc-), ReferencedDescID: 100 (defaultdb)}
       │    │    ├── PUBLIC           → ABSENT      Owner:{DescID: 105 (sc-)}
       │    │    ├── PUBLIC           → ABSENT      UserPrivileges:{DescID: 105 (sc-), Name: "admin"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_index_create_schema_separate_statements/create_index_create_schema_separate_statements__rollback_5_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_index_create_schema_separate_statements/create_index_create_schema_separate_statements__rollback_5_of_7.explain
@@ -19,7 +19,7 @@ Schema change plan for rolling back CREATE SCHEMA defaultdb.sc; following CREATE
       │    │    ├── MERGE_ONLY       → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx-), ConstraintID: 2, TemporaryIndexID: 3 (crdb_internal_index_3_name_placeholder), SourceIndexID: 1 (t_pkey), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
       │    │    ├── WRITE_ONLY       → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3 (crdb_internal_index_3_name_placeholder), ConstraintID: 3, SourceIndexID: 1 (t_pkey)}
       │    │    ├── DESCRIPTOR_ADDED → DROPPED     Schema:{DescID: 105 (sc-)}
-      │    │    ├── PUBLIC           → ABSENT      Namespace:{DescID: 105 (sc-), Name: "sc", ReferencedDescID: 100 (defaultdb), IntValue: 0}
+      │    │    ├── PUBLIC           → ABSENT      Namespace:{DescID: 105 (sc-), Name: "sc", ReferencedDescID: 100 (defaultdb), UInt32Value: 0}
       │    │    ├── PUBLIC           → ABSENT      SchemaParent:{DescID: 105 (sc-), ReferencedDescID: 100 (defaultdb)}
       │    │    ├── PUBLIC           → ABSENT      Owner:{DescID: 105 (sc-)}
       │    │    ├── PUBLIC           → ABSENT      UserPrivileges:{DescID: 105 (sc-), Name: "admin"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_index_create_schema_separate_statements/create_index_create_schema_separate_statements__rollback_6_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_index_create_schema_separate_statements/create_index_create_schema_separate_statements__rollback_6_of_7.explain
@@ -19,7 +19,7 @@ Schema change plan for rolling back CREATE SCHEMA defaultdb.sc; following CREATE
       │    │    ├── MERGE_ONLY       → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx-), ConstraintID: 2, TemporaryIndexID: 3 (crdb_internal_index_3_name_placeholder), SourceIndexID: 1 (t_pkey), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
       │    │    ├── WRITE_ONLY       → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3 (crdb_internal_index_3_name_placeholder), ConstraintID: 3, SourceIndexID: 1 (t_pkey)}
       │    │    ├── DESCRIPTOR_ADDED → DROPPED     Schema:{DescID: 105 (sc-)}
-      │    │    ├── PUBLIC           → ABSENT      Namespace:{DescID: 105 (sc-), Name: "sc", ReferencedDescID: 100 (defaultdb), IntValue: 0}
+      │    │    ├── PUBLIC           → ABSENT      Namespace:{DescID: 105 (sc-), Name: "sc", ReferencedDescID: 100 (defaultdb), UInt32Value: 0}
       │    │    ├── PUBLIC           → ABSENT      SchemaParent:{DescID: 105 (sc-), ReferencedDescID: 100 (defaultdb)}
       │    │    ├── PUBLIC           → ABSENT      Owner:{DescID: 105 (sc-)}
       │    │    ├── PUBLIC           → ABSENT      UserPrivileges:{DescID: 105 (sc-), Name: "admin"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_index_create_schema_separate_statements/create_index_create_schema_separate_statements__rollback_7_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_index_create_schema_separate_statements/create_index_create_schema_separate_statements__rollback_7_of_7.explain
@@ -19,7 +19,7 @@ Schema change plan for rolling back CREATE SCHEMA defaultdb.sc; following CREATE
       │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx-), ConstraintID: 2, TemporaryIndexID: 3 (crdb_internal_index_3_name_placeholder), SourceIndexID: 1 (t_pkey), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 3 (crdb_internal_index_3_name_placeholder), ConstraintID: 3, SourceIndexID: 1 (t_pkey)}
       │    │    ├── DESCRIPTOR_ADDED      → DROPPED     Schema:{DescID: 105 (sc-)}
-      │    │    ├── PUBLIC                → ABSENT      Namespace:{DescID: 105 (sc-), Name: "sc", ReferencedDescID: 100 (defaultdb), IntValue: 0}
+      │    │    ├── PUBLIC                → ABSENT      Namespace:{DescID: 105 (sc-), Name: "sc", ReferencedDescID: 100 (defaultdb), UInt32Value: 0}
       │    │    ├── PUBLIC                → ABSENT      SchemaParent:{DescID: 105 (sc-), ReferencedDescID: 100 (defaultdb)}
       │    │    ├── PUBLIC                → ABSENT      Owner:{DescID: 105 (sc-)}
       │    │    ├── PUBLIC                → ABSENT      UserPrivileges:{DescID: 105 (sc-), Name: "admin"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_index_create_schema_separate_statements/create_index_create_schema_separate_statements__statement_2_of_2.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_index_create_schema_separate_statements/create_index_create_schema_separate_statements__statement_2_of_2.explain
@@ -11,7 +11,7 @@ Schema change plan for CREATE SCHEMA ‹defaultdb›.‹sc›; following CREATE 
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 6 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC Schema:{DescID: 105 (sc+)}
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (sc+), Name: "sc", ReferencedDescID: 100 (defaultdb), IntValue: 0}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (sc+), Name: "sc", ReferencedDescID: 100 (defaultdb), UInt32Value: 0}
  │         │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 105 (sc+), ReferencedDescID: 100 (defaultdb)}
  │         │    ├── ABSENT → PUBLIC Owner:{DescID: 105 (sc+)}
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (sc+), Name: "admin"}
@@ -34,7 +34,7 @@ Schema change plan for CREATE SCHEMA ‹defaultdb›.‹sc›; following CREATE 
  │    │    │    ├── PUBLIC        → ABSENT IndexData:{DescID: 104 (t), IndexID: 2 (idx+)}
  │    │    │    ├── BACKFILL_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx+), ConstraintID: 2, TemporaryIndexID: 3 (crdb_internal_index_3_name_placeholder), SourceIndexID: 1 (t_pkey), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
  │    │    │    ├── PUBLIC        → ABSENT Schema:{DescID: 105 (sc+)}
- │    │    │    ├── PUBLIC        → ABSENT Namespace:{DescID: 105 (sc+), Name: "sc", ReferencedDescID: 100 (defaultdb), IntValue: 0}
+ │    │    │    ├── PUBLIC        → ABSENT Namespace:{DescID: 105 (sc+), Name: "sc", ReferencedDescID: 100 (defaultdb), UInt32Value: 0}
  │    │    │    ├── PUBLIC        → ABSENT SchemaParent:{DescID: 105 (sc+), ReferencedDescID: 100 (defaultdb)}
  │    │    │    ├── PUBLIC        → ABSENT Owner:{DescID: 105 (sc+)}
  │    │    │    ├── PUBLIC        → ABSENT UserPrivileges:{DescID: 105 (sc+), Name: "admin"}
@@ -55,7 +55,7 @@ Schema change plan for CREATE SCHEMA ‹defaultdb›.‹sc›; following CREATE 
  │         │    ├── ABSENT → PUBLIC           IndexData:{DescID: 104 (t), IndexID: 2 (idx+)}
  │         │    ├── ABSENT → BACKFILL_ONLY    SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx+), ConstraintID: 2, TemporaryIndexID: 3 (crdb_internal_index_3_name_placeholder), SourceIndexID: 1 (t_pkey), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
  │         │    ├── ABSENT → DESCRIPTOR_ADDED Schema:{DescID: 105 (sc+)}
- │         │    ├── ABSENT → PUBLIC           Namespace:{DescID: 105 (sc+), Name: "sc", ReferencedDescID: 100 (defaultdb), IntValue: 0}
+ │         │    ├── ABSENT → PUBLIC           Namespace:{DescID: 105 (sc+), Name: "sc", ReferencedDescID: 100 (defaultdb), UInt32Value: 0}
  │         │    ├── ABSENT → PUBLIC           SchemaParent:{DescID: 105 (sc+), ReferencedDescID: 100 (defaultdb)}
  │         │    ├── ABSENT → PUBLIC           Owner:{DescID: 105 (sc+)}
  │         │    ├── ABSENT → PUBLIC           UserPrivileges:{DescID: 105 (sc+), Name: "admin"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_schema/create_schema.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_schema/create_schema.explain
@@ -9,7 +9,7 @@ Schema change plan for CREATE SCHEMA ‹defaultdb›.‹sc› AUTHORIZATION foo;
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 6 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC Schema:{DescID: 104 (sc+)}
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (sc+), Name: "sc", ReferencedDescID: 100 (defaultdb), IntValue: 0}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (sc+), Name: "sc", ReferencedDescID: 100 (defaultdb), UInt32Value: 0}
  │         │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 104 (sc+), ReferencedDescID: 100 (defaultdb)}
  │         │    ├── ABSENT → PUBLIC Owner:{DescID: 104 (sc+)}
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (sc+), Name: "admin"}
@@ -27,7 +27,7 @@ Schema change plan for CREATE SCHEMA ‹defaultdb›.‹sc› AUTHORIZATION foo;
       ├── Stage 1 of 2 in PreCommitPhase
       │    ├── 6 elements transitioning toward PUBLIC
       │    │    ├── PUBLIC → ABSENT Schema:{DescID: 104 (sc+)}
-      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (sc+), Name: "sc", ReferencedDescID: 100 (defaultdb), IntValue: 0}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (sc+), Name: "sc", ReferencedDescID: 100 (defaultdb), UInt32Value: 0}
       │    │    ├── PUBLIC → ABSENT SchemaParent:{DescID: 104 (sc+), ReferencedDescID: 100 (defaultdb)}
       │    │    ├── PUBLIC → ABSENT Owner:{DescID: 104 (sc+)}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 104 (sc+), Name: "admin"}
@@ -37,7 +37,7 @@ Schema change plan for CREATE SCHEMA ‹defaultdb›.‹sc› AUTHORIZATION foo;
       └── Stage 2 of 2 in PreCommitPhase
            ├── 6 elements transitioning toward PUBLIC
            │    ├── ABSENT → PUBLIC Schema:{DescID: 104 (sc+)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (sc+), Name: "sc", ReferencedDescID: 100 (defaultdb), IntValue: 0}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (sc+), Name: "sc", ReferencedDescID: 100 (defaultdb), UInt32Value: 0}
            │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 104 (sc+), ReferencedDescID: 100 (defaultdb)}
            │    ├── ABSENT → PUBLIC Owner:{DescID: 104 (sc+)}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (sc+), Name: "admin"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_schema_drop_schema_separate_statements/create_schema_drop_schema_separate_statements__statement_1_of_3.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_schema_drop_schema_separate_statements/create_schema_drop_schema_separate_statements__statement_1_of_3.explain
@@ -8,7 +8,7 @@ Schema change plan for CREATE SCHEMA ‹defaultdb›.‹sc›;
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 6 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC Schema:{DescID: 104 (sc+)}
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (sc+), Name: "sc", ReferencedDescID: 100 (defaultdb), IntValue: 0}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (sc+), Name: "sc", ReferencedDescID: 100 (defaultdb), UInt32Value: 0}
  │         │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 104 (sc+), ReferencedDescID: 100 (defaultdb)}
  │         │    ├── ABSENT → PUBLIC Owner:{DescID: 104 (sc+)}
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (sc+), Name: "admin"}
@@ -26,7 +26,7 @@ Schema change plan for CREATE SCHEMA ‹defaultdb›.‹sc›;
       ├── Stage 1 of 2 in PreCommitPhase
       │    ├── 6 elements transitioning toward PUBLIC
       │    │    ├── PUBLIC → ABSENT Schema:{DescID: 104 (sc+)}
-      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (sc+), Name: "sc", ReferencedDescID: 100 (defaultdb), IntValue: 0}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (sc+), Name: "sc", ReferencedDescID: 100 (defaultdb), UInt32Value: 0}
       │    │    ├── PUBLIC → ABSENT SchemaParent:{DescID: 104 (sc+), ReferencedDescID: 100 (defaultdb)}
       │    │    ├── PUBLIC → ABSENT Owner:{DescID: 104 (sc+)}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 104 (sc+), Name: "admin"}
@@ -36,7 +36,7 @@ Schema change plan for CREATE SCHEMA ‹defaultdb›.‹sc›;
       └── Stage 2 of 2 in PreCommitPhase
            ├── 6 elements transitioning toward PUBLIC
            │    ├── ABSENT → PUBLIC Schema:{DescID: 104 (sc+)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (sc+), Name: "sc", ReferencedDescID: 100 (defaultdb), IntValue: 0}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (sc+), Name: "sc", ReferencedDescID: 100 (defaultdb), UInt32Value: 0}
            │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 104 (sc+), ReferencedDescID: 100 (defaultdb)}
            │    ├── ABSENT → PUBLIC Owner:{DescID: 104 (sc+)}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (sc+), Name: "admin"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_schema_drop_schema_separate_statements/create_schema_drop_schema_separate_statements__statement_2_of_3.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_schema_drop_schema_separate_statements/create_schema_drop_schema_separate_statements__statement_2_of_3.explain
@@ -8,7 +8,7 @@ Schema change plan for DROP SCHEMA ‹""›.‹sc›; following CREATE SCHEMA �
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 6 elements transitioning toward ABSENT
- │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 104 (sc-), Name: "sc", ReferencedDescID: 100 (defaultdb), IntValue: 0}
+ │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 104 (sc-), Name: "sc", ReferencedDescID: 100 (defaultdb), UInt32Value: 0}
  │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 104 (sc-)}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 104 (sc-), Name: "admin"}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 104 (sc-), Name: "root"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_schema_drop_schema_separate_statements/create_schema_drop_schema_separate_statements__statement_3_of_3.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_schema_drop_schema_separate_statements/create_schema_drop_schema_separate_statements__statement_3_of_3.explain
@@ -10,7 +10,7 @@ Schema change plan for CREATE SCHEMA ‹defaultdb›.‹sc›; following CREATE 
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 6 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC Schema:{DescID: 105 (sc+)}
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (sc+), Name: "sc", ReferencedDescID: 100 (defaultdb), IntValue: 0}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (sc+), Name: "sc", ReferencedDescID: 100 (defaultdb), UInt32Value: 0}
  │         │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 105 (sc+), ReferencedDescID: 100 (defaultdb)}
  │         │    ├── ABSENT → PUBLIC Owner:{DescID: 105 (sc+)}
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (sc+), Name: "admin"}
@@ -28,7 +28,7 @@ Schema change plan for CREATE SCHEMA ‹defaultdb›.‹sc›; following CREATE 
       ├── Stage 1 of 2 in PreCommitPhase
       │    ├── 6 elements transitioning toward PUBLIC
       │    │    ├── PUBLIC  → ABSENT Schema:{DescID: 105 (sc+)}
-      │    │    ├── PUBLIC  → ABSENT Namespace:{DescID: 105 (sc+), Name: "sc", ReferencedDescID: 100 (defaultdb), IntValue: 0}
+      │    │    ├── PUBLIC  → ABSENT Namespace:{DescID: 105 (sc+), Name: "sc", ReferencedDescID: 100 (defaultdb), UInt32Value: 0}
       │    │    ├── PUBLIC  → ABSENT SchemaParent:{DescID: 105 (sc+), ReferencedDescID: 100 (defaultdb)}
       │    │    ├── PUBLIC  → ABSENT Owner:{DescID: 105 (sc+)}
       │    │    ├── PUBLIC  → ABSENT UserPrivileges:{DescID: 105 (sc+), Name: "admin"}
@@ -40,7 +40,7 @@ Schema change plan for CREATE SCHEMA ‹defaultdb›.‹sc›; following CREATE 
       └── Stage 2 of 2 in PreCommitPhase
            ├── 6 elements transitioning toward PUBLIC
            │    ├── ABSENT → PUBLIC Schema:{DescID: 105 (sc+)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (sc+), Name: "sc", ReferencedDescID: 100 (defaultdb), IntValue: 0}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (sc+), Name: "sc", ReferencedDescID: 100 (defaultdb), UInt32Value: 0}
            │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 105 (sc+), ReferencedDescID: 100 (defaultdb)}
            │    ├── ABSENT → PUBLIC Owner:{DescID: 105 (sc+)}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (sc+), Name: "admin"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence/create_sequence.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence/create_sequence.explain
@@ -8,7 +8,7 @@ Schema change plan for CREATE SEQUENCE ‹defaultdb›.‹public›.‹sq1› MI
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 15 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC Sequence:{DescID: 104 (sq1+)}
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb), UInt32Value: 101}
  │         │    ├── ABSENT → PUBLIC SchemaChild:{DescID: 104 (sq1+), ReferencedDescID: 101 (public)}
  │         │    ├── ABSENT → PUBLIC TableData:{DescID: 104 (sq1+), ReferencedDescID: 100 (defaultdb)}
  │         │    ├── ABSENT → PUBLIC SequenceOption:{DescID: 104 (sq1+), Name: "START", Value: "32"}
@@ -51,7 +51,7 @@ Schema change plan for CREATE SEQUENCE ‹defaultdb›.‹public›.‹sq1› MI
       ├── Stage 1 of 2 in PreCommitPhase
       │    ├── 15 elements transitioning toward PUBLIC
       │    │    ├── PUBLIC → ABSENT Sequence:{DescID: 104 (sq1+)}
-      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb), UInt32Value: 101}
       │    │    ├── PUBLIC → ABSENT SchemaChild:{DescID: 104 (sq1+), ReferencedDescID: 101 (public)}
       │    │    ├── PUBLIC → ABSENT TableData:{DescID: 104 (sq1+), ReferencedDescID: 100 (defaultdb)}
       │    │    ├── PUBLIC → ABSENT SequenceOption:{DescID: 104 (sq1+), Name: "START", Value: "32"}
@@ -70,7 +70,7 @@ Schema change plan for CREATE SEQUENCE ‹defaultdb›.‹public›.‹sq1› MI
       └── Stage 2 of 2 in PreCommitPhase
            ├── 15 elements transitioning toward PUBLIC
            │    ├── ABSENT → PUBLIC Sequence:{DescID: 104 (sq1+)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb), UInt32Value: 101}
            │    ├── ABSENT → PUBLIC SchemaChild:{DescID: 104 (sq1+), ReferencedDescID: 101 (public)}
            │    ├── ABSENT → PUBLIC TableData:{DescID: 104 (sq1+), ReferencedDescID: 100 (defaultdb)}
            │    ├── ABSENT → PUBLIC SequenceOption:{DescID: 104 (sq1+), Name: "START", Value: "32"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_1_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_1_of_7.explain
@@ -10,7 +10,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN j 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
       │    ├── 25 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC        → ABSENT  Namespace:{DescID: 105 (sq1-), Name: "sq1", ReferencedDescID: 100 (#100), IntValue: 101}
+      │    │    ├── PUBLIC        → ABSENT  Namespace:{DescID: 105 (sq1-), Name: "sq1", ReferencedDescID: 100 (#100), UInt32Value: 101}
       │    │    ├── PUBLIC        → ABSENT  Owner:{DescID: 105 (sq1-)}
       │    │    ├── PUBLIC        → ABSENT  UserPrivileges:{DescID: 105 (sq1-), Name: "admin"}
       │    │    ├── PUBLIC        → ABSENT  UserPrivileges:{DescID: 105 (sq1-), Name: "root"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_2_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_2_of_7.explain
@@ -38,7 +38,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN j 
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 19 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 105 (sq1-), Name: "sq1", ReferencedDescID: 100 (#100), IntValue: 101}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 105 (sq1-), Name: "sq1", ReferencedDescID: 100 (#100), UInt32Value: 101}
       │    │    ├── PUBLIC      → ABSENT  Owner:{DescID: 105 (sq1-)}
       │    │    ├── PUBLIC      → ABSENT  UserPrivileges:{DescID: 105 (sq1-), Name: "admin"}
       │    │    ├── PUBLIC      → ABSENT  UserPrivileges:{DescID: 105 (sq1-), Name: "root"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_3_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_3_of_7.explain
@@ -38,7 +38,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN j 
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 19 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 105 (sq1-), Name: "sq1", ReferencedDescID: 100 (#100), IntValue: 101}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 105 (sq1-), Name: "sq1", ReferencedDescID: 100 (#100), UInt32Value: 101}
       │    │    ├── PUBLIC      → ABSENT  Owner:{DescID: 105 (sq1-)}
       │    │    ├── PUBLIC      → ABSENT  UserPrivileges:{DescID: 105 (sq1-), Name: "admin"}
       │    │    ├── PUBLIC      → ABSENT  UserPrivileges:{DescID: 105 (sq1-), Name: "root"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_4_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_4_of_7.explain
@@ -38,7 +38,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN j 
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 19 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 105 (sq1-), Name: "sq1", ReferencedDescID: 100 (#100), IntValue: 101}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 105 (sq1-), Name: "sq1", ReferencedDescID: 100 (#100), UInt32Value: 101}
       │    │    ├── PUBLIC      → ABSENT  Owner:{DescID: 105 (sq1-)}
       │    │    ├── PUBLIC      → ABSENT  UserPrivileges:{DescID: 105 (sq1-), Name: "admin"}
       │    │    ├── PUBLIC      → ABSENT  UserPrivileges:{DescID: 105 (sq1-), Name: "root"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_5_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_5_of_7.explain
@@ -38,7 +38,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN j 
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 20 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 105 (sq1-), Name: "sq1", ReferencedDescID: 100 (#100), IntValue: 101}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 105 (sq1-), Name: "sq1", ReferencedDescID: 100 (#100), UInt32Value: 101}
       │    │    ├── PUBLIC      → ABSENT  Owner:{DescID: 105 (sq1-)}
       │    │    ├── PUBLIC      → ABSENT  UserPrivileges:{DescID: 105 (sq1-), Name: "admin"}
       │    │    ├── PUBLIC      → ABSENT  UserPrivileges:{DescID: 105 (sq1-), Name: "root"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_6_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_6_of_7.explain
@@ -38,7 +38,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN j 
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 20 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 105 (sq1-), Name: "sq1", ReferencedDescID: 100 (#100), IntValue: 101}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 105 (sq1-), Name: "sq1", ReferencedDescID: 100 (#100), UInt32Value: 101}
       │    │    ├── PUBLIC      → ABSENT  Owner:{DescID: 105 (sq1-)}
       │    │    ├── PUBLIC      → ABSENT  UserPrivileges:{DescID: 105 (sq1-), Name: "admin"}
       │    │    ├── PUBLIC      → ABSENT  UserPrivileges:{DescID: 105 (sq1-), Name: "root"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_7_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_7_of_7.explain
@@ -38,7 +38,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN j 
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 19 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 105 (sq1-), Name: "sq1", ReferencedDescID: 100 (#100), IntValue: 101}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 105 (sq1-), Name: "sq1", ReferencedDescID: 100 (#100), UInt32Value: 101}
       │    │    ├── PUBLIC      → ABSENT  Owner:{DescID: 105 (sq1-)}
       │    │    ├── PUBLIC      → ABSENT  UserPrivileges:{DescID: 105 (sq1-), Name: "admin"}
       │    │    ├── PUBLIC      → ABSENT  UserPrivileges:{DescID: 105 (sq1-), Name: "root"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__statement_1_of_2.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__statement_1_of_2.explain
@@ -9,7 +9,7 @@ Schema change plan for CREATE SEQUENCE ‹defaultdb›.‹public›.‹sq1› MI
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 15 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC Sequence:{DescID: 105 (sq1+)}
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb), UInt32Value: 101}
  │         │    ├── ABSENT → PUBLIC SchemaChild:{DescID: 105 (sq1+), ReferencedDescID: 101 (public)}
  │         │    ├── ABSENT → PUBLIC TableData:{DescID: 105 (sq1+), ReferencedDescID: 100 (defaultdb)}
  │         │    ├── ABSENT → PUBLIC SequenceOption:{DescID: 105 (sq1+), Name: "START", Value: "32"}
@@ -52,7 +52,7 @@ Schema change plan for CREATE SEQUENCE ‹defaultdb›.‹public›.‹sq1› MI
       ├── Stage 1 of 2 in PreCommitPhase
       │    ├── 15 elements transitioning toward PUBLIC
       │    │    ├── PUBLIC → ABSENT Sequence:{DescID: 105 (sq1+)}
-      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 105 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 105 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb), UInt32Value: 101}
       │    │    ├── PUBLIC → ABSENT SchemaChild:{DescID: 105 (sq1+), ReferencedDescID: 101 (public)}
       │    │    ├── PUBLIC → ABSENT TableData:{DescID: 105 (sq1+), ReferencedDescID: 100 (defaultdb)}
       │    │    ├── PUBLIC → ABSENT SequenceOption:{DescID: 105 (sq1+), Name: "START", Value: "32"}
@@ -71,7 +71,7 @@ Schema change plan for CREATE SEQUENCE ‹defaultdb›.‹public›.‹sq1› MI
       └── Stage 2 of 2 in PreCommitPhase
            ├── 15 elements transitioning toward PUBLIC
            │    ├── ABSENT → PUBLIC Sequence:{DescID: 105 (sq1+)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb), UInt32Value: 101}
            │    ├── ABSENT → PUBLIC SchemaChild:{DescID: 105 (sq1+), ReferencedDescID: 101 (public)}
            │    ├── ABSENT → PUBLIC TableData:{DescID: 105 (sq1+), ReferencedDescID: 100 (defaultdb)}
            │    ├── ABSENT → PUBLIC SequenceOption:{DescID: 105 (sq1+), Name: "START", Value: "32"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__statement_2_of_2.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__statement_2_of_2.explain
@@ -39,7 +39,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD COLU
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
  │    │    ├── 23 elements transitioning toward PUBLIC
- │    │    │    ├── PUBLIC        → ABSENT Namespace:{DescID: 105 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+ │    │    │    ├── PUBLIC        → ABSENT Namespace:{DescID: 105 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb), UInt32Value: 101}
  │    │    │    ├── PUBLIC        → ABSENT Owner:{DescID: 105 (sq1+)}
  │    │    │    ├── PUBLIC        → ABSENT UserPrivileges:{DescID: 105 (sq1+), Name: "admin"}
  │    │    │    ├── PUBLIC        → ABSENT UserPrivileges:{DescID: 105 (sq1+), Name: "root"}
@@ -72,7 +72,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD COLU
  │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
  │    └── Stage 2 of 2 in PreCommitPhase
  │         ├── 23 elements transitioning toward PUBLIC
- │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 105 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+ │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 105 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb), UInt32Value: 101}
  │         │    ├── ABSENT → PUBLIC        Owner:{DescID: 105 (sq1+)}
  │         │    ├── ABSENT → PUBLIC        UserPrivileges:{DescID: 105 (sq1+), Name: "admin"}
  │         │    ├── ABSENT → PUBLIC        UserPrivileges:{DescID: 105 (sq1+), Name: "root"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_drop_sequence/create_sequence_drop_sequence__statement_1_of_2.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_drop_sequence/create_sequence_drop_sequence__statement_1_of_2.explain
@@ -8,7 +8,7 @@ Schema change plan for CREATE SEQUENCE ‹defaultdb›.‹public›.‹sq1› MI
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 15 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC Sequence:{DescID: 104 (sq1+)}
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb), UInt32Value: 101}
  │         │    ├── ABSENT → PUBLIC SchemaChild:{DescID: 104 (sq1+), ReferencedDescID: 101 (public)}
  │         │    ├── ABSENT → PUBLIC TableData:{DescID: 104 (sq1+), ReferencedDescID: 100 (defaultdb)}
  │         │    ├── ABSENT → PUBLIC SequenceOption:{DescID: 104 (sq1+), Name: "START", Value: "32"}
@@ -51,7 +51,7 @@ Schema change plan for CREATE SEQUENCE ‹defaultdb›.‹public›.‹sq1› MI
       ├── Stage 1 of 2 in PreCommitPhase
       │    ├── 15 elements transitioning toward PUBLIC
       │    │    ├── PUBLIC → ABSENT Sequence:{DescID: 104 (sq1+)}
-      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb), UInt32Value: 101}
       │    │    ├── PUBLIC → ABSENT SchemaChild:{DescID: 104 (sq1+), ReferencedDescID: 101 (public)}
       │    │    ├── PUBLIC → ABSENT TableData:{DescID: 104 (sq1+), ReferencedDescID: 100 (defaultdb)}
       │    │    ├── PUBLIC → ABSENT SequenceOption:{DescID: 104 (sq1+), Name: "START", Value: "32"}
@@ -70,7 +70,7 @@ Schema change plan for CREATE SEQUENCE ‹defaultdb›.‹public›.‹sq1› MI
       └── Stage 2 of 2 in PreCommitPhase
            ├── 15 elements transitioning toward PUBLIC
            │    ├── ABSENT → PUBLIC Sequence:{DescID: 104 (sq1+)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb), UInt32Value: 101}
            │    ├── ABSENT → PUBLIC SchemaChild:{DescID: 104 (sq1+), ReferencedDescID: 101 (public)}
            │    ├── ABSENT → PUBLIC TableData:{DescID: 104 (sq1+), ReferencedDescID: 100 (defaultdb)}
            │    ├── ABSENT → PUBLIC SequenceOption:{DescID: 104 (sq1+), Name: "START", Value: "32"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_drop_sequence/create_sequence_drop_sequence__statement_2_of_2.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_drop_sequence/create_sequence_drop_sequence__statement_2_of_2.explain
@@ -8,7 +8,7 @@ Schema change plan for DROP SEQUENCE ‹defaultdb›.‹public›.‹sq1›; fol
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 14 elements transitioning toward ABSENT
- │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 104 (sq1-), Name: "sq1", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+ │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 104 (sq1-), Name: "sq1", ReferencedDescID: 100 (defaultdb), UInt32Value: 101}
  │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 104 (sq1-)}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 104 (sq1-), Name: "admin"}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 104 (sq1-), Name: "root"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_temp_sequence/create_temp_sequence.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_temp_sequence/create_temp_sequence.explain
@@ -10,9 +10,9 @@ Schema change plan for CREATE TEMPORARY SEQUENCE ‹defaultdb›.‹pg_temp_123_
  │         ├── 18 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC Schema:{DescID: 104 (pg_temp_123_456+)}
  │         │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 104 (pg_temp_123_456+), ReferencedDescID: 100 (defaultdb)}
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (pg_temp_123_456+), Name: "pg_temp_123_456", ReferencedDescID: 100 (defaultdb), IntValue: 0}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (pg_temp_123_456+), Name: "pg_temp_123_456", ReferencedDescID: 100 (defaultdb), UInt32Value: 0}
  │         │    ├── ABSENT → PUBLIC Sequence:{DescID: 105 (sq1+)}
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb), IntValue: 104}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb), UInt32Value: 104}
  │         │    ├── ABSENT → PUBLIC SchemaChild:{DescID: 105 (sq1+), ReferencedDescID: 104 (pg_temp_123_456+)}
  │         │    ├── ABSENT → PUBLIC TableData:{DescID: 105 (sq1+), ReferencedDescID: 100 (defaultdb)}
  │         │    ├── ABSENT → PUBLIC SequenceOption:{DescID: 105 (sq1+), Name: "START", Value: "32"}
@@ -59,9 +59,9 @@ Schema change plan for CREATE TEMPORARY SEQUENCE ‹defaultdb›.‹pg_temp_123_
       │    ├── 18 elements transitioning toward PUBLIC
       │    │    ├── PUBLIC → ABSENT Schema:{DescID: 104 (pg_temp_123_456+)}
       │    │    ├── PUBLIC → ABSENT SchemaParent:{DescID: 104 (pg_temp_123_456+), ReferencedDescID: 100 (defaultdb)}
-      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (pg_temp_123_456+), Name: "pg_temp_123_456", ReferencedDescID: 100 (defaultdb), IntValue: 0}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (pg_temp_123_456+), Name: "pg_temp_123_456", ReferencedDescID: 100 (defaultdb), UInt32Value: 0}
       │    │    ├── PUBLIC → ABSENT Sequence:{DescID: 105 (sq1+)}
-      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 105 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb), IntValue: 104}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 105 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb), UInt32Value: 104}
       │    │    ├── PUBLIC → ABSENT SchemaChild:{DescID: 105 (sq1+), ReferencedDescID: 104 (pg_temp_123_456+)}
       │    │    ├── PUBLIC → ABSENT TableData:{DescID: 105 (sq1+), ReferencedDescID: 100 (defaultdb)}
       │    │    ├── PUBLIC → ABSENT SequenceOption:{DescID: 105 (sq1+), Name: "START", Value: "32"}
@@ -81,9 +81,9 @@ Schema change plan for CREATE TEMPORARY SEQUENCE ‹defaultdb›.‹pg_temp_123_
            ├── 18 elements transitioning toward PUBLIC
            │    ├── ABSENT → PUBLIC Schema:{DescID: 104 (pg_temp_123_456+)}
            │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 104 (pg_temp_123_456+), ReferencedDescID: 100 (defaultdb)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (pg_temp_123_456+), Name: "pg_temp_123_456", ReferencedDescID: 100 (defaultdb), IntValue: 0}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (pg_temp_123_456+), Name: "pg_temp_123_456", ReferencedDescID: 100 (defaultdb), UInt32Value: 0}
            │    ├── ABSENT → PUBLIC Sequence:{DescID: 105 (sq1+)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb), IntValue: 104}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb), UInt32Value: 104}
            │    ├── ABSENT → PUBLIC SchemaChild:{DescID: 105 (sq1+), ReferencedDescID: 104 (pg_temp_123_456+)}
            │    ├── ABSENT → PUBLIC TableData:{DescID: 105 (sq1+), ReferencedDescID: 100 (defaultdb)}
            │    ├── ABSENT → PUBLIC SequenceOption:{DescID: 105 (sq1+), Name: "START", Value: "32"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_sequence_owner/drop_column_sequence_owner.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_sequence_owner/drop_column_sequence_owner.explain
@@ -190,7 +190,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
       │    │    ├── PUBLIC      → ABSENT           SequenceOwner:{DescID: 104 (t), ColumnID: 2 (j-), ReferencedDescID: 105 (sq1-)}
       │    │    ├── DELETE_ONLY → ABSENT           PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
       │    │    ├── PUBLIC      → ABSENT           IndexData:{DescID: 104 (t), IndexID: 1 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT           Namespace:{DescID: 105 (sq1-), Name: "sq1", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+      │    │    ├── PUBLIC      → ABSENT           Namespace:{DescID: 105 (sq1-), Name: "sq1", ReferencedDescID: 100 (defaultdb), UInt32Value: 101}
       │    │    ├── PUBLIC      → ABSENT           Owner:{DescID: 105 (sq1-)}
       │    │    ├── PUBLIC      → ABSENT           UserPrivileges:{DescID: 105 (sq1-), Name: "admin"}
       │    │    ├── PUBLIC      → ABSENT           UserPrivileges:{DescID: 105 (sq1-), Name: "root"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_index_with_materialized_view_dep/drop_index_with_materialized_view_dep.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_index_with_materialized_view_dep/drop_index_with_materialized_view_dep.explain
@@ -12,7 +12,7 @@ Schema change plan for DROP INDEX ‹defaultdb›.‹public›.‹v2›@‹idx�
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 37 elements transitioning toward ABSENT
  │         │    ├── PUBLIC → VALIDATED SecondaryIndex:{DescID: 105 (v2), IndexID: 2 (idx-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
- │         │    ├── PUBLIC → ABSENT    Namespace:{DescID: 106 (v3-), Name: "v3", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+ │         │    ├── PUBLIC → ABSENT    Namespace:{DescID: 106 (v3-), Name: "v3", ReferencedDescID: 100 (defaultdb), UInt32Value: 101}
  │         │    ├── PUBLIC → ABSENT    Owner:{DescID: 106 (v3-)}
  │         │    ├── PUBLIC → ABSENT    UserPrivileges:{DescID: 106 (v3-), Name: "admin"}
  │         │    ├── PUBLIC → ABSENT    UserPrivileges:{DescID: 106 (v3-), Name: "root"}
@@ -100,7 +100,7 @@ Schema change plan for DROP INDEX ‹defaultdb›.‹public›.‹v2›@‹idx�
  │    ├── Stage 1 of 2 in PreCommitPhase
  │    │    ├── 37 elements transitioning toward ABSENT
  │    │    │    ├── VALIDATED → PUBLIC SecondaryIndex:{DescID: 105 (v2), IndexID: 2 (idx-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
- │    │    │    ├── ABSENT    → PUBLIC Namespace:{DescID: 106 (v3-), Name: "v3", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+ │    │    │    ├── ABSENT    → PUBLIC Namespace:{DescID: 106 (v3-), Name: "v3", ReferencedDescID: 100 (defaultdb), UInt32Value: 101}
  │    │    │    ├── ABSENT    → PUBLIC Owner:{DescID: 106 (v3-)}
  │    │    │    ├── ABSENT    → PUBLIC UserPrivileges:{DescID: 106 (v3-), Name: "admin"}
  │    │    │    ├── ABSENT    → PUBLIC UserPrivileges:{DescID: 106 (v3-), Name: "root"}
@@ -141,7 +141,7 @@ Schema change plan for DROP INDEX ‹defaultdb›.‹public›.‹v2›@‹idx�
  │    └── Stage 2 of 2 in PreCommitPhase
  │         ├── 37 elements transitioning toward ABSENT
  │         │    ├── PUBLIC → VALIDATED SecondaryIndex:{DescID: 105 (v2), IndexID: 2 (idx-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
- │         │    ├── PUBLIC → ABSENT    Namespace:{DescID: 106 (v3-), Name: "v3", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+ │         │    ├── PUBLIC → ABSENT    Namespace:{DescID: 106 (v3-), Name: "v3", ReferencedDescID: 100 (defaultdb), UInt32Value: 101}
  │         │    ├── PUBLIC → ABSENT    Owner:{DescID: 106 (v3-)}
  │         │    ├── PUBLIC → ABSENT    UserPrivileges:{DescID: 106 (v3-), Name: "admin"}
  │         │    ├── PUBLIC → ABSENT    UserPrivileges:{DescID: 106 (v3-), Name: "root"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_schema/drop_schema.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_schema/drop_schema.explain
@@ -9,7 +9,7 @@ Schema change plan for DROP SCHEMA ‹db›.‹sc›;
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 6 elements transitioning toward ABSENT
- │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 106 (sc-), Name: "sc", ReferencedDescID: 104 (db), IntValue: 0}
+ │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 106 (sc-), Name: "sc", ReferencedDescID: 104 (db), UInt32Value: 0}
  │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 106 (sc-)}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 106 (sc-), Name: "admin"}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 106 (sc-), Name: "root"}
@@ -25,7 +25,7 @@ Schema change plan for DROP SCHEMA ‹db›.‹sc›;
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
  │    │    ├── 6 elements transitioning toward ABSENT
- │    │    │    ├── ABSENT  → PUBLIC Namespace:{DescID: 106 (sc-), Name: "sc", ReferencedDescID: 104 (db), IntValue: 0}
+ │    │    │    ├── ABSENT  → PUBLIC Namespace:{DescID: 106 (sc-), Name: "sc", ReferencedDescID: 104 (db), UInt32Value: 0}
  │    │    │    ├── ABSENT  → PUBLIC Owner:{DescID: 106 (sc-)}
  │    │    │    ├── ABSENT  → PUBLIC UserPrivileges:{DescID: 106 (sc-), Name: "admin"}
  │    │    │    ├── ABSENT  → PUBLIC UserPrivileges:{DescID: 106 (sc-), Name: "root"}
@@ -35,7 +35,7 @@ Schema change plan for DROP SCHEMA ‹db›.‹sc›;
  │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
  │    └── Stage 2 of 2 in PreCommitPhase
  │         ├── 6 elements transitioning toward ABSENT
- │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 106 (sc-), Name: "sc", ReferencedDescID: 104 (db), IntValue: 0}
+ │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 106 (sc-), Name: "sc", ReferencedDescID: 104 (db), UInt32Value: 0}
  │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 106 (sc-)}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 106 (sc-), Name: "admin"}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 106 (sc-), Name: "root"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_table/drop_table.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_table/drop_table.explain
@@ -12,7 +12,7 @@ Schema change plan for DROP TABLE ‹db›.‹sc›.‹t›;
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 42 elements transitioning toward ABSENT
- │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 107 (t-), Name: "t", ReferencedDescID: 104 (db), IntValue: 106}
+ │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 107 (t-), Name: "t", ReferencedDescID: 104 (db), UInt32Value: 106}
  │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 107 (t-)}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 107 (t-), Name: "admin"}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 107 (t-), Name: "root"}
@@ -110,7 +110,7 @@ Schema change plan for DROP TABLE ‹db›.‹sc›.‹t›;
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
  │    │    ├── 42 elements transitioning toward ABSENT
- │    │    │    ├── ABSENT  → PUBLIC Namespace:{DescID: 107 (t-), Name: "t", ReferencedDescID: 104 (db), IntValue: 106}
+ │    │    │    ├── ABSENT  → PUBLIC Namespace:{DescID: 107 (t-), Name: "t", ReferencedDescID: 104 (db), UInt32Value: 106}
  │    │    │    ├── ABSENT  → PUBLIC Owner:{DescID: 107 (t-)}
  │    │    │    ├── ABSENT  → PUBLIC UserPrivileges:{DescID: 107 (t-), Name: "admin"}
  │    │    │    ├── ABSENT  → PUBLIC UserPrivileges:{DescID: 107 (t-), Name: "root"}
@@ -156,7 +156,7 @@ Schema change plan for DROP TABLE ‹db›.‹sc›.‹t›;
  │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
  │    └── Stage 2 of 2 in PreCommitPhase
  │         ├── 42 elements transitioning toward ABSENT
- │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 107 (t-), Name: "t", ReferencedDescID: 104 (db), IntValue: 106}
+ │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 107 (t-), Name: "t", ReferencedDescID: 104 (db), UInt32Value: 106}
  │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 107 (t-)}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 107 (t-), Name: "admin"}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 107 (t-), Name: "root"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_table_udf_default/drop_table_udf_default.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_table_udf_default/drop_table_udf_default.explain
@@ -9,7 +9,7 @@ Schema change plan for DROP TABLE ‹defaultdb›.‹public›.‹t›;
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 36 elements transitioning toward ABSENT
- │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 105 (t-), Name: "t", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+ │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 105 (t-), Name: "t", ReferencedDescID: 100 (defaultdb), UInt32Value: 101}
  │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 105 (t-)}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 105 (t-), Name: "admin"}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 105 (t-), Name: "root"}
@@ -95,7 +95,7 @@ Schema change plan for DROP TABLE ‹defaultdb›.‹public›.‹t›;
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
  │    │    ├── 36 elements transitioning toward ABSENT
- │    │    │    ├── ABSENT  → PUBLIC Namespace:{DescID: 105 (t-), Name: "t", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+ │    │    │    ├── ABSENT  → PUBLIC Namespace:{DescID: 105 (t-), Name: "t", ReferencedDescID: 100 (defaultdb), UInt32Value: 101}
  │    │    │    ├── ABSENT  → PUBLIC Owner:{DescID: 105 (t-)}
  │    │    │    ├── ABSENT  → PUBLIC UserPrivileges:{DescID: 105 (t-), Name: "admin"}
  │    │    │    ├── ABSENT  → PUBLIC UserPrivileges:{DescID: 105 (t-), Name: "root"}
@@ -135,7 +135,7 @@ Schema change plan for DROP TABLE ‹defaultdb›.‹public›.‹t›;
  │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
  │    └── Stage 2 of 2 in PreCommitPhase
  │         ├── 36 elements transitioning toward ABSENT
- │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 105 (t-), Name: "t", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+ │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 105 (t-), Name: "t", ReferencedDescID: 100 (defaultdb), UInt32Value: 101}
  │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 105 (t-)}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 105 (t-), Name: "admin"}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 105 (t-), Name: "root"}


### PR DESCRIPTION
Add support for bool fields in the rel package's schema system, alongside new UInt32Value, BoolValue, and Int32Value attributes in screl. These attributes enable function element properties (Volatility, LeakProof, NullInputBehavior, Security, Body) to be mapped with distinguishing keys, which is a prerequisite for using the drop+add pattern for CREATE OR REPLACE FUNCTION.

The rel package changes include:
- Bool field support in schema, comparison, and value conversion
- Relaxed checkType to compare scalar kinds by their comparable base type rather than named type, allowing different named types of the same kind (e.g. Function_Volatility and Function_NullInputBehavior) to share a single attribute

The screl changes add entity attr mappings for:
- FunctionVolatility (Int32Value)
- FunctionLeakProof (BoolValue)
- FunctionNullInputBehavior (Int32Value)
- FunctionBody (Value)
- FunctionSecurity (Int32Value)

Epic: None
Release note: none
