### PR TITLE
release-25.4: release: increase bincheck init time on macOS

### DIFF
--- a/build/release/bincheck/bincheck
+++ b/build/release/bincheck/bincheck
@@ -20,8 +20,8 @@ readonly pidfile=/tmp/server_pid
 # Verify that the startup time is within a reasonable upper-bound. 
 # At the time of writing, the total `init` time is well under 200ms on m1pro.
 max_init_time=500
-if [[ $(uname -sm) == "Darwin x86_64" ]]; then
-  # MacOS Intel GitHub Actions runners are a bit slow
+if [[ $(uname -s) == "Darwin" ]]; then
+  # MacOS GitHub Actions runners are a bit slow
   max_init_time=3000
 fi
 init_time=`GODEBUG=inittrace=1 $cockroach version 2>&1|awk '/init/ {sum += $5} END {printf("%d\n", sum)}'`


### PR DESCRIPTION
Backport 1/1 commits from #163429 on behalf of @rail.

----

Recently we have been having issues on MacOS github runners where the `bincheck` test is failing because the `init` time is above 500ms. This is likely due to the fact that the MacOS runners are a bit slow, and we have seen init times of up to 2.5s on these runners. This commit increases the max init time to 3s on MacOS to prevent these failures.

Epic: none
Release note: none

----

Release justification: release automation changes