### PR TITLE
db-console: Convert metricsTimeManager to functional component

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/app/containers/metricsTimeManager/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/app/containers/metricsTimeManager/index.tsx
@@ -3,26 +3,16 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
-import isEqual from "lodash/isEqual";
 import moment from "moment-timezone";
-import React from "react";
-import { connect } from "react-redux";
+import React, { useCallback, useEffect, useRef } from "react";
+import { useDispatch, useSelector } from "react-redux";
 
 import { AdminUIState } from "src/redux/state";
 import * as timewindow from "src/redux/timeScale";
 
 interface MetricsTimeManagerProps {
-  // The current timescale redux state.
-  timeScale: timewindow.TimeScaleState;
-  // Callback function used to set a new time window.
-  setMetricsMovingWindow: typeof timewindow.setMetricsMovingWindow;
   // Optional override method to obtain the current time. Used for tests.
   now?: () => moment.Moment;
-}
-
-interface MetricsTimeManagerState {
-  // Identifier from an outstanding call to setTimeout.
-  timeout: number;
 }
 
 /**
@@ -31,14 +21,45 @@ interface MetricsTimeManagerState {
  * updated time window into the redux store whenever the previous time window is
  * expired.
  */
-class MetricsTimeManager extends React.Component<
-  MetricsTimeManagerProps,
-  MetricsTimeManagerState
-> {
-  constructor(props?: MetricsTimeManagerProps, context?: any) {
-    super(props, context);
-    this.state = { timeout: null };
-  }
+function MetricsTimeManager({
+  now,
+}: MetricsTimeManagerProps): React.ReactElement {
+  const timeScale = useSelector((state: AdminUIState) => state.timeScale);
+  const dispatch = useDispatch();
+  const timeoutRef = useRef<number | null>(null);
+
+  /**
+   * setWindow dispatches a new time window, extending backwards from the
+   * current time, by deriving the time from timeScale.
+   */
+  const setWindow = useCallback(
+    (ts: timewindow.TimeScaleState) => {
+      // The following two `if` blocks check two things that in theory should always be in sync.
+      // They check if the time selection is a dynamic, moving, now.
+      if (!ts.scale.fixedWindowEnd) {
+        if (!ts.metricsTime.isFixedWindow) {
+          const currentNow = now ? now() : moment();
+          // Update the metrics page window with the new "now" time for polling.
+          dispatch(
+            timewindow.setMetricsMovingWindow({
+              start: currentNow.clone().subtract(ts.scale.windowSize),
+              end: currentNow,
+            }),
+          );
+        }
+      } else {
+        const fixedWindowEnd = ts.scale.fixedWindowEnd;
+        // Update the metrics page window with the fixed, custom end time.
+        dispatch(
+          timewindow.setMetricsMovingWindow({
+            start: fixedWindowEnd.clone().subtract(ts.scale.windowSize),
+            end: fixedWindowEnd,
+          }),
+        );
+      }
+    },
+    [now, dispatch],
+  );
 
   /**
    * checkWindow determines when the metrics current time window will expire. If it is
@@ -46,100 +67,64 @@ class MetricsTimeManager extends React.Component<
    * setTimeout is used to asynchronously set a new time window when the current
    * one expires.
    */
-  checkWindow(props: MetricsTimeManagerProps) {
-    // Clear any existing timeout.
-    if (this.state.timeout) {
-      clearTimeout(this.state.timeout);
-      this.setState({ timeout: null });
-    }
-
-    // If there is no current window, or if scale have changed since this
-    // window was generated, set one immediately.
-    if (
-      !props.timeScale.metricsTime.currentWindow ||
-      props.timeScale.metricsTime.shouldUpdateMetricsWindowFromScale
-    ) {
-      this.setWindow(props);
-      return;
-    }
-
-    // Fixed time ranges can't expire.
-    if (props.timeScale.scale.fixedWindowEnd) {
-      return;
-    }
-
-    const now = props.now ? props.now() : moment();
-    const currentEnd = props.timeScale.metricsTime.currentWindow.end;
-    const expires = currentEnd.clone().add(props.timeScale.scale.windowValid);
-    if (now.isAfter(expires)) {
-      // Current time window is expired, reset it.
-      this.setWindow(props);
-    } else {
-      // Set a timeout to reset the window when the current window expires.
-      const newTimeout = window.setTimeout(
-        () => this.setWindow(props),
-        expires.diff(now).valueOf(),
-      );
-      this.setState({
-        timeout: newTimeout,
-      });
-    }
-  }
-
-  /**
-   * setWindow dispatches a new time window, extending backwards from the
-   * current time, by deriving the time from timeScale.
-   */
-  setWindow(props: MetricsTimeManagerProps) {
-    // The following two `if` blocks check two things that in theory should always be in sync.
-    // They check if the time selection is a dynamic, moving, now.
-    if (!props.timeScale.scale.fixedWindowEnd) {
-      if (!props.timeScale.metricsTime.isFixedWindow) {
-        const now = props.now ? props.now() : moment();
-        // Update the metrics page window with the new "now" time for polling.
-        props.setMetricsMovingWindow({
-          start: now.clone().subtract(props.timeScale.scale.windowSize),
-          end: now,
-        });
+  const checkWindow = useCallback(
+    (ts: timewindow.TimeScaleState) => {
+      // Clear any existing timeout.
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
       }
-    } else {
-      const fixedWindowEnd = props.timeScale.scale.fixedWindowEnd;
-      // Update the metrics page window with the fixed, custom end time.
-      props.setMetricsMovingWindow({
-        start: fixedWindowEnd
-          .clone()
-          .subtract(props.timeScale.scale.windowSize),
-        end: fixedWindowEnd,
-      });
-    }
-  }
 
-  componentDidMount() {
-    this.checkWindow(this.props);
-  }
+      // If there is no current window, or if scale have changed since this
+      // window was generated, set one immediately.
+      if (
+        !ts.metricsTime.currentWindow ||
+        ts.metricsTime.shouldUpdateMetricsWindowFromScale
+      ) {
+        setWindow(ts);
+        return;
+      }
 
-  componentDidUpdate(prevProps: MetricsTimeManagerProps) {
-    if (!isEqual(prevProps.timeScale, this.props.timeScale)) {
-      this.checkWindow(this.props);
-    }
-  }
+      // Fixed time ranges can't expire.
+      if (ts.scale.fixedWindowEnd) {
+        return;
+      }
 
-  render(): any {
-    // Render nothing.
-    return null;
-  }
+      const currentNow = now ? now() : moment();
+      const currentEnd = ts.metricsTime.currentWindow.end;
+      const expires = currentEnd.clone().add(ts.scale.windowValid);
+      if (currentNow.isAfter(expires)) {
+        // Current time window is expired, reset it.
+        setWindow(ts);
+      } else {
+        // Set a timeout to reset the window when the current window expires.
+        const newTimeout = window.setTimeout(
+          () => setWindow(ts),
+          expires.diff(currentNow).valueOf(),
+        );
+        timeoutRef.current = newTimeout;
+      }
+    },
+    [now, setWindow],
+  );
+
+  // Run on mount and whenever timeScale changes.
+  useEffect(() => {
+    checkWindow(timeScale);
+  }, [timeScale, checkWindow]);
+
+  // Clean up timeout on unmount.
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+    };
+  }, []);
+
+  // Render nothing.
+  return null;
 }
 
-const metricsTimeManagerConnected = connect(
-  (state: AdminUIState) => {
-    return {
-      timeScale: state.timeScale,
-    };
-  },
-  {
-    setMetricsMovingWindow: timewindow.setMetricsMovingWindow,
-  },
-)(MetricsTimeManager);
-
-export default metricsTimeManagerConnected;
-export { MetricsTimeManager as MetricsTimeManagerUnconnected };
+export default MetricsTimeManager;


### PR DESCRIPTION
Convert metricsTimeManager from class + connect() into a single function using useSelector/useDispatch hooks inline. useCallback retained for setWindow and checkWindow since they are useEffect dependencies. useRef for timeout handle and previous timeScale state (deep comparison via isEqual to avoid spurious updates from Redux returning new objects). Separate unmount-only useEffect for timeout cleanup to prevent clearing the timeout on every re-render.

Existing Enzyme test converted to RTL with:
mocked react-redux hooks (useSelector, useDispatch) and a spy on setMetricsMovingWindow action creator. jest.useFakeTimers/advanceTimersByTime for deterministic timer tests.

Epic: CRDB-58145
Release Note: None