### PR TITLE
release-24.3: logictest: reduce pg_sleep duration in cursor statement timeout test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cursor
+++ b/pkg/sql/logictest/testdata/logic_test/cursor
@@ -693,7 +693,7 @@ COMMIT
 
 # Regression test for statement timeouts during DECLARE CURSOR.
 # We set timeout to 1s so that DECLARE CURSOR can execute, then sleep
-# 0.5s each to make up 1s and attempt to fetch.
+# 0.3s each to make up 0.6s and attempt to fetch.
 # Setting the timeout to 0.001ms means DECLARE CURSOR times out thus
 # voiding the test.
 statement ok
@@ -704,7 +704,7 @@ DECLARE a CURSOR FOR SELECT * FROM ( VALUES (1), (2) ) t(id);
 
 # Note we can't set pg_sleep to 1 or else it'll statement timeout!
 statement ok
-select pg_sleep(0.7)
+select pg_sleep(0.3)
 
 query I
 FETCH 1 FROM a
@@ -712,7 +712,7 @@ FETCH 1 FROM a
 1
 
 statement ok
-select pg_sleep(0.7)
+select pg_sleep(0.3)
 
 query I
 FETCH 1 FROM a


### PR DESCRIPTION
Backport 1/1 commits from #163806 on behalf of @rafiss.

----

The cursor regression test for statement timeouts used pg_sleep(0.7) with a 1s statement_timeout, leaving only 0.3s of headroom. Under CI load, the overhead could push execution past 1s, triggering a statement timeout that aborts the transaction. The retry directive then repeatedly retries pg_sleep in the aborted transaction, getting 25P02 every time until the retry timeout expires.

Reduce pg_sleep to 0.3s, giving 0.7s of headroom per call.

Fixes: #163398

Release note: None

----

Release justification: