### PR TITLE
release-25.4: sql: prevent concurrent DROP and SET SCHEMA operations

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/schema
+++ b/pkg/sql/logictest/testdata/logic_test/schema
@@ -1562,3 +1562,53 @@ statement ok
 DROP SCHEMA drop_schema_with_triggers CASCADE;
 
 subtest end
+
+subtest concurrent_schema_drop
+
+statement ok
+CREATE SCHEMA concurrent_drop_sc;
+
+statement ok
+CREATE TABLE concurrent_drop_sc.t1 (id INT PRIMARY KEY);
+
+statement ok
+CREATE TABLE public.fk_ref_to_concurrent_t1 (
+    id INT PRIMARY KEY,
+    fk INT REFERENCES concurrent_drop_sc.t1(id)
+);
+
+statement ok
+CREATE OR REPLACE FUNCTION concurrent_rename_fn (a INT) RETURNS INT AS 'SELECT a*a' LANGUAGE SQL;
+
+statement ok
+SET CLUSTER SETTING jobs.debug.pausepoints = 'newschemachanger.before.exec';
+
+skipif config local-legacy-schema-changer
+statement error pq: job \d+ was paused before it completed with reason: pause point
+DROP SCHEMA concurrent_drop_sc CASCADE;
+
+statement ok
+BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+
+statement ok
+set autocommit_before_ddl=false;
+
+# Confirm we hit a retry error if attempt to us the schema.
+skipif config local-legacy-schema-changer
+statement error restart transaction: descriptor \d+ is undergoing another schema change
+ALTER FUNCTION concurrent_rename_fn SET SCHEMA concurrent_drop_sc;
+
+statement ok
+ROLLBACK;
+
+statement ok
+RESET autocommit_before_ddl;
+
+statement ok
+RESET CLUSTER SETTING jobs.debug.pausepoints;
+
+statement ok
+RESUME JOBS (SELECT job_id FROM crdb_internal.jobs WHERE status = 'paused');
+
+
+subtest end

--- a/pkg/sql/schema.go
+++ b/pkg/sql/schema.go
@@ -41,6 +41,11 @@ func schemaExists(
 }
 
 func (p *planner) writeSchemaDesc(ctx context.Context, desc *schemadesc.Mutable) error {
+	// Exit early with an error if the schema is undergoing a declarative schema
+	// change.
+	if catalog.HasConcurrentDeclarativeSchemaChange(desc) {
+		return scerrors.ConcurrentSchemaChangeError(desc)
+	}
 	b := p.txn.NewBatch()
 	if err := p.Descriptors().WriteDescToBatch(
 		ctx, p.extendedEvalCtx.Tracing.KVTracingEnabled(), desc, b,
@@ -53,11 +58,6 @@ func (p *planner) writeSchemaDesc(ctx context.Context, desc *schemadesc.Mutable)
 func (p *planner) writeSchemaDescChange(
 	ctx context.Context, desc *schemadesc.Mutable, jobDesc string,
 ) error {
-	// Exit early with an error if the schema is undergoing a declarative schema
-	// change.
-	if catalog.HasConcurrentDeclarativeSchemaChange(desc) {
-		return scerrors.ConcurrentSchemaChangeError(desc)
-	}
 	record, recordExists := p.extendedEvalCtx.jobs.uniqueToCreate[desc.ID]
 	if recordExists {
 		// Update it.


### PR DESCRIPTION
Backport 1/1 commits from #164043 on behalf of @fqazi.

----

Previously, we added logic to prevent legacy schema modification operations while a schema was undergoing declarative schema changes. Unfortunately, this logic did not cover ALTER FUNCTION ... SET SCHEMA. This patch ensures all legacy schema write operations are blocked if a concurrent declarative schema change is in progress.

Fixes: #163156
Release note (bug fix): Prevented a race condition/conflict between concurrent ALTER FUNCTION ... SET SCHEMA and DROP SCHEMA operations.

----

Release justification: low risk change that prevents concurrent schema changes to prevent dangling descriptors.