### PR TITLE
workload/schemachange: add version gate for unique constraint drop

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -2002,13 +2002,21 @@ func (og *operationGenerator) dropConstraint(ctx context.Context, tx pgx.Tx) (*o
 
 	// DROP INDEX CASCADE is preferred for dropping unique constraints, and
 	// dropping the constraint with ALTER TABLE ... DROP CONSTRAINT is not
-	// supported by the legacy schema changer.
+	// supported by the legacy schema changer. The declarative schema changer
+	// added support for this in v26.2, so in mixed-version clusters running
+	// older versions, the error is still expected.
 	constraintIsUnique, err := og.constraintIsUnique(ctx, tx, tableName, constraintName)
 	if err != nil {
 		return nil, err
 	}
-	if constraintIsUnique && !og.useDeclarativeSchemaChanger {
-		stmt.expectedExecErrors.add(pgcode.FeatureNotSupported)
+	if constraintIsUnique {
+		uniqueDropNotSupported, err := isClusterVersionLessThan(ctx, tx, clusterversion.V26_2.Version())
+		if err != nil {
+			return nil, err
+		}
+		if !og.useDeclarativeSchemaChanger || uniqueDropNotSupported {
+			stmt.expectedExecErrors.add(pgcode.FeatureNotSupported)
+		}
 	}
 
 	constraintAddingOrDropping, err := og.constraintInAddOrDropState(ctx, tx, tableName, constraintName)


### PR DESCRIPTION
The random schema workload expected that dropping a unique constraint via `ALTER TABLE ... DROP CONSTRAINT` would always succeed when using the declarative schema changer. However, declarative support for this was only added in v26.2. In mixed-version clusters where some nodes run an older version, the declarative schema changer falls back to the legacy schema changer, which returns a FeatureNotSupported error.

Add a cluster version check so the workload expects the error when the cluster version is less than v26.2.

Resolves: #163149

Release note: None