### PR TITLE
release-25.4: kvserver: log skipped candidates and load in lease transfer decisions

### DIFF
--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -758,6 +758,12 @@ func (sr *StoreRebalancer) chooseLeaseToTransfer(
 ) (CandidateReplica, roachpb.ReplicaDescriptor, []CandidateReplica) {
 	var considerForRebalance []CandidateReplica
 	now := sr.storePool.Clock().NowAsClockTimestamp()
+	// candidatesConsidered and loadConsidered track the number and cumulative
+	// load of lease-holding candidates we've looked at (and held the lease
+	// for). These include the candidate we ultimately pick (if any), so the log
+	// message subtracts it back out to report what was skipped.
+	var candidatesConsidered int
+	var loadConsidered load.Load = load.Vector{}
 	for {
 		if len(rctx.hottestRanges) == 0 {
 			return nil, roachpb.ReplicaDescriptor{}, considerForRebalance
@@ -775,11 +781,14 @@ func (sr *StoreRebalancer) chooseLeaseToTransfer(
 			continue
 		}
 
+		candidateImpact := candidateReplica.RangeUsageInfo().TransferImpact()
+		candidatesConsidered++
+		loadConsidered = load.Add(loadConsidered, candidateImpact)
+
 		// Don't bother moving leases whose load is below some small fraction of the
 		// store's load. It's just unnecessary churn with no benefit to move leases
 		// responsible for, for example, 1 load unit on a store with 5000 load units.
-		if candidateReplica.RangeUsageInfo().TransferImpact().Dim(rctx.loadDimension) <
-			rctx.LocalDesc.Capacity.Load().Dim(rctx.loadDimension)*minLeaseLoadFraction {
+		if candidateImpact.Dim(rctx.loadDimension) < rctx.LocalDesc.Capacity.Load().Dim(rctx.loadDimension)*minLeaseLoadFraction {
 			log.KvDistribution.VEventf(ctx, 3, "r%d's %s load is too little to matter relative to s%d's %s total load",
 				candidateReplica.GetRangeID(), candidateReplica.RangeUsageInfo().TransferImpact(),
 				rctx.LocalDesc.StoreID, rctx.LocalDesc.Capacity.Load())
@@ -853,13 +862,16 @@ func (sr *StoreRebalancer) chooseLeaseToTransfer(
 		if targetStore, ok := rctx.allStoresList.FindStoreByID(candidate.StoreID); ok {
 			log.KvDistribution.Infof(
 				ctx,
-				"transferring lease for r%d load=%s to store s%d load=%s from local store s%d load=%s",
+				"transferring lease for r%d load=%s to store s%d load=%s from local store s%d load=%s"+
+					" (skipped %d candidates with load=%s)",
 				desc.RangeID,
-				candidateReplica.RangeUsageInfo().TransferImpact(),
+				candidateImpact,
 				targetStore.StoreID,
 				targetStore.Capacity.Load(),
 				rctx.LocalDesc.StoreID,
 				rctx.LocalDesc.Capacity.Load(),
+				candidatesConsidered-1,
+				load.Sub(loadConsidered, candidateImpact),
 			)
 		}
 		return candidateReplica, candidate, considerForRebalance


### PR DESCRIPTION
Backport 1/1 commits from #162584 on behalf of @tbg.

----

When the store rebalancer picks a lease to transfer, it may skip over many candidates that it owns but can't move (e.g. due to constraints or lease preferences). Previously there was no visibility into this.

Add tracking of how many lease-holding candidates were considered and their cumulative load. The "transferring lease" log message now includes this information, making it easy to spot when the rebalancer is churning through many unmovable hot leases before settling on a cold one (e.g. the liveness range).

Motivated by https://github.com/cockroachlabs/support/issues/3544.

----

Release justification: improve observability in lease thrashing scenarios.