### PR TITLE
db-console: Convert remaining cluster views to functional components

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/linegraph.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/linegraph.spec.tsx
@@ -3,35 +3,43 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
-import {
-  calculateXAxisDomain,
-  calculateYAxisDomain,
-  util,
-} from "@cockroachlabs/cluster-ui";
-import { shallow, ShallowWrapper } from "enzyme";
-import flatMap from "lodash/flatMap";
-import isEmpty from "lodash/isEmpty";
+import { render } from "@testing-library/react";
 import Long from "long";
 import React from "react";
 import uPlot from "uplot";
 
-import * as protos from "src/js/protos";
 import * as timewindow from "src/redux/timeScale";
-import { configureUPlotLineChart } from "src/views/cluster/util/graphs";
 import { Axis } from "src/views/shared/components/metricQuery";
 
-import LineGraph, { fillGaps, InternalLineGraph, OwnProps } from "./index";
+import { fillGaps, InternalLineGraph, LineGraphProps } from "./index";
+
+// Mock uPlot — JSDOM can't render real charts, so we verify the
+// component drives uPlot correctly via constructor and method calls.
+jest.mock("uplot", () => {
+  return jest.fn().mockImplementation(() => ({
+    setData: jest.fn(),
+    destroy: jest.fn(),
+    axes: [{}, { label: "" }],
+  }));
+});
+
+// Mock chart helpers to avoid needing the full metrics pipeline.
+// formatMetricData returns a stable key (".0") so the effect can
+// distinguish "same series, new data" from "new series".
+jest.mock("src/views/cluster/util/graphs", () => ({
+  ...jest.requireActual("src/views/cluster/util/graphs"),
+  configureUPlotLineChart: jest.fn().mockReturnValue({}),
+  formatMetricData: jest.fn().mockReturnValue([{ key: ".0", values: [] }]),
+}));
+
+const MockUPlot = uPlot as unknown as jest.Mock;
 
 describe("<LineGraph>", function () {
-  let mockProps: OwnProps;
-  const linegraph = (props: OwnProps) =>
-    shallow(
-      <LineGraph {...props}>
-        <Axis />
-      </LineGraph>,
-    );
+  let mockProps: LineGraphProps;
 
   beforeEach(() => {
+    MockUPlot.mockClear();
+
     mockProps = {
       title: "Test Title",
       subtitle: "Test Subtitle",
@@ -45,142 +53,117 @@ describe("<LineGraph>", function () {
       },
       setMetricsFixedWindow: timewindow.setMetricsFixedWindow,
       setTimeScale: timewindow.setTimeScale,
+      timezone: "UTC",
       history: {
         length: 0,
-        action: "PUSH",
+        action: "PUSH" as const,
         location: {
           pathname: "",
           search: "",
           state: jest.fn(),
           hash: "",
         },
-        push: () => {},
-        replace: () => {},
-        go: () => {},
-        goBack: () => {},
-        goForward: () => {},
+        push: jest.fn(),
+        replace: jest.fn(),
+        go: jest.fn(),
+        goBack: jest.fn(),
+        goForward: jest.fn(),
         block: jest.fn(),
         listen: jest.fn(),
-        createHref: () => {
-          return "";
-        },
+        createHref: () => "",
       },
     };
   });
 
   it("should render a root component on mount", () => {
-    const wrapper = linegraph({ ...mockProps });
-    const root = wrapper.dive().find(".linegraph");
-    expect(root.length).toBe(1);
+    const { container } = render(
+      <InternalLineGraph {...mockProps}>
+        <Axis />
+      </InternalLineGraph>,
+    );
+    expect(container.querySelector(".linegraph")).not.toBeNull();
   });
 
   it("should display an empty state if viewing a virtual cluster and there is no data", () => {
-    mockProps.tenantSource = "demoapp";
-    const wrapper = linegraph({ ...mockProps }).dive() as ShallowWrapper<
-      any,
-      Readonly<{}>,
-      React.Component<{}, {}, any>
-    >;
-    const root = wrapper.find(".linegraph-empty");
-    expect(root.length).toBe(1);
+    const { container } = render(
+      <InternalLineGraph {...mockProps} tenantSource="demoapp">
+        <Axis />
+      </InternalLineGraph>,
+    );
+    expect(container.querySelector(".linegraph-empty")).not.toBeNull();
   });
 
-  it("should set a new chart on update", () => {
-    const wrapper = linegraph({ ...mockProps }).dive() as ShallowWrapper<
-      any,
-      Readonly<{}>,
-      React.Component<{}, {}, any>
-    >;
-    const instance = wrapper.instance() as any as InternalLineGraph;
-    wrapper.setProps({
-      data: {
-        results: [
-          {
-            datapoints: [
-              {
-                timestamp_nanos: {
-                  high: 999999,
-                  low: 111111,
-                  unsigned: false,
+  it("should create a chart when data with datapoints arrives", () => {
+    render(
+      <InternalLineGraph
+        {...mockProps}
+        data={{
+          results: [
+            {
+              datapoints: [
+                {
+                  timestamp_nanos: new Long(111111, 999999),
+                  value: 123456,
                 },
-                value: 123456,
-              },
-            ],
-          },
-        ],
-      },
-    });
-    const result = isEmpty(instance.u);
-    expect(result).toEqual(false);
+              ],
+            },
+          ],
+        }}
+      >
+        <Axis />
+      </InternalLineGraph>,
+    );
+
+    expect(MockUPlot).toHaveBeenCalled();
   });
 
-  it("should update the existing chart", () => {
-    // test setup
-    const wrapper = linegraph({
-      ...mockProps,
-      data: { results: [{}] },
-    }).dive() as ShallowWrapper<
-      any,
-      Readonly<{}>,
-      React.Component<{}, {}, any>
-    >;
-    const instance = wrapper.instance() as unknown as InternalLineGraph;
-    const mockFn = jest.fn();
-    const mockMetrics = [
-      {
-        key: ".0",
-        props: { name: "test", nonNegativeRate: true, title: "Selects" },
-        type: mockFn,
-        _owner: {},
-        _store: { validated: false },
-      },
-    ];
-    const mockAxis = {
-      type: "AxisProps",
-      key: ".0",
-      props: { label: "queries", children: [{}], units: 3 },
-      _owner: {},
-      _store: { validated: false },
+  it("should update the existing chart when data changes", () => {
+    const initialData = {
+      results: [
+        {
+          datapoints: [
+            {
+              timestamp_nanos: new Long(111111, 999999),
+              value: 100,
+            },
+          ],
+        },
+      ],
     };
-    const mockData: protos.cockroach.ts.tspb.TimeSeriesQueryResponse =
-      new protos.cockroach.ts.tspb.TimeSeriesQueryResponse();
-    const resultDatapoints = flatMap(mockData.results, result =>
-      result.datapoints.map(dp => dp.value),
+
+    const { rerender } = render(
+      <InternalLineGraph {...mockProps} data={initialData}>
+        <Axis />
+      </InternalLineGraph>,
     );
-    const mockOptions = configureUPlotLineChart(
-      mockMetrics,
-      mockAxis,
-      mockData,
-      instance.setNewTimeRange,
-      () => calculateYAxisDomain(0, resultDatapoints),
-      () =>
-        calculateXAxisDomain(
-          util.NanoToMilli(mockProps.timeInfo.start.toNumber()),
-          util.NanoToMilli(mockProps.timeInfo.end.toNumber()),
-        ),
-    );
-    instance.u = new uPlot(mockOptions);
-    const setDataSpy = jest.spyOn(instance.u, "setData");
-    // run test
-    wrapper.setProps({
-      data: {
-        results: [
-          {
-            datapoints: [
-              {
-                timestamp_nanos: {
-                  high: 999999,
-                  low: 111111,
-                  unsigned: false,
+
+    // First render should create the chart.
+    expect(MockUPlot).toHaveBeenCalledTimes(1);
+    const chartInstance = MockUPlot.mock.results[0].value;
+
+    // Rerender with a new data object (same series structure).
+    rerender(
+      <InternalLineGraph
+        {...mockProps}
+        data={{
+          results: [
+            {
+              datapoints: [
+                {
+                  timestamp_nanos: new Long(222222, 999999),
+                  value: 200,
                 },
-                value: 123456,
-              },
-            ],
-          },
-        ],
-      },
-    });
-    expect(setDataSpy).toHaveBeenCalled();
+              ],
+            },
+          ],
+        }}
+      >
+        <Axis />
+      </InternalLineGraph>,
+    );
+
+    // Should update existing chart via setData, not create a new one.
+    expect(chartInstance.setData).toHaveBeenCalled();
   });
 });
 

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/dataDistribution/replicaMatrix.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/dataDistribution/replicaMatrix.tsx
@@ -6,7 +6,7 @@
 import { util } from "@cockroachlabs/cluster-ui";
 import classNames from "classnames";
 import isEqual from "lodash/isEqual";
-import React, { Component } from "react";
+import React, { useState } from "react";
 
 import { cockroach, google } from "src/js/protos";
 import { ToolTipWrapper } from "src/views/shared/components/toolTip";
@@ -29,11 +29,6 @@ import "./replicaMatrix.scss";
 const DOWN_ARROW = "▼";
 const SIDE_ARROW = "▶";
 
-interface ReplicaMatrixState {
-  collapsedRows: TreePath[];
-  collapsedCols: TreePath[];
-}
-
 interface ReplicaMatrixProps {
   cols: TreeNode<NodeDescriptor$Properties>;
   rows: TreeNode<SchemaObject>;
@@ -46,189 +41,171 @@ const ROW_TREE_INDENT_PX = 18;
 // applied in CSS.
 const ROW_LEFT_MARGIN_PX = 5;
 
-class ReplicaMatrix extends Component<ReplicaMatrixProps, ReplicaMatrixState> {
-  constructor(props: ReplicaMatrixProps) {
-    super(props);
-    this.state = {
-      collapsedRows: [["system"], ["defaultdb"], ["postgres"]],
-      collapsedCols: [],
-    };
+// Default databases collapsed on initial render.
+const INITIAL_COLLAPSED_ROWS: TreePath[] = [
+  ["system"],
+  ["defaultdb"],
+  ["postgres"],
+];
+
+function colLabel(col: LayoutCell<NodeDescriptor$Properties>): string {
+  if (col.isPlaceholder) {
+    return null;
   }
-
-  expandRow = (path: TreePath) => {
-    this.setState({
-      collapsedRows: this.state.collapsedRows.filter(tp => !isEqual(tp, path)),
-    });
-  };
-
-  collapseRow = (path: TreePath) => {
-    this.setState({
-      collapsedRows: [...this.state.collapsedRows, path],
-    });
-  };
-
-  expandCol = (path: TreePath) => {
-    this.setState({
-      collapsedCols: this.state.collapsedCols.filter(tp => !isEqual(tp, path)),
-    });
-  };
-
-  collapseCol = (path: TreePath) => {
-    this.setState({
-      collapsedCols: [...this.state.collapsedCols, path],
-    });
-  };
-
-  colLabel(col: LayoutCell<NodeDescriptor$Properties>): string {
-    if (col.isPlaceholder) {
-      return null;
-    }
-
-    if (col.isLeaf) {
-      return `n${col.data.node_id}`;
-    }
-
-    const arrow = col.isCollapsed ? SIDE_ARROW : DOWN_ARROW;
-    const localityLabel =
-      col.path.length === 0 ? "Cluster" : col.path[col.path.length - 1];
-    return `${arrow} ${localityLabel}`;
+  if (col.isLeaf) {
+    return `n${col.data.node_id}`;
   }
+  const arrow = col.isCollapsed ? SIDE_ARROW : DOWN_ARROW;
+  const localityLabel =
+    col.path.length === 0 ? "Cluster" : col.path[col.path.length - 1];
+  return `${arrow} ${localityLabel}`;
+}
 
-  rowLabelText(row: FlattenedNode<SchemaObject>) {
-    if (row.isLeaf) {
-      return row.data.tableName;
-    }
-
-    const arrow = row.isCollapsed ? SIDE_ARROW : DOWN_ARROW;
-    const label = row.data.dbName ? `DB: ${row.data.dbName}` : "Cluster";
-
-    return `${arrow} ${label}`;
+function rowLabelText(row: FlattenedNode<SchemaObject>): string {
+  if (row.isLeaf) {
+    return row.data.tableName;
   }
+  const arrow = row.isCollapsed ? SIDE_ARROW : DOWN_ARROW;
+  const label = row.data.dbName ? `DB: ${row.data.dbName}` : "Cluster";
+  return `${arrow} ${label}`;
+}
 
-  rowLabel(row: FlattenedNode<SchemaObject>) {
-    const text = this.rowLabelText(row);
+function rowLabel(row: FlattenedNode<SchemaObject>): React.ReactNode {
+  const text = rowLabelText(row);
+  const label = (
+    <span
+      className={classNames("table-label", {
+        "table-label--dropped": !!row.data.droppedAt,
+      })}
+    >
+      {text}
+    </span>
+  );
 
-    const label = (
-      <span
-        className={classNames("table-label", {
-          "table-label--dropped": !!row.data.droppedAt,
-        })}
-      >
-        {text}
-      </span>
-    );
-
-    if (row.data.droppedAt) {
-      return (
-        <ToolTipWrapper
-          text={
-            <span>
-              Dropped at {util.TimestampToMoment(row.data.droppedAt).format()}.
-              Will eventually be garbage collected according to this schema
-              object's GC TTL.
-            </span>
-          }
-        >
-          {label}
-        </ToolTipWrapper>
-      );
-    } else {
-      return label;
-    }
-  }
-
-  render() {
-    const { cols, rows, getValue } = this.props;
-    const { collapsedRows, collapsedCols } = this.state;
-
-    const flattenedRows = flatten(rows, collapsedRows, true /* includeNodes */);
-    const headerRows = layoutTreeHorizontal(cols, collapsedCols);
-    const flattenedCols = flatten(
-      cols,
-      collapsedCols,
-      false /* includeNodes */,
-    );
-
+  if (row.data.droppedAt) {
     return (
-      <table className="matrix">
-        <thead>
-          {headerRows.map((row, idx) => (
-            <tr key={idx}>
-              {idx === 0 ? (
-                <th className="matrix__metric-label"># Replicas</th>
-              ) : (
-                <th />
-              )}
-              {row.map(col => (
-                <th
-                  key={col.path.join("/")}
-                  colSpan={col.width}
-                  className={classNames("matrix__column-header", {
-                    "matrix__column-header--internal-node": !(
-                      col.isLeaf || col.isPlaceholder
-                    ),
-                  })}
-                  onClick={() =>
-                    col.isCollapsed
-                      ? this.expandCol(col.path)
-                      : this.collapseCol(col.path)
-                  }
-                >
-                  {this.colLabel(col)}
-                </th>
-              ))}
-            </tr>
-          ))}
-        </thead>
-        <tbody>
-          {flattenedRows.map(row => {
-            return (
-              <tr
-                key={row.path.join("/")}
-                className={classNames("matrix__row", {
-                  "matrix__row--internal-node": !row.isLeaf,
+      <ToolTipWrapper
+        text={
+          <span>
+            Dropped at {util.TimestampToMoment(row.data.droppedAt).format()}.
+            Will eventually be garbage collected according to this schema
+            object's GC TTL.
+          </span>
+        }
+      >
+        {label}
+      </ToolTipWrapper>
+    );
+  }
+
+  return label;
+}
+
+function ReplicaMatrix({
+  cols,
+  rows,
+  getValue,
+}: ReplicaMatrixProps): React.ReactElement {
+  const [collapsedRows, setCollapsedRows] = useState<TreePath[]>(
+    INITIAL_COLLAPSED_ROWS,
+  );
+  const [collapsedCols, setCollapsedCols] = useState<TreePath[]>([]);
+
+  const expandRow = (path: TreePath) => {
+    setCollapsedRows(prev => prev.filter(tp => !isEqual(tp, path)));
+  };
+
+  const collapseRow = (path: TreePath) => {
+    setCollapsedRows(prev => [...prev, path]);
+  };
+
+  const expandCol = (path: TreePath) => {
+    setCollapsedCols(prev => prev.filter(tp => !isEqual(tp, path)));
+  };
+
+  const collapseCol = (path: TreePath) => {
+    setCollapsedCols(prev => [...prev, path]);
+  };
+
+  const flattenedRows = flatten(rows, collapsedRows, true /* includeNodes */);
+  const headerRows = layoutTreeHorizontal(cols, collapsedCols);
+  const flattenedCols = flatten(cols, collapsedCols, false /* includeNodes */);
+
+  return (
+    <table className="matrix">
+      <thead>
+        {headerRows.map((row, idx) => (
+          <tr key={idx}>
+            {idx === 0 ? (
+              <th className="matrix__metric-label"># Replicas</th>
+            ) : (
+              <th />
+            )}
+            {row.map(col => (
+              <th
+                key={col.path.join("/")}
+                colSpan={col.width}
+                className={classNames("matrix__column-header", {
+                  "matrix__column-header--internal-node": !(
+                    col.isLeaf || col.isPlaceholder
+                  ),
                 })}
                 onClick={() =>
-                  row.isCollapsed
-                    ? this.expandRow(row.path)
-                    : this.collapseRow(row.path)
+                  col.isCollapsed ? expandCol(col.path) : collapseCol(col.path)
                 }
               >
-                <th
-                  className={classNames("matrix__row-header", {
-                    "matrix__row-header--internal-node": !row.isLeaf,
-                  })}
-                  style={{
-                    paddingLeft:
-                      row.depth * ROW_TREE_INDENT_PX + ROW_LEFT_MARGIN_PX,
-                  }}
-                >
-                  {this.rowLabel(row)}
-                </th>
-                {flattenedCols.map(col => {
-                  return (
-                    <td key={col.path.join("/")} className="matrix__cell-value">
-                      {row.isLeaf || row.isCollapsed
-                        ? emptyIfZero(
-                            sumValuesUnderPaths(
-                              rows,
-                              cols,
-                              row.path,
-                              col.path,
-                              getValue,
-                            ),
-                          )
-                        : null}
-                    </td>
-                  );
+                {colLabel(col)}
+              </th>
+            ))}
+          </tr>
+        ))}
+      </thead>
+      <tbody>
+        {flattenedRows.map(row => {
+          return (
+            <tr
+              key={row.path.join("/")}
+              className={classNames("matrix__row", {
+                "matrix__row--internal-node": !row.isLeaf,
+              })}
+              onClick={() =>
+                row.isCollapsed ? expandRow(row.path) : collapseRow(row.path)
+              }
+            >
+              <th
+                className={classNames("matrix__row-header", {
+                  "matrix__row-header--internal-node": !row.isLeaf,
                 })}
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
-    );
-  }
+                style={{
+                  paddingLeft:
+                    row.depth * ROW_TREE_INDENT_PX + ROW_LEFT_MARGIN_PX,
+                }}
+              >
+                {rowLabel(row)}
+              </th>
+              {flattenedCols.map(col => {
+                return (
+                  <td key={col.path.join("/")} className="matrix__cell-value">
+                    {row.isLeaf || row.isCollapsed
+                      ? emptyIfZero(
+                          sumValuesUnderPaths(
+                            rows,
+                            cols,
+                            row.path,
+                            col.path,
+                            getValue,
+                          ),
+                        )
+                      : null}
+                  </td>
+                );
+              })}
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
 }
 
 function emptyIfZero(n: number): string {

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -7,7 +7,7 @@ import { Anchor, TimeScale } from "@cockroachlabs/cluster-ui";
 import has from "lodash/has";
 import map from "lodash/map";
 import moment from "moment-timezone";
-import React from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { Helmet } from "react-helmet";
 import { connect } from "react-redux";
 import { withRouter, RouteComponentProps } from "react-router-dom";
@@ -207,311 +207,295 @@ type NodeGraphsProps = RouteComponentProps &
   MapStateToProps &
   MapDispatchToProps;
 
-type NodeGraphsState = {
-  showLowResolutionAlert: boolean;
-  showDeletedDataAlert: boolean;
-};
-
 /**
  * NodeGraphs renders the main content of the cluster graphs page.
  */
-export class NodeGraphs extends React.Component<
-  NodeGraphsProps,
-  NodeGraphsState
-> {
-  constructor(props: NodeGraphsProps) {
-    super(props);
-    this.state = {
-      showDeletedDataAlert: false,
-      showLowResolutionAlert: false,
-    };
-  }
+export function NodeGraphs({
+  match,
+  history,
+  hoverState,
+  hoverOn: hoverOnAction,
+  hoverOff: hoverOffAction,
+  resolution10sStorageTTL,
+  resolution30mStorageTTL,
+  timeScale,
+  nodeDropdownOptions,
+  nodeIds,
+  storeIDsByNodeID,
+  nodeDisplayNameByID,
+  tenantOptions,
+  currentTenant,
+  refreshNodes: refreshNodesAction,
+  refreshLiveness: refreshLivenessAction,
+  refreshNodeSettings: refreshNodeSettingsAction,
+  refreshTenantsList: refreshTenantsListAction,
+  setMetricsFixedWindow: setMetricsFixedWindowAction,
+  setTimeScale: setTimeScaleAction,
+}: NodeGraphsProps): React.ReactElement {
+  const [showLowResolutionAlert, setShowLowResolutionAlert] = useState(false);
+  const [showDeletedDataAlert, setShowDeletedDataAlert] = useState(false);
 
-  refresh = () => {
-    this.props.refreshNodes();
-    this.props.refreshLiveness();
-    this.props.refreshNodeSettings();
-  };
+  // Refresh nodes and liveness data on every render so stale data triggers
+  // a re-fetch (these calls short-circuit internally when data is fresh).
+  useEffect(() => {
+    refreshNodesAction();
+    refreshLivenessAction();
+  });
 
-  setClusterPath = (key: string, selected: DropdownOption) => {
-    const { match, history } = this.props;
-    const { value } = selected;
-    const nodeID = getMatchParamByName(match, nodeIDAttr) || "";
-    const dashName = getMatchParamByName(match, dashboardNameAttr) || "";
-    const tenantName = getMatchParamByName(match, tenantNameAttr) || "";
-    const nodeMatchParam = (val: string): string =>
-      val === "" ? "/cluster" : `/node/${val}`;
-    const tenantMatchParam = (val: string): string =>
-      val === "" ? "" : `/tenant/${val}`;
-    let path = "/metrics/";
-    switch (key) {
-      case "dashboard":
-        path += value + nodeMatchParam(nodeID) + tenantMatchParam(tenantName);
-        break;
-      case "node":
-        path += dashName + nodeMatchParam(value) + tenantMatchParam(tenantName);
-        break;
-      default:
-        path += dashName + nodeMatchParam(nodeID) + tenantMatchParam(value);
-        break;
+  // Settings and tenants list only need to be fetched once on mount —
+  // they don't change frequently.
+  useEffect(() => {
+    refreshNodeSettingsAction();
+    if (isSystemTenant(currentTenant)) {
+      refreshTenantsListAction();
     }
-    history.push({
-      pathname: path,
-      search: history.location.search,
-    });
-  };
+  }, [refreshNodeSettingsAction, refreshTenantsListAction, currentTenant]);
 
-  componentDidMount() {
-    this.refresh();
-    // settings won't change frequently so it's safe to request one
-    // when page is loaded.
-    this.props.refreshNodeSettings();
-    if (isSystemTenant(this.props.currentTenant)) {
-      this.props.refreshTenantsList();
-    }
-  }
+  const setClusterPath = useCallback(
+    (key: string, selected: DropdownOption) => {
+      const { value } = selected;
+      const nodeID = getMatchParamByName(match, nodeIDAttr) || "";
+      const dashName = getMatchParamByName(match, dashboardNameAttr) || "";
+      const tenantName = getMatchParamByName(match, tenantNameAttr) || "";
+      const nodeMatchParam = (val: string): string =>
+        val === "" ? "/cluster" : `/node/${val}`;
+      const tenantMatchParam = (val: string): string =>
+        val === "" ? "" : `/tenant/${val}`;
+      let path = "/metrics/";
+      switch (key) {
+        case "dashboard":
+          path += value + nodeMatchParam(nodeID) + tenantMatchParam(tenantName);
+          break;
+        case "node":
+          path +=
+            dashName + nodeMatchParam(value) + tenantMatchParam(tenantName);
+          break;
+        default:
+          path += dashName + nodeMatchParam(nodeID) + tenantMatchParam(value);
+          break;
+      }
+      history.push({
+        pathname: path,
+        search: history.location.search,
+      });
+    },
+    [match, history],
+  );
 
-  componentDidUpdate() {
-    this.refresh();
-  }
-
-  adjustTimeScaleOnChange = (
-    curTimeScale: TimeScale,
-    timeWindow: TimeWindow,
-  ): TimeScale => {
-    const { resolution10sStorageTTL, resolution30mStorageTTL } = this.props;
-    const adjustedTimeScale = adjustTimeScale(
-      curTimeScale,
-      timeWindow,
-      resolution10sStorageTTL,
-      resolution30mStorageTTL,
-    );
-    switch (adjustedTimeScale.adjustmentReason) {
-      case "low_resolution_period":
-        this.setState({
-          showLowResolutionAlert: true,
-          showDeletedDataAlert: false,
-        });
-        break;
-      case "deleted_data_period":
-        this.setState({
-          showLowResolutionAlert: false,
-          showDeletedDataAlert: true,
-        });
-        break;
-      default:
-        this.setState({
-          showLowResolutionAlert: false,
-          showDeletedDataAlert: false,
-        });
-        break;
-    }
-    return adjustedTimeScale.timeScale;
-  };
-
-  render() {
-    const {
-      match,
-      nodeDropdownOptions,
-      storeIDsByNodeID,
-      nodeDisplayNameByID,
-      nodeIds,
-      tenantOptions,
-      currentTenant,
-    } = this.props;
-    const canViewKvGraphs =
-      getDataFromServer().FeatureFlags.can_view_kv_metric_dashboards;
-    const { showLowResolutionAlert, showDeletedDataAlert } = this.state;
-    let selectedDashboard = getMatchParamByName(match, dashboardNameAttr);
-    if (dashboards[selectedDashboard].isKvDashboard && !canViewKvGraphs) {
-      selectedDashboard = defaultDashboard;
-    }
-    const dashboard = has(dashboards, selectedDashboard)
-      ? selectedDashboard
-      : defaultDashboard;
-
-    const selectedNode = getMatchParamByName(match, nodeIDAttr) || "";
-    const nodeSources = selectedNode !== "" ? [selectedNode] : null;
-    const selectedTenant = isSystemTenant(currentTenant)
-      ? getMatchParamByName(match, tenantNameAttr) || ""
-      : undefined;
-    // When "all" is the selected source, some graphs display a line for every
-    // node in the cluster using the nodeIDs collection. However, if a specific
-    // node is already selected, these per-node graphs should only display data
-    // only for the selected node.
-    const nodeIDs = nodeSources ? nodeSources : nodeIds;
-
-    // If a single node is selected, we need to restrict the set of stores
-    // queried for per-store metrics (only stores that belong to that node will
-    // be queried).
-    const storeSources = nodeSources
-      ? storeIDsForNode(storeIDsByNodeID, nodeSources[0])
-      : null;
-
-    // tooltipSelection is a string used in tooltips to reference the currently
-    // selected nodes. This is a prepositional phrase, currently either "across
-    // all nodes" or "on node X".
-    const tooltipSelection =
-      nodeSources && nodeSources.length === 1
-        ? `on node ${nodeSources[0]}`
-        : "across all nodes";
-
-    const dashboardProps: GraphDashboardProps = {
-      nodeIDs,
-      nodeSources,
-      storeSources,
-      tooltipSelection,
-      nodeDisplayNameByID,
-      storeIDsByNodeID,
-      tenantSource: selectedTenant,
-    };
-
-    const forwardParams = {
-      hoverOn: this.props.hoverOn,
-      hoverOff: this.props.hoverOff,
-      hoverState: this.props.hoverState,
-    };
-
-    // Generate graphs for the current dashboard, wrapping each one in a
-    // MetricsDataProvider with a unique key.
-    const graphs = dashboards[dashboard]
-      .component(dashboardProps)
-      .filter(d => canViewKvGraphs || !d.props.isKvGraph);
-    const graphComponents = map(graphs, (graph, idx) => {
-      const key = `nodes.${dashboard}.${idx}`;
-      return (
-        <MetricsDataProvider
-          id={key}
-          key={key}
-          setMetricsFixedWindow={this.props.setMetricsFixedWindow}
-          setTimeScale={this.props.setTimeScale}
-          history={this.props.history}
-          adjustTimeScaleOnChange={this.adjustTimeScaleOnChange}
-        >
-          {React.cloneElement(graph, forwardParams)}
-        </MetricsDataProvider>
+  const adjustTimeScaleOnChange = useCallback(
+    (curTimeScale: TimeScale, timeWindow: TimeWindow): TimeScale => {
+      const adjustedTimeScale = adjustTimeScale(
+        curTimeScale,
+        timeWindow,
+        resolution10sStorageTTL,
+        resolution30mStorageTTL,
       );
-    });
+      switch (adjustedTimeScale.adjustmentReason) {
+        case "low_resolution_period":
+          setShowLowResolutionAlert(true);
+          setShowDeletedDataAlert(false);
+          break;
+        case "deleted_data_period":
+          setShowLowResolutionAlert(false);
+          setShowDeletedDataAlert(true);
+          break;
+        default:
+          setShowLowResolutionAlert(false);
+          setShowDeletedDataAlert(false);
+          break;
+      }
+      return adjustedTimeScale.timeScale;
+    },
+    [resolution10sStorageTTL, resolution30mStorageTTL],
+  );
 
-    // add padding to have last chart tooltip visible
-    // tooltip layout with header and paddings take up
-    // somewhere around 50px, after it have more than
-    // 9 nodes it switch to multicolumn layout that take
-    // somewhere around 90px height + 10px for per node
-    // as we have 3 columns, we divide node amount on 3
-    const paddingBottom =
-      nodeIDs.length > 8 ? 90 + Math.ceil(nodeIDs.length / 3) * 10 : 50;
-    const filteredDropdownOptions = dashboardDropdownOptions
-      // Don't show KV dashboards if the logged-in user doesn't have permission to view them.
-      .filter(option => canViewKvGraphs || !option.isKvDashboard);
-
-    return (
-      <div style={{ paddingBottom }}>
-        <Helmet title={"Metrics"} />
-        <h3 className="base-heading">Metrics</h3>
-        <PageConfig>
-          {/* By default, `tenantOptions` will have a length of 2 for
-          "All" and "system" tenant. We should omit showing the
-          dropdown in those cases */}
-          {isSystemTenant(currentTenant) &&
-            containsApplicationTenants(tenantOptions) && (
-              <PageConfigItem>
-                <Dropdown
-                  title="Virtual Cluster"
-                  options={tenantOptions}
-                  selected={selectedTenant}
-                  onChange={selection =>
-                    this.setClusterPath("tenant", selection)
-                  }
-                />
-              </PageConfigItem>
-            )}
-          <PageConfigItem>
-            <Dropdown
-              title="Graph"
-              options={nodeDropdownOptions}
-              selected={selectedNode}
-              onChange={selection => this.setClusterPath("node", selection)}
-            />
-          </PageConfigItem>
-          <PageConfigItem>
-            <Dropdown
-              title="Dashboard"
-              options={filteredDropdownOptions}
-              selected={dashboard}
-              onChange={selection =>
-                this.setClusterPath("dashboard", selection)
-              }
-              className="full-size"
-            />
-          </PageConfigItem>
-          <PageConfigItem>
-            <TimeScaleDropdown
-              currentScale={this.props.timeScale}
-              setTimeScale={this.props.setTimeScale}
-              adjustTimeScaleOnChange={this.adjustTimeScaleOnChange}
-            />
-          </PageConfigItem>
-        </PageConfig>
-        <section className="section">
-          {showLowResolutionAlert && (
-            <InlineAlert
-              title="Some data in this timeframe is shown at lower resolution."
-              intent="warning"
-              message={
-                <span>
-                  The 'timeseries.storage.resolution_10s.ttl' cluster setting
-                  determines how long data is stored at 10-second resolution.
-                  The remaining data is stored at 30-minute resolution. To
-                  configure these settings, refer to{" "}
-                  <Anchor
-                    href={reduceStorageOfTimeSeriesDataOperationalFlags}
-                    target="_blank"
-                  >
-                    the docs
-                  </Anchor>
-                  .
-                </span>
-              }
-            />
-          )}
-          {showDeletedDataAlert && (
-            <InlineAlert
-              title="Some data in this timeframe is no longer stored."
-              intent="warning"
-              message={
-                <span>
-                  The 'timeseries.storage.resolution_30m.ttl' cluster setting
-                  determines how long data is stored at 30-minute resolution.
-                  Data is no longer stored after this time period. To configure
-                  this setting, refer to{" "}
-                  <Anchor
-                    href={reduceStorageOfTimeSeriesDataOperationalFlags}
-                    target="_blank"
-                  >
-                    the docs
-                  </Anchor>
-                  .
-                </span>
-              }
-            />
-          )}
-        </section>
-        <section className="section">
-          <div className="l-columns">
-            <div className="chart-group l-columns__left">{graphComponents}</div>
-            <div className="l-columns__right">
-              <Alerts />
-              <ClusterSummaryBar
-                nodeSources={nodeSources}
-                tenantSource={selectedTenant}
-              />
-            </div>
-          </div>
-        </section>
-      </div>
-    );
+  const canViewKvGraphs =
+    getDataFromServer().FeatureFlags.can_view_kv_metric_dashboards;
+  let selectedDashboard = getMatchParamByName(match, dashboardNameAttr);
+  if (dashboards[selectedDashboard].isKvDashboard && !canViewKvGraphs) {
+    selectedDashboard = defaultDashboard;
   }
+  const dashboard = has(dashboards, selectedDashboard)
+    ? selectedDashboard
+    : defaultDashboard;
+
+  const selectedNode = getMatchParamByName(match, nodeIDAttr) || "";
+  const nodeSources = selectedNode !== "" ? [selectedNode] : null;
+  const selectedTenant = isSystemTenant(currentTenant)
+    ? getMatchParamByName(match, tenantNameAttr) || ""
+    : undefined;
+  // When "all" is the selected source, some graphs display a line for every
+  // node in the cluster using the nodeIDs collection. However, if a specific
+  // node is already selected, these per-node graphs should only display data
+  // only for the selected node.
+  const nodeIDs = nodeSources ? nodeSources : nodeIds;
+
+  // If a single node is selected, we need to restrict the set of stores
+  // queried for per-store metrics (only stores that belong to that node will
+  // be queried).
+  const storeSources = nodeSources
+    ? storeIDsForNode(storeIDsByNodeID, nodeSources[0])
+    : null;
+
+  // tooltipSelection is a string used in tooltips to reference the currently
+  // selected nodes. This is a prepositional phrase, currently either "across
+  // all nodes" or "on node X".
+  const tooltipSelection =
+    nodeSources && nodeSources.length === 1
+      ? `on node ${nodeSources[0]}`
+      : "across all nodes";
+
+  const dashboardProps: GraphDashboardProps = {
+    nodeIDs,
+    nodeSources,
+    storeSources,
+    tooltipSelection,
+    nodeDisplayNameByID,
+    storeIDsByNodeID,
+    tenantSource: selectedTenant,
+  };
+
+  const forwardParams = {
+    hoverOn: hoverOnAction,
+    hoverOff: hoverOffAction,
+    hoverState,
+  };
+
+  // Generate graphs for the current dashboard, wrapping each one in a
+  // MetricsDataProvider with a unique key.
+  const graphs = dashboards[dashboard]
+    .component(dashboardProps)
+    .filter(d => canViewKvGraphs || !d.props.isKvGraph);
+  const graphComponents = map(graphs, (graph, idx) => {
+    const key = `nodes.${dashboard}.${idx}`;
+    return (
+      <MetricsDataProvider
+        id={key}
+        key={key}
+        setMetricsFixedWindow={setMetricsFixedWindowAction}
+        setTimeScale={setTimeScaleAction}
+        history={history}
+        adjustTimeScaleOnChange={adjustTimeScaleOnChange}
+      >
+        {React.cloneElement(graph, forwardParams)}
+      </MetricsDataProvider>
+    );
+  });
+
+  // add padding to have last chart tooltip visible
+  // tooltip layout with header and paddings take up
+  // somewhere around 50px, after it have more than
+  // 9 nodes it switch to multicolumn layout that take
+  // somewhere around 90px height + 10px for per node
+  // as we have 3 columns, we divide node amount on 3
+  const paddingBottom =
+    nodeIDs.length > 8 ? 90 + Math.ceil(nodeIDs.length / 3) * 10 : 50;
+  const filteredDropdownOptions = dashboardDropdownOptions
+    // Don't show KV dashboards if the logged-in user doesn't have permission to view them.
+    .filter(option => canViewKvGraphs || !option.isKvDashboard);
+
+  return (
+    <div style={{ paddingBottom }}>
+      <Helmet title={"Metrics"} />
+      <h3 className="base-heading">Metrics</h3>
+      <PageConfig>
+        {/* By default, `tenantOptions` will have a length of 2 for
+        "All" and "system" tenant. We should omit showing the
+        dropdown in those cases */}
+        {isSystemTenant(currentTenant) &&
+          containsApplicationTenants(tenantOptions) && (
+            <PageConfigItem>
+              <Dropdown
+                title="Virtual Cluster"
+                options={tenantOptions}
+                selected={selectedTenant}
+                onChange={selection => setClusterPath("tenant", selection)}
+              />
+            </PageConfigItem>
+          )}
+        <PageConfigItem>
+          <Dropdown
+            title="Graph"
+            options={nodeDropdownOptions}
+            selected={selectedNode}
+            onChange={selection => setClusterPath("node", selection)}
+          />
+        </PageConfigItem>
+        <PageConfigItem>
+          <Dropdown
+            title="Dashboard"
+            options={filteredDropdownOptions}
+            selected={dashboard}
+            onChange={selection => setClusterPath("dashboard", selection)}
+            className="full-size"
+          />
+        </PageConfigItem>
+        <PageConfigItem>
+          <TimeScaleDropdown
+            currentScale={timeScale}
+            setTimeScale={setTimeScaleAction}
+            adjustTimeScaleOnChange={adjustTimeScaleOnChange}
+          />
+        </PageConfigItem>
+      </PageConfig>
+      <section className="section">
+        {showLowResolutionAlert && (
+          <InlineAlert
+            title="Some data in this timeframe is shown at lower resolution."
+            intent="warning"
+            message={
+              <span>
+                The 'timeseries.storage.resolution_10s.ttl' cluster setting
+                determines how long data is stored at 10-second resolution. The
+                remaining data is stored at 30-minute resolution. To configure
+                these settings, refer to{" "}
+                <Anchor
+                  href={reduceStorageOfTimeSeriesDataOperationalFlags}
+                  target="_blank"
+                >
+                  the docs
+                </Anchor>
+                .
+              </span>
+            }
+          />
+        )}
+        {showDeletedDataAlert && (
+          <InlineAlert
+            title="Some data in this timeframe is no longer stored."
+            intent="warning"
+            message={
+              <span>
+                The 'timeseries.storage.resolution_30m.ttl' cluster setting
+                determines how long data is stored at 30-minute resolution. Data
+                is no longer stored after this time period. To configure this
+                setting, refer to{" "}
+                <Anchor
+                  href={reduceStorageOfTimeSeriesDataOperationalFlags}
+                  target="_blank"
+                >
+                  the docs
+                </Anchor>
+                .
+              </span>
+            }
+          />
+        )}
+      </section>
+      <section className="section">
+        <div className="l-columns">
+          <div className="chart-group l-columns__left">{graphComponents}</div>
+          <div className="l-columns__right">
+            <Alerts />
+            <ClusterSummaryBar
+              nodeSources={nodeSources}
+              tenantSource={selectedTenant}
+            />
+          </div>
+        </div>
+      </section>
+    </div>
+  );
 }
 
 /**


### PR DESCRIPTION
Convert the following class components to functional style:
 - lineGraph: createSelector → useMemo, componentDidUpdate → useEffect with ref-based prev-props comparison, setNewTimeRange stabilized via useCallback
    + ref pattern for uPlot capture, componentWillUnmount → cleanup useEffect.
 - nodeGraphs: componentDidMount + componentDidUpdate → two useEffects (every-render for node/liveness refresh, mount-only for settings/tenants), useState for alert state.
 - replicaMatrix: useState for collapsed rows/cols with functional state updates, helper methods extracted to module scope.

Existing Enzyme tests converted to RTL for lineGraph. The changes were manually smoke tested.

Epic: CRDB-58145
Release Note: None