### PR TITLE
release-25.4: roachprod: don't propagate errors from prometheus target updates

### DIFF
--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -792,11 +792,25 @@ func UpdateTargets(
 	if err := LoadClusters(); err != nil {
 		return err
 	}
-	return updatePrometheusTargets(ctx, l, clusterName, clusterSettingsOpts...)
+	updatePrometheusTargets(ctx, l, clusterName, clusterSettingsOpts...)
+	return nil
 }
 
-// updatePrometheusTargets updates the prometheus instance cluster config. Any error is logged and ignored.
+// updatePrometheusTargets updates the prometheus instance cluster config.
+// This is best-effort: errors are logged but never propagated, since
+// monitoring failures should not cause test or start failures.
 func updatePrometheusTargets(
+	ctx context.Context,
+	l *logger.Logger,
+	clusterName string,
+	clusterSettingsOpts ...install.ClusterSettingOption,
+) {
+	if err := updatePrometheusTargetsErr(ctx, l, clusterName, clusterSettingsOpts...); err != nil {
+		l.Errorf("updating prometheus targets: %v", err)
+	}
+}
+
+func updatePrometheusTargetsErr(
 	ctx context.Context,
 	l *logger.Logger,
 	clusterName string,
@@ -887,10 +901,10 @@ func updatePrometheusTargets(
 	if len(nodeIPPorts) > 0 {
 		cl, err := promhelperclient.NewPromClient()
 		if err != nil {
-			return err
+			return errors.Wrap(err, "creating prometheus helper client")
 		}
 		if err := cl.UpdatePrometheusTargets(ctx, c.Name, nodeIPPorts, l); err != nil {
-			l.Errorf("creating cluster config failed for the ip:ports %v: %v", nodeIPPorts, err)
+			return errors.Wrapf(err, "updating targets for ip:ports %v", nodeIPPorts)
 		}
 	}
 	return nil


### PR DESCRIPTION
Backport 1/1 commits from #163270 on behalf of @tbg.

----

Previously, `updatePrometheusTargets` returned errors from
`NewPromClient()` and `newCluster()` as hard failures. This caused
transient GCE infrastructure errors (such as IAP token HTTP 503s) to
fail roachtests during node restarts, even though the CockroachDB node
itself started successfully. There is a long history of issues caused
by this (all closed as infra flakes): #160684, #160180, #160775,
#161369, #158320, #157870.

The function's own comment stated that errors should be "logged and
ignored", but two of the three error paths were propagated. Split the
function into a thin best-effort wrapper (`updatePrometheusTargets`, which
logs and swallows errors) and an inner function
(`updatePrometheusTargetsErr`) that uses natural error returns. This
enforces at the call site that monitoring failures can never cause test
or start failures.

Fixes-26.1: #163205
Epic: None

Release note: None

Made with [Cursor](https://cursor.com)

----

Release justification: