### PR TITLE
roachprod: minor refactor of `chaos`

### DIFF
--- a/pkg/cmd/roachprod/cli/BUILD.bazel
+++ b/pkg/cmd/roachprod/cli/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
         "@com_github_cockroachdb_errors//oserror",
         "@com_github_fatih_color//:color",
         "@com_github_spf13_cobra//:cobra",
+        "@com_github_spf13_pflag//:pflag",
         "@com_google_cloud_go_storage//:storage",
         "@org_golang_google_api//option",
         "@org_golang_x_crypto//ssh",

--- a/pkg/cmd/roachprod/cli/chaos_disk.go
+++ b/pkg/cmd/roachprod/cli/chaos_disk.go
@@ -56,7 +56,7 @@ Examples:
   roachprod chaos disk-stall mycluster --type cgroup --nodes 1 --run-forever
 
   # Stall for 15 minutes before recovery
-  roachprod chaos disk-stall mycluster --type cgroup --nodes 1 --wait-before-cleanup 15m
+  roachprod chaos disk-stall mycluster --type cgroup --nodes 1 --wait-before-recover 15m
 
   # For a secure cluster, specify the local path to certificates
   roachprod chaos disk-stall mycluster --type cgroup --nodes 1 --certs-dir /path/to/certs --secure

--- a/pkg/cmd/roachprod/cli/chaos_network.go
+++ b/pkg/cmd/roachprod/cli/chaos_network.go
@@ -50,7 +50,7 @@ Examples:
   roachprod chaos network-partition mycluster --src 1 --dest 2,3 --type asymmetric --direction incoming
 
   # Run partition for 10 minutes before cleanup
-  roachprod chaos network-partition mycluster --src 1 --dest 2 --type bidirectional --wait-before-cleanup 10m
+  roachprod chaos network-partition mycluster --src 1 --dest 2 --type bidirectional --wait-before-recover 10m
 `,
 		Args: cobra.ExactArgs(1),
 		Run: Wrap(func(cmd *cobra.Command, args []string) error {
@@ -227,7 +227,7 @@ Examples:
 
   # Run with custom cleanup time
   roachprod chaos network-latency mycluster \
-    --src 1 --dest 2 --delay 500ms --wait-before-cleanup 15m
+    --src 1 --dest 2 --delay 500ms --wait-before-recover 15m
 `,
 		Args: cobra.ExactArgs(1),
 		Run: Wrap(func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/roachprod/cli/chaos_reset.go
+++ b/pkg/cmd/roachprod/cli/chaos_reset.go
@@ -48,7 +48,7 @@ Examples:
   roachprod chaos reset-vm mycluster --nodes 1 --run-forever
 
   # Reset VM with custom wait time before cleanup
-  roachprod chaos reset-vm mycluster --nodes 1 --wait-before-cleanup 15m
+  roachprod chaos reset-vm mycluster --nodes 1 --wait-before-recover 15m
 
   # For a secure cluster, specify the local path to certificates
   roachprod chaos reset-vm mycluster --nodes 1 --certs-dir /path/to/certs --secure


### PR DESCRIPTION
Format `--help` to separate roachprod-global
flags from `chaos`-global flags, to improve
readability.

Epic: none
Release note: None