### PR TITLE
kv: fix tests failing due to incorrect error codes returned by drpc

### DIFF
--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -2867,10 +2867,6 @@ func TestReportUnreachableHeartbeats(t *testing.T) {
 	ctx := context.Background()
 	tc := testcluster.StartTestCluster(t, 3,
 		base.TestClusterArgs{
-			ServerArgs: base.TestServerArgs{
-				// TODO(server): enabled DRPC once serverutils adds support for DRPC.
-				DefaultDRPCOption: base.TestDRPCDisabled,
-			},
 			ReplicationMode: base.ReplicationManual,
 		})
 	defer tc.Stopper().Stop(ctx)

--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -559,8 +559,7 @@ func TestFlowControlCrashedNodeV2(t *testing.T) {
 		tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{
 			ReplicationMode: base.ReplicationManual,
 			ServerArgs: base.TestServerArgs{
-				DefaultDRPCOption: base.TestDRPCDisabled,
-				Settings:          settings,
+				Settings: settings,
 				RaftConfig: base.RaftConfig{
 					// Reduce the RangeLeaseDuration to speeds up failure detection
 					// below.
@@ -1813,10 +1812,7 @@ func TestFlowControlSendQueue(t *testing.T) {
 	}
 
 	tc := testcluster.StartTestCluster(t, 5, base.TestClusterArgs{
-		ReplicationMode: base.ReplicationManual,
-		ServerArgs: base.TestServerArgs{
-			DefaultDRPCOption: base.TestDRPCDisabled,
-		},
+		ReplicationMode:   base.ReplicationManual,
 		ServerArgsPerNode: stickyArgsPerServer,
 	})
 	defer tc.Stopper().Stop(ctx)
@@ -3346,10 +3342,7 @@ func TestFlowControlSendQueueRangeFeed(t *testing.T) {
 	}
 
 	tc := testcluster.StartTestCluster(t, numNodes, base.TestClusterArgs{
-		ReplicationMode: base.ReplicationManual,
-		ServerArgs: base.TestServerArgs{
-			DefaultDRPCOption: base.TestDRPCDisabled,
-		},
+		ReplicationMode:   base.ReplicationManual,
 		ServerArgsPerNode: argsPerServer,
 	})
 	defer tc.Stopper().Stop(ctx)

--- a/pkg/kv/kvserver/replica_learner_test.go
+++ b/pkg/kv/kvserver/replica_learner_test.go
@@ -1055,9 +1055,6 @@ func TestSnapshotsToDrainingNodes(t *testing.T) {
 		tc := testcluster.StartTestCluster(
 			t, 2, base.TestClusterArgs{
 				ReplicationMode: base.ReplicationManual,
-				ServerArgs: base.TestServerArgs{
-					DefaultDRPCOption: base.TestDRPCDisabled,
-				},
 			},
 		)
 		defer tc.Stopper().Stop(ctx)

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -231,10 +231,7 @@ func TestReplicateQueueRebalanceMultiStore(t *testing.T) {
 			}
 			// Set up a test cluster with multiple stores per node if needed.
 			args := base.TestClusterArgs{
-				ReplicationMode: base.ReplicationAuto,
-				ServerArgs: base.TestServerArgs{
-					DefaultDRPCOption: base.TestDRPCDisabled,
-				},
+				ReplicationMode:   base.ReplicationAuto,
 				ServerArgsPerNode: map[int]base.TestServerArgs{},
 			}
 			for i := 0; i < testCase.nodes; i++ {


### PR DESCRIPTION
Previously, errors returned by DRPC were not consistently mapped to the gRPC status codes expected by certain database code paths, causing test failures.

cockroachdb/drpc#28 updates DRPC to translate errors into the appropriate gRPC status errors for backward compatibility with gRPC.

This change consumes the DRPC updates from the above PR and restores the previously failing tests.

All tests pass with DRPC enabled across default, shared, and external tenant modes (verified with 25 runs each).

Epic: CRDB-55382
Fixes: #161568
Fixes: #161555
Fixes: #161574
Fixes: #161575
Fixes: #161577
Fixes: #161578
Release note: None