### PR TITLE
sql: fix transaction bundle collection reliability

### DIFF
--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -4292,6 +4292,10 @@ FROM (
 		)
 	}
 
+	if !found {
+		return &txnDiagnosticsRequestGenerator{created: false}, nil
+	}
+
 	var username string
 	if sd := evalCtx.SessionData(); sd != nil {
 		username = sd.User().Normalized()
@@ -4307,10 +4311,6 @@ FROM (
 		redacted)
 	if err != nil {
 		return nil, err
-	}
-
-	if !found {
-		return &txnDiagnosticsRequestGenerator{created: false}, nil
 	}
 	return &txnDiagnosticsRequestGenerator{requestId: reqId, created: true}, nil
 }

--- a/pkg/sql/stmtdiagnostics/txn_diagnostics_helpers_test.go
+++ b/pkg/sql/stmtdiagnostics/txn_diagnostics_helpers_test.go
@@ -14,9 +14,6 @@ func (r *TxnRegistry) GetRequest(requestID RequestID) (TxnRequest, bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	req, ok := r.mu.requests[requestID]
-	if !ok {
-		req, ok = r.mu.unconditionalOngoingRequests[requestID]
-	}
 	return req, ok
 }
 


### PR DESCRIPTION
Previously, transaction bundle collection had three issues:

1. Similar transactions blocked collection: when many transactions shared the same first statement fingerprint, similar (non-target) transactions would grab the exclusive per-node lock via unconditionalOngoingRequests, discover a mismatch later, release it, and repeat -- starving the target transaction from ever being collected.

2. Multiple requests matching the same first statement fingerprint could never all be fulfilled because ShouldStartTxnDiagnostic iterated a Go map and broke at the first match. Non-deterministic map iteration meant some requests were never picked.

3. makeTxnDiagnosticsRequestGenerator called InsertRequest before checking whether the fingerprint was actually found in transaction statistics, creating orphaned rows in transaction_diagnostics_requests.

This commit replaces the single-request exclusive ownership model with multi-request non-exclusive matching:

- ShouldStartTxnDiagnostic now returns all matching requests instead of just the first one.
- The unconditionalOngoingRequests exclusive lock mechanism is removed; requests stay in mu.requests even when matched.
- txnDiagnosticsCollector tracks multiple candidate requests, each with their own expected fingerprint state. As each statement executes, candidates whose next expected fingerprint doesn't match are eliminated. At finalization, the first qualifying candidate is persisted. The existing completed=false DB-level check in InsertTxnDiagnostic handles races where multiple transactions complete the same request concurrently.
- The !found check in generator_builtins.go is moved before the InsertRequest call to prevent orphaned DB entries.

Resolves: #163488

Release note (bug fix): Fixed a bug where
`crdb_internal.request_transaction_bundle()` could fail to collect bundles when many transactions shared the same first statement fingerprint.