### PR TITLE
workload/schemachange: handle FK dependency error for DROP CONSTRAINT

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -2018,6 +2018,10 @@ func (og *operationGenerator) dropConstraint(ctx context.Context, tx pgx.Tx) (*o
 		}
 		if !og.useDeclarativeSchemaChanger || uniqueDropNotSupported {
 			stmt.expectedExecErrors.add(pgcode.FeatureNotSupported)
+		} else {
+			// The unique constraint may be referenced by a foreign key from
+			// another table, which would cause the drop to fail.
+			stmt.potentialExecErrors.add(pgcode.DependentObjectsStillExist)
 		}
 	}
 


### PR DESCRIPTION
When dropping a unique constraint that is referenced by a foreign key
from another table, the operation fails with pgcode
DependentObjectsStillExist (2BP01). This was not accounted for in the
random schema change workload, causing unexpected test failures.

Add DependentObjectsStillExist as a potential execution error for the
DROP CONSTRAINT operation when the constraint is a unique constraint
and the drop is supported (declarative schema changer on v26.2+).

Resolves: #163310
Resolves: #163539
Resolves: #163535
Resolves: #163323

Release note: None