### PR TITLE
importer: track entry counts in distributed merge import path

### DIFF
--- a/pkg/sql/importer/import_processor.go
+++ b/pkg/sql/importer/import_processor.go
@@ -572,6 +572,8 @@ func makeIngestHelper(
 			rowStorage:            rowStorage,
 			fileAllocator:         fileAllocator,
 			baseBulkAdderProgress: baseProgress,
+			tableID:               uint64(table.Desc.ID),
+			entryCounts:           make(map[uint64]int64),
 		}
 		indexAdder = helper
 	} else {
@@ -787,12 +789,47 @@ type mergeImportBulkAdder struct {
 	fileAllocator bulksst.FileAllocator
 
 	*baseBulkAdderProgress
+
+	// tableID is the table descriptor ID, used to construct BulkOpSummaryID
+	// keys for entry counting.
+	tableID uint64
+	// currentSummaryID is the precomputed BulkOpSummaryID for the current
+	// index, updated by SetIndexID to avoid recomputing on every Add call.
+	currentSummaryID uint64
+	// entryCounts tracks the number of KV entries added per
+	// BulkOpSummaryID(tableID, indexID).
+	entryCounts map[uint64]int64
 }
 
 var _ ingestHelper = &mergeImportBulkAdder{}
 
-// SetIndexID() implements the importHelper interface.
-func (miba *mergeImportBulkAdder) SetIndexID(_ catid.IndexID) {}
+// SetIndexID implements the importHelper interface.
+func (miba *mergeImportBulkAdder) SetIndexID(indexID catid.IndexID) {
+	miba.currentSummaryID = kvpb.BulkOpSummaryID(miba.tableID, uint64(indexID))
+}
+
+// Add implements the BulkAdder interface, delegating to Writer.Add while
+// tracking entry counts per index.
+func (miba *mergeImportBulkAdder) Add(ctx context.Context, key roachpb.Key, value []byte) error {
+	if err := miba.Writer.Add(ctx, key, value); err != nil {
+		return err
+	}
+	miba.entryCounts[miba.currentSummaryID]++
+	return nil
+}
+
+// GetSummary implements the BulkAdder interface. It returns the Writer's
+// summary augmented with entry counts tracked by this adder.
+func (miba *mergeImportBulkAdder) GetSummary() kvpb.BulkOpSummary {
+	summary := miba.Writer.GetSummary()
+	if summary.EntryCounts == nil {
+		summary.EntryCounts = make(map[uint64]int64, len(miba.entryCounts))
+	}
+	for id, count := range miba.entryCounts {
+		summary.EntryCounts[id] += count
+	}
+	return summary
+}
 
 // GetFileList() implements the importHelper interface.
 func (miba *mergeImportBulkAdder) GetFileList() *bulksst.SSTFiles {

--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -109,7 +109,6 @@ func TestImportDistributedMerge(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.WithIssue(t, 163425)
 	dirname, cleanup := testutils.TempDir(t)
 	t.Cleanup(cleanup)
 
@@ -5743,8 +5742,6 @@ CREATE TABLE t (
 func TestImportDistributedMergeStoragePrefixTracking(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-
-	skip.WithIssue(t, 163380)
 
 	ctx := context.Background()
 


### PR DESCRIPTION
The distributed merge import path uses `mergeImportBulkAdder` which embeds `bulksst.Writer`. Unlike the KV-based `SSTBatcher` used in the legacy path, `Writer.GetSummary()` returns an empty `EntryCounts` map. This caused the INSPECT row count validation (introduced in PR #161289) to compare an expected count of 0 against the actual row count, always finding a mismatch when the metamorphic `import-row-count-validation` constant selected `sync` mode.

Fix this by overriding `SetIndexID`, `Add`, and `GetSummary` on `mergeImportBulkAdder` to track entry counts per
`BulkOpSummaryID(tableID, indexID)`, matching what the legacy path already provides via `SSTBatcher`.

Resolves: #163425
Resolves: #163380

Release note: None