### PR TITLE
restore: restore full zcfgs during table/database restores

### DIFF
--- a/pkg/backup/restore_job.go
+++ b/pkg/backup/restore_job.go
@@ -1996,7 +1996,9 @@ func createImportingDescriptors(
 			}
 		}
 
-		if details.DescriptorCoverage != tree.AllDescriptors {
+		// If there's a temp system database, then we assume that zone configs will
+		// be restored via the pre data restore flow.
+		if tempSystemDBID == descpb.InvalidID {
 			if err := synthesizeZoneConfigsForPartialRestore(
 				ctx,
 				p,
@@ -2327,7 +2329,12 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 
 		resTotal.Add(res)
 
-		if details.DescriptorCoverage == tree.AllDescriptors {
+		if isSystemUserRestore(details) {
+			return errors.AssertionFailedf("system user restore should not have pre-data to restore")
+		}
+
+		tempSystemDBID := tempSystemDatabaseID(details, preData.getSystemTables(), r.job.Payload().CreationClusterVersion)
+		if tempSystemDBID != descpb.InvalidID {
 			if err := r.restoreSystemTables(
 				ctx, p.ExecCfg().InternalDB, preData.getSystemTables(),
 			); err != nil {
@@ -2452,7 +2459,12 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 	details = r.job.Details().(jobspb.RestoreDetails)
 	p.ExecCfg().JobRegistry.NotifyToAdoptJobs()
 
-	if details.DescriptorCoverage == tree.AllDescriptors {
+	tempSystemDBID := tempSystemDatabaseID(details, mainData.getSystemTables(), r.job.Payload().CreationClusterVersion)
+	if isSystemUserRestore(details) {
+		if err := r.restoreSystemUsers(ctx, p.ExecCfg().InternalDB, mainData.getSystemTables()); err != nil {
+			return err
+		}
+	} else if tempSystemDBID != descpb.InvalidID {
 		// We restore the system tables from the main data bundle so late because it
 		// includes the jobs that are being restored. As soon as we restore these
 		// jobs, they become accessible to the user, and may start executing. We
@@ -2460,11 +2472,6 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 		if err := r.restoreSystemTables(
 			ctx, p.ExecCfg().InternalDB, mainData.getSystemTables(),
 		); err != nil {
-			return err
-		}
-		details = r.job.Details().(jobspb.RestoreDetails)
-	} else if isSystemUserRestore(details) {
-		if err := r.restoreSystemUsers(ctx, p.ExecCfg().InternalDB, mainData.getSystemTables()); err != nil {
 			return err
 		}
 	}
@@ -3856,6 +3863,8 @@ func (r *restoreResumer) restoreSystemTables(
 	ctx context.Context, db isql.DB, tables []catalog.TableDescriptor,
 ) error {
 	details := r.job.Details().(jobspb.RestoreDetails)
+	isClusterRestore := details.DescriptorCoverage == tree.AllDescriptors
+
 	if details.SystemTablesMigrated == nil {
 		details.SystemTablesMigrated = make(map[string]bool)
 	}
@@ -3888,13 +3897,22 @@ func (r *restoreResumer) restoreSystemTables(
 
 	// Copy the data from the temporary system DB to the real system table.
 	for _, systemTable := range systemTablesToRestore {
-		if systemTable.config.migrationFunc != nil {
+		var migrationFunc func(context.Context, isql.Txn, string, jobspb.DescRewriteMap) error
+		if isClusterRestore {
+			migrationFunc = systemTable.config.migrationFunc
+		} else if systemTable.config.nonClusterMigrationFunc != nil {
+			migrationFunc = systemTable.config.nonClusterMigrationFunc
+		} else {
+			return errors.AssertionFailedf("found system table in non cluster without a non cluster migration func")
+		}
+
+		if migrationFunc != nil {
 			if details.SystemTablesMigrated[systemTable.systemTableName] {
 				continue
 			}
 
 			if err := db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-				if err := systemTable.config.migrationFunc(
+				if err := migrationFunc(
 					ctx, txn, systemTable.stagingTableName, details.DescriptorRewrites,
 				); err != nil {
 					return err
@@ -3910,14 +3928,20 @@ func (r *restoreResumer) restoreSystemTables(
 			}
 		}
 
+		restoreFunc := defaultSystemTableRestoreFunc
+		if isClusterRestore {
+			if systemTable.config.customRestoreFunc != nil {
+				restoreFunc = systemTable.config.customRestoreFunc
+			}
+		} else if systemTable.config.nonClusterRestoreFunc != nil {
+			restoreFunc = systemTable.config.nonClusterRestoreFunc
+		} else {
+			return errors.AssertionFailedf("found system table in non cluster without a non cluster restore func")
+		}
+
 		if err := db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 			txn.KV().SetDebugName("system-restore-txn")
 
-			restoreFunc := defaultSystemTableRestoreFunc
-			if systemTable.config.customRestoreFunc != nil {
-				restoreFunc = systemTable.config.customRestoreFunc
-				log.Eventf(ctx, "using custom restore function for table %s", systemTable.systemTableName)
-			}
 			deps := customRestoreFuncDeps{
 				settings: r.execCfg.Settings,
 				codec:    r.execCfg.Codec,

--- a/pkg/backup/system_schema_test.go
+++ b/pkg/backup/system_schema_test.go
@@ -7,16 +7,22 @@ package backup
 
 import (
 	"context"
+	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
 )
 
 // TestAllSystemTablesHaveBackupConfig is a test that enumerates all system
@@ -71,5 +77,207 @@ func TestConfigurationDetailsOnlySetForIncludedTables(t *testing.T) {
 					systemTable)
 			}
 		}
+	}
+}
+
+type rekeyPair struct {
+	oldID descpb.ID
+	newID descpb.ID
+}
+
+func rekey(oldID, newID descpb.ID) rekeyPair {
+	return rekeyPair{oldID: oldID, newID: newID}
+}
+
+func rekeyMap(pairs ...rekeyPair) jobspb.DescRewriteMap {
+	m := make(jobspb.DescRewriteMap)
+	for _, p := range pairs {
+		m[p.oldID] = &jobspb.DescriptorRewrite{ID: p.newID}
+	}
+	return m
+}
+
+type testRow struct {
+	id descpb.ID
+}
+
+func row(id descpb.ID) testRow {
+	return testRow{id: id}
+}
+
+type rekeyTestCase struct {
+	name         string
+	colName      string
+	initialRows  []testRow
+	rekeys       jobspb.DescRewriteMap
+	expectedRows []descpb.ID
+}
+
+func rekeyTestHelper(
+	ctx context.Context,
+	t *testing.T,
+	s serverutils.TestServerInterface,
+	tableName string,
+	tc rekeyTestCase,
+	rekeyFunc func(string) func(context.Context, isql.Txn, string, jobspb.DescRewriteMap) error,
+) {
+	sqlDB := sqlutils.MakeSQLRunner(s.SQLConn(t, serverutils.DBName("defaultdb")))
+	ie := s.InternalDB().(isql.DB)
+
+	// Delete existing data from previous test iteration.
+	sqlDB.Exec(t, fmt.Sprintf("DELETE FROM %s", tableName))
+
+	for _, r := range tc.initialRows {
+		sqlDB.Exec(t, fmt.Sprintf("INSERT INTO %s (%s) VALUES ($1)", tableName, tc.colName), r.id)
+	}
+
+	err := ie.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+		return rekeyFunc(tc.colName)(ctx, txn, tableName, tc.rekeys)
+	})
+	require.NoError(t, err)
+
+	rows := sqlDB.Query(t, fmt.Sprintf("SELECT %s FROM %s ORDER BY %s", tc.colName, tableName, tc.colName))
+	defer rows.Close()
+
+	actualRows := make([]descpb.ID, 0)
+	for rows.Next() {
+		var id descpb.ID
+		require.NoError(t, rows.Scan(&id))
+		actualRows = append(actualRows, id)
+	}
+
+	// Sort expected rows for comparison.
+	expected := make([]descpb.ID, len(tc.expectedRows))
+	copy(expected, tc.expectedRows)
+	sort.Slice(expected, func(i, j int) bool { return expected[i] < expected[j] })
+
+	require.Equal(t, expected, actualRows)
+}
+
+func TestRekeySystemTable(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	sqlDB := sqlutils.MakeSQLRunner(s.SQLConn(t, serverutils.DBName("defaultdb")))
+	const tableName = "defaultdb.public.test_rekey_table"
+	sqlDB.Exec(t, fmt.Sprintf("CREATE TABLE %s (id INT PRIMARY KEY)", tableName))
+
+	testcases := []rekeyTestCase{
+		{
+			name:         "basic single remapping",
+			colName:      "id",
+			initialRows:  []testRow{row(100)},
+			rekeys:       rekeyMap(rekey(100, 1001)),
+			expectedRows: []descpb.ID{1001},
+		},
+		{
+			name:         "multiple remappings",
+			colName:      "id",
+			initialRows:  []testRow{row(100), row(200), row(300)},
+			rekeys:       rekeyMap(rekey(100, 1001), rekey(200, 2002), rekey(300, 3003)),
+			expectedRows: []descpb.ID{1001, 2002, 3003},
+		},
+		{
+			name:         "below 50 is preserved even without rekey",
+			colName:      "id",
+			initialRows:  []testRow{row(10)},
+			rekeys:       rekeyMap(rekey(100, 1001)),
+			expectedRows: []descpb.ID{10},
+		},
+		{
+			name:         "above 50 removed without rekey",
+			colName:      "id",
+			initialRows:  []testRow{row(150)},
+			rekeys:       rekeyMap(rekey(100, 1001)),
+			expectedRows: []descpb.ID{},
+		},
+		{
+			name:         "overlapping IDs where old ID matches another new ID",
+			colName:      "id",
+			initialRows:  []testRow{row(100), row(200)},
+			rekeys:       rekeyMap(rekey(100, 200), rekey(200, 300)),
+			expectedRows: []descpb.ID{200, 300},
+		},
+		{
+			name:         "empty table",
+			colName:      "id",
+			initialRows:  []testRow{},
+			rekeys:       rekeyMap(rekey(100, 1001)),
+			expectedRows: []descpb.ID{},
+		},
+		{
+			name:         "ID 50 remapped",
+			colName:      "id",
+			initialRows:  []testRow{row(50)},
+			rekeys:       rekeyMap(rekey(50, 5000)),
+			expectedRows: []descpb.ID{5000},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			rekeyTestHelper(ctx, t, s, tableName, tc, rekeySystemTable)
+		})
+	}
+}
+
+func TestNonClusterRekeySystemTable(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	sqlDB := sqlutils.MakeSQLRunner(s.SQLConn(t, serverutils.DBName("defaultdb")))
+	const tableName = "defaultdb.public.test_rekey_table"
+	sqlDB.Exec(t, fmt.Sprintf("CREATE TABLE %s (id INT PRIMARY KEY)", tableName))
+
+	testcases := []rekeyTestCase{
+		{
+			name:         "basic single remapping",
+			colName:      "id",
+			initialRows:  []testRow{row(100)},
+			rekeys:       rekeyMap(rekey(100, 1001)),
+			expectedRows: []descpb.ID{1001},
+		},
+		{
+			name:         "filters out rows not in rekey map",
+			colName:      "id",
+			initialRows:  []testRow{row(100), row(200)},
+			rekeys:       rekeyMap(rekey(100, 1001)),
+			expectedRows: []descpb.ID{1001},
+		},
+		{
+			name:         "filters out system table IDs under 50 not in rekey map",
+			colName:      "id",
+			initialRows:  []testRow{row(10), row(100)},
+			rekeys:       rekeyMap(rekey(100, 1001)),
+			expectedRows: []descpb.ID{1001},
+		},
+		{
+			name:         "overlapping IDs",
+			colName:      "id",
+			initialRows:  []testRow{row(100), row(200)},
+			rekeys:       rekeyMap(rekey(100, 200), rekey(200, 300)),
+			expectedRows: []descpb.ID{200, 300},
+		},
+		{
+			name:         "empty table",
+			colName:      "id",
+			initialRows:  []testRow{},
+			rekeys:       rekeyMap(rekey(100, 1001)),
+			expectedRows: []descpb.ID{},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			rekeyTestHelper(ctx, t, s, tableName, tc, nonClusterRekeySystemTable)
+		})
 	}
 }


### PR DESCRIPTION
If the zoneconfig table is in the backup, we now restore zone table/db
zoneconfigs via the tempDB, instead of via incomplete MR Zone config synthesis.
More concretely, we now restore arbitrary zone configs (e.g. TTL, region
constraints).

Informs https://github.com/cockroachdb/cockroach/issues/159929

Release note: none