### PR TITLE
sql/schemachange: revert distributed merge gate change

### DIFF
--- a/pkg/sql/backfill/distributed_merge_mode.go
+++ b/pkg/sql/backfill/distributed_merge_mode.go
@@ -95,9 +95,9 @@ func shouldEnableDistributedMergeIndexBackfill(
 		return jobspb.IndexBackfillDistributedMergeMode_Disabled,
 			errors.AssertionFailedf("unrecognized distributed merge index backfill mode %d", mode)
 	}
-	if !st.Version.IsActive(ctx, clusterversion.V26_2) {
+	if !st.Version.IsActive(ctx, clusterversion.V26_1) {
 		return jobspb.IndexBackfillDistributedMergeMode_Disabled,
-			pgerror.New(pgcode.FeatureNotSupported, "distributed merge requires cluster version 26.2")
+			pgerror.New(pgcode.FeatureNotSupported, "distributed merge requires cluster version 26.1")
 	}
 	return result, nil
 }


### PR DESCRIPTION
In #162610, the version gates for distributed merge were changed from 26.1 to 26.2 to reflect the additional work done in 26.2 to make distributed merge production ready.

However, the 26.1 gates have already shipped and must remain immutable. This commit reverts the gate change and restores the original 26.1 version for distributed merge.

NOTE: The version gate for distributed merge + IMPORT was also updated in #162610. That gate was never backported to 26.1, so it remains correct and is intentionally left unchanged.

Informs #162610
Release note: none
Epic: CRDB-48845