### PR TITLE
workload/schemachange: use information_schema.tables instead of SHOW TABLES

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -1697,8 +1697,8 @@ func (og *operationGenerator) dropColumn(ctx context.Context, tx pgx.Tx) (*opStm
 		return nil, err
 	}
 
-	// Check if the table has any policies, triggers, or foreign keys.
-	tableHasPolicies, tableHasTriggers, tableHasFK := false, false, false
+	// Check if the table has any policies, triggers, foreign keys, or row-level TTL.
+	tableHasPolicies, tableHasTriggers, tableHasFK, tableHasTTL := false, false, false, false
 	if tableExists {
 		if tableHasPolicies, err = og.tableHasPolicies(ctx, tx, tableName); err != nil {
 			return nil, err
@@ -1707,6 +1707,9 @@ func (og *operationGenerator) dropColumn(ctx context.Context, tx pgx.Tx) (*opStm
 			return nil, err
 		}
 		if tableHasFK, err = og.tableHasFK(ctx, tx, tableName); err != nil {
+			return nil, err
+		}
+		if tableHasTTL, err = og.tableHasRowLevelTTL(ctx, tx, tableName); err != nil {
 			return nil, err
 		}
 	}
@@ -1755,9 +1758,9 @@ func (og *operationGenerator) dropColumn(ctx context.Context, tx pgx.Tx) (*opStm
 		// It is possible the column we are dropping is in the new primary key,
 		// so a potential error is an invalid reference in this case.
 		{code: pgcode.InvalidColumnReference, condition: og.useDeclarativeSchemaChanger && hasAlterPKSchemaChange},
-		// It is possible that we cannot drop column because
-		// it is referenced in a policy expression.
-		{code: pgcode.InvalidTableDefinition, condition: tableHasPolicies},
+		// It is possible that we cannot drop column because it is referenced
+		// in a policy expression or a row-level TTL expiration expression.
+		{code: pgcode.InvalidTableDefinition, condition: tableHasPolicies || tableHasTTL},
 		// It is possible that we cannot drop column because
 		// it is depended on by a trigger or foreign key.
 		{code: pgcode.DependentObjectsStillExist, condition: tableHasTriggers || tableHasFK},
@@ -1827,6 +1830,19 @@ SELECT EXISTS (
 	 WHERE contype = 'f'
 	   AND (conrelid = $1::REGCLASS OR confrelid = $1::REGCLASS)
 )`, tableName.String())
+}
+
+// tableHasRowLevelTTL checks if a table has a row-level TTL configured.
+func (og *operationGenerator) tableHasRowLevelTTL(
+	ctx context.Context, tx pgx.Tx, tableName *tree.TableName,
+) (bool, error) {
+	return og.scanBool(ctx, tx, `
+SELECT crdb_internal.pb_to_json(
+         'cockroach.sql.sqlbase.Descriptor',
+         descriptor
+       )->'table'->'rowLevelTtl' IS NOT NULL
+  FROM system.descriptor
+ WHERE id = $1::REGCLASS`, tableName.String())
 }
 
 func (og *operationGenerator) dropColumnDefault(ctx context.Context, tx pgx.Tx) (*opStmt, error) {
@@ -3009,7 +3025,7 @@ func (og *operationGenerator) commentOn(ctx context.Context, tx pgx.Tx) (*opStmt
 	}, fmt.Sprintf(`
 	SELECT 'SCHEMA ' || quote_ident(schema_name) FROM [SHOW SCHEMAS] WHERE owner != 'node'
 		UNION ALL
-	SELECT 'TABLE ' || quote_ident(schema_name) || '.' || quote_ident(table_name) FROM [SHOW TABLES] WHERE type = 'table'
+	SELECT 'TABLE ' || quote_ident(table_schema) || '.' || quote_ident(table_name) FROM information_schema.tables WHERE table_type = 'BASE TABLE' AND table_schema NOT IN ('information_schema', 'pg_catalog', 'pg_extension', 'crdb_internal')
 		UNION ALL
 	SELECT 'COLUMN ' || quote_ident(schema_name) || '.' || quote_ident(table_name) || '.' || quote_ident("column"->>'name') FROM columns
 		UNION ALL
@@ -4122,9 +4138,10 @@ func (og *operationGenerator) randView(
 
 		q := fmt.Sprintf(`
 		  SELECT table_name
-		    FROM [SHOW TABLES]
+		    FROM information_schema.tables
 		   WHERE table_name LIKE 'view%%'
-				 AND schema_name = '%s'
+				 AND table_schema = '%s'
+				 AND table_schema NOT IN ('information_schema', 'pg_catalog', 'pg_extension', 'crdb_internal')
 		ORDER BY random()
 		   LIMIT 1;
 		`, desiredSchema)
@@ -4159,9 +4176,10 @@ func (og *operationGenerator) randView(
 		return nil, err
 	}
 	const q = `
-  SELECT schema_name, table_name
-    FROM [SHOW TABLES]
+  SELECT table_schema, table_name
+    FROM information_schema.tables
    WHERE table_name LIKE 'view%'
+     AND table_schema NOT IN ('information_schema', 'pg_catalog', 'pg_extension', 'crdb_internal')
 ORDER BY random()
    LIMIT 1;
 `
@@ -4358,7 +4376,7 @@ func (og *operationGenerator) createFunction(ctx context.Context, tx pgx.Tx) (*o
 	// TODO(chrisseto): Allow referencing sequences as well. Currently, `DROP
 	// SEQUENCE CASCADE` will break if we allow sequences. It may also be good to
 	// reference sequences with next_val or something.
-	tables, err := Collect(ctx, og, tx, pgx.RowTo[string], `SELECT quote_ident(schema_name) || '.' || quote_ident(table_name) FROM [SHOW TABLES] WHERE type != 'sequence'`)
+	tables, err := Collect(ctx, og, tx, pgx.RowTo[string], `SELECT quote_ident(table_schema) || '.' || quote_ident(table_name) FROM information_schema.tables WHERE table_type IN ('BASE TABLE', 'VIEW') AND table_schema NOT IN ('information_schema', 'pg_catalog', 'pg_extension', 'crdb_internal')`)
 	if err != nil {
 		return nil, err
 	}
@@ -5698,7 +5716,7 @@ func (og *operationGenerator) findExistingTrigger(
 // truncateTable generates a TRUNCATE TABLE statement.
 func (og *operationGenerator) truncateTable(ctx context.Context, tx pgx.Tx) (*opStmt, error) {
 	tbls, err := Collect(ctx, og, tx, pgx.RowTo[string],
-		`SELECT quote_ident(schema_name) || '.' || quote_ident(table_name) FROM [SHOW TABLES] WHERE type = 'table'`)
+		`SELECT quote_ident(table_schema) || '.' || quote_ident(table_name) FROM information_schema.tables WHERE table_type = 'BASE TABLE' AND table_schema NOT IN ('information_schema', 'pg_catalog', 'pg_extension', 'crdb_internal')`)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION

Replace all uses of `[SHOW TABLES]` with queries against `information_schema.tables`, which is a standard PostgreSQL catalog view. This avoids relying on CockroachDB-specific `SHOW` syntax in the schemachange workload. System schemas (information_schema, pg_catalog, pg_extension, crdb_internal) are excluded to match the previous behavior.

We want to avoid SHOW TABLES here since that delegates to reading from pg_roles to determine table ownership, and all reads from pg_roles need to fetch users from the role membership cache. Since this workload can concurrently create and drop users, relying on the cache here could sometimes hit "role does not exist" errors. It's better to avoid SHOW TABLES in this kind of code anyway, as our docs specify that it's not meant for machine consumption.
See: https://www.cockroachlabs.com/docs/stable/api-support-policy

fixes https://github.com/cockroachdb/cockroach/issues/163831
fixes https://github.com/cockroachdb/cockroach/issues/163558
fixes https://github.com/cockroachdb/cockroach/issues/163601
fixes https://github.com/cockroachdb/cockroach/issues/163152

Release note: None