### PR TITLE
load,roachpb: report SQL CPU rates in `NodeCapacity`

### DIFF
--- a/pkg/kv/db.go
+++ b/pkg/kv/db.go
@@ -278,6 +278,8 @@ type DB struct {
 	// Especially SettingsValue.
 	SQLKVResponseAdmissionQ *admission.WorkQueue
 	AdmissionPacerFactory   admission.PacerFactory
+
+	SQLCPUProvider admission.SQLCPUProvider
 }
 
 // NonTransactionalSender returns a Sender that can be used for sending

--- a/pkg/kv/kvserver/kvadmission/kvadmission.go
+++ b/pkg/kv/kvserver/kvadmission/kvadmission.go
@@ -239,6 +239,7 @@ type Handle struct {
 	storeWorkHandle      admission.StoreWorkHandle
 	elasticCPUWorkHandle *admission.ElasticCPUWorkHandle
 	raftAdmissionMeta    *kvflowcontrolpb.RaftAdmissionMeta
+	ghToUnpause          *admission.GoroutineCPUHandle
 
 	cpuStart            time.Duration
 	cpuAdmissionQueue   *admission.WorkQueue
@@ -429,6 +430,13 @@ func (n *controllerImpl) AdmitKVWork(
 			ah.cpuKVAdmissionQResp = resp
 		}
 	}
+	// Pause CPU measurement for SQL work if it is happening locally on this
+	// goroutine.
+	sqlHandle := admission.SQLCPUHandleFromContext(ctx)
+	if sqlHandle != nil {
+		ah.ghToUnpause = sqlHandle.RegisterGoroutine()
+		ah.ghToUnpause.PauseMeasuring()
+	}
 	return ah, nil
 }
 
@@ -463,6 +471,9 @@ func (n *controllerImpl) AdmittedKVWorkDone(ah Handle, writeBytes *StoreWriteByt
 				log.KvDistribution.Errorf(context.Background(), "%s", err)
 			}
 		}
+	}
+	if ah.ghToUnpause != nil {
+		ah.ghToUnpause.UnpauseMeasuring()
 	}
 }
 

--- a/pkg/kv/kvserver/kvadmission/kvadmission.go
+++ b/pkg/kv/kvserver/kvadmission/kvadmission.go
@@ -432,6 +432,14 @@ func (n *controllerImpl) AdmitKVWork(
 	}
 	// Pause CPU measurement for SQL work if it is happening locally on this
 	// goroutine.
+	//
+	// NB: if we never reach this point in the function, either there is an
+	// error, or some aspect of admission is disabled (which is never the case
+	// in production). In the latter case, we will not pause measurement, which
+	// we deem acceptable.
+	//
+	// TODO(sumeer): improve the structure of AdmitKVWork to make the behavior
+	// easier to understand.
 	sqlHandle := admission.SQLCPUHandleFromContext(ctx)
 	if sqlHandle != nil {
 		ah.ghToUnpause = sqlHandle.RegisterGoroutine()

--- a/pkg/kv/kvserver/load/BUILD.bazel
+++ b/pkg/kv/kvserver/load/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/kv/kvserver/replicastats",
         "//pkg/roachpb",
         "//pkg/server/status",
+        "//pkg/util/admission",
         "//pkg/util/buildutil",
         "//pkg/util/hlc",
         "//pkg/util/log",

--- a/pkg/kv/kvserver/load/node_capacity_provider.go
+++ b/pkg/kv/kvserver/load/node_capacity_provider.go
@@ -69,6 +69,8 @@ func NewNodeCapacityProvider(
 		capacityRefreshInterval: config.CPUCapacityRefreshInterval,
 	}
 	monitor.mu.usageEWMA = ewma.NewMovingAverage(config.CPUUsageMovingAverageAge)
+	monitor.mu.sqlGatewayEWMA = ewma.NewMovingAverage(config.CPUUsageMovingAverageAge)
+	monitor.mu.sqlDistEWMA = ewma.NewMovingAverage(config.CPUUsageMovingAverageAge)
 	monitor.recordCPUCapacity(context.Background())
 	return &NodeCapacityProvider{
 		stores:             stores,
@@ -105,12 +107,14 @@ func (n *NodeCapacityProvider) GetNodeCapacity(useCached bool) (roachpb.NodeCapa
 	// runtimeLoadMonitor to also fetch updated stats.
 	// TODO(wenyihu6): NodeCPURateCapacity <= NodeCPURateUsage fails on CI and
 	// requires more investigation.
-	cpuUsageNanoPerSec, cpuCapacityNanoPerSec := n.runtimeLoadMonitor.GetCPUStats()
+	cpuUsageNanoPerSec, cpuCapacityNanoPerSec, sqlGatewayCPUNanoPerSec, sqlDistCPUNanoPerSec := n.runtimeLoadMonitor.GetCPUStats()
 	return roachpb.NodeCapacity{
-		StoresCPURate:       storesCPURate,
-		NumStores:           numStores,
-		NodeCPURateCapacity: cpuCapacityNanoPerSec,
-		NodeCPURateUsage:    cpuUsageNanoPerSec,
+		StoresCPURate:           storesCPURate,
+		NumStores:               numStores,
+		NodeCPURateCapacity:     cpuCapacityNanoPerSec,
+		NodeCPURateUsage:        cpuUsageNanoPerSec,
+		SQLGatewayCPUNanoPerSec: int64(sqlGatewayCPUNanoPerSec),
+		SQLDistCPUNanoPerSec:    int64(sqlDistCPUNanoPerSec),
 	}, nil
 }
 
@@ -131,6 +135,23 @@ type runtimeLoadMonitor struct {
 		// subsequent polls in nanoseconds. The cpu usage is obtained by polling
 		// stats from status.GetProcCPUTime which is cumulative.
 		usageEWMA ewma.MovingAverage
+
+		// lastGatewayCPUNanos tracks the last cumulative SQL gateway CPU usage
+		// in nanoseconds, used to compute the delta between subsequent polls.
+		lastGatewayCPUNanos float64
+
+		// lastDistCPUNanos tracks the last cumulative dist SQL CPU usage in
+		// nanoseconds, used to compute the delta between subsequent polls.
+		lastDistCPUNanos float64
+
+		// sqlGatewayEWMA maintains a moving average of delta SQL gateway CPU
+		// usage between two subsequent polls in nanoseconds.
+		sqlGatewayEWMA ewma.MovingAverage
+
+		// sqlDistEWMA maintains a moving average of delta dist SQL CPU usage
+		// between two subsequent polls in nanoseconds.
+		sqlDistEWMA ewma.MovingAverage
+
 		// logicalCPUsPerSec represents the node's cpu capacity in logical
 		// CPU-seconds per second, obtained from status.GetCPUCapacity.
 		logicalCPUsPerSec int64
@@ -138,7 +159,9 @@ type runtimeLoadMonitor struct {
 }
 
 // GetCPUStats returns the current cpu usage and capacity stats for the node.
-func (m *runtimeLoadMonitor) GetCPUStats() (cpuUsageNanoPerSec int64, cpuCapacityNanoPerSec int64) {
+func (m *runtimeLoadMonitor) GetCPUStats() (
+	cpuUsageNanoPerSec int64, cpuCapacityNanoPerSec int64,
+	sqlGatewayCPUNanoPerSec float64, sqlDistCPUNanoPerSec float64) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	// usageEWMA is usage in nanoseconds. Divide by refresh interval to get the
@@ -147,11 +170,17 @@ func (m *runtimeLoadMonitor) GetCPUStats() (cpuUsageNanoPerSec int64, cpuCapacit
 	// logicalCPUsPerSec is in logical cpu-seconds per second. Convert the unit
 	// from cpu-seconds to cpu-nanoseconds.
 	cpuCapacityNanoPerSec = m.mu.logicalCPUsPerSec * time.Second.Nanoseconds()
+	sqlGatewayCPUNanoPerSec = m.mu.sqlGatewayEWMA.Value() / m.usageRefreshInterval.Seconds()
+	sqlDistCPUNanoPerSec = m.mu.sqlDistEWMA.Value() / m.usageRefreshInterval.Seconds()
 	return
 }
 
 // recordCPUUsage samples and records the current cpu usage of the node.
 func (m *runtimeLoadMonitor) recordCPUUsage(ctx context.Context) error {
+	var gatewayCPUNanos, distCPUNanos int64
+	if m.SQLCPUProvider != nil {
+		gatewayCPUNanos, distCPUNanos = m.SQLCPUProvider.GetCumulativeSQLCPUNanos()
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	userTimeMillis, sysTimeMillis, err := status.GetProcCPUTime(ctx)
@@ -163,6 +192,13 @@ func (m *runtimeLoadMonitor) recordCPUUsage(ctx context.Context) error {
 	totalUsageNanos := float64(userTimeMillis*1e6 + sysTimeMillis*1e6)
 	cpuUsageDelta, m.mu.lastTotalUsageNanos = cumulativeDelta(ctx, totalUsageNanos, m.mu.lastTotalUsageNanos)
 	m.mu.usageEWMA.Add(cpuUsageDelta)
+	if m.SQLCPUProvider != nil {
+		var gatewayDelta, distDelta float64
+		gatewayDelta, m.mu.lastGatewayCPUNanos = cumulativeDelta(ctx, float64(gatewayCPUNanos), m.mu.lastGatewayCPUNanos)
+		distDelta, m.mu.lastDistCPUNanos = cumulativeDelta(ctx, float64(distCPUNanos), m.mu.lastDistCPUNanos)
+		m.mu.sqlGatewayEWMA.Add(gatewayDelta)
+		m.mu.sqlDistEWMA.Add(distDelta)
+	}
 	return nil
 }
 

--- a/pkg/kv/kvserver/load/node_capacity_provider_test.go
+++ b/pkg/kv/kvserver/load/node_capacity_provider_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/load"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/admission"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
@@ -40,7 +41,7 @@ func TestNodeCapacityProvider(t *testing.T) {
 		storeCount: 3,
 	}
 
-	provider := load.NewNodeCapacityProvider(stopper, mockStores, load.NodeCapacityProviderConfig{
+	provider := load.NewNodeCapacityProvider(stopper, mockStores, admission.NewSQLCPUProvider(), load.NodeCapacityProviderConfig{
 		CPUUsageRefreshInterval:    1 * time.Millisecond,
 		CPUCapacityRefreshInterval: 1 * time.Millisecond,
 		CPUUsageMovingAverageAge:   20,

--- a/pkg/roachpb/metadata.proto
+++ b/pkg/roachpb/metadata.proto
@@ -312,6 +312,15 @@ message NodeCapacity {
   // sec, calculated by the runtime load monitor based on number of logical CPU
   // processors available for use by the processor.
   optional int64 node_cpu_rate_capacity = 4 [(gogoproto.nullable) = false, (gogoproto.customname) = "NodeCPURateCapacity"];
+
+  // SQLGatewayCPUNanoPerSec is the SQL gateway CPU usage in nanoseconds per
+  // second, measured by the runtime load monitor tracking SQL work executed at
+  // gateway nodes.
+  optional int64 sql_gateway_cpu_nano_per_sec = 6 [(gogoproto.nullable) = false, (gogoproto.customname) = "SQLGatewayCPUNanoPerSec"];
+
+  // SQLDistCPUNanoPerSec is the distributed SQL CPU usage in nanoseconds per
+  // second, measured by the runtime load monitor tracking distributed SQL work.
+  optional int64 sql_dist_cpu_nano_per_sec = 7 [(gogoproto.nullable) = false, (gogoproto.customname) = "SQLDistCPUNanoPerSec"];
 }
 
 // StoreCapacity contains capacity information for a storage device.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -590,6 +590,8 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 	)
 	db.SQLKVResponseAdmissionQ = gcoords.RegularCPU.GetSQLWorkQueue(admission.SQLKVResponseWork)
 	db.AdmissionPacerFactory = gcoords.ElasticCPU
+	sqlCPUProvider := admission.NewSQLCPUProvider()
+	db.SQLCPUProvider = sqlCPUProvider
 	goschedstats.RegisterSettings(st)
 	if goschedstats.Supported {
 		cbID := goschedstats.RegisterRunnableCountCallback(gcoords.RegularCPU.GetRunnableCountCallback())
@@ -1271,6 +1273,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		monitorAndMetrics:        sqlMonitorAndMetrics,
 		settingsStorage:          settingsWriter,
 		admissionPacerFactory:    gcoords.ElasticCPU,
+		sqlCPUProvider:           sqlCPUProvider,
 		rangeDescIteratorFactory: rangedesc.NewIteratorFactory(db),
 		tenantCapabilitiesReader: sql.MakeSystemTenantOnly[tenantcapabilities.Reader](tenantCapabilitiesWatcher),
 	})

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -721,7 +721,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		CPUCapacityRefreshInterval: cpuCapacityRefreshInterval,
 		CPUUsageMovingAverageAge:   base.DefaultCPUUsageMovingAverageAge,
 	}
-	nodeCapacityProvider := load.NewNodeCapacityProvider(stopper, stores, nodeCapacityProviderConfig)
+	nodeCapacityProvider := load.NewNodeCapacityProvider(stopper, stores, sqlCPUProvider, nodeCapacityProviderConfig)
 
 	// The Executor will be further initialized later, as we create more
 	// of the server's components. There's a circular dependency - many things

--- a/pkg/server/server_controller_new_server.go
+++ b/pkg/server/server_controller_new_server.go
@@ -95,7 +95,9 @@ func (s *topLevelServer) newTenantServer(
 		serverutils.SetUnsafeOverride(&baseCfg.TestingKnobs)
 	}
 
-	tenantServer, err := newTenantServerInternal(ctx, baseCfg, sqlCfg, tenantStopper, tenantNameContainer, s.db.AdmissionPacerFactory)
+	tenantServer, err := newTenantServerInternal(
+		ctx, baseCfg, sqlCfg, tenantStopper, tenantNameContainer, s.db.AdmissionPacerFactory,
+		s.db.SQLCPUProvider)
 	if err != nil {
 		return nil, err
 	}
@@ -152,6 +154,7 @@ func newTenantServerInternal(
 	stopper *stop.Stopper,
 	tenantNameContainer *roachpb.TenantNameContainer,
 	elastic admission.PacerFactory,
+	sqlCPUProvider admission.SQLCPUProvider,
 ) (*SQLServerWrapper, error) {
 	ambientCtx := baseCfg.AmbientCtx
 	stopper.SetTracer(baseCfg.Tracer)
@@ -163,7 +166,8 @@ func newTenantServerInternal(
 	log.Dev.Infof(newCtx, "creating tenant server")
 
 	// Now instantiate the tenant server proper.
-	return newSharedProcessTenantServer(newCtx, stopper, baseCfg, sqlCfg, tenantNameContainer, elastic)
+	return newSharedProcessTenantServer(
+		newCtx, stopper, baseCfg, sqlCfg, tenantNameContainer, elastic, sqlCPUProvider)
 }
 
 func (s *topLevelServer) makeSharedProcessTenantConfig(

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -414,6 +414,10 @@ type sqlServerArgs struct {
 	// CPU intensive operations, such as CDC event encoding/decoding.
 	admissionPacerFactory admission.PacerFactory
 
+	// sqlCPUProvider is used to report CPU usage and foreground (non-elastic)
+	// SQL CPU admission control.
+	sqlCPUProvider admission.SQLCPUProvider
+
 	// rangeDescIteratorFactory is used to construct iterators over range
 	// descriptors.
 	rangeDescIteratorFactory rangedesc.IteratorFactory
@@ -860,6 +864,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		TenantCostController:     cfg.costController,
 		RangeStatsFetcher:        rangeStatsFetcher,
 		AdmissionPacerFactory:    cfg.admissionPacerFactory,
+		SQLCPUProvider:           cfg.sqlCPUProvider,
 		ExecutorConfig:           execCfg,
 		RootSQLMemoryPoolSize:    cfg.MemoryPoolSize,
 		VecIndexManager:          vecIndexManager,

--- a/pkg/sql/colexec/BUILD.bazel
+++ b/pkg/sql/colexec/BUILD.bazel
@@ -74,6 +74,7 @@ go_library(
         "//pkg/sql/sessiondata",
         "//pkg/sql/sqltelemetry",  # keep
         "//pkg/sql/types",
+        "//pkg/util/admission",
         "//pkg/util/buildutil",
         "//pkg/util/cancelchecker",
         "//pkg/util/duration",  # keep

--- a/pkg/sql/colexec/colexecutils/BUILD.bazel
+++ b/pkg/sql/colexec/colexecutils/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/sqlerrors",
         "//pkg/sql/types",
+        "//pkg/util/admission",
         "//pkg/util/cancelchecker",
         "//pkg/util/log",
         "//pkg/util/metamorphic",

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -719,6 +719,10 @@ func (s *vectorizedFlowCreator) accumulateAsyncComponent(run runFn) {
 		flowinfra.StartableFn(func(ctx context.Context, wg *sync.WaitGroup, flowCtxCancel context.CancelFunc) {
 			wg.Add(1)
 			go func() {
+				if cpuHandle := admission.SQLCPUHandleFromContext(ctx); cpuHandle != nil {
+					gh := cpuHandle.RegisterGoroutine()
+					defer gh.Close(ctx)
+				}
 				growstack.Grow()
 				defer wg.Done()
 				run(ctx, flowCtxCancel)

--- a/pkg/sql/distsql/BUILD.bazel
+++ b/pkg/sql/distsql/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//pkg/sql/sessiondata",
         "//pkg/sql/sessiondatapb",
         "//pkg/sql/sqltelemetry",
+        "//pkg/util/admission",
         "//pkg/util/log",
         "//pkg/util/mon",
         "//pkg/util/pprofutil",

--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -202,6 +202,8 @@ type ServerConfig struct {
 	// with elastic CPU control.
 	AdmissionPacerFactory admission.PacerFactory
 
+	SQLCPUProvider admission.SQLCPUProvider
+
 	// Allow mutation operations to trigger stats refresh.
 	StatsRefresher *stats.Refresher
 

--- a/pkg/sql/rowflow/BUILD.bazel
+++ b/pkg/sql/rowflow/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
+        "//pkg/util/admission",
         "//pkg/util/buildutil",
         "//pkg/util/log",
         "//pkg/util/mon",

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -170,13 +170,6 @@ func (ltc *LocalTestCluster) Start(t testing.TB, initFactory InitFactoryFn) {
 	ltc.Eng = kvstorage.MakeEngines(eng)
 
 	ltc.Stores = kvserver.NewStores(ambient, ltc.Clock)
-	// Faster refresh intervals for testing.
-	cfg.NodeCapacityProvider = load.NewNodeCapacityProvider(ltc.stopper, ltc.Stores, load.NodeCapacityProviderConfig{
-		CPUUsageRefreshInterval:    10 * time.Millisecond,
-		CPUCapacityRefreshInterval: 10 * time.Millisecond,
-		CPUUsageMovingAverageAge:   20,
-	})
-
 	factory := initFactory(ctx, cfg.Settings, nodeDesc, ltc.stopper.Tracer(), ltc.Clock, ltc.Latency,
 		kvserver.ToSenderForTesting(ltc.Stores), ltc.stopper, ltc.Gossip)
 
@@ -201,6 +194,12 @@ func (ltc *LocalTestCluster) Start(t testing.TB, initFactory InitFactoryFn) {
 	}
 	cfg.DB = ltc.DB
 	cfg.Gossip = ltc.Gossip
+	// Faster refresh intervals for testing.
+	cfg.NodeCapacityProvider = load.NewNodeCapacityProvider(ltc.stopper, ltc.Stores, ltc.DB.SQLCPUProvider, load.NodeCapacityProviderConfig{
+		CPUUsageRefreshInterval:    10 * time.Millisecond,
+		CPUCapacityRefreshInterval: 10 * time.Millisecond,
+		CPUUsageMovingAverageAge:   20,
+	})
 	cfg.HistogramWindowInterval = metric.TestSampleInterval
 	active, renewal := cfg.NodeLivenessDurations()
 	cfg.NodeLiveness = liveness.NewNodeLiveness(liveness.NodeLivenessOptions{

--- a/pkg/util/admission/BUILD.bazel
+++ b/pkg/util/admission/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "scheduler_latency_listener.go",
         "sequencer.go",
         "snapshot_queue.go",
+        "sql_cpu_handle.go",
         "store_grant_coordinator.go",
         "store_token_estimation.go",
         "testing_knobs.go",
@@ -39,6 +40,7 @@ go_library(
         "//pkg/util",
         "//pkg/util/admission/admissionpb",
         "//pkg/util/buildutil",
+        "//pkg/util/ctxutil",
         "//pkg/util/goschedstats",
         "//pkg/util/grunning",
         "//pkg/util/humanizeutil",
@@ -57,6 +59,7 @@ go_library(
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_cockroachdb_tokenbucket//:tokenbucket",
         "@com_github_olekukonko_tablewriter//:tablewriter",
+        "@com_github_petermattis_goid//:goid",
     ],
 )
 

--- a/pkg/util/admission/sql_cpu_handle.go
+++ b/pkg/util/admission/sql_cpu_handle.go
@@ -188,7 +188,7 @@ func (h *GoroutineCPUHandle) reset() {
 // will be pooled when SQLCPUHandle.Close is called, so MeasureAndAdmit must
 // never be called after Close.
 func (h *GoroutineCPUHandle) Close(ctx context.Context) {
-	_ = h.measureAndAdmit(ctx, true)
+	_ = h.measureAndAdmit(ctx, true /* noWait */)
 	h.closed.Store(true)
 }
 
@@ -199,7 +199,7 @@ func (h *GoroutineCPUHandle) Close(ctx context.Context) {
 //
 // TODO(sumeer): implement the measurement and admission logic.
 func (h *GoroutineCPUHandle) MeasureAndAdmit(ctx context.Context) error {
-	return h.measureAndAdmit(ctx, false)
+	return h.measureAndAdmit(ctx, false /* noWait */)
 }
 
 // measureAndAdmit is the internal implementation of MeasureAndAdmit. The
@@ -226,8 +226,8 @@ func (h *GoroutineCPUHandle) measureAndAdmit(ctx context.Context, noWait bool) e
 
 // PauseMeasuring is used to pause the CPU accounting for this goroutine. It
 // must be paired with UnpauseMeasuring. Used when the goroutine is being used
-// for KV work. If pause is called multiple times, an equal number of unpause
-// calls are needed to resume measuring.
+// for KV work. If PauseMeasuring is called multiple times, an equal number of
+// UnpauseMeasuring calls are needed to resume measuring.
 func (h *GoroutineCPUHandle) PauseMeasuring() {
 	h.paused++
 	if h.paused == 1 {

--- a/pkg/util/admission/sql_cpu_handle.go
+++ b/pkg/util/admission/sql_cpu_handle.go
@@ -1,0 +1,260 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package admission
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxutil"
+	"github.com/cockroachdb/cockroach/pkg/util/grunning"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/petermattis/goid"
+)
+
+// SQLWorkInfo captures identifying information about SQL work for CPU
+// accounting and admission.
+type SQLWorkInfo struct {
+	// AtGateway is true if the work is being executed at a gateway node.
+	AtGateway bool
+	// TenantID is the id of the tenant. For single-tenant clusters, this will
+	// always be the SystemTenantID.
+	TenantID roachpb.TenantID
+	// Priority is utilized within a tenant.
+	Priority admissionpb.WorkPriority
+	// CreateTime is equivalent to Time.UnixNano() at the creation time of this
+	// work or a parent work (e.g. could be the start time of the transaction,
+	// if this work was created as part of a transaction). It is used to order
+	// work within a (WorkloadID, Priority) pair -- earlier CreateTime is given
+	// preference.
+	CreateTime int64
+}
+
+// SQLCPUProvider is used to get a SQLCPUHandle that is used for CPU
+// accounting and admission.
+type SQLCPUProvider interface {
+	// GetHandle returns a SQLCPUHandle for the supplied work info.
+	GetHandle(work SQLWorkInfo) *SQLCPUHandle
+}
+
+var sqlCPUAdmissionHandleContextKey = ctxutil.RegisterFastValueKey()
+
+// ContextWithSQLCPUHandle returns a Context wrapping the supplied handle, if
+// any.
+func ContextWithSQLCPUHandle(ctx context.Context, h *SQLCPUHandle) context.Context {
+	if h == nil {
+		return ctx
+	}
+	return ctxutil.WithFastValue(ctx, sqlCPUAdmissionHandleContextKey, h)
+}
+
+// SQLCPUHandleFromContext returns the handle contained in the Context, if
+// any.
+func SQLCPUHandleFromContext(ctx context.Context) *SQLCPUHandle {
+	val := ctxutil.FastValue(ctx, sqlCPUAdmissionHandleContextKey)
+	h, ok := val.(*SQLCPUHandle)
+	if !ok {
+		return nil
+	}
+	return h
+}
+
+var goroutineCPUHandlePool = sync.Pool{
+	New: func() interface{} {
+		return &GoroutineCPUHandle{}
+	},
+}
+
+// SQLCPUHandle manages CPU accounting and admission for SQL work across
+// multiple goroutines.
+//
+// TODO(sumeer): fill in more details.
+type SQLCPUHandle struct {
+	workInfo SQLWorkInfo
+	p        *sqlCPUProviderImpl
+
+	mu struct {
+		syncutil.Mutex
+		closed   bool
+		gHandles []*GoroutineCPUHandle
+	}
+}
+
+func newSQLCPUAdmissionHandle(workInfo SQLWorkInfo, p *sqlCPUProviderImpl) *SQLCPUHandle {
+	h := &SQLCPUHandle{
+		workInfo: workInfo,
+		p:        p,
+	}
+	return h
+}
+
+// TODO(sumeer): see the comment
+// https://github.com/cockroachdb/cockroach/pull/161952#pullrequestreview-3741525716
+// on additional integrations that may need to call RegisterGoroutine.
+
+// RegisterGoroutine returns a GoroutineCPUHandle to use for reporting and
+// admission. If the goroutine was already registered, the existing handle
+// will be returned. CPU time is accounted for at this goroutine from the
+// instant the handle was first created for this goroutine. The cpu accounting
+// will end for this goroutine when it is closed by calling
+// GoroutineCPUHandle.Close, or if never closed, until the last call to
+// GoroutineCPUHandle.MeasureAndAdmit.
+func (h *SQLCPUHandle) RegisterGoroutine() *GoroutineCPUHandle {
+	gid := goid.Get()
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, gh := range h.mu.gHandles {
+		if gh.gid == gid {
+			// Already registered.
+			return gh
+		}
+	}
+	// Not registered, create a new handle.
+	gh := newGoroutineCPUHandle(gid, h)
+	h.mu.gHandles = append(h.mu.gHandles, gh)
+
+	return gh
+}
+
+// Close is called when no more reporting is needed. It pools
+// GoroutineCPUHandles that have been closed. GoroutineCPUHandles that are not
+// yet closed are left for GC.
+func (h *SQLCPUHandle) Close() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.mu.closed = true
+	for i, gh := range h.mu.gHandles {
+		if gh.closed.Load() {
+			gh.reset()
+			goroutineCPUHandlePool.Put(gh)
+		}
+		h.mu.gHandles[i] = nil
+	}
+	h.mu.gHandles = nil
+}
+
+// GoroutineCPUHandle is used for CPU accounting on a single goroutine. It
+// should be closed by calling Close when the goroutine's flow-related work is
+// done. The Close call must be at the goroutine boundary, to structurally
+// guarantee that MeasureAndAdmit is never called after Close. This structural
+// guarantee is essential for safe pooling - the handle may be reused for a
+// different goroutine after being pooled. It is safe to never Close a
+// GoroutineCPUHandle -- it will be garbage collected.
+type GoroutineCPUHandle struct {
+	gid int64
+	h   *SQLCPUHandle
+
+	// cpuStart captures the running time of the calling goroutine when this
+	// handle is constructed.
+	cpuStart time.Duration
+	// cpuAccounted is the total CPU time accounted for on this goroutine.
+	// Monotonically increasing.
+	cpuAccounted time.Duration
+
+	pauseDur   time.Duration
+	paused     int
+	pauseStart time.Duration
+
+	// closed is set to true when Close() is called. This is primarily for
+	// debugging - the structural guarantee (Close at goroutine boundary)
+	// is the primary safety mechanism, not this field.
+	closed atomic.Bool
+}
+
+func newGoroutineCPUHandle(gid int64, h *SQLCPUHandle) *GoroutineCPUHandle {
+	gh := goroutineCPUHandlePool.Get().(*GoroutineCPUHandle)
+	*gh = GoroutineCPUHandle{
+		gid:      gid,
+		h:        h,
+		cpuStart: grunning.Time(),
+	}
+	return gh
+}
+
+// reset clears all fields in preparation for returning to the pool.
+func (h *GoroutineCPUHandle) reset() {
+	*h = GoroutineCPUHandle{}
+}
+
+// Close marks this handle as closed. It must be called at the goroutine
+// boundary when the goroutine's SQL work is done. After Close, the handle
+// will be pooled when SQLCPUHandle.Close is called, so MeasureAndAdmit must
+// never be called after Close.
+func (h *GoroutineCPUHandle) Close(ctx context.Context) {
+	_ = h.measureAndAdmit(ctx, true)
+	h.closed.Store(true)
+}
+
+// MeasureAndAdmit should be called frequently. The callee will measure the
+// CPU time spent in the goroutine and decide whether more CPU needs to be
+// allocated. If more CPU is needed, it can block in acquiring CPU tokens.
+// Returns a non-nil error iff the context is canceled while waiting.
+//
+// TODO(sumeer): implement the measurement and admission logic.
+func (h *GoroutineCPUHandle) MeasureAndAdmit(ctx context.Context) error {
+	return h.measureAndAdmit(ctx, false)
+}
+
+// measureAndAdmit is the internal implementation of MeasureAndAdmit. The
+// noWait parameter should only be set to true when the work is finished, so
+// only measurement is desired (blocking is no longer productive). When noWait
+// is true, this function never returns an error.
+func (h *GoroutineCPUHandle) measureAndAdmit(ctx context.Context, noWait bool) error {
+	if h.paused > 0 {
+		return nil
+	}
+	cpuUsed := grunning.Elapsed(h.cpuStart, grunning.Time()) - h.pauseDur
+	diff := cpuUsed - h.cpuAccounted
+	if diff <= 0 {
+		return nil
+	}
+	// TODO(sumeer): adding this diff to an atomic in SQLCPUHandle may be too
+	// much overhead. An alternative would be implement an atomic here, and
+	// only update the SQLCPUHandle when enough has accumulated. The reason
+	// we would need an atomic here is that when SQLCPUHandle is closed, it
+	// needs to reach in and grab whatever CPU has not yet been reported.
+	h.cpuAccounted += diff
+	return nil
+}
+
+// PauseMeasuring is used to pause the CPU accounting for this goroutine. It
+// must be paired with UnpauseMeasuring. Used when the goroutine is being used
+// for KV work. If pause is called multiple times, an equal number of unpause
+// calls are needed to resume measuring.
+func (h *GoroutineCPUHandle) PauseMeasuring() {
+	h.paused++
+	if h.paused == 1 {
+		h.pauseStart = grunning.Time()
+	}
+}
+
+// UnpauseMeasuring resumes CPU accounting for this goroutine.
+func (h *GoroutineCPUHandle) UnpauseMeasuring() {
+	h.paused--
+	if h.paused == 0 {
+		h.pauseDur += grunning.Elapsed(h.pauseStart, grunning.Time())
+	}
+}
+
+type sqlCPUProviderImpl struct {
+	// TODO(sumeer): implement.
+}
+
+func (p *sqlCPUProviderImpl) GetHandle(workInfo SQLWorkInfo) *SQLCPUHandle {
+	// TODO(sumeer): implement.
+	return newSQLCPUAdmissionHandle(workInfo, p)
+}
+
+// NewSQLCPUProvider creates a new SQLCPUProvider.
+//
+// TODO(sumeer): real implementation.
+func NewSQLCPUProvider() SQLCPUProvider {
+	return &sqlCPUProviderImpl{}
+}

--- a/pkg/util/admission/sql_cpu_handle.go
+++ b/pkg/util/admission/sql_cpu_handle.go
@@ -84,6 +84,9 @@ type SQLCPUHandle struct {
 		syncutil.Mutex
 		closed   bool
 		gHandles []*GoroutineCPUHandle
+		// Backing for up to 2 goroutine handles, to avoid allocations in
+		// gHandles when there are 2 or fewer goroutines.
+		handlesBacking [2]*GoroutineCPUHandle
 	}
 }
 
@@ -92,6 +95,7 @@ func newSQLCPUAdmissionHandle(workInfo SQLWorkInfo, p *sqlCPUProviderImpl) *SQLC
 		workInfo: workInfo,
 		p:        p,
 	}
+	h.mu.gHandles = h.mu.handlesBacking[:0]
 	return h
 }
 

--- a/pkg/util/cancelchecker/BUILD.bazel
+++ b/pkg/util/cancelchecker/BUILD.bazel
@@ -8,5 +8,6 @@ go_library(
     deps = [
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
+        "//pkg/util/admission",
     ],
 )

--- a/pkg/util/cancelchecker/cancel_checker.go
+++ b/pkg/util/cancelchecker/cancel_checker.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/util/admission"
 )
 
 // CancelChecker is a helper object for repeatedly checking whether the associated context
@@ -29,6 +30,8 @@ type CancelChecker struct {
 
 	// The number of Check() calls to skip the context cancellation check.
 	checkInterval uint32
+
+	cpuHandle *admission.GoroutineCPUHandle
 }
 
 // The default interval of Check() calls to wait between checks for context
@@ -47,6 +50,12 @@ func (c *CancelChecker) Check() error {
 			// to Check().
 			return QueryCanceledError
 		default:
+		}
+		if c.cpuHandle != nil {
+			err := c.cpuHandle.MeasureAndAdmit(c.ctx)
+			if err != nil {
+				return QueryCanceledError
+			}
 		}
 	}
 
@@ -68,6 +77,10 @@ func (c *CancelChecker) Reset(ctx context.Context, checkInterval ...uint32) {
 		c.checkInterval = checkInterval[0]
 	} else {
 		c.checkInterval = cancelCheckInterval
+	}
+	cpuHandle := admission.SQLCPUHandleFromContext(ctx)
+	if cpuHandle != nil {
+		c.cpuHandle = cpuHandle.RegisterGoroutine()
 	}
 }
 


### PR DESCRIPTION
Only last four commits. Rebased on top of https://github.com/cockroachdb/cockroach/pull/161952. 
Epic: CRDB-55052
Release note: none

---
**load: extract `cumulativeDelta` helper from `recordCPUUsage`**

This commit extracts the delta computation and monotonicity from
`recordCPUUsage` into a standalone `cumulativeDelta` helper.

Note that this is a pure refactor with no behavior change.

---
**admission: track cumulative SQL CPU in `SQLCPUHandle`**

This change adds per-category cumulative CPU counters to
`sqlCPUProviderImpl` — one for gateway SQL work and one for distributed
SQL work. Each call to `GoroutineCPUHandle.measureAndAdmit` now reports
its CPU delta through `SQLCPUHandle.reportCPU`, which atomically
increments the appropriate counter.

The new `GetCumulativeSQLCPUNanos` method on the `SQLCPUProvider`
interface exposes these counters so that the node capacity provider can
derive per-second rates.

---
**load: plumb `SQLCPUProvider` into `NewNodeCapacityProvider`**

This change plumbs `SQLCPUProvider` through to `runtimeLoadMonitor`
so that a follow-up commit can use it to derive SQL CPU rates. No new
tracking logic is added.

---
**load,roachpb: report SQL CPU rates in `NodeCapacity`**

This change teaches `runtimeLoadMonitor` to poll cumulative SQL CPU
counters from `SQLCPUProvider` and derive EWMA-smoothed per-second
rates for gateway and distributed SQL CPU usage.

Two new fields are added to the `NodeCapacity` proto:
`SQLGatewayCPUNanoPerSec` and `SQLDistCPUNanoPerSec`.
`GetNodeCapacity` populates them from `GetCPUStats`. These fields are
gossiped via store descriptors and will be used by MMA to distinguish
SQL CPU from other node CPU consumption.

