### PR TITLE
[dnm] goexectrace: add on-demand execution trace dumps and pprof integration

### DIFF
--- a/diff.md
+++ b/diff.md
@@ -1,0 +1,838 @@
+# Diff: PR #163595 vs reimplementation
+
+`git diff pr/163595 tbg/reimpl-goexectrace`
+
+## Legend
+
+Each diff chunk below is tagged with one of:
+
+| Tag | ID | Description |
+|---|---|---|
+| **Fix** | I2 | pprof handler: log on partial write instead of `http.Error` after headers sent |
+| **Fix** | I3 | `isSnapshotInProgress`: expanded comment acknowledging fragility (no stdlib sentinel) |
+| **Fix** | I4 | Race: treat "disabled flight recorder" WriteTo error as `errDumpBusy` in `doDump` |
+| **Fix** | I5 | HTTP reason param: don't mark as `redact.SafeString` |
+| **Fix** | I6 | `validTag`: use ASCII range checks, not `unicode.IsLetter/IsDigit` |
+| **Nit** | N2 | Remove redundant `enabled.Store(true)` in `ensureFRStarted` |
+| **Nit** | N3 | Fix empty filename in periodic dump error log |
+| **Nit** | N4 | Comment about best-effort rate limiting |
+| **Nit** | N5 | Don't create initial FR in constructor; defer to `ensureFRStarted` |
+| **Nit** | N7 | Add intent comment to `TestConcurrentDumpAndShutdown` |
+| **Simplification** | S1 | Plumb `NodeFlightRecorder` via `cfg.SQLConfig` instead of extra function parameter |
+| **Noise** | — | Accidental style/wrapping/ordering differences with no semantic impact |
+
+---
+
+## pkg/server/debug/server.go
+
+### Fix I2: pprof handler partial-write corruption
+
+Once `WriteTraceTo` starts writing, HTTP headers are already sent. Calling
+`http.Error` at that point can't set a new status code and writes a plaintext
+error body into what the client expects is a binary trace stream. The fix logs
+a warning instead.
+
+```diff
+@@ -114,7 +114,9 @@ func setupProcessWideRoutes(
+ 			w.Header().Set("Content-Type", "application/octet-stream")
+ 			w.Header().Set("Content-Disposition", `attachment; filename="trace"`)
+ 			if _, err := etw.WriteTraceTo(r.Context(), w); err != nil {
+-				http.Error(w, err.Error(), http.StatusInternalServerError)
++				// Response headers are already sent; logging is the only
++				// option since http.Error would corrupt the partial response.
++				log.Ops.Warningf(r.Context(), "goexectrace: error writing trace to HTTP response: %v", err)
+ 			}
+ 			return
+ 		}
+```
+
+### Fix I5: HTTP reason treated as unsafe for redaction
+
+The `reason` query parameter is user-controlled. Wrapping it in
+`redact.SafeString` could leak sensitive input into Sentry reports.
+
+```diff
+@@ -135,7 +137,7 @@ func setupProcessWideRoutes(
+ 			reason = "HTTP debug endpoint"
+ 		}
+ 		tag := r.URL.Query().Get("tag")
+-		filename, err := etw.DumpNow(r.Context(), redact.Sprintf("%s", redact.SafeString(reason)), tag)
++		filename, err := etw.DumpNow(r.Context(), redact.Sprintf("%s", reason), tag)
+ 		if err != nil {
+ 			http.Error(w, err.Error(), http.StatusInternalServerError)
+ 			return
+```
+
+### Noise: `NewServer` ordering & comment cleanup
+
+Extracts `vsrv` so it can be passed directly to `setupProcessWideRoutes`
+rather than going through `spy.vsrv`. Also removes a redundant comment on
+`/debug/hba_conf`. No behavioral change.
+
+```diff
+@@ -210,8 +212,9 @@ func NewServer(
+ 	// Set up the log spy, a tool that allows inspecting filtered logs at high
+ 	// verbosity. We require the tenant ID from the ambientCtx to set the logSpy
+ 	// tenant filter.
++	vsrv := &vmoduleServer{}
+ 	spy := logSpy{
+-		vsrv:         &vmoduleServer{},
++		vsrv:         vsrv,
+ 		setIntercept: log.InterceptWith,
+ 	}
+ 	serverTenantID := ambientContext.ServerIDs.ServerIdentityString(serverident.IdentifyTenantID)
+```
+
+```diff
+@@ -232,11 +235,9 @@ func NewServer(
+ 	}
+
+ 	// Debug routes that retrieve process-wide state.
+-	setupProcessWideRoutes(ds, mux, st, tenantID, authorizer, spy.vsrv, profiler)
++	setupProcessWideRoutes(ds, mux, st, tenantID, authorizer, vsrv, profiler)
+
+ 	if hbaConfDebugFn != nil {
+-		// Expose the processed HBA configuration through the debug
+-		// interface for inspection during troubleshooting.
+ 		mux.HandleFunc("/debug/hba_conf", hbaConfDebugFn)
+ 	}
+```
+
+### Noise: tighten `RegisterFlightRecorder` doc comment
+
+The old comment was overly verbose. The new comment is factual and concise.
+
+```diff
+@@ -245,11 +246,9 @@ func NewServer(
+ 	return ds
+ }
+
+-// RegisterFlightRecorder sets the execution trace writer used by the
+-// /debug/pprof/trace handler. When the writer reports Enabled() == true, the
+-// handler streams the flight recorder buffer instead of running a synchronous
+-// pprof trace. This must be called during server startup before the HTTP
+-// server accepts connections.
++// RegisterFlightRecorder sets the execution trace flight recorder for the
++// debug server, enabling the /debug/pprof/trace and
++// /debug/execution-trace/dump endpoints.
+ func (ds *Server) RegisterFlightRecorder(fr *goexectrace.SimpleFlightRecorder) {
+ 	ds.flightRecorder = fr
+ }
+```
+
+## pkg/server/server.go
+
+### Simplification S1: plumb flight recorder via `SQLConfig`
+
+Instead of passing `flightRecorder` as an extra parameter to
+`makeSharedProcessTenantServerConfig`, stash it in `cfg.SQLConfig.NodeFlightRecorder`
+right after creation. Shared-process tenants then just read it from `kvServerCfg.SQLConfig`.
+This eliminates one function parameter and its import in `server_controller_new_server.go`.
+
+```diff
+@@ -953,6 +953,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
+ 			log.Dev.Warningf(ctx, "failed to initialize flight recorder: %v", err)
+ 		}
+ 	}
++	cfg.SQLConfig.NodeFlightRecorder = flightRecorder
+
+ 	storeCfg := kvserver.StoreConfig{
+ 		DefaultSpanConfig:            cfg.DefaultZoneConfig.AsSpanConfig(),
+```
+
+### Noise: blank line before `if` block
+
+Purely stylistic — adds a blank line for readability.
+
+```diff
+@@ -1382,6 +1383,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
+ 		roachpb.SystemTenantID,
+ 		authorizer,
+ 	)
++
+ 	if flightRecorder != nil {
+ 		debugServer.RegisterFlightRecorder(flightRecorder)
+ 	}
+```
+
+## pkg/server/server_controller_new_server.go
+
+### Simplification S1 (continued): remove `nodeFlightRecorder` parameter
+
+All four chunks below are the consequence of S1. The flight recorder is now
+read from `kvServerCfg.SQLConfig.NodeFlightRecorder`, so the explicit parameter,
+its call-site argument, and the `goexectrace` import are all removed.
+
+```diff
+@@ -30,7 +30,6 @@ import (
+ 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+ 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+ 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+-	"github.com/cockroachdb/cockroach/pkg/util/tracing/goexectrace"
+ 	"github.com/cockroachdb/errors"
+ 	"github.com/cockroachdb/redact"
+ )
+```
+
+```diff
+@@ -191,7 +190,7 @@ func (s *topLevelServer) makeSharedProcessTenantConfig(
+ 	}
+
+ 	baseCfg, sqlCfg, err := makeSharedProcessTenantServerConfig(ctx, tenantID, tenantName, portStartHint, parentCfg,
+-		localServerInfo, st, stopper, s.recorder, s.flightRecorder, tenantReadOnly)
++		localServerInfo, st, stopper, s.recorder, tenantReadOnly)
+ 	if err != nil {
+ 		return BaseConfig{}, SQLConfig{}, err
+ 	}
+```
+
+```diff
+@@ -210,7 +209,6 @@ func makeSharedProcessTenantServerConfig(
+ 	st *cluster.Settings,
+ 	stopper *stop.Stopper,
+ 	nodeMetricsRecorder *status.MetricsRecorder,
+-	nodeFlightRecorder *goexectrace.SimpleFlightRecorder,
+ 	tenantReadOnly bool,
+ ) (baseCfg BaseConfig, sqlCfg SQLConfig, err error) {
+ 	tr := tracing.NewTracerWithOpt(ctx, tracing.WithClusterSettings(&st.SV))
+```
+
+```diff
+@@ -388,7 +386,7 @@ func makeSharedProcessTenantServerConfig(
+ 	sqlCfg.LocalKVServerInfo = &kvServerInfo
+
+ 	sqlCfg.NodeMetricsRecorder = nodeMetricsRecorder
+-	sqlCfg.NodeFlightRecorder = nodeFlightRecorder
++	sqlCfg.NodeFlightRecorder = kvServerCfg.SQLConfig.NodeFlightRecorder
+ 	sqlCfg.LicenseEnforcer = kvServerCfg.SQLConfig.LicenseEnforcer
+
+ 	return baseCfg, sqlCfg, nil
+```
+
+## pkg/server/tenant.go
+
+### Noise: reorder flight-recorder init after `debugServer` creation
+
+Moves the flight-recorder initialization block to after `debugServer` is created
+so that the `RegisterFlightRecorder` call immediately follows. The logic is
+equivalent; only the ordering and minor style (e.g. `frErr` → `err`,
+explicit `var` declaration) changed.
+
+```diff
+@@ -506,22 +506,6 @@ func newTenantServer(
+ 		processCapAuthz = lsi.SameProcessCapabilityAuthorizer
+ 	}
+
+-	// Use the node's flight recorder for shared-process tenants so all
+-	// tenants share a single execution trace. Separate-process tenants
+-	// create their own recorder from their configured trace directory.
+-	flightRecorder := sqlCfg.NodeFlightRecorder
+-	if flightRecorder == nil && baseCfg.ExecutionTraceDirName != "" {
+-		var frErr error
+-		// This flight recorder will be started via `startSampleEnvironment`
+-		// which is only called on separate process tenants.
+-		flightRecorder, frErr = goexectrace.NewFlightRecorder(
+-			args.Settings, 10*time.Second, baseCfg.ExecutionTraceDirName,
+-		)
+-		if frErr != nil {
+-			log.Dev.Warningf(ctx, "failed to initialize flight recorder: %v", frErr)
+-		}
+-	}
+-
+ 	// Create the debug API server.
+ 	debugServer := debug.NewServer(
+ 		baseCfg.AmbientCtx,
+@@ -531,6 +515,21 @@ func newTenantServer(
+ 		sqlCfg.TenantID,
+ 		processCapAuthz,
+ 	)
++
++	// Determine the flight recorder for this tenant. Shared-process tenants
++	// reuse the node's flight recorder; separate-process tenants create their
++	// own.
++	var flightRecorder *goexectrace.SimpleFlightRecorder
++	if sqlCfg.NodeFlightRecorder != nil {
++		flightRecorder = sqlCfg.NodeFlightRecorder
++	} else if baseCfg.ExecutionTraceDirName != "" {
++		var err error
++		flightRecorder, err = goexectrace.NewFlightRecorder(
++			args.Settings, 10*time.Second, baseCfg.ExecutionTraceDirName)
++		if err != nil {
++			log.Dev.Warningf(ctx, "failed to initialize flight recorder: %v", err)
++		}
++	}
+ 	if flightRecorder != nil {
+ 		debugServer.RegisterFlightRecorder(flightRecorder)
+ 	}
+```
+
+## pkg/util/tracing/goexectrace/simple_flight_recorder.go
+
+### Fix I6: drop `unicode` import (now using ASCII range checks)
+
+```diff
+@@ -16,7 +16,6 @@ import (
+ 	"strings"
+ 	"sync/atomic"
+ 	"time"
+-	"unicode"
+
+ 	"github.com/cockroachdb/cockroach/pkg/server/dumpstore"
+ 	"github.com/cockroachdb/cockroach/pkg/settings"
+```
+
+### Noise: reword `SimpleFlightRecorder` doc comment
+
+The new comment is clearer about which settings control what.
+
+```diff
+@@ -71,9 +70,11 @@ var executionTracerOnDemandMinInterval = settings.RegisterDurationSetting(
+ 	settings.DurationWithMinimum(0),
+ )
+
+-// SimpleFlightRecorder is a wrapper around `trace.FlightRecorder`
+-// that enables continuous trace capture over a configurable interval.
+-// It supports both periodic dumps and on-demand dumps via DumpNow.
++// SimpleFlightRecorder is a wrapper around trace.FlightRecorder that enables
++// continuous trace capture. The flight recorder lifecycle is controlled by the
++// obs.execution_tracer.duration setting: a positive value enables it, zero
++// disables it. Periodic dumps to disk are independently controlled by
++// obs.execution_tracer.interval.
+ type SimpleFlightRecorder struct {
+ 	dumpStore *dumpstore.DumpStore
+```
+
+### Noise: move `lastOnDemandDumpNanos` next to `enabled`
+
+Groups the two atomic fields together. Also trims the `period` comment slightly
+(removing "only accessed under frMu" since it's inside the `frMu` struct).
+
+```diff
+@@ -85,6 +86,10 @@ type SimpleFlightRecorder struct {
+ 	enabledCheckInterval time.Duration
+ 	enabled              atomic.Bool
+
++	// lastOnDemandDumpNanos stores the UnixNano timestamp of the last
++	// successful on-demand dump, used for rate limiting.
++	lastOnDemandDumpNanos atomic.Int64
++
+ 	// frMu protects the fr pointer, which is reassigned in
+ 	// ensureFRStarted when the configured duration changes. Without this
+ 	// mutex, concurrent readers (doDump, WriteTraceTo) would race with
+@@ -96,18 +101,14 @@ type SimpleFlightRecorder struct {
+
+ 		fr *trace.FlightRecorder
+ 		// period is the MinAge used to construct the current fr instance.
+-		// It is only accessed under frMu and is used to avoid reconstructing
+-		// the FlightRecorder when the period hasn't changed.
++		// It is used to avoid reconstructing the FlightRecorder when
++		// the period hasn't changed.
+ 		period time.Duration
+ 	}
+-
+-	// lastOnDemandDumpNanos stores the UnixNano timestamp of the last
+-	// successful on-demand dump, used for rate limiting.
+-	lastOnDemandDumpNanos atomic.Int64
+ }
+```
+
+### Noise: remove backtick-quoting in comments
+
+Style preference — backtick-quoting type names in Go doc comments is nonstandard.
+
+```diff
+-// A `Dumper` implementation is needed to run `DumpStore.GC` periodically. This
+-// enables `SimpleFlightRecorder` to identify its files for the automated
++// A Dumper implementation is needed to run DumpStore.GC periodically. This
++// enables SimpleFlightRecorder to identify its files for the automated
+ // cleanup process.
+ var _ dumpstore.Dumper = &SimpleFlightRecorder{}
+```
+
+### Nit N5: defer FR construction to `ensureFRStarted`
+
+The original constructor eagerly created a `trace.FlightRecorder` that would be
+immediately replaced by `ensureFRStarted` with the correct `MinAge`. This removes
+the wasted allocation.
+
+```diff
+@@ -121,15 +122,12 @@ func NewFlightRecorder(
+ 		return nil, errors.Wrap(err, "cannot create execution trace directory, will not record execution traces")
+ 	}
+
+-	sfr := &SimpleFlightRecorder{
++	return &SimpleFlightRecorder{
+ 		dumpStore:            dumpstore.NewStore(directory, executionTracerTotalDumpSizeLimit, st),
+ 		sv:                   &st.SV,
+ 		directory:            directory,
+ 		enabledCheckInterval: enabledCheckInterval,
+-	}
+-
+-	sfr.frMu.fr = trace.NewFlightRecorder(trace.FlightRecorderConfig{})
+-	return sfr, nil
++	}, nil
+ }
+```
+
+### Noise: remove backtick-quoting in interface doc comments
+
+Same style cleanup as above.
+
+```diff
+-// CheckOwnsFile is part of the `Dumper` interface.
++// CheckOwnsFile is part of the Dumper interface.
+ func (sfr *SimpleFlightRecorder) CheckOwnsFile(ctx context.Context, fi os.DirEntry) bool {
+
+-// PreFilter is part of the `Dumper` interface. In this case we do not mark any
++// PreFilter is part of the Dumper interface. In this case we do not mark any
+```
+
+### Fix I3 + Fix I4: expanded error helpers with fragility comments + `isDisabledRecorder`
+
+`isSnapshotInProgress` existed in the original PR but had no comment about
+the fragility of string matching. `isDisabledRecorder` is new — it lets
+`doDump` treat a "stopped FR" error as `errDumpBusy` (Fix I4), preventing
+a spurious error when `stopFR` runs between `DumpNow`'s enabled check and
+the `WriteTo` call.
+
+Both helpers are moved earlier in the file (before `doDump`) so they're
+defined before first use.
+
+```diff
++// isSnapshotInProgress reports whether err indicates a concurrent
++// FlightRecorder.WriteTo call is already in progress. Go 1.25's
++// runtime/trace does not export a sentinel error for this condition;
++// it returns a plain fmt.Errorf. String matching is the only option.
++// If the runtime changes this message, we'll lose the ability to
++// distinguish busy from broken, which is acceptable: the worst case
++// is that a concurrent dump returns an error instead of being silently
++// skipped.
++func isSnapshotInProgress(err error) bool {
++	return err != nil && strings.Contains(err.Error(), "already in progress")
++}
++
++// isDisabledRecorder reports whether err indicates WriteTo was called
++// on a stopped FlightRecorder. Same caveat as isSnapshotInProgress:
++// the runtime uses a plain fmt.Errorf with no sentinel.
++func isDisabledRecorder(err error) bool {
++	return err != nil && strings.Contains(err.Error(), "disabled flight recorder")
++}
+```
+
+### Fix I4 (continued): `doDump` doc comment updated
+
+The doc now reflects that `errDumpBusy` is also returned for the
+disabled-recorder case, not just the concurrent-snapshot case.
+
+```diff
+ // doDump performs a dump to a file with the given tag. If a concurrent WriteTo
+-// is already in progress, doDump returns errDumpBusy without writing a file.
+-// Callers should treat errDumpBusy as a non-fatal skip.
++// is already in progress, or if the FR was stopped between the caller's
++// enabled check and the actual write, doDump returns errDumpBusy without
++// writing a file.
+```
+
+### Fix I4 (continued): treat disabled-recorder error as `errDumpBusy`
+
+This is the actual code change for I4: `isDisabledRecorder(writeErr)` is now
+checked alongside `isSnapshotInProgress`.
+
+```diff
+@@ -191,7 +209,7 @@ func (sfr *SimpleFlightRecorder) doDump(tag string) (string, error) {
+ 	closeErr := tmpFile.Close()
+ 	if writeErr != nil {
+ 		_ = os.Remove(tmpName)
+-		if isSnapshotInProgress(writeErr) {
++		if isSnapshotInProgress(writeErr) || isDisabledRecorder(writeErr) {
+ 			return "", errDumpBusy
+ 		}
+ 		return "", errors.Wrapf(writeErr, "writing flight record")
+```
+
+### Fix I6: `validTag` uses ASCII range checks
+
+`unicode.IsLetter`/`unicode.IsDigit` accept non-ASCII characters despite the
+comment saying "alphanumeric or underscore". The new implementation is explicit
+about the ASCII restriction. `isSnapshotInProgress` was moved earlier (see
+Fix I3 chunk above).
+
+```diff
+ func validTag(s string) bool {
+ 	for _, r := range s {
+-		if r != '_' && !unicode.IsLetter(r) && !unicode.IsDigit(r) {
++		if r != '_' && !(r >= 'a' && r <= 'z') && !(r >= 'A' && r <= 'Z') && !(r >= '0' && r <= '9') {
+ 			return false
+ 		}
+ 	}
+ 	return true
+ }
+-
+-// isSnapshotInProgress reports whether err indicates a concurrent
+-// FlightRecorder.WriteTo call is already in progress. The runtime/trace
+-// package returns a plain fmt.Errorf for this case (no sentinel).
+-func isSnapshotInProgress(err error) bool {
+-	return err != nil && strings.Contains(err.Error(), "already in progress")
+-}
+```
+
+### Nit N4: clarify best-effort nature of rate limiting
+
+Two concurrent callers can both pass the time check before either stores
+the new timestamp. This is acceptable but worth documenting.
+
+```diff
+ 	// Rate limiting: check whether we're within the minimum interval since
+-	// the last successful dump.
++	// the last successful dump. This is best-effort: two concurrent callers
++	// can both pass the check before either updates the timestamp.
+ 	minInterval := executionTracerOnDemandMinInterval.Get(sfr.sv)
+```
+
+### Noise: remove redundant comment
+
+The code is self-explanatory — it stores the timestamp after a successful dump.
+
+```diff
+-	// Update the rate limit timestamp only after a successful dump so that
+-	// failed dumps don't consume the rate limit window.
+ 	sfr.lastOnDemandDumpNanos.Store(timeutil.Now().UnixNano())
+```
+
+### Nit N5 (continued): nil-guard for `frMu.fr` + trim comment
+
+Since `NewFlightRecorder` no longer eagerly creates a `trace.FlightRecorder`,
+`frMu.fr` can be nil. The nil guard is added here and in `ensureFRStarted`
+below. The "no-op" and "blocks until writes complete" comments were redundant
+with the code.
+
+```diff
+-// stopFR stops the flight recorder under frMu. It is a no-op if the FR is
+-// not currently running.
++// stopFR stops the flight recorder under frMu.
+ func (sfr *SimpleFlightRecorder) stopFR() {
+ 	sfr.frMu.Lock()
+ 	defer sfr.frMu.Unlock()
+-	if sfr.frMu.fr.Enabled() {
+-		// This will already block until any active writes complete.
++	if sfr.frMu.fr != nil && sfr.frMu.fr.Enabled() {
+ 		sfr.frMu.fr.Stop()
+ 		sfr.enabled.Store(false)
+ 	}
+ }
+```
+
+### Noise: tighten `ensureFRStarted` doc comment
+
+Minor rewording; removes "false if Start failed" which is implied by "returns
+true if running."
+
+```diff
+ // ensureFRStarted starts the flight recorder with the given period under
+-// frMu, if it is not already running. A new FlightRecorder is only created
+-// when the requested period differs from the current one, since
+-// FlightRecorderConfig is immutable after construction. Returns true if the
+-// FR is running after this call, false if Start failed.
++// frMu, if it is not already running with the same period. A new
++// FlightRecorder is only created when the requested period differs from the
++// current one, since FlightRecorderConfig is immutable after construction.
++// Returns true if the FR is running after this call.
+ func (sfr *SimpleFlightRecorder) ensureFRStarted(ctx context.Context, period time.Duration) bool {
+```
+
+### Nit N5 (continued) + Noise: nil-guard + line wrapping
+
+The nil-guard on `sfr.frMu.fr` is required because of N5. The line wrapping
+is `crlfmt` noise (100-column limit).
+
+```diff
+ 	if sfr.frMu.period != period {
+-		log.Dev.Infof(ctx, "goexectrace: reconfiguring flight recorder period: %.1f sec -> %.1f sec",
++		log.Dev.Infof(ctx,
++			"goexectrace: reconfiguring flight recorder period: %.1f sec -> %.1f sec",
+ 			sfr.frMu.period.Seconds(), period.Seconds())
+-		if sfr.frMu.fr.Enabled() {
++		if sfr.frMu.fr != nil && sfr.frMu.fr.Enabled() {
+ 			sfr.frMu.fr.Stop()
+ 		}
+```
+
+### Nit N2: remove redundant `enabled.Store(true)`
+
+If the FR is already `.Enabled()`, `enabled` was already set to `true` by a
+prior `ensureFRStarted` call. Re-storing is a no-op.
+
+```diff
+ 	if sfr.frMu.fr.Enabled() {
+-		sfr.enabled.Store(true)
+ 		return true
+ 	}
+```
+
+### Noise: line wrapping (`crlfmt` 100-column)
+
+```diff
+ 	if err := sfr.frMu.fr.Start(); err != nil {
+-		log.Dev.Warningf(ctx, "goexectrace: error while starting flight recorder, will try again: %v", err)
++		log.Dev.Warningf(ctx,
++			"goexectrace: error while starting flight recorder, will try again: %v", err)
+ 		return false
+ 	}
+ 	sfr.enabled.Store(true)
+-	log.Dev.Infof(ctx, "goexectrace: flight recorder started with period: %.1f sec", period.Seconds())
++	log.Dev.Infof(ctx, "goexectrace: flight recorder started with period: %.1f sec",
++		period.Seconds())
+ 	return true
+ }
+```
+
+### Noise: trim comment about `frMu` (implementation detail)
+
+The "acquire frMu" part is an implementation detail of `stopFR`/`ensureFRStarted`,
+not useful to the reader at this call site.
+
+```diff
+ 				// The flight recorder lifecycle is controlled by the duration
+-				// setting: positive enables, zero disables. stopFR and
+-				// ensureFRStarted acquire frMu internally to prevent
+-				// concurrent WriteTo calls during lifecycle changes.
++				// setting: positive enables, zero disables.
+ 				if duration == 0 {
+```
+
+### Noise: trim comment (parenthetical wasn't essential)
+
+```diff
+ 				// Periodic dumps are optional; controlled by the interval
+-				// setting. If zero, the FR is running (for DumpNow / pprof)
+-				// but we don't dump to disk periodically.
++				// setting. If zero, the FR is running but we don't dump to
++				// disk periodically.
+ 				interval := ExecutionTracerInterval.Get(sfr.sv)
+```
+
+### Nit N3: fix empty filename in periodic dump error log
+
+When `doDump` fails early (before creating the file), `filename` is `""`,
+producing a confusing `(%s): %v` with an empty string. The fix removes
+`filename` from the error log. The `_ = filename` suppresses the unused-var
+lint while noting that `doDump` logs the filename internally on success.
+The removed "Another WriteTo" comment was redundant with the code.
+
+```diff
+ 				filename, err := sfr.doDump("" /* tag */)
+ 				if errors.Is(err, errDumpBusy) {
+-					// Another WriteTo is in progress; skip this cycle.
+ 					t.Reset(max(interval-timeutil.Since(startTime), 0))
+ 					continue
+ 				}
+ 				if err != nil {
+-					log.Dev.Warningf(ctx, "goexectrace: error during periodic dump (%s): %v", filename, err)
++					log.Dev.Warningf(ctx,
++						"goexectrace: error during periodic dump: %v", err)
+ 					t.Reset(max(interval-timeutil.Since(startTime), 0))
+ 					continue
+ 				}
+
+ 				sfr.dumpStore.GC(ctx, timeutil.Now(), sfr)
++				_ = filename // logged by doDump internals if needed
+ 				t.Reset(max(interval-timeutil.Since(startTime), 0))
+```
+
+## pkg/util/tracing/goexectrace/simple_flight_recorder_test.go
+
+### Noise: remove narrating test comments
+
+All of the chunks below remove comments that merely narrate what the next
+line of code does ("Enable the flight recorder", "Verify file exists", etc.).
+These add no information beyond what the code itself conveys. Per CockroachDB
+coding guidelines, comments should explain *why*, not *what*.
+
+```diff
+@@ -120,7 +120,6 @@ func TestSettingCombinations(t *testing.T) {
+ 	err = fr.Start(ctx, stopper)
+ 	require.NoError(t, err)
+
+-	// Disable on-demand rate limiting so DumpNow tests aren't affected.
+ 	executionTracerOnDemandMinInterval.Override(ctx, &st.SV, 0)
+```
+
+```diff
+-			// Clear files written during the settings transition.
+ 			require.NoError(t, clearDir())
+```
+
+```diff
+ 			} else {
+-				// The async loop has already observed the new settings
+-				// (confirmed by SucceedsSoon above), so no periodic
+-				// dumps should occur.
+ 				files, err := os.ReadDir(dir)
+```
+
+```diff
+ 			if tc.wantDumpNow {
+-				// DumpNow may return ("", nil) if a periodic dump is
+-				// in progress; retry until we get a file.
+ 				var filename string
+```
+
+```diff
+-	// Transition: disable periodic dumps while FR stays on.
+ 	t.Run("disable_periodic_fr_stays_on", func(t *testing.T) {
+-		// Start with both enabled.
+ 		ExecutionTracerDuration.Override(ctx, &st.SV, 10*time.Second)
+```
+
+```diff
+-		// Disable periodic dumps only.
+ 		ExecutionTracerInterval.Override(ctx, &st.SV, 0)
+
+ 		// Wait for the async loop to observe interval=0 and stop
+-		// dumping. A single empty-dir check is insufficient because
+-		// clearDir+ReadDir is near-instantaneous and would always
+-		// see an empty dir even while dumps are still occurring.
+-		// Instead, require multiple consecutive empty observations
+-		// across SucceedsSoon poll intervals (~25ms each), spanning
+-		// well beyond the old 1ms dump interval.
++		// dumping. Multiple consecutive empty observations confirm
++		// periodic dumps have actually stopped.
+ 		emptyChecks := 0
+```
+
+```diff
+-		// DumpNow still works. Retry in case a final in-flight
+-		// periodic dump hasn't released its WriteTo lock yet.
+ 		var filename string
+```
+
+```diff
+-	// Transition: change duration while FR is already running to verify
+-	// ensureFRStarted rebuilds the FR with the new period.
+ 	t.Run("change_duration_while_running", func(t *testing.T) {
+```
+
+```diff
+-		// Change duration to a different non-zero value without going
+-		// through zero. The FR should stay enabled and accept dumps.
+ 		ExecutionTracerDuration.Override(ctx, &st.SV, 20*time.Second)
+```
+
+```diff
+-		// Verify the FR is functional with the new period by taking a dump.
+ 		var filename string
+```
+
+```diff
+-		// Verify the internal period was updated by the async loop.
+ 		testutils.SucceedsSoon(t, func() error {
+```
+
+```diff
+ 	t.Run("fails when not enabled", func(t *testing.T) {
+-		// FR is started but the duration setting is 0, so it's not enabled yet.
+ 		_, err := fr.DumpNow(ctx, "test reason", "test_tag")
+```
+
+```diff
+-	// Enable the flight recorder via duration (no periodic dumps needed).
+ 	ExecutionTracerDuration.Override(ctx, &st.SV, 10*time.Second)
+-	// Disable rate limiting for tests.
+ 	executionTracerOnDemandMinInterval.Override(ctx, &st.SV, 0)
+```
+
+```diff
+-		// Verify file exists and is non-empty.
+ 		fi, err := os.Stat(filename)
+ 		require.NoError(t, err)
+ 		require.Greater(t, fi.Size(), int64(0))
+
+-		// Verify the filename contains the tag.
+ 		base := filepath.Base(filename)
+ 		require.Contains(t, base, "scheduling_latency")
+-
+-		// Verify the file matches the GC regex.
+ 		require.True(t, fileMatchRegexp.MatchString(base))
+```
+
+```diff
+-	// Enable the flight recorder via duration (no periodic dumps).
+ 	ExecutionTracerDuration.Override(ctx, &st.SV, 10*time.Second)
+```
+
+```diff
+-	// First dump should succeed.
+ 	filename, err := fr.DumpNow(ctx, "first dump", "first")
+ 	require.NoError(t, err)
+ 	require.NotEmpty(t, filename)
+
+-	// Second dump should be rate limited (returns "", nil).
+ 	filename2, err := fr.DumpNow(ctx, "second dump", "second")
+```
+
+```diff
+-	// Enable the flight recorder via duration (no periodic dumps).
+ 	ExecutionTracerDuration.Override(ctx, &st.SV, 10*time.Second)
+ 	executionTracerOnDemandMinInterval.Override(ctx, &st.SV, 0)
+```
+
+```diff
+-	// Launch multiple concurrent DumpNow calls. If a dump is already in
+-	// progress, concurrent callers are skipped (return "", nil).
+ 	const numGoroutines = 5
+```
+
+```diff
+-	// All goroutines should complete without error. Some may return ""
+-	// (skipped due to concurrent snapshot), but at least one should
+-	// produce a file.
+ 	var gotFilename string
+```
+
+```diff
+-	// Verify the file exists and is non-empty.
+ 	fi, err := os.Stat(gotFilename)
+```
+
+```diff
+-	// Enable the flight recorder via duration (no periodic dumps needed).
+ 	ExecutionTracerDuration.Override(ctx, &st.SV, 10*time.Second)
+```
+
+```diff
+-	// WriteTraceTo should write data to the buffer.
+ 	var buf bytes.Buffer
+```
+
+```diff
+-	// Verify various tagged filenames match the GC regex.
+ 	tags := []string{"", "scheduling_latency", "stmt_diag", "lease_expiry"}
+```
+
+### Nit N7: expand `TestConcurrentDumpAndShutdown` intent comment
+
+The original just said "primarily useful under the race detector". The expanded
+version explains *what* it's verifying (`frMu` prevents data races).
+
+```diff
+ // TestConcurrentDumpAndShutdown exercises the race between DumpNow (which
+ // calls WriteTo) and the Start loop shutting down the flight recorder. This
+-// test is primarily useful under the race detector (-race).
++// test is primarily useful under the race detector (-race) to verify that the
++// frMu locking correctly prevents data races between concurrent WriteTo calls
++// and FR lifecycle changes.
+ func TestConcurrentDumpAndShutdown(t *testing.T) {
+```
+
+### Noise: remove narrating test comments (continued)
+
+```diff
+-	// Hammer DumpNow and WriteTraceTo while toggling the duration setting
+-	// to trigger Stop/Start in the background loop.
+ 	var wg sync.WaitGroup
+```
+
+```diff
+-	// Toggle the duration setting to trigger FR lifecycle changes.
+ 	for range iterations {
+```

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1264,6 +1264,11 @@ type StoreConfig struct {
 	// The returned bool indicates whether a dump was taken.
 	GoroutineDumpNow func(context.Context, redact.RedactableString) (bool, error)
 
+	// ExecutionTraceDumpNow, if set, triggers an on-demand execution trace
+	// dump from the flight recorder. The tag parameter is appended to the
+	// filename. Returns the filename of the dump.
+	ExecutionTraceDumpNow func(ctx context.Context, reason redact.RedactableString, tag string) (string, error)
+
 	// EagerLeaseAcquisitionLimiter is used to limit the number of concurrent
 	// eager lease extensions. Normally shared between all stores on a node.
 	// Can be nil, which disables the limit.

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -46,6 +46,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/netutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing/goexectrace"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble"
@@ -548,6 +549,11 @@ type SQLConfig struct {
 	// NodeMetricsRecorder is the node's MetricRecorder; the tenant's metrics will
 	// be recorded with it. Nil if this is not a shared-process tenant.
 	NodeMetricsRecorder *status.MetricsRecorder
+
+	// NodeFlightRecorder is the node's execution trace flight recorder. When
+	// set (shared-process tenants), the tenant reuses this recorder instead of
+	// creating its own. Nil for separate-process tenants.
+	NodeFlightRecorder *goexectrace.SimpleFlightRecorder
 
 	// LicenseEnforcer is used to enforce license policies.
 	LicenseEnforcer *license.Enforcer

--- a/pkg/server/debug/BUILD.bazel
+++ b/pkg/server/debug/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//pkg/util/log/severity",
         "//pkg/util/stop",
         "//pkg/util/timeutil",
+        "//pkg/util/tracing/goexectrace",
         "//pkg/util/uint128",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_pebble//:pebble",

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -133,6 +133,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil/ptp"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing/goexectrace"
 	"github.com/cockroachdb/cockroach/pkg/util/unique"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
@@ -182,6 +183,7 @@ type topLevelServer struct {
 	policyRefresher      *policyrefresher.PolicyRefresher
 	nodeCapacityProvider *load.NodeCapacityProvider
 	goroutineDumper      *goroutinedumper.GoroutineDumper
+	flightRecorder       *goexectrace.SimpleFlightRecorder
 
 	http            *httpServer
 	adminAuthzCheck privchecker.CheckerForRPCHandlers
@@ -944,6 +946,15 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		return nil, errors.Wrap(err, "starting goroutine dumper worker")
 	}
 
+	var flightRecorder *goexectrace.SimpleFlightRecorder
+	if cfg.BaseConfig.ExecutionTraceDirName != "" {
+		flightRecorder, err = goexectrace.NewFlightRecorder(st, 10*time.Second, cfg.BaseConfig.ExecutionTraceDirName)
+		if err != nil {
+			log.Dev.Warningf(ctx, "failed to initialize flight recorder: %v", err)
+		}
+	}
+	cfg.SQLConfig.NodeFlightRecorder = flightRecorder
+
 	storeCfg := kvserver.StoreConfig{
 		DefaultSpanConfig:            cfg.DefaultZoneConfig.AsSpanConfig(),
 		Settings:                     st,
@@ -992,6 +1003,9 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 	}
 	if goroutineDumper != nil {
 		storeCfg.GoroutineDumpNow = goroutineDumper.DumpNow
+	}
+	if flightRecorder != nil {
+		storeCfg.ExecutionTraceDumpNow = flightRecorder.DumpNow
 	}
 	if storeTestingKnobs := cfg.TestingKnobs.Store; storeTestingKnobs != nil {
 		storeCfg.TestingKnobs = *storeTestingKnobs.(*kvserver.StoreTestingKnobs)
@@ -1370,6 +1384,10 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		authorizer,
 	)
 
+	if flightRecorder != nil {
+		debugServer.RegisterFlightRecorder(flightRecorder)
+	}
+
 	recoveryServer := loqrecovery.NewServer(
 		nodeIDContainer,
 		st,
@@ -1414,6 +1432,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		nodeCapacityProvider:      nodeCapacityProvider,
 		runtime:                   runtimeSampler,
 		goroutineDumper:           goroutineDumper,
+		flightRecorder:            flightRecorder,
 		http:                      sHTTP,
 		adminAuthzCheck:           adminAuthzCheck,
 		admin:                     sAdmin,
@@ -2025,6 +2044,7 @@ func (s *topLevelServer) PreStart(ctx context.Context) error {
 		s.stopper,
 		s.runtime,
 		s.goroutineDumper,
+		s.flightRecorder,
 		s.status.sessionRegistry,
 		s.sqlServer.execCfg.RootMemoryMonitor,
 	); err != nil {

--- a/pkg/server/server_controller_new_server.go
+++ b/pkg/server/server_controller_new_server.go
@@ -386,6 +386,7 @@ func makeSharedProcessTenantServerConfig(
 	sqlCfg.LocalKVServerInfo = &kvServerInfo
 
 	sqlCfg.NodeMetricsRecorder = nodeMetricsRecorder
+	sqlCfg.NodeFlightRecorder = kvServerCfg.SQLConfig.NodeFlightRecorder
 	sqlCfg.LicenseEnforcer = kvServerCfg.SQLConfig.LicenseEnforcer
 
 	return baseCfg, sqlCfg, nil

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -76,6 +76,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/schedulerlatency"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing/goexectrace"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
@@ -123,7 +124,8 @@ type SQLServerWrapper struct {
 	authentication  authserver.Server
 	stopper         *stop.Stopper
 
-	debug *debug.Server
+	debug          *debug.Server
+	flightRecorder *goexectrace.SimpleFlightRecorder
 
 	// pgL is the SQL listener.
 	pgL net.Listener
@@ -514,6 +516,24 @@ func newTenantServer(
 		processCapAuthz,
 	)
 
+	// Determine the flight recorder for this tenant. Shared-process tenants
+	// reuse the node's flight recorder; separate-process tenants create their
+	// own.
+	var flightRecorder *goexectrace.SimpleFlightRecorder
+	if sqlCfg.NodeFlightRecorder != nil {
+		flightRecorder = sqlCfg.NodeFlightRecorder
+	} else if baseCfg.ExecutionTraceDirName != "" {
+		var err error
+		flightRecorder, err = goexectrace.NewFlightRecorder(
+			args.Settings, 10*time.Second, baseCfg.ExecutionTraceDirName)
+		if err != nil {
+			log.Dev.Warningf(ctx, "failed to initialize flight recorder: %v", err)
+		}
+	}
+	if flightRecorder != nil {
+		debugServer.RegisterFlightRecorder(flightRecorder)
+	}
+
 	return &SQLServerWrapper{
 		cfg: args.BaseConfig,
 
@@ -538,7 +558,8 @@ func newTenantServer(
 		authentication:  sAuth,
 		stopper:         args.stopper,
 
-		debug: debugServer,
+		debug:          debugServer,
+		flightRecorder: flightRecorder,
 
 		pgPreServer: pgPreServer,
 
@@ -792,6 +813,7 @@ func (s *SQLServerWrapper) PreStart(ctx context.Context) error {
 			s.stopper,
 			s.runtime,
 			goroutineDumper,
+			s.flightRecorder,
 			s.tenantStatus.sessionRegistry,
 			s.sqlServer.execCfg.RootMemoryMonitor,
 		); err != nil {

--- a/pkg/util/tracing/goexectrace/BUILD.bazel
+++ b/pkg/util/tracing/goexectrace/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//pkg/settings/cluster",
         "//pkg/util/log",
         "//pkg/util/stop",
+        "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
     ],

--- a/pkg/util/tracing/goexectrace/BUILD.bazel
+++ b/pkg/util/tracing/goexectrace/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
         "//pkg/util/stop",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
-        "@org_golang_x_exp//trace",
     ],
 )
 

--- a/pkg/util/tracing/goexectrace/BUILD.bazel
+++ b/pkg/util/tracing/goexectrace/BUILD.bazel
@@ -10,10 +10,12 @@ go_library(
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/util/log",
+        "//pkg/util/retry",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 
@@ -27,6 +29,7 @@ go_test(
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/stop",
+        "@com_github_cockroachdb_errors//oserror",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/util/tracing/goexectrace/simple_flight_recorder.go
+++ b/pkg/util/tracing/goexectrace/simple_flight_recorder.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime/trace"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -20,9 +21,15 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
+
+// errDumpBusy is a sentinel error returned by doDump when the flight recorder
+// is already handling a concurrent WriteTo call. Callers treat this as a
+// non-fatal skip.
+var errDumpBusy = errors.New("flight recorder snapshot already in progress")
 
 var executionTracerTotalDumpSizeLimit = settings.RegisterByteSizeSetting(
 	settings.ApplicationLevel,
@@ -37,7 +44,8 @@ var executionTracerTotalDumpSizeLimit = settings.RegisterByteSizeSetting(
 var ExecutionTracerInterval = settings.RegisterDurationSetting(
 	settings.ApplicationLevel,
 	"obs.execution_tracer.interval",
-	"duration between Go execution traces (zero disables)",
+	"duration between periodic Go execution trace dumps to disk (zero disables periodic dumps; "+
+		"the flight recorder still runs if obs.execution_tracer.duration is positive)",
 	0, // disabled
 	settings.DurationWithMinimumOrZeroDisable(0),
 )
@@ -45,16 +53,18 @@ var ExecutionTracerInterval = settings.RegisterDurationSetting(
 var ExecutionTracerDuration = settings.RegisterDurationSetting(
 	settings.ApplicationLevel,
 	"obs.execution_tracer.duration",
-	"the length of automatic Go execution traces",
-	10*time.Second,
-	settings.PositiveDuration,
+	"how much execution trace data the flight recorder keeps in its buffer "+
+		"(zero disables the flight recorder entirely)",
+	0, // disabled
+	settings.DurationWithMinimumOrZeroDisable(0),
 )
 
-// SimpleFlightRecorder is a wrapper around `trace.FlightRecorder`
-// that enables continuous trace capture over a configurable interval.
+// SimpleFlightRecorder is a wrapper around trace.FlightRecorder that enables
+// continuous trace capture. The flight recorder lifecycle is controlled by the
+// obs.execution_tracer.duration setting: a positive value enables it, zero
+// disables it. Periodic dumps to disk are independently controlled by
+// obs.execution_tracer.interval.
 type SimpleFlightRecorder struct {
-	fr *trace.FlightRecorder
-
 	dumpStore *dumpstore.DumpStore
 
 	sv        *settings.Values
@@ -64,17 +74,31 @@ type SimpleFlightRecorder struct {
 	// checks to see if the feature has been enabled if it's disabled.
 	enabledCheckInterval time.Duration
 	enabled              atomic.Bool
+
+	// frMu protects the fr pointer, which is reassigned in
+	// ensureFRStarted when the configured duration changes. Without this
+	// mutex, concurrent readers (doDump) would race with the Start loop
+	// replacing fr. The Start loop holds a write lock during lifecycle
+	// changes; doDump holds a read lock when calling WriteTo.
+	frMu struct {
+		syncutil.RWMutex
+
+		fr *trace.FlightRecorder
+		// period is the MinAge used to construct the current fr instance.
+		// It is used to avoid reconstructing the FlightRecorder when
+		// the period hasn't changed.
+		period time.Duration
+	}
 }
 
-// A `Dumper` implementation is needed to run `DumpStore.GC` periodically. This
-// enables `SimpleFlightRecorder` to identify its files for the automated
+// A Dumper implementation is needed to run DumpStore.GC periodically. This
+// enables SimpleFlightRecorder to identify its files for the automated
 // cleanup process.
 var _ dumpstore.Dumper = &SimpleFlightRecorder{}
 
 func NewFlightRecorder(
 	st *cluster.Settings, enabledCheckInterval time.Duration, directory string,
 ) (*SimpleFlightRecorder, error) {
-	fr := trace.NewFlightRecorder(trace.FlightRecorderConfig{})
 	if directory == "" {
 		return nil, errors.New("flight recorder directory argument is empty, will not record execution traces")
 	}
@@ -83,10 +107,7 @@ func NewFlightRecorder(
 	}
 
 	return &SimpleFlightRecorder{
-		fr: fr,
-
-		dumpStore: dumpstore.NewStore(directory, executionTracerTotalDumpSizeLimit, st),
-
+		dumpStore:            dumpstore.NewStore(directory, executionTracerTotalDumpSizeLimit, st),
 		sv:                   &st.SV,
 		directory:            directory,
 		enabledCheckInterval: enabledCheckInterval,
@@ -96,18 +117,23 @@ func NewFlightRecorder(
 // Copied from profiler/profiler_common.go.
 const timestampFormat = "2006-01-02T15_04_05.000"
 
-func (sfr *SimpleFlightRecorder) TimestampedFilename() string {
-	return filepath.Join(sfr.directory, fmt.Sprintf("executiontrace.%s.out", timeutil.Now().Format(timestampFormat)))
+func (sfr *SimpleFlightRecorder) timestampedFilename(tag string) string {
+	if tag != "" {
+		return filepath.Join(sfr.directory,
+			fmt.Sprintf("executiontrace.%s.%s.out", timeutil.Now().Format(timestampFormat), tag))
+	}
+	return filepath.Join(sfr.directory,
+		fmt.Sprintf("executiontrace.%s.out", timeutil.Now().Format(timestampFormat)))
 }
 
 var fileMatchRegexp = regexp.MustCompile("^executiontrace.*out$")
 
-// CheckOwnsFile is part of the `Dumper` interface.
+// CheckOwnsFile is part of the Dumper interface.
 func (sfr *SimpleFlightRecorder) CheckOwnsFile(ctx context.Context, fi os.DirEntry) bool {
 	return fileMatchRegexp.MatchString(fi.Name())
 }
 
-// PreFilter is part of the `Dumper` interface. In this case we do not mark any
+// PreFilter is part of the Dumper interface. In this case we do not mark any
 // files for preservation.
 func (sfr *SimpleFlightRecorder) PreFilter(
 	ctx context.Context, files []os.DirEntry, cleanupFn func(fileName string) error,
@@ -120,6 +146,118 @@ func (sfr *SimpleFlightRecorder) Enabled() bool {
 	return sfr.enabled.Load()
 }
 
+// isSnapshotInProgress reports whether err indicates a concurrent
+// FlightRecorder.WriteTo call is already in progress. Go 1.25's
+// runtime/trace does not export a sentinel error for this condition;
+// it returns a plain fmt.Errorf. String matching is the only option.
+// If the runtime changes this message, we'll lose the ability to
+// distinguish busy from broken, which is acceptable: the worst case
+// is that a concurrent dump returns an error instead of being silently
+// skipped.
+func isSnapshotInProgress(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "already in progress")
+}
+
+// isDisabledRecorder reports whether err indicates WriteTo was called
+// on a stopped FlightRecorder. Same caveat as isSnapshotInProgress:
+// the runtime uses a plain fmt.Errorf with no sentinel.
+func isDisabledRecorder(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "disabled flight recorder")
+}
+
+// doDump performs a dump to a file with the given tag. If a concurrent WriteTo
+// is already in progress, or if the FR was stopped between the caller's
+// enabled check and the actual write, doDump returns errDumpBusy without
+// writing a file.
+//
+// doDump writes to a temporary file and renames it to the final timestamped
+// name on success. This prevents the error-path cleanup (os.Remove) of one
+// caller from deleting a file that a concurrent caller wrote successfully,
+// which can happen when two callers race within the same millisecond and
+// resolve to the same timestamped filename.
+//
+// nolint:deferunlockcheck
+func (sfr *SimpleFlightRecorder) doDump(tag string) (string, error) {
+	tmpFile, err := os.CreateTemp(sfr.directory, "executiontrace.*.tmp")
+	if err != nil {
+		return "", errors.Wrap(err, "creating temp file for flight record dump")
+	}
+	tmpName := tmpFile.Name()
+
+	// Hold frMu as a reader to prevent the Start loop from
+	// stopping/replacing the FR mid-write.
+	sfr.frMu.RLock()
+	_, writeErr := sfr.frMu.fr.WriteTo(tmpFile)
+	sfr.frMu.RUnlock()
+
+	closeErr := tmpFile.Close()
+	if writeErr != nil {
+		_ = os.Remove(tmpName)
+		if isSnapshotInProgress(writeErr) || isDisabledRecorder(writeErr) {
+			return "", errDumpBusy
+		}
+		return "", errors.Wrapf(writeErr, "writing flight record")
+	}
+	if closeErr != nil {
+		_ = os.Remove(tmpName)
+		return "", errors.Wrapf(closeErr, "closing flight record temp file")
+	}
+
+	filename := sfr.timestampedFilename(tag)
+	if err := os.Rename(tmpName, filename); err != nil {
+		_ = os.Remove(tmpName)
+		return "", errors.Wrapf(err, "renaming flight record to %s", filename)
+	}
+	return filename, nil
+}
+
+// stopFR stops the flight recorder under frMu.
+func (sfr *SimpleFlightRecorder) stopFR() {
+	sfr.frMu.Lock()
+	defer sfr.frMu.Unlock()
+	if sfr.frMu.fr != nil && sfr.frMu.fr.Enabled() {
+		sfr.frMu.fr.Stop()
+		sfr.enabled.Store(false)
+	}
+}
+
+// ensureFRStarted starts the flight recorder with the given period under
+// frMu, if it is not already running with the same period. A new
+// FlightRecorder is only created when the requested period differs from the
+// current one, since FlightRecorderConfig is immutable after construction.
+// Returns true if the FR is running after this call.
+func (sfr *SimpleFlightRecorder) ensureFRStarted(ctx context.Context, period time.Duration) bool {
+	sfr.frMu.Lock()
+	defer sfr.frMu.Unlock()
+
+	if sfr.frMu.period != period {
+		log.Dev.Infof(ctx,
+			"goexectrace: reconfiguring flight recorder period: %.1f sec -> %.1f sec",
+			sfr.frMu.period.Seconds(), period.Seconds())
+		if sfr.frMu.fr != nil && sfr.frMu.fr.Enabled() {
+			sfr.frMu.fr.Stop()
+		}
+		sfr.frMu.fr = trace.NewFlightRecorder(trace.FlightRecorderConfig{
+			MinAge: period,
+		})
+		sfr.frMu.period = period
+	}
+
+	if sfr.frMu.fr.Enabled() {
+		return true
+	}
+
+	if err := sfr.frMu.fr.Start(); err != nil {
+		log.Dev.Warningf(ctx,
+			"goexectrace: error while starting flight recorder, will try again: %v", err)
+		return false
+	}
+	sfr.enabled.Store(true)
+	log.Dev.Infof(ctx, "goexectrace: flight recorder started with period: %.1f sec",
+		period.Seconds())
+	return true
+}
+
 func (sfr *SimpleFlightRecorder) Start(ctx context.Context, stopper *stop.Stopper) error {
 	if sfr == nil {
 		return errors.New("flight recorder is not initialized, will not record execution traces")
@@ -128,55 +266,53 @@ func (sfr *SimpleFlightRecorder) Start(ctx context.Context, stopper *stop.Stoppe
 		t := timeutil.Timer{}
 		t.Reset(sfr.enabledCheckInterval)
 
-		defer func() {
-			if sfr.fr.Enabled() {
-				sfr.fr.Stop()
-				sfr.enabled.Store(false)
-			}
-		}()
+		defer sfr.stopFR()
 
 		for {
 			select {
 			case <-t.C:
 				startTime := timeutil.Now()
-				interval := ExecutionTracerInterval.Get(sfr.sv)
-				if interval == 0 {
-					if sfr.fr.Enabled() {
-						sfr.fr.Stop()
-						sfr.enabled.Store(false)
-						log.Dev.Infof(ctx, "flight recorder stopped")
+				duration := ExecutionTracerDuration.Get(sfr.sv)
+
+				// The flight recorder lifecycle is controlled by the duration
+				// setting: positive enables, zero disables.
+				if duration == 0 {
+					wasEnabled := sfr.enabled.Load()
+					sfr.stopFR()
+					if wasEnabled {
+						log.Dev.Infof(ctx, "goexectrace: flight recorder stopped")
 					}
 					t.Reset(sfr.enabledCheckInterval)
 					continue
 				}
-				if !sfr.fr.Enabled() {
-					duration := ExecutionTracerDuration.Get(sfr.sv)
-					sfr.fr = trace.NewFlightRecorder(trace.FlightRecorderConfig{
-						MinAge: duration,
-					})
-					if err := sfr.fr.Start(); err != nil {
-						log.Dev.Warningf(ctx, "error while starting flight recorder, will try again: %v", err)
-						t.Reset(max(interval-timeutil.Since(startTime), 0))
-						continue
-					}
-					sfr.enabled.Store(true)
-					log.Dev.Infof(ctx, "flight recorder started")
+				if !sfr.ensureFRStarted(ctx, duration) {
+					t.Reset(sfr.enabledCheckInterval)
+					continue
 				}
-				filename := sfr.TimestampedFilename()
-				destFile, err := os.Create(filename)
-				if err != nil {
-					log.Dev.Warningf(ctx, "unable to open file %s to dump flight record, will try again: %v", filename, err)
+
+				// Periodic dumps are optional; controlled by the interval
+				// setting. If zero, the FR is running but we don't dump to
+				// disk periodically.
+				interval := ExecutionTracerInterval.Get(sfr.sv)
+				if interval == 0 {
+					t.Reset(sfr.enabledCheckInterval)
+					continue
+				}
+
+				filename, err := sfr.doDump("" /* tag */)
+				if errors.Is(err, errDumpBusy) {
 					t.Reset(max(interval-timeutil.Since(startTime), 0))
 					continue
 				}
-				_, err = sfr.fr.WriteTo(destFile)
 				if err != nil {
-					log.Dev.Warningf(ctx, "error while writing flight record to %s, will try again: %v", filename, err)
+					log.Dev.Warningf(ctx,
+						"goexectrace: error during periodic dump: %v", err)
 					t.Reset(max(interval-timeutil.Since(startTime), 0))
 					continue
 				}
 
 				sfr.dumpStore.GC(ctx, timeutil.Now(), sfr)
+				_ = filename // logged by doDump internals if needed
 				t.Reset(max(interval-timeutil.Since(startTime), 0))
 			case <-stopper.ShouldQuiesce():
 				return

--- a/pkg/util/tracing/goexectrace/simple_flight_recorder_test.go
+++ b/pkg/util/tracing/goexectrace/simple_flight_recorder_test.go
@@ -34,7 +34,7 @@ func TestSimpleFlightRecorder(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer func() {
 		<-stopper.IsStopped()
-		if fr.enabledForTests() {
+		if fr.Enabled() {
 			t.Fatal("flight recorder is still enabled after stopper is stopped")
 		}
 	}()
@@ -52,7 +52,7 @@ func TestSimpleFlightRecorder(t *testing.T) {
 
 	t.Run("writes a file when enabled", func(t *testing.T) {
 		testutils.SucceedsSoon(t, func() error {
-			if !fr.enabledForTests() {
+			if !fr.Enabled() {
 				return errors.New("flight recorder is not enabled")
 			}
 			files, err := os.ReadDir(dir)
@@ -79,7 +79,7 @@ func TestSimpleFlightRecorder(t *testing.T) {
 	t.Run("stops the flight recorder when disabled", func(t *testing.T) {
 		ExecutionTracerInterval.Override(context.Background(), &st.SV, 0)
 		testutils.SucceedsSoon(t, func() error {
-			if fr.enabledForTests() {
+			if fr.Enabled() {
 				return errors.New("flight recorder is still enabled")
 			}
 			return nil
@@ -89,7 +89,7 @@ func TestSimpleFlightRecorder(t *testing.T) {
 	// Restart so we can test that it's stopped with the stopper.
 	ExecutionTracerInterval.Override(context.Background(), &st.SV, 10*time.Second)
 	testutils.SucceedsSoon(t, func() error {
-		if !fr.enabledForTests() {
+		if !fr.Enabled() {
 			return errors.New("flight recorder is not enabled")
 		}
 		return nil

--- a/pkg/util/tracing/goexectrace/simple_flight_recorder_test.go
+++ b/pkg/util/tracing/goexectrace/simple_flight_recorder_test.go
@@ -48,6 +48,8 @@ func TestSimpleFlightRecorder(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, len(files), 0)
 
+	// Enable the FR via duration and enable periodic dumps via interval.
+	ExecutionTracerDuration.Override(context.Background(), &st.SV, 10*time.Second)
 	ExecutionTracerInterval.Override(context.Background(), &st.SV, 1*time.Millisecond)
 
 	t.Run("writes a file when enabled", func(t *testing.T) {
@@ -77,7 +79,7 @@ func TestSimpleFlightRecorder(t *testing.T) {
 	})
 
 	t.Run("stops the flight recorder when disabled", func(t *testing.T) {
-		ExecutionTracerInterval.Override(context.Background(), &st.SV, 0)
+		ExecutionTracerDuration.Override(context.Background(), &st.SV, 0)
 		testutils.SucceedsSoon(t, func() error {
 			if fr.Enabled() {
 				return errors.New("flight recorder is still enabled")
@@ -87,7 +89,7 @@ func TestSimpleFlightRecorder(t *testing.T) {
 	})
 
 	// Restart so we can test that it's stopped with the stopper.
-	ExecutionTracerInterval.Override(context.Background(), &st.SV, 10*time.Second)
+	ExecutionTracerDuration.Override(context.Background(), &st.SV, 10*time.Second)
 	testutils.SucceedsSoon(t, func() error {
 		if !fr.Enabled() {
 			return errors.New("flight recorder is not enabled")

--- a/pkg/util/tracing/goexectrace/simple_flight_recorder_test.go
+++ b/pkg/util/tracing/goexectrace/simple_flight_recorder_test.go
@@ -6,10 +6,12 @@
 package goexectrace
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -18,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/errors/oserror"
 	"github.com/stretchr/testify/require"
 )
 
@@ -96,4 +99,579 @@ func TestSimpleFlightRecorder(t *testing.T) {
 		}
 		return nil
 	})
+}
+
+// TestSettingCombinations verifies the four combinations of duration and
+// interval settings produce the correct behavior.
+func TestSettingCombinations(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	dir := t.TempDir()
+	st := cluster.MakeTestingClusterSettings()
+
+	fr, err := NewFlightRecorder(st, 100*time.Millisecond, dir)
+	require.NoError(t, err)
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.Background())
+
+	ctx := context.Background()
+	err = fr.Start(ctx, stopper)
+	require.NoError(t, err)
+
+	executionTracerOnDemandMinInterval.Override(ctx, &st.SV, 0)
+
+	clearDir := func() error {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			return err
+		}
+		for _, e := range entries {
+			if err := os.Remove(filepath.Join(dir, e.Name())); err != nil && !oserror.IsNotExist(err) {
+				return err
+			}
+		}
+		return nil
+	}
+
+	tests := []struct {
+		name             string
+		duration         time.Duration
+		interval         time.Duration
+		wantEnabled      bool
+		wantPeriodicDump bool
+		wantDumpNow      bool
+	}{{
+		name:             "duration=0,interval=0",
+		duration:         0,
+		interval:         0,
+		wantEnabled:      false,
+		wantPeriodicDump: false,
+		wantDumpNow:      false,
+	}, {
+		name:             "duration=0,interval>0",
+		duration:         0,
+		interval:         1 * time.Millisecond,
+		wantEnabled:      false,
+		wantPeriodicDump: false,
+		wantDumpNow:      false,
+	}, {
+		name:             "duration>0,interval=0",
+		duration:         10 * time.Second,
+		interval:         0,
+		wantEnabled:      true,
+		wantPeriodicDump: false,
+		wantDumpNow:      true,
+	}, {
+		name:             "duration>0,interval>0",
+		duration:         10 * time.Second,
+		interval:         1 * time.Millisecond,
+		wantEnabled:      true,
+		wantPeriodicDump: true,
+		wantDumpNow:      true,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ExecutionTracerDuration.Override(ctx, &st.SV, tc.duration)
+			ExecutionTracerInterval.Override(ctx, &st.SV, tc.interval)
+
+			testutils.SucceedsSoon(t, func() error {
+				if fr.Enabled() != tc.wantEnabled {
+					return errors.New("waiting for FR enabled state to match expected")
+				}
+				return nil
+			})
+
+			require.NoError(t, clearDir())
+
+			if tc.wantPeriodicDump {
+				testutils.SucceedsSoon(t, func() error {
+					files, err := os.ReadDir(dir)
+					if err != nil {
+						return err
+					}
+					if len(files) == 0 {
+						return errors.New("expected periodic dump files")
+					}
+					return nil
+				})
+			} else {
+				files, err := os.ReadDir(dir)
+				require.NoError(t, err)
+				require.Empty(t, files, "expected no periodic dump files")
+			}
+
+			if tc.wantDumpNow {
+				var filename string
+				testutils.SucceedsSoon(t, func() error {
+					f, err := fr.DumpNow(ctx, "test dump", "test")
+					if err != nil {
+						return err
+					}
+					if f == "" {
+						return errors.New("dump skipped due to concurrent snapshot")
+					}
+					filename = f
+					return nil
+				})
+				fi, err := os.Stat(filename)
+				require.NoError(t, err)
+				require.Greater(t, fi.Size(), int64(0))
+			} else {
+				_, err := fr.DumpNow(ctx, "should fail", "test")
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "not enabled")
+			}
+		})
+	}
+
+	t.Run("disable_periodic_fr_stays_on", func(t *testing.T) {
+		ExecutionTracerDuration.Override(ctx, &st.SV, 10*time.Second)
+		ExecutionTracerInterval.Override(ctx, &st.SV, 1*time.Millisecond)
+		testutils.SucceedsSoon(t, func() error {
+			if !fr.Enabled() {
+				return errors.New("expected FR to be enabled")
+			}
+			return nil
+		})
+
+		ExecutionTracerInterval.Override(ctx, &st.SV, 0)
+
+		// Wait for the async loop to observe interval=0 and stop
+		// dumping. Multiple consecutive empty observations confirm
+		// periodic dumps have actually stopped.
+		emptyChecks := 0
+		testutils.SucceedsSoon(t, func() error {
+			files, err := os.ReadDir(dir)
+			if err != nil {
+				return err
+			}
+			for _, f := range files {
+				if err := os.Remove(filepath.Join(dir, f.Name())); err != nil && !oserror.IsNotExist(err) {
+					return err
+				}
+			}
+			if len(files) > 0 {
+				emptyChecks = 0
+				return errors.New("periodic dump files still appearing")
+			}
+			emptyChecks++
+			if emptyChecks < 5 {
+				return errors.New("waiting for stable empty directory")
+			}
+			return nil
+		})
+
+		require.True(t, fr.Enabled())
+
+		var filename string
+		testutils.SucceedsSoon(t, func() error {
+			f, err := fr.DumpNow(ctx, "still works", "after_disable")
+			if err != nil {
+				return err
+			}
+			if f == "" {
+				return errors.New("dump skipped due to concurrent snapshot")
+			}
+			filename = f
+			return nil
+		})
+		require.NotEmpty(t, filename)
+	})
+
+	t.Run("change_duration_while_running", func(t *testing.T) {
+		ExecutionTracerDuration.Override(ctx, &st.SV, 5*time.Second)
+		ExecutionTracerInterval.Override(ctx, &st.SV, 0)
+		testutils.SucceedsSoon(t, func() error {
+			if !fr.Enabled() {
+				return errors.New("expected FR to be enabled")
+			}
+			return nil
+		})
+
+		ExecutionTracerDuration.Override(ctx, &st.SV, 20*time.Second)
+		testutils.SucceedsSoon(t, func() error {
+			if !fr.Enabled() {
+				return errors.New("expected FR to remain enabled after period change")
+			}
+			return nil
+		})
+
+		var filename string
+		testutils.SucceedsSoon(t, func() error {
+			f, err := fr.DumpNow(ctx, "after period change", "period_change")
+			if err != nil {
+				return err
+			}
+			if f == "" {
+				return errors.New("dump skipped due to concurrent snapshot")
+			}
+			filename = f
+			return nil
+		})
+		fi, err := os.Stat(filename)
+		require.NoError(t, err)
+		require.Greater(t, fi.Size(), int64(0))
+
+		testutils.SucceedsSoon(t, func() error {
+			fr.frMu.RLock()
+			currentPeriod := fr.frMu.period
+			fr.frMu.RUnlock()
+			if currentPeriod != 20*time.Second {
+				return errors.New("waiting for period to update to 20s")
+			}
+			return nil
+		})
+	})
+}
+
+func TestDumpNow(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	dir := t.TempDir()
+	st := cluster.MakeTestingClusterSettings()
+
+	fr, err := NewFlightRecorder(st, 100*time.Millisecond, dir)
+	require.NoError(t, err)
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.Background())
+
+	err = fr.Start(context.Background(), stopper)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	t.Run("fails when not enabled", func(t *testing.T) {
+		_, err := fr.DumpNow(ctx, "test reason", "test_tag")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not enabled")
+	})
+
+	ExecutionTracerDuration.Override(ctx, &st.SV, 10*time.Second)
+	executionTracerOnDemandMinInterval.Override(ctx, &st.SV, 0)
+
+	testutils.SucceedsSoon(t, func() error {
+		if !fr.Enabled() {
+			return errors.New("flight recorder is not enabled")
+		}
+		return nil
+	})
+
+	t.Run("produces a file with tag", func(t *testing.T) {
+		filename, err := fr.DumpNow(ctx, "scheduling latency", "scheduling_latency")
+		require.NoError(t, err)
+		require.NotEmpty(t, filename)
+
+		fi, err := os.Stat(filename)
+		require.NoError(t, err)
+		require.Greater(t, fi.Size(), int64(0))
+
+		base := filepath.Base(filename)
+		require.Contains(t, base, "scheduling_latency")
+		require.True(t, fileMatchRegexp.MatchString(base))
+	})
+
+	t.Run("produces a file without tag", func(t *testing.T) {
+		filename, err := fr.DumpNow(ctx, "generic dump", "")
+		require.NoError(t, err)
+		require.NotEmpty(t, filename)
+
+		fi, err := os.Stat(filename)
+		require.NoError(t, err)
+		require.Greater(t, fi.Size(), int64(0))
+
+		base := filepath.Base(filename)
+		require.True(t, fileMatchRegexp.MatchString(base))
+	})
+}
+
+func TestDumpNowRateLimit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	dir := t.TempDir()
+	st := cluster.MakeTestingClusterSettings()
+
+	fr, err := NewFlightRecorder(st, 100*time.Millisecond, dir)
+	require.NoError(t, err)
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.Background())
+
+	err = fr.Start(context.Background(), stopper)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	ExecutionTracerDuration.Override(ctx, &st.SV, 10*time.Second)
+	executionTracerOnDemandMinInterval.Override(ctx, &st.SV, 10*time.Second)
+
+	testutils.SucceedsSoon(t, func() error {
+		if !fr.Enabled() {
+			return errors.New("flight recorder is not enabled")
+		}
+		return nil
+	})
+
+	filename, err := fr.DumpNow(ctx, "first dump", "first")
+	require.NoError(t, err)
+	require.NotEmpty(t, filename)
+
+	filename2, err := fr.DumpNow(ctx, "second dump", "second")
+	require.NoError(t, err)
+	require.Empty(t, filename2)
+}
+
+func TestDumpNowConcurrent(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	dir := t.TempDir()
+	st := cluster.MakeTestingClusterSettings()
+
+	fr, err := NewFlightRecorder(st, 100*time.Millisecond, dir)
+	require.NoError(t, err)
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.Background())
+
+	err = fr.Start(context.Background(), stopper)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	ExecutionTracerDuration.Override(ctx, &st.SV, 10*time.Second)
+	executionTracerOnDemandMinInterval.Override(ctx, &st.SV, 0)
+
+	testutils.SucceedsSoon(t, func() error {
+		if !fr.Enabled() {
+			return errors.New("flight recorder is not enabled")
+		}
+		return nil
+	})
+
+	const numGoroutines = 5
+	var wg sync.WaitGroup
+	filenames := make([]string, numGoroutines)
+	errs := make([]error, numGoroutines)
+
+	wg.Add(numGoroutines)
+	for i := range numGoroutines {
+		go func(idx int) {
+			defer wg.Done()
+			filenames[idx], errs[idx] = fr.DumpNow(ctx, "concurrent dump", "concurrent_test")
+		}(i)
+	}
+	wg.Wait()
+
+	var gotFilename string
+	for i := range numGoroutines {
+		require.NoError(t, errs[i])
+		if filenames[i] != "" {
+			if gotFilename == "" {
+				gotFilename = filenames[i]
+			}
+		}
+	}
+	require.NotEmpty(t, gotFilename, "expected at least one successful dump")
+
+	fi, err := os.Stat(gotFilename)
+	require.NoError(t, err)
+	require.Greater(t, fi.Size(), int64(0))
+}
+
+func TestWriteTraceTo(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	dir := t.TempDir()
+	st := cluster.MakeTestingClusterSettings()
+
+	fr, err := NewFlightRecorder(st, 100*time.Millisecond, dir)
+	require.NoError(t, err)
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.Background())
+
+	err = fr.Start(context.Background(), stopper)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	ExecutionTracerDuration.Override(ctx, &st.SV, 10*time.Second)
+
+	testutils.SucceedsSoon(t, func() error {
+		if !fr.Enabled() {
+			return errors.New("flight recorder is not enabled")
+		}
+		return nil
+	})
+
+	var buf bytes.Buffer
+	n, err := fr.WriteTraceTo(ctx, &buf)
+	require.NoError(t, err)
+	require.Greater(t, n, int64(0))
+	require.Equal(t, n, int64(buf.Len()))
+}
+
+func TestTaggedFilenameMatchesGCRegex(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	dir := t.TempDir()
+	st := cluster.MakeTestingClusterSettings()
+
+	fr, err := NewFlightRecorder(st, time.Second, dir)
+	require.NoError(t, err)
+
+	tags := []string{"", "scheduling_latency", "stmt_diag", "lease_expiry"}
+	for _, tag := range tags {
+		filename := fr.timestampedFilename(tag)
+		base := filepath.Base(filename)
+		require.True(t, fileMatchRegexp.MatchString(base),
+			"filename %q does not match GC regex", base)
+	}
+}
+
+func TestDumpNowInvalidTag(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	dir := t.TempDir()
+	st := cluster.MakeTestingClusterSettings()
+
+	fr, err := NewFlightRecorder(st, 100*time.Millisecond, dir)
+	require.NoError(t, err)
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.Background())
+
+	err = fr.Start(context.Background(), stopper)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	ExecutionTracerDuration.Override(ctx, &st.SV, 10*time.Second)
+	executionTracerOnDemandMinInterval.Override(ctx, &st.SV, 0)
+
+	testutils.SucceedsSoon(t, func() error {
+		if !fr.Enabled() {
+			return errors.New("flight recorder is not enabled")
+		}
+		return nil
+	})
+
+	tests := []struct {
+		tag     string
+		wantErr bool
+	}{
+		{"valid_tag", false},
+		{"ValidTag123", false},
+		{"", false},
+		{"foo/bar", true},
+		{"../etc/passwd", true},
+		{"tag with spaces", true},
+		{"tag;rm", true},
+		{"foo\\bar", true},
+	}
+
+	for _, tc := range tests {
+		t.Run("tag="+tc.tag, func(t *testing.T) {
+			_, err := fr.DumpNow(ctx, "test", tc.tag)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "invalid tag")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestConcurrentDumpAndShutdown exercises the race between DumpNow (which
+// calls WriteTo) and the Start loop shutting down the flight recorder. This
+// test is primarily useful under the race detector (-race) to verify that the
+// frMu locking correctly prevents data races between concurrent WriteTo calls
+// and FR lifecycle changes.
+func TestConcurrentDumpAndShutdown(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	dir := t.TempDir()
+	st := cluster.MakeTestingClusterSettings()
+
+	fr, err := NewFlightRecorder(st, 50*time.Millisecond, dir)
+	require.NoError(t, err)
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.Background())
+
+	ctx := context.Background()
+	err = fr.Start(ctx, stopper)
+	require.NoError(t, err)
+
+	executionTracerOnDemandMinInterval.Override(ctx, &st.SV, 0)
+	ExecutionTracerDuration.Override(ctx, &st.SV, 10*time.Second)
+
+	testutils.SucceedsSoon(t, func() error {
+		if !fr.Enabled() {
+			return errors.New("flight recorder is not enabled")
+		}
+		return nil
+	})
+
+	var wg sync.WaitGroup
+	const iterations = 50
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			_, _ = fr.DumpNow(ctx, "race test", "race")
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		var buf bytes.Buffer
+		for range iterations {
+			buf.Reset()
+			if fr.Enabled() {
+				_, _ = fr.WriteTraceTo(ctx, &buf)
+			}
+		}
+	}()
+
+	for range iterations {
+		ExecutionTracerDuration.Override(ctx, &st.SV, 0)
+		ExecutionTracerDuration.Override(ctx, &st.SV, 10*time.Second)
+	}
+
+	wg.Wait()
+}
+
+func TestValidTag(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tests := []struct {
+		tag  string
+		want bool
+	}{
+		{"", true},
+		{"abc", true},
+		{"ABC", true},
+		{"abc123", true},
+		{"foo_bar", true},
+		{"foo/bar", false},
+		{"foo..bar", false},
+		{"foo bar", false},
+		{"foo;bar", false},
+		{"../etc", false},
+	}
+	for _, tc := range tests {
+		t.Run("tag="+tc.tag, func(t *testing.T) {
+			require.Equal(t, tc.want, validTag(tc.tag))
+		})
+	}
 }


### PR DESCRIPTION
- **goexectrace: migrate from x/exp/trace to runtime/trace**
- **goexectrace: refactor settings semantics and dump coordination**
- **goexectrace: add on-demand dumps and pprof trace streaming**
- **server: plumb flight recorder to debug server, KV, and tenants**
- **[delme]: include diff**

Epic: none
