### PR TITLE
ccl/serverccl: Increase timeout in TestExecSQL

### DIFF
--- a/pkg/ccl/serverccl/testdata/api_v2_sql
+++ b/pkg/ccl/serverccl/testdata/api_v2_sql
@@ -347,6 +347,7 @@ sql admin
 {
   "database": "mydb",
   "execute": true,
+  "timeout": "30s",
   "statements": [
     {"sql": "ALTER TABLE foo RENAME TO bar"},
     {"sql": "INSERT INTO bar (i) VALUES (1), (2)"},


### PR DESCRIPTION
This increases the sql_alter_table test timeout from 5 seconds to 10 seconds

Resolves: #162011
Epic: None
Release note: None