### PR TITLE
release-24.3: changefeedccl: add observability into backoff blocking time

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -1318,9 +1318,9 @@ func (b *changefeedResumer) resumeWithRetries(
 		}
 
 		// All other errors retry.
-		log.Warningf(ctx, `Changefeed job %d encountered transient error: %v (attempt %d)`,
-			jobID, flowErr, 1+r.CurrentAttempt())
-		lastRunStatusUpdate = b.setJobRunningStatus(ctx, lastRunStatusUpdate, "transient error: %s", flowErr)
+		log.Warningf(ctx, `Changefeed job %d encountered transient error: %v (attempt %d) (approx backoff: %s)`,
+			jobID, flowErr, 1+r.CurrentAttempt(), r.NextBackoff())
+		lastRunStatusUpdate = b.setJobStatusMessage(ctx, lastRunStatusUpdate, "transient error: %s", flowErr)
 
 		if metrics, ok := execCfg.JobRegistry.MetricsStruct().Changefeed.(*Metrics); ok {
 			sli, err := metrics.getSLIMetrics(details.Opts[changefeedbase.OptMetricsScope])
@@ -1351,8 +1351,8 @@ func (b *changefeedResumer) resumeWithRetries(
 				// and this node restarting changefeed before this happens.
 				// We could come up with a mechanism to provide additional
 				// information to dist sql planner.  Or... we could just wait a bit.
-				log.Warningf(ctx, "Changefeed %d delaying restart due to %d node(s) (%v) draining",
-					jobID, len(localState.drainingNodes), localState.drainingNodes)
+				log.Warningf(ctx, "Changefeed %d delaying restart due to %d node(s) (%v) draining (approx backoff: %s)",
+					jobID, len(localState.drainingNodes), localState.drainingNodes, r.NextBackoff())
 				r.Next() // default config: ~5 sec delay, plus 10 sec on the retry loop.
 			}
 		}

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -1261,17 +1261,11 @@ func (b *changefeedResumer) resumeWithRetries(
 		}
 	}
 
-	// Grab a "reference" to this nodes job registry in order to make sure
+	// Grab a "reference" to this node's job registry in order to make sure
 	// this resumer has enough time to persist up to date checkpoint in case
 	// of node drain.
 	drainCh, cleanup := execCfg.JobRegistry.OnDrain()
 	defer cleanup()
-
-	// We'd like to avoid failing a changefeed unnecessarily, so when an error
-	// bubbles up to this level, we'd like to "retry" the flow if possible. This
-	// could be because the sink is down or because a cockroach node has crashed
-	// or for many other reasons.
-	var lastRunStatusUpdate time.Time
 
 	// Setup local state information.
 	// This information is used by dist flow process to communicate back
@@ -1281,8 +1275,17 @@ func (b *changefeedResumer) resumeWithRetries(
 	jobExec.ExtendedEvalContext().ChangefeedState = localState
 	knobs, _ := execCfg.DistSQLSrv.TestingKnobs.Changefeed.(*TestingKnobs)
 
+	// We'd like to avoid failing a changefeed unnecessarily, so when an error
+	// bubbles up to this level, we'd like to "retry" the flow if possible. This
+	// could be because the sink is down or because a cockroach node has crashed
+	// or for many other reasons.
 	maxBackoff := changefeedbase.MaxRetryBackoff.Get(&execCfg.Settings.SV)
 	backoffReset := changefeedbase.RetryBackoffReset.Get(&execCfg.Settings.SV)
+
+	// lastRunStatusUpdate is used to track the last time the job status was updated
+	// to avoid updating the job status too frequently.
+	var lastRunStatusUpdate time.Time
+
 	for r := getRetry(ctx, maxBackoff, backoffReset); r.Next(); {
 		flowErr := maybeUpgradePreProductionReadyExpression(ctx, jobID, details, jobExec)
 

--- a/pkg/ccl/changefeedccl/retry.go
+++ b/pkg/ccl/changefeedccl/retry.go
@@ -68,3 +68,7 @@ func (r *Retry) Next() bool {
 	}
 	return r.Retry.Next()
 }
+
+func (r *Retry) NextBackoff() time.Duration {
+	return r.Retry.NextBackoff()
+}

--- a/pkg/util/retry/retry_test.go
+++ b/pkg/util/retry/retry_test.go
@@ -23,9 +23,8 @@ func TestRetryExceedsMaxBackoff(t *testing.T) {
 	}
 
 	r := Start(opts)
-	r.opts.RandomizationFactor = 0
 	for i := 0; i < 10; i++ {
-		d := r.retryIn()
+		d := r.retryIn(0)
 		if d > opts.MaxBackoff {
 			t.Fatalf("expected backoff less than max-backoff: %s vs %s", d, opts.MaxBackoff)
 		}


### PR DESCRIPTION
Backport 2/2 commits from #161644.

/cc @cockroachdb/release

---

changefeedccl: add observability into backoff blocking time
Previously, changefeeds would retry with exponential backoff up to a
configurable maximum (default 10 minutes), but there was no visibility
into how long these backoff periods were actually blocking changefeed
progress. This made it difficult to determine whether the maximum backoff
duration could be safely reduced.

This commit adds instrumentation to the changefeed retry logic to track
and log backoff durations. Specifically:
- The Retry struct now has a method NextBackoff that will return the
average value of the next backoff.
- Logs for transient errors (that trigger a retry) will include the
expected backoff they incur.

This observability will help determine if it's safe to reduce the maximum
backoff duration by revealing how frequently long backoffs occur in
production environments.

Release notes: None

Epic: None
