### PR TITLE
server: fix settingswatcher tests failing due to wrong DRPC error codes

### DIFF
--- a/pkg/server/settingswatcher/settings_watcher_external_test.go
+++ b/pkg/server/settingswatcher/settings_watcher_external_test.go
@@ -49,7 +49,6 @@ func TestSettingWatcherOnTenant(t *testing.T) {
 	ctx := context.Background()
 	srv, sqlDB, db := serverutils.StartServer(t, base.TestServerArgs{
 		DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
-		DefaultDRPCOption: base.TestDRPCDisabled,
 	})
 	defer srv.Stopper().Stop(ctx)
 	s0 := srv.ApplicationLayer()


### PR DESCRIPTION
Previously, errors returned by DRPC were not consistently mapped to the gRPC status codes expected by certain database code paths, causing test failures.

cockroachdb/drpc#28 updates DRPC to translate errors into the appropriate gRPC status errors for backward compatibility with gRPC.

This change consumes the DRPC updates from the above PR and restores the previously failing tests.

Tests pass with DRPC enabled (verified with 100 runs).

Epic: CRDB-55382
Fixes: #161594
Release note: None