### PR TITLE
sql: include trigger dependencies in statement bundles

### DIFF
--- a/pkg/cli/interactive_tests/test_sb_recreate.tcl
+++ b/pkg/cli/interactive_tests/test_sb_recreate.tcl
@@ -28,6 +28,12 @@ send "CREATE VIEW \"sc ' view\".v AS SELECT * FROM t;\r"
 
 send "RESET database;\r"
 send "CREATE FUNCTION f() RETURNS INT LANGUAGE SQL AS 'SELECT 1';\r"
+
+# Create a trigger on one of the tables to ensure triggers are included in
+# the bundle and can be recreated (#142041).
+send "CREATE TABLE trigger_dest (k INT PRIMARY KEY, v INT);\r"
+send "CREATE FUNCTION trigger_f() RETURNS TRIGGER LANGUAGE PLpgSQL AS \$\$ BEGIN INSERT INTO trigger_dest VALUES ((NEW).k, 0); RETURN NEW; END \$\$;\r"
+send "CREATE TRIGGER trig AFTER INSERT ON \"db.table\".\"sc.t\".t FOR EACH ROW EXECUTE FUNCTION trigger_f();\r"
 eexpect "defaultdb>"
 
 send "EXPLAIN ANALYZE (DEBUG) SELECT *, f() FROM \"db.table\".\"sc.t\".t, \" db ' view \".\"sc ' view\".v;\r"

--- a/pkg/sql/logictest/testdata/logic_test/explain_analyze
+++ b/pkg/sql/logictest/testdata/logic_test/explain_analyze
@@ -100,3 +100,4 @@ EXPLAIN ANALYZE (DISTSQL) INSERT INTO c SELECT x, x + 1 FROM (VALUES (1), (2)) A
 # LocalPlanNodes (#62261).
 query error pgcode 23503 insert on table \"c\" violates foreign key constraint \"c_p_fkey\"
 EXPLAIN ANALYZE (DEBUG) INSERT INTO c SELECT x, x + 1 FROM (VALUES (1), (2)) AS v (x)
+


### PR DESCRIPTION
Previously, EXPLAIN ANALYZE (DEBUG) statement bundles did not include triggers on mutation target tables, their trigger functions, or tables those triggers modify. This made bundles unusable for reproducing trigger-related issues because the schema.sql file was missing the CREATE TRIGGER, CREATE FUNCTION, and CREATE TABLE statements needed to recreate the environment.

Now, the bundle builder inspects all referenced tables for triggers and collects their dependencies:
- Trigger functions (via FuncID and DependsOnRoutines) are included as CREATE FUNCTION statements.
- Tables that triggers modify (via DependsOn) are included as CREATE TABLE statements with statistics.
- UDTs that triggers reference (via DependsOnTypes) are included as CREATE TYPE statements.
- The triggers themselves are emitted as CREATE TRIGGER statements after FK constraints, using SHOW CREATE TRIGGER.

Resolves: #142041

Release note (bug fix): Fixed a bug where EXPLAIN ANALYZE (DEBUG) statement bundles did not include triggers, their functions, or tables modified by those triggers. The bundle's schema.sql file now contains the CREATE TRIGGER, CREATE FUNCTION, and CREATE TABLE statements needed to fully reproduce the query environment when triggers are involved.