### PR TITLE
release-26.1: backup: remove TestBackupSharedProcessTenantNodeDown

### DIFF
--- a/pkg/backup/BUILD.bazel
+++ b/pkg/backup/BUILD.bazel
@@ -294,7 +294,6 @@ go_test(
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sqlclustersettings",
-        "//pkg/sql/sqlliveness/slbase",
         "//pkg/sql/sqltestutils",
         "//pkg/sql/stats",
         "//pkg/storage",

--- a/pkg/backup/backup_tenant_test.go
+++ b/pkg/backup/backup_tenant_test.go
@@ -9,19 +9,16 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/multiregionccl/multiregionccltestutils"
 	_ "github.com/cockroachdb/cockroach/pkg/cloud/impl" // register cloud storage providers
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
-	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilitiespb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	_ "github.com/cockroachdb/cockroach/pkg/sql/importer"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlclustersettings"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness/slbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -30,77 +27,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
-
-func TestBackupSharedProcessTenantNodeDown(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	ctx := context.Background()
-
-	skip.UnderRace(t, "multi-node, multi-tenant test too slow under race")
-	skip.UnderDeadlock(t, "too slow under deadlock detector")
-	params := base.TestClusterArgs{
-		ServerArgs: base.TestServerArgs{
-			DefaultTestTenant: base.TestControlsTenantsExplicitly,
-		},
-	}
-	params.ServerArgs.Knobs.JobsTestingKnobs = jobs.NewTestingKnobsWithShortIntervals()
-	tc, hostDB, _, cleanup := backupRestoreTestSetupWithParams(t, multiNode, 0, /* numAccounts */
-		InitManualReplication, params)
-	defer cleanup()
-
-	hostDB.Exec(t, "ALTER TENANT ALL SET CLUSTER SETTING server.sqlliveness.ttl='2s'")
-	hostDB.Exec(t, "ALTER TENANT ALL SET CLUSTER SETTING server.sqlliveness.heartbeat='250ms'")
-
-	testTenantID := roachpb.MustMakeTenantID(11)
-	tenantApp, tenantDB, err := tc.Server(0).TenantController().StartSharedProcessTenant(ctx,
-		base.TestSharedProcessTenantArgs{
-			TenantID:   testTenantID,
-			TenantName: "test",
-		})
-	require.NoError(t, err)
-
-	tc.GrantTenantCapabilities(
-		ctx, t, testTenantID,
-		map[tenantcapabilitiespb.ID]string{tenantcapabilitiespb.CanUseNodelocalStorage: "true"})
-
-	tenantSQL := sqlutils.MakeSQLRunner(tenantDB)
-	tenantSQL.Exec(t, "CREATE TABLE foo AS SELECT generate_series(1, 4000)")
-	tenantSQL.Exec(t, "ALTER TABLE foo SPLIT AT VALUES (500), (1000), (1500), (2000), (2500), (3000)")
-	tenantSQL.Exec(t, "ALTER TABLE foo SCATTER")
-
-	t.Log("waiting for SQL instances")
-	waitStart := timeutil.Now()
-	for i := 1; i < multiNode; i++ {
-		testutils.SucceedsSoon(t, func() error {
-			t.Logf("waiting for server %d", i)
-			db, err := tc.Server(i).SystemLayer().SQLConnE(serverutils.DBName("cluster:test/defaultdb"))
-			if err != nil {
-				return err
-			}
-			return db.Ping()
-		})
-	}
-	t.Logf("all SQL instances (took %s)", timeutil.Since(waitStart))
-
-	// Shut down a node.
-	t.Log("shutting down server 2 (n3)")
-	tc.StopServer(2)
-
-	// We use succeeds soon here since it still takes some time
-	// for instance-based planning to recognize the downed node.
-	sv := &tenantApp.ClusterSettings().SV
-	padding := 10 * time.Second
-	timeout := slbase.DefaultTTL.Get(sv) + slbase.DefaultHeartBeat.Get(sv) + padding
-	testutils.SucceedsWithin(t, func() error {
-		_, err := tenantDB.Exec("BACKUP INTO 'nodelocal://1/worker-failure'")
-		return err
-	}, timeout)
-}
 
 func TestBackupTenantImportingTable(t *testing.T) {
 	defer leaktest.AfterTest(t)()


### PR DESCRIPTION
Backport 1/1 commits from #159006 on behalf of @kev-cao.

----

This test is flaky and superfluous as our mixed version roachtests already test backup with offline nodes.

Fixes: #158654

Release note: None

----

Release justification: