### PR TITLE
release-25.2: server: remove one of the two redundant liveness scans

### DIFF
--- a/pkg/server/auto_upgrade.go
+++ b/pkg/server/auto_upgrade.go
@@ -153,7 +153,7 @@ func (s *topLevelServer) isAutoUpgradeEnabled(currentClusterVersion string) upgr
 func (s *topLevelServer) upgradeStatus(
 	ctx context.Context, clusterVersion string,
 ) (st upgradeStatus, err error) {
-	nodes, err := s.status.ListNodesInternal(ctx, nil)
+	statuses, _, err := getNodeStatuses(ctx, s.db, 0 /* limit */, 0 /* offset */)
 	if err != nil {
 		return UpgradeBlockedDueToError, err
 	}
@@ -164,7 +164,7 @@ func (s *topLevelServer) upgradeStatus(
 
 	var newVersion string
 	var notRunningErr error
-	for _, node := range nodes.Nodes {
+	for _, node := range statuses {
 		nodeID := node.Desc.NodeID
 		v := vitalities[nodeID]
 


### PR DESCRIPTION
Backport 1/1 commits from #163805 on behalf of @wenyihu6.

----

Informs: https://github.com/cockroachdb/cockroach/issues/152916
Epic: none 
Release note: none

---
**server: remove one of the two redundant liveness scans**

Previously, `upgradeStatus` called `ListNodesInternal`, which internally
calls `ScanNodeVitalityFromKV` to populate `LivenessByNodeID` in the
response. `upgradeStatus` then also called `ScanNodeVitalityFromKV` directly,
resulting in two full KV scans of the `NodeLiveness` range per `upgradeStatus`
call. But the `LivenessByNodeID` field from the first scan was never used.

This patch replaces the `ListNodesInternal` call with a direct call to
`getNodeStatuses`, which only fetches node status descriptors without
scanning the liveness range. This eliminates one of the two redundant
liveness scans. During version upgrades, `upgradeStatus` is called
repeatedly from every node in the cluster.

Each liveness KV scan acquires a range-wide read latch on the
NodeLiveness range which can block heartbeat writes.



----

Release justification: low risk optimization