### PR TITLE
sql/inspect: make inspect test lease relocation deterministic

### DIFF
--- a/pkg/sql/inspect/BUILD.bazel
+++ b/pkg/sql/inspect/BUILD.bazel
@@ -104,6 +104,7 @@ go_test(
         "//pkg/keys",
         "//pkg/kv",
         "//pkg/kv/kvserver/protectedts",
+        "//pkg/multitenant/tenantcapabilitiespb",
         "//pkg/roachpb",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",


### PR DESCRIPTION
TestInspectProgressWithMultiRangeTable used ALTER TABLE ... SCATTER to spread leases, but SCATTER is probabilistic and can fail to move leases. Use EXPERIMENTAL_RELOCATE for more determinstic relocation.

Closes #162576
Release note: none