### PR TITLE
opt/norm: allow inlining JSON fetch operators through projections

### DIFF
--- a/pkg/sql/opt/norm/inline_funcs.go
+++ b/pkg/sql/opt/norm/inline_funcs.go
@@ -163,7 +163,8 @@ func (c *CustomFuncs) CanInline(scalar opt.ScalarExpr) bool {
 		opt.IsOp, opt.IsNotOp, opt.InOp, opt.NotInOp,
 		opt.VariableOp, opt.ConstOp, opt.NullOp,
 		opt.PlusOp, opt.MinusOp, opt.MultOp,
-		opt.CaseOp, opt.WhenOp, opt.ScalarListOp:
+		opt.CaseOp, opt.WhenOp, opt.ScalarListOp,
+		opt.FetchValOp, opt.FetchTextOp, opt.FetchValPathOp, opt.FetchTextPathOp:
 
 		// Recursively verify that children are also inlinable.
 		for i, n := 0, scalar.ChildCount(); i < n; i++ {

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -1892,3 +1892,40 @@ project-set
  │    └── ()
  └── zip
       └── x_y(1, 2) [immutable, udf]
+
+exec-ddl
+CREATE TABLE json_tab (
+  id INT PRIMARY KEY,
+  data JSONB,
+  code STRING AS (data->'seg'->>'code') STORED,
+  INDEX (code)
+)
+----
+
+# Regression test for #162504. Ensure that JSON fetch operators can be inlined
+# through projections, allowing filters to be pushed down and use indexes on
+# computed columns.
+norm expect=PushSelectIntoInlinableProject
+SELECT * FROM (SELECT id, data->'seg'->>'code' AS code FROM json_tab) WHERE code = 'foo'
+----
+project
+ ├── columns: id:1!null code:6
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(6)
+ ├── select
+ │    ├── columns: id:1!null data:2
+ │    ├── immutable
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
+ │    ├── scan json_tab
+ │    │    ├── columns: id:1!null data:2
+ │    │    ├── computed column expressions
+ │    │    │    └── json_tab.code:3
+ │    │    │         └── (data:2->'seg')->>'code'
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2)
+ │    └── filters
+ │         └── ((data:2->'seg')->>'code') = 'foo' [outer=(2), immutable]
+ └── projections
+      └── (data:2->'seg')->>'code' [as=code:6, outer=(2), immutable]

--- a/pkg/sql/opt/xform/testdata/rules/computed
+++ b/pkg/sql/opt/xform/testdata/rules/computed
@@ -287,3 +287,36 @@ index-join t83390
       ├── constraint: /5/1: [/true - /true]
       ├── flags: force-index=idx
       └── key: (1)
+
+# Regression test for #162504. JSON fetch operators should be inlined through
+# projections (e.g., views), allowing filters to use indexes on computed columns.
+exec-ddl
+CREATE TABLE json_data (
+  id INT PRIMARY KEY,
+  data JSONB,
+  seg_code STRING AS (data->'seg'->>'code') STORED,
+  INDEX (seg_code)
+)
+----
+
+# Query with a projection of JSON fetch expression should allow index usage
+# when the projection is inlined by PushSelectIntoInlinableProject.
+opt
+SELECT * FROM (SELECT id, data->'seg'->>'code' AS code FROM json_data) WHERE code = 'ABC'
+----
+project
+ ├── columns: id:1!null code:6
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(6)
+ ├── index-join json_data
+ │    ├── columns: id:1!null data:2
+ │    ├── immutable
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
+ │    └── scan json_data@json_data_seg_code_idx
+ │         ├── columns: id:1!null
+ │         ├── constraint: /3/1: [/'ABC' - /'ABC']
+ │         └── key: (1)
+ └── projections
+      └── (data:2->'seg')->>'code' [as=code:6, outer=(2), immutable]


### PR DESCRIPTION
Previously, the optimizer's `PushSelectIntoInlinableProject` rule could not inline JSON fetch operators (FetchVal, FetchText, FetchValPath, FetchTextPath) through projections. This prevented the optimizer from recognizing when expressions in views matched indexed computed columns, resulting in full table scans instead of efficient index lookups.

For example, a view projecting `data->'seg'->>'code'` that matched a stored computed column definition would still cause a full scan when filtered, even though an index existed on the computed column.

This commit adds the four JSON fetch operators to the `CanInline` allowlist, enabling the normalization rule to push filters through projections containing these expressions. This allows the optimizer to recognize the equivalence with indexed computed columns and generate plans using constrained index scans.

Resolves: #162504

Release note (bug fix): Fixed an optimizer limitation that prevented index usage on computed columns when querying through views or subqueries containing JSON fetch expressions (such as ->, ->>, #>, #>>). Queries that project JSON expressions matching indexed computed column definitions now correctly use indexes instead of performing full table scans, significantly improving performance for JSON workloads.