### PR TITLE
concurrency: condense virtual ResolveIntents to ResolveIntentRange requests

### DIFF
--- a/pkg/kv/kvserver/concurrency/concurrency_control.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_control.go
@@ -518,6 +518,10 @@ type Guard interface {
 	// IntentsToResolveVirtually delegates listing the locks to be resolved to the
 	// lock table guard.
 	IntentsToResolveVirtually() []roachpb.LockUpdate
+
+	// PrepareForLockConflictRetry called on the lock conflict error path, before
+	// the guard is re-sequenced.
+	PrepareForLockConflictRetry(context.Context)
 }
 
 // guardImpl implements the Guard interface.
@@ -894,6 +898,11 @@ type lockTableGuard interface {
 	// VirtuallyResolvesIntents returns true if the guard will resolve intents
 	// virtually during evaluation rather than physically before re-scanning.
 	VirtuallyResolvesIntents() bool
+
+	// PrepareForLockConflictRetry is called when handling a LockConflictError
+	// after an evaluation. If VIR is in use, it collapses the guard's point
+	// resolve entries into range entries that persist across re-sequencing.
+	PrepareForLockConflictRetry(context.Context)
 
 	// CheckOptimisticNoConflicts uses the LockSpanSet representing the spans that
 	// were actually read, to check for conflicting locks, after an optimistic

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -596,6 +596,12 @@ func (m *managerImpl) HandleLockConflictError(
 	//
 	// Either way, there is no possibility of the request entering an infinite
 	// loop without making progress.
+
+	// If VIR was used, collapse point resolve entries into persistent range
+	// entries before they are cleared by the next ScanAndEnqueue. This prevents
+	// livelock when the lock table evicts entries under memory pressure.
+	g.PrepareForLockConflictRetry(ctx)
+
 	consultTxnStatusCache :=
 		int64(len(t.Locks)) > DiscoveredLocksThresholdToConsultTxnStatusCache.Get(&m.st.SV)
 	var numAdded int
@@ -897,6 +903,12 @@ func (g *guardImpl) TakeSpanSets() (*spanset.SpanSet, *lockspanset.LockSpanSet) 
 // HoldingLatches implements the Guard interface.
 func (g *guardImpl) HoldingLatches() bool {
 	return g != nil && g.lg != nil
+}
+
+func (g *guardImpl) PrepareForLockConflictRetry(ctx context.Context) {
+	if g != nil && g.ltg != nil {
+		g.ltg.PrepareForLockConflictRetry(ctx)
+	}
 }
 
 // AssertLatches implements the Guard interface.

--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -412,6 +412,7 @@ type lockTableGuardImpl struct {
 	// PushUsingCachedClockObservation cluster setting at the this request.
 	pushUsingCachedClockObs bool
 	maxWaitQueueLength      int
+	maxToResolveRangeTxns   int
 
 	// Snapshot of the tree for which this request has some spans. Note that
 	// the lockStates in this snapshot may have been removed from
@@ -518,6 +519,10 @@ type lockTableGuardImpl struct {
 	// toResolveUnreplicated is used instead.
 	toResolve []roachpb.LockUpdate
 
+	// toResolveRange maps txn IDs to range LockUpdates that persist across scan
+	// attempts. It is only used when virtual intent resolution is enabled.
+	toResolveRange map[uuid.UUID]roachpb.LockUpdate
+
 	// toResolveUnreplicated is a list of locks (only held with durability
 	// unreplicated) that are known to belong to finalized transactions. Such
 	// locks may be cleared from the lock table (and some requests queueing in the
@@ -596,17 +601,38 @@ func (g *lockTableGuardImpl) ResolveBeforeScanning() []roachpb.LockUpdate {
 }
 
 // IntentsToResolveVirtually implements the lockTableGuard interface. The locks
-// to resolve are returned only if virtualized resolution is enabled.
+// to resolve are returned only if virtualized resolution is enabled. Returns
+// both point entries from toResolve and range entries from toResolveRange.
 func (g *lockTableGuardImpl) IntentsToResolveVirtually() []roachpb.LockUpdate {
-	if g.virtuallyResolveIntents {
+	if !g.virtuallyResolveIntents {
+		return nil
+	}
+	if len(g.toResolveRange) == 0 {
 		return g.toResolve
 	}
-	return nil
+	combined := make([]roachpb.LockUpdate, 0, len(g.toResolve)+len(g.toResolveRange))
+	combined = append(combined, g.toResolve...)
+	for _, up := range g.toResolveRange {
+		combined = append(combined, up)
+	}
+	return combined
 }
 
 // VirtuallyResolvesIntents implements the lockTableGuard interface.
 func (g *lockTableGuardImpl) VirtuallyResolvesIntents() bool {
 	return g.virtuallyResolveIntents
+}
+
+// keyAlreadyCoveredByRangeResolve returns true if the given key for the given
+// txn is already covered by a range entry in toResolveRange.
+func (g *lockTableGuardImpl) keyAlreadyCoveredByRangeResolve(
+	txnID uuid.UUID, key roachpb.Key,
+) bool {
+	if g.toResolveRange == nil {
+		return false
+	}
+	rangeUp, ok := g.toResolveRange[txnID]
+	return ok && rangeUp.Span.ContainsKey(key)
 }
 
 func (g *lockTableGuardImpl) NewStateChan() chan struct{} {
@@ -949,8 +975,9 @@ func (g *lockTableGuardImpl) conflictsWithHeldLock(
 				// block on Exclusive locks. Once non-locking reads start only
 				// blocking on intents, it can be removed and asserted against.
 				g.toResolveUnreplicated = append(g.toResolveUnreplicated, up)
-			} else {
-				// Resolve to push the replicated intent.
+			} else if !g.keyAlreadyCoveredByRangeResolve(lockHolderTxn.ID, key) {
+				// Resolve to push the replicated intent, unless this key
+				// is already covered by a range resolve range request.
 				g.toResolve = append(g.toResolve, up)
 			}
 			return false // No conflict on a lock we are going to resolve.
@@ -1137,6 +1164,57 @@ func (g *lockTableGuardImpl) resumeScan(notify bool) error {
 		g.notify()
 	}
 	return nil
+}
+
+// defaultMaxToResolveRangeTxns is the default maximum number of distinct txns
+// tracked in toResolveRange. If exceeded, VIR is disabled for the remainder of
+// this guard's lifetime to bound memory usage.
+const defaultMaxToResolveRangeTxns = 128
+
+// PrepareForLockConflictRetry implements the lockTableGuard interface.
+//
+// It collapses all point entries in toResolve into range entries in
+// toResolveRange, keyed by txn ID. This ensures that virtually resolved intents
+// are not forgotten if the lock table evicts their entries under memory
+// pressure.
+//
+// If the number of distinct txns in toResolveRange exceeds a safety bound, VIR
+// is disabled for this guard to prevent unbounded memory growth.
+func (g *lockTableGuardImpl) PrepareForLockConflictRetry(ctx context.Context) {
+	if !g.virtuallyResolveIntents || len(g.toResolve) == 0 {
+		return
+	}
+	g.collapseToResolveIntoRange(ctx)
+	if len(g.toResolveRange) > g.maxToResolveRangeTxns {
+		log.VEventf(ctx, 2,
+			"disabling virtual intent resolution: resolve range request count exceeds maximum: %d > %d",
+			len(g.toResolveRange), g.maxToResolveRangeTxns)
+		g.virtuallyResolveIntents = false
+		g.toResolveRange = nil
+	}
+}
+
+// collapseToResolveIntoRange moves all point entries from toResolve into
+// toResolveRange, extending existing entries if they exist.
+func (g *lockTableGuardImpl) collapseToResolveIntoRange(ctx context.Context) {
+	if g.toResolveRange == nil {
+		g.toResolveRange = make(map[uuid.UUID]roachpb.LockUpdate)
+	}
+	for i := range g.toResolve {
+		up := g.toResolve[i]
+		txnID := up.Txn.ID
+		existing, ok := g.toResolveRange[txnID]
+		if !ok {
+			up.Span.EndKey = up.Key.Next()
+			g.toResolveRange[txnID] = up
+		} else {
+			existing.Span = existing.Combine(up.Span)
+			g.toResolveRange[txnID] = existing
+		}
+	}
+	log.VEventf(ctx, 2, "collapsing %d point intent resolution requests into %d ranged intent resolution requests",
+		len(g.toResolve), len(g.toResolveRange))
+	g.toResolve = g.toResolve[:0]
 }
 
 func (g *lockTableGuardImpl) String() string {
@@ -4358,6 +4436,7 @@ func (t *lockTableImpl) newGuardForReq(req Request) *lockTableGuardImpl {
 	g.spans = req.LockSpans
 	g.waitPolicy = req.WaitPolicy
 	g.maxWaitQueueLength = req.MaxLockWaitQueueLength
+	g.maxToResolveRangeTxns = defaultMaxToResolveRangeTxns
 	g.str = lock.MaxStrength
 	g.index = -1
 	g.pushUsingCachedClockObs = PushUsingCachedClockObservation.Get(&g.lt.settings.SV)
@@ -4459,7 +4538,9 @@ func (t *lockTableImpl) AddDiscoveredLock(
 	}
 	if consultTxnStatusCache {
 		if canResolve, up := g.canResolveKeyForHoldingTransaction(&foundLock.Txn, str, key); canResolve {
-			g.toResolve = append(g.toResolve, up)
+			if !g.keyAlreadyCoveredByRangeResolve(foundLock.Txn.ID, key) {
+				g.toResolve = append(g.toResolve, up)
+			}
 			return true, nil
 		}
 	}

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -2215,6 +2215,184 @@ func TestKeyLocksSafeFormatWaitQueue(t *testing.T) {
 		redact.Sprint(kl).Redact())
 }
 
+// TestPrepareForLockConflictRetry exercises the guard's collapse and VIR
+// disable behavior. Point entries in toResolve are collapsed into range entries
+// in toResolveRange on each lock conflict retry. When the number of distinct
+// txns in toResolveRange exceeds the configured threshold, VIR is disabled
+// stickily for the guard's lifetime.
+func TestPrepareForLockConflictRetry(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	makeTxnMeta := func(name string) enginepb.TxnMeta {
+		return enginepb.TxnMeta{
+			ID:             uuid.MakeV4(),
+			WriteTimestamp: hlc.Timestamp{WallTime: 10},
+			Key:            roachpb.Key(name),
+		}
+	}
+	makeLockUpdate := func(txn enginepb.TxnMeta, key roachpb.Key) roachpb.LockUpdate {
+		return roachpb.LockUpdate{
+			Span:   roachpb.Span{Key: key},
+			Txn:    txn,
+			Status: roachpb.PENDING,
+		}
+	}
+	txn := makeTxnMeta("txn1")
+
+	t.Run("noop when VIR disabled", func(t *testing.T) {
+		g := &lockTableGuardImpl{
+			virtuallyResolveIntents: false,
+			maxToResolveRangeTxns:   2,
+			toResolve: []roachpb.LockUpdate{
+				makeLockUpdate(txn, roachpb.Key("a")),
+			},
+		}
+		g.PrepareForLockConflictRetry(ctx)
+		// toResolve should be untouched since VIR is disabled.
+		require.Len(t, g.toResolve, 1)
+		require.Nil(t, g.toResolveRange)
+	})
+
+	t.Run("noop when toResolve is empty", func(t *testing.T) {
+		g := &lockTableGuardImpl{
+			virtuallyResolveIntents: true,
+			maxToResolveRangeTxns:   2,
+		}
+		g.PrepareForLockConflictRetry(ctx)
+		require.Nil(t, g.toResolveRange)
+	})
+
+	t.Run("collapse single txn", func(t *testing.T) {
+		g := &lockTableGuardImpl{
+			virtuallyResolveIntents: true,
+			maxToResolveRangeTxns:   10,
+			toResolve: []roachpb.LockUpdate{
+				makeLockUpdate(txn, roachpb.Key("b")),
+				makeLockUpdate(txn, roachpb.Key("d")),
+				makeLockUpdate(txn, roachpb.Key("a")),
+			},
+		}
+		g.PrepareForLockConflictRetry(ctx)
+		require.Empty(t, g.toResolve)
+		require.Len(t, g.toResolveRange, 1)
+		// Range should span [a, d.Next()).
+		rangeUp := g.toResolveRange[txn.ID]
+		require.Equal(t, roachpb.Key("a"), rangeUp.Key)
+		require.Equal(t, roachpb.Key("d").Next(), rangeUp.EndKey)
+		require.True(t, g.virtuallyResolveIntents)
+	})
+
+	t.Run("extend existing range", func(t *testing.T) {
+		g := &lockTableGuardImpl{
+			virtuallyResolveIntents: true,
+			maxToResolveRangeTxns:   10,
+			toResolve: []roachpb.LockUpdate{
+				makeLockUpdate(txn, roachpb.Key("b")),
+				makeLockUpdate(txn, roachpb.Key("c")),
+			},
+		}
+		// First round: collapse "b" and "c".
+		g.PrepareForLockConflictRetry(ctx)
+		require.Empty(t, g.toResolve)
+		require.Equal(t, roachpb.Key("b"), g.toResolveRange[txn.ID].Key)
+		require.Equal(t, roachpb.Key("c").Next(), g.toResolveRange[txn.ID].EndKey)
+
+		// Second round: extend left with "a" and right with "e".
+		g.toResolve = append(g.toResolve,
+			makeLockUpdate(txn, roachpb.Key("a")),
+			makeLockUpdate(txn, roachpb.Key("e")),
+		)
+		g.PrepareForLockConflictRetry(ctx)
+		require.Len(t, g.toResolveRange, 1)
+		rangeUp := g.toResolveRange[txn.ID]
+		require.Equal(t, roachpb.Key("a"), rangeUp.Key)
+		require.Equal(t, roachpb.Key("e").Next(), rangeUp.EndKey)
+	})
+
+	t.Run("covered keys skipped", func(t *testing.T) {
+		g := &lockTableGuardImpl{
+			virtuallyResolveIntents: true,
+			maxToResolveRangeTxns:   10,
+			toResolve: []roachpb.LockUpdate{
+				makeLockUpdate(txn, roachpb.Key("a")),
+				makeLockUpdate(txn, roachpb.Key("c")),
+			},
+		}
+		g.PrepareForLockConflictRetry(ctx)
+		// "b" is inside the range [a, c.Next()) and should be covered.
+		require.True(t, g.keyAlreadyCoveredByRangeResolve(txn.ID, roachpb.Key("b")))
+		// "d" is outside.
+		require.False(t, g.keyAlreadyCoveredByRangeResolve(txn.ID, roachpb.Key("d")))
+		// Unknown txn is not covered.
+		require.False(t, g.keyAlreadyCoveredByRangeResolve(uuid.MakeV4(), roachpb.Key("b")))
+	})
+
+	t.Run("VIR disabled when threshold exceeded", func(t *testing.T) {
+		g := &lockTableGuardImpl{
+			virtuallyResolveIntents: true,
+			maxToResolveRangeTxns:   2,
+			toResolve: []roachpb.LockUpdate{
+				makeLockUpdate(txn, roachpb.Key("a")),
+				makeLockUpdate(makeTxnMeta("txn2"), roachpb.Key("b")),
+				makeLockUpdate(makeTxnMeta("txn3"), roachpb.Key("c")),
+			},
+		}
+		g.PrepareForLockConflictRetry(ctx)
+		require.False(t, g.virtuallyResolveIntents)
+		require.Nil(t, g.toResolveRange)
+		require.Empty(t, g.toResolve)
+	})
+
+	t.Run("below threshold no disable", func(t *testing.T) {
+		g := &lockTableGuardImpl{
+			virtuallyResolveIntents: true,
+			maxToResolveRangeTxns:   3,
+			toResolve: []roachpb.LockUpdate{
+				makeLockUpdate(txn, roachpb.Key("a")),
+				makeLockUpdate(makeTxnMeta("txn2"), roachpb.Key("b")),
+				makeLockUpdate(makeTxnMeta("txn3"), roachpb.Key("c")),
+			},
+		}
+		// 3 txns at threshold of 3 — should not disable.
+		g.PrepareForLockConflictRetry(ctx)
+		require.True(t, g.virtuallyResolveIntents)
+		require.Len(t, g.toResolveRange, 3)
+	})
+
+	t.Run("IntentsToResolveVirtually combines point and range", func(t *testing.T) {
+		txn2 := makeTxnMeta("txn2")
+		g := &lockTableGuardImpl{
+			virtuallyResolveIntents: true,
+			maxToResolveRangeTxns:   10,
+			toResolve: []roachpb.LockUpdate{
+				makeLockUpdate(txn, roachpb.Key("a")),
+			},
+		}
+		// Collapse txn into toResolveRange.
+		g.PrepareForLockConflictRetry(ctx)
+		// Add a point entry for txn2 (not yet collapsed).
+		g.toResolve = append(g.toResolve, makeLockUpdate(txn2, roachpb.Key("x")))
+
+		combined := g.IntentsToResolveVirtually()
+		require.Len(t, combined, 2)
+		// One point (txn2) and one range (txn).
+		var hasPoint, hasRange bool
+		for _, up := range combined {
+			if len(up.EndKey) > 0 {
+				hasRange = true
+				require.Equal(t, txn.ID, up.Txn.ID)
+			} else {
+				hasPoint = true
+				require.Equal(t, txn2.ID, up.Txn.ID)
+			}
+		}
+		require.True(t, hasPoint)
+		require.True(t, hasRange)
+	})
+}
+
 // TestElideWaitingStateUpdatesConsidersAllFields ensures all fields in the
 // waitingState struct have been considered for inclusion/non-inclusion in the
 // logic of canElideWaitingStateUpdate. The test doesn't check if the

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
@@ -89,6 +89,7 @@ func (g *mockLockTableGuard) VirtuallyResolvesIntents() bool {
 func (g *mockLockTableGuard) CheckOptimisticNoConflicts(*lockspanset.LockSpanSet) (ok bool) {
 	return true
 }
+func (g *mockLockTableGuard) PrepareForLockConflictRetry(context.Context) {}
 func (g *mockLockTableGuard) IsKeyLockedByConflictingTxn(
 	context.Context, roachpb.Key, lock.Strength,
 ) (bool, *enginepb.TxnMeta, error) {

--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -95,7 +95,6 @@ func (r *Replica) executeReadOnlyBatch(
 	defer rw.Close()
 
 	if len(intentsToResolveVirtually) > 0 {
-
 		log.Eventf(
 			ctx, "resolving %d intents virtually before executing read",
 			len(intentsToResolveVirtually),
@@ -111,21 +110,37 @@ func (r *Replica) executeReadOnlyBatch(
 		// below. Depending on the result of the intent resolution, the read-only
 		// batch request may not conflict with the intents anymore.
 		for _, intent := range intentsToResolveVirtually {
-			ir := kvpb.ResolveIntentRequest{
-				RequestHeader:     kvpb.RequestHeaderFromSpan(intent.Span),
-				IntentTxn:         intent.Txn,
-				Status:            intent.Status,
-				IgnoredSeqNums:    intent.IgnoredSeqNums,
-				ClockWhilePending: intent.ClockWhilePending,
+			var (
+				// It's ok to pass an empty header since during intent resolution it's only
+				// used to ensure that this is not a transactional request, and to apply
+				// MaxTargetBytes (which we don't need because the batch is not committed).
+				h kvpb.Header
+				// The reply coming from evaluation is discarded below.
+				reply kvpb.Response
+				req   kvpb.Request
+			)
+			if len(intent.EndKey) > 0 {
+				// Range LockUpdate: resolve all intents for this txn in the span.
+				req = &kvpb.ResolveIntentRangeRequest{
+					RequestHeader:     kvpb.RequestHeaderFromSpan(intent.Span),
+					IntentTxn:         intent.Txn,
+					Status:            intent.Status,
+					IgnoredSeqNums:    intent.IgnoredSeqNums,
+					ClockWhilePending: intent.ClockWhilePending,
+				}
+				reply = &kvpb.ResolveIntentRangeResponse{}
+			} else {
+				req = &kvpb.ResolveIntentRequest{
+					RequestHeader:     kvpb.RequestHeaderFromSpan(intent.Span),
+					IntentTxn:         intent.Txn,
+					Status:            intent.Status,
+					IgnoredSeqNums:    intent.IgnoredSeqNums,
+					ClockWhilePending: intent.ClockWhilePending,
+				}
+				reply = &kvpb.ResolveIntentResponse{}
 			}
-			// The reply coming from evaluation is discarded below.
-			reply := &kvpb.ResolveIntentResponse{}
-			// It's ok to pass an empty header since during intent resolution it's only
-			// used to ensure that this is not a transactional request, and to apply
-			// MaxTargetBytes (which we don't need because the batch is not committed).
-			h := kvpb.Header{}
 			_, err = evaluateCommand(
-				ctx, rwNoAssert, rec, nil /* ms */, nil /* ss */, h, &ir,
+				ctx, rwNoAssert, rec, nil /* ms */, nil /* ss */, h, req,
 				reply, g, &st, ui, readWrite, false, /* omitInRangefeeds */
 			)
 			if err != nil {

--- a/pkg/kv/kvserver/replica_read_test.go
+++ b/pkg/kv/kvserver/replica_read_test.go
@@ -116,45 +116,53 @@ func TestVirtualizedIntentResolution(t *testing.T) {
 		{readTs: ts300, readGUL: ts600, toResolve: &toResolve{txnStatus: roachpb.PENDING, txnWriteTs: ts500, obsTs: ts400, obsNode: 2}, exp: res{error: "uncertainty interval"}},
 	}
 
-	for _, c := range testCases {
-		// Set up the intents to resolve.
-		if c.toResolve != nil {
-			writeTxn.TxnMeta.WriteTimestamp = c.toResolve.txnWriteTs
-			status := c.toResolve.txnStatus
-			obs := roachpb.ObservedTimestamp{Timestamp: hlc.ClockTimestamp(c.toResolve.obsTs), NodeID: roachpb.NodeID(c.toResolve.obsNode)}
-			intents := []roachpb.LockUpdate{{Span: roachpb.Span{Key: k}, Status: status, Txn: writeTxn.TxnMeta, ClockWhilePending: obs}}
-			intentsToResolve.Store(intents)
-		}
-		// Construct the read-only request.
-		ba := &kvpb.BatchRequest{}
-		ba.Timestamp = c.readTs
-		// If the read wants to set a GUL, use a transactional read.
-		if !c.readGUL.IsEmpty() {
-			readTxn := newTransaction("readTxn", k, 1, nil)
-			readTxn.ReadTimestamp = c.readTs
-			readTxn.GlobalUncertaintyLimit = c.readGUL
-			// We need a fairly old observation here to make sure the read's local
-			// uncertainty limit lets it read under the intent with a clock
-			// observation while pending. This observation needs to be lower than the
-			// local timestamp set on the intent (set using ClockWhilePending).
-			// The txn's observed timestamp is usually set when the request is first
-			// received by the store, so here we'll record it as the read's ts.
-			readTxn.UpdateObservedTimestamp(roachpb.NodeID(1), c.readTs.UnsafeToClockTimestamp())
-			ba.Txn = readTxn
-		}
-		gArgs := getArgs(k)
-		ba.Add(&gArgs)
-		// TODO(mira): It would be nice to inject the intents to resolve in the
-		// concurrency.Guard passed below, instead of injecting them via a knob.
-		// Currently, this is not possible because the Guard is not an interface.
-		br, _, _, pErr := tc.repl.executeReadOnlyBatch(ctx, ba, allSpansGuard(), kvadmission.AdmissionInfo{})
+	for _, resolveRange := range []bool{true, false} {
+		for _, c := range testCases {
+			// Set up the intents to resolve.
+			if c.toResolve != nil {
+				writeTxn.TxnMeta.WriteTimestamp = c.toResolve.txnWriteTs
+				status := c.toResolve.txnStatus
+				obs := roachpb.ObservedTimestamp{Timestamp: hlc.ClockTimestamp(c.toResolve.obsTs), NodeID: roachpb.NodeID(c.toResolve.obsNode)}
+				var span roachpb.Span
+				if resolveRange {
+					span = roachpb.Span{Key: k, EndKey: k.Next()}
+				} else {
+					span = roachpb.Span{Key: k}
+				}
+				intents := []roachpb.LockUpdate{{Span: span, Status: status, Txn: writeTxn.TxnMeta, ClockWhilePending: obs}}
+				intentsToResolve.Store(intents)
+			}
+			// Construct the read-only request.
+			ba := &kvpb.BatchRequest{}
+			ba.Timestamp = c.readTs
+			// If the read wants to set a GUL, use a transactional read.
+			if !c.readGUL.IsEmpty() {
+				readTxn := newTransaction("readTxn", k, 1, nil)
+				readTxn.ReadTimestamp = c.readTs
+				readTxn.GlobalUncertaintyLimit = c.readGUL
+				// We need a fairly old observation here to make sure the read's local
+				// uncertainty limit lets it read under the intent with a clock
+				// observation while pending. This observation needs to be lower than the
+				// local timestamp set on the intent (set using ClockWhilePending).
+				// The txn's observed timestamp is usually set when the request is first
+				// received by the store, so here we'll record it as the read's ts.
+				readTxn.UpdateObservedTimestamp(roachpb.NodeID(1), c.readTs.UnsafeToClockTimestamp())
+				ba.Txn = readTxn
+			}
+			gArgs := getArgs(k)
+			ba.Add(&gArgs)
+			// TODO(mira): It would be nice to inject the intents to resolve in the
+			// concurrency.Guard passed below, instead of injecting them via a knob.
+			// Currently, this is not possible because the Guard is not an interface.
+			br, _, _, pErr := tc.repl.executeReadOnlyBatch(ctx, ba, allSpansGuard(), kvadmission.AdmissionInfo{})
 
-		if c.exp.error == "" {
-			require.NoError(t, pErr.GoError())
-			require.Regexp(t, c.exp.value, string(br.Responses[0].GetGet().Value.RawBytes))
-		} else {
-			require.Nil(t, br)
-			require.Regexp(t, c.exp.error, pErr.GoError())
+			if c.exp.error == "" {
+				require.NoError(t, pErr.GoError())
+				require.Regexp(t, c.exp.value, string(br.Responses[0].GetGet().Value.RawBytes))
+			} else {
+				require.Nil(t, br)
+				require.Regexp(t, c.exp.error, pErr.GoError())
+			}
 		}
 	}
 }

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -123,6 +123,7 @@ func (mg mockGuard) IsKeyLockedByConflictingTxn(
 func (mg mockGuard) IntentsToResolveVirtually() []roachpb.LockUpdate {
 	return nil
 }
+func (mg mockGuard) PrepareForLockConflictRetry(context.Context) {}
 
 var _ concurrency.Guard = (*mockGuard)(nil)
 

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -58,6 +58,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/gossiputil"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -2349,6 +2350,100 @@ func TestStoreScanIntentsRespectsLimit(t *testing.T) {
 	}()
 
 	wg.Wait()
+}
+
+// TestVirtualIntentResolutionLivelock demonstrates that virtual intent
+// resolution (VIR) can livelock under lock table memory pressure when a reader
+// must discover intents across multiple evaluation rounds (#163924).
+//
+// # Test Setup
+//
+// - VIR is enabled, Low lock table size limit (4), and a low MaxConflictsPerLockConflictError (3) is set.
+// - A writer creates 6 intents.
+// - High-priority reader scans the range.
+//
+// Hazard before the fix:
+//
+//  1. Reader discovers intents 0-2 (truncated at MaxConflicts=3), adds to lock
+//     table, pushes writer, proceeds with VIR.
+//  2. VIR resolves 0-2 on ephemeral batch (discarded). Scan discovers intents
+//     3-5. Added to lock table (now 6 > max 4), evicting intents 0-2.
+//  3. Re-sequence clears toResolve, repopulates from lock table (only 3-5).
+//     VIR resolves 3-5, rediscovers evicted 0-2. Cycle repeats.
+func TestVirtualIntentResolutionLivelock(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	var lockConflictCount atomic.Int32
+	var readerTxnID atomic.Value // uuid.UUID
+	readerTxnID.Store(uuid.Nil)
+
+	tc := serverutils.StartCluster(t, 1, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				Store: &StoreTestingKnobs{
+					TestingConcurrencyRetryFilter: func(
+						_ context.Context, ba *kvpb.BatchRequest, pErr *kvpb.Error,
+					) {
+						if ba.Txn == nil || ba.Txn.ID != readerTxnID.Load().(uuid.UUID) {
+							return // not our reader
+						}
+						if errors.HasType(pErr.GoError(), (*kvpb.LockConflictError)(nil)) {
+							lockConflictCount.Add(1)
+						}
+					},
+				},
+			},
+		},
+	})
+	defer tc.Stopper().Stop(ctx)
+
+	// Enable VIR, set low lock table size, and low max conflicts per error to
+	// force multi-round intent discovery with frequent lock table eviction.
+	st := tc.Server(0).ClusterSettings()
+	concurrency.VirtualIntentResolution.Override(ctx, &st.SV, true)
+	concurrency.DefaultLockTableSize.Override(ctx, &st.SV, 4)
+	storage.MaxConflictsPerLockConflictError.Override(ctx, &st.SV, 3)
+
+	store, err := tc.Server(0).GetStores().(*Stores).GetStore(tc.Server(0).GetFirstStoreID())
+	require.NoError(t, err)
+
+	// Writer creates 6 intents (more than MaxConflictsPerLockConflictError but
+	// more than the lock table can hold simultaneously).
+	const numIntents = 6
+	writerTxn := newTransaction(
+		"writer", keys.ScratchRangeMin, roachpb.NormalUserPriority, tc.Server(0).Clock(),
+	)
+	for i := 0; i < numIntents; i++ {
+		key := append(keys.ScratchRangeMin.Clone(), []byte(fmt.Sprintf("%04d", i))...)
+		args := putArgs(key, []byte(fmt.Sprintf("value%d", i)))
+		assignSeqNumsForReqs(writerTxn, &args)
+		_, pErr := kv.SendWrappedWith(ctx, store.TestSender(), kvpb.Header{Txn: writerTxn}, &args)
+		require.Nil(t, pErr)
+	}
+
+	// High-priority scan to push the writer.
+	startKey := keys.ScratchRangeMin
+	endKey := keys.ScratchRangeMax
+
+	readerTxn := newTransaction(
+		"reader", startKey, roachpb.MaxUserPriority, tc.Server(0).Clock(),
+	)
+	readerTxnID.Store(readerTxn.ID)
+
+	readCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	g := ctxgroup.WithContext(readCtx)
+	g.GoCtx(func(ctx context.Context) error {
+		_, pErr := kv.SendWrappedWith(ctx, store.TestSender(), kvpb.Header{
+			Txn: readerTxn,
+		}, scanArgs(startKey, endKey))
+		return pErr.GoError()
+	})
+	require.NoError(t, g.Wait(), "reader failed (%d lock conflicts observed)", lockConflictCount.Load())
+	count := lockConflictCount.Load()
+	t.Logf("reader completed with %d lock conflict retries", count)
 }
 
 // TestStoreScanInconsistentResolvesIntents lays down 10 intents,


### PR DESCRIPTION
If we encounter a LockConflictError after our first attempt to virtually resolve all of our intents, it must mean that we hit the maximum lock conflicts on our first scan. In this case, we want to avoid a situation where we end up with either

(1) a huge number of lock updates in memory, or

(2) a livelock in which we the lock table memory limit continues to evict previously found locks, resulting in a virtual resolve set that is never complete.

We solve this by condensing all virtually resolved locks to per-transaction resolve range requests after the first retry.

If we hit too many resolve range requests, we then give up on virtual intent resolution.

Fixes #163924
Release note: None