### PR TITLE
release-25.3: keys: handle case where keys targeted by GC request straddle header

### DIFF
--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -1049,10 +1049,51 @@ func EnsureSafeSplitKey(key roachpb.Key) (roachpb.Key, error) {
 	return key[:idx], nil
 }
 
+// extend expands the given RSpan to include the key range [key, endKey) (or
+// [key, key.Next()) if an empty endKey is supplied).
+func extend(rs roachpb.RSpan, key, endKey roachpb.Key) (roachpb.RSpan, error) {
+	rKey, err := Addr(key)
+	if err != nil {
+		return roachpb.RSpan{}, err
+	}
+	if rKey.Less(rs.Key) {
+		// rKey is smaller than the current start key.
+		rs.Key = rKey
+	}
+	if !rKey.Less(rs.EndKey) {
+		// rKey.Next() is larger than the current end key.
+		if bytes.Compare(rKey, roachpb.RKeyMax) > 0 {
+			return roachpb.RSpan{}, errors.Errorf("%s must be less than KeyMax", rKey)
+		}
+		rs.EndKey = rKey.Next()
+	}
+
+	// Check if endKey exists; if it does, consider it for the upper bound.
+	// Otherwise, return the extended span.
+	if len(endKey) == 0 {
+		return rs, nil
+	}
+
+	// NB: AddrUpperBound is suitable for use as the EndKey of a span with a
+	// range-local key EndKey. See the comment on AddrUpperBound for more
+	// details.
+	rEndKey, err := AddrUpperBound(endKey)
+	if err != nil {
+		return roachpb.RSpan{}, err
+	}
+	if bytes.Compare(roachpb.RKeyMax, rEndKey) < 0 {
+		return roachpb.RSpan{}, errors.Errorf("%s must be less than or equal to KeyMax", rEndKey)
+	}
+	if rs.EndKey.Less(rEndKey) {
+		// rEndKey is larger than the current end key.
+		rs.EndKey = rEndKey
+	}
+	return rs, nil
+}
+
 // Range returns a key range encompassing the key ranges of all requests.
 func Range(reqs []kvpb.RequestUnion) (roachpb.RSpan, error) {
-	from := roachpb.RKeyMax
-	to := roachpb.RKeyMin
+	rs := roachpb.RSpan{Key: roachpb.RKeyMax, EndKey: roachpb.RKeyMin}
 	for _, arg := range reqs {
 		req := arg.GetInner()
 		h := req.Header()
@@ -1060,38 +1101,52 @@ func Range(reqs []kvpb.RequestUnion) (roachpb.RSpan, error) {
 			return roachpb.RSpan{}, errors.Errorf("end key specified for non-range operation: %s", req)
 		}
 
-		key, err := Addr(h.Key)
+		var err error
+		rs, err = extend(rs, h.Key, h.EndKey)
 		if err != nil {
 			return roachpb.RSpan{}, err
-		}
-		if key.Less(from) {
-			// Key is smaller than `from`.
-			from = key
-		}
-		if !key.Less(to) {
-			// Key.Next() is larger than `to`.
-			if bytes.Compare(key, roachpb.RKeyMax) > 0 {
-				return roachpb.RSpan{}, errors.Errorf("%s must be less than KeyMax", key)
-			}
-			to = key.Next()
 		}
 
-		if len(h.EndKey) == 0 {
-			continue
+		// For GCRequests, also consider the individual keys, range keys, and
+		// clear range spans which may extend beyond the request header.
+		if req.Method() == kvpb.GC {
+			rs, err = extendRangeForGCRequest(req.(*kvpb.GCRequest), rs)
+			if err != nil {
+				return roachpb.RSpan{}, err
+			}
 		}
-		endKey, err := AddrUpperBound(h.EndKey)
+	}
+	return rs, nil
+}
+
+// extendRangeForGCRequest examines the individual keys, range keys, and clear
+// range within a GCRequest and extends the bounds if any of them fall outside
+// the current range. This handles cases where the GC request erroneously
+// targets keys outside its header span (see #162085).
+func extendRangeForGCRequest(gcReq *kvpb.GCRequest, rs roachpb.RSpan) (roachpb.RSpan, error) {
+	var err error
+	// Check point keys.
+	for _, gcKey := range gcReq.Keys {
+		rs, err = extend(rs, gcKey.Key, nil)
 		if err != nil {
 			return roachpb.RSpan{}, err
 		}
-		if bytes.Compare(roachpb.RKeyMax, endKey) < 0 {
-			return roachpb.RSpan{}, errors.Errorf("%s must be less than or equal to KeyMax", endKey)
-		}
-		if to.Less(endKey) {
-			// EndKey is larger than `to`.
-			to = endKey
+	}
+	// Check range keys.
+	for _, rk := range gcReq.RangeKeys {
+		rs, err = extend(rs, rk.StartKey, rk.EndKey)
+		if err != nil {
+			return roachpb.RSpan{}, err
 		}
 	}
-	return roachpb.RSpan{Key: from, EndKey: to}, nil
+	// Check clear range.
+	if gcReq.ClearRange != nil {
+		rs, err = extend(rs, gcReq.ClearRange.StartKey, gcReq.ClearRange.EndKey)
+		if err != nil {
+			return roachpb.RSpan{}, err
+		}
+	}
+	return rs, nil
 }
 
 // RangeIDPrefixBuf provides methods for generating range ID local keys while

--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -1127,6 +1127,16 @@ func extendRangeForGCRequest(gcReq *kvpb.GCRequest, rs roachpb.RSpan) (roachpb.R
 	var err error
 	// Check point keys.
 	for _, gcKey := range gcReq.Keys {
+		// Skip range-ID local keys, as such keys aren't addressable in the
+		// global key map. As such, they don't contribute to the key span
+		// touched by the GC request. As a result, we cannot compare them
+		// against a replica's key span to determine whether or not they've been
+		// routed to the right place; instead, we handle them during evaluation
+		// time by checking whether they match the replica's RangeID or not. See
+		// the call to  ContainsKey() in cmd_gc.go for more details.
+		if bytes.HasPrefix(gcKey.Key, LocalRangeIDPrefix) {
+			continue
+		}
 		rs, err = extend(rs, gcKey.Key, nil)
 		if err != nil {
 			return roachpb.RSpan{}, err
@@ -1141,6 +1151,16 @@ func extendRangeForGCRequest(gcReq *kvpb.GCRequest, rs roachpb.RSpan) (roachpb.R
 	}
 	// Check clear range.
 	if gcReq.ClearRange != nil {
+		// NB: We create a new gcKeyBatcher for each "plane" of a replica's
+		// spans, so a GC request should never span LocalRangeID keys and (say)
+		// user keys. At the time of writing, all LocalRangeID keys are inline keys
+		// which aren't versioned -- so we should never be constructing a ClearRange
+		// request over them. Assert this, because if we were, we would need
+		// extra validation in GC evaluation to ensure we're not touching keys
+		// that don't belong to our range.
+		if bytes.HasPrefix(gcReq.ClearRange.StartKey, LocalRangeIDPrefix) || bytes.HasPrefix(gcReq.ClearRange.EndKey, LocalRangeIDPrefix) {
+			return rs, errors.AssertionFailedf("ClearRange request cannot span LocalRangeID keys")
+		}
 		rs, err = extend(rs, gcReq.ClearRange.StartKey, gcReq.ClearRange.EndKey)
 		if err != nil {
 			return roachpb.RSpan{}, err

--- a/pkg/keys/keys_test.go
+++ b/pkg/keys/keys_test.go
@@ -618,54 +618,54 @@ func TestRangeBatchWithGCRequests(t *testing.T) {
 		// Tests for keys that straddle the request header. Such constructions
 		// were historically possible when the MVCC GC queue constructed GC
 		// requests: see https://github.com/cockroachdb/cockroach/issues/162085.
-		// The result (as of this commit) is the request header span.
+		// The result should expand to include the straddling keys.
 		{
 			name:       "clear range straddles header on the left",
 			header:     span("c", "z"),
 			clearRange: span("a", "m"),
-			want:       span("c", "z"),
+			want:       span("a", "z"),
 		},
 		{
 			name:       "clear range straddles header on the right",
 			header:     span("a", "m"),
 			clearRange: span("f", "z"),
-			want:       span("a", "m"),
+			want:       span("a", "z"),
 		},
 		{
 			name:       "clear range straddles header on both sides",
 			header:     span("c", "m"),
 			clearRange: span("a", "z"),
-			want:       span("c", "m"),
+			want:       span("a", "z"),
 		},
 		{
 			name:      "range keys straddle header on the left",
 			header:    span("c", "z"),
 			rangeKeys: span("a", "f"),
-			want:      span("c", "z"),
+			want:      span("a", "z"),
 		},
 		{
 			name:      "range keys straddle header on the right",
 			header:    span("a", "m"),
 			rangeKeys: span("f", "z"),
-			want:      span("a", "m"),
+			want:      span("a", "z"),
 		},
 		{
 			name:      "range keys straddle header on both sides",
 			header:    span("c", "m"),
 			rangeKeys: span("a", "z"),
-			want:      span("c", "m"),
+			want:      span("a", "z"),
 		},
 		{
 			name:   "point key straddles header on the left",
 			header: span("c", "m"),
 			keys:   keys("a", "d"),
-			want:   span("c", "m"),
+			want:   span("a", "m"),
 		},
 		{
 			name:   "point key straddles header on the right",
 			header: span("c", "m"),
 			keys:   keys("d", "z"),
-			want:   span("c", "m"),
+			want:   span("c", "z\x00"),
 		},
 	}
 

--- a/pkg/keys/keys_test.go
+++ b/pkg/keys/keys_test.go
@@ -551,6 +551,153 @@ func TestBatchRange(t *testing.T) {
 	}
 }
 
+// TestRangeBatchWithGCRequests tests the Range function with GC requests
+// containing different subtypes: point keys, range keys, and clear range.
+func TestRangeBatchWithGCRequests(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	span := func(start, end string) roachpb.Span {
+		return roachpb.Span{
+			Key:    roachpb.Key(start),
+			EndKey: roachpb.Key(end),
+		}
+	}
+
+	keys := func(ks ...string) []kvpb.GCRequest_GCKey {
+		result := make([]kvpb.GCRequest_GCKey, len(ks))
+		for i, k := range ks {
+			result[i] = kvpb.GCRequest_GCKey{Key: roachpb.Key(k)}
+		}
+		return result
+	}
+
+	testCases := []struct {
+		name       string
+		header     roachpb.Span
+		keys       []kvpb.GCRequest_GCKey
+		clearRange roachpb.Span
+		rangeKeys  roachpb.Span
+		want       roachpb.Span
+	}{
+		{
+			name:   "point keys fully contained in header span",
+			header: span("a", "z"),
+			keys:   keys("b", "c", "d"),
+			want:   span("a", "z"),
+		},
+		{
+			name:      "range keys fully contained in header span",
+			header:    span("a", "z"),
+			rangeKeys: span("b", "h"),
+			want:      span("a", "z"),
+		},
+		{
+			name:       "clear range fully contained in header span",
+			header:     span("a", "z"),
+			clearRange: span("m", "n"),
+			want:       span("a", "z"),
+		},
+		{
+			name:   "point keys at header span boundaries",
+			header: span("a", "z"),
+			keys:   keys("a", "y"),
+			want:   span("a", "z"),
+		},
+		{
+			name:      "range keys at header span boundaries",
+			header:    span("a", "z"),
+			rangeKeys: span("a", "z"),
+			want:      span("a", "z"),
+		},
+		{
+			name:       "clear range at header span boundaries",
+			header:     span("a", "z"),
+			clearRange: span("a", "z"),
+			want:       span("a", "z"),
+		},
+		// Tests for keys that straddle the request header. Such constructions
+		// were historically possible when the MVCC GC queue constructed GC
+		// requests: see https://github.com/cockroachdb/cockroach/issues/162085.
+		// The result (as of this commit) is the request header span.
+		{
+			name:       "clear range straddles header on the left",
+			header:     span("c", "z"),
+			clearRange: span("a", "m"),
+			want:       span("c", "z"),
+		},
+		{
+			name:       "clear range straddles header on the right",
+			header:     span("a", "m"),
+			clearRange: span("f", "z"),
+			want:       span("a", "m"),
+		},
+		{
+			name:       "clear range straddles header on both sides",
+			header:     span("c", "m"),
+			clearRange: span("a", "z"),
+			want:       span("c", "m"),
+		},
+		{
+			name:      "range keys straddle header on the left",
+			header:    span("c", "z"),
+			rangeKeys: span("a", "f"),
+			want:      span("c", "z"),
+		},
+		{
+			name:      "range keys straddle header on the right",
+			header:    span("a", "m"),
+			rangeKeys: span("f", "z"),
+			want:      span("a", "m"),
+		},
+		{
+			name:      "range keys straddle header on both sides",
+			header:    span("c", "m"),
+			rangeKeys: span("a", "z"),
+			want:      span("c", "m"),
+		},
+		{
+			name:   "point key straddles header on the left",
+			header: span("c", "m"),
+			keys:   keys("a", "d"),
+			want:   span("c", "m"),
+		},
+		{
+			name:   "point key straddles header on the right",
+			header: span("c", "m"),
+			keys:   keys("d", "z"),
+			want:   span("c", "m"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := kvpb.GCRequest{
+				RequestHeader: kvpb.RequestHeader{
+					Key:    tc.header.Key,
+					EndKey: tc.header.EndKey,
+				},
+				Keys: tc.keys,
+			}
+			if tc.clearRange.Key != nil {
+				req.ClearRange = &kvpb.GCRequest_GCClearRange{
+					StartKey: tc.clearRange.Key,
+					EndKey:   tc.clearRange.EndKey,
+				}
+			}
+			if tc.rangeKeys.Key != nil {
+				req.RangeKeys = []kvpb.GCRequest_GCRangeKey{
+					{StartKey: tc.rangeKeys.Key, EndKey: tc.rangeKeys.EndKey},
+				}
+			}
+			var ba kvpb.BatchRequest
+			ba.Add(&req)
+			rs, err := Range(ba.Requests)
+			require.NoError(t, err)
+			require.Equal(t, roachpb.RSpan{Key: roachpb.RKey(tc.want.Key), EndKey: roachpb.RKey(tc.want.EndKey)}, rs)
+		})
+	}
+}
+
 // TestBatchError verifies that Range returns an error if a request has an invalid range.
 func TestBatchError(t *testing.T) {
 	testCases := []struct {

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -4694,3 +4694,87 @@ func TestStoreRangeSplitRaftSnapshotAfterRHSRebalanced(t *testing.T) {
 		return nil
 	})
 }
+
+// TestGCRequestStraddlingSplit verifies that a GCRequest that targets keys in
+// the post split RHS correctly receives a RangeKeyMismatchError, even when the
+// request header is constrainted to the LHS. This serves as a regression test
+// for https://github.com/cockroachdb/cockroach/issues/162085, to ensure erroneous
+// GC requests as a result of that issue are gracefully rejected, instead of
+// silently working and causing potential data loss.
+func TestGCRequestStraddlingSplit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
+		ReplicationMode: base.ReplicationManual,
+	})
+	defer tc.Stopper().Stop(ctx)
+
+	scratch := tc.ScratchRange(t)
+	store := tc.GetFirstStoreFromServer(t, 0)
+
+	// Create a split key within the scratch range.
+	splitKey := testutils.MakeKey(scratch, roachpb.Key("b"))
+	tc.SplitRangeOrFatal(t, splitKey)
+	lhsDesc := store.LookupReplica(roachpb.RKey(scratch)).Desc()
+	rhsDesc := store.LookupReplica(roachpb.RKey(splitKey)).Desc()
+
+	testCases := []struct {
+		name  string
+		gcReq *kvpb.GCRequest
+	}{
+		{
+			name: "clear range straddling split",
+			gcReq: &kvpb.GCRequest{
+				RequestHeader: kvpb.RequestHeader{
+					Key:    lhsDesc.StartKey.AsRawKey(),
+					EndKey: lhsDesc.EndKey.AsRawKey(),
+				},
+				ClearRange: &kvpb.GCRequest_GCClearRange{
+					StartKey: lhsDesc.StartKey.AsRawKey(),
+					EndKey:   rhsDesc.EndKey.AsRawKey(), // Extends beyond the LHS into RHS
+				},
+			},
+		},
+		{
+			name: "range keys straddling split",
+			gcReq: &kvpb.GCRequest{
+				RequestHeader: kvpb.RequestHeader{
+					Key:    lhsDesc.StartKey.AsRawKey(),
+					EndKey: lhsDesc.EndKey.AsRawKey(),
+				},
+				RangeKeys: []kvpb.GCRequest_GCRangeKey{
+					{
+						StartKey: lhsDesc.StartKey.AsRawKey(),
+						EndKey:   rhsDesc.EndKey.AsRawKey(), // Extends beyond the LHS into RHS
+					},
+				},
+			},
+		},
+		{
+			name: "point key in RHS",
+			gcReq: &kvpb.GCRequest{
+				RequestHeader: kvpb.RequestHeader{
+					Key:    lhsDesc.StartKey.AsRawKey(),
+					EndKey: lhsDesc.EndKey.AsRawKey(),
+				},
+				Keys: []kvpb.GCRequest_GCKey{
+					{Key: rhsDesc.StartKey.AsRawKey()}, // Point key in the RHS
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Send the GC request. It should fail with a RangeKeyMismatchError
+			// because the keys being targeted extend beyond the LHS range, into
+			// the RHS.
+			_, pErr := kv.SendWrapped(ctx, store.TestSender(), tc.gcReq)
+			require.NotNil(t, pErr, "expected RangeKeyMismatchError but got success")
+			_, ok := pErr.GetDetail().(*kvpb.RangeKeyMismatchError)
+			require.True(t, ok, "expected RangeKeyMismatchError, got %v", pErr)
+		})
+	}
+}

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -7462,62 +7462,87 @@ func TestGCIncorrectRange(t *testing.T) {
 	repl1 := tc.repl
 	repl2 := splitTestRange(tc.store, splitKey, t)
 
-	// Write a key to range 2 at two different timestamps so we can
+	checkKeyExists := func(repl *Replica, key roachpb.Key, ts hlc.Timestamp, shouldExist bool) {
+		getReq := getArgs(key)
+		header := kvpb.Header{RangeID: repl.RangeID, Timestamp: ts}
+		res, pErr := kv.SendWrappedWith(ctx, ToSenderForTesting(repl), header, &getReq)
+		require.Nil(t, pErr)
+		resVal := res.(*kvpb.GetResponse).Value
+		if shouldExist {
+			require.NotNil(t, resVal, "expected key %s to exist at %s", key, ts)
+		} else {
+			require.Nil(t, resVal, "expected key %s to not exist at %s", key, ts)
+		}
+	}
+
+	// Write a key to both ranges at two different timestamps so we can
 	// GC the earlier timestamp without needing to delete it.
-	key := splitKey.PrefixEnd().AsRawKey()
-	val := []byte("value")
-	putReq := putArgs(key, val)
 	now := tc.Clock().Now()
 	ts1 := now.Add(1, 0)
 	ts2 := now.Add(2, 0)
-	ts1Header := kvpb.Header{RangeID: repl2.RangeID, Timestamp: ts1}
-	ts2Header := kvpb.Header{RangeID: repl2.RangeID, Timestamp: ts2}
-	if _, pErr := kv.SendWrappedWith(ctx, repl2, ts1Header, &putReq); pErr != nil {
-		t.Errorf("unexpected pError on put key request: %s", pErr)
-	}
-	if _, pErr := kv.SendWrappedWith(ctx, repl2, ts2Header, &putReq); pErr != nil {
-		t.Errorf("unexpected pError on put key request: %s", pErr)
-	}
+	val := []byte("value")
 
-	// Send GC request to range 1 for the key on range 2, which
-	// should succeed even though it doesn't contain the key, because
-	// the request for the incorrect key will be silently dropped.
-	gKey := gcKey(key, ts1)
-	gcReq := gcArgs(repl1.Desc().StartKey, repl1.Desc().EndKey, gKey)
-	if _, pErr := kv.SendWrappedWith(
+	// Key for range 1 (before split key "c").
+	key1 := roachpb.Key("a")
+	putReq1 := putArgs(key1, val)
+	ts1Header1 := kvpb.Header{RangeID: repl1.RangeID, Timestamp: ts1}
+	ts2Header1 := kvpb.Header{RangeID: repl1.RangeID, Timestamp: ts2}
+	_, pErr := kv.SendWrappedWith(ctx, ToSenderForTesting(repl1), ts1Header1, &putReq1)
+	require.Nil(t, pErr)
+	_, pErr = kv.SendWrappedWith(ctx, ToSenderForTesting(repl1), ts2Header1, &putReq1)
+	require.Nil(t, pErr)
+
+	// Key for range 2 (after split key "c").
+	key2 := splitKey.PrefixEnd().AsRawKey()
+	putReq2 := putArgs(key2, val)
+	ts1Header2 := kvpb.Header{RangeID: repl2.RangeID, Timestamp: ts1}
+	ts2Header2 := kvpb.Header{RangeID: repl2.RangeID, Timestamp: ts2}
+	_, pErr = kv.SendWrappedWith(ctx, ToSenderForTesting(repl2), ts1Header2, &putReq2)
+	require.Nil(t, pErr)
+	_, pErr = kv.SendWrappedWith(ctx, ToSenderForTesting(repl2), ts2Header2, &putReq2)
+	require.Nil(t, pErr)
+
+	// Send GC request to range 1 for the key on range 2. This should return a
+	// RangeKeyMismatchError because the request spans multiple ranges.
+	gKey2 := gcKey(key2, ts1)
+	gcReq := gcArgs(repl1.Desc().StartKey, repl1.Desc().EndKey, gKey2)
+	_, pErr = kv.SendWrappedWith(
 		ctx,
 		repl1,
 		kvpb.Header{RangeID: 1, Timestamp: tc.Clock().Now()},
 		&gcReq,
-	); pErr != nil {
-		t.Errorf("unexpected pError on garbage collection request to incorrect range: %s", pErr)
-	}
+	)
+	require.NotNil(t, pErr, "expected RangeKeyMismatchError but got success")
+	_, ok := pErr.GetDetail().(*kvpb.RangeKeyMismatchError)
+	require.True(t, ok, "expected RangeKeyMismatchError, got %v", pErr)
 
-	// Make sure the key still exists on range 2.
-	getReq := getArgs(key)
-	if res, pErr := kv.SendWrappedWith(ctx, repl2, ts1Header, &getReq); pErr != nil {
-		t.Errorf("unexpected pError on get request to correct range: %s", pErr)
-	} else if resVal := res.(*kvpb.GetResponse).Value; resVal == nil {
-		t.Errorf("expected value %s to exists after GC to incorrect range but before GC to correct range, found %v", val, resVal)
-	}
+	// Verify that keys still exist on both ranges after the failed GC request.
+	checkKeyExists(repl1, key1, ts1, true /* shouldExist */)
+	checkKeyExists(repl2, key2, ts1, true /* shouldExist */)
 
-	// Send GC request to range 2 for the same key.
-	gcReq = gcArgs(repl2.Desc().StartKey, repl2.Desc().EndKey, gKey)
-	if _, pErr := kv.SendWrappedWith(
+	// Send correct GC requests to both ranges.
+	gKey1 := gcKey(key1, ts1)
+	gcReq1 := gcArgs(repl1.Desc().StartKey, repl1.Desc().EndKey, gKey1)
+	_, pErr = kv.SendWrappedWith(
+		ctx,
+		ToSenderForTesting(repl1),
+		kvpb.Header{RangeID: repl1.RangeID, Timestamp: tc.Clock().Now()},
+		&gcReq1,
+	)
+	require.Nil(t, pErr)
+
+	gcReq2 := gcArgs(repl2.Desc().StartKey, repl2.Desc().EndKey, gKey2)
+	_, pErr = kv.SendWrappedWith(
 		ctx,
 		repl2,
 		kvpb.Header{RangeID: repl2.RangeID, Timestamp: tc.Clock().Now()},
-		&gcReq,
-	); pErr != nil {
-		t.Errorf("unexpected pError on garbage collection request to correct range: %s", pErr)
-	}
+		&gcReq2,
+	)
+	require.Nil(t, pErr)
 
-	// Make sure the key no longer exists on range 2.
-	if res, pErr := kv.SendWrappedWith(ctx, repl2, ts1Header, &getReq); pErr != nil {
-		t.Errorf("unexpected pError on get request to correct range: %s", pErr)
-	} else if resVal := res.(*kvpb.GetResponse).Value; resVal != nil {
-		t.Errorf("expected value at key %s to no longer exist after GC to correct range, found value %v", key, resVal)
-	}
+	// Verify that keys no longer exist on both ranges after proper GC.
+	checkKeyExists(repl1, key1, ts1, false /* shouldExist */)
+	checkKeyExists(repl2, key2, ts1, false /* shouldExist */)
 }
 
 // TestReplicaCancelRaft checks that it is possible to safely abandon Raft


### PR DESCRIPTION
Backport 3/3 commits from #162271 (on behalf of @arulajmani).

/cc @cockroachdb/kv

---

Individual commits:

1. **keys: add TestRangeBatchWithGCRequests** — adds test for GC requests where targeted keys don't fall within request header bounds.
2. **keys: handle case where keys targeted by GC request straddle header** — adds special case handling to return RangeKeyMismatchError for erroneous GC requests instead of silently proceeding.
3. **kvserver: account for LocalRangeID keys extendRangeForGCRequest** — handles LocalRangeID keys that can't be addressed in the global key map.

Release justification: bug fix for potential data loss via incorrect GC requests.

---

Release note: None

Made with [Cursor](https://cursor.com)