### PR TITLE
release-26.1: concurrency: disable slow latch request logging in TestConcurrencyManagerBasic

### DIFF
--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -682,9 +682,11 @@ func newCluster() *cluster {
 }
 
 func newClusterWithSettings(st *clustersettings.Settings) *cluster {
-	// Set the latch manager's long latch threshold to infinity to disable
-	// logging, which could cause a test to erroneously fail.
+	// Set the latch manager's long latch hold and slow latch request thresholds
+	// to infinity to disable logging, which could cause a test to erroneously
+	// fail when wall-clock time exceeds the threshold.
 	spanlatch.LongLatchHoldThreshold.Override(context.Background(), &st.SV, math.MaxInt64)
+	spanlatch.SlowLatchRequestThreshold.Override(context.Background(), &st.SV, math.MaxInt64)
 	concurrency.UnreplicatedLockReliabilitySplit.Override(context.Background(), &st.SV, true)
 	concurrency.UnreplicatedLockReliabilityMerge.Override(context.Background(), &st.SV, true)
 	concurrency.UnreplicatedLockReliabilityLeaseTransfer.Override(context.Background(), &st.SV, true)


### PR DESCRIPTION
Backport 1/1 commits from #163421 on behalf of @tbg.

----

## Summary

- Disable the slow latch request logging threshold in `TestConcurrencyManagerBasic` to prevent flaky failures when wall-clock time exceeds 5s due to CI resource contention.

## Details

Commit 9bbbc849cd6 ("spanlatch: add cluster setting for slow latch request threshold") reduced the slow latch request logging threshold from 15s to 5s. The `waitForSignal` path in `spanlatch.Manager` uses a real `time.Timer` (not the test's mock clock), so when a test run takes longer than 5s of wall time, unexpected `"have been waiting 5s to acquire ..."` warning lines appear in the output, breaking the datadriven test expectations.

The fix overrides `SlowLatchRequestThreshold` to `math.MaxInt64` in the test setup, matching the existing pattern for `LongLatchHoldThreshold` which was already disabled for the same reason.

## Test plan

- `TestConcurrencyManagerBasic/shared_locks_latches` passes 3/3 runs locally.

Fixes #163381

Epic: CRDB-56265
Release note: None


Made with [Cursor](https://cursor.com)

----

Release justification: avoids test flakes.