### PR TITLE
db-console: Convert range report components to functional components

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/enqueueRange/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/enqueueRange/index.tsx
@@ -4,7 +4,7 @@
 // included in the /LICENSE file.
 
 import moment from "moment-timezone";
-import React, { Fragment } from "react";
+import React, { Fragment, useState } from "react";
 import Helmet from "react-helmet";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 
@@ -36,260 +36,185 @@ const queueOptions = QUEUES.map(q => {
   return { value: q, label: q };
 });
 
-interface EnqueueRangeProps {
-  handleEnqueueRange: (
-    queue: string,
-    rangeID: number,
-    nodeID: number,
-    skipShouldQueue: boolean,
-  ) => Promise<EnqueueRangeResponse>;
+export type EnqueueRangeAllProps = RouteComponentProps;
+
+function renderNodeResponse(details: EnqueueRangeResponse.IDetails) {
+  return (
+    <Fragment>
+      <p>
+        {details.error ? (
+          <Fragment>
+            <b>Error:</b> {details.error}
+          </Fragment>
+        ) : (
+          "Call succeeded"
+        )}
+      </p>
+      <table className="enqueue-range-table">
+        <thead>
+          <tr className="enqueue-range-table__row enqueue-range-table__row--header">
+            <th className="enqueue-range-table__cell enqueue-range-table__cell--header">
+              Timestamp
+            </th>
+            <th className="enqueue-range-table__cell enqueue-range-table__cell--header">
+              Message
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {details.events.map((event, i) => (
+            <tr key={i} className="enqueue-range-table__row--body">
+              <td className="enqueue-range-table__cell enqueue-range-table__cell--date">
+                {Print.Timestamp(event.time)}
+              </td>
+              <td className="enqueue-range-table__cell">
+                <pre>{event.message}</pre>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </Fragment>
+  );
 }
 
-interface EnqueueRangeState {
-  queue: string;
-  rangeID: string;
-  nodeID: string;
-  skipShouldQueue: boolean;
-  response: EnqueueRangeResponse;
-  error: Error;
-}
+export function EnqueueRange({
+  history,
+}: EnqueueRangeAllProps): React.ReactElement {
+  const searchParams = new URLSearchParams(history.location.search);
+  const initialRangeID = searchParams.get("rangeID") || "";
 
-export type EnqueueRangeAllProps = EnqueueRangeProps & RouteComponentProps;
+  const [queue, setQueue] = useState(QUEUES[0]);
+  const [rangeID, setRangeID] = useState(initialRangeID);
+  const [nodeID, setNodeID] = useState("");
+  const [skipShouldQueue, setSkipShouldQueue] = useState(false);
+  const [response, setResponse] = useState<EnqueueRangeResponse>(null);
+  const [error, setError] = useState<Error>(null);
 
-export class EnqueueRange extends React.Component<
-  EnqueueRangeAllProps,
-  EnqueueRangeState
-> {
-  constructor(props: EnqueueRangeAllProps) {
-    super(props);
-    const { history } = this.props;
-    const searchParams = new URLSearchParams(history.location.search);
-    const rangeID = searchParams.get("rangeID") || "";
+  const handleSubmit = (evt: React.FormEvent<any>) => {
+    evt.preventDefault();
 
-    this.state = {
-      queue: QUEUES[0],
-      rangeID: rangeID,
-      nodeID: "",
-      skipShouldQueue: false,
-      response: null,
-      error: null,
-    };
-  }
-
-  handleUpdateQueue = (selectedOption: DropdownOption) => {
-    this.setState({
-      queue: selectedOption.value,
-    });
-  };
-
-  handleUpdateRangeID = (evt: React.FormEvent<{ value: string }>) => {
-    this.setState({
-      rangeID: evt.currentTarget.value,
-    });
-  };
-
-  handleUpdateNodeID = (evt: React.FormEvent<{ value: string }>) => {
-    this.setState({
-      nodeID: evt.currentTarget.value,
-    });
-  };
-
-  handleEnqueueRange = (
-    queue: string,
-    rangeID: number,
-    nodeID: number,
-    skipShouldQueue: boolean,
-  ) => {
     // Handle mixed-version clusters across the "gc" to "mvccGC" queue rename.
     // TODO(nvanbenschoten): remove this in v22.2. The server logic will continue
     // to map "gc" to "mvccGC" until v23.1.
-    if (queue === "mvccGC") {
-      queue = "gc";
+    let q = queue;
+    if (q === "mvccGC") {
+      q = "gc";
     }
     const req = new EnqueueRangeRequest({
-      queue: queue,
-      range_id: rangeID,
-      node_id: nodeID,
-      skip_should_queue: skipShouldQueue,
-    });
-    return enqueueRange(req, moment.duration({ hours: 1 }));
-  };
-
-  handleSubmit = (evt: React.FormEvent<any>) => {
-    evt.preventDefault();
-
-    this.handleEnqueueRange(
-      this.state.queue,
+      queue: q,
       // These parseInts should succeed because <input type="number" />
       // enforces numeric input. Otherwise they're NaN.
-      parseInt(this.state.rangeID, 10),
-      parseInt(this.state.nodeID, 10),
-      this.state.skipShouldQueue,
-    ).then(
-      response => {
-        this.setState({ response, error: null });
+      range_id: parseInt(rangeID, 10),
+      node_id: parseInt(nodeID, 10),
+      skip_should_queue: skipShouldQueue,
+    });
+    enqueueRange(req, moment.duration({ hours: 1 })).then(
+      resp => {
+        setResponse(resp);
+        setError(null);
       },
-      error => {
-        this.setState({ response: null, error });
+      err => {
+        setResponse(null);
+        setError(err);
       },
     );
   };
 
-  renderNodeResponse(details: EnqueueRangeResponse.IDetails) {
-    return (
-      <Fragment>
-        <p>
-          {details.error ? (
-            <Fragment>
-              <b>Error:</b> {details.error}
-            </Fragment>
-          ) : (
-            "Call succeeded"
-          )}
-        </p>
-        <table className="enqueue-range-table">
-          <thead>
-            <tr className="enqueue-range-table__row enqueue-range-table__row--header">
-              <th className="enqueue-range-table__cell enqueue-range-table__cell--header">
-                Timestamp
-              </th>
-              <th className="enqueue-range-table__cell enqueue-range-table__cell--header">
-                Message
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {details.events.map(event => (
-              <tr className="enqueue-range-table__row--body">
-                <td className="enqueue-range-table__cell enqueue-range-table__cell--date">
-                  {Print.Timestamp(event.time)}
-                </td>
-                <td className="enqueue-range-table__cell">
-                  <pre>{event.message}</pre>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </Fragment>
-    );
-  }
-
-  renderResponse() {
-    const { response } = this.state;
-
-    if (!response) {
-      return null;
-    }
-
-    return (
-      <Fragment>
-        <h2 className="base-heading">Enqueue Range Output</h2>
-        {response.details.map(details => (
-          <div>
-            <h3>Node n{details.node_id}</h3>
-
-            {this.renderNodeResponse(details)}
-          </div>
-        ))}
-      </Fragment>
-    );
-  }
-
-  renderError() {
-    const { error } = this.state;
-
-    if (!error) {
-      return null;
-    }
-
-    return <Fragment>Error running EnqueueRange: {error.message}</Fragment>;
-  }
-
-  render() {
-    return (
-      <Fragment>
-        <Helmet title="Enqueue Range" />
-        <BackToAdvanceDebug history={this.props.history} />
-        <div className="content">
-          <section className="section">
-            <div className="form-container">
-              <h1 className="base-heading heading">
-                Manually enqueue range in a replica queue
-              </h1>
-              <br />
-              <form
-                onSubmit={this.handleSubmit}
-                className="form-internal"
-                method="post"
-              >
-                <label>
-                  <span className={"label-text"}>Queue:</span>
-                  <Dropdown
-                    title=""
-                    options={queueOptions}
-                    selected={this.state.queue}
-                    onChange={this.handleUpdateQueue}
-                    className={"dropdown-area"}
-                  />
-                </label>
-                <br />
-                <label>
-                  <span className={"label-text"}>RangeID:</span>
-                  <input
-                    type="number"
-                    name="rangeID"
-                    className="input-text"
-                    onChange={this.handleUpdateRangeID}
-                    value={this.state.rangeID}
-                    placeholder="RangeID"
-                  />
-                </label>
-                <br />
-                <label>
-                  <span className={"label-text"}>NodeID:</span>
-                  <input
-                    type="number"
-                    name="nodeID"
-                    className="input-text"
-                    onChange={this.handleUpdateNodeID}
-                    value={this.state.nodeID}
-                    placeholder="NodeID (optional)"
-                  />
-                  <span className={"label-tooltip"}>
-                    If not specified, we'll attempt to enqueue on all the nodes.
-                  </span>
-                </label>
-                <br />
-                <label>
-                  <span className={"label-text"}>SkipShouldQueue:</span>
-                  <input
-                    type="checkbox"
-                    className="checkbox-area"
-                    checked={this.state.skipShouldQueue}
-                    name="skipShouldQueue"
-                    onChange={() =>
-                      this.setState({
-                        skipShouldQueue: !this.state.skipShouldQueue,
-                      })
-                    }
-                  />
-                </label>
-                <br />
-                <input type="submit" className="button-crl" value="Submit" />
-              </form>
-            </div>
-          </section>
-        </div>
+  return (
+    <Fragment>
+      <Helmet title="Enqueue Range" />
+      <BackToAdvanceDebug history={history} />
+      <div className="content">
         <section className="section">
-          {this.renderResponse()}
-          {this.renderError()}
+          <div className="form-container">
+            <h1 className="base-heading heading">
+              Manually enqueue range in a replica queue
+            </h1>
+            <br />
+            <form
+              onSubmit={handleSubmit}
+              className="form-internal"
+              method="post"
+            >
+              <label>
+                <span className={"label-text"}>Queue:</span>
+                <Dropdown
+                  title=""
+                  options={queueOptions}
+                  selected={queue}
+                  onChange={(selected: DropdownOption) =>
+                    setQueue(selected.value)
+                  }
+                  className={"dropdown-area"}
+                />
+              </label>
+              <br />
+              <label>
+                <span className={"label-text"}>RangeID:</span>
+                <input
+                  type="number"
+                  name="rangeID"
+                  className="input-text"
+                  onChange={(evt: React.FormEvent<{ value: string }>) =>
+                    setRangeID(evt.currentTarget.value)
+                  }
+                  value={rangeID}
+                  placeholder="RangeID"
+                />
+              </label>
+              <br />
+              <label>
+                <span className={"label-text"}>NodeID:</span>
+                <input
+                  type="number"
+                  name="nodeID"
+                  className="input-text"
+                  onChange={(evt: React.FormEvent<{ value: string }>) =>
+                    setNodeID(evt.currentTarget.value)
+                  }
+                  value={nodeID}
+                  placeholder="NodeID (optional)"
+                />
+                <span className={"label-tooltip"}>
+                  If not specified, we'll attempt to enqueue on all the nodes.
+                </span>
+              </label>
+              <br />
+              <label>
+                <span className={"label-text"}>SkipShouldQueue:</span>
+                <input
+                  type="checkbox"
+                  className="checkbox-area"
+                  checked={skipShouldQueue}
+                  name="skipShouldQueue"
+                  onChange={() => setSkipShouldQueue(prev => !prev)}
+                />
+              </label>
+              <br />
+              <input type="submit" className="button-crl" value="Submit" />
+            </form>
+          </div>
         </section>
-      </Fragment>
-    );
-  }
+      </div>
+      <section className="section">
+        {response && (
+          <Fragment>
+            <h2 className="base-heading">Enqueue Range Output</h2>
+            {response.details.map((details, i) => (
+              <div key={i}>
+                <h3>Node n{details.node_id}</h3>
+                {renderNodeResponse(details)}
+              </div>
+            ))}
+          </Fragment>
+        )}
+        {error && (
+          <Fragment>Error running EnqueueRange: {error.message}</Fragment>
+        )}
+      </section>
+    </Fragment>
+  );
 }
 
-const EnqueueRangeConnected = withRouter(EnqueueRange);
-
-export default EnqueueRangeConnected;
+export default withRouter(EnqueueRange);

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/problemRanges/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/problemRanges/index.tsx
@@ -8,7 +8,6 @@ import filter from "lodash/filter";
 import flatMap from "lodash/flatMap";
 import flow from "lodash/flow";
 import isEmpty from "lodash/isEmpty";
-import isEqual from "lodash/isEqual";
 import isNil from "lodash/isNil";
 import keys from "lodash/keys";
 import map from "lodash/map";
@@ -17,7 +16,7 @@ import sortBy from "lodash/sortBy";
 import sortedUniq from "lodash/sortedUniq";
 import values from "lodash/values";
 import Long from "long";
-import React from "react";
+import React, { useEffect } from "react";
 import { Helmet } from "react-helmet";
 import { connect } from "react-redux";
 import { Link, RouteComponentProps, withRouter } from "react-router-dom";
@@ -104,27 +103,24 @@ function problemRangeRequestFromProps(props: ProblemRangesProps) {
  * per node basis. This page aggregates those lists together and displays all
  * unique range IDs that have problems.
  */
-export class ProblemRanges extends React.Component<ProblemRangesProps, {}> {
-  refresh(props = this.props) {
-    props.refreshProblemRanges(problemRangeRequestFromProps(props));
-  }
+export function ProblemRanges({
+  problemRanges,
+  refreshProblemRanges: refreshProblemRangesAction,
+  match,
+  history,
+}: ProblemRangesProps): React.ReactElement {
+  const nodeId = getMatchParamByName(match, nodeIDAttr);
 
-  componentDidMount() {
-    // Refresh nodes status query when mounting.
-    this.refresh();
-  }
+  useEffect(() => {
+    refreshProblemRangesAction(
+      new protos.cockroach.server.serverpb.ProblemRangesRequest({
+        node_id: nodeId,
+      }),
+    );
+  }, [refreshProblemRangesAction, nodeId]);
 
-  componentDidUpdate(prevProps: ProblemRangesProps) {
-    if (!isEqual(this.props.location, prevProps.location)) {
-      this.refresh(this.props);
-    }
-  }
-
-  renderReportBody() {
-    const { problemRanges, match } = this.props;
-    const nodeId = getMatchParamByName(match, nodeIDAttr);
-
-    if (isLoading(this.props.problemRanges)) {
+  const renderReportBody = () => {
+    if (isLoading(problemRanges)) {
       return null;
     }
 
@@ -234,28 +230,26 @@ export class ProblemRanges extends React.Component<ProblemRangesProps, {}> {
         />
       </div>
     );
-  }
+  };
 
-  render() {
-    return (
-      <div className="section">
-        <Helmet title="Problem Ranges | Debug" />
-        <BackToAdvanceDebug history={this.props.history} />
-        <h1 className="base-heading">Problem Ranges Report</h1>
-        <Loading
-          loading={isLoading(this.props.problemRanges)}
-          page={"problems range"}
-          error={this.props.problemRanges && this.props.problemRanges.lastError}
-          render={() => (
-            <div>
-              {this.renderReportBody()}
-              <ConnectionsTable problemRanges={this.props.problemRanges} />
-            </div>
-          )}
-        />
-      </div>
-    );
-  }
+  return (
+    <div className="section">
+      <Helmet title="Problem Ranges | Debug" />
+      <BackToAdvanceDebug history={history} />
+      <h1 className="base-heading">Problem Ranges Report</h1>
+      <Loading
+        loading={isLoading(problemRanges)}
+        page={"problems range"}
+        error={problemRanges && problemRanges.lastError}
+        render={() => (
+          <div>
+            {renderReportBody()}
+            <ConnectionsTable problemRanges={problemRanges} />
+          </div>
+        )}
+      />
+    </div>
+  );
 }
 
 const mapStateToProps = (state: AdminUIState, props: ProblemRangesProps) => {

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/range/allocator.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/range/allocator.tsx
@@ -17,13 +17,10 @@ interface AllocatorOutputProps {
   allocator: CachedDataReducerState<protos.cockroach.server.serverpb.AllocatorRangeResponse>;
 }
 
-export default class AllocatorOutput extends React.Component<
-  AllocatorOutputProps,
-  {}
-> {
-  renderContent = () => {
-    const { allocator } = this.props;
-
+export default function AllocatorOutput({
+  allocator,
+}: AllocatorOutputProps): React.ReactElement {
+  const renderContent = () => {
     if (
       allocator &&
       (isEmpty(allocator.data) || isEmpty(allocator.data.dry_run))
@@ -55,40 +52,36 @@ export default class AllocatorOutput extends React.Component<
     );
   };
 
-  render() {
-    const { allocator } = this.props;
-
-    // TODO(couchand): This is a really myopic way to check for this particular
-    // case, but making major changes to the CachedDataReducer or util.api seems
-    // fraught at this point.  We should revisit this soon.
-    if (
-      allocator &&
-      allocator.lastError &&
-      allocator.lastError.message === "Forbidden"
-    ) {
-      return (
-        <div>
-          <h2 className="base-heading">Simulated Allocator Output</h2>
-          {REMOTE_DEBUGGING_ERROR_TEXT}
-        </div>
-      );
-    }
-
-    let fromNodeID = "";
-    if (allocator && !isEmpty(allocator.data)) {
-      fromNodeID = ` (from n${allocator.data.node_id.toString()})`;
-    }
-
+  // TODO(couchand): This is a really myopic way to check for this particular
+  // case, but making major changes to the CachedDataReducer or util.api seems
+  // fraught at this point.  We should revisit this soon.
+  if (
+    allocator &&
+    allocator.lastError &&
+    allocator.lastError.message === "Forbidden"
+  ) {
     return (
       <div>
-        <h2 className="base-heading">Simulated Allocator Output{fromNodeID}</h2>
-        <Loading
-          loading={!allocator || allocator.inFlight}
-          page={"allocator"}
-          error={allocator && allocator.lastError}
-          render={this.renderContent}
-        />
+        <h2 className="base-heading">Simulated Allocator Output</h2>
+        {REMOTE_DEBUGGING_ERROR_TEXT}
       </div>
     );
   }
+
+  let fromNodeID = "";
+  if (allocator && !isEmpty(allocator.data)) {
+    fromNodeID = ` (from n${allocator.data.node_id.toString()})`;
+  }
+
+  return (
+    <div>
+      <h2 className="base-heading">Simulated Allocator Output{fromNodeID}</h2>
+      <Loading
+        loading={!allocator || allocator.inFlight}
+        page={"allocator"}
+        error={allocator && allocator.lastError}
+        render={renderContent}
+      />
+    </div>
+  );
 }

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/range/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/range/index.tsx
@@ -10,14 +10,13 @@ import flatMap from "lodash/flatMap";
 import flow from "lodash/flow";
 import head from "lodash/head";
 import isEmpty from "lodash/isEmpty";
-import isEqual from "lodash/isEqual";
 import isNil from "lodash/isNil";
 import orderBy from "lodash/orderBy";
 import some from "lodash/some";
 import sortBy from "lodash/sortBy";
 import sortedUniqBy from "lodash/sortedUniqBy";
 import Long from "long";
-import React from "react";
+import React, { useEffect } from "react";
 import { Helmet } from "react-helmet";
 import { connect } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
@@ -91,7 +90,6 @@ function allocatorRequestFromProps(props: RouteComponentProps) {
 
 function rangeLogRequestFromProps(props: RouteComponentProps) {
   const rangeId = getMatchParamByName(props.match, rangeIDAttr);
-  // TODO(bram): Remove this limit once #18159 is resolved.
   return new protos.cockroach.server.serverpb.RangeLogRequest({
     range_id: Long.fromString(rangeId),
     limit: -1,
@@ -101,130 +99,138 @@ function rangeLogRequestFromProps(props: RouteComponentProps) {
 /**
  * Renders the Range Report page.
  */
-export class Range extends React.Component<RangeProps, {}> {
-  refresh(props = this.props) {
-    props.refreshRange(rangeRequestFromProps(props));
-    props.refreshAllocatorRange(allocatorRequestFromProps(props));
-    props.refreshRangeLog(rangeLogRequestFromProps(props));
-  }
+export function Range({
+  range,
+  allocator,
+  rangeLog,
+  refreshRange: refreshRangeAction,
+  refreshAllocatorRange: refreshAllocatorRangeAction,
+  refreshRangeLog: refreshRangeLogAction,
+  match,
+  history,
+}: RangeProps): React.ReactElement {
+  const rangeID = getMatchParamByName(match, rangeIDAttr);
 
-  componentDidMount() {
-    // Refresh nodes status query when mounting.
-    this.refresh();
-  }
-
-  componentDidUpdate(prevProps: RangeProps) {
-    if (!isEqual(this.props.location, prevProps.location)) {
-      this.refresh(this.props);
-    }
-  }
-
-  backToHotRanges = (): void => {
-    this.props.history.push("/hotranges");
-  };
-
-  render() {
-    const { range, match } = this.props;
-    const rangeID = getMatchParamByName(match, rangeIDAttr);
-
-    // A bunch of quick error cases.
-    if (!isNil(range) && !isNil(range.lastError)) {
-      return (
-        <ErrorPage
-          rangeID={rangeID}
-          errorText={`Error loading range ${range.lastError}`}
-        />
-      );
-    }
-    if (isNil(range) || isEmpty(range.data)) {
-      return (
-        <ErrorPage rangeID={rangeID} errorText={`Loading cluster status...`} />
-      );
-    }
-    const responseRangeID = FixLong(range.data.range_id);
-    if (!responseRangeID.eq(rangeID)) {
-      return (
-        <ErrorPage rangeID={rangeID} errorText={`Updating cluster status...`} />
-      );
-    }
-    if (responseRangeID.isNegative() || responseRangeID.isZero()) {
-      return (
-        <ErrorPage
-          rangeID={rangeID}
-          errorText={`Range ID must be a positive non-zero integer. "${rangeID}"`}
-        />
-      );
-    }
-
-    // Did we get any responses?
-    if (!some(range.data.responses_by_node_id, resp => resp.infos.length > 0)) {
-      return (
-        <ErrorPage
-          rangeID={rangeID}
-          errorText={`No results found, perhaps r${rangeID} doesn't exist.`}
-          range={range}
-        />
-      );
-    }
-
-    // Collect all the infos and sort them, putting the leader (or the replica
-    // with the highest term, first.
-    const infos = orderBy(
-      flatMap(range.data.responses_by_node_id, resp => {
-        if (resp.response && isEmpty(resp.error_message)) {
-          return resp.infos;
-        }
-        return [];
+  useEffect(() => {
+    const rangeIdLong = Long.fromString(rangeID);
+    refreshRangeAction(
+      new protos.cockroach.server.serverpb.RangeRequest({
+        range_id: rangeIdLong,
       }),
-      [
-        info => RangeInfo.IsLeader(info),
-        info => FixLong(info.raft_state.applied).toNumber(),
-        info => FixLong(info.raft_state.hard_state.term).toNumber(),
-        info => {
-          const localReplica = RangeInfo.GetLocalReplica(info);
-          return isNil(localReplica) ? 0 : localReplica.replica_id;
-        },
-      ],
-      ["desc", "desc", "desc", "asc"],
     );
+    refreshAllocatorRangeAction(
+      new protos.cockroach.server.serverpb.AllocatorRangeRequest({
+        range_id: rangeIdLong,
+      }),
+    );
+    refreshRangeLogAction(
+      new protos.cockroach.server.serverpb.RangeLogRequest({
+        range_id: rangeIdLong,
+        limit: -1,
+      }),
+    );
+  }, [
+    refreshRangeAction,
+    refreshAllocatorRangeAction,
+    refreshRangeLogAction,
+    rangeID,
+  ]);
 
-    // Gather all replica IDs.
-    const replicas = flow(
-      (infos: IRangeInfo[]) =>
-        flatMap(infos, info => info.state.state.desc.internal_replicas),
-      descriptors => sortBy(descriptors, d => d.replica_id),
-      descriptors => sortedUniqBy(descriptors, d => d.replica_id),
-    )(infos);
-
+  // A bunch of quick error cases.
+  if (!isNil(range) && !isNil(range.lastError)) {
     return (
-      <div className="section">
-        <Helmet title={`r${responseRangeID.toString()} Range | Debug`} />
-        <Button
-          onClick={this.backToHotRanges}
-          type="unstyled-link"
-          size="small"
-          icon={<ArrowLeft fontSize={"10px"} />}
-          iconPosition="left"
-          className={commonStyles("small-margin")}
-        >
-          Hot Ranges
-        </Button>
-        <h1 className="base-heading">
-          Range Report for r{responseRangeID.toString()}
-        </h1>
-        <a
-          href={`/#/debug/enqueue_range?rangeID=${responseRangeID.toString()}`}
-        >
-          Enqueue Range
-        </a>
-        <RangeTable infos={infos} replicas={replicas} />
-        <LeaseTable info={head(infos)} />
-        <ConnectionsTable range={range} />
-        <AllocatorOutput allocator={this.props.allocator} />
-        <LogTable rangeID={responseRangeID} log={this.props.rangeLog} />
-      </div>
+      <ErrorPage
+        rangeID={rangeID}
+        errorText={`Error loading range ${range.lastError}`}
+      />
     );
   }
+  if (isNil(range) || isEmpty(range.data)) {
+    return (
+      <ErrorPage rangeID={rangeID} errorText={`Loading cluster status...`} />
+    );
+  }
+  const responseRangeID = FixLong(range.data.range_id);
+  if (!responseRangeID.eq(rangeID)) {
+    return (
+      <ErrorPage rangeID={rangeID} errorText={`Updating cluster status...`} />
+    );
+  }
+  if (responseRangeID.isNegative() || responseRangeID.isZero()) {
+    return (
+      <ErrorPage
+        rangeID={rangeID}
+        errorText={`Range ID must be a positive non-zero integer. "${rangeID}"`}
+      />
+    );
+  }
+
+  // Did we get any responses?
+  if (!some(range.data.responses_by_node_id, resp => resp.infos.length > 0)) {
+    return (
+      <ErrorPage
+        rangeID={rangeID}
+        errorText={`No results found, perhaps r${rangeID} doesn't exist.`}
+        range={range}
+      />
+    );
+  }
+
+  // Collect all the infos and sort them, putting the leader (or the replica
+  // with the highest term, first.
+  const infos = orderBy(
+    flatMap(range.data.responses_by_node_id, resp => {
+      if (resp.response && isEmpty(resp.error_message)) {
+        return resp.infos;
+      }
+      return [];
+    }),
+    [
+      info => RangeInfo.IsLeader(info),
+      info => FixLong(info.raft_state.applied).toNumber(),
+      info => FixLong(info.raft_state.hard_state.term).toNumber(),
+      info => {
+        const localReplica = RangeInfo.GetLocalReplica(info);
+        return isNil(localReplica) ? 0 : localReplica.replica_id;
+      },
+    ],
+    ["desc", "desc", "desc", "asc"],
+  );
+
+  // Gather all replica IDs.
+  const replicas = flow(
+    (infos: IRangeInfo[]) =>
+      flatMap(infos, info => info.state.state.desc.internal_replicas),
+    descriptors => sortBy(descriptors, d => d.replica_id),
+    descriptors => sortedUniqBy(descriptors, d => d.replica_id),
+  )(infos);
+
+  return (
+    <div className="section">
+      <Helmet title={`r${responseRangeID.toString()} Range | Debug`} />
+      <Button
+        onClick={() => history.push("/hotranges")}
+        type="unstyled-link"
+        size="small"
+        icon={<ArrowLeft fontSize={"10px"} />}
+        iconPosition="left"
+        className={commonStyles("small-margin")}
+      >
+        Hot Ranges
+      </Button>
+      <h1 className="base-heading">
+        Range Report for r{responseRangeID.toString()}
+      </h1>
+      <a href={`/#/debug/enqueue_range?rangeID=${responseRangeID.toString()}`}>
+        Enqueue Range
+      </a>
+      <RangeTable infos={infos} replicas={replicas} />
+      <LeaseTable info={head(infos)} />
+      <ConnectionsTable range={range} />
+      <AllocatorOutput allocator={allocator} />
+      <LogTable rangeID={responseRangeID} log={rangeLog} />
+    </div>
+  );
 }
 
 const mapStateToProps = (state: AdminUIState, props: RouteComponentProps) => ({

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/range/leaseTable.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/range/leaseTable.tsx
@@ -45,107 +45,100 @@ function renderLeaseTimestampCell(
   return renderLeaseCell(value, `${value}\n${timestamp.wall_time.toString()}`);
 }
 
-export default class LeaseTable extends React.Component<LeaseTableProps, {}> {
-  render() {
-    const { info } = this.props;
-    // TODO(bram): Maybe search for the latest lease record instead of just trusting the
-    // leader?
-    const rangeID = info.state.state.desc.range_id;
-    const header = (
-      <h2 className="base-heading">
-        Lease History (from{" "}
-        {Print.ReplicaID(rangeID, RangeInfo.GetLocalReplica(info))})
-      </h2>
-    );
-    if (isEmpty(info.lease_history)) {
-      return (
-        <div>
-          {header}
-          <h3>There is no lease history for this range</h3>
-        </div>
-      );
-    }
-
-    const isEpoch = Lease.IsEpoch(head(info.lease_history));
-    const leaseHistory = reverse(info.lease_history);
+export default function LeaseTable({
+  info,
+}: LeaseTableProps): React.ReactElement {
+  // TODO(bram): Maybe search for the latest lease record instead of just trusting the
+  // leader?
+  const rangeID = info.state.state.desc.range_id;
+  const header = (
+    <h2 className="base-heading">
+      Lease History (from{" "}
+      {Print.ReplicaID(rangeID, RangeInfo.GetLocalReplica(info))})
+    </h2>
+  );
+  if (isEmpty(info.lease_history)) {
     return (
       <div>
         {header}
-        <table className="lease-table">
-          <tbody>
-            <tr className="lease-table__row lease-table__row--header">
-              <th className="lease-table__cell lease-table__cell--header">
-                Replica
-              </th>
-              {isEpoch ? (
-                <th className="lease-table__cell lease-table__cell--header">
-                  Epoch
-                </th>
-              ) : null}
-              <th className="lease-table__cell lease-table__cell--header">
-                Proposed
-              </th>
-              <th className="lease-table__cell lease-table__cell--header">
-                Proposed Delta
-              </th>
-              {!isEpoch ? (
-                <th className="lease-table__cell lease-table__cell--header">
-                  Expiration
-                </th>
-              ) : null}
-              <th className="lease-table__cell lease-table__cell--header">
-                Start
-              </th>
-              <th className="lease-table__cell lease-table__cell--header">
-                Start Delta
-              </th>
-              <th className="lease-table__cell lease-table__cell--header">
-                Acquisition Type
-              </th>
-            </tr>
-            {map(leaseHistory, (lease, key) => {
-              let prevProposedTimestamp: protos.cockroach.util.hlc.ITimestamp =
-                null;
-              let prevStart: protos.cockroach.util.hlc.ITimestamp = null;
-              if (key < leaseHistory.length - 1) {
-                prevProposedTimestamp = leaseHistory[key + 1].proposed_ts;
-                prevStart = leaseHistory[key + 1].start;
-              }
-              return (
-                <tr key={key} className="lease-table__row">
-                  {renderLeaseCell(
-                    Print.ReplicaID(rangeID, lease.replica),
-                  )}
-                  {isEpoch
-                    ? renderLeaseCell(
-                        `n${lease.replica.node_id}, ${lease.epoch.toString()}`,
-                      )
-                    : null}
-                  {renderLeaseTimestampCell(lease.proposed_ts)}
-                  {renderLeaseCell(
-                    Print.TimestampDelta(
-                      lease.proposed_ts,
-                      prevProposedTimestamp,
-                    ),
-                  )}
-                  {!isEpoch
-                    ? renderLeaseTimestampCell(lease.expiration)
-                    : null}
-                  {renderLeaseTimestampCell(lease.start)}
-                  {renderLeaseCell(
-                    Print.TimestampDelta(lease.start, prevStart),
-                  )}
-                  {renderLeaseCell(
-                    protos.cockroach.roachpb.LeaseAcquisitionType[
-                      lease.acquisition_type
-                    ],
-                  )}
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
+        <h3>There is no lease history for this range</h3>
       </div>
     );
   }
+
+  const isEpoch = Lease.IsEpoch(head(info.lease_history));
+  const leaseHistory = reverse(info.lease_history);
+  return (
+    <div>
+      {header}
+      <table className="lease-table">
+        <tbody>
+          <tr className="lease-table__row lease-table__row--header">
+            <th className="lease-table__cell lease-table__cell--header">
+              Replica
+            </th>
+            {isEpoch ? (
+              <th className="lease-table__cell lease-table__cell--header">
+                Epoch
+              </th>
+            ) : null}
+            <th className="lease-table__cell lease-table__cell--header">
+              Proposed
+            </th>
+            <th className="lease-table__cell lease-table__cell--header">
+              Proposed Delta
+            </th>
+            {!isEpoch ? (
+              <th className="lease-table__cell lease-table__cell--header">
+                Expiration
+              </th>
+            ) : null}
+            <th className="lease-table__cell lease-table__cell--header">
+              Start
+            </th>
+            <th className="lease-table__cell lease-table__cell--header">
+              Start Delta
+            </th>
+            <th className="lease-table__cell lease-table__cell--header">
+              Acquisition Type
+            </th>
+          </tr>
+          {map(leaseHistory, (lease, key) => {
+            let prevProposedTimestamp: protos.cockroach.util.hlc.ITimestamp =
+              null;
+            let prevStart: protos.cockroach.util.hlc.ITimestamp = null;
+            if (key < leaseHistory.length - 1) {
+              prevProposedTimestamp = leaseHistory[key + 1].proposed_ts;
+              prevStart = leaseHistory[key + 1].start;
+            }
+            return (
+              <tr key={key} className="lease-table__row">
+                {renderLeaseCell(Print.ReplicaID(rangeID, lease.replica))}
+                {isEpoch
+                  ? renderLeaseCell(
+                      `n${lease.replica.node_id}, ${lease.epoch.toString()}`,
+                    )
+                  : null}
+                {renderLeaseTimestampCell(lease.proposed_ts)}
+                {renderLeaseCell(
+                  Print.TimestampDelta(
+                    lease.proposed_ts,
+                    prevProposedTimestamp,
+                  ),
+                )}
+                {!isEpoch ? renderLeaseTimestampCell(lease.expiration) : null}
+                {renderLeaseTimestampCell(lease.start)}
+                {renderLeaseCell(Print.TimestampDelta(lease.start, prevStart))}
+                {renderLeaseCell(
+                  protos.cockroach.roachpb.LeaseAcquisitionType[
+                    lease.acquisition_type
+                  ],
+                )}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
 }

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/range/leaseTable.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/range/leaseTable.tsx
@@ -19,34 +19,33 @@ interface LeaseTableProps {
   info: protos.cockroach.server.serverpb.IRangeInfo;
 }
 
-export default class LeaseTable extends React.Component<LeaseTableProps, {}> {
-  renderLeaseCell(value: string, title = "") {
-    if (isEmpty(title)) {
-      return (
-        <td className="lease-table__cell" title={value}>
-          {value}
-        </td>
-      );
-    }
+function renderLeaseCell(value: string, title = "") {
+  if (isEmpty(title)) {
     return (
-      <td className="lease-table__cell" title={title}>
+      <td className="lease-table__cell" title={value}>
         {value}
       </td>
     );
   }
+  return (
+    <td className="lease-table__cell" title={title}>
+      {value}
+    </td>
+  );
+}
 
-  renderLeaseTimestampCell(timestamp: protos.cockroach.util.hlc.ITimestamp) {
-    if (isNil(timestamp)) {
-      return this.renderLeaseCell("<no value>");
-    }
-
-    const value = Print.Timestamp(timestamp);
-    return this.renderLeaseCell(
-      value,
-      `${value}\n${timestamp.wall_time.toString()}`,
-    );
+function renderLeaseTimestampCell(
+  timestamp: protos.cockroach.util.hlc.ITimestamp,
+) {
+  if (isNil(timestamp)) {
+    return renderLeaseCell("<no value>");
   }
 
+  const value = Print.Timestamp(timestamp);
+  return renderLeaseCell(value, `${value}\n${timestamp.wall_time.toString()}`);
+}
+
+export default class LeaseTable extends React.Component<LeaseTableProps, {}> {
   render() {
     const { info } = this.props;
     // TODO(bram): Maybe search for the latest lease record instead of just trusting the
@@ -114,29 +113,29 @@ export default class LeaseTable extends React.Component<LeaseTableProps, {}> {
               }
               return (
                 <tr key={key} className="lease-table__row">
-                  {this.renderLeaseCell(
+                  {renderLeaseCell(
                     Print.ReplicaID(rangeID, lease.replica),
                   )}
                   {isEpoch
-                    ? this.renderLeaseCell(
+                    ? renderLeaseCell(
                         `n${lease.replica.node_id}, ${lease.epoch.toString()}`,
                       )
                     : null}
-                  {this.renderLeaseTimestampCell(lease.proposed_ts)}
-                  {this.renderLeaseCell(
+                  {renderLeaseTimestampCell(lease.proposed_ts)}
+                  {renderLeaseCell(
                     Print.TimestampDelta(
                       lease.proposed_ts,
                       prevProposedTimestamp,
                     ),
                   )}
                   {!isEpoch
-                    ? this.renderLeaseTimestampCell(lease.expiration)
+                    ? renderLeaseTimestampCell(lease.expiration)
                     : null}
-                  {this.renderLeaseTimestampCell(lease.start)}
-                  {this.renderLeaseCell(
+                  {renderLeaseTimestampCell(lease.start)}
+                  {renderLeaseCell(
                     Print.TimestampDelta(lease.start, prevStart),
                   )}
-                  {this.renderLeaseCell(
+                  {renderLeaseCell(
                     protos.cockroach.roachpb.LeaseAcquisitionType[
                       lease.acquisition_type
                     ],

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/range/logTable.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/range/logTable.tsx
@@ -44,6 +44,32 @@ function printLogEventType(
   }
 }
 
+function renderLogInfoDescriptor(title: string, desc: string) {
+  if (isEmpty(desc)) {
+    return null;
+  }
+  return (
+    <li>
+      {title}: {desc}
+    </li>
+  );
+}
+
+function renderLogInfo(
+  info: protos.cockroach.server.serverpb.RangeLogResponse.IPrettyInfo,
+) {
+  return (
+    <ul className="log-entries-list">
+      {renderLogInfoDescriptor("Updated Range Descriptor", info.updated_desc)}
+      {renderLogInfoDescriptor("New Range Descriptor", info.new_desc)}
+      {renderLogInfoDescriptor("Added Replica", info.added_replica)}
+      {renderLogInfoDescriptor("Removed Replica", info.removed_replica)}
+      {renderLogInfoDescriptor("Reason", info.reason)}
+      {renderLogInfoDescriptor("Details", info.details)}
+    </ul>
+  );
+}
+
 export default class LogTable extends React.Component<LogTableProps, {}> {
   // If there is no otherRangeID, it comes back as the number 0.
   renderRangeID(otherRangeID: Long | number) {
@@ -61,35 +87,6 @@ export default class LogTable extends React.Component<LogTableProps, {}> {
       <a href={`#/reports/range/${fixedOtherRangeID.toString()}`}>
         r{fixedOtherRangeID.toString()}
       </a>
-    );
-  }
-
-  renderLogInfoDescriptor(title: string, desc: string) {
-    if (isEmpty(desc)) {
-      return null;
-    }
-    return (
-      <li>
-        {title}: {desc}
-      </li>
-    );
-  }
-
-  renderLogInfo(
-    info: protos.cockroach.server.serverpb.RangeLogResponse.IPrettyInfo,
-  ) {
-    return (
-      <ul className="log-entries-list">
-        {this.renderLogInfoDescriptor(
-          "Updated Range Descriptor",
-          info.updated_desc,
-        )}
-        {this.renderLogInfoDescriptor("New Range Descriptor", info.new_desc)}
-        {this.renderLogInfoDescriptor("Added Replica", info.added_replica)}
-        {this.renderLogInfoDescriptor("Removed Replica", info.removed_replica)}
-        {this.renderLogInfoDescriptor("Reason", info.reason)}
-        {this.renderLogInfoDescriptor("Details", info.details)}
-      </ul>
     );
   }
 
@@ -136,7 +133,7 @@ export default class LogTable extends React.Component<LogTableProps, {}> {
                 {this.renderRangeID(event.event.other_range_id)}
               </td>
               <td className="log-table__cell">
-                {this.renderLogInfo(event.pretty_info)}
+                {renderLogInfo(event.pretty_info)}
               </td>
             </tr>
           ))}

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/range/logTable.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/range/logTable.tsx
@@ -70,11 +70,14 @@ function renderLogInfo(
   );
 }
 
-export default class LogTable extends React.Component<LogTableProps, {}> {
+export default function LogTable({
+  rangeID,
+  log,
+}: LogTableProps): React.ReactElement {
   // If there is no otherRangeID, it comes back as the number 0.
-  renderRangeID(otherRangeID: Long | number) {
+  const renderRangeID = (otherRangeID: Long | number) => {
     const fixedOtherRangeID = FixLong(otherRangeID);
-    const fixedCurrentRangeID = FixLong(this.props.rangeID);
+    const fixedCurrentRangeID = FixLong(rangeID);
     if (fixedOtherRangeID.eq(0)) {
       return null;
     }
@@ -88,11 +91,9 @@ export default class LogTable extends React.Component<LogTableProps, {}> {
         r{fixedOtherRangeID.toString()}
       </a>
     );
-  }
+  };
 
-  renderContent = () => {
-    const { log } = this.props;
-
+  const renderContent = () => {
     // Sort by descending timestamp.
     const events = orderBy(
       log && log.data && log.data.events,
@@ -127,10 +128,10 @@ export default class LogTable extends React.Component<LogTableProps, {}> {
                 {printLogEventType(event.event.event_type)}
               </td>
               <td className="log-table__cell">
-                {this.renderRangeID(event.event.range_id)}
+                {renderRangeID(event.event.range_id)}
               </td>
               <td className="log-table__cell">
-                {this.renderRangeID(event.event.other_range_id)}
+                {renderRangeID(event.event.other_range_id)}
               </td>
               <td className="log-table__cell">
                 {renderLogInfo(event.pretty_info)}
@@ -142,19 +143,15 @@ export default class LogTable extends React.Component<LogTableProps, {}> {
     );
   };
 
-  render() {
-    const { log } = this.props;
-
-    return (
-      <div>
-        <h2 className="base-heading">Range Log</h2>
-        <Loading
-          loading={!log || log.inFlight}
-          page={"log table"}
-          error={log && log.lastError}
-          render={this.renderContent}
-        />
-      </div>
-    );
-  }
+  return (
+    <div>
+      <h2 className="base-heading">Range Log</h2>
+      <Loading
+        loading={!log || log.inFlight}
+        page={"log table"}
+        error={log && log.lastError}
+        render={renderContent}
+      />
+    </div>
+  );
 }

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/range/rangeTable.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/range/rangeTable.tsx
@@ -673,329 +673,313 @@ function renderRangeReplicaRow(
   );
 }
 
-export default class RangeTable extends React.Component<RangeTableProps, {}> {
-  render() {
-    const { infos, replicas } = this.props;
-    const leader = head(infos);
-    const rangeID = leader.state.state.desc.range_id;
+export default function RangeTable({
+  infos,
+  replicas,
+}: RangeTableProps): React.ReactElement {
+  const leader = head(infos);
+  const rangeID = leader.state.state.desc.range_id;
 
-    // We want to display ordered by store ID.
-    const sortedStoreIDs = flow(
-      (infos: IRangeInfo[]) => map(infos, info => info.source_store_id),
-      storeIds => sortBy(storeIds, id => id),
-    )(infos);
+  // We want to display ordered by store ID.
+  const sortedStoreIDs = flow(
+    (infos: IRangeInfo[]) => map(infos, info => info.source_store_id),
+    storeIds => sortBy(storeIds, id => id),
+  )(infos);
 
-    const dormantStoreIDs: Set<number> = new Set();
+  const dormantStoreIDs: Set<number> = new Set();
 
-    const now = moment();
+  const now = moment();
 
-    // Convert the infos to a simpler object for display purposes. This helps when trying to
-    // determine if any warnings should be displayed.
-    const detailsByStoreID: Map<number, RangeTableDetail> = new Map();
-    forEach(infos, info => {
-      const localReplica = RangeInfo.GetLocalReplica(info);
-      const awaitingGC = isNil(localReplica);
-      const lease = info.state.state.lease;
-      const leaseEpoch = Lease.IsEpoch(lease);
-      const leaseLeader = Lease.IsLeader(lease);
-      const leaseExpiration = !leaseEpoch && !leaseLeader;
-      const raftLeader =
-        !awaitingGC &&
-        FixLong(info.raft_state.lead).eq(localReplica.replica_id);
-      const leaseHolder =
-        !awaitingGC && localReplica.replica_id === lease.replica.replica_id;
-      const mvcc = info.state.state.stats;
-      const raftState = contentRaftState(info.raft_state.state);
-      const vote = FixLong(info.raft_state.hard_state.vote);
-      let leaseState: RangeTableCellContent;
-      if (isNil(info.lease_status)) {
-        leaseState = rangeTableEmptyContentWithWarning;
-      } else {
-        leaseState = createContent(
-          convertLeaseState(info.lease_status.state),
-          info.lease_status.state ===
-            protos.cockroach.kv.kvserver.storagepb.LeaseState.VALID
-            ? ""
-            : "range-table__cell--warning",
-        );
-      }
-      const dormant = raftState.value[0] === "dormant";
-      if (dormant) {
-        dormantStoreIDs.add(info.source_store_id);
-      }
-      detailsByStoreID.set(info.source_store_id, {
-        id: createContent(
-          Print.ReplicaID(
-            rangeID,
-            localReplica,
-            info.source_node_id,
-            info.source_store_id,
-          ),
-        ),
-        keyRange: createContent(
-          `${info.span.start_key} to ${info.span.end_key}`,
-        ),
-        problems: contentProblems(info.problems, awaitingGC),
-        replicaType: awaitingGC
-          ? createContent("") // `problems` above will report "Awaiting GC" in this case
-          : createContent(contentReplicaType(localReplica.type)),
-        raftState: raftState,
-        leadSupportUntil: contentTimestamp(
-          info.raft_state.lead_support_until,
-          now,
-        ),
-        quiescent: info.quiescent
-          ? rangeTableQuiescent
-          : rangeTableEmptyContent,
-        ticking: createContent(info.ticking.toString()),
-        leaseState: leaseState,
-        leaseHolder: createContent(
-          Print.ReplicaID(rangeID, lease.replica),
-          leaseHolder
-            ? "range-table__cell--lease-holder"
-            : "range-table__cell--lease-follower",
-        ),
-        leaseType: createContent(
-          leaseEpoch ? "epoch" : leaseLeader ? "leader" : "expiration",
-        ),
-        leaseEpoch: leaseEpoch
-          ? createContent(lease.epoch)
-          : rangeTableEmptyContent,
-        leaseTerm: leaseLeader
-          ? createContent(lease.term)
-          : rangeTableEmptyContent,
-        isLeaseholder: createContent(String(info.is_leaseholder)),
-        leaseValid: createContent(String(info.lease_valid)),
-        leaseStart: contentTimestamp(lease.start, now),
-        leaseExpiration: leaseExpiration
-          ? contentTimestamp(lease.expiration, now)
-          : rangeTableEmptyContent,
-        leaseMinExpiration: !leaseExpiration
-          ? contentTimestamp(lease.min_expiration, now)
-          : rangeTableEmptyContent,
-        leaseAppliedIndex: createContent(
-          FixLong(info.state.state.lease_applied_index),
-        ),
-        raftLeader: contentIf(!dormant, () =>
-          createContent(
-            FixLong(info.raft_state.lead),
-            raftLeader
-              ? "range-table__cell--raftstate-leader"
-              : "range-table__cell--raftstate-follower",
-          ),
-        ),
-        vote: contentIf(!dormant, () =>
-          createContent(vote.greaterThan(0) ? vote : "-"),
-        ),
-        term: contentIf(!dormant, () =>
-          createContent(FixLong(info.raft_state.hard_state.term)),
-        ),
-        leadTransferee: contentIf(!dormant, () => {
-          const leadTransferee = FixLong(info.raft_state.lead_transferee);
-          return createContent(
-            leadTransferee.greaterThan(0) ? leadTransferee : "-",
-          );
-        }),
-        applied: contentIf(!dormant, () =>
-          createContent(FixLong(info.raft_state.applied)),
-        ),
-        commit: contentIf(!dormant, () =>
-          createContent(FixLong(info.raft_state.hard_state.commit)),
-        ),
-        lastIndex: createContent(FixLong(info.state.last_index)),
-        logSize: contentBytes(
-          FixLong(info.state.raft_log_size),
-          info.state.raft_log_size_trusted ? "" : "range-table__cell--dormant",
-          "Log size is known to not be correct. This isn't an error condition. " +
-            "The log size will became exact the next time it is recomputed. " +
-            "This replica does not perform log truncation (because the log might already " +
-            "be truncated sufficiently).",
-        ),
-        leaseHolderQPS: leaseHolder
-          ? createContent(info.stats.queries_per_second.toFixed(4))
-          : rangeTableEmptyContent,
-        keysWrittenPS: createContent(
-          info.stats.writes_per_second.toFixed(4),
-        ),
-        approxProposalQuota: raftLeader
-          ? createContent(FixLong(info.state.approximate_proposal_quota))
-          : rangeTableEmptyContent,
-        pendingCommands: createContent(FixLong(info.state.num_pending)),
-        droppedCommands: createContent(
-          FixLong(info.state.num_dropped),
-          FixLong(info.state.num_dropped).greaterThan(0)
-            ? "range-table__cell--warning"
-            : "",
-        ),
-        truncatedIndex: createContent(
-          FixLong(info.state.state.truncated_state.index),
-        ),
-        truncatedTerm: createContent(
-          FixLong(info.state.state.truncated_state.term),
-        ),
-        mvccLastUpdate: contentNanos(FixLong(mvcc.last_update_nanos)),
-        mvccLiveBytesCount: contentMVCC(
-          FixLong(mvcc.live_bytes),
-          FixLong(mvcc.live_count),
-        ),
-        mvccKeyBytesCount: contentMVCC(
-          FixLong(mvcc.key_bytes),
-          FixLong(mvcc.key_count),
-        ),
-        mvccValueBytesCount: contentMVCC(
-          FixLong(mvcc.val_bytes),
-          FixLong(mvcc.val_count),
-        ),
-        mvccRangeKeyBytesCount: contentMVCC(
-          FixLong(mvcc.range_key_bytes || 0),
-          FixLong(mvcc.range_key_count || 0),
-        ),
-        mvccRangeValueBytesCount: contentMVCC(
-          FixLong(mvcc.range_val_bytes || 0),
-          FixLong(mvcc.range_val_count || 0),
-        ),
-        mvccIntentBytesCount: contentMVCC(
-          FixLong(mvcc.intent_bytes),
-          FixLong(mvcc.intent_count),
-        ),
-        mvccSystemBytesCount: contentMVCC(
-          FixLong(mvcc.sys_bytes),
-          FixLong(mvcc.sys_count),
-        ),
-        rangeMaxBytes: contentBytes(FixLong(info.state.range_max_bytes)),
-        mvccIntentAge: contentDuration(FixLong(mvcc.lock_age)),
-
-        gcAvgAge: contentGCAvgAge(mvcc),
-        gcBytesAge: createContent(FixLong(mvcc.gc_bytes_age)),
-
-        numIntents: createContent(FixLong(mvcc.intent_count)),
-        intentAvgAge: createContentIntentAvgAge(mvcc),
-        intentAge: createContent(FixLong(mvcc.lock_age)),
-
-        readLatches: createContent(FixLong(info.read_latches)),
-        writeLatches: createContent(FixLong(info.write_latches)),
-        locks: createContent(FixLong(info.locks)),
-        locksWithWaitQueues: createContent(
-          FixLong(info.locks_with_wait_queues),
-        ),
-        lockWaitQueueWaiters: createContent(
-          FixLong(info.lock_wait_queue_waiters),
-        ),
-        top_k_locks_by_wait_queue_waiters: contentIf(
-          size(info.top_k_locks_by_wait_queue_waiters) > 0,
-          () => ({
-            value: map(
-              info.top_k_locks_by_wait_queue_waiters,
-              lock => `${lock.pretty_key} (${lock.waiters} waiters)`,
-            ),
-          }),
-        ),
-
-        closedTimestampPolicy: createContent(
-          // We index into the enum in order to get the label string, instead of
-          // the numeric value.
-          cockroach.roachpb.RangeClosedTimestampPolicy[
-            info.state.closed_timestamp_policy
-          ],
-          info.state.closed_timestamp_policy ===
-            cockroach.roachpb.RangeClosedTimestampPolicy.LEAD_FOR_GLOBAL_READS
-            ? "range-table__cell--global-range"
-            : "",
-        ),
-        closedTimestampRaft: contentTimestamp(
-          info.state.state.raft_closed_timestamp,
-          now,
-        ),
-        closedTimestampSideTransportReplica: contentTimestamp(
-          info.state.closed_timestamp_sidetransport_info.replica_closed,
-          now,
-        ),
-        closedTimestampSideTransportReplicaLAI: createContent(
-          FixLong(info.state.closed_timestamp_sidetransport_info.replica_lai),
-          // Warn if the LAI hasn't applied yet.
-          FixLong(info.state.state.lease_applied_index) <
-            FixLong(info.state.closed_timestamp_sidetransport_info.replica_lai)
-            ? "range-table__cell--warning"
-            : "",
-        ),
-        closedTimestampSideTransportCentral: contentTimestamp(
-          info.state.closed_timestamp_sidetransport_info.central_closed,
-          now,
-        ),
-        closedTimestampSideTransportCentralLAI: createContent(
-          FixLong(info.state.closed_timestamp_sidetransport_info.central_lai),
-          // Warn if the LAI hasn't applied yet.
-          FixLong(info.state.state.lease_applied_index) <
-            FixLong(info.state.closed_timestamp_sidetransport_info.central_lai)
-            ? "range-table__cell--warning"
-            : "",
-        ),
-        circuitBreakerError: createContent(
-          info.state.circuit_breaker_error,
-        ),
-        locality: contentIf(size(info.locality.tiers) > 0, () => ({
-          value: map(info.locality.tiers, tier => `${tier.key}: ${tier.value}`),
-        })),
-        pausedFollowers: createContent(
-          info.state.paused_replicas?.join(", "),
-        ),
-      });
-    });
-
-    const leaderReplicaIDs = new Set(
-      map(leader.state.state.desc.internal_replicas, rep => rep.replica_id),
-    );
-
-    // Go through all the replicas and add them to map for easy printing.
-    const replicasByReplicaIDByStoreID: Map<
-      number,
-      Map<number, protos.cockroach.roachpb.IReplicaDescriptor>
-    > = new Map();
-    forEach(infos, info => {
-      const replicasByReplicaID: Map<
-        number,
-        protos.cockroach.roachpb.IReplicaDescriptor
-      > = new Map();
-      forEach(info.state.state.desc.internal_replicas, rep => {
-        replicasByReplicaID.set(rep.replica_id, rep);
-      });
-      replicasByReplicaIDByStoreID.set(
-        info.source_store_id,
-        replicasByReplicaID,
+  // Convert the infos to a simpler object for display purposes. This helps when trying to
+  // determine if any warnings should be displayed.
+  const detailsByStoreID: Map<number, RangeTableDetail> = new Map();
+  forEach(infos, info => {
+    const localReplica = RangeInfo.GetLocalReplica(info);
+    const awaitingGC = isNil(localReplica);
+    const lease = info.state.state.lease;
+    const leaseEpoch = Lease.IsEpoch(lease);
+    const leaseLeader = Lease.IsLeader(lease);
+    const leaseExpiration = !leaseEpoch && !leaseLeader;
+    const raftLeader =
+      !awaitingGC && FixLong(info.raft_state.lead).eq(localReplica.replica_id);
+    const leaseHolder =
+      !awaitingGC && localReplica.replica_id === lease.replica.replica_id;
+    const mvcc = info.state.state.stats;
+    const raftState = contentRaftState(info.raft_state.state);
+    const vote = FixLong(info.raft_state.hard_state.vote);
+    let leaseState: RangeTableCellContent;
+    if (isNil(info.lease_status)) {
+      leaseState = rangeTableEmptyContentWithWarning;
+    } else {
+      leaseState = createContent(
+        convertLeaseState(info.lease_status.state),
+        info.lease_status.state ===
+          protos.cockroach.kv.kvserver.storagepb.LeaseState.VALID
+          ? ""
+          : "range-table__cell--warning",
       );
-    });
+    }
+    const dormant = raftState.value[0] === "dormant";
+    if (dormant) {
+      dormantStoreIDs.add(info.source_store_id);
+    }
+    detailsByStoreID.set(info.source_store_id, {
+      id: createContent(
+        Print.ReplicaID(
+          rangeID,
+          localReplica,
+          info.source_node_id,
+          info.source_store_id,
+        ),
+      ),
+      keyRange: createContent(`${info.span.start_key} to ${info.span.end_key}`),
+      problems: contentProblems(info.problems, awaitingGC),
+      replicaType: awaitingGC
+        ? createContent("") // `problems` above will report "Awaiting GC" in this case
+        : createContent(contentReplicaType(localReplica.type)),
+      raftState: raftState,
+      leadSupportUntil: contentTimestamp(
+        info.raft_state.lead_support_until,
+        now,
+      ),
+      quiescent: info.quiescent ? rangeTableQuiescent : rangeTableEmptyContent,
+      ticking: createContent(info.ticking.toString()),
+      leaseState: leaseState,
+      leaseHolder: createContent(
+        Print.ReplicaID(rangeID, lease.replica),
+        leaseHolder
+          ? "range-table__cell--lease-holder"
+          : "range-table__cell--lease-follower",
+      ),
+      leaseType: createContent(
+        leaseEpoch ? "epoch" : leaseLeader ? "leader" : "expiration",
+      ),
+      leaseEpoch: leaseEpoch
+        ? createContent(lease.epoch)
+        : rangeTableEmptyContent,
+      leaseTerm: leaseLeader
+        ? createContent(lease.term)
+        : rangeTableEmptyContent,
+      isLeaseholder: createContent(String(info.is_leaseholder)),
+      leaseValid: createContent(String(info.lease_valid)),
+      leaseStart: contentTimestamp(lease.start, now),
+      leaseExpiration: leaseExpiration
+        ? contentTimestamp(lease.expiration, now)
+        : rangeTableEmptyContent,
+      leaseMinExpiration: !leaseExpiration
+        ? contentTimestamp(lease.min_expiration, now)
+        : rangeTableEmptyContent,
+      leaseAppliedIndex: createContent(
+        FixLong(info.state.state.lease_applied_index),
+      ),
+      raftLeader: contentIf(!dormant, () =>
+        createContent(
+          FixLong(info.raft_state.lead),
+          raftLeader
+            ? "range-table__cell--raftstate-leader"
+            : "range-table__cell--raftstate-follower",
+        ),
+      ),
+      vote: contentIf(!dormant, () =>
+        createContent(vote.greaterThan(0) ? vote : "-"),
+      ),
+      term: contentIf(!dormant, () =>
+        createContent(FixLong(info.raft_state.hard_state.term)),
+      ),
+      leadTransferee: contentIf(!dormant, () => {
+        const leadTransferee = FixLong(info.raft_state.lead_transferee);
+        return createContent(
+          leadTransferee.greaterThan(0) ? leadTransferee : "-",
+        );
+      }),
+      applied: contentIf(!dormant, () =>
+        createContent(FixLong(info.raft_state.applied)),
+      ),
+      commit: contentIf(!dormant, () =>
+        createContent(FixLong(info.raft_state.hard_state.commit)),
+      ),
+      lastIndex: createContent(FixLong(info.state.last_index)),
+      logSize: contentBytes(
+        FixLong(info.state.raft_log_size),
+        info.state.raft_log_size_trusted ? "" : "range-table__cell--dormant",
+        "Log size is known to not be correct. This isn't an error condition. " +
+          "The log size will became exact the next time it is recomputed. " +
+          "This replica does not perform log truncation (because the log might already " +
+          "be truncated sufficiently).",
+      ),
+      leaseHolderQPS: leaseHolder
+        ? createContent(info.stats.queries_per_second.toFixed(4))
+        : rangeTableEmptyContent,
+      keysWrittenPS: createContent(info.stats.writes_per_second.toFixed(4)),
+      approxProposalQuota: raftLeader
+        ? createContent(FixLong(info.state.approximate_proposal_quota))
+        : rangeTableEmptyContent,
+      pendingCommands: createContent(FixLong(info.state.num_pending)),
+      droppedCommands: createContent(
+        FixLong(info.state.num_dropped),
+        FixLong(info.state.num_dropped).greaterThan(0)
+          ? "range-table__cell--warning"
+          : "",
+      ),
+      truncatedIndex: createContent(
+        FixLong(info.state.state.truncated_state.index),
+      ),
+      truncatedTerm: createContent(
+        FixLong(info.state.state.truncated_state.term),
+      ),
+      mvccLastUpdate: contentNanos(FixLong(mvcc.last_update_nanos)),
+      mvccLiveBytesCount: contentMVCC(
+        FixLong(mvcc.live_bytes),
+        FixLong(mvcc.live_count),
+      ),
+      mvccKeyBytesCount: contentMVCC(
+        FixLong(mvcc.key_bytes),
+        FixLong(mvcc.key_count),
+      ),
+      mvccValueBytesCount: contentMVCC(
+        FixLong(mvcc.val_bytes),
+        FixLong(mvcc.val_count),
+      ),
+      mvccRangeKeyBytesCount: contentMVCC(
+        FixLong(mvcc.range_key_bytes || 0),
+        FixLong(mvcc.range_key_count || 0),
+      ),
+      mvccRangeValueBytesCount: contentMVCC(
+        FixLong(mvcc.range_val_bytes || 0),
+        FixLong(mvcc.range_val_count || 0),
+      ),
+      mvccIntentBytesCount: contentMVCC(
+        FixLong(mvcc.intent_bytes),
+        FixLong(mvcc.intent_count),
+      ),
+      mvccSystemBytesCount: contentMVCC(
+        FixLong(mvcc.sys_bytes),
+        FixLong(mvcc.sys_count),
+      ),
+      rangeMaxBytes: contentBytes(FixLong(info.state.range_max_bytes)),
+      mvccIntentAge: contentDuration(FixLong(mvcc.lock_age)),
 
-    return (
-      <div>
-        <h2 className="base-heading">
-          Range r{rangeID.toString()} at {Print.Time(moment().utc())} UTC
-        </h2>
-        <table className="range-table">
-          <tbody>
-            {map(rangeTableDisplayList, (title, key) =>
-              renderRangeRow(
-                title,
-                detailsByStoreID,
-                dormantStoreIDs,
-                leader.source_store_id,
-                sortedStoreIDs,
-                key,
-              ),
-            )}
-            {map(replicas, (replica, key) =>
-              renderRangeReplicaRow(
-                replicasByReplicaIDByStoreID,
-                replica,
-                leaderReplicaIDs,
-                dormantStoreIDs,
-                sortedStoreIDs,
-                rangeID,
-                "replica" + key,
-              ),
-            )}
-          </tbody>
-        </table>
-      </div>
-    );
-  }
+      gcAvgAge: contentGCAvgAge(mvcc),
+      gcBytesAge: createContent(FixLong(mvcc.gc_bytes_age)),
+
+      numIntents: createContent(FixLong(mvcc.intent_count)),
+      intentAvgAge: createContentIntentAvgAge(mvcc),
+      intentAge: createContent(FixLong(mvcc.lock_age)),
+
+      readLatches: createContent(FixLong(info.read_latches)),
+      writeLatches: createContent(FixLong(info.write_latches)),
+      locks: createContent(FixLong(info.locks)),
+      locksWithWaitQueues: createContent(FixLong(info.locks_with_wait_queues)),
+      lockWaitQueueWaiters: createContent(
+        FixLong(info.lock_wait_queue_waiters),
+      ),
+      top_k_locks_by_wait_queue_waiters: contentIf(
+        size(info.top_k_locks_by_wait_queue_waiters) > 0,
+        () => ({
+          value: map(
+            info.top_k_locks_by_wait_queue_waiters,
+            lock => `${lock.pretty_key} (${lock.waiters} waiters)`,
+          ),
+        }),
+      ),
+
+      closedTimestampPolicy: createContent(
+        // We index into the enum in order to get the label string, instead of
+        // the numeric value.
+        cockroach.roachpb.RangeClosedTimestampPolicy[
+          info.state.closed_timestamp_policy
+        ],
+        info.state.closed_timestamp_policy ===
+          cockroach.roachpb.RangeClosedTimestampPolicy.LEAD_FOR_GLOBAL_READS
+          ? "range-table__cell--global-range"
+          : "",
+      ),
+      closedTimestampRaft: contentTimestamp(
+        info.state.state.raft_closed_timestamp,
+        now,
+      ),
+      closedTimestampSideTransportReplica: contentTimestamp(
+        info.state.closed_timestamp_sidetransport_info.replica_closed,
+        now,
+      ),
+      closedTimestampSideTransportReplicaLAI: createContent(
+        FixLong(info.state.closed_timestamp_sidetransport_info.replica_lai),
+        // Warn if the LAI hasn't applied yet.
+        FixLong(info.state.state.lease_applied_index) <
+          FixLong(info.state.closed_timestamp_sidetransport_info.replica_lai)
+          ? "range-table__cell--warning"
+          : "",
+      ),
+      closedTimestampSideTransportCentral: contentTimestamp(
+        info.state.closed_timestamp_sidetransport_info.central_closed,
+        now,
+      ),
+      closedTimestampSideTransportCentralLAI: createContent(
+        FixLong(info.state.closed_timestamp_sidetransport_info.central_lai),
+        // Warn if the LAI hasn't applied yet.
+        FixLong(info.state.state.lease_applied_index) <
+          FixLong(info.state.closed_timestamp_sidetransport_info.central_lai)
+          ? "range-table__cell--warning"
+          : "",
+      ),
+      circuitBreakerError: createContent(info.state.circuit_breaker_error),
+      locality: contentIf(size(info.locality.tiers) > 0, () => ({
+        value: map(info.locality.tiers, tier => `${tier.key}: ${tier.value}`),
+      })),
+      pausedFollowers: createContent(info.state.paused_replicas?.join(", ")),
+    });
+  });
+
+  const leaderReplicaIDs = new Set(
+    map(leader.state.state.desc.internal_replicas, rep => rep.replica_id),
+  );
+
+  // Go through all the replicas and add them to map for easy printing.
+  const replicasByReplicaIDByStoreID: Map<
+    number,
+    Map<number, protos.cockroach.roachpb.IReplicaDescriptor>
+  > = new Map();
+  forEach(infos, info => {
+    const replicasByReplicaID: Map<
+      number,
+      protos.cockroach.roachpb.IReplicaDescriptor
+    > = new Map();
+    forEach(info.state.state.desc.internal_replicas, rep => {
+      replicasByReplicaID.set(rep.replica_id, rep);
+    });
+    replicasByReplicaIDByStoreID.set(info.source_store_id, replicasByReplicaID);
+  });
+
+  return (
+    <div>
+      <h2 className="base-heading">
+        Range r{rangeID.toString()} at {Print.Time(moment().utc())} UTC
+      </h2>
+      <table className="range-table">
+        <tbody>
+          {map(rangeTableDisplayList, (title, key) =>
+            renderRangeRow(
+              title,
+              detailsByStoreID,
+              dormantStoreIDs,
+              leader.source_store_id,
+              sortedStoreIDs,
+              key,
+            ),
+          )}
+          {map(replicas, (replica, key) =>
+            renderRangeReplicaRow(
+              replicasByReplicaIDByStoreID,
+              replica,
+              leaderReplicaIDs,
+              dormantStoreIDs,
+              sortedStoreIDs,
+              rangeID,
+              "replica" + key,
+            ),
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
 }

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/range/rangeTable.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/range/rangeTable.tsx
@@ -317,363 +317,363 @@ function convertLeaseState(
   ].toLowerCase();
 }
 
-export default class RangeTable extends React.Component<RangeTableProps, {}> {
-  cleanRaftState(state: string) {
-    switch (toLower(state)) {
-      case "statedormant":
-        return "dormant";
-      case "stateleader":
-        return "leader";
-      case "statefollower":
-        return "follower";
-      case "statecandidate":
-        return "candidate";
-      case "stateprecandidate":
-        return "precandidate";
-      default:
-        return "unknown";
-    }
+function cleanRaftState(state: string) {
+  switch (toLower(state)) {
+    case "statedormant":
+      return "dormant";
+    case "stateleader":
+      return "leader";
+    case "statefollower":
+      return "follower";
+    case "statecandidate":
+      return "candidate";
+    case "stateprecandidate":
+      return "precandidate";
+    default:
+      return "unknown";
   }
+}
 
-  contentRaftState(state: string): RangeTableCellContent {
-    const cleanedState = this.cleanRaftState(state);
-    return {
-      value: [cleanedState],
-      className: [`range-table__cell--raftstate-${cleanedState}`],
-    };
-  }
+function contentRaftState(state: string): RangeTableCellContent {
+  const cleanedState = cleanRaftState(state);
+  return {
+    value: [cleanedState],
+    className: [`range-table__cell--raftstate-${cleanedState}`],
+  };
+}
 
-  contentNanos(nanos: Long): RangeTableCellContent {
-    const humanized = Print.Time(util.LongToMoment(nanos));
+function contentNanos(nanos: Long): RangeTableCellContent {
+  const humanized = Print.Time(util.LongToMoment(nanos));
+  return {
+    value: [humanized],
+    title: [humanized, nanos.toString()],
+  };
+}
+
+function contentDuration(nanos: Long): RangeTableCellContent {
+  const humanized = Print.Duration(
+    moment.duration(util.NanoToMilli(nanos.toNumber())),
+  );
+  return {
+    value: [humanized],
+    title: [humanized, nanos.toString()],
+  };
+}
+
+function contentMVCC(bytes: Long, count: Long): RangeTableCellContent {
+  const humanizedBytes = util.Bytes(bytes.toNumber());
+  return {
+    value: [`${humanizedBytes} / ${count.toString()} count`],
+    title: [
+      `${humanizedBytes} / ${count.toString()} count`,
+      `${bytes.toString()} bytes / ${count.toString()} count`,
+    ],
+  };
+}
+
+function contentBytes(
+  bytes: Long,
+  className: string = null,
+  toolTip: string = null,
+): RangeTableCellContent {
+  const humanized = util.Bytes(bytes.toNumber());
+  if (isNull(className)) {
     return {
       value: [humanized],
-      title: [humanized, nanos.toString()],
+      title: [humanized, bytes.toString()],
     };
   }
+  return {
+    value: [humanized],
+    title: [humanized, bytes.toString(), toolTip],
+    className: [className],
+  };
+}
 
-  contentDuration(nanos: Long): RangeTableCellContent {
-    const humanized = Print.Duration(
-      moment.duration(util.NanoToMilli(nanos.toNumber())),
+function contentGCAvgAge(
+  mvcc: cockroach.storage.enginepb.IMVCCStats,
+): RangeTableCellContent {
+  if (mvcc === null) {
+    return contentDuration(Long.fromNumber(0));
+  }
+  const deadBytes = mvcc.key_bytes.add(mvcc.val_bytes).sub(mvcc.live_bytes);
+  if (!deadBytes.eq(0)) {
+    const avgDeadByteAgeSec = mvcc.gc_bytes_age.div(deadBytes);
+    return contentDuration(
+      Long.fromNumber(util.SecondsToNano(avgDeadByteAgeSec.toNumber())),
     );
-    return {
-      value: [humanized],
-      title: [humanized, nanos.toString()],
-    };
+  } else {
+    return contentDuration(Long.fromNumber(0));
   }
+}
 
-  contentMVCC(bytes: Long, count: Long): RangeTableCellContent {
-    const humanizedBytes = util.Bytes(bytes.toNumber());
-    return {
-      value: [`${humanizedBytes} / ${count.toString()} count`],
-      title: [
-        `${humanizedBytes} / ${count.toString()} count`,
-        `${bytes.toString()} bytes / ${count.toString()} count`,
-      ],
-    };
+function createContentIntentAvgAge(
+  mvcc: cockroach.storage.enginepb.IMVCCStats,
+): RangeTableCellContent {
+  if (mvcc === null) {
+    return contentDuration(Long.fromNumber(0));
   }
-
-  contentBytes(
-    bytes: Long,
-    className: string = null,
-    toolTip: string = null,
-  ): RangeTableCellContent {
-    const humanized = util.Bytes(bytes.toNumber());
-    if (isNull(className)) {
-      return {
-        value: [humanized],
-        title: [humanized, bytes.toString()],
-      };
-    }
-    return {
-      value: [humanized],
-      title: [humanized, bytes.toString(), toolTip],
-      className: [className],
-    };
+  if (!mvcc.intent_count.eq(0)) {
+    const avgIntentAgeSec = mvcc.lock_age.div(mvcc.intent_count);
+    return contentDuration(
+      Long.fromNumber(util.SecondsToNano(avgIntentAgeSec.toNumber())),
+    );
+  } else {
+    return contentDuration(Long.fromNumber(0));
   }
+}
 
-  contentGCAvgAge(
-    mvcc: cockroach.storage.enginepb.IMVCCStats,
-  ): RangeTableCellContent {
-    if (mvcc === null) {
-      return this.contentDuration(Long.fromNumber(0));
-    }
-    const deadBytes = mvcc.key_bytes.add(mvcc.val_bytes).sub(mvcc.live_bytes);
-    if (!deadBytes.eq(0)) {
-      const avgDeadByteAgeSec = mvcc.gc_bytes_age.div(deadBytes);
-      return this.contentDuration(
-        Long.fromNumber(util.SecondsToNano(avgDeadByteAgeSec.toNumber())),
-      );
-    } else {
-      return this.contentDuration(Long.fromNumber(0));
-    }
-  }
-
-  createContentIntentAvgAge(
-    mvcc: cockroach.storage.enginepb.IMVCCStats,
-  ): RangeTableCellContent {
-    if (mvcc === null) {
-      return this.contentDuration(Long.fromNumber(0));
-    }
-    if (!mvcc.intent_count.eq(0)) {
-      const avgIntentAgeSec = mvcc.lock_age.div(mvcc.intent_count);
-      return this.contentDuration(
-        Long.fromNumber(util.SecondsToNano(avgIntentAgeSec.toNumber())),
-      );
-    } else {
-      return this.contentDuration(Long.fromNumber(0));
-    }
-  }
-
-  createContent(
-    value: string | Long | number,
-    className: string = null,
-  ): RangeTableCellContent {
-    if (isNull(className)) {
-      return {
-        value: [value.toString()],
-      };
-    }
+function createContent(
+  value: string | Long | number,
+  className: string = null,
+): RangeTableCellContent {
+  if (isNull(className)) {
     return {
       value: [value.toString()],
-      className: [className],
     };
   }
+  return {
+    value: [value.toString()],
+    className: [className],
+  };
+}
 
-  contentTimestamp(
-    timestamp: protos.cockroach.util.hlc.ITimestamp,
-    now: moment.Moment,
-  ): RangeTableCellContent {
-    if (isNil(timestamp) || isNil(timestamp.wall_time)) {
-      return {
-        value: ["no timestamp"],
-        className: ["range-table__cell--warning"],
-      };
-    }
-    if (FixLong(timestamp.wall_time).isZero()) {
-      return {
-        value: [""],
-        title: ["0"],
-      };
-    }
-    const humanized = Print.Timestamp(timestamp);
-    const delta = Print.TimestampDeltaFromNow(timestamp, now);
+function contentTimestamp(
+  timestamp: protos.cockroach.util.hlc.ITimestamp,
+  now: moment.Moment,
+): RangeTableCellContent {
+  if (isNil(timestamp) || isNil(timestamp.wall_time)) {
     return {
-      value: [humanized, delta],
-      title: [humanized, FixLong(timestamp.wall_time).toString()],
+      value: ["no timestamp"],
+      className: ["range-table__cell--warning"],
     };
   }
-
-  contentProblems(
-    problems: protos.cockroach.server.serverpb.IRangeProblems,
-    awaitingGC: boolean,
-  ): RangeTableCellContent {
-    let results: string[] = [];
-    if (problems.no_lease) {
-      results = concat(results, "Invalid Lease");
-    }
-    if (problems.leader_not_lease_holder) {
-      results = concat(results, "Leader is Not Lease holder");
-    }
-    if (problems.underreplicated) {
-      results = concat(results, "Underreplicated (or slow)");
-    }
-    if (problems.overreplicated) {
-      results = concat(results, "Overreplicated");
-    }
-    if (problems.no_raft_leader) {
-      results = concat(results, "No Raft Leader");
-    }
-    if (problems.unavailable) {
-      results = concat(results, "Unavailable");
-    }
-    if (problems.quiescent_equals_ticking) {
-      results = concat(results, "Quiescent equals ticking");
-    }
-    if (problems.raft_log_too_large) {
-      results = concat(results, "Raft log too large");
-    }
-    if (problems.range_too_large) {
-      results = concat(results, "Range too large");
-    }
-    if (awaitingGC) {
-      results = concat(results, "Awaiting GC");
-    }
+  if (FixLong(timestamp.wall_time).isZero()) {
     return {
-      value: results,
-      title: results,
-      className: results.length > 0 ? ["range-table__cell--warning"] : [],
+      value: [""],
+      title: ["0"],
     };
   }
+  const humanized = Print.Timestamp(timestamp);
+  const delta = Print.TimestampDeltaFromNow(timestamp, now);
+  return {
+    value: [humanized, delta],
+    title: [humanized, FixLong(timestamp.wall_time).toString()],
+  };
+}
 
-  // contentIf returns an empty value if the condition is false, and if true,
-  // executes and returns the content function.
-  contentIf(
-    showContent: boolean,
-    content: () => RangeTableCellContent,
-  ): RangeTableCellContent {
-    if (!showContent) {
-      return rangeTableEmptyContent;
-    }
-    return content();
+function contentProblems(
+  problems: protos.cockroach.server.serverpb.IRangeProblems,
+  awaitingGC: boolean,
+): RangeTableCellContent {
+  let results: string[] = [];
+  if (problems.no_lease) {
+    results = concat(results, "Invalid Lease");
   }
-
-  renderRangeCell(
-    row: RangeTableRow,
-    cell: RangeTableCellContent,
-    key: number,
-    dormant: boolean,
-    leaderCell?: RangeTableCellContent,
-  ) {
-    const title = join(isNil(cell.title) ? cell.value : cell.title, "\n");
-    const differentFromLeader =
-      !dormant &&
-      !isNil(leaderCell) &&
-      row.compareToLeader &&
-      (!isEqual(cell.value, leaderCell.value) ||
-        !isEqual(cell.title, leaderCell.title));
-    const className = classNames(
-      "range-table__cell",
-      {
-        "range-table__cell--dormant": dormant,
-        "range-table__cell--different-from-leader-warning": differentFromLeader,
-      },
-      !dormant && !isNil(cell.className) ? cell.className : [],
-    );
-    return (
-      <td key={key} className={className} title={title}>
-        <ul className="range-entries-list">
-          {map(cell.value, (value, k) => (
-            <li key={k}>{value}</li>
-          ))}
-        </ul>
-      </td>
-    );
+  if (problems.leader_not_lease_holder) {
+    results = concat(results, "Leader is Not Lease holder");
   }
-
-  renderRangeRow(
-    row: RangeTableRow,
-    detailsByStoreID: Map<number, RangeTableDetail>,
-    dormantStoreIDs: Set<number>,
-    leaderStoreID: number,
-    sortedStoreIDs: number[],
-    key: number,
-  ) {
-    const leaderDetail = detailsByStoreID.get(leaderStoreID);
-    const values: Set<string> = new Set();
-    if (row.compareToLeader) {
-      detailsByStoreID.forEach((detail, storeID) => {
-        if (!dormantStoreIDs.has(storeID)) {
-          values.add(join(detail[row.variable].value, " "));
-        }
-      });
-    }
-    const headerClassName = classNames(
-      "range-table__cell",
-      "range-table__cell--header",
-      { "range-table__cell--header-warning": values.size > 1 },
-    );
-    return (
-      <tr key={key} className="range-table__row">
-        <th className={headerClassName}>{row.display}</th>
-        {map(sortedStoreIDs, storeID => {
-          const cell = detailsByStoreID.get(storeID)[row.variable];
-          const leaderCell =
-            storeID === leaderStoreID ? null : leaderDetail[row.variable];
-          return this.renderRangeCell(
-            row,
-            cell,
-            storeID,
-            dormantStoreIDs.has(storeID),
-            leaderCell,
-          );
-        })}
-      </tr>
-    );
+  if (problems.underreplicated) {
+    results = concat(results, "Underreplicated (or slow)");
   }
+  if (problems.overreplicated) {
+    results = concat(results, "Overreplicated");
+  }
+  if (problems.no_raft_leader) {
+    results = concat(results, "No Raft Leader");
+  }
+  if (problems.unavailable) {
+    results = concat(results, "Unavailable");
+  }
+  if (problems.quiescent_equals_ticking) {
+    results = concat(results, "Quiescent equals ticking");
+  }
+  if (problems.raft_log_too_large) {
+    results = concat(results, "Raft log too large");
+  }
+  if (problems.range_too_large) {
+    results = concat(results, "Range too large");
+  }
+  if (awaitingGC) {
+    results = concat(results, "Awaiting GC");
+  }
+  return {
+    value: results,
+    title: results,
+    className: results.length > 0 ? ["range-table__cell--warning"] : [],
+  };
+}
 
-  renderRangeReplicaCell(
-    leaderReplicaIDs: Set<number>,
-    replicaID: number,
-    replica: protos.cockroach.roachpb.IReplicaDescriptor,
-    rangeID: Long,
-    localStoreID: number,
-    dormant: boolean,
-  ) {
-    const differentFromLeader =
-      !dormant &&
-      (isNil(replica)
-        ? leaderReplicaIDs.has(replicaID)
-        : !leaderReplicaIDs.has(replica.replica_id));
-    const localReplica =
-      !dormant &&
-      !differentFromLeader &&
-      replica &&
-      replica.store_id === localStoreID;
-    const className = classNames({
-      "range-table__cell": true,
+// contentIf returns an empty value if the condition is false, and if true,
+// executes and returns the content function.
+function contentIf(
+  showContent: boolean,
+  content: () => RangeTableCellContent,
+): RangeTableCellContent {
+  if (!showContent) {
+    return rangeTableEmptyContent;
+  }
+  return content();
+}
+
+function renderRangeCell(
+  row: RangeTableRow,
+  cell: RangeTableCellContent,
+  key: number,
+  dormant: boolean,
+  leaderCell?: RangeTableCellContent,
+) {
+  const title = join(isNil(cell.title) ? cell.value : cell.title, "\n");
+  const differentFromLeader =
+    !dormant &&
+    !isNil(leaderCell) &&
+    row.compareToLeader &&
+    (!isEqual(cell.value, leaderCell.value) ||
+      !isEqual(cell.title, leaderCell.title));
+  const className = classNames(
+    "range-table__cell",
+    {
       "range-table__cell--dormant": dormant,
       "range-table__cell--different-from-leader-warning": differentFromLeader,
-      "range-table__cell--local-replica": localReplica,
+    },
+    !dormant && !isNil(cell.className) ? cell.className : [],
+  );
+  return (
+    <td key={key} className={className} title={title}>
+      <ul className="range-entries-list">
+        {map(cell.value, (value, k) => (
+          <li key={k}>{value}</li>
+        ))}
+      </ul>
+    </td>
+  );
+}
+
+function renderRangeRow(
+  row: RangeTableRow,
+  detailsByStoreID: Map<number, RangeTableDetail>,
+  dormantStoreIDs: Set<number>,
+  leaderStoreID: number,
+  sortedStoreIDs: number[],
+  key: number,
+) {
+  const leaderDetail = detailsByStoreID.get(leaderStoreID);
+  const values: Set<string> = new Set();
+  if (row.compareToLeader) {
+    detailsByStoreID.forEach((detail, storeID) => {
+      if (!dormantStoreIDs.has(storeID)) {
+        values.add(join(detail[row.variable].value, " "));
+      }
     });
-    if (isNil(replica)) {
-      return (
-        <td key={localStoreID} className={className}>
-          -
-        </td>
-      );
-    }
-    const value = Print.ReplicaID(rangeID, replica);
+  }
+  const headerClassName = classNames(
+    "range-table__cell",
+    "range-table__cell--header",
+    { "range-table__cell--header-warning": values.size > 1 },
+  );
+  return (
+    <tr key={key} className="range-table__row">
+      <th className={headerClassName}>{row.display}</th>
+      {map(sortedStoreIDs, storeID => {
+        const cell = detailsByStoreID.get(storeID)[row.variable];
+        const leaderCell =
+          storeID === leaderStoreID ? null : leaderDetail[row.variable];
+        return renderRangeCell(
+          row,
+          cell,
+          storeID,
+          dormantStoreIDs.has(storeID),
+          leaderCell,
+        );
+      })}
+    </tr>
+  );
+}
+
+function renderRangeReplicaCell(
+  leaderReplicaIDs: Set<number>,
+  replicaID: number,
+  replica: protos.cockroach.roachpb.IReplicaDescriptor,
+  rangeID: Long,
+  localStoreID: number,
+  dormant: boolean,
+) {
+  const differentFromLeader =
+    !dormant &&
+    (isNil(replica)
+      ? leaderReplicaIDs.has(replicaID)
+      : !leaderReplicaIDs.has(replica.replica_id));
+  const localReplica =
+    !dormant &&
+    !differentFromLeader &&
+    replica &&
+    replica.store_id === localStoreID;
+  const className = classNames({
+    "range-table__cell": true,
+    "range-table__cell--dormant": dormant,
+    "range-table__cell--different-from-leader-warning": differentFromLeader,
+    "range-table__cell--local-replica": localReplica,
+  });
+  if (isNil(replica)) {
     return (
-      <td key={localStoreID} className={className} title={value}>
-        {value}
+      <td key={localStoreID} className={className}>
+        -
       </td>
     );
   }
+  const value = Print.ReplicaID(rangeID, replica);
+  return (
+    <td key={localStoreID} className={className} title={value}>
+      {value}
+    </td>
+  );
+}
 
-  renderRangeReplicaRow(
-    replicasByReplicaIDByStoreID: Map<
-      number,
-      Map<number, protos.cockroach.roachpb.IReplicaDescriptor>
-    >,
-    referenceReplica: protos.cockroach.roachpb.IReplicaDescriptor,
-    leaderReplicaIDs: Set<number>,
-    dormantStoreIDs: Set<number>,
-    sortedStoreIDs: number[],
-    rangeID: Long,
-    key: string,
-  ) {
-    const headerClassName = "range-table__cell range-table__cell--header";
-    return (
-      <tr key={key} className="range-table__row">
-        <th className={headerClassName}>
-          Replica {referenceReplica.replica_id} - (
-          {Print.ReplicaID(rangeID, referenceReplica)})
-        </th>
-        {map(sortedStoreIDs, storeID => {
-          let replica: protos.cockroach.roachpb.IReplicaDescriptor = null;
-          if (
-            replicasByReplicaIDByStoreID.has(storeID) &&
-            replicasByReplicaIDByStoreID
-              .get(storeID)
-              .has(referenceReplica.replica_id)
-          ) {
-            replica = replicasByReplicaIDByStoreID
-              .get(storeID)
-              .get(referenceReplica.replica_id);
-          }
-          return this.renderRangeReplicaCell(
-            leaderReplicaIDs,
-            referenceReplica.replica_id,
-            replica,
-            rangeID,
-            storeID,
-            dormantStoreIDs.has(storeID),
-          );
-        })}
-      </tr>
-    );
-  }
+function renderRangeReplicaRow(
+  replicasByReplicaIDByStoreID: Map<
+    number,
+    Map<number, protos.cockroach.roachpb.IReplicaDescriptor>
+  >,
+  referenceReplica: protos.cockroach.roachpb.IReplicaDescriptor,
+  leaderReplicaIDs: Set<number>,
+  dormantStoreIDs: Set<number>,
+  sortedStoreIDs: number[],
+  rangeID: Long,
+  key: string,
+) {
+  const headerClassName = "range-table__cell range-table__cell--header";
+  return (
+    <tr key={key} className="range-table__row">
+      <th className={headerClassName}>
+        Replica {referenceReplica.replica_id} - (
+        {Print.ReplicaID(rangeID, referenceReplica)})
+      </th>
+      {map(sortedStoreIDs, storeID => {
+        let replica: protos.cockroach.roachpb.IReplicaDescriptor = null;
+        if (
+          replicasByReplicaIDByStoreID.has(storeID) &&
+          replicasByReplicaIDByStoreID
+            .get(storeID)
+            .has(referenceReplica.replica_id)
+        ) {
+          replica = replicasByReplicaIDByStoreID
+            .get(storeID)
+            .get(referenceReplica.replica_id);
+        }
+        return renderRangeReplicaCell(
+          leaderReplicaIDs,
+          referenceReplica.replica_id,
+          replica,
+          rangeID,
+          storeID,
+          dormantStoreIDs.has(storeID),
+        );
+      })}
+    </tr>
+  );
+}
 
+export default class RangeTable extends React.Component<RangeTableProps, {}> {
   render() {
     const { infos, replicas } = this.props;
     const leader = head(infos);
@@ -705,13 +705,13 @@ export default class RangeTable extends React.Component<RangeTableProps, {}> {
       const leaseHolder =
         !awaitingGC && localReplica.replica_id === lease.replica.replica_id;
       const mvcc = info.state.state.stats;
-      const raftState = this.contentRaftState(info.raft_state.state);
+      const raftState = contentRaftState(info.raft_state.state);
       const vote = FixLong(info.raft_state.hard_state.vote);
       let leaseState: RangeTableCellContent;
       if (isNil(info.lease_status)) {
         leaseState = rangeTableEmptyContentWithWarning;
       } else {
-        leaseState = this.createContent(
+        leaseState = createContent(
           convertLeaseState(info.lease_status.state),
           info.lease_status.state ===
             protos.cockroach.kv.kvserver.storagepb.LeaseState.VALID
@@ -724,7 +724,7 @@ export default class RangeTable extends React.Component<RangeTableProps, {}> {
         dormantStoreIDs.add(info.source_store_id);
       }
       detailsByStoreID.set(info.source_store_id, {
-        id: this.createContent(
+        id: createContent(
           Print.ReplicaID(
             rangeID,
             localReplica,
@@ -732,78 +732,78 @@ export default class RangeTable extends React.Component<RangeTableProps, {}> {
             info.source_store_id,
           ),
         ),
-        keyRange: this.createContent(
+        keyRange: createContent(
           `${info.span.start_key} to ${info.span.end_key}`,
         ),
-        problems: this.contentProblems(info.problems, awaitingGC),
+        problems: contentProblems(info.problems, awaitingGC),
         replicaType: awaitingGC
-          ? this.createContent("") // `problems` above will report "Awaiting GC" in this case
-          : this.createContent(contentReplicaType(localReplica.type)),
+          ? createContent("") // `problems` above will report "Awaiting GC" in this case
+          : createContent(contentReplicaType(localReplica.type)),
         raftState: raftState,
-        leadSupportUntil: this.contentTimestamp(
+        leadSupportUntil: contentTimestamp(
           info.raft_state.lead_support_until,
           now,
         ),
         quiescent: info.quiescent
           ? rangeTableQuiescent
           : rangeTableEmptyContent,
-        ticking: this.createContent(info.ticking.toString()),
+        ticking: createContent(info.ticking.toString()),
         leaseState: leaseState,
-        leaseHolder: this.createContent(
+        leaseHolder: createContent(
           Print.ReplicaID(rangeID, lease.replica),
           leaseHolder
             ? "range-table__cell--lease-holder"
             : "range-table__cell--lease-follower",
         ),
-        leaseType: this.createContent(
+        leaseType: createContent(
           leaseEpoch ? "epoch" : leaseLeader ? "leader" : "expiration",
         ),
         leaseEpoch: leaseEpoch
-          ? this.createContent(lease.epoch)
+          ? createContent(lease.epoch)
           : rangeTableEmptyContent,
         leaseTerm: leaseLeader
-          ? this.createContent(lease.term)
+          ? createContent(lease.term)
           : rangeTableEmptyContent,
-        isLeaseholder: this.createContent(String(info.is_leaseholder)),
-        leaseValid: this.createContent(String(info.lease_valid)),
-        leaseStart: this.contentTimestamp(lease.start, now),
+        isLeaseholder: createContent(String(info.is_leaseholder)),
+        leaseValid: createContent(String(info.lease_valid)),
+        leaseStart: contentTimestamp(lease.start, now),
         leaseExpiration: leaseExpiration
-          ? this.contentTimestamp(lease.expiration, now)
+          ? contentTimestamp(lease.expiration, now)
           : rangeTableEmptyContent,
         leaseMinExpiration: !leaseExpiration
-          ? this.contentTimestamp(lease.min_expiration, now)
+          ? contentTimestamp(lease.min_expiration, now)
           : rangeTableEmptyContent,
-        leaseAppliedIndex: this.createContent(
+        leaseAppliedIndex: createContent(
           FixLong(info.state.state.lease_applied_index),
         ),
-        raftLeader: this.contentIf(!dormant, () =>
-          this.createContent(
+        raftLeader: contentIf(!dormant, () =>
+          createContent(
             FixLong(info.raft_state.lead),
             raftLeader
               ? "range-table__cell--raftstate-leader"
               : "range-table__cell--raftstate-follower",
           ),
         ),
-        vote: this.contentIf(!dormant, () =>
-          this.createContent(vote.greaterThan(0) ? vote : "-"),
+        vote: contentIf(!dormant, () =>
+          createContent(vote.greaterThan(0) ? vote : "-"),
         ),
-        term: this.contentIf(!dormant, () =>
-          this.createContent(FixLong(info.raft_state.hard_state.term)),
+        term: contentIf(!dormant, () =>
+          createContent(FixLong(info.raft_state.hard_state.term)),
         ),
-        leadTransferee: this.contentIf(!dormant, () => {
+        leadTransferee: contentIf(!dormant, () => {
           const leadTransferee = FixLong(info.raft_state.lead_transferee);
-          return this.createContent(
+          return createContent(
             leadTransferee.greaterThan(0) ? leadTransferee : "-",
           );
         }),
-        applied: this.contentIf(!dormant, () =>
-          this.createContent(FixLong(info.raft_state.applied)),
+        applied: contentIf(!dormant, () =>
+          createContent(FixLong(info.raft_state.applied)),
         ),
-        commit: this.contentIf(!dormant, () =>
-          this.createContent(FixLong(info.raft_state.hard_state.commit)),
+        commit: contentIf(!dormant, () =>
+          createContent(FixLong(info.raft_state.hard_state.commit)),
         ),
-        lastIndex: this.createContent(FixLong(info.state.last_index)),
-        logSize: this.contentBytes(
+        lastIndex: createContent(FixLong(info.state.last_index)),
+        logSize: contentBytes(
           FixLong(info.state.raft_log_size),
           info.state.raft_log_size_trusted ? "" : "range-table__cell--dormant",
           "Log size is known to not be correct. This isn't an error condition. " +
@@ -812,76 +812,76 @@ export default class RangeTable extends React.Component<RangeTableProps, {}> {
             "be truncated sufficiently).",
         ),
         leaseHolderQPS: leaseHolder
-          ? this.createContent(info.stats.queries_per_second.toFixed(4))
+          ? createContent(info.stats.queries_per_second.toFixed(4))
           : rangeTableEmptyContent,
-        keysWrittenPS: this.createContent(
+        keysWrittenPS: createContent(
           info.stats.writes_per_second.toFixed(4),
         ),
         approxProposalQuota: raftLeader
-          ? this.createContent(FixLong(info.state.approximate_proposal_quota))
+          ? createContent(FixLong(info.state.approximate_proposal_quota))
           : rangeTableEmptyContent,
-        pendingCommands: this.createContent(FixLong(info.state.num_pending)),
-        droppedCommands: this.createContent(
+        pendingCommands: createContent(FixLong(info.state.num_pending)),
+        droppedCommands: createContent(
           FixLong(info.state.num_dropped),
           FixLong(info.state.num_dropped).greaterThan(0)
             ? "range-table__cell--warning"
             : "",
         ),
-        truncatedIndex: this.createContent(
+        truncatedIndex: createContent(
           FixLong(info.state.state.truncated_state.index),
         ),
-        truncatedTerm: this.createContent(
+        truncatedTerm: createContent(
           FixLong(info.state.state.truncated_state.term),
         ),
-        mvccLastUpdate: this.contentNanos(FixLong(mvcc.last_update_nanos)),
-        mvccLiveBytesCount: this.contentMVCC(
+        mvccLastUpdate: contentNanos(FixLong(mvcc.last_update_nanos)),
+        mvccLiveBytesCount: contentMVCC(
           FixLong(mvcc.live_bytes),
           FixLong(mvcc.live_count),
         ),
-        mvccKeyBytesCount: this.contentMVCC(
+        mvccKeyBytesCount: contentMVCC(
           FixLong(mvcc.key_bytes),
           FixLong(mvcc.key_count),
         ),
-        mvccValueBytesCount: this.contentMVCC(
+        mvccValueBytesCount: contentMVCC(
           FixLong(mvcc.val_bytes),
           FixLong(mvcc.val_count),
         ),
-        mvccRangeKeyBytesCount: this.contentMVCC(
+        mvccRangeKeyBytesCount: contentMVCC(
           FixLong(mvcc.range_key_bytes || 0),
           FixLong(mvcc.range_key_count || 0),
         ),
-        mvccRangeValueBytesCount: this.contentMVCC(
+        mvccRangeValueBytesCount: contentMVCC(
           FixLong(mvcc.range_val_bytes || 0),
           FixLong(mvcc.range_val_count || 0),
         ),
-        mvccIntentBytesCount: this.contentMVCC(
+        mvccIntentBytesCount: contentMVCC(
           FixLong(mvcc.intent_bytes),
           FixLong(mvcc.intent_count),
         ),
-        mvccSystemBytesCount: this.contentMVCC(
+        mvccSystemBytesCount: contentMVCC(
           FixLong(mvcc.sys_bytes),
           FixLong(mvcc.sys_count),
         ),
-        rangeMaxBytes: this.contentBytes(FixLong(info.state.range_max_bytes)),
-        mvccIntentAge: this.contentDuration(FixLong(mvcc.lock_age)),
+        rangeMaxBytes: contentBytes(FixLong(info.state.range_max_bytes)),
+        mvccIntentAge: contentDuration(FixLong(mvcc.lock_age)),
 
-        gcAvgAge: this.contentGCAvgAge(mvcc),
-        gcBytesAge: this.createContent(FixLong(mvcc.gc_bytes_age)),
+        gcAvgAge: contentGCAvgAge(mvcc),
+        gcBytesAge: createContent(FixLong(mvcc.gc_bytes_age)),
 
-        numIntents: this.createContent(FixLong(mvcc.intent_count)),
-        intentAvgAge: this.createContentIntentAvgAge(mvcc),
-        intentAge: this.createContent(FixLong(mvcc.lock_age)),
+        numIntents: createContent(FixLong(mvcc.intent_count)),
+        intentAvgAge: createContentIntentAvgAge(mvcc),
+        intentAge: createContent(FixLong(mvcc.lock_age)),
 
-        readLatches: this.createContent(FixLong(info.read_latches)),
-        writeLatches: this.createContent(FixLong(info.write_latches)),
-        locks: this.createContent(FixLong(info.locks)),
-        locksWithWaitQueues: this.createContent(
+        readLatches: createContent(FixLong(info.read_latches)),
+        writeLatches: createContent(FixLong(info.write_latches)),
+        locks: createContent(FixLong(info.locks)),
+        locksWithWaitQueues: createContent(
           FixLong(info.locks_with_wait_queues),
         ),
-        lockWaitQueueWaiters: this.createContent(
+        lockWaitQueueWaiters: createContent(
           FixLong(info.lock_wait_queue_waiters),
         ),
-        top_k_locks_by_wait_queue_waiters: this.contentIf(
+        top_k_locks_by_wait_queue_waiters: contentIf(
           size(info.top_k_locks_by_wait_queue_waiters) > 0,
           () => ({
             value: map(
@@ -891,7 +891,7 @@ export default class RangeTable extends React.Component<RangeTableProps, {}> {
           }),
         ),
 
-        closedTimestampPolicy: this.createContent(
+        closedTimestampPolicy: createContent(
           // We index into the enum in order to get the label string, instead of
           // the numeric value.
           cockroach.roachpb.RangeClosedTimestampPolicy[
@@ -902,15 +902,15 @@ export default class RangeTable extends React.Component<RangeTableProps, {}> {
             ? "range-table__cell--global-range"
             : "",
         ),
-        closedTimestampRaft: this.contentTimestamp(
+        closedTimestampRaft: contentTimestamp(
           info.state.state.raft_closed_timestamp,
           now,
         ),
-        closedTimestampSideTransportReplica: this.contentTimestamp(
+        closedTimestampSideTransportReplica: contentTimestamp(
           info.state.closed_timestamp_sidetransport_info.replica_closed,
           now,
         ),
-        closedTimestampSideTransportReplicaLAI: this.createContent(
+        closedTimestampSideTransportReplicaLAI: createContent(
           FixLong(info.state.closed_timestamp_sidetransport_info.replica_lai),
           // Warn if the LAI hasn't applied yet.
           FixLong(info.state.state.lease_applied_index) <
@@ -918,11 +918,11 @@ export default class RangeTable extends React.Component<RangeTableProps, {}> {
             ? "range-table__cell--warning"
             : "",
         ),
-        closedTimestampSideTransportCentral: this.contentTimestamp(
+        closedTimestampSideTransportCentral: contentTimestamp(
           info.state.closed_timestamp_sidetransport_info.central_closed,
           now,
         ),
-        closedTimestampSideTransportCentralLAI: this.createContent(
+        closedTimestampSideTransportCentralLAI: createContent(
           FixLong(info.state.closed_timestamp_sidetransport_info.central_lai),
           // Warn if the LAI hasn't applied yet.
           FixLong(info.state.state.lease_applied_index) <
@@ -930,13 +930,13 @@ export default class RangeTable extends React.Component<RangeTableProps, {}> {
             ? "range-table__cell--warning"
             : "",
         ),
-        circuitBreakerError: this.createContent(
+        circuitBreakerError: createContent(
           info.state.circuit_breaker_error,
         ),
-        locality: this.contentIf(size(info.locality.tiers) > 0, () => ({
+        locality: contentIf(size(info.locality.tiers) > 0, () => ({
           value: map(info.locality.tiers, tier => `${tier.key}: ${tier.value}`),
         })),
-        pausedFollowers: this.createContent(
+        pausedFollowers: createContent(
           info.state.paused_replicas?.join(", "),
         ),
       });
@@ -973,7 +973,7 @@ export default class RangeTable extends React.Component<RangeTableProps, {}> {
         <table className="range-table">
           <tbody>
             {map(rangeTableDisplayList, (title, key) =>
-              this.renderRangeRow(
+              renderRangeRow(
                 title,
                 detailsByStoreID,
                 dormantStoreIDs,
@@ -983,7 +983,7 @@ export default class RangeTable extends React.Component<RangeTableProps, {}> {
               ),
             )}
             {map(replicas, (replica, key) =>
-              this.renderRangeReplicaRow(
+              renderRangeReplicaRow(
                 replicasByReplicaIDByStoreID,
                 replica,
                 leaderReplicaIDs,


### PR DESCRIPTION
Convert the following class components to functional style:
- AllocatorOutput: renderContent kept as inner function closure
  over destructured allocator prop.
- rangeTable: ~20 pure instance methods (contentRaftState, contentNanos,
  contentDuration, contentMVCC, contentBytes, contentTimestamp, contentProblems,
  renderRangeCell, renderRangeRow, renderRangeReplicaCell, etc.) extracted to
  module-level functions.
- LeaseTable: renderLeaseCell, renderLeaseTimestampCell extracted
  to module-level pure functions.
- LogTable: renderLogInfoDescriptor, renderLogInfo extracted to
  module scope, renderRangeID kept as inner function (closes over
  rangeID prop).

- Range: componentDidMount + componentDidUpdate(isEqual) → useEffect
  with rangeID deps, backToHotRanges
  inlined as onClick lambda.
- ProblemRanges: componentDidMount + componentDidUpdate(isEqual) →
  useEffect with rangeID  deps.
- EnqueueRange: class state → multiple useState hooks, dead
  EnqueueRangeProps interface removed (handleEnqueueRange prop was
  never injected via mapDispatchToProps, class method shadowed it),
  handleEnqueueRange merged into handleSubmit, renderResponse/
  renderError inlined as conditional JSX.

Epic: CRDB-58145
Release note: None