### PR TITLE
kvserver: use separated batch in destroyRaftMuLocked

### DIFF
--- a/pkg/kv/kvserver/spanset/engine.go
+++ b/pkg/kv/kvserver/spanset/engine.go
@@ -134,7 +134,13 @@ func (s *spanSetEngine) NewSnapshot(keyRanges ...roachpb.Span) storage.Reader {
 
 // NewWriteBatch implements the storage.EngineWithoutRW interface.
 func (s *spanSetEngine) NewWriteBatch() storage.WriteBatch {
-	wb := s.e.NewWriteBatch()
+	return s.WrapWriteBatch(s.e.NewWriteBatch())
+}
+
+// WrapWriteBatch associates the given WriteBatch with this Engine, and returns
+// a wrapped WriteBatch. This enables the corresponding assertions, e.g.
+// checking that the batch accesses only the keys allowed by this Engine.
+func (s *spanSetEngine) WrapWriteBatch(wb storage.WriteBatch) storage.WriteBatch {
 	return &spanSetWriteBatch{
 		spanSetWriter: spanSetWriter{w: wb, spans: s.spans, spansOnly: true},
 		wb:            wb,


### PR DESCRIPTION
This PR introduces the `kvstorage.WriteBatch` type which encapsulates a pair of per-engine `WriteBatch`es, and helps with their lifecycle: creating, writing to, committing and closing. The type mostly hides the storage separation quirks.

The first user is `destroyRaftMuLocked`. It currently syncs unconditionally, so we mirror that with the `CommitAndSync` method. It may need generalization in the future.

Part of #97627