### PR TITLE
mmaintegration: add capped multiplier CPU capacity model

### DIFF
--- a/pkg/kv/kvserver/mmaintegration/BUILD.bazel
+++ b/pkg/kv/kvserver/mmaintegration/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
     name = "mmaintegration_test",
     srcs = [
         "capacity_model_test.go",
+        "legacy_model_test.go",
         "mma_conversion_test.go",
         "store_status_test.go",
     ],

--- a/pkg/kv/kvserver/mmaintegration/BUILD.bazel
+++ b/pkg/kv/kvserver/mmaintegration/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "allocator_op.go",
         "allocator_sync.go",
+        "capacity_model.go",
         "mma_conversion.go",
         "store_load_msg.go",
         "store_status.go",
@@ -31,6 +32,7 @@ go_library(
 go_test(
     name = "mmaintegration_test",
     srcs = [
+        "capacity_model_test.go",
         "mma_conversion_test.go",
         "store_status_test.go",
     ],
@@ -44,6 +46,7 @@ go_test(
         "//pkg/roachpb",
         "//pkg/testutils/datapathutils",
         "//pkg/testutils/echotest",
+        "//pkg/util/humanizeutil",
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "@com_github_cockroachdb_datadriven//:datadriven",

--- a/pkg/kv/kvserver/mmaintegration/capacity_model.go
+++ b/pkg/kv/kvserver/mmaintegration/capacity_model.go
@@ -33,111 +33,6 @@ type storeCPURateCapacityInput struct {
 	numStores int32
 }
 
-// computeStoreCPURateCapacity computes the CPU rate capacity for a single store
-// given node-level CPU metrics. The model ensures that the mean store
-// utilization (sum of store loads / sum of store capacities) equals the
-// node-level CPU utilization, so that overload is detected at the store level
-// exactly when it is detected at the node level. Individual stores may have
-// different utilizations depending on their load.
-//
-// The two cases are:
-//
-//  1. Normal: storesCPURate > 0, cpuUtil >= 0.01.
-//     We compute cpuUtil = nodeCPURateUsage / nodeCPURateCapacity, then
-//     derive a per-store capacity = (storesCPURate / cpuUtil) / numStores.
-//     See MakeStoreLoadMsg for why this construction preserves the
-//     node-level utilization as the mean store-level utilization.
-//
-//  2. Low utilization fallback: storesCPURate is zero or cpuUtil < 0.01.
-//     We assume 50% of the node capacity is attributable to stores and
-//     split evenly.
-//
-// Panics if numStores <= 0 or nodeCPURateCapacity <= 0.
-func computeStoreCPURateCapacity(in storeCPURateCapacityInput) mmaprototype.LoadValue {
-	if in.numStores <= 0 || in.nodeCPURateCapacity <= 0 {
-		log.KvDistribution.Fatalf(context.Background(), "numStores and nodeCPURateCapacity must be > 0")
-	}
-
-	// CPU is a shared resource across all stores on a node, and we choose to
-	// divide the CPU capacity evenly across stores on the node (any other
-	// choice would be arbitrary).
-	//
-	// Furthermore, there are CPU consumers that we don't track on a
-	// per-replica (and thus per-store) level. Examples include RPC work, Go
-	// GC, SQL work etc. Some of the distributed SQL work could be happening
-	// because of a local replica, so ideally we should improve our
-	// instrumentation to track it per replica. Due to these gaps, we expect
-	// the NodeCPURateCapacity to be higher than StoresCPURate. So simply
-	// using NodeCPURateCapacity/NumStores as the per-store capacity would
-	// lead to over-utilization.
-	//
-	// Our approach is to apply the CPU utilization to StoresCPURate to
-	// compute a capacity and divide that evenly across stores. Specifically,
-	//
-	//   cpuUtil = NodeCPURateUsage/NodeCPURateCapacity
-	//
-	// we want to define StoresCPURateCapacity such that
-	//
-	//    StoresCPURate/StoresCPURateCapacity = cpuUtil,
-	//
-	// i.e. we want to give the (collective) stores a capacity that results
-	// in the same utilization as reported at the process (node) level, i.e.
-	//
-	//    StoresCPURateCapacity = StoresCPURate/cpuUtil.
-	//
-	// Finally, we split StoresCPURateCapacity evenly across the stores.
-	//
-	// This construction ensures that there is overload as measured by node
-	// CPU usage exactly when there is overload as measured by mean store
-	// CPU usage:
-	//
-	// meanCPUUtil = sum_i StoreCPURate_i / sum_i StoreCPURateCapacity_i
-	//             = 1/StoresCPURateCapacity * sum_i StoreCPURate_i
-	//             = StoresCPURate / StoresCPURateCapacity
-	//             = cpuUtil
-	//
-	// The above mathematical property is used to avoid having any explicit
-	// communication of node load to MMA. The
-	// NodeLoad.{ReportedCPU,CapacityCPU} is incrementally maintained as a sum
-	// of the load and capacity reported by each store (at different times).
-	//
-	// Additionally, when the meanCPUUtil indicates overload, at least one
-	// store will be above that mean, so it is overloaded as well and will
-	// induce load shedding.
-	//
-	// It's worth noting that this construction assumes that all load on the
-	// node is due to the stores. Take an extreme example in which there is
-	// a single store using up 1vcpu, but the node is fully utilized (at,
-	// say, 16 vcpus). In this case, the node will be at 100%, and we will
-	// assign a capacity of 1 to the store, i.e. the store will also be at
-	// 100% utilization despite contributing only 1/16th of the node CPU
-	// utilization. The effect of the construction is that the store will
-	// take on responsibility for shedding load to compensate for auxiliary
-	// consumption of CPU, which is generally sensible.
-	cpuUtil := in.nodeCPURateUsage / in.nodeCPURateCapacity
-	// cpuUtil can be zero or close to zero.
-	almostZeroUtil := cpuUtil < 0.01
-	if in.storesCPURate == 0 || almostZeroUtil {
-		// almostZeroUtil or StoresCPURate is zero. We assume that only 50% of
-		// the usage can be accounted for in StoresCPURate, so we divide 50% of
-		// the NodeCPURateCapacity among all the stores.
-		return mmaprototype.LoadValue(in.nodeCPURateCapacity / 2 / float64(in.numStores))
-	}
-	// cpuUtil is distributed across the stores, by constructing a
-	// nodeCapacity, and then splitting nodeCapacity evenly across all the
-	// stores. If the cpuUtil of a node is higher than the mean across nodes
-	// of the cluster, then cpu util of at least one store on that node will
-	// be higher than the mean across all stores in the cluster (since the
-	// cpu util of a node is simply the mean across all its stores), which
-	// will result in load shedding. Note that this can cause cpu util of a
-	// store to be > 100% e.g. if a node is at 80% cpu util and has 10
-	// stores, and all the cpu usage is due to store s1, then s1 will have
-	// 800% util.
-	nodeCapacity := in.storesCPURate / cpuUtil
-	storeCapacity := nodeCapacity / float64(in.numStores)
-	return mmaprototype.LoadValue(storeCapacity)
-}
-
 // computeStoreByteSizeCapacity computes the byte size (disk) capacity for a
 // store. The load is LogicalBytes (uncompressed) and the capacity is expressed
 // in the same LogicalBytes-space, so that load/capacity recovers the actual
@@ -183,9 +78,10 @@ func computeStoreByteSizeCapacity(
 const cpuIndirectOverheadMultiplier = 3.0
 
 // computeCPUCapacityWithCap computes per-store CPU capacity using a clamped
-// multiplier. Unlike computeStoreCPURateCapacity (which assumes all node CPU
-// usage is caused by MMA-tracked store work), this model distinguishes between
-// MMA-attributed load and background load.
+// multiplier. Unlike the naive model (computeStoreCPURateCapacityNaive in
+// legacy_model_test.go, which assumes all node CPU usage is caused by
+// MMA-tracked store work), this model distinguishes between MMA-attributed
+// load and background load.
 //
 // The formula:
 //

--- a/pkg/kv/kvserver/mmaintegration/capacity_model.go
+++ b/pkg/kv/kvserver/mmaintegration/capacity_model.go
@@ -113,10 +113,7 @@ const cpuIndirectOverheadMultiplier = 3.0
 // When storesCPURate is 0 (no replicas reporting CPU yet), we use the limiting
 // behavior: MMA attributes none of the node usage to itself (all is
 // background), and divides the idle capacity by the multiplier across stores.
-func computeCPUCapacityWithCap(
-	in storeCPURateCapacityInput,
-	observer func(mult float64, backgroundLoad float64, mmaShareOfCapacity float64, mmaDirectCapacity float64),
-) (capacity float64) {
+func computeCPUCapacityWithCap(in storeCPURateCapacityInput) (capacity float64) {
 	mult := 0.0
 	if in.numStores <= 0 || in.nodeCPURateCapacity <= 0 {
 		log.KvDistribution.Fatalf(context.Background(), "numStores and nodeCPURateCapacity must be > 0")
@@ -155,6 +152,5 @@ func computeCPUCapacityWithCap(
 
 	// Divide evenly across stores.
 	capacity = mmaDirectCapacity / float64(in.numStores)
-	observer(mult, backgroundLoad, mmaShareOfCapacity, mmaDirectCapacity)
 	return capacity
 }

--- a/pkg/kv/kvserver/mmaintegration/capacity_model.go
+++ b/pkg/kv/kvserver/mmaintegration/capacity_model.go
@@ -245,7 +245,9 @@ func computeCPUCapacityWithCap(
 	backgroundLoad := max(0.0, nodeCPURateUsage-mmaAttributedLoad)
 
 	// MMA's share of capacity is what remains after background load.
-	mmaShareOfCapacity := nodeCPURateCapacity - backgroundLoad
+	// Clamp to non-negative to handle overloaded nodes where backgroundLoad
+	// exceeds nodeCPURateCapacity.
+	mmaShareOfCapacity := max(0.0, nodeCPURateCapacity-backgroundLoad)
 
 	// MMA's direct capacity is scaled down by the multiplier to account
 	// for indirect overhead.

--- a/pkg/kv/kvserver/mmaintegration/capacity_model.go
+++ b/pkg/kv/kvserver/mmaintegration/capacity_model.go
@@ -1,0 +1,161 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package mmaintegration
+
+import "github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/mmaprototype"
+
+// This file contains the capacity model functions used by MMA to derive
+// per-store capacity from node-level and disk-level metrics. These are
+// extracted here so they can be unit tested directly.
+
+// computeStoreCPURateCapacity computes the CPU rate capacity for a single store
+// given node-level CPU metrics. The model ensures that the per-store utilization
+// (load/capacity) equals the node-level CPU utilization, so that overload is
+// detected at the store level exactly when it is detected at the node level.
+//
+// The three cases are:
+//
+//  1. Normal: nodeCPURateCapacity > 0, storesCPURate > 0, cpuUtil >= 0.01.
+//     We compute cpuUtil = nodeCPURateUsage / nodeCPURateCapacity, then
+//     derive a per-store capacity = (storesCPURate / cpuUtil) / numStores.
+//     See MakeStoreLoadMsg for why this construction preserves the
+//     node-level utilization as the mean store-level utilization.
+//
+//  2. Low utilization fallback: nodeCPURateCapacity > 0, but storesCPURate
+//     is zero or cpuUtil < 0.01. We assume 50% of the node capacity is
+//     attributable to stores and split evenly.
+//
+//  3. Unknown capacity: nodeCPURateCapacity <= 0 (should not happen in
+//     production). Falls back to assuming 50% utilization from the store's
+//     own CPU usage.
+func computeStoreCPURateCapacity(
+	currentStoreCPUUsage mmaprototype.LoadValue,
+	nodeCPURateUsage float64,
+	nodeCPURateCapacity float64,
+	storesCPURate float64,
+	numStores int32,
+) mmaprototype.LoadValue {
+	if nodeCPURateCapacity > 0 {
+		// CPU is a shared resource across all stores on a node, and we choose to
+		// divide the CPU capacity evenly across stores on the node (any other
+		// choice would be arbitrary).
+		//
+		// Furthermore, there are CPU consumers that we don't track on a
+		// per-replica (and thus per-store) level. Examples include RPC work, Go
+		// GC, SQL work etc. Some of the distributed SQL work could be happening
+		// because of a local replica, so ideally we should improve our
+		// instrumentation to track it per replica. Due to these gaps, we expect
+		// the NodeCPURateCapacity to be higher than StoresCPURate. So simply
+		// using NodeCPURateCapacity/NumStores as the per-store capacity would
+		// lead to over-utilization.
+		//
+		// Our approach is to apply the CPU utilization to StoresCPURate to
+		// compute a capacity and divide that evenly across stores. Specifically,
+		//
+		//   cpuUtil = NodeCPURateUsage/NodeCPURateCapacity
+		//
+		// we want to define StoresCPURateCapacity such that
+		//
+		//    StoresCPURate/StoresCPURateCapacity = cpuUtil,
+		//
+		// i.e. we want to give the (collective) stores a capacity that results
+		// in the same utilization as reported at the process (node) level, i.e.
+		//
+		//    StoresCPURateCapacity = StoresCPURate/cpuUtil.
+		//
+		// Finally, we split StoresCPURateCapacity evenly across the stores.
+		//
+		// This construction ensures that there is overload as measured by node
+		// CPU usage exactly when there is overload as measured by mean store
+		// CPU usage:
+		//
+		// meanCPUUtil = sum_i StoreCPURate_i / sum_i StoreCPURateCapacity_i
+		//             = 1/StoresCPURateCapacity * sum_i StoreCPURate_i
+		//             = StoresCPURate / StoresCPURateCapacity
+		//             = cpuUtil
+		//
+		// The above mathematical property is used to avoid having any explicit
+		// communication of node load to MMA. The
+		// NodeLoad.{ReportedCPU,CapacityCPU} is incrementally maintained as a sum
+		// of the load and capacity reported by each store (at different times).
+		//
+		// Additionally, when the meanCPUUtil indicates overload, at least one
+		// store will be above that mean, so it is overloaded as well and will
+		// induce load shedding.
+		//
+		// It's worth noting that this construction assumes that all load on the
+		// node is due to the stores. Take an extreme example in which there is
+		// a single store using up 1vcpu, but the node is fully utilized (at,
+		// say, 16 vcpus). In this case, the node will be at 100%, and we will
+		// assign a capacity of 1 to the store, i.e. the store will also be at
+		// 100% utilization despite contributing only 1/16th of the node CPU
+		// utilization. The effect of the construction is that the store will
+		// take on responsibility for shedding load to compensate for auxiliary
+		// consumption of CPU, which is generally sensible.
+		cpuUtil := nodeCPURateUsage / nodeCPURateCapacity
+		// cpuUtil can be zero or close to zero.
+		almostZeroUtil := cpuUtil < 0.01
+		if storesCPURate != 0 && !almostZeroUtil {
+			// cpuUtil is distributed across the stores, by constructing a
+			// nodeCapacity, and then splitting nodeCapacity evenly across all the
+			// stores. If the cpuUtil of a node is higher than the mean across nodes
+			// of the cluster, then cpu util of at least one store on that node will
+			// be higher than the mean across all stores in the cluster (since the
+			// cpu util of a node is simply the mean across all its stores), which
+			// will result in load shedding. Note that this can cause cpu util of a
+			// store to be > 100% e.g. if a node is at 80% cpu util and has 10
+			// stores, and all the cpu usage is due to store s1, then s1 will have
+			// 800% util.
+			nodeCapacity := storesCPURate / cpuUtil
+			storeCapacity := nodeCapacity / float64(numStores)
+			return mmaprototype.LoadValue(storeCapacity)
+		}
+		// almostZeroUtil or StoresCPURate is zero. We assume that only 50% of
+		// the usage can be accounted for in StoresCPURate, so we divide 50% of
+		// the NodeCPURateCapacity among all the stores.
+		return mmaprototype.LoadValue(nodeCPURateCapacity / 2 / float64(numStores))
+	}
+	// TODO(sumeer): remove this hack of defaulting to 50% utilization, since
+	// NodeCPURateCapacity should never be 0.
+	// TODO(tbg): when do we expect to hit this branch? Mixed version cluster?
+	return currentStoreCPUUsage * 2
+}
+
+// computeStoreByteSizeCapacity computes the byte size (disk) capacity for a
+// store. The load is LogicalBytes (uncompressed) and the capacity is expressed
+// in the same LogicalBytes-space, so that load/capacity recovers the actual
+// disk utilization.
+//
+// The two cases are:
+//
+//  1. Normal: logicalBytes > 0 and diskFractionUsed >= 0.01.
+//     capacity = logicalBytes / diskFractionUsed.
+//     This encodes the space amplification factor (physical/logical) into
+//     the capacity, so that highDiskSpaceUtilization(load, capacity, threshold)
+//     recovers the real disk utilization.
+//
+//  2. Empty/new store: logicalBytes is 0 or diskFractionUsed < 0.01.
+//     We fall back to availableBytes (compressed/physical), which is
+//     pessimistic since LogicalBytes are uncompressed.
+//
+// diskFractionUsed should be computed via StoreCapacity.FractionUsed(), which
+// prefers Used/(Available+Used) to scope utilization to the store's own data.
+// Available does not compensate for the ballast, so utilization will look
+// slightly higher than actual. This is acceptable since the ballast is small
+// (default 1% of capacity) and is for emergency use.
+func computeStoreByteSizeCapacity(
+	logicalBytes mmaprototype.LoadValue, diskFractionUsed float64, availableBytes int64,
+) mmaprototype.LoadValue {
+	almostZeroUtil := diskFractionUsed < 0.01
+	if logicalBytes != 0 && !almostZeroUtil {
+		// Normal case. The store has some ranges, and is not almost empty.
+		return mmaprototype.LoadValue(float64(logicalBytes) / diskFractionUsed)
+	}
+	// Has no ranges or is almost empty. This is likely a new store. Since
+	// LogicalBytes are uncompressed, we start with the compressed available,
+	// which is desirably pessimistic.
+	return mmaprototype.LoadValue(availableBytes)
+}

--- a/pkg/kv/kvserver/mmaintegration/capacity_model.go
+++ b/pkg/kv/kvserver/mmaintegration/capacity_model.go
@@ -38,90 +38,94 @@ func computeStoreCPURateCapacity(
 	storesCPURate float64,
 	numStores int32,
 ) mmaprototype.LoadValue {
-	if nodeCPURateCapacity > 0 {
-		// CPU is a shared resource across all stores on a node, and we choose to
-		// divide the CPU capacity evenly across stores on the node (any other
-		// choice would be arbitrary).
-		//
-		// Furthermore, there are CPU consumers that we don't track on a
-		// per-replica (and thus per-store) level. Examples include RPC work, Go
-		// GC, SQL work etc. Some of the distributed SQL work could be happening
-		// because of a local replica, so ideally we should improve our
-		// instrumentation to track it per replica. Due to these gaps, we expect
-		// the NodeCPURateCapacity to be higher than StoresCPURate. So simply
-		// using NodeCPURateCapacity/NumStores as the per-store capacity would
-		// lead to over-utilization.
-		//
-		// Our approach is to apply the CPU utilization to StoresCPURate to
-		// compute a capacity and divide that evenly across stores. Specifically,
-		//
-		//   cpuUtil = NodeCPURateUsage/NodeCPURateCapacity
-		//
-		// we want to define StoresCPURateCapacity such that
-		//
-		//    StoresCPURate/StoresCPURateCapacity = cpuUtil,
-		//
-		// i.e. we want to give the (collective) stores a capacity that results
-		// in the same utilization as reported at the process (node) level, i.e.
-		//
-		//    StoresCPURateCapacity = StoresCPURate/cpuUtil.
-		//
-		// Finally, we split StoresCPURateCapacity evenly across the stores.
-		//
-		// This construction ensures that there is overload as measured by node
-		// CPU usage exactly when there is overload as measured by mean store
-		// CPU usage:
-		//
-		// meanCPUUtil = sum_i StoreCPURate_i / sum_i StoreCPURateCapacity_i
-		//             = 1/StoresCPURateCapacity * sum_i StoreCPURate_i
-		//             = StoresCPURate / StoresCPURateCapacity
-		//             = cpuUtil
-		//
-		// The above mathematical property is used to avoid having any explicit
-		// communication of node load to MMA. The
-		// NodeLoad.{ReportedCPU,CapacityCPU} is incrementally maintained as a sum
-		// of the load and capacity reported by each store (at different times).
-		//
-		// Additionally, when the meanCPUUtil indicates overload, at least one
-		// store will be above that mean, so it is overloaded as well and will
-		// induce load shedding.
-		//
-		// It's worth noting that this construction assumes that all load on the
-		// node is due to the stores. Take an extreme example in which there is
-		// a single store using up 1vcpu, but the node is fully utilized (at,
-		// say, 16 vcpus). In this case, the node will be at 100%, and we will
-		// assign a capacity of 1 to the store, i.e. the store will also be at
-		// 100% utilization despite contributing only 1/16th of the node CPU
-		// utilization. The effect of the construction is that the store will
-		// take on responsibility for shedding load to compensate for auxiliary
-		// consumption of CPU, which is generally sensible.
-		cpuUtil := nodeCPURateUsage / nodeCPURateCapacity
-		// cpuUtil can be zero or close to zero.
-		almostZeroUtil := cpuUtil < 0.01
-		if storesCPURate != 0 && !almostZeroUtil {
-			// cpuUtil is distributed across the stores, by constructing a
-			// nodeCapacity, and then splitting nodeCapacity evenly across all the
-			// stores. If the cpuUtil of a node is higher than the mean across nodes
-			// of the cluster, then cpu util of at least one store on that node will
-			// be higher than the mean across all stores in the cluster (since the
-			// cpu util of a node is simply the mean across all its stores), which
-			// will result in load shedding. Note that this can cause cpu util of a
-			// store to be > 100% e.g. if a node is at 80% cpu util and has 10
-			// stores, and all the cpu usage is due to store s1, then s1 will have
-			// 800% util.
-			nodeCapacity := storesCPURate / cpuUtil
-			storeCapacity := nodeCapacity / float64(numStores)
-			return mmaprototype.LoadValue(storeCapacity)
-		}
+	if nodeCPURateCapacity <= 0 {
+		// TODO(sumeer): remove this hack of defaulting to 50% utilization, since
+		// NodeCPURateCapacity should never be 0.
+		// TODO(tbg): when do we expect to hit this branch? Mixed version cluster?
+		return currentStoreCPUUsage * 2
+	}
+	if numStores <= 0 {
+		return 0
+	}
+
+	// CPU is a shared resource across all stores on a node, and we choose to
+	// divide the CPU capacity evenly across stores on the node (any other
+	// choice would be arbitrary).
+	//
+	// Furthermore, there are CPU consumers that we don't track on a
+	// per-replica (and thus per-store) level. Examples include RPC work, Go
+	// GC, SQL work etc. Some of the distributed SQL work could be happening
+	// because of a local replica, so ideally we should improve our
+	// instrumentation to track it per replica. Due to these gaps, we expect
+	// the NodeCPURateCapacity to be higher than StoresCPURate. So simply
+	// using NodeCPURateCapacity/NumStores as the per-store capacity would
+	// lead to over-utilization.
+	//
+	// Our approach is to apply the CPU utilization to StoresCPURate to
+	// compute a capacity and divide that evenly across stores. Specifically,
+	//
+	//   cpuUtil = NodeCPURateUsage/NodeCPURateCapacity
+	//
+	// we want to define StoresCPURateCapacity such that
+	//
+	//    StoresCPURate/StoresCPURateCapacity = cpuUtil,
+	//
+	// i.e. we want to give the (collective) stores a capacity that results
+	// in the same utilization as reported at the process (node) level, i.e.
+	//
+	//    StoresCPURateCapacity = StoresCPURate/cpuUtil.
+	//
+	// Finally, we split StoresCPURateCapacity evenly across the stores.
+	//
+	// This construction ensures that there is overload as measured by node
+	// CPU usage exactly when there is overload as measured by mean store
+	// CPU usage:
+	//
+	// meanCPUUtil = sum_i StoreCPURate_i / sum_i StoreCPURateCapacity_i
+	//             = 1/StoresCPURateCapacity * sum_i StoreCPURate_i
+	//             = StoresCPURate / StoresCPURateCapacity
+	//             = cpuUtil
+	//
+	// The above mathematical property is used to avoid having any explicit
+	// communication of node load to MMA. The
+	// NodeLoad.{ReportedCPU,CapacityCPU} is incrementally maintained as a sum
+	// of the load and capacity reported by each store (at different times).
+	//
+	// Additionally, when the meanCPUUtil indicates overload, at least one
+	// store will be above that mean, so it is overloaded as well and will
+	// induce load shedding.
+	//
+	// It's worth noting that this construction assumes that all load on the
+	// node is due to the stores. Take an extreme example in which there is
+	// a single store using up 1vcpu, but the node is fully utilized (at,
+	// say, 16 vcpus). In this case, the node will be at 100%, and we will
+	// assign a capacity of 1 to the store, i.e. the store will also be at
+	// 100% utilization despite contributing only 1/16th of the node CPU
+	// utilization. The effect of the construction is that the store will
+	// take on responsibility for shedding load to compensate for auxiliary
+	// consumption of CPU, which is generally sensible.
+	cpuUtil := nodeCPURateUsage / nodeCPURateCapacity
+	// cpuUtil can be zero or close to zero.
+	almostZeroUtil := cpuUtil < 0.01
+	if storesCPURate == 0 || almostZeroUtil {
 		// almostZeroUtil or StoresCPURate is zero. We assume that only 50% of
 		// the usage can be accounted for in StoresCPURate, so we divide 50% of
 		// the NodeCPURateCapacity among all the stores.
 		return mmaprototype.LoadValue(nodeCPURateCapacity / 2 / float64(numStores))
 	}
-	// TODO(sumeer): remove this hack of defaulting to 50% utilization, since
-	// NodeCPURateCapacity should never be 0.
-	// TODO(tbg): when do we expect to hit this branch? Mixed version cluster?
-	return currentStoreCPUUsage * 2
+	// cpuUtil is distributed across the stores, by constructing a
+	// nodeCapacity, and then splitting nodeCapacity evenly across all the
+	// stores. If the cpuUtil of a node is higher than the mean across nodes
+	// of the cluster, then cpu util of at least one store on that node will
+	// be higher than the mean across all stores in the cluster (since the
+	// cpu util of a node is simply the mean across all its stores), which
+	// will result in load shedding. Note that this can cause cpu util of a
+	// store to be > 100% e.g. if a node is at 80% cpu util and has 10
+	// stores, and all the cpu usage is due to store s1, then s1 will have
+	// 800% util.
+	nodeCapacity := storesCPURate / cpuUtil
+	storeCapacity := nodeCapacity / float64(numStores)
+	return mmaprototype.LoadValue(storeCapacity)
 }
 
 // computeStoreByteSizeCapacity computes the byte size (disk) capacity for a
@@ -150,12 +154,12 @@ func computeStoreByteSizeCapacity(
 	logicalBytes mmaprototype.LoadValue, diskFractionUsed float64, availableBytes int64,
 ) mmaprototype.LoadValue {
 	almostZeroUtil := diskFractionUsed < 0.01
-	if logicalBytes != 0 && !almostZeroUtil {
-		// Normal case. The store has some ranges, and is not almost empty.
-		return mmaprototype.LoadValue(float64(logicalBytes) / diskFractionUsed)
+	if logicalBytes == 0 || almostZeroUtil {
+		// Has no ranges or is almost empty. This is likely a new store. Since
+		// LogicalBytes are uncompressed, we start with the compressed available,
+		// which is desirably pessimistic.
+		return mmaprototype.LoadValue(availableBytes)
 	}
-	// Has no ranges or is almost empty. This is likely a new store. Since
-	// LogicalBytes are uncompressed, we start with the compressed available,
-	// which is desirably pessimistic.
-	return mmaprototype.LoadValue(availableBytes)
+	// Normal case. The store has some ranges, and is not almost empty.
+	return mmaprototype.LoadValue(float64(logicalBytes) / diskFractionUsed)
 }

--- a/pkg/kv/kvserver/mmaintegration/capacity_model_test.go
+++ b/pkg/kv/kvserver/mmaintegration/capacity_model_test.go
@@ -63,23 +63,20 @@ func TestComputeStoreCPURateCapacity(t *testing.T) {
 				totalPerStore := nodeCapCores / float64(numStores)
 
 				// Naive model: assumes all node CPU scales directly with store work.
-				naiveResult := computeStoreCPURateCapacity(
-					mmaprototype.LoadValue(storeCPUCores*nsPerCore),
-					nodeUsageCores*nsPerCore,
-					nodeCapCores*nsPerCore,
-					storesCPUCores*nsPerCore,
-					int32(numStores),
-				)
+				in := storeCPURateCapacityInput{
+					currentStoreCPUUsage: mmaprototype.LoadValue(storeCPUCores * nsPerCore),
+					storesCPURate:        storesCPUCores * nsPerCore,
+					nodeCPURateUsage:     nodeUsageCores * nsPerCore,
+					nodeCPURateCapacity:  nodeCapCores * nsPerCore,
+					numStores:            int32(numStores),
+				}
+				naiveResult := computeStoreCPURateCapacity(in)
 				naiveCap := float64(naiveResult) / nsPerCore
 
 				// Capped model: caps the indirect overhead multiplier.
 				var cappedMult, bgLoad, mmaShare, mmaDirect float64
 				cappedCapNs := computeCPUCapacityWithCap(
-					mmaprototype.LoadValue(storeCPUCores*nsPerCore),
-					storesCPUCores*nsPerCore,
-					nodeUsageCores*nsPerCore,
-					nodeCapCores*nsPerCore,
-					int32(numStores),
+					in,
 					func(mult, backgroundLoad, mmaShareOfCapacity, mmaDirectCapacity float64) {
 						cappedMult = mult
 						bgLoad = backgroundLoad / nsPerCore

--- a/pkg/kv/kvserver/mmaintegration/capacity_model_test.go
+++ b/pkg/kv/kvserver/mmaintegration/capacity_model_test.go
@@ -1,0 +1,144 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package mmaintegration
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/mmaprototype"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
+	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/datadriven"
+	"github.com/stretchr/testify/require"
+)
+
+// computeStoreByteSizeCapacityWithOverhead uses (Total-Available)/Total as the
+// disk fraction instead of Used/(Used+Available). This is the wrong model
+// because Total-Available includes filesystem reserved blocks, ballast, and
+// other non-store files on the same mount — all of which inflate the fraction
+// and produce an unrealistically small capacity for stores with little data.
+func computeStoreByteSizeCapacityWrong(
+	logicalBytes mmaprototype.LoadValue, total int64, available int64,
+) mmaprototype.LoadValue {
+	var fullDiskFraction float64
+	if total > 0 {
+		fullDiskFraction = float64(total-available) / float64(total)
+	}
+	return computeStoreByteSizeCapacity(logicalBytes, fullDiskFraction, available)
+}
+
+func TestComputeStoreCPURateCapacity(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// All CPU inputs are in cores (1 core = 1e9 ns/s).
+	const nsPerCore = 1e9
+
+	datadriven.RunTest(t, datapathutils.TestDataPath(t, t.Name()),
+		func(t *testing.T, d *datadriven.TestData) string {
+			switch d.Cmd {
+			case "compute":
+				var storeCPUCores float64
+				var nodeUsageCores, nodeCapCores float64
+				var storesCPUCores float64
+				var numStores int
+
+				d.ScanArgs(t, "store-load", &storeCPUCores)
+				d.ScanArgs(t, "node-cpu-usage", &nodeUsageCores)
+				d.ScanArgs(t, "node-cpu-capacity", &nodeCapCores)
+				d.ScanArgs(t, "total-stores-cpu-usage", &storesCPUCores)
+				d.ScanArgs(t, "num-stores", &numStores)
+
+				result := computeStoreCPURateCapacity(
+					mmaprototype.LoadValue(storeCPUCores*nsPerCore),
+					nodeUsageCores*nsPerCore,
+					nodeCapCores*nsPerCore,
+					storesCPUCores*nsPerCore,
+					int32(numStores),
+				)
+				capacityCores := float64(result) / nsPerCore
+				fairShareCores := nodeCapCores / float64(numStores)
+
+				var storeUtil string
+				if result > 0 {
+					storeUtil = fmt.Sprintf("%.2f%%", storeCPUCores/capacityCores*100)
+				} else {
+					storeUtil = "N/A"
+				}
+				return fmt.Sprintf(
+					"kv-capacity: %.2f cores (total: %.2f cores)\nkv-util: %s (%.2f/%.2f cores)\n",
+					capacityCores, fairShareCores,
+					storeUtil, storeCPUCores, capacityCores,
+				)
+
+			default:
+				return fmt.Sprintf("unknown command: %s", d.Cmd)
+			}
+		})
+}
+
+func TestComputeStoreByteSizeCapacity(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	datadriven.RunTest(t, datapathutils.TestDataPath(t, t.Name()),
+		func(t *testing.T, d *datadriven.TestData) string {
+			switch d.Cmd {
+			case "compute":
+				var logicalBytesStr, totalStr, usedStr, availableStr string
+
+				d.ScanArgs(t, "logical-bytes", &logicalBytesStr)
+				d.ScanArgs(t, "total", &totalStr)
+				d.ScanArgs(t, "used", &usedStr)
+				d.ScanArgs(t, "available", &availableStr)
+
+				logicalBytes, err := humanizeutil.ParseBytes(logicalBytesStr)
+				require.NoError(t, err)
+				total, err := humanizeutil.ParseBytes(totalStr)
+				require.NoError(t, err)
+				used, err := humanizeutil.ParseBytes(usedStr)
+				require.NoError(t, err)
+				available, err := humanizeutil.ParseBytes(availableStr)
+				require.NoError(t, err)
+
+				sc := roachpb.StoreCapacity{
+					Capacity:  total,
+					Used:      used,
+					Available: available,
+				}
+				fractionUsed := sc.FractionUsed()
+
+				// Current model: uses FractionUsed() = Used/(Used+Available).
+				result := computeStoreByteSizeCapacity(
+					mmaprototype.LoadValue(logicalBytes), fractionUsed, available,
+				)
+				// Wrong model: uses (Total-Available)/Total.
+				wrongResult := computeStoreByteSizeCapacityWrong(
+					mmaprototype.LoadValue(logicalBytes), total, available,
+				)
+
+				fmtUtil := func(load int64, cap mmaprototype.LoadValue) string {
+					if cap > 0 {
+						return fmt.Sprintf("%.2f%%", float64(load)/float64(cap)*100)
+					}
+					return "N/A"
+				}
+				return fmt.Sprintf(
+					"fraction-used: %.4f (via Used) vs %.4f (via Total-Available)\nkv-capacity: %s (kv-util: %s, available: %s)\nkv-capacity(wrong): %s (kv-util: %s, available: %s)\n",
+					fractionUsed, float64(total-available)/float64(total),
+					humanizeutil.IBytes(int64(result)), fmtUtil(logicalBytes, result), humanizeutil.IBytes(available),
+					humanizeutil.IBytes(int64(wrongResult)), fmtUtil(logicalBytes, wrongResult), humanizeutil.IBytes(available),
+				)
+
+			default:
+				return fmt.Sprintf("unknown command: %s", d.Cmd)
+			}
+		})
+}

--- a/pkg/kv/kvserver/mmaintegration/capacity_model_test.go
+++ b/pkg/kv/kvserver/mmaintegration/capacity_model_test.go
@@ -64,11 +64,10 @@ func TestComputeStoreCPURateCapacity(t *testing.T) {
 
 				// Naive model: assumes all node CPU scales directly with store work.
 				in := storeCPURateCapacityInput{
-					currentStoreCPUUsage: mmaprototype.LoadValue(storeCPUCores * nsPerCore),
-					storesCPURate:        storesCPUCores * nsPerCore,
-					nodeCPURateUsage:     nodeUsageCores * nsPerCore,
-					nodeCPURateCapacity:  nodeCapCores * nsPerCore,
-					numStores:            int32(numStores),
+					storesCPURate:       storesCPUCores * nsPerCore,
+					nodeCPURateUsage:    nodeUsageCores * nsPerCore,
+					nodeCPURateCapacity: nodeCapCores * nsPerCore,
+					numStores:           int32(numStores),
 				}
 				naiveResult := computeStoreCPURateCapacity(in)
 				naiveCap := float64(naiveResult) / nsPerCore

--- a/pkg/kv/kvserver/mmaintegration/capacity_model_test.go
+++ b/pkg/kv/kvserver/mmaintegration/capacity_model_test.go
@@ -79,10 +79,7 @@ func TestComputeStoreCPURateCapacity(t *testing.T) {
 
 				// Run models.
 				naiveCap := float64(computeStoreCPURateCapacityNaive(in)) / nsPerCore
-				cappedCap := computeCPUCapacityWithCap(
-					in,
-					func(float64, float64, float64, float64) {}, // observer unused
-				) / nsPerCore
+				cappedCap := computeCPUCapacityWithCap(in) / nsPerCore
 
 				// Compute error percentage.
 				// Negative = pessimistic (underestimates capacity, safer).

--- a/pkg/kv/kvserver/mmaintegration/legacy_model_test.go
+++ b/pkg/kv/kvserver/mmaintegration/legacy_model_test.go
@@ -1,0 +1,137 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package mmaintegration
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/mmaprototype"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+// computeStoreCPURateCapacityNaive is the original (naive) CPU capacity model,
+// retained here only for comparison with the capped multiplier approach
+// (computeCPUCapacityWithCap).
+//
+// The model ensures that the mean store utilization (sum of store loads / sum of
+// store capacities) equals the node-level CPU utilization, so that overload is
+// detected at the store level exactly when it is detected at the node level.
+// Individual stores may have different utilizations depending on their load.
+//
+// The two cases are:
+//
+//  1. Normal: storesCPURate > 0, cpuUtil >= 0.01.
+//     We compute cpuUtil = nodeCPURateUsage / nodeCPURateCapacity, then
+//     derive a per-store capacity = (storesCPURate / cpuUtil) / numStores.
+//     See MakeStoreLoadMsg for why this construction preserves the
+//     node-level utilization as the mean store-level utilization.
+//
+//  2. Low utilization fallback: storesCPURate is zero or cpuUtil < 0.01.
+//     We assume 50% of the node capacity is attributable to stores and
+//     split evenly.
+//
+// CPU is a shared resource across all stores on a node, and we choose to
+// divide the CPU capacity evenly across stores on the node (any other
+// choice would be arbitrary).
+//
+// Furthermore, there are CPU consumers that we don't track on a
+// per-replica (and thus per-store) level. Examples include RPC work, Go
+// GC, SQL work etc. Some of the distributed SQL work could be happening
+// because of a local replica, so ideally we should improve our
+// instrumentation to track it per replica. Due to these gaps, we expect
+// the NodeCPURateCapacity to be higher than StoresCPURate. So simply
+// using NodeCPURateCapacity/NumStores as the per-store capacity would
+// lead to over-utilization.
+//
+// Our approach is to apply the CPU utilization to StoresCPURate to
+// compute a capacity and divide that evenly across stores. Specifically,
+//
+//	cpuUtil = NodeCPURateUsage/NodeCPURateCapacity
+//
+// we want to define StoresCPURateCapacity such that
+//
+//	StoresCPURate/StoresCPURateCapacity = cpuUtil,
+//
+// i.e. we want to give the (collective) stores a capacity that results
+// in the same utilization as reported at the process (node) level, i.e.
+//
+//	StoresCPURateCapacity = StoresCPURate/cpuUtil.
+//
+// Finally, we split StoresCPURateCapacity evenly across the stores.
+//
+// This construction ensures that there is overload as measured by node
+// CPU usage exactly when there is overload as measured by mean store
+// CPU usage:
+//
+//	meanCPUUtil = sum_i StoreCPURate_i / sum_i StoreCPURateCapacity_i
+//	            = 1/StoresCPURateCapacity * sum_i StoreCPURate_i
+//	            = StoresCPURate / StoresCPURateCapacity
+//	            = cpuUtil
+//
+// The above mathematical property is used to avoid having any explicit
+// communication of node load to MMA. The
+// NodeLoad.{ReportedCPU,CapacityCPU} is incrementally maintained as a sum
+// of the load and capacity reported by each store (at different times).
+//
+// Additionally, when the meanCPUUtil indicates overload, at least one
+// store will be above that mean, so it is overloaded as well and will
+// induce load shedding.
+//
+// It's worth noting that this construction assumes that all load on the
+// node is due to the stores. Take an extreme example in which there is
+// a single store using up 1vcpu, but the node is fully utilized (at,
+// say, 16 vcpus). In this case, the node will be at 100%, and we will
+// assign a capacity of 1 to the store, i.e. the store will also be at
+// 100% utilization despite contributing only 1/16th of the node CPU
+// utilization. The effect of the construction is that the store will
+// take on responsibility for shedding load to compensate for auxiliary
+// consumption of CPU, which is generally sensible.
+//
+// Panics if numStores <= 0 or nodeCPURateCapacity <= 0.
+func computeStoreCPURateCapacityNaive(in storeCPURateCapacityInput) mmaprototype.LoadValue {
+	if in.numStores <= 0 || in.nodeCPURateCapacity <= 0 {
+		log.KvDistribution.Fatalf(context.Background(), "numStores and nodeCPURateCapacity must be > 0")
+	}
+	cpuUtil := in.nodeCPURateUsage / in.nodeCPURateCapacity
+	// cpuUtil can be zero or close to zero.
+	almostZeroUtil := cpuUtil < 0.01
+	if in.storesCPURate == 0 || almostZeroUtil {
+		// almostZeroUtil or StoresCPURate is zero. We assume that only 50% of
+		// the usage can be accounted for in StoresCPURate, so we divide 50% of
+		// the NodeCPURateCapacity among all the stores.
+		return mmaprototype.LoadValue(in.nodeCPURateCapacity / 2 / float64(in.numStores))
+	}
+	// cpuUtil is distributed across the stores, by constructing a
+	// nodeCapacity, and then splitting nodeCapacity evenly across all the
+	// stores. If the cpuUtil of a node is higher than the mean across nodes
+	// of the cluster, then cpu util of at least one store on that node will
+	// be higher than the mean across all stores in the cluster (since the
+	// cpu util of a node is simply the mean across all its stores), which
+	// will result in load shedding. Note that this can cause cpu util of a
+	// store to be > 100% e.g. if a node is at 80% cpu util and has 10
+	// stores, and all the cpu usage is due to store s1, then s1 will have
+	// 800% util.
+	nodeCapacity := in.storesCPURate / cpuUtil
+	storeCapacity := nodeCapacity / float64(in.numStores)
+	return mmaprototype.LoadValue(storeCapacity)
+}
+
+// computeStoreByteSizeCapacityNaive uses (Total-Available)/Total as the
+// disk fraction instead of Used/(Used+Available). This is the naive model
+// because Total-Available includes filesystem reserved blocks, ballast, and
+// other non-store files on the same mount — all of which inflate the fraction
+// and produce an unrealistically small capacity for stores with little data.
+// Retained here only for comparison with the correct model
+// (computeStoreByteSizeCapacity).
+func computeStoreByteSizeCapacityNaive(
+	logicalBytes mmaprototype.LoadValue, total int64, available int64,
+) mmaprototype.LoadValue {
+	var fullDiskFraction float64
+	if total > 0 {
+		fullDiskFraction = float64(total-available) / float64(total)
+	}
+	return computeStoreByteSizeCapacity(logicalBytes, fullDiskFraction, available)
+}

--- a/pkg/kv/kvserver/mmaintegration/store_load_msg.go
+++ b/pkg/kv/kvserver/mmaintegration/store_load_msg.go
@@ -19,13 +19,15 @@ func MakeStoreLoadMsg(
 	var load, capacity mmaprototype.LoadVector
 
 	load[mmaprototype.CPURate] = mmaprototype.LoadValue(desc.Capacity.CPUPerSecond)
-	capacity[mmaprototype.CPURate] = computeStoreCPURateCapacity(
+	cpuCap := computeCPUCapacityWithCap(
 		load[mmaprototype.CPURate],
+		float64(desc.NodeCapacity.StoresCPURate),
 		float64(desc.NodeCapacity.NodeCPURateUsage),
 		float64(desc.NodeCapacity.NodeCPURateCapacity),
-		float64(desc.NodeCapacity.StoresCPURate),
 		desc.NodeCapacity.NumStores,
+		func(_ float64, _ float64, _ float64, _ float64) {},
 	)
+	capacity[mmaprototype.CPURate] = mmaprototype.LoadValue(cpuCap)
 
 	load[mmaprototype.WriteBandwidth] = mmaprototype.LoadValue(desc.Capacity.WriteBytesPerSecond)
 	capacity[mmaprototype.WriteBandwidth] = mmaprototype.UnknownCapacity

--- a/pkg/kv/kvserver/mmaintegration/store_load_msg.go
+++ b/pkg/kv/kvserver/mmaintegration/store_load_msg.go
@@ -18,15 +18,12 @@ func MakeStoreLoadMsg(
 	var load, capacity mmaprototype.LoadVector
 
 	load[mmaprototype.CPURate] = mmaprototype.LoadValue(desc.Capacity.CPUPerSecond)
-	cpuCap := computeCPUCapacityWithCap(
-		storeCPURateCapacityInput{
-			storesCPURate:       float64(desc.NodeCapacity.StoresCPURate),
-			nodeCPURateUsage:    float64(desc.NodeCapacity.NodeCPURateUsage),
-			nodeCPURateCapacity: float64(desc.NodeCapacity.NodeCPURateCapacity),
-			numStores:           desc.NodeCapacity.NumStores,
-		},
-		func(_ float64, _ float64, _ float64, _ float64) {},
-	)
+	cpuCap := computeCPUCapacityWithCap(storeCPURateCapacityInput{
+		storesCPURate:       float64(desc.NodeCapacity.StoresCPURate),
+		nodeCPURateUsage:    float64(desc.NodeCapacity.NodeCPURateUsage),
+		nodeCPURateCapacity: float64(desc.NodeCapacity.NodeCPURateCapacity),
+		numStores:           desc.NodeCapacity.NumStores,
+	})
 	// cpuCap can be 0 when the node is overloaded (nodeCPURateUsage >
 	// nodeCPURateCapacity). This is correct behavior - it signals that the
 	// store has no CPU capacity available and should trigger load shedding.

--- a/pkg/kv/kvserver/mmaintegration/store_load_msg.go
+++ b/pkg/kv/kvserver/mmaintegration/store_load_msg.go
@@ -27,6 +27,9 @@ func MakeStoreLoadMsg(
 		desc.NodeCapacity.NumStores,
 		func(_ float64, _ float64, _ float64, _ float64) {},
 	)
+	// cpuCap can be 0 when the node is overloaded (nodeCPURateUsage >
+	// nodeCPURateCapacity). This is correct behavior - it signals that the
+	// store has no CPU capacity available and should trigger load shedding.
 	capacity[mmaprototype.CPURate] = mmaprototype.LoadValue(cpuCap)
 
 	load[mmaprototype.WriteBandwidth] = mmaprototype.LoadValue(desc.Capacity.WriteBytesPerSecond)

--- a/pkg/kv/kvserver/mmaintegration/store_load_msg.go
+++ b/pkg/kv/kvserver/mmaintegration/store_load_msg.go
@@ -11,121 +11,32 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
-// MakeStoreLoadMsg makes a store load message.
-//
-// TODO(wenyihu6): Add more tests for this function.
+// MakeStoreLoadMsg makes a store load message. The capacity model logic is in
+// computeStoreCPURateCapacity and computeStoreByteSizeCapacity.
 func MakeStoreLoadMsg(
 	desc roachpb.StoreDescriptor, origTimestampNanos int64,
 ) mmaprototype.StoreLoadMsg {
 	var load, capacity mmaprototype.LoadVector
+
 	load[mmaprototype.CPURate] = mmaprototype.LoadValue(desc.Capacity.CPUPerSecond)
-	if desc.NodeCapacity.NodeCPURateCapacity > 0 {
-		// CPU is a shared resource across all stores on a node, and we choose to
-		// divide the CPU capacity evenly across stores on the node (any other
-		// choice would be arbitrary).
-		//
-		// Furthermore, there are CPU consumers that we don't track on a
-		// per-replica (and thus per-store) level. Examples include RPC work, Go
-		// GC, SQL work etc. Some of the distributed SQL work could be happening
-		// because of a local replica, so ideally we should improve our
-		// instrumentation to track it per replica. Due to these gaps, we expect
-		// the NodeCPURateCapacity to be higher than StoresCPURate. So simply
-		// using NodeCPURateCapacity/NumStores as the per-store capacity would
-		// lead to over-utilization.
-		//
-		// Our approach is to apply the CPU utilization to StoresCPURate to
-		// compute a capacity and divide that evenly across stores. Specifically,
-		//
-		//   cpuUtil = NodeCPURateUsage/NodeCPURateCapacity
-		//
-		// we want to define StoresCPURateCapacity such that
-		//
-		//    StoresCPURate/StoresCPURateCapacity = cpuUtil,
-		//
-		// i.e. we want to give the (collective) stores a capacity that results
-		// in the same utilization as reported at the process (node) level, i.e.
-		//
-		//    StoresCPURateCapacity = StoresCPURate/cpuUtil.
-		//
-		// Finally, we split StoresCPURateCapacity evenly across the stores.
-		//
-		// This construction ensures that there is overload as measured by node
-		// CPU usage exactly when there is overload as measured by mean store
-		// CPU usage:
-		//
-		// meanCPUUtil = sum_i StoreCPURate_i / sum_i StoreCPURateCapacity_i
-		//             = 1/StoresCPURateCapacity * sum_i StoreCPURate_i
-		//             = StoresCPURate / StoresCPURateCapacity
-		//             = cpuUtil
-		//
-		// The above mathematical property is used to avoid having any explicit
-		// communication of node load to MMA. The
-		// NodeLoad.{ReportedCPU,CapacityCPU} is incrementally maintained as a sum
-		// of the load and capacity reported by each store (at different times).
-		//
-		// Additionally, when the meanCPUUtil indicates overload, at least one
-		// store will be above that mean, so it is overloaded as well and will
-		// induce load shedding.
-		//
-		// It's worth noting that this construction assumes that all load on the
-		// node is due to the stores. Take an extreme example in which there is
-		// a single store using up 1vcpu, but the node is fully utilized (at,
-		// say, 16 vcpus). In this case, the node will be at 100%, and we will
-		// assign a capacity of 1 to the store, i.e. the store will also be at
-		// 100% utilization despite contributing only 1/16th of the node CPU
-		// utilization. The effect of the construction is that the store will
-		// take on responsibility for shedding load to compensate for auxiliary
-		// consumption of CPU, which is generally sensible.
-		cpuUtil :=
-			float64(desc.NodeCapacity.NodeCPURateUsage) / float64(desc.NodeCapacity.NodeCPURateCapacity)
-		// cpuUtil can be zero or close to zero.
-		almostZeroUtil := cpuUtil < 0.01
-		if desc.NodeCapacity.StoresCPURate != 0 && !almostZeroUtil {
-			// cpuUtil is distributed across the stores, by constructing a
-			// nodeCapacity, and then splitting nodeCapacity evenly across all the
-			// stores. If the cpuUtil of a node is higher than the mean across nodes
-			// of the cluster, then cpu util of at least one store on that node will
-			// be higher than the mean across all stores in the cluster (since the
-			// cpu util of a node is simply the mean across all its stores), which
-			// will result in load shedding. Note that this can cause cpu util of a
-			// store to be > 100% e.g. if a node is at 80% cpu util and has 10
-			// stores, and all the cpu usage is due to store s1, then s1 will have
-			// 800% util.
-			nodeCapacity := float64(desc.NodeCapacity.StoresCPURate) / cpuUtil
-			storeCapacity := nodeCapacity / float64(desc.NodeCapacity.NumStores)
-			capacity[mmaprototype.CPURate] = mmaprototype.LoadValue(storeCapacity)
-		} else {
-			// almostZeroUtil or StoresCPURate is zero. We assume that only 50% of
-			// the usage can be accounted for in StoresCPURate, so we divide 50% of
-			// the NodeCPURateCapacity among all the stores.
-			capacity[mmaprototype.CPURate] = mmaprototype.LoadValue(
-				float64(desc.NodeCapacity.NodeCPURateCapacity/2) / float64(desc.NodeCapacity.NumStores))
-		}
-	} else {
-		// TODO(sumeer): remove this hack of defaulting to 50% utilization, since
-		// NodeCPURateCapacity should never be 0.
-		// TODO(tbg): when do we expect to hit this branch? Mixed version cluster?
-		capacity[mmaprototype.CPURate] = load[mmaprototype.CPURate] * 2
-	}
+	capacity[mmaprototype.CPURate] = computeStoreCPURateCapacity(
+		load[mmaprototype.CPURate],
+		float64(desc.NodeCapacity.NodeCPURateUsage),
+		float64(desc.NodeCapacity.NodeCPURateCapacity),
+		float64(desc.NodeCapacity.StoresCPURate),
+		desc.NodeCapacity.NumStores,
+	)
+
 	load[mmaprototype.WriteBandwidth] = mmaprototype.LoadValue(desc.Capacity.WriteBytesPerSecond)
 	capacity[mmaprototype.WriteBandwidth] = mmaprototype.UnknownCapacity
-	// ByteSize is based on LogicalBytes since that is how we measure the size
-	// of each range
+
 	load[mmaprototype.ByteSize] = mmaprototype.LoadValue(desc.Capacity.LogicalBytes)
-	// Available does not compensate for the ballast, so utilization will look
-	// higher than actual. This is fine since the ballast is small (default is
-	// 1% of capacity) and is for use in an emergency.
-	byteSizeUtil := desc.Capacity.FractionUsed()
-	almostZeroUtil := byteSizeUtil < 0.01
-	if load[mmaprototype.ByteSize] != 0 && !almostZeroUtil {
-		// Normal case. The store has some ranges, and is not almost empty.
-		capacity[mmaprototype.ByteSize] = mmaprototype.LoadValue(float64(load[mmaprototype.ByteSize]) / byteSizeUtil)
-	} else {
-		// Has no ranges or is almost empty. This is likely a new store. Since
-		// LogicalBytes are uncompressed, we start with the compressed available,
-		// which is desirably pessimistic.
-		capacity[mmaprototype.ByteSize] = mmaprototype.LoadValue(desc.Capacity.Available)
-	}
+	capacity[mmaprototype.ByteSize] = computeStoreByteSizeCapacity(
+		load[mmaprototype.ByteSize],
+		desc.Capacity.FractionUsed(),
+		desc.Capacity.Available,
+	)
+
 	var secondaryLoad mmaprototype.SecondaryLoadVector
 	secondaryLoad[mmaprototype.LeaseCount] = mmaprototype.LoadValue(desc.Capacity.LeaseCount)
 	secondaryLoad[mmaprototype.ReplicaCount] = mmaprototype.LoadValue(desc.Capacity.RangeCount)

--- a/pkg/kv/kvserver/mmaintegration/store_load_msg.go
+++ b/pkg/kv/kvserver/mmaintegration/store_load_msg.go
@@ -11,8 +11,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
-// MakeStoreLoadMsg makes a store load message. The capacity model logic is in
-// computeStoreCPURateCapacity and computeStoreByteSizeCapacity.
+// MakeStoreLoadMsg makes a store load message.
 func MakeStoreLoadMsg(
 	desc roachpb.StoreDescriptor, origTimestampNanos int64,
 ) mmaprototype.StoreLoadMsg {
@@ -21,11 +20,10 @@ func MakeStoreLoadMsg(
 	load[mmaprototype.CPURate] = mmaprototype.LoadValue(desc.Capacity.CPUPerSecond)
 	cpuCap := computeCPUCapacityWithCap(
 		storeCPURateCapacityInput{
-			currentStoreCPUUsage: load[mmaprototype.CPURate],
-			storesCPURate:        float64(desc.NodeCapacity.StoresCPURate),
-			nodeCPURateUsage:     float64(desc.NodeCapacity.NodeCPURateUsage),
-			nodeCPURateCapacity:  float64(desc.NodeCapacity.NodeCPURateCapacity),
-			numStores:            desc.NodeCapacity.NumStores,
+			storesCPURate:       float64(desc.NodeCapacity.StoresCPURate),
+			nodeCPURateUsage:    float64(desc.NodeCapacity.NodeCPURateUsage),
+			nodeCPURateCapacity: float64(desc.NodeCapacity.NodeCPURateCapacity),
+			numStores:           desc.NodeCapacity.NumStores,
 		},
 		func(_ float64, _ float64, _ float64, _ float64) {},
 	)

--- a/pkg/kv/kvserver/mmaintegration/store_load_msg.go
+++ b/pkg/kv/kvserver/mmaintegration/store_load_msg.go
@@ -20,11 +20,13 @@ func MakeStoreLoadMsg(
 
 	load[mmaprototype.CPURate] = mmaprototype.LoadValue(desc.Capacity.CPUPerSecond)
 	cpuCap := computeCPUCapacityWithCap(
-		load[mmaprototype.CPURate],
-		float64(desc.NodeCapacity.StoresCPURate),
-		float64(desc.NodeCapacity.NodeCPURateUsage),
-		float64(desc.NodeCapacity.NodeCPURateCapacity),
-		desc.NodeCapacity.NumStores,
+		storeCPURateCapacityInput{
+			currentStoreCPUUsage: load[mmaprototype.CPURate],
+			storesCPURate:        float64(desc.NodeCapacity.StoresCPURate),
+			nodeCPURateUsage:     float64(desc.NodeCapacity.NodeCPURateUsage),
+			nodeCPURateCapacity:  float64(desc.NodeCapacity.NodeCPURateCapacity),
+			numStores:            desc.NodeCapacity.NumStores,
+		},
 		func(_ float64, _ float64, _ float64, _ float64) {},
 	)
 	// cpuCap can be 0 when the node is overloaded (nodeCPURateUsage >

--- a/pkg/kv/kvserver/mmaintegration/testdata/TestComputeStoreByteSizeCapacity
+++ b/pkg/kv/kvserver/mmaintegration/testdata/TestComputeStoreByteSizeCapacity
@@ -1,0 +1,78 @@
+# Inputs map to StoreCapacity fields:
+#   logical-bytes: LogicalBytes (uncompressed MVCC live bytes across all replicas)
+#   total:         Capacity (total filesystem capacity at store path)
+#   used:          Used (store files: pebble data + auxiliary dir + ballast)
+#   available:     Available (free space remaining on the filesystem)
+#
+# Outputs show both fraction-used formulas:
+#   "via Used":           Used / (Used + Available)  — includes ballast, excludes
+#                          reserved blocks and other non-CRDB files
+#   "via Total-Available": (Total - Available) / Total — includes reserved blocks,
+#                          ballast, other non-CRDB files under the mount point
+
+# Normal case: 1TiB disk, store is 50% full, no significant non-store overhead.
+# Used ≈ Total - Available, so both fraction formulas agree.
+compute logical-bytes=500GiB total=1000GiB used=500GiB available=500GiB
+----
+fraction-used: 0.5000 (via Used) vs 0.5000 (via Total-Available)
+kv-capacity: 1000 GiB (kv-util: 50.00%, available: 500 GiB)
+kv-capacity(wrong): 1000 GiB (kv-util: 50.00%, available: 500 GiB)
+
+# Space amplification: logical=100GiB but physical Used=500GiB (5x amplification
+# from compression ratio, tombstones, LSM overhead, WAL, auxiliary).
+# capacity = 100GiB / 0.5 = 200GiB — correctly reflects that the store can
+# hold ~200GiB of logical data at this amplification ratio.
+compute logical-bytes=100GiB total=1000GiB used=500GiB available=500GiB
+----
+fraction-used: 0.5000 (via Used) vs 0.5000 (via Total-Available)
+kv-capacity: 200 GiB (kv-util: 50.00%, available: 500 GiB)
+kv-capacity(wrong): 200 GiB (kv-util: 50.00%, available: 500 GiB)
+
+# Almost empty store (fraction-used < 1%). Falls back to available.
+compute logical-bytes=1MiB total=1000GiB used=1MiB available=999GiB
+----
+fraction-used: 0.0000 (via Used) vs 0.0010 (via Total-Available)
+kv-capacity: 999 GiB (kv-util: 0.00%, available: 999 GiB)
+kv-capacity(wrong): 999 GiB (kv-util: 0.00%, available: 999 GiB)
+
+# New store: no ranges yet (logicalBytes = 0). Falls back to available.
+compute logical-bytes=0B total=1000GiB used=0B available=1000GiB
+----
+fraction-used: 0.0000 (via Used) vs 0.0000 (via Total-Available)
+kv-capacity: 1000 GiB (kv-util: 0.00%, available: 1000 GiB)
+kv-capacity(wrong): 1000 GiB (kv-util: 0.00%, available: 1000 GiB)
+
+# ---------------------------------------------------------------------------
+# Problems with (Total-Available)/Total
+# ---------------------------------------------------------------------------
+# Total - Available includes reserved blocks, ballast, and other non-CRDB
+# files on the same mount. Since Total-Available >= Used, the wrong fraction
+# is always >= the correct one, and kv-capacity (= LogicalBytes / fraction)
+# is always <= the correct capacity. The wrong model always underestimates
+# how much data the store can hold, making stores look fuller than they are.
+# This triggers premature rebalancing away from stores that actually have
+# plenty of disk space.
+#
+# FractionUsed() avoids this by using Used/(Used+Available), which includes
+# ballast but excludes reserved blocks and other non-CRDB files.
+
+# 10GiB ext4 reserved blocks on a 196GiB disk, no ballast, store barely used.
+# Total - Available = 10GiB (all reserved blocks), Used = 100MiB (store metadata).
+# Naive: (196-186)/196 = 5.1% -> capacity = 4.8MiB/0.051 = 94MiB (way too small).
+# Used-based: 100MiB/(100MiB+186GiB) ≈ 0.05% -> almost-empty fallback -> 186GiB.
+compute logical-bytes=4.8MiB total=196GiB used=100MiB available=186GiB
+----
+fraction-used: 0.0005 (via Used) vs 0.0510 (via Total-Available)
+kv-capacity: 186 GiB (kv-util: 0.00%, available: 186 GiB)
+kv-capacity(wrong): 94 MiB (kv-util: 5.10%, available: 186 GiB)
+
+# Store has 10GiB of logical data but only 5GiB physical (0.5x amplification
+# due to compression). Still on the 196GiB disk with 10GiB reserved blocks.
+# Used-based: 5/(5+181) = 2.69% -> capacity = 10GiB/0.0269 = 372GiB.
+# Wrong: (196-181)/196 = 7.65% -> capacity = 10GiB/0.0765 = 131GiB.
+# The wrong formula shrinks capacity by ~3x due to reserved blocks.
+compute logical-bytes=10GiB total=196GiB used=5GiB available=181GiB
+----
+fraction-used: 0.0269 (via Used) vs 0.0765 (via Total-Available)
+kv-capacity: 372 GiB (kv-util: 2.69%, available: 181 GiB)
+kv-capacity(wrong): 131 GiB (kv-util: 7.65%, available: 181 GiB)

--- a/pkg/kv/kvserver/mmaintegration/testdata/TestComputeStoreCPURateCapacity
+++ b/pkg/kv/kvserver/mmaintegration/testdata/TestComputeStoreCPURateCapacity
@@ -151,3 +151,18 @@ capped_mult: (steps below)
   mma-direct  = 12.60 / 3.0 = 4.20 cores
   per-store   = 4.20 / 4 = 1.05 cores
   kv-capacity: 1.05 cores, kv-util: 9.52% (0.10/1.05 cores)
+
+# Overloaded node: node CPU usage exceeds capacity (nodeCPURateUsage > nodeCPURateCapacity).
+# When backgroundLoad exceeds nodeCPURateCapacity, mmaShareOfCapacity would be negative
+# without clamping. The fix clamps it to 0, resulting in 0 capacity (correct behavior).
+compute store-load=1 node-cpu-usage=32 node-cpu-capacity=16 total-stores-cpu-usage=2 num-stores=1
+----
+              node-cpu-capacity/num-stores: 16.00 cores/store
+naive:        kv-capacity: 1.00 cores, kv-util: 100.00% (1.00/1.00 cores)
+capped_mult: (steps below)
+  mult        = max(1, min(32.00/2.00, 3)) = 3.0
+  background  = max(0, 32.00 - 2.00*3.0) = 26.00 cores
+  mma-share   = 16.00 - 26.00 = 0.00 cores
+  mma-direct  = 0.00 / 3.0 = 0.00 cores
+  per-store   = 0.00 / 1 = 0.00 cores
+  kv-capacity: 0.00 cores, kv-util: +Inf% (1.00/0.00 cores)

--- a/pkg/kv/kvserver/mmaintegration/testdata/TestComputeStoreCPURateCapacity
+++ b/pkg/kv/kvserver/mmaintegration/testdata/TestComputeStoreCPURateCapacity
@@ -1,150 +1,229 @@
-# All CPU values are in cores (1 core = 1e9 ns/s).
+# ==========================================================================
+# CPU Capacity Model Evaluation
+# ==========================================================================
+#
+# Each scenario defines the of what's happening on the node:
+#   kv-cpu:                  Direct KV replica CPU (total across all stores)
+#   proportional-overhead:   CPU that scales with KV (dist SQL, RPC, compactions)
+#   background:              CPU that does NOT scale with KV (gateway SQL, GC, jobs)
+#
+# From ground truth we derive:
+#   node-cpu-usage = kv-cpu + proportional-overhead + background
+#   true-mult      = (kv-cpu + proportional-overhead) / kv-cpu
+#   true-capacity  = (node-cpu-capacity - background) / true-mult / num-stores
+#
+# capacity_err = (model - true-capacity) / true-capacity * 100
+#   < 0: pessimistic (safe — sheds load too early)
+#   > 0: optimistic (dangerous — accepts too much work)
+#
+# Where each model fails:
+# naive:
+#   Computes mult = nodeUsage / kvCores, capacity = nodeCapacity / mult. Assumes
+#   all node CPU is caused by KV work. Background inflates mult, making per-KV
+#   cost too high — the more background, the worse it gets.
+#
+# capped_mult:
+#   Like naive, but caps the multiplier at 3x. Misclassifies in both directions:
+#   when mult ≤ 3x, all CPU is attributed to KV (background treated as kv
+#   overhead). When mult > 3x, excess is called background (real kv overhead
+#   treated as background if kv overhead exceeds 3x).
+# 
+# ==========================================================================
+# SECTION 1: No background — all models accurate (0% error)
+# ==========================================================================
+# When all node CPU is proportional to KV work, every model computes the
+# correct capacity. No background means nothing to separate.
 
-# Normal case: single store on a node. All node CPU usage comes from store work.
-# Node is at 50% utilization.
-compute store-load=8 node-cpu-usage=8 node-cpu-capacity=16 total-stores-cpu-usage=8 num-stores=1
+# Pure KV, no overhead: 8 of 16 cores used, all direct KV.
+scenario kv-cpu=8 proportional-overhead=0 background=0 node-cpu-capacity=16 num-stores=1
 ----
-              node-cpu-capacity/num-stores: 16.00 cores/store
-naive:        kv-capacity: 16.00 cores, kv-util: 50.00% (8.00/16.00 cores)
-capped_mult: (steps below)
-  mult        = max(1, min(8.00/8.00, 3)) = 1.0
-  background  = max(0, 8.00 - 8.00*1.0) = 0.00 cores
-  mma-share   = 16.00 - 0.00 = 16.00 cores
-  mma-direct  = 16.00 / 1.0 = 16.00 cores
-  per-store   = 16.00 / 1 = 16.00 cores
-  kv-capacity: 16.00 cores, kv-util: 50.00% (8.00/16.00 cores)
+node-cpu: 8.00 used / 16.00 capacity (8.00 kv + 0.00 proportional + 0.00 background)
+truth:    kv-capacity: 16.00 cores/store (true-mult: 1.00)
+naive:    kv-capacity: 16.00 cores/store, capacity_err: 0.00%
+capped:   kv-capacity: 16.00 cores/store, capacity_err: 0.00%
 
-# Normal case: 2 stores on a node with uneven load. Node at 80% utilization, all
-# from store work. This store uses 7 cores, other uses 3. This store at 112%
-# util will shed load to other at 48%.
-compute store-load=7 node-cpu-usage=12.8 node-cpu-capacity=16 total-stores-cpu-usage=10 num-stores=2
+# KV + 2x overhead: 4 KV + 8 overhead = 12 total. Multiplier = 12/4 = 3x (at the
+# capped_mult cap).
+scenario kv-cpu=4 proportional-overhead=8 background=0 node-cpu-capacity=16 num-stores=1
 ----
-              node-cpu-capacity/num-stores: 8.00 cores/store
-naive:        kv-capacity: 6.25 cores, kv-util: 112.00% (7.00/6.25 cores)
-capped_mult: (steps below)
-  mult        = max(1, min(12.80/10.00, 3)) = 1.3
-  background  = max(0, 12.80 - 10.00*1.3) = 0.00 cores
-  mma-share   = 16.00 - 0.00 = 16.00 cores
-  mma-direct  = 16.00 / 1.3 = 12.50 cores
-  per-store   = 12.50 / 2 = 6.25 cores
-  kv-capacity: 6.25 cores, kv-util: 112.00% (7.00/6.25 cores)
+node-cpu: 12.00 used / 16.00 capacity (4.00 kv + 8.00 proportional + 0.00 background)
+truth:    kv-capacity: 5.33 cores/store (true-mult: 3.00)
+naive:    kv-capacity: 5.33 cores/store, capacity_err: 0.00%
+capped:   kv-capacity: 5.33 cores/store, capacity_err: 0.00%
 
-# Measurement lag: stores report more CPU than node is using (implicit mult < 1).
-# This can happen due to timing differences in measurement collection. The
-# implicit multiplier would be 0.5 (= 4/8), but it gets clamped to 1.0.
-compute store-load=4 node-cpu-usage=4 node-cpu-capacity=16 total-stores-cpu-usage=8 num-stores=1
+# KV + 4x overhead: 4 KV + 16 overhead = 20 total. True mult = 5x.
+# - naive: mult = 20/4 = 5. capacity = 16/5 = 3.2. Correct: 0%.
+# - capped: clips mult to 3, so bgLoad = 20 - 3*4 = 8. But there is no
+#   background — those 8 cores are real overhead that got misclassified.
+#   capacity = (16-8)/3 = 2.67. Pessimistic: -16.67%.
+scenario kv-cpu=4 proportional-overhead=16 background=0 node-cpu-capacity=16 num-stores=1
 ----
-              node-cpu-capacity/num-stores: 16.00 cores/store
-naive:        kv-capacity: 32.00 cores, kv-util: 12.50% (4.00/32.00 cores)
-capped_mult: (steps below)
-  mult        = max(1, min(4.00/8.00, 3)) = 1.0
-  background  = max(0, 4.00 - 8.00*1.0) = 0.00 cores
-  mma-share   = 16.00 - 0.00 = 16.00 cores
-  mma-direct  = 16.00 / 1.0 = 16.00 cores
-  per-store   = 16.00 / 1 = 16.00 cores
-  kv-capacity: 16.00 cores, kv-util: 25.00% (4.00/16.00 cores)
+node-cpu: 20.00 used / 16.00 capacity (4.00 kv + 16.00 proportional + 0.00 background)
+truth:    kv-capacity: 3.20 cores/store (true-mult: 5.00)
+naive:    kv-capacity: 3.20 cores/store, capacity_err: 0.00%
+capped:   kv-capacity: 2.67 cores/store, capacity_err: -16.67%
 
-# Moderate indirect overhead: store uses 4 cores, node uses 8 cores (2x overhead).
-# Implicit multiplier is 2.0 (= 8/4), which is between 1 and 3, so it's used
-# directly. This represents moderate indirect CPU overhead (RPC, compactions, etc.).
-compute store-load=4 node-cpu-usage=8 node-cpu-capacity=16 total-stores-cpu-usage=4 num-stores=1
+# Same 4x overhead but on a larger machine (40 cores, only 20 used). Same capped
+# misclassification as above (bgLoad=8 of fake background), but on a bigger
+# machine the error flips direction. Subtracting 8 fake background from 40
+# leaves (40-8)/3 = 10.67 > true 8.0 (optimistic). On the 16-core machine,
+# subtracting the same 8 from 16 left (16-8)/3 = 2.67 < true 3.2 (pessimistic).
+# More headroom + underestimated mult → optimistic.
+# True capacity = 40/5 = 8.0.
+# - naive: mult = 20/4 = 5. capacity = 40/5 = 8.0. Correct: 0%.
+# - capped: clips mult to 3, bgLoad = 20 - 12 = 8 (misclassified overhead).
+#   capacity = (40-8)/3 = 10.67. Optimistic: +33%.
+scenario kv-cpu=4 proportional-overhead=16 background=0 node-cpu-capacity=40 num-stores=1
 ----
-              node-cpu-capacity/num-stores: 16.00 cores/store
-naive:        kv-capacity: 8.00 cores, kv-util: 50.00% (4.00/8.00 cores)
-capped_mult: (steps below)
-  mult        = max(1, min(8.00/4.00, 3)) = 2.0
-  background  = max(0, 8.00 - 4.00*2.0) = 0.00 cores
-  mma-share   = 16.00 - 0.00 = 16.00 cores
-  mma-direct  = 16.00 / 2.0 = 8.00 cores
-  per-store   = 8.00 / 1 = 8.00 cores
-  kv-capacity: 8.00 cores, kv-util: 50.00% (4.00/8.00 cores)
+node-cpu: 20.00 used / 40.00 capacity (4.00 kv + 16.00 proportional + 0.00 background)
+truth:    kv-capacity: 8.00 cores/store (true-mult: 5.00)
+naive:    kv-capacity: 8.00 cores/store, capacity_err: 0.00%
+capped:   kv-capacity: 10.67 cores/store, capacity_err: +33.33%
 
-# Low utilization fallback: node CPU utilization is very low (< 1%).
-# Naive model assumes 50% overhead and gives 4 cores capacity.
-# Capped_mult gives 8 cores (half of node capacity per store) since it
-# doesn't assume overhead.
-compute store-load=0.1 node-cpu-usage=0.1 node-cpu-capacity=16 total-stores-cpu-usage=0.1 num-stores=2
+# ==========================================================================
+# SECTION 2: Background load present
+# ==========================================================================
+# Background CPU doesn't move with KV replicas. naive treats it all as
+# proportional to KV, inflating per-KV cost. capped_mult helps when the
+# implied multiplier exceeds 3x, but can't separate overhead from background.
+
+# Background only, no proportional overhead.
+# - kv=2, background=8. True capacity = (16-8)/1 = 8.0.
+# - naive: mult = nodeUsage/kv = 10/2 = 5. capacity = 16/5 = 3.2. It treats
+#   all 10 cores as KV-caused, so each KV core costs 5 total (1 direct + 4
+#   overhead) but there's no overhead. Pessimistic: -60%.
+# - capped: clips mult to 3, so bgLoad = 10 - 3*2 = 4. But true background is
+#   8 — 4 background cores are still misattributed as KV overhead.
+#   capacity = (16-4)/3 = 4.0. Pessimistic: -50%.
+scenario kv-cpu=2 proportional-overhead=0 background=8 node-cpu-capacity=16 num-stores=1
 ----
-              node-cpu-capacity/num-stores: 8.00 cores/store
-naive:        kv-capacity: 4.00 cores, kv-util: 2.50% (0.10/4.00 cores)
-capped_mult: (steps below)
-  mult        = max(1, min(0.10/0.10, 3)) = 1.0
-  background  = max(0, 0.10 - 0.10*1.0) = 0.00 cores
-  mma-share   = 16.00 - 0.00 = 16.00 cores
-  mma-direct  = 16.00 / 1.0 = 16.00 cores
-  per-store   = 16.00 / 2 = 8.00 cores
-  kv-capacity: 8.00 cores, kv-util: 1.25% (0.10/8.00 cores)
+node-cpu: 10.00 used / 16.00 capacity (2.00 kv + 0.00 proportional + 8.00 background)
+truth:    kv-capacity: 8.00 cores/store (true-mult: 1.00)
+naive:    kv-capacity: 3.20 cores/store, capacity_err: -60.00%
+capped:   kv-capacity: 4.00 cores/store, capacity_err: -50.00%
 
-# StoresCPURate is zero: no replicas reporting CPU usage yet (startup or
-# measurement lag). Node at 50% utilization, but stores haven't reported any
-# CPU. Naive gives 8 cores. Capped_mult gives 2.67 cores (more conservative,
-# assumes all node usage is background).
-compute store-load=0 node-cpu-usage=8 node-cpu-capacity=16 total-stores-cpu-usage=0 num-stores=1
+# Background + proportional overhead.
+# kv=2, overhead=2, background=8. True capacity = (16-8)/2 = 4.0.
+# - naive computes mult=12/2=6, treating 8 cores of background as KV overhead.
+# - capped_mult clips to 3x, finding 12-6=6 background (true is 8). Both over-
+# estimate per-KV cost because they can't distinguish background from KV work.
+scenario kv-cpu=2 proportional-overhead=2 background=8 node-cpu-capacity=16 num-stores=1
 ----
-              node-cpu-capacity/num-stores: 16.00 cores/store
-naive:        kv-capacity: 8.00 cores, kv-util: 0.00% (0.00/8.00 cores)
-capped_mult: (steps below)
-  mult        = max(1, min(8.00/0.00, 3)) = 3.0
-  background  = max(0, 8.00 - 0.00*3.0) = 8.00 cores
-  mma-share   = 16.00 - 8.00 = 8.00 cores
-  mma-direct  = 8.00 / 3.0 = 2.67 cores
-  per-store   = 2.67 / 1 = 2.67 cores
-  kv-capacity: 2.67 cores, kv-util: 0.00% (0.00/2.67 cores)
+node-cpu: 12.00 used / 16.00 capacity (2.00 kv + 2.00 proportional + 8.00 background)
+truth:    kv-capacity: 4.00 cores/store (true-mult: 2.00)
+naive:    kv-capacity: 2.67 cores/store, capacity_err: -33.33%
+capped:   kv-capacity: 3.33 cores/store, capacity_err: -16.67%
 
-# ---------------------------------------------------------------------------
-# Problems with the naive model
-# ---------------------------------------------------------------------------
-# The naive model assumes ALL node CPU usage is caused by store work, so
-# store utilization always equals node utilization. When there is significant
-# non-store CPU (SQL, GC, etc.), it assigns unrealistically low capacity,
-# causing premature load shedding.
-
-# Problem case 1: naive model over-attributes non-store CPU to stores.
-# Store uses only 0.1 cores, but node uses 6.4 cores. 6.3 cores are from
-# non-store work. Naive model: 0.25 cores capacity, store appears 40% utilized
-# (matches node util). Capped_mult: 3.3 cores capacity, store appears 3%
-# utilized (correctly low).
-compute store-load=0.1 node-cpu-usage=6.4 node-cpu-capacity=16 total-stores-cpu-usage=0.1 num-stores=1
+# At capacity: kv=4, overhead=4, background=8. Node at 16/16.
+# True capacity = (16-8)/2 = 4.0.
+# All models converge at 100% utilization: the store's current KV load (4)
+# equals the true capacity, so even a wrong multiplier produces the right answer
+# — the store is exactly at its limit no matter how you slice the overhead.
+scenario kv-cpu=4 proportional-overhead=4 background=8 node-cpu-capacity=16 num-stores=1
 ----
-              node-cpu-capacity/num-stores: 16.00 cores/store
-naive:        kv-capacity: 0.25 cores, kv-util: 40.00% (0.10/0.25 cores)
-capped_mult: (steps below)
-  mult        = max(1, min(6.40/0.10, 3)) = 3.0
-  background  = max(0, 6.40 - 0.10*3.0) = 6.10 cores
-  mma-share   = 16.00 - 6.10 = 9.90 cores
-  mma-direct  = 9.90 / 3.0 = 3.30 cores
-  per-store   = 3.30 / 1 = 3.30 cores
-  kv-capacity: 3.30 cores, kv-util: 3.03% (0.10/3.30 cores)
+node-cpu: 16.00 used / 16.00 capacity (4.00 kv + 4.00 proportional + 8.00 background)
+truth:    kv-capacity: 4.00 cores/store (true-mult: 2.00)
+naive:    kv-capacity: 4.00 cores/store, capacity_err: 0.00%
+capped:   kv-capacity: 4.00 cores/store, capacity_err: 0.00%
 
-# Problem case 2: naive model over-attributes non-store CPU in multi-store
-# scenario. 4 stores using 1.0 cores total, but node uses 6.4 cores. 5.4 cores
-# are non-store work. Fair share would be 4 cores per store. This store uses
-# only 0.1 cores. Naive model: 0.62 cores capacity, store appears 16% utilized
-# (inflated by non-store CPU). Capped_mult: 1.05 cores capacity, store appears
-# 9.5% utilized (still conservative but better).
-compute store-load=0.1 node-cpu-usage=6.4 node-cpu-capacity=16 total-stores-cpu-usage=1.0 num-stores=4
+# Extreme background: kv=0.5, background=13.5, no overhead.
+# True capacity = (16-13.5)/1 = 2.5.
+# - naive: mult = 14/0.5 = 28. capacity = 16/28 = 0.57. Treats all 14 cores as
+#   KV-caused, so each KV core costs 28 total — but true overhead is 0.
+#   Catastrophically pessimistic: -77%.
+# - capped: clips mult to 3, bgLoad = 14 - 3*0.5 = 12.5. Close to true 13.5,
+#   but divides by 3 instead of true 1. capacity = (16-12.5)/3 = 1.17.
+#   Pessimistic: -53%.
+scenario kv-cpu=0.5 proportional-overhead=0 background=13.5 node-cpu-capacity=16 num-stores=1
 ----
-              node-cpu-capacity/num-stores: 4.00 cores/store
-naive:        kv-capacity: 0.62 cores, kv-util: 16.00% (0.10/0.62 cores)
-capped_mult: (steps below)
-  mult        = max(1, min(6.40/1.00, 3)) = 3.0
-  background  = max(0, 6.40 - 1.00*3.0) = 3.40 cores
-  mma-share   = 16.00 - 3.40 = 12.60 cores
-  mma-direct  = 12.60 / 3.0 = 4.20 cores
-  per-store   = 4.20 / 4 = 1.05 cores
-  kv-capacity: 1.05 cores, kv-util: 9.52% (0.10/1.05 cores)
+node-cpu: 14.00 used / 16.00 capacity (0.50 kv + 0.00 proportional + 13.50 background)
+truth:    kv-capacity: 2.50 cores/store (true-mult: 1.00)
+naive:    kv-capacity: 0.57 cores/store, capacity_err: -77.14%
+capped:   kv-capacity: 1.17 cores/store, capacity_err: -53.33%
 
-# Overloaded node: node CPU usage exceeds capacity (nodeCPURateUsage > nodeCPURateCapacity).
-# When backgroundLoad exceeds nodeCPURateCapacity, mmaShareOfCapacity would be negative
-# without clamping. The fix clamps it to 0, resulting in 0 capacity (correct behavior).
-compute store-load=1 node-cpu-usage=32 node-cpu-capacity=16 total-stores-cpu-usage=2 num-stores=1
+# ==========================================================================
+# SECTION 3: Multi-store scenarios
+# ==========================================================================
+
+# 2 stores, kv=4 total. overhead=2, background=6.
+# True capacity = (16-6)/1.5/2 = 3.33 per store.
+# - naive/capped_mult compute mult=12/4=3 (exactly at the cap), treating all 12
+# cores as KV-proportional — including 6 cores of background that don't move
+# with replicas. Neither detects any background.
+scenario kv-cpu=4 proportional-overhead=2 background=6 node-cpu-capacity=16 num-stores=2
 ----
-              node-cpu-capacity/num-stores: 16.00 cores/store
-naive:        kv-capacity: 1.00 cores, kv-util: 100.00% (1.00/1.00 cores)
-capped_mult: (steps below)
-  mult        = max(1, min(32.00/2.00, 3)) = 3.0
-  background  = max(0, 32.00 - 2.00*3.0) = 26.00 cores
-  mma-share   = 16.00 - 26.00 = 0.00 cores
-  mma-direct  = 0.00 / 3.0 = 0.00 cores
-  per-store   = 0.00 / 1 = 0.00 cores
-  kv-capacity: 0.00 cores, kv-util: +Inf% (1.00/0.00 cores)
+node-cpu: 12.00 used / 16.00 capacity (4.00 kv + 2.00 proportional + 6.00 background)
+truth:    kv-capacity: 3.33 cores/store (true-mult: 1.50)
+naive:    kv-capacity: 2.67 cores/store, capacity_err: -20.00%
+capped:   kv-capacity: 2.67 cores/store, capacity_err: -20.00%
+
+# ==========================================================================
+# SECTION 4: Edge cases
+# ==========================================================================
+
+# Zero KV CPU (startup, no replicas reporting yet). Heavy background.
+# True mult = 1 (no overhead). True capacity = (16-12)/1 = 4.
+# - naive falls back to nodeCapacity/2 = 8 when storesCPU=0, completely ignoring
+#   background, reporting double the real capacity.
+# - capped: correctly identifies all background, but divides by 3 instead of
+#   true 1.
+scenario kv-cpu=0 proportional-overhead=0 background=12 node-cpu-capacity=16 num-stores=1
+----
+node-cpu: 12.00 used / 16.00 capacity (0.00 kv + 0.00 proportional + 12.00 background)
+truth:    kv-capacity: 4.00 cores/store (true-mult: 1.00)
+naive:    kv-capacity: 8.00 cores/store, capacity_err: +100.00%
+capped:   kv-capacity: 1.33 cores/store, capacity_err: -66.67%
+
+# Overloaded node (nodeUsage=18 > nodeCapacity=16) without background.
+# All 14 non-KV cores are proportional overhead (overhead=14, bg=0).
+# True capacity = 16/4.5 = 3.56: no background to subtract, but each KV core
+# costs 4.5 total (mult = 18/4 = 4.5).
+# - naive: mult = 18/4 = 4.5. capacity = 16/4.5 = 3.56. With bg=0, naive is
+#   always correct — there's nothing to misclassify. Correct: 0%.
+# - capped: clips mult to 3, bgLoad = 18 - 12 = 6. These 6 cores are real
+#   overhead, not background, but the model subtracts them from capacity anyway.
+#   capacity = (16-6)/3 = 3.33 < true 3.56. Pessimistic: -6%.
+scenario kv-cpu=4 proportional-overhead=14 background=0 node-cpu-capacity=16 num-stores=1
+----
+node-cpu: 18.00 used / 16.00 capacity (4.00 kv + 14.00 proportional + 0.00 background)
+truth:    kv-capacity: 3.56 cores/store (true-mult: 4.50)
+naive:    kv-capacity: 3.56 cores/store, capacity_err: 0.00%
+capped:   kv-capacity: 3.33 cores/store, capacity_err: -6.25%
+
+# Same node as above but now with background.
+# True capacity = (16-10)/2 = 3.0: after reserving 10 for background, only 6
+# cores remain for KV+overhead, and each KV core costs 2 total (mult=2).
+# - naive: mult = 18/4 = 4.5. capacity = 16/4.5 = 3.56. It uses the ratio of
+#   usage (18) to compute the multiplier, but divides capacity (16) by it.
+#   Since 18 > 16, the model makes KV look cheaper than what the node can
+#   actually sustain. Optimistic: +19%.
+# - capped: clips mult to 3, bgLoad = 18 - 3*4 = 6. But the real background
+#   is 10 - 4 cores of background get hidden inside the multiplier. So the
+#   model only subtracts 6 from capacity instead of 10.
+#   capacity = (16-6)/3 = 3.33 > true 3.0. Optimistic: +11%.
+scenario kv-cpu=4 proportional-overhead=4 background=10 node-cpu-capacity=16 num-stores=1
+----
+node-cpu: 18.00 used / 16.00 capacity (4.00 kv + 4.00 proportional + 10.00 background)
+truth:    kv-capacity: 3.00 cores/store (true-mult: 2.00)
+naive:    kv-capacity: 3.56 cores/store, capacity_err: +18.52%
+capped:   kv-capacity: 3.33 cores/store, capacity_err: +11.11%
+
+# Overloaded: background exceeds node capacity.
+# True capacity = max(0, 16-30)/2 = 0 (node is crushed by background).
+# - naive: mult = 32/1 = 32. capacity = 16/32 = 0.5. Doesn't model background
+#   at all, so it still thinks KV can do some work.
+# - capped: clips mult to 3, bgLoad = 32 - 3*1 = 29. capacity = max(0,
+#   (16-29)/3) = 0. Correctly detects the node is overwhelmed. 
+scenario kv-cpu=1 proportional-overhead=1 background=30 node-cpu-capacity=16 num-stores=1
+----
+node-cpu: 32.00 used / 16.00 capacity (1.00 kv + 1.00 proportional + 30.00 background)
+truth:    kv-capacity: 0.00 cores/store (true-mult: 2.00)
+naive:    kv-capacity: 0.50 cores/store, capacity_err: +Inf%
+capped:   kv-capacity: 0.00 cores/store, capacity_err: 0.00%
+
+# ==========================================================================
+# Mean |capacity_err| across all scenarios (excluding +Inf).
+# ==========================================================================
+mean
+----
+Mean |capacity_err| across 12 scenarios: naive: 25.7%  capped: 21.1%

--- a/pkg/kv/kvserver/mmaintegration/testdata/TestComputeStoreCPURateCapacity
+++ b/pkg/kv/kvserver/mmaintegration/testdata/TestComputeStoreCPURateCapacity
@@ -91,24 +91,6 @@ capped_mult: (steps below)
   per-store   = 2.67 / 1 = 2.67 cores
   kv-capacity: 2.67 cores, kv-util: 0.00% (0.00/2.67 cores)
 
-# Unknown capacity: node CPU capacity is 0 (mixed version cluster or missing
-# metrics). Both models fall back to assuming 50% utilization.
-compute store-load=4 node-cpu-usage=8 node-cpu-capacity=0 total-stores-cpu-usage=4 num-stores=1
-----
-              node-cpu-capacity/num-stores: 0.00 cores/store
-naive:        kv-capacity: 8.00 cores, kv-util: 50.00% (4.00/8.00 cores)
-capped_mult: (node-cpu-capacity unknown, assuming 50% util)
-  kv-capacity: 8.00 cores, kv-util: 50.00% (4.00/8.00 cores)
-
-# Invalid case: num-stores is 0 (should not happen in production).
-# Both models return 0 capacity.
-compute store-load=4 node-cpu-usage=8 node-cpu-capacity=16 total-stores-cpu-usage=4 num-stores=0
-----
-              node-cpu-capacity/num-stores: +Inf cores/store
-naive:        kv-capacity: 0.00 cores, kv-util: +Inf% (4.00/0.00 cores)
-capped_mult: (early return: num-stores=0)
-  kv-capacity: 8.00 cores, kv-util: 50.00% (4.00/8.00 cores)
-
 # ---------------------------------------------------------------------------
 # Problems with the naive model
 # ---------------------------------------------------------------------------

--- a/pkg/kv/kvserver/mmaintegration/testdata/TestComputeStoreCPURateCapacity
+++ b/pkg/kv/kvserver/mmaintegration/testdata/TestComputeStoreCPURateCapacity
@@ -1,0 +1,79 @@
+# All CPU values are in cores (1 core = 1e9 ns/s).
+
+# Normal case: node at 50% CPU, single store, all CPU from stores.
+# cpuUtil = 8/16 = 0.5, nodeCapacity = 8/0.5 = 16, storeCapacity = 16/1 = 16
+compute store-load=8 node-cpu-usage=8 node-cpu-capacity=16 total-stores-cpu-usage=8 num-stores=1
+----
+kv-capacity: 16.00 cores (total: 16.00 cores)
+kv-util: 50.00% (8.00/16.00 cores)
+
+# Normal case: node at 80%, 2 stores with uneven load (7 + 3 = 10 cores).
+# Both stores get the same capacity = (10/0.8)/2 = 6.25 cores.
+# The hot store (this one, 7 cores) is at 112% and will shed load to the
+# lighter store (3 cores, 48%), driving rebalancing.
+compute store-load=7 node-cpu-usage=12.8 node-cpu-capacity=16 total-stores-cpu-usage=10 num-stores=2
+----
+kv-capacity: 6.25 cores (total: 8.00 cores)
+kv-util: 112.00% (7.00/6.25 cores)
+
+# Auxiliary CPU dominates: store uses 1 core, but node is fully utilized at 16 cores.
+# The store gets capacity=1, so it appears 100% utilized and will shed load.
+# cpuUtil = 16/16 = 1.0, nodeCapacity = 1/1.0 = 1, storeCapacity = 1/1 = 1
+compute store-load=1 node-cpu-usage=16 node-cpu-capacity=16 total-stores-cpu-usage=1 num-stores=1
+----
+kv-capacity: 1.00 cores (total: 16.00 cores)
+kv-util: 100.00% (1.00/1.00 cores)
+
+# Low utilization fallback: cpuUtil < 1%.
+# Falls back to nodeCapacity/2/numStores = 16/2/2 = 4.
+compute store-load=0.1 node-cpu-usage=0.1 node-cpu-capacity=16 total-stores-cpu-usage=0.1 num-stores=2
+----
+kv-capacity: 4.00 cores (total: 8.00 cores)
+kv-util: 2.50% (0.10/4.00 cores)
+
+# StoresCPURate is zero (no replicas reporting CPU yet).
+# Falls back to nodeCapacity/2/numStores = 16/2/1 = 8.
+compute store-load=0.5 node-cpu-usage=8 node-cpu-capacity=16 total-stores-cpu-usage=0 num-stores=1
+----
+kv-capacity: 8.00 cores (total: 16.00 cores)
+kv-util: 6.25% (0.50/8.00 cores)
+
+# Unknown capacity: nodeCapacity is 0 (mixed version cluster?).
+# Falls back to storeCPULoad * 2, i.e. 50% utilization.
+compute store-load=4 node-cpu-usage=0 node-cpu-capacity=0 total-stores-cpu-usage=0 num-stores=1
+----
+kv-capacity: 8.00 cores (total: 0.00 cores)
+kv-util: 50.00% (4.00/8.00 cores)
+
+# ---------------------------------------------------------------------------
+# Problems with the current model
+# ---------------------------------------------------------------------------
+# The current formula assumes ALL node CPU usage is caused (directly or
+# indirectly) by MMA-tracked store work:
+#
+#   mma-capacity = total-stores-cpu-usage / (node-cpu-usage / node-cpu-capacity) / num-stores
+#
+# This means a store's MMA utilization always equals the node's CPU utilization,
+# regardless of how much of the node CPU usage is actually store-related.
+# When there is significant non-store CPU (SQL gateway, background jobs,
+# GC, etc.), the model assigns an unrealistically low capacity to the
+# store, causing premature load shedding.
+
+# Problem case 1: store uses 0.1 cores, node uses 6.4 cores (40% util). The
+# implied multiplier is 64x (= 6.4 / 0.1) - the model blames the store for 64x
+# its direct load. The store gets mma-capacity=0.25 and appears 40% utilized
+# despite consuming 0.1 out of 16 available cores. The node has 9.6 idle cores.
+compute store-load=0.1 node-cpu-usage=6.4 node-cpu-capacity=16 total-stores-cpu-usage=0.1 num-stores=1
+----
+kv-capacity: 0.25 cores (total: 16.00 cores)
+kv-util: 40.00% (0.10/0.25 cores)
+
+# Problem case 2: multi-store node. 4 stores using 1.0 cores total, but the
+# node uses 6.4 of 16 cores (40% util) — 5.4 cores are non-store work.
+# The model gives each store capacity = (1.0/0.4)/4 = 0.62 cores instead of
+# a fair share of 16/4 = 4 cores. This store uses only 0.1 cores but reports
+# 16% util, inflated by non-store CPU that the model attributes to the stores.
+compute store-load=0.1 node-cpu-usage=6.4 node-cpu-capacity=16 total-stores-cpu-usage=1.0 num-stores=4
+----
+kv-capacity: 0.62 cores (total: 4.00 cores)
+kv-util: 16.00% (0.10/0.62 cores)

--- a/pkg/kv/kvserver/mmaintegration/testdata/TestComputeStoreCPURateCapacity
+++ b/pkg/kv/kvserver/mmaintegration/testdata/TestComputeStoreCPURateCapacity
@@ -1,79 +1,153 @@
 # All CPU values are in cores (1 core = 1e9 ns/s).
 
-# Normal case: node at 50% CPU, single store, all CPU from stores.
-# cpuUtil = 8/16 = 0.5, nodeCapacity = 8/0.5 = 16, storeCapacity = 16/1 = 16
+# Normal case: single store on a node. All node CPU usage comes from store work.
+# Node is at 50% utilization.
 compute store-load=8 node-cpu-usage=8 node-cpu-capacity=16 total-stores-cpu-usage=8 num-stores=1
 ----
-kv-capacity: 16.00 cores (total: 16.00 cores)
-kv-util: 50.00% (8.00/16.00 cores)
+              node-cpu-capacity/num-stores: 16.00 cores/store
+naive:        kv-capacity: 16.00 cores, kv-util: 50.00% (8.00/16.00 cores)
+capped_mult: (steps below)
+  mult        = max(1, min(8.00/8.00, 3)) = 1.0
+  background  = max(0, 8.00 - 8.00*1.0) = 0.00 cores
+  mma-share   = 16.00 - 0.00 = 16.00 cores
+  mma-direct  = 16.00 / 1.0 = 16.00 cores
+  per-store   = 16.00 / 1 = 16.00 cores
+  kv-capacity: 16.00 cores, kv-util: 50.00% (8.00/16.00 cores)
 
-# Normal case: node at 80%, 2 stores with uneven load (7 + 3 = 10 cores).
-# Both stores get the same capacity = (10/0.8)/2 = 6.25 cores.
-# The hot store (this one, 7 cores) is at 112% and will shed load to the
-# lighter store (3 cores, 48%), driving rebalancing.
+# Normal case: 2 stores on a node with uneven load. Node at 80% utilization, all
+# from store work. This store uses 7 cores, other uses 3. This store at 112%
+# util will shed load to other at 48%.
 compute store-load=7 node-cpu-usage=12.8 node-cpu-capacity=16 total-stores-cpu-usage=10 num-stores=2
 ----
-kv-capacity: 6.25 cores (total: 8.00 cores)
-kv-util: 112.00% (7.00/6.25 cores)
+              node-cpu-capacity/num-stores: 8.00 cores/store
+naive:        kv-capacity: 6.25 cores, kv-util: 112.00% (7.00/6.25 cores)
+capped_mult: (steps below)
+  mult        = max(1, min(12.80/10.00, 3)) = 1.3
+  background  = max(0, 12.80 - 10.00*1.3) = 0.00 cores
+  mma-share   = 16.00 - 0.00 = 16.00 cores
+  mma-direct  = 16.00 / 1.3 = 12.50 cores
+  per-store   = 12.50 / 2 = 6.25 cores
+  kv-capacity: 6.25 cores, kv-util: 112.00% (7.00/6.25 cores)
 
-# Auxiliary CPU dominates: store uses 1 core, but node is fully utilized at 16 cores.
-# The store gets capacity=1, so it appears 100% utilized and will shed load.
-# cpuUtil = 16/16 = 1.0, nodeCapacity = 1/1.0 = 1, storeCapacity = 1/1 = 1
-compute store-load=1 node-cpu-usage=16 node-cpu-capacity=16 total-stores-cpu-usage=1 num-stores=1
+# Measurement lag: stores report more CPU than node is using (implicit mult < 1).
+# This can happen due to timing differences in measurement collection. The
+# implicit multiplier would be 0.5 (= 4/8), but it gets clamped to 1.0.
+compute store-load=4 node-cpu-usage=4 node-cpu-capacity=16 total-stores-cpu-usage=8 num-stores=1
 ----
-kv-capacity: 1.00 cores (total: 16.00 cores)
-kv-util: 100.00% (1.00/1.00 cores)
+              node-cpu-capacity/num-stores: 16.00 cores/store
+naive:        kv-capacity: 32.00 cores, kv-util: 12.50% (4.00/32.00 cores)
+capped_mult: (steps below)
+  mult        = max(1, min(4.00/8.00, 3)) = 1.0
+  background  = max(0, 4.00 - 8.00*1.0) = 0.00 cores
+  mma-share   = 16.00 - 0.00 = 16.00 cores
+  mma-direct  = 16.00 / 1.0 = 16.00 cores
+  per-store   = 16.00 / 1 = 16.00 cores
+  kv-capacity: 16.00 cores, kv-util: 25.00% (4.00/16.00 cores)
 
-# Low utilization fallback: cpuUtil < 1%.
-# Falls back to nodeCapacity/2/numStores = 16/2/2 = 4.
+# Moderate indirect overhead: store uses 4 cores, node uses 8 cores (2x overhead).
+# Implicit multiplier is 2.0 (= 8/4), which is between 1 and 3, so it's used
+# directly. This represents moderate indirect CPU overhead (RPC, compactions, etc.).
+compute store-load=4 node-cpu-usage=8 node-cpu-capacity=16 total-stores-cpu-usage=4 num-stores=1
+----
+              node-cpu-capacity/num-stores: 16.00 cores/store
+naive:        kv-capacity: 8.00 cores, kv-util: 50.00% (4.00/8.00 cores)
+capped_mult: (steps below)
+  mult        = max(1, min(8.00/4.00, 3)) = 2.0
+  background  = max(0, 8.00 - 4.00*2.0) = 0.00 cores
+  mma-share   = 16.00 - 0.00 = 16.00 cores
+  mma-direct  = 16.00 / 2.0 = 8.00 cores
+  per-store   = 8.00 / 1 = 8.00 cores
+  kv-capacity: 8.00 cores, kv-util: 50.00% (4.00/8.00 cores)
+
+# Low utilization fallback: node CPU utilization is very low (< 1%).
+# Naive model assumes 50% overhead and gives 4 cores capacity.
+# Capped_mult gives 8 cores (half of node capacity per store) since it
+# doesn't assume overhead.
 compute store-load=0.1 node-cpu-usage=0.1 node-cpu-capacity=16 total-stores-cpu-usage=0.1 num-stores=2
 ----
-kv-capacity: 4.00 cores (total: 8.00 cores)
-kv-util: 2.50% (0.10/4.00 cores)
+              node-cpu-capacity/num-stores: 8.00 cores/store
+naive:        kv-capacity: 4.00 cores, kv-util: 2.50% (0.10/4.00 cores)
+capped_mult: (steps below)
+  mult        = max(1, min(0.10/0.10, 3)) = 1.0
+  background  = max(0, 0.10 - 0.10*1.0) = 0.00 cores
+  mma-share   = 16.00 - 0.00 = 16.00 cores
+  mma-direct  = 16.00 / 1.0 = 16.00 cores
+  per-store   = 16.00 / 2 = 8.00 cores
+  kv-capacity: 8.00 cores, kv-util: 1.25% (0.10/8.00 cores)
 
-# StoresCPURate is zero (no replicas reporting CPU yet).
-# Falls back to nodeCapacity/2/numStores = 16/2/1 = 8.
-compute store-load=0.5 node-cpu-usage=8 node-cpu-capacity=16 total-stores-cpu-usage=0 num-stores=1
+# StoresCPURate is zero: no replicas reporting CPU usage yet (startup or
+# measurement lag). Node at 50% utilization, but stores haven't reported any
+# CPU. Naive gives 8 cores. Capped_mult gives 2.67 cores (more conservative,
+# assumes all node usage is background).
+compute store-load=0 node-cpu-usage=8 node-cpu-capacity=16 total-stores-cpu-usage=0 num-stores=1
 ----
-kv-capacity: 8.00 cores (total: 16.00 cores)
-kv-util: 6.25% (0.50/8.00 cores)
+              node-cpu-capacity/num-stores: 16.00 cores/store
+naive:        kv-capacity: 8.00 cores, kv-util: 0.00% (0.00/8.00 cores)
+capped_mult: (steps below)
+  mult        = max(1, min(8.00/0.00, 3)) = 3.0
+  background  = max(0, 8.00 - 0.00*3.0) = 8.00 cores
+  mma-share   = 16.00 - 8.00 = 8.00 cores
+  mma-direct  = 8.00 / 3.0 = 2.67 cores
+  per-store   = 2.67 / 1 = 2.67 cores
+  kv-capacity: 2.67 cores, kv-util: 0.00% (0.00/2.67 cores)
 
-# Unknown capacity: nodeCapacity is 0 (mixed version cluster?).
-# Falls back to storeCPULoad * 2, i.e. 50% utilization.
-compute store-load=4 node-cpu-usage=0 node-cpu-capacity=0 total-stores-cpu-usage=0 num-stores=1
+# Unknown capacity: node CPU capacity is 0 (mixed version cluster or missing
+# metrics). Both models fall back to assuming 50% utilization.
+compute store-load=4 node-cpu-usage=8 node-cpu-capacity=0 total-stores-cpu-usage=4 num-stores=1
 ----
-kv-capacity: 8.00 cores (total: 0.00 cores)
-kv-util: 50.00% (4.00/8.00 cores)
+              node-cpu-capacity/num-stores: 0.00 cores/store
+naive:        kv-capacity: 8.00 cores, kv-util: 50.00% (4.00/8.00 cores)
+capped_mult: (node-cpu-capacity unknown, assuming 50% util)
+  kv-capacity: 8.00 cores, kv-util: 50.00% (4.00/8.00 cores)
+
+# Invalid case: num-stores is 0 (should not happen in production).
+# Both models return 0 capacity.
+compute store-load=4 node-cpu-usage=8 node-cpu-capacity=16 total-stores-cpu-usage=4 num-stores=0
+----
+              node-cpu-capacity/num-stores: +Inf cores/store
+naive:        kv-capacity: 0.00 cores, kv-util: +Inf% (4.00/0.00 cores)
+capped_mult: (early return: num-stores=0)
+  kv-capacity: 8.00 cores, kv-util: 50.00% (4.00/8.00 cores)
 
 # ---------------------------------------------------------------------------
-# Problems with the current model
+# Problems with the naive model
 # ---------------------------------------------------------------------------
-# The current formula assumes ALL node CPU usage is caused (directly or
-# indirectly) by MMA-tracked store work:
-#
-#   mma-capacity = total-stores-cpu-usage / (node-cpu-usage / node-cpu-capacity) / num-stores
-#
-# This means a store's MMA utilization always equals the node's CPU utilization,
-# regardless of how much of the node CPU usage is actually store-related.
-# When there is significant non-store CPU (SQL gateway, background jobs,
-# GC, etc.), the model assigns an unrealistically low capacity to the
-# store, causing premature load shedding.
+# The naive model assumes ALL node CPU usage is caused by store work, so
+# store utilization always equals node utilization. When there is significant
+# non-store CPU (SQL, GC, etc.), it assigns unrealistically low capacity,
+# causing premature load shedding.
 
-# Problem case 1: store uses 0.1 cores, node uses 6.4 cores (40% util). The
-# implied multiplier is 64x (= 6.4 / 0.1) - the model blames the store for 64x
-# its direct load. The store gets mma-capacity=0.25 and appears 40% utilized
-# despite consuming 0.1 out of 16 available cores. The node has 9.6 idle cores.
+# Problem case 1: naive model over-attributes non-store CPU to stores.
+# Store uses only 0.1 cores, but node uses 6.4 cores. 6.3 cores are from
+# non-store work. Naive model: 0.25 cores capacity, store appears 40% utilized
+# (matches node util). Capped_mult: 3.3 cores capacity, store appears 3%
+# utilized (correctly low).
 compute store-load=0.1 node-cpu-usage=6.4 node-cpu-capacity=16 total-stores-cpu-usage=0.1 num-stores=1
 ----
-kv-capacity: 0.25 cores (total: 16.00 cores)
-kv-util: 40.00% (0.10/0.25 cores)
+              node-cpu-capacity/num-stores: 16.00 cores/store
+naive:        kv-capacity: 0.25 cores, kv-util: 40.00% (0.10/0.25 cores)
+capped_mult: (steps below)
+  mult        = max(1, min(6.40/0.10, 3)) = 3.0
+  background  = max(0, 6.40 - 0.10*3.0) = 6.10 cores
+  mma-share   = 16.00 - 6.10 = 9.90 cores
+  mma-direct  = 9.90 / 3.0 = 3.30 cores
+  per-store   = 3.30 / 1 = 3.30 cores
+  kv-capacity: 3.30 cores, kv-util: 3.03% (0.10/3.30 cores)
 
-# Problem case 2: multi-store node. 4 stores using 1.0 cores total, but the
-# node uses 6.4 of 16 cores (40% util) — 5.4 cores are non-store work.
-# The model gives each store capacity = (1.0/0.4)/4 = 0.62 cores instead of
-# a fair share of 16/4 = 4 cores. This store uses only 0.1 cores but reports
-# 16% util, inflated by non-store CPU that the model attributes to the stores.
+# Problem case 2: naive model over-attributes non-store CPU in multi-store
+# scenario. 4 stores using 1.0 cores total, but node uses 6.4 cores. 5.4 cores
+# are non-store work. Fair share would be 4 cores per store. This store uses
+# only 0.1 cores. Naive model: 0.62 cores capacity, store appears 16% utilized
+# (inflated by non-store CPU). Capped_mult: 1.05 cores capacity, store appears
+# 9.5% utilized (still conservative but better).
 compute store-load=0.1 node-cpu-usage=6.4 node-cpu-capacity=16 total-stores-cpu-usage=1.0 num-stores=4
 ----
-kv-capacity: 0.62 cores (total: 4.00 cores)
-kv-util: 16.00% (0.10/0.62 cores)
+              node-cpu-capacity/num-stores: 4.00 cores/store
+naive:        kv-capacity: 0.62 cores, kv-util: 16.00% (0.10/0.62 cores)
+capped_mult: (steps below)
+  mult        = max(1, min(6.40/1.00, 3)) = 3.0
+  background  = max(0, 6.40 - 1.00*3.0) = 3.40 cores
+  mma-share   = 16.00 - 3.40 = 12.60 cores
+  mma-direct  = 12.60 / 3.0 = 4.20 cores
+  per-store   = 4.20 / 4 = 1.05 cores
+  kv-capacity: 1.05 cores, kv-util: 9.52% (0.10/1.05 cores)


### PR DESCRIPTION
Epic: CRDB-55052 
Release note: none

---
**mmaintegration: extract capacity model functions from mmaprototype**

Previously, the logic for computing store capacity was inline in
MakeStoreLoadMsg. This commit extracts it to a separate function in the
mmaintegration package.

---
**mmaintegration: refactor capacity model code**

This commit refactors some capacity model code to improve readability.

---
**mmaintegration: add capped multiplier CPU capacity model**

Previously, the naive CPU capacity model assumed all node CPU usage
was caused by store work, causing it to over-attribute non-store CPU
(SQL gateway, GC, background jobs, etc.) to stores. This led to
unrealistically low capacity estimates and inaccurate utilization
measurements.

This commit adds computeStoreCPURateCapacityWithCap, a new CPU capacity
model that assumes store work can scale to at most 3.0x its direct CPU
usage (1x direct + up to 2x indirect overhead related to kv work, etc.).
Any CPU usage beyond this 3.0x multiplier is treated as fixed overhead
unrelated to store work. This prevents premature load shedding when there
is significant non-store CPU usage.

---
**mmaintegration: fix negative capacity**


---
**mmaintegration: extract input into storeCPURateCapacityInput**


---
**mmaintegration: remove `currentStoreCPUUsage` from capacity input**

The `currentStoreCPUUsage` field in `storeCPURateCapacityInput` was used
only in a fallback path that assumed 50% utilization when
`nodeCPURateCapacity` was unknown. In practice, `nodeCPURateCapacity`
should always be populated in production.

This change removes the field and replaces the fallback with a fatal
assertion requiring both `nodeCPURateCapacity > 0` and `numStores > 0`.
The same assertion is added to `computeCPUCapacityWithCap`.

---
**mmaintegration: move naive capacity models to test-only file**

This change moves `computeStoreCPURateCapacity` and
`computeStoreByteSizeCapacityWrong` out of `capacity_model.go` into a
new `legacy_model_test.go`, renaming them to
`computeStoreCPURateCapacityNaive` and
`computeStoreByteSizeCapacityNaive` respectively.

Neither function is used in production. The active implementations are
`computeCPUCapacityWithCap` (capped multiplier model) and the
`FractionUsed()` based disk model. The naive models are retained solely
for comparison in tests, where they illustrate the failure modes that
the newer models address.

---
**mmaintegration: rewrite CPU capacity test with ground-truth scenarios**

The existing `TestComputeStoreCPURateCapacity` exercised model outputs
without a reference for the correct answer. This made it difficult to
assess whether a model was producing reasonable results or to compare
models against each other.

This change restructures the test so that each scenario specifies the
true breakdown of node CPU into three components:

  1. kv-cpu: direct KV replica CPU (what MMA tracks as store load).
  2. proportional-overhead: CPU that scales with KV work (DistSQL,
     RPC, etc.).
  3. background: CPU independent of KV (gateway SQL, GC, jobs).

From these, the true per-store capacity is derived analytically, and
each model's output is compared against it as a `capacity_err`
percentage. Negative errors indicate pessimism (premature load
shedding); positive errors indicate optimism (delayed overload
detection).

---
**mmaintegration: remove observer callback from `computeCPUCapacityWithCap`**

The `observer` parameter in `computeCPUCapacityWithCap` existed solely to
extract intermediate values (`mult`, `backgroundLoad`, `mmaShareOfCapacity`,
`mmaDirectCapacity`) for display in test output. With the test now focused
on result rather than internal model steps, the parameter is unused at all
call sites.

This change removes the `observer` parameter and simplifies the call sites
in `store_load_msg.go` and `capacity_model_test.go` accordingly.

Note that this is a pure cleanup — no behavioral change.

