### PR TITLE
workflows: stablize working directory for `docker_image_amd64` job

### DIFF
--- a/build/github/docker-image.sh
+++ b/build/github/docker-image.sh
@@ -29,8 +29,9 @@ build_arch=${1:-amd64}
 
 bazel build //pkg/cmd/cockroach //c-deps:libgeos --config $CROSSCONFIG --jobs 50 $(./build/github/engflow-args.sh)
 cp _bazel/bin/pkg/cmd/cockroach/cockroach_/cockroach build/deploy
-cp _bazel/cockroach/external/$ARCHIVEDIR/lib/libgeos.so build/deploy
-cp _bazel/cockroach/external/$ARCHIVEDIR/lib/libgeos_c.so build/deploy
+LIBDIR=$(bazel info execution_root --config $CROSSCONFIG)/external/$ARCHIVEDIR/lib
+cp $LIBDIR/libgeos.so build/deploy
+cp $LIBDIR/libgeos_c.so build/deploy
 
 cp LICENSE licenses/THIRD-PARTY-NOTICES.txt build/deploy/
 


### PR DESCRIPTION
The script currently assumes the repo is named `cockroach`. This change
makes it resilient in case the directory does not happen to have that
specific name.

Release note: none
Epic: none