### PR TITLE
drtprod: add AWS chaos testing cluster configuration

### DIFF
--- a/pkg/cmd/drt/scripts/roachtest_operations_run.sh
+++ b/pkg/cmd/drt/scripts/roachtest_operations_run.sh
@@ -5,6 +5,26 @@
 # Use of this software is governed by the CockroachDB Software License
 # included in the /LICENSE file.
 
+# Usage: ./roachtest_operations_run.sh <cluster> <workload_cluster> <cloud>
+# Example: ./roachtest_operations_run.sh drt-chaos-aws workload-chaos-aws aws
+# Example: ./roachtest_operations_run.sh drt-chaos workload-chaos gcp
+
+set -euo pipefail
+
+CLUSTER="${1:-}"
+WORKLOAD_CLUSTER="${2:-}"
+CLOUD="${3:-}"
+
+if [ -z "${CLUSTER}" ] || [ -z "${WORKLOAD_CLUSTER}" ] || [ -z "${CLOUD}" ]; then
+  echo "Usage: $0 <cluster> <workload_cluster> <cloud>"
+  echo "  cloud: aws or gcp"
+  echo ""
+  echo "Examples:"
+  echo "  $0 drt-chaos-aws workload-chaos-aws aws"
+  echo "  $0 drt-chaos workload-chaos gcp"
+  exit 1
+fi
+
 cd /home/ubuntu
 
 export ROACHPROD_GCE_DEFAULT_PROJECT=cockroach-drt
@@ -12,8 +32,59 @@ export ROACHPROD_DNS="drt.crdb.io"
 ./roachprod sync
 sleep 20
 
-# add --datadog-api-key and --datadog-app-key
+# Fetch secrets from cloud provider at runtime (not stored in any file)
+# AWS secrets are stored in us-east-1 region for consistency across all clusters
+AWS_SECRETS_REGION="us-east-1"
+
+fetch_secret() {
+  local secret_name="$1"
+  local secret_value=""
+
+  case "${CLOUD}" in
+    aws)
+      if ! secret_value="$(aws secretsmanager get-secret-value \
+        --region "${AWS_SECRETS_REGION}" \
+        --secret-id "${secret_name}" \
+        --query SecretString \
+        --output text 2>&1)"; then
+        echo "Error: Failed to fetch secret '${secret_name}' from AWS Secrets Manager (region: ${AWS_SECRETS_REGION})" >&2
+        echo "Details: ${secret_value}" >&2
+        exit 1
+      fi
+      ;;
+    gcp)
+      if ! secret_value="$(gcloud --project=cockroach-drt secrets versions access latest \
+        --secret "${secret_name}" 2>&1)"; then
+        echo "Error: Failed to fetch secret '${secret_name}' from GCP Secret Manager" >&2
+        echo "Details: ${secret_value}" >&2
+        exit 1
+      fi
+      ;;
+    *)
+      echo "Error: Unknown cloud '${CLOUD}'. Must be 'aws' or 'gcp'." >&2
+      exit 1
+      ;;
+  esac
+
+  if [ -z "${secret_value}" ]; then
+    echo "Error: Secret '${secret_name}' exists but has an empty value" >&2
+    exit 1
+  fi
+
+  echo "${secret_value}"
+}
+
+DD_API_KEY="$(fetch_secret datadog-api-key)"
+
+if [ -z "${DD_API_KEY}" ]; then
+  echo "Error: Datadog API key is empty" >&2
+  exit 1
+fi
+
 while true; do
-  ./roachtest-operations run-operation "drt-scale" ".*" --datadog-tags env:development,cluster:workload-scale,team:drt,service:drt-cockroachdb --certs-dir ./certs  | tee -a roachtest_ops.log
+  ./roachtest-operations run-operation "${CLUSTER}" ".*" \
+    --datadog-api-key "${DD_API_KEY}" \
+    --datadog-tags "env:development,cluster:${WORKLOAD_CLUSTER},team:drt,service:drt-cockroachdb" \
+    --certs-dir ./certs | tee -a roachtest_ops.log
   sleep 600
 done

--- a/pkg/cmd/drtprod/configs/drt_chaos_aws.yaml
+++ b/pkg/cmd/drtprod/configs/drt_chaos_aws.yaml
@@ -1,19 +1,16 @@
-# Yaml for creating and configuring the drt-chaos and workload-chaos clusters. This also configures the datadog.
+# Yaml for creating and configuring the drt-chaos-aws and workload-chaos-aws clusters on AWS.
+# This is the AWS equivalent of drt_chaos.yaml which uses GCE.
+# Uses AWS Auto Scaling Groups (equivalent to GCE managed instance groups).
 environment:
-  ROACHPROD_GCE_DEFAULT_SERVICE_ACCOUNT: 622274581499-compute@developer.gserviceaccount.com
   ROACHPROD_DNS: drt.crdb.io
-  ROACHPROD_GCE_DNS_DOMAIN: drt.crdb.io
-  ROACHPROD_GCE_DNS_ZONE: drt
-  ROACHPROD_GCE_DEFAULT_PROJECT: cockroach-drt
-  CLUSTER: drt-chaos
+  CLUSTER: drt-chaos-aws
   CLUSTER_NODES: 6
-  WORKLOAD_CLUSTER: workload-chaos
+  WORKLOAD_CLUSTER: workload-chaos-aws
   WORKLOAD_NODES: 1
 
 dependent_file_locations:
   - artifacts/roachprod
   - artifacts/roachtest
-  - pkg/cmd/drtprod/scripts/setup_dmsetup_disk_staller
   - pkg/cmd/drtprod/scripts/setup_datadog_cluster
   - pkg/cmd/drtprod/scripts/setup_datadog_workload
   - pkg/cmd/drtprod/scripts/tpcc_init.sh
@@ -28,29 +25,40 @@ targets:
         args:
           - $CLUSTER
         flags:
-          clouds: gce
-          gce-managed: true
-          gce-enable-multiple-stores: true
-          gce-zones: "us-east1-d,us-east1-b,us-east1-c"
+          clouds: aws
+          aws-managed: true
+          aws-enable-multiple-stores: true
+          aws-zones: "us-east-2a,us-east-2b,us-east-2c"
           nodes: $CLUSTER_NODES
-          gce-machine-type: n2-standard-16
-          local-ssd: true
-          gce-local-ssd-count: 4
+          # m6i.4xlarge: 16 vCPU, 64GB RAM (equivalent to n2-standard-16)
+          aws-machine-type: m6i.4xlarge
+          local-ssd: false
+          # 4 EBS gp3 volumes to match 4 local SSDs in GCE config
+          aws-ebs-volume:
+            - >-
+              {"VolumeType":"gp3","VolumeSize":375}
+            - >-
+              {"VolumeType":"gp3","VolumeSize":375}
+            - >-
+              {"VolumeType":"gp3","VolumeSize":375}
+            - >-
+              {"VolumeType":"gp3","VolumeSize":375}
           username: drt
           lifetime: 8760h
-          gce-image: "ubuntu-2204-jammy-v20240319"
+          label: drt=true
+          # IAM instance profile for AWS resource access (S3, secrets, etc.)
+          aws-iam-profile: drt-testing
         on_rollback:
           - command: destroy
             args:
               - $CLUSTER
       - command: sync
         flags:
-          clouds: gce
+          clouds: aws
       - command: stage
         args:
           - $CLUSTER
           - cockroach
-      - script: "pkg/cmd/drtprod/scripts/setup_dmsetup_disk_staller"
       - script: "pkg/cmd/drtprod/scripts/setup_datadog_cluster"
       - command: start
         args:
@@ -67,31 +75,61 @@ targets:
           - command: stop
             args:
               - $CLUSTER
-      - command: run
+      # setup dmsetup for disk-stalls
+      - command: chaos
         args:
+          - disk-stall
           - $CLUSTER
-          - --
-          - "sudo systemctl unmask cron.service ; sudo systemctl enable cron.service ; echo \"crontab -l ; echo '@reboot sleep 100 && ~/cockroach.sh' | crontab -\" > t.sh ; sh t.sh ; rm t.sh"
+        flags:
+          type: dmsetup
+          stage: setup
+          nodes: 1
   - target_name: $WORKLOAD_CLUSTER
     steps:
       - command: create
         args:
           - $WORKLOAD_CLUSTER
         flags:
-          clouds: gce
-          gce-zones: "us-east1-c"
+          clouds: aws
+          aws-zones: "us-east-2c"
           nodes: $WORKLOAD_NODES
-          gce-machine-type: n2-standard-8
-          os-volume-size: 100
+          # m6i.2xlarge: 8 vCPU, 32GB RAM (equivalent to n2-standard-8)
+          aws-machine-type: m6i.2xlarge
+          local-ssd: false
+          aws-ebs-volume-size: 100
           username: workload
           lifetime: 8760h
+          label: drt=true
+          # IAM instance profile for AWS resource access (S3, secrets, etc.)
+          aws-iam-profile: drt-testing
         on_rollback:
           - command: destroy
             args:
               - $WORKLOAD_CLUSTER
       - command: sync
         flags:
-          clouds: gce
+          clouds: aws
+      # Install AWS CLI v2 on workload node
+      - command: run
+        args:
+          - $WORKLOAD_CLUSTER
+          - --
+          - >-
+            sudo apt-get install -y unzip &&
+            curl -fsSL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o /tmp/awscliv2.zip &&
+            cd /tmp &&
+            unzip -q -o awscliv2.zip &&
+            sudo ./aws/install &&
+            rm -rf /tmp/aws /tmp/awscliv2.zip
+      # Create AWS config file so roachprod detects AWS credentials from IAM instance profile
+      - command: run
+        args:
+          - $WORKLOAD_CLUSTER
+          - --
+          - >-
+            mkdir -p ~/.aws &&
+            echo '[default]' > ~/.aws/config &&
+            echo 'region = us-east-1' >> ~/.aws/config
       - command: stage
         args:
           - $WORKLOAD_CLUSTER
@@ -106,28 +144,22 @@ targets:
       - $CLUSTER
       - $WORKLOAD_CLUSTER
     steps:
-      - script: rm
-        args:
-          - -rf
-          - certs-$CLUSTER
-      - command: get
+      # Fetch certs from cluster node 1 to local directory
+      - command: fetch-certs
         args:
           - $CLUSTER:1
-          - certs
           - certs-$CLUSTER
-      - command: ssh
-        args:
-          - $WORKLOAD_CLUSTER
-          - --
-          - sudo
-          - rm
-          - -rf
-          - certs
+      # Copy certs to workload cluster
       - command: put
         args:
           - $WORKLOAD_CLUSTER
           - certs-$CLUSTER
           - certs
+      # Clean up local certs directory
+      - script: rm
+        args:
+          - -rf
+          - certs-$CLUSTER
       - command: put
         args:
           - $WORKLOAD_CLUSTER
@@ -149,13 +181,6 @@ targets:
           - pkg/cmd/drt/scripts/roachtest_operations_run.sh
           - roachtest_operations_run.sh
       - script: pkg/cmd/drtprod/scripts/populate_workload_keys.sh
-      - command: ssh
-        args:
-          - $WORKLOAD_CLUSTER
-          - --
-          - chmod
-          - 600
-          - './certs/*'
       - script: "pkg/cmd/drtprod/scripts/tpcc_init.sh"
         args:
           - cct_tpcc # suffix added to script name tpcc_init_cct_tpcc.sh

--- a/pkg/cmd/drtprod/scripts/generate_tpcc_drop.sh
+++ b/pkg/cmd/drtprod/scripts/generate_tpcc_drop.sh
@@ -83,7 +83,7 @@ while true; do
         --prometheus-port 2113 \
         --ramp 5m \
         --display-every 5s \
-        --duration 60m \
+        --duration 24h \
         --tolerate-errors \
         "\${PGURLS_ARR[@]}" | tee "\$RUN_LOG"
     if [ \$? -eq 0 ]; then


### PR DESCRIPTION
Add drt_chaos_aws.yaml, the AWS equivalent of drt_chaos.yaml for running chaos testing on AWS. Key differences from the GCE configuration:

- Uses AWS Auto Scaling Groups (aws-managed: true) instead of GCE managed instance groups
- Uses m6i.4xlarge (16 vCPU, 64GB) for cluster nodes and m6i.2xlarge (8 vCPU, 32GB) for workload nodes
- Uses 4x EBS gp3 volumes (375GB each) instead of local SSDs
- Deploys in us-east-1a/b/c availability zones

The instances use IAM instance profile `drt-testing` which provides:
- Read access to AWS Secrets Manager for fetching datadog-api-key
- Read/write access to S3 buckets for backups and artifacts
- EC2 describe permissions for roachprod cluster management

Also update roachtest_operations_run.sh to support multi-cloud secret fetching. The script now accepts cluster, workload_cluster, and cloud parameters, fetching secrets from AWS Secrets Manager or GCP Secret Manager based on the cloud parameter.

Informs: https://github.com/cockroachdb/cockroach/issues/156499

Release note: None