### PR TITLE
authserver,pgwire: populate estimated_last_login_time for ldap db console login

### DIFF
--- a/pkg/ccl/ldapccl/authorization_ldap_test.go
+++ b/pkg/ccl/ldapccl/authorization_ldap_test.go
@@ -449,6 +449,23 @@ func TestLDAPProvisioningDBConsole(t *testing.T) {
 			"user should not have been provisioned when setting is disabled")
 	})
 
+	t.Run("provisioning disabled, existing user login does not set last login time", func(t *testing.T) {
+		tdb.Exec(t, "SET CLUSTER SETTING security.provisioning.ldap.enabled = false")
+		tdb.Exec(t, "CREATE USER existinguser2")
+		mockLDAP.SetGroups("cn=existinguser2", []string{"cn=db_admins"})
+
+		resp, err := httpLogin("existinguser2", "password")
+		require.NoError(t, err, "DB Console login should succeed for existing user")
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		// estimated_last_login_time should remain NULL since provisioning is
+		// disabled.
+		rows := tdb.QueryStr(t,
+			`SELECT count(*) FROM system.users WHERE username = 'existinguser2' AND estimated_last_login_time IS NOT NULL`)
+		require.Equal(t, "0", rows[0][0],
+			"estimated_last_login_time should not be populated when provisioning is disabled")
+	})
+
 	t.Run("provisioning enabled, new user succeeds login", func(t *testing.T) {
 		tdb.Exec(t, "SET CLUSTER SETTING security.provisioning.ldap.enabled = true")
 		mockLDAP.SetGroups("cn=newuser2", []string{"cn=db_admins"})
@@ -473,6 +490,16 @@ func TestLDAPProvisioningDBConsole(t *testing.T) {
 			`SELECT options FROM [SHOW USERS] WHERE username = 'newuser2'`)
 		require.Len(t, rows, 1)
 		require.Contains(t, rows[0][0], "PROVISIONSRC=ldap:localhost")
+
+		// Verify estimated_last_login_time is populated.
+		testutils.SucceedsSoon(t, func() error {
+			rows := tdb.QueryStr(t,
+				`SELECT count(*) FROM system.users WHERE username = 'newuser2' AND estimated_last_login_time IS NOT NULL`)
+			if len(rows) == 0 || rows[0][0] != "1" {
+				return errors.New("estimated_last_login_time not yet updated for newuser2")
+			}
+			return nil
+		})
 	})
 
 	t.Run("provisioning enabled, existing user", func(t *testing.T) {


### PR DESCRIPTION
Previously, when a user authenticated against the DB Console via LDAP, their
`estimated_last_login_time` in the `system.users` table was not updated. This
meant that administrators could not track when LDAP-authenticated users last
logged in through the DB Console, creating an observability gap compared to the
SQL shell path where this column is already populated for all authentication
methods.

This commit adds `estimated_last_login_time` population for LDAP-authenticated
DB Console logins, gated behind the `security.provisioning.ldap.enabled` cluster
setting. 

Epic: CRDB-52460
Informs: #147602

Release note (security change): When the `security.provisioning.ldap.enabled`
cluster setting is enabled, LDAP-authenticated DB Consloe logins now update the
`estimated_last_login_time` column in the `system.users` table.