### PR TITLE
release-26.1: util/metric: fix +Inf values from histogram quantile computation

### DIFF
--- a/pkg/util/metric/histogram_snapshot.go
+++ b/pkg/util/metric/histogram_snapshot.go
@@ -62,8 +62,19 @@ func (hs HistogramSnapshot) ValueAtQuantile(q float64) float64 {
 		count -= *buckets[b-1].CumulativeCount
 		rank -= *buckets[b-1].CumulativeCount
 	}
-	val := bucketStart + (bucketEnd-bucketStart)*(float64(rank)/float64(count))
-	if math.IsNaN(val) || math.IsInf(val, -1) {
+	var val float64
+	if count == 0 {
+		// The bucket has no observations. Use the bucket start as the estimate
+		// when rank is also 0 (quantile 0), otherwise use the bucket end.
+		if rank == 0 {
+			val = bucketStart
+		} else {
+			val = bucketEnd
+		}
+	} else {
+		val = bucketStart + (bucketEnd-bucketStart)*(float64(rank)/float64(count))
+	}
+	if math.IsNaN(val) || math.IsInf(val, 0) {
 		return 0
 	}
 


### PR DESCRIPTION
Backport 1/1 commits from #164006 on behalf of @dhartunian.

----

ValueAtQuantile could produce +Inf when a histogram bucket had zero observations, causing division by zero in the interpolation formula. The existing guard only checked for NaN and negative infinity, letting +Inf slip through into node status metrics. This caused debug zip to fail with "json: unsupported value: +Inf" when serializing nodes.json, since Go's encoding/json rejects infinity values.

Fix by explicitly handling the count==0 case before division: return bucketStart for rank 0, or bucketEnd otherwise, consistent with the existing upper-bound clamping behavior.

Fixes #163958

Release note: None

----

Release justification: small bugfix to histogram serialization