### PR TITLE
logictest: enforce lower bound on distsql_workmem in distsql_agg

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_agg
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_agg
@@ -546,6 +546,10 @@ SELECT c, min(b), a FROM sorted_data GROUP BY a, c ORDER BY a
 23    -2   9
 -3.1  100  10
 
+# Require some reasonable minimum workmem (necessary for the streamer).
+statement ok
+SET distsql_workmem = '100KiB';
+
 # If the underlying ordering isn't from the primary index, it needs to be hinted
 # for now.
 query IR rowsort


### PR DESCRIPTION
There are two queries in this file that are powered by the streamer that could hit "memory budget exceeded" errors with too low of workmem limit (after some recent changes). Require 100KiB workmem to avoid the flakes.

Fixes: #163509.
Release note: None