### PR TITLE
jobs: clear running status on success

### DIFF
--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -524,7 +524,7 @@ func (u Updater) succeeded(ctx context.Context, fn func(context.Context, isql.Tx
 			FractionCompleted: 1.0,
 		}
 		ju.UpdateProgress(md.Progress)
-		return nil
+		return u.j.StatusStorage().Clear(ctx, txn)
 	})
 }
 


### PR DESCRIPTION
This teaches the job system to clear job running statuses on successful completion. This avoids any confusion with old running statuses still being displayed after the job has completed.

Epic: None

Release note: Job running statuses are now cleared after completing successfully.