### PR TITLE
drt-operations: use cloud-specific URI scheme

### DIFF
--- a/pkg/cmd/roachtest/operations/BUILD.bazel
+++ b/pkg/cmd/roachtest/operations/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "//pkg/cmd/roachtest/registry",
         "//pkg/cmd/roachtest/roachtestflags",
         "//pkg/cmd/roachtest/roachtestutil",
+        "//pkg/cmd/roachtest/spec",
         "//pkg/cmd/roachtest/tests",
         "//pkg/sql/catalog/catpb",
         "//pkg/sql/lexbase",

--- a/pkg/cmd/roachtest/operations/backup_restore.go
+++ b/pkg/cmd/roachtest/operations/backup_restore.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestflags"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/tests"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -75,7 +76,18 @@ outer:
 	}
 
 	o.Status(fmt.Sprintf("backing db %s (full)", dbName))
-	bucket := fmt.Sprintf("gs://%s/operation-backup-restore/%d/?AUTH=implicit", testutils.BackupTestingBucket(), timeutil.Now().UnixNano())
+	var scheme string
+	switch c.Cloud() {
+	case spec.AWS:
+		scheme = "s3"
+	case spec.Azure:
+		scheme = "azure"
+	case spec.GCE:
+		scheme = "gs"
+	default:
+		scheme = ""
+	}
+	bucket := fmt.Sprintf("%s://%s/operation-backup-restore/%d/?AUTH=implicit", scheme, testutils.BackupTestingBucket(), timeutil.Now().UnixNano())
 
 	backupTS := hlc.Timestamp{WallTime: timeutil.Now().Add(-10 * time.Second).UTC().UnixNano()}
 


### PR DESCRIPTION
The backup operation hardcoded the `gs://` scheme. Select the appropriate scheme (s3, azure, gs) based on the cluster's cloud provider.

We use the bucket `cockroachdb-backup-testing` for testing backup and restores. The bucket already exists in the three clouds.

Fixes: #156499

Release note: None