### PR TITLE
roachtest: add -w flag to iptables invocations to wait for xtables lock

### DIFF
--- a/pkg/cmd/roachtest/operations/network_partition.go
+++ b/pkg/cmd/roachtest/operations/network_partition.go
@@ -26,7 +26,7 @@ func (np *cleanupNetworkPartition) Cleanup(
 	ctx context.Context, o operation.Operation, c cluster.Cluster,
 ) {
 	o.Status(fmt.Sprintf("remove the partition on node n%d", np.nodeID))
-	c.Run(ctx, option.WithNodes(c.Node(np.nodeID)), `sudo iptables -F`)
+	c.Run(ctx, option.WithNodes(c.Node(np.nodeID)), `sudo iptables -w -F`)
 }
 
 // createNetworkPartition creates a network partition between two random nodes.
@@ -57,8 +57,8 @@ func createNetworkPartialPartition(
 	otherNodeIP := ips[0]
 	o.Status(fmt.Sprintf("creating a partition between nodes n%d and n%d", nodeID, otherNodeID))
 	// Block all input and output traffic between the two nodes.
-	c.Run(ctx, option.WithNodes(c.Node(nodeID)), fmt.Sprintf(`sudo iptables -A INPUT  -p tcp -s %s -j DROP`, otherNodeIP))
-	c.Run(ctx, option.WithNodes(c.Node(nodeID)), fmt.Sprintf(`sudo iptables -A OUTPUT -p tcp -d %s -j DROP`, otherNodeIP))
+	c.Run(ctx, option.WithNodes(c.Node(nodeID)), fmt.Sprintf(`sudo iptables -w -A INPUT  -p tcp -s %s -j DROP`, otherNodeIP))
+	c.Run(ctx, option.WithNodes(c.Node(nodeID)), fmt.Sprintf(`sudo iptables -w -A OUTPUT -p tcp -d %s -j DROP`, otherNodeIP))
 
 	return &cleanupNetworkPartition{nodeID: nodeID}
 }
@@ -77,10 +77,10 @@ func createNetworkFullPartition(
 	// Drop bi-directional traffic between the node and all other nodes on the
 	// pgport.
 	o.Status(fmt.Sprintf("partition node n%d from the cluster", nodeID))
-	c.Run(ctx, option.WithNodes(c.Node(nodeID)), fmt.Sprintf(`sudo iptables -A INPUT  -p tcp --sport {pgport:%d} -j DROP`, nodeID))
-	c.Run(ctx, option.WithNodes(c.Node(nodeID)), fmt.Sprintf(`sudo iptables -A OUTPUT -p tcp --sport {pgport:%d} -j DROP`, nodeID))
-	c.Run(ctx, option.WithNodes(c.Node(nodeID)), fmt.Sprintf(`sudo iptables -A INPUT  -p tcp --dport {pgport:%d} -j DROP`, nodeID))
-	c.Run(ctx, option.WithNodes(c.Node(nodeID)), fmt.Sprintf(`sudo iptables -A OUTPUT -p tcp --dport {pgport:%d} -j DROP`, nodeID))
+	c.Run(ctx, option.WithNodes(c.Node(nodeID)), fmt.Sprintf(`sudo iptables -w -A INPUT  -p tcp --sport {pgport:%d} -j DROP`, nodeID))
+	c.Run(ctx, option.WithNodes(c.Node(nodeID)), fmt.Sprintf(`sudo iptables -w -A OUTPUT -p tcp --sport {pgport:%d} -j DROP`, nodeID))
+	c.Run(ctx, option.WithNodes(c.Node(nodeID)), fmt.Sprintf(`sudo iptables -w -A INPUT  -p tcp --dport {pgport:%d} -j DROP`, nodeID))
+	c.Run(ctx, option.WithNodes(c.Node(nodeID)), fmt.Sprintf(`sudo iptables -w -A OUTPUT -p tcp --dport {pgport:%d} -j DROP`, nodeID))
 
 	return &cleanupNetworkPartition{nodeID: nodeID}
 }

--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -1354,7 +1354,7 @@ func (f *blackholeFailer) Setup(context.Context)       {}
 func (f *blackholeFailer) Ready(context.Context, int)  {}
 
 func (f *blackholeFailer) Cleanup(ctx context.Context) {
-	f.c.Run(ctx, option.WithNodes(f.c.All()), `sudo iptables -F`)
+	f.c.Run(ctx, option.WithNodes(f.c.All()), `sudo iptables -w -F`)
 }
 
 func (f *blackholeFailer) Fail(ctx context.Context, nodeID int) {
@@ -1371,15 +1371,15 @@ func (f *blackholeFailer) Fail(ctx context.Context, nodeID int) {
 	// outages in the wild.
 	if f.input && f.output {
 		// Inbound TCP connections, both received and sent packets.
-		f.c.Run(ctx, option.WithNodes(f.c.Node(nodeID)), fmt.Sprintf(`sudo iptables -A INPUT -p tcp --dport %s -j DROP`, pgport))
-		f.c.Run(ctx, option.WithNodes(f.c.Node(nodeID)), fmt.Sprintf(`sudo iptables -A OUTPUT -p tcp --sport %s -j DROP`, pgport))
+		f.c.Run(ctx, option.WithNodes(f.c.Node(nodeID)), fmt.Sprintf(`sudo iptables -w -A INPUT -p tcp --dport %s -j DROP`, pgport))
+		f.c.Run(ctx, option.WithNodes(f.c.Node(nodeID)), fmt.Sprintf(`sudo iptables -w -A OUTPUT -p tcp --sport %s -j DROP`, pgport))
 		// Outbound TCP connections, both sent and received packets.
-		f.c.Run(ctx, option.WithNodes(f.c.Node(nodeID)), fmt.Sprintf(`sudo iptables -A OUTPUT -p tcp --dport %s -j DROP`, pgport))
-		f.c.Run(ctx, option.WithNodes(f.c.Node(nodeID)), fmt.Sprintf(`sudo iptables -A INPUT -p tcp --sport %s -j DROP`, pgport))
+		f.c.Run(ctx, option.WithNodes(f.c.Node(nodeID)), fmt.Sprintf(`sudo iptables -w -A OUTPUT -p tcp --dport %s -j DROP`, pgport))
+		f.c.Run(ctx, option.WithNodes(f.c.Node(nodeID)), fmt.Sprintf(`sudo iptables -w -A INPUT -p tcp --sport %s -j DROP`, pgport))
 	} else if f.input {
-		f.c.Run(ctx, option.WithNodes(f.c.Node(nodeID)), fmt.Sprintf(`sudo iptables -A INPUT -p tcp --dport %s -j DROP`, pgport))
+		f.c.Run(ctx, option.WithNodes(f.c.Node(nodeID)), fmt.Sprintf(`sudo iptables -w -A INPUT -p tcp --dport %s -j DROP`, pgport))
 	} else if f.output {
-		f.c.Run(ctx, option.WithNodes(f.c.Node(nodeID)), fmt.Sprintf(`sudo iptables -A OUTPUT -p tcp --dport %s -j DROP`, pgport))
+		f.c.Run(ctx, option.WithNodes(f.c.Node(nodeID)), fmt.Sprintf(`sudo iptables -w -A OUTPUT -p tcp --dport %s -j DROP`, pgport))
 	}
 }
 
@@ -1402,26 +1402,26 @@ func (f *blackholeFailer) FailPartial(ctx context.Context, nodeID int, peerIDs [
 		if f.input && f.output {
 			// Inbound TCP connections, both received and sent packets.
 			f.c.Run(ctx, option.WithNodes(f.c.Node(nodeID)), fmt.Sprintf(
-				`sudo iptables -A INPUT -p tcp -s %s --dport %s -j DROP`, peerIP, pgport))
+				`sudo iptables -w -A INPUT -p tcp -s %s --dport %s -j DROP`, peerIP, pgport))
 			f.c.Run(ctx, option.WithNodes(f.c.Node(nodeID)), fmt.Sprintf(
-				`sudo iptables -A OUTPUT -p tcp -d %s --sport %s -j DROP`, peerIP, pgport))
+				`sudo iptables -w -A OUTPUT -p tcp -d %s --sport %s -j DROP`, peerIP, pgport))
 			// Outbound TCP connections, both sent and received packets.
 			f.c.Run(ctx, option.WithNodes(f.c.Node(nodeID)), fmt.Sprintf(
-				`sudo iptables -A OUTPUT -p tcp -d %s --dport %s -j DROP`, peerIP, pgport))
+				`sudo iptables -w -A OUTPUT -p tcp -d %s --dport %s -j DROP`, peerIP, pgport))
 			f.c.Run(ctx, option.WithNodes(f.c.Node(nodeID)), fmt.Sprintf(
-				`sudo iptables -A INPUT -p tcp -s %s --sport %s -j DROP`, peerIP, pgport))
+				`sudo iptables -w -A INPUT -p tcp -s %s --sport %s -j DROP`, peerIP, pgport))
 		} else if f.input {
 			f.c.Run(ctx, option.WithNodes(f.c.Node(nodeID)), fmt.Sprintf(
-				`sudo iptables -A INPUT -p tcp -s %s --dport %s -j DROP`, peerIP, pgport))
+				`sudo iptables -w -A INPUT -p tcp -s %s --dport %s -j DROP`, peerIP, pgport))
 		} else if f.output {
 			f.c.Run(ctx, option.WithNodes(f.c.Node(nodeID)), fmt.Sprintf(
-				`sudo iptables -A OUTPUT -p tcp -d %s --dport %s -j DROP`, peerIP, pgport))
+				`sudo iptables -w -A OUTPUT -p tcp -d %s --dport %s -j DROP`, peerIP, pgport))
 		}
 	}
 }
 
 func (f *blackholeFailer) Recover(ctx context.Context, nodeID int) {
-	f.c.Run(ctx, option.WithNodes(f.c.Node(nodeID)), `sudo iptables -F`)
+	f.c.Run(ctx, option.WithNodes(f.c.Node(nodeID)), `sudo iptables -w -F`)
 }
 
 // crashFailer is a process crash where the TCP/IP stack remains responsive

--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -724,10 +724,10 @@ func drainWithIpTables(
 	// packets in both directions.
 	// TODO(baptist): Convert this to use a network partitioning utility.
 	if !c.IsLocal() {
-		c.Run(ctx, option.WithNodes(restartNode), `sudo iptables -A INPUT -p tcp --dport 26257 -j DROP`)
-		c.Run(ctx, option.WithNodes(restartNode), `sudo iptables -A OUTPUT -p tcp --dport 26257 -j DROP`)
+		c.Run(ctx, option.WithNodes(restartNode), `sudo iptables -w -A INPUT -p tcp --dport 26257 -j DROP`)
+		c.Run(ctx, option.WithNodes(restartNode), `sudo iptables -w -A OUTPUT -p tcp --dport 26257 -j DROP`)
 		// NB: We don't use the original context as it might be cancelled.
-		defer c.Run(context.Background(), option.WithNodes(restartNode), `sudo iptables -F`)
+		defer c.Run(context.Background(), option.WithNodes(restartNode), `sudo iptables -w -F`)
 	}
 	c.Stop(ctx, t.L(), option.DefaultStopOpts(), restartNode)
 

--- a/pkg/cmd/roachtest/tests/perturbation/network_partition.go
+++ b/pkg/cmd/roachtest/tests/perturbation/network_partition.go
@@ -65,7 +65,7 @@ func (p partition) startPerturbation(ctx context.Context, t test.Test, v variati
 			ctx,
 			v.withPartitionedNodes(v, p.partitionSite),
 			fmt.Sprintf(
-				`sudo iptables -A INPUT -p tcp -s %s -j DROP`, targetIPs[0]))
+				`sudo iptables -w -A INPUT -p tcp -s %s -j DROP`, targetIPs[0]))
 	}
 	waitDuration(ctx, v.perturbationDuration)
 	// During the first 10 seconds after the partition, we expect latency to drop,
@@ -76,7 +76,7 @@ func (p partition) startPerturbation(ctx context.Context, t test.Test, v variati
 func (p partition) endPerturbation(ctx context.Context, t test.Test, v variations) time.Duration {
 	startTime := timeutil.Now()
 	if !v.IsLocal() {
-		v.Run(ctx, v.withPartitionedNodes(v, p.partitionSite), `sudo iptables -F`)
+		v.Run(ctx, v.withPartitionedNodes(v, p.partitionSite), `sudo iptables -w -F`)
 	}
 	waitDuration(ctx, v.validationDuration)
 	return timeutil.Since(startTime)


### PR DESCRIPTION
  Without -w, iptables fails immediately with exit status 4 when another
  process holds the xtables lock ("Another app is currently holding the
  xtables lock"). This caused a flaky test failure in
  failover/partial/lease-gateway on FIPS nodes.

  Unclear _what_ exactly had the xtables lock.

  Fixes #163538
  Release note: None