### PR TITLE
goexectrace: add on-demand execution trace dumps and pprof integration

### DIFF
--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1264,6 +1264,11 @@ type StoreConfig struct {
 	// The returned bool indicates whether a dump was taken.
 	GoroutineDumpNow func(context.Context, redact.RedactableString) (bool, error)
 
+	// ExecutionTraceDumpNow, if set, triggers an on-demand execution trace
+	// dump from the flight recorder. The tag parameter is appended to the
+	// filename. Returns the filename of the dump.
+	ExecutionTraceDumpNow func(ctx context.Context, reason redact.RedactableString, tag string) (string, error)
+
 	// EagerLeaseAcquisitionLimiter is used to limit the number of concurrent
 	// eager lease extensions. Normally shared between all stores on a node.
 	// Can be nil, which disables the limit.

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -46,6 +46,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/netutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing/goexectrace"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble"
@@ -548,6 +549,11 @@ type SQLConfig struct {
 	// NodeMetricsRecorder is the node's MetricRecorder; the tenant's metrics will
 	// be recorded with it. Nil if this is not a shared-process tenant.
 	NodeMetricsRecorder *status.MetricsRecorder
+
+	// NodeFlightRecorder is the node's execution trace flight recorder. When
+	// set (shared-process tenants), the tenant reuses this recorder instead of
+	// creating its own. Nil for separate-process tenants.
+	NodeFlightRecorder *goexectrace.SimpleFlightRecorder
 
 	// LicenseEnforcer is used to enforce license policies.
 	LicenseEnforcer *license.Enforcer

--- a/pkg/server/debug/BUILD.bazel
+++ b/pkg/server/debug/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//pkg/util/log/severity",
         "//pkg/util/stop",
         "//pkg/util/timeutil",
+        "//pkg/util/tracing/goexectrace",
         "//pkg/util/uint128",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_pebble//:pebble",

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -133,6 +133,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil/ptp"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing/goexectrace"
 	"github.com/cockroachdb/cockroach/pkg/util/unique"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
@@ -182,6 +183,7 @@ type topLevelServer struct {
 	policyRefresher      *policyrefresher.PolicyRefresher
 	nodeCapacityProvider *load.NodeCapacityProvider
 	goroutineDumper      *goroutinedumper.GoroutineDumper
+	flightRecorder       *goexectrace.SimpleFlightRecorder
 
 	http            *httpServer
 	adminAuthzCheck privchecker.CheckerForRPCHandlers
@@ -944,6 +946,15 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		return nil, errors.Wrap(err, "starting goroutine dumper worker")
 	}
 
+	var flightRecorder *goexectrace.SimpleFlightRecorder
+	if cfg.BaseConfig.ExecutionTraceDirName != "" {
+		flightRecorder, err = goexectrace.NewFlightRecorder(st, 10*time.Second, cfg.BaseConfig.ExecutionTraceDirName)
+		if err != nil {
+			log.Dev.Warningf(ctx, "failed to initialize flight recorder: %v", err)
+		}
+	}
+	cfg.SQLConfig.NodeFlightRecorder = flightRecorder
+
 	storeCfg := kvserver.StoreConfig{
 		DefaultSpanConfig:            cfg.DefaultZoneConfig.AsSpanConfig(),
 		Settings:                     st,
@@ -992,6 +1003,9 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 	}
 	if goroutineDumper != nil {
 		storeCfg.GoroutineDumpNow = goroutineDumper.DumpNow
+	}
+	if flightRecorder != nil {
+		storeCfg.ExecutionTraceDumpNow = flightRecorder.DumpNow
 	}
 	if storeTestingKnobs := cfg.TestingKnobs.Store; storeTestingKnobs != nil {
 		storeCfg.TestingKnobs = *storeTestingKnobs.(*kvserver.StoreTestingKnobs)
@@ -1370,6 +1384,10 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		authorizer,
 	)
 
+	if flightRecorder != nil {
+		debugServer.RegisterFlightRecorder(flightRecorder)
+	}
+
 	recoveryServer := loqrecovery.NewServer(
 		nodeIDContainer,
 		st,
@@ -1414,6 +1432,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		nodeCapacityProvider:      nodeCapacityProvider,
 		runtime:                   runtimeSampler,
 		goroutineDumper:           goroutineDumper,
+		flightRecorder:            flightRecorder,
 		http:                      sHTTP,
 		adminAuthzCheck:           adminAuthzCheck,
 		admin:                     sAdmin,
@@ -2025,6 +2044,7 @@ func (s *topLevelServer) PreStart(ctx context.Context) error {
 		s.stopper,
 		s.runtime,
 		s.goroutineDumper,
+		s.flightRecorder,
 		s.status.sessionRegistry,
 		s.sqlServer.execCfg.RootMemoryMonitor,
 	); err != nil {

--- a/pkg/server/server_controller_new_server.go
+++ b/pkg/server/server_controller_new_server.go
@@ -386,6 +386,7 @@ func makeSharedProcessTenantServerConfig(
 	sqlCfg.LocalKVServerInfo = &kvServerInfo
 
 	sqlCfg.NodeMetricsRecorder = nodeMetricsRecorder
+	sqlCfg.NodeFlightRecorder = kvServerCfg.SQLConfig.NodeFlightRecorder
 	sqlCfg.LicenseEnforcer = kvServerCfg.SQLConfig.LicenseEnforcer
 
 	return baseCfg, sqlCfg, nil

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -76,6 +76,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/schedulerlatency"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing/goexectrace"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
@@ -123,7 +124,8 @@ type SQLServerWrapper struct {
 	authentication  authserver.Server
 	stopper         *stop.Stopper
 
-	debug *debug.Server
+	debug          *debug.Server
+	flightRecorder *goexectrace.SimpleFlightRecorder
 
 	// pgL is the SQL listener.
 	pgL net.Listener
@@ -514,6 +516,24 @@ func newTenantServer(
 		processCapAuthz,
 	)
 
+	// Determine the flight recorder for this tenant. Shared-process tenants
+	// reuse the node's flight recorder; separate-process tenants create their
+	// own.
+	var flightRecorder *goexectrace.SimpleFlightRecorder
+	if sqlCfg.NodeFlightRecorder != nil {
+		flightRecorder = sqlCfg.NodeFlightRecorder
+	} else if baseCfg.ExecutionTraceDirName != "" {
+		var err error
+		flightRecorder, err = goexectrace.NewFlightRecorder(
+			args.Settings, 10*time.Second, baseCfg.ExecutionTraceDirName)
+		if err != nil {
+			log.Dev.Warningf(ctx, "failed to initialize flight recorder: %v", err)
+		}
+	}
+	if flightRecorder != nil {
+		debugServer.RegisterFlightRecorder(flightRecorder)
+	}
+
 	return &SQLServerWrapper{
 		cfg: args.BaseConfig,
 
@@ -538,7 +558,8 @@ func newTenantServer(
 		authentication:  sAuth,
 		stopper:         args.stopper,
 
-		debug: debugServer,
+		debug:          debugServer,
+		flightRecorder: flightRecorder,
 
 		pgPreServer: pgPreServer,
 
@@ -792,6 +813,7 @@ func (s *SQLServerWrapper) PreStart(ctx context.Context) error {
 			s.stopper,
 			s.runtime,
 			goroutineDumper,
+			s.flightRecorder,
 			s.tenantStatus.sessionRegistry,
 			s.sqlServer.execCfg.RootMemoryMonitor,
 		); err != nil {

--- a/pkg/util/tracing/goexectrace/BUILD.bazel
+++ b/pkg/util/tracing/goexectrace/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//pkg/settings/cluster",
         "//pkg/util/log",
         "//pkg/util/stop",
+        "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
     ],

--- a/pkg/util/tracing/goexectrace/BUILD.bazel
+++ b/pkg/util/tracing/goexectrace/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
         "//pkg/util/stop",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
-        "@org_golang_x_exp//trace",
     ],
 )
 

--- a/pkg/util/tracing/goexectrace/BUILD.bazel
+++ b/pkg/util/tracing/goexectrace/BUILD.bazel
@@ -10,10 +10,12 @@ go_library(
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/util/log",
+        "//pkg/util/retry",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 
@@ -27,6 +29,7 @@ go_test(
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/stop",
+        "@com_github_cockroachdb_errors//oserror",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/util/tracing/goexectrace/simple_flight_recorder.go
+++ b/pkg/util/tracing/goexectrace/simple_flight_recorder.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime/trace"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -20,9 +21,15 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
+
+// errDumpBusy is a sentinel error returned by doDump when the flight recorder
+// is already handling a concurrent WriteTo call. Callers treat this as a
+// non-fatal skip.
+var errDumpBusy = errors.New("flight recorder snapshot already in progress")
 
 var executionTracerTotalDumpSizeLimit = settings.RegisterByteSizeSetting(
 	settings.ApplicationLevel,
@@ -37,7 +44,8 @@ var executionTracerTotalDumpSizeLimit = settings.RegisterByteSizeSetting(
 var ExecutionTracerInterval = settings.RegisterDurationSetting(
 	settings.ApplicationLevel,
 	"obs.execution_tracer.interval",
-	"duration between Go execution traces (zero disables)",
+	"duration between periodic Go execution trace dumps to disk (zero disables periodic dumps; "+
+		"the flight recorder still runs if obs.execution_tracer.duration is positive)",
 	0, // disabled
 	settings.DurationWithMinimumOrZeroDisable(0),
 )
@@ -45,16 +53,18 @@ var ExecutionTracerInterval = settings.RegisterDurationSetting(
 var ExecutionTracerDuration = settings.RegisterDurationSetting(
 	settings.ApplicationLevel,
 	"obs.execution_tracer.duration",
-	"the length of automatic Go execution traces",
-	10*time.Second,
-	settings.PositiveDuration,
+	"how much execution trace data the flight recorder keeps in its buffer "+
+		"(zero disables the flight recorder entirely)",
+	0, // disabled
+	settings.DurationWithMinimumOrZeroDisable(0),
 )
 
-// SimpleFlightRecorder is a wrapper around `trace.FlightRecorder`
-// that enables continuous trace capture over a configurable interval.
+// SimpleFlightRecorder is a wrapper around trace.FlightRecorder that enables
+// continuous trace capture. The flight recorder lifecycle is controlled by the
+// obs.execution_tracer.duration setting: a positive value enables it, zero
+// disables it. Periodic dumps to disk are independently controlled by
+// obs.execution_tracer.interval.
 type SimpleFlightRecorder struct {
-	fr *trace.FlightRecorder
-
 	dumpStore *dumpstore.DumpStore
 
 	sv        *settings.Values
@@ -64,17 +74,31 @@ type SimpleFlightRecorder struct {
 	// checks to see if the feature has been enabled if it's disabled.
 	enabledCheckInterval time.Duration
 	enabled              atomic.Bool
+
+	// frMu protects the fr pointer, which is reassigned in
+	// ensureFRStarted when the configured duration changes. Without this
+	// mutex, concurrent readers (doDump) would race with the Start loop
+	// replacing fr. The Start loop holds a write lock during lifecycle
+	// changes; doDump holds a read lock when calling WriteTo.
+	frMu struct {
+		syncutil.RWMutex
+
+		fr *trace.FlightRecorder
+		// period is the MinAge used to construct the current fr instance.
+		// It is used to avoid reconstructing the FlightRecorder when
+		// the period hasn't changed.
+		period time.Duration
+	}
 }
 
-// A `Dumper` implementation is needed to run `DumpStore.GC` periodically. This
-// enables `SimpleFlightRecorder` to identify its files for the automated
+// A Dumper implementation is needed to run DumpStore.GC periodically. This
+// enables SimpleFlightRecorder to identify its files for the automated
 // cleanup process.
 var _ dumpstore.Dumper = &SimpleFlightRecorder{}
 
 func NewFlightRecorder(
 	st *cluster.Settings, enabledCheckInterval time.Duration, directory string,
 ) (*SimpleFlightRecorder, error) {
-	fr := trace.NewFlightRecorder(trace.FlightRecorderConfig{})
 	if directory == "" {
 		return nil, errors.New("flight recorder directory argument is empty, will not record execution traces")
 	}
@@ -83,10 +107,7 @@ func NewFlightRecorder(
 	}
 
 	return &SimpleFlightRecorder{
-		fr: fr,
-
-		dumpStore: dumpstore.NewStore(directory, executionTracerTotalDumpSizeLimit, st),
-
+		dumpStore:            dumpstore.NewStore(directory, executionTracerTotalDumpSizeLimit, st),
 		sv:                   &st.SV,
 		directory:            directory,
 		enabledCheckInterval: enabledCheckInterval,
@@ -96,18 +117,23 @@ func NewFlightRecorder(
 // Copied from profiler/profiler_common.go.
 const timestampFormat = "2006-01-02T15_04_05.000"
 
-func (sfr *SimpleFlightRecorder) TimestampedFilename() string {
-	return filepath.Join(sfr.directory, fmt.Sprintf("executiontrace.%s.out", timeutil.Now().Format(timestampFormat)))
+func (sfr *SimpleFlightRecorder) timestampedFilename(tag string) string {
+	if tag != "" {
+		return filepath.Join(sfr.directory,
+			fmt.Sprintf("executiontrace.%s.%s.out", timeutil.Now().Format(timestampFormat), tag))
+	}
+	return filepath.Join(sfr.directory,
+		fmt.Sprintf("executiontrace.%s.out", timeutil.Now().Format(timestampFormat)))
 }
 
 var fileMatchRegexp = regexp.MustCompile("^executiontrace.*out$")
 
-// CheckOwnsFile is part of the `Dumper` interface.
+// CheckOwnsFile is part of the Dumper interface.
 func (sfr *SimpleFlightRecorder) CheckOwnsFile(ctx context.Context, fi os.DirEntry) bool {
 	return fileMatchRegexp.MatchString(fi.Name())
 }
 
-// PreFilter is part of the `Dumper` interface. In this case we do not mark any
+// PreFilter is part of the Dumper interface. In this case we do not mark any
 // files for preservation.
 func (sfr *SimpleFlightRecorder) PreFilter(
 	ctx context.Context, files []os.DirEntry, cleanupFn func(fileName string) error,
@@ -120,6 +146,118 @@ func (sfr *SimpleFlightRecorder) Enabled() bool {
 	return sfr.enabled.Load()
 }
 
+// isSnapshotInProgress reports whether err indicates a concurrent
+// FlightRecorder.WriteTo call is already in progress. Go 1.25's
+// runtime/trace does not export a sentinel error for this condition;
+// it returns a plain fmt.Errorf. String matching is the only option.
+// If the runtime changes this message, we'll lose the ability to
+// distinguish busy from broken, which is acceptable: the worst case
+// is that a concurrent dump returns an error instead of being silently
+// skipped.
+func isSnapshotInProgress(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "already in progress")
+}
+
+// isDisabledRecorder reports whether err indicates WriteTo was called
+// on a stopped FlightRecorder. Same caveat as isSnapshotInProgress:
+// the runtime uses a plain fmt.Errorf with no sentinel.
+func isDisabledRecorder(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "disabled flight recorder")
+}
+
+// doDump performs a dump to a file with the given tag. If a concurrent WriteTo
+// is already in progress, or if the FR was stopped between the caller's
+// enabled check and the actual write, doDump returns errDumpBusy without
+// writing a file.
+//
+// doDump writes to a temporary file and renames it to the final timestamped
+// name on success. This prevents the error-path cleanup (os.Remove) of one
+// caller from deleting a file that a concurrent caller wrote successfully,
+// which can happen when two callers race within the same millisecond and
+// resolve to the same timestamped filename.
+//
+// nolint:deferunlockcheck
+func (sfr *SimpleFlightRecorder) doDump(tag string) (string, error) {
+	tmpFile, err := os.CreateTemp(sfr.directory, "executiontrace.*.tmp")
+	if err != nil {
+		return "", errors.Wrap(err, "creating temp file for flight record dump")
+	}
+	tmpName := tmpFile.Name()
+
+	// Hold frMu as a reader to prevent the Start loop from
+	// stopping/replacing the FR mid-write.
+	sfr.frMu.RLock()
+	_, writeErr := sfr.frMu.fr.WriteTo(tmpFile)
+	sfr.frMu.RUnlock()
+
+	closeErr := tmpFile.Close()
+	if writeErr != nil {
+		_ = os.Remove(tmpName)
+		if isSnapshotInProgress(writeErr) || isDisabledRecorder(writeErr) {
+			return "", errDumpBusy
+		}
+		return "", errors.Wrapf(writeErr, "writing flight record")
+	}
+	if closeErr != nil {
+		_ = os.Remove(tmpName)
+		return "", errors.Wrapf(closeErr, "closing flight record temp file")
+	}
+
+	filename := sfr.timestampedFilename(tag)
+	if err := os.Rename(tmpName, filename); err != nil {
+		_ = os.Remove(tmpName)
+		return "", errors.Wrapf(err, "renaming flight record to %s", filename)
+	}
+	return filename, nil
+}
+
+// stopFR stops the flight recorder under frMu.
+func (sfr *SimpleFlightRecorder) stopFR() {
+	sfr.frMu.Lock()
+	defer sfr.frMu.Unlock()
+	if sfr.frMu.fr != nil && sfr.frMu.fr.Enabled() {
+		sfr.frMu.fr.Stop()
+		sfr.enabled.Store(false)
+	}
+}
+
+// ensureFRStarted starts the flight recorder with the given period under
+// frMu, if it is not already running with the same period. A new
+// FlightRecorder is only created when the requested period differs from the
+// current one, since FlightRecorderConfig is immutable after construction.
+// Returns true if the FR is running after this call.
+func (sfr *SimpleFlightRecorder) ensureFRStarted(ctx context.Context, period time.Duration) bool {
+	sfr.frMu.Lock()
+	defer sfr.frMu.Unlock()
+
+	if sfr.frMu.period != period {
+		log.Dev.Infof(ctx,
+			"goexectrace: reconfiguring flight recorder period: %.1f sec -> %.1f sec",
+			sfr.frMu.period.Seconds(), period.Seconds())
+		if sfr.frMu.fr != nil && sfr.frMu.fr.Enabled() {
+			sfr.frMu.fr.Stop()
+		}
+		sfr.frMu.fr = trace.NewFlightRecorder(trace.FlightRecorderConfig{
+			MinAge: period,
+		})
+		sfr.frMu.period = period
+	}
+
+	if sfr.frMu.fr.Enabled() {
+		return true
+	}
+
+	if err := sfr.frMu.fr.Start(); err != nil {
+		log.Dev.Warningf(ctx,
+			"goexectrace: error while starting flight recorder, will try again: %v", err)
+		return false
+	}
+	sfr.enabled.Store(true)
+	log.Dev.Infof(ctx, "goexectrace: flight recorder started with period: %.1f sec",
+		period.Seconds())
+	return true
+}
+
 func (sfr *SimpleFlightRecorder) Start(ctx context.Context, stopper *stop.Stopper) error {
 	if sfr == nil {
 		return errors.New("flight recorder is not initialized, will not record execution traces")
@@ -128,55 +266,53 @@ func (sfr *SimpleFlightRecorder) Start(ctx context.Context, stopper *stop.Stoppe
 		t := timeutil.Timer{}
 		t.Reset(sfr.enabledCheckInterval)
 
-		defer func() {
-			if sfr.fr.Enabled() {
-				sfr.fr.Stop()
-				sfr.enabled.Store(false)
-			}
-		}()
+		defer sfr.stopFR()
 
 		for {
 			select {
 			case <-t.C:
 				startTime := timeutil.Now()
-				interval := ExecutionTracerInterval.Get(sfr.sv)
-				if interval == 0 {
-					if sfr.fr.Enabled() {
-						sfr.fr.Stop()
-						sfr.enabled.Store(false)
-						log.Dev.Infof(ctx, "flight recorder stopped")
+				duration := ExecutionTracerDuration.Get(sfr.sv)
+
+				// The flight recorder lifecycle is controlled by the duration
+				// setting: positive enables, zero disables.
+				if duration == 0 {
+					wasEnabled := sfr.enabled.Load()
+					sfr.stopFR()
+					if wasEnabled {
+						log.Dev.Infof(ctx, "goexectrace: flight recorder stopped")
 					}
 					t.Reset(sfr.enabledCheckInterval)
 					continue
 				}
-				if !sfr.fr.Enabled() {
-					duration := ExecutionTracerDuration.Get(sfr.sv)
-					sfr.fr = trace.NewFlightRecorder(trace.FlightRecorderConfig{
-						MinAge: duration,
-					})
-					if err := sfr.fr.Start(); err != nil {
-						log.Dev.Warningf(ctx, "error while starting flight recorder, will try again: %v", err)
-						t.Reset(max(interval-timeutil.Since(startTime), 0))
-						continue
-					}
-					sfr.enabled.Store(true)
-					log.Dev.Infof(ctx, "flight recorder started")
+				if !sfr.ensureFRStarted(ctx, duration) {
+					t.Reset(sfr.enabledCheckInterval)
+					continue
 				}
-				filename := sfr.TimestampedFilename()
-				destFile, err := os.Create(filename)
-				if err != nil {
-					log.Dev.Warningf(ctx, "unable to open file %s to dump flight record, will try again: %v", filename, err)
+
+				// Periodic dumps are optional; controlled by the interval
+				// setting. If zero, the FR is running but we don't dump to
+				// disk periodically.
+				interval := ExecutionTracerInterval.Get(sfr.sv)
+				if interval == 0 {
+					t.Reset(sfr.enabledCheckInterval)
+					continue
+				}
+
+				filename, err := sfr.doDump("" /* tag */)
+				if errors.Is(err, errDumpBusy) {
 					t.Reset(max(interval-timeutil.Since(startTime), 0))
 					continue
 				}
-				_, err = sfr.fr.WriteTo(destFile)
 				if err != nil {
-					log.Dev.Warningf(ctx, "error while writing flight record to %s, will try again: %v", filename, err)
+					log.Dev.Warningf(ctx,
+						"goexectrace: error during periodic dump: %v", err)
 					t.Reset(max(interval-timeutil.Since(startTime), 0))
 					continue
 				}
 
 				sfr.dumpStore.GC(ctx, timeutil.Now(), sfr)
+				_ = filename // logged by doDump internals if needed
 				t.Reset(max(interval-timeutil.Since(startTime), 0))
 			case <-stopper.ShouldQuiesce():
 				return

--- a/pkg/util/tracing/goexectrace/simple_flight_recorder_test.go
+++ b/pkg/util/tracing/goexectrace/simple_flight_recorder_test.go
@@ -34,7 +34,7 @@ func TestSimpleFlightRecorder(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer func() {
 		<-stopper.IsStopped()
-		if fr.enabledForTests() {
+		if fr.Enabled() {
 			t.Fatal("flight recorder is still enabled after stopper is stopped")
 		}
 	}()
@@ -52,7 +52,7 @@ func TestSimpleFlightRecorder(t *testing.T) {
 
 	t.Run("writes a file when enabled", func(t *testing.T) {
 		testutils.SucceedsSoon(t, func() error {
-			if !fr.enabledForTests() {
+			if !fr.Enabled() {
 				return errors.New("flight recorder is not enabled")
 			}
 			files, err := os.ReadDir(dir)
@@ -79,7 +79,7 @@ func TestSimpleFlightRecorder(t *testing.T) {
 	t.Run("stops the flight recorder when disabled", func(t *testing.T) {
 		ExecutionTracerInterval.Override(context.Background(), &st.SV, 0)
 		testutils.SucceedsSoon(t, func() error {
-			if fr.enabledForTests() {
+			if fr.Enabled() {
 				return errors.New("flight recorder is still enabled")
 			}
 			return nil
@@ -89,7 +89,7 @@ func TestSimpleFlightRecorder(t *testing.T) {
 	// Restart so we can test that it's stopped with the stopper.
 	ExecutionTracerInterval.Override(context.Background(), &st.SV, 10*time.Second)
 	testutils.SucceedsSoon(t, func() error {
-		if !fr.enabledForTests() {
+		if !fr.Enabled() {
 			return errors.New("flight recorder is not enabled")
 		}
 		return nil

--- a/pkg/util/tracing/goexectrace/simple_flight_recorder_test.go
+++ b/pkg/util/tracing/goexectrace/simple_flight_recorder_test.go
@@ -48,6 +48,8 @@ func TestSimpleFlightRecorder(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, len(files), 0)
 
+	// Enable the FR via duration and enable periodic dumps via interval.
+	ExecutionTracerDuration.Override(context.Background(), &st.SV, 10*time.Second)
 	ExecutionTracerInterval.Override(context.Background(), &st.SV, 1*time.Millisecond)
 
 	t.Run("writes a file when enabled", func(t *testing.T) {
@@ -77,7 +79,7 @@ func TestSimpleFlightRecorder(t *testing.T) {
 	})
 
 	t.Run("stops the flight recorder when disabled", func(t *testing.T) {
-		ExecutionTracerInterval.Override(context.Background(), &st.SV, 0)
+		ExecutionTracerDuration.Override(context.Background(), &st.SV, 0)
 		testutils.SucceedsSoon(t, func() error {
 			if fr.Enabled() {
 				return errors.New("flight recorder is still enabled")
@@ -87,7 +89,7 @@ func TestSimpleFlightRecorder(t *testing.T) {
 	})
 
 	// Restart so we can test that it's stopped with the stopper.
-	ExecutionTracerInterval.Override(context.Background(), &st.SV, 10*time.Second)
+	ExecutionTracerDuration.Override(context.Background(), &st.SV, 10*time.Second)
 	testutils.SucceedsSoon(t, func() error {
 		if !fr.Enabled() {
 			return errors.New("flight recorder is not enabled")

--- a/pkg/util/tracing/goexectrace/simple_flight_recorder_test.go
+++ b/pkg/util/tracing/goexectrace/simple_flight_recorder_test.go
@@ -6,10 +6,12 @@
 package goexectrace
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -18,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/errors/oserror"
 	"github.com/stretchr/testify/require"
 )
 
@@ -96,4 +99,579 @@ func TestSimpleFlightRecorder(t *testing.T) {
 		}
 		return nil
 	})
+}
+
+// TestSettingCombinations verifies the four combinations of duration and
+// interval settings produce the correct behavior.
+func TestSettingCombinations(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	dir := t.TempDir()
+	st := cluster.MakeTestingClusterSettings()
+
+	fr, err := NewFlightRecorder(st, 100*time.Millisecond, dir)
+	require.NoError(t, err)
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.Background())
+
+	ctx := context.Background()
+	err = fr.Start(ctx, stopper)
+	require.NoError(t, err)
+
+	executionTracerOnDemandMinInterval.Override(ctx, &st.SV, 0)
+
+	clearDir := func() error {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			return err
+		}
+		for _, e := range entries {
+			if err := os.Remove(filepath.Join(dir, e.Name())); err != nil && !oserror.IsNotExist(err) {
+				return err
+			}
+		}
+		return nil
+	}
+
+	tests := []struct {
+		name             string
+		duration         time.Duration
+		interval         time.Duration
+		wantEnabled      bool
+		wantPeriodicDump bool
+		wantDumpNow      bool
+	}{{
+		name:             "duration=0,interval=0",
+		duration:         0,
+		interval:         0,
+		wantEnabled:      false,
+		wantPeriodicDump: false,
+		wantDumpNow:      false,
+	}, {
+		name:             "duration=0,interval>0",
+		duration:         0,
+		interval:         1 * time.Millisecond,
+		wantEnabled:      false,
+		wantPeriodicDump: false,
+		wantDumpNow:      false,
+	}, {
+		name:             "duration>0,interval=0",
+		duration:         10 * time.Second,
+		interval:         0,
+		wantEnabled:      true,
+		wantPeriodicDump: false,
+		wantDumpNow:      true,
+	}, {
+		name:             "duration>0,interval>0",
+		duration:         10 * time.Second,
+		interval:         1 * time.Millisecond,
+		wantEnabled:      true,
+		wantPeriodicDump: true,
+		wantDumpNow:      true,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ExecutionTracerDuration.Override(ctx, &st.SV, tc.duration)
+			ExecutionTracerInterval.Override(ctx, &st.SV, tc.interval)
+
+			testutils.SucceedsSoon(t, func() error {
+				if fr.Enabled() != tc.wantEnabled {
+					return errors.New("waiting for FR enabled state to match expected")
+				}
+				return nil
+			})
+
+			require.NoError(t, clearDir())
+
+			if tc.wantPeriodicDump {
+				testutils.SucceedsSoon(t, func() error {
+					files, err := os.ReadDir(dir)
+					if err != nil {
+						return err
+					}
+					if len(files) == 0 {
+						return errors.New("expected periodic dump files")
+					}
+					return nil
+				})
+			} else {
+				files, err := os.ReadDir(dir)
+				require.NoError(t, err)
+				require.Empty(t, files, "expected no periodic dump files")
+			}
+
+			if tc.wantDumpNow {
+				var filename string
+				testutils.SucceedsSoon(t, func() error {
+					f, err := fr.DumpNow(ctx, "test dump", "test")
+					if err != nil {
+						return err
+					}
+					if f == "" {
+						return errors.New("dump skipped due to concurrent snapshot")
+					}
+					filename = f
+					return nil
+				})
+				fi, err := os.Stat(filename)
+				require.NoError(t, err)
+				require.Greater(t, fi.Size(), int64(0))
+			} else {
+				_, err := fr.DumpNow(ctx, "should fail", "test")
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "not enabled")
+			}
+		})
+	}
+
+	t.Run("disable_periodic_fr_stays_on", func(t *testing.T) {
+		ExecutionTracerDuration.Override(ctx, &st.SV, 10*time.Second)
+		ExecutionTracerInterval.Override(ctx, &st.SV, 1*time.Millisecond)
+		testutils.SucceedsSoon(t, func() error {
+			if !fr.Enabled() {
+				return errors.New("expected FR to be enabled")
+			}
+			return nil
+		})
+
+		ExecutionTracerInterval.Override(ctx, &st.SV, 0)
+
+		// Wait for the async loop to observe interval=0 and stop
+		// dumping. Multiple consecutive empty observations confirm
+		// periodic dumps have actually stopped.
+		emptyChecks := 0
+		testutils.SucceedsSoon(t, func() error {
+			files, err := os.ReadDir(dir)
+			if err != nil {
+				return err
+			}
+			for _, f := range files {
+				if err := os.Remove(filepath.Join(dir, f.Name())); err != nil && !oserror.IsNotExist(err) {
+					return err
+				}
+			}
+			if len(files) > 0 {
+				emptyChecks = 0
+				return errors.New("periodic dump files still appearing")
+			}
+			emptyChecks++
+			if emptyChecks < 5 {
+				return errors.New("waiting for stable empty directory")
+			}
+			return nil
+		})
+
+		require.True(t, fr.Enabled())
+
+		var filename string
+		testutils.SucceedsSoon(t, func() error {
+			f, err := fr.DumpNow(ctx, "still works", "after_disable")
+			if err != nil {
+				return err
+			}
+			if f == "" {
+				return errors.New("dump skipped due to concurrent snapshot")
+			}
+			filename = f
+			return nil
+		})
+		require.NotEmpty(t, filename)
+	})
+
+	t.Run("change_duration_while_running", func(t *testing.T) {
+		ExecutionTracerDuration.Override(ctx, &st.SV, 5*time.Second)
+		ExecutionTracerInterval.Override(ctx, &st.SV, 0)
+		testutils.SucceedsSoon(t, func() error {
+			if !fr.Enabled() {
+				return errors.New("expected FR to be enabled")
+			}
+			return nil
+		})
+
+		ExecutionTracerDuration.Override(ctx, &st.SV, 20*time.Second)
+		testutils.SucceedsSoon(t, func() error {
+			if !fr.Enabled() {
+				return errors.New("expected FR to remain enabled after period change")
+			}
+			return nil
+		})
+
+		var filename string
+		testutils.SucceedsSoon(t, func() error {
+			f, err := fr.DumpNow(ctx, "after period change", "period_change")
+			if err != nil {
+				return err
+			}
+			if f == "" {
+				return errors.New("dump skipped due to concurrent snapshot")
+			}
+			filename = f
+			return nil
+		})
+		fi, err := os.Stat(filename)
+		require.NoError(t, err)
+		require.Greater(t, fi.Size(), int64(0))
+
+		testutils.SucceedsSoon(t, func() error {
+			fr.frMu.RLock()
+			currentPeriod := fr.frMu.period
+			fr.frMu.RUnlock()
+			if currentPeriod != 20*time.Second {
+				return errors.New("waiting for period to update to 20s")
+			}
+			return nil
+		})
+	})
+}
+
+func TestDumpNow(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	dir := t.TempDir()
+	st := cluster.MakeTestingClusterSettings()
+
+	fr, err := NewFlightRecorder(st, 100*time.Millisecond, dir)
+	require.NoError(t, err)
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.Background())
+
+	err = fr.Start(context.Background(), stopper)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	t.Run("fails when not enabled", func(t *testing.T) {
+		_, err := fr.DumpNow(ctx, "test reason", "test_tag")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not enabled")
+	})
+
+	ExecutionTracerDuration.Override(ctx, &st.SV, 10*time.Second)
+	executionTracerOnDemandMinInterval.Override(ctx, &st.SV, 0)
+
+	testutils.SucceedsSoon(t, func() error {
+		if !fr.Enabled() {
+			return errors.New("flight recorder is not enabled")
+		}
+		return nil
+	})
+
+	t.Run("produces a file with tag", func(t *testing.T) {
+		filename, err := fr.DumpNow(ctx, "scheduling latency", "scheduling_latency")
+		require.NoError(t, err)
+		require.NotEmpty(t, filename)
+
+		fi, err := os.Stat(filename)
+		require.NoError(t, err)
+		require.Greater(t, fi.Size(), int64(0))
+
+		base := filepath.Base(filename)
+		require.Contains(t, base, "scheduling_latency")
+		require.True(t, fileMatchRegexp.MatchString(base))
+	})
+
+	t.Run("produces a file without tag", func(t *testing.T) {
+		filename, err := fr.DumpNow(ctx, "generic dump", "")
+		require.NoError(t, err)
+		require.NotEmpty(t, filename)
+
+		fi, err := os.Stat(filename)
+		require.NoError(t, err)
+		require.Greater(t, fi.Size(), int64(0))
+
+		base := filepath.Base(filename)
+		require.True(t, fileMatchRegexp.MatchString(base))
+	})
+}
+
+func TestDumpNowRateLimit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	dir := t.TempDir()
+	st := cluster.MakeTestingClusterSettings()
+
+	fr, err := NewFlightRecorder(st, 100*time.Millisecond, dir)
+	require.NoError(t, err)
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.Background())
+
+	err = fr.Start(context.Background(), stopper)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	ExecutionTracerDuration.Override(ctx, &st.SV, 10*time.Second)
+	executionTracerOnDemandMinInterval.Override(ctx, &st.SV, 10*time.Second)
+
+	testutils.SucceedsSoon(t, func() error {
+		if !fr.Enabled() {
+			return errors.New("flight recorder is not enabled")
+		}
+		return nil
+	})
+
+	filename, err := fr.DumpNow(ctx, "first dump", "first")
+	require.NoError(t, err)
+	require.NotEmpty(t, filename)
+
+	filename2, err := fr.DumpNow(ctx, "second dump", "second")
+	require.NoError(t, err)
+	require.Empty(t, filename2)
+}
+
+func TestDumpNowConcurrent(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	dir := t.TempDir()
+	st := cluster.MakeTestingClusterSettings()
+
+	fr, err := NewFlightRecorder(st, 100*time.Millisecond, dir)
+	require.NoError(t, err)
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.Background())
+
+	err = fr.Start(context.Background(), stopper)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	ExecutionTracerDuration.Override(ctx, &st.SV, 10*time.Second)
+	executionTracerOnDemandMinInterval.Override(ctx, &st.SV, 0)
+
+	testutils.SucceedsSoon(t, func() error {
+		if !fr.Enabled() {
+			return errors.New("flight recorder is not enabled")
+		}
+		return nil
+	})
+
+	const numGoroutines = 5
+	var wg sync.WaitGroup
+	filenames := make([]string, numGoroutines)
+	errs := make([]error, numGoroutines)
+
+	wg.Add(numGoroutines)
+	for i := range numGoroutines {
+		go func(idx int) {
+			defer wg.Done()
+			filenames[idx], errs[idx] = fr.DumpNow(ctx, "concurrent dump", "concurrent_test")
+		}(i)
+	}
+	wg.Wait()
+
+	var gotFilename string
+	for i := range numGoroutines {
+		require.NoError(t, errs[i])
+		if filenames[i] != "" {
+			if gotFilename == "" {
+				gotFilename = filenames[i]
+			}
+		}
+	}
+	require.NotEmpty(t, gotFilename, "expected at least one successful dump")
+
+	fi, err := os.Stat(gotFilename)
+	require.NoError(t, err)
+	require.Greater(t, fi.Size(), int64(0))
+}
+
+func TestWriteTraceTo(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	dir := t.TempDir()
+	st := cluster.MakeTestingClusterSettings()
+
+	fr, err := NewFlightRecorder(st, 100*time.Millisecond, dir)
+	require.NoError(t, err)
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.Background())
+
+	err = fr.Start(context.Background(), stopper)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	ExecutionTracerDuration.Override(ctx, &st.SV, 10*time.Second)
+
+	testutils.SucceedsSoon(t, func() error {
+		if !fr.Enabled() {
+			return errors.New("flight recorder is not enabled")
+		}
+		return nil
+	})
+
+	var buf bytes.Buffer
+	n, err := fr.WriteTraceTo(ctx, &buf)
+	require.NoError(t, err)
+	require.Greater(t, n, int64(0))
+	require.Equal(t, n, int64(buf.Len()))
+}
+
+func TestTaggedFilenameMatchesGCRegex(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	dir := t.TempDir()
+	st := cluster.MakeTestingClusterSettings()
+
+	fr, err := NewFlightRecorder(st, time.Second, dir)
+	require.NoError(t, err)
+
+	tags := []string{"", "scheduling_latency", "stmt_diag", "lease_expiry"}
+	for _, tag := range tags {
+		filename := fr.timestampedFilename(tag)
+		base := filepath.Base(filename)
+		require.True(t, fileMatchRegexp.MatchString(base),
+			"filename %q does not match GC regex", base)
+	}
+}
+
+func TestDumpNowInvalidTag(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	dir := t.TempDir()
+	st := cluster.MakeTestingClusterSettings()
+
+	fr, err := NewFlightRecorder(st, 100*time.Millisecond, dir)
+	require.NoError(t, err)
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.Background())
+
+	err = fr.Start(context.Background(), stopper)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	ExecutionTracerDuration.Override(ctx, &st.SV, 10*time.Second)
+	executionTracerOnDemandMinInterval.Override(ctx, &st.SV, 0)
+
+	testutils.SucceedsSoon(t, func() error {
+		if !fr.Enabled() {
+			return errors.New("flight recorder is not enabled")
+		}
+		return nil
+	})
+
+	tests := []struct {
+		tag     string
+		wantErr bool
+	}{
+		{"valid_tag", false},
+		{"ValidTag123", false},
+		{"", false},
+		{"foo/bar", true},
+		{"../etc/passwd", true},
+		{"tag with spaces", true},
+		{"tag;rm", true},
+		{"foo\\bar", true},
+	}
+
+	for _, tc := range tests {
+		t.Run("tag="+tc.tag, func(t *testing.T) {
+			_, err := fr.DumpNow(ctx, "test", tc.tag)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "invalid tag")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestConcurrentDumpAndShutdown exercises the race between DumpNow (which
+// calls WriteTo) and the Start loop shutting down the flight recorder. This
+// test is primarily useful under the race detector (-race) to verify that the
+// frMu locking correctly prevents data races between concurrent WriteTo calls
+// and FR lifecycle changes.
+func TestConcurrentDumpAndShutdown(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	dir := t.TempDir()
+	st := cluster.MakeTestingClusterSettings()
+
+	fr, err := NewFlightRecorder(st, 50*time.Millisecond, dir)
+	require.NoError(t, err)
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.Background())
+
+	ctx := context.Background()
+	err = fr.Start(ctx, stopper)
+	require.NoError(t, err)
+
+	executionTracerOnDemandMinInterval.Override(ctx, &st.SV, 0)
+	ExecutionTracerDuration.Override(ctx, &st.SV, 10*time.Second)
+
+	testutils.SucceedsSoon(t, func() error {
+		if !fr.Enabled() {
+			return errors.New("flight recorder is not enabled")
+		}
+		return nil
+	})
+
+	var wg sync.WaitGroup
+	const iterations = 50
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			_, _ = fr.DumpNow(ctx, "race test", "race")
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		var buf bytes.Buffer
+		for range iterations {
+			buf.Reset()
+			if fr.Enabled() {
+				_, _ = fr.WriteTraceTo(ctx, &buf)
+			}
+		}
+	}()
+
+	for range iterations {
+		ExecutionTracerDuration.Override(ctx, &st.SV, 0)
+		ExecutionTracerDuration.Override(ctx, &st.SV, 10*time.Second)
+	}
+
+	wg.Wait()
+}
+
+func TestValidTag(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tests := []struct {
+		tag  string
+		want bool
+	}{
+		{"", true},
+		{"abc", true},
+		{"ABC", true},
+		{"abc123", true},
+		{"foo_bar", true},
+		{"foo/bar", false},
+		{"foo..bar", false},
+		{"foo bar", false},
+		{"foo;bar", false},
+		{"../etc", false},
+	}
+	for _, tc := range tests {
+		t.Run("tag="+tc.tag, func(t *testing.T) {
+			require.Equal(t, tc.want, validTag(tc.tag))
+		})
+	}
 }


### PR DESCRIPTION
This change extends the SimpleFlightRecorder to support on-demand execution trace dumps, alongside the existing periodic dump mechanism. It also resolves the Go runtime's single-trace-consumer constraint by integrating the flight recorder with the /debug/pprof/trace endpoint.

Go 1.25 promotes the flight recorder to the standard library as runtime/trace.FlightRecorder. This commit migrates SimpleFlightRecorder to use it.

Motivation: when CockroachDB experiences runtime anomalies (CPU spikes, scheduling latency, heartbeat failures), execution traces are critical for diagnosis but must have been actively recording at the time. On-demand dumps allow subsystems to trigger a trace capture the moment something interesting happens rather than relying on periodic dumps alone.

**Breaking change to cluster settings:**

The flight recorder lifecycle is now controlled by `obs.execution_tracer.duration` (default: 0, previously 10s with PositiveDuration validation). Setting this to a positive value enables the flight recorder. Setting it to zero disables it entirely. The `obs.execution_tracer.interval` setting now only controls periodic dumps to disk; when zero, the FR still runs for on-demand dumps and pprof, but does not write files periodically. This means a customer only needs to set one setting (`duration`) to enable the flight recorder.

**DumpNow method:**

`SimpleFlightRecorder.DumpNow(ctx, reason, tag)` triggers an on-demand dump. It requires the FR to already be enabled (returns an error otherwise). The `tag` parameter is appended to the filename (e.g., `executiontrace.2025-02-10T14_30_45.123.scheduling_latency.out`). Tagged filenames match the existing GC regex, so the DumpStore size-based cleanup applies uniformly to all trace files.

On-demand dumps are rate-limited by `obs.execution_tracer.on_demand.min_interval` (default 10s). When rate-limited, DumpNow returns ("", nil) rather than an error, so callers can fire-and-forget without error handling overhead.

**Dump coordination:**

All dump operations (periodic, on-demand, and pprof reads) are coordinated through an `frMu` RWMutex that protects the flight recorder lifecycle. The Start loop holds a write lock when starting/stopping the FR (via `ensureFRStarted` and `stopFR`), while `doDump` and `WriteTraceTo` hold a read lock when calling `WriteTo`. This prevents the Go runtime's `trace.FlightRecorder` from being started or stopped while a snapshot is being written.

Since the runtime only allows one concurrent `WriteTo` call, concurrent snapshot attempts are handled via the `trace.ErrSnapshotActive` error: `doDump` treats it as a non-fatal skip (returns `errDumpBusy`), while `WriteTraceTo` retries up to 5 times with exponential backoff from 100s to 1 second before giving up.

To avoid filename collisions between concurrent callers that run within the same millisecond, `doDump` writes to a temporary file and renames it to the final timestamped name only on success.

**Surfaces for triggering execution trace dumps:**

1. `SimpleFlightRecorder.DumpNow()` - direct Go API for subsystems
2. `StoreConfig.ExecutionTraceDumpNow` - plumbed to KV for store-level triggers
3. `GET /debug/execution-trace/dump?reason=...&tag=...` - HTTP endpoint for operators, returns the saved filename (503 if FR disabled, 429 if rate-limited)
4. `GET /debug/pprof/trace` - streams the current FR buffer without saving to disk (falls back to standard pprof.Trace when FR is inactive)

**New cluster setting:**

- `obs.execution_tracer.on_demand.min_interval` (default 10s): minimum interval between on-demand execution trace dumps to prevent overwhelming the system.

**Tenant support:**

Separate-process tenant servers now get their own flight recorder, enabling on-demand dumps and /debug/pprof/trace from tenant debug endpoints. In-process secondary tenants continue to skip the flight recorder since the system tenant handles it for the shared process.

Resolves: #163265
Epic: None

Release note (ops change): The default value of `obs.execution_tracer.duration` is now `0` because this setting now controls whether the Go Execution Trace Flight Recorder is enabled on each node. Set this to a positive value to enable the flight recorder. Internal events will automatically trigger execution trace writes to the logs directory if the tracer is enabled. If you would like to enable periodic execution trace capture, please note that both `obs.execution_trace.interval` *and* `obs.execution_trace.duration` need to be set to positive values.