### PR TITLE
db-console: Convert Cluster Views

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/clusterOverview/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/clusterOverview/index.tsx
@@ -7,7 +7,7 @@ import { util } from "@cockroachlabs/cluster-ui";
 import { Skeleton } from "antd";
 import classNames from "classnames";
 import { format } from "d3-format";
-import React from "react";
+import React, { useEffect } from "react";
 import { Helmet } from "react-helmet";
 import { connect } from "react-redux";
 import { createSelector } from "reselect";
@@ -262,40 +262,37 @@ interface ClusterSummaryActionsProps {
 type ClusterSummaryProps = ClusterSummaryStateProps &
   ClusterSummaryActionsProps;
 
-class ClusterSummary extends React.Component<ClusterSummaryProps, {}> {
-  componentDidMount() {
-    this.refresh();
-  }
+function ClusterSummary({
+  capacityUsage,
+  nodeLiveness,
+  replicationStatus,
+  loading,
+  refreshLiveness: refreshLivenessAction,
+  refreshNodes: refreshNodesAction,
+}: ClusterSummaryProps): React.ReactElement {
+  useEffect(() => {
+    refreshLivenessAction();
+    refreshNodesAction();
+  });
 
-  componentDidUpdate() {
-    this.refresh();
-  }
+  const children = [
+    ...renderCapacityUsage(capacityUsage),
+    ...renderNodeLiveness(nodeLiveness),
+    ...renderReplicationStatus(replicationStatus),
+  ];
 
-  refresh() {
-    this.props.refreshLiveness();
-    this.props.refreshNodes();
-  }
-
-  render() {
-    const children = [
-      ...renderCapacityUsage(this.props.capacityUsage),
-      ...renderNodeLiveness(this.props.nodeLiveness),
-      ...renderReplicationStatus(this.props.replicationStatus),
-    ];
-
-    return (
-      <section className="cluster-summary">
-        <Skeleton
-          loading={this.props.loading}
-          active
-          // This styling is necessary because this section is a grid.
-          style={{ gridColumn: "1 / span all" }}
-        >
-          {React.Children.toArray(children)}
-        </Skeleton>
-      </section>
-    );
-  }
+  return (
+    <section className="cluster-summary">
+      <Skeleton
+        loading={loading}
+        active
+        // This styling is necessary because this section is a grid.
+        style={{ gridColumn: "1 / span all" }}
+      >
+        {React.Children.toArray(children)}
+      </Skeleton>
+    </section>
+  );
 }
 
 function mapStateToClusterSummaryProps(state: AdminUIState) {
@@ -320,20 +317,18 @@ const ClusterSummaryConnected = connect(
 /**
  * Renders the main content of the cluster visualization page.
  */
-export default class ClusterOverview extends React.Component<any, any> {
-  render() {
-    return (
-      <div className="cluster-page">
-        <Helmet title="Cluster Overview" />
-        <EmailSubscription />
-        <OverviewListAlerts />
-        <section className="section cluster-overview">
-          <ClusterSummaryConnected />
-        </section>
-        <section className="cluster-overview--fixed">
-          {this.props.children}
-        </section>
-      </div>
-    );
-  }
+export default function ClusterOverview({
+  children,
+}: React.PropsWithChildren<{}>): React.ReactElement {
+  return (
+    <div className="cluster-page">
+      <Helmet title="Cluster Overview" />
+      <EmailSubscription />
+      <OverviewListAlerts />
+      <section className="section cluster-overview">
+        <ClusterSummaryConnected />
+      </section>
+      <section className="cluster-overview--fixed">{children}</section>
+    </div>
+  );
 }

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/events/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/events/index.tsx
@@ -140,21 +140,23 @@ export interface EventPageProps {
   timezone: string;
 }
 
-export class EventPageUnconnected extends React.Component<EventPageProps, {}> {
-  componentDidMount() {
-    // Refresh events when mounting.
-    this.props.refreshEvents();
-  }
+export function EventPageUnconnected({
+  events,
+  refreshEvents: refreshEventsAction,
+  sortSetting,
+  setSort,
+  lastError,
+  maxSizeApiReached,
+  timezone,
+}: EventPageProps): React.ReactElement {
+  useEffect(() => {
+    // Refresh events when mounting and when props change.
+    refreshEventsAction();
+  });
 
-  componentDidUpdate() {
-    // Refresh events when props change.
-    this.props.refreshEvents();
-  }
-
-  renderContent() {
-    const { events, sortSetting, maxSizeApiReached } = this.props;
+  const renderContent = () => {
     const simplifiedEvents = map(events, event => {
-      return getEventInfo(event, this.props.timezone);
+      return getEventInfo(event, timezone);
     });
 
     return (
@@ -163,9 +165,7 @@ export class EventPageUnconnected extends React.Component<EventPageProps, {}> {
           <EventSortedTable
             data={simplifiedEvents}
             sortSetting={sortSetting}
-            onChangeSortSetting={(setting: SortSetting) =>
-              this.props.setSort(setting)
-            }
+            onChangeSortSetting={(setting: SortSetting) => setSort(setting)}
             columns={[
               {
                 title: "Event",
@@ -194,27 +194,24 @@ export class EventPageUnconnected extends React.Component<EventPageProps, {}> {
         )}
       </>
     );
-  }
+  };
 
-  render() {
-    const { events, lastError } = this.props;
-    return (
-      <div>
-        <Helmet title="Events" />
-        <section className="section section--heading">
-          <h1 className="base-heading">Events</h1>
-        </section>
-        <section className="section">
-          <Loading
-            loading={!events}
-            page={"events"}
-            error={lastError}
-            render={this.renderContent.bind(this)}
-          />
-        </section>
-      </div>
-    );
-  }
+  return (
+    <div>
+      <Helmet title="Events" />
+      <section className="section section--heading">
+        <h1 className="base-heading">Events</h1>
+      </section>
+      <section className="section">
+        <Loading
+          loading={!events}
+          page={"events"}
+          error={lastError}
+          render={renderContent}
+        />
+      </section>
+    </div>
+  );
 }
 
 // Connect the EventsList class with our redux store.

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/events/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/events/index.tsx
@@ -16,7 +16,7 @@ import { InlineAlert } from "@cockroachlabs/ui-components";
 import map from "lodash/map";
 import take from "lodash/take";
 import moment from "moment-timezone";
-import React, { useContext } from "react";
+import React, { useContext, useEffect } from "react";
 import { Helmet } from "react-helmet";
 import { connect } from "react-redux";
 import { Link, RouteComponentProps, withRouter } from "react-router-dom";
@@ -97,39 +97,34 @@ export interface EventBoxProps {
   refreshEvents: typeof refreshEvents;
 }
 
-export class EventBoxUnconnected extends React.Component<EventBoxProps, {}> {
-  componentDidMount() {
-    // Refresh events when mounting.
-    this.props.refreshEvents();
-  }
+export function EventBoxUnconnected({
+  events,
+  refreshEvents: refreshEventsAction,
+}: EventBoxProps): React.ReactElement {
+  useEffect(() => {
+    // Refresh events when mounting and when props change.
+    refreshEventsAction();
+  });
 
-  componentDidUpdate() {
-    // Refresh events when props change.
-    this.props.refreshEvents();
-  }
-
-  render() {
-    const events = this.props.events;
-    return (
-      <div className="events">
-        <table>
-          <tbody>
-            {map(
-              take(events, EVENT_BOX_NUM_EVENTS),
-              (e: clusterUiApi.EventColumns, i: number) => {
-                return <EventRow event={e} key={i} />;
-              },
-            )}
-            <tr>
-              <td className="events__more-link" colSpan={2}>
-                <Link to="/events">View all events</Link>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    );
-  }
+  return (
+    <div className="events">
+      <table>
+        <tbody>
+          {map(
+            take(events, EVENT_BOX_NUM_EVENTS),
+            (e: clusterUiApi.EventColumns, i: number) => {
+              return <EventRow event={e} key={i} />;
+            },
+          )}
+          <tr>
+            <td className="events__more-link" colSpan={2}>
+              <Link to="/events">View all events</Link>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
 }
 
 export interface EventPageProps {

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodesOverview/index.tsx
@@ -240,215 +240,218 @@ const formatWithPossibleStaleIndicator = (
  * both healthy and suspect nodes. Included is a side-bar with summary
  * statistics for these nodes.
  */
-export class NodeList extends React.Component<LiveNodeListProps> {
-  readonly columns: ColumnsConfig<NodeStatusRow> = [
-    {
-      key: "region",
-      title: "nodes",
-      render: (_text: string, record: NodeStatusRow) => {
-        if (record.nodeId) {
-          return <NodeNameColumn record={record} />;
-        } else {
-          return <NodeLocalityColumn record={record} />;
-        }
-      },
-      sorter: (a: NodeStatusRow, b: NodeStatusRow) => {
-        if (!isUndefined(a.nodeId) && !isUndefined(b.nodeId)) {
-          // If nodeId is defined but regionId is not, this means that there is only
-          // a single region. In this case, sort the by nodeId.
-          if (isUndefined(a.region) && isUndefined(b.region)) {
-            return a.nodeId - b.nodeId;
-          }
-          return 0;
-        }
-        if (a.region < b.region) {
-          return -1;
-        }
-        if (a.region > b.region) {
-          return 1;
+
+const nodeListColumns: ColumnsConfig<NodeStatusRow> = [
+  {
+    key: "region",
+    title: "nodes",
+    render: (_text: string, record: NodeStatusRow) => {
+      if (record.nodeId) {
+        return <NodeNameColumn record={record} />;
+      } else {
+        return <NodeLocalityColumn record={record} />;
+      }
+    },
+    sorter: (a: NodeStatusRow, b: NodeStatusRow) => {
+      if (!isUndefined(a.nodeId) && !isUndefined(b.nodeId)) {
+        // If nodeId is defined but regionId is not, this means that there is only
+        // a single region. In this case, sort the by nodeId.
+        if (isUndefined(a.region) && isUndefined(b.region)) {
+          return a.nodeId - b.nodeId;
         }
         return 0;
-      },
-      className: "column--border-right",
-      width: "20%",
+      }
+      if (a.region < b.region) {
+        return -1;
+      }
+      if (a.region > b.region) {
+        return 1;
+      }
+      return 0;
     },
-    {
-      key: "nodesCount",
-      title: <NodeCountTooltip>Node Count</NodeCountTooltip>,
-      sorter: (a: NodeStatusRow, b: NodeStatusRow) => {
-        if (isUndefined(a.nodesCount) || isUndefined(b.nodesCount)) {
-          return 0;
-        }
-        return a.nodesCount - b.nodesCount;
-      },
-      render: (_text: string, record: NodeStatusRow) => record.nodesCount,
-      sortDirections: ["ascend", "descend"],
-      className: "column--align-right",
-      width: "10%",
+    className: "column--border-right",
+    width: "20%",
+  },
+  {
+    key: "nodesCount",
+    title: <NodeCountTooltip>Node Count</NodeCountTooltip>,
+    sorter: (a: NodeStatusRow, b: NodeStatusRow) => {
+      if (isUndefined(a.nodesCount) || isUndefined(b.nodesCount)) {
+        return 0;
+      }
+      return a.nodesCount - b.nodesCount;
     },
-    {
-      key: "uptime",
-      dataIndex: "uptime",
-      render: formatWithPossibleStaleIndicator,
-      title: <UptimeTooltip>Uptime</UptimeTooltip>,
-      sorter: false,
-      className: "column--align-right",
-      width: "10%",
-      ellipsis: true,
-    },
-    {
-      key: "replicas",
-      dataIndex: "replicas",
-      render: formatWithPossibleStaleIndicator,
-      title: <ReplicasTooltip>Replicas</ReplicasTooltip>,
-      sorter: (a: NodeStatusRow, b: NodeStatusRow) => a.replicas - b.replicas,
-      className: "column--align-right",
-      width: "10%",
-    },
-    {
-      key: "capacityUsage",
-      title: (
-        <NodelistCapacityUsageTooltip>
-          Capacity Usage
-        </NodelistCapacityUsageTooltip>
+    render: (_text: string, record: NodeStatusRow) => record.nodesCount,
+    sortDirections: ["ascend", "descend"],
+    className: "column--align-right",
+    width: "10%",
+  },
+  {
+    key: "uptime",
+    dataIndex: "uptime",
+    render: formatWithPossibleStaleIndicator,
+    title: <UptimeTooltip>Uptime</UptimeTooltip>,
+    sorter: false,
+    className: "column--align-right",
+    width: "10%",
+    ellipsis: true,
+  },
+  {
+    key: "replicas",
+    dataIndex: "replicas",
+    render: formatWithPossibleStaleIndicator,
+    title: <ReplicasTooltip>Replicas</ReplicasTooltip>,
+    sorter: (a: NodeStatusRow, b: NodeStatusRow) => a.replicas - b.replicas,
+    className: "column--align-right",
+    width: "10%",
+  },
+  {
+    key: "capacityUsage",
+    title: (
+      <NodelistCapacityUsageTooltip>
+        Capacity Usage
+      </NodelistCapacityUsageTooltip>
+    ),
+    render: (_text: string, record: NodeStatusRow) =>
+      formatWithPossibleStaleIndicator(
+        util.Percentage(record.usedCapacity, record.availableCapacity),
+        record,
       ),
-      render: (_text: string, record: NodeStatusRow) =>
-        formatWithPossibleStaleIndicator(
-          util.Percentage(record.usedCapacity, record.availableCapacity),
-          record,
-        ),
-      sorter: (a: NodeStatusRow, b: NodeStatusRow) =>
-        a.usedCapacity / a.availableCapacity -
-        b.usedCapacity / b.availableCapacity,
-      className: "column--align-right",
-      width: "10%",
-    },
-    {
-      key: "memoryUse",
-      title: <MemoryUseTooltip>Memory Use</MemoryUseTooltip>,
-      render: (_text: string, record: NodeStatusRow) =>
-        formatWithPossibleStaleIndicator(
-          util.Percentage(record.usedMemory, record.availableMemory),
-          record,
-        ),
-      sorter: (a: NodeStatusRow, b: NodeStatusRow) =>
-        a.usedMemory / a.availableMemory - b.usedMemory / b.availableMemory,
-      className: "column--align-right",
-      width: "10%",
-    },
-    {
-      key: "vCpus",
-      title: <CPUsTooltip>vCPUs</CPUsTooltip>,
-      dataIndex: "numVcpus",
-      sorter: (a: NodeStatusRow, b: NodeStatusRow) => a.numVcpus - b.numVcpus,
-      className: "column--align-right",
-      width: "8%",
-    },
-    {
-      key: "version",
-      dataIndex: "version",
-      title: <VersionTooltip>Version</VersionTooltip>,
-      sorter: false,
-      width: "8%",
-      ellipsis: true,
-    },
-    {
-      key: "status",
-      title: <StatusTooltip>Status</StatusTooltip>,
-      render: (_text: string, record: NodeStatusRow) => {
-        let badgeText: string;
-        let tooltipText: string | JSX.Element;
-        let nodeTooltip: string | JSX.Element;
+    sorter: (a: NodeStatusRow, b: NodeStatusRow) =>
+      a.usedCapacity / a.availableCapacity -
+      b.usedCapacity / b.availableCapacity,
+    className: "column--align-right",
+    width: "10%",
+  },
+  {
+    key: "memoryUse",
+    title: <MemoryUseTooltip>Memory Use</MemoryUseTooltip>,
+    render: (_text: string, record: NodeStatusRow) =>
+      formatWithPossibleStaleIndicator(
+        util.Percentage(record.usedMemory, record.availableMemory),
+        record,
+      ),
+    sorter: (a: NodeStatusRow, b: NodeStatusRow) =>
+      a.usedMemory / a.availableMemory - b.usedMemory / b.availableMemory,
+    className: "column--align-right",
+    width: "10%",
+  },
+  {
+    key: "vCpus",
+    title: <CPUsTooltip>vCPUs</CPUsTooltip>,
+    dataIndex: "numVcpus",
+    sorter: (a: NodeStatusRow, b: NodeStatusRow) => a.numVcpus - b.numVcpus,
+    className: "column--align-right",
+    width: "8%",
+  },
+  {
+    key: "version",
+    dataIndex: "version",
+    title: <VersionTooltip>Version</VersionTooltip>,
+    sorter: false,
+    width: "8%",
+    ellipsis: true,
+  },
+  {
+    key: "status",
+    title: <StatusTooltip>Status</StatusTooltip>,
+    render: (_text: string, record: NodeStatusRow) => {
+      let badgeText: string;
+      let tooltipText: string | JSX.Element;
+      let nodeTooltip: string | JSX.Element;
 
-        // single node row
-        const badgeType = getBadgeTypeByNodeStatus(record.status);
-        switch (record.status) {
-          case AggregatedNodeStatus.DEAD:
-            badgeText = "warning";
-            tooltipText = getStatusDescription(LivenessStatus.NODE_STATUS_DEAD);
-            nodeTooltip = getNodeStatusDescription(record.status);
-            break;
-          case AggregatedNodeStatus.LIVE:
-          case AggregatedNodeStatus.WARNING:
-            badgeText = AggregatedNodeStatus[record.status];
-            nodeTooltip = getNodeStatusDescription(record.status);
-            break;
-          case LivenessStatus.NODE_STATUS_UNKNOWN:
-          case LivenessStatus.NODE_STATUS_UNAVAILABLE:
-            badgeText = "suspect";
-            tooltipText = getStatusDescription(record.status);
-            break;
-          default:
-            badgeText = getLivenessStatusName(record.status);
-            tooltipText = getStatusDescription(record.status);
-            break;
-        }
+      // single node row
+      const badgeType = getBadgeTypeByNodeStatus(record.status);
+      switch (record.status) {
+        case AggregatedNodeStatus.DEAD:
+          badgeText = "warning";
+          tooltipText = getStatusDescription(LivenessStatus.NODE_STATUS_DEAD);
+          nodeTooltip = getNodeStatusDescription(record.status);
+          break;
+        case AggregatedNodeStatus.LIVE:
+        case AggregatedNodeStatus.WARNING:
+          badgeText = AggregatedNodeStatus[record.status];
+          nodeTooltip = getNodeStatusDescription(record.status);
+          break;
+        case LivenessStatus.NODE_STATUS_UNKNOWN:
+        case LivenessStatus.NODE_STATUS_UNAVAILABLE:
+          badgeText = "suspect";
+          tooltipText = getStatusDescription(record.status);
+          break;
+        default:
+          badgeText = getLivenessStatusName(record.status);
+          tooltipText = getStatusDescription(record.status);
+          break;
+      }
 
-        // if aggregated row
-        if (!record.nodeId) {
-          return (
-            <Tooltip title={nodeTooltip}>
-              {""}
-              <Badge status={badgeType} text={badgeText} />
-            </Tooltip>
-          );
-        }
-
+      // if aggregated row
+      if (!record.nodeId) {
         return (
-          <Badge
-            status={badgeType}
-            text={<Tooltip title={tooltipText}>{badgeText}</Tooltip>}
-          />
+          <Tooltip title={nodeTooltip}>
+            {""}
+            <Badge status={badgeType} text={badgeText} />
+          </Tooltip>
         );
-      },
-      sorter: (a: NodeStatusRow, b: NodeStatusRow) => a.status - b.status,
-      width: "13%",
-    },
-    {
-      key: "logs",
-      title: <span />,
-      render: (_text: string, record: NodeStatusRow) =>
-        record.nodeId && (
-          <div className="cell--show-on-hover ">
-            <Link
-              className="nodes-table__link"
-              to={`/node/${record.nodeId}/logs`}
-            >
-              Logs
-            </Link>
-          </div>
-        ),
-      width: "5%",
-    },
-  ];
+      }
 
-  render() {
-    const { nodesCount, regionsCount } = this.props;
-    let columns = this.columns;
-    let dataSource = this.props.dataSource;
+      return (
+        <Badge
+          status={badgeType}
+          text={<Tooltip title={tooltipText}>{badgeText}</Tooltip>}
+        />
+      );
+    },
+    sorter: (a: NodeStatusRow, b: NodeStatusRow) => a.status - b.status,
+    width: "13%",
+  },
+  {
+    key: "logs",
+    title: <span />,
+    render: (_text: string, record: NodeStatusRow) =>
+      record.nodeId && (
+        <div className="cell--show-on-hover ">
+          <Link
+            className="nodes-table__link"
+            to={`/node/${record.nodeId}/logs`}
+          >
+            Logs
+          </Link>
+        </div>
+      ),
+    width: "5%",
+  },
+];
 
-    // Remove "Nodes Count" column If nodes are not partitioned by regions,
-    if (regionsCount === 1) {
-      columns = columns.filter(column => column.key !== "nodesCount");
-      dataSource = head(dataSource).children;
-    }
-    return (
-      <div className="nodes-overview__panel">
-        <TableSection
-          id={`nodes-overview__live-nodes`}
-          title={`Nodes (${nodesCount})`}
-          className="embedded-table"
-        >
-          <Table
-            dataSource={dataSource}
-            columns={columns}
-            tableLayout="fixed"
-            className="nodes-overview__live-nodes-table"
-          />
-        </TableSection>
-      </div>
-    );
+export function NodeList({
+  dataSource,
+  nodesCount,
+  regionsCount,
+}: LiveNodeListProps): React.ReactElement {
+  let columns = nodeListColumns;
+  let adjustedDataSource = dataSource;
+
+  // Remove "Nodes Count" column if nodes are not partitioned by regions.
+  if (regionsCount === 1) {
+    columns = nodeListColumns.filter(column => column.key !== "nodesCount");
+    adjustedDataSource = head(dataSource).children;
   }
+
+  return (
+    <div className="nodes-overview__panel">
+      <TableSection
+        id={`nodes-overview__live-nodes`}
+        title={`Nodes (${nodesCount})`}
+        className="embedded-table"
+      >
+        <Table
+          dataSource={adjustedDataSource}
+          columns={columns}
+          tableLayout="fixed"
+          className="nodes-overview__live-nodes-table"
+        />
+      </TableSection>
+    </div>
+  );
 }
 
 /**


### PR DESCRIPTION
This PR aims to convert the following cluster view class components to functional style

These conversions are more straight-forward compared to others.

Convert the following class components to functional style:
 - clusterOverview: ClusterSummary componentDidMount + componentDidUpdate → useEffect,
    ClusterOverview render-only with PropsWithChildren.
 - eventBox: componentDidMount + componentDidUpdate → useEffect.
 - nodeLogs: componentDidMount → mount-only useEffect with proper dependency array.
 - nodesOverview: DecommissionedNodeList render-only, destructure props.
    NodesMain componentDidMount + componentDidUpdate → useEffect.
 - tableSection: useState for collapse toggle, useRef to avoid stale closure in
    unmount cleanup, defaultProps → default params.
 - dataDistribution: renderZoneConfigs() inlined, getCellValue method → local function.
    DataDistributionPage: componentDidMount + componentDidUpdate → useEffect.
 - eventPage: componentDidMount + componentDidUpdate → useEffect,
    renderContent method → local function.
 - nodeOverview: componentDidMount + componentDidUpdate → useEffect,
    prevPage method → inline arrow.
 - nodesOverview (NodeList): columns hoisted to module-level const to avoid
    re-creation on every render.

Existing Enzyme tests converted to RTL for events and nodesOverview.
The changes were manually smoke tested

Epic: CRDB-58145
Release Note: None