### PR TITLE
changefeedccl: add debug log to detect incorrect initial highwater on restart

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -91,6 +91,7 @@ func computeDistChangefeedTimestamps(
 
 	schemaTS = details.StatementTime
 	if h := progress.GetHighWater(); h != nil && !h.IsEmpty() {
+		log.Changefeed.Infof(ctx, "setting initial high water to %s", h)
 		initialHighWater = *h
 		// If we have a high-water set, use it to compute the spans, since the
 		// ones at the statement time may have been garbage collected by now.


### PR DESCRIPTION
We're seeing a GC error on changefeed restart for a v25.4 cluster.
```
job failed (batch timestamp 1769003105.416211346,0 must be after replica GC threshold 1770697331.882991151,0 (r6: /Table/{0-4}))
```

This is a debugging log to detect incorrect the initial highwater. The
log is added here because the timestamp we're trying to fetch with is
the statement time of changefeed creation, and
`computeDistChangefeedTimestamps` defaults to the statement time if
there is no highwater. If we see the GC error again without this log,
this means that we are unable to fetch the highwater at all. If we see
the log, it means that we are able to fetch the highwater, but it is
incorrect.

It's possible that this affect multiple versions so we'll probably
backport to multiple versions.

Informs: https://github.com/cockroachlabs/support/issues/3553
Release note: None