### PR TITLE
server: increase timeout in TestExecSQL for ALTER TABLE batch

### DIFF
--- a/pkg/server/testdata/api_v2_sql
+++ b/pkg/server/testdata/api_v2_sql
@@ -308,6 +308,7 @@ sql admin
 {
   "database": "mydb",
   "execute": true,
+  "timeout": "30s",
   "statements": [
     {"sql": "ALTER TABLE foo RENAME TO bar"},
     {"sql": "INSERT INTO bar (i) VALUES (1), (2)"},


### PR DESCRIPTION
The multi-statement ALTER TABLE test case (RENAME, INSERT, DROP COLUMN, ADD COLUMN) can exceed the default 5s API timeout under load or with the race detector. PR #163372 fixed this in the CCL version but missed the non-CCL version at pkg/server/testdata/api_v2_sql.

Apply the same fix: increase the timeout to 30s for this test case.

Fixes: #164002
Epic: None
Release note: None