### PR TITLE
concurrency: wake blocked readers regardless of VIR

### DIFF
--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -885,13 +885,7 @@ func (g *lockTableGuardImpl) isSameTxn(txn *enginepb.TxnMeta) bool {
 
 // conflictWithHeld locks return true if the given lock conflicts with the
 // request for this guard.
-//
-// The resolveMustBeVirtual indicates whether locks which can be resolved based
-// on the txn status cache should only be considered when the request is
-// configured for a virtual resolution.
-func (g *lockTableGuardImpl) conflictsWithHeldLock(
-	tl *txnLock, key roachpb.Key, resolveMustBeVirtual bool,
-) bool {
+func (g *lockTableGuardImpl) conflictsWithHeldLock(tl *txnLock, key roachpb.Key) bool {
 	lockHolderTxn := tl.getLockHolderTxn()
 	if g.isSameTxn(lockHolderTxn) {
 		// We should never get here if the lock is already held by another request
@@ -906,24 +900,20 @@ func (g *lockTableGuardImpl) conflictsWithHeldLock(
 	if canResolve, up := g.canResolveKeyForHoldingTransaction(lockHolderTxn, g.curStrength(), key); canResolve {
 		// We share this code with a couple of contexts. For now, we want to avoid waking up
 		// readers who are not going to virtually resolve their intents.
-		//
-		// TODO(ssd): Should we just wake up everyone?
-		if (resolveMustBeVirtual && g.virtuallyResolveIntents) || !resolveMustBeVirtual {
-			if !tl.isHeldReplicated() {
-				// Only held unreplicated. Accumulate it as an unreplicated lock to
-				// resolve, in case any other waiting readers can benefit from the
-				// pushed timestamp.
-				//
-				// TODO(arul): this case is only possible while non-locking reads
-				// block on Exclusive locks. Once non-locking reads start only
-				// blocking on intents, it can be removed and asserted against.
-				g.toResolveUnreplicated = append(g.toResolveUnreplicated, up)
-			} else {
-				// Resolve to push the replicated intent.
-				g.toResolve = append(g.toResolve, up)
-			}
-			return false // No conflict on a lock we are going to resolve.
+		if !tl.isHeldReplicated() {
+			// Only held unreplicated. Accumulate it as an unreplicated lock to
+			// resolve, in case any other waiting readers can benefit from the
+			// pushed timestamp.
+			//
+			// TODO(arul): this case is only possible while non-locking reads
+			// block on Exclusive locks. Once non-locking reads start only
+			// blocking on intents, it can be removed and asserted against.
+			g.toResolveUnreplicated = append(g.toResolveUnreplicated, up)
+		} else {
+			// Resolve to push the replicated intent.
+			g.toResolve = append(g.toResolve, up)
 		}
+		return false // No conflict on a lock we are going to resolve.
 	}
 
 	// The held lock neither belongs to the request's transaction (which has
@@ -2795,7 +2785,7 @@ func (kl *keyLocks) conflictsWithLockHolders(g *lockTableGuardImpl) bool {
 	}
 
 	for e := kl.holders.Front(); e != nil; e = e.Next() {
-		if g.conflictsWithHeldLock(e.Value, kl.key, false) {
+		if g.conflictsWithHeldLock(e.Value, kl.key) {
 			return true
 		}
 	}
@@ -3617,7 +3607,7 @@ func (kl *keyLocks) recomputeWaitQueues(st *cluster.Settings) {
 		reader := e.Value
 		curr := e
 		e = e.Next()
-		if !reader.conflictsWithHeldLock(txnLock, kl.key, true /* only allow virtual resolve */) {
+		if !reader.conflictsWithHeldLock(txnLock, kl.key) {
 			kl.removeReader(curr)
 		}
 	}

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/isolation_level
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/isolation_level
@@ -292,6 +292,8 @@ sequence req=req6
 [7] sequence req5: resolving intent ‹"kSSINormal1"› for txn 00000001 with PENDING status and clock observation {1 123.000000000,1}
 [7] sequence req5: lock wait-queue event: done waiting
 [7] sequence req5: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"kSSINormal1"› for 0.000s
+[7] sequence req5: resolving a batch of 1 intent(s)
+[7] sequence req5: resolving intent ‹"kSSINormal1"› for txn 00000001 with PENDING status
 [7] sequence req5: acquiring latches
 [7] sequence req5: scanning lock table for conflicting locks
 [7] sequence req5: sequencing complete, returned guard
@@ -306,6 +308,8 @@ sequence req=req6
 [8] sequence req6: resolving intent ‹"kSSINormal2"› for txn 00000001 with PENDING status and clock observation {1 123.000000000,3}
 [8] sequence req6: lock wait-queue event: done waiting
 [8] sequence req6: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"kSSINormal2"› for 0.000s
+[8] sequence req6: resolving a batch of 1 intent(s)
+[8] sequence req6: resolving intent ‹"kSSINormal2"› for txn 00000001 with PENDING status
 [8] sequence req6: acquiring latches
 [8] sequence req6: scanning lock table for conflicting locks
 [8] sequence req6: sequencing complete, returned guard
@@ -343,6 +347,8 @@ sequence req=req7
 [9] sequence req7: resolving intent ‹"kSSINormal3"› for txn 00000001 with PENDING status and clock observation {1 123.000000000,5}
 [9] sequence req7: lock wait-queue event: done waiting
 [9] sequence req7: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"kSSINormal3"› for 0.000s
+[9] sequence req7: resolving a batch of 1 intent(s)
+[9] sequence req7: resolving intent ‹"kSSINormal3"› for txn 00000001 with PENDING status
 [9] sequence req7: acquiring latches
 [9] sequence req7: scanning lock table for conflicting locks
 [9] sequence req7: sequencing complete, returned guard
@@ -376,6 +382,8 @@ sequence req=req8
 [10] sequence req8: resolving intent ‹"kSSINormal4"› for txn 00000001 with PENDING status and clock observation {1 123.000000000,7}
 [10] sequence req8: lock wait-queue event: done waiting
 [10] sequence req8: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"kSSINormal4"› for 0.000s
+[10] sequence req8: resolving a batch of 1 intent(s)
+[10] sequence req8: resolving intent ‹"kSSINormal4"› for txn 00000001 with PENDING status
 [10] sequence req8: acquiring latches
 [10] sequence req8: scanning lock table for conflicting locks
 [10] sequence req8: sequencing complete, returned guard
@@ -501,18 +509,24 @@ sequence req=req12
 [11] sequence req9: resolving intent ‹"kSSIHigh1"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,9}
 [11] sequence req9: lock wait-queue event: done waiting
 [11] sequence req9: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"kSSIHigh1"› for 0.000s
+[11] sequence req9: resolving a batch of 1 intent(s)
+[11] sequence req9: resolving intent ‹"kSSIHigh1"› for txn 00000002 with PENDING status
 [11] sequence req9: acquiring latches
 [11] sequence req9: scanning lock table for conflicting locks
 [11] sequence req9: sequencing complete, returned guard
 [12] sequence req10: resolving intent ‹"kSSIHigh2"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,11}
 [12] sequence req10: lock wait-queue event: done waiting
 [12] sequence req10: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"kSSIHigh2"› for 0.000s
+[12] sequence req10: resolving a batch of 1 intent(s)
+[12] sequence req10: resolving intent ‹"kSSIHigh2"› for txn 00000002 with PENDING status
 [12] sequence req10: acquiring latches
 [12] sequence req10: scanning lock table for conflicting locks
 [12] sequence req10: sequencing complete, returned guard
 [13] sequence req11: resolving intent ‹"kSSIHigh3"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,13}
 [13] sequence req11: lock wait-queue event: done waiting
 [13] sequence req11: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"kSSIHigh3"› for 0.000s
+[13] sequence req11: resolving a batch of 1 intent(s)
+[13] sequence req11: resolving intent ‹"kSSIHigh3"› for txn 00000002 with PENDING status
 [13] sequence req11: acquiring latches
 [13] sequence req11: scanning lock table for conflicting locks
 [13] sequence req11: sequencing complete, returned guard
@@ -527,6 +541,8 @@ sequence req=req12
 [14] sequence req12: resolving intent ‹"kSSIHigh4"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,15}
 [14] sequence req12: lock wait-queue event: done waiting
 [14] sequence req12: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"kSSIHigh4"› for 0.000s
+[14] sequence req12: resolving a batch of 1 intent(s)
+[14] sequence req12: resolving intent ‹"kSSIHigh4"› for txn 00000002 with PENDING status
 [14] sequence req12: acquiring latches
 [14] sequence req12: scanning lock table for conflicting locks
 [14] sequence req12: sequencing complete, returned guard
@@ -591,6 +607,8 @@ sequence req=req13
 [15] sequence req13: resolving intent ‹"kRCNormal1"› for txn 00000003 with PENDING status and clock observation {1 123.000000000,17}
 [15] sequence req13: lock wait-queue event: done waiting
 [15] sequence req13: conflicted with 00000003-0000-0000-0000-000000000000 on ‹"kRCNormal1"› for 0.000s
+[15] sequence req13: resolving a batch of 1 intent(s)
+[15] sequence req13: resolving intent ‹"kRCNormal1"› for txn 00000003 with PENDING status
 [15] sequence req13: acquiring latches
 [15] sequence req13: scanning lock table for conflicting locks
 [15] sequence req13: sequencing complete, returned guard
@@ -623,6 +641,8 @@ sequence req=req14
 [16] sequence req14: resolving intent ‹"kRCNormal2"› for txn 00000003 with PENDING status and clock observation {1 123.000000000,19}
 [16] sequence req14: lock wait-queue event: done waiting
 [16] sequence req14: conflicted with 00000003-0000-0000-0000-000000000000 on ‹"kRCNormal2"› for 0.000s
+[16] sequence req14: resolving a batch of 1 intent(s)
+[16] sequence req14: resolving intent ‹"kRCNormal2"› for txn 00000003 with PENDING status
 [16] sequence req14: acquiring latches
 [16] sequence req14: scanning lock table for conflicting locks
 [16] sequence req14: sequencing complete, returned guard
@@ -655,6 +675,8 @@ sequence req=req15
 [17] sequence req15: resolving intent ‹"kRCNormal3"› for txn 00000003 with PENDING status and clock observation {1 123.000000000,21}
 [17] sequence req15: lock wait-queue event: done waiting
 [17] sequence req15: conflicted with 00000003-0000-0000-0000-000000000000 on ‹"kRCNormal3"› for 0.000s
+[17] sequence req15: resolving a batch of 1 intent(s)
+[17] sequence req15: resolving intent ‹"kRCNormal3"› for txn 00000003 with PENDING status
 [17] sequence req15: acquiring latches
 [17] sequence req15: scanning lock table for conflicting locks
 [17] sequence req15: sequencing complete, returned guard
@@ -687,6 +709,8 @@ sequence req=req16
 [18] sequence req16: resolving intent ‹"kRCNormal4"› for txn 00000003 with PENDING status and clock observation {1 123.000000000,23}
 [18] sequence req16: lock wait-queue event: done waiting
 [18] sequence req16: conflicted with 00000003-0000-0000-0000-000000000000 on ‹"kRCNormal4"› for 0.000s
+[18] sequence req16: resolving a batch of 1 intent(s)
+[18] sequence req16: resolving intent ‹"kRCNormal4"› for txn 00000003 with PENDING status
 [18] sequence req16: acquiring latches
 [18] sequence req16: scanning lock table for conflicting locks
 [18] sequence req16: sequencing complete, returned guard
@@ -731,6 +755,8 @@ sequence req=req17
 [19] sequence req17: resolving intent ‹"kRCHigh1"› for txn 00000004 with PENDING status and clock observation {1 123.000000000,25}
 [19] sequence req17: lock wait-queue event: done waiting
 [19] sequence req17: conflicted with 00000004-0000-0000-0000-000000000000 on ‹"kRCHigh1"› for 0.000s
+[19] sequence req17: resolving a batch of 1 intent(s)
+[19] sequence req17: resolving intent ‹"kRCHigh1"› for txn 00000004 with PENDING status
 [19] sequence req17: acquiring latches
 [19] sequence req17: scanning lock table for conflicting locks
 [19] sequence req17: sequencing complete, returned guard
@@ -763,6 +789,8 @@ sequence req=req18
 [20] sequence req18: resolving intent ‹"kRCHigh2"› for txn 00000004 with PENDING status and clock observation {1 123.000000000,27}
 [20] sequence req18: lock wait-queue event: done waiting
 [20] sequence req18: conflicted with 00000004-0000-0000-0000-000000000000 on ‹"kRCHigh2"› for 0.000s
+[20] sequence req18: resolving a batch of 1 intent(s)
+[20] sequence req18: resolving intent ‹"kRCHigh2"› for txn 00000004 with PENDING status
 [20] sequence req18: acquiring latches
 [20] sequence req18: scanning lock table for conflicting locks
 [20] sequence req18: sequencing complete, returned guard
@@ -795,6 +823,8 @@ sequence req=req19
 [21] sequence req19: resolving intent ‹"kRCHigh3"› for txn 00000004 with PENDING status and clock observation {1 123.000000000,29}
 [21] sequence req19: lock wait-queue event: done waiting
 [21] sequence req19: conflicted with 00000004-0000-0000-0000-000000000000 on ‹"kRCHigh3"› for 0.000s
+[21] sequence req19: resolving a batch of 1 intent(s)
+[21] sequence req19: resolving intent ‹"kRCHigh3"› for txn 00000004 with PENDING status
 [21] sequence req19: acquiring latches
 [21] sequence req19: scanning lock table for conflicting locks
 [21] sequence req19: sequencing complete, returned guard
@@ -827,6 +857,8 @@ sequence req=req20
 [22] sequence req20: resolving intent ‹"kRCHigh4"› for txn 00000004 with PENDING status and clock observation {1 123.000000000,31}
 [22] sequence req20: lock wait-queue event: done waiting
 [22] sequence req20: conflicted with 00000004-0000-0000-0000-000000000000 on ‹"kRCHigh4"› for 0.000s
+[22] sequence req20: resolving a batch of 1 intent(s)
+[22] sequence req20: resolving intent ‹"kRCHigh4"› for txn 00000004 with PENDING status
 [22] sequence req20: acquiring latches
 [22] sequence req20: scanning lock table for conflicting locks
 [22] sequence req20: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents
@@ -99,7 +99,8 @@ sequence req=req1
 [4] sequence req1: resolving intent ‹"a"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,2}
 [4] sequence req1: lock wait-queue event: done waiting
 [4] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
-[4] sequence req1: resolving a batch of 9 intent(s)
+[4] sequence req1: resolving a batch of 10 intent(s)
+[4] sequence req1: resolving intent ‹"a"› for txn 00000002 with PENDING status
 [4] sequence req1: resolving intent ‹"b"› for txn 00000002 with PENDING status
 [4] sequence req1: resolving intent ‹"c"› for txn 00000002 with PENDING status
 [4] sequence req1: resolving intent ‹"d"› for txn 00000002 with PENDING status
@@ -245,7 +246,8 @@ sequence req=req1
 [4] sequence req1: resolving intent ‹"a"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,5}
 [4] sequence req1: lock wait-queue event: done waiting
 [4] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
-[4] sequence req1: resolving a batch of 1 intent(s)
+[4] sequence req1: resolving a batch of 2 intent(s)
+[4] sequence req1: resolving intent ‹"a"› for txn 00000002 with PENDING status
 [4] sequence req1: resolving intent ‹"b"› for txn 00000002 with PENDING status
 [4] sequence req1: acquiring latches
 [4] sequence req1: scanning lock table for conflicting locks

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents_without_adding_to_lock_table
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents_without_adding_to_lock_table
@@ -49,6 +49,8 @@ sequence req=req1
 [3] sequence req1: resolving intent ‹"a"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,1}
 [3] sequence req1: lock wait-queue event: done waiting
 [3] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
+[3] sequence req1: resolving a batch of 1 intent(s)
+[3] sequence req1: resolving intent ‹"a"› for txn 00000002 with PENDING status
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
@@ -323,7 +323,8 @@ on-txn-updated txn=txn1 status=pending ts=15,2
 [3] sequence req1: resolving intent ‹"a"› for txn 00000001 with PENDING status and clock observation {1 135.000000000,7}
 [3] sequence req1: lock wait-queue event: done waiting
 [3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
-[3] sequence req1: resolving a batch of 2 intent(s)
+[3] sequence req1: resolving a batch of 3 intent(s)
+[3] sequence req1: resolving intent ‹"a"› for txn 00000001 with PENDING status and clock observation {1 135.000000000,7}
 [3] sequence req1: resolving intent ‹"b"› for txn 00000001 with PENDING status and clock observation {1 135.000000000,7}
 [3] sequence req1: resolving intent ‹"c"› for txn 00000001 with PENDING status and clock observation {1 135.000000000,7}
 [3] sequence req1: acquiring latches
@@ -407,7 +408,8 @@ on-txn-updated txn=txn1 status=pending ts=12,2
 [3] sequence req1: resolving intent ‹"a"› for txn 00000001 with PENDING status and clock observation {1 135.000000000,9}
 [3] sequence req1: lock wait-queue event: done waiting
 [3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
-[3] sequence req1: resolving a batch of 2 intent(s)
+[3] sequence req1: resolving a batch of 3 intent(s)
+[3] sequence req1: resolving intent ‹"a"› for txn 00000001 with PENDING status
 [3] sequence req1: resolving intent ‹"b"› for txn 00000001 with PENDING status
 [3] sequence req1: resolving intent ‹"c"› for txn 00000001 with PENDING status
 [3] sequence req1: acquiring latches

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_elsewhere
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_elsewhere
@@ -256,12 +256,16 @@ on-txn-updated txn=txnThreeKeyWriter status=pending ts=20,2
 [10] sequence reqTwoKeyWaiter: resolving intent ‹"k1"› for txn 00000003 with PENDING status and clock observation {1 246.000000000,1}
 [10] sequence reqTwoKeyWaiter: lock wait-queue event: done waiting
 [10] sequence reqTwoKeyWaiter: conflicted with 00000003-0000-0000-0000-000000000000 on ‹"k1"› for 0.000s
+[10] sequence reqTwoKeyWaiter: resolving a batch of 1 intent(s)
+[10] sequence reqTwoKeyWaiter: resolving intent ‹"k1"› for txn 00000003 with PENDING status
 [10] sequence reqTwoKeyWaiter: acquiring latches
 [10] sequence reqTwoKeyWaiter: scanning lock table for conflicting locks
 [10] sequence reqTwoKeyWaiter: sequencing complete, returned guard
 [12] sequence reqThreeKeyWaiter: resolving intent ‹"k1"› for txn 00000003 with PENDING status and clock observation {1 246.000000000,3}
 [12] sequence reqThreeKeyWaiter: lock wait-queue event: done waiting
 [12] sequence reqThreeKeyWaiter: conflicted with 00000003-0000-0000-0000-000000000000 on ‹"k1"› for 0.000s
+[12] sequence reqThreeKeyWaiter: resolving a batch of 1 intent(s)
+[12] sequence reqThreeKeyWaiter: resolving intent ‹"k1"› for txn 00000003 with PENDING status
 [12] sequence reqThreeKeyWaiter: acquiring latches
 [12] sequence reqThreeKeyWaiter: scanning lock table for conflicting locks
 [12] sequence reqThreeKeyWaiter: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/pushed_txn_wakes_readers
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/pushed_txn_wakes_readers
@@ -257,7 +257,7 @@ num=1
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
 
 # ---------------------------------------------------------------------------
-# Test 5: Reader without virtuallyResolveIntents — NOT woken.
+# Test 5: Reader without virtuallyResolveIntents — also woken.
 # ---------------------------------------------------------------------------
 
 new-lock-table maxlocks=10000
@@ -309,15 +309,15 @@ pushed-txn-updated txn=txn2 status=pending ts=11,1
 # Reader should NOT be woken.
 guard-state r=req2
 ----
-old: state=waitFor txn=txn2 key="a" held=true guard-strength=None
+new: state=doneWaiting
+Intents to resolve:
+ key="a" txn=00000000-0000-0000-0000-000000000002 epoch=0 ts=11.000000000,1 status=PENDING
 
 print
 ----
 num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
-   waiting readers:
-    req: 2, txn: 00000000-0000-0000-0000-000000000001
 
 dequeue r=req2
 ----
@@ -326,9 +326,8 @@ num=1
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
 
 # ---------------------------------------------------------------------------
-# Test 6: Multiple readers on same lock — mix of eligible/ineligible.
-# One with virtuallyResolveIntents=true, one without. Only the eligible
-# one is woken.
+# Test 6: Multiple readers on same lock, one with
+# virtuallyResolveIntents=true, one without. Both are woken.
 # ---------------------------------------------------------------------------
 
 new-lock-table maxlocks=10000
@@ -399,7 +398,9 @@ pushed-txn-updated txn=txn2 status=pending ts=11,1
 # req2 should remain waiting; req3 should be woken.
 guard-state r=req2
 ----
-new: state=waitFor txn=txn2 key="a" held=true guard-strength=None
+new: state=doneWaiting
+Intents to resolve:
+ key="a" txn=00000000-0000-0000-0000-000000000002 epoch=0 ts=11.000000000,1 status=PENDING
 
 guard-state r=req3
 ----
@@ -412,8 +413,6 @@ print
 num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
-   waiting readers:
-    req: 2, txn: 00000000-0000-0000-0000-000000000001
 
 dequeue r=req2
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/resolve_pushed_txn_locks
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/resolve_pushed_txn_locks
@@ -125,12 +125,8 @@ num=3
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent], unrepl [(str: Exclusive seq: 0)]
-   waiting readers:
-    req: 4, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
-   waiting readers:
-    req: 5, txn: 00000000-0000-0000-0000-000000000001
 
 guard-state r=req1
 ----
@@ -138,11 +134,15 @@ new: state=doneWaiting
 
 guard-state r=req2
 ----
-new: state=waitFor txn=txn2 key="b" held=true guard-strength=None
+new: state=doneWaiting
+Intents to resolve:
+ key="b" txn=00000000-0000-0000-0000-000000000002 epoch=0 ts=11.000000000,1 status=PENDING
 
 guard-state r=req3
 ----
-new: state=waitFor txn=txn2 key="c" held=true guard-strength=None
+new: state=doneWaiting
+Intents to resolve:
+ key="c" txn=00000000-0000-0000-0000-000000000002 epoch=0 ts=11.000000000,1 status=PENDING
 
 guard-state r=req4
 ----
@@ -160,8 +160,6 @@ num=3
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
-   waiting readers:
-    req: 5, txn: 00000000-0000-0000-0000-000000000001
 
 update txn=txn2 ts=11,1 epoch=0 span=c
 ----
@@ -173,11 +171,11 @@ num=2
 
 guard-state r=req2
 ----
-new: state=doneWaiting
+old: state=doneWaiting
 
 guard-state r=req3
 ----
-new: state=doneWaiting
+old: state=doneWaiting
 
 clear
 ----


### PR DESCRIPTION
Previously we would only wake a waiting reader in response to a push if it was enabled for virtual intent resolution. Now, we wake all readers.

Epic: none
Release note: None