### PR TITLE
release-25.2: sql: deflake TestStatusAPIContentionEvents stats checks

### DIFF
--- a/pkg/server/application_api/contention_test.go
+++ b/pkg/server/application_api/contention_test.go
@@ -110,7 +110,7 @@ SET TRACING=off;
 	require.True(t, found,
 		"expect to find contention event for table %d, but found %+v", testTableID, resp)
 
-	server1Conn.CheckQueryResults(t, `
+	server1Conn.CheckQueryResultsRetry(t, `
   SELECT count(*)
   FROM crdb_internal.statement_statistics
   WHERE
@@ -118,7 +118,7 @@ SET TRACING=off;
     AND app_name = 'contentionTest'
 `, [][]string{{"1"}})
 
-	server1Conn.CheckQueryResults(t, `
+	server1Conn.CheckQueryResultsRetry(t, `
   SELECT count(*)
   FROM crdb_internal.transaction_statistics
   WHERE


### PR DESCRIPTION
Backport 1/1 commits from #163964 on behalf of @dhartunian.

----

Use CheckQueryResultsRetry instead of CheckQueryResults for the statement_statistics and transaction_statistics contentionTime checks. The execution stats may not be immediately visible in the virtual tables after the transaction completes, particularly under the race detector.

Fixes: #163933
Release note: None

----

Release justification: test-only change