### PR TITLE
sql: set atttypid=0 for dropped columns in pg_attribute

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -752,9 +752,9 @@ attrelid    relname            attname                       atttypid  attstatta
 120         t6                 c                             25        0              -1      3       0         -1
 120         t6                 m                             100118    0              -1      4       0         -1
 120         t6                 rowid                         20        0              8       6       0         -1
-120         t6                 ........pg.dropped.5........  2283      0              -1      5       0         -1
-120         t6                 ........pg.dropped.7........  2283      0              -1      7       0         -1
-120         t6                 ........pg.dropped.8........  2283      0              -1      8       0         -1
+120         t6                 ........pg.dropped.5........  0         0              -1      5       0         -1
+120         t6                 ........pg.dropped.7........  0         0              -1      7       0         -1
+120         t6                 ........pg.dropped.8........  0         0              -1      8       0         -1
 2129466852  t6_pkey            rowid                         20        0              8       1       0         -1
 2129466855  t6_expr_idx        crdb_internal_idx_expr        20        0              8       1       0         -1
 2129466854  t6_expr_expr1_idx  crdb_internal_idx_expr_1      25        0              -1      1       0         -1
@@ -910,6 +910,27 @@ t6_expr_idx1       crdb_internal_idx_expr_2      false         true        0    
 mv1                ?column?                      false         true        0            NULL    NULL        NULL
 mv1                rowid                         false         true        0            NULL    NULL        NULL
 mv1_pkey           rowid                         false         true        0            NULL    NULL        NULL
+
+# Regression test for #163948: dropped columns should have atttypid=0, so they
+# are filtered out by joins with pg_type (matching PostgreSQL behavior).
+query TTBII
+SELECT
+  a.attname,
+  t.typname,
+  a.attnotnull,
+  a.attlen,
+  a.atttypmod
+FROM pg_attribute AS a
+JOIN pg_type AS t ON a.atttypid = t.oid
+WHERE a.attrelid = 'constraint_db.t6'::regclass
+  AND a.attnum > 0
+ORDER BY a.attnum
+----
+a      int8     false  8   -1
+b      int8     false  8   -1
+c      text     false  -1  -1
+m      mytype   false  -1  -1
+rowid  int8     true   8   -1
 
 # Check relkind codes.
 statement ok

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -496,8 +496,8 @@ https://www.postgresql.org/docs/12/catalog-pg-attribute.html`,
 		}
 		// Add a dropped entry for any attribute numbers in the middle that are
 		// missing, assuming there are any numeric gaps in the number of columns
-		// observed.
-		missingColumnType := types.AnyElement
+		// observed. Use atttypid=0 to match PostgreSQL behavior, where dropped
+		// columns have no valid type.
 		if populatedColumns.Len() != maxPGAttributeNum {
 			for colOrdinal := 1; colOrdinal <= maxPGAttributeNum; colOrdinal++ {
 				if populatedColumns.Contains(colOrdinal) {
@@ -507,27 +507,27 @@ https://www.postgresql.org/docs/12/catalog-pg-attribute.html`,
 				if err := addRow(
 					tableID,                             // attrelid
 					tree.NewDName(colName),              // attname
-					typOid(missingColumnType),           // atttypid
+					oidZero,                             // atttypid
 					zeroVal,                             // attstattarget
-					typLen(missingColumnType),           // attlen
+					negOneVal,                           // attlen
 					tree.NewDInt(tree.DInt(colOrdinal)), // attnum
 					zeroVal,                             // attndims
 					negOneVal,                           // attcacheoff
-					tree.NewDInt(tree.DInt(missingColumnType.TypeModifier())), // atttypmod
-					tree.DNull,                    // attbyval (see pg_type.typbyval)
-					tree.DNull,                    // attstorage
-					tree.DNull,                    // attalign
-					tree.DBoolFalse,               // attnotnull
-					tree.DBoolFalse,               // atthasdef
-					tree.NewDString(""),           // attidentity
-					tree.NewDString(""),           // attgenerated
-					tree.DBoolTrue,                // attisdropped
-					tree.DBoolTrue,                // attislocal
-					zeroVal,                       // attinhcount
-					typColl(missingColumnType, h), // attcollation
-					tree.DNull,                    // attacl
-					tree.DNull,                    // attoptions
-					tree.DNull,                    // attfdwoptions
+					negOneVal,                           // atttypmod
+					tree.DNull,                          // attbyval (see pg_type.typbyval)
+					tree.DNull,                          // attstorage
+					tree.DNull,                          // attalign
+					tree.DBoolFalse,                     // attnotnull
+					tree.DBoolFalse,                     // atthasdef
+					tree.NewDString(""),                 // attidentity
+					tree.NewDString(""),                 // attgenerated
+					tree.DBoolTrue,                      // attisdropped
+					tree.DBoolTrue,                      // attislocal
+					zeroVal,                             // attinhcount
+					oidZero,                             // attcollation
+					tree.DNull,                          // attacl
+					tree.DNull,                          // attoptions
+					tree.DNull,                          // attfdwoptions
 					// These columns were automatically created by pg_catalog_test's missing column generator.
 					tree.DNull, // atthasmissing
 					// These columns were automatically created by pg_catalog_test's missing column generator.


### PR DESCRIPTION
Previously, dropped columns in pg_attribute had atttypid=2283 (anyelement), which is a valid type OID. This caused queries that join pg_attribute with pg_type to include dropped columns in their results, since the join on atttypid would succeed. PostgreSQL sets atttypid=0 for dropped columns, which means joins with pg_type automatically filter them out (no pg_type row has oid=0).

This broke third-party tools (like Sigma) that use the common pattern of joining pg_attribute with pg_type to discover column metadata.

Resolves: #163948

Release note (bug fix): Fixed a bug where dropped columns appeared in pg_catalog.pg_attribute with the atttypid column equal to 2283 (anyelement). Now this column will be 0 for dropped columns. This matches PostgreSQL behavior, where atttypid=0 is used for dropped columns.