### PR TITLE
mmaprototype: fix disk utilization modeling

### DIFF
--- a/pkg/kv/kvserver/allocator/mmaprototype/load.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/load.go
@@ -689,6 +689,20 @@ func highDiskSpaceUtilization(load LoadValue, capacity LoadValue, threshold floa
 		log.KvDistribution.Errorf(context.Background(), "disk capacity is unknown")
 		return false
 	}
+	// load and capacity are both in terms of logical bytes.
+	//
+	//   load     = LogicalBytes
+	//   diskUtil = FractionUsed()  (i.e. Used/(Available+Used), or
+	//                               (Capacity-Available)/Capacity as fallback)
+	//   capacity = LogicalBytes / diskUtil
+	//
+	// Therefore:
+	//   fractionUsed = load / capacity
+	//                = LogicalBytes / (LogicalBytes / diskUtil)
+	//                = diskUtil
+	//
+	// This recovers the actual disk utilization as reported by the store
+	// descriptor, expressed in terms of the logical byte load and capacity.
 	fractionUsed := float64(load) / float64(capacity)
 	return fractionUsed >= threshold
 }

--- a/pkg/kv/kvserver/mmaintegration/store_load_msg.go
+++ b/pkg/kv/kvserver/mmaintegration/store_load_msg.go
@@ -115,8 +115,7 @@ func MakeStoreLoadMsg(
 	// Available does not compensate for the ballast, so utilization will look
 	// higher than actual. This is fine since the ballast is small (default is
 	// 1% of capacity) and is for use in an emergency.
-	byteSizeUtil :=
-		float64(desc.Capacity.Capacity-desc.Capacity.Available) / float64(desc.Capacity.Capacity)
+	byteSizeUtil := desc.Capacity.FractionUsed()
 	almostZeroUtil := byteSizeUtil < 0.01
 	if load[mmaprototype.ByteSize] != 0 && !almostZeroUtil {
 		// Normal case. The store has some ranges, and is not almost empty.


### PR DESCRIPTION
Previously, MakeStoreLoadMsg computed disk utilization as (Capacity - Available)
/ Capacity. This approach includes non-store filesystem overhead (e.g., reserved
blocks, unrelated non-crdb files) in the numerator, inflating the utilization
signal and leading to a systematic underestimation of store capacity.

This change switches to desc.Capacity.FractionUsed(), which prefers Used /
(Available + Used) when Used is populated. That scopes the calculation to the
store’s physical disk usage as tracked by the store itself, rather than total
filesystem consumption. Note that Used still includes store-owned auxiliary
files (e.g. ballast file). The existing (Capacity - Available) / Capacity
formula is retained within FractionUsed() as a fallback when Used is
unavailable.

Resolves: https://github.com/cockroachdb/cockroach/issues/162245
Epic: [CRDB-55052](https://cockroachlabs.atlassian.net/browse/CRDB-55052)