### PR TITLE
concurrency: VIR-enabled requests should not wait because of pending resolves

### DIFF
--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -92,6 +92,7 @@ import (
 // debug-set-batch-pushed-lock-resolution-enabled ok=<enabled>
 // debug-set-push-using-cached-clock-observation-enabled ok=<enabled>
 // debug-set-max-locks n=<count>
+// debug-set-virtual-intent-resolution-enabled ok=<enabled>
 // reset [namespace|force]
 func TestConcurrencyManagerBasic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -610,6 +611,11 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 				c.setPushUsingCachedClockObservationEnabled(ok)
 				return ""
 
+			case "debug-set-virtual-intent-resolution-enabled":
+				ok := dd.ScanArg[bool](t, d, "ok")
+				c.setVirtualIntentResolutionEnabled(ok)
+				return ""
+
 			case "debug-set-max-locks":
 				n := dd.ScanArg[int64](t, d, "n")
 				m.SetMaxLockTableSize(n)
@@ -1016,6 +1022,10 @@ func (c *cluster) setBatchPushedLockResolutionEnabled(ok bool) {
 
 func (c *cluster) setPushUsingCachedClockObservationEnabled(ok bool) {
 	concurrency.PushUsingCachedClockObservation.Override(context.Background(), &c.st.SV, ok)
+}
+
+func (c *cluster) setVirtualIntentResolutionEnabled(ok bool) {
+	concurrency.VirtualIntentResolution.Override(context.Background(), &c.st.SV, ok)
 }
 
 // reset clears all request state in the cluster. This avoids portions of tests

--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -579,8 +579,11 @@ func (g *lockTableGuardImpl) ShouldWait() bool {
 	// 1. The lock table indicated as such (e.g. the request ran into a
 	// conflicting lock).
 	// 2. OR the request successfully performed its scan but discovered replicated
-	// locks that need to be resolved before it can evaluate.
-	return g.mu.startWait || len(g.toResolve) > 0
+	// locks that need to be resolved before it can evaluate. When virtual intent
+	// resolution is enabled, these locks will be resolved during evaluation (on
+	// a temporary batch) rather than before re-scanning, so the request does not
+	// need to wait.
+	return g.mu.startWait || (!g.virtuallyResolveIntents && len(g.toResolve) > 0)
 }
 
 // ResolveBeforeScanning implements the lockTableGuard interface. The locks to

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/virtual_intent_resolution
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/virtual_intent_resolution
@@ -1,0 +1,80 @@
+# -------------------------------------------------------------------------
+# A non-locking read discovers intents from a pending transaction with
+# virtual intent resolution enabled. The reader should push the intent
+# holder, then proceed directly to evaluation (where intents are resolved
+# virtually on a temporary batch) rather than looping forever trying to
+# resolve intents before re-scanning.
+#
+# This is a regression test for a bug where ShouldWait() returned true
+# due to non-empty toResolve, but the doneWaiting handler in WaitOn
+# discarded those entries (ResolveBeforeScanning returns nil with VIR),
+# and the lock table was never updated (updateLockInternal is skipped
+# with VIR), causing the reader to rediscover the same locks on every
+# re-scan.
+# -------------------------------------------------------------------------
+
+debug-set-virtual-intent-resolution-enabled ok=true
+----
+
+new-txn name=txnReader ts=12,1 epoch=0 priority=high
+----
+
+new-txn name=txnWriter ts=10,1 epoch=0
+----
+
+# Reader issues a non-locking scan.
+new-request name=reqRead txn=txnReader ts=12,1
+  scan key=a endkey=z
+----
+
+# First sequence succeeds — no locks in the lock table yet.
+sequence req=reqRead
+----
+[1] sequence reqRead: sequencing request
+[1] sequence reqRead: acquiring latches
+[1] sequence reqRead: scanning lock table for conflicting locks
+[1] sequence reqRead: sequencing complete, returned guard
+
+# During evaluation, the reader discovers intents written by txnWriter.
+handle-lock-conflict-error req=reqRead lease-seq=1
+  lock txn=txnWriter key=a
+  lock txn=txnWriter key=b
+  lock txn=txnWriter key=c
+----
+[2] handle lock conflict error reqRead: added 3 discovered lock(s) to lock table: conflicting locks on ‹"a"›, ‹"b"›, ‹"c"›
+
+debug-lock-table
+----
+num=3
+ lock: "a"
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
+ lock: "b"
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
+ lock: "c"
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
+
+# Re-sequence the reader. With VIR enabled, after pushing txnWriter, the
+# reader should proceed to evaluation without trying to resolve intents
+# before scanning. Previously this would loop forever.
+sequence req=reqRead
+----
+[3] sequence reqRead: re-sequencing request
+[3] sequence reqRead: acquiring latches
+[3] sequence reqRead: scanning lock table for conflicting locks
+[3] sequence reqRead: waiting in lock wait-queues
+[3] sequence reqRead: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"a"› (queuedLockingRequests: 0, queuedReaders: 1)
+[3] sequence reqRead: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
+[3] sequence reqRead: pushing timestamp of txn 00000002 above 12.000000000,1
+[3] sequence reqRead: pusher pushed pushee to 12.000000000,2
+[3] sequence reqRead: resolving intent ‹"a"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,1}
+[3] sequence reqRead: lock wait-queue event: done waiting
+[3] sequence reqRead: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
+[3] sequence reqRead: acquiring latches
+[3] sequence reqRead: scanning lock table for conflicting locks
+[3] sequence reqRead: sequencing complete, returned guard
+
+finish req=reqRead
+----
+[-] finish reqRead: finishing request
+
+reset namespace


### PR DESCRIPTION
Previously, the len(g.toResolve) > 0 would result in us constantly re-entering the waiting state, assuming that we needed to wait on intent resolution.

Epic: CRDB-49120
Release note: None