### PR TITLE
kvserver: reduce scope of disabled assertions during VIR

### DIFF
--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -77,11 +77,6 @@ func (r *Replica) executeReadOnlyBatch(
 	// the intent resolution will be evaluated before the read-only batch request.
 	if len(intentsToResolveVirtually) > 0 {
 		rw, _ = r.newBatchedEngine(g)
-		// Latch assertions will fail here because latches are not acquired for the
-		// intent resolution in this batch. This is safe because this batch is used
-		// only for evaluating the read-only batch request, and the underlying
-		// intent resolutions will not be committed.
-		rw = spanset.DisableUndeclaredSpanAssertions(rw)
 	} else {
 		// TODO(irfansharif): It's unfortunate that in this read-only code path,
 		// we're stuck with a ReadWriter because of the way evaluateBatch is
@@ -99,34 +94,43 @@ func (r *Replica) executeReadOnlyBatch(
 	}
 	defer rw.Close()
 
-	// For each intent to be resolved virtually, evaluate the intent resolution
-	// directly on the storage batch before evaluating the read-only batch request
-	// below. Depending on the result of the intent resolution, the read-only
-	// batch request may not conflict with the intents anymore.
-	log.Eventf(
-		ctx, "resolving %d intents virtually before executing read",
-		len(intentsToResolveVirtually),
-	)
-	for _, intent := range intentsToResolveVirtually {
-		ir := kvpb.ResolveIntentRequest{
-			RequestHeader:     kvpb.RequestHeaderFromSpan(intent.Span),
-			IntentTxn:         intent.Txn,
-			Status:            intent.Status,
-			IgnoredSeqNums:    intent.IgnoredSeqNums,
-			ClockWhilePending: intent.ClockWhilePending,
-		}
-		// The reply coming from evaluation is discarded below.
-		reply := &kvpb.ResolveIntentResponse{}
-		// It's ok to pass an empty header since during intent resolution it's only
-		// used to ensure that this is not a transactional request, and to apply
-		// MaxTargetBytes (which we don't need because the batch is not committed).
-		h := kvpb.Header{}
-		_, err = evaluateCommand(
-			ctx, rw, rec, nil /* ms */, nil /* ss */, h, &ir,
-			reply, g, &st, ui, readWrite, false, /* omitInRangefeeds */
+	if len(intentsToResolveVirtually) > 0 {
+
+		log.Eventf(
+			ctx, "resolving %d intents virtually before executing read",
+			len(intentsToResolveVirtually),
 		)
-		if err != nil {
-			return nil, g, nil, kvpb.NewError(err)
+		// Latch assertions will fail here because latches are not acquired for the
+		// intent resolution in this batch. This is safe because this batch is used
+		// only for evaluating the read-only batch request, and the underlying
+		// intent resolutions will not be committed.
+		rwNoAssert := spanset.DisableUndeclaredSpanAssertions(rw)
+
+		// For each intent to be resolved virtually, evaluate the intent resolution
+		// directly on the storage batch before evaluating the read-only batch request
+		// below. Depending on the result of the intent resolution, the read-only
+		// batch request may not conflict with the intents anymore.
+		for _, intent := range intentsToResolveVirtually {
+			ir := kvpb.ResolveIntentRequest{
+				RequestHeader:     kvpb.RequestHeaderFromSpan(intent.Span),
+				IntentTxn:         intent.Txn,
+				Status:            intent.Status,
+				IgnoredSeqNums:    intent.IgnoredSeqNums,
+				ClockWhilePending: intent.ClockWhilePending,
+			}
+			// The reply coming from evaluation is discarded below.
+			reply := &kvpb.ResolveIntentResponse{}
+			// It's ok to pass an empty header since during intent resolution it's only
+			// used to ensure that this is not a transactional request, and to apply
+			// MaxTargetBytes (which we don't need because the batch is not committed).
+			h := kvpb.Header{}
+			_, err = evaluateCommand(
+				ctx, rwNoAssert, rec, nil /* ms */, nil /* ss */, h, &ir,
+				reply, g, &st, ui, readWrite, false, /* omitInRangefeeds */
+			)
+			if err != nil {
+				return nil, g, nil, kvpb.NewError(err)
+			}
 		}
 	}
 


### PR DESCRIPTION
This attempts to ensure that we only disable spanset assertions for the resolve intents rounds. It would be nice to go even further and generate assertion checks that are correct for the resolve intents as well.

Epic: CRDB-49120
Release note: None