### PR TITLE
server: fix tests failing due to incorrect DRPC error codes

### DIFF
--- a/pkg/server/api_v2_databases_metadata_test.go
+++ b/pkg/server/api_v2_databases_metadata_test.go
@@ -918,7 +918,6 @@ func TestTriggerMetadataUpdateJobTriggerFailed(t *testing.T) {
 	// won't be adopted in this test run.
 	adoptDuration := time.Hour
 	ts := serverutils.StartServerOnly(t, base.TestServerArgs{
-		DefaultDRPCOption: base.TestDRPCDisabled,
 		Knobs: base.TestingKnobs{
 			JobsTestingKnobs: &jobs.TestingKnobs{
 				IntervalOverrides: jobs.TestingIntervalOverrides{

--- a/pkg/server/connectivity_test.go
+++ b/pkg/server/connectivity_test.go
@@ -356,9 +356,6 @@ func TestDecommissionedNodeCannotConnect(t *testing.T) {
 	numNodes := 3
 	tcArgs := base.TestClusterArgs{
 		ReplicationMode: base.ReplicationManual, // saves time
-		ServerArgs: base.TestServerArgs{
-			DefaultDRPCOption: base.TestDRPCDisabled,
-		},
 	}
 
 	tc := testcluster.StartTestCluster(t, numNodes, tcArgs)

--- a/pkg/server/drain_test.go
+++ b/pkg/server/drain_test.go
@@ -223,7 +223,6 @@ func newTestDrainContext(t *testing.T, drainSleepCallCount *int) *testDrainConte
 			// We need to start the cluster insecure in order to not
 			// care about TLS settings for the RPC client connection.
 			ServerArgs: base.TestServerArgs{
-				DefaultDRPCOption: base.TestDRPCDisabled,
 				DefaultTestTenant: base.TestControlsTenantsExplicitly,
 				Knobs: base.TestingKnobs{
 					Server: &server.TestingKnobs{

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -968,8 +968,7 @@ func TestSQLDecommissioned(t *testing.T) {
 	tc := serverutils.StartCluster(t, 2, base.TestClusterArgs{
 		ReplicationMode: base.ReplicationManual, // saves time
 		ServerArgs: base.TestServerArgs{
-			DefaultDRPCOption: base.TestDRPCDisabled,
-			Insecure:          true, // to set up a simple SQL client
+			Insecure: true, // to set up a simple SQL client
 		},
 	})
 	defer tc.Stopper().Stop(ctx)

--- a/pkg/server/user_test.go
+++ b/pkg/server/user_test.go
@@ -83,9 +83,7 @@ func TestSQLRolesAPI(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
-		DefaultDRPCOption: base.TestDRPCDisabled,
-	})
+	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 	db := sqlutils.MakeSQLRunner(sqlDB)
 	var res serverpb.UserSQLRolesResponse


### PR DESCRIPTION
Previously, errors returned by DRPC were not consistently mapped to the gRPC status codes expected by certain database code paths, causing test failures.

cockroachdb/drpc#28 updates DRPC to translate errors into the appropriate gRPC status errors for backward compatibility with gRPC.

This change consumes the DRPC updates from the above PR and restores the previously failing tests.

All tests pass with DRPC enabled across default, shared, and external tenant modes (verified with 25 runs each).

Epic: CRDB-55382
Fixes: #161582
Fixes: #161588
Fixes: #161589
Fixes: #161592
Fixes: #161597
Release note: None