### PR TITLE
kvserver/concurrency: keep latest ClockWhilePending in pendingTxnCache

### DIFF
--- a/pkg/kv/kvserver/concurrency/lock_table_waiter.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter.go
@@ -980,10 +980,9 @@ func (c *pendingTxnCache) add(
 			newEntry.Txn = txn
 		}
 
-		// Always keep the earliest ClockWhilePending available.
-		if (currentEntry.ClockWhilePending == roachpb.ObservedTimestamp{}) ||
-			((clockObservation != roachpb.ObservedTimestamp{}) &&
-				clockObservation.Timestamp.Less(currentEntry.ClockWhilePending.Timestamp)) {
+		// Always keep the latest ClockWhilePending available.
+		if !clockObservation.Timestamp.IsEmpty() &&
+			currentEntry.ClockWhilePending.Timestamp.Less(clockObservation.Timestamp) {
 			newEntry.ClockWhilePending = clockObservation
 		}
 


### PR DESCRIPTION
(*pendingTxnCache).add was preserving the earliest ClockWhilePending observation. That is stricter than needed. Pending pushed txn resolution checks `observed_ts <= ClockWhilePending`, so a later observation allows more cache hits.

Release note: None
Epic: None