### PR TITLE
release-26.1: kvserver: deflake TestStoreRangeMergeRaftSnapshot

### DIFF
--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -4176,14 +4176,25 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 		// Wait for all replicas to catch up to the same point. Because we
 		// truncated the log while store2 was unavailable, this will require a
 		// Raft snapshot.
+		//
+		// When the RHS was rebalanced away, limit the key comparison to
+		// [keyStart, keyD) — the LHS that both stores are guaranteed to hold.
+		// store0 may retain stale data from its old RHS replica (r85) while
+		// the conf change removing it propagates and replica GC runs; store2
+		// had the corresponding key span cleared during snapshot subsumption.
+		// Comparing the full [keyStart, keyEnd) would race against the
+		// asynchronous replica GC of store0's stale RHS replica.
+		scanEnd := keyEnd
+		if rebalanceRHSAway {
+			scanEnd = keyD
+		}
 		testutils.SucceedsSoon(t, func() error {
 			afterRaftSnaps := store2.Metrics().RangeSnapshotsAppliedByVoters.Count()
 			if afterRaftSnaps <= beforeRaftSnaps {
 				return errors.New("expected store2 to apply at least 1 additional raft snapshot")
 			}
-			// We only look at the range of keys the test has been manipulating.
 			getKeySet := func(engine storage.Engine) map[string]struct{} {
-				kvs, err := storage.Scan(context.Background(), engine, keyStart, keyEnd, 0)
+				kvs, err := storage.Scan(context.Background(), engine, keyStart, scanEnd, 0)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -3811,6 +3811,28 @@ func TestStoreRangeMergeSlowWatcher(t *testing.T) {
 	}
 }
 
+// TestStoreRangeMergeRaftSnapshot exercises Raft snapshot application across
+// range merges and splits. It sets up a 5-node cluster (stores s1–s5) with
+// manual replication, then:
+//
+//  1. Creates a scratch range [Start, End) replicated to s1, s2, s3.
+//  2. Splits it into four ranges:
+//     r1=[Start, a)  r2=[a, b)  r3=[b, c)  r4=[c, End)
+//  3. Writes values at keys a, b, c and 10 keys past d in [d, End).
+//  4. Blocks all Raft traffic for r2 on s3 so that s3 falls behind.
+//  5. Merges r2+r3+r4 into r2=[a, End), then splits at d:
+//     r2=[a, d)  r5=[d, End)
+//  6. Truncates the Raft log on r2 so that s3 cannot catch up via log entries.
+//  7. (rebalanceRHSAway=true only) Rebalances r5 away from s1 and s3 onto
+//     s4 and s5.
+//  8. Restores Raft traffic to s3 (still filtering stale MsgApp), forcing s3
+//     to catch up via a Raft snapshot for r2.
+//  9. Verifies that the Raft snapshot was applied and that the engine key sets
+//     on s1 and s3 match for the key span both stores hold.
+//
+// The beforeSnapshotSSTIngestion hook additionally verifies the byte-level
+// contents of the SSTs that make up the snapshot, including the SSTs that
+// clear range-ID local keys and user data of the subsumed replicas (r3, r4).
 func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)


### PR DESCRIPTION
Backport 3/3 commits from #163420 on behalf of @tbg.

----

In the `rebalanceRHSAway=true` subtest, the RHS (r85) is rebalanced away from
both store0 and store2. After the Raft snapshot lands on store2, the test
compares engine keys in `[keyStart, keyEnd)` between both stores. This races
with the asynchronous replica GC of store0's stale r85 replica: store2 had the
`[keyD, keyEnd)` key span cleared as part of snapshot subsumption, while store0
may still retain stale data from r85 if the conf change removing it has not yet
been applied (a well-known Raft race where the leader applies a removal before
delivering the entry to the removed node).

Fix this by scoping the engine key comparison to `[keyStart, keyD)` when the
RHS has been rebalanced away. This is the key span that both stores are
guaranteed to hold, and it's the span relevant to what the test is actually
exercising (the merged-range Raft snapshot).

Fixes #163405

Release note: None
Epic: CRDB-60204

Made with [Cursor](https://cursor.com)

----

Release justification: