### PR TITLE
mmaintegration: add per-store CPU capacity floor

### DIFF
--- a/pkg/kv/kvserver/mmaintegration/capacity_model.go
+++ b/pkg/kv/kvserver/mmaintegration/capacity_model.go
@@ -77,6 +77,38 @@ func computeStoreByteSizeCapacity(
 // treated as background load unrelated to MMA.
 const cpuIndirectOverheadMultiplier = 3.0
 
+// cpuCapacityFloorPerStore is the minimum per-store CPU capacity (in ns/s)
+// returned by computeCPUCapacityWithCap. The capacity formula is:
+//
+//	mult = clamp(nodeCPURateUsage / storesCPURate, 1, cpuIndirectOverheadMultiplier)
+//	backgroundLoad = nodeCPURateUsage - storesCPURate * mult
+//	capacity = (nodeCPURateCapacity - backgroundLoad) / mult
+//
+// As background load grows (SQL gateway, GC, etc.), capacity shrinks
+// toward 0 while storesCPURate stays constant, causing utilization
+// (load/capacity) to spike to infinity. The floor prevents this.
+//
+// Example: 16-core node, 1 store, storesCPURate=2, mult clamped to
+// cpuIndirectOverheadMultiplier=3 (implicit mult exceeds cap in all rows):
+//
+//	bg = nodeCPURateUsage - storesCPURate*mult
+//	cap = (nodeCPURateCapacity - bg) / mult
+//
+//	usage=10     bg=4      cap=(16-4)/3    = 4.0 cores
+//	usage=14     bg=8      cap=(16-8)/3    = 2.67 cores
+//	usage=16     bg=10     cap=(16-10)/3   = 2.0 cores   (node saturated)
+//	usage=21.7   bg=15.7   cap=(16-15.7)/3 = 0.1 cores
+//	usage=21.91  bg=15.91  cap=(16-15.91)/3= 0.03 cores  (without floor)
+//	usage=22     bg=16     cap=(16-16)/3   = 0.0 cores   (without floor)
+//
+// The floor keeps capacity at 0.1 cores - small enough that the store
+// looks nearly saturated, large enough to keep utilization finite.
+//
+// Note: due to flooring, severe overloads become indistinguishable (load=2 over
+// a 0.1-core floor is 20x util regardless of how much background exists). This
+// is acceptable because MMA has no stronger action beyond 20x.
+const cpuCapacityFloorPerStore = 0.1 * 1e9 // 0.1 cores in ns/s
+
 // computeCPUCapacityWithCap computes per-store CPU capacity using a clamped
 // multiplier. Unlike the naive model (computeStoreCPURateCapacityNaive in
 // legacy_model_test.go, which assumes all node CPU usage is caused by
@@ -114,6 +146,10 @@ const cpuIndirectOverheadMultiplier = 3.0
 // behavior: MMA attributes none of the node usage to itself (all is
 // background), and divides the idle capacity by the multiplier across stores.
 func computeCPUCapacityWithCap(in storeCPURateCapacityInput) (capacity float64) {
+	defer func() {
+		capacity = max(cpuCapacityFloorPerStore, capacity)
+	}()
+
 	mult := 0.0
 	if in.numStores <= 0 || in.nodeCPURateCapacity <= 0 {
 		log.KvDistribution.Fatalf(context.Background(), "numStores and nodeCPURateCapacity must be > 0")

--- a/pkg/kv/kvserver/mmaintegration/testdata/TestComputeStoreCPURateCapacity
+++ b/pkg/kv/kvserver/mmaintegration/testdata/TestComputeStoreCPURateCapacity
@@ -213,17 +213,20 @@ capped:   kv-capacity: 3.33 cores/store, capacity_err: +11.11%
 # - naive: mult = 32/1 = 32. capacity = 16/32 = 0.5. Doesn't model background
 #   at all, so it still thinks KV can do some work.
 # - capped: clips mult to 3, bgLoad = 32 - 3*1 = 29. capacity = max(0,
-#   (16-29)/3) = 0. Correctly detects the node is overwhelmed. 
+#   (16-29)/3) = 0. Correctly detects the node is overwhelmed.
+# The capped formula yields 0 but hits cpuCapacityFloorPerStore (0.1 cores),
+# so it reports 0.10 instead — the floor keeps utilization finite while still
+# signaling near-total saturation.
 scenario kv-cpu=1 proportional-overhead=1 background=30 node-cpu-capacity=16 num-stores=1
 ----
 node-cpu: 32.00 used / 16.00 capacity (1.00 kv + 1.00 proportional + 30.00 background)
 truth:    kv-capacity: 0.00 cores/store (true-mult: 2.00)
 naive:    kv-capacity: 0.50 cores/store, capacity_err: +Inf%
-capped:   kv-capacity: 0.00 cores/store, capacity_err: 0.00%
+capped:   kv-capacity: 0.10 cores/store, capacity_err: +Inf%
 
 # ==========================================================================
 # Mean |capacity_err| across all scenarios (excluding +Inf).
 # ==========================================================================
 mean
 ----
-Mean |capacity_err| across 12 scenarios: naive: 25.7%  capped: 21.1%
+Mean |capacity_err| across 12 scenarios: naive: 25.7%  capped: 22.8%


### PR DESCRIPTION
This commit add a minimum per-store CPU capacity floor of 0.1 cores
(in ns/s) to computeCPUCapacityWithCap. When background load (e.x. GC)
grows to consume most of the node's CPU, the capacity formula can
produce near-zero or zero values, causing utilization (load/capacity)
to spike to infinity. The floor keeps utilization finite and bounded
for severe overloads, which is acceptable since mma has no stronger
action beyond that threshold.

Epic: none
Release note: None
Fixes: https://github.com/cockroachdb/cockroach/issues/163416