### PR TITLE
roachtest: export mean total bandwidth to roachperf for disk-bandwidth-limiter

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
@@ -248,6 +248,14 @@ func registerDiskBandwidthOverload(r registry.Registry) {
 				if numErrors > numSuccesses {
 					t.Fatalf("too many errors retrieving metrics")
 				}
+				// Export mean total bandwidth to roachperf.
+				if len(totalBWValues) > 0 {
+					finalMeanTotalBW := roachtestutil.GetMeanOverLastN(len(totalBWValues), totalBWValues)
+					c.Run(ctx, option.WithNodes(c.CRDBNodes()), "mkdir", "-p", t.PerfArtifactsDir())
+					perfResult := fmt.Sprintf(`{"mean_total_bandwidth_mbs": %.1f}`, finalMeanTotalBW)
+					c.Run(ctx, option.WithNodes(c.CRDBNodes()),
+						fmt.Sprintf(`echo '%s' > %s/stats.json`, perfResult, t.PerfArtifactsDir()))
+				}
 				return nil
 			})
 


### PR DESCRIPTION
This adds a roachperf export for the mean total disk bandwidth observed during the monitoring phase of the disk-bandwidth-limiter roachtest. Previously, the collected bandwidth values were only used for pass/fail assertions and logging. Now, we write the mean to stats.json so we can track it over time on roachperf without digging through test logs.

Epic: CRDB-47073
Release note: None