### PR TITLE
db-console: Convert shared class components to functional components

### DIFF
--- a/pkg/ui/workspaces/db-console/ccl/src/views/clusterviz/containers/map/sparkline.tsx
+++ b/pkg/ui/workspaces/db-console/ccl/src/views/clusterviz/containers/map/sparkline.tsx
@@ -109,7 +109,7 @@ interface SparklineMetricsDataComponentProps {
 export class SparklineMetricsDataComponent extends React.Component<
   MetricsDataComponentProps & SparklineMetricsDataComponentProps
 > {
-  chart: React.ComponentClass<SparklineChartProps>;
+  chart: React.ComponentType<SparklineChartProps>;
 
   constructor(
     props: MetricsDataComponentProps & SparklineMetricsDataComponentProps,

--- a/pkg/ui/workspaces/db-console/ccl/src/views/shared/containers/licenseSwap/index.tsx
+++ b/pkg/ui/workspaces/db-console/ccl/src/views/shared/containers/licenseSwap/index.tsx
@@ -47,10 +47,7 @@ export default function swapByLicense<
   OSSProps,
   CCLProps,
   TProps = OSSProps | CCLProps,
->(
-  OSSComponent: React.ComponentClass<OSSProps>,
-  CCLComponent: React.ComponentClass<CCLProps>,
-) {
+>(OSSComponent: Component<OSSProps>, CCLComponent: Component<CCLProps>) {
   const ossName = getComponentName(OSSComponent);
   const cclName = getComponentName(CCLComponent);
 

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/alertBox/alertBox.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/alertBox/alertBox.spec.tsx
@@ -1,0 +1,73 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import { AlertLevel } from "src/redux/alerts";
+
+import { AlertBox, AlertBoxProps } from "./index";
+
+describe("AlertBox", () => {
+  const defaultProps: AlertBoxProps = {
+    title: "Test Alert",
+    level: AlertLevel.WARNING,
+    dismiss: jest.fn(),
+  };
+
+  const renderAlertBox = (overrides: Partial<AlertBoxProps> = {}) =>
+    render(<AlertBox {...defaultProps} {...overrides} />);
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("renders title and text", () => {
+    renderAlertBox({ text: "Some details" });
+    expect(screen.getByText("Test Alert")).toBeDefined();
+    expect(screen.getByText("Some details")).toBeDefined();
+  });
+
+  it("calls dismiss when close button is clicked", async () => {
+    const dismiss = jest.fn();
+    renderAlertBox({ dismiss });
+    await userEvent.click(screen.getByText("✕"));
+    expect(dismiss).toHaveBeenCalledTimes(1);
+  });
+
+  describe("Learn More link", () => {
+    it("renders when link prop is provided", () => {
+      renderAlertBox({ link: "https://example.com" });
+      const learnMore = screen.getByText("Learn More");
+      expect(learnMore).toBeDefined();
+      expect(learnMore.getAttribute("href")).toBe("https://example.com");
+    });
+
+    it("does not render when link prop is absent", () => {
+      renderAlertBox();
+      expect(screen.queryByText("Learn More")).toBeNull();
+    });
+  });
+
+  describe("CSS class by alert level", () => {
+    const levels: { level: AlertLevel; className: string }[] = [
+      { level: AlertLevel.CRITICAL, className: "alert-box--critical" },
+      { level: AlertLevel.WARNING, className: "alert-box--warning" },
+      { level: AlertLevel.INFORMATION, className: "alert-box--information" },
+      { level: AlertLevel.NOTIFICATION, className: "alert-box--notification" },
+      { level: AlertLevel.SUCCESS, className: "alert-box--success" },
+    ];
+
+    test.each(levels)(
+      "applies $className for AlertLevel.$level",
+      ({ level, className }) => {
+        const { container } = renderAlertBox({ level });
+        const root = container.querySelector(".alert-box");
+        expect(root?.classList.contains(className)).toBe(true);
+      },
+    );
+  });
+});

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/alertBox/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/alertBox/index.tsx
@@ -33,46 +33,50 @@ export interface AlertBoxProps extends AlertInfo {
   dismiss(): void;
 }
 
-export class AlertBox extends React.Component<AlertBoxProps, {}> {
-  render() {
-    // build up content element, which has a wrapping anchor element that is
-    // conditionally present.
-    let content = (
-      <div>
-        <div className="alert-box__title">{this.props.title}</div>
-        <div className="alert-box__text">{this.props.text}</div>
-      </div>
-    );
+export function AlertBox({
+  title,
+  text,
+  link,
+  level,
+  dismiss,
+}: AlertBoxProps): React.ReactElement {
+  // build up content element, which has a wrapping anchor element that is
+  // conditionally present.
+  let content = (
+    <div>
+      <div className="alert-box__title">{title}</div>
+      <div className="alert-box__text">{text}</div>
+    </div>
+  );
 
-    const learnMore = this.props.link && (
-      <a className="" href={this.props.link}>
-        Learn More
-      </a>
-    );
-    content = (
-      <>
-        <div className="alert-box__content">
-          {content}
-          {learnMore}
-        </div>
-      </>
-    );
-
-    return (
-      <div
-        className={classNames(
-          "alert-box",
-          `alert-box--${AlertLevel[this.props.level].toLowerCase()}`,
-        )}
-      >
-        <div className="alert-box__icon">{alertIcon(this.props.level)}</div>
+  const learnMore = link && (
+    <a className="" href={link}>
+      Learn More
+    </a>
+  );
+  content = (
+    <>
+      <div className="alert-box__content">
         {content}
-        <div className="alert-box__dismiss">
-          <a className="alert-box__link" onClick={this.props.dismiss}>
-            ✕
-          </a>
-        </div>
+        {learnMore}
       </div>
-    );
-  }
+    </>
+  );
+
+  return (
+    <div
+      className={classNames(
+        "alert-box",
+        `alert-box--${AlertLevel[level].toLowerCase()}`,
+      )}
+    >
+      <div className="alert-box__icon">{alertIcon(level)}</div>
+      {content}
+      <div className="alert-box__dismiss">
+        <a className="alert-box__link" onClick={dismiss}>
+          ✕
+        </a>
+      </div>
+    </div>
+  );
 }

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/alertMessage/alertMessage.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/alertMessage/alertMessage.spec.tsx
@@ -1,0 +1,94 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+
+import { AlertLevel } from "src/redux/alerts";
+
+import { AlertMessage } from "./alertMessage";
+
+describe("AlertMessage", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  const defaultProps = {
+    title: "Test title",
+    level: AlertLevel.WARNING,
+    autoClose: false,
+    dismiss: jest.fn(),
+  };
+
+  const renderAlertMessage = (overrides: Record<string, unknown> = {}) =>
+    render(
+      <MemoryRouter>
+        <AlertMessage {...defaultProps} {...overrides} />
+      </MemoryRouter>,
+    );
+
+  describe("auto-close timer", () => {
+    it("calls dismiss after autoCloseTimeout when autoClose is true", () => {
+      const dismiss = jest.fn();
+      renderAlertMessage({ autoClose: true, autoCloseTimeout: 3000, dismiss });
+
+      expect(dismiss).not.toHaveBeenCalled();
+      jest.advanceTimersByTime(3000);
+      expect(dismiss).toHaveBeenCalledTimes(1);
+    });
+
+    it("uses default 6000ms timeout when autoCloseTimeout is not provided", () => {
+      const dismiss = jest.fn();
+      renderAlertMessage({ autoClose: true, dismiss });
+
+      jest.advanceTimersByTime(5999);
+      expect(dismiss).not.toHaveBeenCalled();
+      jest.advanceTimersByTime(1);
+      expect(dismiss).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not set timer when autoClose is false", () => {
+      const dismiss = jest.fn();
+      renderAlertMessage({ autoClose: false, dismiss });
+
+      jest.advanceTimersByTime(10000);
+      expect(dismiss).not.toHaveBeenCalled();
+    });
+
+    it("clears timer on unmount before it fires", () => {
+      const dismiss = jest.fn();
+      const { unmount } = renderAlertMessage({
+        autoClose: true,
+        autoCloseTimeout: 5000,
+        dismiss,
+      });
+
+      jest.advanceTimersByTime(2000);
+      unmount();
+      jest.advanceTimersByTime(5000);
+      expect(dismiss).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("description link", () => {
+    it("renders text as a Link when link prop is provided", () => {
+      renderAlertMessage({ text: "Click here", link: "/some/path" });
+      const linkEl = screen.getByText("Click here");
+      expect(linkEl.tagName).toBe("A");
+      expect(linkEl.getAttribute("href")).toBe("/some/path");
+    });
+
+    it("renders plain text when link prop is absent", () => {
+      renderAlertMessage({ text: "Plain text" });
+      const textEl = screen.getByText("Plain text");
+      expect(textEl.tagName).not.toBe("A");
+    });
+  });
+});

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/alertMessage/alertMessage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/alertMessage/alertMessage.tsx
@@ -10,16 +10,16 @@ import {
   WarningFilled,
 } from "@ant-design/icons";
 import { Alert } from "antd";
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { Link } from "react-router-dom";
 
 import { AlertInfo, AlertLevel } from "src/redux/alerts";
 import "./alertMessage.scss";
 
 interface AlertMessageProps extends AlertInfo {
-  autoClose: boolean;
-  autoCloseTimeout: number;
-  closable: boolean;
+  autoClose?: boolean;
+  autoCloseTimeout?: number;
+  closable?: boolean;
   dismiss(): void;
 }
 
@@ -55,51 +55,50 @@ const getIcon = (alertLevel: AlertLevel): React.ReactNode => {
   }
 };
 
-export class AlertMessage extends React.Component<AlertMessageProps> {
-  static defaultProps = {
-    closable: true,
-    autoCloseTimeout: 6000,
-  };
+export function AlertMessage({
+  autoClose = false,
+  autoCloseTimeout = 6000,
+  closable = true,
+  dismiss,
+  level,
+  link,
+  title,
+  text,
+}: AlertMessageProps): React.ReactElement {
+  const timeoutRef = useRef<number>();
 
-  timeoutHandler: number;
-
-  componentDidMount() {
-    const { autoClose, dismiss, autoCloseTimeout } = this.props;
+  useEffect(() => {
     if (autoClose) {
-      this.timeoutHandler = window.setTimeout(dismiss, autoCloseTimeout);
+      timeoutRef.current = window.setTimeout(dismiss, autoCloseTimeout);
     }
-  }
+    return () => {
+      clearTimeout(timeoutRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-  componentWillUnmount() {
-    clearTimeout(this.timeoutHandler);
-  }
+  let description: React.ReactNode = text;
 
-  render() {
-    const { level, dismiss, link, title, text, closable } = this.props;
-
-    let description: React.ReactNode = text;
-
-    if (link) {
-      description = (
-        <Link to={link} onClick={dismiss}>
-          {text}
-        </Link>
-      );
-    }
-
-    const type = mapAlertLevelToType(level);
-    return (
-      <Alert
-        className="alert-massage"
-        message={title}
-        description={description}
-        showIcon
-        icon={getIcon(level)}
-        closable={closable}
-        onClose={dismiss}
-        type={type}
-        banner
-      />
+  if (link) {
+    description = (
+      <Link to={link} onClick={dismiss}>
+        {text}
+      </Link>
     );
   }
+
+  const type = mapAlertLevelToType(level);
+  return (
+    <Alert
+      className="alert-massage"
+      message={title}
+      description={description}
+      showIcon
+      icon={getIcon(level)}
+      closable={closable}
+      onClose={dismiss}
+      type={type}
+      banner
+    />
+  );
 }

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/debugAnnotation/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/debugAnnotation/index.tsx
@@ -15,13 +15,14 @@ export interface DebugAnnotationProps {
 /**
  * DebugAnnotation is an indicator showing a bit of information on the debug page.
  */
-export default class DebugAnnotation extends React.Component<DebugAnnotationProps> {
-  render() {
-    return (
-      <h3>
-        <span className="debug-annotation__label">{this.props.label}:</span>{" "}
-        <span className="debug-annotation__value">{this.props.value}</span>
-      </h3>
-    );
-  }
+export default function DebugAnnotation({
+  label,
+  value,
+}: DebugAnnotationProps): React.ReactElement {
+  return (
+    <h3>
+      <span className="debug-annotation__label">{label}:</span>{" "}
+      <span className="debug-annotation__value">{value}</span>
+    </h3>
+  );
 }

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/dropdown/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/dropdown/index.tsx
@@ -6,7 +6,7 @@
 import classNames from "classnames/bind";
 import includes from "lodash/includes";
 import isNil from "lodash/isNil";
-import React from "react";
+import React, { useRef, useState } from "react";
 import Select from "react-select";
 
 import { CaretDown } from "src/components/icon/caretDown";
@@ -54,24 +54,34 @@ export const arrowRenderer = ({ isOpen }: { isOpen: boolean }) => (
 /**
  * Dropdown component that uses the URL query string for state.
  */
-export default class Dropdown extends React.Component<DropdownOwnProps, {}> {
-  state = {
-    is_focused: false,
-  };
+export default function Dropdown({
+  title,
+  selected,
+  options,
+  onChange,
+  onArrowClick,
+  onDropdownClick,
+  disabledArrows,
+  content,
+  isTimeRange,
+  className: classNameProp,
+  type = "secondary",
+}: DropdownOwnProps): React.ReactElement {
+  const [isFocused, setIsFocused] = useState(false);
 
-  dropdownRef: React.RefObject<HTMLDivElement> = React.createRef();
-  titleRef: React.RefObject<HTMLDivElement> = React.createRef();
-  selectRef: React.RefObject<Select<DropdownOption>> = React.createRef();
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const titleRef = useRef<HTMLDivElement>(null);
+  const selectRef = useRef<Select<DropdownOption>>(null);
 
-  triggerSelectClick = (e: any) => {
-    this.props.onDropdownClick && this.props.onDropdownClick();
+  const triggerSelectClick = (e: any) => {
+    onDropdownClick && onDropdownClick();
     // Don't handle click if custom dropdown menu content is rendered.
-    if (this.props.content) {
+    if (content) {
       return;
     }
-    const dropdownNode = this.dropdownRef.current as Node;
-    const titleNode = this.titleRef.current as Node;
-    const selectNode = this.selectRef.current;
+    const dropdownNode = dropdownRef.current as Node;
+    const titleNode = titleRef.current as Node;
+    const selectNode = selectRef.current;
 
     if (
       e.target.isSameNode(dropdownNode) ||
@@ -91,98 +101,77 @@ export default class Dropdown extends React.Component<DropdownOwnProps, {}> {
     }
   };
 
-  onFocus = () => this.setState({ is_focused: true });
-
-  onClose = () => this.setState({ is_focused: false });
-
-  render() {
-    const {
-      selected,
-      options,
-      onChange,
-      onArrowClick,
+  const className = cx(
+    "dropdown",
+    `dropdown--type-${type}`,
+    {
+      _range: isTimeRange,
+      "dropdown--side-arrows": !isNil(onArrowClick),
+      dropdown__focused: isFocused,
+    },
+    classNameProp,
+  );
+  const leftClassName = cx("dropdown__side-arrow", {
+    "dropdown__side-arrow--disabled": includes(
       disabledArrows,
-      content,
-      isTimeRange,
-      type = "secondary",
-    } = this.props;
+      ArrowDirection.LEFT,
+    ),
+  });
+  const rightClassName = cx("dropdown__side-arrow", {
+    "dropdown__side-arrow--disabled": includes(
+      disabledArrows,
+      ArrowDirection.RIGHT,
+    ),
+  });
 
-    const className = cx(
-      "dropdown",
-      `dropdown--type-${type}`,
-      {
-        _range: isTimeRange,
-        "dropdown--side-arrows": !isNil(onArrowClick),
-        dropdown__focused: this.state.is_focused,
-      },
-      this.props.className,
-    );
-    const leftClassName = cx("dropdown__side-arrow", {
-      "dropdown__side-arrow--disabled": includes(
-        disabledArrows,
-        ArrowDirection.LEFT,
-      ),
-    });
-    const rightClassName = cx("dropdown__side-arrow", {
-      "dropdown__side-arrow--disabled": includes(
-        disabledArrows,
-        ArrowDirection.RIGHT,
-      ),
-    });
-
-    return (
-      <div
-        className={className}
-        onClick={this.triggerSelectClick}
-        ref={this.dropdownRef}
+  return (
+    <div className={className} onClick={triggerSelectClick} ref={dropdownRef}>
+      {/* TODO (maxlang): consider moving arrows outside the dropdown component */}
+      <span
+        className={leftClassName}
+        dangerouslySetInnerHTML={trustIcon(leftArrow)}
+        onClick={() => onArrowClick(ArrowDirection.LEFT)}
+      ></span>
+      <span
+        className={cx({
+          "dropdown__range-title": isTimeRange,
+          dropdown__title: !isTimeRange,
+        })}
+        ref={titleRef}
       >
-        {/* TODO (maxlang): consider moving arrows outside the dropdown component */}
-        <span
-          className={leftClassName}
-          dangerouslySetInnerHTML={trustIcon(leftArrow)}
-          onClick={() => this.props.onArrowClick(ArrowDirection.LEFT)}
-        ></span>
-        <span
-          className={cx({
-            "dropdown__range-title": isTimeRange,
-            dropdown__title: !isTimeRange,
-          })}
-          ref={this.titleRef}
-        >
-          {this.props.title}
-          {this.props.title && !isTimeRange ? ":" : ""}
-        </span>
-        {content ? (
-          content
-        ) : (
-          // The below typescript fails to typecheck because the
-          // react-select library's types aren't flexible enough to
-          // accept the `options` and `onChange` props that use the
-          // custom `DropdownOption` type as the target. It's likely
-          // that an upgrade of react-select would fix this but we
-          // avoid it here because it will likely break implementation.
+        {title}
+        {title && !isTimeRange ? ":" : ""}
+      </span>
+      {content ? (
+        content
+      ) : (
+        // The below typescript fails to typecheck because the
+        // react-select library's types aren't flexible enough to
+        // accept the `options` and `onChange` props that use the
+        // custom `DropdownOption` type as the target. It's likely
+        // that an upgrade of react-select would fix this but we
+        // avoid it here because it will likely break implementation.
 
-          /* eslint @typescript-eslint/ban-ts-comment: "off" */
-          // @ts-ignore
-          <Select
-            className={cx("dropdown__select")}
-            arrowRenderer={arrowRenderer}
-            clearable={false}
-            searchable={false}
-            options={options}
-            value={selected}
-            onChange={onChange}
-            onFocus={this.onFocus}
-            onClose={this.onClose}
-            ref={this.selectRef}
-          />
-        )}
-        <span
-          className={rightClassName}
-          dangerouslySetInnerHTML={trustIcon(rightArrow)}
-          onClick={() => this.props.onArrowClick(ArrowDirection.RIGHT)}
-        ></span>
-      </div>
-    );
-  }
+        /* eslint @typescript-eslint/ban-ts-comment: "off" */
+        // @ts-ignore
+        <Select
+          className={cx("dropdown__select")}
+          arrowRenderer={arrowRenderer}
+          clearable={false}
+          searchable={false}
+          options={options}
+          value={selected}
+          onChange={onChange}
+          onFocus={() => setIsFocused(true)}
+          onClose={() => setIsFocused(false)}
+          ref={selectRef}
+        />
+      )}
+      <span
+        className={rightClassName}
+        dangerouslySetInnerHTML={trustIcon(rightArrow)}
+        onClick={() => onArrowClick(ArrowDirection.RIGHT)}
+      ></span>
+    </div>
+  );
 }

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/emailSubscriptionForm/emailSubscriptionForm.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/emailSubscriptionForm/emailSubscriptionForm.spec.tsx
@@ -3,27 +3,26 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
-import { mount, ReactWrapper } from "enzyme";
+import { render, screen, fireEvent } from "@testing-library/react";
 import React from "react";
 
 import { EmailSubscriptionForm } from "./index";
 
 describe("EmailSubscriptionForm", () => {
-  let wrapper: ReactWrapper;
   const onSubmitHandler = jest.fn();
 
   beforeEach(() => {
     onSubmitHandler.mockReset();
-    wrapper = mount(<EmailSubscriptionForm onSubmit={onSubmitHandler} />);
   });
 
   describe("when correct email", () => {
     it("provides entered email on submit callback", () => {
+      render(<EmailSubscriptionForm onSubmit={onSubmitHandler} />);
       const emailAddress = "foo@bar.com";
-      const inputComponent = wrapper.find("input.crl-input__text").first();
-      inputComponent.simulate("change", { target: { value: emailAddress } });
-      const buttonComponent = wrapper.find(`button`).first();
-      buttonComponent.simulate("click");
+      fireEvent.change(screen.getByPlaceholderText("Enter your email"), {
+        target: { value: emailAddress },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "Sign up" }));
 
       expect(onSubmitHandler).toHaveBeenCalledWith(emailAddress);
     });
@@ -31,29 +30,27 @@ describe("EmailSubscriptionForm", () => {
 
   describe("when invalid email", () => {
     beforeEach(() => {
-      const emailAddress = "foo";
-      const inputComponent = wrapper.find("input.crl-input__text").first();
-      inputComponent.simulate("change", { target: { value: emailAddress } });
-      inputComponent.simulate("blur");
+      render(<EmailSubscriptionForm onSubmit={onSubmitHandler} />);
+      const input = screen.getByPlaceholderText("Enter your email");
+      fireEvent.change(input, { target: { value: "foo" } });
+      fireEvent.blur(input);
     });
 
     it("doesn't call onSubmit callback", () => {
-      const buttonComponent = wrapper.find(`button`).first();
-      buttonComponent.simulate("click");
+      fireEvent.click(screen.getByRole("button", { name: "Sign up" }));
       expect(onSubmitHandler).not.toHaveBeenCalled();
     });
 
     it("submit button is disabled", () => {
-      const buttonComponent = wrapper.find(`button[disabled]`).first();
-      expect(buttonComponent.exists()).toBe(true);
+      const button = screen.getByRole("button", {
+        name: "Sign up",
+      }) as HTMLButtonElement;
+      expect(button.disabled).toBe(true);
     });
 
     it("validation message is shown", () => {
-      const validationMessageWrapper = wrapper
-        .find(".crl-input__text--error-message")
-        .first();
-      expect(validationMessageWrapper.exists()).toBe(true);
-      expect(validationMessageWrapper.text()).toEqual("Invalid email address.");
+      const errorMessage = screen.getByText("Invalid email address.");
+      expect(errorMessage).toBeDefined();
     });
   });
 });

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/emailSubscriptionForm/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/emailSubscriptionForm/index.tsx
@@ -3,58 +3,30 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
-import React from "react";
+import React, { useState } from "react";
 
 import { TextInput, Button } from "src/components";
 import { isValidEmail } from "src/util/validation/isValidEmail";
 
 import "./emailSubscriptionForm.scss";
 
-interface EmailSubscriptionFormState {
-  emailAddress: string | undefined;
-  canSubmit: boolean;
-}
-
 interface EmailSubscriptionFormProps {
   onSubmit?: (emailAddress: string) => void;
 }
 
-export class EmailSubscriptionForm extends React.Component<
-  EmailSubscriptionFormProps,
-  EmailSubscriptionFormState
-> {
-  constructor(props: EmailSubscriptionFormProps) {
-    super(props);
-    this.state = {
-      emailAddress: undefined,
-      canSubmit: false,
-    };
-  }
+export function EmailSubscriptionForm({
+  onSubmit,
+}: EmailSubscriptionFormProps): React.ReactElement {
+  const [emailAddress, setEmailAddress] = useState<string | undefined>(
+    undefined,
+  );
+  const [canSubmit, setCanSubmit] = useState(false);
 
-  handleSubmit = () => {
-    if (this.state.canSubmit) {
-      this.props.onSubmit(this.state.emailAddress);
-      this.setState({
-        emailAddress: "",
-        canSubmit: false,
-      });
-    }
-  };
-
-  handleChange = (value: string) => {
-    this.handleEmailValidation(value);
-    this.setState({
-      emailAddress: value,
-    });
-  };
-
-  handleEmailValidation = (value: string) => {
+  const handleEmailValidation = (value: string) => {
     const isCorrectEmail = isValidEmail(value);
     const isEmpty = value.length === 0;
 
-    this.setState({
-      canSubmit: isCorrectEmail && !isEmpty,
-    });
+    setCanSubmit(isCorrectEmail && !isEmpty);
 
     if (isCorrectEmail || isEmpty) {
       return undefined;
@@ -62,27 +34,37 @@ export class EmailSubscriptionForm extends React.Component<
     return "Invalid email address.";
   };
 
-  render() {
-    const { canSubmit, emailAddress } = this.state;
-    return (
-      <div className="email-subscription-form">
-        <TextInput
-          name="email"
-          className="email-subscription-form__input"
-          placeholder="Enter your email"
-          validate={this.handleEmailValidation}
-          onChange={this.handleChange}
-          value={emailAddress}
-        />
-        <Button
-          type={"primary"}
-          onClick={this.handleSubmit}
-          disabled={!canSubmit}
-          className="email-subscription-form__submit-button"
-        >
-          Sign up
-        </Button>
-      </div>
-    );
-  }
+  const handleChange = (value: string) => {
+    handleEmailValidation(value);
+    setEmailAddress(value);
+  };
+
+  const handleSubmit = () => {
+    if (canSubmit) {
+      onSubmit(emailAddress);
+      setEmailAddress("");
+      setCanSubmit(false);
+    }
+  };
+
+  return (
+    <div className="email-subscription-form">
+      <TextInput
+        name="email"
+        className="email-subscription-form__input"
+        placeholder="Enter your email"
+        validate={handleEmailValidation}
+        onChange={handleChange}
+        value={emailAddress}
+      />
+      <Button
+        type={"primary"}
+        onClick={handleSubmit}
+        disabled={!canSubmit}
+        className="email-subscription-form__submit-button"
+      >
+        Sign up
+      </Button>
+    </div>
+  );
 }

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/expandableString/expandableString.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/expandableString/expandableString.spec.tsx
@@ -1,0 +1,101 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+
+import { ExpandableString } from "./index";
+
+describe("ExpandableString", () => {
+  const shortText = "a]short string";
+  // 52 chars — at the boundary (truncateLength + 2 = 52), still neverCollapse.
+  const boundaryText = "a".repeat(52);
+  // 53 chars — exceeds the boundary, becomes collapsible.
+  const longText = "a]".repeat(25) + "bcd";
+  const customShort = "custom summary";
+
+  describe("when text is short enough to never collapse", () => {
+    it("renders the full text without expand control", () => {
+      const { container } = render(<ExpandableString long={shortText} />);
+      expect(screen.getByText(shortText)).toBeDefined();
+      // No clickable expandable wrapper should exist.
+      expect(container.querySelector(".expandable")).toBeNull();
+    });
+
+    it("renders full text at exactly the boundary length (52 chars)", () => {
+      const { container } = render(<ExpandableString long={boundaryText} />);
+      expect(screen.getByText(boundaryText)).toBeDefined();
+      expect(container.querySelector(".expandable")).toBeNull();
+    });
+  });
+
+  describe("when text exceeds the collapse threshold", () => {
+    it("renders truncated text with ellipsis", () => {
+      const { container } = render(<ExpandableString long={longText} />);
+      // Should show the expandable wrapper.
+      expect(container.querySelector(".expandable")).not.toBeNull();
+      // The truncated text is the first 50 chars trimmed.
+      const truncated = longText.substr(0, 50).trim();
+      expect(container.textContent).toContain(truncated);
+      // Should show ellipsis character (…).
+      expect(container.textContent).toContain("\u2026");
+      // Full text should NOT be visible.
+      expect(container.querySelector(".expandable__text--expanded")).toBeNull();
+    });
+
+    it("expands to show full text on click", () => {
+      const { container } = render(<ExpandableString long={longText} />);
+      fireEvent.click(container.querySelector(".expandable"));
+      // After clicking, the expanded class should appear.
+      expect(
+        container.querySelector(".expandable__text--expanded"),
+      ).not.toBeNull();
+      expect(container.textContent).toContain(longText);
+    });
+
+    it("collapses back to truncated text on second click", () => {
+      const { container } = render(<ExpandableString long={longText} />);
+      const wrapper = container.querySelector(".expandable");
+      // Expand.
+      fireEvent.click(wrapper);
+      expect(
+        container.querySelector(".expandable__text--expanded"),
+      ).not.toBeNull();
+      // Collapse.
+      fireEvent.click(wrapper);
+      expect(container.querySelector(".expandable__text--expanded")).toBeNull();
+      const truncated = longText.substr(0, 50).trim();
+      expect(container.textContent).toContain(truncated);
+    });
+  });
+
+  describe("when a custom short prop is provided", () => {
+    it("renders the custom short text instead of auto-truncating", () => {
+      const { container } = render(
+        <ExpandableString long={longText} short={customShort} />,
+      );
+      expect(container.textContent).toContain(customShort);
+      // Should still be expandable.
+      expect(container.querySelector(".expandable")).not.toBeNull();
+    });
+
+    it("always shows expand control even for short long text", () => {
+      // With an explicit short prop, even short long text is collapsible.
+      const { container } = render(
+        <ExpandableString long={shortText} short={customShort} />,
+      );
+      expect(container.querySelector(".expandable")).not.toBeNull();
+      expect(container.textContent).toContain(customShort);
+    });
+
+    it("expands to show the full long text on click", () => {
+      const { container } = render(
+        <ExpandableString long={longText} short={customShort} />,
+      );
+      fireEvent.click(container.querySelector(".expandable"));
+      expect(container.textContent).toContain(longText);
+    });
+  });
+});

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/expandableString/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/expandableString/index.tsx
@@ -4,7 +4,7 @@
 // included in the /LICENSE file.
 
 import isNil from "lodash/isNil";
-import React from "react";
+import React, { useState } from "react";
 
 import { trustIcon } from "src/util/trust";
 
@@ -20,58 +20,46 @@ interface ExpandableStringProps {
   long: string;
 }
 
-interface ExpandableStringState {
-  expanded: boolean;
-}
-
 // ExpandableString displays a short string with a clickable ellipsis. When
 // clicked, the component displays long. If short is not specified, it uses
 // the first 50 chars of long.
-export class ExpandableString extends React.Component<
-  ExpandableStringProps,
-  ExpandableStringState
-> {
-  state: ExpandableStringState = {
-    expanded: false,
-  };
+export function ExpandableString({
+  short,
+  long,
+}: ExpandableStringProps): React.ReactElement {
+  const [expanded, setExpanded] = useState(false);
 
-  onClick = (ev: any) => {
+  const onClick = (ev: any) => {
     ev.preventDefault();
-    this.setState({ expanded: !this.state.expanded });
+    setExpanded(prev => !prev);
   };
 
-  renderText(expanded: boolean) {
+  const renderText = () => {
     if (expanded) {
       return (
         <span className="expandable__text expandable__text--expanded">
-          {this.props.long}
+          {long}
         </span>
       );
     }
 
-    const short =
-      this.props.short || this.props.long.substr(0, truncateLength).trim();
-    return <span className="expandable__text">{short}&nbsp;&hellip;</span>;
+    const shortText = short || long.substr(0, truncateLength).trim();
+    return <span className="expandable__text">{shortText}&nbsp;&hellip;</span>;
+  };
+
+  const neverCollapse = isNil(short) && long.length <= truncateLength + 2;
+  if (neverCollapse) {
+    return <span className="expandable__long">{long}</span>;
   }
 
-  render() {
-    const { short, long } = this.props;
-
-    const neverCollapse = isNil(short) && long.length <= truncateLength + 2;
-    if (neverCollapse) {
-      return <span className="expandable__long">{this.props.long}</span>;
-    }
-
-    const { expanded } = this.state;
-    const icon = expanded ? collapseIcon : expandIcon;
-    return (
-      <div className="expandable" onClick={this.onClick}>
-        <span className="expandable__long">{this.renderText(expanded)}</span>
-        <span
-          className="expandable__icon"
-          dangerouslySetInnerHTML={trustIcon(icon)}
-        />
-      </div>
-    );
-  }
+  const icon = expanded ? collapseIcon : expandIcon;
+  return (
+    <div className="expandable" onClick={onClick}>
+      <span className="expandable__long">{renderText()}</span>
+      <span
+        className="expandable__icon"
+        dangerouslySetInnerHTML={trustIcon(icon)}
+      />
+    </div>
+  );
 }

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/infoBox/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/infoBox/index.tsx
@@ -7,8 +7,8 @@ import React from "react";
 
 import "./infoBox.scss";
 
-export default class InfoBox extends React.Component {
-  render() {
-    return <div className="info-box">{this.props.children}</div>;
-  }
+export default function InfoBox({
+  children,
+}: React.PropsWithChildren<object>): React.ReactElement {
+  return <div className="info-box">{children}</div>;
 }

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/licenseType/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/licenseType/index.tsx
@@ -10,8 +10,6 @@ import DebugAnnotation from "src/views/shared/components/debugAnnotation";
 /**
  * LicenseType is an indicator showing the current build license.
  */
-export default class LicenseType extends React.Component<{}, {}> {
-  render() {
-    return <DebugAnnotation label="License type" value="OSS" />;
-  }
+export default function LicenseType(): React.ReactElement {
+  return <DebugAnnotation label="License type" value="OSS" />;
 }

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/metricQuery/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/metricQuery/index.tsx
@@ -59,15 +59,18 @@ export interface AxisProps {
  * component should contain axes as children and use them only informationally
  * without rendering them.
  */
-export class Axis extends React.Component<AxisProps, {}> {
-  static defaultProps: AxisProps = {
-    units: AxisUnits.Count,
-  };
-
-  render(): React.ReactElement<any> {
-    throw new Error("Component <Axis /> should never render.");
-  }
+export function Axis(
+  _props: React.PropsWithChildren<AxisProps>,
+): React.ReactElement {
+  throw new Error("Component <Axis /> should never render.");
 }
+// defaultProps is used instead of default parameter values because Axis is a
+// data container that throws on render — the function body never executes.
+// React applies defaultProps to the element before calling the component,
+// so parent components reading element.props will see the defaults.
+Axis.defaultProps = {
+  units: AxisUnits.Count,
+} as AxisProps;
 
 /**
  * MetricProps represents the properties of a Metric being selected as part of
@@ -120,10 +123,8 @@ export interface MetricProps {
  * component should contain axes as children and use them only informationally
  * without rendering them.
  */
-export class Metric extends React.Component<MetricProps> {
-  render(): React.ReactElement<any> {
-    throw new Error("Component <Metric /> should never render.");
-  }
+export function Metric(_props: MetricProps): React.ReactElement {
+  throw new Error("Component <Metric /> should never render.");
 }
 
 /**

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/panelSection/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/panelSection/index.tsx
@@ -7,36 +7,36 @@ import React from "react";
 
 import "./panels.scss";
 
-export class PanelSection extends React.Component {
-  render() {
-    return (
-      <table className="panel-section">
-        <tbody>{this.props.children}</tbody>
-      </table>
-    );
-  }
+export function PanelSection({
+  children,
+}: React.PropsWithChildren<object>): React.ReactElement {
+  return (
+    <table className="panel-section">
+      <tbody>{children}</tbody>
+    </table>
+  );
 }
 
-export class PanelTitle extends React.Component {
-  render() {
-    return (
-      <tr>
-        <th colSpan={2} className="panel-title">
-          {this.props.children}
-        </th>
-      </tr>
-    );
-  }
+export function PanelTitle({
+  children,
+}: React.PropsWithChildren<object>): React.ReactElement {
+  return (
+    <tr>
+      <th colSpan={2} className="panel-title">
+        {children}
+      </th>
+    </tr>
+  );
 }
 
-export class PanelPair extends React.Component {
-  render() {
-    return <tr className="panel-pair">{this.props.children}</tr>;
-  }
+export function PanelPair({
+  children,
+}: React.PropsWithChildren<object>): React.ReactElement {
+  return <tr className="panel-pair">{children}</tr>;
 }
 
-export class Panel extends React.Component {
-  render() {
-    return <td className="panel">{this.props.children}</td>;
-  }
+export function Panel({
+  children,
+}: React.PropsWithChildren<object>): React.ReactElement {
+  return <td className="panel">{children}</td>;
 }

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/popover/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/popover/index.tsx
@@ -4,7 +4,7 @@
 // included in the /LICENSE file.
 
 import classNames from "classnames";
-import React from "react";
+import React, { useRef } from "react";
 
 import { OutsideEventHandler } from "src/components/outsideEventHandler";
 
@@ -17,35 +17,38 @@ export interface PopoverProps {
   children: any;
 }
 
-export default class Popover extends React.Component<PopoverProps> {
+function Popover({
+  content,
+  children,
+  visible,
+  onVisibleChange,
+}: PopoverProps): React.ReactElement {
   // contentRef is used to pass as element to avoid handling outside event handler
   // on its instance.
-  contentRef: React.RefObject<HTMLDivElement> = React.createRef();
+  const contentRef = useRef<HTMLDivElement>(null);
 
-  render() {
-    const { content, children, visible, onVisibleChange } = this.props;
+  const popoverClasses = classNames("popover", {
+    "popover--visible": visible,
+  });
 
-    const popoverClasses = classNames("popover", {
-      "popover--visible": visible,
-    });
-
-    return (
-      <React.Fragment>
-        <div
-          ref={this.contentRef}
-          className="popover__content"
-          onClick={() => onVisibleChange(!visible)}
-        >
-          {content}
-        </div>
-        <OutsideEventHandler
-          onOutsideClick={() => onVisibleChange(false)}
-          mountNodePosition={"fixed"}
-          ignoreClickOnRefs={[this.contentRef]}
-        >
-          <div className={popoverClasses}>{children}</div>
-        </OutsideEventHandler>
-      </React.Fragment>
-    );
-  }
+  return (
+    <>
+      <div
+        ref={contentRef}
+        className="popover__content"
+        onClick={() => onVisibleChange(!visible)}
+      >
+        {content}
+      </div>
+      <OutsideEventHandler
+        onOutsideClick={() => onVisibleChange(false)}
+        mountNodePosition={"fixed"}
+        ignoreClickOnRefs={[contentRef]}
+      >
+        <div className={popoverClasses}>{children}</div>
+      </OutsideEventHandler>
+    </>
+  );
 }
+
+export default Popover;

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/sql/box.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/sql/box.tsx
@@ -16,13 +16,11 @@ export interface SqlBoxProps {
 
 const cx = classNames.bind(styles);
 
-class SqlBox extends React.Component<SqlBoxProps> {
-  render() {
-    return (
-      <div className={cx("box-highlight")}>
-        <Highlight {...this.props} />
-      </div>
-    );
-  }
+function SqlBox({ value, secondaryValue }: SqlBoxProps): React.ReactElement {
+  return (
+    <div className={cx("box-highlight")}>
+      <Highlight value={value} secondaryValue={secondaryValue} />
+    </div>
+  );
 }
 export default SqlBox;

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/sql/highlight.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/sql/highlight.tsx
@@ -5,55 +5,53 @@
 
 import classNames from "classnames/bind";
 import * as hljs from "highlight.js";
-import React from "react";
+import React, { memo, useEffect, useRef } from "react";
 
 import { SqlBoxProps } from "./box";
 import styles from "./sqlhighlight.module.scss";
 
 const cx = classNames.bind(styles);
 
-export class Highlight extends React.Component<SqlBoxProps> {
-  preNode: React.RefObject<HTMLPreElement> = React.createRef();
-  preNodeSecondary: React.RefObject<HTMLPreElement> = React.createRef();
+// Configure hljs once at module level.
+hljs.configure({
+  tabReplace: "  ",
+  languages: ["sql"],
+});
 
-  shouldComponentUpdate(newProps: SqlBoxProps) {
-    return newProps.value !== this.props.value;
-  }
+function HighlightInternal({
+  value,
+  secondaryValue,
+}: SqlBoxProps): React.ReactElement {
+  const preNode = useRef<HTMLPreElement>(null);
+  const preNodeSecondary = useRef<HTMLPreElement>(null);
 
-  componentDidMount() {
-    hljs.configure({
-      tabReplace: "  ",
-      languages: ["sql"],
-    });
-    hljs.highlightBlock(this.preNode.current);
-    if (this.preNodeSecondary.current) {
-      hljs.highlightBlock(this.preNodeSecondary.current);
+  // Highlight on mount and whenever value/secondaryValue changes.
+  useEffect(() => {
+    hljs.highlightBlock(preNode.current);
+    if (preNodeSecondary.current) {
+      hljs.highlightBlock(preNodeSecondary.current);
     }
-  }
+  }, [value, secondaryValue]);
 
-  componentDidUpdate() {
-    hljs.highlightBlock(this.preNode.current);
-    if (this.preNodeSecondary.current) {
-      hljs.highlightBlock(this.preNodeSecondary.current);
-    }
-  }
-
-  render() {
-    const { value, secondaryValue } = this.props;
-    return (
-      <>
-        <span className={cx("sql-highlight")} ref={this.preNode}>
-          {value}
-        </span>
-        {secondaryValue && (
-          <>
-            <div className={cx("highlight-divider")} />
-            <span className={cx("sql-highlight")} ref={this.preNodeSecondary}>
-              {secondaryValue}
-            </span>
-          </>
-        )}
-      </>
-    );
-  }
+  return (
+    <>
+      <span className={cx("sql-highlight")} ref={preNode}>
+        {value}
+      </span>
+      {secondaryValue && (
+        <>
+          <div className={cx("highlight-divider")} />
+          <span className={cx("sql-highlight")} ref={preNodeSecondary}>
+            {secondaryValue}
+          </span>
+        </>
+      )}
+    </>
+  );
 }
+
+// Wrap with memo to replicate shouldComponentUpdate behavior:
+// only re-render when value changes.
+export const Highlight = memo(HighlightInternal, (prevProps, nextProps) => {
+  return prevProps.value === nextProps.value;
+});

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/summaryBar/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/summaryBar/index.tsx
@@ -230,21 +230,21 @@ function aggregateLatestValuesFromMetrics(
  * SummaryHeadlineStat is similar to a normal SummaryStat, but is visually laid
  * out to draw attention to the numerical statistic.
  */
-export class SummaryHeadlineStat extends React.Component<
-  SummaryHeadlineStatProps,
-  {}
-> {
-  render() {
-    return (
-      <div className="summary-headline-stat">
-        <div className="summary-headline-stat__value">
-          {formatNumberForDisplay(this.props.value, this.props.format)}
-        </div>
-        <div className="summary-headline-stat__title">
-          {this.props.title}
-          <InfoTooltip text={this.props.tooltip} />
-        </div>
+export function SummaryHeadlineStat({
+  value,
+  format,
+  title,
+  tooltip,
+}: SummaryHeadlineStatProps): React.ReactElement {
+  return (
+    <div className="summary-headline-stat">
+      <div className="summary-headline-stat__value">
+        {formatNumberForDisplay(value, format)}
       </div>
-    );
-  }
+      <div className="summary-headline-stat__title">
+        {title}
+        <InfoTooltip text={tooltip} />
+      </div>
+    </div>
+  );
 }

--- a/pkg/ui/workspaces/db-console/src/views/shared/containers/alerts/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/containers/alerts/index.tsx
@@ -5,53 +5,30 @@
 
 import map from "lodash/map";
 import React from "react";
-import { connect } from "react-redux";
-import { Dispatch, Action, bindActionCreators } from "redux";
+import { useSelector, useDispatch } from "react-redux";
+import { bindActionCreators } from "redux";
 
-import { Alert, panelAlertsSelector } from "src/redux/alerts";
+import { panelAlertsSelector } from "src/redux/alerts";
 import { AdminUIState } from "src/redux/state";
 import { AlertBox } from "src/views/shared/components/alertBox";
 
-interface AlertSectionProps {
-  /**
-   * List of alerts to display in the alert section.
-   */
-  alerts: Alert[];
-  /**
-   * Raw dispatch method for the current store, will be used to dispatch
-   * alert dismissal callbacks.
-   */
-  dispatch: Dispatch<Action>;
+function AlertSection(): React.ReactElement {
+  const alerts = useSelector((state: AdminUIState) =>
+    panelAlertsSelector(state),
+  );
+  const dispatch = useDispatch();
+
+  return (
+    <div>
+      {map(alerts, (a, i) => {
+        // Extract values we don't want.
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { dismiss, ...alertProps } = a;
+        const boundDismiss = bindActionCreators(() => a.dismiss, dispatch);
+        return <AlertBox key={i} dismiss={boundDismiss} {...alertProps} />;
+      })}
+    </div>
+  );
 }
 
-class AlertSection extends React.Component<AlertSectionProps, {}> {
-  render() {
-    const { alerts, dispatch } = this.props;
-    return (
-      <div>
-        {map(alerts, (a, i) => {
-          // Extract values we don't want.
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          const { dismiss, ...alertProps } = a;
-          const boundDismiss = bindActionCreators(() => a.dismiss, dispatch);
-          return <AlertBox key={i} dismiss={boundDismiss} {...alertProps} />;
-        })}
-      </div>
-    );
-  }
-}
-
-const alertSectionConnected = connect(
-  (state: AdminUIState) => {
-    return {
-      alerts: panelAlertsSelector(state),
-    };
-  },
-  dispatch => {
-    return {
-      dispatch: dispatch,
-    };
-  },
-)(AlertSection);
-
-export default alertSectionConnected;
+export default AlertSection;

--- a/pkg/ui/workspaces/db-console/src/views/shared/containers/alerts/overviewListAlerts.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/containers/alerts/overviewListAlerts.tsx
@@ -5,56 +5,34 @@
 
 import map from "lodash/map";
 import React from "react";
-import { connect } from "react-redux";
-import { Dispatch, Action, bindActionCreators } from "redux";
+import { useSelector, useDispatch } from "react-redux";
+import { bindActionCreators } from "redux";
 
-import { Alert, overviewListAlertsSelector } from "src/redux/alerts";
+import { overviewListAlertsSelector } from "src/redux/alerts";
 import { AdminUIState } from "src/redux/state";
 import { AlertBox } from "src/views/shared/components/alertBox";
 
-interface AlertSectionProps {
-  /**
-   * List of alerts to display in the alert section.
-   */
-  alerts: Alert[];
-  /**
-   * Raw dispatch method for the current store, will be used to dispatch
-   * alert dismissal callbacks.
-   */
-  dispatch: Dispatch<Action>;
-}
+function OverviewAlertListSection(): React.ReactElement {
+  const alerts = useSelector((state: AdminUIState) =>
+    overviewListAlertsSelector(state),
+  );
+  const dispatch = useDispatch();
 
-class OverviewAlertListSection extends React.Component<AlertSectionProps, {}> {
-  render() {
-    const { alerts, dispatch } = this.props;
-    if (alerts.length === 0) {
-      return null;
-    }
-    return (
-      <section className="section">
-        {map(alerts, (a, i) => {
-          // Extract values we don't want.
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          const { dismiss, ...alertProps } = a;
-          const boundDismiss = bindActionCreators(() => a.dismiss, dispatch);
-          return <AlertBox key={i} dismiss={boundDismiss} {...alertProps} />;
-        })}
-      </section>
-    );
+  if (alerts.length === 0) {
+    return null;
   }
+
+  return (
+    <section className="section">
+      {map(alerts, (a, i) => {
+        // Extract values we don't want.
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { dismiss, ...alertProps } = a;
+        const boundDismiss = bindActionCreators(() => a.dismiss, dispatch);
+        return <AlertBox key={i} dismiss={boundDismiss} {...alertProps} />;
+      })}
+    </section>
+  );
 }
 
-const overviewAlertListSectionConnected = connect(
-  (state: AdminUIState) => {
-    return {
-      alerts: overviewListAlertsSelector(state),
-    };
-  },
-  dispatch => {
-    return {
-      dispatch: dispatch,
-    };
-  },
-)(OverviewAlertListSection);
-
-export default overviewAlertListSectionConnected;
+export default OverviewAlertListSection;


### PR DESCRIPTION
Convert the following class components to functional style:
 - dropdown: useState for focus state, 3 useRefs (dropdown, title, select),
   event handlers become local functions
 - sqlBox: render-only, destructure props
 - highlight: separate HighlightInternal function wrapped with memo() and a custom comparator
 - summaryHeadlineStat: render-only, destructure props (only classin summaryBar;
   other exports were already functional)

highlight uses React.memo with a custom comparator that only checks the value prop, replicating
the original shouldComponentUpdate behavior. hljs.configure() moved to module level since it
only needs to run once (the original redundantly called it on every mount).

dropdown preserves the existing react-select integration hack that programmatically triggers
the select menu via handleMouseDownOnMenu. The className prop is renamed to classNameProp
in destructuring to avoid shadowing the computed className variable.

-----

Convert the following class components to functional style:
 - debugAnnotation: render-only, destructure props
 - expandableString: useState for expanded toggle
 - metricQuery (Axis, Metric): never-render data containers that throw on render.
   Axis.defaultProps kept as a function property because default params won't work when
   the body never executes
 - d3-react (createChartComponent): HOC factory returning a class replaced with one
   returning a function component
 - metricDataProvider: collapsed from class + connect() into a single function using
   useSelector/useDispatch hooks inline

metricDataProvider is the most complex conversion. The original class used connect() to inject
metrics state and timeInfo from Redux, plus createSelector for per-instance memoization.
The refactored version uses useSelector for both, useMemo for query building and request
construction, and useEffect for the data-fetching side effect (replacing componentDidMount +
componentDidUpdate).

The component was collapsed into a single function rather than an inner/outer split because an
upcoming Redux+Saga removal would make the split counterproductive — it would preserve a
Redux-shaped prop interface that needs to be deleted anyway.

d3-react's shouldComponentUpdate was used for imperative side effects (D3 redraw),
it called redraw() then returned false. This maps to a useEffect with no dependency array
(runs after every render). A separate mount-only useEffect handles the resize listener,
using a propsRef to keep the handler closure current without re-registering the listener.

Existing Enzyme tests for metricDataProvider converted to RTL with mocked react-redux hooks
(useSelector, useDispatch) and a spy on the requestMetrics action creator.
New RTL tests added for expandableString covering collapse/expand toggle and custom short text.

Effects manually smoke tested on /metrics page graphs and /debug.

-----

Convert the following class components to functional style:
 - emailSubscriptionForm: useState for emailAddress and canSubmit, event handlers to local functions
 - infoBox: render-only, destructure props
 - licenseType: render-only, destructure props
 - panelSection: render-only, destructure props

These are all simple presentational components with no Redux connections or lifecycle methods
(except emailSubscriptionForm which had state for form validation).

Existing Enzyme test for emailSubscriptionForm converted to RTL.
The test structure and assertions are preserved, only the rendering and query APIs changed
(mount → render, wrapper.find → screen.getBy).

-----

Convert the following class components to functional style:
 - alertBox: render-only, destructure props
 - alertMessage: useState for expand state, useEffect+useRef for auto-close timeout,
   defaultProps replaced with default params
 - popover: useState for isOpen toggle
 - alertsContainer: connect() replaced with useSelector/useDispatch,
   AlertSectionProps interface removed
 - overviewListAlerts: same connect() → hooks pattern

The alerts containers previously used connect() to inject a raw dispatch prop,
which was then used with bindActionCreators to bind alert dismiss callbacks.
The refactored versions call useDispatch() directly, removing the intermediate props interface and
mapDispatchToProps boilerplate.

alertMessage.autoCloseTimeout defaults to 6000ms via default params instead of defaultProps.
The auto-close timer is put in a mount-only useEffect with cleanup to prevent firing after unmount.

New RTL tests added for alertBox (dismiss callback, alert level CSS classes,
learn-more link rendering) and alertMessage (auto-close timer with fake timers,
alert level icon mapping, link rendering).

Effects manually smoke tested on /overview/list and panel alerts.

Closes: CRDB-59177
Epic: CRDB-58145
Release Note: None