### PR TITLE
security: fix tests failing due to incorrect DRPC error codes

### DIFF
--- a/pkg/security/certs_rotation_test.go
+++ b/pkg/security/certs_rotation_test.go
@@ -64,11 +64,7 @@ func TestRotateCerts(t *testing.T) {
 	params := base.TestServerArgs{
 		SSLCertsDir:       certsDir,
 		InsecureWebAccess: true,
-
 		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(110007),
-		// Disable DRPC for this test due to #159661: since it's flaky
-		// with "connection closed" errors when DRPC is enabled.
-		DefaultDRPCOption: base.TestDRPCDisabled,
 	}
 	srv := serverutils.StartServerOnly(t, params)
 	defer srv.Stopper().Stop(context.Background())

--- a/pkg/security/tls_test.go
+++ b/pkg/security/tls_test.go
@@ -162,9 +162,7 @@ func TestTLSCipherRestrict(t *testing.T) {
 			})()
 			ctx := context.Background()
 
-			s := serverutils.StartServerOnly(t, base.TestServerArgs{
-				DefaultDRPCOption: base.TestDRPCDisabled,
-			})
+			s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 			defer s.Stopper().Stop(ctx)
 
 			// set the custom test ciphers


### PR DESCRIPTION
Previously, errors returned by DRPC were not consistently mapped to the gRPC status codes expected by certain database code paths, causing test failures.

cockroachdb/drpc#28 updates DRPC to translate errors into the appropriate gRPC status errors for backward compatibility with gRPC.

This change consumes the DRPC updates from the above PR and restores the previously failing tests.

All tests pass with DRPC enabled across default, shared, and external tenant modes (verified with 25 runs each).

Epic: CRDB-55382
Fixes: #161579
Fixes: #161581
Release note: None