### PR TITLE
release-26.1: kvserver: deflake TestLargeUnsplittableRangeReplicate

### DIFF
--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvtestutils"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/raft/tracker"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -1834,11 +1835,12 @@ func TestLargeUnsplittableRangeReplicate(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderStress(t, 38565)
-	skip.UnderRaceWithIssue(t, 38565)
+	skip.UnderDuressWithIssue(t, 38565)
 	skip.UnderShort(t, 38565)
-	skip.UnderDeadlockWithIssue(t, 38565)
+
 	ctx := context.Background()
+
+	testutils.SetVModule(t, "allocator_scorer=3")
 
 	const rangeMaxSize = 64 << 20
 	zcfg := zonepb.DefaultZoneConfig()
@@ -1876,8 +1878,14 @@ func TestLargeUnsplittableRangeReplicate(t *testing.T) {
 	_, err := db.Exec("create table t (i int primary key, s string)")
 	require.NoError(t, err)
 
-	_, err = db.Exec(`ALTER TABLE t EXPERIMENTAL_RELOCATE VALUES (ARRAY[1,2,3], 1)`)
-	require.NoError(t, err)
+	testutils.SucceedsSoon(t, func() error {
+		_, err := db.Exec(`ALTER TABLE t EXPERIMENTAL_RELOCATE VALUES (ARRAY[1,2,3], 1)`)
+		if kvtestutils.IsExpectedRelocateError(err) {
+			return err
+		}
+		require.NoError(t, err)
+		return nil
+	})
 	_, err = db.Exec(`ALTER TABLE t SPLIT AT VALUES (1)`)
 	require.NoError(t, err)
 	_, err = db.Exec(`ALTER TABLE t SPLIT AT VALUES (2)`)


### PR DESCRIPTION
Backport 1/1 commits from #163837 on behalf of @stevendanna.

----

This test recently flaked because EXPERIMENTAL_RELOCATE failed with:

    pq: none of the remaining voters [n2,s2] are legal additions to
    (n1,s1):1,(n5,s5):2,(n3,s3):4

I have not been able to reproduce this locally. I've added logging to the allocator that perhaps could have helped dtermine _why_ this was an illegal addition.

I've also added a retry to the EXPERIMETNAL_RELOCATE, which we use elsewhere when relocating ranges.

Fixes #163779
Release note: None

----

Release justification: Test and observability update