### PR TITLE
descs: force KV lookup for parent-uncommitted descriptors in fresh collections in the same txn

### DIFF
--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -151,6 +151,17 @@ type Collection struct {
 	// txn. This guarantees the generation for long-running transactions
 	// this value stays the same for the life of the transaction.
 	leaseGeneration int64
+
+	// forceStorageLookupIDs contains descriptor IDs that must bypass all
+	// non-storage layers (leased, cached, uncommitted, synthetic) and be
+	// resolved directly from KV. This is used when a fresh Collection is
+	// created for parallel check worker goroutines: the parent (planner's)
+	// Collection has uncommitted descriptors that are only visible via KV
+	// within the same transaction. Without this, a leased or cached descriptor
+	// with a stale version could be returned.
+	// When set, the collection is implicitly read-only to avoid multiple sources
+	// of uncommitted descriptor state.
+	forceStorageLookupIDs catalog.DescriptorIDSet
 }
 
 // FromTxn is a convenience function to extract a descs.Collection which is
@@ -332,6 +343,16 @@ func (tc *Collection) CountUncommittedNewOrDroppedDescriptors() int {
 		return nil
 	})
 	return count
+}
+
+// GetUncommittedDescriptorIDs returns the IDs of all uncommitted descriptors.
+func (tc *Collection) GetUncommittedDescriptorIDs() catalog.DescriptorIDSet {
+	var ids catalog.DescriptorIDSet
+	_ = tc.uncommitted.iterateUncommittedByID(func(desc catalog.Descriptor) error {
+		ids.Add(desc.GetID())
+		return nil
+	})
+	return ids
 }
 
 // HasUncommittedTypes returns true if the Collection contains uncommitted
@@ -562,6 +583,11 @@ func (tc *Collection) WriteDescToBatch(
 	b *kv.Batch,
 	opts ...WriteDescOption,
 ) error {
+	if !tc.forceStorageLookupIDs.Empty() {
+		return errors.AssertionFailedf("descriptor collection with " +
+			"forceStorageLookupIDs set is read-only, should not be used to write " +
+			"descriptors")
+	}
 	if desc.GetID() == descpb.InvalidID {
 		return errors.AssertionFailedf("cannot write descriptor with an empty ID: %v", desc)
 	}

--- a/pkg/sql/catalog/descs/collection_test.go
+++ b/pkg/sql/catalog/descs/collection_test.go
@@ -1296,3 +1296,106 @@ func getDatabaseNames(allDBs []catalog.DatabaseDescriptor) []string {
 	}
 	return names
 }
+
+// TestForceStorageLookupIDs verifies that when a Collection is created with
+// WithForceStorageLookupIDs, descriptor lookups for IDs in the forced set
+// bypass the leased/cached layers and resolve directly from KV storage.
+func TestForceStorageLookupIDs(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer srv.Stopper().Stop(ctx)
+	s := srv.ApplicationLayer()
+
+	tdb := sqlutils.MakeSQLRunner(sqlDB)
+	tdb.Exec(t, "CREATE DATABASE db")
+	tdb.Exec(t, "USE db")
+	// Here the descriptor of db.public.typ is commited with initial version = 1.
+	tdb.Exec(t, "CREATE TYPE db.public.typ AS ENUM ('a')")
+
+	execCfg := s.ExecutorConfig().(sql.ExecutorConfig)
+
+	require.NoError(t, sql.DescsTxn(ctx, &execCfg, func(
+		ctx context.Context, txn isql.Txn, parentCollection *descs.Collection,
+	) error {
+		tn := tree.MakeQualifiedTypeName("db", "public", "typ")
+		_, typ, err := descs.PrefixAndMutableType(ctx, parentCollection.MutableByName(txn.KV()), &tn)
+		require.NoError(t, err)
+		committedVersion := typ.Version
+
+		// Here `WriteDesc()` calls `MaybeIncrementVersion()` that increase the UDT
+		// version by 1.
+		// It also writes to KV within this transaction but without committing.
+		require.NoError(t, parentCollection.WriteDesc(ctx, false /* kvTrace */, typ, txn.KV()))
+		kvVersion := typ.Version
+		require.Greater(t, kvVersion, committedVersion,
+			"WriteDesc should have incremented the version")
+		typID := typ.GetID()
+
+		// Create the child collection with forceStorageLookupIDs set to the
+		// parent's uncommitted descriptor IDs.
+		uncommittedIDs := parentCollection.GetUncommittedDescriptorIDs()
+		require.True(t, uncommittedIDs.Contains(typID),
+			"type descriptor should be in uncommitted IDs")
+
+		childCollection := execCfg.CollectionFactory.NewCollection(
+			ctx, descs.WithForceStorageLookupIDs(uncommittedIDs),
+		)
+		defer childCollection.ReleaseAll(ctx)
+
+		// Also create a child without forceStorageLookupIDs to contrast.
+		childCollectionNoForce := execCfg.CollectionFactory.NewCollection(ctx)
+		defer childCollectionNoForce.ReleaseAll(ctx)
+
+		nonExistentID := descpb.ID(999999)
+
+		testCases := []struct {
+			name            string
+			collection      *descs.Collection
+			id              descpb.ID
+			expectedVersion descpb.DescriptorVersion // 0 means don't check (error case)
+			expectErrStr    string
+		}{
+			{
+				name:            "forced ID resolves from KV storage",
+				collection:      childCollection,
+				id:              typID,
+				expectedVersion: kvVersion,
+			},
+			{
+				name:            "non-forced child gets stale leased version",
+				collection:      childCollectionNoForce,
+				id:              typID,
+				expectedVersion: committedVersion,
+			},
+			{
+				name:         "forced child returns error for non-existent ID",
+				collection:   childCollection,
+				id:           nonExistentID,
+				expectErrStr: "descriptor not found",
+			},
+			{
+				name:         "non-forced child returns error for non-existent ID",
+				collection:   childCollectionNoForce,
+				id:           nonExistentID,
+				expectErrStr: "descriptor not found",
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				desc, err := tc.collection.ByIDWithLeased(txn.KV()).WithoutNonPublic().Get().Desc(ctx, tc.id)
+				if tc.expectErrStr != "" {
+					require.Contains(t, err.Error(), tc.expectErrStr)
+					return
+				}
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedVersion, desc.GetVersion())
+			})
+		}
+
+		return nil
+	}))
+}

--- a/pkg/sql/catalog/descs/descriptor.go
+++ b/pkg/sql/catalog/descs/descriptor.go
@@ -483,6 +483,9 @@ func (q *byIDLookupContext) lookupLeased(
 	if q.flags.layerFilters.withoutLeased || lease.TestingTableLeasesAreDisabled() {
 		return nil, catalog.NoValidation, nil
 	}
+	if q.tc.forceStorageLookupIDs.Contains(id) {
+		return nil, catalog.NoValidation, nil
+	}
 	// If we have already read all of the descriptors, use it as a negative
 	// cache to short-circuit a lookup we know will be doomed to fail.
 	if q.tc.cr.IsDescIDKnownToNotExist(id, q.flags.descFilters.maybeParentID) {

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -545,9 +545,13 @@ func (ds *ServerImpl) newFlowContext(
 		// responsible for cleaning it up and releasing any accessed descriptors
 		// on flow cleanup.
 		dsdp := catsessiondata.NewDescriptorSessionDataStackProvider(evalCtx.SessionDataStack)
-		flowCtx.Descriptors = ds.CollectionFactory.NewCollection(
-			ctx, descs.WithDescriptorSessionDataProvider(dsdp),
-		)
+		opts := []descs.Option{descs.WithDescriptorSessionDataProvider(dsdp)}
+		if localState.Collection != nil {
+			opts = append(opts, descs.WithForceStorageLookupIDs(
+				localState.Collection.GetUncommittedDescriptorIDs(),
+			))
+		}
+		flowCtx.Descriptors = ds.CollectionFactory.NewCollection(ctx, opts...)
 		flowCtx.IsDescriptorsCleanupRequired = true
 		var evalCatalogBuiltins evalcatalog.Builtins
 		// In distributed execution, authorization was already checked on the gateway node.


### PR DESCRIPTION
Fixes #161528

Previously, in 777eb14 we create new descriptor collection for the worker goroutine when parallel check is enabled. This is causing data race when the parent descriptor has uncommited descriptors, which is uninherited and invisible to the new collection. If the new collection accidentally stores outdated leased descriptors with the same OID, the outdated one would be used, which, in our particular test case in #161528, caused some confusing UDT version downgrading.

This commit is to add a forceStorageLookupIDs oid set field to descs.Collection, and for oid in this set, the descriptor look up always go straight to the storage layer, where the uncommited descriptors should be visible.

I ran with patch over the original test with 
```
./dev test ./pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs --ignore-cache -f=TestCCLLogic_regional_by_row_foreign_key --stress --count=30000
```
on engflow, and it passed.

Release note (bug fix): Fixed a rare data race during parallel constraint checks where a fresh descriptor collection could resolve a stale enum type version. This data race should only affect 26.1.0.