### PR TITLE
cockroach: add local Claude files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ pkg/testutils/serverutils/*_generated.go
 .idea/
 .vscode/
 CLAUDE.local.md
+.claude/*.local.*


### PR DESCRIPTION
Based on the glob in https://code.claude.com/docs/en/settings#available-scopes. Skips the `.claude/settings.local.json` which Claude generates pretty soon when interacting with the repo (e.g. permissions).

Epic: none
Release note: none