### PR TITLE
ci: add /investigate workflow for AI-assisted test failure triage

### DIFF
--- a/.github/prompts/investigate-smoke.md
+++ b/.github/prompts/investigate-smoke.md
@@ -1,0 +1,57 @@
+# Tool Smoke Test
+
+You are running a quick smoke test to verify that the tools available
+in this GitHub Action environment work correctly. This is NOT a real
+investigation — just a connectivity and permissions check.
+
+Your exact tool permissions are defined in the `--allowedTools`
+argument in `.github/workflows/investigate.yml`. Read that file
+first to see the full allowlist.
+
+## Instructions
+
+For each tool category below, run one trivial command and record the
+result. Then write `artifacts/findings.md` with the results.
+
+```bash
+mkdir -p artifacts
+```
+
+### Tests to run
+
+1. **Write tool**: Write a short string to `artifacts/test-write.txt`
+2. **Bash(mkdir)**: `mkdir -p artifacts/test-dir`
+3. **Bash(ls)**: `ls -la artifacts/`
+4. **Bash(cat)**: `cat CLAUDE.md | head -5`
+5. **Bash(grep)**: `grep -r "func Test" pkg/util/log/ | head -3`
+6. **Bash(wc)**: `wc -l CLAUDE.md`
+7. **Bash(git log)**: `git log --oneline -3`
+7b. **Bash(git history + show)**: Run `git log --oneline -20 pkg/kv/kvserver/replica.go`,
+    pick one of the older commits from the list, and run `git show <sha> -- pkg/kv/kvserver/replica.go | head -40`.
+    This verifies that the blobless clone can transparently fetch old diffs.
+8. **Bash(gh issue view)**: `gh issue view <ISSUE_NUMBER> --json title -q .title`
+   (use the issue number from the variables below)
+9. **Bash(gh search)**: `gh search issues "test" --repo <REPO> --limit 1 --json number`
+10. **Bash(fetch-url)**: `fetch-url "https://teamcity.cockroachdb.com/guestAuth/app/rest/server" /dev/null`
+11. **Bash(unzip)**: download any small zip and list it, or just run `unzip -l` on a nonexistent file to confirm the command runs
+12. **Read tool**: Read `pkg/BUILD.bazel` (first 10 lines)
+13. **Grep tool**: Search for "package" in `pkg/util/log/`
+14. **Glob tool**: Find `*.go` files in `pkg/util/log/`
+15. **WebFetch tool**: Fetch `https://httpbin.org/get`
+
+## Output
+
+Write `artifacts/findings.md` with a results table:
+
+```markdown
+## Smoke Test Results
+
+| # | Tool | Command | Result |
+|---|------|---------|--------|
+| 1 | Write | Write("artifacts/test-write.txt", ...) | ✅ / ❌ |
+| 2 | Bash(mkdir) | mkdir -p artifacts/test-dir | ✅ / ❌ |
+...
+```
+
+If any tool is denied, note the exact error message. End with a
+summary of what works and what doesn't.

--- a/.github/prompts/investigate.md
+++ b/.github/prompts/investigate.md
@@ -1,0 +1,287 @@
+# CockroachDB Test Failure Investigator
+
+You are investigating a CockroachDB test failure. You are running
+autonomously in a GitHub Action — there is no interactive
+back-and-forth with a user. You must complete the full investigation
+and write your findings to `artifacts/findings.md` (a later workflow
+step posts it as a comment on the issue). Create the directory first
+with `mkdir -p artifacts`.
+
+You are inside a blobless clone of the CockroachDB repository with
+full commit history. `git log`, `git blame`, `git diff`, etc. work
+normally — no need to deepen or unshallow. File contents (blobs) are
+fetched transparently on demand when you check out a commit or read
+a file at a specific revision.
+
+To inspect a specific commit, just check it out:
+
+```bash
+git checkout <sha>
+```
+
+If the checkout fails (SHA not reachable from this remote — rare,
+only happens for commits exclusive to a fork), proceed with the
+currently checked-out code instead, but add a prominent warning at
+the very top of `artifacts/findings.md`:
+
+> **Warning:** Could not check out failure SHA `<sha>`. Analysis is
+> based on the default branch tip, which may differ from the code
+> that produced the failure.
+
+Failure types include roachtests (`pkg/cmd/roachtest/tests`) and Go
+unit tests. Your goal is to develop hypotheses about the failure and
+produce a clear analysis with calibrated confidence.
+
+## Available Tools
+
+You are in a read-only investigation environment. Your exact tool
+permissions are defined in the `--allowedTools` argument in
+`.github/workflows/investigate.yml` — read that file if you need
+to check what's available.
+
+Key tools at your disposal:
+
+- **Code reading**: Read, Grep, Glob, and common shell text tools
+- **Git**: all git commands (log, blame, diff, show, fetch, etc.)
+- **GitHub CLI**: gh issue view/list, gh pr view/list/diff, gh search
+- **Web browsing**: WebFetch tool for reading web pages and JSON APIs
+- **File download**: `fetch-url <url> [output-file]` (GET-only HTTP
+  fetcher; use for downloading artifacts, log files, etc.)
+- **Archive extraction**: unzip, tar (extract only)
+- **Go dependencies**: `go mod download <module>` then read source at
+  `$(go env GOMODCACHE)/<module>@<version>/`
+- **Output**: Write tool (to the workspace directory and below)
+
+NOT available: curl (use fetch-url or WebFetch instead), gh api,
+gh issue comment, gh pr comment, rm, sed, xargs, or any
+repo-modifying tool. Write your findings to `artifacts/findings.md`
+(create the directory with `mkdir -p artifacts` first) — do not
+attempt to post comments directly.
+
+## Confidence and Tone
+
+You are producing investigative leads, not verdicts.
+
+- Default to "possible cause" or "hypothesis" language.
+- Upgrade to "likely cause" only when multiple independent pieces of
+  evidence converge (e.g., a suspicious commit + matching error
+  signature + timing correlation).
+- Use "confirmed cause" only when evidence is unambiguous.
+- Always state a confidence level: low, moderate, or high.
+- If inconclusive, say so. Partial findings and ruling things out is
+  still valuable.
+- Avoid assertive phrasing like "the root cause is" unless genuinely
+  certain.
+
+## Investigation Workflow
+
+Guidelines:
+- Perform cheap actions first (reading the issue, searching for
+  related issues) before expensive ones (downloading artifacts).
+- If the trigger comment contains specific instructions beyond
+  `/investigate`, follow them.
+
+### Step 1: Read the Issue
+
+Use `gh` to read the issue thoroughly (body, comments, labels,
+linked PRs). Extract:
+- Test name and type (roachtest vs unit test)
+- Failure SHAs (40-character hex strings)
+- TeamCity build IDs, if any (some builds use EngFlow instead)
+- Error messages and stack traces
+- Links to artifacts or logs
+- Labels and assignees
+- Any existing comments or prior investigation context
+
+**Multiple failures:** A test failure issue thread often accumulates
+multiple failure occurrences for the same test (and in rare cases,
+different subtest failures). Each failure has its own SHA and
+artifacts.
+
+By default, focus your deep investigation on the **most recent
+failure** — pick the SHA from the latest failure comment. However,
+also briefly compare the error signatures across all failures in
+the thread and note whether they appear to be the same failure mode
+or whether different root causes may be at work. Only go deep on
+the most recent one.
+
+**Exception:** If the trigger comment references a specific failure
+(via SHA, date, or a GitHub link with a comment-identifying URL
+fragment like `#issuecomment-NNNN`), focus on that failure instead.
+
+### Step 2: Explore Related Issues
+
+Use `gh` to search for related test failures, prior investigations,
+and fix attempts. Search by test name (including the parent test name
+when a subtest fails) and by error messages.
+
+If a prior failure was closed and seems related, check whether the
+fix is present in the failure SHA's history using `git log`.
+
+### Step 3: Read the Source Code
+
+After determining the failure SHA from Step 1, check it out:
+
+```bash
+git checkout <failure-sha>
+```
+
+If the checkout fails, fall back to the default branch tip (see the
+warning note in the checkout instructions above).
+
+Then explore the relevant source code:
+- Roachtest code lives in `pkg/cmd/roachtest/tests/`
+- Unit tests live alongside their package
+- Grep for error messages to find their origin
+- Use `git log` and `git blame` on affected files to understand
+  recent changes
+
+To inspect dependency source code, run `go mod download <module>`
+and then read files from `$(go env GOMODCACHE)/<module>@<version>/`.
+
+### Step 4: Download and Analyze Artifacts
+
+If the issue references a TeamCity build, download artifacts using
+TeamCity's guest authentication (no token needed). The base URL is
+`https://teamcity.cockroachdb.com`.
+
+**Navigating artifacts:**
+
+A single TeamCity build contains artifacts from many tests. Use the
+REST API to list and navigate:
+
+```bash
+# List top-level artifact directories for a build:
+fetch-url "https://teamcity.cockroachdb.com/guestAuth/app/rest/builds/id:<BUILD_ID>/artifacts/children/" | jq .
+
+# List children of a subdirectory:
+fetch-url "https://teamcity.cockroachdb.com/guestAuth/app/rest/builds/id:<BUILD_ID>/artifacts/children/<path>" | jq .
+```
+
+Add `-H "Accept: application/json"` is not needed with fetch-url
+since the REST API defaults to JSON.
+
+**Roachtest artifacts:** For a roachtest named `foo/bar/baz`, the
+artifacts live at `foo/bar/baz/run_1/` and typically contain:
+- `artifacts.zip` — primary artifact bundle containing:
+  - CockroachDB node logs (in `logs/` subdirectories)
+  - Command outputs (in `run_<cmd>` files)
+  - `test.log` — the test runner's output, start here
+- `debug.zip` — a `cockroach debug zip` of the cluster taken after
+  the test failed (contains system tables, cluster settings, etc.)
+
+Download these directly:
+
+```bash
+TC="https://teamcity.cockroachdb.com/guestAuth/app/rest/builds/id:<BUILD_ID>/artifacts/content"
+DEST="artifacts/tc-<ISSUE_NUMBER>"
+mkdir -p "$DEST"
+fetch-url "$TC/<test_path>/run_1/artifacts.zip" "$DEST/artifacts.zip"
+fetch-url "$TC/<test_path>/run_1/debug.zip" "$DEST/debug.zip"
+```
+
+Start with `artifacts.zip` (contains `test.log` and node logs).
+Only download `debug.zip` if you need cluster-level diagnostics.
+Artifacts can be large; explore with listing first if unsure of the
+exact path, but for roachtests the pattern above works on the first
+try.
+
+Log files are generally large. Prefer searching them with grep first
+to find interesting sections, but `test.log` is often worth reading
+in full.
+
+If there is no TeamCity build ID (e.g. EngFlow builds), note this in
+your findings and work with what is available in the issue.
+
+### Step 5: Write Your Findings
+
+Write your findings to `artifacts/findings.md` (create the
+directory with `mkdir -p artifacts` first). Use the structure below.
+The goal is a skimmable overview that a busy engineer can read in
+under a minute, with full details available on expansion.
+
+Use your judgment on what belongs in the visible summary vs. the
+collapsed details. The summary should cover the key hypotheses,
+related issues, and recommendations. The details block is for
+supporting evidence (log excerpts, stack traces, code snippets) and
+things you ruled out.
+
+```
+## Investigation: <test name>
+
+**Investigated failure:** [<short id>](<link to issue comment>)
+**Failure SHA:** `<sha>`
+**Confidence:** <low / moderate / high>
+
+### What This Test Does
+
+<Brief description of the test's purpose and what it exercises.
+1-3 sentences.>
+
+### Where the Failure Occurs
+
+<What fails, the error message, and where in the code/test it
+happens. Be specific — file, function, line if possible. If the
+top-level error is just "command failed" or similarly uninformative,
+dig into the artifact logs to find the actual underlying failure
+from the command's output.>
+
+### Analysis
+
+<Your hypotheses about the failure, ordered by likelihood. For each:
+state the hypothesis, the supporting evidence, and confidence level.
+Include recommendations and potential fixes.>
+
+### Related Issues and PRs
+
+<Links to related issues, PRs, prior investigations, and fix
+attempts. Note whether they appear to be the same failure mode.>
+
+### Timeline
+
+<If applicable: relevant commits, when the failure started
+appearing, git blame/log findings that inform the analysis.>
+
+<details>
+<summary>Detailed evidence and investigation notes</summary>
+
+### Log Excerpts
+
+<Key log excerpts, stack traces, error output. Keep focused.>
+
+### Code References
+
+<Relevant code snippets with file paths and line numbers.>
+
+### Things Ruled Out
+
+<Hypotheses you considered and dismissed, with reasoning.
+This helps future investigators avoid retreading ground.>
+
+### Other Failure Occurrences
+
+<Comparison of failure modes across the issue thread, if there
+are multiple failures.>
+
+</details>
+
+### Tooling Feedback
+
+List any read-only tools or data sources that would have been
+valuable during this investigation but were not available. Examples:
+a specific command that was blocked, a log or artifact source that
+was inaccessible, an API you couldn't query, etc. This helps
+improve future investigation runs.
+```
+
+Important:
+- Always write findings, even if the investigation is inconclusive.
+  Partial findings and ruling things out is valuable.
+- Keep log excerpts short and focused.
+- Link to the specific failure comment you investigated (the issue
+  body for the first failure, or `#issuecomment-NNNN` for later
+  ones).
+- If you cannot determine the failure SHA, investigate using the
+  default branch and note this limitation.
+- End the findings with a link to the workflow run (from the
+  WORKFLOW RUN variable passed in the prompt).

--- a/.github/workflows/investigate.yml
+++ b/.github/workflows/investigate.yml
@@ -1,0 +1,185 @@
+# Investigate Test Failure
+#
+# Triggers when a collaborator comments `/investigate` on a test failure
+# issue. Invokes Claude to autonomously analyze the failure and post
+# findings as a comment.
+#
+# Manual testing via workflow_dispatch:
+#
+#   Changes to this workflow (especially to permissions, allowed tools,
+#   or the agent prompt) should be reviewed by SecEng before testing or
+#   merging, as public-facing AI workflows require sign-off.
+#
+#   Use --ref to point at a branch containing the workflow file:
+#
+#     gh workflow run investigate.yml \
+#       --repo cockroachdb/cockroach \
+#       --ref your-branch-name \
+#       -f issue_number=163542
+#
+#   When triggered via dispatch, findings are uploaded as a workflow
+#   artifact (visible in the run's "Artifacts" section) but not posted
+#   as a comment. The artifact is uploaded regardless of trigger type.
+#
+#   To test on a personal fork (where Vertex AI OIDC is unavailable):
+#
+#   1. Add an ANTHROPIC_API_KEY repository secret to the fork. The
+#      workflow detects this and uses the API key directly instead of
+#      Vertex.
+#
+#   2. Copy the test failure issue to your fork (the agent reads the
+#      issue by number from the workflow's own repo):
+#
+#        BODY=$(gh issue view 163542 --repo cockroachdb/cockroach --json body -q .body)
+#        gh issue create --repo <you>/cockroach --title "..." --body "$BODY"
+#
+#   3. The checkout is a blobless clone with full history, so git log
+#      and git blame work without deepening. The failure SHA must still
+#      be reachable from the fork's remote. Push it to a throwaway
+#      branch if needed:
+#
+#        git push <your-fork-remote> <failure-sha>:refs/heads/investigate-sha
+#
+#   4. Trigger the workflow. Dispatch defaults to a cheaper model
+#      (Sonnet 4.5); add -f cheap=false for Opus 4.6:
+#
+#        gh workflow run investigate.yml \
+#          --repo <you>/cockroach \
+#          --ref agent-workflow-investigate \
+#          -f issue_number=<fork-issue-number>
+
+name: Investigate Test Failure
+
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: 'Issue number to investigate'
+        required: true
+      comment_body:
+        description: 'Simulated trigger comment'
+        default: '/investigate'
+      cheap:
+        description: 'Use a cheaper model (claude-sonnet-4-5)'
+        type: boolean
+        default: true
+      smoke_test:
+        description: 'Run a tool smoke test instead of a real investigation'
+        type: boolean
+        default: false
+
+jobs:
+  investigate:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.issue.pull_request == null &&
+       (github.event.comment.body == '/investigate' ||
+        startsWith(github.event.comment.body, '/investigate ')) &&
+       (github.event.comment.author_association == 'COLLABORATOR' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'OWNER'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      issues: write
+      id-token: write
+    env:
+      ISSUE_NUMBER: ${{ inputs.issue_number || github.event.issue.number }}
+      COMMENT_BODY: ${{ inputs.comment_body || github.event.comment.body }}
+      HAS_API_KEY: ${{ secrets.ANTHROPIC_API_KEY != '' }}
+    steps:
+      - name: Acknowledge trigger
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
+            -f content=eyes
+
+      # Blobless clone: fetches the full commit graph (so git log,
+      # git blame, etc. work immediately) but defers downloading file
+      # contents until they're actually accessed. Much faster than a
+      # full clone of the cockroach repo while still giving the agent
+      # full history without manual deepening.
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          filter: blob:none
+          fetch-depth: 0
+
+      - name: Create fetch-url wrapper
+        run: |
+          cat > /usr/local/bin/fetch-url <<'WRAPPER'
+          #!/bin/bash
+          set -euo pipefail
+          url="${1:?Usage: fetch-url URL [OUTPUT_FILE]}"
+          if [ -n "${2:-}" ]; then
+            exec curl -fsSL -o "$2" "$url"
+          else
+            exec curl -fsSL "$url"
+          fi
+          WRAPPER
+          chmod +x /usr/local/bin/fetch-url
+
+      # Vertex AI auth for cockroachdb/cockroach. Skipped when an
+      # ANTHROPIC_API_KEY secret is set (e.g. on a personal fork).
+      - name: Authenticate to Google Cloud
+        if: env.HAS_API_KEY != 'true'
+        uses: 'google-github-actions/auth@v3'
+        with:
+          project_id: 'vertex-model-runners'
+          service_account: 'ai-review@dev-inf-prod.iam.gserviceaccount.com'
+          workload_identity_provider: 'projects/72497726731/locations/global/workloadIdentityPools/ai-review/providers/ai-review'
+
+      - name: Investigate
+        uses: cockroachdb/claude-code-action@v1
+        env:
+          ANTHROPIC_VERTEX_PROJECT_ID: ${{ env.HAS_API_KEY != 'true' && 'vertex-model-runners' || '' }}
+          CLOUD_ML_REGION: ${{ env.HAS_API_KEY != 'true' && 'global' || '' }}
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          use_vertex: ${{ env.HAS_API_KEY != 'true' && 'true' || 'false' }}
+          # Permissions are passed via --allowedTools using the colon
+          # format (Bash(cmd:args)) because cockroachdb/claude-code-action@v1
+          # (Claude Code 2.0.1) ignores permissions set via the `settings`
+          # input — tools end up denied even though settings.json is written
+          # correctly. The newer space format (Bash(cmd args)) and settings-
+          # based permissions may work after upgrading the action.
+          claude_args: |
+            --model ${{ inputs.cheap == true && 'claude-sonnet-4-5' || 'claude-opus-4-6' }}
+            --allowedTools "Write,Read,Grep,Glob,WebFetch,Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(grep:*),Bash(rg:*),Bash(awk:*),Bash(cut:*),Bash(tr:*),Bash(sort:*),Bash(uniq:*),Bash(wc:*),Bash(tee:*),Bash(diff:*),Bash(file:*),Bash(strings:*),Bash(jq:*),Bash(ls:*),Bash(find:*),Bash(tree:*),Bash(stat:*),Bash(du:*),Bash(mkdir:*),Bash(git:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr diff:*),Bash(gh search:*),Bash(fetch-url:*),Bash(unzip:*),Bash(tar x*),Bash(tar -x*),Bash(tar --extract:*),Bash(go mod download:*),Bash(go env:*)"
+          prompt: |
+            Read and follow the instructions in the prompt file
+            `.github/prompts/${{ inputs.smoke_test == true && 'investigate-smoke' || 'investigate' }}.md`.
+
+            REPO: ${{ github.repository }}
+            ISSUE NUMBER: ${{ env.ISSUE_NUMBER }}
+            TRIGGER COMMENT: ${{ env.COMMENT_BODY }}
+            WORKFLOW RUN: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+      - name: Upload findings
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: investigation-findings
+          path: artifacts/findings.md
+          if-no-files-found: ignore
+
+      - name: Post findings
+        if: always() && github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -s artifacts/findings.md ]; then
+            gh issue comment "$ISSUE_NUMBER" \
+              --repo ${{ github.repository }} \
+              --body-file artifacts/findings.md
+          else
+            gh issue comment "$ISSUE_NUMBER" \
+              --repo ${{ github.repository }} \
+              --body "Investigation did not produce findings. Check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details."
+          fi


### PR DESCRIPTION
Add a GitHub Actions workflow that triggers when a collaborator
comments `/investigate` on a test failure issue. The workflow launches
a Claude Code agent that autonomously reads the issue, checks out the
failure SHA, analyzes source code and TeamCity artifacts, searches for
related issues, and posts a structured analysis as an issue comment.

On a personal note, this took a lot of duct taping things together in
just the right way. Couldn't have done it without AI and the ability
to test this against my fork.

This workflow is pretty optimized for malleability and performance. Notably call-outs:

- Can run on your fork - "just" get an ANTHROPIC_API_KEY and it will
use that instead of the Vertex AI OIDC we use on our main repo.

- Action can be invoked via `workload_dispatch`, so you can actually run it from a dev branch (on your fork, or on the upstream repo if you get permission to push a branch there). It has a "cheap" mode (so it doesn't burn through your API credits as quickly) and a "smoke test" mode (in which it mostly tries out the tools and reports). In either mode, when dispatched manually, it won't post on any issues (but you can find the output in the workload artifacts).

- Git checkout is optimized via blobless clone (filter=blob:none). This immediately gives the agent full commit
  history for git log/blame without downloading all file contents
  upfront. Blobs are fetched transparently on demand.

- Strict tool allowlist: the agent can only run read-only Bash
  commands (no rm, sed, xargs, or gh api). Findings are written to a
  file and posted by a separate workflow step, so the agent never
  needs write access to GitHub. The agent will report back on tools it was trying to use that weren't allowed, so we can iterate as needed.

- Prompt is externalized to .github/prompts/investigate.md for easy
  iteration. A separate smoke-test prompt (investigate-smoke.md)
  validates tool access cheaply via workflow_dispatch.

Example output (using cheap model): https://gist.github.com/tbg/6da602775c017d3ad02ef61bcfd54396
Corresponding workflow run: https://github.com/tbg/cockroach/actions/runs/22186502670

Epic: none
