### PR TITLE
ci: do not update cockroach_releases.yaml for 25.3 and 23.2

### DIFF
--- a/.github/workflows/update_releases.yaml
+++ b/.github/workflows/update_releases.yaml
@@ -26,11 +26,9 @@ jobs:
       matrix:
         branch:
           - "master"
-          - "release-23.2"
           - "release-24.1"
           - "release-24.3"
           - "release-25.2"
-          - "release-25.3"
           - "release-25.4"
           - "release-26.1"
     name: Update pkg/testutils/release/cockroach_releases.yaml on ${{ matrix.branch }}


### PR DESCRIPTION
These branches are EOL.

Epic: none
Release note: none