### PR TITLE
sql: skip column ordinals in scalar replacer

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/procedure_schema_change
+++ b/pkg/sql/logictest/testdata/logic_test/procedure_schema_change
@@ -1,4 +1,3 @@
-# LogicTest: !local-prepared
 subtest alter_procedure_name
 
 statement ok
@@ -131,26 +130,29 @@ SELECT get_function_id('public', 'p', 1)
 let $sc_p
 SELECT get_function_id('sc', 'p', 0)
 
-query TTT
-SELECT oid, proname, prosrc
-FROM pg_catalog.pg_proc WHERE proname IN ('p')
-ORDER BY oid
-----
-100110  p  SELECT 1;
-100111  p  SELECT 2;
-100113  p  SELECT 3;
-
 query TT
+SELECT proname, prosrc
+FROM pg_catalog.pg_proc WHERE proname IN ('p')
+ORDER BY prosrc
+----
+p  SELECT 1;
+p  SELECT 2;
+p  SELECT 3;
+
+query TTT
 WITH procs AS (
   SELECT crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', descriptor, false)->'function' AS proc
   FROM system.descriptor
   WHERE id IN ($public_p, $public_p_int, $sc_p)
 )
-SELECT proc->>'id' AS id, proc->'parentSchemaId' FROM procs ORDER BY id
+SELECT proc->>'name', n.name, pg.prosrc FROM procs
+JOIN system.namespace n ON n.id = (proc->>'parentSchemaId')::INT
+JOIN pg_catalog.pg_proc pg ON pg.oid = (proc->>'id')::INT + 100000
+ORDER BY pg.prosrc
 ----
-110  105
-111  105
-113  112
+p  public  SELECT 1;
+p  public  SELECT 2;
+p  sc  SELECT 3;
 
 statement error pgcode 0A000 pq: cannot move objects into or out of virtual schemas
 ALTER PROCEDURE p() SET SCHEMA pg_catalog
@@ -165,17 +167,20 @@ ALTER FUNCTION p(INT) SET SCHEMA sc;
 statement ok
 ALTER PROCEDURE p(INT) SET SCHEMA public
 
-query TT
+query TTT
 WITH procs AS (
   SELECT crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', descriptor, false)->'function' AS proc
   FROM system.descriptor
   WHERE id IN ($public_p, $public_p_int, $sc_p)
 )
-SELECT proc->>'id' AS id, proc->'parentSchemaId' FROM procs ORDER BY id
+SELECT proc->>'name', n.name, pg.prosrc FROM procs
+JOIN system.namespace n ON n.id = (proc->>'parentSchemaId')::INT
+JOIN pg_catalog.pg_proc pg ON pg.oid = (proc->>'id')::INT + 100000
+ORDER BY pg.prosrc
 ----
-110  105
-111  105
-113  112
+p  public  SELECT 1;
+p  public  SELECT 2;
+p  sc  SELECT 3;
 
 query T
 SELECT create_statement FROM [SHOW CREATE PROCEDURE public.p] ORDER BY 1
@@ -198,17 +203,20 @@ $$
 statement ok
 ALTER PROCEDURE p(INT) SET SCHEMA sc;
 
-query TT
+query TTT
 WITH procs AS (
   SELECT crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', descriptor, false)->'function' AS proc
   FROM system.descriptor
   WHERE id IN ($public_p, $public_p_int, $sc_p)
 )
-SELECT proc->>'id' AS id, proc->'parentSchemaId' FROM procs ORDER BY id
+SELECT proc->>'name', n.name, pg.prosrc FROM procs
+JOIN system.namespace n ON n.id = (proc->>'parentSchemaId')::INT
+JOIN pg_catalog.pg_proc pg ON pg.oid = (proc->>'id')::INT + 100000
+ORDER BY pg.prosrc
 ----
-110  105
-111  112
-113  112
+p  public  SELECT 1;
+p  sc  SELECT 2;
+p  sc  SELECT 3;
 
 query T
 SELECT create_statement FROM [SHOW CREATE PROCEDURE public.p];

--- a/pkg/sql/logictest/tests/local-prepared/generated_test.go
+++ b/pkg/sql/logictest/tests/local-prepared/generated_test.go
@@ -1004,6 +1004,13 @@ func TestLogic_procedure_params(
 	runLogicTest(t, "procedure_params")
 }
 
+func TestLogic_procedure_schema_change(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "procedure_schema_change")
+}
+
 func TestLogic_propagate_input_ordering(
 	t *testing.T,
 ) {

--- a/pkg/sql/sem/tree/BUILD.bazel
+++ b/pkg/sql/sem/tree/BUILD.bazel
@@ -230,6 +230,7 @@ go_test(
         "parse_tuple_test.go",
         "placeholders_test.go",
         "pretty_test.go",
+        "replace_scalars_test.go",
         "schema_helpers_test.go",
         "table_name_test.go",
         "time_test.go",

--- a/pkg/sql/sem/tree/replace_scalars.go
+++ b/pkg/sql/sem/tree/replace_scalars.go
@@ -15,8 +15,34 @@ func TestingReplaceScalarsWithPlaceholders(s Statement) (Statement, Exprs) {
 	return newStmt, v.scalars
 }
 
+// scalarReplacer replaces scalar constants with placeholders. It implements
+// ExtendedVisitor so that WalkStmt also walks into table expressions, join
+// conditions, and statement nodes. The VisitStatementPre method collects bare
+// integer literals used as column ordinal references (in ORDER BY, GROUP BY,
+// and DISTINCT ON) so that VisitPre can skip replacing them.
 type scalarReplacer struct {
 	scalars Exprs
+	// skipExprs tracks specific AST nodes (by pointer identity) that should
+	// not be replaced with placeholders. These are bare integer literals used
+	// as column ordinal references in ORDER BY, GROUP BY, and DISTINCT ON
+	// clauses. Because the map keys are pointers to the original AST nodes,
+	// other NumVal nodes with the same value in different parts of the AST
+	// (e.g. SELECT 1 FROM t ORDER BY 1) are not affected.
+	skipExprs map[Expr]struct{}
+}
+
+var _ ExtendedVisitor = &scalarReplacer{}
+
+// skipOrdinal adds expr to the skip set if it is a bare integer NumVal,
+// matching the optbuilder's colIndex detection logic.
+func (s *scalarReplacer) skipOrdinal(expr Expr) {
+	expr = StripParens(expr)
+	if n, ok := expr.(*NumVal); ok && n.ShouldBeInt64() {
+		if s.skipExprs == nil {
+			s.skipExprs = make(map[Expr]struct{})
+		}
+		s.skipExprs[n] = struct{}{}
+	}
 }
 
 func (s *scalarReplacer) VisitPre(expr Expr) (recurse bool, newExpr Expr) {
@@ -26,6 +52,9 @@ func (s *scalarReplacer) VisitPre(expr Expr) (recurse bool, newExpr Expr) {
 		// needs to know the type of the NULL in order to send it properly.
 		return false, expr
 	case Constant, Datum:
+		if _, skip := s.skipExprs[t]; skip {
+			return false, expr
+		}
 		s.scalars = append(s.scalars, t)
 		return false, &Placeholder{Idx: PlaceholderIdx(len(s.scalars) - 1)}
 	}
@@ -34,4 +63,41 @@ func (s *scalarReplacer) VisitPre(expr Expr) (recurse bool, newExpr Expr) {
 
 func (s scalarReplacer) VisitPost(expr Expr) (newNode Expr) {
 	return expr
+}
+
+func (s *scalarReplacer) VisitTablePre(expr TableExpr) (recurse bool, newExpr TableExpr) {
+	return true, expr
+}
+
+func (s *scalarReplacer) VisitTablePost(expr TableExpr) (newNode TableExpr) {
+	return expr
+}
+
+func (s *scalarReplacer) VisitStatementPre(stmt Statement) (recurse bool, newStmt Statement) {
+	switch t := stmt.(type) {
+	case *SelectClause:
+		for _, e := range t.GroupBy {
+			s.skipOrdinal(e)
+		}
+		for _, e := range t.DistinctOn {
+			s.skipOrdinal(e)
+		}
+	case *Select:
+		for _, o := range t.OrderBy {
+			s.skipOrdinal(o.Expr)
+		}
+	case *Delete:
+		for _, o := range t.OrderBy {
+			s.skipOrdinal(o.Expr)
+		}
+	case *Update:
+		for _, o := range t.OrderBy {
+			s.skipOrdinal(o.Expr)
+		}
+	}
+	return true, stmt
+}
+
+func (s *scalarReplacer) VisitStatementPost(stmt Statement) (newStmt Statement) {
+	return stmt
 }

--- a/pkg/sql/sem/tree/replace_scalars_test.go
+++ b/pkg/sql/sem/tree/replace_scalars_test.go
@@ -1,0 +1,66 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package tree_test
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReplaceScalarsSkipsOrdinals(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testCases := []struct {
+		name string
+		sql  string
+		// expected is the SQL after scalar replacement. Column ordinals in
+		// ORDER BY, GROUP BY, and DISTINCT ON should be preserved, while
+		// other constants should be replaced with placeholders.
+		expected string
+	}{{
+		name:     "order_by_ordinal_with_select_constant",
+		sql:      "SELECT x, 1 FROM t ORDER BY 1",
+		expected: "SELECT x, $1 FROM t ORDER BY 1",
+	}, {
+		name:     "group_by_ordinal",
+		sql:      "SELECT x, count(y) FROM t GROUP BY 1",
+		expected: "SELECT x, count(y) FROM t GROUP BY 1",
+	}, {
+		name:     "distinct_on_ordinal",
+		sql:      "SELECT DISTINCT ON (1) x, y FROM t ORDER BY 1",
+		expected: "SELECT DISTINCT ON (1) x, y FROM t ORDER BY 1",
+	}, {
+		name:     "order_by_non_ordinal_expr",
+		sql:      "SELECT x FROM t ORDER BY x + 1",
+		expected: "SELECT x FROM t ORDER BY x + $1",
+	}, {
+		name:     "order_by_ordinal_with_where",
+		sql:      "SELECT x FROM t WHERE x > 5 ORDER BY 1",
+		expected: "SELECT x FROM t WHERE x > $1 ORDER BY 1",
+	}, {
+		name:     "group_by_and_order_by_ordinals",
+		sql:      "SELECT x, count(y) FROM t WHERE x > 5 GROUP BY 1 ORDER BY 1",
+		expected: "SELECT x, count(y) FROM t WHERE x > $1 GROUP BY 1 ORDER BY 1",
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			stmts, err := parser.Parse(tc.sql)
+			require.NoError(t, err)
+			require.Len(t, stmts, 1)
+
+			newStmt, _ := tree.TestingReplaceScalarsWithPlaceholders(stmts[0].AST)
+			result := newStmt.String()
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
Make `scalarReplacer` implement `ExtendedVisitor` so that it can
intercept statement nodes before their child expressions are walked.
In `VisitStatementPre`, bare integer `NumVal` expressions used as
column ordinal references in ORDER BY, GROUP BY, and DISTINCT ON
clauses are collected into a skip set. `VisitPre` then checks this
set before replacing a constant with a placeholder, preserving
ordinal semantics (e.g. `ORDER BY 1` remains a column reference
instead of becoming `ORDER BY $1` with arg=1).

As a side effect, becoming an `ExtendedVisitor` causes `WalkStmt` to
also walk into table expressions and join conditions, parameterizing
more constants and improving test coverage. The existing fallback
logic in `logic.go` handles cases where placeholder types can't be
inferred.

With this fix, remove the `!local-prepared` blocklist from the
`procedure_schema_change` logic test. Also update queries in that
test that hardcoded descriptor OIDs — replace them with schema-name
joins and `prosrc` columns for config-independent expected output.

Add a unit test (`TestReplaceScalarsSkipsOrdinals`) that directly
verifies `TestingReplaceScalarsWithPlaceholders` preserves ordinals
while replacing other constants.

Informs #152139

Release note: None