### PR TITLE
sql: block DROP REGION when system tables reference the region

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_system_database
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_system_database
@@ -63,3 +63,63 @@ SHOW REGIONS FROM DATABASE "with-primary-setting"
 ----
 database              region  primary  secondary  zones
 with-primary-setting  test1   true     false      {}
+
+subtest regional_by_table_follows_primary
+
+# Add a third region to enable multiple primary region switches.
+statement ok
+ALTER DATABASE system ADD REGION "test2"
+
+query TTBBT colnames,rowsort
+SHOW REGIONS FROM DATABASE system
+----
+database  region  primary  secondary  zones
+system    test    true     false      {}
+system    test1   false    false      {}
+system    test2   false    false      {}
+
+statement ok
+ALTER DATABASE system SET PRIMARY REGION "test1"
+
+query T
+SELECT create_statement FROM [SHOW CREATE DATABASE system]
+----
+CREATE DATABASE system PRIMARY REGION test1 REGIONS = test, test1, test2 SURVIVE REGION FAILURE
+
+# Verify system tables show "LOCALITY REGIONAL BY TABLE IN PRIMARY REGION"
+# syntax (not an explicit region like "test" or "test1").
+query B
+SELECT create_statement LIKE '%LOCALITY REGIONAL BY TABLE IN PRIMARY REGION%'
+FROM [SHOW CREATE TABLE system.jobs]
+----
+true
+
+query B
+SELECT create_statement LIKE '%LOCALITY REGIONAL BY TABLE IN PRIMARY REGION%'
+FROM [SHOW CREATE TABLE system.scheduled_jobs]
+----
+true
+
+statement ok
+ALTER DATABASE system SET PRIMARY REGION "test2"
+
+query T
+SELECT create_statement FROM [SHOW CREATE DATABASE system]
+----
+CREATE DATABASE system PRIMARY REGION test2 REGIONS = test, test1, test2 SURVIVE REGION FAILURE
+
+# Verify tables still show PRIMARY REGION syntax after the second switch.
+# This ensures they're not reverting to explicit region references.
+query B
+SELECT create_statement LIKE '%LOCALITY REGIONAL BY TABLE IN PRIMARY REGION%'
+FROM [SHOW CREATE TABLE system.jobs]
+----
+true
+
+query B
+SELECT create_statement LIKE '%LOCALITY REGIONAL BY TABLE IN PRIMARY REGION%'
+FROM [SHOW CREATE TABLE system.scheduled_jobs]
+----
+true
+
+subtest end

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -2059,10 +2059,6 @@ func (p *planner) optimizeSystemDatabase(ctx context.Context) error {
 	}
 
 	// Configure by region tables next.
-	primaryRegionName, err := systemDB.PrimaryRegionName()
-	if err != nil {
-		return err
-	}
 	for _, tableName := range regionTables {
 		descriptor, err := getDescriptor(tableName)
 		// Some system tables only come into effect once the
@@ -2073,7 +2069,11 @@ func (p *planner) optimizeSystemDatabase(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		descriptor.SetTableLocalityRegionalByTable(tree.Name(primaryRegionName))
+		// Set the region to be tree.PrimaryRegionNotSpecifiedName. This forces
+		// these system tables to inherit the primary region of the database. The
+		// benefit here is that it will automatically change if the primary changes
+		// too.
+		descriptor.SetTableLocalityRegionalByTable(tree.PrimaryRegionNotSpecifiedName)
 		if err := applyLocalityChange(descriptor, "global"); err != nil {
 			return err
 		}


### PR DESCRIPTION
Previously, the system database bypassed validation that prevents dropping regions which are still referenced by database objects. As a result, DROP REGION could succeed even when system tables had explicit REGIONAL BY TABLE locality settings or zone configurations referencing the region.

This change adds validation to ensure that a region cannot be dropped from the system database while explicit references still exist. In particular, DROP REGION is now blocked if:
- any system table has an explicit REGIONAL BY TABLE locality configuration referencing the region
- any system table has an explicit zone configuration referencing the region
- the system database zone configuration references the region

In addition, this commit updates how REGIONAL BY TABLE system tables are configured during system database optimization. Instead of storing an explicit region name, these tables now use the
PrimaryRegionNotSpecifiedName sentinel. This allows them to automatically track the current primary region as it changes. This will make it easier to drop regions in the system database.

Resolves: #163418
Epic: None

Release note (bug fix): DROP REGION on the system database is now correctly blocked if locality settings or zone configs reference the region being dropped.