### PR TITLE
changefeedccl: deflake TestAlterChangefeedAddTargetsDuringSchemaChangeError

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -351,6 +351,7 @@ go_test(
         "//pkg/util/encoding",
         "//pkg/util/grpcutil",
         "//pkg/util/hlc",
+        "//pkg/util/interval",
         "//pkg/util/intsets",
         "//pkg/util/ioctx",
         "//pkg/util/json",


### PR DESCRIPTION
There was a bug in TestAlterChangefeedAddTargetsDuringSchemaChangeError. It was trying to filter spans that cover the entire index, but it was using the index id from the original index, not the index id from the rewritten index. The only reason the test used to pass most of the time is one of the partial spans would trigger a checkpoint flush before the full index span was observed.

Fixes: #163294
Release note: None