### PR TITLE
dev: add --local-pebble flag for building against local pebble sources

### DIFF
--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -150,6 +150,11 @@ func (d *dev) build(cmd *cobra.Command, commandLine []string) error {
 	lint := mustGetFlagBool(cmd, lintFlag)
 	dockerArgs := mustGetFlagStringArray(cmd, dockerArgsFlag)
 
+	if cross != "" && localPebble != "" {
+		return fmt.Errorf("--cross and --local-pebble cannot be used together; " +
+			"for cross builds with custom pebble, push your changes and update DEPS.bzl instead")
+	}
+
 	args, buildTargets, err := d.getBasicBuildArgs(ctx, targets)
 	if err != nil {
 		return err

--- a/pkg/cmd/dev/testdata/datadriven/dev-build
+++ b/pkg/cmd/dev/testdata/datadriven/dev-build
@@ -84,3 +84,27 @@ rm crdb-checkout/cockroach-short
 cp sandbox/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short crdb-checkout/cockroach-short
 rm crdb-checkout/cockroach
 cp sandbox/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short crdb-checkout/cockroach
+
+exec
+dev build cockroach-short --local-pebble=/some/pebble/path
+----
+bazel build --override_repository=com_github_cockroachdb_pebble=/some/pebble/path //pkg/cmd/cockroach-short:cockroach-short --build_event_binary_file=/tmp/path
+bazel info workspace --color=no
+mkdir crdb-checkout/bin
+bazel info bazel-bin --color=no
+rm crdb-checkout/cockroach-short
+cp sandbox/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short crdb-checkout/cockroach-short
+rm crdb-checkout/cockroach
+cp sandbox/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short crdb-checkout/cockroach
+
+exec
+dev build cockroach-short --local-pebble=../my-pebble
+----
+bazel build --override_repository=com_github_cockroachdb_pebble=my-pebble //pkg/cmd/cockroach-short:cockroach-short --build_event_binary_file=/tmp/path
+bazel info workspace --color=no
+mkdir crdb-checkout/bin
+bazel info bazel-bin --color=no
+rm crdb-checkout/cockroach-short
+cp sandbox/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short crdb-checkout/cockroach-short
+rm crdb-checkout/cockroach
+cp sandbox/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short crdb-checkout/cockroach

--- a/pkg/cmd/dev/util.go
+++ b/pkg/cmd/dev/util.go
@@ -28,10 +28,17 @@ const (
 	shortFlag   = "short"
 )
 
+const (
+	localPebbleFlag        = "local-pebble"
+	defaultLocalPebblePath = "../pebble"
+	pebbleOverrideRepo     = "com_github_cockroachdb_pebble"
+)
+
 var (
 	// Shared flags.
-	numCPUs    int
-	pgoEnabled bool
+	numCPUs     int
+	pgoEnabled  bool
+	localPebble string
 )
 
 var archivedCdepConfigurations = []configuration{
@@ -166,6 +173,8 @@ func (d *dev) getArchivedCdepString(bazelBin string) (string, error) {
 func addCommonBuildFlags(cmd *cobra.Command) {
 	cmd.Flags().IntVar(&numCPUs, "cpus", 0, "cap the number of CPU cores used for building and testing at the Bazel level (note that this has no impact on GOMAXPROCS or the functionality of any build or test action under the Bazel level)")
 	cmd.Flags().BoolVar(&pgoEnabled, "pgo", false, "build with profile-guided optimization (PGO)")
+	cmd.Flags().StringVar(&localPebble, localPebbleFlag, "", "build using a local pebble checkout (default path: ../pebble relative to workspace)")
+	cmd.Flags().Lookup(localPebbleFlag).NoOptDefVal = defaultLocalPebblePath
 }
 
 func addCommonTestFlags(cmd *cobra.Command) {
@@ -270,5 +279,8 @@ func addCommonBazelArguments(args *[]string) {
 	}
 	if pgoEnabled {
 		*args = append(*args, "--config=pgo")
+	}
+	if localPebble != "" {
+		*args = append(*args, fmt.Sprintf("--override_repository=%s=%s", pebbleOverrideRepo, localPebble))
 	}
 }

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1092,6 +1092,7 @@ func TestLint(t *testing.T) {
 			":!util/syncutil/mutex_tracing.go",
 			":!util/timeutil/time.go",
 			":!util/timeutil/zoneinfo.go",
+			":!cmd/dev/**",
 			":!cmd/roachtest/tests/gorm_helpers.go",
 		)
 		if err != nil {


### PR DESCRIPTION
Building CockroachDB against a local pebble checkout currently requires manually running `make gen-bazel` in the pebble directory and passing `-- --override_repository=com_github_cockroachdb_pebble=<path>` to every `./dev` invocation. This is tedious and error-prone.

Add a `--local-pebble` flag to `./dev` that automates both steps:

- `--local-pebble` (no value): uses `../pebble` relative to workspace
- `--local-pebble=/path` or `--local-pebble=../rel`: uses the given path

The flag is registered via `addCommonBuildFlags` so it's available on build, test, bench, testlogic, lint, acceptance, and compose. Processing happens in `PersistentPreRunE` (path resolution, validation, gen-bazel) and `addCommonBazelArguments` (appending the override arg).

The gen-bazel step is skipped if the pebble WORKSPACE file was modified within the last 60 minutes, avoiding redundant work across repeated invocations.

Cross builds with `--local-pebble` are explicitly rejected for now.

Epic: none

Release note: None