### PR TITLE
sql: fix flaky TestSecondaryIndexWithOldStoringEncoding

### DIFF
--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -3693,24 +3693,32 @@ CREATE TABLE d.t (
 	tableDesc := desctestutils.TestingGetMutableExistingTableDescriptor(
 		kvDB, server.Codec(), "d", "t")
 	// Verify that this descriptor uses the new STORING encoding. Overwrite it
-	// with one that uses the old encoding.
-	for _, index := range tableDesc.PublicNonPrimaryIndexes() {
-		if index.NumKeySuffixColumns() != 1 {
-			t.Fatalf("KeySuffixColumnIDs not set properly: %s", tableDesc)
+	// with one that uses the old encoding. Use TestingDescsTxn so that the
+	// descriptor version is properly incremented and the lease manager waits
+	// for all old leases to drain before proceeding.
+	if err := sqltestutils.TestingDescsTxn(context.Background(), server, func(ctx context.Context, txn isql.Txn, col *descs.Collection) error {
+		tbl, err := col.MutableByID(txn.KV()).Table(ctx, tableDesc.GetID())
+		if err != nil {
+			return err
 		}
-		if index.NumSecondaryStoredColumns() != 1 {
-			t.Fatalf("StoreColumnIDs not set properly: %s", tableDesc)
+		for _, index := range tbl.PublicNonPrimaryIndexes() {
+			if index.NumKeySuffixColumns() != 1 {
+				t.Fatalf("KeySuffixColumnIDs not set properly: %s", tbl)
+			}
+			if index.NumSecondaryStoredColumns() != 1 {
+				t.Fatalf("StoreColumnIDs not set properly: %s", tbl)
+			}
+			newIndexDesc := index.IndexDescDeepCopy()
+			newIndexDesc.KeySuffixColumnIDs = append(newIndexDesc.KeySuffixColumnIDs, newIndexDesc.StoreColumnIDs...)
+			newIndexDesc.StoreColumnIDs = nil
+			tbl.SetPublicNonPrimaryIndex(index.Ordinal(), newIndexDesc)
 		}
-		newIndexDesc := index.IndexDescDeepCopy()
-		newIndexDesc.KeySuffixColumnIDs = append(newIndexDesc.KeySuffixColumnIDs, newIndexDesc.StoreColumnIDs...)
-		newIndexDesc.StoreColumnIDs = nil
-		tableDesc.SetPublicNonPrimaryIndex(index.Ordinal(), newIndexDesc)
-	}
-	if err := kvDB.Put(
-		context.Background(),
-		catalogkeys.MakeDescMetadataKey(server.Codec(), tableDesc.GetID()),
-		tableDesc.DescriptorProto(),
-	); err != nil {
+		ba := txn.KV().NewBatch()
+		if err := col.WriteDescToBatch(ctx, false /* kvTrace */, tbl, ba); err != nil {
+			return err
+		}
+		return txn.KV().Run(ctx, ba)
+	}); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := sqlDB.Exec(`INSERT INTO d.t VALUES (11, 1, 2);`); err != nil {

--- a/pkg/testutils/sqlutils/inspect.go
+++ b/pkg/testutils/sqlutils/inspect.go
@@ -9,7 +9,6 @@ import (
 	gosql "database/sql"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/cockroachdb/errors"
 )
@@ -22,7 +21,7 @@ type InspectResult struct {
 	Table      string
 	PrimaryKey string
 	JobID      int64
-	Aost       time.Time
+	Aost       string
 	Details    string
 }
 


### PR DESCRIPTION
The test modifies a table descriptor directly in KV via kvDB.Put() to simulate the old STORING encoding (moving StoreColumnIDs into KeySuffixColumnIDs). However, it did not increment the descriptor version, so the lease manager had no signal to refresh its cached descriptor. When the INSERT ran before the ALTER TABLE ADD COLUMN (which bumps the version and triggers a lease refresh), it could write data using the cached new-encoding descriptor. Subsequent reads after the lease refresh would use the old-encoding descriptor and decode column b as 0 instead of 2, or fail with a varint decode error on the unique index.

Fix by bumping tableDesc.Version before the kvDB.Put so the lease manager detects the change and serves the modified descriptor to the INSERT.

Additionally, fix the InspectResult.Aost field type from time.Time to string. The SHOW INSPECT ERRORS query uses to_char() to format the aost column, which returns a string. The type mismatch caused a scan error whenever RunInspect detected inconsistencies.

Fixes: #162135

Release note: None