### PR TITLE
workloadccl: parallelize tpccmultidb in TestAllRegisteredImportFixture

### DIFF
--- a/pkg/ccl/workloadccl/allccl/all_test.go
+++ b/pkg/ccl/workloadccl/allccl/all_test.go
@@ -84,7 +84,7 @@ func TestAllRegisteredImportFixture(t *testing.T) {
 		}
 
 		t.Run(meta.Name, func(t *testing.T) {
-			if meta.Name == "tpcc" {
+			if meta.Name == "tpcc" || meta.Name == "tpccmultidb" {
 				t.Parallel() // SAFE FOR TESTING
 			}
 			if bigInitialData(meta) {


### PR DESCRIPTION
TestAllRegisteredImportFixture was timing out after 15 minutes because it sequentially imported multiple large workloads. The test marked tpcc as parallel (using t.Parallel()), but tpccmultidb was not marked parallel and ran sequentially before tpcc could start.

Due to how Go's t.Parallel() works, parallel tests wait for all non-parallel tests to complete first. This meant:
- 7 workloads ran sequentially (9m 49s total)
- tpccmultidb started sequentially but timed out mid-import
- tpcc blocked waiting for tpccmultidb, never got to run

The fix marks tpccmultidb as parallel alongside tpcc, allowing both large workloads to run concurrently after the faster workloads complete.

Timeline before fix:
  Sequential: bank(3s) + bulkingest(102s) + geospatial(262s) +
              insights(5s) + intro(3s) + ledger(178s) + movr(36s)
              + tpccmultidb (timeout at 15min)
  Parallel: tpcc (blocked, never runs)

Timeline after fix:
  Sequential: bank(3s) + bulkingest(102s) + geospatial(262s) +
              insights(5s) + intro(3s) + ledger(178s) + movr(36s)
  Parallel: tpcc + tpccmultidb (run concurrently)

Fixes: #163978

Release note: None