### PR TITLE
rpc, server: add drpc client and server interceptor metrics

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -8049,15 +8049,31 @@ layers:
       aggregation: AVG
       derivative: NONE
       owner: cockroachdb/kv
+    - name: rpc.drpc.enabled
+      exported_name: rpc_drpc_enabled
+      description: 1 if this node is using DRPC for internode RPC, 0 otherwise.
+      y_axis_label: Enabled
+      type: GAUGE
+      unit: CONST
+      aggregation: AVG
+      derivative: NONE
     - name: rpc.server.request.duration.nanos
       exported_name: rpc_server_request_duration_nanos
-      description: Duration of an RPC request in nanoseconds.
+      description: Duration of an RPC request at the server in nanoseconds.
       y_axis_label: Duration
       type: HISTOGRAM
       unit: NANOSECONDS
       aggregation: AVG
       derivative: NONE
       owner: cockroachdb/kv
+    - name: rpc.server.requests.total
+      exported_name: rpc_server_requests_total
+      description: Total number of RPCs requests received by the server.
+      y_axis_label: Requests
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
     - name: schedules.BACKUP.last-completed-time-by-virtual_cluster
       exported_name: schedules_BACKUP_last_completed_time_by_virtual_cluster
       description: The unix timestamp of the most recently completed host scheduled backup by virtual cluster specified as maintaining this metric

--- a/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
+++ b/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
@@ -2216,6 +2216,7 @@ rpc_connection_tcp_rtt: rpc.connection.tcp_rtt
 rpc_connection_tcp_rtt_var: rpc.connection.tcp_rtt_var
 rpc_connection_unhealthy: rpc.connection.unhealthy
 rpc_connection_unhealthy_nanos: rpc.connection.unhealthy_nanos
+rpc_drpc_enabled: rpc.drpc.enabled
 rpc_method_addsstable_recv: rpc.method.addsstable.recv
 rpc_method_adminchangereplicas_recv: rpc.method.adminchangereplicas.recv
 rpc_method_adminmerge_recv: rpc.method.adminmerge.recv
@@ -2271,6 +2272,7 @@ rpc_server_request_duration_nanos: rpc.server.request.duration.nanos
 rpc_server_request_duration_nanos_bucket: rpc.server.request.duration.nanos.bucket
 rpc_server_request_duration_nanos_count: rpc.server.request.duration.nanos.count
 rpc_server_request_duration_nanos_sum: rpc.server.request.duration.nanos.sum
+rpc_server_requests_total: rpc.server.requests.total
 rpc_streams_mux_rangefeed_active: rpc.streams.mux_rangefeed.active
 rpc_streams_mux_rangefeed_recv: rpc.streams.mux_rangefeed.recv
 rpc_streams_rangefeed_active: rpc.streams.rangefeed.active

--- a/pkg/rpc/BUILD.bazel
+++ b/pkg/rpc/BUILD.bazel
@@ -183,6 +183,7 @@ go_test(
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@io_storj_drpc//:drpc",
+        "@io_storj_drpc//drpcclient",
         "@io_storj_drpc//drpcctx",
         "@io_storj_drpc//drpcmux",
         "@io_storj_drpc//drpcserver",

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -592,6 +592,18 @@ func NewContext(ctx context.Context, opts ContextOptions) *Context {
 		metrics:         newMetrics(opts.Locality),
 	}
 
+	if opts.UseDRPC {
+		if !opts.ClientOnly {
+			rpcCtx.metrics.DRPCEnabled.Update(1)
+		}
+		clientRequestMetrics := NewClientRequestMetrics()
+		rpcCtx.metrics.clientRequestMetrics = clientRequestMetrics
+		rpcCtx.clientUnaryInterceptorsDRPC = append(rpcCtx.clientUnaryInterceptorsDRPC,
+			NewDRPCUnaryClientRequestMetricsInterceptor(clientRequestMetrics))
+		rpcCtx.clientStreamInterceptorsDRPC = append(rpcCtx.clientStreamInterceptorsDRPC,
+			NewDRPCStreamClientRequestMetricsInterceptor(clientRequestMetrics))
+	}
+
 	rpcCtx.dialbackMu.Lock()
 	rpcCtx.dialbackMu.m = map[roachpb.NodeID]*GRPCConnection{}
 	rpcCtx.dialbackMu.Unlock()
@@ -686,6 +698,11 @@ func (rpcCtx *Context) ClusterName() string {
 // Metrics returns the Context's Metrics struct.
 func (rpcCtx *Context) Metrics() *Metrics {
 	return rpcCtx.metrics
+}
+
+// Metrics returns the Context's ClientRequestMetrics struct.
+func (rpcCtx *Context) ClientRequestMetrics() *ClientRequestMetrics {
+	return rpcCtx.metrics.clientRequestMetrics
 }
 
 // GetLocalInternalClientForAddr returns the context's internal batch client

--- a/pkg/rpc/drpc.go
+++ b/pkg/rpc/drpc.go
@@ -125,6 +125,7 @@ func (rpcCtx *Context) drpcDialOptsCommon(
 			unaryInterceptors = append(unaryInterceptors, interceptor)
 		}
 	}
+
 	drpcDialOpts = append(drpcDialOpts, drpcclient.WithChainUnaryInterceptor(unaryInterceptors...))
 
 	streamInterceptors := rpcCtx.clientStreamInterceptorsDRPC
@@ -337,8 +338,13 @@ func NewDRPCServer(_ context.Context, rpcCtx *Context, opts ...ServerOption) (DR
 
 	// If the metrics interceptor is set, it should be registered second so
 	// that all other interceptors are included in the response time durations.
-	if o.drpcRequestMetricsInterceptor != nil {
-		unaryInterceptors = append(unaryInterceptors, drpcmux.UnaryServerInterceptor(o.drpcRequestMetricsInterceptor))
+	if o.drpcUnaryRequestMetricsInterceptor != nil {
+		unaryInterceptors = append(unaryInterceptors,
+			drpcmux.UnaryServerInterceptor(o.drpcUnaryRequestMetricsInterceptor))
+	}
+	if o.drpcStreamRequestMetricsInterceptor != nil {
+		streamInterceptors = append(streamInterceptors,
+			drpcmux.StreamServerInterceptor(o.drpcStreamRequestMetricsInterceptor))
 	}
 
 	if !rpcCtx.ContextOptions.Insecure {

--- a/pkg/rpc/metrics.go
+++ b/pkg/rpc/metrics.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/VividCortex/ewma"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -208,12 +209,39 @@ over this connection.
 		Help:        `Counter of TCP bytes received via gRPC on connections we initiated.`,
 		Measurement: "Bytes",
 	}
-	metaRequestDuration = metric.Metadata{
+	metaServerRequestDuration = metric.Metadata{
 		Name:        "rpc.server.request.duration.nanos",
-		Help:        "Duration of an RPC request in nanoseconds.",
+		Help:        "Duration of an RPC request at the server in nanoseconds.",
 		Measurement: "Duration",
 		Unit:        metric.Unit_NANOSECONDS,
 		MetricType:  prometheusgo.MetricType_HISTOGRAM,
+	}
+	metaServerRequestsTotal = metric.Metadata{
+		Name:        "rpc.server.requests.total",
+		Help:        "Total number of RPCs requests received by the server.",
+		Measurement: "Requests",
+		Unit:        metric.Unit_COUNT,
+		MetricType:  prometheusgo.MetricType_COUNTER,
+	}
+	metaClientRequestsTotal = metric.Metadata{
+		Name:        "rpc.client.requests.total",
+		Help:        "Total number of RPC requests sent by the client.",
+		Measurement: "Requests",
+		Unit:        metric.Unit_COUNT,
+		MetricType:  prometheusgo.MetricType_COUNTER,
+	}
+	metaClientRequestDuration = metric.Metadata{
+		Name:        "rpc.client.request.duration.nanos",
+		Help:        "Duration of a RPC request at the client in nanoseconds.",
+		Measurement: "Duration",
+		Unit:        metric.Unit_NANOSECONDS,
+		MetricType:  prometheusgo.MetricType_HISTOGRAM,
+	}
+	metaDRPCEnabled = metric.Metadata{
+		Name:        "rpc.drpc.enabled",
+		Help:        "1 if this node is using DRPC for internode RPC, 0 otherwise.",
+		Measurement: "Enabled",
+		Unit:        metric.Unit_CONST,
 	}
 )
 
@@ -271,6 +299,7 @@ func newMetrics(locality roachpb.Locality) *Metrics {
 		ConnectionAvgRoundTripLatency: aggmetric.NewGauge(metaConnectionAvgRoundTripLatency, childLabels...),
 		ConnectionTCPRTT:              aggmetric.NewGauge(metaConnectionTCPRTT, childLabels...),
 		ConnectionTCPRTTVar:           aggmetric.NewGauge(metaConnectionTCPRTTVar, childLabels...),
+		DRPCEnabled:                   metric.NewGauge(metaDRPCEnabled),
 	}
 	m.mu.peerMetrics = make(map[string]peerMetrics)
 	m.mu.localityMetrics = make(map[string]localityMetrics)
@@ -317,6 +346,8 @@ type Metrics struct {
 	ConnectionAvgRoundTripLatency *aggmetric.AggGauge
 	ConnectionTCPRTT              *aggmetric.AggGauge
 	ConnectionTCPRTTVar           *aggmetric.AggGauge
+	DRPCEnabled                   *metric.Gauge
+	clientRequestMetrics          *ClientRequestMetrics
 	mu                            struct {
 		syncutil.Mutex
 		// peerMetrics is a map of peerKey to peerMetrics.
@@ -435,37 +466,51 @@ func (m *Metrics) acquire(
 }
 
 const (
-	RpcMethodLabel     = "methodName"
-	RpcStatusCodeLabel = "statusCode"
-	RpcProtocolLabel   = "protocol"
+	// RPC method label
+	RPCMethodLabel     = "methodName"
+	RPCStatusCodeLabel = "statusCode"
+	RPCState           = "state"
+
+	RPCStateStarted   = "started"
+	RPCStateCompleted = "completed"
 
 	rpcProtocolGRPC = "grpc"
 	rpcProtocolDRPC = "drpc"
 )
 
-// RequestMetrics contains metrics for RPC requests.
-type RequestMetrics struct {
-	Duration *metric.HistogramVec
+// ServerRequestMetrics contains server metrics for both gRPC and DRPC requests.
+type ServerRequestMetrics struct {
+	RequestsTotal   *metric.CounterVec
+	RequestDuration *metric.HistogramVec
 }
 
-func NewRequestMetrics() *RequestMetrics {
-	return &RequestMetrics{
-		Duration: metric.NewExportedHistogramVec(
-			metaRequestDuration,
-			metric.ResponseTime30sBuckets,
-			[]string{RpcMethodLabel, RpcStatusCodeLabel, RpcProtocolLabel}),
-	}
+func (m *ServerRequestMetrics) recordMetricsPreCall(rpc string) time.Time {
+	startTime := timeutil.Now()
+	m.RequestsTotal.Inc(map[string]string{
+		RPCMethodLabel: rpc, RPCState: RPCStateStarted,
+	}, 1)
+	return startTime
+}
+
+func (m *ServerRequestMetrics) recordMetricsPostCall(rpc string, err error, startTime time.Time) {
+	errString := drpcCodeString(err)
+	m.RequestsTotal.Inc(map[string]string{
+		RPCMethodLabel: rpc, RPCState: RPCStateCompleted,
+		RPCStatusCodeLabel: errString,
+	}, 1)
+	m.RequestDuration.Observe(map[string]string{
+		RPCMethodLabel: rpc, RPCStatusCodeLabel: errString,
+	}, float64(timeutil.Since(startTime).Nanoseconds()))
 }
 
 type RequestMetricsInterceptor grpc.UnaryServerInterceptor
-type DRPCRequestMetricsInterceptor drpcmux.UnaryServerInterceptor
 
 // NewRequestMetricsInterceptor creates a new gRPC server interceptor that records
 // the duration of each RPC. The metric is labeled by the method name and the
 // status code of the RPC. The interceptor will only record durations if
 // shouldRecord returns true. Otherwise, this interceptor will be a no-op.
 func NewRequestMetricsInterceptor(
-	requestMetrics *RequestMetrics, shouldRecord func(fullMethodName string) bool,
+	requestMetrics *ServerRequestMetrics, shouldRecord func(fullMethodName string) bool,
 ) RequestMetricsInterceptor {
 	return func(
 		ctx context.Context,
@@ -487,48 +532,166 @@ func NewRequestMetricsInterceptor(
 			code = codes.OK
 		}
 
-		requestMetrics.Duration.Observe(map[string]string{
-			RpcMethodLabel:     info.FullMethod,
-			RpcStatusCodeLabel: code.String(),
-			RpcProtocolLabel:   rpcProtocolGRPC,
+		// We record only the request duration metric for gRPC.
+		requestMetrics.RequestDuration.Observe(map[string]string{
+			RPCMethodLabel:     info.FullMethod,
+			RPCStatusCodeLabel: code.String(),
 		}, float64(duration.Nanoseconds()))
 		return resp, err
 	}
 }
 
-// NewDRPCRequestMetricsInterceptor creates a new DRPC server interceptor that records
-// the duration of each RPC. The metric is labeled by the method name and the
-// status code of the RPC. The interceptor will only record durations if
-// shouldRecord returns true. Otherwise, this interceptor will be a no-op.
-func NewDRPCRequestMetricsInterceptor(
-	requestMetrics *RequestMetrics, shouldRecord func(rpc string) bool,
-) DRPCRequestMetricsInterceptor {
+func drpcCodeString(err error) string {
+	return status.Code(err).String()
+}
+
+func NewServerRequestMetrics() *ServerRequestMetrics {
+	return &ServerRequestMetrics{
+		RequestsTotal: metric.NewExportedCounterVec(
+			metaServerRequestsTotal,
+			[]string{RPCMethodLabel, RPCState, RPCStatusCodeLabel}),
+		RequestDuration: metric.NewExportedHistogramVec(
+			metaServerRequestDuration,
+			metric.ResponseTime30sBuckets,
+			[]string{RPCMethodLabel, RPCStatusCodeLabel}),
+	}
+}
+
+// DRPCUnaryServerRequestMetricsInterceptor is a DRPC unary server interceptor
+// that records request metrics.
+type DRPCUnaryServerRequestMetricsInterceptor drpcmux.UnaryServerInterceptor
+
+// DRPCStreamServerRequestMetricsInterceptor is a DRPC streaming server
+// interceptor that records request metrics.
+type DRPCStreamServerRequestMetricsInterceptor drpcmux.StreamServerInterceptor
+
+// NewDRPCUnaryServerRequestMetricsInterceptor creates a new DRPC server interceptor
+// that records server request metrics for each unary RPC.
+// The metric is labeled by the method name and the status code of the RPC.
+// The interceptor will only record durations if shouldRecord returns true.
+// Otherwise, this interceptor will be a no-op.
+func NewDRPCUnaryServerRequestMetricsInterceptor(
+	serverMetrics *ServerRequestMetrics, shouldRecord func(rpc string) bool,
+) DRPCUnaryServerRequestMetricsInterceptor {
 	return func(
 		ctx context.Context,
 		req any,
 		rpc string,
 		handler drpcmux.UnaryHandler,
-	) (any, error) {
+	) (resp any, err error) {
 		if !shouldRecord(rpc) {
 			return handler(ctx, req)
 		}
-		startTime := timeutil.Now()
-		resp, err := handler(ctx, req)
-		duration := timeutil.Since(startTime)
-		var code codes.Code
-		if err != nil {
-			// TODO(server): use drpc status code
-			code = status.Code(err)
-		} else {
-			code = codes.OK
-		}
-
-		requestMetrics.Duration.Observe(map[string]string{
-			RpcMethodLabel:     rpc,
-			RpcStatusCodeLabel: code.String(),
-			RpcProtocolLabel:   rpcProtocolDRPC,
-		}, float64(duration.Nanoseconds()))
+		startTime := serverMetrics.recordMetricsPreCall(rpc)
+		defer func() { serverMetrics.recordMetricsPostCall(rpc, err, startTime) }()
+		resp, err = handler(ctx, req)
 		return resp, err
+	}
+}
+
+// NewDRPCStreamServerRequestMetricsInterceptor creates a new DRPC server
+// interceptor that records server request metrics for each streaming RPC.
+// The metric is labeled by the method name and the status code of the RPC.
+// The interceptor will only record durations if shouldRecord returns true.
+// Otherwise, this interceptor will be a no-op.
+func NewDRPCStreamServerRequestMetricsInterceptor(
+	serverMetrics *ServerRequestMetrics, shouldRecord func(rpc string) bool,
+) DRPCStreamServerRequestMetricsInterceptor {
+	return func(
+		stream drpc.Stream,
+		rpc string,
+		handler drpcmux.StreamHandler,
+	) (resp interface{}, err error) {
+		if !shouldRecord(rpc) {
+			return handler(stream)
+		}
+		startTime := serverMetrics.recordMetricsPreCall(rpc)
+		defer func() { serverMetrics.recordMetricsPostCall(rpc, err, startTime) }()
+		resp, err = handler(stream)
+		return resp, err
+	}
+}
+
+type ClientRequestMetrics struct {
+	RequestsTotal   *metric.CounterVec
+	RequestDuration *metric.HistogramVec
+}
+
+func (m *ClientRequestMetrics) recordMetricsPreCall(rpc string) time.Time {
+	startTime := timeutil.Now()
+	m.RequestsTotal.Inc(map[string]string{
+		RPCMethodLabel: rpc, RPCState: RPCStateStarted,
+	}, 1)
+	return startTime
+}
+
+func (m *ClientRequestMetrics) recordMetricsPostCall(rpc string, err error, startTime time.Time) {
+	errString := drpcCodeString(err)
+	m.RequestsTotal.Inc(map[string]string{
+		RPCMethodLabel: rpc, RPCState: RPCStateCompleted,
+		RPCStatusCodeLabel: errString,
+	}, 1)
+	m.RequestDuration.Observe(map[string]string{
+		RPCMethodLabel: rpc, RPCStatusCodeLabel: errString,
+	}, float64(timeutil.Since(startTime).Nanoseconds()))
+}
+
+func NewClientRequestMetrics() *ClientRequestMetrics {
+	return &ClientRequestMetrics{
+		RequestsTotal: metric.NewExportedCounterVec(
+			metaClientRequestsTotal,
+			[]string{RPCMethodLabel, RPCState, RPCStatusCodeLabel}),
+		RequestDuration: metric.NewExportedHistogramVec(
+			metaClientRequestDuration,
+			metric.ResponseTime30sBuckets,
+			[]string{RPCMethodLabel, RPCStatusCodeLabel}),
+	}
+}
+
+// TODO: use to filter out apis we don't want to record metrics for.
+func shouldRecordClientMetrics(rpc string) bool {
+	return true
+}
+
+// NewDRPCUnaryClientRequestMetricsInterceptor reports unary DRPC client metrics.
+func NewDRPCUnaryClientRequestMetricsInterceptor(
+	clientMetrics *ClientRequestMetrics,
+) drpcclient.UnaryClientInterceptor {
+	return func(
+		ctx context.Context,
+		rpc string,
+		enc drpc.Encoding,
+		in, out drpc.Message,
+		cc *drpcclient.ClientConn,
+		invoker drpcclient.UnaryInvoker,
+	) (err error) {
+		if !shouldRecordClientMetrics(rpc) {
+			return invoker(ctx, rpc, enc, in, out, cc)
+		}
+		startTime := clientMetrics.recordMetricsPreCall(rpc)
+		defer func() { clientMetrics.recordMetricsPostCall(rpc, err, startTime) }()
+		return invoker(ctx, rpc, enc, in, out, cc)
+	}
+}
+
+// NewDRPCStreamClientRequestMetricsInterceptor reports streaming DRPC client metrics.
+func NewDRPCStreamClientRequestMetricsInterceptor(
+	clientMetrics *ClientRequestMetrics,
+) drpcclient.StreamClientInterceptor {
+	return func(
+		ctx context.Context,
+		rpc string,
+		enc drpc.Encoding,
+		cc *drpcclient.ClientConn,
+		streamer drpcclient.Streamer,
+	) (str drpc.Stream, err error) {
+		if !shouldRecordClientMetrics(rpc) {
+			return streamer(ctx, rpc, enc, cc)
+		}
+		startTime := clientMetrics.recordMetricsPreCall(rpc)
+		defer func() { clientMetrics.recordMetricsPostCall(rpc, err, startTime) }()
+		str, err = streamer(ctx, rpc, enc, cc)
+		return str, err
 	}
 }
 

--- a/pkg/rpc/metrics_test.go
+++ b/pkg/rpc/metrics_test.go
@@ -23,6 +23,8 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+	"storj.io/drpc"
+	"storj.io/drpc/drpcclient"
 )
 
 // TestMetricsRelease verifies that peerMetrics.release() removes tracking for
@@ -98,11 +100,60 @@ func TestMetricsRelease(t *testing.T) {
 	require.Equal(t, lm, lm5)
 }
 
+func TestDRPCServerRequestInterceptor(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	req := struct{}{}
+
+	testcase := []struct {
+		service      string
+		methodName   string
+		statusCode   codes.Code
+		shouldRecord bool
+	}{
+		{"testservice", "rpc/test/method", codes.OK, true},
+		{"testservice", "rpc/test/method", codes.Internal, true},
+		{"testservice", "rpc/test/method", codes.Aborted, true},
+		{"testservice", "rpc/test/notRecorded", codes.OK, false},
+	}
+
+	for _, tc := range testcase {
+		t.Run(fmt.Sprintf("%s %s", tc.methodName, tc.statusCode),
+			func(t *testing.T) {
+				requestMetrics := NewServerRequestMetrics()
+				rpc := "/" + tc.service + "/" + tc.methodName
+				handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+					if tc.statusCode == codes.OK {
+						time.Sleep(time.Millisecond)
+						return struct{}{}, nil
+					}
+					return nil, status.Error(tc.statusCode, tc.statusCode.String())
+				}
+				interceptor := NewDRPCUnaryServerRequestMetricsInterceptor(requestMetrics, func(fullMethodName string) bool {
+					return tc.shouldRecord
+				})
+				_, err := interceptor(ctx, req, rpc, handler)
+				if err != nil {
+					require.Equal(t, tc.statusCode, status.Code(err))
+				}
+				var expectedCount uint64
+				if tc.shouldRecord {
+					expectedCount = 1
+				}
+				assertRpcMetrics(t, requestMetrics.RequestDuration.ToPrometheusMetrics(), map[string]uint64{
+					fmt.Sprintf("%s %s", rpc, tc.statusCode): expectedCount,
+				})
+			})
+	}
+}
+
 func TestServerRequestInstrumentInterceptor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	requestMetrics := NewRequestMetrics()
+	requestMetrics := NewServerRequestMetrics()
 
 	ctx := context.Background()
 	req := struct{}{}
@@ -110,17 +161,16 @@ func TestServerRequestInstrumentInterceptor(t *testing.T) {
 	testcase := []struct {
 		methodName   string
 		statusCode   codes.Code
-		rpcProtocol  string
 		shouldRecord bool
 	}{
-		{"rpc/test/method", codes.OK, rpcProtocolGRPC, true},
-		{"rpc/test/method", codes.Internal, rpcProtocolGRPC, true},
-		{"rpc/test/method", codes.Aborted, rpcProtocolGRPC, true},
-		{"rpc/test/notRecorded", codes.OK, rpcProtocolGRPC, false},
+		{"rpc/test/method", codes.OK, true},
+		{"rpc/test/method", codes.Internal, true},
+		{"rpc/test/method", codes.Aborted, true},
+		{"rpc/test/notRecorded", codes.OK, false},
 	}
 
 	for _, tc := range testcase {
-		t.Run(fmt.Sprintf("%s %s %s", tc.methodName, tc.statusCode, tc.rpcProtocol),
+		t.Run(fmt.Sprintf("%s %s", tc.methodName, tc.statusCode),
 			func(t *testing.T) {
 				info := &grpc.UnaryServerInfo{FullMethod: tc.methodName}
 				handler := func(ctx context.Context, req interface{}) (interface{}, error) {
@@ -141,10 +191,10 @@ func TestServerRequestInstrumentInterceptor(t *testing.T) {
 				if tc.shouldRecord {
 					expectedCount = 1
 				}
-				assertRpcMetrics(t, requestMetrics.Duration.ToPrometheusMetrics(), map[string]uint64{
-					fmt.Sprintf("%s %s %s", tc.methodName, tc.statusCode,
-						tc.rpcProtocol): expectedCount,
-				})
+				assertRpcMetrics(t, requestMetrics.RequestDuration.ToPrometheusMetrics(),
+					map[string]uint64{
+						fmt.Sprintf("%s %s", tc.methodName, tc.statusCode): expectedCount,
+					})
 			})
 	}
 }
@@ -217,26 +267,155 @@ func TestGatewayRequestRecoveryInterceptor(t *testing.T) {
 	})
 }
 
+func TestDRPCServerUnaryInterceptorAllMetrics(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	requestMetrics := NewServerRequestMetrics()
+
+	ctx := context.Background()
+	req := struct{}{}
+
+	rpc := "/testservice/TestMethod"
+	interceptor := NewDRPCUnaryServerRequestMetricsInterceptor(
+		requestMetrics, func(string) bool { return true })
+
+	// Successful call.
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		time.Sleep(time.Millisecond)
+		return struct{}{}, nil
+	}
+	_, err := interceptor(ctx, req, rpc, handler)
+	require.NoError(t, err)
+
+	startedLabels := map[string]string{
+		RPCMethodLabel: rpc,
+		RPCState:       "started",
+	}
+	codeLabelsOK := map[string]string{
+		RPCMethodLabel:     rpc,
+		RPCState:           "completed",
+		RPCStatusCodeLabel: "OK",
+	}
+
+	// RequestsTotal with state="started" tracks started requests.
+	require.Equal(t, int64(1), requestMetrics.RequestsTotal.Count(startedLabels))
+	// RequestsTotal with state="completed" tracks completed requests.
+	require.Equal(t, int64(1), requestMetrics.RequestsTotal.Count(codeLabelsOK))
+
+	// Error call.
+	errHandler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return nil, status.Error(codes.Internal, "internal error")
+	}
+	_, err = interceptor(ctx, req, rpc, errHandler)
+	require.Error(t, err)
+
+	codeLabelsInternal := map[string]string{
+		RPCMethodLabel:     rpc,
+		RPCState:           "completed",
+		RPCStatusCodeLabel: "Internal",
+	}
+
+	// Two RPCs started total.
+	require.Equal(t, int64(2), requestMetrics.RequestsTotal.Count(startedLabels))
+	// One completed with OK, one with Internal.
+	require.Equal(t, int64(1), requestMetrics.RequestsTotal.Count(codeLabelsOK))
+	require.Equal(t, int64(1), requestMetrics.RequestsTotal.Count(codeLabelsInternal))
+}
+
+// mockDRPCStream is a minimal drpc.Stream implementation for testing.
+type mockDRPCStream struct {
+	ctx     context.Context
+	sendErr error
+	recvErr error
+}
+
+var _ drpc.Stream = (*mockDRPCStream)(nil)
+
+func (s *mockDRPCStream) Context() context.Context                  { return s.ctx }
+func (s *mockDRPCStream) Kind() drpc.StreamKind                     { return drpc.StreamKindUnknown }
+func (s *mockDRPCStream) MsgSend(drpc.Message, drpc.Encoding) error { return s.sendErr }
+func (s *mockDRPCStream) MsgRecv(drpc.Message, drpc.Encoding) error { return s.recvErr }
+func (s *mockDRPCStream) CloseSend() error                          { return nil }
+func (s *mockDRPCStream) Close() error                              { return nil }
+
+func TestDRPCStreamServerRequestInterceptor(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	requestMetrics := NewServerRequestMetrics()
+
+	rpc := "/testservice/StreamMethod"
+	interceptor := NewDRPCStreamServerRequestMetricsInterceptor(
+		requestMetrics, func(string) bool { return true })
+
+	startedLabels := map[string]string{
+		RPCMethodLabel: rpc,
+		RPCState:       "started",
+	}
+
+	// Successful stream call.
+	stream := &mockDRPCStream{ctx: context.Background()}
+	_, err := interceptor(stream, rpc, func(s drpc.Stream) (interface{}, error) {
+		return "ok", nil
+	})
+	require.NoError(t, err)
+
+	codeLabelsOK := map[string]string{
+		RPCMethodLabel:     rpc,
+		RPCState:           "completed",
+		RPCStatusCodeLabel: "OK",
+	}
+
+	require.Equal(t, int64(1), requestMetrics.RequestsTotal.Count(startedLabels))
+	require.Equal(t, int64(1), requestMetrics.RequestsTotal.Count(codeLabelsOK))
+
+	// Error stream call.
+	stream2 := &mockDRPCStream{ctx: context.Background()}
+	_, err = interceptor(stream2, rpc, func(s drpc.Stream) (interface{}, error) {
+		return nil, status.Error(codes.Unavailable, "unavailable")
+	})
+	require.Error(t, err)
+
+	codeLabelsUnavailable := map[string]string{
+		RPCMethodLabel:     rpc,
+		RPCState:           "completed",
+		RPCStatusCodeLabel: "Unavailable",
+	}
+
+	require.Equal(t, int64(2), requestMetrics.RequestsTotal.Count(startedLabels))
+	require.Equal(t, int64(1), requestMetrics.RequestsTotal.Count(codeLabelsUnavailable))
+
+	// shouldRecord=false: no metrics recorded.
+	noRecordInterceptor := NewDRPCStreamServerRequestMetricsInterceptor(
+		requestMetrics, func(string) bool { return false })
+	stream3 := &mockDRPCStream{ctx: context.Background()}
+	_, err = noRecordInterceptor(stream3, rpc, func(s drpc.Stream) (interface{}, error) {
+		return "skipped", nil
+	})
+	require.NoError(t, err)
+	// Counts should not have changed.
+	require.Equal(t, int64(2), requestMetrics.RequestsTotal.Count(startedLabels))
+}
+
 func assertRpcMetrics(
 	t *testing.T, metrics []*io_prometheus_client.Metric, expected map[string]uint64,
 ) {
 	t.Helper()
 	actual := map[string]*io_prometheus_client.Histogram{}
 	for _, m := range metrics {
-		var method, statusCode, protocol string
+		var method, statusCode string
 		for _, l := range m.Label {
 			switch *l.Name {
-			case RpcMethodLabel:
+			case RPCMethodLabel:
 				method = *l.Value
-			case RpcStatusCodeLabel:
+			case RPCStatusCodeLabel:
 				statusCode = *l.Value
-			case RpcProtocolLabel:
-				protocol = *l.Value
 			}
 		}
 		histogram := m.Histogram
 		require.NotNil(t, histogram, "expected histogram")
-		key := fmt.Sprintf("%s %s %s", method, statusCode, protocol)
+		key := fmt.Sprintf("%s %s", method, statusCode)
 		actual[key] = histogram
 	}
 
@@ -250,4 +429,116 @@ func assertRpcMetrics(
 			require.Equal(t, val, *histogram.SampleCount, "expected `%s` to have SampleCount of %d", key, val)
 		}
 	}
+}
+
+func TestDRPCUnaryClientRequestMetricsInterceptor(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	clientMetrics := NewClientRequestMetrics()
+	ctx := context.Background()
+	rpc := "/testservice/TestMethod"
+	interceptor := NewDRPCUnaryClientRequestMetricsInterceptor(clientMetrics)
+
+	startedLabels := map[string]string{
+		RPCMethodLabel: rpc,
+		RPCState:       "started",
+	}
+
+	// Successful call.
+	invoker := func(
+		ctx context.Context, rpc string, enc drpc.Encoding,
+		in, out drpc.Message, cc *drpcclient.ClientConn,
+	) error {
+		time.Sleep(time.Millisecond)
+		return nil
+	}
+	err := interceptor(ctx, rpc, nil, nil, nil, nil, invoker)
+	require.NoError(t, err)
+
+	codeLabelsOK := map[string]string{
+		RPCMethodLabel:     rpc,
+		RPCState:           "completed",
+		RPCStatusCodeLabel: "OK",
+	}
+
+	require.Equal(t, int64(1), clientMetrics.RequestsTotal.Count(startedLabels))
+	require.Equal(t, int64(1), clientMetrics.RequestsTotal.Count(codeLabelsOK))
+
+	// Error call.
+	errInvoker := func(
+		ctx context.Context, rpc string, enc drpc.Encoding,
+		in, out drpc.Message, cc *drpcclient.ClientConn,
+	) error {
+		return status.Error(codes.Internal, "internal error")
+	}
+	err = interceptor(ctx, rpc, nil, nil, nil, nil, errInvoker)
+	require.Error(t, err)
+
+	codeLabelsInternal := map[string]string{
+		RPCMethodLabel:     rpc,
+		RPCState:           "completed",
+		RPCStatusCodeLabel: "Internal",
+	}
+
+	require.Equal(t, int64(2), clientMetrics.RequestsTotal.Count(startedLabels))
+	require.Equal(t, int64(1), clientMetrics.RequestsTotal.Count(codeLabelsOK))
+	require.Equal(t, int64(1), clientMetrics.RequestsTotal.Count(codeLabelsInternal))
+}
+
+func TestDRPCStreamClientRequestMetricsInterceptor(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	clientMetrics := NewClientRequestMetrics()
+	ctx := context.Background()
+	rpc := "/testservice/StreamMethod"
+	interceptor := NewDRPCStreamClientRequestMetricsInterceptor(clientMetrics)
+
+	startedLabels := map[string]string{
+		RPCMethodLabel: rpc,
+		RPCState:       "started",
+	}
+
+	// Successful call.
+	successStreamer := func(
+		ctx context.Context, rpc string, enc drpc.Encoding,
+		cc *drpcclient.ClientConn,
+	) (drpc.Stream, error) {
+		return &mockDRPCStream{ctx: ctx}, nil
+	}
+	str, err := interceptor(ctx, rpc, nil, nil, successStreamer)
+	require.NoError(t, err)
+	require.NotNil(t, str)
+
+	codeLabelsOK := map[string]string{
+		RPCMethodLabel:     rpc,
+		RPCState:           "completed",
+		RPCStatusCodeLabel: "OK",
+	}
+
+	require.Equal(t, int64(1), clientMetrics.RequestsTotal.Count(startedLabels))
+	require.Equal(t, int64(1), clientMetrics.RequestsTotal.Count(codeLabelsOK))
+
+	// Error call.
+	errStreamer := func(
+		ctx context.Context, rpc string, enc drpc.Encoding,
+		cc *drpcclient.ClientConn,
+	) (drpc.Stream, error) {
+		return nil, status.Error(codes.Unavailable, "unavailable")
+	}
+	str, err = interceptor(ctx, rpc, nil, nil, errStreamer)
+	require.Error(t, err)
+	require.Nil(t, str)
+
+	codeLabelsUnavailable := map[string]string{
+		RPCMethodLabel:     rpc,
+		RPCState:           "completed",
+		RPCStatusCodeLabel: "Unavailable",
+	}
+
+	require.Equal(t, int64(2), clientMetrics.RequestsTotal.Count(startedLabels))
+	require.Equal(t, int64(1), clientMetrics.RequestsTotal.Count(codeLabelsOK))
+	require.Equal(t, int64(1),
+		clientMetrics.RequestsTotal.Count(codeLabelsUnavailable))
 }

--- a/pkg/rpc/settings.go
+++ b/pkg/rpc/settings.go
@@ -123,11 +123,12 @@ var sourceAddr = func() net.Addr {
 }()
 
 type serverOpts struct {
-	interceptor                   func(fullMethod string) error
-	metricsInterceptor            RequestMetricsInterceptor
-	drpcRequestMetricsInterceptor DRPCRequestMetricsInterceptor
-	tlsConfig                     *tls.Config
-	tlsCipherRestrict             func(conn net.Conn) error
+	interceptor                         func(fullMethod string) error
+	metricsInterceptor                  RequestMetricsInterceptor
+	tlsConfig                           *tls.Config
+	tlsCipherRestrict                   func(conn net.Conn) error
+	drpcUnaryRequestMetricsInterceptor  DRPCUnaryServerRequestMetricsInterceptor
+	drpcStreamRequestMetricsInterceptor DRPCStreamServerRequestMetricsInterceptor
 }
 
 // ServerOption is a configuration option passed to NewServer.
@@ -158,10 +159,21 @@ func WithMetricsServerInterceptor(interceptor RequestMetricsInterceptor) ServerO
 	}
 }
 
-// WithDRPCMetricsServerInterceptor adds a DRPCRequestMetricsInterceptor to the DRPC server.
-func WithDRPCMetricsServerInterceptor(interceptor DRPCRequestMetricsInterceptor) ServerOption {
+// WithDRPCMetricsUnaryServerInterceptor adds a DRPCUnaryServerRequestMetricsInterceptor to the DRPC server.
+func WithDRPCMetricsUnaryServerInterceptor(
+	interceptor DRPCUnaryServerRequestMetricsInterceptor,
+) ServerOption {
 	return func(opts *serverOpts) {
-		opts.drpcRequestMetricsInterceptor = interceptor
+		opts.drpcUnaryRequestMetricsInterceptor = interceptor
+	}
+}
+
+// WithDRPCMetricsUnaryServerInterceptor adds a DRPCUnaryServerRequestMetricsInterceptor to the DRPC server.
+func WithDRPCMetricsStreamServerInterceptor(
+	interceptor DRPCStreamServerRequestMetricsInterceptor,
+) ServerOption {
+	return func(opts *serverOpts) {
+		opts.drpcStreamRequestMetricsInterceptor = interceptor
 	}
 }
 

--- a/pkg/server/drpc_server.go
+++ b/pkg/server/drpc_server.go
@@ -30,7 +30,7 @@ type drpcServer struct {
 // newDRPCServer creates and configures a new drpcServer instance. It enables
 // DRPC if the experimental setting is on, otherwise returns a dummy server.
 func newDRPCServer(
-	ctx context.Context, rpcCtx *rpc.Context, requestMetrics *rpc.RequestMetrics,
+	ctx context.Context, rpcCtx *rpc.Context, serverRequestMetrics *rpc.ServerRequestMetrics,
 ) (*drpcServer, error) {
 	drpcServer := &drpcServer{}
 	drpcServer.setMode(modeInitializing)
@@ -47,15 +47,20 @@ func newDRPCServer(
 			func(path string) error {
 				return drpcServer.intercept(path)
 			}),
-		rpc.WithDRPCMetricsServerInterceptor(
-			rpc.NewDRPCRequestMetricsInterceptor(requestMetrics, func(method string) bool {
-				return shouldRecordRequestDuration(rpcCtx.Settings, method)
-			}),
-		),
 		rpc.WithTLSConfig(tlsCfg),
 		rpc.WithTLSCipherRestrict(func(conn net.Conn) error {
 			return security.TLSCipherRestrict(conn)
 		}),
+		rpc.WithDRPCMetricsUnaryServerInterceptor(
+			rpc.NewDRPCUnaryServerRequestMetricsInterceptor(serverRequestMetrics,
+				func(method string) bool {
+					return shouldRecordServerRequestMetricsDRPC(rpcCtx.Settings)
+				})),
+		rpc.WithDRPCMetricsStreamServerInterceptor(
+			rpc.NewDRPCStreamServerRequestMetricsInterceptor(serverRequestMetrics,
+				func(method string) bool {
+					return shouldRecordServerRequestMetricsDRPC(rpcCtx.Settings)
+				})),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -26,7 +26,7 @@ type grpcServer struct {
 }
 
 func newGRPCServer(
-	ctx context.Context, rpcCtx *rpc.Context, requestMetrics *rpc.RequestMetrics,
+	ctx context.Context, rpcCtx *rpc.Context, requestMetrics *rpc.ServerRequestMetrics,
 ) (*grpcServer, error) {
 	s := &grpcServer{}
 	s.mode.set(modeInitializing)

--- a/pkg/server/rpc_server_test.go
+++ b/pkg/server/rpc_server_test.go
@@ -28,12 +28,12 @@ func TestRequestMetricRegistered(t *testing.T) {
 	ts := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer ts.Stopper().Stop(ctx)
 
-	requestMetrics := rpc.NewRequestMetrics()
+	requestMetrics := rpc.NewServerRequestMetrics()
 
 	var histogramVec *metric.HistogramVec
 	registry := ts.MetricsRecorder().AppRegistry()
 	registry.Select(
-		map[string]struct{}{requestMetrics.Duration.Name: {}},
+		map[string]struct{}{requestMetrics.RequestDuration.Name: {}},
 		func(name string, val interface{}) {
 			histogramVec = val.(*metric.HistogramVec)
 		})
@@ -41,9 +41,11 @@ func TestRequestMetricRegistered(t *testing.T) {
 
 	_, _ = ts.GetAdminClient(t).Settings(ctx, &serverpb.SettingsRequest{})
 	require.Len(t, histogramVec.ToPrometheusMetrics(), 0, "Should not have recorded any metrics yet")
-	serverRPCRequestMetricsEnabled.Override(context.Background(), &ts.ClusterSettings().SV, true)
+	serverRPCRequestMetricsEnabled.Override(context.Background(),
+		&ts.ClusterSettings().SV, true)
 	_, _ = ts.GetAdminClient(t).Settings(ctx, &serverpb.SettingsRequest{})
-	require.Len(t, histogramVec.ToPrometheusMetrics(), 1, "Should have recorded metrics for request")
+	require.Greater(t, len(histogramVec.ToPrometheusMetrics()), 0,
+		"Should have recorded metrics for request")
 }
 
 func TestShouldRecordRequestDuration(t *testing.T) {

--- a/pkg/server/serve_mode.go
+++ b/pkg/server/serve_mode.go
@@ -93,6 +93,10 @@ func shouldRecordRequestDuration(settings *cluster.Settings, method string) bool
 			strings.HasPrefix(method, tsdbPrefix))
 }
 
+func shouldRecordServerRequestMetricsDRPC(settings *cluster.Settings) bool {
+	return serverRPCRequestMetricsEnabled.Get(&settings.SV)
+}
+
 // NewWaitingForInitError creates an error indicating that the server cannot run
 // the specified method until the node has been initialized.
 func NewWaitingForInitError(methodName string) error {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -424,15 +424,18 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 	// and after ValidateAddrs().
 	rpcContext.CheckCertificateAddrs(ctx)
 
-	requestMetrics := rpc.NewRequestMetrics()
-	appRegistry.AddMetricStruct(requestMetrics)
+	serverRequestMetrics := rpc.NewServerRequestMetrics()
+	appRegistry.AddMetricStruct(serverRequestMetrics)
+	if rpcContext.UseDRPC {
+		appRegistry.AddMetricStruct(rpcContext.ClientRequestMetrics())
+	}
 
-	grpcServer, err := newGRPCServer(ctx, rpcContext, requestMetrics)
+	grpcServer, err := newGRPCServer(ctx, rpcContext, serverRequestMetrics)
 	if err != nil {
 		return nil, err
 	}
 
-	drpcServer, err := newDRPCServer(ctx, rpcContext, requestMetrics)
+	drpcServer, err := newDRPCServer(ctx, rpcContext, serverRequestMetrics)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -1397,7 +1397,7 @@ func makeTenantSQLServerArgs(
 	externalStorage := esb.makeExternalStorage
 	externalStorageFromURI := esb.makeExternalStorageFromURI
 
-	requestMetrics := rpc.NewRequestMetrics()
+	requestMetrics := rpc.NewServerRequestMetrics()
 	registry.AddMetricStruct(requestMetrics)
 
 	grpcServer, err := newGRPCServer(startupCtx, rpcContext, requestMetrics)


### PR DESCRIPTION
This PR adds better observability when we migrate from gRPC to DRPC for inter-node RPC communication. Currently, the only DRPC metric is a server-side unary call duration histogram (`rpc.server.request.duration.nanos`), gated behind `server.rpc.request_metrics.enabled` and limited to `/cockroach.server` and `/cockroach.ts` method prefixes. There are no client-side metrics, no streaming RPC metrics, and no call counters. This fix adds DRPC-specific metrics covering all of these gaps.                                                                                                          
All metrics use `HistogramVec / CounterVec` (Prometheus-export-only, not TSDB) and are gated behind the existing cluster setting `server.rpc.request_metrics.enabled` (default: false). There is no method prefix filtering - this feature will be added in a follow-up PR (https://github.com/cockroachdb/cockroach/issues/166819).

Epic: CRDB-48931
Fixes: #163593
Release note: None