### PR TITLE
kvserver: defer RHS isInitialized flip to end of SplitRange

### DIFF
--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/abortspan"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/gc"
@@ -4727,4 +4728,98 @@ func TestGCRequestStraddlingSplit(t *testing.T) {
 			require.True(t, ok, "expected RangeKeyMismatchError, got %v", pErr)
 		})
 	}
+}
+
+// TestSplitWithConcurrentLockAcquisitionOnRHS is a regression test for #155318,
+// which was a bug caused by the fact that, during a split, a Replica becomes
+// available for requests before the end of the application of the EndTxn that
+// creates the replica.
+func TestSplitWithConcurrentLockAcquisitionOnRHS(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	// Create a key that will be on the RHS after the split.
+	rhsKey := roachpb.Key("z")
+	splitKey := roachpb.Key("m")
+
+	// We install a BeforeSplitAcquiresLocksOnRHS testing hook that will pause the
+	// split we issue for splitKey during application so that we can then send a
+	// request targeted to the new RHS replica.
+	splitPaused := make(chan roachpb.RangeID)
+	splitResume := make(chan struct{})
+
+	st := cluster.MakeTestingClusterSettings()
+	concurrency.UnreplicatedLockReliabilitySplit.Override(ctx, &st.SV, true)
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
+		Settings: st,
+		Knobs: base.TestingKnobs{
+			Store: &kvserver.StoreTestingKnobs{
+				DisableMergeQueue: true,
+				DisableSplitQueue: true,
+				BeforeSplitAcquiresLocksOnRHS: func(ctx context.Context, rhsRepl *kvserver.Replica) {
+					startKey := rhsRepl.Desc().StartKey.AsRawKey()
+					if !startKey.Equal(splitKey) {
+						return
+					}
+
+					t.Logf("pausing split for RHS %d: %s", rhsRepl.RangeID, startKey)
+					splitPaused <- rhsRepl.RangeID
+					<-splitResume
+					t.Logf("split resumed for RHS %d", rhsRepl.RangeID)
+				},
+			},
+		},
+	})
+	defer s.Stopper().Stop(ctx)
+
+	store, err := s.GetStores().(*kvserver.Stores).GetStore(s.GetFirstStoreID())
+	require.NoError(t, err)
+	db := s.DB()
+	require.NoError(t, db.Put(ctx, rhsKey, "initial value"))
+
+	// Acquire a lock on rhsKey via txn1.
+	txn1 := kv.NewTxn(ctx, db, s.NodeID())
+	_, err = txn1.GetForUpdate(ctx, rhsKey, kvpb.BestEffort)
+	require.NoError(t, err)
+
+	// Split the range. This blocks until we explicitly unblock it below.
+	g := ctxgroup.WithContext(ctx)
+	g.GoCtx(func(ctx context.Context) error {
+		_, _, err := s.SplitRange(splitKey)
+		return err
+	})
+	rID := <-splitPaused
+
+	// Send a Put to rhsKey targeted at the new range ID. While ReadyToServe()
+	// is false, each attempt returns NLHE. We retry until the request either
+	// succeeds or returns a non-NLHE error.
+	g.GoCtx(func(ctx context.Context) error {
+		txn2 := db.NewTxn(ctx, "test-txn-2")
+		header := kvpb.Header{
+			Txn:     txn2.TestingCloneTxn(),
+			RangeID: rID,
+		}
+		for {
+			_, pErr := kv.SendWrappedWith(ctx, store.TestSender(), header, putArgs(rhsKey, []byte("hello")))
+			if pErr == nil {
+				return nil
+			}
+			if _, ok := pErr.GetDetail().(*kvpb.NotLeaseHolderError); ok {
+				continue
+			}
+			return pErr.GoError()
+		}
+	})
+
+	// Let the split proceed.
+	time.Sleep(100 * time.Millisecond)
+	t.Logf("resuming split")
+	close(splitResume)
+
+	// Rollback txn1 so that txn2 can proceed. The lock from txn1 was
+	// transferred to the RHS during the split, so txn2 waits on it.
+	require.NoError(t, txn1.Rollback(ctx))
+	require.NoError(t, g.Wait())
 }

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -90,6 +90,7 @@ func newInitializedReplica(
 	if err := r.initRaftMuLockedReplicaMuLocked(loaded, waitForPrevLeaseToExpire); err != nil {
 		return nil, err
 	}
+	r.isInitialized.Store(true)
 
 	return r, nil
 }
@@ -326,15 +327,11 @@ func (r *Replica) initRaftMuLockedReplicaMuLocked(
 
 	// Initialize the Raft group. This may replace a Raft group that was installed
 	// for the uninitialized replica to process Raft requests or snapshots.
-	//
-	// We do this before flipping isInitialized and we'd like the Raft group to
-	// be in place before then.
 	if err := r.initRaftGroupRaftMuLockedReplicaMuLocked(); err != nil {
 		return err
 	}
 
 	r.setDescLockedRaftMuLocked(r.AnnotateCtx(context.TODO()), desc)
-	r.isInitialized.Store(true)
 
 	// Only do this if there was a previous lease. This shouldn't be important
 	// to do but consider that the first lease which is obtained is back-dated

--- a/pkg/kv/kvserver/store_split.go
+++ b/pkg/kv/kvserver/store_split.go
@@ -211,6 +211,21 @@ func splitPostApply(
 		log.KvExec.Fatalf(ctx, "%s: failed to update Store after split: %+v", r, err)
 	}
 
+	// Explicitly unquiesce the Raft group on the right-hand range or else the
+	// range could be underreplicated for an indefinite period of time.
+	//
+	// Specifically, suppose one of the replicas of the left-hand range never
+	// applies this split trigger, e.g., because it catches up via a snapshot that
+	// advances it past this split. That store won't create the right-hand replica
+	// until it receives a Raft message addressed to the right-hand range. But
+	// since new replicas start out quiesced, unless we explicitly awaken the
+	// Raft group, there might not be any Raft traffic for quite a while.
+	if rightReplOrNil != nil {
+		rightReplOrNil.mu.Lock()
+		rightReplOrNil.maybeUnquiesceLocked(true /* wakeLeader */, true /* mayCampaign */)
+		rightReplOrNil.mu.Unlock()
+	}
+
 	// Update store stats with difference in stats before and after split.
 	if rightReplOrNil != nil {
 		rightReplOrNil.store.metrics.addMVCCStats(ctx, rightReplOrNil.tenantMetricsRef, deltaMS)
@@ -285,7 +300,6 @@ func prepareRightReplicaForSplit(
 	); err != nil {
 		log.KvExec.Fatalf(ctx, "%v", err)
 	}
-	rightRepl.isInitialized.Store(true)
 
 	// Copy the minLeaseProposedTS from the LHS. loadRaftMuLockedReplicaMuLocked
 	// has already assigned a value for this field; this will overwrite it.
@@ -303,17 +317,6 @@ func prepareRightReplicaForSplit(
 		nil,                        /* priorReadSum */
 		assertNoLeaseJump)
 
-	// We need to explicitly unquiesce the Raft group on the right-hand range or
-	// else the range could be underreplicated for an indefinite period of time.
-	//
-	// Specifically, suppose one of the replicas of the left-hand range never
-	// applies this split trigger, e.g., because it catches up via a snapshot that
-	// advances it past this split. That store won't create the right-hand replica
-	// until it receives a Raft message addressed to the right-hand range. But
-	// since new replicas start out quiesced, unless we explicitly awaken the
-	// Raft group, there might not be any Raft traffic for quite a while.
-	rightRepl.maybeUnquiesceLocked(true /* wakeLeader */, true /* mayCampaign */)
-
 	if fn := r.store.TestingKnobs().AfterSplitApplication; fn != nil {
 		// TODO(pav-kv): we have already checked up the stack that rightDesc exists,
 		// but maybe it would be better to carry a "bus" struct with these kinds of
@@ -330,9 +333,9 @@ func prepareRightReplicaForSplit(
 // range is added to the ranges map and the replicasByKey btree. origRng.raftMu
 // and newRng.raftMu must be held.
 //
-// This is only called from the split trigger in the context of the execution
-// of a Raft command. Note that rightRepl will be nil if the replica described
-// by rightDesc is known to have been removed.
+// This is only called from the split trigger in the context of the execution of
+// a Raft command. rightReplOrNil will be nil if it is known to have been
+// removed. Otherwise, it is marked as initialized before SplitRange returns.
 func (s *Store) SplitRange(
 	ctx context.Context, leftRepl, rightReplOrNil *Replica, split *roachpb.SplitTrigger,
 ) error {
@@ -384,5 +387,6 @@ func (s *Store) SplitRange(
 
 	rightRepl.mu.Lock()
 	defer rightRepl.mu.Unlock()
+	rightRepl.isInitialized.Store(true)
 	return s.markReplicaInitializedLockedReplLocked(ctx, rightRepl)
 }

--- a/pkg/kv/kvserver/store_split.go
+++ b/pkg/kv/kvserver/store_split.go
@@ -368,6 +368,9 @@ func (s *Store) SplitRange(
 
 	// Acquire unreplicated locks on the RHS. We expect locksToAcquireOnRHS to be
 	// empty if UnreplicatedLockReliabilityUpgrade is false.
+	if beforeFn := s.TestingKnobs().BeforeSplitAcquiresLocksOnRHS; beforeFn != nil {
+		beforeFn(ctx, rightRepl)
+	}
 	log.KvExec.VInfof(ctx, 2, "acquiring %d locks on the RHS", len(locksToAcquireOnRHS))
 	for _, l := range locksToAcquireOnRHS {
 		rightRepl.concMgr.OnLockAcquired(ctx, &l)

--- a/pkg/kv/kvserver/store_split.go
+++ b/pkg/kv/kvserver/store_split.go
@@ -285,6 +285,7 @@ func prepareRightReplicaForSplit(
 	); err != nil {
 		log.KvExec.Fatalf(ctx, "%v", err)
 	}
+	rightRepl.isInitialized.Store(true)
 
 	// Copy the minLeaseProposedTS from the LHS. loadRaftMuLockedReplicaMuLocked
 	// has already assigned a value for this field; this will overwrite it.

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -799,6 +799,9 @@ func TestMarkReplicaInitialized(t *testing.T) {
 		defer r.raftMu.Unlock()
 		r.setDescRaftMuLocked(ctx, desc)
 	}()
+	// markReplicaInitializedLockedReplLocked expects the replica to be
+	// initialized.
+	r.isInitialized.Store(true)
 	expectedResult = "not in uninitReplicas"
 	func() {
 		r.mu.Lock()

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -592,6 +592,10 @@ type StoreTestingKnobs struct {
 	// the leaderless watcher's unavailable state during raft ticks.
 	DisableLeaderlessWatcherRefreshOnRaftTick bool
 
+	// BeforeSplitAcquiresLocksOnRHS is invoked during a split application before
+	// we start acquiring locks on the right hand side.
+	BeforeSplitAcquiresLocksOnRHS func(context.Context, *Replica)
+
 	// InjectIntentsToResolveVirtually is called while executing read-only
 	// requests; it helps inject intents to be resolved virtually, usually passed
 	// in by the lock table guard.


### PR DESCRIPTION
See individual commits for details.

Epic: none
Release note: None

Made with [Cursor](https://cursor.com)