### PR TITLE
changefeedccl: set default webhook_client_timeout to 3s

### DIFF
--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -1085,10 +1085,14 @@ func (s StatementOptions) GetFilters() Filters {
 	}
 }
 
+// DefaultWebhookClientTimeout is the default timeout used for webhook HTTP
+// client connections when no explicit webhook_client_timeout is specified.
+// This matches the documented default of 3 seconds.
+var DefaultWebhookClientTimeout = 3 * time.Second
+
 // WebhookSinkOptions are passed in WITH args but
 // are specific to the webhook sink.
-// ClientTimeout is nil if not set as the default
-// is different from 0.
+// ClientTimeout defaults to DefaultWebhookClientTimeout when not explicitly set.
 type WebhookSinkOptions struct {
 	JSONConfig    SinkSpecificJSONConfig
 	AuthHeader    string
@@ -1108,6 +1112,10 @@ func (s StatementOptions) GetWebhookSinkOptions() (WebhookSinkOptions, error) {
 	timeout, err := s.getDurationValue(OptWebhookClientTimeout)
 	if err != nil {
 		return o, err
+	}
+	if timeout == nil {
+		defaultTimeout := DefaultWebhookClientTimeout
+		timeout = &defaultTimeout
 	}
 	o.ClientTimeout = timeout
 

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -1088,7 +1088,7 @@ func (s StatementOptions) GetFilters() Filters {
 // DefaultWebhookClientTimeout is the default timeout used for webhook HTTP
 // client connections when no explicit webhook_client_timeout is specified.
 // This matches the documented default of 3 seconds.
-var DefaultWebhookClientTimeout = 3 * time.Second
+const DefaultWebhookClientTimeout = 3 * time.Second
 
 // WebhookSinkOptions are passed in WITH args but
 // are specific to the webhook sink.


### PR DESCRIPTION
## Summary

Fixes #143375

The `webhook_client_timeout` option was previously unset (defaulting to `0`, meaning no timeout) when not explicitly specified by the user. The [documentation](https://www.cockroachlabs.com/docs/stable/create-changefeed.html) states the default should be `3s`, but the code was not enforcing this.

## Changes

- Adds `DefaultWebhookClientTimeout = 3 * time.Second` in `changefeedbase/options.go`
- In `GetWebhookSinkOptions()`, applies the default when `webhook_client_timeout` is not explicitly set
- Adds `TestWebhookSinkClientTimeoutDefault` unit test to verify the default and custom timeout behavior

## Testing

```
go test ./pkg/ccl/changefeedccl/... -run TestWebhookSinkClientTimeoutDefault
```

The test verifies:
1. When `webhook_client_timeout` is not set, `ClientTimeout` defaults to `3s`
2. When `webhook_client_timeout` is explicitly set (e.g. `10s`), that value is respected

## Release note

```release-note
Bug fix: webhook changefeed sink now uses a 3-second HTTP client timeout by
default, matching the documented behavior. Previously the HTTP client had no
timeout when `webhook_client_timeout` was not explicitly configured.
```