### PR TITLE
kvfollowerreadsccl: fix TestFollowerReadsWithStaleDescriptor with DRPC

### DIFF
--- a/pkg/kv/kvtestutils/test_utils.go
+++ b/pkg/kv/kvtestutils/test_utils.go
@@ -20,7 +20,8 @@ import (
 func OnlyFollowerReads(rec tracingpb.Recording) bool {
 	foundFollowerRead := false
 	for _, sp := range rec {
-		if sp.Operation != "/cockroach.roachpb.Internal/Batch" {
+		if sp.Operation != "/cockroach.roachpb.Internal/Batch" &&
+			sp.Operation != "/cockroach.roachpb.KVBatch/Batch" {
 			continue
 		}
 		anonTagGroup := sp.FindTagGroup(tracingpb.AnonymousTagGroupName)


### PR DESCRIPTION
In 964c33961315bc70f20b54381cf6fb56cb4e46c2 the name of the span for a BatchRequest under DRPC was changed. This test searches the trace to make its assertion, using that changed name.

Fixes #163763
Release note: None