### PR TITLE
pkg/cli: support full zip path matching in --include-files/--exclude-files

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -1721,8 +1721,17 @@ The default is to not exclude any node.`,
 List of glob patterns that determine files that can be included
 in the output. The list can be specified as a comma-delimited
 list of patterns, or by using the flag multiple times.
-The patterns apply to the base name of the file, without
-a path prefix.
+<PRE>
+
+</PRE>
+Patterns without '/' apply to the base name of the file (e.g. '*.json').
+Patterns containing '/' are matched against the full path within the zip
+archive (e.g. 'debug/nodes/1/*.json' or 'debug/nodes/*/ranges.json').
+The path matching uses Go's filepath.Match syntax, where '*' matches
+any sequence of non-separator characters within a single path component.
+<PRE>
+
+</PRE>
 The default is to include all files.
 <PRE>
 
@@ -1744,8 +1753,14 @@ List of glob patterns that determine files that are to
 be excluded from the output. The list can be specified
 as a comma-delimited list of patterns, or by using the
 flag multiple times.
-The patterns apply to the base name of the file, without
-a path prefix.
+<PRE>
+
+</PRE>
+Patterns without '/' apply to the base name of the file (e.g. '*.log').
+Patterns containing '/' are matched against the full path within the zip
+archive (e.g. 'debug/nodes/*/ranges.json').
+The path matching uses Go's filepath.Match syntax, where '*' matches
+any sequence of non-separator characters within a single path component.
 <PRE>
 
 </PRE>

--- a/pkg/cli/testdata/zip/file-filters/testzip_file_filters
+++ b/pkg/cli/testdata/zip/file-filters/testzip_file_filters
@@ -674,3 +674,49 @@ debug/nodes/1/stacks.txt
 debug/nodes/1/stacks_with_labels.txt
 debug/pprof-summary.sh
 debug/tenant_ranges.err.txt
+
+#path-based include: only node 1 json files
+--include-files=debug/nodes/1/*.json
+----
+debug/debug_zip_command_flags.txt
+debug/hot-ranges-tenant.sh
+debug/hot-ranges.sh
+debug/nodes/1/details.json
+debug/nodes/1/gossip.json
+debug/nodes/1/ranges.json
+debug/nodes/1/status.json
+debug/pprof-summary.sh
+debug/tenant_ranges.err.txt
+
+#path-based exclude: include all json but exclude per-node ranges
+--include-files=*.json --exclude-files=debug/nodes/*/ranges.json
+----
+debug/debug_zip_command_flags.txt
+debug/events.json
+debug/hot-ranges-tenant.sh
+debug/hot-ranges.sh
+debug/liveness.json
+debug/nodes.json
+debug/nodes/1/details.json
+debug/nodes/1/gossip.json
+debug/nodes/1/status.json
+debug/pprof-summary.sh
+debug/rangelog.json
+debug/reports/problemranges.json
+debug/settings.json
+debug/tenant_ranges.err.txt
+
+#path-based exclude: include all json but exclude all node-level json files
+--include-files=*.json --exclude-files=debug/nodes/*/*.json
+----
+debug/debug_zip_command_flags.txt
+debug/events.json
+debug/hot-ranges-tenant.sh
+debug/hot-ranges.sh
+debug/liveness.json
+debug/nodes.json
+debug/pprof-summary.sh
+debug/rangelog.json
+debug/reports/problemranges.json
+debug/settings.json
+debug/tenant_ranges.err.txt

--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -559,8 +559,7 @@ func (zc *debugZipContext) dumpTableDataForZip(
 	ctx := context.Background()
 	fileName := sanitizeFilename(table)
 	baseName := path.Join(base, fileName)
-	fileNameWithExtension := fileName + "." + zc.clusterPrinter.sqlOutputFilenameExtension
-	if !zipCtx.files.shouldIncludeFile(fileNameWithExtension) {
+	if !zipCtx.files.shouldIncludeFile(baseName + "." + zc.clusterPrinter.sqlOutputFilenameExtension) {
 		zr.info("skipping table data for %s due to file filters", table)
 		return nil
 	}

--- a/pkg/cli/zip_per_node.go
+++ b/pkg/cli/zip_per_node.go
@@ -137,7 +137,7 @@ func makePerNodeZipRequests(
 ) []zipRequest {
 	var zipRequests []zipRequest
 
-	if zipCtx.files.shouldIncludeFile(detailsFileName) {
+	if zipCtx.files.shouldIncludeFile(path.Join(prefix, detailsFileName)) {
 		zipRequests = append(zipRequests, zipRequest{
 			fn: func(ctx context.Context) (interface{}, error) {
 				return status.Details(ctx, &serverpb.DetailsRequest{NodeId: id, Redact: zipCtx.redact})
@@ -149,7 +149,7 @@ func makePerNodeZipRequests(
 		zr.info("skipping %s due to file filters", detailsFileName)
 	}
 
-	if zipCtx.files.shouldIncludeFile(gossipFileName) {
+	if zipCtx.files.shouldIncludeFile(path.Join(prefix, gossipFileName)) {
 		zipRequests = append(zipRequests, zipRequest{
 			fn: func(ctx context.Context) (interface{}, error) {
 				return status.Gossip(ctx, &serverpb.GossipRequest{NodeId: id, Redact: zipCtx.redact})
@@ -187,10 +187,6 @@ func (zc *debugZipContext) collectCPUProfiles(
 	}
 
 	zc.clusterPrinter.info("requesting CPU profiles")
-	if !zipCtx.files.shouldIncludeFile(cpuProfileFileName) {
-		zc.clusterPrinter.info("skipping %s due to file filters", cpuProfileFileName)
-		return nil
-	}
 
 	if ni == nil {
 		return errors.AssertionFailedf("nodes list is empty; nothing to do")
@@ -206,6 +202,13 @@ func (zc *debugZipContext) collectCPUProfiles(
 		}
 		if !zipCtx.nodes.isIncluded(nodeID) {
 			zc.clusterPrinter.info("skipping excluded node %d", nodeID)
+			continue
+		}
+		// Per-node check with the full zip path so that path-based
+		// patterns like 'debug/nodes/1/cpu.pprof' are respected.
+		nodePrefix := fmt.Sprintf("%s%s/%d", zc.prefix, nodesPrefix, nodeID)
+		if !zipCtx.files.shouldIncludeFile(path.Join(nodePrefix, cpuProfileFileName)) {
+			zc.clusterPrinter.info("skipping %s for node %d due to file filters", cpuProfileFileName, nodeID)
 			continue
 		}
 		wg.Add(1)
@@ -249,7 +252,7 @@ func (zc *debugZipContext) collectCPUProfiles(
 		nodeID := nodeList[i].NodeID
 		prefix := fmt.Sprintf("%s%s/%s", zc.prefix, nodesPrefix, fmt.Sprintf("%d", nodeID))
 		s := zc.clusterPrinter.start(redact.Sprintf("profile for node %d", nodeID))
-		if err := zc.z.createRawOrError(s, prefix+"/"+cpuProfileFileName, pd.data, pd.err); err != nil {
+		if err := zc.z.createRawOrError(s, path.Join(prefix, cpuProfileFileName), pd.data, pd.err); err != nil {
 			return err
 		}
 	}
@@ -310,7 +313,7 @@ func (zc *debugZipContext) collectFileList(
 		nodePrinter.info("%d %ss found", len(files.Files), fileKind)
 		for _, file := range files.Files {
 			ctime := extractTimeFromFileName(file.Name)
-			if !zipCtx.files.isIncluded(file.Name, ctime, ctime) {
+			if !zipCtx.files.isIncluded(path.Join(prefix, file.Name), ctime, ctime) {
 				nodePrinter.info("skipping excluded %s: %s due to file filters", fileKind, file.Name)
 				continue
 			}
@@ -354,7 +357,7 @@ func (zc *debugZipContext) getRangeInformation(
 	ctx context.Context, nodePrinter *zipReporter, id string, prefix string,
 ) error {
 	if zipCtx.includeRangeInfo {
-		if !zipCtx.files.shouldIncludeFile(rangesInfoFileName) {
+		if !zipCtx.files.shouldIncludeFile(path.Join(prefix, rangesInfoFileName)) {
 			nodePrinter.info("skipping %s due to file filters", rangesInfoFileName)
 			return nil
 		}
@@ -419,7 +422,7 @@ func (zc *debugZipContext) getLogFiles(
 		for _, file := range logs.Files {
 			ctime := extractTimeFromFileName(file.Name)
 			mtime := timeutil.Unix(0, file.ModTimeNanos)
-			if !zipCtx.files.isIncluded(file.Name, ctime, mtime) {
+			if !zipCtx.files.isIncluded(path.Join(prefix, "logs", file.Name), ctime, mtime) {
 				nodePrinter.info("skipping excluded log file: %s due to file filters", file.Name)
 				continue
 			}
@@ -530,7 +533,7 @@ func (zc *debugZipContext) getProfiles(
 func (zc *debugZipContext) getEngineStats(
 	ctx context.Context, nodePrinter *zipReporter, id string, prefix string,
 ) error {
-	if !zipCtx.files.shouldIncludeFile(lsmFileName) {
+	if !zipCtx.files.shouldIncludeFile(path.Join(prefix, lsmFileName)) {
 		nodePrinter.info("skipping %s due to file filters", lsmFileName)
 		return nil
 	}
@@ -554,7 +557,7 @@ func (zc *debugZipContext) getEngineStats(
 func (zc *debugZipContext) getCurrentHeapProfile(
 	ctx context.Context, nodePrinter *zipReporter, id string, prefix string,
 ) error {
-	if !zipCtx.files.shouldIncludeFile(heapPprofFileName) {
+	if !zipCtx.files.shouldIncludeFile(path.Join(prefix, heapPprofFileName)) {
 		nodePrinter.info("skipping %s due to file filters", heapPprofFileName)
 		return nil
 	}
@@ -587,7 +590,7 @@ func (zc *debugZipContext) getStackInformation(
 	// binary goroutine profile (debug=3 or debug=0), as these do not have that
 	// same stop-the-world disruption.
 	if zipCtx.includeStacks {
-		if zipCtx.files.shouldIncludeFile(stacksFileName) {
+		if zipCtx.files.shouldIncludeFile(path.Join(prefix, stacksFileName)) {
 			var stacksData []byte
 			s := nodePrinter.start("requesting stacks")
 			requestErr := zc.runZipFn(ctx, s,
@@ -612,7 +615,7 @@ func (zc *debugZipContext) getStackInformation(
 	}
 
 	var stacksDataWithLabels []byte
-	if zipCtx.files.shouldIncludeFile(stacksWithLabelFileName) {
+	if zipCtx.files.shouldIncludeFile(path.Join(prefix, stacksWithLabelFileName)) {
 		s := nodePrinter.start("requesting stacks with labels")
 		requestErr := zc.runZipFn(ctx, s,
 			func(ctx context.Context) error {
@@ -635,7 +638,7 @@ func (zc *debugZipContext) getStackInformation(
 		nodePrinter.info("skipping %s due to file filters", stacksWithLabelFileName)
 	}
 
-	if zipCtx.files.shouldIncludeFile(stacksPprofFileName) {
+	if zipCtx.files.shouldIncludeFile(path.Join(prefix, stacksPprofFileName)) {
 		var stacksPprofData []byte
 		s := nodePrinter.start("requesting goroutine profile")
 		requestErr := zc.runZipFn(ctx, s,
@@ -706,7 +709,7 @@ func (zc *debugZipContext) getNodeStatus(
 	prefix string,
 	redactedNodeDetails serverpb.NodeDetails,
 ) error {
-	if !zipCtx.files.shouldIncludeFile(statusFileName) {
+	if !zipCtx.files.shouldIncludeFile(path.Join(prefix, statusFileName)) {
 		nodePrinter.info("skipping %s due to file filters", statusFileName)
 		return nil
 	}


### PR DESCRIPTION
Previously, the --include-files and --exclude-files flags in `debug zip` 
only matched against the base file name (e.g. "details.json"). This made 
it impossible to filter by location within the zip archive, for example 
including only a specific node's files, or excluding per-node ranges.json 
while keeping the cluster-wide copy.

This commit extends the file filter flags to support full zip path 
matching. Patterns without '/' continue to match the base file name, 
preserving the backward compatibility. Patterns with '/' are matched 
against the full path within the zip archive using filepath.Match 
semantics (e.g. "debug/nodes/1/*.json" or "debug/nodes/*/ranges.json").

The core change adds a zipPath parameter to shouldIncludeFile and 
isIncluded, with a matchPattern helper that routes each pattern to the 
appropriate match target. Server-side retrieval patterns only forward 
base-name patterns since the server does not know the zip directory 
layout.

Fixes: #158450
Part of: CRDB-57302
Epic: none
Release note (cli change): The `cockroach debug zip` command's 
`--include-files` and `--exclude-files` flags now support full zip path 
patterns. Patterns containing '/' are matched against the full path 
within the zip archive (e.g. `--include-files='debug/nodes/1/*.json'`). 
Patterns without '/' continue to match the base file name as before.