### PR TITLE
sql: improve transaction diagnostics bundle lifecycle logging

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -4402,6 +4402,7 @@ func (ex *connExecutor) recordTransactionStart(txnID uuid.UUID) {
 	ex.phaseTimes.SetSessionPhaseTime(sessionphase.SessionMostRecentStartExecTransaction,
 		ex.phaseTimes.GetSessionPhaseTime(sessionphase.SessionFirstStartExecTransaction))
 	ex.extraTxnState.transactionStatementsHash = util.MakeFNV64()
+	ex.state.txnInstrumentationHelper.txnFingerprintHash = &ex.extraTxnState.transactionStatementsHash
 	ex.extraTxnState.transactionStatementFingerprintIDs = nil
 	ex.extraTxnState.numRows = 0
 	ex.extraTxnState.accumulatedStats = execstats.QueryLevelStats{}


### PR DESCRIPTION
## Summary

Adds targeted `log.Dev.VInfof` logs at key lifecycle points in transaction
diagnostics bundle collection, each including the transaction ID for
correlation when debugging bundle collection issues:

- **Starting**: logged in `MaybeStartDiagnostics` when a diagnostics request
  matches the current statement fingerprint
- **Aborting**: logged in `MaybeContinueDiagnostics` when a fingerprint mismatch
  stops collection, including expected vs received fingerprints and the number of
  bundles collected so far
- **Finalizing**: logged in `Finalize` with distinct messages for abandoned
  (transaction finished before all expected statements executed) and completed
  collections, including the target transaction fingerprint

These logs use `log.Dev.VInfof` at verbosity 2 with sufficient context
(txn ID, txn fingerprint, request ID, statement fingerprints) for
debugging bundle collection issues.

To facilitate these changes a new state, `txnDiagnosticsSkipped`, is added to
differentiate between transactions that have reset the diagnostics collector and
transactions that were skipped entirely due to not meeting the criteria of any
existing diagnostics requests. `Finalize` also adds an early return for the
`NotStarted()` state to avoid unnecessary fingerprint computation.

Epic: None
Release note: None