### PR TITLE
jobs: fix tests failing due to incorrect error codes returned by drpc

### DIFF
--- a/pkg/jobs/jobsprofiler/profiler_test.go
+++ b/pkg/jobs/jobsprofiler/profiler_test.go
@@ -43,8 +43,6 @@ func TestProfilerStorePlanDiagram(t *testing.T) {
 		Knobs: base.TestingKnobs{
 			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 		},
-		// already inconsistently failing, disabling to avoid noise, see #158660
-		DefaultDRPCOption: base.TestDRPCDisabled,
 	})
 	ctx := context.Background()
 	defer s.Stopper().Stop(ctx)


### PR DESCRIPTION
Previously, errors returned by DRPC were not consistently mapped to the gRPC status codes expected by certain database code paths, causing test failures.

cockroachdb/drpc#28 updates DRPC to translate errors into the appropriate gRPC status errors for backward compatibility with gRPC.

This change consumes the DRPC updates from the above PR and restores the previously failing tests.

All tests pass with DRPC enabled across default, shared, and external tenant modes (verified with 25 runs each).

Epic: CRDB-55382
Fixes: #161563
Release note: None