### PR TITLE
disk: return empty stats instead of error when no disks are monitored

### DIFF
--- a/pkg/storage/disk/monitor.go
+++ b/pkg/storage/disk/monitor.go
@@ -217,7 +217,8 @@ func (m *MonitorManager) CollectInstantaneous(
 	m.mu.Unlock()
 	statsBuf = statsBuf[:0]
 	if collector == nil {
-		return statsBuf, byteBuf, errors.Errorf("no disks are being monitored")
+		// No collector set, so no disks are being monitored. Return empty stats and byte buffer.
+		return statsBuf, byteBuf, nil
 	}
 	now := timeutil.Now()
 	var err error

--- a/pkg/storage/disk/monitor_test.go
+++ b/pkg/storage/disk/monitor_test.go
@@ -134,12 +134,11 @@ func TestMonitorManager_CollectInstantaneous(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	t.Run("no collector returns error", func(t *testing.T) {
+	t.Run("no collector does not return error", func(t *testing.T) {
 		manager := NewMonitorManager(vfs.NewMem())
-		// No statsCollector set, should return error.
+		// No statsCollector set, should not return error.
 		stats, buf, err := manager.CollectInstantaneous(nil, nil)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "no disks are being monitored")
+		require.NoError(t, err)
 		require.Empty(t, stats)
 		require.Nil(t, buf)
 	})


### PR DESCRIPTION
Previously, CollectInstantaneous returned an error when no disks were registered with the MonitorManager. This caused the store grant coordinator's ticker to log a warning ("unable to get disk stats for token error adjustment: no disks are being monitored") on every tick, spamming logs for anyone using a TestServer with in-memory stores. Now, CollectInstantaneous returns empty stats and a nil error, so the caller silently no-ops.

Epic: CRDB-47073
Release note: None

[See thread here for context](https://cockroachlabs.slack.com/archives/C048HDZJSAY/p1771497551447299).