### PR TITLE
WIP on pausable portals exec monitor

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -2810,8 +2810,8 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 	pausablePortalInfo := getPausablePortalInfo(planner)
 	if pausablePortalInfo != nil {
 		// This is ugly, but we need to override the execMon to the specific one
-		// owned by the pausable portals.
-		planner.execMon = ex.ppExecMon
+		// owned by the pausable portal.
+		planner.execMon = pausablePortalInfo.execMon
 	} else {
 		// Guarantee that we use the global execMon in case we had some pausable
 		// portal executions in between.


### PR DESCRIPTION
`./dev test pkg/sql/pgwire -f=TestPGTest/portal -v --stream-output` fails with

```
panic: found 2 short-living non-stopped monitors in txn
	txn 0 B
	    exec-pausable-portal 0 B
	    exec-pausable-portal 0 B
	 [recovered]
	panic: found 2 short-living non-stopped monitors in txn
	txn 0 B
	    exec-pausable-portal 0 B
	    exec-pausable-portal 0 B

goroutine 5027 [running]:
github.com/cockroachdb/cockroach/pkg/util/mon.(*BytesMonitor).doStop(0x14003731810, {0x10c0909d0, 0x14005c0cdc0}, 0x0)
	pkg/util/mon/bytes_usage.go:781 +0x544
github.com/cockroachdb/cockroach/pkg/util/mon.(*BytesMonitor).EmergencyStop(...)
	pkg/util/mon/bytes_usage.go:717
github.com/cockroachdb/cockroach/pkg/sql.(*connExecutor).close(0x1400560e508, {0x10c0909d0, 0x14005c0cdc0}, 0x1)
	pkg/sql/conn_executor.go:1498 +0x5cc
github.com/cockroachdb/cockroach/pkg/sql.(*connExecutor).closeWrapper(0x1400560e508, {0x10c0909d0, 0x14005c0cdc0}, {0x10b8c4d60?, 0x140023cab60?})
	pkg/sql/conn_executor.go:1386 +0x124
github.com/cockroachdb/cockroach/pkg/sql.(*Server).ServeConn.func1({0x10c0909d0, 0x14005c0cdc0}, {0x140036c12c0?})
	pkg/sql/conn_executor.go:1098 +0x48
panic({0x10b8c4d60?, 0x140023cab60?})
	GOROOT/src/runtime/panic.go:783 +0x120
github.com/cockroachdb/cockroach/pkg/util/mon.(*BytesMonitor).doStop(0x14003731810, {0x10c08f1c0, 0x14005d320f0}, 0x1)
	pkg/util/mon/bytes_usage.go:781 +0x544
github.com/cockroachdb/cockroach/pkg/util/mon.(*BytesMonitor).Stop(...)
	pkg/util/mon/bytes_usage.go:722
github.com/cockroachdb/cockroach/pkg/sql.(*txnState).finishSQLTxn(0x1400560e5d8)
	pkg/sql/txn_state.go:321 +0x38
github.com/cockroachdb/cockroach/pkg/sql.(*txnState).finishTxn(0x1400560e5d8, 0x2, 0x2)
	pkg/sql/conn_fsm.go:625 +0x2c
github.com/cockroachdb/cockroach/pkg/sql.init.func340({{0x10c08f1c0, 0x14005d320f0}, {0x10c027fc0, 0x14002c03a60}, {0x10bceca20, 0x1400560e5d8}, {0x10c028000, 0x110bce680}, {0x0, 0x0}})
	pkg/sql/conn_fsm.go:315 +0x50
github.com/cockroachdb/cockroach/pkg/util/fsm.Transitions.apply({0x0?}, {{0x10c08f1c0, 0x14005d320f0}, {0x10c027fc0, 0x14002c03a60}, {0x10bceca20, 0x1400560e5d8}, {0x10c028000, 0x110bce680}, {0x0, ...}})
	pkg/util/fsm/fsm.go:101 +0xc0
github.com/cockroachdb/cockroach/pkg/util/fsm.(*Machine).ApplyWithPayload(...)
	pkg/util/fsm/fsm.go:130
github.com/cockroachdb/cockroach/pkg/sql.(*connExecutor).txnStateTransitionsApplyWrapper.func1(0x1400560e508, {0x10c028000, 0x110bce680}, {0x0, 0x0})
	pkg/sql/conn_executor.go:4103 +0x12c
github.com/cockroachdb/cockroach/pkg/sql.(*connExecutor).txnStateTransitionsApplyWrapper(0x1400560e508, {0x10c028000?, 0x110bce680?}, {0x0, 0x0}, {0x13d822000, 0x14005323f60}, 0x10c08f1c0?)
	pkg/sql/conn_executor.go:4104 +0xa8
github.com/cockroachdb/cockroach/pkg/sql.(*connExecutor).execCmd(0x1400560e508)
	pkg/sql/conn_executor.go:2680 +0xb08
github.com/cockroachdb/cockroach/pkg/sql.(*connExecutor).run(0x1400560e508, {0x10c0909d0, 0x14005c0cdc0}, 0x30000007d?, 0x140074f1c78?, 0x1400162ab60?)
	pkg/sql/conn_executor.go:2342 +0x158
github.com/cockroachdb/cockroach/pkg/sql.(*Server).ServeConn(0x1400529a0e0?, {0x10c0909d0?, 0x14005c0cdc0?}, {0x140030deaa0?}, 0x2?, 0x0?)
	pkg/sql/conn_executor.go:1100 +0xa0
github.com/cockroachdb/cockroach/pkg/sql/pgwire.(*conn).processCommands(0x14005323808, {0x10c0909d0, 0x14005c0cdc0}, {0x1, 0x2, {0x1, {0x109bb625d, 0x3}, {0x1400295b490, 0xf}, ...}, ...}, ...)
	pkg/sql/pgwire/conn.go:253 +0x304
github.com/cockroachdb/cockroach/pkg/sql/pgwire.(*Server).serveImpl.func4()
	pkg/sql/pgwire/server.go:1260 +0xa4
created by github.com/cockroachdb/cockroach/pkg/sql/pgwire.(*Server).serveImpl in goroutine 4897
	pkg/sql/pgwire/server.go:1257 +0x424
```

suggesting that we attempt to finish the txn _before_ closing all the portals.

Epic: None
Release note: None