### PR TITLE
concurrency: convert Guard to an interface

### DIFF
--- a/pkg/kv/kvserver/batcheval/declare.go
+++ b/pkg/kv/kvserver/batcheval/declare.go
@@ -211,7 +211,7 @@ type CommandArgs struct {
 	// ScanStats should be mutated to reflect Get, Scan, ReverseScan,
 	// ExportRequest reads made by the command.
 	ScanStats             *kvpb.ScanStats
-	Concurrency           *concurrency.Guard
+	Concurrency           concurrency.Guard
 	Uncertainty           uncertainty.Interval
 	DontInterleaveIntents bool
 	OmitInRangefeeds      bool

--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -368,7 +368,7 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 					d.Fatalf(t, "unknown request: %s", reqName)
 				}
 				reqs, _ := scanRequests(t, d, c)
-				latchSpans, lockSpans := c.collectSpans(t, g.Req.Txn, g.Req.Timestamp, g.Req.WaitPolicy, reqs)
+				latchSpans, lockSpans := c.collectSpans(t, g.Req().Txn, g.Req().Timestamp, g.Req().WaitPolicy, reqs)
 				return fmt.Sprintf("no-conflicts: %t", g.CheckOptimisticNoConflicts(latchSpans, lockSpans))
 
 			case "is-key-locked-by-conflicting-txn":
@@ -399,7 +399,7 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 				if !ok {
 					d.Fatalf(t, "unknown request: %s", reqName)
 				}
-				txn := guard.Req.Txn
+				txn := guard.Req().Txn
 
 				key := dd.ScanArg[string](t, d, "key")
 				seqNum := dd.ScanArgOr[enginepb.TxnSeq](t, d, "seq", 0)
@@ -426,7 +426,7 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 				}
 				// Confirm that the request has a corresponding write request.
 				found := false
-				for _, ru := range guard.Req.Requests {
+				for _, ru := range guard.Req().Requests {
 					req := ru.GetInner()
 					keySpan := roachpb.Span{Key: roachpb.Key(key)}
 					if kvpb.IsLocking(req) &&
@@ -472,7 +472,7 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 
 				// Confirm that the request has a corresponding ResolveIntent.
 				found := false
-				for _, ru := range guard.Req.Requests {
+				for _, ru := range guard.Req().Requests {
 					if riReq := ru.GetResolveIntent(); riReq != nil &&
 						riReq.IntentTxn.ID == txn.ID &&
 						riReq.Key.Equal(roachpb.Key(key)) &&
@@ -679,7 +679,7 @@ type cluster struct {
 
 	// Request state. Cleared on reset.
 	mu              syncutil.Mutex
-	guardsByReqName map[string]*concurrency.Guard
+	guardsByReqName map[string]concurrency.Guard
 	txnRecords      map[uuid.UUID]*txnRecord
 	txnPushes       map[uuid.UUID]*txnPush
 }
@@ -721,7 +721,7 @@ func newClusterWithSettings(st *clustersettings.Settings) *cluster {
 
 		txnsByName:      make(map[string]*roachpb.Transaction),
 		requestsByName:  make(map[string]concurrency.Request),
-		guardsByReqName: make(map[string]*concurrency.Guard),
+		guardsByReqName: make(map[string]concurrency.Guard),
 		txnRecords:      make(map[uuid.UUID]*txnRecord),
 		txnPushes:       make(map[uuid.UUID]*txnPush),
 	}

--- a/pkg/kv/kvserver/replica_batch_updates.go
+++ b/pkg/kv/kvserver/replica_batch_updates.go
@@ -181,7 +181,7 @@ func maybeStripInFlightWrites(ba *kvpb.BatchRequest) (*kvpb.BatchRequest, error)
 // works for batches that exclusively contain writes; reads cannot be bumped
 // like this because they've already acquired timestamp-aware latches.
 func maybeBumpReadTimestampToWriteTimestamp(
-	ctx context.Context, ba *kvpb.BatchRequest, g *concurrency.Guard,
+	ctx context.Context, ba *kvpb.BatchRequest, g concurrency.Guard,
 ) (*kvpb.BatchRequest, bool) {
 	if ba.Txn == nil {
 		return ba, false
@@ -217,7 +217,7 @@ func maybeBumpReadTimestampToWriteTimestamp(
 // could not be bumped. Also returns the possibly updated batch request, which
 // is shallow-copied on write.
 func tryBumpBatchTimestamp(
-	ctx context.Context, ba *kvpb.BatchRequest, g *concurrency.Guard, ts hlc.Timestamp,
+	ctx context.Context, ba *kvpb.BatchRequest, g concurrency.Guard, ts hlc.Timestamp,
 ) (*kvpb.BatchRequest, bool) {
 	if g != nil && !g.IsolatedAtLaterTimestamps() {
 		return ba, false

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -978,7 +978,7 @@ func (r *Replica) evaluateProposal(
 	ctx context.Context,
 	idKey kvserverbase.CmdIDKey,
 	ba *kvpb.BatchRequest,
-	g *concurrency.Guard,
+	g concurrency.Guard,
 	st *kvserverpb.LeaseStatus,
 	ui uncertainty.Interval,
 ) (*kvpb.BatchRequest, *result.Result, bool, *kvpb.Error) {
@@ -1088,7 +1088,7 @@ func (r *Replica) requestToProposal(
 	ctx context.Context,
 	idKey kvserverbase.CmdIDKey,
 	ba *kvpb.BatchRequest,
-	g *concurrency.Guard,
+	g concurrency.Guard,
 	st *kvserverpb.LeaseStatus,
 	ui uncertainty.Interval,
 ) (*ProposalData, *kvpb.Error) {

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -114,7 +114,7 @@ var ReplicaLeaderlessUnavailableThreshold = settings.RegisterDurationSettingWith
 func (r *Replica) evalAndPropose(
 	ctx context.Context,
 	ba *kvpb.BatchRequest,
-	g *concurrency.Guard,
+	g concurrency.Guard,
 	st *kvserverpb.LeaseStatus,
 	ui uncertainty.Interval,
 	tok TrackedRequestToken,
@@ -1748,7 +1748,7 @@ func (r *Replica) poisonInflightLatches(err error) {
 		p.ec.poison()
 		// TODO(tbg): find out how `p.ec.done()` can have been called at this point,
 		// See: https://github.com/cockroachdb/cockroach/issues/86547
-		if p.ec.g != nil && p.ec.g.Req.PoisonPolicy == poison.Policy_Error {
+		if p.ec.g != nil && p.ec.g.Req().PoisonPolicy == poison.Policy_Error {
 			aErr := kvpb.NewAmbiguousResultError(err)
 			// NB: this does not release the request's latches. It's important that
 			// the latches stay in place, since the command could still apply.

--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -76,11 +76,11 @@ var migrateApplicationTimeout = settings.RegisterDurationSetting(
 func (r *Replica) executeWriteBatch(
 	ctx context.Context,
 	ba *kvpb.BatchRequest,
-	g *concurrency.Guard,
+	g concurrency.Guard,
 	admissionInfo kvadmission.AdmissionInfo,
 ) (
 	br *kvpb.BatchResponse,
-	_ *concurrency.Guard,
+	_ concurrency.Guard,
 	_ *kvadmission.StoreWriteBytes,
 	pErr *kvpb.Error,
 ) {
@@ -369,7 +369,7 @@ func (r *Replica) executeWriteBatch(
 // possible to evaluate the batch as 1PC. If it does so, it will return the
 // updated batch request, which is shallow-copied on write.
 func (r *Replica) canAttempt1PCEvaluation(
-	ctx context.Context, ba *kvpb.BatchRequest, g *concurrency.Guard,
+	ctx context.Context, ba *kvpb.BatchRequest, g concurrency.Guard,
 ) (*kvpb.BatchRequest, bool) {
 	if !isOnePhaseCommit(ba) {
 		return ba, false
@@ -420,7 +420,7 @@ func (r *Replica) evaluateWriteBatch(
 	ctx context.Context,
 	idKey kvserverbase.CmdIDKey,
 	ba *kvpb.BatchRequest,
-	g *concurrency.Guard,
+	g concurrency.Guard,
 	st *kvserverpb.LeaseStatus,
 	ui uncertainty.Interval,
 ) (
@@ -522,7 +522,7 @@ func (r *Replica) evaluate1PC(
 	ctx context.Context,
 	idKey kvserverbase.CmdIDKey,
 	ba *kvpb.BatchRequest,
-	g *concurrency.Guard,
+	g concurrency.Guard,
 	st *kvserverpb.LeaseStatus,
 ) (onePCRes onePCResult) {
 	log.VEventf(ctx, 2, "attempting 1PC execution")
@@ -692,7 +692,7 @@ func (r *Replica) evaluateWriteBatchWithServersideRefreshes(
 	rec batcheval.EvalContext,
 	ms *enginepb.MVCCStats,
 	ba *kvpb.BatchRequest,
-	g *concurrency.Guard,
+	g concurrency.Guard,
 	st *kvserverpb.LeaseStatus,
 	ui uncertainty.Interval,
 	deadline hlc.Timestamp,
@@ -743,7 +743,7 @@ func (r *Replica) evaluateWriteBatchWrapper(
 	rec batcheval.EvalContext,
 	ms *enginepb.MVCCStats,
 	ba *kvpb.BatchRequest,
-	g *concurrency.Guard,
+	g concurrency.Guard,
 	st *kvserverpb.LeaseStatus,
 	ui uncertainty.Interval,
 	omitInRangefeeds bool,
@@ -766,7 +766,7 @@ func (r *Replica) evaluateWriteBatchWrapper(
 // are enabled, it also returns an engine.OpLoggerBatch. If non-nil, then this
 // OpLogger is attached to the returned engine.Batch, recording all operations.
 // Its recording should be attached to the Result of request evaluation.
-func (r *Replica) newBatchedEngine(g *concurrency.Guard) (storage.Batch, *storage.OpLoggerBatch) {
+func (r *Replica) newBatchedEngine(g concurrency.Guard) (storage.Batch, *storage.OpLoggerBatch) {
 	batch := r.store.StateEngine().NewBatch()
 	if !batch.ConsistentIterators() {
 		// This is not currently needed for correctness, but future optimizations


### PR DESCRIPTION
Previously, the `concurrency.Guard` was implemented as a struct, which made it hard to mock in tests.

This commit (pure refactoring) converts the guard to an interface; the commit also includes a prod implementation and a mock test implementation.

Informs: #162204

Release note: None