### PR TITLE
jobs: deprecate JobUpdater based chunk progress logger

### DIFF
--- a/pkg/backup/backup_job.go
+++ b/pkg/backup/backup_job.go
@@ -223,7 +223,7 @@ func backup(
 		numTotalSpans += len(spec.IntroducedSpans) + len(spec.Spans)
 	}
 
-	progressLogger := jobs.NewChunkProgressLoggerForJob(job, numTotalSpans, job.FractionCompleted(), jobs.ProgressUpdateOnly)
+	progressLogger := jobs.DeprecatedNewChunkProgressLoggerForJob(job, numTotalSpans, job.FractionCompleted(), jobs.DeprecatedProgressUpdateOnly)
 
 	requestFinishedCh := make(chan struct{}, numTotalSpans) // enough buffer to never block
 	var jobProgressLoop func(ctx context.Context) error

--- a/pkg/backup/restore_job.go
+++ b/pkg/backup/restore_job.go
@@ -574,7 +574,7 @@ func restore(
 		// Only update the job progress on the main data bundle. This should account
 		// for the bulk of the data to restore. Other data (e.g. zone configs in
 		// cluster restores) may be restored first.
-		progressLogger := jobs.NewChunkProgressLoggerForJob(job, numImportSpans, job.FractionCompleted(), progressTracker.updateJobCallback)
+		progressLogger := jobs.DeprecatedNewChunkProgressLoggerForJob(job, numImportSpans, job.FractionCompleted(), progressTracker.updateJobCallback)
 
 		jobProgressLoop := func(ctx context.Context) error {
 			ctx, progressSpan := tracing.ChildSpan(ctx, "progress-loop")

--- a/pkg/jobs/progress.go
+++ b/pkg/jobs/progress.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/util/startup"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -24,7 +25,7 @@ import (
 // progressFractionThreshold.
 var (
 	progressTimeThreshold             = 15 * time.Second
-	progressFractionThreshold float32 = 0.05
+	progressFractionThreshold float64 = 0.05
 )
 
 // TestingSetProgressThresholds overrides batching limits to update more often.
@@ -53,35 +54,48 @@ type ChunkProgressLogger struct {
 	batcher ProgressUpdateBatcher
 }
 
-// ProgressUpdateOnly is for use with NewChunkProgressLogger to just update job
-// progress fraction (ie. when a custom func with side-effects is not needed).
-var ProgressUpdateOnly func(context.Context, jobspb.ProgressDetails)
-
 func NewChunkProgressLoggerForJob(
+	jobID jobspb.JobID, db isql.DB, expectedChunks int, startFraction float64,
+) *ChunkProgressLogger {
+	return NewChunkProgressLogger(
+		func(ctx context.Context, fraction float64) error {
+			return db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+				return ProgressStorage(jobID).SetFraction(ctx, txn, fraction)
+			})
+		},
+		expectedChunks, startFraction,
+	)
+}
+
+// DeprecatedProgressUpdateOnly is for use with NewChunkProgressLogger to just update job
+// progress fraction (ie. when a custom func with side-effects is not needed).
+var DeprecatedProgressUpdateOnly func(context.Context, jobspb.ProgressDetails)
+
+func DeprecatedNewChunkProgressLoggerForJob(
 	j *Job,
 	expectedChunks int,
 	startFraction float32,
 	progressedFn func(context.Context, jobspb.ProgressDetails),
 ) *ChunkProgressLogger {
 	return NewChunkProgressLogger(
-		func(ctx context.Context, pct float32) error {
+		func(ctx context.Context, fraction float64) error {
 			return j.NoTxn().FractionProgressed(ctx, func(ctx context.Context, details jobspb.ProgressDetails) float32 {
 				if progressedFn != nil {
 					progressedFn(ctx, details)
 				}
-				return pct
+				return float32(fraction)
 			})
-		}, expectedChunks, startFraction)
+		}, expectedChunks, float64(startFraction))
 }
 
 // NewChunkProgressLogger returns a ChunkProgressLogger.
 func NewChunkProgressLogger(
-	report func(ctx context.Context, pct float32) error, expectedChunks int, startFraction float32,
+	report func(ctx context.Context, pct float64) error, expectedChunks int, startFraction float64,
 ) *ChunkProgressLogger {
 	return &ChunkProgressLogger{
 		expectedChunks: expectedChunks,
 		batcher: ProgressUpdateBatcher{
-			perChunkContribution: (1.0 - startFraction) * 1.0 / float32(expectedChunks),
+			perChunkContribution: (1.0 - startFraction) * 1.0 / float64(expectedChunks),
 			start:                startFraction,
 			reported:             startFraction,
 			Report:               report,
@@ -126,17 +140,17 @@ func (jpl *ChunkProgressLogger) Loop(ctx context.Context, chunkCh <-chan struct{
 // not less than 30s apart).
 type ProgressUpdateBatcher struct {
 	// Report is the function called to record progress
-	Report func(context.Context, float32) error
+	Report func(context.Context, float64) error
 
 	// The following are set at initialization time.
 	// start is the starting percentage complete.
-	start                float32
-	perChunkContribution float32
+	start                float64
+	perChunkContribution float64
 
 	syncutil.Mutex
 
 	// reported is the most recently reported value of completed
-	reported  float32
+	reported  float64
 	completed int
 	// lastReported is when we last called report
 	lastReported time.Time
@@ -146,12 +160,12 @@ type ProgressUpdateBatcher struct {
 // change in the completed progress (and enough time has passed) to report the
 // new progress amount.
 func (p *ProgressUpdateBatcher) Add(ctx context.Context) error {
-	shouldReport, completed := func() (bool, float32) {
+	shouldReport, completed := func() (bool, float64) {
 		p.Lock()
 		defer p.Unlock()
 		p.completed += 1
 
-		next := p.start + (float32(p.completed) * p.perChunkContribution)
+		next := p.start + (float64(p.completed) * p.perChunkContribution)
 		sReport := next-p.reported > progressFractionThreshold
 		sReport = sReport || (next > p.reported && p.lastReported.Add(progressTimeThreshold).Before(timeutil.Now()))
 		if sReport {
@@ -170,7 +184,7 @@ func (p *ProgressUpdateBatcher) Add(ctx context.Context) error {
 // worrying about update frequency now that it is done.
 func (p *ProgressUpdateBatcher) Done(ctx context.Context) error {
 	p.Lock()
-	next := p.start + (float32(p.completed) * p.perChunkContribution)
+	next := p.start + (float64(p.completed) * p.perChunkContribution)
 	shouldReport := next-p.reported > progressFractionThreshold
 	p.Unlock()
 	if shouldReport {

--- a/pkg/jobs/progress_test.go
+++ b/pkg/jobs/progress_test.go
@@ -7,12 +7,83 @@ package jobs
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/sql/isql"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
 )
+
+func TestChunkProgressLogger(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	defer TestingSetProgressThresholds()()
+
+	ctx := context.Background()
+
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	// Set up a stub job.
+	defaultRecord := Record{
+		Details:  jobspb.BackupDetails{},
+		Progress: jobspb.BackupProgress{},
+		Username: username.TestUserName(),
+	}
+	jobID := jobspb.JobID(1)
+	_, err := s.JobRegistry().(*Registry).CreateJobWithTxn(ctx, defaultRecord, jobID, nil /* txn */)
+	require.NoError(t, err)
+
+	requestFinishedCh := make(chan struct{}, 100)
+	defer close(requestFinishedCh)
+	logger := NewChunkProgressLoggerForJob(
+		jobID, s.InternalDB().(isql.DB), 100 /* expectedChunks */, 0, /* startFraction */
+	)
+	go func() {
+		require.NoError(t, logger.Loop(ctx, requestFinishedCh))
+	}()
+
+	db := sqlutils.MakeSQLRunner(s.SQLConn(t))
+	validateFrac := func(expected float64) {
+		testutils.SucceedsSoon(t, func() error {
+			var frac float64
+			db.QueryRow(t, fmt.Sprintf(
+				"SELECT fraction_completed FROM [SHOW JOBS] WHERE job_id = %d",
+				jobID,
+			)).Scan(&frac)
+			if frac != expected {
+				return fmt.Errorf("fraction not yet caught up")
+			}
+			return nil
+		})
+	}
+
+	for range 10 {
+		requestFinishedCh <- struct{}{}
+	}
+	validateFrac(0.1)
+
+	for range 50 {
+		requestFinishedCh <- struct{}{}
+	}
+	validateFrac(0.6)
+
+	for range 39 {
+		requestFinishedCh <- struct{}{}
+	}
+	validateFrac(0.99)
+
+	requestFinishedCh <- struct{}{}
+	validateFrac(1)
+}
 
 func TestChunkProgressLoggerLimitsFloatingPointError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -23,14 +94,14 @@ func TestChunkProgressLoggerLimitsFloatingPointError(t *testing.T) {
 
 	rangeCount := 1240725
 
-	var lastReported float32
-	l := NewChunkProgressLogger(func(_ context.Context, pct float32) error {
-		require.Less(t, pct, float32(1.01))
+	var lastReported float64
+	l := NewChunkProgressLogger(func(_ context.Context, pct float64) error {
+		require.Less(t, pct, float64(1.01))
 		lastReported = pct
 		return nil
 	}, rangeCount, 0)
 	for i := 0; i < rangeCount; i++ {
 		require.NoError(t, l.chunkFinished(ctx), "failed at update %d", i)
 	}
-	require.Greater(t, lastReported, float32(0.99))
+	require.Greater(t, lastReported, float64(0.99))
 }


### PR DESCRIPTION
This patch deprecates the previous `JobUpdater` based `NewChunkProgressLoggerForJob` function in favor of one based on `ProgressStorage`.

Informs: https://github.com/cockroachdb/cockroach/issues/159428

Release note: None