### PR TITLE
roachprod-microbench: fix InfluxDB push error handling and skip NaN values

### DIFF
--- a/pkg/cmd/roachprod-microbench/model/metric.go
+++ b/pkg/cmd/roachprod-microbench/model/metric.go
@@ -65,6 +65,12 @@ var UndefinedConfidenceInterval = ConfidenceInterval{
 	Center: math.NaN(),
 }
 
+// IsUndefinedConfidenceInterval returns true if the confidence interval is
+// undefined.
+func IsUndefinedConfidenceInterval(ci ConfidenceInterval) bool {
+	return math.IsNaN(ci.Low) || math.IsNaN(ci.High) || math.IsNaN(ci.Center)
+}
+
 // ComparisonResult holds the comparison results for a specific metric.
 type ComparisonResult struct {
 	Metric      *Metric


### PR DESCRIPTION
Previously, pushToInfluxDB would only catch the first error from the InfluxDB write API and miss subsequent ones, or return nil if Flush completed before an error was received. It also had no mechanism to stop writing points after a failure.

Now, a background goroutine drains the error channel and captures the first error. On that first error, a context is cancelled to stop writing further points. Subsequent errors are swallowed. Flush is called synchronously, which also closes the error channel and terminates the monitoring goroutine.

Additionally, skip writing points with undefined (NaN) confidence intervals to InfluxDB, since these represent benchmarks without enough data to compute a comparison.

Epic: none
Release note: None