### PR TITLE
sql: introduce `information_schema.crdb_delete_statement_hints` builtin

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -690,10 +690,37 @@ preserved in each tenant's own system.eventlog table.
 Events in this category are logged to the `OPS` channel.
 
 
+### `delete_rewrite_inline_hints`
+
+An event of type `delete_rewrite_inline_hints` is recorded when a rewrite inline hint is
+deleted via information_schema.crdb_delete_statement_hints.
+
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `StatementFingerprint` | The target statement fingerprint for which inline hints are being deleted. | no |
+| `HintID` | The hint ID of the to-delete statement hint. | no |
+| `DonorSql` | The donor sql of the deleted inline hint. | no |
+
+
+#### Common fields
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
+| `EventType` | The type of the event. | no |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
+| `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
+| `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
+| `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
+| `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
+
 ### `rewrite_inline_hints`
 
 An event of type `rewrite_inline_hints` is recorded when a new inline-hints rewrite rule is added
-via information_schema.crdb_rewrite_inline_hints.
+via information_schema.crdb_rewrite_inline_hints or crdb_internal.inject_hint.
 
 
 | Field | Description | Sensitive |

--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -3380,6 +3380,10 @@ may increase either contention or retry errors, or both.</p>
 <table>
 <thead><tr><th>Function &rarr; Returns</th><th>Description</th><th>Volatility</th></tr></thead>
 <tbody>
+<tr><td><a name="information_schema.crdb_delete_statement_hints"></a><code>information_schema.crdb_delete_statement_hints(rowid: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function deletes an inline-hints rewrite rule by its row ID. It returns the number of deleted rows.</p>
+</span></td><td>Volatile</td></tr>
+<tr><td><a name="information_schema.crdb_delete_statement_hints"></a><code>information_schema.crdb_delete_statement_hints(statement_fingerprint: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function deletes all inline-hints rewrite rules matching the given statement fingerprint. The statement fingerprint argument is normalized before matching. It returns the number of deleted rows.</p>
+</span></td><td>Volatile</td></tr>
 <tr><td><a name="information_schema.crdb_rewrite_inline_hints"></a><code>information_schema.crdb_rewrite_inline_hints(statement_fingerprint: <a href="string.html">string</a>, donor_sql: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function adds an inline-hints rewrite rule for a statement fingerprint. It returns the hint ID of the newly created rewrite rule. The rewrite rule only applies to matching statement fingerprints. It first removes all inline hints from the target statement, and then copies inline hints from the donor statement.</p>
 </span></td><td>Volatile</td></tr></tbody>
 </table>

--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -564,7 +564,8 @@ var stmtBundleIncludeAllFKReferences = settings.RegisterBoolSetting(
 func (c *stmtEnvCollector) getStmtHintRecreateStmts(
 	ctx context.Context, stmt string, sv *settings.Values,
 ) (recreateStmts []string, err error) {
-	fingerprint, err := parserutils.FingerprintStatement(stmt,
+	fingerprint, err := parserutils.FingerprintStatement(
+		parserutils.FingerprintTagStatement, stmt,
 		tree.FmtFlags(tree.QueryFormattingForFingerprintsMask.Get(
 			sv,
 		)))

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -615,6 +615,13 @@ func (ep *DummyEvalPlanner) InsertStatementHint(
 	return 0, nil
 }
 
+// DeleteStatementHint is part of the eval.Planner interface.
+func (ep *DummyEvalPlanner) DeleteStatementHint(
+	ctx context.Context, rowID int64, statementFingerprint string,
+) ([]int64, []string, [][]byte, error) {
+	return nil, nil, nil, nil
+}
+
 // UsingHintInjection is part of the eval.Planner interface.
 func (ep *DummyEvalPlanner) UsingHintInjection() bool {
 	return false

--- a/pkg/sql/hintpb/BUILD.bazel
+++ b/pkg/sql/hintpb/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
     deps = [
         "//pkg/sql/lexbase",
         "//pkg/sql/protoreflect",
+        "//pkg/util/errorutil",
         "//pkg/util/json",
         "//pkg/util/protoutil",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/hintpb/statement_hint.go
+++ b/pkg/sql/hintpb/statement_hint.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/protoreflect"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
@@ -46,6 +47,15 @@ func FromBytes(bytes []byte) (StatementHintUnion, error) {
 		return StatementHintUnion{}, errors.New("invalid hint bytes: no value set")
 	}
 	return res, nil
+}
+
+// ParseHintProto unmarshals raw hint protobuf bytes, guarding against panics.
+// Returns the deserialized StatementHintUnion, or an error if unmarshaling
+// fails.
+func ParseHintProto(hintBytes []byte) (hint StatementHintUnion, retErr error) {
+	defer errorutil.MaybeCatchPanic(&retErr, nil /* errCallback */)
+	hint, retErr = FromBytes(hintBytes)
+	return hint, retErr
 }
 
 // ToBytes converts the StatementHintUnion to a raw bytes representation that

--- a/pkg/sql/hints/hint_table.go
+++ b/pkg/sql/hints/hint_table.go
@@ -7,6 +7,8 @@ package hints
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
@@ -196,6 +198,62 @@ func InsertHintIntoDB(
 	// StatementHintsCache.handleIncrementalUpdate here to eagerly update the
 	// local node's cache.
 	return int64(tree.MustBeDInt(row[0])), nil
+}
+
+// DeleteHintFromDB deletes statement hints from system.statement_hints,
+// filtered by row ID or fingerprint. If the provided rowID is zero, we don't
+// filter on row ID. If the fingerprint is empty string, we don't filter on
+// fingerprint. Returns the row_id, fingerprint, and raw hint protobuf bytes of
+// all deleted rows.
+func DeleteHintFromDB(
+	ctx context.Context, txn isql.Txn, rowID int64, fingerprint string,
+) (rowIDs []int64, fingerprints []string, hintBytes [][]byte, err error) {
+	const opName = "delete-statement-hint"
+	filterCols := make([]string, 0, 2)
+	vals := make([]interface{}, 0, 2)
+	if rowID != 0 {
+		filterCols = append(filterCols, `"row_id"`)
+		vals = append(vals, rowID)
+	}
+	if fingerprint != "" {
+		filterCols = append(filterCols, "fingerprint")
+		vals = append(vals, fingerprint)
+	}
+
+	if len(filterCols) == 0 {
+		return nil, nil, nil, errors.New("delete statement hint must specify at least one of row_id or fingerprint")
+	}
+
+	var b strings.Builder
+	for i, filterCol := range filterCols {
+		_, err := fmt.Fprintf(&b, "%s = $%d", filterCol, i+1)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		if i != len(filterCols)-1 {
+			b.WriteString(" AND ")
+		}
+	}
+	rows, err := txn.QueryBufferedEx(
+		ctx, opName, txn.KV(), sessiondata.NodeUserSessionDataOverride,
+		fmt.Sprintf("DELETE FROM system.statement_hints WHERE %s RETURNING row_id, fingerprint, hint", b.String()), vals...,
+	)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	for _, row := range rows {
+		if len(row) < 3 {
+			return nil, nil, nil, errors.AssertionFailedf("expecting 3 columns from query, got %d", len(row))
+		}
+		rowIDs = append(rowIDs, int64(tree.MustBeDInt(row[0])))
+		fingerprints = append(fingerprints, string(tree.MustBeDString(row[1])))
+		rawBytes, ok := row[2].(*tree.DBytes)
+		if !ok {
+			return nil, nil, nil, errors.AssertionFailedf("expected hint to be bytes, got %T", row[2])
+		}
+		hintBytes = append(hintBytes, []byte(*rawBytes))
+	}
+	return rowIDs, fingerprints, hintBytes, nil
 }
 
 // Size returns an estimate of the memory usage of the Hint in bytes.

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -341,7 +341,6 @@ SHOW GRANTS ON pg_catalog.pg_namespace
 database_name  schema_name  table_name    grantee  privilege_type  is_grantable
 test           pg_catalog   pg_namespace  public   SELECT          false
 
-
 # Verify selecting from pg_catalog.
 
 statement ok
@@ -998,7 +997,6 @@ t1                 j                         char      3403232968    default
 t1                 i                         _varchar  3403232968    default
 t1                 h                         _bpchar   3403232968    default
 t1                 k                         varchar   999873346     sv
-
 
 ## pg_catalog.pg_am
 
@@ -1868,7 +1866,6 @@ t1             r
 t1             r
 t1_a_key       i
 t_with_pk_seq  r
-
 
 # Some entries in pg_depend are linked to a foreign key constraint whose
 # supporting index is the referenced object id. Other entries are table-view dependencies
@@ -3023,7 +3020,6 @@ backend_xmin      INT8         true         NULL            ·                  
 query             STRING       true         NULL            ·                      {}       false
 backend_type      STRING       true         NULL            ·                      {}       false
 leader_pid        INT4         true         NULL            ·                      {}       false
-
 
 ## pg_catalog.pg_settings
 
@@ -4649,8 +4645,6 @@ h      timestamp without time zone     NULL            false  1114  -1
 i      timestamp with time zone        NULL            false  1184  -1
 j      interval                        NULL            false  1186  -1
 rowid  bigint                          unique_rowid()  true   20    -1
-
-
 
 # Regression test for limits on virtual index scans. (#53522)
 

--- a/pkg/sql/logictest/testdata/logic_test/statement_hint_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/statement_hint_builtins
@@ -310,3 +310,220 @@ SELECT information_schema.crdb_rewrite_inline_hints(
   'SELECT b FROM ab WHERE a = $1',
   'SELECT b FROM ab WHERE a = _'
 )
+
+subtest delete_hints
+
+query TTT
+SELECT fingerprint, '|', crdb_internal.pb_to_json('hintpb.StatementHintUnion', hint)->'injectHints'->>'donorSql' AS donor_sql FROM system.statement_hints ORDER BY "created_at";
+----
+SELECT a FROM ab WHERE b = _  |  SELECT a FROM ab WHERE b = _
+SELECT a FROM ab WHERE b = _  |  SELECT a FROM ab WHERE b = _
+SELECT b FROM ab WHERE a = _  |  SELECT b FROM ab WHERE a = _
+
+statement ok
+CREATE INDEX ab_b ON ab (b)
+
+let $id
+SELECT information_schema.crdb_rewrite_inline_hints(
+  'SELECT b FROM ab WHERE b = $1',
+  'SELECT b FROM ab@b WHERE b = _'
+)
+
+query TTT
+SELECT fingerprint, '|', crdb_internal.pb_to_json('hintpb.StatementHintUnion', hint)->'injectHints'->>'donorSql' AS donor_sql FROM system.statement_hints ORDER BY "created_at";
+----
+SELECT a FROM ab WHERE b = _  |  SELECT a FROM ab WHERE b = _
+SELECT a FROM ab WHERE b = _  |  SELECT a FROM ab WHERE b = _
+SELECT b FROM ab WHERE a = _  |  SELECT b FROM ab WHERE a = _
+SELECT b FROM ab WHERE b = _  |  SELECT b FROM ab@b WHERE b = _
+
+# Delete by row id.
+statement ok
+SELECT information_schema.crdb_delete_statement_hints($id)
+
+query TTT
+SELECT fingerprint, '|', crdb_internal.pb_to_json('hintpb.StatementHintUnion', hint)->'injectHints'->>'donorSql' AS donor_sql FROM system.statement_hints ORDER BY "created_at";
+----
+SELECT a FROM ab WHERE b = _  |  SELECT a FROM ab WHERE b = _
+SELECT a FROM ab WHERE b = _  |  SELECT a FROM ab WHERE b = _
+SELECT b FROM ab WHERE a = _  |  SELECT b FROM ab WHERE a = _
+
+statement ok
+CREATE INDEX xy_yx ON xy (y, x);
+
+statement ok
+CREATE INDEX xy_y ON xy (y);
+
+# Make some hints bound to the same fingerprint.
+statement ok
+SELECT information_schema.crdb_rewrite_inline_hints(
+  'SELECT * FROM xy WHERE y = 10',
+  'SELECT * FROM xy@primary WHERE y = 10'
+);
+
+statement ok
+SELECT information_schema.crdb_rewrite_inline_hints(
+  'SELECT * FROM xy WHERE y = 10',
+  'SELECT * FROM xy@xy_yx WHERE y = 10'
+);
+
+statement ok
+SELECT information_schema.crdb_rewrite_inline_hints(
+  'SELECT * FROM xy WHERE y = 10',
+  'SELECT * FROM xy@xy_y WHERE y = 10'
+);
+
+query TTT
+SELECT fingerprint, '|', crdb_internal.pb_to_json('hintpb.StatementHintUnion', hint)->'injectHints'->>'donorSql' AS donor_sql FROM system.statement_hints ORDER BY "created_at";
+----
+SELECT a FROM ab WHERE b = _  |  SELECT a FROM ab WHERE b = _
+SELECT a FROM ab WHERE b = _  |  SELECT a FROM ab WHERE b = _
+SELECT b FROM ab WHERE a = _  |  SELECT b FROM ab WHERE a = _
+SELECT * FROM xy WHERE y = _  |  SELECT * FROM xy@primary WHERE y = _
+SELECT * FROM xy WHERE y = _  |  SELECT * FROM xy@xy_yx WHERE y = _
+SELECT * FROM xy WHERE y = _  |  SELECT * FROM xy@xy_y WHERE y = _
+
+# Test with more complicated embedded query.
+query I
+SELECT information_schema.crdb_delete_statement_hints(row_id)
+FROM [SHOW STATEMENT HINTS FOR 'SELECT * FROM xy WHERE y = 10' WITH DETAILS]
+WHERE details->>'donorSql' LIKE '%xy@primary%';
+----
+1
+
+query TTT
+SELECT fingerprint, '|', crdb_internal.pb_to_json('hintpb.StatementHintUnion', hint)->'injectHints'->>'donorSql' AS donor_sql FROM system.statement_hints ORDER BY "created_at";
+----
+SELECT a FROM ab WHERE b = _  |  SELECT a FROM ab WHERE b = _
+SELECT a FROM ab WHERE b = _  |  SELECT a FROM ab WHERE b = _
+SELECT b FROM ab WHERE a = _  |  SELECT b FROM ab WHERE a = _
+SELECT * FROM xy WHERE y = _  |  SELECT * FROM xy@xy_yx WHERE y = _
+SELECT * FROM xy WHERE y = _  |  SELECT * FROM xy@xy_y WHERE y = _
+
+# Delete by fingerprinted fingerprint.
+statement ok
+SELECT information_schema.crdb_delete_statement_hints('SELECT * FROM xy WHERE y = _');
+
+query TTT
+SELECT fingerprint, '|', crdb_internal.pb_to_json('hintpb.StatementHintUnion', hint)->'injectHints'->>'donorSql' AS donor_sql FROM system.statement_hints ORDER BY "created_at";
+----
+SELECT a FROM ab WHERE b = _  |  SELECT a FROM ab WHERE b = _
+SELECT a FROM ab WHERE b = _  |  SELECT a FROM ab WHERE b = _
+SELECT b FROM ab WHERE a = _  |  SELECT b FROM ab WHERE a = _
+
+# Now test with non-fingerprinted inputs (constants instead of _).
+# The delete builtins should normalize them to fingerprints before matching.
+
+# Add hints back for xy.
+statement ok
+SELECT information_schema.crdb_rewrite_inline_hints(
+  'SELECT * FROM xy WHERE y = 10',
+  'SELECT * FROM xy@primary WHERE y = 10'
+);
+
+statement ok
+SELECT information_schema.crdb_rewrite_inline_hints(
+  'SELECT * FROM xy WHERE y = 10',
+  'SELECT * FROM xy@xy_yx WHERE y = 10'
+);
+
+statement ok
+SELECT information_schema.crdb_rewrite_inline_hints(
+  'SELECT * FROM xy WHERE y = 10',
+  'SELECT * FROM xy@xy_y WHERE y = 10'
+);
+
+query TTT
+SELECT fingerprint, '|', crdb_internal.pb_to_json('hintpb.StatementHintUnion', hint)->'injectHints'->>'donorSql' AS donor_sql FROM system.statement_hints ORDER BY "created_at";
+----
+SELECT a FROM ab WHERE b = _  |  SELECT a FROM ab WHERE b = _
+SELECT a FROM ab WHERE b = _  |  SELECT a FROM ab WHERE b = _
+SELECT b FROM ab WHERE a = _  |  SELECT b FROM ab WHERE a = _
+SELECT * FROM xy WHERE y = _  |  SELECT * FROM xy@primary WHERE y = _
+SELECT * FROM xy WHERE y = _  |  SELECT * FROM xy@xy_yx WHERE y = _
+SELECT * FROM xy WHERE y = _  |  SELECT * FROM xy@xy_y WHERE y = _
+
+# Delete by non-fingerprinted fingerprint.
+statement ok
+SELECT information_schema.crdb_delete_statement_hints('SELECT * FROM xy WHERE y = 81');
+
+query TTT
+SELECT fingerprint, '|', crdb_internal.pb_to_json('hintpb.StatementHintUnion', hint)->'injectHints'->>'donorSql' AS donor_sql FROM system.statement_hints ORDER BY "created_at";
+----
+SELECT a FROM ab WHERE b = _  |  SELECT a FROM ab WHERE b = _
+SELECT a FROM ab WHERE b = _  |  SELECT a FROM ab WHERE b = _
+SELECT b FROM ab WHERE a = _  |  SELECT b FROM ab WHERE a = _
+
+# Test the event log.
+query TT
+SELECT info::JSONB->>'StatementFingerprint',
+       info::JSONB->>'DonorSql'
+FROM system.eventlog
+WHERE "eventType" = 'delete_rewrite_inline_hints'
+ORDER BY "timestamp" DESC
+LIMIT 1
+----
+SELECT * FROM xy WHERE y = _  SELECT * FROM xy@xy_y WHERE y = _
+
+# Test delete within an explicit txn.
+statement ok
+BEGIN;
+
+statement ok
+SELECT information_schema.crdb_rewrite_inline_hints(
+  'SELECT * FROM xy WHERE y = 10',
+  'SELECT * FROM xy@primary WHERE y = 10'
+);
+
+statement ok
+SELECT information_schema.crdb_rewrite_inline_hints(
+  'SELECT x FROM xy WHERE y = 10',
+  'SELECT x FROM xy@primary WHERE y = 10'
+);
+
+query TTT
+SELECT fingerprint, '|', crdb_internal.pb_to_json('hintpb.StatementHintUnion', hint)->'injectHints'->>'donorSql' AS donor_sql FROM system.statement_hints ORDER BY "created_at";
+----
+SELECT a FROM ab WHERE b = _  |  SELECT a FROM ab WHERE b = _
+SELECT a FROM ab WHERE b = _  |  SELECT a FROM ab WHERE b = _
+SELECT b FROM ab WHERE a = _  |  SELECT b FROM ab WHERE a = _
+SELECT * FROM xy WHERE y = _  |  SELECT * FROM xy@primary WHERE y = _
+SELECT x FROM xy WHERE y = _  |  SELECT x FROM xy@primary WHERE y = _
+
+statement ok
+SAVEPOINT s1
+
+statement ok
+SELECT information_schema.crdb_delete_statement_hints('SELECT * FROM xy WHERE y = 10');
+
+query TTT
+SELECT fingerprint, '|', crdb_internal.pb_to_json('hintpb.StatementHintUnion', hint)->'injectHints'->>'donorSql' AS donor_sql FROM system.statement_hints ORDER BY "created_at";
+----
+SELECT a FROM ab WHERE b = _  |  SELECT a FROM ab WHERE b = _
+SELECT a FROM ab WHERE b = _  |  SELECT a FROM ab WHERE b = _
+SELECT b FROM ab WHERE a = _  |  SELECT b FROM ab WHERE a = _
+SELECT x FROM xy WHERE y = _  |  SELECT x FROM xy@primary WHERE y = _
+
+statement ok
+ROLLBACK TO s1
+
+query TTT
+SELECT fingerprint, '|', crdb_internal.pb_to_json('hintpb.StatementHintUnion', hint)->'injectHints'->>'donorSql' AS donor_sql FROM system.statement_hints ORDER BY "created_at";
+----
+SELECT a FROM ab WHERE b = _  |  SELECT a FROM ab WHERE b = _
+SELECT a FROM ab WHERE b = _  |  SELECT a FROM ab WHERE b = _
+SELECT b FROM ab WHERE a = _  |  SELECT b FROM ab WHERE a = _
+SELECT * FROM xy WHERE y = _  |  SELECT * FROM xy@primary WHERE y = _
+SELECT x FROM xy WHERE y = _  |  SELECT x FROM xy@primary WHERE y = _
+
+statement ok
+ROLLBACK
+
+query TTT
+SELECT fingerprint, '|', crdb_internal.pb_to_json('hintpb.StatementHintUnion', hint)->'injectHints'->>'donorSql' AS donor_sql FROM system.statement_hints ORDER BY "created_at";
+----
+SELECT a FROM ab WHERE b = _  |  SELECT a FROM ab WHERE b = _
+SELECT a FROM ab WHERE b = _  |  SELECT a FROM ab WHERE b = _
+SELECT b FROM ab WHERE a = _  |  SELECT b FROM ab WHERE a = _
+
+subtest end

--- a/pkg/sql/parserutils/utils.go
+++ b/pkg/sql/parserutils/utils.go
@@ -106,20 +106,37 @@ var PLpgSQLParse = func(sql string) (statements.PLpgStatement, error) {
 	return statements.PLpgStatement{}, errors.AssertionFailedf("sql.DoParserInjection hasn't been called")
 }
 
+// FingerprintTag describes what is being fingerprinted, for use in error
+// messages.
+type FingerprintTag string
+
+const (
+	// FingerprintTagStatement is for generic statement fingerprinting.
+	FingerprintTagStatement FingerprintTag = "statement"
+	// FingerprintTagStatementFingerprint is for parsing a statement fingerprint
+	// argument.
+	FingerprintTagStatementFingerprint FingerprintTag = "statement fingerprint"
+	// FingerprintTagHintDonor is for parsing a hint donor statement argument.
+	FingerprintTagHintDonor FingerprintTag = "hint donor statement"
+)
+
 // FingerprintStatement parses a SQL string and converts it to a statement
 // fingerprint. If the input is already a fingerprint, it is returned as-is.
+// The tag describes what is being fingerprinted, for use in error messages.
 // The optional extraFlags are OR'd into the default FmtHideConstants flags used
 // for fingerprinting.
-func FingerprintStatement(sql string, extraFlags ...tree.FmtFlags) (string, error) {
+func FingerprintStatement(
+	tag FingerprintTag, sql string, extraFlags ...tree.FmtFlags,
+) (string, error) {
 	stmts, err := Parse(sql)
 	if err != nil {
 		return "", pgerror.Wrapf(
-			err, pgcode.InvalidParameterValue, "could not parse statement",
+			err, pgcode.InvalidParameterValue, "could not parse %s", tag,
 		)
 	}
 	if len(stmts) != 1 {
 		return "", pgerror.Newf(
-			pgcode.InvalidParameterValue, "could not parse as a single SQL statement",
+			pgcode.InvalidParameterValue, "could not parse %s as a single SQL statement", tag,
 		)
 	}
 	return tree.FormatStatementHideConstants(stmts[0].AST, extraFlags...), nil

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -1169,6 +1169,13 @@ func (p *planner) InsertStatementHint(
 	return hints.InsertHintIntoDB(ctx, p.execCfg.Settings, p.InternalSQLTxn(), statementFingerprint, hint)
 }
 
+// DeleteStatementHint is part of the eval.Planner interface.
+func (p *planner) DeleteStatementHint(
+	ctx context.Context, rowID int64, statementFingerprint string,
+) ([]int64, []string, [][]byte, error) {
+	return hints.DeleteHintFromDB(ctx, p.InternalSQLTxn(), rowID, statementFingerprint)
+}
+
 // UsingHintInjection is part of the eval.Planner interface.
 func (p *planner) UsingHintInjection() bool {
 	return p.usingHintInjection

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -9803,7 +9803,6 @@ WHERE object_id = table_descriptor_id
 			},
 		},
 	),
-
 	"crdb_internal.inject_hint": makeBuiltin(
 		tree.FunctionProperties{
 			Category:         builtinconstants.CategorySystemRepair,
@@ -9817,6 +9816,109 @@ WHERE object_id = table_descriptor_id
 			DistsqlBlocklist: true,
 		},
 		rewriteInlineHintsOverload,
+	),
+	"information_schema.crdb_delete_statement_hints": makeBuiltin(
+		tree.FunctionProperties{
+			Category:         builtinconstants.CategorySystemRepair,
+			DistsqlBlocklist: true,
+		},
+		tree.Overload{
+			Types: tree.ParamTypes{
+				{Name: "rowid", Typ: types.Int},
+			},
+			ReturnType: tree.FixedReturnType(types.Int),
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				// The user must have REPAIRCLUSTER to use this builtin.
+				if err := evalCtx.SessionAccessor.CheckPrivilege(
+					ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.REPAIRCLUSTER,
+				); err != nil {
+					return nil, err
+				}
+				rowIDArg := int64(tree.MustBeDInt(args[0]))
+				rowIDs, fingerprints, rawHintBytes, err := evalCtx.Planner.DeleteStatementHint(ctx, rowIDArg, "" /* statementFingerprint */)
+				if err != nil {
+					return nil, err
+				}
+				for i := range rowIDs {
+					hint, err := hintpb.ParseHintProto(rawHintBytes[i])
+					if err != nil {
+						log.Dev.Warningf(ctx, "could not unmarshal hint for row %d: %v", rowIDs[i], err)
+						continue
+					}
+					switch t := hint.GetValue().(type) {
+					case *hintpb.InjectHints:
+						// Log the statement hint deletion event for every hint we delete.
+						if err := evalCtx.Planner.LogEvent(ctx, &eventpb.DeleteRewriteInlineHints{
+							HintID:               rowIDs[i],
+							StatementFingerprint: fingerprints[i],
+							DonorSql:             t.DonorSQL,
+						}); err != nil {
+							return nil, err
+						}
+					default:
+					}
+				}
+				return tree.NewDInt(tree.DInt(len(rowIDs))), nil
+			},
+			Info: `This function deletes an inline-hints rewrite rule by its row ID. ` +
+				`It returns the number of deleted rows.`,
+			Volatility: volatility.Volatile,
+		},
+		tree.Overload{
+			Types: tree.ParamTypes{
+				{Name: "statement_fingerprint", Typ: types.String},
+			},
+			ReturnType: tree.FixedReturnType(types.Int),
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				// The user must have REPAIRCLUSTER to use this builtin.
+				if err := evalCtx.SessionAccessor.CheckPrivilege(
+					ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.REPAIRCLUSTER,
+				); err != nil {
+					return nil, err
+				}
+				arg := string(tree.MustBeDString(args[0]))
+				fingerprintFlags := tree.FmtFlags(tree.QueryFormattingForFingerprintsMask.Get(
+					&evalCtx.Settings.SV,
+				))
+				fingerprintArg, err := parserutils.FingerprintStatement(parserutils.FingerprintTagStatementFingerprint, arg, fingerprintFlags)
+				if err != nil {
+					return nil, err
+				}
+				if fingerprintArg != arg {
+					evalCtx.ClientNoticeSender.BufferClientNotice(
+						ctx, pgnotice.Newf("statement fingerprint changed to: %s", fingerprintArg),
+					)
+				}
+				rowIDs, fingerprints, rawHintBytes, err := evalCtx.Planner.DeleteStatementHint(ctx, 0 /* rowID */, fingerprintArg)
+				if err != nil {
+					return nil, err
+				}
+				for i := range rowIDs {
+					hint, err := hintpb.ParseHintProto(rawHintBytes[i])
+					if err != nil {
+						log.Dev.Warningf(ctx, "could not unmarshal hint for row %d: %v", rowIDs[i], err)
+						continue
+					}
+					switch t := hint.GetValue().(type) {
+					case *hintpb.InjectHints:
+						// Log the statement hint deletion event for every hint we delete.
+						if err := evalCtx.Planner.LogEvent(ctx, &eventpb.DeleteRewriteInlineHints{
+							HintID:               rowIDs[i],
+							StatementFingerprint: fingerprints[i],
+							DonorSql:             t.DonorSQL,
+						}); err != nil {
+							return nil, err
+						}
+					default:
+					}
+				}
+				return tree.NewDInt(tree.DInt(len(rowIDs))), nil
+			},
+			Info: `This function deletes all inline-hints rewrite rules matching the ` +
+				`given statement fingerprint. The statement fingerprint argument is ` +
+				`normalized before matching. It returns the number of deleted rows.`,
+			Volatility: volatility.Volatile,
+		},
 	),
 	"crdb_internal.clear_statement_hints_cache": makeBuiltin(
 		tree.FunctionProperties{
@@ -12970,40 +13072,30 @@ var rewriteInlineHintsOverload = tree.Overload{
 		fingerprintFlags := tree.FmtFlags(tree.QueryFormattingForFingerprintsMask.Get(
 			&evalCtx.Settings.SV,
 		))
-		parse := func(arg, which string) (stmt statements.Statement[tree.Statement], fingerprint string, err error) {
-			stmts, err := parserutils.Parse(arg)
+		parse := func(arg string, tag parserutils.FingerprintTag, evalCtx *eval.Context) (stmt statements.Statement[tree.Statement], fingerprint string, err error) {
+			fingerprint, err = parserutils.FingerprintStatement(tag, arg, fingerprintFlags)
 			if err != nil {
-				return stmt, fingerprint, pgerror.Wrapf(
-					err, pgcode.InvalidParameterValue, "could not parse %s", which,
-				)
+				return stmt, fingerprint, err
 			}
-			if len(stmts) != 1 {
-				return stmt, fingerprint, pgerror.Newf(
-					pgcode.InvalidParameterValue, "could not parse %s as a single SQL statement", which,
-				)
-			}
-			stmt = stmts[0]
-			fingerprint = tree.FormatStatementHideConstants(stmt.AST, fingerprintFlags)
 			if fingerprint != arg {
 				evalCtx.ClientNoticeSender.BufferClientNotice(
-					ctx, pgnotice.Newf("%s changed to: %s", which, fingerprint),
+					ctx, pgnotice.Newf("%s changed to: %s", tag, fingerprint),
 				)
-				// Re-parse the statement fingerprint to get an updated AST.
-				stmt, err = parserutils.ParseOne(fingerprint)
-				if err != nil {
-					// Assertion failure is appropriate here, so no error wrapping.
-					return stmt, fingerprint, err
-				}
+			}
+			stmt, err = parserutils.ParseOne(fingerprint)
+			if err != nil {
+				// Assertion failure is appropriate here, so no error wrapping.
+				return stmt, fingerprint, err
 			}
 			return stmt, fingerprint, nil
 		}
 
-		targetStmt, targetSQL, err := parse(targetArg, "statement fingerprint")
+		targetStmt, targetSQL, err := parse(targetArg, parserutils.FingerprintTagStatementFingerprint, evalCtx)
 		if err != nil {
 			return nil, err
 		}
 
-		donorStmt, donorSQL, err := parse(donorArg, "hint donor statement")
+		donorStmt, donorSQL, err := parse(donorArg, parserutils.FingerprintTagHintDonor, evalCtx)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2870,6 +2870,8 @@ var builtinOidsArray = []string{
 	2915: `dmetaphone(source: string) -> string`,
 	2916: `dmetaphone_alt(source: string) -> string`,
 	2917: `daitch_mokotoff(source: string) -> string[]`,
+	2918: `information_schema.crdb_delete_statement_hints(statement_fingerprint: string) -> int`,
+	2919: `information_schema.crdb_delete_statement_hints(rowid: int) -> int`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -500,6 +500,13 @@ type Planner interface {
 	// created hint.
 	InsertStatementHint(ctx context.Context, statementFingerprint string, hint hintpb.StatementHintUnion) (int64, error)
 
+	// DeleteStatementHint deletes statement hints from
+	// system.statement_hints, filtered by the row ID or fingerprint. If the
+	// provided rowID is zero, we don't filter on row ID. If the fingerprint
+	// is empty string, we don't filter on fingerprint. Returns the row_id,
+	// fingerprint, and raw hint protobuf bytes of all deleted rows.
+	DeleteStatementHint(ctx context.Context, rowID int64, statementFingerprint string) (rowIDs []int64, fingerprints []string, hintBytes [][]byte, err error)
+
 	// UsingHintInjection returns whether we are planning with externally-injected
 	// hints.
 	UsingHintInjection() bool

--- a/pkg/util/log/eventpb/eventlog_channels_generated.go
+++ b/pkg/util/log/eventpb/eventlog_channels_generated.go
@@ -83,6 +83,9 @@ func (m *Restore) LoggingChannel() logpb.Channel { return logpb.Channel_OPS }
 func (m *StatusChange) LoggingChannel() logpb.Channel { return logpb.Channel_OPS }
 
 // LoggingChannel implements the EventPayload interface.
+func (m *DeleteRewriteInlineHints) LoggingChannel() logpb.Channel { return logpb.Channel_OPS }
+
+// LoggingChannel implements the EventPayload interface.
 func (m *RewriteInlineHints) LoggingChannel() logpb.Channel { return logpb.Channel_OPS }
 
 // LoggingChannel implements the EventPayload interface.

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -2964,6 +2964,45 @@ func (m *DebugSendKvBatch) AppendJSONFields(printComma bool, b redact.Redactable
 }
 
 // AppendJSONFields implements the EventPayload interface.
+func (m *DeleteRewriteInlineHints) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
+
+	printComma, b = m.CommonEventDetails.AppendJSONFields(printComma, b)
+
+	printComma, b = m.CommonSQLEventDetails.AppendJSONFields(printComma, b)
+
+	if m.StatementFingerprint != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"StatementFingerprint\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.StatementFingerprint)))
+		b = append(b, '"')
+	}
+
+	if m.HintID != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"HintID\":"...)
+		b = strconv.AppendInt(b, int64(m.HintID), 10)
+	}
+
+	if m.DonorSql != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"DonorSql\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.DonorSql)))
+		b = append(b, '"')
+	}
+
+	return printComma, b
+}
+
+// AppendJSONFields implements the EventPayload interface.
 func (m *DiskSlownessCleared) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
 
 	printComma, b = m.CommonEventDetails.AppendJSONFields(printComma, b)

--- a/pkg/util/log/eventpb/misc_sql_events.proto
+++ b/pkg/util/log/eventpb/misc_sql_events.proto
@@ -54,7 +54,7 @@ message SetTenantClusterSetting {
 }
 
 // RewriteInlineHints is recorded when a new inline-hints rewrite rule is added
-// via information_schema.crdb_rewrite_inline_hints.
+// via information_schema.crdb_rewrite_inline_hints or crdb_internal.inject_hint.
 message RewriteInlineHints {
   CommonEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
   CommonSQLEventDetails sql = 2 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
@@ -64,4 +64,17 @@ message RewriteInlineHints {
   string donor_sql = 4 [(gogoproto.customname) = "DonorSQL", (gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
   // The hint ID of the newly created statement hint.
   int64 hint_id = 5 [(gogoproto.customname) = "HintID", (gogoproto.jsontag) = ",omitempty"];
+}
+
+// DeleteRewriteInlineHints is recorded when a rewrite inline hint is
+// deleted via information_schema.crdb_delete_statement_hints.
+message DeleteRewriteInlineHints {
+  CommonEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+  CommonSQLEventDetails sql = 2 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+  // The target statement fingerprint for which inline hints are being deleted.
+  string statement_fingerprint = 3 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+  // The hint ID of the to-delete statement hint.
+  int64 hint_id = 4 [(gogoproto.customname) = "HintID", (gogoproto.jsontag) = ",omitempty"];
+  // The donor sql of the deleted inline hint.
+  string donor_sql = 5 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
 }


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/161959

This commit introduces the
`information_schema.crdb_delete_statement_hints` builtin function,
that is designed to delete statement hints from the
system.statement_hints table.

The builtin takes 2 versions of payload, and returns the number of rows
deleted: 
1. row_id (int): the pk of the system.statement_hints; 
2. fingerprint (string).

The fingerprint str will be fingrerprinted, so the user can provide both
the non-fingerprinted or the fingerprinted string to the builtin
function.

Release note (sql change): introduce
information_schema.crdb_delete_statement_hints builtin function that
takes 2 kinds of payload:
1. row_id (int): the pk of the system.statement_hints;
2. fingerprint (string).
And it returns the the number of rows deleted.