### PR TITLE
roachtest: preserve GCE default CPU minimum platform

### DIFF
--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -395,8 +395,13 @@ func getGCEOpts(
 	bootDiskOnly bool,
 ) vm.ProviderOpts {
 	opts := gce.DefaultProviderOpts()
+	hasDifferentMachineType := machineType != "" && machineType != opts.MachineType
 	opts.MachineType = machineType
-	opts.MinCPUPlatform = minCPUPlatform
+	// Use the default CPU platform if the user has not
+	// overriden it or specified a different machine type.
+	if minCPUPlatform != "" || hasDifferentMachineType {
+		opts.MinCPUPlatform = minCPUPlatform
+	}
 	if volumeSize != 0 {
 		opts.PDVolumeSize = volumeSize
 	}


### PR DESCRIPTION
As part of #160893, we inadvertently began using a newer CPU platform when the default machine type was selected. The original PR intended to maintain the default CPU platform for that machine type, but the shift caused a regression in the connection_latency test. This patch ensures the default CPU platform remains unchanged for n2 instances.

Fixes: #161820

Release note: None