### PR TITLE
release-26.1: roachtest: restrict kv-rangefeed to GCE only

### DIFF
--- a/pkg/cmd/roachtest/tests/kv_rangefeed.go
+++ b/pkg/cmd/roachtest/tests/kv_rangefeed.go
@@ -501,7 +501,11 @@ func registerKVRangefeed(r registry.Registry) {
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runKVRangefeed(ctx, t, c, opts)
 			},
-			CompatibleClouds: registry.AllClouds,
+			// This test is compatible with all clouds, but suspected disk
+			// throughput issues (e.g. gp3 on AWS) and lower observability
+			// (no Grafana on AWS) prompted us to restrict to GCE for the
+			// time being. See #163197.
+			CompatibleClouds: registry.OnlyGCE,
 			Suites:           registry.Suites(registry.Nightly),
 		})
 	}


### PR DESCRIPTION
Backport 1/1 commits from #163204 on behalf of @tbg.

----

The kv-rangefeed roachtest has been experiencing recurring failures across clouds, but with different characteristics. On AWS, the sink-rate=8000 variant repeatedly fails during workload init with "ambiguous result" errors caused by circuit breaker trips from slow Raft proposals, correlated with Pebble write stalls and IO overload on gp3 volumes. Additionally, AWS clusters lack Grafana integration, making triage significantly harder.

Restrict the test to GCE for the time being, where pd-ssd provides better disk throughput and Grafana dashboards are available for investigating failures.

Closes #163197
Epic: None

Release note: None

----

Release justification: test flake improvement