### PR TITLE
kvserver: virtualized intent resolution using storage batch

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -368,6 +368,7 @@ go_test(
         "replica_rangefeed_lag_observer_test.go",
         "replica_rangefeed_test.go",
         "replica_rankings_test.go",
+        "replica_read_test.go",
         "replica_sideload_test.go",
         "replica_split_load_test.go",
         "replica_store_liveness_test.go",

--- a/pkg/kv/kvserver/concurrency/concurrency_control.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_control.go
@@ -829,6 +829,11 @@ type lockTableGuard interface {
 	//   the discovered locks have been added.
 	ResolveBeforeScanning() []roachpb.LockUpdate
 
+	// IntentsToResolveVirtually lists the locks to resolve before scanning
+	// similarly to ResolveBeforeScanning. However, these locks are intended to be
+	// resolved virtually.
+	IntentsToResolveVirtually() []roachpb.LockUpdate
+
 	// CheckOptimisticNoConflicts uses the LockSpanSet representing the spans that
 	// were actually read, to check for conflicting locks, after an optimistic
 	// evaluation. It returns true if there were no conflicts. See

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -961,6 +961,15 @@ func (g *Guard) IsKeyLockedByConflictingTxn(
 	return g.ltg.IsKeyLockedByConflictingTxn(ctx, key, strength)
 }
 
+// IntentsToResolveVirtually delegates listing the locks to be resolved to the
+// lock table guard.
+func (g *Guard) IntentsToResolveVirtually() []roachpb.LockUpdate {
+	if g.ltg != nil {
+		return g.ltg.IntentsToResolveVirtually()
+	}
+	return nil
+}
+
 func (g *Guard) moveLatchGuard() latchGuard {
 	lg := g.lg
 	g.lg = nil

--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -578,8 +578,22 @@ func (g *lockTableGuardImpl) ShouldWait() bool {
 	return g.mu.startWait || len(g.toResolve) > 0
 }
 
+// ResolveBeforeScanning implements the lockTableGuard interface. The locks to
+// resolve are returned only if virtualized resolution is disabled.
 func (g *lockTableGuardImpl) ResolveBeforeScanning() []roachpb.LockUpdate {
-	return g.toResolve
+	if !g.virtuallyResolveIntents {
+		return g.toResolve
+	}
+	return nil
+}
+
+// IntentsToResolveVirtually implements the lockTableGuard interface. The locks
+// to resolve are returned only if virtualized resolution is enabled.
+func (g *lockTableGuardImpl) IntentsToResolveVirtually() []roachpb.LockUpdate {
+	if g.virtuallyResolveIntents {
+		return g.toResolve
+	}
+	return nil
 }
 
 func (g *lockTableGuardImpl) NewStateChan() chan struct{} {

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -568,7 +568,7 @@ func TestLockTableBasic(t *testing.T) {
 				case doneWaiting:
 					var toResolveStr string
 					if stateTransition {
-						toResolveStr = intentsToResolveToStr(g.ResolveBeforeScanning(), true)
+						toResolveStr = intentsToResolveToStr(g, true)
 					}
 					return str + "state=doneWaiting" + toResolveStr
 				default:
@@ -594,7 +594,7 @@ func TestLockTableBasic(t *testing.T) {
 				if g == nil {
 					d.Fatalf(t, "unknown guard: %s", reqName)
 				}
-				return intentsToResolveToStr(g.ResolveBeforeScanning(), false)
+				return intentsToResolveToStr(g, false)
 
 			case "enable":
 				lt.Enable(dd.ScanArgOr[roachpb.LeaseSequence](t, d, "lease-seq", 1))
@@ -825,7 +825,10 @@ func ScanIgnoredSeqNumbers(t *testing.T, d *datadriven.TestData) []enginepb.Igno
 	return ignored
 }
 
-func intentsToResolveToStr(toResolve []roachpb.LockUpdate, startOnNewLine bool) string {
+func intentsToResolveToStr(g lockTableGuard, startOnNewLine bool) string {
+	// Depending on whether intent resolution is virtual or not, the intents to
+	// resolve are returned from either of the following functions.
+	toResolve := append(g.IntentsToResolveVirtually(), g.ResolveBeforeScanning()...)
 	if len(toResolve) == 0 {
 		return ""
 	}

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
@@ -79,6 +79,9 @@ func (g *mockLockTableGuard) CurState() (waitingState, error) {
 func (g *mockLockTableGuard) ResolveBeforeScanning() []roachpb.LockUpdate {
 	return g.toResolve
 }
+func (g *mockLockTableGuard) IntentsToResolveVirtually() []roachpb.LockUpdate {
+	return g.toResolve
+}
 func (g *mockLockTableGuard) CheckOptimisticNoConflicts(*lockspanset.LockSpanSet) (ok bool) {
 	return true
 }

--- a/pkg/kv/kvserver/replica_read_test.go
+++ b/pkg/kv/kvserver/replica_read_test.go
@@ -1,0 +1,160 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package kvserver
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvadmission"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/stretchr/testify/require"
+)
+
+// TestVirtualizedIntentResolution exercises read-only request execution and
+// checks that reads have the correct behavior with and without intents to
+// resolve virtually, returned by the concurrency (and lock table) guard.
+func TestVirtualizedIntentResolution(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	tc := testContext{manualClock: timeutil.NewManualTime(timeutil.Unix(0, 123))}
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+
+	tsc := TestStoreConfig(hlc.NewClockForTesting(tc.manualClock))
+	var intentsToResolve atomic.Value // []roachpb.LockUpdate
+	tsc.TestingKnobs.InjectIntentsToResolveVirtually = func() []roachpb.LockUpdate {
+		if intentsToResolve.Load() != nil {
+			return intentsToResolve.Load().([]roachpb.LockUpdate)
+		}
+		return nil
+	}
+	tc.StartWithStoreConfig(ctx, t, stopper, tsc)
+
+	// The manual clock starts at time 123.
+	ts200 := makeTS(200, 0)
+	ts300 := makeTS(300, 0)
+	ts400 := makeTS(400, 0)
+	ts500 := makeTS(500, 0)
+	ts600 := makeTS(600, 0)
+
+	// Setup: write an original value at time 200.
+	k := roachpb.Key("a")
+	pArgs := putArgs(k, []byte("original"))
+	_, pErr := tc.SendWrappedWith(kvpb.Header{Timestamp: ts200}, &pArgs)
+	require.NoError(t, pErr.GoError())
+
+	// Setup: write an intent at time 300.
+	writeTxn := newTransaction("writeTxn", k, 1, nil)
+	pArgs = putArgs(k, []byte("intent"))
+	writeTxn.ReadTimestamp = ts300
+	writeTxn.WriteTimestamp = ts300
+	_, pErr = tc.SendWrappedWith(kvpb.Header{Txn: writeTxn}, &pArgs)
+	require.NoError(t, pErr.GoError())
+
+	type res struct {
+		value string
+		error string
+	}
+	type toResolve struct {
+		txnStatus  roachpb.TransactionStatus
+		txnWriteTs hlc.Timestamp
+		obsTs      hlc.Timestamp
+		obsNode    int
+	}
+	testCases := []struct {
+		readTs    hlc.Timestamp
+		readGUL   hlc.Timestamp
+		toResolve *toResolve
+		exp       res
+	}{
+		// Reading below the intent's ts results in seeing the original value.
+		{readTs: ts200, exp: res{value: "original"}},
+		// Reading at or above the intent's ts results in a lock conflict error.
+		{readTs: ts300, exp: res{error: "conflicting locks"}},
+		{readTs: ts400, exp: res{error: "conflicting locks"}},
+		// Next, we look at cases where we have intents to resolve virtually.
+		// Reading below the pushed writeTxn's ts results in the original value
+		// since these reads have no uncertainty interval.
+		{readTs: ts300, toResolve: &toResolve{txnStatus: roachpb.PENDING, txnWriteTs: ts400}, exp: res{value: "original"}},
+		{readTs: ts300, toResolve: &toResolve{txnStatus: roachpb.STAGING, txnWriteTs: ts400}, exp: res{value: "original"}},
+		{readTs: ts300, toResolve: &toResolve{txnStatus: roachpb.COMMITTED, txnWriteTs: ts400}, exp: res{value: "original"}},
+		{readTs: ts300, toResolve: &toResolve{txnStatus: roachpb.ABORTED, txnWriteTs: ts400}, exp: res{value: "original"}},
+		// Reading at or above the pushed writeTxn's ts results in a lock conflict
+		// error if the txn is not finalized. Otherwise, the intent value is
+		// expected if the txn is committed, and the original value is expected if
+		// the txn is aborted.
+		{readTs: ts400, toResolve: &toResolve{txnStatus: roachpb.PENDING, txnWriteTs: ts400}, exp: res{error: "conflicting lock"}},
+		{readTs: ts400, toResolve: &toResolve{txnStatus: roachpb.STAGING, txnWriteTs: ts400}, exp: res{error: "conflicting lock"}},
+		{readTs: ts400, toResolve: &toResolve{txnStatus: roachpb.COMMITTED, txnWriteTs: ts400}, exp: res{value: "intent"}},
+		{readTs: ts400, toResolve: &toResolve{txnStatus: roachpb.ABORTED, txnWriteTs: ts400}, exp: res{value: "original"}},
+		// Next, we look at more subtle cases with uncertainty intervals. To do so,
+		// the read is now a transactional read with a global uncertainty limit.
+		// Reading below the pushed txn's write ts is no longer enough to avoid
+		// conflict because the read GUL is above that ts.
+		{readTs: ts300, readGUL: ts500, toResolve: &toResolve{txnStatus: roachpb.PENDING, txnWriteTs: ts400}, exp: res{error: "uncertainty interval"}},
+		{readTs: ts300, readGUL: ts500, toResolve: &toResolve{txnStatus: roachpb.STAGING, txnWriteTs: ts400}, exp: res{error: "uncertainty interval"}},
+		{readTs: ts300, readGUL: ts500, toResolve: &toResolve{txnStatus: roachpb.COMMITTED, txnWriteTs: ts400}, exp: res{error: "uncertainty interval"}},
+		{readTs: ts300, readGUL: ts500, toResolve: &toResolve{txnStatus: roachpb.ABORTED, txnWriteTs: ts400}, exp: res{value: "original"}},
+		// To circumvent the uncertainty restart, we can pass in a clock observation
+		// via the intents to resolve. Using a clock observation to set the intent's
+		// local timestamp for non-pending transactions is not safe. See the comment
+		// in pushLockTxn in lock_table_waiter.go.
+		{readTs: ts300, readGUL: ts600, toResolve: &toResolve{txnStatus: roachpb.PENDING, txnWriteTs: ts500, obsTs: ts400, obsNode: 1}, exp: res{value: "original"}},
+		// A clock observation from a different node doesn't help.
+		{readTs: ts300, readGUL: ts600, toResolve: &toResolve{txnStatus: roachpb.PENDING, txnWriteTs: ts500, obsTs: ts400, obsNode: 2}, exp: res{error: "uncertainty interval"}},
+	}
+
+	for _, c := range testCases {
+		// Set up the intents to resolve.
+		if c.toResolve != nil {
+			writeTxn.TxnMeta.WriteTimestamp = c.toResolve.txnWriteTs
+			status := c.toResolve.txnStatus
+			obs := roachpb.ObservedTimestamp{Timestamp: hlc.ClockTimestamp(c.toResolve.obsTs), NodeID: roachpb.NodeID(c.toResolve.obsNode)}
+			intents := []roachpb.LockUpdate{{Span: roachpb.Span{Key: k}, Status: status, Txn: writeTxn.TxnMeta, ClockWhilePending: obs}}
+			intentsToResolve.Store(intents)
+		}
+		// Construct the read-only request.
+		ba := &kvpb.BatchRequest{}
+		ba.Timestamp = c.readTs
+		// If the read wants to set a GUL, use a transactional read.
+		if !c.readGUL.IsEmpty() {
+			readTxn := newTransaction("readTxn", k, 1, nil)
+			readTxn.ReadTimestamp = c.readTs
+			readTxn.GlobalUncertaintyLimit = c.readGUL
+			// We need a fairly old observation here to make sure the read's local
+			// uncertainty limit lets it read under the intent with a clock
+			// observation while pending. This observation needs to be lower than the
+			// local timestamp set on the intent (set using ClockWhilePending).
+			// The txn's observed timestamp is usually set when the request is first
+			// received by the store, so here we'll record it as the read's ts.
+			readTxn.UpdateObservedTimestamp(roachpb.NodeID(1), c.readTs.UnsafeToClockTimestamp())
+			ba.Txn = readTxn
+		}
+		gArgs := getArgs(k)
+		ba.Add(&gArgs)
+		// TODO(mira): It would be nice to inject the intents to resolve in the
+		// concurrency.Guard passed below, instead of injecting them via a knob.
+		// Currently, this is not possible because the Guard is not an interface.
+		br, _, _, pErr := tc.repl.executeReadOnlyBatch(ctx, ba, allSpansGuard(), kvadmission.AdmissionInfo{})
+
+		if c.exp.error == "" {
+			require.NoError(t, pErr.GoError())
+			require.Regexp(t, c.exp.value, string(br.Responses[0].GetGet().Value.RawBytes))
+		} else {
+			require.Nil(t, br)
+			require.Regexp(t, c.exp.error, pErr.GoError())
+		}
+	}
+}

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -591,6 +591,11 @@ type StoreTestingKnobs struct {
 	// DisableLeaderlessWatcherRefreshOnRaftTick, if set, disables refreshing
 	// the leaderless watcher's unavailable state during raft ticks.
 	DisableLeaderlessWatcherRefreshOnRaftTick bool
+
+	// InjectIntentsToResolveVirtually is called while executing read-only
+	// requests; it helps inject intents to be resolved virtually, usually passed
+	// in by the lock table guard.
+	InjectIntentsToResolveVirtually func() []roachpb.LockUpdate
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.


### PR DESCRIPTION
Previously, non-locking read-only requests had to physically resolve intents of transactions they have pushed in order to stop conflicting with these intents. This essentially required a read-only request to perform a replicated write.

This commit uses a signal from the lock table to inform a read-only request that it can ignore (read below) or see the values (read above) of some conflicting intents. This is done by evaluating the read on top of a storage batch (instead of a storage reader) and prepending the intent resolutions of the relevant intents before the evaluation of the read-only request.

More details on the original idea in #94730.

Fixes: #162204

Release note: None