### PR TITLE
bulkio: enable elastic CPU control for SST batcher by default

### DIFF
--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -76,7 +76,7 @@ var (
 		settings.ApplicationLevel,
 		"bulkio.ingest.sst_batcher_elastic_control.enabled",
 		"determines whether the sst batcher integrates with elastic CPU control",
-		false, // TODO(dt): enable this by default.
+		true,
 	)
 )
 


### PR DESCRIPTION
This change enables the bulkio.ingest.sst_batcher_elastic_control.enabled cluster setting by default, integrating SST batcher operations with elastic CPU control. This allows SST ingestion workloads to automatically throttle based on available CPU resources, improving cluster stability during bulk ingestion operations.

Release note (ops change): The bulkio.ingest.sst_batcher_elastic_control.enabled cluster setting is now enabled by default, allowing SST batcher operations to integrate with elastic CPU control and automatically throttle based on available resources.

Epic: CRDB-48845.