### PR TITLE
changefeedccl: extract ResolvedSpans Stats into ChangefeedCheckpoint

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -1113,6 +1113,8 @@ GO_TARGETS = [
     "//pkg/ccl/workloadccl:workloadccl",
     "//pkg/ccl/workloadccl:workloadccl_test",
     "//pkg/ccl:ccl",
+    "//pkg/changefeed/changefeedpb:changefeedpb",
+    "//pkg/changefeed/changefeedpb:checkpointpb",
     "//pkg/cli/clicfg:clicfg",
     "//pkg/cli/clientflags:clientflags",
     "//pkg/cli/clienturl:clienturl",

--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -67,6 +67,7 @@ go_library(
         "//pkg/ccl/changefeedccl/tableset",
         "//pkg/ccl/changefeedccl/timers",
         "//pkg/ccl/utilccl",
+        "//pkg/changefeed/changefeedpb",
         "//pkg/cloud",
         "//pkg/cloud/externalconn",
         "//pkg/cloud/externalconn/connectionpb",

--- a/pkg/changefeed/changefeedpb/BUILD.bazel
+++ b/pkg/changefeed/changefeedpb/BUILD.bazel
@@ -1,0 +1,40 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+go_library(
+    name = "checkpointpb",
+    embed = [":checkpointpb_go_proto"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/checkpointpb",
+    visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "changefeedpb_proto",
+    srcs = ["changefeed.proto"],
+    strip_import_prefix = "/pkg",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/jobs/jobspb:jobspb_proto",
+        "@com_github_gogo_protobuf//gogoproto:gogo_proto",
+    ],
+)
+
+go_proto_library(
+    name = "changefeedpb_go_proto",
+    compilers = ["//pkg/cmd/protoc-gen-gogoroach:protoc-gen-gogoroach_compiler"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/changefeed/changefeedpb",
+    proto = ":changefeedpb_proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/jobs/jobspb",
+        "@com_github_gogo_protobuf//gogoproto",
+    ],
+)
+
+go_library(
+    name = "changefeedpb",
+    embed = [":changefeedpb_go_proto"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/changefeed/changefeedpb",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/changefeed/changefeedpb/changefeed.proto
+++ b/pkg/changefeed/changefeedpb/changefeed.proto
@@ -1,0 +1,22 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+syntax = "proto3";
+package cockroach.changefeed.changefeedpb;
+option go_package = "github.com/cockroachdb/cockroach/pkg/changefeed/changefeedpb";
+
+import "jobs/jobspb/jobs.proto";
+import "gogoproto/gogo.proto";
+
+// ChangefeedCheckpoint represents a changefeed checkpoint sent to the frontier.
+message ChangefeedCheckpoint {
+  repeated cockroach.sql.jobs.jobspb.ResolvedSpan ResolvedSpans = 1 [(gogoproto.nullable) = false];
+
+  message Stats {
+    uint64 recent_kv_count = 1;
+  }
+
+  Stats stats = 2 [(gogoproto.nullable) = false];
+}

--- a/pkg/gen/protobuf.bzl
+++ b/pkg/gen/protobuf.bzl
@@ -14,6 +14,7 @@ PROTOBUF_SRCS = [
     "//pkg/ccl/changefeedccl/changefeedpb:changefeedpb_go_proto",
     "//pkg/ccl/sqlproxyccl/tenant:tenant_go_proto",
     "//pkg/ccl/utilccl/licenseccl:licenseccl_go_proto",
+    "//pkg/changefeed/changefeedpb:changefeedpb_go_proto",
     "//pkg/cloud/cloudpb:cloudpb_go_proto",
     "//pkg/cloud/externalconn/connectionpb:connectionpb_go_proto",
     "//pkg/clusterversion:clusterversion_go_proto",

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -1266,11 +1266,7 @@ message ResolvedSpan {
 message ResolvedSpans {
   repeated ResolvedSpan resolved_spans = 1 [(gogoproto.nullable) = false];
 
-  message Stats {
-    uint64 recent_kv_count = 1;
-  }
-
-  Stats stats = 2 [(gogoproto.nullable) = false];
+  reserved 2;
 }
 
 // TimestampSpansMap is a map from timestamps to lists of spans.


### PR DESCRIPTION
ResolvedSpans previously had a Stats field used by only changefeeds to send aggregator stats over the wire to the frontier. This is not ideal as ResolvedSpans is a job agnostic struct used by LDR/PCR/etc.

This commit extracts stats to a new ChangefeedCheckpoint proto that will be used instead. This allows us to add new stats in the future without worrying about bloating jobspb.

Informs: https://github.com/cockroachdb/cockroach/pull/162459
Epic: https://cockroachlabs.atlassian.net/browse/CRDB-59356
Release note: none