### PR TITLE
asim: add issue= tracking for expected assertion failures

### DIFF
--- a/pkg/kv/kvserver/asim/tests/testdata/non_rand/mma/heterogeneous_cpu_unconstrained.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/non_rand/mma/heterogeneous_cpu_unconstrained.txt
@@ -24,7 +24,7 @@ gen_load rate=40000 rw_ratio=1 request_cpu_per_access=500000 min_key=1 max_key=1
 # We want the CPU load to balance based on %cpu. But both the MMA and SMA balance
 # on absolute cpu-nanos, i.e. not taking into account that n3 has double the capacity.
 # See tracking issue: https://github.com/cockroachdb/cockroach/issues/153777
-assertion stat=cpu_util type=balance ticks=6 upper_bound=1.1
+assertion stat=cpu_util type=balance ticks=6 upper_bound=1.1 issue=https://github.com/cockroachdb/cockroach/issues/153777
 ----
 asserting: max_{stores}(cpu_util)/mean_{stores}(cpu_util) ≤ 1.10 at each of last 6 ticks
 

--- a/pkg/kv/kvserver/asim/tests/testdata/non_rand/sma/gateway_overload.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/non_rand/sma/gateway_overload.txt
@@ -34,7 +34,7 @@ gen_load rate=5000 rw_ratio=0.95 min_block=128 max_block=128 request_cpu_per_acc
 
 # Assert that leases are stable (not bouncing) over the last 100 ticks.
 # SMA is expected to fail this due to the diluted-mean churn described above.
-assertion type=steady stat=leases ticks=100 upper_bound=0.15
+assertion type=steady stat=leases ticks=100 upper_bound=0.15 issue=https://github.com/cockroachdb/cockroach/issues/162590
 ----
 asserting: |leases(t)/mean_{T}(leases) - 1| ≤ 0.15 ∀ t∈T and each store (T=last 100 ticks)
 

--- a/pkg/kv/kvserver/asim/tests/testdata/non_rand/sma/rebalancing_qps.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/non_rand/sma/rebalancing_qps.txt
@@ -20,7 +20,7 @@ gen_load rate=7000 rw_ratio=0.95 access_skew=false min_block=128 max_block=256
 66 KiB/s goodput
 
 # Add two assertions (balanced, stable steady state) on QPS of the cluster.
-assertion stat=qps type=balance ticks=6 upper_bound=1.15
+assertion stat=qps type=balance ticks=6 upper_bound=1.15 issue=https://cockroachlabs.atlassian.net/browse/CRDB-58513
 ----
 asserting: max_{stores}(qps)/mean_{stores}(qps) ≤ 1.15 at each of last 6 ticks
 


### PR DESCRIPTION
The asim datadriven tests have a number of assertions that are expected to
fail due to known limitations. Previously, these failures were silently
tolerated: they appeared in the datadriven output but never caused the
test to fail, making it easy for new failures to slip in unnoticed.

This PR adds an `issue=<url>` parameter to the `assertion` command. After each
`eval`, the test enforces two invariants:

1. A failing assertion without `issue=` causes a test error, prompting
   the author to either fix the problem or annotate it with a tracking
   issue.
2. An assertion with `issue=` that no longer fails also causes a test
   error, signaling that the issue may be resolved and the annotation
   should be cleaned up.

Annotates the three existing expected-failure assertions:
- `heterogeneous_cpu_unconstrained`: [#153777](https://github.com/cockroachdb/cockroach/issues/153777) (balance on absolute CPU nanos)
- `rebalancing_qps`: [CRDB-58513](https://cockroachlabs.atlassian.net/browse/CRDB-58513) (mma-only doesn't rebalance leases)
- `gateway_overload`: [#162590](https://github.com/cockroachdb/cockroach/issues/162590) (SMA diluted-mean lease churn)

Informs #153565

Epic: CRDB-56265
Release note: None

Made with [Cursor](https://cursor.com)