### PR TITLE
roachtest: add CDC rolling restart test

### DIFF
--- a/pkg/ccl/changefeedccl/retry.go
+++ b/pkg/ccl/changefeedccl/retry.go
@@ -17,6 +17,12 @@ import (
 var useFastRetry = envutil.EnvOrDefaultBool(
 	"COCKROACH_CHANGEFEED_TESTING_FAST_RETRY", false)
 
+// useSlowRetry is useful for testing the retry behavior near its
+// maximum. This way, it doesn't take 10 retries to reach 1 minute
+// of backoff.
+var useSlowRetry = envutil.EnvOrDefaultBool(
+	"COCKROACH_CHANGEFEED_TESTING_SLOW_RETRY", false)
+
 // getRetry returns retry object for changefeed.
 func getRetry(ctx context.Context, maxBackoff, backoffReset time.Duration) Retry {
 	opts := retry.Options{
@@ -30,6 +36,14 @@ func getRetry(ctx context.Context, maxBackoff, backoffReset time.Duration) Retry
 			InitialBackoff: 5 * time.Millisecond,
 			Multiplier:     2,
 			MaxBackoff:     250 * time.Millisecond,
+		}
+	}
+
+	if useSlowRetry {
+		opts = retry.Options{
+			InitialBackoff: 32 * time.Second,
+			Multiplier:     2,
+			MaxBackoff:     maxBackoff,
 		}
 	}
 

--- a/pkg/ccl/changefeedccl/retry.go
+++ b/pkg/ccl/changefeedccl/retry.go
@@ -39,6 +39,7 @@ func getRetry(ctx context.Context, maxBackoff, backoffReset time.Duration) Retry
 		}
 	}
 
+	// useSlowRetry takes precedence over useFastRetry if both are set.
 	if useSlowRetry {
 		opts = retry.Options{
 			InitialBackoff: 32 * time.Second,

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -1294,8 +1294,8 @@ type rollingRestartParams struct {
 	maxBackoff          string // e.g., "1m" or "10m"
 	doRestarts          bool
 	frontierPersistence bool
-	testDuration        time.Duration // Total test duration (default 15m)
-	restartDuration     time.Duration // How long to do restarts before stopping (default 12m)
+	testDuration        time.Duration // Total test duration (default 20m)
+	restartDuration     time.Duration // How long to do restarts before stopping (default 17m)
 }
 
 // runCDCRollingRestart tests changefeed behavior during rolling node restarts.
@@ -1347,6 +1347,7 @@ func runCDCRollingRestart(
 	// Connect to node 4 (workload node) for queries since we'll be
 	// restarting nodes 1, 2, 3 during the test.
 	db := c.Conn(ctx, t.L(), 4)
+	defer db.Close()
 	t.L().Printf("setting up test with maxBackoff=%s, doRestarts=%t, frontierPersistence=%t",
 		params.maxBackoff, params.doRestarts, params.frontierPersistence)
 	setupStmts := []string{
@@ -1387,13 +1388,23 @@ func runCDCRollingRestart(
 		defer func() {
 			t.L().Printf("done restarting nodes")
 		}()
+
+		if !params.doRestarts {
+			t.L().Printf("control mode: skipping restarts, changefeed will run uninterrupted for %s", testDuration)
+			select {
+			case <-stopRestarts:
+			case <-ctx.Done():
+			}
+			return nil
+		}
+
 		t.L().Printf("starting rolling drain+restarts of nodes 1, 2, 3 at %s interval for %s...", restartInterval, restartDuration)
 
-		timer := time.NewTimer(0 * time.Second)
+		timer := time.NewTimer(0)
 		restartDeadline := testBeginTime.Add(restartDuration)
 		for {
 			for _, n := range []int{1, 2, 3} {
-				if timeutil.Now().After(restartDeadline) && params.doRestarts {
+				if timeutil.Now().After(restartDeadline) {
 					t.L().Printf("=== RESTART DEADLINE REACHED at %s (after %s) ===", timeutil.Now(), timeutil.Since(testBeginTime))
 					t.L().Printf("=== STOPPING RESTARTS TO MEASURE RECOVERY ===")
 					t.L().Printf("Changefeed will now run uninterrupted for remaining %s", testDuration-restartDuration)
@@ -1408,12 +1419,8 @@ func runCDCRollingRestart(
 				case <-timer.C:
 				}
 
-				if !params.doRestarts {
-					t.L().Printf("control mode: NOT restarting node %d", n)
-				} else {
-					if err := restart(n); err != nil {
-						return err
-					}
+				if err := restart(n); err != nil {
+					return err
 				}
 				// Wait between restarts to let changefeeds make progress and
 				// allow backoff to climb higher before the next disruption.
@@ -1452,6 +1459,9 @@ func runCDCRollingRestart(
 				jobID, testDuration, restartDuration, testDuration-restartDuration)
 		}
 
+		const maxLagDuringRestarts = 5 * time.Minute
+		const maxLagAfterRecovery = 2 * time.Minute
+
 		beginTime := timeutil.Now()
 		// Sample every 10 seconds for the duration of the test.
 		numSamples := int(testDuration / (10 * time.Second))
@@ -1459,6 +1469,7 @@ func runCDCRollingRestart(
 		var recoveryPhaseStarted bool
 		var recoveryStartLag time.Duration
 		var recoveryStartTime time.Time
+		var finalLag time.Duration
 
 		for i := 0; i < numSamples; i++ {
 			time.Sleep(10 * time.Second)
@@ -1501,18 +1512,34 @@ func runCDCRollingRestart(
 			}
 
 			if hwNanos.Valid {
-				highwater := timeutil.Unix(0, int64(hwNanos.Float64))
-				lag := timeutil.Since(highwater)
 				t.L().Printf("%s[%s] changefeed %d: status=%s, running_status=%s, lag=%s, highwater=%s",
-					prefix, runtime, jobID, status, runningStatus.String, lag, highwater)
+					prefix, runtime, jobID, status, runningStatus.String, currentLag,
+					timeutil.Unix(0, int64(hwNanos.Float64)))
 			} else {
 				t.L().Printf("%s[%s] changefeed %d: status=%s, running_status=%s, highwater=not yet set",
 					prefix, runtime, jobID, status, runningStatus.String)
 			}
+
+			// Assert that lag never exceeds the maximum during rolling restarts.
+			if params.doRestarts && currentLag > maxLagDuringRestarts {
+				t.Fatalf("changefeed lag %s exceeded maximum allowed %s during rolling restarts",
+					currentLag, maxLagDuringRestarts)
+			}
+
+			finalLag = currentLag
 		}
 
-		t.L().Printf("changefeed %d completed %s test run", jobID, testDuration)
+		t.L().Printf("changefeed %d completed %s test run, final lag=%s", jobID, testDuration, finalLag)
+
+		// After the recovery period, lag should have settled below the threshold.
+		if params.doRestarts && finalLag > maxLagAfterRecovery {
+			t.Fatalf("changefeed lag %s exceeded maximum allowed %s after recovery period",
+				finalLag, maxLagAfterRecovery)
+		}
 	}()
+
+	<-wait
+	m.Wait()
 }
 
 type fineGrainedCheckpointingParams struct {
@@ -2434,9 +2461,7 @@ CONFIGURE ZONE USING
 			Owner:            registry.OwnerCDC,
 			Cluster:          r.MakeClusterSpec(4),
 			CompatibleClouds: registry.OnlyGCE,
-			// This test doesn't currently make any assertions.
-			// If it did, it wouldn't pass (#164041).
-			// TODO(#164041): Investigate this lag and run test in Nightly.
+			// TODO(#164041): Investigate lag issues and promote to Nightly.
 			Suites:  registry.ManualOnly,
 			Timeout: 30 * time.Minute,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -1289,6 +1289,232 @@ WITH initial_scan='only', min_checkpoint_frequency='1s'`, sinkURL),
 	}
 }
 
+type rollingRestartParams struct {
+	name                string
+	maxBackoff          string // e.g., "1m" or "10m"
+	doRestarts          bool
+	frontierPersistence bool
+	testDuration        time.Duration // Total test duration (default 15m)
+	restartDuration     time.Duration // How long to do restarts before stopping (default 12m)
+}
+
+// runCDCRollingRestart tests changefeed behavior during rolling node restarts.
+// It runs a kv workload while periodically draining and restarting nodes to
+// simulate rolling upgrades. The test parametrizes over:
+//   - maxBackoff: controls changefeed.max_retry_backoff (1m vs 10m)
+//   - doRestarts: whether to actually restart nodes (vs control without restarts)
+//   - frontierPersistence: whether frontier persistence is enabled (vs span checkpoints)
+//
+// The test monitors changefeed lag during the restart cycle to ensure the
+// changefeed can keep up with the workload.
+func runCDCRollingRestart(
+	ctx context.Context, t test.Test, c cluster.Cluster, params rollingRestartParams,
+) {
+	testDuration := params.testDuration
+	if testDuration == 0 {
+		testDuration = 20 * time.Minute
+	}
+	restartDuration := params.restartDuration
+	if restartDuration == 0 {
+		restartDuration = 17 * time.Minute
+	}
+	const restartInterval = 2 * time.Minute
+
+	startOpts := option.DefaultStartOpts()
+	racks := install.MakeClusterSettings(install.NumRacksOption(c.Spec().NodeCount))
+	// Use the slow retries so that it doesn't take many retries to get the max
+	// backoff behavior.
+	racks.Env = append(racks.Env, `COCKROACH_CHANGEFEED_TESTING_SLOW_RETRY=true`)
+	c.Start(ctx, t.L(), startOpts, racks)
+	m := c.NewDeprecatedMonitor(ctx, c.All())
+
+	restart := func(n int) error {
+		t.L().Printf("draining and restarting node %d", n)
+		cmd := fmt.Sprintf("./cockroach node drain --certs-dir=%s --port={pgport:%d} --self", install.CockroachNodeCertsDir, n)
+		if err := c.RunE(ctx, option.WithNodes(c.Node(n)), cmd); err != nil {
+			return err
+		}
+		m.ExpectDeath()
+		c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Node(n))
+		opts := startOpts
+		opts.RoachprodOpts.IsRestart = true
+		c.Start(ctx, t.L(), opts, racks, c.Node(n))
+		m.ResetDeaths()
+		t.L().Printf("node %d restarted successfully", n)
+		return nil
+	}
+
+	// Connect to node 4 (workload node) for queries since we'll be
+	// restarting nodes 1, 2, 3 during the test.
+	db := c.Conn(ctx, t.L(), 4)
+	t.L().Printf("setting up test with maxBackoff=%s, doRestarts=%t, frontierPersistence=%t",
+		params.maxBackoff, params.doRestarts, params.frontierPersistence)
+	setupStmts := []string{
+		`SET CLUSTER SETTING kv.rangefeed.enabled = 'true'`,
+		fmt.Sprintf(`SET CLUSTER SETTING changefeed.max_retry_backoff = '%s'`, params.maxBackoff),
+		`SET CLUSTER SETTING changefeed.shutdown_checkpoint.enabled = 'false'`,
+	}
+	if params.frontierPersistence {
+		setupStmts = append(setupStmts,
+			`SET CLUSTER SETTING changefeed.span_checkpoint.interval = '0'`,
+			`SET CLUSTER SETTING changefeed.progress.frontier_persistence.interval = '5s'`,
+		)
+	} else {
+		setupStmts = append(setupStmts,
+			`SET CLUSTER SETTING changefeed.span_checkpoint.interval = '5s'`,
+			// Set frontier persistence to max allowed value (10m) to effectively disable it.
+			`SET CLUSTER SETTING changefeed.progress.frontier_persistence.interval = '10m'`,
+		)
+	}
+
+	for _, s := range setupStmts {
+		t.L().Printf(s)
+		if _, err := db.Exec(s); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cmd := fmt.Sprintf("./cockroach workload init kv --splits 50 {pgurl:%d}", c.Spec().NodeCount)
+	if err := c.RunE(ctx, option.WithNodes(c.Node(c.Spec().NodeCount)), cmd); err != nil {
+		t.Fatal(err)
+	}
+
+	testBeginTime := timeutil.Now()
+
+	// Restart nodes in a loop.
+	stopRestarts := make(chan struct{})
+	m.Go(func(ctx context.Context) error {
+		defer func() {
+			t.L().Printf("done restarting nodes")
+		}()
+		t.L().Printf("starting rolling drain+restarts of nodes 1, 2, 3 at %s interval for %s...", restartInterval, restartDuration)
+
+		timer := time.NewTimer(0 * time.Second)
+		restartDeadline := testBeginTime.Add(restartDuration)
+		for {
+			for _, n := range []int{1, 2, 3} {
+				if timeutil.Now().After(restartDeadline) && params.doRestarts {
+					t.L().Printf("=== RESTART DEADLINE REACHED at %s (after %s) ===", timeutil.Now(), timeutil.Since(testBeginTime))
+					t.L().Printf("=== STOPPING RESTARTS TO MEASURE RECOVERY ===")
+					t.L().Printf("Changefeed will now run uninterrupted for remaining %s", testDuration-restartDuration)
+					return nil
+				}
+
+				select {
+				case <-stopRestarts:
+					return nil
+				case <-ctx.Done():
+					return nil
+				case <-timer.C:
+				}
+
+				if !params.doRestarts {
+					t.L().Printf("control mode: NOT restarting node %d", n)
+				} else {
+					if err := restart(n); err != nil {
+						return err
+					}
+				}
+				// Wait between restarts to let changefeeds make progress and
+				// allow backoff to climb higher before the next disruption.
+				timer.Reset(restartInterval)
+			}
+		}
+	})
+
+	m.Go(func(ctx context.Context) error {
+		cmd := fmt.Sprintf("./cockroach workload run kv --zipfian --duration=%s {pgurl:%d} --tolerate-errors",
+			testDuration, c.Spec().NodeCount)
+		if err := c.RunE(ctx, option.WithNodes(c.Node(c.Spec().NodeCount)), cmd); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	})
+
+	wait := make(chan struct{})
+
+	func() {
+		defer close(wait)
+		defer close(stopRestarts)
+
+		t.L().Printf("starting changefeed...")
+		var jobID int
+		if err := db.QueryRow(`CREATE CHANGEFEED FOR TABLE kv.kv INTO 'null://' WITH initial_scan='no'`).Scan(&jobID); err != nil {
+			t.Fatal(err)
+		}
+
+		if restartDuration == 0 {
+			t.L().Printf("changefeed %d will run for %s (no restarts, baseline test)", jobID, testDuration)
+		} else if restartDuration >= testDuration {
+			t.L().Printf("changefeed %d will run for %s (restarts throughout)", jobID, testDuration)
+		} else {
+			t.L().Printf("changefeed %d will run for %s (restarts for %s, then recovery measurement for %s)",
+				jobID, testDuration, restartDuration, testDuration-restartDuration)
+		}
+
+		beginTime := timeutil.Now()
+		// Sample every 10 seconds for the duration of the test.
+		numSamples := int(testDuration / (10 * time.Second))
+
+		var recoveryPhaseStarted bool
+		var recoveryStartLag time.Duration
+		var recoveryStartTime time.Time
+
+		for i := 0; i < numSamples; i++ {
+			time.Sleep(10 * time.Second)
+			runtime := timeutil.Since(beginTime)
+
+			if !recoveryPhaseStarted && runtime > restartDuration {
+				recoveryPhaseStarted = true
+				recoveryStartTime = timeutil.Now()
+				t.L().Printf("=== ENTERING RECOVERY PHASE at %s ===", runtime)
+			}
+
+			var status string
+			var hwNanos gosql.NullFloat64
+			var runningStatus gosql.NullString
+			err := db.QueryRow(`
+				SELECT status, running_status, high_water_timestamp
+				FROM [SHOW CHANGEFEED JOB $1]`, jobID).Scan(&status, &runningStatus, &hwNanos)
+			if err != nil {
+				t.L().Printf("error querying changefeed status: %v", err)
+				continue
+			}
+
+			var currentLag time.Duration
+			if hwNanos.Valid {
+				highwater := timeutil.Unix(0, int64(hwNanos.Float64))
+				currentLag = timeutil.Since(highwater)
+			}
+
+			if recoveryPhaseStarted && recoveryStartLag == 0 && currentLag > 0 {
+				recoveryStartLag = currentLag
+				t.L().Printf("=== RECOVERY BASELINE: lag=%s at %s ===", currentLag, timeutil.Since(recoveryStartTime))
+			}
+
+			// Enhanced logging with recovery tracking.
+			prefix := ""
+			if recoveryPhaseStarted {
+				recoveryTime := timeutil.Since(recoveryStartTime)
+				lagReduction := recoveryStartLag - currentLag
+				prefix = fmt.Sprintf("[RECOVERY +%s lag_reduction=%s] ", recoveryTime, lagReduction)
+			}
+
+			if hwNanos.Valid {
+				highwater := timeutil.Unix(0, int64(hwNanos.Float64))
+				lag := timeutil.Since(highwater)
+				t.L().Printf("%s[%s] changefeed %d: status=%s, running_status=%s, lag=%s, highwater=%s",
+					prefix, runtime, jobID, status, runningStatus.String, lag, highwater)
+			} else {
+				t.L().Printf("%s[%s] changefeed %d: status=%s, running_status=%s, highwater=not yet set",
+					prefix, runtime, jobID, status, runningStatus.String)
+			}
+		}
+
+		t.L().Printf("changefeed %d completed %s test run", jobID, testDuration)
+	}()
+}
+
 type fineGrainedCheckpointingParams struct {
 	numRanges               int
 	transientErrorFrequency time.Duration
@@ -2195,6 +2421,29 @@ CONFIGURE ZONE USING
 		Skip: "frontier persistence will not happen during an initial-scan only changefeed " +
 			"without periodic aggregator frontier flushes",
 	})
+	for _, params := range []rollingRestartParams{
+		{name: "backoff=1m/restarts=yes/frontier=on", maxBackoff: "1m", doRestarts: true, frontierPersistence: true},
+		{name: "backoff=1m/restarts=yes/frontier=off", maxBackoff: "1m", doRestarts: true, frontierPersistence: false},
+		{name: "backoff=10m/restarts=yes/frontier=on", maxBackoff: "10m", doRestarts: true, frontierPersistence: true},
+		{name: "backoff=10m/restarts=yes/frontier=off", maxBackoff: "10m", doRestarts: true, frontierPersistence: false},
+		{name: "backoff=10m/restarts=no/frontier=off", maxBackoff: "10m", doRestarts: false, frontierPersistence: false},
+	} {
+		params := params
+		r.Add(registry.TestSpec{
+			Name:             fmt.Sprintf("cdc/rolling-restart/%s", params.name),
+			Owner:            registry.OwnerCDC,
+			Cluster:          r.MakeClusterSpec(4),
+			CompatibleClouds: registry.OnlyGCE,
+			// This test doesn't currently make any assertions.
+			// If it did, it wouldn't pass (#164041).
+			// TODO(#164041): Investigate this lag and run test in Nightly.
+			Suites:  registry.ManualOnly,
+			Timeout: 30 * time.Minute,
+			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+				runCDCRollingRestart(ctx, t, c, params)
+			},
+		})
+	}
 	r.Add(registry.TestSpec{
 		Name:             "cdc/fine-grained-checkpointing",
 		Owner:            registry.OwnerCDC,


### PR DESCRIPTION
This commit adds a new roachtest that validates changefeed behavior
during rolling node restarts, simulating rolling upgrade scenarios.

The test runs a kv workload while periodically draining and restarting
nodes 1-3, monitoring changefeed lag throughout the process. It
parametrizes over three dimensions:

- maxBackoff: changefeed.max_retry_backoff setting (1m vs 10m)
- doRestarts: whether to perform restarts (vs control baseline)
- frontierPersistence: frontier persistence enabled or disabled

Five test variants are registered covering different combinations of
these parameters. Each test runs for 15 minutes total, with 12 minutes
of rolling restarts followed by 3 minutes of recovery measurement to
track lag reduction after disruptions cease.

The test is currently marked as ManualOnly pending investigation of
observed lag issues.

Informs: https://github.com/cockroachdb/cockroach/issues/164041
Fixes: https://github.com/cockroachdb/cockroach/issues/163855

Release note: None