### PR TITLE
load: extract cumulativeDelta helper from recordCPUUsage

### DIFF
--- a/pkg/kv/kvserver/load/BUILD.bazel
+++ b/pkg/kv/kvserver/load/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/kv/kvserver/replicastats",
         "//pkg/roachpb",
         "//pkg/server/status",
+        "//pkg/util/admission",
         "//pkg/util/buildutil",
         "//pkg/util/hlc",
         "//pkg/util/log",
@@ -31,6 +32,7 @@ go_test(
     deps = [
         ":load",
         "//pkg/testutils",
+        "//pkg/util/admission",
         "//pkg/util/stop",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",

--- a/pkg/kv/kvserver/load/node_capacity_provider.go
+++ b/pkg/kv/kvserver/load/node_capacity_provider.go
@@ -69,6 +69,8 @@ func NewNodeCapacityProvider(
 		capacityRefreshInterval: config.CPUCapacityRefreshInterval,
 	}
 	monitor.mu.usageEWMA = ewma.NewMovingAverage(config.CPUUsageMovingAverageAge)
+	monitor.mu.sqlGatewayEWMA = ewma.NewMovingAverage(config.CPUUsageMovingAverageAge)
+	monitor.mu.sqlDistEWMA = ewma.NewMovingAverage(config.CPUUsageMovingAverageAge)
 	monitor.recordCPUCapacity(context.Background())
 	return &NodeCapacityProvider{
 		stores:             stores,
@@ -105,12 +107,14 @@ func (n *NodeCapacityProvider) GetNodeCapacity(useCached bool) (roachpb.NodeCapa
 	// runtimeLoadMonitor to also fetch updated stats.
 	// TODO(wenyihu6): NodeCPURateCapacity <= NodeCPURateUsage fails on CI and
 	// requires more investigation.
-	cpuUsageNanoPerSec, cpuCapacityNanoPerSec := n.runtimeLoadMonitor.GetCPUStats()
+	cpuUsageNanoPerSec, cpuCapacityNanoPerSec, sqlGatewayCPUNanoPerSec, sqlDistCPUNanoPerSec := n.runtimeLoadMonitor.GetCPUStats()
 	return roachpb.NodeCapacity{
-		StoresCPURate:       storesCPURate,
-		NumStores:           numStores,
-		NodeCPURateCapacity: cpuCapacityNanoPerSec,
-		NodeCPURateUsage:    cpuUsageNanoPerSec,
+		StoresCPURate:           storesCPURate,
+		NumStores:               numStores,
+		NodeCPURateCapacity:     cpuCapacityNanoPerSec,
+		NodeCPURateUsage:        cpuUsageNanoPerSec,
+		SQLGatewayCPUNanoPerSec: int64(sqlGatewayCPUNanoPerSec),
+		SQLDistCPUNanoPerSec:    int64(sqlDistCPUNanoPerSec),
 	}, nil
 }
 
@@ -131,6 +135,23 @@ type runtimeLoadMonitor struct {
 		// subsequent polls in nanoseconds. The cpu usage is obtained by polling
 		// stats from status.GetProcCPUTime which is cumulative.
 		usageEWMA ewma.MovingAverage
+
+		// lastGatewayCPUNanos tracks the last cumulative SQL gateway CPU usage
+		// in nanoseconds, used to compute the delta between subsequent polls.
+		lastGatewayCPUNanos float64
+
+		// lastDistCPUNanos tracks the last cumulative dist SQL CPU usage in
+		// nanoseconds, used to compute the delta between subsequent polls.
+		lastDistCPUNanos float64
+
+		// sqlGatewayEWMA maintains a moving average of delta SQL gateway CPU
+		// usage between two subsequent polls in nanoseconds.
+		sqlGatewayEWMA ewma.MovingAverage
+
+		// sqlDistEWMA maintains a moving average of delta dist SQL CPU usage
+		// between two subsequent polls in nanoseconds.
+		sqlDistEWMA ewma.MovingAverage
+
 		// logicalCPUsPerSec represents the node's cpu capacity in logical
 		// CPU-seconds per second, obtained from status.GetCPUCapacity.
 		logicalCPUsPerSec int64
@@ -138,7 +159,12 @@ type runtimeLoadMonitor struct {
 }
 
 // GetCPUStats returns the current cpu usage and capacity stats for the node.
-func (m *runtimeLoadMonitor) GetCPUStats() (cpuUsageNanoPerSec int64, cpuCapacityNanoPerSec int64) {
+func (m *runtimeLoadMonitor) GetCPUStats() (
+	cpuUsageNanoPerSec int64,
+	cpuCapacityNanoPerSec int64,
+	sqlGatewayCPUNanoPerSec float64,
+	sqlDistCPUNanoPerSec float64,
+) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	// usageEWMA is usage in nanoseconds. Divide by refresh interval to get the
@@ -147,11 +173,17 @@ func (m *runtimeLoadMonitor) GetCPUStats() (cpuUsageNanoPerSec int64, cpuCapacit
 	// logicalCPUsPerSec is in logical cpu-seconds per second. Convert the unit
 	// from cpu-seconds to cpu-nanoseconds.
 	cpuCapacityNanoPerSec = m.mu.logicalCPUsPerSec * time.Second.Nanoseconds()
+	sqlGatewayCPUNanoPerSec = m.mu.sqlGatewayEWMA.Value() / m.usageRefreshInterval.Seconds()
+	sqlDistCPUNanoPerSec = m.mu.sqlDistEWMA.Value() / m.usageRefreshInterval.Seconds()
 	return
 }
 
 // recordCPUUsage samples and records the current cpu usage of the node.
 func (m *runtimeLoadMonitor) recordCPUUsage(ctx context.Context) error {
+	var gatewayCPUNanos, distCPUNanos int64
+	if m.SQLCPUProvider != nil {
+		gatewayCPUNanos, distCPUNanos = m.SQLCPUProvider.GetCumulativeSQLCPUNanos()
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	userTimeMillis, sysTimeMillis, err := status.GetProcCPUTime(ctx)
@@ -163,6 +195,13 @@ func (m *runtimeLoadMonitor) recordCPUUsage(ctx context.Context) error {
 	totalUsageNanos := float64(userTimeMillis*1e6 + sysTimeMillis*1e6)
 	cpuUsageDelta, m.mu.lastTotalUsageNanos = cumulativeDelta(ctx, totalUsageNanos, m.mu.lastTotalUsageNanos)
 	m.mu.usageEWMA.Add(cpuUsageDelta)
+	if m.SQLCPUProvider != nil {
+		var gatewayDelta, distDelta float64
+		gatewayDelta, m.mu.lastGatewayCPUNanos = cumulativeDelta(ctx, float64(gatewayCPUNanos), m.mu.lastGatewayCPUNanos)
+		distDelta, m.mu.lastDistCPUNanos = cumulativeDelta(ctx, float64(distCPUNanos), m.mu.lastDistCPUNanos)
+		m.mu.sqlGatewayEWMA.Add(gatewayDelta)
+		m.mu.sqlDistEWMA.Add(distDelta)
+	}
 	return nil
 }
 

--- a/pkg/kv/kvserver/load/node_capacity_provider_test.go
+++ b/pkg/kv/kvserver/load/node_capacity_provider_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/load"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/admission"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
@@ -40,7 +41,7 @@ func TestNodeCapacityProvider(t *testing.T) {
 		storeCount: 3,
 	}
 
-	provider := load.NewNodeCapacityProvider(stopper, mockStores, load.NodeCapacityProviderConfig{
+	provider := load.NewNodeCapacityProvider(stopper, mockStores, admission.NewSQLCPUProvider(), load.NodeCapacityProviderConfig{
 		CPUUsageRefreshInterval:    1 * time.Millisecond,
 		CPUCapacityRefreshInterval: 1 * time.Millisecond,
 		CPUUsageMovingAverageAge:   20,

--- a/pkg/roachpb/metadata.proto
+++ b/pkg/roachpb/metadata.proto
@@ -312,6 +312,15 @@ message NodeCapacity {
   // sec, calculated by the runtime load monitor based on number of logical CPU
   // processors available for use by the processor.
   optional int64 node_cpu_rate_capacity = 4 [(gogoproto.nullable) = false, (gogoproto.customname) = "NodeCPURateCapacity"];
+
+  // SQLGatewayCPUNanoPerSec is the SQL gateway CPU usage in nanoseconds per
+  // second, measured by the runtime load monitor tracking SQL work executed at
+  // gateway nodes.
+  optional int64 sql_gateway_cpu_nano_per_sec = 6 [(gogoproto.nullable) = false, (gogoproto.customname) = "SQLGatewayCPUNanoPerSec"];
+
+  // SQLDistCPUNanoPerSec is the distributed SQL CPU usage in nanoseconds per
+  // second, measured by the runtime load monitor tracking distributed SQL work.
+  optional int64 sql_dist_cpu_nano_per_sec = 7 [(gogoproto.nullable) = false, (gogoproto.customname) = "SQLDistCPUNanoPerSec"];
 }
 
 // StoreCapacity contains capacity information for a storage device.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -721,7 +721,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		CPUCapacityRefreshInterval: cpuCapacityRefreshInterval,
 		CPUUsageMovingAverageAge:   base.DefaultCPUUsageMovingAverageAge,
 	}
-	nodeCapacityProvider := load.NewNodeCapacityProvider(stopper, stores, nodeCapacityProviderConfig)
+	nodeCapacityProvider := load.NewNodeCapacityProvider(stopper, stores, sqlCPUProvider, nodeCapacityProviderConfig)
 
 	// The Executor will be further initialized later, as we create more
 	// of the server's components. There's a circular dependency - many things

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -170,13 +170,6 @@ func (ltc *LocalTestCluster) Start(t testing.TB, initFactory InitFactoryFn) {
 	ltc.Eng = kvstorage.MakeEngines(eng)
 
 	ltc.Stores = kvserver.NewStores(ambient, ltc.Clock)
-	// Faster refresh intervals for testing.
-	cfg.NodeCapacityProvider = load.NewNodeCapacityProvider(ltc.stopper, ltc.Stores, load.NodeCapacityProviderConfig{
-		CPUUsageRefreshInterval:    10 * time.Millisecond,
-		CPUCapacityRefreshInterval: 10 * time.Millisecond,
-		CPUUsageMovingAverageAge:   20,
-	})
-
 	factory := initFactory(ctx, cfg.Settings, nodeDesc, ltc.stopper.Tracer(), ltc.Clock, ltc.Latency,
 		kvserver.ToSenderForTesting(ltc.Stores), ltc.stopper, ltc.Gossip)
 
@@ -201,6 +194,12 @@ func (ltc *LocalTestCluster) Start(t testing.TB, initFactory InitFactoryFn) {
 	}
 	cfg.DB = ltc.DB
 	cfg.Gossip = ltc.Gossip
+	// Faster refresh intervals for testing.
+	cfg.NodeCapacityProvider = load.NewNodeCapacityProvider(ltc.stopper, ltc.Stores, ltc.DB.SQLCPUProvider, load.NodeCapacityProviderConfig{
+		CPUUsageRefreshInterval:    10 * time.Millisecond,
+		CPUCapacityRefreshInterval: 10 * time.Millisecond,
+		CPUUsageMovingAverageAge:   20,
+	})
 	cfg.HistogramWindowInterval = metric.TestSampleInterval
 	active, renewal := cfg.NodeLivenessDurations()
 	cfg.NodeLiveness = liveness.NewNodeLiveness(liveness.NodeLivenessOptions{


### PR DESCRIPTION
Epic: CRDB-56265
Release note: none

---
**load: extract `cumulativeDelta` helper from `recordCPUUsage`**

This commit extracts the delta computation and monotonicity from
`recordCPUUsage` into a standalone `cumulativeDelta` helper.

Note that this is a pure refactor with no behavior change.

---
**admission: track cumulative SQL CPU in `SQLCPUHandle`**

This change adds per-category cumulative CPU counters to
`sqlCPUProviderImpl` — one for gateway SQL work and one for distributed
SQL work. Each call to `GoroutineCPUHandle.measureAndAdmit` now reports
its CPU delta through `SQLCPUHandle.reportCPU`, which atomically
increments the appropriate counter.

The new `GetCumulativeSQLCPUNanos` method on the `SQLCPUProvider`
interface exposes these counters so that the node capacity provider can
derive per-second rates.

---
**load: plumb `SQLCPUProvider` into `NewNodeCapacityProvider`**

This change plumbs `SQLCPUProvider` through to `runtimeLoadMonitor`
so that a follow-up commit can use it to derive SQL CPU rates. No new
tracking logic is added.

---
**load,roachpb: report SQL CPU rates in `NodeCapacity`**

This change teaches `runtimeLoadMonitor` to poll cumulative SQL CPU
counters from `SQLCPUProvider` and derive EWMA-smoothed per-second
rates for gateway and distributed SQL CPU usage.

Two new fields are added to the `NodeCapacity` proto:
`SQLGatewayCPUNanoPerSec` and `SQLDistCPUNanoPerSec`.
`GetNodeCapacity` populates them from `GetCPUStats`. These fields are
gossiped via store descriptors and will be used by MMA to distinguish
SQL CPU from other node CPU consumption.

