### PR TITLE
operations: disable node kill operation registration

### DIFF
--- a/pkg/cmd/roachtest/operations/node_kill.go
+++ b/pkg/cmd/roachtest/operations/node_kill.go
@@ -19,10 +19,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
+//lint:ignore U1000 temporarily disabled
 type cleanupNodeKill struct {
 	nodes option.NodeListOption
 }
 
+//lint:ignore U1000 temporarily disabled
 func (cl *cleanupNodeKill) Cleanup(ctx context.Context, o operation.Operation, c cluster.Cluster) {
 	db, err := c.ConnE(ctx, o.L(), cl.nodes[0])
 	if err != nil {
@@ -46,6 +48,7 @@ func (cl *cleanupNodeKill) Cleanup(ctx context.Context, o operation.Operation, c
 	}
 }
 
+//lint:ignore U1000 temporarily disabled
 func nodeKillRunner(
 	signal int, drain bool,
 ) func(ctx context.Context, o operation.Operation, c cluster.Cluster) registry.OperationCleanup {
@@ -54,6 +57,7 @@ func nodeKillRunner(
 	}
 }
 
+//lint:ignore U1000 temporarily disabled
 func runNodeKill(
 	ctx context.Context, o operation.Operation, c cluster.Cluster, signal int, drain bool,
 ) registry.OperationCleanup {
@@ -90,6 +94,7 @@ func runNodeKill(
 	return &cleanupNodeKill{nodes: node}
 }
 
+//lint:ignore U1000 temporarily disabled
 func registerNodeKill(r registry.Registry) {
 	for _, spec := range []struct {
 		name     string

--- a/pkg/cmd/roachtest/operations/register.go
+++ b/pkg/cmd/roachtest/operations/register.go
@@ -21,7 +21,7 @@ func RegisterOperations(r registry.Registry) {
 	registerGrantRevoke(r)
 	registerNetworkPartition(r)
 	registerDiskStall(r)
-	registerNodeKill(r)
+	//registerNodeKill(r)
 	registerClusterSettings(r)
 	registerCreateSQLOperations(r)
 	registerBackupRestore(r)


### PR DESCRIPTION
The registerNodeKill operation is temporarily commented out
 to prevent it from running during roachtest operations

Epic: none

Release note: None