### PR TITLE
metrics: Add new FunctionalGauge and DerivedGauge types

### DIFF
--- a/pkg/ccl/changefeedccl/metrics.go
+++ b/pkg/ccl/changefeedccl/metrics.go
@@ -87,16 +87,16 @@ type AggMetrics struct {
 	InternalRetryMessageCount   *aggmetric.AggGauge
 	SchemaRegistrations         *aggmetric.AggCounter
 	SchemaRegistryRetries       *aggmetric.AggCounter
-	AggregatorProgress          *aggmetric.AggGauge
-	CheckpointProgress          *aggmetric.AggGauge
+	AggregatorProgress          *aggmetric.AggFunctionalGauge
+	CheckpointProgress          *aggmetric.AggFunctionalGauge
 	LaggingRanges               *aggmetric.AggGauge
 	TotalRanges                 *aggmetric.AggGauge
 	CloudstorageBufferedBytes   *aggmetric.AggGauge
 	KafkaThrottlingNanos        *aggmetric.AggHistogram
 	SinkErrors                  *aggmetric.AggCounter
-	MaxBehindNanos              *aggmetric.AggGauge
-	SpanProgressSkew            *aggmetric.AggGauge
-	TableProgressSkew           *aggmetric.AggGauge
+	MaxBehindNanos              *aggmetric.AggFunctionalGauge
+	SpanProgressSkew            *aggmetric.AggFunctionalGauge
+	TableProgressSkew           *aggmetric.AggFunctionalGauge
 
 	Timers *timers.Timers
 
@@ -178,16 +178,16 @@ type sliMetrics struct {
 	InternalRetryMessageCount   *aggmetric.Gauge
 	SchemaRegistrations         *aggmetric.Counter
 	SchemaRegistryRetries       *aggmetric.Counter
-	AggregatorProgress          *aggmetric.Gauge
-	CheckpointProgress          *aggmetric.Gauge
+	AggregatorProgress          *aggmetric.FunctionalGauge
+	CheckpointProgress          *aggmetric.FunctionalGauge
 	LaggingRanges               *aggmetric.Gauge
 	TotalRanges                 *aggmetric.Gauge
 	CloudstorageBufferedBytes   *aggmetric.Gauge
 	KafkaThrottlingNanos        *aggmetric.Histogram
 	SinkErrors                  *aggmetric.Counter
-	MaxBehindNanos              *aggmetric.Gauge
-	SpanProgressSkew            *aggmetric.Gauge
-	TableProgressSkew           *aggmetric.Gauge
+	MaxBehindNanos              *aggmetric.FunctionalGauge
+	SpanProgressSkew            *aggmetric.FunctionalGauge
+	TableProgressSkew           *aggmetric.FunctionalGauge
 
 	Timers *timers.ScopedTimers
 
@@ -417,7 +417,7 @@ func (m *sliMetrics) timers() *timers.ScopedTimers {
 // components because they don't support reliable deregistration, which is
 // desirable in this use-case.
 type JobScopedUsageMetrics struct {
-	UsageTableBytes    *metric.Gauge
+	UsageTableBytes    *metric.FunctionalGauge
 	UsageErrorCount    *metric.Counter
 	UsageQueryDuration metric.IHistogram
 
@@ -1424,12 +1424,12 @@ func (a *AggMetrics) getOrCreateScope(scope string) (*sliMetrics, error) {
 		}
 	}
 
-	sm.AggregatorProgress = a.AggregatorProgress.AddFunctionalChild(minTimestampGetter(sm.mu.resolved), scope)
-	sm.CheckpointProgress = a.CheckpointProgress.AddFunctionalChild(minTimestampGetter(sm.mu.checkpoint), scope)
-	sm.MaxBehindNanos = a.MaxBehindNanos.AddFunctionalChild(maxBehindNanosGetter(sm.mu.resolved), scope)
-	sm.SpanProgressSkew = a.SpanProgressSkew.AddFunctionalChild(
+	sm.AggregatorProgress = a.AggregatorProgress.AddChild(minTimestampGetter(sm.mu.resolved), scope)
+	sm.CheckpointProgress = a.CheckpointProgress.AddChild(minTimestampGetter(sm.mu.checkpoint), scope)
+	sm.MaxBehindNanos = a.MaxBehindNanos.AddChild(maxBehindNanosGetter(sm.mu.resolved), scope)
+	sm.SpanProgressSkew = a.SpanProgressSkew.AddChild(
 		maxTimestampSkewGetter(sm.mu.spanSkew), scope)
-	sm.TableProgressSkew = a.TableProgressSkew.AddFunctionalChild(
+	sm.TableProgressSkew = a.TableProgressSkew.AddChild(
 		maxTimestampSkewGetter(sm.mu.tableSkew), scope)
 
 	a.mu.sliMetrics[scope] = sm

--- a/pkg/kv/kvprober/kvprober.go
+++ b/pkg/kv/kvprober/kvprober.go
@@ -145,7 +145,7 @@ type Metrics struct {
 	WriteProbeAttempts                 *metric.Counter
 	WriteProbeFailures                 *metric.Counter
 	WriteProbeLatency                  metric.IHistogram
-	WriteProbeQuarantineOldestDuration *metric.Gauge
+	WriteProbeQuarantineOldestDuration *metric.FunctionalGauge
 	ProbePlanAttempts                  *metric.Counter
 	ProbePlanFailures                  *metric.Counter
 }

--- a/pkg/kv/kvserver/liveness/liveness.go
+++ b/pkg/kv/kvserver/liveness/liveness.go
@@ -213,7 +213,7 @@ var (
 
 // Metrics holds metrics for use with node liveness activity.
 type Metrics struct {
-	LiveNodes          *metric.Gauge
+	LiveNodes          *metric.FunctionalGauge
 	HeartbeatsInFlight *metric.Gauge
 	HeartbeatSuccesses *metric.Counter
 	HeartbeatFailures  telemetry.CounterWithMetric

--- a/pkg/kv/kvserver/raft_transport_metrics.go
+++ b/pkg/kv/kvserver/raft_transport_metrics.go
@@ -9,8 +9,8 @@ import "github.com/cockroachdb/cockroach/pkg/util/metric"
 
 // RaftTransportMetrics is the set of metrics for a given RaftTransport.
 type RaftTransportMetrics struct {
-	SendQueueSize  *metric.Gauge
-	SendQueueBytes *metric.Gauge
+	SendQueueSize  *metric.FunctionalGauge
+	SendQueueBytes *metric.FunctionalGauge
 
 	MessagesDropped *metric.Counter
 	MessagesSent    *metric.Counter

--- a/pkg/security/clientcert/cert_expiry_cache.go
+++ b/pkg/security/clientcert/cert_expiry_cache.go
@@ -8,6 +8,7 @@ package clientcert
 import (
 	"context"
 	math_rand "math/rand"
+	"sync/atomic"
 	"time"
 	"unsafe"
 
@@ -49,7 +50,12 @@ type Cache struct {
 	account           MemAccount
 	expirationMetrics *aggmetric.AggGauge
 	ttlMetrics        *aggmetric.AggGauge
-	timeSrc           timeutil.TimeSource
+	// ttlExpirations stores an atomic expiration value per user, captured by
+	// the TTL closure. Updating this value changes what the TTL gauge reports
+	// without replacing the closure itself, avoiding a data race between
+	// concurrent writers (Upsert) and readers (metric scraping).
+	ttlExpirations map[string]*atomic.Int64
+	timeSrc        timeutil.TimeSource
 }
 
 // Cache keeps track of when users certificates are expiring. It does this by
@@ -68,6 +74,7 @@ func NewCache(
 		account:           account,
 		expirationMetrics: expirationMetrics,
 		ttlMetrics:        ttlMetrics,
+		ttlExpirations:    make(map[string]*atomic.Int64),
 		timeSrc:           timeSrc,
 	}
 }
@@ -197,30 +204,43 @@ func (c *Cache) evictLocked(ctx context.Context, user, serial string) {
 	}
 }
 
-// ttlFunc returns a function which computes the ttl for a given expiration.
-func ttlFunc(now func() time.Time, exp int64) func() int64 {
+// ttlFunc returns a function which computes the TTL from a shared atomic
+// expiration value. The returned closure never needs to be replaced — callers
+// update the expiration by storing a new value in exp.
+func ttlFunc(now func() time.Time, exp *atomic.Int64) func() int64 {
 	return func() int64 {
-		ttl := exp - now().Unix()
+		ttl := exp.Load() - now().Unix()
 		if ttl > 0 {
 			return ttl
-		} else {
-			return 0
 		}
+		return 0
 	}
 }
 
 // upsertMetricsLocked updates the expiration and ttl for a given user in the cache.
 func (c *Cache) upsertMetricsLocked(user string) {
 	expiration := c.getExpirationLocked(user)
-	// the update functions on the metrics objects act as upserts.
 	c.expirationMetrics.Update(expiration, user)
-	c.ttlMetrics.UpdateFn(ttlFunc(c.timeSrc.Now, expiration), user)
+
+	exp, ok := c.ttlExpirations[user]
+	if !ok {
+		// First time seeing this user: create a shared atomic for the expiration
+		// and a TTL child gauge whose closure reads from it.
+		exp = new(atomic.Int64)
+		c.ttlExpirations[user] = exp
+		exp.Store(expiration)
+		c.ttlMetrics.AddFunctionalChild(ttlFunc(c.timeSrc.Now, exp), user)
+	} else {
+		// User already has a TTL gauge — just update the shared expiration.
+		exp.Store(expiration)
+	}
 }
 
 // removeMetricsLocked removes the expiration and ttl for a given user from the cache.
 func (c *Cache) removeMetricsLocked(user string) {
 	c.expirationMetrics.RemoveChild(user)
 	c.ttlMetrics.RemoveChild(user)
+	delete(c.ttlExpirations, user)
 }
 
 // jitteredInterval returns a randomly jittered (+/-25%) duration

--- a/pkg/security/clientcert/cert_expiry_cache_test.go
+++ b/pkg/security/clientcert/cert_expiry_cache_test.go
@@ -40,7 +40,7 @@ func setup(t *testing.T) (context.Context, *timeutil.ManualTime, *stop.Stopper, 
 	return ctx, clock, stopper, teardown
 }
 
-func metricsHasUser(metrics *aggmetric.AggGauge, user string) bool {
+func metricsHasUser(metrics metric.PrometheusIterable, user string) bool {
 	has := false
 	metrics.Each([]*io_prometheus_client.LabelPair{}, func(metric *io_prometheus_client.Metric) {
 		if metric.GetLabel()[0].GetValue() == user {
@@ -51,7 +51,7 @@ func metricsHasUser(metrics *aggmetric.AggGauge, user string) bool {
 }
 
 func assertMetricsHasUser(
-	t *testing.T, expiration *aggmetric.AggGauge, ttl *aggmetric.AggGauge, user string,
+	t *testing.T, expiration *aggmetric.AggGauge, ttl *aggmetric.AggFunctionalGauge, user string,
 ) {
 	if !metricsHasUser(expiration, user) {
 		t.Fatal("expiration metrics does not contain user", user)
@@ -62,7 +62,7 @@ func assertMetricsHasUser(
 }
 
 func assertMetricsMissingUser(
-	t *testing.T, expiration *aggmetric.AggGauge, ttl *aggmetric.AggGauge, user string,
+	t *testing.T, expiration *aggmetric.AggGauge, ttl *aggmetric.AggFunctionalGauge, user string,
 ) {
 	if metricsHasUser(expiration, user) {
 		t.Fatal("expiration metrics does not contain user", user)
@@ -73,6 +73,14 @@ func assertMetricsMissingUser(
 }
 
 func assertMetricValue(t *testing.T, metrics *aggmetric.AggGauge, user string, value int64) {
+	c := metrics.GetChild(user)
+	require.NotNil(t, c)
+	require.Equal(t, value, c.Value())
+}
+
+func assertMetricValueFunctional(
+	t *testing.T, metrics *aggmetric.AggFunctionalGauge, user string, value int64,
+) {
 	c := metrics.GetChild(user)
 	require.NotNil(t, c)
 	require.Equal(t, value, c.Value())
@@ -120,8 +128,8 @@ func TestEntryCache(t *testing.T) {
 	clock.AdvanceTo(when)
 	cache.Upsert(ctx, fooUser, defaultSerial, closerExpiration)
 	cache.Upsert(ctx, barUser, defaultSerial, laterExpiration)
-	assertMetricValue(t, ttlMetrics, fooUser, int64(0))
-	assertMetricValue(t, ttlMetrics, barUser, laterExpiration-(closerExpiration+20))
+	assertMetricValueFunctional(t, ttlMetrics, fooUser, int64(0))
+	assertMetricValueFunctional(t, ttlMetrics, barUser, laterExpiration-(closerExpiration+20))
 }
 
 func TestPurge(t *testing.T) {
@@ -431,7 +439,12 @@ func TestTTL(t *testing.T) {
 		cache, _, ttlMetrics := newCacheAndMetrics(ctx, manClock, stopper)
 
 		cache.Upsert(ctx, "user1", "serial1", 100)
-		assertMetricValue(t, ttlMetrics, "user1", 50)
+		assertMetricValueFunctional(t, ttlMetrics, "user1", 50)
+
+		// Update the expiration date to assert that the TTL function has been
+		// updated with the new expiration.
+		cache.Upsert(ctx, "user1", "serial1", 60)
+		assertMetricValueFunctional(t, ttlMetrics, "user1", 10)
 	})
 
 	t.Run("negative ttls get clamped to 0", func(t *testing.T) {
@@ -439,7 +452,7 @@ func TestTTL(t *testing.T) {
 		cache, _, ttlMetrics := newCacheAndMetrics(ctx, manClock, stopper)
 		cache.Upsert(ctx, "user1", "serial1", 49)
 
-		assertMetricValue(t, ttlMetrics, "user1", 0)
+		assertMetricValueFunctional(t, ttlMetrics, "user1", 0)
 	})
 }
 
@@ -467,7 +480,7 @@ func newCache(
 
 func newCacheAndMetrics(
 	ctx context.Context, clock *timeutil.ManualTime, stopper *stop.Stopper,
-) (*clientcert.Cache, *aggmetric.AggGauge, *aggmetric.AggGauge) {
+) (*clientcert.Cache, *aggmetric.AggGauge, *aggmetric.AggFunctionalGauge) {
 	cache, expirationMetrics, ttlMetrics, _ := newCacheAndMetricsAndAccount(ctx, clock, stopper)
 	return cache, expirationMetrics, ttlMetrics
 }
@@ -481,10 +494,10 @@ func newCacheAndAccount(
 
 func newCacheAndMetricsAndAccount(
 	ctx context.Context, clock *timeutil.ManualTime, stopper *stop.Stopper,
-) (*clientcert.Cache, *aggmetric.AggGauge, *aggmetric.AggGauge, *mon.BoundAccount) {
+) (*clientcert.Cache, *aggmetric.AggGauge, *aggmetric.AggFunctionalGauge, *mon.BoundAccount) {
 	clientcert.CacheTTL = time.Minute
 	expirationMetrics := aggmetric.MakeBuilder("user").Gauge(metric.Metadata{})
-	ttlMetrics := aggmetric.MakeBuilder("user").Gauge(metric.Metadata{})
+	ttlMetrics := aggmetric.MakeBuilder("user").FunctionalGauge(metric.Metadata{}, func(_ []int64) int64 { return 0 })
 	account := mon.NewStandaloneUnlimitedAccount()
 	cache := clientcert.NewCache(clock, account, expirationMetrics, ttlMetrics)
 	return cache, expirationMetrics, ttlMetrics, account

--- a/pkg/util/metric/aggmetric/agg_metric.go
+++ b/pkg/util/metric/aggmetric/agg_metric.go
@@ -63,9 +63,11 @@ func (b Builder) Gauge(metadata metric.Metadata) *AggGauge {
 	return NewGauge(metadata, b.labels...)
 }
 
-// FunctionalGauge constructs a new AggGauge with the Builder's labels who's
-// value is determined when asked for.
-func (b Builder) FunctionalGauge(metadata metric.Metadata, f func(cvs []int64) int64) *AggGauge {
+// FunctionalGauge constructs a new AggFunctionalGauge with the Builder's
+// labels whose value is determined when asked for.
+func (b Builder) FunctionalGauge(
+	metadata metric.Metadata, f func(cvs []int64) int64,
+) *AggFunctionalGauge {
 	return NewFunctionalGauge(metadata, f, b.labels...)
 }
 


### PR DESCRIPTION
commit 1/2:

clientcert: fix data race in TTL metric updates
Previously, updating the TTL metric for a user required replacing
the closure on the child gauge via UpdateFn. This wrote to the
Gauge.fn field without synchronization while metric scraping could
concurrently read it via Value(), constituting a data race.

Fix this by capturing a shared *atomic.Int64 in the closure instead
of a plain int64 expiration value. The closure is set once at child
creation and never replaced. When a user's certificate expiration
changes, only the atomic value is updated, which is safe for
concurrent reads.

Epic: None
Release note: None

----

commit 2/2: 

Previously, there existed a "NewFunctionalGauge" constructor
that created a Gauge with a callback that was invoked
when Value() was called. The value returned was not related
to the value of the Gauge, which was still able to be updated
via Update(), Inc(), and Dec() methods.

Now, there are three types of Gauge:
  1. Gauge - The same as before.
  2. FunctionalGauge - Same functionality as before, but is
     now a concrete type with no Update, Inc, or Dec methods.
  3. DerivedGauge - Similar to functional gauge, but it has
     access to the underlying Gauges value to computed a
     derived value. It is an alias of the Gauge type and thus
     has the same API.

Additionally, a new `DerivedGaugeVec` type has been added to
provide the same functionality as `DerivedGauge` but for
vector types.

A new AggFunctionalGauge type is added to replace
the existing NewFunctionalGauge agg metric. This new type
uses functional gauges as its children. All old functional
gauge methods and  constructors are removed from the existing
AggGauge type and their usages have been  replaced with this
new type.

The ClientTTL metric in cert_expiry_cache has been updated to
use the new AggFunctionalGauge instead of the previously used
AggGauge. The implementation of this metric added functionality
to the AggGauge to support adding child functional gauges, which
is now removed and only exists in AggFunctionalGauge. The same
functionality of this agg metric is left intact otherwise: the
agg metric's parent gauge returns 0 as it doesn't do any sort
of aggregation and is used purely for reporting labeled child
gauges.

Part of: [CRDB-60768](https://cockroachlabs.atlassian.net/browse/CRDB-60768)
Epic: [CRDB-58342](https://cockroachlabs.atlassian.net/browse/CRDB-58342)
Release note: None