### PR TITLE
sql: simplify release of flow specs

### DIFF
--- a/pkg/sql/physicalplan/specs.go
+++ b/pkg/sql/physicalplan/specs.go
@@ -27,21 +27,6 @@ func newFlowSpec(flowID execinfrapb.FlowID, gateway base.SQLInstanceID) *execinf
 	return spec
 }
 
-// ReleaseFlowSpec returns this FlowSpec back to the pool of FlowSpecs. It may
-// not be used again after this call.
-func ReleaseFlowSpec(spec *execinfrapb.FlowSpec) {
-	for i := range spec.Processors {
-		if tr := spec.Processors[i].Core.TableReader; tr != nil {
-			releaseTableReaderSpec(tr)
-		}
-		spec.Processors[i] = execinfrapb.ProcessorSpec{}
-	}
-	*spec = execinfrapb.FlowSpec{
-		Processors: spec.Processors[:0],
-	}
-	flowSpecPool.Put(spec)
-}
-
 var trSpecPool = sync.Pool{
 	New: func() interface{} {
 		return &execinfrapb.TableReaderSpec{}


### PR DESCRIPTION
In 0c1095e31cf93ea7f177f8bf1750ebab188e02d7 we introduced separate release of flow specs for the local / gateway flow as well as remote flows. This was needed since the former might have exited before remote RPCs are performed. However, that behavior turned out to be problematic, so recently in 702912791f0eae4e31694c0974cc42557a3a7528 we made it so that the cleanup of the local flow blocks until the remote RPCs are complete. As a result, we can now simplify the release of flow specs.

Epic: None
Release note: None