### PR TITLE
concurrency: improve lock table observability

### DIFF
--- a/pkg/kv/kvserver/concurrency/concurrency_control.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_control.go
@@ -630,7 +630,7 @@ type lockTable interface {
 	// lockTableGuard and the subsequent calls reuse the previously returned
 	// one. The latches needed by the request must be held when calling this
 	// function.
-	ScanAndEnqueue(Request, lockTableGuard) (lockTableGuard, *Error)
+	ScanAndEnqueue(context.Context, Request, lockTableGuard) (lockTableGuard, *Error)
 
 	// ScanOptimistic takes a snapshot of the lock table for later checking for
 	// conflicts, and returns a guard. It is for optimistic evaluation of
@@ -648,7 +648,7 @@ type lockTable interface {
 	// the (a) lockTable calls that use a lockTableGuard parameter, or (b) a
 	// lockTableGuard call, returned an error. The method allows but does not
 	// require latches to be held.
-	Dequeue(lockTableGuard)
+	Dequeue(context.Context, lockTableGuard)
 
 	// AddDiscoveredLock informs the lockTable of a lock which is wasn't
 	// previously tracking that was discovered during evaluation under the
@@ -679,7 +679,7 @@ type lockTable interface {
 	// true) or whether it was ignored because the lockTable is currently
 	// disabled (false).
 	AddDiscoveredLock(
-		foundLock *roachpb.Lock, seq roachpb.LeaseSequence,
+		ctx context.Context, foundLock *roachpb.Lock, seq roachpb.LeaseSequence,
 		consultTxnStatusCache bool, guard lockTableGuard,
 	) (bool, error)
 
@@ -709,12 +709,12 @@ type lockTable interface {
 	//
 	// For replicated locks, this must be called after the corresponding write
 	// intent has been applied to the replicated state machine.
-	AcquireLock(*roachpb.LockAcquisition) error
+	AcquireLock(context.Context, *roachpb.LockAcquisition) error
 
 	// MarkIneligibleForExport marks any locks held by this transaction on the
 	// same key as ineligible for export from the lock table for replication since
 	// doing so could result in a transaction being erroneously committed.
-	MarkIneligibleForExport(*roachpb.LockAcquisition) error
+	MarkIneligibleForExport(context.Context, *roachpb.LockAcquisition) error
 
 	// UpdateLocks informs the lockTable that an existing lock or range of locks
 	// was either updated or released.
@@ -768,7 +768,7 @@ type lockTable interface {
 	//     contained in IgnoredSeqNums are dropped.
 	//   - the remaining locks are changed to timestamp equal to
 	//     txn.WriteTimestamp.
-	UpdateLocks(*roachpb.LockUpdate) error
+	UpdateLocks(context.Context, *roachpb.LockUpdate) error
 
 	// PushedTransactionUpdated informs the lock table that a transaction has been
 	// pushed and is either finalized or has been moved to a higher timestamp.

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -414,7 +414,7 @@ func (m *managerImpl) sequenceReqWithGuard(
 		} else {
 			// Scan for conflicting locks.
 			log.Event(ctx, "scanning lock table for conflicting locks")
-			g.ltg, err = m.lt.ScanAndEnqueue(g.Req, g.ltg)
+			g.ltg, err = m.lt.ScanAndEnqueue(ctx, g.Req, g.ltg)
 			if err != nil {
 				return nil, err
 			}
@@ -530,7 +530,7 @@ func (m *managerImpl) FinishReq(ctx context.Context, g *Guard) {
 		m.lm.Release(ctx, lg)
 	}
 	if ltg := g.moveLockTableGuard(); ltg != nil {
-		m.lt.Dequeue(ltg)
+		m.lt.Dequeue(ctx, ltg)
 	}
 	releaseGuard(g)
 }
@@ -566,17 +566,22 @@ func (m *managerImpl) HandleLockConflictError(
 	// loop without making progress.
 	consultTxnStatusCache :=
 		int64(len(t.Locks)) > DiscoveredLocksThresholdToConsultTxnStatusCache.Get(&m.st.SV)
+	var numAdded int
 	for i := range t.Locks {
 		foundLock := &t.Locks[i]
-		added, err := m.lt.AddDiscoveredLock(foundLock, seq, consultTxnStatusCache, g.ltg)
+		added, err := m.lt.AddDiscoveredLock(ctx, foundLock, seq, consultTxnStatusCache, g.ltg)
 		if err != nil {
 			log.KvExec.Fatalf(ctx, "%v", err)
 		}
-		if !added {
+		if added {
+			numAdded++
+		} else {
 			log.VEventf(ctx, 2,
-				"intent on %s discovered but not added to disabled lock table",
-				foundLock.Key.String())
+				"discovered lock on %s not added to disabled lock table", foundLock.Key)
 		}
+	}
+	if numAdded > 0 {
+		log.VEventf(ctx, 2, "added %d discovered lock(s) to lock table: %v", numAdded, t)
 	}
 
 	// Release the Guard's latches but continue to remain in lock wait-queues by
@@ -614,7 +619,7 @@ func (m *managerImpl) HandleTransactionPushError(
 
 // OnLockAcquired implements the LockManager interface.
 func (m *managerImpl) OnLockAcquired(ctx context.Context, acq *roachpb.LockAcquisition) {
-	if err := m.lt.AcquireLock(acq); err != nil {
+	if err := m.lt.AcquireLock(ctx, acq); err != nil {
 		if errors.IsAssertionFailure(err) {
 			log.KvExec.Fatalf(ctx, "%v", err)
 		}
@@ -629,7 +634,7 @@ func (m *managerImpl) OnLockAcquired(ctx context.Context, acq *roachpb.LockAcqui
 
 // OnLockMissing implements the LockManager interface.
 func (m *managerImpl) OnLockMissing(ctx context.Context, acq *roachpb.LockAcquisition) {
-	if err := m.lt.MarkIneligibleForExport(acq); err != nil {
+	if err := m.lt.MarkIneligibleForExport(ctx, acq); err != nil {
 		// We don't currently expect any errors other than assertion failures that represent
 		// programming errors from this method.
 		log.KvExec.Fatalf(ctx, "%v", err)
@@ -638,7 +643,7 @@ func (m *managerImpl) OnLockMissing(ctx context.Context, acq *roachpb.LockAcquis
 
 // OnLockUpdated implements the LockManager interface.
 func (m *managerImpl) OnLockUpdated(ctx context.Context, up *roachpb.LockUpdate) {
-	if err := m.lt.UpdateLocks(up); err != nil {
+	if err := m.lt.UpdateLocks(ctx, up); err != nil {
 		log.KvExec.Fatalf(ctx, "%v", err)
 	}
 }

--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -348,12 +348,11 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 					lcErr := &kvpb.LockConflictError{Locks: locks}
 					guard, err := m.HandleLockConflictError(ctx, prev, leaseSeq, lcErr)
 					if err != nil {
-						log.Eventf(ctx, "handled %v, returned error: %v", lcErr, err)
+						log.Eventf(ctx, "returned error: %v", err)
 						c.mu.Lock()
 						delete(c.guardsByReqName, reqName)
 						c.mu.Unlock()
 					} else {
-						log.Eventf(ctx, "handled %v, released latches", lcErr)
 						c.mu.Lock()
 						c.guardsByReqName[reqName] = guard
 						c.mu.Unlock()
@@ -444,7 +443,6 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 				txnAcquire.Sequence = seqNum
 
 				mon.runSync("acquire lock", func(ctx context.Context) {
-					log.Eventf(ctx, "txn %s @ %s", txn.Short(), key)
 					acq := roachpb.MakeLockAcquisition(txnAcquire.TxnMeta, roachpb.Key(key), dur, str, nil)
 					m.OnLockAcquired(ctx, &acq)
 				})

--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/container/list"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -4241,7 +4242,9 @@ func (t *lockTableImpl) ScanOptimistic(req Request) lockTableGuard {
 }
 
 // ScanAndEnqueue implements the lockTable interface.
-func (t *lockTableImpl) ScanAndEnqueue(req Request, guard lockTableGuard) (lockTableGuard, *Error) {
+func (t *lockTableImpl) ScanAndEnqueue(
+	ctx context.Context, req Request, guard lockTableGuard,
+) (lockTableGuard, *Error) {
 	// NOTE: there is no need to synchronize with enabledMu here. ScanAndEnqueue
 	// scans the lockTable and enters any conflicting lock wait-queues, but a
 	// disabled lockTable will be empty. If the scan's btree snapshot races with
@@ -4277,7 +4280,7 @@ func (t *lockTableImpl) ScanAndEnqueue(req Request, guard lockTableGuard) (lockT
 	if err != nil {
 		// We're not returning the guard on this error path, so we need to
 		// release the guard in case it has already entered any wait-queues.
-		t.Dequeue(g)
+		t.Dequeue(ctx, g)
 		return nil, kvpb.NewError(err)
 	}
 	if g.notRemovableLock != nil {
@@ -4317,7 +4320,7 @@ func (t *lockTableImpl) doSnapshotForGuard(g *lockTableGuardImpl) {
 }
 
 // Dequeue implements the lockTable interface.
-func (t *lockTableImpl) Dequeue(guard lockTableGuard) {
+func (t *lockTableImpl) Dequeue(_ context.Context, guard lockTableGuard) {
 	// NOTE: there is no need to synchronize with enabledMu here. Dequeue only
 	// accesses state already held by the guard and does not add anything to the
 	// lockTable.
@@ -4368,6 +4371,7 @@ func (t *lockTableImpl) Dequeue(guard lockTableGuard) {
 // each of the locks. At that point a decision is made whether to consult the
 // txnStatusCache eagerly when adding discovered locks.
 func (t *lockTableImpl) AddDiscoveredLock(
+	ctx context.Context,
 	foundLock *roachpb.Lock,
 	seq roachpb.LeaseSequence,
 	consultTxnStatusCache bool,
@@ -4441,7 +4445,7 @@ func (t *lockTableImpl) AddDiscoveredLock(
 }
 
 // AcquireLock implements the lockTable interface.
-func (t *lockTableImpl) AcquireLock(acq *roachpb.LockAcquisition) error {
+func (t *lockTableImpl) AcquireLock(ctx context.Context, acq *roachpb.LockAcquisition) error {
 	t.enabledMu.RLock()
 	defer t.enabledMu.RUnlock()
 	if !t.enabled {
@@ -4460,6 +4464,8 @@ func (t *lockTableImpl) AcquireLock(acq *roachpb.LockAcquisition) error {
 	default:
 		return errors.AssertionFailedf("unsupported lock strength %s", acq.Strength)
 	}
+	log.VEventf(ctx, 2, "txn %s acquiring %s %s lock on %s",
+		acq.Txn.Short(), acq.Durability, acq.Strength, acq.Key)
 	var kl *keyLocks
 	t.locks.mu.Lock()
 	// Can't release tree.mu until call kl.acquireLock() since someone may find
@@ -4523,7 +4529,9 @@ func (t *lockTableImpl) AcquireLock(acq *roachpb.LockAcquisition) error {
 }
 
 // MarkIneligibleForExport implements the lockTable interface.
-func (t *lockTableImpl) MarkIneligibleForExport(acq *roachpb.LockAcquisition) error {
+func (t *lockTableImpl) MarkIneligibleForExport(
+	_ context.Context, acq *roachpb.LockAcquisition,
+) error {
 	if acq == nil {
 		return errors.AssertionFailedf("unexpected nil lock acquisition")
 	}
@@ -4568,6 +4576,9 @@ func (t *lockTableImpl) checkMaxKeysLockedAndTryClear() {
 		if numCleared != 0 {
 			t.locksShedDueToMemoryLimit.Inc(numCleared)
 			t.numLockShedDueToMemoryLimitEvents.Inc(1)
+			log.KvExec.Warningf(context.Background(),
+				"lock table exceeded memory limit (%d locks > %d max); shed %d locks",
+				totalLocks, t.lockTableLimitsMu.maxKeysLocked, numCleared)
 		}
 	}
 }
@@ -4711,7 +4722,7 @@ func (t *lockTableImpl) tryGCLocks(tree *treeMu, locks []*keyLocks) {
 }
 
 // UpdateLocks implements the lockTable interface.
-func (t *lockTableImpl) UpdateLocks(up *roachpb.LockUpdate) error {
+func (t *lockTableImpl) UpdateLocks(_ context.Context, up *roachpb.LockUpdate) error {
 	_ = t.updateLockInternal(up)
 	return nil
 }
@@ -4814,6 +4825,11 @@ func (t *lockTableImpl) Clear(disable bool) {
 		defer t.enabledMu.Unlock()
 		t.enabled = false
 	}
+	numLocks := t.locks.numKeysLocked.Load()
+	if numLocks > 0 {
+		log.KvExec.VInfof(context.Background(), 2,
+			"clearing lock table (locks=%d)", numLocks)
+	}
 	// The numToClear=0 is arbitrary since it is unused when force=true.
 	t.tryClearLocks(true /* force */, 0)
 	// Also clear the txn status cache, since it won't be needed any time
@@ -4823,7 +4839,15 @@ func (t *lockTableImpl) Clear(disable bool) {
 
 // ClearGE implements the lockTable interface.
 func (t *lockTableImpl) ClearGE(key roachpb.Key) []roachpb.LockAcquisition {
-	return t.tryClearLocksGE(key)
+	numBefore := t.locks.numKeysLocked.Load()
+	acqs := t.tryClearLocksGE(key)
+	numCleared := numBefore - t.locks.numKeysLocked.Load()
+	if numCleared > 0 || len(acqs) > 0 {
+		log.KvExec.VInfof(context.Background(), 2,
+			"cleared %d lock(s) >= key %s, returning %d lock acquisitions",
+			numCleared, key, len(acqs))
+	}
+	return acqs
 }
 
 // ExportUnreplicatedLocks implements the lockTable interface.

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -185,6 +185,7 @@ func TestLockTableBasic(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	datadriven.Walk(t, datapathutils.TestDataPath(t, "lock_table"), func(t *testing.T, path string) {
+		ctx := context.Background()
 		var lt lockTable
 		var txnsByName map[string]*enginepb.TxnMeta
 		var uncertaintyLimitsByTxn map[string]hlc.Timestamp
@@ -358,7 +359,7 @@ func TestLockTableBasic(t *testing.T) {
 				}
 				g := guardsByReqName[reqName]
 				var err *Error
-				g, err = lt.ScanAndEnqueue(req, g)
+				g, err = lt.ScanAndEnqueue(ctx, req, g)
 				if err != nil {
 					return err.String()
 				}
@@ -399,7 +400,7 @@ func TestLockTableBasic(t *testing.T) {
 					req.Txn.TxnMeta, roachpb.Key(key), durability, strength, req.Txn.IgnoredSeqNums,
 				)
 				acq.IgnoredSeqNums = ScanIgnoredSeqNumbers(t, d)
-				if err := lt.AcquireLock(&acq); err != nil {
+				if err := lt.AcquireLock(ctx, &acq); err != nil {
 					return err.Error()
 				}
 				return lt.String()
@@ -413,7 +414,7 @@ func TestLockTableBasic(t *testing.T) {
 				span := getSpan(t, d, dd.ScanArg[string](t, d, "span"))
 				// TODO(sbhola): also test ABORTED.
 				intent := &roachpb.LockUpdate{Span: span, Txn: *txnMeta, Status: roachpb.COMMITTED}
-				if err := lt.UpdateLocks(intent); err != nil {
+				if err := lt.UpdateLocks(ctx, intent); err != nil {
 					return err.Error()
 				}
 				return lt.String()
@@ -435,7 +436,7 @@ func TestLockTableBasic(t *testing.T) {
 				// TODO(sbhola): also test STAGING.
 				intent := &roachpb.LockUpdate{
 					Span: span, Txn: *txnMeta, Status: roachpb.PENDING, IgnoredSeqNums: ignored}
-				if err := lt.UpdateLocks(intent); err != nil {
+				if err := lt.UpdateLocks(ctx, intent); err != nil {
 					return err.Error()
 				}
 				return lt.String()
@@ -476,7 +477,7 @@ func TestLockTableBasic(t *testing.T) {
 				foundLock.Strength = str
 
 				if _, err := lt.AddDiscoveredLock(
-					&foundLock, leaseSeq, consultTxnStatusCache, g); err != nil {
+					ctx, &foundLock, leaseSeq, consultTxnStatusCache, g); err != nil {
 					return err.Error()
 				}
 				return lt.String()
@@ -502,7 +503,7 @@ func TestLockTableBasic(t *testing.T) {
 				}
 				key := dd.ScanArg[string](t, d, "k")
 				strength := ScanLockStrength(t, d)
-				ok, txn, err := g.IsKeyLockedByConflictingTxn(context.Background(), roachpb.Key(key), strength)
+				ok, txn, err := g.IsKeyLockedByConflictingTxn(ctx, roachpb.Key(key), strength)
 				if err != nil {
 					return err.Error()
 				}
@@ -521,7 +522,7 @@ func TestLockTableBasic(t *testing.T) {
 				if g == nil {
 					d.Fatalf(t, "unknown guard: %s", reqName)
 				}
-				lt.Dequeue(g)
+				lt.Dequeue(ctx, g)
 				delete(guardsByReqName, reqName)
 				delete(requestsByName, reqName)
 				return lt.String()
@@ -841,6 +842,7 @@ func newLock(txn *enginepb.TxnMeta, key roachpb.Key, str lock.Strength) *roachpb
 }
 
 func TestLockTableMaxLocks(t *testing.T) {
+	ctx := context.Background()
 	m := TestingMakeLockTableMetricsCfg()
 	lt := newLockTable(
 		5, roachpb.RangeID(3), hlc.NewClockForTesting(nil), cluster.MakeTestingClusterSettings(),
@@ -871,7 +873,7 @@ func TestLockTableMaxLocks(t *testing.T) {
 			Batch:      ba,
 		}
 		reqs = append(reqs, req)
-		ltg, err := lt.ScanAndEnqueue(req, nil)
+		ltg, err := lt.ScanAndEnqueue(ctx, req, nil)
 		require.Nil(t, err)
 		require.Nil(t, ltg.ResolveBeforeScanning())
 		require.False(t, ltg.ShouldWait())
@@ -888,7 +890,7 @@ func TestLockTableMaxLocks(t *testing.T) {
 		for j := 0; j < 10; j++ {
 			k := i*20 + j
 			added, err := lt.AddDiscoveredLock(
-				newLock(&txnMeta, keys[k], lock.Intent),
+				ctx, newLock(&txnMeta, keys[k], lock.Intent),
 				0, false, guards[i])
 			require.True(t, added)
 			require.NoError(t, err)
@@ -901,21 +903,21 @@ func TestLockTableMaxLocks(t *testing.T) {
 	require.Equal(t, int64(66), m.NumLockShedDueToMemoryLimitEvents.Count())
 	// Two guards are dequeued. This marks 2 notRemovable locks as removable.
 	// We're at 8 notRemovable locks now.
-	lt.Dequeue(guards[0])
-	lt.Dequeue(guards[1])
+	lt.Dequeue(ctx, guards[0])
+	lt.Dequeue(ctx, guards[1])
 	require.Equal(t, int64(10), lt.lockCountForTesting())
 	// Two guards do ScanAndEnqueue. This marks 2 notRemovable locks as
 	// removable. We're at 6 notRemovable locks now.
 	for i := 2; i < 4; i++ {
 		var err *Error
-		guards[i], err = lt.ScanAndEnqueue(reqs[i], guards[i])
+		guards[i], err = lt.ScanAndEnqueue(ctx, reqs[i], guards[i])
 		require.Nil(t, err)
 		require.True(t, guards[i].ShouldWait())
 	}
 	require.Equal(t, int64(10), lt.lockCountForTesting())
 	// Add another discovered lock, to trigger tryClearLocks.
 	added, err := lt.AddDiscoveredLock(
-		newLock(&txnMeta, keys[9*20+10], lock.Intent),
+		ctx, newLock(&txnMeta, keys[9*20+10], lock.Intent),
 		0, false, guards[9])
 	require.True(t, added)
 	require.NoError(t, err)
@@ -928,7 +930,7 @@ func TestLockTableMaxLocks(t *testing.T) {
 	require.Equal(t, int64(101), int64(lt.locks.lockIDSeqNum))
 	// Add another discovered lock, to trigger tryClearLocks.
 	added, err = lt.AddDiscoveredLock(
-		newLock(&txnMeta, keys[9*20+11], lock.Intent),
+		ctx, newLock(&txnMeta, keys[9*20+11], lock.Intent),
 		0, false, guards[9])
 	require.True(t, added)
 	require.NoError(t, err)
@@ -938,13 +940,13 @@ func TestLockTableMaxLocks(t *testing.T) {
 	require.Equal(t, int64(96), m.LocksShedDueToMemoryLimit.Count())
 	require.Equal(t, int64(68), m.NumLockShedDueToMemoryLimitEvents.Count())
 	// Two more guards are dequeued, so we are down to 4 notRemovable locks.
-	lt.Dequeue(guards[4])
-	lt.Dequeue(guards[5])
+	lt.Dequeue(ctx, guards[4])
+	lt.Dequeue(ctx, guards[5])
 	// Bump up the enforcement interval manually.
 	lt.lockTableLimitsMu.lockAddMaxLocksCheckInterval = 2
 	// Add another discovered lock.
 	added, err = lt.AddDiscoveredLock(
-		newLock(&txnMeta, keys[9*20+12], lock.Intent),
+		ctx, newLock(&txnMeta, keys[9*20+12], lock.Intent),
 		0, false, guards[9])
 	require.True(t, added)
 	require.NoError(t, err)
@@ -955,7 +957,7 @@ func TestLockTableMaxLocks(t *testing.T) {
 	require.Equal(t, int64(68), m.NumLockShedDueToMemoryLimitEvents.Count())
 	// Add another discovered lock, to trigger tryClearLocks.
 	added, err = lt.AddDiscoveredLock(
-		newLock(&txnMeta, keys[9*20+13], lock.Intent),
+		ctx, newLock(&txnMeta, keys[9*20+13], lock.Intent),
 		0, false, guards[9])
 	require.True(t, added)
 	require.NoError(t, err)
@@ -969,12 +971,12 @@ func TestLockTableMaxLocks(t *testing.T) {
 	lt.lockTableLimitsMu.lockAddMaxLocksCheckInterval = 1
 	lt.lockTableLimitsMu.minKeysLocked = 2
 	// Three more guards dequeued. Now only 1 lock is notRemovable.
-	lt.Dequeue(guards[6])
-	lt.Dequeue(guards[7])
-	lt.Dequeue(guards[8])
+	lt.Dequeue(ctx, guards[6])
+	lt.Dequeue(ctx, guards[7])
+	lt.Dequeue(ctx, guards[8])
 	// Add another discovered lock.
 	added, err = lt.AddDiscoveredLock(
-		newLock(&txnMeta, keys[9*20+14], lock.Intent),
+		ctx, newLock(&txnMeta, keys[9*20+14], lock.Intent),
 		0, false, guards[9])
 	require.True(t, added)
 	require.NoError(t, err)
@@ -986,7 +988,7 @@ func TestLockTableMaxLocks(t *testing.T) {
 	// Add another discovered lock, to trigger tryClearLocks, and push us over 5
 	// locks.
 	added, err = lt.AddDiscoveredLock(
-		newLock(&txnMeta, keys[9*20+15], lock.Intent),
+		ctx, newLock(&txnMeta, keys[9*20+15], lock.Intent),
 		0, false, guards[9])
 	require.True(t, added)
 	require.NoError(t, err)
@@ -1001,7 +1003,7 @@ func TestLockTableMaxLocks(t *testing.T) {
 	// Add locks to push us over 5 locks.
 	for i := 16; i < 20; i++ {
 		added, err = lt.AddDiscoveredLock(
-			newLock(&txnMeta, keys[9*20+i], lock.Intent),
+			ctx, newLock(&txnMeta, keys[9*20+i], lock.Intent),
 			0, false, guards[9])
 		require.True(t, added)
 		require.NoError(t, err)
@@ -1017,6 +1019,7 @@ func TestLockTableMaxLocks(t *testing.T) {
 // TestLockTableMaxLocksWithMultipleNotRemovableRefs tests the notRemovable
 // ref counting.
 func TestLockTableMaxLocksWithMultipleNotRemovableRefs(t *testing.T) {
+	ctx := context.Background()
 	m := TestingMakeLockTableMetricsCfg()
 	lt := newLockTable(
 		2, roachpb.RangeID(3), hlc.NewClockForTesting(nil), cluster.MakeTestingClusterSettings(),
@@ -1044,7 +1047,7 @@ func TestLockTableMaxLocksWithMultipleNotRemovableRefs(t *testing.T) {
 			LockSpans:  lockSpans,
 			Batch:      ba,
 		}
-		ltg, err := lt.ScanAndEnqueue(req, nil)
+		ltg, err := lt.ScanAndEnqueue(ctx, req, nil)
 		require.Nil(t, err)
 		require.Nil(t, ltg.ResolveBeforeScanning())
 		require.False(t, ltg.ShouldWait())
@@ -1057,7 +1060,7 @@ func TestLockTableMaxLocksWithMultipleNotRemovableRefs(t *testing.T) {
 	// The first 6 requests discover 3 locks total.
 	for i := 0; i < 6; i++ {
 		added, err := lt.AddDiscoveredLock(
-			newLock(&txnMeta, keys[i/2], lock.Intent),
+			ctx, newLock(&txnMeta, keys[i/2], lock.Intent),
 			0, false, guards[i])
 		require.True(t, added)
 		require.NoError(t, err)
@@ -1067,12 +1070,12 @@ func TestLockTableMaxLocksWithMultipleNotRemovableRefs(t *testing.T) {
 	// Remove one of the notRemovable refs from each lock.
 	for i := 0; i < 6; i++ {
 		if i%2 == 0 {
-			lt.Dequeue(guards[i])
+			lt.Dequeue(ctx, guards[i])
 		}
 	}
 	// Add another lock using request 6.
 	added, err := lt.AddDiscoveredLock(
-		newLock(&txnMeta, keys[6/2], lock.Intent),
+		ctx, newLock(&txnMeta, keys[6/2], lock.Intent),
 		0, false, guards[6])
 	require.True(t, added)
 	require.NoError(t, err)
@@ -1081,16 +1084,16 @@ func TestLockTableMaxLocksWithMultipleNotRemovableRefs(t *testing.T) {
 	// Remove the remaining notRemovable refs.
 	for i := 0; i < 6; i++ {
 		if i%2 == 1 {
-			lt.Dequeue(guards[i])
+			lt.Dequeue(ctx, guards[i])
 		}
 	}
-	lt.Dequeue(guards[6])
+	lt.Dequeue(ctx, guards[6])
 	// There are still 4 locks since tryClearLocks has not happened since the
 	// ref counts went to 0.
 	require.Equal(t, int64(4), lt.lockCountForTesting())
 	// Add another lock using request 8.
 	added, err = lt.AddDiscoveredLock(
-		newLock(&txnMeta, keys[8/2], lock.Intent),
+		ctx, newLock(&txnMeta, keys[8/2], lock.Intent),
 		0, false, guards[8])
 	require.True(t, added)
 	require.NoError(t, err)
@@ -1129,7 +1132,7 @@ func doWork(ctx context.Context, item *workItem, e *workloadExecutor) error {
 				lg = nil
 			}
 			if g != nil {
-				e.lt.Dequeue(g)
+				e.lt.Dequeue(ctx, g)
 				g = nil
 			}
 		}()
@@ -1141,12 +1144,12 @@ func doWork(ctx context.Context, item *workItem, e *workloadExecutor) error {
 			// cancellation, the code makes sure to release latches when returning
 			// early due to error. Otherwise other requests will get stuck and
 			// group.Wait() will not return until the test times out.
-			lg, err = e.lm.Acquire(context.Background(), item.request.LatchSpans, poison.Policy_Error, item.request.Batch)
+			lg, err = e.lm.Acquire(ctx, item.request.LatchSpans, poison.Policy_Error, item.request.Batch)
 			if err != nil {
 				return err
 			}
 			var kvErr *Error
-			g, kvErr = e.lt.ScanAndEnqueue(*item.request, g)
+			g, kvErr = e.lt.ScanAndEnqueue(ctx, *item.request, g)
 			if kvErr != nil {
 				return kvErr.GoError()
 			}
@@ -1214,7 +1217,7 @@ func doWork(ctx context.Context, item *workItem, e *workloadExecutor) error {
 		return err
 	}
 	for i := range item.intents {
-		if err := e.lt.UpdateLocks(&item.intents[i]); err != nil {
+		if err := e.lt.UpdateLocks(ctx, &item.intents[i]); err != nil {
 			return err
 		}
 	}
@@ -1322,10 +1325,11 @@ func newWorkLoadExecutor(items []workloadItem, concurrency int) *workloadExecuto
 }
 
 func (e *workloadExecutor) acquireLock(txn *roachpb.Transaction, toAcq lockToAcquire) error {
+	ctx := context.Background()
 	acq := roachpb.MakeLockAcquisition(
 		txn.TxnMeta, toAcq.key, toAcq.dur, toAcq.str, txn.IgnoredSeqNums,
 	)
-	err := e.lt.AcquireLock(&acq)
+	err := e.lt.AcquireLock(ctx, &acq)
 	if err != nil {
 		return err
 	}
@@ -1827,12 +1831,12 @@ func doBenchWork(item *benchWorkItem, env benchEnv, doneCh chan<- error) {
 	firstIter := true
 	ctx := context.Background()
 	for {
-		if lg, err = env.lm.Acquire(context.Background(), item.LatchSpans, poison.Policy_Error, item.Batch); err != nil {
+		if lg, err = env.lm.Acquire(ctx, item.LatchSpans, poison.Policy_Error, item.Batch); err != nil {
 			doneCh <- err
 			return
 		}
 		var kvErr *Error
-		g, kvErr = env.lt.ScanAndEnqueue(item.Request, g)
+		g, kvErr = env.lt.ScanAndEnqueue(ctx, item.Request, g)
 		if kvErr != nil {
 			doneCh <- kvErr.GoError()
 			return
@@ -1862,19 +1866,19 @@ func doBenchWork(item *benchWorkItem, env benchEnv, doneCh chan<- error) {
 		acq := roachpb.MakeLockAcquisition(
 			item.Txn.TxnMeta, toAcq.key, toAcq.dur, toAcq.str, item.Txn.IgnoredSeqNums,
 		)
-		if err = env.lt.AcquireLock(&acq); err != nil {
+		if err = env.lt.AcquireLock(ctx, &acq); err != nil {
 			doneCh <- err
 			return
 		}
 	}
-	env.lt.Dequeue(g)
+	env.lt.Dequeue(ctx, g)
 	env.lm.Release(ctx, lg)
 	if len(item.locksToAcquire) == 0 {
 		doneCh <- nil
 		return
 	}
 	// Release locks.
-	if lg, err = env.lm.Acquire(context.Background(), item.LatchSpans, poison.Policy_Error, item.Batch); err != nil {
+	if lg, err = env.lm.Acquire(ctx, item.LatchSpans, poison.Policy_Error, item.Batch); err != nil {
 		doneCh <- err
 		return
 	}
@@ -1884,7 +1888,7 @@ func doBenchWork(item *benchWorkItem, env benchEnv, doneCh chan<- error) {
 			Txn:    item.Request.Txn.TxnMeta,
 			Status: roachpb.COMMITTED,
 		}
-		if err = env.lt.UpdateLocks(&intent); err != nil {
+		if err = env.lt.UpdateLocks(ctx, &intent); err != nil {
 			doneCh <- err
 			return
 		}
@@ -2063,6 +2067,7 @@ func BenchmarkLockTableMetrics(b *testing.B) {
 			)
 			lt.enabled = true
 
+			ctx := context.Background()
 			txn := &roachpb.Transaction{
 				TxnMeta: enginepb.TxnMeta{ID: uuid.MakeV4()},
 			}
@@ -2071,7 +2076,7 @@ func BenchmarkLockTableMetrics(b *testing.B) {
 				acq := roachpb.MakeLockAcquisition(
 					txn.TxnMeta, k, lock.Unreplicated, lock.Exclusive, txn.IgnoredSeqNums,
 				)
-				err := lt.AcquireLock(&acq)
+				err := lt.AcquireLock(ctx, &acq)
 				if err != nil {
 					b.Fatal(err)
 				}

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/basic
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/basic
@@ -52,7 +52,7 @@ sequence req=req2
 
 on-lock-acquired req=req2 key=k
 ----
-[-] acquire lock: txn 00000002 @ ‹k›
+[-] acquire lock: txn 00000002 acquiring Unreplicated Exclusive lock on ‹"k"›
 
 debug-lock-table
 ----
@@ -96,7 +96,7 @@ sequence req=req2
 
 on-lock-acquired req=req2 key=k
 ----
-[-] acquire lock: txn 00000002 @ ‹k›
+[-] acquire lock: txn 00000002 acquiring Unreplicated Exclusive lock on ‹"k"›
 
 finish req=req2
 ----
@@ -188,7 +188,7 @@ sequence req=req2
 
 on-lock-acquired req=req2 key=k
 ----
-[-] acquire lock: txn 00000002 @ ‹k›
+[-] acquire lock: txn 00000002 acquiring Unreplicated Exclusive lock on ‹"k"›
 
 finish req=req2
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents
@@ -31,7 +31,7 @@ handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn2 key=i
   lock txn=txn2 key=j
 ----
-[2] handle lock conflict error req1: handled conflicting locks on ‹"a"›, ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
+[2] handle lock conflict error req1: added 10 discovered lock(s) to lock table: conflicting locks on ‹"a"›, ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›
 
 debug-lock-table
 ----
@@ -157,7 +157,7 @@ sequence req=req1
 handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn2 key=a
 ----
-[2] handle lock conflict error req1: handled conflicting locks on ‹"a"›, released latches
+[2] handle lock conflict error req1: added 1 discovered lock(s) to lock table: conflicting locks on ‹"a"›
 
 debug-lock-table
 ----
@@ -194,7 +194,7 @@ on-txn-updated txn=txn2 status=committed
 handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn2 key=b
 ----
-[4] handle lock conflict error req1: handled conflicting locks on ‹"b"›, released latches
+[4] handle lock conflict error req1: added 1 discovered lock(s) to lock table: conflicting locks on ‹"b"›
 
 debug-lock-table
 ----
@@ -223,7 +223,7 @@ sequence req=req1
 handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn2 key=c
 ----
-[6] handle lock conflict error req1: handled conflicting locks on ‹"c"›, released latches
+[6] handle lock conflict error req1: added 1 discovered lock(s) to lock table: conflicting locks on ‹"c"›
 
 debug-lock-table
 ----
@@ -299,7 +299,7 @@ handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn2 key=a
   lock txn=txn2 key=b
 ----
-[2] handle lock conflict error req1: handled conflicting locks on ‹"a"›, ‹"b"›, released latches
+[2] handle lock conflict error req1: added 2 discovered lock(s) to lock table: conflicting locks on ‹"a"›, ‹"b"›
 
 debug-lock-table
 ----
@@ -323,11 +323,11 @@ sequence req=req2
 
 on-lock-acquired req=req2 key=g dur=u
 ----
-[-] acquire lock: txn 00000002 @ ‹g›
+[-] acquire lock: txn 00000002 acquiring Unreplicated Exclusive lock on ‹"g"›
 
 on-lock-acquired req=req2 key=h dur=u
 ----
-[-] acquire lock: txn 00000002 @ ‹h›
+[-] acquire lock: txn 00000002 acquiring Unreplicated Exclusive lock on ‹"h"›
 
 finish req=req2
 ----
@@ -441,7 +441,7 @@ handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn3 key=d
   lock txn=txn5 key=e
 ----
-[2] handle lock conflict error req1: handled conflicting locks on ‹"c"›, ‹"d"›, ‹"e"›, released latches
+[2] handle lock conflict error req1: added 3 discovered lock(s) to lock table: conflicting locks on ‹"c"›, ‹"d"›, ‹"e"›
 
 debug-lock-table
 ----
@@ -499,7 +499,7 @@ sequence req=req3
 
 on-lock-acquired req=req3 key=a dur=u
 ----
-[-] acquire lock: txn 00000003 @ ‹a›
+[-] acquire lock: txn 00000003 acquiring Unreplicated Exclusive lock on ‹"a"›
 
 finish req=req3
 ----
@@ -518,7 +518,7 @@ sequence req=req4
 
 on-lock-acquired req=req4 key=b dur=u
 ----
-[-] acquire lock: txn 00000004 @ ‹b›
+[-] acquire lock: txn 00000004 acquiring Unreplicated Exclusive lock on ‹"b"›
 
 finish req=req4
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents_wait_policy_error
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents_wait_policy_error
@@ -35,7 +35,7 @@ handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn2 key=i
   lock txn=txn2 key=j
 ----
-[2] handle lock conflict error req1: handled conflicting locks on ‹"a"›, ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
+[2] handle lock conflict error req1: added 10 discovered lock(s) to lock table: conflicting locks on ‹"a"›, ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›
 
 debug-lock-table
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents_without_adding_to_lock_table
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents_without_adding_to_lock_table
@@ -28,7 +28,7 @@ sequence req=req1
 handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn2 key=a
 ----
-[2] handle lock conflict error req1: handled conflicting locks on ‹"a"›, released latches
+[2] handle lock conflict error req1: added 1 discovered lock(s) to lock table: conflicting locks on ‹"a"›
 
 debug-lock-table
 ----
@@ -101,6 +101,7 @@ handle-lock-conflict-error req=req2 lease-seq=1
   lock txn=txn2 key=i
   lock txn=txn2 key=j
 ----
+[5] handle lock conflict error req2: added 9 discovered lock(s) to lock table: conflicting locks on ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›
 [5] handle lock conflict error req2: resolving a batch of 9 intent(s)
 [5] handle lock conflict error req2: resolving intent ‹"b"› for txn 00000002 with ABORTED status
 [5] handle lock conflict error req2: resolving intent ‹"c"› for txn 00000002 with ABORTED status
@@ -111,7 +112,6 @@ handle-lock-conflict-error req=req2 lease-seq=1
 [5] handle lock conflict error req2: resolving intent ‹"h"› for txn 00000002 with ABORTED status
 [5] handle lock conflict error req2: resolving intent ‹"i"› for txn 00000002 with ABORTED status
 [5] handle lock conflict error req2: resolving intent ‹"j"› for txn 00000002 with ABORTED status
-[5] handle lock conflict error req2: handled conflicting locks on ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
 
 debug-lock-table
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/deadlocks
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/deadlocks
@@ -57,15 +57,15 @@ sequence req=req3w
 
 on-lock-acquired req=req1w key=a
 ----
-[-] acquire lock: txn 00000001 @ ‹a›
+[-] acquire lock: txn 00000001 acquiring Unreplicated Exclusive lock on ‹"a"›
 
 on-lock-acquired req=req2w key=b
 ----
-[-] acquire lock: txn 00000002 @ ‹b›
+[-] acquire lock: txn 00000002 acquiring Unreplicated Exclusive lock on ‹"b"›
 
 on-lock-acquired req=req3w key=c
 ----
-[-] acquire lock: txn 00000003 @ ‹c›
+[-] acquire lock: txn 00000003 acquiring Unreplicated Exclusive lock on ‹"c"›
 
 finish req=req1w
 ----
@@ -264,15 +264,15 @@ sequence req=req3w
 
 on-lock-acquired req=req1w key=a
 ----
-[-] acquire lock: txn 00000001 @ ‹a›
+[-] acquire lock: txn 00000001 acquiring Unreplicated Exclusive lock on ‹"a"›
 
 on-lock-acquired req=req2w key=b
 ----
-[-] acquire lock: txn 00000002 @ ‹b›
+[-] acquire lock: txn 00000002 acquiring Unreplicated Exclusive lock on ‹"b"›
 
 on-lock-acquired req=req3w key=c
 ----
-[-] acquire lock: txn 00000003 @ ‹c›
+[-] acquire lock: txn 00000003 acquiring Unreplicated Exclusive lock on ‹"c"›
 
 finish req=req1w
 ----
@@ -505,15 +505,15 @@ sequence req=req3w
 
 on-lock-acquired req=req1w key=a
 ----
-[-] acquire lock: txn 00000001 @ ‹a›
+[-] acquire lock: txn 00000001 acquiring Unreplicated Exclusive lock on ‹"a"›
 
 on-lock-acquired req=req2w key=b
 ----
-[-] acquire lock: txn 00000002 @ ‹b›
+[-] acquire lock: txn 00000002 acquiring Unreplicated Exclusive lock on ‹"b"›
 
 on-lock-acquired req=req3w key=c
 ----
-[-] acquire lock: txn 00000003 @ ‹c›
+[-] acquire lock: txn 00000003 acquiring Unreplicated Exclusive lock on ‹"c"›
 
 finish req=req1w
 ----
@@ -737,15 +737,15 @@ sequence req=req3w
 
 on-lock-acquired req=req1w key=a
 ----
-[-] acquire lock: txn 00000001 @ ‹a›
+[-] acquire lock: txn 00000001 acquiring Unreplicated Exclusive lock on ‹"a"›
 
 on-lock-acquired req=req2w key=b
 ----
-[-] acquire lock: txn 00000002 @ ‹b›
+[-] acquire lock: txn 00000002 acquiring Unreplicated Exclusive lock on ‹"b"›
 
 on-lock-acquired req=req3w key=c
 ----
-[-] acquire lock: txn 00000003 @ ‹c›
+[-] acquire lock: txn 00000003 acquiring Unreplicated Exclusive lock on ‹"c"›
 
 finish req=req1w
 ----
@@ -976,15 +976,15 @@ sequence req=req3w
 
 on-lock-acquired req=req1w key=a
 ----
-[-] acquire lock: txn 00000001 @ ‹a›
+[-] acquire lock: txn 00000001 acquiring Unreplicated Exclusive lock on ‹"a"›
 
 on-lock-acquired req=req2w key=b
 ----
-[-] acquire lock: txn 00000002 @ ‹b›
+[-] acquire lock: txn 00000002 acquiring Unreplicated Exclusive lock on ‹"b"›
 
 on-lock-acquired req=req3w key=c
 ----
-[-] acquire lock: txn 00000003 @ ‹c›
+[-] acquire lock: txn 00000003 acquiring Unreplicated Exclusive lock on ‹"c"›
 
 finish req=req1w
 ----
@@ -1210,11 +1210,11 @@ sequence req=req2w
 
 on-lock-acquired req=req1w key=a
 ----
-[-] acquire lock: txn 00000001 @ ‹a›
+[-] acquire lock: txn 00000001 acquiring Unreplicated Exclusive lock on ‹"a"›
 
 on-lock-acquired req=req2w key=b
 ----
-[-] acquire lock: txn 00000002 @ ‹b›
+[-] acquire lock: txn 00000002 acquiring Unreplicated Exclusive lock on ‹"b"›
 
 finish req=req1w
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discover_lock_after_lease_race
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discover_lock_after_lease_race
@@ -70,7 +70,7 @@ sequence req=req1
 # NOTE: replicated locks are not immediately stored in the lock-table.
 on-lock-acquired req=req1 key=k dur=r
 ----
-[-] acquire lock: txn 00000001 @ ‹k›
+[-] acquire lock: txn 00000001 acquiring Replicated Intent lock on ‹"k"›
 
 finish req=req1
 ----
@@ -132,7 +132,7 @@ sequence req=req4
 handle-lock-conflict-error req=req4 lease-seq=3
   lock txn=txn3 key=k
 ----
-[4] handle lock conflict error req4: handled conflicting locks on ‹"k"›, released latches
+[4] handle lock conflict error req4: added 1 discovered lock(s) to lock table: conflicting locks on ‹"k"›
 
 debug-lock-table
 ----
@@ -154,8 +154,7 @@ sequence req=req4
 handle-lock-conflict-error req=req2 lease-seq=1
   lock txn=txn1 key=k
 ----
-[6] handle lock conflict error req2: intent on ‹"k"› discovered but not added to disabled lock table
-[6] handle lock conflict error req2: handled conflicting locks on ‹"k"›, released latches
+[6] handle lock conflict error req2: discovered lock on ‹"k"› not added to disabled lock table
 
 debug-lock-table
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discovered_lock
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discovered_lock
@@ -23,7 +23,7 @@ sequence req=req1
 handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn1 key=k
 ----
-[2] handle lock conflict error req1: handled conflicting locks on ‹"k"›, released latches
+[2] handle lock conflict error req1: added 1 discovered lock(s) to lock table: conflicting locks on ‹"k"›
 
 debug-lock-table
 ----
@@ -90,8 +90,7 @@ sequence req=req1
 handle-lock-conflict-error req=req1 lease-seq=2
   lock txn=txn1 key=k
 ----
-[2] handle lock conflict error req1: intent on ‹"k"› discovered but not added to disabled lock table
-[2] handle lock conflict error req1: handled conflicting locks on ‹"k"›, released latches
+[2] handle lock conflict error req1: discovered lock on ‹"k"› not added to disabled lock table
 
 sequence req=req1
 ----
@@ -139,8 +138,7 @@ sequence req=req1
 handle-lock-conflict-error req=req1 lease-seq=2
   lock txn=txn1 key=k
 ----
-[2] handle lock conflict error req1: intent on ‹"k"› discovered but not added to disabled lock table
-[2] handle lock conflict error req1: handled conflicting locks on ‹"k"›, released latches
+[2] handle lock conflict error req1: discovered lock on ‹"k"› not added to disabled lock table
 
 sequence req=req1
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/isolation_level
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/isolation_level
@@ -45,19 +45,19 @@ sequence req=req1
 
 on-lock-acquired req=req1 key=kSSINormal1 dur=r
 ----
-[-] acquire lock: txn 00000001 @ ‹kSSINormal1›
+[-] acquire lock: txn 00000001 acquiring Replicated Intent lock on ‹"kSSINormal1"›
 
 on-lock-acquired req=req1 key=kSSINormal2 dur=r
 ----
-[-] acquire lock: txn 00000001 @ ‹kSSINormal2›
+[-] acquire lock: txn 00000001 acquiring Replicated Intent lock on ‹"kSSINormal2"›
 
 on-lock-acquired req=req1 key=kSSINormal3 dur=r
 ----
-[-] acquire lock: txn 00000001 @ ‹kSSINormal3›
+[-] acquire lock: txn 00000001 acquiring Replicated Intent lock on ‹"kSSINormal3"›
 
 on-lock-acquired req=req1 key=kSSINormal4 dur=r
 ----
-[-] acquire lock: txn 00000001 @ ‹kSSINormal4›
+[-] acquire lock: txn 00000001 acquiring Replicated Intent lock on ‹"kSSINormal4"›
 
 finish req=req1
 ----
@@ -79,19 +79,19 @@ sequence req=req2
 
 on-lock-acquired req=req2 key=kSSIHigh1 dur=r
 ----
-[-] acquire lock: txn 00000002 @ ‹kSSIHigh1›
+[-] acquire lock: txn 00000002 acquiring Replicated Intent lock on ‹"kSSIHigh1"›
 
 on-lock-acquired req=req2 key=kSSIHigh2 dur=r
 ----
-[-] acquire lock: txn 00000002 @ ‹kSSIHigh2›
+[-] acquire lock: txn 00000002 acquiring Replicated Intent lock on ‹"kSSIHigh2"›
 
 on-lock-acquired req=req2 key=kSSIHigh3 dur=r
 ----
-[-] acquire lock: txn 00000002 @ ‹kSSIHigh3›
+[-] acquire lock: txn 00000002 acquiring Replicated Intent lock on ‹"kSSIHigh3"›
 
 on-lock-acquired req=req2 key=kSSIHigh4 dur=r
 ----
-[-] acquire lock: txn 00000002 @ ‹kSSIHigh4›
+[-] acquire lock: txn 00000002 acquiring Replicated Intent lock on ‹"kSSIHigh4"›
 
 finish req=req2
 ----
@@ -113,19 +113,19 @@ sequence req=req3
 
 on-lock-acquired req=req3 key=kRCNormal1 dur=r
 ----
-[-] acquire lock: txn 00000003 @ ‹kRCNormal1›
+[-] acquire lock: txn 00000003 acquiring Replicated Intent lock on ‹"kRCNormal1"›
 
 on-lock-acquired req=req3 key=kRCNormal2 dur=r
 ----
-[-] acquire lock: txn 00000003 @ ‹kRCNormal2›
+[-] acquire lock: txn 00000003 acquiring Replicated Intent lock on ‹"kRCNormal2"›
 
 on-lock-acquired req=req3 key=kRCNormal3 dur=r
 ----
-[-] acquire lock: txn 00000003 @ ‹kRCNormal3›
+[-] acquire lock: txn 00000003 acquiring Replicated Intent lock on ‹"kRCNormal3"›
 
 on-lock-acquired req=req3 key=kRCNormal4 dur=r
 ----
-[-] acquire lock: txn 00000003 @ ‹kRCNormal4›
+[-] acquire lock: txn 00000003 acquiring Replicated Intent lock on ‹"kRCNormal4"›
 
 finish req=req3
 ----
@@ -147,19 +147,19 @@ sequence req=req4
 
 on-lock-acquired req=req4 key=kRCHigh1 dur=r
 ----
-[-] acquire lock: txn 00000004 @ ‹kRCHigh1›
+[-] acquire lock: txn 00000004 acquiring Replicated Intent lock on ‹"kRCHigh1"›
 
 on-lock-acquired req=req4 key=kRCHigh2 dur=r
 ----
-[-] acquire lock: txn 00000004 @ ‹kRCHigh2›
+[-] acquire lock: txn 00000004 acquiring Replicated Intent lock on ‹"kRCHigh2"›
 
 on-lock-acquired req=req4 key=kRCHigh3 dur=r
 ----
-[-] acquire lock: txn 00000004 @ ‹kRCHigh3›
+[-] acquire lock: txn 00000004 acquiring Replicated Intent lock on ‹"kRCHigh3"›
 
 on-lock-acquired req=req4 key=kRCHigh4 dur=r
 ----
-[-] acquire lock: txn 00000004 @ ‹kRCHigh4›
+[-] acquire lock: txn 00000004 acquiring Replicated Intent lock on ‹"kRCHigh4"›
 
 finish req=req4
 ----
@@ -209,7 +209,7 @@ handle-lock-conflict-error req=reqDiscoverInitial lease-seq=1
   lock txn=txnSSINormalPushee  key=kSSINormal3
   lock txn=txnSSINormalPushee  key=kSSINormal4
 ----
-[6] handle lock conflict error reqDiscoverInitial: handled conflicting locks on ‹"kRCHigh1"›, ‹"kRCHigh2"›, ‹"kRCHigh3"›, ‹"kRCHigh4"›, ‹"kRCNormal1"› ... ‹"kSSIHigh4"›, ‹"kSSINormal1"›, ‹"kSSINormal2"›, ‹"kSSINormal3"›, ‹"kSSINormal4"›, released latches
+[6] handle lock conflict error reqDiscoverInitial: added 16 discovered lock(s) to lock table: conflicting locks on ‹"kRCHigh1"›, ‹"kRCHigh2"›, ‹"kRCHigh3"›, ‹"kRCHigh4"›, ‹"kRCNormal1"› ... ‹"kSSIHigh4"›, ‹"kSSINormal1"›, ‹"kSSINormal2"›, ‹"kSSINormal3"›, ‹"kSSINormal4"›
 
 finish req=reqDiscoverInitial
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/lock_timeout
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/lock_timeout
@@ -30,11 +30,11 @@ sequence req=req1
 
 on-lock-acquired req=req1 key=k
 ----
-[-] acquire lock: txn 00000001 @ ‹k›
+[-] acquire lock: txn 00000001 acquiring Unreplicated Exclusive lock on ‹"k"›
 
 on-lock-acquired req=req1 key=k2
 ----
-[-] acquire lock: txn 00000001 @ ‹k2›
+[-] acquire lock: txn 00000001 acquiring Unreplicated Exclusive lock on ‹"k2"›
 
 finish req=req1
 ----
@@ -53,7 +53,7 @@ sequence req=req2
 
 on-lock-acquired req=req2 key=k3
 ----
-[-] acquire lock: txn 00000002 @ ‹k3›
+[-] acquire lock: txn 00000002 acquiring Unreplicated Exclusive lock on ‹"k3"›
 
 finish req=req2
 ----
@@ -188,7 +188,7 @@ sequence req=reqTimeout3
 handle-lock-conflict-error req=reqTimeout3 lease-seq=1
   lock txn=txn2 key=k4
 ----
-[8] handle lock conflict error reqTimeout3: handled conflicting locks on ‹"k4"›, released latches
+[8] handle lock conflict error reqTimeout3: added 1 discovered lock(s) to lock table: conflicting locks on ‹"k4"›
 
 sequence req=reqTimeout3
 ----
@@ -245,7 +245,7 @@ sequence req=reqTimeout4
 handle-lock-conflict-error req=reqTimeout4 lease-seq=1
   lock txn=txn2 key=k5
 ----
-[11] handle lock conflict error reqTimeout4: handled conflicting locks on ‹"k5"›, released latches
+[11] handle lock conflict error reqTimeout4: added 1 discovered lock(s) to lock table: conflicting locks on ‹"k5"›
 
 sequence req=reqTimeout4
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/optimistic
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/optimistic
@@ -17,7 +17,7 @@ sequence req=req1
 
 on-lock-acquired req=req1 key=d
 ----
-[-] acquire lock: txn 00000001 @ ‹d›
+[-] acquire lock: txn 00000001 acquiring Unreplicated Exclusive lock on ‹"d"›
 
 debug-lock-table
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/priority
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/priority
@@ -43,11 +43,11 @@ sequence req=req1
 
 on-lock-acquired req=req1 key=kLow1
 ----
-[-] acquire lock: txn 00000001 @ ‹kLow1›
+[-] acquire lock: txn 00000001 acquiring Unreplicated Exclusive lock on ‹"kLow1"›
 
 on-lock-acquired req=req1 key=kLow2
 ----
-[-] acquire lock: txn 00000001 @ ‹kLow2›
+[-] acquire lock: txn 00000001 acquiring Unreplicated Exclusive lock on ‹"kLow2"›
 
 finish req=req1
 ----
@@ -67,11 +67,11 @@ sequence req=req2
 
 on-lock-acquired req=req2 key=kNormal1
 ----
-[-] acquire lock: txn 00000002 @ ‹kNormal1›
+[-] acquire lock: txn 00000002 acquiring Unreplicated Exclusive lock on ‹"kNormal1"›
 
 on-lock-acquired req=req2 key=kNormal2
 ----
-[-] acquire lock: txn 00000002 @ ‹kNormal2›
+[-] acquire lock: txn 00000002 acquiring Unreplicated Exclusive lock on ‹"kNormal2"›
 
 finish req=req2
 ----
@@ -91,11 +91,11 @@ sequence req=req3
 
 on-lock-acquired req=req3 key=kHigh1
 ----
-[-] acquire lock: txn 00000003 @ ‹kHigh1›
+[-] acquire lock: txn 00000003 acquiring Unreplicated Exclusive lock on ‹"kHigh1"›
 
 on-lock-acquired req=req3 key=kHigh2
 ----
-[-] acquire lock: txn 00000003 @ ‹kHigh2›
+[-] acquire lock: txn 00000003 acquiring Unreplicated Exclusive lock on ‹"kHigh2"›
 
 finish req=req3
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/queue_length_exceeded
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/queue_length_exceeded
@@ -34,7 +34,7 @@ sequence req=req1
 
 on-lock-acquired req=req1 key=k
 ----
-[-] acquire lock: txn 00000001 @ ‹k›
+[-] acquire lock: txn 00000001 acquiring Unreplicated Exclusive lock on ‹"k"›
 
 finish req=req1
 ----
@@ -150,7 +150,7 @@ finish req=req5r
 
 on-lock-acquired req=req2 key=k
 ----
-[-] acquire lock: txn 00000002 @ ‹k›
+[-] acquire lock: txn 00000002 acquiring Unreplicated Exclusive lock on ‹"k"›
 [3] sequence req3: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"k"› (queuedLockingRequests: 2, queuedReaders: 0)
 [3] sequence req3: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [3] sequence req3: pushing txn 00000002 to abort

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
@@ -65,11 +65,11 @@ sequence req=req1
 
 on-lock-acquired req=req1 key=k
 ----
-[-] acquire lock: txn 00000001 @ ‹k›
+[-] acquire lock: txn 00000001 acquiring Unreplicated Exclusive lock on ‹"k"›
 
 on-lock-acquired req=req1 key=k2
 ----
-[-] acquire lock: txn 00000001 @ ‹k2›
+[-] acquire lock: txn 00000001 acquiring Unreplicated Exclusive lock on ‹"k2"›
 
 finish req=req1
 ----
@@ -129,8 +129,7 @@ num=0
 handle-lock-conflict-error req=req2 lease-seq=1
   lock txn=txn1 key=k
 ----
-[3] handle lock conflict error req2: intent on ‹"k"› discovered but not added to disabled lock table
-[3] handle lock conflict error req2: handled conflicting locks on ‹"k"›, released latches
+[3] handle lock conflict error req2: discovered lock on ‹"k"› not added to disabled lock table
 
 debug-lock-table
 ----
@@ -162,7 +161,7 @@ sequence req=req2
 handle-lock-conflict-error req=req2 lease-seq=2
   lock txn=txn1 key=k
 ----
-[6] handle lock conflict error req2: handled conflicting locks on ‹"k"›, released latches
+[6] handle lock conflict error req2: added 1 discovered lock(s) to lock table: conflicting locks on ‹"k"›
 
 debug-lock-table
 ----
@@ -225,7 +224,7 @@ num=1
 
 on-lock-acquired req=req2 key=k
 ----
-[-] acquire lock: txn 00000002 @ ‹k›
+[-] acquire lock: txn 00000002 acquiring Unreplicated Exclusive lock on ‹"k"›
 
 debug-lock-table
 ----
@@ -264,8 +263,7 @@ sequence req=req3
 handle-lock-conflict-error req=req3 lease-seq=2
   lock txn=txn1 key=k
 ----
-[10] handle lock conflict error req3: intent on ‹"k"› discovered but not added to disabled lock table
-[10] handle lock conflict error req3: handled conflicting locks on ‹"k"›, released latches
+[10] handle lock conflict error req3: discovered lock on ‹"k"› not added to disabled lock table
 
 debug-lock-table
 ----
@@ -281,7 +279,7 @@ sequence req=req3
 handle-lock-conflict-error req=req3 lease-seq=4
   lock txn=txn2 key=k
 ----
-[12] handle lock conflict error req3: handled conflicting locks on ‹"k"›, released latches
+[12] handle lock conflict error req3: added 1 discovered lock(s) to lock table: conflicting locks on ‹"k"›
 
 debug-lock-table
 ----
@@ -339,7 +337,7 @@ num=1
 
 on-lock-acquired req=req3 key=k
 ----
-[-] acquire lock: txn 00000003 @ ‹k›
+[-] acquire lock: txn 00000003 acquiring Unreplicated Exclusive lock on ‹"k"›
 
 debug-lock-table
 ----
@@ -392,7 +390,7 @@ sequence req=req1
 
 on-lock-acquired req=req1 key=k
 ----
-[-] acquire lock: txn 00000001 @ ‹k›
+[-] acquire lock: txn 00000001 acquiring Unreplicated Exclusive lock on ‹"k"›
 
 finish req=req1
 ----
@@ -444,7 +442,7 @@ num=0
 handle-lock-conflict-error req=req2 lease-seq=1
   lock txn=txn1 key=k
 ----
-[3] handle lock conflict error req2: handled conflicting locks on ‹"k"›, released latches
+[3] handle lock conflict error req2: added 1 discovered lock(s) to lock table: conflicting locks on ‹"k"›
 
 debug-lock-table
 ----
@@ -502,7 +500,7 @@ num=1
 
 on-lock-acquired req=req2 key=k
 ----
-[-] acquire lock: txn 00000002 @ ‹k›
+[-] acquire lock: txn 00000002 acquiring Unreplicated Exclusive lock on ‹"k"›
 
 debug-lock-table
 ----
@@ -575,11 +573,11 @@ sequence req=req2
 
 on-lock-acquired req=req1 key=k1
 ----
-[-] acquire lock: txn 00000001 @ ‹k1›
+[-] acquire lock: txn 00000001 acquiring Unreplicated Exclusive lock on ‹"k1"›
 
 on-lock-acquired req=req2 key=k3
 ----
-[-] acquire lock: txn 00000002 @ ‹k3›
+[-] acquire lock: txn 00000002 acquiring Unreplicated Exclusive lock on ‹"k3"›
 
 finish req=req1
 ----
@@ -757,7 +755,7 @@ sequence req=req1
 
 on-lock-acquired req=req1 key=k
 ----
-[-] acquire lock: txn 00000001 @ ‹k›
+[-] acquire lock: txn 00000001 acquiring Unreplicated Exclusive lock on ‹"k"›
 
 finish req=req1
 ----
@@ -813,7 +811,6 @@ num=0
 
 on-lock-acquired req=req3 key=k2
 ----
-[-] acquire lock: txn 00000003 @ ‹k2›
 
 debug-lock-table
 ----
@@ -826,8 +823,7 @@ finish req=req3
 handle-lock-conflict-error req=req2 lease-seq=1
   lock txn=txn1 key=k
 ----
-[4] handle lock conflict error req2: intent on ‹"k"› discovered but not added to disabled lock table
-[4] handle lock conflict error req2: handled conflicting locks on ‹"k"›, released latches
+[4] handle lock conflict error req2: discovered lock on ‹"k"› not added to disabled lock table
 
 sequence req=req2
 ----
@@ -855,7 +851,7 @@ sequence req=req2
 handle-lock-conflict-error req=req2 lease-seq=2
   lock txn=txn1 key=k
 ----
-[7] handle lock conflict error req2: handled conflicting locks on ‹"k"›, released latches
+[7] handle lock conflict error req2: added 1 discovered lock(s) to lock table: conflicting locks on ‹"k"›
 
 debug-lock-table
 ----
@@ -913,7 +909,7 @@ num=1
 
 on-lock-acquired req=req2 key=k
 ----
-[-] acquire lock: txn 00000002 @ ‹k›
+[-] acquire lock: txn 00000002 acquiring Unreplicated Exclusive lock on ‹"k"›
 
 debug-lock-table
 ----
@@ -966,7 +962,7 @@ sequence req=req1
 
 on-lock-acquired req=req1 key=k
 ----
-[-] acquire lock: txn 00000001 @ ‹k›
+[-] acquire lock: txn 00000001 acquiring Unreplicated Exclusive lock on ‹"k"›
 
 finish req=req1
 ----
@@ -1016,7 +1012,7 @@ num=0
 handle-lock-conflict-error req=req2 lease-seq=1
   lock txn=txn1 key=k
 ----
-[3] handle lock conflict error req2: handled conflicting locks on ‹"k"›, released latches
+[3] handle lock conflict error req2: added 1 discovered lock(s) to lock table: conflicting locks on ‹"k"›
 
 debug-lock-table
 ----
@@ -1074,7 +1070,7 @@ num=1
 
 on-lock-acquired req=req2 key=k
 ----
-[-] acquire lock: txn 00000002 @ ‹k›
+[-] acquire lock: txn 00000002 acquiring Unreplicated Exclusive lock on ‹"k"›
 
 debug-lock-table
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/refresh
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/refresh
@@ -20,7 +20,7 @@ sequence req=reqNormalPri
 
 on-lock-acquired req=reqNormalPri key=k
 ----
-[-] acquire lock: txn 00000001 @ ‹k›
+[-] acquire lock: txn 00000001 acquiring Unreplicated Exclusive lock on ‹"k"›
 
 finish req=reqNormalPri
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/replicated
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/replicated
@@ -33,7 +33,7 @@ sequence req=req1
 
 on-lock-acquired req=req1 key=a dur=r str=shared
 ----
-[-] acquire lock: txn 00000001 @ ‹a›
+[-] acquire lock: txn 00000001 acquiring Replicated Shared lock on ‹"a"›
 
 finish req=req1
 ----
@@ -52,7 +52,7 @@ sequence req=req2
 
 on-lock-acquired req=req2 key=a dur=r str=shared
 ----
-[-] acquire lock: txn 00000002 @ ‹a›
+[-] acquire lock: txn 00000002 acquiring Replicated Shared lock on ‹"a"›
 
 finish req=req2
 ----
@@ -78,7 +78,7 @@ handle-lock-conflict-error req=req3 lease-seq=1
   lock txn=txn1 key=a str=shared
   lock txn=txn2 key=a str=shared
 ----
-[4] handle lock conflict error req3: handled conflicting locks on ‹"a"›, ‹"a"›, released latches
+[4] handle lock conflict error req3: added 2 discovered lock(s) to lock table: conflicting locks on ‹"a"›, ‹"a"›
 
 debug-lock-table
 ----
@@ -146,7 +146,7 @@ sequence req=req4
 
 on-lock-acquired req=req4 key=a dur=r str=exclusive
 ----
-[-] acquire lock: txn 00000003 @ ‹a›
+[-] acquire lock: txn 00000003 acquiring Replicated Exclusive lock on ‹"a"›
 
 finish req=req4
 ----
@@ -171,7 +171,7 @@ sequence req=req5
 handle-lock-conflict-error req=req5 lease-seq=1
   lock txn=txn3 key=a str=exclusive
 ----
-[3] handle lock conflict error req5: handled conflicting locks on ‹"a"›, released latches
+[3] handle lock conflict error req5: added 1 discovered lock(s) to lock table: conflicting locks on ‹"a"›
 
 debug-lock-table
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents
@@ -34,7 +34,7 @@ handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn2 key=i
   lock txn=txn2 key=j
 ----
-[2] handle lock conflict error req1: handled conflicting locks on ‹"a"›, ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
+[2] handle lock conflict error req1: added 10 discovered lock(s) to lock table: conflicting locks on ‹"a"›, ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›
 
 debug-lock-table
 ----
@@ -120,7 +120,7 @@ finish req=req1
 handle-lock-conflict-error req=req2 lease-seq=1
   lock txn=txn2 key=c
 ----
-[5] handle lock conflict error req2: handled conflicting locks on ‹"c"›, released latches
+[5] handle lock conflict error req2: added 1 discovered lock(s) to lock table: conflicting locks on ‹"c"›
 
 # Only the contended lock remains.
 debug-lock-table
@@ -186,7 +186,7 @@ handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn2 key=a
   lock txn=txn2 key=b
 ----
-[2] handle lock conflict error req1: handled conflicting locks on ‹"a"›, ‹"b"›, released latches
+[2] handle lock conflict error req1: added 2 discovered lock(s) to lock table: conflicting locks on ‹"a"›, ‹"b"›
 
 debug-lock-table
 ----
@@ -210,11 +210,11 @@ sequence req=req2
 
 on-lock-acquired req=req2 key=g dur=u
 ----
-[-] acquire lock: txn 00000002 @ ‹g›
+[-] acquire lock: txn 00000002 acquiring Unreplicated Exclusive lock on ‹"g"›
 
 on-lock-acquired req=req2 key=h dur=u
 ----
-[-] acquire lock: txn 00000002 @ ‹h›
+[-] acquire lock: txn 00000002 acquiring Unreplicated Exclusive lock on ‹"h"›
 
 finish req=req2
 ----
@@ -294,7 +294,7 @@ handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn2 key=b
   lock txn=txn2 key=c
 ----
-[2] handle lock conflict error req1: handled conflicting locks on ‹"a"›, ‹"b"›, ‹"c"›, released latches
+[2] handle lock conflict error req1: added 3 discovered lock(s) to lock table: conflicting locks on ‹"a"›, ‹"b"›, ‹"c"›
 
 debug-lock-table
 ----
@@ -384,7 +384,7 @@ handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn2 key=i
   lock txn=txn2 key=j
 ----
-[2] handle lock conflict error req1: handled conflicting locks on ‹"a"›, ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
+[2] handle lock conflict error req1: added 10 discovered lock(s) to lock table: conflicting locks on ‹"a"›, ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›
 
 debug-lock-table
 ----
@@ -505,7 +505,7 @@ finish req=req1
 handle-lock-conflict-error req=req2 lease-seq=1
   lock txn=txn2 key=c
 ----
-[5] handle lock conflict error req2: handled conflicting locks on ‹"c"›, released latches
+[5] handle lock conflict error req2: added 1 discovered lock(s) to lock table: conflicting locks on ‹"c"›
 
 # Only the contended lock remains.
 debug-lock-table

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents_without_adding_to_lock_table
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents_without_adding_to_lock_table
@@ -28,7 +28,7 @@ sequence req=req1
 handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn2 key=a
 ----
-[2] handle lock conflict error req1: handled conflicting locks on ‹"a"›, released latches
+[2] handle lock conflict error req1: added 1 discovered lock(s) to lock table: conflicting locks on ‹"a"›
 
 debug-lock-table
 ----
@@ -84,6 +84,7 @@ handle-lock-conflict-error req=req2 lease-seq=1
   lock txn=txn2 key=i
   lock txn=txn2 key=j
 ----
+[5] handle lock conflict error req2: added 9 discovered lock(s) to lock table: conflicting locks on ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›
 [5] handle lock conflict error req2: resolving a batch of 9 intent(s)
 [5] handle lock conflict error req2: resolving intent ‹"b"› for txn 00000002 with PENDING status
 [5] handle lock conflict error req2: resolving intent ‹"c"› for txn 00000002 with PENDING status
@@ -94,7 +95,6 @@ handle-lock-conflict-error req=req2 lease-seq=1
 [5] handle lock conflict error req2: resolving intent ‹"h"› for txn 00000002 with PENDING status
 [5] handle lock conflict error req2: resolving intent ‹"i"› for txn 00000002 with PENDING status
 [5] handle lock conflict error req2: resolving intent ‹"j"› for txn 00000002 with PENDING status
-[5] handle lock conflict error req2: handled conflicting locks on ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
 
 debug-lock-table
 ----
@@ -140,7 +140,7 @@ sequence req=req1
 handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn2 key=a
 ----
-[2] handle lock conflict error req1: handled conflicting locks on ‹"a"›, released latches
+[2] handle lock conflict error req1: added 1 discovered lock(s) to lock table: conflicting locks on ‹"a"›
 
 debug-lock-table
 ----
@@ -196,7 +196,7 @@ handle-lock-conflict-error req=req2 lease-seq=1
   lock txn=txn2 key=i
   lock txn=txn2 key=j
 ----
-[5] handle lock conflict error req2: handled conflicting locks on ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
+[5] handle lock conflict error req2: added 9 discovered lock(s) to lock table: conflicting locks on ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›
 
 debug-lock-table
 ----
@@ -311,7 +311,7 @@ sequence req=req1
 handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn2 key=a
 ----
-[2] handle lock conflict error req1: handled conflicting locks on ‹"a"›, released latches
+[2] handle lock conflict error req1: added 1 discovered lock(s) to lock table: conflicting locks on ‹"a"›
 
 debug-lock-table
 ----
@@ -367,7 +367,7 @@ handle-lock-conflict-error req=req2 lease-seq=1
   lock txn=txn2 key=i
   lock txn=txn2 key=j
 ----
-[5] handle lock conflict error req2: handled conflicting locks on ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
+[5] handle lock conflict error req2: added 9 discovered lock(s) to lock table: conflicting locks on ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›
 
 debug-lock-table
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/shared_locks
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/shared_locks
@@ -40,7 +40,7 @@ sequence req=req1
 
 on-lock-acquired req=req1 key=a dur=u str=shared
 ----
-[-] acquire lock: txn 00000001 @ ‹a›
+[-] acquire lock: txn 00000001 acquiring Unreplicated Shared lock on ‹"a"›
 
 finish req=req1
 ----
@@ -59,7 +59,7 @@ sequence req=req2
 
 on-lock-acquired req=req2 key=a dur=u str=shared
 ----
-[-] acquire lock: txn 00000002 @ ‹a›
+[-] acquire lock: txn 00000002 acquiring Unreplicated Shared lock on ‹"a"›
 
 finish req=req2
 ----
@@ -78,7 +78,7 @@ sequence req=req3
 
 on-lock-acquired req=req3 key=a dur=u str=shared
 ----
-[-] acquire lock: txn 00000003 @ ‹a›
+[-] acquire lock: txn 00000003 acquiring Unreplicated Shared lock on ‹"a"›
 
 finish req=req3
 ----
@@ -97,7 +97,7 @@ sequence req=req4
 
 on-lock-acquired req=req4 key=a dur=u str=shared
 ----
-[-] acquire lock: txn 00000004 @ ‹a›
+[-] acquire lock: txn 00000004 acquiring Unreplicated Shared lock on ‹"a"›
 
 finish req=req4
 ----
@@ -210,7 +210,7 @@ sequence req=req6
 
 on-lock-acquired req=req6 key=a dur=r str=intent
 ----
-[-] acquire lock: txn 00000006 @ ‹a›
+[-] acquire lock: txn 00000006 acquiring Replicated Intent lock on ‹"a"›
 
 finish req=req6
 ----
@@ -229,7 +229,7 @@ sequence req=req7
 
 on-lock-acquired req=req7 key=a dur=u str=shared
 ----
-[-] acquire lock: txn 00000006 @ ‹a›
+[-] acquire lock: txn 00000006 acquiring Unreplicated Shared lock on ‹"a"›
 
 finish req=req7
 ----
@@ -257,7 +257,7 @@ sequence req=req8
 handle-lock-conflict-error req=req8 lease-seq=1
   lock txn=txn6 key=a
 ----
-[9] handle lock conflict error req8: handled conflicting locks on ‹"a"›, released latches
+[9] handle lock conflict error req8: added 1 discovered lock(s) to lock table: conflicting locks on ‹"a"›
 
 debug-lock-table
 ----
@@ -308,7 +308,7 @@ sequence req=req9
 handle-lock-conflict-error req=req9 lease-seq=1
   lock txn=txn6 key=a
 ----
-[12] handle lock conflict error req9: handled conflicting locks on ‹"a"›, released latches
+[12] handle lock conflict error req9: added 1 discovered lock(s) to lock table: conflicting locks on ‹"a"›
 
 debug-lock-table
 ----
@@ -402,7 +402,7 @@ sequence req=req11
 
 on-lock-acquired req=req11 key=a dur=u str=shared
 ----
-[-] acquire lock: txn 00000001 @ ‹a›
+[-] acquire lock: txn 00000001 acquiring Unreplicated Shared lock on ‹"a"›
 
 debug-lock-table
 ----
@@ -470,7 +470,7 @@ sequence req=req15
 
 on-lock-acquired req=req14 key=a dur=u str=shared
 ----
-[-] acquire lock: txn 00000002 @ ‹a›
+[-] acquire lock: txn 00000002 acquiring Unreplicated Shared lock on ‹"a"›
 
 finish req=req14
 ----
@@ -644,7 +644,7 @@ sequence req=req19
 
 on-lock-acquired req=req19 key=a dur=u str=exclusive
 ----
-[-] acquire lock: txn 00000001 @ ‹a›
+[-] acquire lock: txn 00000001 acquiring Unreplicated Exclusive lock on ‹"a"›
 
 finish req=req19
 ----
@@ -873,7 +873,7 @@ sequence req=req25
 
 on-lock-acquired req=req25 key=a dur=u str=shared
 ----
-[-] acquire lock: txn 00000001 @ ‹a›
+[-] acquire lock: txn 00000001 acquiring Unreplicated Shared lock on ‹"a"›
 
 finish req=req25
 ----
@@ -971,7 +971,7 @@ sequence req=req28
 
 on-lock-acquired req=req28 key=a dur=u str=shared
 ----
-[-] acquire lock: txn 00000001 @ ‹a›
+[-] acquire lock: txn 00000001 acquiring Unreplicated Shared lock on ‹"a"›
 
 finish req=req28
 ----
@@ -990,7 +990,7 @@ sequence req=req29
 
 on-lock-acquired req=req29 key=b dur=u str=shared
 ----
-[-] acquire lock: txn 00000002 @ ‹b›
+[-] acquire lock: txn 00000002 acquiring Unreplicated Shared lock on ‹"b"›
 
 finish req=req29
 ----
@@ -1085,7 +1085,7 @@ sequence req=req1
 
 on-lock-acquired req=req1 key=a dur=u str=exclusive
 ----
-[-] acquire lock: txn 00000001 @ ‹a›
+[-] acquire lock: txn 00000001 acquiring Unreplicated Exclusive lock on ‹"a"›
 
 finish req=req1
 ----
@@ -1104,7 +1104,7 @@ sequence req=req2
 
 on-lock-acquired req=req2 key=b dur=u str=exclusive
 ----
-[-] acquire lock: txn 00000002 @ ‹b›
+[-] acquire lock: txn 00000002 acquiring Unreplicated Exclusive lock on ‹"b"›
 
 finish req=req2
 ----
@@ -1211,7 +1211,7 @@ sequence req=req1
 
 on-lock-acquired req=req1 key=a dur=u str=shared
 ----
-[-] acquire lock: txn 00000001 @ ‹a›
+[-] acquire lock: txn 00000001 acquiring Unreplicated Shared lock on ‹"a"›
 
 finish req=req1
 ----
@@ -1230,7 +1230,7 @@ sequence req=req2
 
 on-lock-acquired req=req2 key=a dur=u str=shared
 ----
-[-] acquire lock: txn 00000002 @ ‹a›
+[-] acquire lock: txn 00000002 acquiring Unreplicated Shared lock on ‹"a"›
 
 finish req=req2
 ----
@@ -1249,7 +1249,7 @@ sequence req=req3
 
 on-lock-acquired req=req3 key=b dur=u str=exclusive
 ----
-[-] acquire lock: txn 00000003 @ ‹b›
+[-] acquire lock: txn 00000003 acquiring Unreplicated Exclusive lock on ‹"b"›
 
 finish req=req3
 ----
@@ -1355,7 +1355,7 @@ sequence req=req1
 
 on-lock-acquired req=req1 key=a dur=u str=shared
 ----
-[-] acquire lock: txn 00000001 @ ‹a›
+[-] acquire lock: txn 00000001 acquiring Unreplicated Shared lock on ‹"a"›
 
 finish req=req1
 ----
@@ -1374,7 +1374,7 @@ sequence req=req2
 
 on-lock-acquired req=req2 key=a dur=u str=shared
 ----
-[-] acquire lock: txn 00000002 @ ‹a›
+[-] acquire lock: txn 00000002 acquiring Unreplicated Shared lock on ‹"a"›
 
 finish req=req2
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
@@ -25,7 +25,7 @@ sequence req=req1
 handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn1 key=k
 ----
-[2] handle lock conflict error req1: handled conflicting locks on ‹"k"›, released latches
+[2] handle lock conflict error req1: added 1 discovered lock(s) to lock table: conflicting locks on ‹"k"›
 
 debug-lock-table
 ----
@@ -91,7 +91,7 @@ sequence req=req1
 handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn1 key=k
 ----
-[2] handle lock conflict error req1: handled conflicting locks on ‹"k"›, released latches
+[2] handle lock conflict error req1: added 1 discovered lock(s) to lock table: conflicting locks on ‹"k"›
 
 debug-lock-table
 ----
@@ -166,7 +166,7 @@ sequence req=req1
 handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn1 key=k
 ----
-[2] handle lock conflict error req1: handled conflicting locks on ‹"k"›, released latches
+[2] handle lock conflict error req1: added 1 discovered lock(s) to lock table: conflicting locks on ‹"k"›
 
 debug-lock-table
 ----
@@ -292,7 +292,7 @@ handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn1 key=b
   lock txn=txn1 key=c
 ----
-[2] handle lock conflict error req1: handled conflicting locks on ‹"a"›, ‹"b"›, ‹"c"›, released latches
+[2] handle lock conflict error req1: added 3 discovered lock(s) to lock table: conflicting locks on ‹"a"›, ‹"b"›, ‹"c"›
 
 debug-lock-table
 ----
@@ -373,7 +373,7 @@ handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn1 key=b
   lock txn=txn1 key=c
 ----
-[2] handle lock conflict error req1: handled conflicting locks on ‹"a"›, ‹"b"›, ‹"c"›, released latches
+[2] handle lock conflict error req1: added 3 discovered lock(s) to lock table: conflicting locks on ‹"a"›, ‹"b"›, ‹"c"›
 
 debug-lock-table
 ----
@@ -459,7 +459,7 @@ handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn1 key=a
   lock txn=txn1 key=b
 ----
-[2] handle lock conflict error req1: handled conflicting locks on ‹"a"›, ‹"b"›, released latches
+[2] handle lock conflict error req1: added 2 discovered lock(s) to lock table: conflicting locks on ‹"a"›, ‹"b"›
 
 debug-lock-table
 ----
@@ -538,7 +538,7 @@ handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn1 key=a
   lock txn=txn1 key=b
 ----
-[2] handle lock conflict error req1: handled conflicting locks on ‹"a"›, ‹"b"›, released latches
+[2] handle lock conflict error req1: added 2 discovered lock(s) to lock table: conflicting locks on ‹"a"›, ‹"b"›
 
 debug-lock-table
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/update
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/update
@@ -37,7 +37,7 @@ sequence req=req1
 
 on-lock-acquired req=req1 key=k
 ----
-[-] acquire lock: txn 00000001 @ ‹k›
+[-] acquire lock: txn 00000001 acquiring Unreplicated Exclusive lock on ‹"k"›
 
 finish req=req1
 ----
@@ -102,7 +102,7 @@ sequence req=req3
 
 on-lock-acquired req=req3 key=k seq=1
 ----
-[-] acquire lock: txn 00000001 @ ‹k›
+[-] acquire lock: txn 00000001 acquiring Unreplicated Exclusive lock on ‹"k"›
 
 finish req=req3
 ----
@@ -155,7 +155,7 @@ sequence req=req1
 
 on-lock-acquired req=req1 key=k
 ----
-[-] acquire lock: txn 00000001 @ ‹k›
+[-] acquire lock: txn 00000001 acquiring Unreplicated Exclusive lock on ‹"k"›
 
 finish req=req1
 ----
@@ -224,7 +224,7 @@ sequence req=req3
 
 on-lock-acquired req=req3 key=k
 ----
-[-] acquire lock: txn 00000001 @ ‹k›
+[-] acquire lock: txn 00000001 acquiring Unreplicated Exclusive lock on ‹"k"›
 
 finish req=req3
 ----
@@ -282,7 +282,7 @@ sequence req=req1
 
 on-lock-acquired req=req1 key=k dur=u
 ----
-[-] acquire lock: txn 00000001 @ ‹k›
+[-] acquire lock: txn 00000001 acquiring Unreplicated Exclusive lock on ‹"k"›
 
 finish req=req1
 ----
@@ -368,7 +368,7 @@ sequence req=req3
 
 on-lock-acquired req=req3 key=k seq=1 dur=r
 ----
-[-] acquire lock: txn 00000001 @ ‹k›
+[-] acquire lock: txn 00000001 acquiring Replicated Intent lock on ‹"k"›
 
 finish req=req3
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_elsewhere
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_elsewhere
@@ -34,7 +34,7 @@ sequence req=reqFirstLock
 
 on-lock-acquired req=reqFirstLock key=k dur=r
 ----
-[-] acquire lock: txn 00000001 @ ‹k›
+[-] acquire lock: txn 00000001 acquiring Replicated Intent lock on ‹"k"›
 
 finish req=reqFirstLock
 ----
@@ -52,7 +52,7 @@ sequence req=reqWaiter
 handle-lock-conflict-error req=reqWaiter lease-seq=1
   lock txn=txnWriter key=k
 ----
-[3] handle lock conflict error reqWaiter: handled conflicting locks on ‹"k"›, released latches
+[3] handle lock conflict error reqWaiter: added 1 discovered lock(s) to lock table: conflicting locks on ‹"k"›
 
 sequence req=reqWaiter
 ----
@@ -82,7 +82,7 @@ sequence req=reqSecondLock
 
 on-lock-acquired req=reqSecondLock key=k2 dur=u
 ----
-[-] acquire lock: txn 00000001 @ ‹k2›
+[-] acquire lock: txn 00000001 acquiring Unreplicated Exclusive lock on ‹"k2"›
 [4] sequence reqWaiter: lock wait-queue event: wait elsewhere for txn 00000001 @ key ‹"k"›
 [4] sequence reqWaiter: pushing txn 00000001 to abort
 [4] sequence reqWaiter: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -155,15 +155,15 @@ sequence req=reqThreeKeyWriter
 
 on-lock-acquired req=reqThreeKeyWriter key=k1 dur=r
 ----
-[-] acquire lock: txn 00000003 @ ‹k1›
+[-] acquire lock: txn 00000003 acquiring Replicated Intent lock on ‹"k1"›
 
 on-lock-acquired req=reqThreeKeyWriter key=k2 dur=r
 ----
-[-] acquire lock: txn 00000003 @ ‹k2›
+[-] acquire lock: txn 00000003 acquiring Replicated Intent lock on ‹"k2"›
 
 on-lock-acquired req=reqThreeKeyWriter key=k3 dur=r
 ----
-[-] acquire lock: txn 00000003 @ ‹k3›
+[-] acquire lock: txn 00000003 acquiring Replicated Intent lock on ‹"k3"›
 
 finish req=reqThreeKeyWriter
 ----
@@ -193,7 +193,7 @@ handle-lock-conflict-error req=reqTwoKeyWaiter lease-seq=1
   lock txn=txnThreeKeyWriter key=k1
   lock txn=txnThreeKeyWriter key=k2
 ----
-[9] handle lock conflict error reqTwoKeyWaiter: handled conflicting locks on ‹"k1"›, ‹"k2"›, released latches
+[9] handle lock conflict error reqTwoKeyWaiter: added 2 discovered lock(s) to lock table: conflicting locks on ‹"k1"›, ‹"k2"›
 
 sequence req=reqTwoKeyWaiter
 ----
@@ -223,7 +223,7 @@ handle-lock-conflict-error req=reqThreeKeyWaiter lease-seq=1
   lock txn=txnThreeKeyWriter key=k2
   lock txn=txnThreeKeyWriter key=k3
 ----
-[11] handle lock conflict error reqThreeKeyWaiter: handled conflicting locks on ‹"k1"›, ‹"k2"›, ‹"k3"›, released latches
+[11] handle lock conflict error reqThreeKeyWaiter: added 3 discovered lock(s) to lock table: conflicting locks on ‹"k1"›, ‹"k2"›, ‹"k3"›
 
 sequence req=reqThreeKeyWaiter
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_error
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_error
@@ -30,11 +30,11 @@ sequence req=req1
 
 on-lock-acquired req=req1 key=k
 ----
-[-] acquire lock: txn 00000001 @ ‹k›
+[-] acquire lock: txn 00000001 acquiring Unreplicated Exclusive lock on ‹"k"›
 
 on-lock-acquired req=req1 key=k2
 ----
-[-] acquire lock: txn 00000001 @ ‹k2›
+[-] acquire lock: txn 00000001 acquiring Unreplicated Exclusive lock on ‹"k2"›
 
 finish req=req1
 ----
@@ -53,7 +53,7 @@ sequence req=req2
 
 on-lock-acquired req=req2 key=k3
 ----
-[-] acquire lock: txn 00000002 @ ‹k3›
+[-] acquire lock: txn 00000002 acquiring Unreplicated Exclusive lock on ‹"k3"›
 
 finish req=req2
 ----
@@ -191,7 +191,7 @@ sequence req=reqNoWait3
 handle-lock-conflict-error req=reqNoWait3 lease-seq=1
   lock txn=txn2 key=k4
 ----
-[8] handle lock conflict error reqNoWait3: handled conflicting locks on ‹"k4"›, released latches
+[8] handle lock conflict error reqNoWait3: added 1 discovered lock(s) to lock table: conflicting locks on ‹"k4"›
 
 sequence req=reqNoWait3
 ----
@@ -251,7 +251,7 @@ sequence req=reqNoWait4
 handle-lock-conflict-error req=reqNoWait4 lease-seq=1
   lock txn=txn2 key=k5
 ----
-[11] handle lock conflict error reqNoWait4: handled conflicting locks on ‹"k5"›, released latches
+[11] handle lock conflict error reqNoWait4: added 1 discovered lock(s) to lock table: conflicting locks on ‹"k5"›
 
 sequence req=reqNoWait4
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_skip
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_skip
@@ -30,11 +30,11 @@ sequence req=req1
 
 on-lock-acquired req=req1 key=k
 ----
-[-] acquire lock: txn 00000001 @ ‹k›
+[-] acquire lock: txn 00000001 acquiring Unreplicated Exclusive lock on ‹"k"›
 
 on-lock-acquired req=req1 key=k2
 ----
-[-] acquire lock: txn 00000001 @ ‹k2›
+[-] acquire lock: txn 00000001 acquiring Unreplicated Exclusive lock on ‹"k2"›
 
 finish req=req1
 ----
@@ -53,7 +53,7 @@ sequence req=req2
 
 on-lock-acquired req=req2 key=k3
 ----
-[-] acquire lock: txn 00000002 @ ‹k3›
+[-] acquire lock: txn 00000002 acquiring Unreplicated Exclusive lock on ‹"k3"›
 
 finish req=req2
 ----
@@ -72,7 +72,7 @@ sequence req=req3
 
 on-lock-acquired req=req3 key=k4
 ----
-[-] acquire lock: txn 00000003 @ ‹k4›
+[-] acquire lock: txn 00000003 acquiring Unreplicated Exclusive lock on ‹"k4"›
 
 finish req=req3
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_skip_shared
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_skip_shared
@@ -30,11 +30,11 @@ sequence req=req1
 
 on-lock-acquired req=req1 key=k1 str=shared
 ----
-[-] acquire lock: txn 00000001 @ ‹k1›
+[-] acquire lock: txn 00000001 acquiring Unreplicated Shared lock on ‹"k1"›
 
 on-lock-acquired req=req1 key=k2 str=shared
 ----
-[-] acquire lock: txn 00000001 @ ‹k2›
+[-] acquire lock: txn 00000001 acquiring Unreplicated Shared lock on ‹"k2"›
 
 finish req=req1
 ----
@@ -53,7 +53,7 @@ sequence req=req2
 
 on-lock-acquired req=req2 key=k2 str=shared
 ----
-[-] acquire lock: txn 00000002 @ ‹k2›
+[-] acquire lock: txn 00000002 acquiring Unreplicated Shared lock on ‹"k2"›
 
 new-request name=req3 txn=txn3 ts=12,1
   get key=k3 str=exclusive
@@ -72,7 +72,7 @@ sequence req=req3
 
 on-lock-acquired req=req3 key=k3 str=exclusive
 ----
-[-] acquire lock: txn 00000003 @ ‹k3›
+[-] acquire lock: txn 00000003 acquiring Unreplicated Exclusive lock on ‹"k3"›
 
 finish req=req3
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_self
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_self
@@ -35,7 +35,7 @@ sequence req=reqOld
 
 on-lock-acquired req=reqOld key=k
 ----
-[-] acquire lock: txn 00000002 @ ‹k›
+[-] acquire lock: txn 00000002 acquiring Unreplicated Exclusive lock on ‹"k"›
 
 finish req=reqOld
 ----

--- a/pkg/kv/kvserver/concurrency/verifiable_lock_table.go
+++ b/pkg/kv/kvserver/concurrency/verifiable_lock_table.go
@@ -6,6 +6,8 @@
 package concurrency
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -65,10 +67,10 @@ func (v verifyingLockTable) ClearGE(key roachpb.Key) []roachpb.LockAcquisition {
 
 // ScanAndEnqueue implements the lockTable interface.
 func (v verifyingLockTable) ScanAndEnqueue(
-	req Request, guard lockTableGuard,
+	ctx context.Context, req Request, guard lockTableGuard,
 ) (lockTableGuard, *Error) {
 	defer v.lt.verify()
-	return v.lt.ScanAndEnqueue(req, guard)
+	return v.lt.ScanAndEnqueue(ctx, req, guard)
 }
 
 // ScanOptimistic implements the lockTable interface.
@@ -78,37 +80,40 @@ func (v verifyingLockTable) ScanOptimistic(req Request) lockTableGuard {
 }
 
 // Dequeue implements the lockTable interface.
-func (v verifyingLockTable) Dequeue(guard lockTableGuard) {
+func (v verifyingLockTable) Dequeue(ctx context.Context, guard lockTableGuard) {
 	defer v.lt.verify()
-	v.lt.Dequeue(guard)
+	v.lt.Dequeue(ctx, guard)
 }
 
 // AddDiscoveredLock implements the lockTable interface.
 func (v verifyingLockTable) AddDiscoveredLock(
+	ctx context.Context,
 	foundLock *roachpb.Lock,
 	seq roachpb.LeaseSequence,
 	consultTxnStatusCache bool,
 	guard lockTableGuard,
 ) (bool, error) {
 	defer v.lt.verifyKey(foundLock.Key)
-	return v.lt.AddDiscoveredLock(foundLock, seq, consultTxnStatusCache, guard)
+	return v.lt.AddDiscoveredLock(ctx, foundLock, seq, consultTxnStatusCache, guard)
 }
 
 // AcquireLock implements the lockTable interface.
-func (v verifyingLockTable) AcquireLock(acq *roachpb.LockAcquisition) error {
+func (v verifyingLockTable) AcquireLock(ctx context.Context, acq *roachpb.LockAcquisition) error {
 	defer v.lt.verifyKey(acq.Key)
-	return v.lt.AcquireLock(acq)
+	return v.lt.AcquireLock(ctx, acq)
 }
 
 // MarkIneligibleForExport implements the lockTable interface.
-func (v verifyingLockTable) MarkIneligibleForExport(acq *roachpb.LockAcquisition) error {
-	return v.lt.MarkIneligibleForExport(acq)
+func (v verifyingLockTable) MarkIneligibleForExport(
+	ctx context.Context, acq *roachpb.LockAcquisition,
+) error {
+	return v.lt.MarkIneligibleForExport(ctx, acq)
 }
 
 // UpdateLocks implements the lockTable interface.
-func (v verifyingLockTable) UpdateLocks(up *roachpb.LockUpdate) error {
+func (v verifyingLockTable) UpdateLocks(ctx context.Context, up *roachpb.LockUpdate) error {
 	defer v.lt.verify()
-	return v.lt.UpdateLocks(up)
+	return v.lt.UpdateLocks(ctx, up)
 }
 
 // PushedTransactionUpdated implements the lockTable interface.


### PR DESCRIPTION
This commit plumbs a context to the lock table and adds logging for some key transitions.

Fixes: #131248

Release note: None