### PR TITLE
sql: gate InstanceInfo fix behind cluster setting

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -13622,6 +13622,9 @@ func TestChangefeedServerlessLocalityFilter(t *testing.T) {
 	tenantServer, tenantDB := serverutils.StartTenant(t, kvServer, tenantArgs)
 	tenantSQL := sqlutils.MakeSQLRunner(tenantDB)
 	tenantSQL.ExecMultiple(t, strings.Split(tenantSetupStatements, ";")...)
+
+	tenantSQL.Exec(t, `SET CLUSTER SETTING sql.instance_info.use_instance_resolver.enabled = true`)
+
 	tenantSQL.Exec(t, `CREATE TABLE foo (pk INT PRIMARY KEY)`)
 	tenantSQL.Exec(t, `INSERT INTO foo VALUES (1)`)
 

--- a/pkg/crosscluster/producer/stream_lifetime.go
+++ b/pkg/crosscluster/producer/stream_lifetime.go
@@ -319,17 +319,17 @@ func (r *replicationStreamManagerImpl) buildReplicationStreamSpec(
 	}
 
 	for _, sp := range spanPartitions {
-		nodeInfo, err := dsp.GetSQLInstanceInfo(ctx, sp.SQLInstanceID)
+		instanceInfo, err := dsp.GetSQLInstanceInfo(ctx, sp.SQLInstanceID)
 		if err != nil {
 			return nil, err
 		}
 		if r.knobs != nil && r.knobs.OnGetSQLInstanceInfo != nil {
-			nodeInfo = r.knobs.OnGetSQLInstanceInfo(nodeInfo)
+			instanceInfo = r.knobs.OnGetSQLInstanceInfo(instanceInfo)
 		}
 		res.Partitions = append(res.Partitions, streampb.ReplicationStreamSpec_Partition{
 			NodeID:     roachpb.NodeID(sp.SQLInstanceID),
-			SQLAddress: util.MakeUnresolvedAddr("tcp", nodeInfo.InstanceSQLAddr),
-			Locality:   nodeInfo.Locality,
+			SQLAddress: util.MakeUnresolvedAddr("tcp", instanceInfo.InstanceSQLAddr),
+			Locality:   instanceInfo.Locality,
 			SourcePartition: &streampb.SourcePartition{
 				Spans: sp.Spans,
 			},

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -48,6 +48,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/span"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlclustersettings"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlinstance"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -240,11 +241,30 @@ func (dsp *DistSQLPlanner) GetAllInstancesByLocality(
 	return all[:pos], nil
 }
 
-// GetSQLInstanceInfo gets SQL instance info by instance ID.
+// GetSQLInstanceInfo gets SQL instance info by instance ID. This properly handles
+// SQL instances in multi-tenant environments where instances may not map to KV nodes.
+// The previous behavior is available by turning off the instance resolver
+// via cluster settings.
 func (dsp *DistSQLPlanner) GetSQLInstanceInfo(
 	ctx context.Context, sqlInstanceID base.SQLInstanceID,
 ) (sqlinstance.InstanceInfo, error) {
-	return dsp.sqlAddressResolver.GetInstance(ctx, sqlInstanceID)
+	if sqlclustersettings.UseInstanceInfoForSQLInstances.Get(&dsp.st.SV) {
+		return dsp.sqlAddressResolver.GetInstance(ctx, sqlInstanceID)
+	}
+
+	// This only works when SQL instances map 1:1 to KV nodes, i.e. not in
+	// serverless tenants.
+	nodeDesc, err := dsp.nodeDescs.GetNodeDescriptor(roachpb.NodeID(sqlInstanceID))
+	if err != nil {
+		return sqlinstance.InstanceInfo{}, err
+	}
+	return sqlinstance.InstanceInfo{
+		InstanceID:      base.SQLInstanceID(nodeDesc.NodeID),
+		InstanceSQLAddr: nodeDesc.SQLAddress.String(),
+		InstanceRPCAddr: nodeDesc.Address.String(),
+		Locality:        nodeDesc.Locality,
+		BinaryVersion:   nodeDesc.ServerVersion,
+	}, nil
 }
 
 // ReplicaOracleConfig returns the DSP's replicaoracle.Config.

--- a/pkg/sql/sqlclustersettings/clustersettings.go
+++ b/pkg/sql/sqlclustersettings/clustersettings.go
@@ -152,3 +152,14 @@ var LDRImmediateModeWriter = settings.RegisterStringSetting(
 		return nil
 	}),
 )
+
+// UseInstanceInfoForSQLInstances controls whether to use sqlinstance.InstanceInfo
+// instead of roachpb.NodeDescriptor when retrieving SQL instance information.
+// This is necessary for proper handling of SQL instances in multi-tenant
+// environments where SQL instances may not have corresponding KV nodes.
+var UseInstanceInfoForSQLInstances = settings.RegisterBoolSetting(
+	settings.ApplicationLevel,
+	"sql.instance_info.use_instance_resolver.enabled",
+	"use sqlinstance.InstanceInfo instead of NodeDescriptor for SQL instance lookups; "+
+		"enables proper handling of SQL instances in serverless environments",
+	metamorphic.ConstantWithTestBool("sql.instance_info.use_instance_resolver.enabled", true))


### PR DESCRIPTION
This commit puts the fix for GetSQLInstanceInfo (which
changed it from returning *roachpb.NodeDescriptor to
sqlinstance.InstanceInfo) behind a cluster setting:
sql.instance_info.use_instance_resolver.enabled.

The setting is enabled by default on master, allowing
the fix to resolve "node descriptor not found" errors
for jobs with locality filters in serverless clusters.
This gating allows the change to be backported to release
branches where the setting will be disabled by default
for safety.

Release note (bug fix): The fix for "node descriptor
not found" errors for changefeeds with execution_locality
filters in serverless clusters is now controlled by
cluster setting:
sql.instance_info.use_instance_resolver.enabled
(default: true).

Epic: none
Informs: https://github.com/cockroachdb/cockroach/issues/163752