### PR TITLE
.claude: add table-driven-test and integration-test skills

### DIFF
--- a/.claude/skills/integration-test/SKILL.md
+++ b/.claude/skills/integration-test/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: integration-test
+description: Guidelines for writing integration tests with CockroachDB test servers, including when to use them and how to use sqlutils.
+---
+
+# Integration Test Guidelines
+
+Integration tests use `testserver`, a fully functional CockroachDB server with
+all components in-memory and in the same process. They're **SLOW** to spin up
+(can add seconds per test case), so use them only when necessary.
+
+## When to Use Integration Tests
+
+**Use for:**
+- SQL execution and query validation
+- Transaction behavior
+- Schema operations
+- Distributed systems behavior
+
+**Avoid for:**
+- Pure logic and data transformations
+- Parsing and validation
+- Anything that can be unit tested
+
+## Test Server Types
+
+**Single Server** (`serverutils.StartServerOnly`):
+- Use for: Single-node behavior, SQL queries, schema operations
+- Faster than clusters
+- Sufficient for most integration tests
+
+**Test Cluster** (`testcluster.StartTestCluster`):
+- Use for: Distributed behavior, replication, multi-node coordination
+- Much slower than single server
+- Only use when you specifically need multiple nodes
+
+## Basic Setup
+
+```go
+func TestDatabaseOperation(t *testing.T) {
+    ctx := context.Background()
+    s := serverutils.StartServerOnly(t, base.TestServerArgs{})
+    defer s.Stopper().Stop(ctx)
+
+    sqlDB := sqlutils.MakeSQLRunner(s.ApplicationLayer().SQLConn(t))
+
+    // Use sqlDB for queries
+}
+```
+
+**With configuration:**
+```go
+s := serverutils.StartServerOnly(t, base.TestServerArgs{
+    // Custom configuration
+    Knobs: base.TestingKnobs{
+        // Testing knobs to control behavior
+    },
+})
+```
+
+## Using sqlutils.MakeSQLRunner
+
+**Prefer** `sqlutils.MakeSQLRunner` over raw database connections in most cases.
+It provides automatic error handling (fails the test on error), cleaner syntax,
+and helper methods for common operations.
+
+**Common methods:**
+```go
+sqlDB := sqlutils.MakeSQLRunner(s.ApplicationLayer().SQLConn(t))
+
+// Execute statements (fails test on error)
+sqlDB.Exec(t, "CREATE TABLE foo (id INT PRIMARY KEY)")
+sqlDB.Exec(t, "INSERT INTO foo VALUES (1), (2), (3)")
+
+// Query single value to use in test logic - PREFER QueryRow
+var jobID jobspb.JobID
+sqlDB.QueryRow(t, "SELECT job_id FROM system.jobs ORDER BY created DESC LIMIT 1").Scan(&jobID)
+// Now use jobID in test logic
+
+var count int
+sqlDB.QueryRow(t, "SELECT count(*) FROM foo").Scan(&count)
+require.Greater(t, count, 0)
+
+// Query results as strings - use for validation
+results := sqlDB.QueryStr(t, "SELECT * FROM foo ORDER BY id")
+// returns [][]string
+
+// Check query results - best for exact result verification
+sqlDB.CheckQueryResults(t,
+    "SELECT id FROM foo ORDER BY id",
+    [][]string{{"1"}, {"2"}, {"3"}},
+)
+```
+
+**When to use the raw `sqlDB.DB` handle instead:**
+
+Use `sqlDB.DB` when you need direct error handling rather than automatic test
+failure:
+- **Retry loops** (e.g., `testutils.SucceedsSoon`) - need to return errors for retry logic
+- **Custom error handling** - when you need to inspect or handle specific error types
+
+```go
+// Raw DB access in retry loop
+testutils.SucceedsSoon(t, func() error {
+    _, err := sqlDB.DB.ExecContext(context.Background(), query)
+    return err  // return error for retry logic
+})
+
+// Raw DB access for custom error handling
+_, err := sqlDB.DB.ExecContext(ctx, query)
+if err != nil {
+    if strings.Contains(err.Error(), "specific condition") {
+        // handle specific error
+    }
+}
+```
+
+**Choosing the right query method:**
+- `sqlDB.QueryRow` - **Preferred** when reading data to use later in test logic (IDs, counts, values). Preserves datatypes and enables clean scanning into typed variables.
+- `sqlDB.QueryStr` - Use when you need all results as strings for manipulation or comparison.
+- `sqlDB.CheckQueryResults` - Use for validating exact query output matches expected strings.
+- `sqlDB.DB` - Use when you need the raw `*gosql.DB` handle for direct error handling, such as retry loops or custom error inspection (see above).
+
+## Performance: Reuse Test Servers
+
+**CRITICAL:** Spin up the server ONCE before the test loop, not inside each iteration.
+
+**Good:**
+```go
+func TestMultipleCases(t *testing.T) {
+    s := serverutils.StartServerOnly(t, base.TestServerArgs{})
+    defer s.Stopper().Stop(context.Background())
+    sqlDB := sqlutils.MakeSQLRunner(s.ApplicationLayer().SQLConn(t))
+
+    tests := []struct {
+        name     string
+        query    string
+        expected [][]string
+    }{
+        {name: "select 1", query: "SELECT 1", expected: [][]string{{"1"}}},
+        {name: "select 2", query: "SELECT 2", expected: [][]string{{"2"}}},
+    }
+
+    for _, tc := range tests {
+        t.Run(tc.name, func(t *testing.T) {
+            result := sqlDB.QueryStr(t, tc.query)
+            require.Equal(t, tc.expected, result)
+        })
+    }
+}
+```
+
+## Database and Table Management
+
+Balance performance with test isolation. Choose based on your test needs:
+
+**Pattern 1: Reuse table, clear data (faster)**
+```go
+sqlDB.Exec(t, "CREATE TABLE test_table (id INT PRIMARY KEY, data TEXT)")
+
+for _, tc := range tests {
+    t.Run(tc.name, func(t *testing.T) {
+        sqlDB.Exec(t, "DELETE FROM test_table")
+        // Run test case
+    })
+}
+```
+
+**Pattern 2: Unique table per case**
+```go
+for _, tc := range tests {
+    t.Run(tc.name, func(t *testing.T) {
+        tableName := fmt.Sprintf("test_%s", strings.ReplaceAll(tc.name, " ", "_"))
+        sqlDB.Exec(t, fmt.Sprintf("CREATE TABLE %s (id INT PRIMARY KEY)", tableName))
+        // Run test case
+    })
+}
+```
+
+**Pattern 3: Schema changes require per-case tables**
+
+When test cases modify schema (ALTER TABLE, ADD COLUMN), each needs its own table to avoid conflicts.
+
+## Combining with Table-Driven Tests
+
+Use the `/table-driven-test` skill for structuring test cases. The key pattern: set up the server once, then use table-driven structure for the test cases.
+
+```go
+func TestDatabaseOperations(t *testing.T) {
+    // Setup server ONCE
+    ctx := context.Background()
+    s := serverutils.StartServerOnly(t, base.TestServerArgs{})
+    defer s.Stopper().Stop(ctx)
+    sqlDB := sqlutils.MakeSQLRunner(s.ApplicationLayer().SQLConn(t))
+
+    // Table-driven test cases
+    tests := []struct {
+        name     string
+        setup    string
+        query    string
+        expected [][]string
+    }{
+        {
+            name:     "basic select",
+            setup:    "CREATE TABLE t1 (id INT); INSERT INTO t1 VALUES (1)",
+            query:    "SELECT * FROM t1",
+            expected: [][]string{{"1"}},
+        },
+        {
+            name:     "empty table",
+            setup:    "CREATE TABLE t2 (id INT)",
+            query:    "SELECT * FROM t2",
+            expected: [][]string{},
+        },
+    }
+
+    for _, tc := range tests {
+        t.Run(tc.name, func(t *testing.T) {
+            sqlDB.Exec(t, tc.setup)
+            result := sqlDB.QueryStr(t, tc.query)
+            require.Equal(t, tc.expected, result)
+        })
+    }
+}
+```

--- a/.claude/skills/table-driven-test/SKILL.md
+++ b/.claude/skills/table-driven-test/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: table-driven-test
+description: Guidelines for creating clean, well-structured table-driven tests in Go following CockroachDB conventions.
+---
+
+# Table-Driven Test Guidelines
+
+Table-driven tests define multiple test cases in a slice of structs, then iterate over them executing the same test logic. This makes it easy to add cases, improves readability, and reduces duplication.
+
+**When to use table-driven tests:**
+- You have 3+ similar test cases that vary by inputs/outputs
+- Tests follow the same logic pattern with different data
+- Most unit and integration tests benefit from this structure
+
+**When to skip:**
+- Only 1-2 simple test cases (overhead not worth it)
+- Each test requires completely different logic
+- Test setup/teardown varies significantly between cases
+
+**Not the same as:** Datadriven tests (different library with testdata files)
+
+## Basic Structure
+
+```go
+func TestMyFunction(t *testing.T) {
+    tests := []struct {
+        name        string
+        input       string
+        expectedLen int
+    }{
+        {name: "basic case", input: "hello", expectedLen: 5},
+        {name: "empty input", input: "", expectedLen: 0},
+    }
+
+    for _, tc := range tests {
+        t.Run(tc.name, func(t *testing.T) {
+            result, err := MyFunction(tc.input)
+            require.NoError(t, err)
+            require.Equal(t, tc.expectedLen, result)
+        })
+    }
+}
+```
+
+## Core Principles
+
+### 1. Only Specify What's Necessary
+
+**Bad:**
+```go
+{
+    name: "remap table",
+    tableID: 100, tableName: "users", schemaID: 1,
+    schemaName: "public", databaseID: 50, databaseName: "mydb",
+    expectedID: 51,  // only this is actually tested!
+}
+```
+
+**Good:**
+```go
+{name: "remap table", tableID: 100, expectedID: 51}
+```
+
+### 2. Struct Field Ordering: Inputs First, Then Expected
+
+Order struct fields with input fields at the top and verification fields at the bottom. Prefix all verification fields with `expected` so readers can immediately distinguish inputs from outputs.
+
+**Bad:**
+```go
+tests := []struct {
+    name      string
+    wantErr   bool       // verification mixed with inputs
+    input     string
+    output    int        // unclear if this is input or verification
+}
+```
+
+**Good:**
+```go
+tests := []struct {
+    name          string
+    input         string
+    expectedCount int
+    expectedErr   string
+}
+```
+
+### 3. One Concern Per Test Case
+
+**Bad:**
+```go
+{
+    name: "multiple behaviors",
+    input: map[int]int{
+        10: 60,  // normal remapping
+        49: 99,  // edge case
+        50: 50,  // system table preservation
+    },
+}
+```
+
+**Good:**
+```go
+{name: "normal remapping", input: map[int]int{10: 60}},
+{name: "preserve system table IDs under 50", input: map[int]int{49: 49}},
+{name: "remap IDs at or above 50", input: map[int]int{50: 100}},
+```
+
+### 4. Independent Test Cases
+
+Each case should be self-contained. Don't build dependent state across cases.
+
+### 5. Names Describe Intent, Not Inputs
+
+Test case names should hint at the **intention** or **scenario**, not duplicate the input data. A reader should understand what the case is testing from the name alone.
+
+- Good: `"two matched regions"`, `"error on negative input"`
+- Bad: `"match region x and y"`, `"test1"`, `"input_abc"`
+
+The name should answer "what scenario is this?" not "what data does this use?"
+
+## Assertions
+
+Use `require.*` (stops on failure) for most checks. Use `assert.*` (continues on failure) only when you want to see multiple failures.
+
+**Common patterns:**
+```go
+// Errors
+require.NoError(t, err)
+require.Error(t, err)
+require.ErrorContains(t, err, "not found")
+
+// Equality
+require.Equal(t, expected, actual)  // shows both values on failure
+require.True(t, result == expected) // don't do this - hides values
+
+// Collections
+require.Len(t, slice, expectedLen)
+require.Contains(t, slice, element)
+```
+
+**Avoid redundant nil checks:** Don't use `require.NotNil` before an assertion that will already fail on nil (like `require.Equal` or `require.Contains`). The subsequent assertion provides a clearer failure message anyway.
+
+```go
+// Bad: redundant nil check
+require.NotNil(t, result)
+require.Equal(t, expectedVal, result.Field)
+
+// Good: Equal already fails clearly if result is nil
+require.Equal(t, expectedVal, result.Field)
+```
+
+**Error handling in test cases:**
+```go
+tests := []struct {
+    name        string
+    input       string
+    expectedErr string
+}{
+    {name: "valid input", input: "hello"},
+    {name: "empty input rejected", input: "", expectedErr: "must not be empty"},
+}
+
+for _, tc := range tests {
+    t.Run(tc.name, func(t *testing.T) {
+        err := Validate(tc.input)
+        if tc.expectedErr != "" {
+            require.ErrorContains(t, err, tc.expectedErr)
+        } else {
+            require.NoError(t, err)
+        }
+    })
+}
+```
+
+## Variadic Helper Functions
+
+Use helpers to reduce boilerplate and make test data readable.
+
+**Example from CockroachDB** (`pkg/backup/compaction_dist_test.go`):
+
+```go
+// Helper types
+type mockEntry struct {
+    span     roachpb.Span
+    locality string
+}
+
+// Variadic helpers
+func entry(start, end string, locality string) mockEntry {
+    return mockEntry{
+        span:     mockSpan(start, end),
+        locality: locality,
+    }
+}
+
+func entries(specs ...mockEntry) []execinfrapb.RestoreSpanEntry {
+    var entries []execinfrapb.RestoreSpanEntry
+    for _, s := range specs {
+        var dir cloudpb.ExternalStorage
+        if s.locality != "" {
+            dir = cloudpb.ExternalStorage{
+                URI: "nodelocal://1/test?COCKROACH_LOCALITY=" + s.locality,
+            }
+        }
+        entries = append(entries, execinfrapb.RestoreSpanEntry{
+            Span:  s.span,
+            Files: []execinfrapb.RestoreFileSpec{{Dir: dir}},
+        })
+    }
+    return entries
+}
+
+// Usage - reads like a specification
+entries := entries(
+    entry("a", "b", "dc=dc1"),
+    entry("c", "d", "dc=dc2"),
+    entry("e", "f", "dc=dc3"),
+)
+```
+
+**When to create helpers:**
+- Complex struct initialization obscures test intent
+- Patterns repeat across test cases
+- Building composite data structures
+
+**When NOT to use:**
+- Simple values that don't need transformation
+- One-off test cases
+- Helpers add more complexity than they remove
+
+## Integration Tests
+
+For tests requiring a database server, see the `/integration-test` skill. The table-driven patterns here apply to both unit and integration tests.


### PR DESCRIPTION
This patch adds two new skills to help create tests that will be run via `./dev
test`.

Epic: none

Release note: none