### PR TITLE
release-26.1: multi-metric allocator observability

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -13490,6 +13490,62 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NONE
+    - name: mma.store.cpu.capacity
+      exported_name: mma_store_cpu_capacity
+      description: Logical CPU capacity estimated by MMA by extrapolating from the current load and system CPU utilization after accounting for CPU load that MMA cannot account for that scales with KV work (RPC, DistSender, etc.) and load that doesn't (SQL).
+      y_axis_label: Nanoseconds/Sec
+      type: GAUGE
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+    - name: mma.store.cpu.load
+      exported_name: mma_store_cpu_load
+      description: CPU load that is attributed to the replicas on this store. This includes reads (for leaseholder) and raft. Since CPU is shared across stores on a node, we approximate this by measuring the CPU usage on the node and then dividing this equally among all stores on the node.
+      y_axis_label: Nanoseconds/Sec
+      type: GAUGE
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+    - name: mma.store.cpu.utilization
+      exported_name: mma_store_cpu_utilization
+      description: Ratio of logical CPU load to capacity expressed as a percentage
+      y_axis_label: CPU Utilization
+      type: GAUGE
+      unit: PERCENT
+      aggregation: AVG
+      derivative: NONE
+    - name: mma.store.disk.capacity
+      exported_name: mma_store_disk_capacity
+      description: Logical disk capacity estimated by MMA by extrapolating from the logical bytes consumed by the replicas and the current used and free physical disk bytes.
+      y_axis_label: Bytes
+      type: GAUGE
+      unit: BYTES
+      aggregation: AVG
+      derivative: NONE
+    - name: mma.store.disk.logical
+      exported_name: mma_store_disk_logical
+      description: Logical bytes consumed by the replicas on this store as reported by MVCC statistics without accounting for any space amplification or compression.
+      y_axis_label: Bytes
+      type: GAUGE
+      unit: BYTES
+      aggregation: AVG
+      derivative: NONE
+    - name: mma.store.disk.utilization
+      exported_name: mma_store_disk_utilization
+      description: Ratio of logical disk usage to capacity expressed as a percentage
+      y_axis_label: Disk Utilization
+      type: GAUGE
+      unit: PERCENT
+      aggregation: AVG
+      derivative: NONE
+    - name: mma.store.write.bandwidth
+      exported_name: mma_store_write_bandwidth
+      description: Disk write bandwidth as observed by MMA corresponding to the store
+      y_axis_label: Bytes/Sec
+      type: GAUGE
+      unit: BYTES
+      aggregation: AVG
+      derivative: NONE
     - name: node-id
       exported_name: node_id
       description: node ID with labels for advertised RPC and HTTP addresses

--- a/pkg/kv/kvserver/allocator/mmaprototype/BUILD.bazel
+++ b/pkg/kv/kvserver/allocator/mmaprototype/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//pkg/util/metric",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
+        "@com_github_cockroachdb_crlib//crstrings",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_cockroachdb_redact//:redact",

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
@@ -2363,6 +2363,7 @@ func (cs *clusterState) canShedAndAddLoad(
 	ctx context.Context,
 	srcSS *storeState,
 	targetSS *storeState,
+	rangeID roachpb.RangeID,
 	delta LoadVector,
 	means *meansLoad,
 	onlyConsiderTargetCPUSummary bool,
@@ -2414,8 +2415,10 @@ func (cs *clusterState) canShedAndAddLoad(
 			log.KvDistribution.VEventf(ctx, 3, "can add load to n%vs%v: %v targetSLS[%v] srcSLS[%v]",
 				targetNS.NodeID, targetSS.StoreID, canAddLoad, targetSLS, srcSLS)
 		} else if populateFailureReason {
-			log.KvDistribution.VEventf(ctx, 2, "cannot add load to n%vs%v: due to %s", targetNS.NodeID, targetSS.StoreID, failureReason.String())
-			log.KvDistribution.VEventf(ctx, 2, "[target_sls:%v,src_sls:%v]", targetSLS, srcSLS)
+			log.KvDistribution.VEventf(ctx, 2,
+				"cannot add load from n%vs%v to n%vs%v for r%v due to %s: delta(%v) targetSLS[%v] srcSLS[%v]",
+				srcNS.NodeID, srcSS.StoreID, targetNS.NodeID, targetSS.StoreID, rangeID,
+				failureReason.String(), delta, targetSLS, srcSLS)
 		}
 	}()
 	// Check if the target would have high disk utilization after the transfer.

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
@@ -603,9 +603,7 @@ func (re *rebalanceEnv) rebalanceReplicas(
 		if !isLeaseholder {
 			addedLoad[CPURate] = rstate.load.RaftCPU
 		}
-		if !re.canShedAndAddLoad(ctx, ss, targetSS, addedLoad, cands.means, false, loadDim) {
-			log.KvDistribution.VEventf(ctx, 2, "result(failed): cannot shed from s%d to s%d for r%d: delta load %v",
-				store.StoreID, targetStoreID, rangeID, addedLoad)
+		if !re.canShedAndAddLoad(ctx, ss, targetSS, rangeID, addedLoad, cands.means, false, loadDim) {
 			re.passObs.replicaShed(noCandidateToAcceptLoad)
 			continue
 		}
@@ -827,10 +825,8 @@ func (re *rebalanceEnv) rebalanceLeasesFromLocalStoreID(
 			addedLoad[CPURate] = 0
 			panic("raft cpu higher than total cpu")
 		}
-		if !re.canShedAndAddLoad(ctx, ss, targetSS, addedLoad, &means, true, CPURate) {
+		if !re.canShedAndAddLoad(ctx, ss, targetSS, rangeID, addedLoad, &means, true, CPURate) {
 			re.passObs.leaseShed(noCandidateToAcceptLoad)
-			log.KvDistribution.VEventf(ctx, 2, "result(failed): cannot shed from s%d to s%d for r%d: delta load %v",
-				store.StoreID, targetStoreID, rangeID, addedLoad)
 			continue
 		}
 		addTarget := roachpb.ReplicationTarget{

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_test.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_test.go
@@ -543,7 +543,7 @@ func TestClusterState(t *testing.T) {
 					// Consider making it relative to ts.
 					for line := range strings.Lines(d.Input) {
 						msg := parseStoreLoadMsg(t, line)
-						cs.processStoreLoadMsg(context.Background(), &msg)
+						cs.processStoreLoadMsg(context.Background(), &msg, nil)
 					}
 					return ""
 

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_capacity_mismatch.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_capacity_mismatch.txt
@@ -204,9 +204,7 @@ rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-t
 [mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n1): loadNormal, reason: load is within 5% of mean [load=720 meanLoad=693 fractionUsed=72.00% meanUtil=83.20% capacity=1000]
-[mmaid=1] cannot add load to n5s5: due to overloadUrgent
-[mmaid=1] [target_sls:(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent frac_pending=0.00,0.00(true)),src_sls:(store=loadNormal worst=CPURate cpu=loadNormal writes=loadNormal bytes=loadNormal node=loadNormal frac_pending=0.00,0.00(true))]
-[mmaid=1] result(failed): cannot shed from s1 to s5 for r3: delta load [cpu:180ns/s, write-bandwidth:0 B/s, byte-size:0 B]
+[mmaid=1] cannot add load from n1s1 to n5s5 for r3 due to overloadUrgent: delta([cpu:180ns/s, write-bandwidth:0 B/s, byte-size:0 B]) targetSLS[(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent frac_pending=0.00,0.00(true))] srcSLS[(store=loadNormal worst=CPURate cpu=loadNormal writes=loadNormal bytes=loadNormal node=loadNormal frac_pending=0.00,0.00(true))]
 [mmaid=1] considering lease-transfer r2 from s1: candidates are [2 4]
 [mmaid=1] load summary for dim=CPURate (s1): overloadSlow, reason: load is >10% above mean [load=900 meanLoad=700 fractionUsed=90.00% meanUtil=84.00% capacity=1000]
 [mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
@@ -230,9 +228,7 @@ rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-t
 [mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n1): loadNormal, reason: load is within 5% of mean [load=720 meanLoad=700 fractionUsed=72.00% meanUtil=84.00% capacity=1000]
-[mmaid=1] cannot add load to n4s4: due to overloadUrgent
-[mmaid=1] [target_sls:(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent frac_pending=0.00,0.00(true)),src_sls:(store=loadNormal worst=CPURate cpu=loadNormal writes=loadNormal bytes=loadNormal node=loadNormal frac_pending=0.00,0.00(true))]
-[mmaid=1] result(failed): cannot shed from s1 to s4 for r2: delta load [cpu:180ns/s, write-bandwidth:0 B/s, byte-size:0 B]
+[mmaid=1] cannot add load from n1s1 to n4s4 for r2 due to overloadUrgent: delta([cpu:180ns/s, write-bandwidth:0 B/s, byte-size:0 B]) targetSLS[(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent frac_pending=0.00,0.00(true))] srcSLS[(store=loadNormal worst=CPURate cpu=loadNormal writes=loadNormal bytes=loadNormal node=loadNormal frac_pending=0.00,0.00(true))]
 [mmaid=1] considering lease-transfer r1 from s1: candidates are [2 3]
 [mmaid=1] load summary for dim=CPURate (s1): loadNormal, reason: load is within 5% of mean [load=900 meanLoad=900 fractionUsed=90.00% meanUtil=90.00% capacity=1000]
 [mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
@@ -276,9 +272,7 @@ rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-t
 [mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n1): overloadSlow, reason: load is >10% above mean [load=700 meanLoad=541 fractionUsed=70.00% meanUtil=75.80% capacity=1000]
-[mmaid=1] cannot add load to n6s6: due to overloadUrgent
-[mmaid=1] [target_sls:(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent frac_pending=0.00,0.00(true)),src_sls:(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow frac_pending=0.00,0.00(true))]
-[mmaid=1] result(failed): cannot shed from s1 to s6 for r3: delta load [cpu:200ns/s, write-bandwidth:0 B/s, byte-size:0 B]
+[mmaid=1] cannot add load from n1s1 to n6s6 for r3 due to overloadUrgent: delta([cpu:200ns/s, write-bandwidth:0 B/s, byte-size:0 B]) targetSLS[(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent frac_pending=0.00,0.00(true))] srcSLS[(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow frac_pending=0.00,0.00(true))]
 [mmaid=1] load summary for dim=CPURate (s1): overloadSlow, reason: fractionUsed > 75% [load=900 meanLoad=541 fractionUsed=90.00% meanUtil=75.80% capacity=1000]
 [mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
@@ -315,9 +309,7 @@ rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-t
 [mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n1): overloadSlow, reason: load is >10% above mean [load=700 meanLoad=541 fractionUsed=70.00% meanUtil=75.80% capacity=1000]
-[mmaid=1] cannot add load to n6s6: due to overloadUrgent
-[mmaid=1] [target_sls:(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent frac_pending=0.00,0.00(true)),src_sls:(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow frac_pending=0.00,0.00(true))]
-[mmaid=1] result(failed): cannot shed from s1 to s6 for r2: delta load [cpu:200ns/s, write-bandwidth:0 B/s, byte-size:0 B]
+[mmaid=1] cannot add load from n1s1 to n6s6 for r2 due to overloadUrgent: delta([cpu:200ns/s, write-bandwidth:0 B/s, byte-size:0 B]) targetSLS[(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent frac_pending=0.00,0.00(true))] srcSLS[(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow frac_pending=0.00,0.00(true))]
 [mmaid=1] load summary for dim=CPURate (s1): overloadSlow, reason: fractionUsed > 75% [load=900 meanLoad=541 fractionUsed=90.00% meanUtil=75.80% capacity=1000]
 [mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
@@ -353,9 +345,7 @@ rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-t
 [mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n1): overloadSlow, reason: load is >10% above mean [load=700 meanLoad=541 fractionUsed=70.00% meanUtil=75.80% capacity=1000]
-[mmaid=1] cannot add load to n7s7: due to overloadUrgent
-[mmaid=1] [target_sls:(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent frac_pending=0.00,0.00(true)),src_sls:(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow frac_pending=0.00,0.00(true))]
-[mmaid=1] result(failed): cannot shed from s1 to s7 for r1: delta load [cpu:200ns/s, write-bandwidth:0 B/s, byte-size:0 B]
+[mmaid=1] cannot add load from n1s1 to n7s7 for r1 due to overloadUrgent: delta([cpu:200ns/s, write-bandwidth:0 B/s, byte-size:0 B]) targetSLS[(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent frac_pending=0.00,0.00(true))] srcSLS[(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow frac_pending=0.00,0.00(true))]
 [mmaid=1] start processing shedding store s2: cpu node load overloadSlow, store load overloadSlow, worst dim CPURate
 [mmaid=1] top-K[CPURate] ranges for s2 with lease on local s1: r2:[cpu:20ns/s, write-bandwidth:0 B/s, byte-size:0 B] r1:[cpu:20ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=1] skipping remote store s2: in lease shedding grace period

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_transfer_unbounded.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_transfer_unbounded.txt
@@ -78,9 +78,7 @@ rebalance-stores store-id=1 fraction-pending-decrease-threshold=10.0 max-lease-t
 [mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n1): overloadSlow, reason: fractionUsed < 75% [load=540 meanLoad=400 fractionUsed=54.00% meanUtil=40.00% capacity=1000]
-[mmaid=1] cannot add load to n2s2: due to target_summary(overloadSlow)>=loadNoChange,targetSLS.frac_pending(2.53or0.00>=epsilon)
-[mmaid=1] [target_sls:(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow frac_pending=2.53,0.00(false)),src_sls:(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow frac_pending=0.00,0.23(false))]
-[mmaid=1] result(failed): cannot shed from s1 to s2 for r3: delta load [cpu:230ns/s, write-bandwidth:0 B/s, byte-size:0 B]
+[mmaid=1] cannot add load from n1s1 to n2s2 for r3 due to target_summary(overloadSlow)>=loadNoChange,targetSLS.frac_pending(2.53or0.00>=epsilon): delta([cpu:230ns/s, write-bandwidth:0 B/s, byte-size:0 B]) targetSLS[(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow frac_pending=2.53,0.00(false))] srcSLS[(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow frac_pending=0.00,0.23(false))]
 [mmaid=1] considering lease-transfer r2 from s1: candidates are [2 3]
 [mmaid=1] load summary for dim=CPURate (s1): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=770 meanLoad=400 fractionUsed=77.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
@@ -131,9 +129,7 @@ rebalance-stores store-id=1 fraction-pending-decrease-threshold=10.0 max-lease-t
 [mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n1): loadLow, reason: load is >10% below mean [load=310 meanLoad=400 fractionUsed=31.00% meanUtil=40.00% capacity=1000]
-[mmaid=1] cannot add load to n2s2: due to !overloadedDimPermitsChange,target_summary(overloadSlow)>=loadNoChange,targetSLS.frac_pending(2.53or0.00>=epsilon),target-store(overloadSlow)>src-store(loadNormal)
-[mmaid=1] [target_sls:(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow frac_pending=2.53,0.00(false)),src_sls:(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow frac_pending=0.00,0.46(false))]
-[mmaid=1] result(failed): cannot shed from s1 to s2 for r1: delta load [cpu:230ns/s, write-bandwidth:0 B/s, byte-size:0 B]
+[mmaid=1] cannot add load from n1s1 to n2s2 for r1 due to !overloadedDimPermitsChange,target_summary(overloadSlow)>=loadNoChange,targetSLS.frac_pending(2.53or0.00>=epsilon),target-store(overloadSlow)>src-store(loadNormal): delta([cpu:230ns/s, write-bandwidth:0 B/s, byte-size:0 B]) targetSLS[(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow frac_pending=2.53,0.00(false))] srcSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow frac_pending=0.00,0.46(false))]
 [mmaid=1] skipping replica transfers for s1 to try more leases next time
 [mmaid=1] rebalancing pass shed: {s1}
 pending(4)

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_lateral.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_lateral.txt
@@ -125,9 +125,7 @@ rebalance-stores store-id=1
 [mmaid=1] load summary for dim=WriteBandwidth (s3): overloadSlow, reason: fractionUsed < 75% and >1.75x meanUtil [load=70000000 meanLoad=32500000 fractionUsed=70.00% meanUtil=32.50% capacity=100000000]
 [mmaid=1] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n3): loadNormal, reason: load is within 5% of mean [load=90 meanLoad=100 fractionUsed=4.50% meanUtil=7.50% capacity=2000]
-[mmaid=1] cannot add load to n3s4: due to target_summary(overloadSlow)>=loadNoChange,target-node(overloadSlow)>target-store(loadNormal)
-[mmaid=1] [target_sls:(store=loadNormal worst=ByteSize cpu=loadLow writes=loadLow bytes=loadNormal node=overloadSlow frac_pending=0.00,0.00(true)),src_sls:(store=overloadSlow worst=WriteBandwidth cpu=loadLow writes=overloadSlow bytes=loadNormal node=loadNormal frac_pending=0.00,0.00(true))]
-[mmaid=1] result(failed): cannot shed from s3 to s4 for r1: delta load [cpu:10ns/s, write-bandwidth:10 MB/s, byte-size:0 B]
+[mmaid=1] cannot add load from n3s3 to n3s4 for r1 due to target_summary(overloadSlow)>=loadNoChange,target-node(overloadSlow)>target-store(loadNormal): delta([cpu:10ns/s, write-bandwidth:10 MB/s, byte-size:0 B]) targetSLS[(store=loadNormal worst=ByteSize cpu=loadLow writes=loadLow bytes=loadNormal node=overloadSlow frac_pending=0.00,0.00(true))] srcSLS[(store=overloadSlow worst=WriteBandwidth cpu=loadLow writes=overloadSlow bytes=loadNormal node=loadNormal frac_pending=0.00,0.00(true))]
 [mmaid=1] rebalancing pass failures (store,reason:count): (s1,no-cand-load:1), (s3,no-cand-to-accept-load:1)
 pending(0)
 
@@ -215,8 +213,6 @@ rebalance-stores store-id=1
 [mmaid=2] load summary for dim=WriteBandwidth (s3): overloadSlow, reason: fractionUsed < 75% and >1.75x meanUtil [load=70000000 meanLoad=32500000 fractionUsed=70.00% meanUtil=32.50% capacity=100000000]
 [mmaid=2] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=2] load summary for dim=CPURate (n3): loadNormal, reason: load is within 5% of mean [load=90 meanLoad=100 fractionUsed=4.50% meanUtil=7.50% capacity=2000]
-[mmaid=2] cannot add load to n3s4: due to target_summary(overloadSlow)>=loadNoChange,target-node(overloadSlow)>target-store(loadNormal)
-[mmaid=2] [target_sls:(store=loadNormal worst=ByteSize cpu=loadLow writes=loadLow bytes=loadNormal node=overloadSlow frac_pending=0.00,0.00(true)),src_sls:(store=overloadSlow worst=WriteBandwidth cpu=loadLow writes=overloadSlow bytes=loadNormal node=loadNormal frac_pending=0.00,0.00(true))]
-[mmaid=2] result(failed): cannot shed from s3 to s4 for r1: delta load [cpu:10ns/s, write-bandwidth:10 MB/s, byte-size:0 B]
+[mmaid=2] cannot add load from n3s3 to n3s4 for r1 due to target_summary(overloadSlow)>=loadNoChange,target-node(overloadSlow)>target-store(loadNormal): delta([cpu:10ns/s, write-bandwidth:10 MB/s, byte-size:0 B]) targetSLS[(store=loadNormal worst=ByteSize cpu=loadLow writes=loadLow bytes=loadNormal node=overloadSlow frac_pending=0.00,0.00(true))] srcSLS[(store=overloadSlow worst=WriteBandwidth cpu=loadLow writes=overloadSlow bytes=loadNormal node=loadNormal frac_pending=0.00,0.00(true))]
 [mmaid=2] rebalancing pass failures (store,reason:count): (s1,no-cand-load:1), (s2,no-cand:1), (s3,no-cand-to-accept-load:1)
 pending(0)

--- a/pkg/kv/kvserver/asim/tests/testdata/non_rand/mma/single_node_disk_balance.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/non_rand/mma/single_node_disk_balance.txt
@@ -1,0 +1,51 @@
+# This test verifies that the MMA can balance disk utilization between stores
+# on a single node. The test sets up one node with two stores, each with 50GiB
+# capacity. Store s1 starts with 100 ranges of 400MiB each (40GiB total, 80%
+# full), while store s2 starts with 100 ranges of 200MiB each (20GiB total, 40%
+# full). There is no workload.
+#
+# The MMA only considers disk utilization a concern when a store exceeds 50%
+# capacity, so s1 starting at 80% should trigger rebalancing. The total cluster
+# utilization is 60% (60GiB / 100GiB), ensuring the balanced state (60% each)
+# remains above the 50% threshold where disk balancing stays active.
+#
+# Expected outcome: The MMA should rebalance replicas between the two stores
+# to equalize disk utilization at ~60% each.
+gen_cluster nodes=1 stores_per_node=2 store_byte_capacity_gib=50
+----
+
+# 100 ranges of 400MiB on store 1 (40GiB total, 80% of 50GiB capacity)
+gen_ranges ranges=100 bytes_mib=400 repl_factor=1 placement_type=replica_placement min_key=1 max_key=10000
+{s1:*}:100
+----
+{s1:*}:100
+
+# 100 ranges of 200MiB on store 2 (20GiB total, 40% of 50GiB capacity)
+gen_ranges ranges=100 bytes_mib=200 repl_factor=1 placement_type=replica_placement min_key=10001 max_key=20000
+{s2:*}:100
+----
+{s2:*}:100
+
+# Assert that disk utilization balances within 10% of mean.
+assertion stat=disk_fraction_used type=balance ticks=6 upper_bound=1.1
+----
+asserting: max_{stores}(disk_fraction_used)/mean_{stores}(disk_fraction_used) ≤ 1.10 at each of last 6 ticks
+
+eval duration=30m seed=42 cfgs=(mma-only,mma-count) metrics=(disk_fraction_used,replicas)
+----
+disk_fraction_used#1: first: [s1=0.98, s2=0.49] (stddev=0.24, mean=0.73, sum=1)
+disk_fraction_used#1: last:  [s1=0.80, s2=0.66] (stddev=0.07, mean=0.73, sum=1)
+disk_fraction_used#1: thrash_pct: [s1=0%, s2=0%]  (sum=0%)
+replicas#1: first: [s1=100, s2=100] (stddev=0.00, mean=100.00, sum=200)
+replicas#1: last:  [s1=82, s2=118] (stddev=18.00, mean=100.00, sum=200)
+replicas#1: thrash_pct: [s1=0%, s2=0%]  (sum=0%)
+artifacts[mma-only]: 5a5007acc8e4ec1d
+==========================
+disk_fraction_used#1: first: [s1=0.98, s2=0.49] (stddev=0.24, mean=0.73, sum=1)
+disk_fraction_used#1: last:  [s1=0.80, s2=0.66] (stddev=0.07, mean=0.73, sum=1)
+disk_fraction_used#1: thrash_pct: [s1=0%, s2=0%]  (sum=0%)
+replicas#1: first: [s1=100, s2=100] (stddev=0.00, mean=100.00, sum=200)
+replicas#1: last:  [s1=82, s2=118] (stddev=18.00, mean=100.00, sum=200)
+replicas#1: thrash_pct: [s1=0%, s2=0%]  (sum=0%)
+artifacts[mma-count]: 5a5007acc8e4ec1d
+==========================

--- a/pkg/kv/kvserver/asim/tests/testdata/non_rand/mma/single_node_disk_balance.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/non_rand/mma/single_node_disk_balance.txt
@@ -1,16 +1,16 @@
 # This test verifies that the MMA can balance disk utilization between stores
 # on a single node. The test sets up one node with two stores, each with 50GiB
-# capacity. Store s1 starts with 100 ranges of 400MiB each (40GiB total, 80%
-# full), while store s2 starts with 100 ranges of 200MiB each (20GiB total, 40%
-# full). There is no workload.
+# capacity. Store s1 starts with 100 ranges of 400MiB each (98% full), while
+# store s2 starts with 100 ranges of 200MiB each (49% full). There is no
+# workload.
 #
 # The MMA only considers disk utilization a concern when a store exceeds 50%
-# capacity, so s1 starting at 80% should trigger rebalancing. The total cluster
-# utilization is 60% (60GiB / 100GiB), ensuring the balanced state (60% each)
-# remains above the 50% threshold where disk balancing stays active.
+# capacity, so s1 starting at 98% should trigger rebalancing. The total cluster
+# utilization is 73%, ensuring the balanced state remains above the 50%
+# threshold where disk balancing stays active.
 #
 # Expected outcome: The MMA should rebalance replicas between the two stores
-# to equalize disk utilization at ~60% each.
+# to equalize disk utilization.
 gen_cluster nodes=1 stores_per_node=2 store_byte_capacity_gib=50
 ----
 
@@ -31,21 +31,14 @@ assertion stat=disk_fraction_used type=balance ticks=6 upper_bound=1.1
 ----
 asserting: max_{stores}(disk_fraction_used)/mean_{stores}(disk_fraction_used) ≤ 1.10 at each of last 6 ticks
 
-eval duration=30m seed=42 cfgs=(mma-only,mma-count) metrics=(disk_fraction_used,replicas)
+eval duration=10m seed=42 cfgs=(mma-count) metrics=(disk_fraction_used,replicas)
 ----
+mma-count:
 disk_fraction_used#1: first: [s1=0.98, s2=0.49] (stddev=0.24, mean=0.73, sum=1)
 disk_fraction_used#1: last:  [s1=0.80, s2=0.66] (stddev=0.07, mean=0.73, sum=1)
 disk_fraction_used#1: thrash_pct: [s1=0%, s2=0%]  (sum=0%)
 replicas#1: first: [s1=100, s2=100] (stddev=0.00, mean=100.00, sum=200)
 replicas#1: last:  [s1=82, s2=118] (stddev=18.00, mean=100.00, sum=200)
 replicas#1: thrash_pct: [s1=0%, s2=0%]  (sum=0%)
-artifacts[mma-only]: 5a5007acc8e4ec1d
-==========================
-disk_fraction_used#1: first: [s1=0.98, s2=0.49] (stddev=0.24, mean=0.73, sum=1)
-disk_fraction_used#1: last:  [s1=0.80, s2=0.66] (stddev=0.07, mean=0.73, sum=1)
-disk_fraction_used#1: thrash_pct: [s1=0%, s2=0%]  (sum=0%)
-replicas#1: first: [s1=100, s2=100] (stddev=0.00, mean=100.00, sum=200)
-replicas#1: last:  [s1=82, s2=118] (stddev=18.00, mean=100.00, sum=200)
-replicas#1: thrash_pct: [s1=0%, s2=0%]  (sum=0%)
-artifacts[mma-count]: 5a5007acc8e4ec1d
+hash: a765097f5f224b9d
 ==========================

--- a/pkg/kv/kvserver/asim/tests/testdata/non_rand/mma/skewed_ranges_write_workload_disk_balance.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/non_rand/mma/skewed_ranges_write_workload_disk_balance.txt
@@ -1,0 +1,49 @@
+# This test verifies that MMA can balance disks when the imbalance is already
+# high under a write-heavy workload. In this setting, doing disk based
+# rebalancing goes against the goals of CPU and write bandwidth balancing. The
+# test creates six nodes with 20 GiB store capacity. The first three nodes have
+# 100 ranges of 90 MiB each (55% full). The last three nodes have 100 ranges of
+# 1 MiB each (1% full). A write-only workload is started that targets both sets
+# of nodes evenly.
+#
+# Expectation: MMA should perform rebalancing based on disk usage while trying
+# to keep CPU utilization and write bandwidth also balanced. The hope is that
+# MMA extends the time it takes for the first node to hit high disk-usage
+# threshold compared to SMA.
+gen_cluster nodes=6 node_cpu_cores=2 store_byte_capacity_gib=20
+----
+
+gen_ranges ranges=100 repl_factor=3 min_key=0 max_key=10000 placement_type=replica_placement bytes_mib=90
+{s1,s2,s3}:1
+----
+{s1:*,s2,s3}:1
+
+gen_ranges ranges=100 repl_factor=3 min_key=10000 max_key=20000 placement_type=replica_placement bytes_mib=1
+{s4,s5,s6}:1
+----
+{s4:*,s5,s6}:1
+
+gen_load rate=5000 rw_ratio=0 min_block=1024 max_block=1024 request_cpu_per_access=100000 raft_cpu_per_write=100000 min_key=0 max_key=20000
+----
+0.50 access-vcpus, 0.50 raft-vcpus, 4.9 MiB/s goodput
+
+eval duration=75m samples=1 seed=42 cfgs=(mma-count) metrics=(cpu,cpu_util,write_bytes_per_second,replicas,leases,disk_fraction_used)
+----
+mma-count:
+cpu#1: last:  [s1=330429138, s2=307506061, s3=316863483, s4=344402356, s5=347292593, s6=332700350] (stddev=14097131.94, mean=329865663.50, sum=1979193981)
+cpu#1: thrash_pct: [s1=491%, s2=413%, s3=461%, s4=425%, s5=431%, s6=386%]  (sum=2605%)
+cpu_util#1: last:  [s1=0.17, s2=0.15, s3=0.16, s4=0.17, s5=0.17, s6=0.17] (stddev=0.01, mean=0.16, sum=1)
+cpu_util#1: thrash_pct: [s1=491%, s2=413%, s3=461%, s4=425%, s5=431%, s6=386%]  (sum=2605%)
+disk_fraction_used#1: first: [s1=0.55, s2=0.55, s3=0.55, s4=0.01, s5=0.01, s6=0.01] (stddev=0.27, mean=0.28, sum=2)
+disk_fraction_used#1: last:  [s1=0.96, s2=0.95, s3=0.93, s4=0.97, s5=0.94, s6=0.94] (stddev=0.01, mean=0.95, sum=6)
+disk_fraction_used#1: thrash_pct: [s1=175%, s2=100%, s3=139%, s4=93%, s5=93%, s6=82%]  (sum=683%)
+leases#1: first: [s1=100, s2=0, s3=0, s4=100, s5=0, s6=0] (stddev=47.14, mean=33.33, sum=200)
+leases#1: last:  [s1=34, s2=30, s3=30, s4=39, s5=34, s6=33] (stddev=3.04, mean=33.33, sum=200)
+leases#1: thrash_pct: [s1=83%, s2=63%, s3=81%, s4=83%, s5=74%, s6=59%]  (sum=443%)
+replicas#1: first: [s1=100, s2=100, s3=100, s4=100, s5=100, s6=100] (stddev=0.00, mean=100.00, sum=600)
+replicas#1: last:  [s1=98, s2=94, s3=98, s4=103, s5=106, s6=101] (stddev=3.87, mean=100.00, sum=600)
+replicas#1: thrash_pct: [s1=935%, s2=538%, s3=693%, s4=786%, s5=813%, s6=651%]  (sum=4416%)
+write_bytes_per_second#1: last:  [s1=2511195, s2=2380741, s3=2479587, s4=2582128, s5=2685024, s6=2561533] (stddev=93852.18, mean=2533368.00, sum=15200208)
+write_bytes_per_second#1: thrash_pct: [s1=1694%, s2=1429%, s3=1563%, s4=1400%, s5=1464%, s6=1353%]  (sum=8901%)
+hash: fcee53f9469a8659
+==========================

--- a/pkg/kv/kvserver/asim/tests/testdata/non_rand/mma/write_skewed_workload_disk_balance.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/non_rand/mma/write_skewed_workload_disk_balance.txt
@@ -1,0 +1,55 @@
+# This test verifies that MMA can balance disks when the write patterns are
+# skewed towards a set of nodes such that without MMA it would lead to
+# imbalanced disk usage in the long run. It creates six nodes with 20 GiB
+# store capacity. It creates 200 ranges of 1 MiB with three replicas each, such
+# that each node has a 100 replicas (1% full). The first three nodes are
+# targeted with a read-only workload. The last three nodes are targeted with a
+# write-only workload. Initially, the CPU utilization is identical on all nodes.
+#
+# Expectation: MMA should perform rebalancing based on disk usage and write
+# bandwidth to prevent one set of nodes from becoming full way in advance of the
+# others
+gen_cluster nodes=6 node_cpu_cores=2 store_byte_capacity_gib=20
+----
+
+gen_ranges ranges=100 repl_factor=3 min_key=0 max_key=10000 placement_type=replica_placement bytes_mib=1
+{s1,s2,s3}:1
+----
+{s1:*,s2,s3}:1
+
+gen_ranges ranges=100 repl_factor=3 min_key=10000 max_key=20000 placement_type=replica_placement bytes_mib=1
+{s4,s5,s6}:1
+----
+{s4:*,s5,s6}:1
+
+# Read-only workload with 1 CPU s/s targeting the first node.
+gen_load rate=1000 rw_ratio=1.0 request_cpu_per_access=1000000 min_key=0 max_key=10000
+----
+1.00 access-vcpus
+
+# Write-only workload with 1 CPU s/s and 5 MiB/s write bandwidth targeting the
+# second node.
+gen_load rate=5000 rw_ratio=0 min_block=1024 max_block=1024 request_cpu_per_access=100000 raft_cpu_per_write=100000 min_key=10000 max_key=20000
+----
+0.50 access-vcpus, 0.50 raft-vcpus, 4.9 MiB/s goodput
+
+eval duration=100m samples=1 seed=42 cfgs=(mma-count) metrics=(cpu,cpu_util,write_bytes_per_second,replicas,leases,disk_fraction_used)
+----
+mma-count:
+cpu#1: last:  [s1=520610798, s2=474823521, s3=495225579, s4=500445393, s5=500004395, s6=510019352] (stddev=14034650.80, mean=500188173.00, sum=3001129038)
+cpu#1: thrash_pct: [s1=224%, s2=206%, s3=207%, s4=296%, s5=297%, s6=323%]  (sum=1553%)
+cpu_util#1: last:  [s1=0.26, s2=0.24, s3=0.25, s4=0.25, s5=0.25, s6=0.26] (stddev=0.01, mean=0.25, sum=2)
+cpu_util#1: thrash_pct: [s1=224%, s2=206%, s3=207%, s4=296%, s5=297%, s6=323%]  (sum=1553%)
+disk_fraction_used#1: first: [s1=0.01, s2=0.01, s3=0.01, s4=0.01, s5=0.01, s6=0.01] (stddev=0.00, mean=0.01, sum=0)
+disk_fraction_used#1: last:  [s1=0.85, s2=0.86, s3=0.92, s4=0.90, s5=0.94, s6=0.94] (stddev=0.03, mean=0.90, sum=5)
+disk_fraction_used#1: thrash_pct: [s1=23%, s2=29%, s3=27%, s4=49%, s5=37%, s6=37%]  (sum=203%)
+leases#1: first: [s1=100, s2=0, s3=0, s4=100, s5=0, s6=0] (stddev=47.14, mean=33.33, sum=200)
+leases#1: last:  [s1=37, s2=33, s3=34, s4=33, s5=32, s6=31] (stddev=1.89, mean=33.33, sum=200)
+leases#1: thrash_pct: [s1=126%, s2=131%, s3=133%, s4=119%, s5=106%, s6=112%]  (sum=727%)
+replicas#1: first: [s1=100, s2=100, s3=100, s4=100, s5=100, s6=100] (stddev=0.00, mean=100.00, sum=600)
+replicas#1: last:  [s1=104, s2=104, s3=106, s4=91, s5=99, s6=96] (stddev=5.26, mean=100.00, sum=600)
+replicas#1: thrash_pct: [s1=419%, s2=478%, s3=488%, s4=344%, s5=362%, s6=334%]  (sum=2424%)
+write_bytes_per_second#1: last:  [s1=2407223, s2=2458357, s3=2611476, s4=2560014, s5=2662641, s6=2664705] (stddev=98163.94, mean=2560736.00, sum=15364416)
+write_bytes_per_second#1: thrash_pct: [s1=202%, s2=203%, s3=214%, s4=417%, s5=391%, s6=427%]  (sum=1853%)
+hash: 1d243026d5373c8f
+==========================

--- a/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
+++ b/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
@@ -1384,6 +1384,13 @@ mma_overloaded_store_short_dur_failure: mma.overloaded_store.short_dur.failure
 mma_overloaded_store_short_dur_success: mma.overloaded_store.short_dur.success
 mma_span_config_normalization_error: mma.span_config.normalization.error
 mma_span_config_normalization_soft_error: mma.span_config.normalization.soft_error
+mma_store_cpu_capacity: mma.store.cpu.capacity
+mma_store_cpu_load: mma.store.cpu.load
+mma_store_cpu_utilization: mma.store.cpu.utilization
+mma_store_disk_capacity: mma.store.disk.capacity
+mma_store_disk_logical: mma.store.disk.logical
+mma_store_disk_utilization: mma.store.disk.utilization
+mma_store_write_bandwidth: mma.store.write.bandwidth
 node_id: node_id
 obs_tablemetadata_update_job_duration: obs.tablemetadata.update_job.duration
 obs_tablemetadata_update_job_duration_bucket: obs.tablemetadata.update_job.duration.bucket


### PR DESCRIPTION
Backport:
  * 2/2 commits from "asim: experimenting with MMA and disk usage based balancing" (#162274)
  * 1/1 commits from "mmaprototype: add more MMA related metrics" (#162562)
  * 1/1 commits from "mmaprototype: consolidate canShedAndAddLoad failure log into one message" (#163441)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: low risk observability improvement for the multi-metric allocator (MMA). The MMA is disabled by default behind the kv.allocator.load_based_rebalancing cluster setting — the new metrics code only executes on clusters that have explicitly opted in. We are beginning selective rollout of MMA to CC clusters on 26.1, and having these observability metrics on the release branch is a prerequisite for safely monitoring MMA behavior in production (i.e. this falls under "inability to detect/debug production issues"). This is consistent with prior MMA observability backports to release-26.1 (#159520, #159593, #159614, #159809), all of which merged with the same rationale.
