### PR TITLE
db-console: Convert custom metric and dev tool components to functional components

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/customChart/customMetric.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/customChart/customMetric.tsx
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 import { AxisUnits } from "@cockroachlabs/cluster-ui";
-import assign from "lodash/assign";
 import isEmpty from "lodash/isEmpty";
 import * as React from "react";
 import Select, { Option } from "react-select";
@@ -76,192 +75,154 @@ interface CustomMetricRowProps {
   onDelete: (index: number) => void;
 }
 
-export class CustomMetricRow extends React.Component<CustomMetricRowProps> {
-  changeState(newState: Partial<CustomMetricState>) {
-    this.props.onChange(
-      this.props.index,
-      assign(this.props.rowState, newState),
-    );
-  }
-
-  changeMetric = (selectedOption: Option<string>) => {
-    this.changeState({
-      metric: selectedOption.value,
-    });
+export function CustomMetricRow({
+  metricOptions,
+  nodeOptions,
+  tenantOptions,
+  canViewTenantOptions,
+  index,
+  rowState,
+  onChange,
+  onDelete,
+}: CustomMetricRowProps): React.ReactElement {
+  const changeState = (newState: Partial<CustomMetricState>) => {
+    onChange(index, { ...rowState, ...newState });
   };
 
-  changeDownsampler = (selectedOption: Option<string>) => {
-    this.changeState({
-      downsampler: +selectedOption.value,
-    });
-  };
+  const {
+    metric,
+    downsampler,
+    aggregator,
+    derivative,
+    nodeSource,
+    perSource,
+    tenantSource,
+    perTenant,
+  } = rowState;
 
-  changeAggregator = (selectedOption: Option<string>) => {
-    this.changeState({
-      aggregator: +selectedOption.value,
-    });
-  };
-
-  changeDerivative = (selectedOption: Option<string>) => {
-    this.changeState({
-      derivative: +selectedOption.value,
-    });
-  };
-
-  changeNodeSource = (selectedOption: Option<string>) => {
-    this.changeState({
-      nodeSource: selectedOption.value,
-    });
-  };
-
-  changeTenant = (selectedOption: Option<string>) => {
-    this.changeState({
-      tenantSource: selectedOption.value,
-    });
-  };
-
-  changePerSource = (selection: React.FormEvent<HTMLInputElement>) => {
-    this.changeState({
-      perSource: selection.currentTarget.checked,
-    });
-  };
-
-  changePerTenant = (selection: React.FormEvent<HTMLInputElement>) => {
-    this.changeState({
-      perTenant: selection.currentTarget.checked,
-    });
-  };
-
-  deleteOption = () => {
-    this.props.onDelete(this.props.index);
-  };
-
-  render() {
-    const {
-      metricOptions,
-      nodeOptions,
-      tenantOptions,
-      canViewTenantOptions,
-      rowState: {
-        metric,
-        downsampler,
-        aggregator,
-        derivative,
-        nodeSource,
-        perSource,
-        tenantSource,
-        perTenant,
-      },
-    } = this.props;
-
-    return (
-      <tr>
-        <td>
-          <div className="metric-table-dropdown">
-            <Select
-              className="metric-table-dropdown__select"
-              clearable={true}
-              resetValue=""
-              searchable={true}
-              value={metric}
-              options={metricOptions}
-              onChange={this.changeMetric}
-              placeholder="Select a metric..."
-              optionComponent={MetricOption}
-              matchProp="label"
-              ignoreCase={true}
-            />
-          </div>
-        </td>
-        <td>
-          <div className="metric-table-dropdown">
-            <Select
-              className="metric-table-dropdown__select"
-              clearable={false}
-              searchable={false}
-              value={downsampler.toString()}
-              options={downsamplerOptions}
-              onChange={this.changeDownsampler}
-            />
-          </div>
-        </td>
-        <td>
-          <div className="metric-table-dropdown">
-            <Select
-              className="metric-table-dropdown__select"
-              clearable={false}
-              searchable={false}
-              value={aggregator.toString()}
-              options={aggregatorOptions}
-              onChange={this.changeAggregator}
-            />
-          </div>
-        </td>
+  return (
+    <tr>
+      <td>
+        <div className="metric-table-dropdown">
+          <Select
+            className="metric-table-dropdown__select"
+            clearable={true}
+            resetValue=""
+            searchable={true}
+            value={metric}
+            options={metricOptions}
+            onChange={(opt: Option<string>) =>
+              changeState({ metric: opt.value })
+            }
+            placeholder="Select a metric..."
+            optionComponent={MetricOption}
+            matchProp="label"
+            ignoreCase={true}
+          />
+        </div>
+      </td>
+      <td>
+        <div className="metric-table-dropdown">
+          <Select
+            className="metric-table-dropdown__select"
+            clearable={false}
+            searchable={false}
+            value={downsampler.toString()}
+            options={downsamplerOptions}
+            onChange={(opt: Option<string>) =>
+              changeState({ downsampler: +opt.value })
+            }
+          />
+        </div>
+      </td>
+      <td>
+        <div className="metric-table-dropdown">
+          <Select
+            className="metric-table-dropdown__select"
+            clearable={false}
+            searchable={false}
+            value={aggregator.toString()}
+            options={aggregatorOptions}
+            onChange={(opt: Option<string>) =>
+              changeState({ aggregator: +opt.value })
+            }
+          />
+        </div>
+      </td>
+      <td>
+        <div className="metric-table-dropdown">
+          <Select
+            className="metric-table-dropdown__select"
+            clearable={false}
+            searchable={false}
+            value={derivative.toString()}
+            options={derivativeOptions}
+            onChange={(opt: Option<string>) =>
+              changeState({ derivative: +opt.value })
+            }
+          />
+        </div>
+      </td>
+      <td>
+        <div className="metric-table-dropdown">
+          <Select
+            className="metric-table-dropdown__select"
+            clearable={false}
+            searchable={false}
+            value={nodeSource}
+            options={nodeOptions}
+            onChange={(opt: Option<string>) =>
+              changeState({ nodeSource: opt.value })
+            }
+          />
+        </div>
+      </td>
+      <td className="metric-table__cell">
+        <input
+          type="checkbox"
+          checked={perSource}
+          onChange={(e: React.FormEvent<HTMLInputElement>) =>
+            changeState({ perSource: e.currentTarget.checked })
+          }
+        />
+      </td>
+      {canViewTenantOptions && (
         <td>
           <div className="metric-table-dropdown">
             <Select
               className="metric-table-dropdown__select"
               clearable={false}
               searchable={false}
-              value={derivative.toString()}
-              options={derivativeOptions}
-              onChange={this.changeDerivative}
+              value={tenantSource}
+              options={tenantOptions}
+              onChange={(opt: Option<string>) =>
+                changeState({ tenantSource: opt.value })
+              }
             />
           </div>
         </td>
-        <td>
-          <div className="metric-table-dropdown">
-            <Select
-              className="metric-table-dropdown__select"
-              clearable={false}
-              searchable={false}
-              value={nodeSource}
-              options={nodeOptions}
-              onChange={this.changeNodeSource}
-            />
-          </div>
-        </td>
+      )}
+      {canViewTenantOptions && (
         <td className="metric-table__cell">
           <input
             type="checkbox"
-            checked={perSource}
-            onChange={this.changePerSource}
+            checked={perTenant}
+            onChange={(e: React.FormEvent<HTMLInputElement>) =>
+              changeState({ perTenant: e.currentTarget.checked })
+            }
           />
         </td>
-        {canViewTenantOptions && (
-          <td>
-            <div className="metric-table-dropdown">
-              <Select
-                className="metric-table-dropdown__select"
-                clearable={false}
-                searchable={false}
-                value={tenantSource}
-                options={tenantOptions}
-                onChange={this.changeTenant}
-              />
-            </div>
-          </td>
-        )}
-        {canViewTenantOptions && (
-          <td className="metric-table__cell">
-            <input
-              type="checkbox"
-              checked={perTenant}
-              onChange={this.changePerTenant}
-            />
-          </td>
-        )}
-        <td className="metric-table__cell">
-          <button
-            className="edit-button metric-edit-button"
-            onClick={this.deleteOption}
-          >
-            Remove Metric
-          </button>
-        </td>
-      </tr>
-    );
-  }
+      )}
+      <td className="metric-table__cell">
+        <button
+          className="edit-button metric-edit-button"
+          onClick={() => onDelete(index)}
+        >
+          Remove Metric
+        </button>
+      </td>
+    </tr>
+  );
 }
 
 interface CustomChartTableProps {
@@ -275,122 +236,109 @@ interface CustomChartTableProps {
   onDelete: (index: number) => void;
 }
 
-export class CustomChartTable extends React.Component<CustomChartTableProps> {
-  currentMetrics() {
-    return this.props.chartState.metrics;
-  }
+export function CustomChartTable({
+  metricOptions,
+  nodeOptions,
+  tenantOptions,
+  currentTenant,
+  index,
+  chartState,
+  onChange,
+  onDelete,
+}: CustomChartTableProps): React.ReactElement {
+  const metrics = chartState.metrics;
+  const axisUnits = chartState.axisUnits;
+  const canViewTenantOptions =
+    isSystemTenant(currentTenant) && tenantOptions.length > 1;
 
-  addMetric = () => {
-    this.props.onChange(this.props.index, {
-      metrics: [...this.currentMetrics(), new CustomMetricState()],
-      axisUnits: this.currentAxisUnits(),
+  const addMetric = () => {
+    onChange(index, {
+      metrics: [...metrics, new CustomMetricState()],
+      axisUnits,
     });
   };
 
-  updateMetricRow = (index: number, newState: CustomMetricState) => {
-    const metrics = this.currentMetrics().slice();
-    metrics[index] = newState;
-    this.props.onChange(this.props.index, {
-      metrics,
-      axisUnits: this.currentAxisUnits(),
+  const updateMetricRow = (i: number, newState: CustomMetricState) => {
+    const updated = metrics.slice();
+    updated[i] = newState;
+    onChange(index, { metrics: updated, axisUnits });
+  };
+
+  const removeMetric = (i: number) => {
+    onChange(index, {
+      metrics: metrics.slice(0, i).concat(metrics.slice(i + 1)),
+      axisUnits,
     });
   };
 
-  removeMetric = (index: number) => {
-    const metrics = this.currentMetrics();
-    this.props.onChange(this.props.index, {
-      metrics: metrics.slice(0, index).concat(metrics.slice(index + 1)),
-      axisUnits: this.currentAxisUnits(),
-    });
-  };
+  let table: JSX.Element = (
+    <h3>Click "Add Metric" to add a metric to the custom chart.</h3>
+  );
 
-  currentAxisUnits(): AxisUnits {
-    return this.props.chartState.axisUnits;
-  }
-
-  changeAxisUnits = (selected: DropdownOption) => {
-    this.props.onChange(this.props.index, {
-      metrics: this.currentMetrics(),
-      axisUnits: +selected.value,
-    });
-  };
-
-  removeChart = () => {
-    this.props.onDelete(this.props.index);
-  };
-
-  render() {
-    const { tenantOptions, currentTenant } = this.props;
-    const metrics = this.currentMetrics();
-    const canViewTenantOptions =
-      isSystemTenant(currentTenant) && tenantOptions.length > 1;
-    let table: JSX.Element = (
-      <h3>Click "Add Metric" to add a metric to the custom chart.</h3>
+  if (!isEmpty(metrics)) {
+    table = (
+      <table className="metric-table">
+        <thead>
+          <tr>
+            <td className="metric-table__header">Metric Name</td>
+            <td className="metric-table__header">Downsampler</td>
+            <td className="metric-table__header">Aggregator</td>
+            <td className="metric-table__header">Rate</td>
+            <td className="metric-table__header">Source</td>
+            <td className="metric-table__header">Per Node/Store</td>
+            {canViewTenantOptions && (
+              <td className="metric-table__header">Virtual Cluster</td>
+            )}
+            {canViewTenantOptions && (
+              <td className="metric-table__header">Per Virtual Cluster</td>
+            )}
+            <td className="metric-table__header"></td>
+          </tr>
+        </thead>
+        <tbody>
+          {metrics.map((row, i) => (
+            <CustomMetricRow
+              key={i}
+              metricOptions={metricOptions}
+              nodeOptions={nodeOptions}
+              tenantOptions={tenantOptions}
+              canViewTenantOptions={canViewTenantOptions}
+              index={i}
+              rowState={row}
+              onChange={updateMetricRow}
+              onDelete={removeMetric}
+            />
+          ))}
+        </tbody>
+      </table>
     );
+  }
 
-    if (!isEmpty(metrics)) {
-      table = (
-        <table className="metric-table">
-          <thead>
-            <tr>
-              <td className="metric-table__header">Metric Name</td>
-              <td className="metric-table__header">Downsampler</td>
-              <td className="metric-table__header">Aggregator</td>
-              <td className="metric-table__header">Rate</td>
-              <td className="metric-table__header">Source</td>
-              <td className="metric-table__header">Per Node/Store</td>
-              {canViewTenantOptions && (
-                <td className="metric-table__header">Virtual Cluster</td>
-              )}
-              {canViewTenantOptions && (
-                <td className="metric-table__header">Per Virtual Cluster</td>
-              )}
-              <td className="metric-table__header"></td>
-            </tr>
-          </thead>
-          <tbody>
-            {metrics.map((row, i) => (
-              <CustomMetricRow
-                key={i}
-                metricOptions={this.props.metricOptions}
-                nodeOptions={this.props.nodeOptions}
-                tenantOptions={tenantOptions}
-                canViewTenantOptions={canViewTenantOptions}
-                index={i}
-                rowState={row}
-                onChange={this.updateMetricRow}
-                onDelete={this.removeMetric}
-              />
-            ))}
-          </tbody>
-        </table>
-      );
-    }
-
-    return (
-      <div>
-        <div className="custom-metric__chart-controls-container">
-          <Dropdown
-            title="Units"
-            selected={this.currentAxisUnits().toString()}
-            options={axisUnitsOptions}
-            onChange={this.changeAxisUnits}
-          />
-          <button
-            className="edit-button chart-edit-button chart-edit-button--remove"
-            onClick={this.removeChart}
-          >
-            Remove Chart
-          </button>
-        </div>
-        {table}
+  return (
+    <div>
+      <div className="custom-metric__chart-controls-container">
+        <Dropdown
+          title="Units"
+          selected={axisUnits.toString()}
+          options={axisUnitsOptions}
+          onChange={(selected: DropdownOption) =>
+            onChange(index, { metrics, axisUnits: +selected.value })
+          }
+        />
         <button
-          className="edit-button metric-edit-button metric-edit-button--add"
-          onClick={this.addMetric}
+          className="edit-button chart-edit-button chart-edit-button--remove"
+          onClick={() => onDelete(index)}
         >
-          Add Metric
+          Remove Chart
         </button>
       </div>
-    );
-  }
+      {table}
+      <button
+        className="edit-button metric-edit-button metric-edit-button--add"
+        onClick={addMetric}
+      >
+        Add Metric
+      </button>
+    </div>
+  );
 }

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/redux/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/redux/index.tsx
@@ -4,7 +4,7 @@
 // included in the /LICENSE file.
 
 import classNames from "classnames";
-import * as React from "react";
+import React, { useState } from "react";
 import CopyToClipboard from "react-copy-to-clipboard";
 import { Helmet } from "react-helmet";
 import { connect } from "react-redux";
@@ -19,47 +19,35 @@ interface ReduxDebugProps extends RouteComponentProps {
   state: AdminUIState;
 }
 
-interface ReduxDebugState {
-  copied: boolean;
-}
+export function ReduxDebug({
+  state,
+  history,
+}: ReduxDebugProps): React.ReactElement {
+  const [copied, setCopied] = useState(false);
 
-export class ReduxDebug extends React.Component<
-  ReduxDebugProps,
-  ReduxDebugState
-> {
-  constructor(props: any) {
-    super(props);
-    this.state = { copied: false };
-  }
+  const text = JSON.stringify(state, null, 2);
+  const spanClass = classNames({
+    "copy-to-clipboard-span": true,
+    "copy-to-clipboard-span--copied": copied,
+  });
 
-  render() {
-    const text = JSON.stringify(this.props.state, null, 2);
-    const spanClass = classNames({
-      "copy-to-clipboard-span": true,
-      "copy-to-clipboard-span--copied": this.state.copied,
-    });
-
-    return (
-      <div>
-        <Helmet title="Redux State | Debug" />
-        <BackToAdvanceDebug history={this.props.history} />
-        <section className="section">
-          <h1 className="base-heading">Redux State</h1>
-        </section>
-        <section className="section">
-          <CopyToClipboard
-            text={text}
-            onCopy={() => this.setState({ copied: true })}
-          >
-            <span className={spanClass}>
-              {this.state.copied ? "Copied." : "Copy to Clipboard"}
-            </span>
-          </CopyToClipboard>
-          <pre className="state-json-box">{text}</pre>
-        </section>
-      </div>
-    );
-  }
+  return (
+    <div>
+      <Helmet title="Redux State | Debug" />
+      <BackToAdvanceDebug history={history} />
+      <section className="section">
+        <h1 className="base-heading">Redux State</h1>
+      </section>
+      <section className="section">
+        <CopyToClipboard text={text} onCopy={() => setCopied(true)}>
+          <span className={spanClass}>
+            {copied ? "Copied." : "Copy to Clipboard"}
+          </span>
+        </CopyToClipboard>
+        <pre className="state-json-box">{text}</pre>
+      </section>
+    </div>
+  );
 }
 
 function mapStateToProps(state: AdminUIState) {


### PR DESCRIPTION
Convert the following class components to functional style:
- CustomMetricRow: seven individual change* class methods → single
  changeState helper with inline lambdas per field.
- CustomChartTable: currentMetrics()/currentAxisUnits() replaced with
  direct destructuring, inner parameters renamed to i to avoid
  shadowing outer index prop, changeAxisUnits/removeChart inlined.
- customChart: createSelector → useMemo for nodeOptions and metricOptions,
  componentDidMount + componentDidUpdate → two useEffects (every-render with
  nodesQueryValid guard for node refresh, mount-only for metadata/tenants).
- reduxDebug: class state → useState for copied flag.

Epic: CRDB-58145
Release note: None