### PR TITLE
sql/execinfrapb: fix GetSchemaTS fallback case

### DIFF
--- a/pkg/sql/execinfrapb/BUILD.bazel
+++ b/pkg/sql/execinfrapb/BUILD.bazel
@@ -53,6 +53,7 @@ go_test(
     name = "execinfrapb_test",
     size = "small",
     srcs = [
+        "api_test.go",
         "component_stats_test.go",
         "flow_diagram_external_test.go",
         "flow_diagram_test.go",
@@ -60,6 +61,7 @@ go_test(
     embed = [":execinfrapb"],
     deps = [
         "//pkg/base",
+        "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/roachpb",
         "//pkg/security/username",
@@ -68,6 +70,7 @@ go_test(
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/fetchpb",
         "//pkg/sql/rowenc",
+        "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/optional",
         "@com_github_stretchr_testify//require",

--- a/pkg/sql/execinfrapb/api.go
+++ b/pkg/sql/execinfrapb/api.go
@@ -67,6 +67,8 @@ func (m *ChangeAggregatorSpec) User() username.SQLUsername {
 func (m *ChangeAggregatorSpec) GetSchemaTS() hlc.Timestamp {
 	if m.SchemaTS != nil && !m.SchemaTS.IsEmpty() {
 		return *m.SchemaTS
+	} else if m.InitialHighWater != nil && !m.InitialHighWater.IsEmpty() {
+		return *m.InitialHighWater
 	}
 	return m.Feed.StatementTime
 }

--- a/pkg/sql/execinfrapb/api_test.go
+++ b/pkg/sql/execinfrapb/api_test.go
@@ -1,0 +1,78 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package execinfrapb
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChangeAggregatorSpecGetSchemaTS(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	statementTime := hlc.Timestamp{WallTime: 1}
+	initialHighWater := hlc.Timestamp{WallTime: 2}
+	schemaTS := hlc.Timestamp{WallTime: 3}
+	empty := hlc.Timestamp{}
+
+	tests := []struct {
+		name     string
+		spec     ChangeAggregatorSpec
+		expected hlc.Timestamp
+	}{
+		{
+			name: "schema_ts set, initial_high_water set",
+			spec: ChangeAggregatorSpec{
+				Feed:             jobspb.ChangefeedDetails{StatementTime: statementTime},
+				InitialHighWater: &initialHighWater,
+				SchemaTS:         &schemaTS,
+			},
+			expected: schemaTS,
+		},
+		{
+			name: "schema_ts nil, initial_high_water set",
+			spec: ChangeAggregatorSpec{
+				Feed:             jobspb.ChangefeedDetails{StatementTime: statementTime},
+				InitialHighWater: &initialHighWater,
+			},
+			expected: initialHighWater,
+		},
+		{
+			name: "schema_ts empty, initial_high_water set",
+			spec: ChangeAggregatorSpec{
+				Feed:             jobspb.ChangefeedDetails{StatementTime: statementTime},
+				InitialHighWater: &initialHighWater,
+				SchemaTS:         &empty,
+			},
+			expected: initialHighWater,
+		},
+		{
+			name: "schema_ts nil, initial_high_water nil",
+			spec: ChangeAggregatorSpec{
+				Feed: jobspb.ChangefeedDetails{StatementTime: statementTime},
+			},
+			expected: statementTime,
+		},
+		{
+			name: "schema_ts nil, initial_high_water empty",
+			spec: ChangeAggregatorSpec{
+				Feed:             jobspb.ChangefeedDetails{StatementTime: statementTime},
+				InitialHighWater: &empty,
+			},
+			expected: statementTime,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, tc.spec.GetSchemaTS())
+		})
+	}
+}


### PR DESCRIPTION
During a cloud investigation, we noticed that 2 long-running 
changefeeds failed unexpectedly.  The summary of the investigation
is that this would prevent changefeed shutdowns when the following 
conditions are all true:

- Changefeed(s) are running
- Rolling upgrade is in progress (any version before 26.1 -> 26.1)
- envelope=enriched is set
- enriched_properties contains source
- GC is past the statement time (almost always the case)

See below for more details.

Fixes: https://github.com/cockroachlabs/support/issues/3553

Release note(bug fix): Fix bug where running changefeeds with envelope=enriched and enriched_properties containing source would fail when the cluster is upgrading to 26.1.