### PR TITLE
release-26.1.0-rc: keys: handle case where keys targeted by GC request straddle header

### DIFF
--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -1086,10 +1086,51 @@ func EnsureSafeSplitKey(key roachpb.Key) (roachpb.Key, error) {
 	return key[:idx], nil
 }
 
+// extend expands the given RSpan to include the key range [key, endKey) (or
+// [key, key.Next()) if an empty endKey is supplied).
+func extend(rs roachpb.RSpan, key, endKey roachpb.Key) (roachpb.RSpan, error) {
+	rKey, err := Addr(key)
+	if err != nil {
+		return roachpb.RSpan{}, err
+	}
+	if rKey.Less(rs.Key) {
+		// rKey is smaller than the current start key.
+		rs.Key = rKey
+	}
+	if !rKey.Less(rs.EndKey) {
+		// rKey.Next() is larger than the current end key.
+		if bytes.Compare(rKey, roachpb.RKeyMax) > 0 {
+			return roachpb.RSpan{}, errors.Errorf("%s must be less than KeyMax", rKey)
+		}
+		rs.EndKey = rKey.Next()
+	}
+
+	// Check if endKey exists; if it does, consider it for the upper bound.
+	// Otherwise, return the extended span.
+	if len(endKey) == 0 {
+		return rs, nil
+	}
+
+	// NB: AddrUpperBound is suitable for use as the EndKey of a span with a
+	// range-local key EndKey. See the comment on AddrUpperBound for more
+	// details.
+	rEndKey, err := AddrUpperBound(endKey)
+	if err != nil {
+		return roachpb.RSpan{}, err
+	}
+	if bytes.Compare(roachpb.RKeyMax, rEndKey) < 0 {
+		return roachpb.RSpan{}, errors.Errorf("%s must be less than or equal to KeyMax", rEndKey)
+	}
+	if rs.EndKey.Less(rEndKey) {
+		// rEndKey is larger than the current end key.
+		rs.EndKey = rEndKey
+	}
+	return rs, nil
+}
+
 // Range returns a key range encompassing the key ranges of all requests.
 func Range(reqs []kvpb.RequestUnion) (roachpb.RSpan, error) {
-	from := roachpb.RKeyMax
-	to := roachpb.RKeyMin
+	rs := roachpb.RSpan{Key: roachpb.RKeyMax, EndKey: roachpb.RKeyMin}
 	for _, arg := range reqs {
 		req := arg.GetInner()
 		h := req.Header()
@@ -1097,38 +1138,52 @@ func Range(reqs []kvpb.RequestUnion) (roachpb.RSpan, error) {
 			return roachpb.RSpan{}, errors.Errorf("end key specified for non-range operation: %s", req)
 		}
 
-		key, err := Addr(h.Key)
+		var err error
+		rs, err = extend(rs, h.Key, h.EndKey)
 		if err != nil {
 			return roachpb.RSpan{}, err
-		}
-		if key.Less(from) {
-			// Key is smaller than `from`.
-			from = key
-		}
-		if !key.Less(to) {
-			// Key.Next() is larger than `to`.
-			if bytes.Compare(key, roachpb.RKeyMax) > 0 {
-				return roachpb.RSpan{}, errors.Errorf("%s must be less than KeyMax", key)
-			}
-			to = key.Next()
 		}
 
-		if len(h.EndKey) == 0 {
-			continue
+		// For GCRequests, also consider the individual keys, range keys, and
+		// clear range spans which may extend beyond the request header.
+		if req.Method() == kvpb.GC {
+			rs, err = extendRangeForGCRequest(req.(*kvpb.GCRequest), rs)
+			if err != nil {
+				return roachpb.RSpan{}, err
+			}
 		}
-		endKey, err := AddrUpperBound(h.EndKey)
+	}
+	return rs, nil
+}
+
+// extendRangeForGCRequest examines the individual keys, range keys, and clear
+// range within a GCRequest and extends the bounds if any of them fall outside
+// the current range. This handles cases where the GC request erroneously
+// targets keys outside its header span (see #162085).
+func extendRangeForGCRequest(gcReq *kvpb.GCRequest, rs roachpb.RSpan) (roachpb.RSpan, error) {
+	var err error
+	// Check point keys.
+	for _, gcKey := range gcReq.Keys {
+		rs, err = extend(rs, gcKey.Key, nil)
 		if err != nil {
 			return roachpb.RSpan{}, err
 		}
-		if bytes.Compare(roachpb.RKeyMax, endKey) < 0 {
-			return roachpb.RSpan{}, errors.Errorf("%s must be less than or equal to KeyMax", endKey)
-		}
-		if to.Less(endKey) {
-			// EndKey is larger than `to`.
-			to = endKey
+	}
+	// Check range keys.
+	for _, rk := range gcReq.RangeKeys {
+		rs, err = extend(rs, rk.StartKey, rk.EndKey)
+		if err != nil {
+			return roachpb.RSpan{}, err
 		}
 	}
-	return roachpb.RSpan{Key: from, EndKey: to}, nil
+	// Check clear range.
+	if gcReq.ClearRange != nil {
+		rs, err = extend(rs, gcReq.ClearRange.StartKey, gcReq.ClearRange.EndKey)
+		if err != nil {
+			return roachpb.RSpan{}, err
+		}
+	}
+	return rs, nil
 }
 
 // RangeIDPrefixBuf provides methods for generating range ID local keys while

--- a/pkg/keys/keys_test.go
+++ b/pkg/keys/keys_test.go
@@ -618,54 +618,54 @@ func TestRangeBatchWithGCRequests(t *testing.T) {
 		// Tests for keys that straddle the request header. Such constructions
 		// were historically possible when the MVCC GC queue constructed GC
 		// requests: see https://github.com/cockroachdb/cockroach/issues/162085.
-		// The result (as of this commit) is the request header span.
+		// The result should expand to include the straddling keys.
 		{
 			name:       "clear range straddles header on the left",
 			header:     span("c", "z"),
 			clearRange: span("a", "m"),
-			want:       span("c", "z"),
+			want:       span("a", "z"),
 		},
 		{
 			name:       "clear range straddles header on the right",
 			header:     span("a", "m"),
 			clearRange: span("f", "z"),
-			want:       span("a", "m"),
+			want:       span("a", "z"),
 		},
 		{
 			name:       "clear range straddles header on both sides",
 			header:     span("c", "m"),
 			clearRange: span("a", "z"),
-			want:       span("c", "m"),
+			want:       span("a", "z"),
 		},
 		{
 			name:      "range keys straddle header on the left",
 			header:    span("c", "z"),
 			rangeKeys: span("a", "f"),
-			want:      span("c", "z"),
+			want:      span("a", "z"),
 		},
 		{
 			name:      "range keys straddle header on the right",
 			header:    span("a", "m"),
 			rangeKeys: span("f", "z"),
-			want:      span("a", "m"),
+			want:      span("a", "z"),
 		},
 		{
 			name:      "range keys straddle header on both sides",
 			header:    span("c", "m"),
 			rangeKeys: span("a", "z"),
-			want:      span("c", "m"),
+			want:      span("a", "z"),
 		},
 		{
 			name:   "point key straddles header on the left",
 			header: span("c", "m"),
 			keys:   keys("a", "d"),
-			want:   span("c", "m"),
+			want:   span("a", "m"),
 		},
 		{
 			name:   "point key straddles header on the right",
 			header: span("c", "m"),
 			keys:   keys("d", "z"),
-			want:   span("c", "m"),
+			want:   span("c", "z\x00"),
 		},
 	}
 

--- a/pkg/keys/keys_test.go
+++ b/pkg/keys/keys_test.go
@@ -551,6 +551,153 @@ func TestBatchRange(t *testing.T) {
 	}
 }
 
+// TestRangeBatchWithGCRequests tests the Range function with GC requests
+// containing different subtypes: point keys, range keys, and clear range.
+func TestRangeBatchWithGCRequests(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	span := func(start, end string) roachpb.Span {
+		return roachpb.Span{
+			Key:    roachpb.Key(start),
+			EndKey: roachpb.Key(end),
+		}
+	}
+
+	keys := func(ks ...string) []kvpb.GCRequest_GCKey {
+		result := make([]kvpb.GCRequest_GCKey, len(ks))
+		for i, k := range ks {
+			result[i] = kvpb.GCRequest_GCKey{Key: roachpb.Key(k)}
+		}
+		return result
+	}
+
+	testCases := []struct {
+		name       string
+		header     roachpb.Span
+		keys       []kvpb.GCRequest_GCKey
+		clearRange roachpb.Span
+		rangeKeys  roachpb.Span
+		want       roachpb.Span
+	}{
+		{
+			name:   "point keys fully contained in header span",
+			header: span("a", "z"),
+			keys:   keys("b", "c", "d"),
+			want:   span("a", "z"),
+		},
+		{
+			name:      "range keys fully contained in header span",
+			header:    span("a", "z"),
+			rangeKeys: span("b", "h"),
+			want:      span("a", "z"),
+		},
+		{
+			name:       "clear range fully contained in header span",
+			header:     span("a", "z"),
+			clearRange: span("m", "n"),
+			want:       span("a", "z"),
+		},
+		{
+			name:   "point keys at header span boundaries",
+			header: span("a", "z"),
+			keys:   keys("a", "y"),
+			want:   span("a", "z"),
+		},
+		{
+			name:      "range keys at header span boundaries",
+			header:    span("a", "z"),
+			rangeKeys: span("a", "z"),
+			want:      span("a", "z"),
+		},
+		{
+			name:       "clear range at header span boundaries",
+			header:     span("a", "z"),
+			clearRange: span("a", "z"),
+			want:       span("a", "z"),
+		},
+		// Tests for keys that straddle the request header. Such constructions
+		// were historically possible when the MVCC GC queue constructed GC
+		// requests: see https://github.com/cockroachdb/cockroach/issues/162085.
+		// The result (as of this commit) is the request header span.
+		{
+			name:       "clear range straddles header on the left",
+			header:     span("c", "z"),
+			clearRange: span("a", "m"),
+			want:       span("c", "z"),
+		},
+		{
+			name:       "clear range straddles header on the right",
+			header:     span("a", "m"),
+			clearRange: span("f", "z"),
+			want:       span("a", "m"),
+		},
+		{
+			name:       "clear range straddles header on both sides",
+			header:     span("c", "m"),
+			clearRange: span("a", "z"),
+			want:       span("c", "m"),
+		},
+		{
+			name:      "range keys straddle header on the left",
+			header:    span("c", "z"),
+			rangeKeys: span("a", "f"),
+			want:      span("c", "z"),
+		},
+		{
+			name:      "range keys straddle header on the right",
+			header:    span("a", "m"),
+			rangeKeys: span("f", "z"),
+			want:      span("a", "m"),
+		},
+		{
+			name:      "range keys straddle header on both sides",
+			header:    span("c", "m"),
+			rangeKeys: span("a", "z"),
+			want:      span("c", "m"),
+		},
+		{
+			name:   "point key straddles header on the left",
+			header: span("c", "m"),
+			keys:   keys("a", "d"),
+			want:   span("c", "m"),
+		},
+		{
+			name:   "point key straddles header on the right",
+			header: span("c", "m"),
+			keys:   keys("d", "z"),
+			want:   span("c", "m"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := kvpb.GCRequest{
+				RequestHeader: kvpb.RequestHeader{
+					Key:    tc.header.Key,
+					EndKey: tc.header.EndKey,
+				},
+				Keys: tc.keys,
+			}
+			if tc.clearRange.Key != nil {
+				req.ClearRange = &kvpb.GCRequest_GCClearRange{
+					StartKey: tc.clearRange.Key,
+					EndKey:   tc.clearRange.EndKey,
+				}
+			}
+			if tc.rangeKeys.Key != nil {
+				req.RangeKeys = []kvpb.GCRequest_GCRangeKey{
+					{StartKey: tc.rangeKeys.Key, EndKey: tc.rangeKeys.EndKey},
+				}
+			}
+			var ba kvpb.BatchRequest
+			ba.Add(&req)
+			rs, err := Range(ba.Requests)
+			require.NoError(t, err)
+			require.Equal(t, roachpb.RSpan{Key: roachpb.RKey(tc.want.Key), EndKey: roachpb.RKey(tc.want.EndKey)}, rs)
+		})
+	}
+}
+
 // TestBatchError verifies that Range returns an error if a request has an invalid range.
 func TestBatchError(t *testing.T) {
 	testCases := []struct {


### PR DESCRIPTION
Backport 3/3 commits from #163447 on behalf of @arulajmani.

----

Backport 3/3 commits from #162271 (on behalf of @arulajmani).

/cc @cockroachdb/kv

---

Individual commits:

1. **keys: add TestRangeBatchWithGCRequests** — adds test for GC requests where targeted keys don't fall within request header bounds.
2. **keys: handle case where keys targeted by GC request straddle header** — adds special case handling to return RangeKeyMismatchError for erroneous GC requests instead of silently proceeding.
3. **kvserver: account for LocalRangeID keys extendRangeForGCRequest** — handles LocalRangeID keys that can't be addressed in the global key map.

Release justification: bug fix for potential data loss via incorrect GC requests.

---

Release note: Fixes a rare bug where a racing split and GC request could result in the GC of data on the post-split RHS. This could, in rare cases, lead to lost writes on the RHS.

Made with [Cursor](https://cursor.com)

----

Release justification: bug fix for potential data loss via incorrect GC requests.