### PR TITLE
sql: auto update system table regions in DROP REGION finalizer

### DIFF
--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -2058,11 +2058,9 @@ func (p *planner) optimizeSystemDatabase(ctx context.Context) error {
 		}
 	}
 
-	// Configure by region tables next.
-	primaryRegionName, err := systemDB.PrimaryRegionName()
-	if err != nil {
-		return err
-	}
+	// Configure by region tables next. Use PrimaryRegionNotSpecifiedName so
+	// tables implicitly follow the primary region rather than explicitly
+	// referencing a region name that could later be dropped.
 	for _, tableName := range regionTables {
 		descriptor, err := getDescriptor(tableName)
 		// Some system tables only come into effect once the
@@ -2073,7 +2071,7 @@ func (p *planner) optimizeSystemDatabase(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		descriptor.SetTableLocalityRegionalByTable(tree.Name(primaryRegionName))
+		descriptor.SetTableLocalityRegionalByTable(tree.PrimaryRegionNotSpecifiedName)
 		if err := applyLocalityChange(descriptor, "global"); err != nil {
 			return err
 		}


### PR DESCRIPTION
Previously, dropping a region from the system database could leave REGIONAL BY TABLE system tables with stale references to the dropped region. Descriptor validation would then fail when it encountered references to a region that no longer existed.

This change extends the database region change finalizer to clean up system tables when a region is dropped. Specifically, the finalizer now:
- Updates affected REGIONAL BY TABLE system tables to reference the current primary region
- Regenerates their zone configurations to reflect the updated region

This ensures system descriptors remain valid after a region is removed and prevents validation errors caused by dangling region references.

Closes: #163418
Epic: None

Release note (bug fix): Dropping a region from the system database no longer leaves REGIONAL BY TABLE system tables referencing the removed region, preventing descriptor validation errors.