### PR TITLE
sql: Skipping TestImportDistributedMergeStoragePrefixTracking and tImportDistributedMerge for INSPECT consistency check

### DIFF
--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -109,6 +109,7 @@ func TestImportDistributedMerge(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	skip.WithIssue(t, 163425)
 	dirname, cleanup := testutils.TempDir(t)
 	t.Cleanup(cleanup)
 
@@ -5742,6 +5743,8 @@ CREATE TABLE t (
 func TestImportDistributedMergeStoragePrefixTracking(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	skip.WithIssue(t, 163380)
 
 	ctx := context.Background()
 


### PR DESCRIPTION
Test flakes due to the error reported by INSPECT, we skip the tests now to unblock dev while investigating the root cause.

Informs: #163425
Informs: #163380
Release note: None