### PR TITLE
concurrency: enable virtualized intent resolution metamorphically

### DIFF
--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -168,7 +168,7 @@ var VirtualIntentResolution = settings.RegisterBoolSetting(
 	settings.SystemOnly,
 	"kv.concurrency.virtual_intent_resolution.enabled",
 	"whether read-only, non-locking requests should virtually resolve intents",
-	false,
+	metamorphic.ConstantWithTestBool("kv.concurrency.virtual_intent_resolution.enabled", false),
 	settings.WithValidateBool(func(_ *settings.Values, b bool) error {
 		if b && !buildutil.CrdbTestBuild {
 			return errors.New("kv.concurrency.virtual_intent_resolution.enabled is not supported in production builds")

--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -101,6 +101,10 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 	datadriven.Walk(t, datapathutils.TestDataPath(t, "concurrency_manager"), func(t *testing.T, path string) {
 		c := newCluster()
 		c.enableTxnPushes()
+		// Keep virtualized intent resolution off, unless tests enable it
+		// explicitly. When it becomes on by default, there will be some test churn
+		// in these data-driven tests.
+		c.setVirtualIntentResolutionEnabled(false)
 		m := concurrency.NewManager(c.makeConfig())
 		m.OnRangeLeaseUpdated(1, true /* isLeaseholder */) // enable
 		c.m = m

--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -882,9 +882,7 @@ func (g *lockTableGuardImpl) canResolveKeyForHoldingTransaction(
 		pushedTxnEntry, ok := g.lt.txnStatusCache.pendingTxns.get(lockHolderTxn.ID)
 		if ok && g.pendingPushedTransactionCanBeResolved(pushedTxnEntry) {
 			up := roachpb.MakeLockUpdate(pushedTxnEntry.Txn, roachpb.Span{Key: key})
-			if g.hasUncertaintyInterval() {
-				up.ClockWhilePending = pushedTxnEntry.ClockWhilePending
-			}
+			up.ClockWhilePending = pushedTxnEntry.ClockWhilePending
 			return true, up
 		}
 	}

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -195,12 +195,16 @@ func TestLockTableBasic(t *testing.T) {
 		var guardsByReqName map[string]lockTableGuard
 		manualClock := timeutil.NewManualTime(timeutil.Unix(0, 123))
 		clock := hlc.NewClockForTesting(manualClock)
+		// Keep virtualized intent resolution off, unless tests enable it
+		// explicitly. When it becomes on by default, there will be some test churn
+		// in these data-driven tests.
+		st = cluster.MakeTestingClusterSettings()
+		VirtualIntentResolution.Override(context.Background(), &st.SV, false)
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 			switch d.Cmd {
 			case "new-lock-table":
 				maxLocks := dd.ScanArg[int64](t, d, "maxlocks")
 				m := TestingMakeLockTableMetricsCfg()
-				st = cluster.MakeTestingClusterSettings()
 				ltImpl := newLockTable(
 					maxLocks, roachpb.RangeID(3), clock, st,
 					m.LocksShedDueToMemoryLimit, m.NumLockShedDueToMemoryLimitEvents,

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents
@@ -100,15 +100,15 @@ sequence req=req1
 [4] sequence req1: lock wait-queue event: done waiting
 [4] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [4] sequence req1: resolving a batch of 9 intent(s)
-[4] sequence req1: resolving intent ‹"b"› for txn 00000002 with PENDING status
-[4] sequence req1: resolving intent ‹"c"› for txn 00000002 with PENDING status
-[4] sequence req1: resolving intent ‹"d"› for txn 00000002 with PENDING status
-[4] sequence req1: resolving intent ‹"e"› for txn 00000002 with PENDING status
-[4] sequence req1: resolving intent ‹"f"› for txn 00000002 with PENDING status
-[4] sequence req1: resolving intent ‹"g"› for txn 00000002 with PENDING status
-[4] sequence req1: resolving intent ‹"h"› for txn 00000002 with PENDING status
-[4] sequence req1: resolving intent ‹"i"› for txn 00000002 with PENDING status
-[4] sequence req1: resolving intent ‹"j"› for txn 00000002 with PENDING status
+[4] sequence req1: resolving intent ‹"b"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,2}
+[4] sequence req1: resolving intent ‹"c"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,2}
+[4] sequence req1: resolving intent ‹"d"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,2}
+[4] sequence req1: resolving intent ‹"e"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,2}
+[4] sequence req1: resolving intent ‹"f"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,2}
+[4] sequence req1: resolving intent ‹"g"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,2}
+[4] sequence req1: resolving intent ‹"h"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,2}
+[4] sequence req1: resolving intent ‹"i"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,2}
+[4] sequence req1: resolving intent ‹"j"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,2}
 [4] sequence req1: acquiring latches
 [4] sequence req1: scanning lock table for conflicting locks
 [4] sequence req1: sequencing complete, returned guard
@@ -246,7 +246,7 @@ sequence req=req1
 [4] sequence req1: lock wait-queue event: done waiting
 [4] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [4] sequence req1: resolving a batch of 1 intent(s)
-[4] sequence req1: resolving intent ‹"b"› for txn 00000002 with PENDING status
+[4] sequence req1: resolving intent ‹"b"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,5}
 [4] sequence req1: acquiring latches
 [4] sequence req1: scanning lock table for conflicting locks
 [4] sequence req1: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents_without_adding_to_lock_table
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents_without_adding_to_lock_table
@@ -86,15 +86,15 @@ handle-lock-conflict-error req=req2 lease-seq=1
 ----
 [5] handle lock conflict error req2: added 9 discovered lock(s) to lock table: conflicting locks on ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›
 [5] handle lock conflict error req2: resolving a batch of 9 intent(s)
-[5] handle lock conflict error req2: resolving intent ‹"b"› for txn 00000002 with PENDING status
-[5] handle lock conflict error req2: resolving intent ‹"c"› for txn 00000002 with PENDING status
-[5] handle lock conflict error req2: resolving intent ‹"d"› for txn 00000002 with PENDING status
-[5] handle lock conflict error req2: resolving intent ‹"e"› for txn 00000002 with PENDING status
-[5] handle lock conflict error req2: resolving intent ‹"f"› for txn 00000002 with PENDING status
-[5] handle lock conflict error req2: resolving intent ‹"g"› for txn 00000002 with PENDING status
-[5] handle lock conflict error req2: resolving intent ‹"h"› for txn 00000002 with PENDING status
-[5] handle lock conflict error req2: resolving intent ‹"i"› for txn 00000002 with PENDING status
-[5] handle lock conflict error req2: resolving intent ‹"j"› for txn 00000002 with PENDING status
+[5] handle lock conflict error req2: resolving intent ‹"b"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,1}
+[5] handle lock conflict error req2: resolving intent ‹"c"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,1}
+[5] handle lock conflict error req2: resolving intent ‹"d"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,1}
+[5] handle lock conflict error req2: resolving intent ‹"e"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,1}
+[5] handle lock conflict error req2: resolving intent ‹"f"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,1}
+[5] handle lock conflict error req2: resolving intent ‹"g"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,1}
+[5] handle lock conflict error req2: resolving intent ‹"h"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,1}
+[5] handle lock conflict error req2: resolving intent ‹"i"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,1}
+[5] handle lock conflict error req2: resolving intent ‹"j"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,1}
 
 debug-lock-table
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
@@ -413,8 +413,8 @@ on-txn-updated txn=txn1 status=pending ts=12,2
 [3] sequence req1: lock wait-queue event: done waiting
 [3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [3] sequence req1: resolving a batch of 2 intent(s)
-[3] sequence req1: resolving intent ‹"b"› for txn 00000001 with PENDING status
-[3] sequence req1: resolving intent ‹"c"› for txn 00000001 with PENDING status
+[3] sequence req1: resolving intent ‹"b"› for txn 00000001 with PENDING status and clock observation {1 135.000000000,9}
+[3] sequence req1: resolving intent ‹"c"› for txn 00000001 with PENDING status and clock observation {1 135.000000000,9}
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/virtual_intent_resolution
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/virtual_intent_resolution
@@ -77,3 +77,4 @@ finish req=reqRead
 [-] finish reqRead: finishing request
 
 reset namespace
+----


### PR DESCRIPTION
**concurrency: enable virtualized intent resolution metamorphically**

Minor test changes needed to get all KV tests to pass.

Fixes: [#163943](https://github.com/cockroachdb/cockroach/issues/163943)

Release note: None

----

**concurrency: always set ClockWhilePending for intents to resolve**

As of cc67daf, we set the `ClockWhilePending` field of a lock update (meant for virtualized intent resolution) only when the request doesn't have an uncertainty interval. However, the way `hasUncertaintlyInterval` is defined, it works only for transactional requests. A non-transactional request may also have an uncetainty interval; not setting the `ClockWhilePending` field for its virtualized intent resolutions can result in repeatedly hitting uncertainty retry errors.

This commit removes the `hasUncertaintlyInterval` check, and always sets the `ClockWhilePending` field. This is also consistent with regular (non-virtualized) intent resolution, where this field is set in the lock table waiter before intent resolution.

Informs: [#163943](https://github.com/cockroachdb/cockroach/issues/163943)

Release note: None