### PR TITLE
release-24.1: log: fix infinite loop bug from malformed log json decoding

### DIFF
--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1317,6 +1317,16 @@ func (s *statusServer) LogFile(
 			if err == io.EOF {
 				break
 			}
+			if errors.Is(err, log.ErrMalformedJSON) {
+				resp.ParseErrors = append(resp.ParseErrors, err.Error())
+				//Append log generated from malformed line.
+				resp.Entries = append(resp.Entries, entry)
+				// The current implementation of decoding JSON formatted logs cannot
+				// recover from malformed lines. Hence, we break out of the loop and
+				// return the logs parsed until now, along with the parse error. This
+				// is better than returning no logs at all.
+				return &resp, nil
+			}
 			if errors.Is(err, log.ErrMalformedLogEntry) {
 				resp.ParseErrors = append(resp.ParseErrors, err.Error())
 				//Append log generated from malformed line.

--- a/pkg/server/storage_api/BUILD.bazel
+++ b/pkg/server/storage_api/BUILD.bazel
@@ -60,6 +60,7 @@ go_test(
         "//pkg/ts",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "//pkg/util/log/logconfig",
         "//pkg/util/log/logpb",
         "//pkg/util/stop",
         "//pkg/util/timeutil",

--- a/pkg/server/storage_api/logfiles_test.go
+++ b/pkg/server/storage_api/logfiles_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/log/logconfig"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/redact"
@@ -472,41 +473,46 @@ func TestStatusLogCorruptedEntry(t *testing.T) {
 		skip.IgnoreLint(t, "Test only works with low verbosity levels")
 	}
 
-	s := log.ScopeWithoutShowLogs(t)
-	defer s.Close(t)
-
 	// This test cares about the number of output files. Ensure
 	// there's just one.
-	defer s.SetupSingleFileLogging()()
+	type testcase struct {
+		format         string
+		expectedErrors int
+	}
+	testutils.RunValues(t, "format", []testcase{{logconfig.DefaultFileFormat, 2}, {logconfig.DefaultStderrFormat, 2}, {logconfig.DefaultFluentFormat, 1}, {logconfig.DefaultHTTPFormat, 1}}, func(t *testing.T, tc testcase) {
+		s := log.ScopeWithoutShowLogs(t)
+		defer s.Close(t)
+		defer s.SetupSingleFileLoggingFormatted(tc.format)()
 
-	srv := serverutils.StartServerOnly(t, base.TestServerArgs{})
-	defer srv.Stopper().Stop(context.Background())
-	ts := srv.ApplicationLayer()
+		srv := serverutils.StartServerOnly(t, base.TestServerArgs{})
+		defer srv.Stopper().Stop(context.Background())
+		ts := srv.ApplicationLayer()
 
-	logCtx := ts.AnnotateCtx(context.Background())
+		logCtx := ts.AnnotateCtx(context.Background())
 
-	log.Errorf(logCtx, "TestStatusLogCorruptedEntry test message")
-	log.FlushFiles()
+		log.Dev.Errorf(logCtx, "TestStatusLogCorruptedEntry test message")
+		log.FlushFiles()
 
-	files, err := log.ListLogFiles()
-	require.NoError(t, err)
-	require.Equal(t, len(files), 1)
-	file := files[0]
-	f, err := os.OpenFile(fmt.Sprintf("%s%s%s", s.GetDirectory(), string(os.PathSeparator), file.Name), os.O_APPEND|os.O_WRONLY, 0600)
-	require.NoError(t, err)
-	// Insert empty lines into log file to simulate corrupted rows that cannot be
-	// parsed. And then append random log.
-	_, err = f.WriteString("\n\n")
-	require.NoError(t, err)
-	err = f.Close()
-	require.NoError(t, err)
-	log.Errorf(logCtx, "TestStatusLogCorruptedEntry test message 2")
-	log.FlushFiles()
+		files, err := log.ListLogFiles()
+		require.NoError(t, err)
+		require.Equal(t, len(files), 1)
+		file := files[0]
+		f, err := os.OpenFile(fmt.Sprintf("%s%s%s", s.GetDirectory(), string(os.PathSeparator), file.Name), os.O_APPEND|os.O_WRONLY, 0600)
+		require.NoError(t, err)
+		// Insert empty line and malformed entry into log file to simulate corrupted rows that cannot be
+		// parsed. And then append random log.
+		_, err = f.WriteString("\nMalformed Log Line")
+		require.NoError(t, err)
+		err = f.Close()
+		require.NoError(t, err)
+		log.Dev.Errorf(logCtx, "TestStatusLogCorruptedEntry test message 2")
+		log.FlushFiles()
 
-	var wrapper serverpb.LogEntriesResponse
-	err = srvtestutils.GetStatusJSONProto(ts, "logfiles/local/"+file.Name, &wrapper)
-	require.NoError(t, err)
-	require.NotEmpty(t, wrapper.Entries)
-	require.NotEmpty(t, wrapper.ParseErrors)
-	require.Equal(t, 2, len(wrapper.ParseErrors))
+		var wrapper serverpb.LogEntriesResponse
+		err = srvtestutils.GetStatusJSONProto(ts, "logfiles/local/"+file.Name, &wrapper)
+		require.NoError(t, err)
+		require.NotEmpty(t, wrapper.Entries)
+		require.NotEmpty(t, wrapper.ParseErrors)
+		require.Equal(t, tc.expectedErrors, len(wrapper.ParseErrors))
+	})
 }

--- a/pkg/util/log/format_json.go
+++ b/pkg/util/log/format_json.go
@@ -653,7 +653,7 @@ func (d *entryDecoderJSON) Decode(entry *logpb.Entry) (err error) {
 		// Wrap all errors except EOF as a malformed entries to make it easier to
 		// handle this type of error later on.
 		if err != nil && err != io.EOF {
-			err = errors.CombineErrors(ErrMalformedLogEntry, err)
+			err = errors.CombineErrors(ErrMalformedJSON, err)
 		}
 	}()
 	var rp *redactablePackage

--- a/pkg/util/log/format_json_test.go
+++ b/pkg/util/log/format_json_test.go
@@ -115,7 +115,7 @@ func TestJsonDecode(t *testing.T) {
 				for {
 					var e logpb.Entry
 					if err := d.Decode(&e); err != nil {
-						if err == io.EOF || errors.Is(err, ErrMalformedLogEntry) {
+						if err == io.EOF || errors.Is(err, ErrMalformedJSON) {
 							break
 						}
 						td.Fatalf(t, "error while decoding: %v", err)

--- a/pkg/util/log/log_decoder.go
+++ b/pkg/util/log/log_decoder.go
@@ -167,3 +167,4 @@ func getLogFormat(data []byte) (string, error) {
 }
 
 var ErrMalformedLogEntry = errors.New("malformed log entry")
+var ErrMalformedJSON = errors.New("malformed JSON log entry")

--- a/pkg/util/log/test_log_scope.go
+++ b/pkg/util/log/test_log_scope.go
@@ -328,6 +328,10 @@ func selectAllChannelsExceptSeparated() []logpb.Channel {
 // To ensure that output always goes to one file, use
 // log.ScopeWithoutShowLogs().
 func (l *TestLogScope) SetupSingleFileLogging() (cleanup func()) {
+	return l.SetupSingleFileLoggingFormatted("")
+}
+
+func (l *TestLogScope) SetupSingleFileLoggingFormatted(format string) (cleanup func()) {
 	if l.logDir == "" {
 		// No log directory: no-op.
 		return func() {}
@@ -335,10 +339,17 @@ func (l *TestLogScope) SetupSingleFileLogging() (cleanup func()) {
 
 	// Set up a logging configuration with just one file sink.
 	cfg := logconfig.DefaultConfig()
-	cfg.Sinks.FileGroups = map[string]*logconfig.FileSinkConfig{
-		"default": {
-			Channels: logconfig.SelectChannels(logconfig.AllChannels()...)},
+	defaultSinkConfig := &logconfig.FileSinkConfig{
+		Channels: logconfig.SelectChannels(logconfig.AllChannels()...),
 	}
+
+	if format != "" {
+		defaultSinkConfig.Format = &format
+	}
+	cfg.Sinks.FileGroups = map[string]*logconfig.FileSinkConfig{
+		"default": defaultSinkConfig,
+	}
+
 	// Disable the -stderr.log output so there's really just 1 file.
 	cfg.CaptureFd2.Enable = false
 


### PR DESCRIPTION
Backport 1/1 commits from #163224.

/cc @cockroachdb/release

---

When the statusServer.LogFile() API encounters malformed json in json
formatted logs, it results in an infinite loop that eventually crashes
a node dude to it going OOM. To fix this, the API will now stop reading
from the log file and return all previously parsed logs. This means that
properly formatted logs after a malformed line will not be returned.

Epic: None
Release note (bug fix): Fixes a bug where generating a debug zip causes
a node to OOM. This OOM happens when a log file contains a malformed
log and is using json (or json-compact) formatting.

Release justification: Fixes a bug that can cause an infinite loop and eventual OOM. The change only low impact and only affects the code path that causes the OOM.
