### PR TITLE
opt: fix cardinality for Limit and Offset with non-constants

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -1762,3 +1762,30 @@ query B
 EXECUTE p152664(true, 4, NULL)
 ----
 true
+
+# Regression tests for #159043.
+statement ok
+CREATE TABLE t159043a (a INT)
+
+statement ok
+CREATE TABLE t159043b (b INT)
+
+statement ok
+INSERT INTO t159043b VALUES (33)
+
+statement ok
+PREPARE p159043 AS
+SELECT 1 FROM t159043b CROSS JOIN (SELECT min(1) FROM t159043a OFFSET $1) GROUP BY b
+
+query empty
+EXECUTE p159043(10)
+
+statement ok
+DEALLOCATE p159043
+
+statement ok
+PREPARE p159043 AS
+SELECT 1 FROM t159043b CROSS JOIN (SELECT min(1) FROM t159043a LIMIT $1) GROUP BY b
+
+statement error negative value for LIMIT
+EXECUTE p159043(-1)

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -1268,11 +1268,12 @@ func (b *logicalPropsBuilder) buildLimitOrTopKProps(
 	// Cardinality
 	// -----------
 	// Limit puts a cap on the number of rows returned by input.
-	rel.Cardinality = inputProps.Cardinality
 	if constLimit <= 0 {
 		rel.Cardinality = props.ZeroCardinality
 	} else if constLimit < math.MaxUint32 {
-		rel.Cardinality = rel.Cardinality.Limit(uint32(constLimit))
+		rel.Cardinality = inputProps.Cardinality.Limit(uint32(constLimit))
+	} else {
+		rel.Cardinality = inputProps.Cardinality.AsLowAs(0)
 	}
 }
 
@@ -1303,7 +1304,7 @@ func (b *logicalPropsBuilder) buildOffsetProps(offset *OffsetExpr, rel *props.Re
 	// Cardinality
 	// -----------
 	// Offset decreases the number of rows that are passed through from input.
-	rel.Cardinality = inputProps.Cardinality
+	rel.Cardinality = inputProps.Cardinality.AsLowAs(0)
 	if cnst, ok := offset.Offset.(*ConstExpr); ok {
 		constOffset := int64(*cnst.Value.(*tree.DInt))
 		if constOffset > 0 {

--- a/pkg/sql/opt/memo/testdata/logprops/limit
+++ b/pkg/sql/opt/memo/testdata/logprops/limit
@@ -222,6 +222,39 @@ scan xyzs@xyzs_s_z_key
  ├── prune: (1)
  └── interesting orderings: (+1 opt(4))
 
+# Placeholder offset.
+build
+SELECT min(x) FROM xyzs LIMIT $1
+----
+limit
+ ├── columns: min:7(int)
+ ├── cardinality: [0 - 1]
+ ├── immutable, has-placeholder
+ ├── key: ()
+ ├── fd: ()-->(7)
+ ├── prune: (7)
+ ├── scalar-group-by
+ │    ├── columns: min:7(int)
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(7)
+ │    ├── prune: (7)
+ │    ├── project
+ │    │    ├── columns: x:1(int!null)
+ │    │    ├── key: (1)
+ │    │    ├── prune: (1)
+ │    │    ├── interesting orderings: (+1)
+ │    │    └── scan xyzs
+ │    │         ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string) crdb_internal_mvcc_timestamp:5(decimal) tableoid:6(oid)
+ │    │         ├── key: (1)
+ │    │         ├── fd: (1)-->(2-6), (3,4)~~>(1,2,5,6)
+ │    │         ├── prune: (1-6)
+ │    │         └── interesting orderings: (+1) (-4,+3,+1)
+ │    └── aggregations
+ │         └── min [as=min:7, type=int, outer=(1)]
+ │              └── variable: x:1 [type=int]
+ └── placeholder: $1 [type=int]
+
 # Regression test for #65038. Copy FDs from input regardless of the limit value
 # to avoid error during test builds: "ordering column group X contains
 # non-equivalent columns".
@@ -365,3 +398,24 @@ top-k
       ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
       ├── prune: (1-4)
       └── interesting orderings: (+1) (-4,+3,+1)
+
+# Placeholder offset.
+opt
+SELECT * FROM (SELECT * FROM (VALUES (1), (2), (3)) v(v) ORDER BY v LIMIT 10) LIMIT $1
+----
+limit
+ ├── columns: v:1(int!null)
+ ├── cardinality: [0 - 3]
+ ├── immutable, has-placeholder
+ ├── prune: (1)
+ ├── values
+ │    ├── columns: column1:1(int!null)
+ │    ├── cardinality: [3 - 3]
+ │    ├── prune: (1)
+ │    ├── tuple [type=tuple{int}]
+ │    │    └── const: 1 [type=int]
+ │    ├── tuple [type=tuple{int}]
+ │    │    └── const: 2 [type=int]
+ │    └── tuple [type=tuple{int}]
+ │         └── const: 3 [type=int]
+ └── placeholder: $1 [type=int]

--- a/pkg/sql/opt/memo/testdata/logprops/offset
+++ b/pkg/sql/opt/memo/testdata/logprops/offset
@@ -93,6 +93,59 @@ offset
  │         └── interesting orderings: (+1) (-4,+3,+1)
  └── const: 0 [type=int]
 
+build
+SELECT * FROM (SELECT * FROM xyzs LIMIT 10) OFFSET 2
+----
+offset
+ ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
+ ├── cardinality: [0 - 8]
+ ├── key: (1)
+ ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
+ ├── prune: (1-4)
+ ├── interesting orderings: (+1) (-4,+3,+1)
+ ├── limit
+ │    ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
+ │    ├── cardinality: [0 - 10]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
+ │    ├── prune: (1-4)
+ │    ├── interesting orderings: (+1) (-4,+3,+1)
+ │    ├── project
+ │    │    ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
+ │    │    ├── limit hint: 10.00
+ │    │    ├── prune: (1-4)
+ │    │    ├── interesting orderings: (+1) (-4,+3,+1)
+ │    │    └── scan xyzs
+ │    │         ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string) crdb_internal_mvcc_timestamp:5(decimal) tableoid:6(oid)
+ │    │         ├── key: (1)
+ │    │         ├── fd: (1)-->(2-6), (3,4)~~>(1,2,5,6)
+ │    │         ├── limit hint: 10.00
+ │    │         ├── prune: (1-6)
+ │    │         └── interesting orderings: (+1) (-4,+3,+1)
+ │    └── const: 10 [type=int]
+ └── const: 2 [type=int]
+
+build
+SELECT * FROM (SELECT * FROM (VALUES (1), (2), (3)) v(v)) OFFSET 2
+----
+offset
+ ├── columns: v:1(int!null)
+ ├── cardinality: [1 - 1]
+ ├── prune: (1)
+ ├── values
+ │    ├── columns: column1:1(int!null)
+ │    ├── cardinality: [3 - 3]
+ │    ├── prune: (1)
+ │    ├── tuple [type=tuple{int}]
+ │    │    └── const: 1 [type=int]
+ │    ├── tuple [type=tuple{int}]
+ │    │    └── const: 2 [type=int]
+ │    └── tuple [type=tuple{int}]
+ │         └── const: 3 [type=int]
+ └── const: 2 [type=int]
+
 # Propagate outer columns.
 build
 SELECT (SELECT x FROM kuv OFFSET y) FROM xyzs
@@ -195,3 +248,36 @@ values
  ├── key: ()
  ├── fd: ()-->(1,4)
  └── prune: (1,4)
+
+# Placeholder offset.
+build
+SELECT min(x) FROM xyzs OFFSET $1
+----
+offset
+ ├── columns: min:7(int)
+ ├── cardinality: [0 - 1]
+ ├── has-placeholder
+ ├── key: ()
+ ├── fd: ()-->(7)
+ ├── prune: (7)
+ ├── scalar-group-by
+ │    ├── columns: min:7(int)
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(7)
+ │    ├── prune: (7)
+ │    ├── project
+ │    │    ├── columns: x:1(int!null)
+ │    │    ├── key: (1)
+ │    │    ├── prune: (1)
+ │    │    ├── interesting orderings: (+1)
+ │    │    └── scan xyzs
+ │    │         ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string) crdb_internal_mvcc_timestamp:5(decimal) tableoid:6(oid)
+ │    │         ├── key: (1)
+ │    │         ├── fd: (1)-->(2-6), (3,4)~~>(1,2,5,6)
+ │    │         ├── prune: (1-6)
+ │    │         └── interesting orderings: (+1) (-4,+3,+1)
+ │    └── aggregations
+ │         └── min [as=min:7, type=int, outer=(1)]
+ │              └── variable: x:1 [type=int]
+ └── placeholder: $1 [type=int]

--- a/pkg/sql/opt/memo/testdata/stats/project
+++ b/pkg/sql/opt/memo/testdata/stats/project
@@ -320,7 +320,7 @@ project
       │    └── stats: [rows=1000]
       ├── limit
       │    ├── outer: (2)
-      │    ├── cardinality: [1 - 1]
+      │    ├── cardinality: [0 - 1]
       │    ├── immutable
       │    ├── stats: [rows=1]
       │    ├── key: ()


### PR DESCRIPTION
This commit fixes a bug that caused incorrect cardinalities to be
assigned to Limit and Offset expressions with non-constant
limits/offsets. This could cause incorrect results for prepared
statements and statements within UDFs and stored procedures.

Fixes #159043

Release note (bug fix): A bug has been fixed that could cause incorrect
results for any of the following types of statements:
  1. Prepared statements with `LIMIT` expressions where the limit is a
     placeholder and the given placeholder value is negative. This could
     result in a successful query when the correct result is an error.
  2. Prepared statements with `OFFSET` expressions where the limit is
     a placeholder. In some cases this could produce incorrect results.
  3. Statements within a UDF or stored procedure similar to (1) and (2)
     where the limit/offset is a reference to an argument of the UDF/SP.