### PR TITLE
logical: fix insert detection

### DIFF
--- a/pkg/crosscluster/logical/ldrdecoder/decoded_row.go
+++ b/pkg/crosscluster/logical/ldrdecoder/decoded_row.go
@@ -38,3 +38,19 @@ type DecodedRow struct {
 	// PrevRow may still lose LWW if there is a recent tombstone.
 	PrevRow tree.Datums
 }
+
+func (d *DecodedRow) IsDeleteRow() bool {
+	return d.IsDelete && len(d.PrevRow) != 0
+}
+
+func (d *DecodedRow) IsTombstoneUpdate() bool {
+	return d.IsDelete && len(d.PrevRow) == 0
+}
+
+func (d *DecodedRow) IsInsertRow() bool {
+	return !d.IsDelete && len(d.PrevRow) == 0
+}
+
+func (d *DecodedRow) IsUpdateRow() bool {
+	return !d.IsDelete && len(d.PrevRow) > 0
+}

--- a/pkg/crosscluster/logical/sqlwriter/BUILD.bazel
+++ b/pkg/crosscluster/logical/sqlwriter/BUILD.bazel
@@ -45,6 +45,7 @@ go_test(
         "//pkg/ccl",
         "//pkg/ccl/changefeedccl/cdctest",
         "//pkg/ccl/storageccl",
+        "//pkg/kv/kvpb",
         "//pkg/roachpb",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",

--- a/pkg/crosscluster/logical/sqlwriter/sql_row_reader.go
+++ b/pkg/crosscluster/logical/sqlwriter/sql_row_reader.go
@@ -7,6 +7,7 @@ package sqlwriter
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
@@ -85,7 +86,7 @@ func newBulkRowReader(
 	if err != nil {
 		return nil, err
 	}
-	selectStatement, err := session.Prepare(ctx, "replication-read-refresh", selectStatementRaw, types)
+	selectStatement, err := session.Prepare(ctx, fmt.Sprintf("replication-read-refresh-%d", table.GetID()), selectStatementRaw, types)
 	if err != nil {
 		return nil, err
 	}
@@ -198,7 +199,7 @@ func newPointRowReader(
 	if err != nil {
 		return nil, err
 	}
-	selectStatement, err := session.Prepare(ctx, "replication-read-point", selectStatementRaw, types)
+	selectStatement, err := session.Prepare(ctx, fmt.Sprintf("replication-read-point-%d", table.GetID()), selectStatementRaw, types)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/crosscluster/logical/tombstone_updater_test.go
+++ b/pkg/crosscluster/logical/tombstone_updater_test.go
@@ -185,7 +185,9 @@ func TestTombstoneUpdaterRandomTables(t *testing.T) {
 		// tombstone was written at a later timestamp. It may fail with integer out
 		// of range error if the table has computed columns and the random datums
 		// add to produces something out of range.
-		err = writer.InsertRow(ctx, before, row)
+		err = session.Txn(ctx, func(ctx context.Context) error {
+			return writer.InsertRow(ctx, before, row)
+		})
 		require.Error(t, err)
 		if !(strings.Contains(err.Error(), "integer out of range") || isLwwLoser(err)) {
 			t.Fatalf("expected LWW or integer out of range error, got: %v", err)

--- a/pkg/sql/isql/isql_session.go
+++ b/pkg/sql/isql/isql_session.go
@@ -70,6 +70,13 @@ type Session interface {
 	// rolled back. If the function succeeds, the savepoint is released.
 	// Savepoints must be used within a transaction.
 	//
+	// TODO(jeffswenson): we should have Savepoint return an error if it is called
+	// outside of a transaction or transparently open a transaction. Right now,
+	// using a savepoint outside of a transaction returns an error, but after the
+	// `do` function is executed. For some reason Postgres does not produce an
+	// error if you create a savepoint outside of a transaction, but it does not
+	// remember the savepoint and returns an error when you attempt to release it.
+	//
 	// Example:
 	// err := session.Txn(ctx, func(ctx context.Context) error {
 	// 	return session.Savepoint(ctx, func(ctx context.Context) error {


### PR DESCRIPTION
Add explicit IsInsertRow/IsUpdateRow/IsDeleteRow/IsTombstoneUpdate methods to DecodedRow for clearer classification logic.

The row decoder was populating PrevRow even when the source event had no previous value, causing inserts to be misclassified as updates. Fix the decoder to only populate PrevRow when there actually is a previous value. The impact of this is pretty mild on the crud writer, it causes a read refresh, which correctly sets PrevRow to nil.

Misclassifying inserts was a major issue for the transaction writer because it impacted the lock derivation logic.

The prepared statement names now include the descriptor id. This allows us to create multiple writes/readers using the same session.

Epic: CRDB-57649
Release note: None