### PR TITLE
server,ui: add per-request include_internal parameter to SQL stats APIs

### DIFF
--- a/pkg/server/cluster_settings.go
+++ b/pkg/server/cluster_settings.go
@@ -22,7 +22,8 @@ var SQLStatsResponseMax = settings.RegisterIntSetting(
 var SQLStatsShowInternal = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
 	"sql.stats.response.show_internal.enabled",
-	"controls if statistics for internal executions should be returned by the CombinedStatements and if "+
+	"deprecated: use the DB Console UI toggle instead. "+
+		"Controls if statistics for internal executions should be returned by the CombinedStatements and if "+
 		"internal sessions should be returned by the ListSessions endpoints. These endpoints are used to display "+
 		"statistics on the SQL Activity pages",
 	false,

--- a/pkg/server/combined_statement_stats.go
+++ b/pkg/server/combined_statement_stats.go
@@ -109,7 +109,7 @@ func getCombinedStatementStats(
 	testingKnobs *sqlstats.TestingKnobs,
 ) (*serverpb.StatementsResponse, error) {
 	var err error
-	showInternal := SQLStatsShowInternal.Get(&settings.SV)
+	showInternal := SQLStatsShowInternal.Get(&settings.SV) || req.IncludeInternal
 	whereClause, orderAndLimit, args := getCombinedStatementsQueryClausesAndArgs(
 		req, testingKnobs, showInternal, settings)
 
@@ -125,6 +125,7 @@ func getCombinedStatementStats(
 		ie,
 		settings,
 		testingKnobs,
+		showInternal,
 		reqStartTime,
 		req.Limit,
 		sort,
@@ -209,6 +210,7 @@ func activityTablesHaveFullData(
 	ie *sql.InternalExecutor,
 	settings *cluster.Settings,
 	testingKnobs *sqlstats.TestingKnobs,
+	showInternal bool,
 	reqStartTime *time.Time,
 	limit int64,
 	order serverpb.StatsSortOptions,
@@ -219,7 +221,7 @@ func activityTablesHaveFullData(
 	}
 
 	// Top Activity table doesn't store internal data.
-	if SQLStatsShowInternal.Get(&settings.SV) {
+	if showInternal {
 		return false, nil
 	}
 

--- a/pkg/server/combined_statement_stats_test.go
+++ b/pkg/server/combined_statement_stats_test.go
@@ -32,6 +32,7 @@ func TestGetCombinedStatementsQueryClausesAndArgs(t *testing.T) {
 			var start int64
 			var end int64
 			var sortString string
+			var showInternal bool
 			if d.HasArg("sort") {
 				d.ScanArgs(t, "sort", &sortString)
 			}
@@ -43,6 +44,9 @@ func TestGetCombinedStatementsQueryClausesAndArgs(t *testing.T) {
 			}
 			if d.HasArg("end") {
 				d.ScanArgs(t, "end", &end)
+			}
+			if d.HasArg("show_internal") {
+				d.ScanArgs(t, "show_internal", &showInternal)
 			}
 
 			gotWhereClause, gotOrderAndLimitClause, gotArgs := getCombinedStatementsQueryClausesAndArgs(
@@ -56,7 +60,7 @@ func TestGetCombinedStatementsQueryClausesAndArgs(t *testing.T) {
 					Limit: limit,
 				},
 				testingKnobs,
-				false,
+				showInternal,
 				settings,
 			)
 

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -1044,11 +1044,9 @@ message ListSessionsRequest {
   // Boolean to exclude closed sessions; if unspecified, defaults
   // to false and closed sessions are included in the response.
   bool exclude_closed_sessions = 2;
-  // Boolean to surface internal sessions in the response. Note
-  // that this param currently serves as an override for the cluster
-  // setting sql.stats.response.show_internal.enabled until #87200
-  // is addressed, and setting this param to false is equivalent
-  // to setting the value to sql.stats.response.show_internal.enabled
+  // If true, include internal sessions in the response. When false,
+  // the cluster setting sql.stats.response.show_internal.enabled is
+  // still respected.
   bool include_internal = 3;
 }
 
@@ -1748,6 +1746,11 @@ message CombinedStatementsStatsRequest {
   FetchMode fetch_mode = 5 [(gogoproto.nullable) = true];
 
   int64 limit = 6;
+
+  // If true, include statistics for internal statements and transactions
+  // in the response. When false, the cluster setting
+  // sql.stats.response.show_internal.enabled is still respected.
+  bool include_internal = 7;
 }
 
 // StatementDetailsRequest requests the details of a Statement, based on its keys.
@@ -1760,6 +1763,11 @@ message StatementDetailsRequest {
   // Unix time range for aggregated statements.
   int64 start = 3 [(gogoproto.nullable) = true];
   int64 end = 4 [(gogoproto.nullable) = true];
+
+  // If true, include statistics for internal statements in the response.
+  // When false, the cluster setting sql.stats.response.show_internal.enabled
+  // is still respected.
+  bool include_internal = 5;
 }
 
 message StatementDetailsResponse {

--- a/pkg/server/statement_details.go
+++ b/pkg/server/statement_details.go
@@ -75,7 +75,7 @@ func getStatementDetails(
 	testingKnobs *sqlstats.TestingKnobs,
 ) (*serverpb.StatementDetailsResponse, error) {
 	limit := SQLStatsResponseMax.Get(&settings.SV)
-	showInternal := SQLStatsShowInternal.Get(&settings.SV)
+	showInternal := SQLStatsShowInternal.Get(&settings.SV) || req.IncludeInternal
 	whereClause, args, err := getStatementDetailsQueryClausesAndArgs(req, testingKnobs, showInternal)
 	if err != nil {
 		return nil, srverrors.ServerError(ctx, err)
@@ -88,6 +88,7 @@ func getStatementDetails(
 		ie,
 		settings,
 		testingKnobs,
+		showInternal,
 		reqStartTime,
 		1,
 		serverpb.StatsSortOptions_SERVICE_LAT, //Order is not used on this endpoint, so any value can be passed here.

--- a/pkg/server/testdata/combined_statement_stats
+++ b/pkg/server/testdata/combined_statement_stats
@@ -139,3 +139,33 @@ query sort=LAST_EXEC limit=100 start=1 end=2
  ORDER BY (statistics -> 'statistics' ->> 'lastExecAt') DESC LIMIT $3
 --ARGS--
 [1970-01-01 00:00:01 +0000 UTC 1970-01-01 00:00:02 +0000 UTC 100]
+
+
+# Check show_internal parameter
+
+query sort=SERVICE_LAT limit=100 start=1 end=2 show_internal=true
+----
+--WHERE--
+ WHERE true AND aggregated_ts >= $1 AND aggregated_ts <= $2
+--ORDER AND LIMIT--
+ ORDER BY (statistics -> 'statistics' -> 'svcLat' ->> 'mean')::FLOAT DESC LIMIT $3
+--ARGS--
+[1970-01-01 00:00:01 +0000 UTC 1970-01-01 00:00:02 +0000 UTC 100]
+
+query sort=SERVICE_LAT limit=100 show_internal=true
+----
+--WHERE--
+ WHERE true
+--ORDER AND LIMIT--
+ ORDER BY (statistics -> 'statistics' -> 'svcLat' ->> 'mean')::FLOAT DESC LIMIT $1
+--ARGS--
+[100]
+
+query sort=SERVICE_LAT limit=100 show_internal=false
+----
+--WHERE--
+ WHERE app_name NOT LIKE '$ internal%' AND app_name NOT LIKE '$$ %'
+--ORDER AND LIMIT--
+ ORDER BY (statistics -> 'statistics' -> 'svcLat' ->> 'mean')::FLOAT DESC LIMIT $1
+--ARGS--
+[100]

--- a/pkg/ui/workspaces/cluster-ui/src/api/sessionsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/sessionsApi.ts
@@ -16,6 +16,7 @@ export type SessionsResponseMessage =
 
 export interface SessionsRequest {
   excludeClosedSessions?: boolean;
+  includeInternal?: boolean;
 }
 
 // getSessions gets all cluster sessions.
@@ -25,6 +26,9 @@ export const getSessions = (
   const params = new URLSearchParams();
   if (req?.excludeClosedSessions) {
     params.set("exclude_closed_sessions", "true");
+  }
+  if (req?.includeInternal) {
+    params.set("include_internal", "true");
   }
   const path =
     params.toString() !== ""

--- a/pkg/ui/workspaces/cluster-ui/src/api/statementsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/statementsApi.ts
@@ -55,6 +55,7 @@ type StmtReqFields = {
   sort: SqlStatsSortType;
   start: moment.Moment;
   end: moment.Moment;
+  includeInternal?: boolean;
 };
 
 export function createCombinedStmtsRequest({
@@ -62,6 +63,7 @@ export function createCombinedStmtsRequest({
   sort,
   start,
   end,
+  includeInternal,
 }: StmtReqFields): StatementsRequest {
   return new cockroach.server.serverpb.CombinedStatementsStatsRequest({
     start: Long.fromNumber(start.unix()),
@@ -71,6 +73,7 @@ export function createCombinedStmtsRequest({
       new cockroach.server.serverpb.CombinedStatementsStatsRequest.FetchMode({
         sort: sort,
       }),
+    include_internal: includeInternal ?? false,
   });
 }
 
@@ -83,6 +86,7 @@ export const getCombinedStatements = (
     "fetch_mode.stats_type": FetchStatsMode.StmtStatsOnly,
     "fetch_mode.sort": req.fetch_mode?.sort,
     limit: req.limit?.toInt() ?? DEFAULT_STATS_REQ_OPTIONS.limit,
+    include_internal: req.include_internal || undefined,
   });
   return fetchData(
     cockroach.server.serverpb.StatementsResponse,
@@ -102,6 +106,7 @@ export const getFlushedTxnStatsApi = (
     "fetch_mode.stats_type": FetchStatsMode.TxnStatsOnly,
     "fetch_mode.sort": req.fetch_mode?.sort,
     limit: req.limit?.toInt() ?? DEFAULT_STATS_REQ_OPTIONS.limit,
+    include_internal: req.include_internal || undefined,
   });
   return fetchData(
     cockroach.server.serverpb.StatementsResponse,
@@ -118,6 +123,7 @@ export const getStatementDetails = (
   let queryStr = propsToQueryString({
     start: req.start.toInt(),
     end: req.end.toInt(),
+    include_internal: req.include_internal || undefined,
   });
   for (const app of req.app_names) {
     queryStr += `&appNames=${encodeURIComponent(app)}`;

--- a/pkg/ui/workspaces/cluster-ui/src/searchCriteria/searchCriteria.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/searchCriteria/searchCriteria.tsx
@@ -4,7 +4,7 @@
 // included in the /LICENSE file.
 
 import { CaretDown } from "@cockroachlabs/icons";
-import { Menu, Dropdown } from "antd";
+import { Menu, Dropdown, Checkbox } from "antd";
 import classNames from "classnames/bind";
 import { MenuClickEventHandler } from "rc-menu/es/interface";
 import React from "react";
@@ -48,6 +48,8 @@ export interface SearchCriteriaProps {
   onChangeTop: (top: number) => void;
   onChangeBy: (by: SqlStatsSortType) => void;
   onApply: () => void;
+  showInternal?: boolean;
+  onShowInternalChange?: (showInternal: boolean) => void;
 }
 
 export function SearchCriteria(props: SearchCriteriaProps): React.ReactElement {
@@ -164,6 +166,16 @@ export function SearchCriteria(props: SearchCriteriaProps): React.ReactElement {
             Apply
           </Button>
         </PageConfigItem>
+        {props.onShowInternalChange !== undefined && (
+          <PageConfigItem>
+            <Checkbox
+              checked={props.showInternal}
+              onChange={e => props.onShowInternalChange(e.target.checked)}
+            >
+              Show internal
+            </Checkbox>
+          </PageConfigItem>
+        )}
       </PageConfig>
     </div>
   );

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
@@ -3,6 +3,7 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
+import { Checkbox } from "antd";
 import classNames from "classnames/bind";
 import isNil from "lodash/isNil";
 import merge from "lodash/merge";
@@ -90,9 +91,11 @@ export interface OwnProps {
   internalAppNamePrefix: string;
   sessionsError: Error | Error[];
   sortSetting: SortSetting;
+  showInternal?: boolean;
   refreshSessions: (req?: SessionsRequest) => void;
   cancelSession: (payload: ICancelSessionRequest) => void;
   cancelQuery: (payload: ICancelQueryRequest) => void;
+  onShowInternalChange?: (showInternal: boolean) => void;
   onPageChanged?: (newPage: number) => void;
   onSortingChange?: (
     name: string,
@@ -232,6 +235,7 @@ export class SessionsPage extends React.Component<
     const filters = this.state.filters || this.props.filters;
     return {
       excludeClosedSessions: shouldExcludeClosedSessions(filters),
+      includeInternal: this.props.showInternal,
     };
   };
 
@@ -450,6 +454,14 @@ export class SessionsPage extends React.Component<
             filters={filters}
             timeLabel={"Session duration"}
           />
+          {this.props.onShowInternalChange !== undefined && (
+            <Checkbox
+              checked={this.props.showInternal}
+              onChange={e => this.props.onShowInternalChange(e.target.checked)}
+            >
+              Show internal
+            </Checkbox>
+          )}
           <SelectedFilters
             filters={filters}
             onRemoveFilter={this.onSubmitFilters}

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPageConnected.tsx
@@ -10,7 +10,10 @@ import { createSelector } from "reselect";
 
 import { SessionsRequest } from "src/api/sessionsApi";
 import { analyticsActions, AppState } from "src/store";
-import { actions as localStorageActions } from "src/store/localStorage";
+import {
+  actions as localStorageActions,
+  updateShowInternalAction,
+} from "src/store/localStorage";
 import { SessionsState, actions as sessionsActions } from "src/store/sessions";
 import {
   actions as terminateQueryActions,
@@ -20,7 +23,10 @@ import {
 
 import { Filters } from "../queryFilter";
 import { sqlStatsSelector } from "../store/sqlStats/sqlStats.selector";
-import { localStorageSelector } from "../store/utils/selectors";
+import {
+  localStorageSelector,
+  selectShowInternal,
+} from "../store/utils/selectors";
 
 import { SessionsPage } from "./index";
 
@@ -78,6 +84,7 @@ export const SessionsPageConnected = withRouter(
       sortSetting: selectSortSetting(state),
       columns: selectColumns(state),
       filters: selectFilters(state),
+      showInternal: selectShowInternal(state),
     }),
     (dispatch: Dispatch) => ({
       refreshSessions: (req?: SessionsRequest) =>
@@ -150,6 +157,8 @@ export const SessionsPageConnected = withRouter(
               selectedColumns.length === 0 ? " " : selectedColumns.join(","),
           }),
         ),
+      onShowInternalChange: (showInternal: boolean) =>
+        dispatch(updateShowInternalAction(showInternal)),
     }),
   )(SessionsPage),
 );

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -135,6 +135,7 @@ export interface StatementsPageDispatchProps {
   onChangeReqSort: (sort: SqlStatsSortType) => void;
   onApplySearchCriteria: (ts: TimeScale, limit: number, sort: string) => void;
   onRequestTimeChange: (t: moment.Moment) => void;
+  onShowInternalChange?: (showInternal: boolean) => void;
 }
 export interface StatementsPageStateProps {
   statementsResponse: RequestState<SqlStatsResponse>;
@@ -154,6 +155,7 @@ export interface StatementsPageStateProps {
   statementDiagnostics: StatementDiagnosticsResponse | null;
   requestTime: moment.Moment;
   oldestDataAvailable: Timestamp;
+  showInternal?: boolean;
 }
 
 export interface StatementsPageState {
@@ -172,7 +174,7 @@ export type StatementsPageProps = StatementsPageDispatchProps &
 type RequestParams = Pick<
   StatementsPageState,
   "limit" | "reqSortSetting" | "timeScale"
->;
+> & { showInternal?: boolean };
 
 function stmtsRequestFromParams(params: RequestParams): StatementsRequest {
   const [start, end] = toRoundedDateRange(params.timeScale);
@@ -181,6 +183,7 @@ function stmtsRequestFromParams(params: RequestParams): StatementsRequest {
     end,
     limit: params.limit,
     sort: params.reqSortSetting,
+    includeInternal: params.showInternal,
   });
 }
 
@@ -323,7 +326,10 @@ export class StatementsPage extends React.Component<
   };
 
   refreshStatements = (): void => {
-    const req = stmtsRequestFromParams(this.state);
+    const req = stmtsRequestFromParams({
+      ...this.state,
+      showInternal: this.props.showInternal,
+    });
     this.props.refreshStatements(req);
   };
 
@@ -753,6 +759,8 @@ export class StatementsPage extends React.Component<
           onChangeBy={this.onChangeReqSort}
           onChangeTimeScale={this.changeTimeScale}
           onApply={this.updateRequestParams}
+          showInternal={this.props.showInternal}
+          onShowInternalChange={this.props.onShowInternalChange}
         />
         <div className={cx("table-area")}>
           <Loading

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
@@ -15,6 +15,7 @@ import {
   actions as localStorageActions,
   updateStmtsPageLimitAction,
   updateStmsPageReqSortAction,
+  updateShowInternalAction,
 } from "src/store/localStorage";
 import { actions as sqlStatsActions } from "src/store/sqlStats";
 import { actions as statementDiagnosticsActions } from "src/store/statementDiagnostics";
@@ -37,6 +38,7 @@ import {
   selectTimeScale,
   selectStmtsPageLimit,
   selectStmtsPageReqSort,
+  selectShowInternal,
 } from "../store/utils/selectors";
 import { TimeScale } from "../timeScaleDropdown";
 
@@ -105,6 +107,7 @@ export const ConnectedStatementsPage = withRouter(
         statementDiagnostics: state.adminUI.statementDiagnostics?.data,
         oldestDataAvailable:
           state.adminUI?.statements?.data?.oldest_aggregated_ts_returned,
+        showInternal: selectShowInternal(state),
       },
       activePageProps: mapStateToActiveStatementsPageProps(state),
     }),
@@ -256,6 +259,8 @@ export const ConnectedStatementsPage = withRouter(
           dispatch(updateStmtsPageLimitAction(limit)),
         onChangeReqSort: (sort: SqlStatsSortType) =>
           dispatch(updateStmsPageReqSortAction(sort)),
+        onShowInternalChange: (showInternal: boolean) =>
+          dispatch(updateShowInternalAction(showInternal)),
         onApplySearchCriteria: (ts: TimeScale, limit: number, sort: string) =>
           dispatch(
             analyticsActions.track({

--- a/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
@@ -36,6 +36,7 @@ export enum LocalStorageKeys {
   DB_DETAILS_GRANTS_PAGE_SORT = "sortSetting/DatabasesDetailsGrantsPage",
   DB_DETAILS_VIEW_MODE = "viewMode/DatabasesDetailsPage",
   ACTIVE_EXECUTIONS_IS_AUTOREFRESH_ENABLED = "isAutoRefreshEnabled/ActiveExecutions",
+  SHOW_INTERNAL = "showInternal/SQLActivity",
 }
 
 export type LocalStorageState = {
@@ -80,6 +81,7 @@ export type LocalStorageState = {
   "statusSetting/JobsPage": string;
   "showSetting/JobsPage": string;
   [LocalStorageKeys.ACTIVE_EXECUTIONS_IS_AUTOREFRESH_ENABLED]: boolean;
+  [LocalStorageKeys.SHOW_INTERNAL]: boolean;
   "requestTime/StatementsPage": moment.Moment;
   "requestTime/TransactionsPage": moment.Moment;
 };
@@ -295,6 +297,8 @@ const initialState: LocalStorageState = {
         LocalStorageKeys.ACTIVE_EXECUTIONS_IS_AUTOREFRESH_ENABLED,
       ),
     ) || defaultIsAutoRefreshEnabledSetting,
+  [LocalStorageKeys.SHOW_INTERNAL]:
+    JSON.parse(localStorage.getItem(LocalStorageKeys.SHOW_INTERNAL)) || false,
   "requestTime/StatementsPage": null,
   "requestTime/TransactionsPage": null,
 };
@@ -347,4 +351,12 @@ export const updateTxnsPageReqSortAction = (
   localStorageSlice.actions.update({
     key: LocalStorageKeys.TXN_FINGERPRINTS_SORT,
     value: sort,
+  });
+
+export const updateShowInternalAction = (
+  showInternal: boolean,
+): PayloadAction<Payload> =>
+  localStorageSlice.actions.update({
+    key: LocalStorageKeys.SHOW_INTERNAL,
+    value: showInternal,
   });

--- a/pkg/ui/workspaces/cluster-ui/src/store/utils/selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/utils/selectors.ts
@@ -51,3 +51,8 @@ export const selectTxnsPageReqSort = createSelector(
   localStorageSelector,
   localStorage => localStorage[LocalStorageKeys.TXN_FINGERPRINTS_SORT],
 );
+
+export const selectShowInternal = createSelector(
+  localStorageSelector,
+  localStorage => localStorage[LocalStorageKeys.SHOW_INTERNAL],
+);

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -111,6 +111,7 @@ export interface TransactionsPageStateProps {
   hasAdminRole?: UIConfigState["hasAdminRole"];
   requestTime: moment.Moment;
   oldestDataAvailable: Timestamp;
+  showInternal?: boolean;
 }
 
 export interface TransactionsPageDispatchProps {
@@ -131,13 +132,16 @@ export interface TransactionsPageDispatchProps {
   ) => void;
   onApplySearchCriteria: (ts: TimeScale, limit: number, sort: string) => void;
   onRequestTimeChange: (t: moment.Moment) => void;
+  onShowInternalChange?: (showInternal: boolean) => void;
 }
 
 export type TransactionsPageProps = TransactionsPageStateProps &
   TransactionsPageDispatchProps &
   RouteComponentProps;
 
-type RequestParams = Pick<TState, "timeScale" | "limit" | "reqSortSetting">;
+type RequestParams = Pick<TState, "timeScale" | "limit" | "reqSortSetting"> & {
+  showInternal?: boolean;
+};
 
 function stmtsRequestFromParams(params: RequestParams): StatementsRequest {
   const [start, end] = toRoundedDateRange(params.timeScale);
@@ -146,6 +150,7 @@ function stmtsRequestFromParams(params: RequestParams): StatementsRequest {
     end,
     limit: params.limit,
     sort: params.reqSortSetting,
+    includeInternal: params.showInternal,
   });
 }
 export class TransactionsPage extends React.Component<
@@ -207,7 +212,10 @@ export class TransactionsPage extends React.Component<
   };
 
   refreshData = (): void => {
-    const req = stmtsRequestFromParams(this.state);
+    const req = stmtsRequestFromParams({
+      ...this.state,
+      showInternal: this.props.showInternal,
+    });
     this.props.refreshData(req);
   };
 
@@ -681,6 +689,8 @@ export class TransactionsPage extends React.Component<
           onChangeBy={this.onChangeReqSort}
           onChangeTimeScale={this.changeTimeScale}
           onApply={this.updateRequestParams}
+          showInternal={this.props.showInternal}
+          onShowInternalChange={this.props.onShowInternalChange}
         />
         <div className={cx("table-area")}>
           <Loading

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
@@ -19,6 +19,7 @@ import {
   actions as localStorageActions,
   updateTxnsPageLimitAction,
   updateTxnsPageReqSortAction,
+  updateShowInternalAction,
 } from "../store/localStorage";
 import { nodeRegionsByIDSelector } from "../store/nodes";
 import { selectHasAdminRole, selectIsTenant } from "../store/uiConfig";
@@ -26,6 +27,7 @@ import {
   selectTxnsPageLimit,
   selectTxnsPageReqSort,
   selectTimeScale,
+  selectShowInternal,
 } from "../store/utils/selectors";
 import { TimeScale } from "../timeScaleDropdown";
 
@@ -88,6 +90,7 @@ export const TransactionsPageConnected = withRouter(
         requestTime: selectRequestTime(state),
         oldestDataAvailable:
           state.adminUI?.transactions?.data?.oldest_aggregated_ts_returned,
+        showInternal: selectShowInternal(state),
       },
       activePageProps: mapStateToActiveTransactionsPageProps(state),
     }),
@@ -164,6 +167,8 @@ export const TransactionsPageConnected = withRouter(
           dispatch(updateTxnsPageLimitAction(limit)),
         onChangeReqSort: (sort: SqlStatsSortType) =>
           dispatch(updateTxnsPageReqSortAction(sort)),
+        onShowInternalChange: (showInternal: boolean) =>
+          dispatch(updateShowInternalAction(showInternal)),
         onApplySearchCriteria: (ts: TimeScale, limit: number, sort: string) =>
           dispatch(
             analyticsActions.track({

--- a/pkg/ui/workspaces/db-console/src/views/sessions/sessionsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/sessions/sessionsPage.tsx
@@ -24,6 +24,7 @@ import {
 import { AdminUIState } from "src/redux/state";
 import { SessionsResponseMessage } from "src/util/api";
 import { Pick } from "src/util/pick";
+import { showInternalLocalSetting } from "src/views/statements/statementsPage";
 
 const SessionsRequest = protos.cockroach.server.serverpb.ListSessionsRequest;
 
@@ -85,9 +86,10 @@ export const filtersLocalSetting = new LocalSetting<AdminUIState, Filters>(
   defaultFiltersForSessionsPage,
 );
 
-// Interface matching cluster-ui's SessionsRequest
+// Interface matching cluster-ui's SessionsRequest.
 interface ClusterUiSessionsRequest {
   excludeClosedSessions?: boolean;
+  includeInternal?: boolean;
 }
 
 const SessionsPageConnected = withRouter(
@@ -99,14 +101,18 @@ const SessionsPageConnected = withRouter(
       sessions: selectSessions(state, props),
       sessionsError: state.cachedData.sessions.lastError,
       sortSetting: sortSettingLocalSetting.selector(state),
+      showInternal: showInternalLocalSetting.selector(state),
     }),
     (dispatch: ThunkDispatch<AdminUIState, unknown, Action>) => ({
       refreshSessions: (req?: ClusterUiSessionsRequest) => {
         const protoReq = new SessionsRequest({
           exclude_closed_sessions: req?.excludeClosedSessions,
+          include_internal: req?.includeInternal,
         });
         dispatch(refreshSessions(protoReq));
       },
+      onShowInternalChange: (showInternal: boolean) =>
+        dispatch(showInternalLocalSetting.set(showInternal)),
       cancelSession: terminateSessionAction,
       cancelQuery: terminateQueryAction,
       onSortingChange: (

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
@@ -129,6 +129,13 @@ export const limitSetting = new LocalSetting(
   api.DEFAULT_STATS_REQ_OPTIONS.limit,
 );
 
+// Shared across all SQL Activity pages.
+export const showInternalLocalSetting = new LocalSetting(
+  "showInternal/SQLActivity",
+  (state: AdminUIState) => state.localSettings,
+  false,
+);
+
 const fingerprintsPageActions = {
   refreshStatements: refreshStatements,
   refreshDatabases: refreshDatabases,
@@ -196,6 +203,8 @@ const fingerprintsPageActions = {
   onChangeLimit: (newLimit: number) => limitSetting.set(newLimit),
   onChangeReqSort: (sort: api.SqlStatsSortType) => reqSortSetting.set(sort),
   onApplySearchCriteria: trackApplySearchCriteriaAction,
+  onShowInternalChange: (showInternal: boolean) =>
+    showInternalLocalSetting.set(showInternal),
 };
 
 type StateProps = {
@@ -245,6 +254,7 @@ export default withRouter(
         statementDiagnostics: selectStatementDiagnostics(state)?.data,
         oldestDataAvailable:
           state.cachedData?.statements?.data?.oldest_aggregated_ts_returned,
+        showInternal: showInternalLocalSetting.selector(state),
       },
       activePageProps: mapStateToActiveStatementViewProps(state),
     }),

--- a/pkg/ui/workspaces/db-console/src/views/transactions/transactionsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/transactions/transactionsPage.tsx
@@ -36,6 +36,8 @@ import { selectTimeScale } from "src/redux/timeScale";
 import { selectHasAdminRole } from "src/redux/user";
 import { PrintTime } from "src/views/reports/containers/range/print";
 
+import { showInternalLocalSetting } from "src/views/statements/statementsPage";
+
 import {
   activeTransactionsPageActionCreators,
   mapStateToActiveTransactionsPageProps,
@@ -135,6 +137,8 @@ const fingerprintsPageActions = {
   onChangeReqSort: (sort: api.SqlStatsSortType) => reqSortSetting.set(sort),
   onApplySearchCriteria: trackApplySearchCriteriaAction,
   onRequestTimeChange: (t: moment.Moment) => requestTimeLocalSetting.set(t),
+  onShowInternalChange: (showInternal: boolean) =>
+    showInternalLocalSetting.set(showInternal),
 };
 
 type StateProps = {
@@ -171,6 +175,7 @@ const TransactionsPageConnected = withRouter(
         reqSortSetting: reqSortSetting.selector(state),
         requestTime: requestTimeLocalSetting.selector(state),
         oldestDataAvailable: selectOldestDate(state),
+        showInternal: showInternalLocalSetting.selector(state),
       },
       activePageProps: mapStateToActiveTransactionsPageProps(state),
     }),


### PR DESCRIPTION
Previously, whether internal sessions and statement/transaction statistics were returned by the server APIs was controlled solely by the cluster setting sql.stats.response.show_internal.enabled. This was problematic because toggling it affected all API consumers globally.

This commit adds an include_internal request parameter to the CombinedStatementsStats, StatementDetails, and ListSessions APIs. The backend ORs this parameter with the cluster setting, so either mechanism can enable showing internal data. On the frontend, a "Show internal" checkbox is added to the SQL Activity pages (Statements, Transactions, Sessions) backed by localStorage, allowing users to toggle visibility of internal queries without changing cluster settings.

The cluster setting is marked as deprecated in favor of the UI toggle.

Resolves: #87200

Release note (ui change): Added a "Show internal" checkbox to the DB Console SQL Activity pages (Statements, Transactions, Sessions). This allows users to view internal sessions and statement statistics without changing the sql.stats.response.show_internal.enabled cluster setting.