### PR TITLE
roachtest: eliminate Docker from db-console Cypress tests

### DIFF
--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -219,7 +219,6 @@ go_library(
         "ruby_pg_helpers.rb",
         "knexfile.js",
         "create-msk-topic/main.go.txt",
-        "db-console/Dockerfile",
         "db-console/admin_endpoints.json",
         "db-console/api_v2_endpoints.json",
         "db-console/status_endpoints.json",

--- a/pkg/cmd/roachtest/tests/db-console/Dockerfile
+++ b/pkg/cmd/roachtest/tests/db-console/Dockerfile
@@ -1,7 +1,0 @@
-FROM cypress/included:13.13.2
-
-RUN npm install -g pnpm@9.15.5
-RUN mkdir /e2e
-COPY . /e2e
-WORKDIR /e2e
-RUN pnpm install


### PR DESCRIPTION
The db-console/cypress, db-console/cypress-pages, and db-console/mixed-version-cypress roachtests flake consistently due to Docker installation failures (apt-get for Docker's third-party repo) and Docker image build timeouts (pulling ~2GB cypress/included image).

Replace Docker with direct Cypress execution on the workload node:
- Add installNode22() to javascript_helpers.go for Node.js 22.14.0 LTS with pnpm support, following the existing installNode18 pattern.
- Rewrite dbConsoleCypressTest to install Node.js, pnpm, Cypress system libraries (from Ubuntu's default repos), and npm dependencies directly on the workload node instead of building a Docker image.
- Replace `docker run` with direct `npx cypress run` invocation.
- Delete the Dockerfile and its BUILD.bazel embed reference.

Fixes: #163910
Fixes: #163476
Fixes: #163480
Fixes: #163510
Fixes: #163483

Release note: None