### PR TITLE
release-25.4: workload/schemachanger: fix duplicate column errors for CTAS

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -1490,7 +1490,9 @@ func (og *operationGenerator) createTableAs(ctx context.Context, tx pgx.Tx) (*op
 				}
 				selectStatement.Exprs = append(selectStatement.Exprs, selectExpr)
 
-				if _, exists := uniqueColumnNames[columnNamesForTable[j]]; exists {
+				// Internal columns will always be aliased to unique names, so they can
+				// never generate duplicate column errors.
+				if _, exists := uniqueColumnNames[columnNamesForTable[j]]; exists && !usingInternalColumn {
 					duplicateColumns = true
 				} else {
 					uniqueColumnNames[columnNamesForTable[j]] = true


### PR DESCRIPTION
Backport 1/1 commits from #163291 on behalf of @fqazi.

----

Previously, when computing duplicate column errors for CREATE TABLE AS (CTAS), we incorrectly assumed they could be generated by internal columns. Since internal columns are always aliased when selected, they never trigger such errors. To address this, this patch ignores internal columns during duplicate column detection.

Fixes: #161665

Release note: None

----

Release justification: test only change