### PR TITLE
workloadccl: fix IMPORT result column scan order for inspect_job_id

### DIFF
--- a/pkg/ccl/workloadccl/fixture.go
+++ b/pkg/ccl/workloadccl/fixture.go
@@ -507,12 +507,14 @@ func importFixtureTable(
 		return 0, err
 	}
 	if len(resCols) == 7 {
+		// See jobs.ImportJobExecutionResultHeader.
 		if err := res.Scan(
-			&discard, &discard, &discard, &rows, &index, &discard, &tableBytes,
+			&discard, &discard, &discard, &rows, &index, &tableBytes, &discard,
 		); err != nil {
 			return 0, err
 		}
 	} else {
+		// See jobs.BulkJobExecutionResultHeader.
 		if err := res.Scan(
 			&discard, &discard, &discard, &rows, &index, &tableBytes,
 		); err != nil {


### PR DESCRIPTION
The 7-column scan branch (for IMPORT results with the new inspect_job_id column) had &discard and &tableBytes swapped, causing tableBytes to scan from the nullable inspect_job_id column instead of the bytes column. This resulted in:
```
  sql: Scan error on column index 6, name "inspect_job_id":
  converting NULL to int64 is unsupported
```
Swap the two scan targets so tableBytes reads from the bytes column (index 5) and the nullable inspect_job_id is discarded.

Resolves: #163929
Resolves: #163920

Release note: None