### PR TITLE
kvserver: fix stuck merge-pending replicas in GC queue

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -16040,6 +16040,15 @@ layers:
       unit: NANOSECONDS
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+    - name: queue.replicagc.purgatory
+      exported_name: queue_replicagc_purgatory
+      description: Number of replicas in the replica GC queue's purgatory, waiting for a prerequisite (e.g. left neighbor GC) before they can be GC'd
+      y_axis_label: Replicas
+      type: GAUGE
+      unit: COUNT
+      aggregation: AVG
+      derivative: NONE
+      visibility: SUPPORT
     - name: queue.replicagc.removereplica
       exported_name: queue_replicagc_removereplica
       description: Number of replica removals attempted by the replica GC queue

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -237,6 +237,14 @@ func (s *Store) ManualReplicaGC(repl *Replica) error {
 	return manualQueue(s, s.replicaGCQueue, repl)
 }
 
+// IsReplicaGCDelayedDueToLeftNeighborError returns true if the error is a
+// replicaGCDelayedDueToLeftNeighborError, i.e. the replica GC queue could not
+// GC the replica because its left neighbor hasn't caught up with meta yet.
+func IsReplicaGCDelayedDueToLeftNeighborError(err error) bool {
+	var target *replicaGCDelayedDueToLeftNeighborError
+	return errors.As(err, &target)
+}
+
 // ManualRaftSnapshot will manually send a raft snapshot to the target replica.
 func (s *Store) ManualRaftSnapshot(repl *Replica, target roachpb.ReplicaID) error {
 	_, err := s.raftSnapshotQueue.processRaftSnapshot(context.Background(), repl, target)

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -2487,6 +2487,13 @@ var (
 		Unit:        metric.Unit_COUNT,
 		Visibility:  metric.Metadata_SUPPORT,
 	}
+	metaReplicaGCQueuePurgatory = metric.Metadata{
+		Name:        "queue.replicagc.purgatory",
+		Help:        "Number of replicas in the replica GC queue's purgatory, waiting for a prerequisite (e.g. left neighbor GC) before they can be GC'd",
+		Measurement: "Replicas",
+		Unit:        metric.Unit_COUNT,
+		Visibility:  metric.Metadata_SUPPORT,
+	}
 	metaReplicaGCQueueProcessingNanos = metric.Metadata{
 		Name:        "queue.replicagc.processingnanos",
 		Help:        "Nanoseconds spent processing replicas in the replica GC queue",
@@ -3659,6 +3666,7 @@ type StoreMetrics struct {
 	ReplicaGCQueueSuccesses                   *metric.Counter
 	ReplicaGCQueueFailures                    *metric.Counter
 	ReplicaGCQueuePending                     *metric.Gauge
+	ReplicaGCQueuePurgatory                   *metric.Gauge
 	ReplicaGCQueueProcessingNanos             *metric.Counter
 	ReplicateQueueEnqueueAdd                  *metric.Counter
 	ReplicateQueueEnqueueFailedPrecondition   *metric.Counter
@@ -4479,6 +4487,7 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		ReplicaGCQueueSuccesses:                   metric.NewCounter(metaReplicaGCQueueSuccesses),
 		ReplicaGCQueueFailures:                    metric.NewCounter(metaReplicaGCQueueFailures),
 		ReplicaGCQueuePending:                     metric.NewGauge(metaReplicaGCQueuePending),
+		ReplicaGCQueuePurgatory:                   metric.NewGauge(metaReplicaGCQueuePurgatory),
 		ReplicaGCQueueProcessingNanos:             metric.NewCounter(metaReplicaGCQueueProcessingNanos),
 		ReplicateQueueEnqueueAdd:                  metric.NewCounter(metaReplicateQueueEnqueueAdd),
 		ReplicateQueueEnqueueFailedPrecondition:   metric.NewCounter(metaReplicateQueueEnqueueFailedPrecondition),

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -2670,11 +2670,13 @@ func (r *Replica) maybeWatchForMergeLocked(ctx context.Context) (bool, error) {
 		r.raftMu.Lock()
 		r.readOnlyCmdMu.Lock()
 		r.mu.Lock()
+		shouldQueueForGC := false
 		if mergeCommitted && r.shMu.destroyStatus.IsAlive() {
 			// The merge committed but the left-hand replica on this store hasn't
 			// subsumed this replica yet. Mark this replica as destroyed so it
 			// doesn't serve requests when we close the mergeCompleteCh below.
 			r.shMu.destroyStatus.Set(kvpb.NewRangeNotFoundError(r.RangeID, r.store.StoreID()), destroyReasonMergePending)
+			shouldQueueForGC = true
 		}
 		// Unblock pending requests. If the merge committed, the requests will
 		// notice that the replica has been destroyed and return an appropriate
@@ -2685,6 +2687,16 @@ func (r *Replica) maybeWatchForMergeLocked(ctx context.Context) (bool, error) {
 		r.mu.Unlock()
 		r.readOnlyCmdMu.Unlock()
 		r.raftMu.Unlock()
+		if shouldQueueForGC {
+			// Queue the replica for GC now that we've marked it as merge-pending.
+			// The scanner won't visit destroyed replicas, and the only other path
+			// into the replica GC queue is via RaftGroupDeletedError responses from
+			// Raft traffic. If the Raft group has quiesced, those responses may
+			// never arrive. Queue directly so the replica GC queue can process this
+			// replica (or place it in purgatory if the left neighbor isn't ready
+			// yet).
+			r.store.replicaGCQueue.AddAsync(ctx, r, replicaGCPriorityDefault)
+		}
 	})
 	if errors.Is(err, stop.ErrUnavailable) {
 		// We weren't able to launch a goroutine to watch for the merge's completion

--- a/pkg/kv/kvserver/replica_gc_queue.go
+++ b/pkg/kv/kvserver/replica_gc_queue.go
@@ -7,6 +7,7 @@ package kvserver
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -36,6 +37,13 @@ const (
 	// collection. See replicaIsSuspect() for details on what makes a replica
 	// suspect.
 	ReplicaGCQueueSuspectCheckInterval = 3 * time.Second
+
+	// replicaGCPurgatoryCheckInterval is the interval at which replicas in
+	// purgatory are retried. The primary use case is merged-away replicas
+	// waiting for their left neighbor to be GC'd first. Each retry involves a
+	// meta2 lookup, so keep the interval moderate to limit load when many
+	// replicas are pending (e.g. a chain of merges).
+	replicaGCPurgatoryCheckInterval = 5 * time.Second
 )
 
 // Priorities for the replica GC queue.
@@ -79,17 +87,51 @@ func makeReplicaGCQueueMetrics() ReplicaGCQueueMetrics {
 // ranges that have been rebalanced away from this store.
 type replicaGCQueue struct {
 	*baseQueue
-	metrics ReplicaGCQueueMetrics
-	db      *kv.DB
+	metrics  ReplicaGCQueueMetrics
+	db       *kv.DB
+	purgChan <-chan time.Time
 }
+
+// replicaGCDelayedDueToLeftNeighborError indicates that a replica GC attempt
+// could not proceed because the left neighbor's descriptor doesn't match meta2
+// (e.g. it hasn't learned about a merge or its own removal). The replica is
+// placed in purgatory for automatic retry.
+type replicaGCDelayedDueToLeftNeighborError struct {
+	cause error
+}
+
+var _ PurgatoryError = (*replicaGCDelayedDueToLeftNeighborError)(nil)
+var _ errors.SafeFormatter = (*replicaGCDelayedDueToLeftNeighborError)(nil)
+var _ fmt.Formatter = (*replicaGCDelayedDueToLeftNeighborError)(nil)
+var _ errors.Wrapper = (*replicaGCDelayedDueToLeftNeighborError)(nil)
+
+// SafeFormatError implements errors.SafeFormatter.
+func (e *replicaGCDelayedDueToLeftNeighborError) SafeFormatError(p errors.Printer) error {
+	p.Printf("replica GC delayed due to left neighbor: %s", e.cause)
+	return nil
+}
+
+// Format implements fmt.Formatter.
+func (e *replicaGCDelayedDueToLeftNeighborError) Format(s fmt.State, verb rune) {
+	errors.FormatError(e, s, verb)
+}
+
+// Error implements error.
+func (e *replicaGCDelayedDueToLeftNeighborError) Error() string { return fmt.Sprint(e) }
+
+// Unwrap implements errors.Wrapper.
+func (e *replicaGCDelayedDueToLeftNeighborError) Unwrap() error { return e.cause }
+
+func (*replicaGCDelayedDueToLeftNeighborError) PurgatoryErrorMarker() {}
 
 var _ queueImpl = &replicaGCQueue{}
 
 // newReplicaGCQueue returns a new instance of replicaGCQueue.
 func newReplicaGCQueue(store *Store, db *kv.DB) *replicaGCQueue {
 	rgcq := &replicaGCQueue{
-		metrics: makeReplicaGCQueueMetrics(),
-		db:      db,
+		metrics:  makeReplicaGCQueueMetrics(),
+		db:       db,
+		purgChan: time.NewTicker(replicaGCPurgatoryCheckInterval).C,
 	}
 	store.metrics.registry.AddMetricStruct(&rgcq.metrics)
 	rgcq.baseQueue = newBaseQueue(
@@ -104,6 +146,7 @@ func newReplicaGCQueue(store *Store, db *kv.DB) *replicaGCQueue {
 			failures:                 store.metrics.ReplicaGCQueueFailures,
 			pending:                  store.metrics.ReplicaGCQueuePending,
 			processingNanos:          store.metrics.ReplicaGCQueueProcessingNanos,
+			purgatory:                store.metrics.ReplicaGCQueuePurgatory,
 			disabledConfig:           kvserverbase.ReplicaGCQueueEnabled,
 		},
 	)
@@ -342,10 +385,15 @@ func (rgcq *replicaGCQueue) process(
 			if leftReplyDesc := &rs[0]; !leftDesc.Equal(leftReplyDesc) {
 				log.VEventf(ctx, 1, "left neighbor %s not up-to-date with meta descriptor %s; cannot safely GC range yet",
 					leftDesc, leftReplyDesc)
-				// Chances are that the left replica needs to be GC'd. Since we don't
-				// have definitive proof, queue it with a low priority.
+				// The left neighbor hasn't caught up with meta yet (e.g. it hasn't
+				// learned about the merge or its own removal from the range). Queue
+				// it so it gets GC'd, and place ourselves in purgatory so we retry
+				// automatically once it's gone.
 				rgcq.AddAsync(ctx, leftRepl, replicaGCPriorityDefault)
-				return false, nil
+				return false, &replicaGCDelayedDueToLeftNeighborError{
+					cause: errors.Errorf("left neighbor %s not up-to-date with meta descriptor %s",
+						leftDesc, leftReplyDesc),
+				}
 			}
 		}
 
@@ -370,9 +418,8 @@ func (*replicaGCQueue) timer(_ time.Duration) time.Duration {
 	return replicaGCQueueTimerDuration
 }
 
-// purgatoryChan returns nil.
-func (*replicaGCQueue) purgatoryChan() <-chan time.Time {
-	return nil
+func (rgcq *replicaGCQueue) purgatoryChan() <-chan time.Time {
+	return rgcq.purgChan
 }
 
 func (*replicaGCQueue) updateChan() <-chan time.Time {

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -655,7 +655,9 @@ func (s *Store) HandleRaftResponse(
 				// also mean that it is so far behind it no longer knows where any of the
 				// other replicas are (#23994). Add it to the replica GC queue to do a
 				// proper check.
-				s.replicaGCQueue.AddAsync(ctx, repl, replicaGCPriorityDefault)
+				if !s.TestingKnobs().DisableReplicaGCQueueAddOnRaftGroupDeleted {
+					s.replicaGCQueue.AddAsync(ctx, repl, replicaGCPriorityDefault)
+				}
 			case *kvpb.StoreNotFoundError:
 				log.KvExec.Warningf(ctx, "raft error: node %d claims to not contain store %d for replica %s: %s",
 					resp.FromReplica.NodeID, resp.FromReplica.StoreID, resp.FromReplica, val)

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -286,6 +286,12 @@ type StoreTestingKnobs struct {
 	// spin attempting to acquire a split or merge lock on a RHS which will
 	// always fail and is generally not safe but is useful for testing.
 	DisableEagerReplicaRemoval bool
+	// DisableReplicaGCQueueAddOnRaftGroupDeleted, when set, prevents
+	// HandleRaftResponse from adding replicas to the GC queue when a
+	// RaftGroupDeletedError is received. This is useful for testing the
+	// merge watcher's ability to queue replicas for GC independently of
+	// Raft traffic.
+	DisableReplicaGCQueueAddOnRaftGroupDeleted bool
 	// RefreshReasonTicksPeriod overrides the default period over which
 	// pending commands are refreshed. The period is specified as a multiple
 	// of Raft group ticks.

--- a/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
+++ b/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
@@ -1868,6 +1868,7 @@ queue_replicagc_pending: queue.replicagc.pending
 queue_replicagc_process_failure: queue.replicagc.process.failure
 queue_replicagc_process_success: queue.replicagc.process.success
 queue_replicagc_processingnanos: queue.replicagc.processingnanos
+queue_replicagc_purgatory: queue.replicagc.purgatory
 queue_replicagc_removereplica: queue.replicagc.removereplica
 queue_replicate_addnonvoterreplica: queue.replicate.addnonvoterreplica
 queue_replicate_addreplica: queue.replicate.addreplica


### PR DESCRIPTION
After a range merge, the RHS replica on a store that missed the merge
(because its LHS had incoming Raft traffic dropped) becomes
`destroyReasonMergePending`. Previously, the only path for this replica to
enter the replica GC queue was via `RaftGroupDeletedError` responses from
Raft heartbeat traffic. If the RHS Raft group quiesced before those
responses arrived, the replica would be permanently stuck — the scanner
skips destroyed replicas and the 12-hour check interval prevents
requeuing via `shouldQueue`.

Even when the RHS did enter the queue via Raft traffic, the first
processing attempt would often fail (the left neighbor hadn't been GC'd
yet), and the replica was silently removed from the queue with no retry
mechanism (`process` returned `(false, nil)`).

Fix both problems:

1. **Add purgatory support to the replica GC queue.** When the merged-away
   branch of `process()` fails because the left neighbor isn't up-to-date,
   return a purgatory error instead of `(false, nil)`. The queue retries
   purgatory replicas every ~1s.

2. **Queue the RHS directly from the merge watcher** after marking it as
   `destroyReasonMergePending`. This ensures the replica enters the GC
   queue immediately, regardless of Raft traffic.

Together, the RHS enters the queue promptly (via the merge watcher),
its first attempt queues the LHS and goes to purgatory, the LHS gets
GC'd, and the next purgatory retry succeeds.

Fixes-25.2 #163482

Epic: none
Release note: None

Made with [Cursor](https://cursor.com)