### PR TITLE
kvserver: add VIR to BenchmarkIntentResolution

### DIFF
--- a/pkg/kv/kvserver/concurrency/concurrency_control.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_control.go
@@ -834,6 +834,10 @@ type lockTableGuard interface {
 	// resolved virtually.
 	IntentsToResolveVirtually() []roachpb.LockUpdate
 
+	// VirtuallyResolvesIntents returns true if the guard will resolve intents
+	// virtually during evaluation rather than physically before re-scanning.
+	VirtuallyResolvesIntents() bool
+
 	// CheckOptimisticNoConflicts uses the LockSpanSet representing the spans that
 	// were actually read, to check for conflicting locks, after an optimistic
 	// evaluation. It returns true if there were no conflicts. See

--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -92,6 +92,7 @@ import (
 // debug-set-batch-pushed-lock-resolution-enabled ok=<enabled>
 // debug-set-push-using-cached-clock-observation-enabled ok=<enabled>
 // debug-set-max-locks n=<count>
+// debug-set-virtual-intent-resolution-enabled ok=<enabled>
 // reset [namespace|force]
 func TestConcurrencyManagerBasic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -610,6 +611,11 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 				c.setPushUsingCachedClockObservationEnabled(ok)
 				return ""
 
+			case "debug-set-virtual-intent-resolution-enabled":
+				ok := dd.ScanArg[bool](t, d, "ok")
+				c.setVirtualIntentResolutionEnabled(ok)
+				return ""
+
 			case "debug-set-max-locks":
 				n := dd.ScanArg[int64](t, d, "n")
 				m.SetMaxLockTableSize(n)
@@ -1016,6 +1022,10 @@ func (c *cluster) setBatchPushedLockResolutionEnabled(ok bool) {
 
 func (c *cluster) setPushUsingCachedClockObservationEnabled(ok bool) {
 	concurrency.PushUsingCachedClockObservation.Override(context.Background(), &c.st.SV, ok)
+}
+
+func (c *cluster) setVirtualIntentResolutionEnabled(ok bool) {
+	concurrency.VirtualIntentResolution.Override(context.Background(), &c.st.SV, ok)
 }
 
 // reset clears all request state in the cluster. This avoids portions of tests

--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -604,6 +604,11 @@ func (g *lockTableGuardImpl) IntentsToResolveVirtually() []roachpb.LockUpdate {
 	return nil
 }
 
+// VirtuallyResolvesIntents implements the lockTableGuard interface.
+func (g *lockTableGuardImpl) VirtuallyResolvesIntents() bool {
+	return g.virtuallyResolveIntents
+}
+
 func (g *lockTableGuardImpl) NewStateChan() chan struct{} {
 	g.mu.Lock()
 	defer g.mu.Unlock()

--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -579,8 +579,11 @@ func (g *lockTableGuardImpl) ShouldWait() bool {
 	// 1. The lock table indicated as such (e.g. the request ran into a
 	// conflicting lock).
 	// 2. OR the request successfully performed its scan but discovered replicated
-	// locks that need to be resolved before it can evaluate.
-	return g.mu.startWait || len(g.toResolve) > 0
+	// locks that need to be resolved before it can evaluate. When virtual intent
+	// resolution is enabled, these locks will be resolved during evaluation (on
+	// a temporary batch) rather than before re-scanning, so the request does not
+	// need to wait.
+	return g.mu.startWait || (!g.virtuallyResolveIntents && len(g.toResolve) > 0)
 }
 
 // ResolveBeforeScanning implements the lockTableGuard interface. The locks to

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter.go
@@ -256,11 +256,11 @@ func (w *lockTableWaiterImpl) WaitOn(
 				if req.LockTimeout != 0 {
 					return doWithTimeoutAndFallback(
 						ctx, req.LockTimeout,
-						func(ctx context.Context) *Error { return w.pushLockTxn(ctx, req, state) },
-						func(ctx context.Context) *Error { return w.pushLockTxnAfterTimeout(ctx, req, state) },
+						func(ctx context.Context) *Error { return w.pushLockTxn(ctx, req, state, guard) },
+						func(ctx context.Context) *Error { return w.pushLockTxnAfterTimeout(ctx, req, state, guard) },
 					)
 				}
-				return w.pushLockTxn(ctx, req, state)
+				return w.pushLockTxn(ctx, req, state, guard)
 
 			case waitSelf:
 				// Another request from the same transaction has claimed the lock (but
@@ -357,7 +357,7 @@ func (w *lockTableWaiterImpl) WaitOn(
 					// edges in the local portion of its dependency graph for deadlock
 					// detection, as doing so is cheaper that finding out the same
 					// information using (QueryTxnRequest) RPCs.
-					err = w.pushLockTxn(pushCtx, req, timerWaitingState)
+					err = w.pushLockTxn(pushCtx, req, timerWaitingState, guard)
 				} else {
 					// The request conflicts with another request that's claimed an unheld
 					// lock. The conflicting request may exit the lock table without
@@ -383,7 +383,7 @@ func (w *lockTableWaiterImpl) WaitOn(
 			pushNoWait := func(ctx context.Context) *Error {
 				// Resolve the conflict without waiting by pushing the lock holder's
 				// transaction.
-				return w.pushLockTxnAfterTimeout(ctx, req, timerWaitingState)
+				return w.pushLockTxnAfterTimeout(ctx, req, timerWaitingState, guard)
 			}
 
 			// We push with or without the option to wait on the conflict,
@@ -391,7 +391,7 @@ func (w *lockTableWaiterImpl) WaitOn(
 			// and depending on the wait policy.
 			var err *Error
 			if req.WaitPolicy == lock.WaitPolicy_Error {
-				err = w.pushLockTxn(ctx, req, timerWaitingState)
+				err = w.pushLockTxn(ctx, req, timerWaitingState, guard)
 			} else if !lockDeadline.IsZero() {
 				untilDeadline := w.timeUntilDeadline(lockDeadline)
 				if untilDeadline == 0 {
@@ -434,7 +434,7 @@ func (w *lockTableWaiterImpl) WaitOn(
 // expect to have an updated waitingState. Otherwise, the method returns with a
 // WriteIntentError and without blocking on the lock holder transaction.
 func (w *lockTableWaiterImpl) pushLockTxn(
-	ctx context.Context, req Request, ws waitingState,
+	ctx context.Context, req Request, ws waitingState, guard lockTableGuard,
 ) *Error {
 	if w.disableTxnPushing {
 		return newWriteIntentErr(req, ws, reasonWaitPolicy)
@@ -602,6 +602,12 @@ func (w *lockTableWaiterImpl) pushLockTxn(
 		// after the reader's read timestamp surpasses its global uncertainty limit.
 		resolve.ClockWhilePending = beforePushObs
 	}
+	// If the guard resolves intents virtually, skip the physical resolution.
+	// The intent is already queued in the guard's toResolve list and will be
+	// resolved virtually during evaluation.
+	if guard.VirtuallyResolvesIntents() {
+		return nil
+	}
 	logResolveIntent(ctx, resolve)
 	opts := intentresolver.ResolveOptions{Poison: true, AdmissionHeader: req.AdmissionHeader}
 	return w.ir.ResolveIntent(ctx, resolve, opts)
@@ -613,10 +619,10 @@ func (w *lockTableWaiterImpl) pushLockTxn(
 // elapsed, and returns a WriteIntentErrors with a LOCK_TIMEOUT reason if the
 // lock holder is not abandoned.
 func (w *lockTableWaiterImpl) pushLockTxnAfterTimeout(
-	ctx context.Context, req Request, ws waitingState,
+	ctx context.Context, req Request, ws waitingState, guard lockTableGuard,
 ) *Error {
 	req.WaitPolicy = lock.WaitPolicy_Error
-	err := w.pushLockTxn(ctx, req, ws)
+	err := w.pushLockTxn(ctx, req, ws, guard)
 	if _, ok := err.GetDetail().(*kvpb.WriteIntentError); ok {
 		err = newWriteIntentErr(req, ws, reasonLockTimeout)
 	}

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
@@ -58,10 +58,11 @@ func (m *mockIntentResolver) ResolveIntents(
 }
 
 type mockLockTableGuard struct {
-	state         waitingState
-	signal        chan struct{}
-	stateObserved chan struct{}
-	toResolve     []roachpb.LockUpdate
+	state                   waitingState
+	signal                  chan struct{}
+	stateObserved           chan struct{}
+	toResolve               []roachpb.LockUpdate
+	virtuallyResolveIntents bool
 }
 
 var _ lockTableGuard = &mockLockTableGuard{}
@@ -81,6 +82,9 @@ func (g *mockLockTableGuard) ResolveBeforeScanning() []roachpb.LockUpdate {
 }
 func (g *mockLockTableGuard) IntentsToResolveVirtually() []roachpb.LockUpdate {
 	return g.toResolve
+}
+func (g *mockLockTableGuard) VirtuallyResolvesIntents() bool {
+	return g.virtuallyResolveIntents
 }
 func (g *mockLockTableGuard) CheckOptimisticNoConflicts(*lockspanset.LockSpanSet) (ok bool) {
 	return true
@@ -379,6 +383,56 @@ func testWaitPush(t *testing.T, k waitKind, makeReq func() Request, expPushTS hl
 			require.Nil(t, err)
 		})
 	})
+}
+
+// TestLockTableWaiterSkipsResolveWithVIR verifies that pushLockTxn does not
+// physically resolve the intent when the guard has virtual intent resolution
+// enabled.
+func TestLockTableWaiterSkipsResolveWithVIR(t *testing.T) {
+	ctx := context.Background()
+	w, ir, g, _ := setupLockTableWaiterTest()
+	defer w.stopper.Stop(ctx)
+
+	g.virtuallyResolveIntents = true
+
+	pusheeTxn := makeTxnProto("pushee")
+	pusherTxn := makeTxnProto("pusher")
+	req := Request{
+		Txn:       &pusherTxn,
+		Timestamp: pusherTxn.ReadTimestamp,
+	}
+	keyA := roachpb.Key("keyA")
+
+	g.state = waitingState{
+		kind:          waitFor,
+		txn:           &pusheeTxn.TxnMeta,
+		key:           keyA,
+		held:          true,
+		guardStrength: lock.None,
+	}
+	g.notify()
+
+	ir.pushTxn = func(
+		_ context.Context,
+		pusheeArg *enginepb.TxnMeta,
+		h kvpb.Header,
+		pushType kvpb.PushTxnType,
+	) (*roachpb.Transaction, bool, *Error) {
+		resp := &roachpb.Transaction{TxnMeta: *pusheeArg, Status: roachpb.ABORTED}
+		w.lt.(*mockLockTable).txnFinalizedFn = func(txn *roachpb.Transaction) {}
+		// With VIR, the physical resolve should be skipped. Transition
+		// directly to doneWaiting.
+		g.state = waitingState{kind: doneWaiting}
+		g.notify()
+		return resp, false, nil
+	}
+	ir.resolveIntent = func(context.Context, roachpb.LockUpdate, intentresolver.ResolveOptions) *Error {
+		t.Fatal("ResolveIntent should not be called when VIR is enabled")
+		return nil
+	}
+
+	err := w.WaitOn(ctx, req, g)
+	require.Nil(t, err)
 }
 
 func testWaitNoopUntilDone(t *testing.T, k waitKind, makeReq func() Request) {

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/virtual_intent_resolution
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/virtual_intent_resolution
@@ -1,0 +1,80 @@
+# -------------------------------------------------------------------------
+# A non-locking read discovers intents from a pending transaction with
+# virtual intent resolution enabled. The reader should push the intent
+# holder, then proceed directly to evaluation (where intents are resolved
+# virtually on a temporary batch) rather than looping forever trying to
+# resolve intents before re-scanning.
+#
+# This is a regression test for a bug where ShouldWait() returned true
+# due to non-empty toResolve, but the doneWaiting handler in WaitOn
+# discarded those entries (ResolveBeforeScanning returns nil with VIR),
+# and the lock table was never updated (updateLockInternal is skipped
+# with VIR), causing the reader to rediscover the same locks on every
+# re-scan.
+# -------------------------------------------------------------------------
+
+debug-set-virtual-intent-resolution-enabled ok=true
+----
+
+new-txn name=txnReader ts=12,1 epoch=0 priority=high
+----
+
+new-txn name=txnWriter ts=10,1 epoch=0
+----
+
+# Reader issues a non-locking scan.
+new-request name=reqRead txn=txnReader ts=12,1
+  scan key=a endkey=z
+----
+
+# First sequence succeeds — no locks in the lock table yet.
+sequence req=reqRead
+----
+[1] sequence reqRead: sequencing request
+[1] sequence reqRead: acquiring latches
+[1] sequence reqRead: scanning lock table for conflicting locks
+[1] sequence reqRead: sequencing complete, returned guard
+
+# During evaluation, the reader discovers intents written by txnWriter.
+handle-lock-conflict-error req=reqRead lease-seq=1
+  lock txn=txnWriter key=a
+  lock txn=txnWriter key=b
+  lock txn=txnWriter key=c
+----
+[2] handle lock conflict error reqRead: added 3 discovered lock(s) to lock table: conflicting locks on ‹"a"›, ‹"b"›, ‹"c"›
+
+debug-lock-table
+----
+num=3
+ lock: "a"
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
+ lock: "b"
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
+ lock: "c"
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
+
+# Re-sequence the reader. With VIR enabled, after pushing txnWriter, the
+# reader should proceed to evaluation without trying to resolve intents
+# before scanning. Previously this would loop forever.
+sequence req=reqRead
+----
+[3] sequence reqRead: re-sequencing request
+[3] sequence reqRead: acquiring latches
+[3] sequence reqRead: scanning lock table for conflicting locks
+[3] sequence reqRead: waiting in lock wait-queues
+[3] sequence reqRead: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"a"› (queuedLockingRequests: 0, queuedReaders: 1)
+[3] sequence reqRead: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
+[3] sequence reqRead: pushing timestamp of txn 00000002 above 12.000000000,1
+[3] sequence reqRead: pusher pushed pushee to 12.000000000,2
+[3] sequence reqRead: resolving intent ‹"a"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,1}
+[3] sequence reqRead: lock wait-queue event: done waiting
+[3] sequence reqRead: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
+[3] sequence reqRead: acquiring latches
+[3] sequence reqRead: scanning lock table for conflicting locks
+[3] sequence reqRead: sequencing complete, returned guard
+
+finish req=reqRead
+----
+[-] finish reqRead: finishing request
+
+reset namespace

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/virtual_intent_resolution
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/virtual_intent_resolution
@@ -66,7 +66,6 @@ sequence req=reqRead
 [3] sequence reqRead: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [3] sequence reqRead: pushing timestamp of txn 00000002 above 12.000000000,1
 [3] sequence reqRead: pusher pushed pushee to 12.000000000,2
-[3] sequence reqRead: resolving intent ‹"a"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,1}
 [3] sequence reqRead: lock wait-queue event: done waiting
 [3] sequence reqRead: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [3] sequence reqRead: acquiring latches


### PR DESCRIPTION
Note that this still isn't much of a _benchmark_ so I wouldn't take
these numbers too seriously.

```
BenchmarkIntentResolution/virtual-resolution=false
BenchmarkIntentResolution/virtual-resolution=false/writer=PENDING/reader=Scan
BenchmarkIntentResolution/virtual-resolution=false/writer=PENDING/reader=Scan                 87          38846719 ns/op         7876641 B/op      30525 allocs/op
BenchmarkIntentResolution/virtual-resolution=false/writer=PENDING/reader=Export
BenchmarkIntentResolution/virtual-resolution=false/writer=PENDING/reader=Export               60          49792224 ns/op         9851689 B/op      31336 allocs/op
BenchmarkIntentResolution/virtual-resolution=false/writer=ABORTED/reader=Scan
BenchmarkIntentResolution/virtual-resolution=false/writer=ABORTED/reader=Scan                 66          22614076 ns/op         3884818 B/op      16841 allocs/op
BenchmarkIntentResolution/virtual-resolution=false/writer=ABORTED/reader=Export
BenchmarkIntentResolution/virtual-resolution=false/writer=ABORTED/reader=Export               99          27223958 ns/op         3980995 B/op      17053 allocs/op
BenchmarkIntentResolution/virtual-resolution=false/writer=force-ABORTED/reader=Scan
BenchmarkIntentResolution/virtual-resolution=false/writer=force-ABORTED/reader=Scan           61          30761135 ns/op         6846280 B/op      32272 allocs/op
BenchmarkIntentResolution/virtual-resolution=false/writer=force-ABORTED/reader=Export
BenchmarkIntentResolution/virtual-resolution=false/writer=force-ABORTED/reader=Export         42          32445736 ns/op         6972580 B/op      32745 allocs/op
BenchmarkIntentResolution/virtual-resolution=true
BenchmarkIntentResolution/virtual-resolution=true/writer=PENDING/reader=Scan
BenchmarkIntentResolution/virtual-resolution=true/writer=PENDING/reader=Scan                 100          33475503 ns/op         4042517 B/op      27612 allocs/op
BenchmarkIntentResolution/virtual-resolution=true/writer=PENDING/reader=Export
BenchmarkIntentResolution/virtual-resolution=true/writer=PENDING/reader=Export                61          26274005 ns/op         3928067 B/op      28280 allocs/op
BenchmarkIntentResolution/virtual-resolution=true/writer=ABORTED/reader=Scan
BenchmarkIntentResolution/virtual-resolution=true/writer=ABORTED/reader=Scan                 100          21238309 ns/op         2042278 B/op      13636 allocs/op
BenchmarkIntentResolution/virtual-resolution=true/writer=ABORTED/reader=Export
BenchmarkIntentResolution/virtual-resolution=true/writer=ABORTED/reader=Export               100          21575458 ns/op         2099722 B/op      13886 allocs/op
BenchmarkIntentResolution/virtual-resolution=true/writer=force-ABORTED/reader=Scan
BenchmarkIntentResolution/virtual-resolution=true/writer=force-ABORTED/reader=Scan           100          34359285 ns/op         3872652 B/op      26334 allocs/op
BenchmarkIntentResolution/virtual-resolution=true/writer=force-ABORTED/reader=Export
BenchmarkIntentResolution/virtual-resolution=true/writer=force-ABORTED/reader=Export         100          33886860 ns/op         3951978 B/op      26473 allocs/op
```

More important, with doDebug = true, we can see in the trace that we now
only push:

```
client_replica_bench_test.go:375: Counters for c2f3eb97-c274-4ba1-be6d-104a210255f8
    client_replica_bench_test.go:376:   2 pushes
    client_replica_bench_test.go:377:   0 resolve intents
    client_replica_bench_test.go:378:   0 resolve intent ranges
```

Epic: [CRDB-49120](https://cockroachlabs.atlassian.net/browse/CRDB-49120)
Release note: None