### PR TITLE
colexec: refactor worker goroutines in ParallelUnorderedSynchronizer

### DIFF
--- a/pkg/sql/colexec/colexecutils/cancel_checker.go
+++ b/pkg/sql/colexec/colexecutils/cancel_checker.go
@@ -30,14 +30,7 @@ type CancelChecker struct {
 	// check.
 	callsSinceLastCheck uint32
 
-	// sqlCPUHandle is the SQL-level CPU handle from which a per-goroutine
-	// handle is lazily registered on the first CheckEveryCall. Registration
-	// is deferred from Init to the first check because Init and Next may
-	// run on different goroutines (e.g. ParallelUnorderedSynchronizer
-	// initializes operator trees on the main goroutine but runs them on
-	// child goroutines).
-	sqlCPUHandle *admission.SQLCPUHandle
-	cpuHandle    *admission.GoroutineCPUHandle
+	cpuHandle *admission.GoroutineCPUHandle
 }
 
 var _ colexecop.Operator = &CancelChecker{}
@@ -57,7 +50,10 @@ func (c *CancelChecker) Init(ctx context.Context) {
 		// Check*() methods, and the input remains nil then.
 		c.Input.Init(c.Ctx)
 	}
-	c.sqlCPUHandle = admission.SQLCPUHandleFromContext(ctx)
+	cpuHandle := admission.SQLCPUHandleFromContext(ctx)
+	if cpuHandle != nil {
+		c.cpuHandle = cpuHandle.RegisterGoroutine()
+	}
 }
 
 // Next is part of colexecop.Operator interface.
@@ -93,11 +89,9 @@ func (c *CancelChecker) CheckEveryCall() {
 		colexecerror.ExpectedError(cancelchecker.QueryCanceledError)
 	default:
 	}
-	if c.cpuHandle == nil && c.sqlCPUHandle != nil {
-		c.cpuHandle = c.sqlCPUHandle.RegisterGoroutine()
-	}
 	if c.cpuHandle != nil {
-		if err := c.cpuHandle.MeasureAndAdmit(c.Ctx); err != nil {
+		err := c.cpuHandle.MeasureAndAdmit(c.Ctx)
+		if err != nil {
 			colexecerror.ExpectedError(cancelchecker.QueryCanceledError)
 		}
 	}

--- a/pkg/sql/colexec/parallel_unordered_synchronizer.go
+++ b/pkg/sql/colexec/parallel_unordered_synchronizer.go
@@ -51,6 +51,9 @@ const (
 	// parallelUnorderedSynchronizerStateUninitialized is the state the
 	// ParallelUnorderedSynchronizer is in when not yet initialized.
 	parallelUnorderedSynchronizerStateUninitialized = iota
+	// parallelUnorderedSynchronizerStateWorkersBlocked is the state the
+	// ParallelUnorderedSynchronizer is in when the workers are blocked.
+	parallelUnorderedSynchronizerStateWorkersBlocked
 	// parallelUnorderedSynchronizerStateRunning is the state the
 	// ParallelUnorderedSynchronizer is in when all input goroutines have been
 	// spawned and are returning batches.
@@ -78,6 +81,12 @@ type ParallelUnorderedSynchronizer struct {
 	// NewParallelUnorderedSynchronizer for more details).
 	cancelInputsOnDrain []context.CancelFunc
 	tracingSpans        []*tracing.Span
+	// blockWorkersCh is the channel that blocks the worker goroutines until
+	// they should actually start consuming batches from their inputs.
+	blockWorkersCh chan struct{}
+	// exitWorkersCh is the channel that blocks the worker goroutines until
+	// they should just short-circuit.
+	exitWorkersCh chan struct{}
 	// readNextBatch is a slice of channels, where each channel corresponds to the
 	// input at the same index in inputs. It is used as a barrier for input
 	// goroutines to wait on until the Next goroutine signals that it is safe to
@@ -119,6 +128,7 @@ type ParallelUnorderedSynchronizer struct {
 	internalWaitGroup *sync.WaitGroup
 	batchCh           chan *unorderedSynchronizerMsg
 	errCh             chan error
+	closed            bool
 }
 
 var _ colexecop.DrainableClosableOperator = &ParallelUnorderedSynchronizer{}
@@ -216,6 +226,8 @@ func NewParallelUnorderedSynchronizer(
 		inputs:              inputs,
 		cancelInputsOnDrain: cancelInputs,
 		tracingSpans:        make([]*tracing.Span, len(inputs)),
+		blockWorkersCh:      make(chan struct{}),
+		exitWorkersCh:       make(chan struct{}),
 		readNextBatch:       readNextBatch,
 		batches:             make([]coldata.Batch, len(inputs)),
 		metas:               make([]*execinfrapb.ProducerMetadata, len(inputs)),
@@ -241,7 +253,8 @@ func (s *ParallelUnorderedSynchronizer) Init(ctx context.Context) {
 	if !s.InitHelper.Init(ctx) {
 		return
 	}
-	for i, input := range s.inputs {
+	s.setState(parallelUnorderedSynchronizerStateWorkersBlocked)
+	for i := range s.inputs {
 		var inputCtx context.Context
 		inputCtx, s.tracingSpans[i] = execinfra.ProcessorSpan(
 			s.Ctx, s.flowCtx, fmt.Sprintf("parallel unordered sync input %d", i), s.processorID,
@@ -249,12 +262,36 @@ func (s *ParallelUnorderedSynchronizer) Init(ctx context.Context) {
 		if s.cancelInputsOnDrain != nil {
 			inputCtx, s.cancelInputsOnDrain[i] = context.WithCancel(inputCtx)
 		}
-		input.Root.Init(inputCtx)
-		s.nextBatch[i] = func(inputOp colexecop.Operator, inputIdx int) func() {
-			return func() {
-				s.batches[inputIdx], s.metas[inputIdx] = inputOp.Next()
+		s.externalWaitGroup.Add(1)
+		s.internalWaitGroup.Add(1)
+		go func(ctx context.Context, inputIdx int) {
+			if cpuHandle := admission.SQLCPUHandleFromContext(ctx); cpuHandle != nil {
+				gh := cpuHandle.RegisterGoroutine()
+				defer gh.Close(ctx)
 			}
-		}(input.Root, i)
+			defer func() {
+				if int(atomic.AddUint32(&s.numFinishedInputs, 1)) == len(s.inputs) {
+					close(s.batchCh)
+				}
+				if s.tracingSpans[inputIdx] != nil {
+					s.tracingSpans[inputIdx].Finish()
+					s.tracingSpans[inputIdx] = nil
+				}
+				s.internalWaitGroup.Done()
+				s.externalWaitGroup.Done()
+			}()
+			input := s.inputs[inputIdx]
+			if err := colexecerror.CatchVectorizedRuntimeError(func() {
+				input.Root.Init(ctx)
+			}); err != nil {
+				s.workerSendErr(err)
+				return
+			}
+			s.nextBatch[inputIdx] = func() {
+				s.batches[inputIdx], s.metas[inputIdx] = input.Root.Next()
+			}
+			s.workerRun(input, inputIdx)
+		}(inputCtx, i)
 	}
 }
 
@@ -266,135 +303,115 @@ func (s *ParallelUnorderedSynchronizer) setState(state parallelUnorderedSynchron
 	atomic.SwapInt32(&s.state, int32(state))
 }
 
-// init starts one goroutine per input to read from each input asynchronously
-// and push to batchCh. Canceling the context (passed in Init() above) results
-// in all goroutines terminating, otherwise they keep on pushing batches until a
-// zero-length batch is encountered. Once all inputs terminate, s.batchCh is
-// closed. If an error occurs, the goroutines will make a non-blocking best
-// effort to push that error on s.errCh, resulting in the first error pushed to
-// be observed by the Next goroutine. Inputs are asynchronous so that the
-// synchronizer is minimally affected by slow inputs.
-func (s *ParallelUnorderedSynchronizer) init() {
-	for i, input := range s.inputs {
-		s.externalWaitGroup.Add(1)
-		s.internalWaitGroup.Add(1)
-		// TODO(asubiotto): Most inputs are Inboxes, and these have handler
-		// goroutines just sitting around waiting for cancellation. I wonder if we
-		// could reuse those goroutines to push batches to batchCh directly.
-		go func(input colexecargs.OpWithMetaInfo, inputIdx int) {
-			if cpuHandle := admission.SQLCPUHandleFromContext(s.Ctx); cpuHandle != nil {
-				gh := cpuHandle.RegisterGoroutine()
-				defer gh.Close(s.Ctx)
-			}
-			span := s.tracingSpans[inputIdx]
-			defer func() {
-				if int(atomic.AddUint32(&s.numFinishedInputs, 1)) == len(s.inputs) {
-					close(s.batchCh)
+func (s *ParallelUnorderedSynchronizer) workerSendErr(err error) {
+	select {
+	// Non-blocking write to errCh, if an error is present the main
+	// goroutine will use that and cancel all inputs.
+	case s.errCh <- err:
+	default:
+	}
+}
+
+// workerRun is the body of the worker goroutine that reads batches from the
+// input and pushes to batchCh. It's initially blocked on the s.blockWorkersCh.
+//
+// Canceling the context (passed in Init() above) results in all goroutines
+// terminating, otherwise they keep on pushing batches until a zero-length batch
+// is encountered. Once all inputs terminate, s.batchCh is closed. If an error
+// occurs, the goroutines will make a non-blocking best effort to push that
+// error on s.errCh, resulting in the first error pushed to be observed by the
+// Next goroutine. Inputs are asynchronous so that the synchronizer is minimally
+// affected by slow inputs.
+func (s *ParallelUnorderedSynchronizer) workerRun(input colexecargs.OpWithMetaInfo, inputIdx int) {
+	select {
+	case <-s.blockWorkersCh:
+	case <-s.exitWorkersCh:
+		return
+	}
+	msg := &unorderedSynchronizerMsg{
+		inputIdx: inputIdx,
+	}
+	var metaScratch [1]execinfrapb.ProducerMetadata
+	var sentDrainedMeta bool
+	for {
+		state := s.getState()
+		switch state {
+		case parallelUnorderedSynchronizerStateRunning:
+			if err := colexecerror.CatchVectorizedRuntimeError(s.nextBatch[inputIdx]); err != nil {
+				if s.getState() == parallelUnorderedSynchronizerStateDraining && s.Ctx.Err() == nil && s.cancelInputsOnDrain != nil {
+					// The synchronizer has just transitioned into the
+					// draining state and eagerly canceled work of this
+					// input. That cancellation is likely to manifest
+					// itself as the context.Canceled error, but it
+					// could be another error too; in any case, we will
+					// swallow the error because the user of the
+					// synchronizer is only interested in the metadata
+					// at this point.
+					continue
 				}
-				if span != nil {
-					span.Finish()
-				}
-				s.internalWaitGroup.Done()
-				s.externalWaitGroup.Done()
-			}()
-			sendErr := func(err error) {
-				select {
-				// Non-blocking write to errCh, if an error is present the main
-				// goroutine will use that and cancel all inputs.
-				case s.errCh <- err:
-				default:
-				}
+				s.workerSendErr(err)
+				// After we encounter an error, we proceed to draining.
+				// If this is a context cancellation, we'll realize that
+				// in the select below, so the drained meta will be
+				// ignored, for all other errors the drained meta will
+				// be sent to the coordinator goroutine.
+				s.setState(parallelUnorderedSynchronizerStateDraining)
+				continue
 			}
-			if s.nextBatch[inputIdx] == nil {
-				// The initialization of this input wasn't successful, so it is
-				// invalid to call Next or DrainMeta on it. Exit early.
-				return
+			msg.b, msg.meta = s.batches[inputIdx], nil
+			if s.metas[inputIdx] != nil {
+				msg.meta = metaScratch[:]
+				msg.meta[0] = *s.metas[inputIdx]
 			}
-			msg := &unorderedSynchronizerMsg{
+			if len(msg.meta) > 0 || msg.b.Length() > 0 {
+				// Send the batch or the metadata.
+				break
+			}
+			// In case of a zero-length batch, proceed to drain the input.
+			fallthrough
+		case parallelUnorderedSynchronizerStateDraining:
+			// Create a new message for metadata. The previous message cannot be
+			// overwritten since it might still be in the channel.
+			msg = &unorderedSynchronizerMsg{
 				inputIdx: inputIdx,
 			}
-			var metaScratch [1]execinfrapb.ProducerMetadata
-			var sentDrainedMeta bool
-			for {
-				state := s.getState()
-				switch state {
-				case parallelUnorderedSynchronizerStateRunning:
-					if err := colexecerror.CatchVectorizedRuntimeError(s.nextBatch[inputIdx]); err != nil {
-						if s.getState() == parallelUnorderedSynchronizerStateDraining && s.Ctx.Err() == nil && s.cancelInputsOnDrain != nil {
-							// The synchronizer has just transitioned into the
-							// draining state and eagerly canceled work of this
-							// input. That cancellation is likely to manifest
-							// itself as the context.Canceled error, but it
-							// could be another error too; in any case, we will
-							// swallow the error because the user of the
-							// synchronizer is only interested in the metadata
-							// at this point.
-							continue
-						}
-						sendErr(err)
-						// After we encounter an error, we proceed to draining.
-						// If this is a context cancellation, we'll realize that
-						// in the select below, so the drained meta will be
-						// ignored, for all other errors the drained meta will
-						// be sent to the coordinator goroutine.
-						s.setState(parallelUnorderedSynchronizerStateDraining)
-						continue
-					}
-					msg.b, msg.meta = s.batches[inputIdx], nil
-					if s.metas[inputIdx] != nil {
-						msg.meta = metaScratch[:]
-						msg.meta[0] = *s.metas[inputIdx]
-					}
-					if len(msg.meta) > 0 || msg.b.Length() > 0 {
-						// Send the batch or the metadata.
-						break
-					}
-					// In case of a zero-length batch, proceed to drain the input.
-					fallthrough
-				case parallelUnorderedSynchronizerStateDraining:
-					// Create a new message for metadata. The previous message cannot be
-					// overwritten since it might still be in the channel.
-					msg = &unorderedSynchronizerMsg{
-						inputIdx: inputIdx,
-					}
-					sentDrainedMeta = true
-					if span != nil {
-						for _, s := range input.StatsCollectors {
-							span.RecordStructured(s.GetStats())
-						}
-						if meta := execinfra.GetTraceDataAsMetadata(s.flowCtx, span); meta != nil {
-							msg.meta = append(msg.meta, *meta)
-						}
-					}
-					if input.MetadataSources != nil {
-						msg.meta = append(msg.meta, input.MetadataSources.DrainMeta()...)
-					}
-				default:
-					sendErr(errors.AssertionFailedf("unhandled state in ParallelUnorderedSynchronizer input goroutine: %d", state))
-					return
+			sentDrainedMeta = true
+			span := s.tracingSpans[inputIdx]
+			if span != nil {
+				for _, s := range input.StatsCollectors {
+					span.RecordStructured(s.GetStats())
 				}
-				select {
-				case <-s.Ctx.Done():
-					sendErr(s.Ctx.Err())
-					return
-				case s.batchCh <- msg:
-				}
-
-				if sentDrainedMeta {
-					// The input has been drained and this input has pushed the metadata
-					// over the channel, exit.
-					return
-				}
-
-				// Wait until Next goroutine tells us we are good to go.
-				select {
-				case <-s.readNextBatch[inputIdx]:
-				case <-s.Ctx.Done():
-					sendErr(s.Ctx.Err())
-					return
+				if meta := execinfra.GetTraceDataAsMetadata(s.flowCtx, span); meta != nil {
+					msg.meta = append(msg.meta, *meta)
 				}
 			}
-		}(input, i)
+			if input.MetadataSources != nil {
+				msg.meta = append(msg.meta, input.MetadataSources.DrainMeta()...)
+			}
+		default:
+			s.workerSendErr(errors.AssertionFailedf("unhandled state in ParallelUnorderedSynchronizer input goroutine: %d", state))
+			return
+		}
+		select {
+		case <-s.Ctx.Done():
+			s.workerSendErr(s.Ctx.Err())
+			return
+		case s.batchCh <- msg:
+		}
+
+		if sentDrainedMeta {
+			// The input has been drained and this input has pushed the metadata
+			// over the channel, exit.
+			return
+		}
+
+		// Wait until Next goroutine tells us we are good to go.
+		select {
+		case <-s.readNextBatch[inputIdx]:
+		case <-s.Ctx.Done():
+			s.workerSendErr(s.Ctx.Err())
+			return
+		}
 	}
 }
 
@@ -420,9 +437,9 @@ func (s *ParallelUnorderedSynchronizer) Next() (coldata.Batch, *execinfrapb.Prod
 		switch state {
 		case parallelUnorderedSynchronizerStateDone:
 			return coldata.ZeroBatch, nil
-		case parallelUnorderedSynchronizerStateUninitialized:
+		case parallelUnorderedSynchronizerStateWorkersBlocked:
 			s.setState(parallelUnorderedSynchronizerStateRunning)
-			s.init()
+			close(s.blockWorkersCh)
 		case parallelUnorderedSynchronizerStateRunning:
 			// Signal the input whose batch or metadata we returned in the last
 			// call to Next that it is safe to retrieve the next batch. Since
@@ -496,8 +513,12 @@ func (s *ParallelUnorderedSynchronizer) notifyInputToReadNextBatch() {
 func (s *ParallelUnorderedSynchronizer) DrainMeta() []execinfrapb.ProducerMetadata {
 	prevState := s.getState()
 	s.setState(parallelUnorderedSynchronizerStateDraining)
-	if prevState == parallelUnorderedSynchronizerStateUninitialized {
-		s.init()
+	switch prevState {
+	case parallelUnorderedSynchronizerStateUninitialized:
+		// Init() was never called, so there is nothing to drain.
+		return nil
+	case parallelUnorderedSynchronizerStateWorkersBlocked:
+		close(s.blockWorkersCh)
 	}
 	// Cancel all inputs if eager cancellation is allowed.
 	for _, cancelFunc := range s.cancelInputsOnDrain {
@@ -605,20 +626,22 @@ func (s *ParallelUnorderedSynchronizer) DrainMeta() []execinfrapb.ProducerMetada
 
 // Close is part of the colexecop.ClosableOperator interface.
 func (s *ParallelUnorderedSynchronizer) Close(ctx context.Context) error {
-	if state := s.getState(); state != parallelUnorderedSynchronizerStateUninitialized {
-		// Input goroutines have been started and will take care of finishing
-		// the tracing spans.
+	if s.closed {
 		return nil
 	}
-	// If the synchronizer is in "uninitialized" state, it means that the
-	// goroutines for each input haven't been started, so they won't be able to
-	// finish their tracing spans. In such a scenario the synchronizer must do
-	// that on its own.
-	for i, span := range s.tracingSpans {
-		if span != nil {
-			span.Finish()
-			s.tracingSpans[i] = nil
-		}
+	s.closed = true
+	switch s.getState() {
+	case parallelUnorderedSynchronizerStateUninitialized:
+		// Init() was never called, so there is nothing to close.
+		return nil
+	case parallelUnorderedSynchronizerStateWorkersBlocked:
+		// Close the exitWorkersCh so that they short-circuit their execution
+		// and simply clean themselves up.
+		close(s.exitWorkersCh)
+		return nil
+	default:
+		// Worker goroutines have been unblocked and will take care of cleaning
+		// themselves up.
+		return nil
 	}
-	return nil
 }

--- a/pkg/sql/colexecop/operator.go
+++ b/pkg/sql/colexecop/operator.go
@@ -32,6 +32,8 @@ type Operator interface {
 	//
 	// It might panic with an expected error, so there must be a "root"
 	// component that will catch that panic.
+	//
+	// Init and Next must be called from the same goroutine.
 	Init(ctx context.Context)
 
 	// Next returns the next Batch from this operator. Once the operator is
@@ -48,6 +50,8 @@ type Operator interface {
 	//
 	// It might panic with an expected error, so there must be a "root"
 	// component that will catch that panic.
+	//
+	// Init and Next must be called from the same goroutine.
 	Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 
 	execopnode.OpNode

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -999,14 +999,17 @@ func TestDistributedQueryErrorIsRetriedLocally(t *testing.T) {
 
 	// We use different queries to simplify handling the node ID on which the
 	// error should be injected (i.e. we avoid the need for synchronization in
-	// the test). In particular, the difficulty comes from the fact that some of
-	// the SetupFlow RPCs might not be issued at all while others are served
-	// after the corresponding flow on the gateway has exited.
+	// the test).
+	//
+	// We'll inject errors for the first two queries, and they must have such
+	// plans that no query result row can be produced by any flow independently
+	// (i.e. we must have a "final" processor on the gateway that waits for
+	// remote flows' data).
 	queries := []string{
-		"SELECT k FROM test.foo",
+		"SELECT count(v) FROM test.foo",
 		// Run one of the queries via EXPLAIN ANALYZE (DEBUG) so that we can
 		// check the contents of the bundle later.
-		"EXPLAIN ANALYZE (DEBUG) SELECT v FROM test.foo",
+		"EXPLAIN ANALYZE (DEBUG) SELECT max(v) FROM test.foo",
 		"SELECT * FROM test.foo",
 	}
 	stmtToNodeIDForError := map[string]base.SQLInstanceID{


### PR DESCRIPTION
**colexec: refactor worker goroutines in ParallelUnorderedSynchronizer**

This commit makes it so that `Init` and `Next` on inputs to the PUS are called from the same goroutine. Previously, we called the former on the main PUS goroutine, but then each worker would call the latter. This can lead to unexpected behavior (e.g. with recently-merged SQL CPU accounting), so this commit changes so that we only start the worker goroutines in `Synchronizer.Init` and they are blocked until `Next` is called on the PUS. This seems like a reasonable cleanup on its own too and allows us to explicitly modify the contract of `colexecop.Operator`.

This commit made it a lot more likely for the flake in `TestDistributedQueryErrorIsRetriedLocally` to happen. Namely, that test ensures that retry-distributed-error-as-local mechanism works, and it was using such query plans where it was possible for the mechanism to not kick in (namely, if the gateway flow happened to produce a row _before_ the injected error is observed, we'd set `DistSQLReceiver.dataPushed` disabling the mechanism). This commit adjusts the two queries to avoid such scenarios by guaranteeing that the gateway flow waits for all remote flows' data.

Fixes: #163845.

**Revert "colexec: fix data race in CancelChecker CPU handle registration"**

This reverts commit 9ffc8cf49d1229b888252d61c4449e66f546b114.

The problem that this commit was trying to address was fixed in a different way by the previous commit making this patch redundant.