### PR TITLE
kv: fix follower lease extensions in stasis

### DIFF
--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -1203,6 +1203,7 @@ func (rp *replicaProposer) verifyLeaseRequestSafetyRLocked(
 	r := (*Replica)(rp)
 	st := r.leaseSettings(ctx)
 	raftStatus := raftGroup.Status()
+	leaseStatus := r.leaseStatusAtRLocked(ctx, r.Clock().NowAsClockTimestamp())
 	in := leases.VerifyInput{
 		LocalStoreID:       r.StoreID(),
 		LocalReplicaID:     r.ReplicaID(),
@@ -1210,7 +1211,7 @@ func (rp *replicaProposer) verifyLeaseRequestSafetyRLocked(
 		RaftStatus:         &raftStatus,
 		RaftCompacted:      r.raftCompactedIndexRLocked(),
 		PrevLease:          prevLease,
-		PrevLeaseExpired:   !r.ownsValidLeaseRLocked(ctx, r.Clock().NowAsClockTimestamp()),
+		PrevLeaseExpired:   leaseStatus.IsExpired() || !leaseStatus.OwnedBy(r.StoreID()),
 		NextLeaseHolder:    nextLease.Replica,
 		BypassSafetyChecks: bypassSafetyChecks,
 		DesiredLeaseType:   r.desiredLeaseType(r.descRLocked()),


### PR DESCRIPTION
The proposal-buffer lease safety check used:

    PrevLeaseExpired = !ownsValidLeaseRLocked(now)

This is wrong for stasis (UNUSABLE) leases. ownsValidLeaseRLocked only treats VALID as valid, so an owned lease in stasis was incorrectly labeled as “expired”. That caused leases.Verify to route a lease extension through acquisition checks (verifyExtension -> verifyAcquisition), where follower proposals are rejected with NotLeaseHolderError.

In practice, this breaks a legitimate case: a leaseholder in stasis must renew its own lease even if Raft leadership has not yet moved to it.

Fixes #163750

Release note: None