### PR TITLE
sql: implement dmetaphone, dmetaphone_alt, and daitch_mokotoff builtins

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/fuzzystrmatch
+++ b/pkg/sql/logictest/testdata/logic_test/fuzzystrmatch
@@ -124,3 +124,97 @@ query TTT
 SELECT metaphone('Night', 4), metaphone('Knight', 4), metaphone('Knives', 4);
 ----
 NFT NFT NFS
+
+# Double Metaphone
+
+query T
+SELECT dmetaphone('gumbo');
+----
+KMP
+
+query TT
+SELECT dmetaphone('Richard'), dmetaphone_alt('Richard');
+----
+RXRT  RKRT
+
+query TT
+SELECT dmetaphone('Smith'), dmetaphone_alt('Smith');
+----
+SM0  XMT
+
+query TT
+SELECT dmetaphone('Schmidt'), dmetaphone_alt('Schmidt');
+----
+XMT  SMT
+
+query T
+SELECT dmetaphone('');
+----
+·
+
+query TT
+SELECT dmetaphone(NULL), dmetaphone_alt(NULL);
+----
+NULL  NULL
+
+query TT
+SELECT dmetaphone('Jose'), dmetaphone_alt('Jose');
+----
+HS  HS
+
+query TT
+SELECT dmetaphone('danger'), dmetaphone_alt('danger');
+----
+TNJR  TNKR
+
+query TT
+SELECT dmetaphone('filipowicz'), dmetaphone_alt('filipowicz');
+----
+FLPT  FLPF
+
+query TT
+SELECT dmetaphone('knight'), dmetaphone_alt('knight');
+----
+NT  NT
+
+# Daitch-Mokotoff Soundex
+
+query T
+SELECT daitch_mokotoff('George');
+----
+{595000}
+
+query T
+SELECT daitch_mokotoff('John');
+----
+{160000,460000}
+
+query T
+SELECT daitch_mokotoff('Augsburg');
+----
+{054795}
+
+query T
+SELECT daitch_mokotoff('Breuer');
+----
+{791900}
+
+query T
+SELECT daitch_mokotoff('Halberstadt');
+----
+{587433,587943}
+
+query T
+SELECT daitch_mokotoff('Chernowitz');
+----
+{496740,596740}
+
+query T
+SELECT daitch_mokotoff('');
+----
+NULL
+
+query T
+SELECT daitch_mokotoff(NULL);
+----
+NULL

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4154,8 +4154,55 @@ value if you rely on the HLC for accuracy.`,
 			Volatility: volatility.Immutable,
 		},
 	),
-	"dmetaphone":     makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 56820, Category: builtinconstants.CategoryFuzzyStringMatching}),
-	"dmetaphone_alt": makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 56820, Category: builtinconstants.CategoryFuzzyStringMatching}),
+	"dmetaphone": makeBuiltin(
+		tree.FunctionProperties{Category: builtinconstants.CategoryFuzzyStringMatching},
+		tree.Overload{
+			Types:      tree.ParamTypes{{Name: "source", Typ: types.String}},
+			ReturnType: tree.FixedReturnType(types.String),
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
+				s := string(tree.MustBeDString(args[0]))
+				return tree.NewDString(fuzzystrmatch.DMetaphone(s)), nil
+			},
+			Info:       "Returns the primary Double Metaphone code for the input string.",
+			Volatility: volatility.Immutable,
+		},
+	),
+	"dmetaphone_alt": makeBuiltin(
+		tree.FunctionProperties{Category: builtinconstants.CategoryFuzzyStringMatching},
+		tree.Overload{
+			Types:      tree.ParamTypes{{Name: "source", Typ: types.String}},
+			ReturnType: tree.FixedReturnType(types.String),
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
+				s := string(tree.MustBeDString(args[0]))
+				return tree.NewDString(fuzzystrmatch.DMetaphoneAlt(s)), nil
+			},
+			Info:       "Returns the alternate Double Metaphone code for the input string.",
+			Volatility: volatility.Immutable,
+		},
+	),
+	"daitch_mokotoff": makeBuiltin(
+		tree.FunctionProperties{Category: builtinconstants.CategoryFuzzyStringMatching},
+		tree.Overload{
+			Types:      tree.ParamTypes{{Name: "source", Typ: types.String}},
+			ReturnType: tree.FixedReturnType(types.MakeArray(types.String)),
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
+				s := string(tree.MustBeDString(args[0]))
+				codes := fuzzystrmatch.DaitchMokotoff(s)
+				if codes == nil {
+					return tree.DNull, nil
+				}
+				arr := tree.NewDArray(types.String)
+				for _, code := range codes {
+					if err := arr.Append(tree.NewDString(code)); err != nil {
+						return nil, err
+					}
+				}
+				return arr, nil
+			},
+			Info:       "Returns an array of Daitch-Mokotoff soundex codes for the input string.",
+			Volatility: volatility.Immutable,
+		},
+	),
 	"levenshtein_less_equal": makeBuiltin(
 		tree.FunctionProperties{Category: builtinconstants.CategoryFuzzyStringMatching},
 		tree.Overload{

--- a/pkg/util/fuzzystrmatch/BUILD.bazel
+++ b/pkg/util/fuzzystrmatch/BUILD.bazel
@@ -3,6 +3,8 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "fuzzystrmatch",
     srcs = [
+        "daitch_mokotoff.go",
+        "dmetaphone.go",
         "leven.go",
         "metaphone.go",
         "soundex.go",
@@ -15,6 +17,8 @@ go_test(
     name = "fuzzystrmatch_test",
     size = "small",
     srcs = [
+        "daitch_mokotoff_test.go",
+        "dmetaphone_test.go",
         "leven_test.go",
         "metaphone_test.go",
         "soundex_test.go",

--- a/pkg/util/fuzzystrmatch/daitch_mokotoff.go
+++ b/pkg/util/fuzzystrmatch/daitch_mokotoff.go
@@ -1,0 +1,399 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package fuzzystrmatch
+
+import (
+	"sort"
+	"strings"
+	"unicode"
+)
+
+// dmCodeLen is the number of digits in a Daitch-Mokotoff soundex code.
+const dmCodeLen = 6
+
+// dmCodes represents the three positional codes for a letter sequence:
+// [0] = at the start of name, [1] = before a vowel, [2] = any other position.
+// "X" means "not coded" (letter is ignored in that position).
+type dmCodes [3]string
+
+// dmRule represents a single letter-to-code mapping in the coding table.
+// A letter sequence may have multiple alternative code sets (branching).
+type dmRule struct {
+	pattern string
+	codes   []dmCodes
+}
+
+// dmTrie is a trie node for efficient longest-match lookup.
+type dmTrieNode struct {
+	children map[byte]*dmTrieNode
+	codes    []dmCodes // non-nil if this node represents a complete match
+}
+
+// dmBranch tracks the state of one code branch being built.
+type dmBranch struct {
+	code      [dmCodeLen]byte
+	length    int
+	lastDigit byte
+}
+
+// The coding table, ported from PostgreSQL's daitch_mokotoff_coding.h.
+// Each entry maps a letter sequence to one or more code alternatives.
+var dmRules = []dmRule{
+	// Vowel combinations.
+	{"AI", []dmCodes{{"0", "1", "X"}}},
+	{"AJ", []dmCodes{{"0", "1", "X"}}},
+	{"AU", []dmCodes{{"0", "7", "X"}}},
+	{"AY", []dmCodes{{"0", "1", "X"}}},
+	{"A", []dmCodes{{"0", "X", "X"}}},
+
+	{"EI", []dmCodes{{"0", "1", "X"}}},
+	{"EJ", []dmCodes{{"0", "1", "X"}}},
+	{"EU", []dmCodes{{"1", "1", "X"}}},
+	{"EY", []dmCodes{{"0", "1", "X"}}},
+	{"E", []dmCodes{{"0", "X", "X"}}},
+
+	{"IA", []dmCodes{{"1", "X", "X"}}},
+	{"IE", []dmCodes{{"1", "X", "X"}}},
+	{"IO", []dmCodes{{"1", "X", "X"}}},
+	{"IU", []dmCodes{{"1", "X", "X"}}},
+	{"I", []dmCodes{{"0", "X", "X"}}},
+
+	{"OI", []dmCodes{{"0", "1", "X"}}},
+	{"OJ", []dmCodes{{"0", "1", "X"}}},
+	{"OY", []dmCodes{{"0", "1", "X"}}},
+	{"O", []dmCodes{{"0", "X", "X"}}},
+
+	{"UI", []dmCodes{{"0", "1", "X"}}},
+	{"UE", []dmCodes{{"0", "1", "X"}}},
+	{"UJ", []dmCodes{{"0", "1", "X"}}},
+	{"UY", []dmCodes{{"0", "1", "X"}}},
+	{"U", []dmCodes{{"0", "X", "X"}}},
+
+	// Consonant combinations.
+	{"B", []dmCodes{{"7", "7", "7"}}},
+
+	{"CHS", []dmCodes{{"5", "54", "54"}}},
+	{"CH", []dmCodes{{"5", "5", "5"}, {"4", "4", "4"}}},
+	{"CK", []dmCodes{{"5", "5", "5"}, {"45", "45", "45"}}},
+	{"CSZ", []dmCodes{{"4", "4", "4"}}},
+	{"CS", []dmCodes{{"4", "4", "4"}}},
+	{"CZS", []dmCodes{{"4", "4", "4"}}},
+	{"CZ", []dmCodes{{"4", "4", "4"}}},
+	{"C", []dmCodes{{"5", "5", "5"}, {"4", "4", "4"}}},
+
+	{"DRS", []dmCodes{{"4", "4", "4"}}},
+	{"DRZ", []dmCodes{{"4", "4", "4"}}},
+	{"DSH", []dmCodes{{"4", "4", "4"}}},
+	{"DSZ", []dmCodes{{"4", "4", "4"}}},
+	{"DS", []dmCodes{{"4", "4", "4"}}},
+	{"DT", []dmCodes{{"3", "3", "3"}}},
+	{"DZH", []dmCodes{{"4", "4", "4"}}},
+	{"DZS", []dmCodes{{"4", "4", "4"}}},
+	{"DZ", []dmCodes{{"4", "4", "4"}}},
+	{"D", []dmCodes{{"3", "3", "3"}}},
+
+	{"FB", []dmCodes{{"7", "7", "7"}}},
+	{"F", []dmCodes{{"7", "7", "7"}}},
+
+	{"G", []dmCodes{{"5", "5", "5"}}},
+
+	{"H", []dmCodes{{"5", "5", "X"}}},
+
+	{"J", []dmCodes{{"1", "X", "X"}, {"4", "4", "4"}}},
+
+	{"KH", []dmCodes{{"5", "5", "5"}}},
+	{"KS", []dmCodes{{"5", "54", "54"}}},
+	{"K", []dmCodes{{"5", "5", "5"}}},
+
+	{"L", []dmCodes{{"8", "8", "8"}}},
+
+	{"MN", []dmCodes{{"66", "66", "66"}}},
+	{"M", []dmCodes{{"6", "6", "6"}}},
+
+	{"NM", []dmCodes{{"66", "66", "66"}}},
+	{"N", []dmCodes{{"6", "6", "6"}}},
+
+	{"PF", []dmCodes{{"7", "7", "7"}}},
+	{"PH", []dmCodes{{"7", "7", "7"}}},
+	{"P", []dmCodes{{"7", "7", "7"}}},
+
+	{"Q", []dmCodes{{"5", "5", "5"}}},
+
+	{"RS", []dmCodes{{"94", "94", "94"}, {"4", "4", "4"}}},
+	{"RZ", []dmCodes{{"94", "94", "94"}, {"4", "4", "4"}}},
+	{"R", []dmCodes{{"9", "9", "9"}}},
+
+	{"SCHTSCH", []dmCodes{{"2", "4", "4"}}},
+	{"SCHTSH", []dmCodes{{"2", "4", "4"}}},
+	{"SCHTCH", []dmCodes{{"2", "4", "4"}}},
+	{"SCHD", []dmCodes{{"2", "43", "43"}}},
+	{"SCHT", []dmCodes{{"2", "43", "43"}}},
+	{"SCH", []dmCodes{{"4", "4", "4"}}},
+	{"SC", []dmCodes{{"2", "4", "4"}}},
+	{"SHTCH", []dmCodes{{"2", "4", "4"}}},
+	{"SHTSH", []dmCodes{{"2", "4", "4"}}},
+	{"SHCH", []dmCodes{{"2", "4", "4"}}},
+	{"SHD", []dmCodes{{"2", "43", "43"}}},
+	{"SHT", []dmCodes{{"2", "43", "43"}}},
+	{"SH", []dmCodes{{"4", "4", "4"}}},
+	{"STCH", []dmCodes{{"2", "4", "4"}}},
+	{"STSCH", []dmCodes{{"2", "4", "4"}}},
+	{"STRZ", []dmCodes{{"2", "4", "4"}}},
+	{"STRS", []dmCodes{{"2", "4", "4"}}},
+	{"STSH", []dmCodes{{"2", "4", "4"}}},
+	{"SD", []dmCodes{{"2", "43", "43"}}},
+	{"ST", []dmCodes{{"2", "43", "43"}}},
+	{"SZCZ", []dmCodes{{"2", "4", "4"}}},
+	{"SZCS", []dmCodes{{"2", "4", "4"}}},
+	{"SZD", []dmCodes{{"2", "43", "43"}}},
+	{"SZT", []dmCodes{{"2", "43", "43"}}},
+	{"SZ", []dmCodes{{"4", "4", "4"}}},
+	{"S", []dmCodes{{"4", "4", "4"}}},
+
+	{"TTSCH", []dmCodes{{"4", "4", "4"}}},
+	{"TTCH", []dmCodes{{"4", "4", "4"}}},
+	{"TTSZ", []dmCodes{{"4", "4", "4"}}},
+	{"TTZ", []dmCodes{{"4", "4", "4"}}},
+	{"TTS", []dmCodes{{"4", "4", "4"}}},
+	{"TSCH", []dmCodes{{"4", "4", "4"}}},
+	{"TSH", []dmCodes{{"4", "4", "4"}}},
+	{"TSZ", []dmCodes{{"4", "4", "4"}}},
+	{"TCH", []dmCodes{{"4", "4", "4"}}},
+	{"TC", []dmCodes{{"4", "4", "4"}}},
+	{"TH", []dmCodes{{"3", "3", "3"}}},
+	{"TRS", []dmCodes{{"4", "4", "4"}}},
+	{"TRZ", []dmCodes{{"4", "4", "4"}}},
+	{"TS", []dmCodes{{"4", "4", "4"}}},
+	{"TZ", []dmCodes{{"4", "4", "4"}}},
+	{"TZS", []dmCodes{{"4", "4", "4"}}},
+	{"T", []dmCodes{{"3", "3", "3"}}},
+
+	{"V", []dmCodes{{"7", "7", "7"}}},
+	{"W", []dmCodes{{"7", "7", "7"}}},
+	{"X", []dmCodes{{"5", "54", "54"}}},
+	{"Y", []dmCodes{{"1", "X", "X"}}},
+
+	{"ZHDZH", []dmCodes{{"2", "4", "4"}}},
+	{"ZHDZ", []dmCodes{{"2", "4", "4"}}},
+	{"ZHD", []dmCodes{{"2", "43", "43"}}},
+	{"ZH", []dmCodes{{"4", "4", "4"}}},
+	{"ZDZH", []dmCodes{{"2", "4", "4"}}},
+	{"ZDZ", []dmCodes{{"2", "4", "4"}}},
+	{"ZD", []dmCodes{{"2", "43", "43"}}},
+	{"ZSCH", []dmCodes{{"4", "4", "4"}}},
+	{"ZSH", []dmCodes{{"4", "4", "4"}}},
+	{"ZS", []dmCodes{{"4", "4", "4"}}},
+	{"Z", []dmCodes{{"4", "4", "4"}}},
+}
+
+var dmTrie *dmTrieNode
+
+func init() {
+	dmTrie = buildDMTrie()
+}
+
+func buildDMTrie() *dmTrieNode {
+	root := &dmTrieNode{children: make(map[byte]*dmTrieNode)}
+	for _, rule := range dmRules {
+		node := root
+		for i := 0; i < len(rule.pattern); i++ {
+			ch := rule.pattern[i]
+			if node.children[ch] == nil {
+				node.children[ch] = &dmTrieNode{
+					children: make(map[byte]*dmTrieNode),
+				}
+			}
+			node = node.children[ch]
+		}
+		node.codes = rule.codes
+	}
+	return root
+}
+
+// dmLookup finds the longest matching letter sequence in the trie starting
+// at position pos in the input string. Returns the codes for that sequence
+// and the number of characters consumed.
+func dmLookup(input string, pos int) ([]dmCodes, int) {
+	node := dmTrie
+	var bestCodes []dmCodes
+	bestLen := 0
+
+	for i := pos; i < len(input); i++ {
+		child := node.children[input[i]]
+		if child == nil {
+			break
+		}
+		node = child
+		if node.codes != nil {
+			bestCodes = node.codes
+			bestLen = i - pos + 1
+		}
+	}
+
+	return bestCodes, bestLen
+}
+
+// dmIsVowelCode returns true if the code set represents a vowel-like sound
+// (starts with '0' or '1'). Used to determine the "before a vowel" context.
+func dmIsVowelCode(codes []dmCodes) bool {
+	if len(codes) == 0 {
+		return false
+	}
+	c := codes[0][0]
+	return len(c) > 0 && (c[0] == '0' || c[0] == '1')
+}
+
+// DaitchMokotoff computes Daitch-Mokotoff soundex codes for the input string.
+// Returns a sorted slice of unique 6-digit code strings.
+func DaitchMokotoff(source string) []string {
+	// Convert to uppercase ASCII, stripping non-alpha characters.
+	input := dmNormalize(source)
+	if len(input) == 0 {
+		return nil
+	}
+
+	// Start with a single branch.
+	branches := []dmBranch{{}}
+
+	pos := 0
+	letterNo := 0
+	for pos < len(input) {
+		// Find the longest matching sequence.
+		codes, advance := dmLookup(input, pos)
+		if advance == 0 {
+			// No match (non-alphabetic character); skip.
+			pos++
+			continue
+		}
+
+		// Look ahead to determine if the next letter is a vowel.
+		nextPos := pos + advance
+		var nextCodes []dmCodes
+		if nextPos < len(input) {
+			nextCodes, _ = dmLookup(input, nextPos)
+		}
+
+		// Determine code column index.
+		var codeIndex int
+		if letterNo == 0 {
+			codeIndex = 0 // start of name
+		} else if dmIsVowelCode(nextCodes) {
+			codeIndex = 1 // before a vowel
+		} else {
+			codeIndex = 2 // any other
+		}
+
+		// Apply codes to all branches, possibly creating new branches.
+		branches = dmApplyCodes(branches, codes, codeIndex)
+
+		pos = nextPos
+		letterNo++
+	}
+
+	// Pad all codes to 6 digits and collect unique results.
+	seen := make(map[string]struct{})
+	var result []string
+	for _, b := range branches {
+		code := dmPadCode(b)
+		if _, ok := seen[code]; !ok {
+			seen[code] = struct{}{}
+			result = append(result, code)
+		}
+	}
+
+	sort.Strings(result)
+	return result
+}
+
+// dmApplyCodes processes one letter's codes across all branches.
+func dmApplyCodes(branches []dmBranch, codes []dmCodes, codeIndex int) []dmBranch {
+	var result []dmBranch
+	for _, b := range branches {
+		if b.length >= dmCodeLen {
+			result = append(result, b)
+			continue
+		}
+		for _, alt := range codes {
+			codeStr := alt[codeIndex]
+			newBranches := dmApplyCodeStr(b, codeStr)
+			result = append(result, newBranches...)
+		}
+	}
+	return result
+}
+
+// dmApplyCodeStr applies a single code string (e.g. "54", "X") to a branch.
+func dmApplyCodeStr(b dmBranch, codeStr string) []dmBranch {
+	if codeStr == "X" {
+		// Not coded. Reset lastDigit so the next consonant won't be
+		// deduped against the consonant before this vowel.
+		b.lastDigit = 0
+		return []dmBranch{b}
+	}
+
+	return dmApplyDigits(b, codeStr, 0)
+}
+
+// dmApplyDigits recursively applies code digits to a branch.
+func dmApplyDigits(b dmBranch, codeStr string, digitIdx int) []dmBranch {
+	if digitIdx >= len(codeStr) || b.length >= dmCodeLen {
+		return []dmBranch{b}
+	}
+
+	digit := codeStr[digitIdx]
+	if digit == 'X' {
+		return dmApplyDigits(b, codeStr, digitIdx+1)
+	}
+
+	var results []dmBranch
+
+	// Dedup: first digit might match previous code digit.
+	if digitIdx == 0 && digit == b.lastDigit {
+		// Same as previous - skip path (dedup).
+		skipBranch := b
+		results = append(results, dmApplyDigits(skipBranch, codeStr, digitIdx+1)...)
+	}
+
+	if digitIdx > 0 || digit != b.lastDigit {
+		// Different from previous - add path.
+		addBranch := b
+		if addBranch.length < dmCodeLen {
+			addBranch.code[addBranch.length] = digit
+			addBranch.length++
+			addBranch.lastDigit = digit
+		}
+		results = append(results, dmApplyDigits(addBranch, codeStr, digitIdx+1)...)
+	}
+
+	return results
+}
+
+// dmPadCode pads a branch's code to 6 digits with zeros.
+func dmPadCode(b dmBranch) string {
+	var buf [dmCodeLen]byte
+	copy(buf[:], b.code[:b.length])
+	for i := b.length; i < dmCodeLen; i++ {
+		buf[i] = '0'
+	}
+	return string(buf[:])
+}
+
+// dmNormalize converts the input to uppercase ASCII letters only.
+func dmNormalize(s string) string {
+	var buf strings.Builder
+	buf.Grow(len(s))
+	for _, r := range s {
+		if r >= 'A' && r <= 'Z' {
+			buf.WriteByte(byte(r))
+		} else if r >= 'a' && r <= 'z' {
+			buf.WriteByte(byte(unicode.ToUpper(r)))
+		} else if r >= 'A' && r <= 'Z' {
+			buf.WriteByte(byte(r))
+		}
+		// Skip non-alpha characters.
+	}
+	return buf.String()
+}

--- a/pkg/util/fuzzystrmatch/daitch_mokotoff_test.go
+++ b/pkg/util/fuzzystrmatch/daitch_mokotoff_test.go
@@ -1,0 +1,71 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package fuzzystrmatch
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestDaitchMokotoff(t *testing.T) {
+	// Test cases from PostgreSQL's contrib/fuzzystrmatch regression tests.
+	tt := []struct {
+		Source   string
+		Expected []string
+	}{
+		{"", nil},
+		{"Augsburg", []string{"054795"}},
+		{"Breuer", []string{"791900"}},
+		{"Freud", []string{"793000"}},
+		{"Halberstadt", []string{"587433", "587943"}},
+		{"Mannheim", []string{"665600"}},
+		{"Chernowitz", []string{"496740", "596740"}},
+		{"Cherkassy", []string{"495400", "595400"}},
+		{"Kleinman", []string{"586660"}},
+		{"Berlin", []string{"798600"}},
+		{"Ceniow", []string{"467000", "567000"}},
+		{"Tsenyuv", []string{"467000"}},
+		{"Holubica", []string{"587400", "587500"}},
+		{"Golubitsa", []string{"587400"}},
+		{"BIERSCHBACH", []string{
+			"745740", "745750", "747400", "747500",
+			"794574", "794575", "794740", "794750",
+		}},
+		{"George", []string{"595000"}},
+		{"John", []string{"160000", "460000"}},
+		{"BESST", []string{"743000"}},
+		{"BOUEY", []string{"710000"}},
+		{"HANNMANN", []string{"566600"}},
+		{"CJC", []string{
+			"400000", "440000", "450000", "540000", "545000", "550000",
+		}},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.Source, func(t *testing.T) {
+			got := DaitchMokotoff(tc.Source)
+			if !dmSlicesEqual(got, tc.Expected) {
+				t.Errorf("DaitchMokotoff(%q):\n  got:  %s\n  want: %s",
+					tc.Source,
+					fmt.Sprintf("{%s}", strings.Join(got, ",")),
+					fmt.Sprintf("{%s}", strings.Join(tc.Expected, ",")))
+			}
+		})
+	}
+}
+
+func dmSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/util/fuzzystrmatch/dmetaphone.go
+++ b/pkg/util/fuzzystrmatch/dmetaphone.go
@@ -1,0 +1,902 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package fuzzystrmatch
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+// DMetaphone returns the primary Double Metaphone code for the input string.
+// Ported from PostgreSQL's contrib/fuzzystrmatch/dmetaphone.c.
+func DMetaphone(source string) string {
+	primary, _ := doubleMetaphone(source)
+	return primary
+}
+
+// DMetaphoneAlt returns the alternate Double Metaphone code for the input
+// string.
+func DMetaphoneAlt(source string) string {
+	_, secondary := doubleMetaphone(source)
+	return secondary
+}
+
+// doubleMetaphone computes both the primary and alternate Double Metaphone
+// codes simultaneously.
+func doubleMetaphone(source string) (string, string) {
+	if utf8.RuneCountInString(source) == 0 {
+		return "", ""
+	}
+
+	// Work with uppercase ASCII. Pad with spaces so we can look ahead safely.
+	original := strings.ToUpper(source) + "     "
+	length := len(source)
+	last := length - 1
+
+	var primary, secondary strings.Builder
+	current := 0
+
+	// Check for Slavo-Germanic indicators.
+	slavoGermanic := dmSlavoGermanic(original)
+
+	// Skip initial silent letters.
+	if dmStringAt(original, 0, 2, "GN", "KN", "PN", "WR", "PS") {
+		current++
+	}
+
+	// Initial 'X' is pronounced 'Z' e.g. 'Xavier'.
+	if dmCharAt(original, 0) == 'X' {
+		primary.WriteString("S")
+		secondary.WriteString("S")
+		current++
+	}
+
+	for primary.Len() < 4 || secondary.Len() < 4 {
+		if current >= length {
+			break
+		}
+
+		switch dmCharAt(original, current) {
+		case 'A', 'E', 'I', 'O', 'U', 'Y':
+			if current == 0 {
+				primary.WriteString("A")
+				secondary.WriteString("A")
+			}
+			current++
+
+		case 'B':
+			primary.WriteString("P")
+			secondary.WriteString("P")
+			if dmCharAt(original, current+1) == 'B' {
+				current += 2
+			} else {
+				current++
+			}
+
+		case '\xc7': // Ç
+			primary.WriteString("S")
+			secondary.WriteString("S")
+			current++
+
+		case 'C':
+			current = dmHandleC(original, current, length, last,
+				slavoGermanic, &primary, &secondary)
+
+		case 'D':
+			current = dmHandleD(original, current, last, &primary, &secondary)
+
+		case 'F':
+			primary.WriteString("F")
+			secondary.WriteString("F")
+			if dmCharAt(original, current+1) == 'F' {
+				current += 2
+			} else {
+				current++
+			}
+
+		case 'G':
+			current = dmHandleG(original, current, length, last,
+				slavoGermanic, &primary, &secondary)
+
+		case 'H':
+			// Only keep if first & before vowel or between 2 vowels.
+			if (current == 0 || dmIsVowel(original, current-1)) &&
+				dmIsVowel(original, current+1) {
+				primary.WriteString("H")
+				secondary.WriteString("H")
+				current += 2
+			} else {
+				current++
+			}
+
+		case 'J':
+			current = dmHandleJ(original, current, length, last,
+				slavoGermanic, &primary, &secondary)
+
+		case 'K':
+			primary.WriteString("K")
+			secondary.WriteString("K")
+			if dmCharAt(original, current+1) == 'K' {
+				current += 2
+			} else {
+				current++
+			}
+
+		case 'L':
+			current = dmHandleL(original, current, length, last,
+				&primary, &secondary)
+
+		case 'M':
+			primary.WriteString("M")
+			secondary.WriteString("M")
+			if (dmStringAt(original, current-1, 3, "UMB") &&
+				(current+1 == last ||
+					dmStringAt(original, current+2, 2, "ER"))) ||
+				dmCharAt(original, current+1) == 'M' {
+				current += 2
+			} else {
+				current++
+			}
+
+		case 'N':
+			primary.WriteString("N")
+			secondary.WriteString("N")
+			if dmCharAt(original, current+1) == 'N' {
+				current += 2
+			} else {
+				current++
+			}
+
+		case '\xd1': // Ñ
+			primary.WriteString("N")
+			secondary.WriteString("N")
+			current++
+
+		case 'P':
+			if dmCharAt(original, current+1) == 'H' {
+				primary.WriteString("F")
+				secondary.WriteString("F")
+				current += 2
+			} else {
+				primary.WriteString("P")
+				secondary.WriteString("P")
+				if dmStringAt(original, current+1, 1, "P", "B") {
+					current += 2
+				} else {
+					current++
+				}
+			}
+
+		case 'Q':
+			primary.WriteString("K")
+			secondary.WriteString("K")
+			if dmCharAt(original, current+1) == 'Q' {
+				current += 2
+			} else {
+				current++
+			}
+
+		case 'R':
+			// French e.g. 'rogier', but exclude 'hochmeier'.
+			if current == last &&
+				!slavoGermanic &&
+				dmStringAt(original, current-2, 2, "IE") &&
+				!dmStringAt(original, current-4, 2, "ME", "MA") {
+				secondary.WriteString("R")
+			} else {
+				primary.WriteString("R")
+				secondary.WriteString("R")
+			}
+			if dmCharAt(original, current+1) == 'R' {
+				current += 2
+			} else {
+				current++
+			}
+
+		case 'S':
+			current = dmHandleS(original, current, length, last,
+				slavoGermanic, &primary, &secondary)
+
+		case 'T':
+			current = dmHandleT(original, current, length, last,
+				&primary, &secondary)
+
+		case 'V':
+			primary.WriteString("F")
+			secondary.WriteString("F")
+			if dmCharAt(original, current+1) == 'V' {
+				current += 2
+			} else {
+				current++
+			}
+
+		case 'W':
+			current = dmHandleW(original, current, length, last,
+				slavoGermanic, &primary, &secondary)
+
+		case 'X':
+			// French e.g. breaux.
+			if !(current == last &&
+				(dmStringAt(original, current-3, 3, "IAU", "EAU") ||
+					dmStringAt(original, current-2, 2, "AU", "OU"))) {
+				primary.WriteString("KS")
+				secondary.WriteString("KS")
+			}
+			if dmStringAt(original, current+1, 1, "C", "X") {
+				current += 2
+			} else {
+				current++
+			}
+
+		case 'Z':
+			current = dmHandleZ(original, current, last,
+				slavoGermanic, &primary, &secondary)
+
+		default:
+			current++
+		}
+	}
+
+	p := primary.String()
+	s := secondary.String()
+	if len(p) > 4 {
+		p = p[:4]
+	}
+	if len(s) > 4 {
+		s = s[:4]
+	}
+	return p, s
+}
+
+// Helper functions.
+
+func dmCharAt(s string, pos int) byte {
+	if pos < 0 || pos >= len(s) {
+		return 0
+	}
+	return s[pos]
+}
+
+func dmStringAt(s string, start, length int, targets ...string) bool {
+	if start < 0 || start >= len(s) {
+		return false
+	}
+	for _, t := range targets {
+		if len(t) != length {
+			continue
+		}
+		if start+length <= len(s) && s[start:start+length] == t {
+			return true
+		}
+	}
+	return false
+}
+
+func dmIsVowel(s string, pos int) bool {
+	if pos < 0 || pos >= len(s) {
+		return false
+	}
+	c := s[pos]
+	return c == 'A' || c == 'E' || c == 'I' || c == 'O' ||
+		c == 'U' || c == 'Y'
+}
+
+func dmSlavoGermanic(s string) bool {
+	return strings.Contains(s, "W") || strings.Contains(s, "K") ||
+		strings.Contains(s, "CZ") || strings.Contains(s, "WITZ")
+}
+
+func dmHandleC(
+	original string,
+	current, length, last int,
+	slavoGermanic bool,
+	primary, secondary *strings.Builder,
+) int {
+	// Various Germanic.
+	if current > 1 &&
+		!dmIsVowel(original, current-2) &&
+		dmStringAt(original, current-1, 3, "ACH") &&
+		dmCharAt(original, current+2) != 'I' &&
+		(dmCharAt(original, current+2) != 'E' ||
+			dmStringAt(original, current-2, 6, "BACHER", "MACHER")) {
+		primary.WriteString("K")
+		secondary.WriteString("K")
+		return current + 2
+	}
+
+	// Special case 'caesar'.
+	if current == 0 && dmStringAt(original, current, 6, "CAESAR") {
+		primary.WriteString("S")
+		secondary.WriteString("S")
+		return current + 2
+	}
+
+	// Italian 'chianti'.
+	if dmStringAt(original, current, 4, "CHIA") {
+		primary.WriteString("K")
+		secondary.WriteString("K")
+		return current + 2
+	}
+
+	if dmStringAt(original, current, 2, "CH") {
+		// Find 'Michael'.
+		if current > 0 && dmStringAt(original, current, 4, "CHAE") {
+			primary.WriteString("K")
+			secondary.WriteString("X")
+			return current + 2
+		}
+
+		// Greek roots e.g. 'chemistry', 'chorus'.
+		if current == 0 &&
+			(dmStringAt(original, current+1, 5, "HARAC", "HARIS") ||
+				dmStringAt(original, current+1, 3, "HOR", "HYM", "HIA", "HEM")) &&
+			!dmStringAt(original, 0, 5, "CHORE") {
+			primary.WriteString("K")
+			secondary.WriteString("K")
+			return current + 2
+		}
+
+		// Germanic, Greek, or otherwise 'ch' for 'kh' sound.
+		if (dmStringAt(original, 0, 4, "VAN ", "VON ") ||
+			dmStringAt(original, 0, 3, "SCH")) ||
+			dmStringAt(original, current-2, 6,
+				"ORCHES", "ARCHIT", "ORCHID") ||
+			dmStringAt(original, current+2, 1, "T", "S") ||
+			((dmStringAt(original, current-1, 1,
+				"A", "O", "U", "E") || current == 0) &&
+				dmStringAt(original, current+2, 1,
+					"L", "R", "N", "M", "B", "H", "F", "V", "W", " ")) {
+			primary.WriteString("K")
+			secondary.WriteString("K")
+		} else {
+			if current > 0 {
+				if dmStringAt(original, 0, 2, "MC") {
+					primary.WriteString("K")
+					secondary.WriteString("K")
+				} else {
+					primary.WriteString("X")
+					secondary.WriteString("K")
+				}
+			} else {
+				primary.WriteString("X")
+				secondary.WriteString("X")
+			}
+		}
+		return current + 2
+	}
+
+	// e.g., 'czerny'.
+	if dmStringAt(original, current, 2, "CZ") &&
+		!dmStringAt(original, current-2, 4, "WICZ") {
+		primary.WriteString("S")
+		secondary.WriteString("X")
+		return current + 2
+	}
+
+	// e.g., 'focaccia'.
+	if dmStringAt(original, current+1, 3, "CIA") {
+		primary.WriteString("X")
+		secondary.WriteString("X")
+		return current + 3
+	}
+
+	// Double 'C', but not if e.g. 'McClellan'.
+	if dmStringAt(original, current, 2, "CC") &&
+		!(current == 1 && dmCharAt(original, 0) == 'M') {
+		// 'bellocchio' but not 'bacchus'.
+		if dmStringAt(original, current+2, 1, "I", "E", "H") &&
+			!dmStringAt(original, current+2, 2, "HU") {
+			// 'accident', 'accede', 'succeed'.
+			if (current == 1 && dmCharAt(original, current-1) == 'A') ||
+				dmStringAt(original, current-1, 5, "UCCEE", "UCCES") {
+				primary.WriteString("KS")
+				secondary.WriteString("KS")
+			} else {
+				primary.WriteString("X")
+				secondary.WriteString("X")
+			}
+			return current + 3
+		}
+		// Pierce's rule.
+		primary.WriteString("K")
+		secondary.WriteString("K")
+		return current + 2
+	}
+
+	if dmStringAt(original, current, 2, "CK", "CG", "CQ") {
+		primary.WriteString("K")
+		secondary.WriteString("K")
+		return current + 2
+	}
+
+	if dmStringAt(original, current, 2, "CI", "CE", "CY") {
+		// Italian vs. English.
+		if dmStringAt(original, current, 3, "CIO", "CIE", "CIA") {
+			primary.WriteString("S")
+			secondary.WriteString("X")
+		} else {
+			primary.WriteString("S")
+			secondary.WriteString("S")
+		}
+		return current + 2
+	}
+
+	// Else.
+	primary.WriteString("K")
+	secondary.WriteString("K")
+
+	// Name sent in 'mac caffrey', 'mac gregor'.
+	if dmStringAt(original, current+1, 2, " C", " Q", " G") {
+		return current + 3
+	}
+	if dmStringAt(original, current+1, 1, "C", "K", "Q") &&
+		!dmStringAt(original, current+1, 2, "CE", "CI") {
+		return current + 2
+	}
+	return current + 1
+}
+
+func dmHandleD(original string, current, last int, primary, secondary *strings.Builder) int {
+	if dmStringAt(original, current, 2, "DG") {
+		if dmStringAt(original, current+2, 1, "I", "E", "Y") {
+			// e.g. 'edge'.
+			primary.WriteString("J")
+			secondary.WriteString("J")
+			return current + 3
+		}
+		// e.g. 'edgar'.
+		primary.WriteString("TK")
+		secondary.WriteString("TK")
+		return current + 2
+	}
+
+	if dmStringAt(original, current, 2, "DT", "DD") {
+		primary.WriteString("T")
+		secondary.WriteString("T")
+		return current + 2
+	}
+
+	primary.WriteString("T")
+	secondary.WriteString("T")
+	return current + 1
+}
+
+func dmHandleG(
+	original string,
+	current, length, last int,
+	slavoGermanic bool,
+	primary, secondary *strings.Builder,
+) int {
+	if dmCharAt(original, current+1) == 'H' {
+		return dmHandleGH(original, current, length, last, &slavoGermanic,
+			primary, secondary)
+	}
+
+	if dmCharAt(original, current+1) == 'N' {
+		if current == 1 && dmIsVowel(original, 0) && !slavoGermanic {
+			primary.WriteString("KN")
+			secondary.WriteString("N")
+		} else if !dmStringAt(original, current+2, 2, "EY") &&
+			dmCharAt(original, current+1) != 'Y' &&
+			!slavoGermanic {
+			primary.WriteString("N")
+			secondary.WriteString("KN")
+		} else {
+			primary.WriteString("KN")
+			secondary.WriteString("KN")
+		}
+		return current + 2
+	}
+
+	// 'tagliaro'.
+	if dmStringAt(original, current+1, 2, "LI") && !slavoGermanic {
+		primary.WriteString("KL")
+		secondary.WriteString("L")
+		return current + 2
+	}
+
+	// -ges-,-gep-,-gel-, -gie- at beginning.
+	if current == 0 &&
+		(dmCharAt(original, current+1) == 'Y' ||
+			dmStringAt(original, current+1, 2,
+				"ES", "EP", "EB", "EL", "EY", "IB", "IL", "IN", "IE",
+				"EI", "ER")) {
+		primary.WriteString("K")
+		secondary.WriteString("J")
+		return current + 2
+	}
+
+	// -ger-, -gy-.
+	if (dmStringAt(original, current+1, 2, "ER") ||
+		dmCharAt(original, current+1) == 'Y') &&
+		!dmStringAt(original, 0, 6, "DANGER", "RANGER", "MANGER") &&
+		!dmStringAt(original, current-1, 1, "E", "I") &&
+		!dmStringAt(original, current-1, 3, "RGY", "OGY") {
+		primary.WriteString("K")
+		secondary.WriteString("J")
+		return current + 2
+	}
+
+	// Italian e.g, 'biaggi'.
+	if dmStringAt(original, current+1, 1, "E", "I", "Y") ||
+		dmStringAt(original, current-1, 4, "AGGI", "OGGI") {
+		// Obvious Germanic.
+		if (dmStringAt(original, 0, 4, "VAN ", "VON ") ||
+			dmStringAt(original, 0, 3, "SCH")) ||
+			dmStringAt(original, current+1, 2, "ET") {
+			primary.WriteString("K")
+			secondary.WriteString("K")
+		} else {
+			// Always soft if French ending.
+			if dmStringAt(original, current+1, 4, "IER ") {
+				primary.WriteString("J")
+				secondary.WriteString("J")
+			} else {
+				primary.WriteString("J")
+				secondary.WriteString("K")
+			}
+		}
+		return current + 2
+	}
+
+	if dmCharAt(original, current+1) == 'G' {
+		return current + 2
+	}
+	primary.WriteString("K")
+	secondary.WriteString("K")
+	return current + 1
+}
+
+func dmHandleGH(
+	original string,
+	current, length, last int,
+	slavoGermanic *bool,
+	primary, secondary *strings.Builder,
+) int {
+	if current > 0 && !dmIsVowel(original, current-1) {
+		primary.WriteString("K")
+		secondary.WriteString("K")
+		return current + 2
+	}
+
+	if current < 3 {
+		// 'ghislane', 'ghiradelli'.
+		if current == 0 {
+			if dmCharAt(original, current+2) == 'I' {
+				primary.WriteString("J")
+				secondary.WriteString("J")
+			} else {
+				primary.WriteString("K")
+				secondary.WriteString("K")
+			}
+			return current + 2
+		}
+	}
+
+	// Parker's rule (with some further refinements) - e.g. 'hugh'.
+	if (current > 1 && dmStringAt(original, current-2, 1,
+		"B", "H", "D")) ||
+		(current > 2 && dmStringAt(original, current-3, 1,
+			"B", "H", "D")) ||
+		(current > 3 && dmStringAt(original, current-4, 1,
+			"B", "H")) {
+		return current + 2
+	}
+
+	// e.g., 'laugh', 'McLaughlin', 'cough', 'gough', 'rough', 'tough'.
+	if current > 2 &&
+		dmCharAt(original, current-1) == 'U' &&
+		dmStringAt(original, current-3, 1,
+			"C", "G", "L", "R", "T") {
+		primary.WriteString("F")
+		secondary.WriteString("F")
+	} else if current > 0 && dmCharAt(original, current-1) != 'I' {
+		primary.WriteString("K")
+		secondary.WriteString("K")
+	}
+
+	return current + 2
+}
+
+func dmHandleJ(
+	original string,
+	current, length, last int,
+	slavoGermanic bool,
+	primary, secondary *strings.Builder,
+) int {
+	// Obvious Spanish, 'jose', 'san jacinto'.
+	if dmStringAt(original, current, 4, "JOSE") ||
+		dmStringAt(original, 0, 4, "SAN ") {
+		if (current == 0 && dmCharAt(original, current+4) == ' ') ||
+			dmStringAt(original, 0, 4, "SAN ") {
+			primary.WriteString("H")
+			secondary.WriteString("H")
+		} else {
+			primary.WriteString("J")
+			secondary.WriteString("H")
+		}
+		return current + 1
+	}
+
+	if current == 0 && !dmStringAt(original, current, 4, "JOSE") {
+		primary.WriteString("J")
+		secondary.WriteString("A")
+	} else {
+		// Spanish pron. of e.g. 'bajador'.
+		if dmIsVowel(original, current-1) &&
+			!slavoGermanic &&
+			(dmCharAt(original, current+1) == 'A' ||
+				dmCharAt(original, current+1) == 'O') {
+			primary.WriteString("J")
+			secondary.WriteString("H")
+		} else {
+			if current == last {
+				primary.WriteString("J")
+			} else {
+				if !dmStringAt(original, current+1, 1,
+					"L", "T", "K", "S", "N", "M", "B", "Z") &&
+					!dmStringAt(original, current-1, 1,
+						"S", "K", "L") {
+					primary.WriteString("J")
+					secondary.WriteString("J")
+				}
+			}
+		}
+	}
+
+	if dmCharAt(original, current+1) == 'J' {
+		return current + 2
+	}
+	return current + 1
+}
+
+func dmHandleL(
+	original string, current, length, last int, primary, secondary *strings.Builder,
+) int {
+	if dmCharAt(original, current+1) == 'L' {
+		// Spanish e.g. 'cabrillo', 'gallegos'.
+		if (current == length-3 &&
+			dmStringAt(original, current-1, 4,
+				"ILLO", "ILLA", "ALLE")) ||
+			((dmStringAt(original, last-1, 2, "AS", "OS") ||
+				dmStringAt(original, last, 1, "A", "O")) &&
+				dmStringAt(original, current-1, 4, "ALLE")) {
+			primary.WriteString("L")
+			return current + 2
+		}
+		current += 2
+	} else {
+		current++
+	}
+	primary.WriteString("L")
+	secondary.WriteString("L")
+	return current
+}
+
+func dmHandleS(
+	original string,
+	current, length, last int,
+	slavoGermanic bool,
+	primary, secondary *strings.Builder,
+) int {
+	// Special cases 'island', 'isle', 'carlisle', 'carlysle'.
+	if dmStringAt(original, current-1, 3, "ISL", "YSL") {
+		return current + 1
+	}
+
+	// Special case 'sugar-'.
+	if current == 0 && dmStringAt(original, current, 5, "SUGAR") {
+		primary.WriteString("X")
+		secondary.WriteString("S")
+		return current + 1
+	}
+
+	if dmStringAt(original, current, 2, "SH") {
+		// Germanic.
+		if dmStringAt(original, current+1, 4,
+			"HEIM", "HOEK", "HOLM", "HOLZ") {
+			primary.WriteString("S")
+			secondary.WriteString("S")
+		} else {
+			primary.WriteString("X")
+			secondary.WriteString("X")
+		}
+		return current + 2
+	}
+
+	// Italian & Armenian.
+	if dmStringAt(original, current, 3, "SIO", "SIA") ||
+		dmStringAt(original, current, 4, "SIAN") {
+		if !slavoGermanic {
+			primary.WriteString("S")
+			secondary.WriteString("X")
+		} else {
+			primary.WriteString("S")
+			secondary.WriteString("S")
+		}
+		return current + 3
+	}
+
+	// German & anglicisations, e.g. 'smith' match 'schmidt',
+	// 'snider' match 'schneider'. Also, -sz- in Slavic language.
+	if (current == 0 &&
+		dmStringAt(original, current+1, 1, "M", "N", "L", "W")) ||
+		dmStringAt(original, current+1, 1, "Z") {
+		primary.WriteString("S")
+		secondary.WriteString("X")
+		if dmStringAt(original, current+1, 1, "Z") {
+			return current + 2
+		}
+		return current + 1
+	}
+
+	if dmStringAt(original, current, 2, "SC") {
+		return dmHandleSC(original, current, length, last,
+			primary, secondary)
+	}
+
+	// French e.g. 'resnais', 'artois'.
+	if current == last &&
+		dmStringAt(original, current-2, 2, "AI", "OI") {
+		secondary.WriteString("S")
+	} else {
+		primary.WriteString("S")
+		secondary.WriteString("S")
+	}
+
+	if dmStringAt(original, current+1, 1, "S", "Z") {
+		return current + 2
+	}
+	return current + 1
+}
+
+func dmHandleSC(
+	original string, current, length, last int, primary, secondary *strings.Builder,
+) int {
+	// Schlesinger's rule.
+	if dmCharAt(original, current+2) == 'H' {
+		// Dutch origin, e.g. 'school', 'schooner'.
+		if dmStringAt(original, current+3, 2,
+			"OO", "ER", "EN", "UY", "ED", "EM") {
+			// 'schermerhorn', 'schenker'.
+			if dmStringAt(original, current+3, 2, "ER", "EN") {
+				primary.WriteString("X")
+				secondary.WriteString("SK")
+			} else {
+				primary.WriteString("SK")
+				secondary.WriteString("SK")
+			}
+			return current + 3
+		}
+		if current == 0 && !dmIsVowel(original, 3) &&
+			dmCharAt(original, 3) != 'W' {
+			primary.WriteString("X")
+			secondary.WriteString("S")
+		} else {
+			primary.WriteString("X")
+			secondary.WriteString("X")
+		}
+		return current + 3
+	}
+
+	if dmStringAt(original, current+2, 1, "I", "E", "Y") {
+		primary.WriteString("S")
+		secondary.WriteString("S")
+		return current + 3
+	}
+
+	primary.WriteString("SK")
+	secondary.WriteString("SK")
+	return current + 3
+}
+
+func dmHandleT(
+	original string, current, length, last int, primary, secondary *strings.Builder,
+) int {
+	if dmStringAt(original, current, 4, "TION") {
+		primary.WriteString("X")
+		secondary.WriteString("X")
+		return current + 3
+	}
+
+	if dmStringAt(original, current, 3, "TIA", "TCH") {
+		primary.WriteString("X")
+		secondary.WriteString("X")
+		return current + 3
+	}
+
+	if dmStringAt(original, current, 2, "TH") ||
+		dmStringAt(original, current, 3, "TTH") {
+		// Special case 'thomas', 'thames' or Germanic.
+		if dmStringAt(original, current+2, 2, "OM", "AM") ||
+			dmStringAt(original, 0, 4, "VAN ", "VON ") ||
+			dmStringAt(original, 0, 3, "SCH") {
+			primary.WriteString("T")
+			secondary.WriteString("T")
+		} else {
+			primary.WriteString("0")
+			secondary.WriteString("T")
+		}
+		return current + 2
+	}
+
+	if dmStringAt(original, current+1, 1, "T", "D") {
+		return current + 2
+	}
+	primary.WriteString("T")
+	secondary.WriteString("T")
+	return current + 1
+}
+
+func dmHandleW(
+	original string,
+	current, length, last int,
+	slavoGermanic bool,
+	primary, secondary *strings.Builder,
+) int {
+	// Can also be in middle of word.
+	if dmStringAt(original, current, 2, "WR") {
+		primary.WriteString("R")
+		secondary.WriteString("R")
+		return current + 2
+	}
+
+	if current == 0 &&
+		(dmIsVowel(original, current+1) ||
+			dmStringAt(original, current, 2, "WH")) {
+		if dmIsVowel(original, current+1) {
+			primary.WriteString("A")
+			secondary.WriteString("F")
+		} else {
+			primary.WriteString("A")
+			secondary.WriteString("A")
+		}
+	}
+
+	// Arnow should match Arnoff.
+	if (current == last && dmIsVowel(original, current-1)) ||
+		dmStringAt(original, current-1, 5,
+			"EWSKI", "EWSKY", "OWSKI", "OWSKY") ||
+		dmStringAt(original, 0, 3, "SCH") {
+		secondary.WriteString("F")
+		return current + 1
+	}
+
+	// Polish e.g. 'filipowicz'.
+	if dmStringAt(original, current, 4, "WICZ", "WITZ") {
+		primary.WriteString("TS")
+		secondary.WriteString("FX")
+		return current + 4
+	}
+
+	return current + 1
+}
+
+func dmHandleZ(
+	original string, current, last int, slavoGermanic bool, primary, secondary *strings.Builder,
+) int {
+	// Chinese pinyin e.g. 'zhao'.
+	if dmCharAt(original, current+1) == 'H' {
+		primary.WriteString("J")
+		secondary.WriteString("J")
+		return current + 2
+	}
+
+	if dmStringAt(original, current+1, 2, "ZO", "ZI", "ZA") ||
+		(slavoGermanic && current > 0 &&
+			dmCharAt(original, current-1) != 'T') {
+		primary.WriteString("S")
+		secondary.WriteString("TS")
+	} else {
+		primary.WriteString("S")
+		secondary.WriteString("S")
+	}
+
+	if dmCharAt(original, current+1) == 'Z' {
+		return current + 2
+	}
+	return current + 1
+}

--- a/pkg/util/fuzzystrmatch/dmetaphone_test.go
+++ b/pkg/util/fuzzystrmatch/dmetaphone_test.go
@@ -1,0 +1,77 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package fuzzystrmatch
+
+import (
+	crypto_rand "crypto/rand"
+	"math/rand"
+	"testing"
+)
+
+func TestDMetaphone(t *testing.T) {
+	// Test cases verified against PostgreSQL dmetaphone()/dmetaphone_alt() output.
+	tt := []struct {
+		Source          string
+		ExpectedPrimary string
+		ExpectedAlt     string
+	}{
+		{"gumbo", "KMP", "KMP"},
+		{"Richard", "RXRT", "RKRT"},
+		{"", "", ""},
+		{"aubrey", "APR", "APR"},
+		{"lee", "L", "L"},
+		{"Smith", "SM0", "XMT"},
+		{"Schmidt", "XMT", "SMT"},
+		{"school", "SKL", "SKL"},
+		{"edgar", "ATKR", "ATKR"},
+		{"edge", "AJ", "AJ"},
+		{"caesar", "SSR", "SSR"},
+		{"Jose", "HS", "HS"},
+		{"Thomas", "TMS", "TMS"},
+		{"harper", "HRPR", "HRPR"},
+		{"knight", "NT", "NT"},
+		{"gnat", "NT", "NT"},
+		{"pneumatic", "NMTK", "NMTK"},
+		{"wrack", "RK", "RK"},
+		{"ghislane", "JLN", "JLN"},
+		{"ghee", "K", "K"},
+		{"laugh", "LF", "LF"},
+		{"bough", "P", "P"},
+		{"broughton", "PRTN", "PRTN"},
+		{"tagliaro", "TKLR", "TLR"},
+		{"danger", "TNJR", "TNKR"},
+		{"biaggi", "PJ", "PK"},
+		{"gallegos", "KLKS", "KKS"},
+		{"sugar", "XKR", "SKR"},
+		{"island", "ALNT", "ALNT"},
+		{"filipowicz", "FLPT", "FLPF"},
+		{"zhao", "J", "J"},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.Source, func(t *testing.T) {
+			primary := DMetaphone(tc.Source)
+			alt := DMetaphoneAlt(tc.Source)
+			if primary != tc.ExpectedPrimary {
+				t.Errorf("DMetaphone(%q): got primary %q, want %q",
+					tc.Source, primary, tc.ExpectedPrimary)
+			}
+			if alt != tc.ExpectedAlt {
+				t.Errorf("DMetaphoneAlt(%q): got alt %q, want %q",
+					tc.Source, alt, tc.ExpectedAlt)
+			}
+		})
+	}
+
+	// Run random test cases to make sure we don't panic.
+	for i := 0; i < 1000; i++ {
+		l := rand.Int31n(20)
+		b := make([]byte, l)
+		_, _ = crypto_rand.Read(b)
+		_ = DMetaphone(string(b))
+		_ = DMetaphoneAlt(string(b))
+	}
+}


### PR DESCRIPTION
## Summary

Implement the three remaining PostgreSQL `fuzzystrmatch` extension functions:

- **`dmetaphone(text)`** — returns the primary Double Metaphone phonetic code
- **`dmetaphone_alt(text)`** — returns the alternate Double Metaphone phonetic code
- **`daitch_mokotoff(text)`** — returns an array of Daitch-Mokotoff soundex codes

This replaces the existing unsupported stubs for `dmetaphone`/`dmetaphone_alt` and adds the new `daitch_mokotoff` function, completing CockroachDB's implementation of the PostgreSQL fuzzystrmatch extension.

Both algorithms are ported from PostgreSQL's `contrib/fuzzystrmatch` and produce output matching PostgreSQL behavior. Verified against PostgreSQL's regression test expected values.

Resolves: #56820

Release note (sql change): Added support for the `dmetaphone()`,
`dmetaphone_alt()`, and `daitch_mokotoff()` built-in functions, completing
CockroachDB's implementation of the PostgreSQL fuzzystrmatch extension.
`dmetaphone` and `dmetaphone_alt` return Double Metaphone phonetic codes for
a string, and `daitch_mokotoff` returns an array of Daitch-Mokotoff soundex
codes. These functions are useful for fuzzy string matching based on
phonetic similarity.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)