### PR TITLE
aggmetric: use inline FNV-64a hash to reduce allocations in metric key compute

### DIFF
--- a/pkg/util/metric/aggmetric/agg_metric.go
+++ b/pkg/util/metric/aggmetric/agg_metric.go
@@ -10,7 +10,6 @@ package aggmetric
 
 import (
 	"context"
-	"hash/fnv"
 	"strings"
 	"time"
 
@@ -24,8 +23,6 @@ import (
 	"github.com/google/btree"
 	io_prometheus_client "github.com/prometheus/client_model/go"
 )
-
-var delimiter = []byte{'_'}
 
 const (
 	dbLabel  = "database"
@@ -247,7 +244,7 @@ func (cs *childSet) getOrAddWithLabelSliceCache(
 	defer cs.mu.Unlock()
 
 	// Create a LabelSliceCacheKey from the label.
-	key := metricKey(labelVals...)
+	key := metricKey(labelVals)
 
 	// Check if the child already exists
 	if child, ok := cs.mu.children.GetValue(key); ok {
@@ -281,7 +278,7 @@ func (cs *childSet) EachWithLabels(
 		childLabels := make([]*io_prometheus_client.LabelPair, 0, len(labels)+len(cs.labels))
 		childLabels = append(childLabels, labels...)
 		lvs := cm.labelValues()
-		key := metricKey(lvs...)
+		key := metricKey(lvs)
 		labelValueCacheValues, _ := labelCache.Get(metric.LabelSliceCacheKey(key))
 		for i := range cs.labels {
 			childLabels = append(childLabels, &io_prometheus_client.LabelPair{
@@ -363,38 +360,13 @@ func (sm *SQLMetric) Each(
 	})
 }
 
-func (sm *SQLMetric) get(labelVals ...string) (ChildMetric, bool) {
-	return sm.mu.children.Get(labelVals...)
-}
-
-func (sm *SQLMetric) add(metric ChildMetric) {
-	sm.mu.children.Add(metric)
-}
-
 type createChildMetricFunc func(labelValues labelValuesSlice) ChildMetric
 
-// getOrAddChildLocked returns the child metric for the given label values. If the child
-// doesn't exist, it creates a new one and adds it to the collection.
-// REQUIRES: sm.mu is locked.
-func (sm *SQLMetric) getOrAddChildLocked(
-	f createChildMetricFunc, labelValues ...string,
-) ChildMetric {
-	// If the child already exists, return it.
-	if child, ok := sm.get(labelValues...); ok {
-		return child
-	}
-
-	child := f(labelValues)
-
-	sm.add(child)
-	return child
-}
-
-// getChildByLabelConfig returns the child metric based on the label configuration.
+// getOrAddChildByLabelConfig returns the child metric based on the label configuration.
 // It returns the child metric and a boolean indicating if the child was found.
 // If the label configuration is either LabelConfigDisabled or unrecognised, it returns
 // ChildMetric as nil and false.
-func (sm *SQLMetric) getChildByLabelConfig(
+func (sm *SQLMetric) getOrAddChildByLabelConfig(
 	f createChildMetricFunc, db string, app string,
 ) (ChildMetric, bool) {
 	// We should acquire the lock before evaluating the label configuration
@@ -403,22 +375,44 @@ func (sm *SQLMetric) getChildByLabelConfig(
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
-	var childMetric ChildMetric
+	// The hash key computation and child creation are intentionally split into
+	// two separate switches on labelConfig. The key computation uses an inline
+	// FNV-64a hash that only needs the raw label strings, while child creation
+	// needs to allocate a labelValuesSlice. By computing the key first and
+	// checking the children map, we avoid the labelValuesSlice allocation
+	// entirely on the fast path (child already exists).
+	var key uint64
 	switch sm.mu.labelConfig {
 	case metric.LabelConfigDisabled:
 		return nil, false
 	case metric.LabelConfigDB:
-		childMetric = sm.getOrAddChildLocked(f, db)
-		return childMetric, true
+		key = hashLabel(fnvBase, db)
 	case metric.LabelConfigApp:
-		childMetric = sm.getOrAddChildLocked(f, app)
-		return childMetric, true
+		key = hashLabel(fnvBase, app)
 	case metric.LabelConfigAppAndDB:
-		childMetric = sm.getOrAddChildLocked(f, db, app)
-		return childMetric, true
+		key = hashLabel(hashLabel(fnvBase, db), app)
 	default:
 		return nil, false
 	}
+
+	// Return existing child.
+	if child, ok := sm.mu.children.GetValue(key); ok {
+		return child, true
+	}
+
+	// Create a new child.
+	var child ChildMetric
+	switch sm.mu.labelConfig {
+	case metric.LabelConfigDB:
+		child = f(labelValuesSlice{db})
+	case metric.LabelConfigApp:
+		child = f(labelValuesSlice{app})
+	case metric.LabelConfigAppAndDB:
+		child = f(labelValuesSlice{db, app})
+	}
+
+	_ = sm.mu.children.AddKey(key, child)
+	return child, true
 }
 
 // ReinitialiseChildMetrics clears the child metrics and
@@ -462,13 +456,32 @@ type labelValuesSlice []string
 
 func (lv *labelValuesSlice) labelValues() []string { return []string(*lv) }
 
-func metricKey(labels ...string) uint64 {
-	hash := fnv.New64a()
-	for _, label := range labels {
-		_, _ = hash.Write([]byte(label))
-		_, _ = hash.Write(delimiter)
+// FNV-64a constants.
+const (
+	fnvBase  = uint64(14695981039346656037)
+	fnvPrime = uint64(1099511628211)
+)
+
+// hashLabel hashes a single label string followed by the delimiter into the
+// running FNV-64a hash state.
+func hashLabel(h uint64, s string) uint64 {
+	for i := 0; i < len(s); i++ {
+		h ^= uint64(s[i])
+		h *= fnvPrime
 	}
-	return hash.Sum64()
+	// Delimiter '_' between labels.
+	h ^= uint64('_')
+	h *= fnvPrime
+	return h
+}
+
+// metricKey computes an FNV-64a hash over the given label values.
+func metricKey(labels []string) uint64 {
+	h := fnvBase
+	for _, label := range labels {
+		h = hashLabel(h, label)
+	}
+	return h
 }
 
 type ChildrenStorage interface {
@@ -506,7 +519,7 @@ func (ucw *UnorderedCacheWrapper) AddKey(key uint64, metric ChildMetric) error {
 }
 
 func (ucw *UnorderedCacheWrapper) Get(labelVals ...string) (ChildMetric, bool) {
-	hashKey := metricKey(labelVals...)
+	hashKey := metricKey(labelVals)
 	value, ok := ucw.cache.Get(hashKey)
 	if !ok {
 		return nil, false
@@ -516,7 +529,7 @@ func (ucw *UnorderedCacheWrapper) Get(labelVals ...string) (ChildMetric, bool) {
 
 func (ucw *UnorderedCacheWrapper) Add(metric ChildMetric) {
 	labelValues := metric.labelValues()
-	hashKey := metricKey(labelValues...)
+	hashKey := metricKey(labelValues)
 	if _, ok := ucw.cache.Get(hashKey); ok {
 		panic(errors.AssertionFailedf("child %v already exists", metric.labelValues()))
 	}
@@ -524,7 +537,7 @@ func (ucw *UnorderedCacheWrapper) Add(metric ChildMetric) {
 }
 
 func (ucw *UnorderedCacheWrapper) Del(metric ChildMetric) {
-	hashKey := metricKey(metric.labelValues()...)
+	hashKey := metricKey(metric.labelValues())
 	if _, ok := ucw.cache.Get(hashKey); ok {
 		ucw.cache.Del(hashKey)
 	}

--- a/pkg/util/metric/aggmetric/agg_metric_test.go
+++ b/pkg/util/metric/aggmetric/agg_metric_test.go
@@ -395,7 +395,7 @@ func TestMetricKey(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.expectedHashValue, metricKey(tc.labelValues...))
+			require.Equal(t, tc.expectedHashValue, metricKey(tc.labelValues))
 		})
 	}
 }
@@ -597,7 +597,7 @@ func TestHighCardinalityMetricsWithOptions(t *testing.T) {
 
 		// Verify that old entries were evicted
 		for i := 0; i < 3; i++ {
-			metricKey := metric.LabelSliceCacheKey(metricKey("db1", strconv.Itoa(i)))
+			metricKey := metric.LabelSliceCacheKey(metricKey([]string{"db1", strconv.Itoa(i)}))
 			_, ok := labelSliceCache.Get(metricKey)
 			require.False(t, ok, "old entry should have been evicted")
 		}
@@ -668,7 +668,7 @@ func TestHighCardinalityMetricsWithOptions(t *testing.T) {
 
 		// Verify all entries are still present (shouldn't evict with default settings)
 		for i := 0; i < 10; i++ {
-			metricKey := metric.LabelSliceCacheKey(metricKey("db1", strconv.Itoa(i)))
+			metricKey := metric.LabelSliceCacheKey(metricKey([]string{"db1", strconv.Itoa(i)}))
 			labelSliceValue, ok := labelSliceCache.Get(metricKey)
 			require.True(t, ok, "entry should still be present with default settings")
 			require.Equal(t, int64(3), labelSliceValue.Counter.Load())

--- a/pkg/util/metric/aggmetric/counter.go
+++ b/pkg/util/metric/aggmetric/counter.go
@@ -356,7 +356,7 @@ func (c *SQLCounter) Count() int64 {
 func (c *SQLCounter) Inc(i int64, db, app string) {
 	c.g.Inc(i)
 
-	childMetric, isChildMetricEnabled := c.getChildByLabelConfig(c.createChildCounter, db, app)
+	childMetric, isChildMetricEnabled := c.getOrAddChildByLabelConfig(c.createChildCounter, db, app)
 	if !isChildMetricEnabled {
 		return
 	}
@@ -500,7 +500,7 @@ func (c *HighCardinalityCounter) GetOrAddChild(labelVals ...string) *HighCardina
 	}
 
 	// Create a LabelSliceCacheKey from the tenantID.
-	key := metric.LabelSliceCacheKey(metricKey(labelVals...))
+	key := metric.LabelSliceCacheKey(metricKey(labelVals))
 
 	child := c.getOrAddWithLabelSliceCache(c.GetMetadata().Name, c.createHighCardinalityChildCounter, c.labelSliceCache, labelVals...)
 

--- a/pkg/util/metric/aggmetric/counter_test.go
+++ b/pkg/util/metric/aggmetric/counter_test.go
@@ -108,7 +108,7 @@ func TestHighCardinalityCounter(t *testing.T) {
 	echotest.Require(t, writePrometheusMetrics(t), datapathutils.TestDataPath(t, testFile))
 
 	for i := 0; i < cacheSize+5; i++ {
-		metricKey := metric.LabelSliceCacheKey(metricKey("1", strconv.Itoa(i)))
+		metricKey := metric.LabelSliceCacheKey(metricKey([]string{"1", strconv.Itoa(i)}))
 		labelSliceValue, ok := labelSliceCache.Get(metricKey)
 		require.True(t, ok, "missing labelSliceValue in label slice cache")
 		require.Equal(t, int64(1), labelSliceValue.Counter.Load(), "the value should be 1")
@@ -124,13 +124,13 @@ func TestHighCardinalityCounter(t *testing.T) {
 	echotest.Require(t, writePrometheusMetrics(t), datapathutils.TestDataPath(t, testFile))
 
 	for i := 0; i < 5; i++ {
-		metricKey := metric.LabelSliceCacheKey(metricKey("1", strconv.Itoa(i)))
+		metricKey := metric.LabelSliceCacheKey(metricKey([]string{"1", strconv.Itoa(i)}))
 		_, ok := labelSliceCache.Get(metricKey)
 		require.False(t, ok, "labelSliceValue should not be present.")
 	}
 
 	for i := 10; i < 15; i++ {
-		metricKey := metric.LabelSliceCacheKey(metricKey("1", strconv.Itoa(i)))
+		metricKey := metric.LabelSliceCacheKey(metricKey([]string{"1", strconv.Itoa(i)}))
 		labelSliceValue, ok := labelSliceCache.Get(metricKey)
 		require.True(t, ok, "missing labelSliceValue in label slice cache")
 		require.Equal(t, int64(1), labelSliceValue.Counter.Load(), "the value should be 1")
@@ -138,7 +138,7 @@ func TestHighCardinalityCounter(t *testing.T) {
 	}
 
 	for i := 10; i < 15; i++ {
-		metricKey := metric.LabelSliceCacheKey(metricKey("2", strconv.Itoa(i)))
+		metricKey := metric.LabelSliceCacheKey(metricKey([]string{"2", strconv.Itoa(i)}))
 		labelSliceValue, ok := labelSliceCache.Get(metricKey)
 		require.True(t, ok, "missing labelSliceValue in label slice cache")
 		require.Equal(t, int64(1), labelSliceValue.Counter.Load(), "the value should be 1")

--- a/pkg/util/metric/aggmetric/gauge.go
+++ b/pkg/util/metric/aggmetric/gauge.go
@@ -439,7 +439,7 @@ func (sg *SQLGauge) Value() int64 {
 // Gauge and updates it. Update increments parent metrics
 // irrespective of labelConfig.
 func (sg *SQLGauge) Update(val int64, db, app string) {
-	childMetric, isChildMetricEnabled := sg.getChildByLabelConfig(sg.createChildGauge, db, app)
+	childMetric, isChildMetricEnabled := sg.getOrAddChildByLabelConfig(sg.createChildGauge, db, app)
 
 	// If the label configuration is either LabelConfigDisabled or unrecognised,
 	// then only update aggregated gauge value.
@@ -460,7 +460,7 @@ func (sg *SQLGauge) Update(val int64, db, app string) {
 func (sg *SQLGauge) Inc(i int64, db, app string) {
 	sg.g.Inc(i)
 
-	childMetric, isChildMetricEnabled := sg.getChildByLabelConfig(sg.createChildGauge, db, app)
+	childMetric, isChildMetricEnabled := sg.getOrAddChildByLabelConfig(sg.createChildGauge, db, app)
 	if !isChildMetricEnabled {
 		return
 	}
@@ -474,7 +474,7 @@ func (sg *SQLGauge) Inc(i int64, db, app string) {
 func (sg *SQLGauge) Dec(i int64, db, app string) {
 	sg.g.Dec(i)
 
-	childMetric, isChildMetricEnabled := sg.getChildByLabelConfig(sg.createChildGauge, db, app)
+	childMetric, isChildMetricEnabled := sg.getOrAddChildByLabelConfig(sg.createChildGauge, db, app)
 	if !isChildMetricEnabled {
 		return
 	}
@@ -659,7 +659,7 @@ func (g *HighCardinalityGauge) GetOrAddChild(labelVals ...string) *HighCardinali
 	}
 
 	// Create a LabelSliceCacheKey from the tenantID.
-	key := metric.LabelSliceCacheKey(metricKey(labelVals...))
+	key := metric.LabelSliceCacheKey(metricKey(labelVals))
 
 	child := g.getOrAddWithLabelSliceCache(g.GetMetadata().Name, g.createHighCardinalityChildGauge, g.labelSliceCache, labelVals...)
 

--- a/pkg/util/metric/aggmetric/gauge_test.go
+++ b/pkg/util/metric/aggmetric/gauge_test.go
@@ -113,7 +113,7 @@ func TestHighCardinalityGauge(t *testing.T) {
 	echotest.Require(t, writePrometheusMetrics(t), datapathutils.TestDataPath(t, testFile))
 
 	for i := 0; i < cacheSize+5; i++ {
-		metricKey := metric.LabelSliceCacheKey(metricKey("1", strconv.Itoa(i)))
+		metricKey := metric.LabelSliceCacheKey(metricKey([]string{"1", strconv.Itoa(i)}))
 		labelSliceValue, ok := labelSliceCache.Get(metricKey)
 		require.True(t, ok, "missing labelSliceValue in label slice cache")
 		require.Equal(t, int64(1), labelSliceValue.Counter.Load(), "the reference count should be 1")
@@ -128,13 +128,13 @@ func TestHighCardinalityGauge(t *testing.T) {
 	echotest.Require(t, writePrometheusMetrics(t), datapathutils.TestDataPath(t, testFile))
 
 	for i := 0; i < 5; i++ {
-		metricKey := metric.LabelSliceCacheKey(metricKey("1", strconv.Itoa(i)))
+		metricKey := metric.LabelSliceCacheKey(metricKey([]string{"1", strconv.Itoa(i)}))
 		_, ok := labelSliceCache.Get(metricKey)
 		require.False(t, ok, "labelSliceValue should not be present.")
 	}
 
 	for i := 10; i < 15; i++ {
-		metricKey := metric.LabelSliceCacheKey(metricKey("1", strconv.Itoa(i)))
+		metricKey := metric.LabelSliceCacheKey(metricKey([]string{"1", strconv.Itoa(i)}))
 		labelSliceValue, ok := labelSliceCache.Get(metricKey)
 		require.True(t, ok, "missing labelSliceValue in label slice cache")
 		require.Equal(t, int64(1), labelSliceValue.Counter.Load(), "the reference count should be 1")
@@ -142,7 +142,7 @@ func TestHighCardinalityGauge(t *testing.T) {
 	}
 
 	for i := 10; i < 15; i++ {
-		metricKey := metric.LabelSliceCacheKey(metricKey("2", strconv.Itoa(i)))
+		metricKey := metric.LabelSliceCacheKey(metricKey([]string{"2", strconv.Itoa(i)}))
 		labelSliceValue, ok := labelSliceCache.Get(metricKey)
 		require.True(t, ok, "missing labelSliceValue in label slice cache")
 		require.Equal(t, int64(1), labelSliceValue.Counter.Load(), "the reference count should be 1")

--- a/pkg/util/metric/aggmetric/histogram.go
+++ b/pkg/util/metric/aggmetric/histogram.go
@@ -337,7 +337,7 @@ func (sh *SQLHistogram) Inspect(f func(interface{})) {
 // Histogram and record against it. RecordValue records value in parent metrics
 // irrespective of labelConfig.
 func (sh *SQLHistogram) RecordValue(v int64, db, app string) {
-	childMetric, isChildMetricEnabled := sh.getChildByLabelConfig(sh.createChildHistogram, db, app)
+	childMetric, isChildMetricEnabled := sh.getOrAddChildByLabelConfig(sh.createChildHistogram, db, app)
 	sh.ticker.RLock()
 	defer sh.ticker.RUnlock()
 
@@ -539,7 +539,7 @@ func (h *HighCardinalityHistogram) GetOrAddChild(
 	}
 
 	// Create a LabelSliceCacheKey from the labelVals.
-	key := metric.LabelSliceCacheKey(metricKey(labelVals...))
+	key := metric.LabelSliceCacheKey(metricKey(labelVals))
 
 	child := h.getOrAddWithLabelSliceCache(h.GetMetadata().Name, h.createHighCardinalityChildHistogram, h.labelSliceCache, labelVals...)
 

--- a/pkg/util/metric/aggmetric/histogram_test.go
+++ b/pkg/util/metric/aggmetric/histogram_test.go
@@ -129,7 +129,7 @@ func TestHighCardinalityHistogram(t *testing.T) {
 	echotest.Require(t, writePrometheusMetrics(t), datapathutils.TestDataPath(t, testFile))
 
 	for i := 0; i < cacheSize+5; i++ {
-		metricKey := metric.LabelSliceCacheKey(metricKey("1", strconv.Itoa(i)))
+		metricKey := metric.LabelSliceCacheKey(metricKey([]string{"1", strconv.Itoa(i)}))
 		labelSliceValue, ok := labelSliceCache.Get(metricKey)
 		require.True(t, ok, "missing labelSliceValue in label slice cache")
 		require.Equal(t, int64(1), labelSliceValue.Counter.Load(), "the value should be 1")
@@ -148,13 +148,13 @@ func TestHighCardinalityHistogram(t *testing.T) {
 	echotest.Require(t, writePrometheusMetrics(t), datapathutils.TestDataPath(t, testFile))
 
 	for i := 0; i < 5; i++ {
-		metricKey := metric.LabelSliceCacheKey(metricKey("1", strconv.Itoa(i)))
+		metricKey := metric.LabelSliceCacheKey(metricKey([]string{"1", strconv.Itoa(i)}))
 		_, ok := labelSliceCache.Get(metricKey)
 		require.False(t, ok, "labelSliceValue should not be present.")
 	}
 
 	for i := 10; i < 15; i++ {
-		metricKey := metric.LabelSliceCacheKey(metricKey("1", strconv.Itoa(i)))
+		metricKey := metric.LabelSliceCacheKey(metricKey([]string{"1", strconv.Itoa(i)}))
 		labelSliceValue, ok := labelSliceCache.Get(metricKey)
 		require.True(t, ok, "missing labelSliceValue in label slice cache")
 		require.Equal(t, int64(1), labelSliceValue.Counter.Load(), "the value should be 1")
@@ -162,7 +162,7 @@ func TestHighCardinalityHistogram(t *testing.T) {
 	}
 
 	for i := 10; i < 15; i++ {
-		metricKey := metric.LabelSliceCacheKey(metricKey("2", strconv.Itoa(i)))
+		metricKey := metric.LabelSliceCacheKey(metricKey([]string{"2", strconv.Itoa(i)}))
 		labelSliceValue, ok := labelSliceCache.Get(metricKey)
 		require.True(t, ok, "missing labelSliceValue in label slice cache")
 		require.Equal(t, int64(1), labelSliceValue.Counter.Load(), "the value should be 1")


### PR DESCRIPTION
This patch updates hash/fnv with an inline FNV-64a implementation to
avoid heap allocations from fnv.New64a() and []byte conversions on every
metric lookup.

SQLMetric was introduced to support per-query metric aggregation by
label dimensions (database, application name, or both). Its
getOrAddChildByLabelConfig method is called on every SQL statement
execution (e.g. SQLCounter.Inc, SQLGauge.Update,
SQLHistogram.RecordValue), making it a hot path where allocations
directly impact per-query overhead. This patch optimizes that path by
computing the hash key directly via hashLabel, bypassing the variadic
[]string allocation that the old getOrAddChildLocked helper required.
The helper methods get/add/getOrAddChildLocked are removed in favor of
direct uint64 key lookups through GetValue/AddKey.

This patch also updates metricKey from variadic to a []string parameter
for consistency with the non-variadic intent.

Part of: CRDB-60321
Epic: CRDB-53398

Release note: None

----
We have performed the benchmarking with `Sysbench/SQL/3node/oltp_read_write`. We have enabled `sql.metrics.application_name.enabled` and `sql.metrics.database_name.enabled` cluster settings so that we can see the difference in number of allocations per operation. Below is the result:

```
building benchmark binaries for ce1d85f: update labelconfig [bazel=true] 1/1 |
building benchmark binaries for 167c564: use custom fnv [bazel=true] 1/1 /
name                                           old time/op    new time/op    delta
Sysbench/SQL/3node/oltp_read_write-12            5.82ms ± 4%    5.99ms ± 9%    ~     (p=0.247 n=10+10)
ParallelSysbench/SQL/3node/oltp_read_write-12    1.76ms ± 6%    1.72ms ± 4%    ~     (p=0.661 n=10+9)

name                                           old errs/op    new errs/op    delta
Sysbench/SQL/3node/oltp_read_write-12              0.00           0.00         ~     (all equal)
ParallelSysbench/SQL/3node/oltp_read_write-12     0.00 ±114%     0.00 ±100%    ~     (p=0.738 n=10+10)

name                                           old alloc/op   new alloc/op   delta
Sysbench/SQL/3node/oltp_read_write-12            1.98MB ± 4%    1.96MB ± 5%    ~     (p=0.353 n=10+10)
ParallelSysbench/SQL/3node/oltp_read_write-12    1.99MB ± 4%    1.98MB ± 4%    ~     (p=0.529 n=10+10)

name                                           old allocs/op  new allocs/op  delta
ParallelSysbench/SQL/3node/oltp_read_write-12     8.11k ± 1%     7.97k ± 1%  -1.73%  (p=0.002 n=10+10)
Sysbench/SQL/3node/oltp_read_write-12             8.35k ± 1%     8.22k ± 1%  -1.62%  (p=0.000 n=8+9)
```

There is significant reduction in new allocations per operations during SQL operations.


