### PR TITLE
bulkio: enable elastic CPU control for index backfill by default

### DIFF
--- a/pkg/cmd/roachtest/tests/schemachange.go
+++ b/pkg/cmd/roachtest/tests/schemachange.go
@@ -648,6 +648,9 @@ func makeSchemaChangeBulkIngestTest(
 				if _, err := db.Exec("SET CLUSTER SETTING kvadmission.elastic_control_bulk_low_priority.enabled = $1", enableElasticCPUControl); err != nil {
 					t.Fatal(err)
 				}
+				if _, err := db.Exec("SET CLUSTER SETTING bulkio.index_backfill.elastic_control.enabled = $1", enableElasticCPUControl); err != nil {
+					t.Fatal(err)
+				}
 
 				t.L().Printf("Computing table statistics manually")
 				if _, err := db.Exec("CREATE STATISTICS stats from bulkingest.bulkingest"); err != nil {

--- a/pkg/sql/backfill/backfill_test.go
+++ b/pkg/sql/backfill/backfill_test.go
@@ -48,6 +48,7 @@ func TestVectorColumnAndIndexBackfill(t *testing.T) {
 				},
 			},
 		},
+		DisableElasticCPUAdmission: true,
 	})
 	defer srv.Stopper().Stop(ctx)
 	sqlDB := sqlutils.MakeSQLRunner(db)
@@ -112,6 +113,7 @@ func TestConcurrentOperationsDuringVectorIndexCreation(t *testing.T) {
 				},
 			},
 		},
+		DisableElasticCPUAdmission: true,
 	})
 	defer srv.Stopper().Stop(ctx)
 	sqlDB := sqlutils.MakeSQLRunner(db)
@@ -194,7 +196,9 @@ func TestVectorIndexWithPrefixBackfill(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		DisableElasticCPUAdmission: true,
+	})
 	defer srv.Stopper().Stop(ctx)
 	sqlDB := sqlutils.MakeSQLRunner(db)
 
@@ -263,6 +267,7 @@ func TestVectorIndexMergingDuringBackfill(t *testing.T) {
 				},
 			},
 		},
+		DisableElasticCPUAdmission: true,
 	})
 	defer srv.Stopper().Stop(ctx)
 	sqlDB := sqlutils.MakeSQLRunner(db)
@@ -364,7 +369,8 @@ func TestVectorIndexMergingDuringBackfillWithPrefix(t *testing.T) {
 				},
 			},
 		},
-		DefaultTestTenant: testTenant,
+		DefaultTestTenant:          testTenant,
+		DisableElasticCPUAdmission: true,
 	})
 	defer srv.Stopper().Stop(ctx)
 	sqlDB := sqlutils.MakeSQLRunner(db)

--- a/pkg/sql/rowexec/indexbackfiller.go
+++ b/pkg/sql/rowexec/indexbackfiller.go
@@ -90,7 +90,7 @@ var indexBackfillElasticCPUControlEnabled = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
 	"bulkio.index_backfill.elastic_control.enabled",
 	"determines whether index backfill operations integrate with elastic CPU control",
-	false, // TODO(dt): enable this by default after more benchmarking.
+	true,
 )
 
 // indexBackfillSink abstracts the destination for index backfill output so the


### PR DESCRIPTION
This change enables the bulkio.index_backfill.elastic_control.enabled cluster setting by default, integrating index backfill operations with elastic CPU control. This allows index backfill workloads to automatically throttle based on available CPU resources, improving cluster stability during schema changes.

Release note (ops change): The bulkio.index_backfill.elastic_control.enabled cluster setting is now enabled by default, allowing index backfill operations to integrate with elastic CPU control and automatically throttle based on available resources.

Epic: CRDB-48845.