### PR TITLE
changefeedccl: refactor core changefeed progress tracking

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -57,17 +57,15 @@ const (
 )
 
 // computeDistChangefeedTimestamps computes the initialHighWater and schemaTS
-// for a changefeed run, and mutates localState.progress when appropriate
-// (e.g., to set the high-water if initial scan should be skipped). It also
-// invokes testing knobs that observe the initial high-water.
+// for a changefeed run. It also invokes testing knobs that observe the initial
+// high-water.
 func computeDistChangefeedTimestamps(
 	ctx context.Context,
 	execCtx sql.JobExecContext,
 	details jobspb.ChangefeedDetails,
-	localState *cachedState,
+	progress jobspb.Progress,
 ) (initialHighWater hlc.Timestamp, schemaTS hlc.Timestamp, _ error) {
 	opts := changefeedbase.MakeStatementOptions(details.Opts)
-	progress := localState.progress
 
 	// NB: A non-empty high water indicates that we have checkpointed a resolved
 	// timestamp. Skipping the initial scan is equivalent to starting the
@@ -226,15 +224,17 @@ func startDistChangefeed(
 	details jobspb.ChangefeedDetails,
 	description string,
 	initialHighWater hlc.Timestamp,
-	localState *cachedState,
+	progress jobspb.Progress,
+	prevResult flowResult,
 	resultsCh chan<- tree.Datums,
 	onTracingEvent func(ctx context.Context, meta *execinfrapb.TracingAggregatorEvents),
 	targets changefeedbase.Targets,
-) error {
+) (flowResult, error) {
+	var result flowResult
 	execCfg := execCtx.ExecCfg()
 	tableDescs, err := fetchTableDescriptors(ctx, execCfg, targets, schemaTS)
 	if err != nil {
-		return err
+		return flowResult{}, err
 	}
 
 	if schemaTS.IsEmpty() {
@@ -242,12 +242,12 @@ func startDistChangefeed(
 	}
 	trackedSpans, err := fetchSpansForTables(ctx, execCtx, tableDescs, details, schemaTS)
 	if err != nil {
-		return err
+		return flowResult{}, err
 	}
 	if log.ExpensiveLogEnabled(ctx, 2) {
 		log.Changefeed.Infof(ctx, "tracked spans: %s", trackedSpans)
 	}
-	localState.trackedSpans = trackedSpans
+	result.trackedSpans = trackedSpans
 
 	// Changefeed flows handle transactional consistency themselves.
 	var noTxn *kv.Txn
@@ -255,16 +255,22 @@ func startDistChangefeed(
 	dsp := execCtx.DistSQLPlanner()
 
 	var spanLevelCheckpoint *jobspb.TimestampSpansMap
-	if progress := localState.progress.GetChangefeed(); progress != nil && progress.SpanLevelCheckpoint != nil {
-		spanLevelCheckpoint = progress.SpanLevelCheckpoint
+	if cfProgress := progress.GetChangefeed(); cfProgress != nil && cfProgress.SpanLevelCheckpoint != nil {
+		spanLevelCheckpoint = cfProgress.SpanLevelCheckpoint
 		if log.V(2) {
 			log.Changefeed.Infof(ctx, "span-level checkpoint: %s", spanLevelCheckpoint)
 		}
 	}
 	p, planCtx, err := makePlan(execCtx, jobID, details, description, initialHighWater,
-		trackedSpans, spanLevelCheckpoint, localState.drainingNodes, schemaTS)(ctx, dsp)
+		trackedSpans, spanLevelCheckpoint, prevResult, schemaTS)(ctx, dsp)
 	if err != nil {
-		return err
+		return flowResult{}, err
+	}
+	// For core changefeeds (no job), create in-memory progress state and
+	// set it on the eval context so the changeFrontier processor can access it.
+	if jobID == 0 {
+		result.coreProgress = &coreProgress{progress: progress}
+		execCtx.ExtendedEvalContext().CoreChangefeedState = result.coreProgress
 	}
 
 	execPlan := func(ctx context.Context) error {
@@ -273,18 +279,14 @@ func startDistChangefeed(
 		ctx, cancel := execCtx.ExecCfg().DistSQLSrv.Stopper.WithCancelOnQuiesce(ctx)
 		defer cancel()
 
-		// clear out previous drain/shutdown information.
-		localState.drainingNodes = localState.drainingNodes[:0]
-		localState.aggregatorFrontier = localState.aggregatorFrontier[:0]
-
 		resultRows := sql.NewMetadataCallbackWriter(
 			makeChangefeedResultWriter(resultsCh, cancel),
 			func(ctx context.Context, meta *execinfrapb.ProducerMetadata) error {
 				if meta.Changefeed != nil {
 					if meta.Changefeed.DrainInfo != nil {
-						localState.drainingNodes = append(localState.drainingNodes, meta.Changefeed.DrainInfo.NodeID)
+						result.drainingNodes = append(result.drainingNodes, meta.Changefeed.DrainInfo.NodeID)
 					}
-					localState.aggregatorFrontier = append(localState.aggregatorFrontier, meta.Changefeed.Checkpoint...)
+					result.aggregatorFrontier = append(result.aggregatorFrontier, meta.Changefeed.Checkpoint...)
 				}
 				if meta.AggregatorEvents != nil && onTracingEvent != nil {
 					onTracingEvent(ctx, meta.AggregatorEvents)
@@ -334,7 +336,7 @@ func startDistChangefeed(
 		return resultRows.Err()
 	}
 
-	return ctxgroup.GoAndWait(ctx, execPlan)
+	return result, ctxgroup.GoAndWait(ctx, execPlan)
 }
 
 // The bin packing choice gives preference to leaseholder replicas if possible.
@@ -388,7 +390,7 @@ func makePlan(
 	initialHighWater hlc.Timestamp,
 	trackedSpans []roachpb.Span,
 	spanLevelCheckpoint *jobspb.TimestampSpansMap,
-	drainingNodes []roachpb.NodeID,
+	prevResult flowResult,
 	schemaTS hlc.Timestamp,
 ) func(context.Context, *sql.DistSQLPlanner) (*sql.PhysicalPlan, *sql.PlanningCtx, error) {
 	return func(ctx context.Context, dsp *sql.DistSQLPlanner) (*sql.PhysicalPlan, *sql.PlanningCtx, error) {
@@ -469,8 +471,8 @@ func makePlan(
 			)
 		}
 
-		if haveKnobs && maybeCfKnobs.FilterDrainingNodes != nil && len(drainingNodes) > 0 {
-			spanPartitions, err = maybeCfKnobs.FilterDrainingNodes(spanPartitions, drainingNodes)
+		if haveKnobs && maybeCfKnobs.FilterDrainingNodes != nil && len(prevResult.drainingNodes) > 0 {
+			spanPartitions, err = maybeCfKnobs.FilterDrainingNodes(spanPartitions, prevResult.drainingNodes)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -510,6 +512,8 @@ func makePlan(
 			}); err != nil {
 				return nil, nil, err
 			}
+		} else if prevResult.coreProgress != nil {
+			resolvedSpans = prevResult.coreProgress.frontierSpans
 		}
 
 		aggregatorSpecs := make([]*execinfrapb.ChangeAggregatorSpec, len(spanPartitions))

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/kvfeed"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/resolvedspan"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/schemafeed"
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobfrontier"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
@@ -1047,11 +1046,9 @@ type changeFrontier struct {
 	// span set.
 	frontier *resolvedspan.CoordinatorFrontier
 
-	// localState contains an in memory cache of progress updates.
-	// Used by core style changefeeds as well as regular changefeeds to make
-	// restarts more efficient with respects to duplicates.
-	// localState reflects an up-to-date information *after* the checkpoint.
-	localState *cachedState
+	// coreChangefeedState, if non-nil, contains in-memory progress for core
+	// (sinkless) changefeeds. It is set from the eval context during Start().
+	coreChangefeedState eval.CoreChangefeedState
 
 	// encoder is the Encoder to use for resolved timestamp serialization.
 	encoder Encoder
@@ -1139,43 +1136,59 @@ type jobState struct {
 	progressUpdatesSkipped bool
 }
 
-// cachedState is a changefeed progress stored in memory.
-// It is used to reduce the number of duplicate events emitted during retries.
-type cachedState struct {
-	progress jobspb.Progress
-
-	// set of spans for this changefeed.
+// flowResult contains state collected during a changefeed DistSQL flow
+// execution. It is returned by startDistChangefeed and consumed by the
+// retry loops in coreChangefeed and resumeWithRetries.
+type flowResult struct {
+	// trackedSpans is the set of spans watched by the changefeed.
 	trackedSpans roachpb.Spans
-	// aggregatorFrontier contains the list of frontier spans
-	// emitted by aggregators when they are being shut down.
+	// aggregatorFrontier contains frontier spans emitted by aggregators
+	// during shutdown via trailing metadata.
 	aggregatorFrontier []execinfrapb.ChangefeedMeta_FrontierSpan
 	// drainingNodes is the list of nodes that are draining.
 	drainingNodes []roachpb.NodeID
+	// coreProgress is the in-memory progress at the end of the flow. This
+	// is only populated for core changefeeds (jobID == 0) where there is
+	// no job record to reload progress from.
+	coreProgress *coreProgress
 }
 
-// SetHighwater implements the eval.ChangefeedState interface.
-func (cs *cachedState) SetHighwater(frontier hlc.Timestamp) {
-	cs.progress.Progress = &jobspb.Progress_HighWater{
-		HighWater: &frontier,
-	}
-}
-
-// SetCheckpoint implements the eval.ChangefeedState interface.
-func (cs *cachedState) SetCheckpoint(checkpoint *jobspb.TimestampSpansMap) {
-	cs.progress.Details.(*jobspb.Progress_Changefeed).Changefeed.SpanLevelCheckpoint = checkpoint
-}
-
-// AggregatorFrontierSpans returns an iterator over the spans in the aggregator
+// aggregatorFrontierSpans returns an iterator over the spans in the aggregator
 // frontier collected during shutdown.
-func (cs *cachedState) AggregatorFrontierSpans() iter.Seq2[roachpb.Span, hlc.Timestamp] {
+func (r *flowResult) aggregatorFrontierSpans() iter.Seq2[roachpb.Span, hlc.Timestamp] {
 	return func(yield func(roachpb.Span, hlc.Timestamp) bool) {
-		for _, entry := range cs.aggregatorFrontier {
+		for _, entry := range r.aggregatorFrontier {
 			if !yield(entry.Span, entry.Timestamp) {
 				return
 			}
 		}
 	}
 }
+
+// coreProgress is changefeed progress stored in memory for core changefeeds.
+// It is not safe for concurrent access and should only be modified by a core
+// changefeed's change frontier and read after the changefeed flow completes.
+type coreProgress struct {
+	progress      jobspb.Progress
+	frontierSpans []jobspb.ResolvedSpan
+}
+
+// SetHighwater sets the frontier timestamp for the changefeed.
+func (cp *coreProgress) SetHighwater(hw hlc.Timestamp) {
+	cp.progress.Progress = &jobspb.Progress_HighWater{
+		HighWater: &hw,
+	}
+}
+
+// SetFrontier saves a snapshot of the frontier spans.
+func (cp *coreProgress) SetFrontier(frontier iter.Seq[jobspb.ResolvedSpan]) {
+	cp.frontierSpans = cp.frontierSpans[:0]
+	for rs := range frontier {
+		cp.frontierSpans = append(cp.frontierSpans, rs)
+	}
+}
+
+var _ eval.CoreChangefeedState = (*coreProgress)(nil)
 
 func newJobState(
 	j *jobs.Job, st *cluster.Settings, metrics *Metrics, ts timeutil.TimeSource,
@@ -1261,8 +1274,6 @@ func newChangeFrontierProcessor(
 	memMonitor := execinfra.NewMonitor(ctx, flowCtx.Mon, mon.MakeName("changefntr-mem"))
 
 	cf := &changeFrontier{
-		// We might modify the ChangefeedState field in the eval.Context, so we
-		// need to make a copy.
 		evalCtx:       flowCtx.NewEvalCtx(),
 		spec:          spec,
 		memAcc:        memMonitor.MakeBoundAccount(),
@@ -1429,13 +1440,14 @@ func (cf *changeFrontier) Start(ctx context.Context) {
 	cf.sink = &errorWrapperSink{wrapped: cf.sink}
 
 	cf.highWaterAtStart = cf.spec.Feed.StatementTime
-	if cf.evalCtx.ChangefeedState == nil {
-		log.Changefeed.Warningf(cf.Ctx(), "moving to draining due to missing changefeed state")
-		cf.MoveToDraining(errors.AssertionFailedf("expected initialized local state"))
-		return
+	if cf.spec.JobID == 0 {
+		cf.coreChangefeedState = cf.evalCtx.CoreChangefeedState
+		if cf.coreChangefeedState == nil {
+			cf.MoveToDraining(errors.AssertionFailedf(
+				"expected initialized CoreChangefeedState"))
+			return
+		}
 	}
-
-	cf.localState = cf.evalCtx.ChangefeedState.(*cachedState)
 	cf.js = newJobState(nil, cf.FlowCtx.Cfg.Settings, cf.metrics, timeutil.DefaultTimeSource{})
 
 	var initialHighwater hlc.Timestamp
@@ -1936,8 +1948,9 @@ func (cf *changeFrontier) checkpointJobProgress(
 		}
 	}
 
-	cf.localState.SetHighwater(frontier)
-	cf.localState.SetCheckpoint(spanLevelCheckpoint)
+	if cf.spec.JobID == 0 {
+		cf.coreChangefeedState.SetHighwater(frontier)
+	}
 
 	return nil
 }
@@ -1946,20 +1959,29 @@ func (cf *changeFrontier) maybePersistFrontier(ctx context.Context) error {
 	ctx, sp := tracing.ChildSpan(ctx, "changefeed.frontier.maybe_persist_frontier")
 	defer sp.Finish()
 
-	if cf.spec.JobID == 0 ||
-		!cf.evalCtx.Settings.Version.IsActive(ctx, clusterversion.V25_4) ||
-		!cf.frontierPersistenceLimiter.canSave(ctx) {
+	if !cf.frontierPersistenceLimiter.canSave(ctx) {
 		return nil
 	}
 
-	timer := cf.sliMetrics.Timers.FrontierPersistence.Start()
-	if err := cf.FlowCtx.Cfg.DB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-		return jobfrontier.Store(ctx, txn, cf.spec.JobID, "coordinator", cf.frontier)
-	}); err != nil {
-		return err
+	if cf.spec.JobID == 0 {
+		cf.coreChangefeedState.SetFrontier(cf.frontier.All())
+		cf.frontierPersistenceLimiter.doneSave(0)
+	} else {
+		timer := cf.sliMetrics.Timers.FrontierPersistence.Start()
+		if err := cf.FlowCtx.Cfg.DB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+			return jobfrontier.Store(ctx, txn, cf.spec.JobID, "coordinator", cf.frontier)
+		}); err != nil {
+			return err
+		}
+		cf.frontierPersistenceLimiter.doneSave(timer.End())
 	}
-	persistDuration := timer.End()
-	cf.frontierPersistenceLimiter.doneSave(persistDuration)
+
+	if cf.knobs.AfterPersistFrontier != nil {
+		if err := cf.knobs.AfterPersistFrontier(cf.coreChangefeedState); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -523,9 +523,8 @@ func coreChangefeed(
 	resultsCh chan<- tree.Datums,
 	targets changefeedbase.Targets,
 ) error {
-	localState := &cachedState{progress: progress}
-	p.ExtendedEvalContext().ChangefeedState = localState
 	knobs, _ := p.ExecCfg().DistSQLSrv.TestingKnobs.Changefeed.(*TestingKnobs)
+	var prevResult flowResult
 
 	maxBackoff := changefeedbase.MaxRetryBackoff.Get(&p.ExecCfg().Settings.SV)
 	backoffReset := changefeedbase.RetryBackoffReset.Get(&p.ExecCfg().Settings.SV)
@@ -540,19 +539,25 @@ func coreChangefeed(
 			knobs.BeforeDistChangefeed()
 		}
 
-		initialHighWater, schemaTS, err := computeDistChangefeedTimestamps(ctx, p, details, localState)
+		initialHighWater, schemaTS, err := computeDistChangefeedTimestamps(ctx, p, details, progress)
 		if err != nil {
 			return err
 		}
-		maybeCfKnobs, haveKnobs := p.ExecCfg().DistSQLSrv.TestingKnobs.Changefeed.(*TestingKnobs)
-		if haveKnobs && maybeCfKnobs.AfterComputeDistChangefeedTimestamps != nil {
-			maybeCfKnobs.AfterComputeDistChangefeedTimestamps(ctx)
+		if knobs != nil && knobs.AfterComputeDistChangefeedTimestamps != nil {
+			knobs.AfterComputeDistChangefeedTimestamps(ctx)
 		}
-		err = startDistChangefeed(ctx, p, 0 /* jobID */, schemaTS, details, description, initialHighWater, localState, resultsCh, nil, targets)
+		result, err := startDistChangefeed(ctx, p, 0 /* jobID */, schemaTS, details, description,
+			initialHighWater, progress, prevResult, resultsCh, nil, targets)
 		if err == nil {
 			log.Changefeed.Infof(ctx, "core changefeed completed with no error")
 			return nil
 		}
+
+		// Update progress from the flow result for the next retry.
+		if result.coreProgress != nil {
+			progress = result.coreProgress.progress
+		}
+		prevResult = result
 
 		if knobs != nil && knobs.HandleDistChangefeedError != nil {
 			err = knobs.HandleDistChangefeedError(err)
@@ -563,8 +568,6 @@ func coreChangefeed(
 			return err
 		}
 
-		// All other errors retry; but we'll use an up-to-date progress
-		// information which is saved in the localState.
 		log.Changefeed.Infof(ctx, "core changefeed retrying due to transient error: %s", err)
 	}
 }
@@ -1792,12 +1795,8 @@ func (b *changefeedResumer) resumeWithRetries(
 	drainCh, cleanup := execCfg.JobRegistry.OnDrain()
 	defer cleanup()
 
-	// Setup local state information.
-	// This information is used by dist flow process to communicate back
-	// the up-to-date checkpoint and node health information in case
-	// changefeed encounters transient error.
-	localState := &cachedState{progress: initialProgress}
-	jobExec.ExtendedEvalContext().ChangefeedState = localState
+	progress := initialProgress
+	var prevResult flowResult
 	knobs, _ := execCfg.DistSQLSrv.TestingKnobs.Changefeed.(*TestingKnobs)
 
 	resolvedDest, err := resolveDest(ctx, execCfg, details.SinkURI)
@@ -1847,7 +1846,7 @@ func (b *changefeedResumer) resumeWithRetries(
 
 			changefeedDoneCh := make(chan struct{})
 			g := ctxgroup.WithContext(ctx)
-			initialHighWater, schemaTS, err := computeDistChangefeedTimestamps(ctx, jobExec, details, localState)
+			initialHighWater, schemaTS, err := computeDistChangefeedTimestamps(ctx, jobExec, details, progress)
 			if err != nil {
 				return err
 			}
@@ -1925,7 +1924,10 @@ func (b *changefeedResumer) resumeWithRetries(
 						}
 					}
 				}
-				return startDistChangefeed(ctx, jobExec, jobID, schemaTS, details, description, initialHighWater, localState, startedCh, onTracingEvent, targets)
+				var err error
+				prevResult, err = startDistChangefeed(ctx, jobExec, jobID, schemaTS, details, description,
+					initialHighWater, progress, prevResult, startedCh, onTracingEvent, targets)
+				return err
 			})
 
 			// Poll for updated configuration or new database tables if hibernating.
@@ -1990,7 +1992,9 @@ func (b *changefeedResumer) resumeWithRetries(
 			sli.ErrorRetries.Inc(1)
 		}
 
-		if err := reconcileJobStateWithLocalState(ctx, jobID, localState, execCfg); err != nil {
+		var err error
+		progress, err = reconcileJobProgress(ctx, jobID, prevResult, execCfg)
+		if err != nil {
 			// Any errors during reconciliation are retry-able.
 			// When retry-able error propagates to jobs registry, it will clear out
 			// claim information, and will restart this job somewhere else (though,
@@ -2011,8 +2015,9 @@ func (b *changefeedResumer) resumeWithRetries(
 				// and this node restarting changefeed before this happens.
 				// We could come up with a mechanism to provide additional
 				// information to dist sql planner.  Or... we could just wait a bit.
-				log.Changefeed.Warningf(ctx, "Changefeed %d delaying restart due to %d node(s) (%v) draining (approx backoff: %s)",
-					jobID, len(localState.drainingNodes), localState.drainingNodes, r.NextBackoff())
+				log.Changefeed.Warningf(ctx,
+					"Changefeed %d delaying restart due to %d node(s) (%v) draining (approx backoff: %s)",
+					jobID, len(prevResult.drainingNodes), prevResult.drainingNodes, r.NextBackoff())
 				r.Next() // default config: ~5 sec delay, plus 10 sec on the retry loop.
 			}
 		}
@@ -2050,84 +2055,88 @@ func reloadDest(ctx context.Context, id jobspb.JobID, execCfg *sql.ExecutorConfi
 	return resolveDest(ctx, execCfg, newDetails.SinkURI)
 }
 
-// reconcileJobStateWithLocalState ensures that the job progress information
-// is consistent with the state present in the local state.
-func reconcileJobStateWithLocalState(
-	ctx context.Context, jobID jobspb.JobID, localState *cachedState, execCfg *sql.ExecutorConfig,
-) error {
-	// Re-load the job in order to update our progress object, which may have
+// reconcileJobProgress reloads job progress from the job table and applies
+// any frontier updates from the flow result. If the frontier advanced or a
+// span-level checkpoint was produced, the updated progress is persisted back
+// to the job table. The returned progress is used for the next retry iteration.
+func reconcileJobProgress(
+	ctx context.Context, jobID jobspb.JobID, result flowResult, execCfg *sql.ExecutorConfig,
+) (jobspb.Progress, error) {
+	// Re-load the job in order to get the latest progress, which may have
 	// been updated by the changeFrontier processor since the flow started.
 	reloadedJob, reloadErr := execCfg.JobRegistry.LoadClaimedJob(ctx, jobID)
 	if reloadErr != nil {
 		log.Changefeed.Warningf(ctx, `CHANGEFEED job %d could not reload job progress (%s); `+
 			`job should be retried later`, jobID, reloadErr)
-		return reloadErr
+		return jobspb.Progress{}, reloadErr
 	}
 	knobs, _ := execCfg.DistSQLSrv.TestingKnobs.Changefeed.(*TestingKnobs)
 	if knobs != nil && knobs.LoadJobErr != nil {
 		if err := knobs.LoadJobErr(); err != nil {
-			return err
+			return jobspb.Progress{}, err
 		}
 	}
 
-	localState.progress = reloadedJob.Progress()
+	progress := reloadedJob.Progress()
 
-	// localState contains an up-to-date checkpoint information transmitted by
-	// aggregator when flow was terminated. To be safe, we don't blindly trust
-	// local state; instead, this checkpoint is applied to the reloaded job
-	// progress, and the resulting progress record persisted back to the jobs
-	// table.
+	// The flow result contains up-to-date frontier information transmitted by
+	// aggregators when the flow was terminated. To be safe, we don't blindly
+	// trust it; instead, this is applied to the reloaded job progress, and
+	// the resulting progress record persisted back to the jobs table.
 	var highWater hlc.Timestamp
-	if hw := localState.progress.GetHighWater(); hw != nil {
+	if hw := progress.GetHighWater(); hw != nil {
 		highWater = *hw
 	}
 
 	// Build frontier based on tracked spans.
-	sf, err := span.MakeFrontierAt(highWater, localState.trackedSpans...)
+	sf, err := span.MakeFrontierAt(highWater, result.trackedSpans...)
 	if err != nil {
-		return err
+		return jobspb.Progress{}, err
 	}
 	// Advance frontier based on the information received from the aggregators.
-	for sp, ts := range localState.AggregatorFrontierSpans() {
+	for sp, ts := range result.aggregatorFrontierSpans() {
 		_, err := sf.Forward(sp, ts)
 		if err != nil {
-			return err
+			return jobspb.Progress{}, err
 		}
 	}
 
 	maxBytes := changefeedbase.SpanCheckpointMaxBytes.Get(&execCfg.Settings.SV)
-	checkpoint := checkpoint.Make(
+	cp := checkpoint.Make(
 		sf.Frontier(),
-		localState.AggregatorFrontierSpans(),
+		result.aggregatorFrontierSpans(),
 		maxBytes,
 		nil, /* metrics */
 	)
 
 	// Update checkpoint.
 	updateHW := highWater.Less(sf.Frontier())
-	updateSpanCheckpoint := !checkpoint.IsEmpty()
+	updateSpanCheckpoint := !cp.IsEmpty()
 
 	if updateHW || updateSpanCheckpoint {
 		if updateHW {
-			localState.SetHighwater(sf.Frontier())
+			frontier := sf.Frontier()
+			progress.Progress = &jobspb.Progress_HighWater{HighWater: &frontier}
 		}
-		localState.SetCheckpoint(checkpoint)
+		progress.Details.(*jobspb.Progress_Changefeed).Changefeed.SpanLevelCheckpoint = cp
 		if log.V(1) {
 			log.Changefeed.Infof(ctx, "Applying checkpoint to job record:  hw=%v, cf=%v",
-				localState.progress.GetHighWater(), localState.progress.GetChangefeed())
+				progress.GetHighWater(), progress.GetChangefeed())
 		}
-		return reloadedJob.NoTxn().Update(ctx,
+		if err := reloadedJob.NoTxn().Update(ctx,
 			func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
 				if err := md.CheckRunningOrReverting(); err != nil {
 					return err
 				}
-				ju.UpdateProgress(&localState.progress)
+				ju.UpdateProgress(&progress)
 				return nil
 			},
-		)
+		); err != nil {
+			return jobspb.Progress{}, err
+		}
 	}
 
-	return nil
+	return progress, nil
 }
 
 // OnFailOrCancel is part of the jobs.Resumer interface.

--- a/pkg/ccl/changefeedccl/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/testing_knobs.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -133,6 +134,13 @@ type TestingKnobs struct {
 	// the initial timestamps are computed and before the changefeed targets'
 	// descriptors are fetched.
 	AfterComputeDistChangefeedTimestamps func(context.Context)
+
+	// AfterPersistFrontier is called after the frontier is persisted
+	// (either to CoreChangefeedState or the job frontier table). For
+	// core changefeeds, the CoreChangefeedState is passed; for job-based
+	// changefeeds, it is nil. A non-nil return error is propagated to
+	// the change frontier.
+	AfterPersistFrontier func(eval.CoreChangefeedState) error
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -270,8 +270,8 @@ type Context struct {
 	// RangeStatsFetcher is used to fetch RangeStats.
 	RangeStatsFetcher RangeStatsFetcher
 
-	// ChangefeedState stores the state (progress) of core changefeeds.
-	ChangefeedState ChangefeedState
+	// CoreChangefeedState stores the in-memory progress of core changefeeds.
+	CoreChangefeedState CoreChangefeedState
 
 	// ParseHelper makes date parsing more efficient.
 	ParseHelper pgdate.ParseHelper

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -7,6 +7,7 @@ package eval
 
 import (
 	"context"
+	"iter"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
@@ -720,15 +721,16 @@ type SequenceOperators interface {
 	GetLastSequenceValueByID(ctx context.Context, seqID uint32) (value int64, wasCalled bool, err error)
 }
 
-// ChangefeedState is used to track progress and checkpointing for sinkless/core changefeeds.
-// Because a CREATE CHANGEFEED statement for a sinkless changefeed will hang and return data
-// over the SQL connection, this state belongs in the EvalCtx.
-type ChangefeedState interface {
+// CoreChangefeedState is used to track progress for core (sinkless) changefeeds.
+// Because a CREATE CHANGEFEED statement for a sinkless changefeed will hang
+// and return data over the SQL connection, this state is stored in the EvalCtx
+// so the changeFrontier processor can write to it.
+type CoreChangefeedState interface {
 	// SetHighwater sets the frontier timestamp for the changefeed.
 	SetHighwater(frontier hlc.Timestamp)
 
-	// SetCheckpoint sets the checkpoint for the changefeed.
-	SetCheckpoint(checkpoint *jobspb.TimestampSpansMap)
+	// SetFrontier saves a snapshot of the frontier spans.
+	SetFrontier(frontier iter.Seq[jobspb.ResolvedSpan])
 }
 
 // TenantOperator is capable of interacting with tenant state, allowing SQL


### PR DESCRIPTION
This patch refactors how core (sinkless) changefeeds track progress
across retries. Core changefeeds now save and restore their full span
frontier instead of using the legacy span-level checkpoint.

This patch also contains the following refactoring changes:
* The core changefeed progress-saving code is no longer also executed
  by jobs-based changefeeds, removing unnecessary in-memory state.
* The changefeed DistSQL flow now returns values instead of modifying
  a pointer arg, making the data flow much clearer.
  
Informs #153253

Release note: None