### PR TITLE
schemachanger: fix race in distributed merge checkpoint updates with lazy SST cleanup

### DIFF
--- a/pkg/sql/indexbackfiller_test.go
+++ b/pkg/sql/indexbackfiller_test.go
@@ -1545,6 +1545,7 @@ func waitForCheckpointPersisted(
 	expectedSpans []roachpb.Span,
 	expectedPhase int32,
 ) {
+	t.Helper()
 	testutils.SucceedsWithin(t, func() error {
 		stmt := `SELECT payload FROM crdb_internal.system_jobs WHERE id = $1`
 		var payloadBytes []byte
@@ -1586,7 +1587,7 @@ func waitForCheckpointPersisted(
 			return errors.Errorf("waiting for phase %d, current: %d",
 				expectedPhase, bp.DistributedMergePhase)
 		}
-		t.Logf("checkpoint contains %d SST manifests", len(bp.SSTManifests))
+		t.Logf("checkpoint contains %d SST manifests, phase=%d", len(bp.SSTManifests), bp.DistributedMergePhase)
 		return nil
 	}, 5*time.Second)
 }

--- a/pkg/sql/schemachanger/scdeps/BUILD.bazel
+++ b/pkg/sql/schemachanger/scdeps/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scdeps",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/cloud",
         "//pkg/config/zonepb",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
@@ -22,6 +23,7 @@ go_library(
         "//pkg/server/telemetry",
         "//pkg/settings",
         "//pkg/settings/cluster",
+        "//pkg/sql/bulkutil",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/catalogkeys",
         "//pkg/sql/catalog/catpb",
@@ -48,6 +50,7 @@ go_library(
         "//pkg/sql/stats",
         "//pkg/sql/types",
         "//pkg/util/admission/admissionpb",
+        "//pkg/util/log",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/uuid",

--- a/pkg/sql/schemachanger/scexec/backfiller/BUILD.bazel
+++ b/pkg/sql/schemachanger/scexec/backfiller/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "backfiller",
     srcs = [
+        "cleanup.go",
         "periodic_progress_flusher.go",
         "progress.go",
         "tracker.go",
@@ -16,6 +17,7 @@ go_library(
         "//pkg/roachpb",
         "//pkg/settings/cluster",
         "//pkg/sql/backfill",
+        "//pkg/sql/bulkutil",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/isql",
         "//pkg/sql/schemachanger/scexec",
@@ -31,6 +33,7 @@ go_library(
 go_test(
     name = "backfiller_test",
     srcs = [
+        "cleanup_test.go",
         "periodic_progress_flusher_test.go",
         "progress_test.go",
         "tracker_test.go",

--- a/pkg/sql/schemachanger/scexec/backfiller/cleanup.go
+++ b/pkg/sql/schemachanger/scexec/backfiller/cleanup.go
@@ -1,0 +1,64 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package backfiller
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/sql/bulkutil"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
+)
+
+// jobSubdirectoryCleaner defines the interface for cleaning up SST subdirectories.
+// It is satisfied by *bulkutil.BulkJobCleaner.
+type jobSubdirectoryCleaner interface {
+	CleanupJobSubdirectory(
+		ctx context.Context, jobID jobspb.JobID, storagePrefixes []string, subdirectory string,
+	) error
+}
+
+// phaseTransition represents a detected phase change in the distributed merge
+// pipeline after checkpoint persistence.
+type phaseTransition struct {
+	TableID            descpb.ID
+	OldPhase           int32
+	NewPhase           int32
+	SSTStoragePrefixes []string
+}
+
+// phaseTransitionCleaner orchestrates SST cleanup for phase transitions.
+type phaseTransitionCleaner struct {
+	jobID   jobspb.JobID
+	cleaner jobSubdirectoryCleaner
+}
+
+// cleanupTransition performs SST cleanup for a single phase transition.
+func (c *phaseTransitionCleaner) cleanupTransition(
+	ctx context.Context, transition phaseTransition,
+) error {
+	log.Dev.Infof(ctx, "triggering SST cleanup for job %d, table %d after phase %d→%d transition",
+		c.jobID, transition.TableID, transition.OldPhase, transition.NewPhase)
+
+	// Determine which subdirectory to clean up based on completed phase:
+	// - newPhase=1: cleanup map/ (map phase output, input to iteration 1)
+	// - newPhase=2: cleanup merge/iter-1/ (iteration 1 output, input to iteration 2)
+	subdirectory := bulkutil.NewDistMergePaths(c.jobID).InputSubdir(int(transition.NewPhase))
+
+	if len(transition.SSTStoragePrefixes) == 0 {
+		log.Dev.Infof(ctx, "no storage prefixes found, skipping cleanup")
+		return nil
+	}
+
+	if err := c.cleaner.CleanupJobSubdirectory(ctx, c.jobID, transition.SSTStoragePrefixes, subdirectory); err != nil {
+		return errors.Wrapf(err, "cleaning up subdirectory %s", subdirectory)
+	}
+
+	log.Dev.Infof(ctx, "successfully cleaned up SSTs in %s", subdirectory)
+	return nil
+}

--- a/pkg/sql/schemachanger/scexec/backfiller/cleanup_test.go
+++ b/pkg/sql/schemachanger/scexec/backfiller/cleanup_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package backfiller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPhaseTransitionCleaner verifies that phase transitions trigger cleanup
+// of the correct subdirectories based on the completed phase.
+func TestPhaseTransitionCleaner(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	const testJobID = jobspb.JobID(12345)
+	testStoragePrefixes := []string{"nodelocal://1/", "nodelocal://2/"}
+
+	tests := []struct {
+		name              string
+		transition        phaseTransition
+		expectedSubdir    string
+		shouldCallCleanup bool
+	}{
+		{
+			name: "phase 0→1 transition cleans map/",
+			transition: phaseTransition{
+				TableID:            descpb.ID(1),
+				OldPhase:           0,
+				NewPhase:           1,
+				SSTStoragePrefixes: testStoragePrefixes,
+			},
+			expectedSubdir:    "map/",
+			shouldCallCleanup: true,
+		},
+		{
+			name: "phase 1→2 transition cleans merge/iter-1/",
+			transition: phaseTransition{
+				TableID:            descpb.ID(1),
+				OldPhase:           1,
+				NewPhase:           2,
+				SSTStoragePrefixes: testStoragePrefixes,
+			},
+			expectedSubdir:    "merge/iter-1/",
+			shouldCallCleanup: true,
+		},
+		{
+			name: "empty storage prefixes skips cleanup",
+			transition: phaseTransition{
+				TableID:            descpb.ID(1),
+				OldPhase:           0,
+				NewPhase:           1,
+				SSTStoragePrefixes: nil,
+			},
+			expectedSubdir:    "",
+			shouldCallCleanup: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			mockCleaner := &mockBulkJobCleaner{}
+			cleaner := &phaseTransitionCleaner{
+				jobID:   testJobID,
+				cleaner: mockCleaner,
+			}
+
+			err := cleaner.cleanupTransition(ctx, tc.transition)
+			require.NoError(t, err)
+
+			if tc.shouldCallCleanup {
+				require.Equal(t, 1, mockCleaner.cleanupCallCount)
+				require.Equal(t, testJobID, mockCleaner.lastJobID)
+				require.Equal(t, testStoragePrefixes, mockCleaner.lastStoragePrefixes)
+				require.Equal(t, tc.expectedSubdir, mockCleaner.lastSubdirectory)
+			} else {
+				require.Equal(t, 0, mockCleaner.cleanupCallCount)
+			}
+		})
+	}
+}
+
+// mockBulkJobCleaner is a test double that tracks calls to CleanupJobSubdirectory.
+type mockBulkJobCleaner struct {
+	cleanupCallCount    int
+	lastJobID           jobspb.JobID
+	lastStoragePrefixes []string
+	lastSubdirectory    string
+}
+
+// CleanupJobSubdirectory records the call parameters for verification.
+func (m *mockBulkJobCleaner) CleanupJobSubdirectory(
+	_ context.Context, jobID jobspb.JobID, storagePrefixes []string, subdirectory string,
+) error {
+	m.cleanupCallCount++
+	m.lastJobID = jobID
+	m.lastStoragePrefixes = storagePrefixes
+	m.lastSubdirectory = subdirectory
+	return nil
+}

--- a/pkg/sql/schemachanger/scexec/backfiller/progress.go
+++ b/pkg/sql/schemachanger/scexec/backfiller/progress.go
@@ -157,8 +157,9 @@ func newBackfillProgress(codec keys.SQLCodec, bp scexec.BackfillProgress) *backf
 		EndKey: indexPrefix.PrefixEnd(),
 	}
 	return &backfillProgress{
-		BackfillProgress: bp,
-		totalSpan:        indexSpan,
+		BackfillProgress:                   bp,
+		totalSpan:                          indexSpan,
+		lastPersistedDistributedMergePhase: bp.DistributedMergePhase,
 	}
 }
 
@@ -181,6 +182,12 @@ type backfillProgress struct {
 	// totalSpan represents the complete span of the source index being
 	// backfilled.
 	totalSpan roachpb.Span
+
+	// lastPersistedDistributedMergePhase tracks the last successfully persisted
+	// DistributedMergePhase value. Used to detect when phase transitions have
+	// been committed to the database. This enables lazy cleanup of SST files from
+	// previous phases.
+	lastPersistedDistributedMergePhase int32
 }
 
 func (p backfillProgress) matches(bf scexec.Backfill) error {

--- a/pkg/sql/schemachanger/scjob/job.go
+++ b/pkg/sql/schemachanger/scjob/job.go
@@ -150,6 +150,7 @@ func (n *newSchemaChangeResumer) run(ctx context.Context, execCtxI interface{}) 
 		payload.Statement,
 		execCtx.SessionData(),
 		execCtx.ExtendedEvalContext().Tracing.KVTracingEnabled(),
+		execCfg.DistSQLSrv.ExternalStorageFromURI,
 	)
 
 	// If there are no descriptors left, then we can short circuit here.


### PR DESCRIPTION
Previously, distributed merge checkpoint progress updates had a race with SST cleanup. SetBackfillProgress only updates in-memory state; a background goroutine persists the checkpoint to disk at regular intervals. However, SST cleanup was triggered immediately after calling SetBackfillProgress, before the updated checkpoint was durably written. This could result in temporary SSTs being removed too early if a distributed merge phase transition occurred before the checkpoint hit disk.

This change moves SST cleanup into the backfill progress tracker and performs it lazily. Cleanup now runs only after the checkpoint has been persisted and a distributed merge phase transition has completed. This ensures that old temporary SSTs are removed only once the corresponding progress is durable, eliminating the race.

Fixes #162330
Fixes #163264
Epic: CRDB-48845

Release note: None