### PR TITLE
schemachanger: prevent stale checkpoint write from periodic flusher

### DIFF
--- a/pkg/sql/schemachanger/scexec/exec_backfill.go
+++ b/pkg/sql/schemachanger/scexec/exec_backfill.go
@@ -348,6 +348,9 @@ func runBackfiller(
 		deps.Telemetry().IncrementSchemaChangeErrorType("uncategorized")
 		return err
 	}
+	// Stop the periodic flusher before the final flush to ensure no in-flight
+	// periodic writes can overwrite the final checkpoint state.
+	stop()
 	if err := tracker.FlushFractionCompleted(ctx); err != nil {
 		return err
 	}


### PR DESCRIPTION
Two concurrent FlushCheckpoint calls could each read the cached backfill progress (set via SetBackfillProgress) and then issue writeCheckpoint writes that commit in arbitrary order. If a periodic flusher snapshots stale cached state and its write commits after the final checkpoint write, the persisted job payload reverts to the stale state.

Stop the periodic flusher before the final flush so that any in-flight checkpoint write completes before the final authoritative write begins. The stop() function is already idempotent, so the deferred stop() remains safe.

Fixes flake in TestDistributedMergePhasedProgress.

Fixes #162330.
Epic: CRDB-48845
Release note: None