### PR TITLE
bulkio: enable elastic CPU control for import operations by default

### DIFF
--- a/pkg/sql/importer/read_import_base.go
+++ b/pkg/sql/importer/read_import_base.go
@@ -51,7 +51,7 @@ var importElasticCPUControlEnabled = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
 	"bulkio.import.elastic_control.enabled",
 	"determines whether import operations integrate with elastic CPU control",
-	false, // TODO(dt): enable this by default after more benchmarking.
+	true,
 )
 
 func getTableFromSpec(


### PR DESCRIPTION
This change enables the bulkio.import.elastic_control.enabled cluster setting by default, integrating import operations with elastic CPU control. This allows import workloads to automatically throttle based on available CPU resources, improving cluster stability during bulk operations.

Release note (ops change): The bulkio.import.elastic_control.enabled cluster setting is now enabled by default, allowing import operations to integrate with elastic CPU control and automatically throttle based on available resources.

Epic: CRDB-48845.