### PR TITLE
status: add major and minor version labels to build.timestamp metric

### DIFF
--- a/pkg/server/status/runtime.go
+++ b/pkg/server/status/runtime.go
@@ -901,7 +901,10 @@ func NewRuntimeStatSampler(ctx context.Context, clock hlc.WallClock) *RuntimeSta
 		log.Dev.Warningf(ctx, "could not parse build timestamp: %v", err)
 	}
 
-	// Build information.
+	// Build information. The labels on this metric enable Prometheus/Datadog
+	// queries to filter or group by CockroachDB version — for example, to
+	// identify which nodes are running a particular release series.
+	year, release := build.BranchReleaseSeries()
 	metaBuildTimestamp := metric.Metadata{
 		Name:        "build.timestamp",
 		Help:        "Build information",
@@ -910,6 +913,8 @@ func NewRuntimeStatSampler(ctx context.Context, clock hlc.WallClock) *RuntimeSta
 	}
 	metaBuildTimestamp.AddLabel("tag", info.Tag)
 	metaBuildTimestamp.AddLabel("go_version", info.GoVersion)
+	metaBuildTimestamp.AddLabel("major", strconv.Itoa(year))
+	metaBuildTimestamp.AddLabel("minor", strconv.Itoa(release))
 
 	buildTimestamp := metric.NewGauge(metaBuildTimestamp)
 	buildTimestamp.Update(timestamp)


### PR DESCRIPTION
Add `major` and `minor` labels to the existing `build.timestamp` Prometheus metric, derived from `build.BranchReleaseSeries()`. This enables monitoring queries to filter or group by CockroachDB release series (e.g. `build_timestamp{major="26", minor="1"}`) without parsing the `tag` label string.

Release note (ops change): The `build.timestamp` Prometheus metric now carries `major` and `minor` labels identifying the release series of the running CockroachDB binary (e.g. major=26, minor=1 for any v26.1.x build).

Epic: none