### PR TITLE
roachprod-microbench: executor config

### DIFF
--- a/pkg/testutils/benchdoc/BUILD.bazel
+++ b/pkg/testutils/benchdoc/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "benchdoc",
-    srcs = ["benchdoc.go"],
+    srcs = [
+        "benchdoc.go",
+        "doc.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/testutils/benchdoc",
     visibility = ["//visibility:public"],
     deps = ["@com_github_cockroachdb_errors//:errors"],

--- a/pkg/testutils/benchdoc/benchdoc_test.go
+++ b/pkg/testutils/benchdoc/benchdoc_test.go
@@ -30,11 +30,12 @@ func TestAnalyzeGoodBenchmarkDocs(t *testing.T) {
 			Package: "pkg_test",
 			Team:    "team_test",
 			RunArgs: RunArgs{
-				Suite:     "manual",
+				Suite:     SuiteManual,
 				Count:     10,
 				BenchTime: "50x",
 				Timeout:   20 * time.Minute,
 			},
+			CompareArgs: NewCompareArgs(),
 		},
 	}, benchmarks)
 }
@@ -68,7 +69,7 @@ func TestAnalyzeCompareArgsBenchmarkDocs(t *testing.T) {
 			Package: "pkg_test",
 			Team:    "team_test",
 			RunArgs: RunArgs{
-				Suite:     "manual",
+				Suite:     SuiteManual,
 				Count:     10,
 				BenchTime: "50x",
 				Timeout:   20 * time.Minute,
@@ -82,6 +83,7 @@ func TestAnalyzeCompareArgsBenchmarkDocs(t *testing.T) {
 			Name:    "BenchmarkCompareArgsOnly",
 			Package: "pkg_test",
 			Team:    "team_test",
+			RunArgs: NewRunArgs(),
 			CompareArgs: CompareArgs{
 				PostIssue: PostIssueNone,
 			},
@@ -90,6 +92,7 @@ func TestAnalyzeCompareArgsBenchmarkDocs(t *testing.T) {
 			Name:    "BenchmarkPostBlockerOnly",
 			Package: "pkg_test",
 			Team:    "team_test",
+			RunArgs: NewRunArgs(),
 			CompareArgs: CompareArgs{
 				PostIssue: PostIssueBlocker,
 			},
@@ -98,14 +101,18 @@ func TestAnalyzeCompareArgsBenchmarkDocs(t *testing.T) {
 			Name:    "BenchmarkThresholdOnly",
 			Package: "pkg_test",
 			Team:    "team_test",
+			RunArgs: NewRunArgs(),
 			CompareArgs: CompareArgs{
+				PostIssue: PostIssueNone,
 				Threshold: 1.0,
 			},
 		},
 		{
-			Name:    "BenchmarkNoDoc",
-			Package: "pkg_test",
-			Team:    "team_test",
+			Name:        "BenchmarkNoDoc",
+			Package:     "pkg_test",
+			Team:        "team_test",
+			RunArgs:     NewRunArgs(),
+			CompareArgs: NewCompareArgs(),
 		},
 	}, benchmarks)
 }

--- a/pkg/testutils/benchdoc/doc.go
+++ b/pkg/testutils/benchdoc/doc.go
@@ -1,0 +1,78 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+//
+
+package benchdoc
+
+/*
+# benchdoc — Benchmark CI Configuration
+
+The benchdoc package allows you to configure how benchmarks are run and
+compared in CI by adding a `benchmark-ci:` comment directly above your
+benchmark function. A nogo linter validates the syntax of these comments
+at build time.
+
+## Usage
+
+Add a comment line starting with `benchmark-ci:` to your benchmark
+function's doc block. The comment contains comma-separated key=value
+pairs:
+
+	// benchmark-ci: count=10, benchtime=50x, timeout=20m
+	func BenchmarkFoo(b *testing.B) { ... }
+
+All parameters are optional. A benchmark function with no `benchmark-ci:`
+comment uses the defaults and is included in the weekly suite.
+
+## Run Arguments
+
+These control how the benchmark is executed:
+
+  - count — Number of times to run each benchmark (maps to `-count`).
+  - benchtime — Duration or iteration count per run (maps to `-benchtime`),
+    e.g. "5s" or "100x".
+  - timeout — Maximum time for the benchmark run as a Go duration, e.g. "20m".
+  - suite — Which CI suite to include this benchmark in. Values: "weekly"
+    (default) or "manual". Manual benchmarks are only run on explicit request.
+
+## Compare Arguments
+
+These control how benchmark results are compared against previous runs:
+
+  - post — Action to take when a regression is detected. Values:
+    "none" (default, no issue filed), "notify" (file an informational
+    issue), or "release-blocker" (file a release-blocking issue).
+  - threshold — Regression sensitivity as a float in [0.0, 1.0]. A lower
+    value means smaller regressions are flagged. For example, 0.3 flags
+    regressions of 30% or more.
+
+## Examples
+
+Minimal configuration (weekly suite, defaults for everything):
+
+	func BenchmarkSimple(b *testing.B) { ... }
+
+Custom run parameters:
+
+	// benchmark-ci: count=5, benchtime=100x, timeout=10m
+	func BenchmarkCustomRun(b *testing.B) { ... }
+
+File a release-blocker on regression:
+
+	// benchmark-ci: post=release-blocker, threshold=0.2
+	func BenchmarkCriticalPath(b *testing.B) { ... }
+
+Multiline parameters are allowed:
+
+	// benchmark-ci: count=5
+	// benchmark-ci: benchtime=100x, timeout=10m
+	func BenchmarkCustomRun(b *testing.B) { ... }
+
+Manual-only benchmark:
+
+	// benchmark-ci: suite=manual
+	func BenchmarkExpensive(b *testing.B) { ... }
+
+*/

--- a/pkg/testutils/benchdoc/testdata/compare_args_bench_test_go
+++ b/pkg/testutils/benchdoc/testdata/compare_args_bench_test_go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-// benchmark-ci: count=10, benchtime=50x, timeout=20m, suite=manual, post=blocker, threshold=0.3
+// benchmark-ci: count=10, benchtime=50x, timeout=20m, suite=manual, post=release-blocker, threshold=0.3
 func BenchmarkAllArgs(b *testing.B) {
 	// noop
 }
@@ -20,7 +20,7 @@ func BenchmarkCompareArgsOnly(b *testing.B) {
 	// noop
 }
 
-// benchmark-ci: post=blocker
+// benchmark-ci: post=release-blocker
 func BenchmarkPostBlockerOnly(b *testing.B) {
 	// noop
 }


### PR DESCRIPTION
This PR adds per-benchmark configuration support to the microbenchmark CI comparison pipeline. The `benchdoc` package is extended with typed `Suite` and `PostIssue` constants, default constructors, and validation, so each benchmark can declare its own regression threshold, issue-filing policy (`none`, `notify`, or `release-blocker`), and suite membership (`weekly` or `manual`) via `benchmark-ci:` doc comments. Benchmarks marked as `suite=manual` are now automatically skipped during CI listing.

On the `roachprod-microbench` side, the `compare` command gains a `--benchmark-config` flag to load the exported benchdoc JSON and a `--post-issues` flag that supports `group` (one issue per package, the existing behavior) or `single` (one issue per benchmark, using each benchmark's `post` and `threshold` settings). The TeamCity weekly script is updated to export the benchmark config and pass it through to both the `run` and `compare` stages, switching to single-issue mode so regressions can be individually routed to owning teams.

Fixes: https://github.com/cockroachdb/cockroach/issues/155707

Epic: None
Release note: None