### PR TITLE
bulkmerge: add pause points for first and final merge iterations

### DIFF
--- a/pkg/sql/bulkmerge/merge.go
+++ b/pkg/sql/bulkmerge/merge.go
@@ -108,6 +108,22 @@ func Merge(
 		return nil, err
 	}
 
+	// Check pausepoints after the merge flow completes.
+	if opts.Iteration == 1 {
+		if err := execCtx.ExecCfg().JobRegistry.CheckPausepoint(
+			"distribute_merge.after_first_iteration",
+		); err != nil {
+			return nil, err
+		}
+	}
+	if opts.Iteration == opts.MaxIterations {
+		if err := execCtx.ExecCfg().JobRegistry.CheckPausepoint(
+			"distribute_merge.after_final_iteration",
+		); err != nil {
+			return nil, err
+		}
+	}
+
 	if opts.Iteration == opts.MaxIterations {
 		// Final iteration writes directly to KV; no SST outputs expected.
 		return nil, nil


### PR DESCRIPTION
Add two CheckPausepoint calls in bulkmerge.Merge() after the DistSQL flow completes. These allow jobs using distributed merge (IMPORT and index backfill) to be paused at critical merge boundaries for debugging and memory profiling:

- distribute_merge.after_first_iteration: fires after the first/local merge iteration completes.
- distribute_merge.after_final_iteration: fires after the final merge iteration completes, before the caller clears manifests.

Epic: CRDB-48845
Release note: None