### PR TITLE
release-25.2: changefeedccl: add observability into backoff blocking time

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -1395,17 +1395,11 @@ func (b *changefeedResumer) resumeWithRetries(
 		}
 	}
 
-	// Grab a "reference" to this nodes job registry in order to make sure
+	// Grab a "reference" to this node's job registry in order to make sure
 	// this resumer has enough time to persist up to date checkpoint in case
 	// of node drain.
 	drainCh, cleanup := execCfg.JobRegistry.OnDrain()
 	defer cleanup()
-
-	// We'd like to avoid failing a changefeed unnecessarily, so when an error
-	// bubbles up to this level, we'd like to "retry" the flow if possible. This
-	// could be because the sink is down or because a cockroach node has crashed
-	// or for many other reasons.
-	var lastRunStatusUpdate time.Time
 
 	// Setup local state information.
 	// This information is used by dist flow process to communicate back
@@ -1420,8 +1414,17 @@ func (b *changefeedResumer) resumeWithRetries(
 		log.Warningf(ctx, "failed to resolve destination details for change monitoring: %v", err)
 	}
 
+	// We'd like to avoid failing a changefeed unnecessarily, so when an error
+	// bubbles up to this level, we'd like to "retry" the flow if possible. This
+	// could be because the sink is down or because a cockroach node has crashed
+	// or for many other reasons.
 	maxBackoff := changefeedbase.MaxRetryBackoff.Get(&execCfg.Settings.SV)
 	backoffReset := changefeedbase.RetryBackoffReset.Get(&execCfg.Settings.SV)
+
+	// lastRunStatusUpdate is used to track the last time the job status was updated
+	// to avoid updating the job status too frequently.
+	var lastRunStatusUpdate time.Time
+
 	for r := getRetry(ctx, maxBackoff, backoffReset); r.Next(); {
 		flowErr := maybeUpgradePreProductionReadyExpression(ctx, jobID, details, jobExec)
 

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -11407,6 +11407,68 @@ func TestChangefeedHeadersJSONVals(t *testing.T) {
 	}
 }
 
+// TestChangefeedRetryBackoffLogging tests that retry backoff duration is
+// included in log messages when changefeeds encounter transient errors.
+func TestChangefeedRetryBackoffLogging(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
+
+		spy := &changefeedLogSpy{}
+		cleanup := log.InterceptWith(context.Background(), spy)
+		defer cleanup()
+
+		var errorCount atomic.Int32
+		knobs := s.TestingKnobs.DistSQL.(*execinfra.TestingKnobs).Changefeed.(*TestingKnobs)
+		knobs.RaiseRetryableError = func() error {
+			if errorCount.Add(1) == 1 {
+				return errors.New("test transient error")
+			}
+			return nil
+		}
+
+		feed := feed(t, f, `CREATE CHANGEFEED FOR foo WITH initial_scan='no'`)
+		defer closeFeed(t, feed)
+
+		// Insert data to trigger the changefeed and error
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (1)`)
+		assertPayloads(t, feed, []string{
+			`foo: [1]->{"after": {"a": 1}}`,
+		})
+
+		testutils.SucceedsSoon(t, func() error {
+			spy.Lock()
+			defer spy.Unlock()
+
+			transientErrorLogs := []string{}
+			for _, log := range spy.logs {
+				if strings.Contains(log, "encountered transient error") {
+					transientErrorLogs = append(transientErrorLogs, log)
+				}
+			}
+			if len(transientErrorLogs) == 0 {
+				return errors.New("expected transient error log not found")
+			}
+			logMsg := transientErrorLogs[0]
+
+			// These logs should look like this:
+			// "Changefeed job %d encountered transient error: %v (attempt %d) (approx backoff: %s)"
+			if !strings.Contains(logMsg, "approx backoff:") {
+				return errors.Newf("log missing 'approx backoff:' - got: %s", logMsg)
+			}
+			if !strings.Contains(logMsg, "attempt") {
+				return errors.Newf("log missing 'attempt' - got: %s", logMsg)
+			}
+			return nil
+		})
+	}
+
+	cdcTest(t, testFn, feedTestEnterpriseSinks)
+}
+
 // TestPubsubAttributes tests that the "attributes" field in the
 // `pubsub_sink_config` behaves as expected.
 func TestPubsubAttributes(t *testing.T) {

--- a/pkg/ccl/changefeedccl/retry.go
+++ b/pkg/ccl/changefeedccl/retry.go
@@ -68,3 +68,7 @@ func (r *Retry) Next() bool {
 	}
 	return r.Retry.Next()
 }
+
+func (r *Retry) NextBackoff() time.Duration {
+	return r.Retry.NextBackoff()
+}

--- a/pkg/util/retry/retry_test.go
+++ b/pkg/util/retry/retry_test.go
@@ -23,9 +23,8 @@ func TestRetryExceedsMaxBackoff(t *testing.T) {
 	}
 
 	r := Start(opts)
-	r.opts.RandomizationFactor = 0
 	for i := 0; i < 10; i++ {
-		d := r.retryIn()
+		d := r.retryIn(0)
 		if d > opts.MaxBackoff {
 			t.Fatalf("expected backoff less than max-backoff: %s vs %s", d, opts.MaxBackoff)
 		}


### PR DESCRIPTION
Backport 2/2 commits from #161644.

/cc @cockroachdb/release

---

changefeedccl: add observability into backoff blocking time
Previously, changefeeds would retry with exponential backoff up to a
configurable maximum (default 10 minutes), but there was no visibility
into how long these backoff periods were actually blocking changefeed
progress. This made it difficult to determine whether the maximum backoff
duration could be safely reduced.

This commit adds instrumentation to the changefeed retry logic to track
and log backoff durations. Specifically:
- The Retry struct now has a method NextBackoff that will return the
average value of the next backoff.
- Logs for transient errors (that trigger a retry) will include the
expected backoff they incur.

This observability will help determine if it's safe to reduce the maximum
backoff duration by revealing how frequently long backoffs occur in
production environments.

Release notes: None

Epic: None
