### PR TITLE
opt/norm: clean up AssignPlaceholders

### DIFF
--- a/pkg/sql/opt/norm/factory.go
+++ b/pkg/sql/opt/norm/factory.go
@@ -346,7 +346,8 @@ func (f *Factory) AssignPlaceholders(from *memo.Memo) (retErr error) {
 	// Copy the "from" memo to this memo, replacing any Placeholder operators as
 	// the copy proceeds.
 	var replaceFn ReplaceFunc
-	var recursiveRoutines map[*memo.UDFDefinition]struct{}
+	// We keep track of UDF definitions so that we don't copy the same UDF more
+	// than once.
 	var newRoutineDefs map[*memo.UDFDefinition]*memo.UDFDefinition
 	replaceFn = func(e opt.Expr) opt.Expr {
 		switch t := e.(type) {
@@ -359,38 +360,30 @@ func (f *Factory) AssignPlaceholders(from *memo.Memo) (retErr error) {
 		case *memo.UDFCallExpr:
 			// Statements in the body of a UDF cannot have placeholders, but
 			// they must be copied so that they reference the new memo.
-			if t.Def.IsRecursive {
-				// It is possible for a routine to recursively invoke itself (e.g. for a
-				// loop), so we have to keep track of which recursive routines we have
-				// seen to avoid infinite recursion.
-				if _, seen := recursiveRoutines[t.Def]; seen {
-					return e
-				}
-				if recursiveRoutines == nil {
-					recursiveRoutines = make(map[*memo.UDFDefinition]struct{})
-				}
-				recursiveRoutines[t.Def] = struct{}{}
+			if newRoutineDefs == nil {
+				newRoutineDefs = make(map[*memo.UDFDefinition]*memo.UDFDefinition)
 			}
+
 			// Copy the arguments, if any.
 			var newArgs memo.ScalarListExpr
 			if t.Args != nil {
 				copiedArgs := f.CopyAndReplaceDefault(&t.Args, replaceFn).(*memo.ScalarListExpr)
 				newArgs = *copiedArgs
 			}
-			if newRoutineDefs == nil {
-				newRoutineDefs = make(map[*memo.UDFDefinition]*memo.UDFDefinition)
-			}
+
+			// Check if we've seen this UDF already.
 			newDef, ok := newRoutineDefs[t.Def]
 			if !ok {
-				// Make sure to copy the slice that stores the body statements, rather
-				// than mutating the original.
+				// Add the new definition before copying the body to handle recursion.
 				defCopy := *t.Def
-				defCopy.Body = make([]memo.RelExpr, len(t.Def.Body))
-				for i := range t.Def.Body {
-					defCopy.Body[i] = f.CopyAndReplaceDefault(t.Def.Body[i], replaceFn).(memo.RelExpr)
-				}
 				newDef = &defCopy
 				newRoutineDefs[t.Def] = newDef
+				// Make sure to copy the slice that stores the body statements, rather
+				// than mutating the original.
+				newDef.Body = make([]memo.RelExpr, len(t.Def.Body))
+				for i := range t.Def.Body {
+					newDef.Body[i] = f.CopyAndReplaceDefault(t.Def.Body[i], replaceFn).(memo.RelExpr)
+				}
 			}
 			return f.ConstructUDFCall(newArgs, &memo.UDFCallPrivate{Def: newDef})
 		case *memo.RecursiveCTEExpr:


### PR DESCRIPTION
As Drew pointed out in https://github.com/cockroachdb/cockroach/pull/162512#pullrequestreview-3757963944 we can use the `newRoutineDefs` map to also handle the recursive routines case, which lets us get rid of the `recursiveRoutines` map.

Informs: #161993

Release note: None

🤖 Generated with [Claude Code](https://claude.ai/code)