### PR TITLE
kvserver: reject lease transfers to replicas with send queues

### DIFF
--- a/pkg/kv/kvnemesis/validator.go
+++ b/pkg/kv/kvnemesis/validator.go
@@ -399,6 +399,7 @@ func transferLeaseResultIsIgnorable(res Result) bool {
 	}
 	return kvserver.IsLeaseTransferRejectedBecauseTargetMayNeedSnapshotError(err) ||
 		kvserver.IsLeaseTransferRejectedBecauseTargetCannotReceiveLease(err) ||
+		kvserver.IsLeaseTransferRejectedBecauseTargetHasSendQueueError(err) ||
 		// A lease transfer is not permitted while a range merge is in its
 		// critical phase.
 		resultIsErrorStr(res, `cannot transfer lease while merge in progress`) ||

--- a/pkg/kv/kvserver/leases/build.go
+++ b/pkg/kv/kvserver/leases/build.go
@@ -136,6 +136,10 @@ type BuildInput struct {
 	// can't tolerate rejected lease transfers.
 	BypassSafetyChecks bool
 
+	// TargetHasSendQueue indicates that the lease transfer target has a send
+	// queue. See VerifyInput.TargetHasSendQueue.
+	TargetHasSendQueue bool
+
 	// DesiredLeaseType is the desired lease type for this replica.
 	DesiredLeaseType roachpb.LeaseType
 }
@@ -262,6 +266,7 @@ func (i BuildInput) toVerifyInput() VerifyInput {
 		PrevLeaseExpired:   i.PrevLeaseExpired,
 		NextLeaseHolder:    i.NextLeaseHolder,
 		BypassSafetyChecks: i.BypassSafetyChecks,
+		TargetHasSendQueue: i.TargetHasSendQueue,
 		DesiredLeaseType:   i.DesiredLeaseType,
 	}
 }

--- a/pkg/kv/kvserver/leases/build_test.go
+++ b/pkg/kv/kvserver/leases/build_test.go
@@ -1218,6 +1218,7 @@ func TestInputToVerifyInput(t *testing.T) {
 			NodeID: 1, StoreID: 1, ReplicaID: 1, Type: 1,
 		},
 		BypassSafetyChecks: true,
+		TargetHasSendQueue: true,
 		DesiredLeaseType:   roachpb.LeaseLeader,
 	}
 	verifyInput := noZeroBuildInput.toVerifyInput()

--- a/pkg/kv/kvserver/leases/errors.go
+++ b/pkg/kv/kvserver/leases/errors.go
@@ -25,7 +25,25 @@ var ErrMarkLeaseTransferRejectedBecauseTargetMayNeedSnapshot = errors.New(
 func NewLeaseTransferRejectedBecauseTargetMayNeedSnapshotError(
 	target roachpb.ReplicaDescriptor, snapStatus raftutil.ReplicaNeedsSnapshotStatus,
 ) error {
-	err := errors.Errorf("refusing to transfer lease to %d because target may need a Raft snapshot: %s",
+	err := errors.Errorf("refusing to transfer lease to %v because target may need a Raft snapshot: %s",
 		target, snapStatus)
 	return errors.Mark(err, ErrMarkLeaseTransferRejectedBecauseTargetMayNeedSnapshot)
+}
+
+// ErrMarkLeaseTransferRejectedBecauseTargetHasSendQueue indicates that the
+// lease transfer failed because the lease transfer target has a send queue,
+// meaning it is behind on its raft log and may cause proportional
+// unavailability if it becomes the leaseholder.
+var ErrMarkLeaseTransferRejectedBecauseTargetHasSendQueue = errors.New(
+	"lease transfer rejected because the target has a send queue")
+
+// NewLeaseTransferRejectedBecauseTargetHasSendQueueError returns an error
+// indicating that a lease transfer failed because the lease transfer target
+// has a send queue.
+func NewLeaseTransferRejectedBecauseTargetHasSendQueueError(
+	target roachpb.ReplicaDescriptor,
+) error {
+	err := errors.Errorf("refusing to transfer lease to %v because target has a send queue",
+		target)
+	return errors.Mark(err, ErrMarkLeaseTransferRejectedBecauseTargetHasSendQueue)
 }

--- a/pkg/kv/kvserver/leases/verify.go
+++ b/pkg/kv/kvserver/leases/verify.go
@@ -252,13 +252,25 @@ func verifyTransfer(ctx context.Context, st Settings, i VerifyInput) error {
 	//
 	// We assume that if a lease transfer target is sufficiently caught up on its
 	// log such that it will be able to apply the lease transfer through log entry
-	// application then this unavailability window will be acceptable. This may be
-	// a faulty assumption in cases with severe replication lag, but we must
-	// balance any heuristics here that attempts to determine "too much lag" with
-	// the possibility of starvation of lease transfers under sustained write load
-	// and a resulting sustained replication lag. See #38065 and #42379, which
-	// removed such a heuristic. For now, we don't try to make such a
-	// determination.
+	// application then this unavailability window will be acceptable. Historically,
+	// we did not try to make any determination about sub-snapshot replication lag
+	// (see #38065 and #42379, which removed such a heuristic). This left a gap:
+	// the proposal-buffer check below only prevents snapshot-level lag, but callers
+	// that bypass the allocator (manual lease transfers via AdminTransferLease,
+	// AdminRelocateRange, scatter, etc.) could transfer leases to replicas with
+	// large send queues — thousands of entries behind — causing proportional
+	// unavailability. The allocator paths protect against this via
+	// excludeReplicasInNeedOfCatchup, which filters out replicas with send queues,
+	// but that protection only applies to allocator-routed transfers.
+	//
+	// To close this gap, we now also reject lease transfers to replicas that have
+	// a send queue, as reported by the RACv2 send stream stats. This is the right
+	// signal: it is less strict than requiring Match >= Commit (which would stall
+	// transfers on busy or WAN ranges) while still preventing transfers that
+	// would cause meaningful unavailability. When send stream stats are
+	// unavailable (e.g. the local replica is not the leader, or RACv2 is not
+	// active), we conservatively allow the transfer — matching the allocator's
+	// fallback behavior in excludeReplicasInNeedOfCatchup.
 	//
 	// However, we draw a distinction between lease transfer targets that will be
 	// able to apply the lease transfer through log entry application and those

--- a/pkg/kv/kvserver/markers.go
+++ b/pkg/kv/kvserver/markers.go
@@ -34,6 +34,7 @@ var errMarkCanRetryReplicationChangeWithUpdatedDesc = errors.New("should retry w
 func IsRetriableReplicationChangeError(err error) bool {
 	return errors.Is(err, errMarkCanRetryReplicationChangeWithUpdatedDesc) ||
 		IsLeaseTransferRejectedBecauseTargetMayNeedSnapshotError(err) ||
+		IsLeaseTransferRejectedBecauseTargetHasSendQueueError(err) ||
 		IsLeaseTransferRejectedBecauseTargetCannotReceiveLease(err) ||
 		isSnapshotError(err)
 }
@@ -99,6 +100,14 @@ func IsReplicationChangeInProgressError(err error) bool {
 // periodically requested in maybeTransferRaftLeadershipToLeaseholderLocked.
 func IsLeaseTransferRejectedBecauseTargetMayNeedSnapshotError(err error) bool {
 	return errors.Is(err, leases.ErrMarkLeaseTransferRejectedBecauseTargetMayNeedSnapshot)
+}
+
+// IsLeaseTransferRejectedBecauseTargetHasSendQueueError detects whether an
+// error (assumed to have been emitted by a lease transfer request) indicates
+// that the lease transfer failed because the lease transfer target has a send
+// queue, meaning it is behind on its raft log.
+func IsLeaseTransferRejectedBecauseTargetHasSendQueueError(err error) bool {
+	return errors.Is(err, leases.ErrMarkLeaseTransferRejectedBecauseTargetHasSendQueue)
 }
 
 // IsLeaseTransferRejectedBecauseTargetCannotReceiveLease returns true if err

--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -1215,6 +1215,11 @@ func (rp *replicaProposer) verifyLeaseRequestSafetyRLocked(
 		BypassSafetyChecks: bypassSafetyChecks,
 		DesiredLeaseType:   r.desiredLeaseType(r.descRLocked()),
 	}
+	// NOTE: we do NOT check send-queue status here. Calling SendStreamStats
+	// is unsafe under repl.mu (lock ordering: rcReferenceUpdateMu < repl.mu).
+	// The above-raft check in InitOrJoinRequest handles the send-queue check
+	// before lease revocation. The proposal buffer retains the airtight
+	// snapshot check via ReplicaMayNeedSnapshot in leases.Verify.
 	if err := leases.Verify(ctx, st, in); err != nil {
 		if in.Transfer() {
 			// The lease transfer is deemed to be unsafe. The intended consequence of

--- a/pkg/kv/kvserver/replica_proposal_buf_test.go
+++ b/pkg/kv/kvserver/replica_proposal_buf_test.go
@@ -690,49 +690,49 @@ func TestProposalBufferRejectUnsafeLeaseTransfer(t *testing.T) {
 		targetState rafttracker.StateType
 		targetMatch kvpb.RaftIndex
 
-		expRejection       bool
-		expRejectionReason raftutil.ReplicaNeedsSnapshotStatus
+		expRejection    bool
+		expRejectionMsg string // substring expected in the rejection error
 	}{
 		{
-			name:               "follower",
-			proposerState:      raftpb.StateFollower,
-			expRejection:       true,
-			expRejectionReason: raftutil.LocalReplicaNotLeader,
+			name:            "follower",
+			proposerState:   raftpb.StateFollower,
+			expRejection:    true,
+			expRejectionMsg: raftutil.LocalReplicaNotLeader.String(),
 		},
 		{
-			name:               "candidate",
-			proposerState:      raftpb.StateCandidate,
-			expRejection:       true,
-			expRejectionReason: raftutil.LocalReplicaNotLeader,
+			name:            "candidate",
+			proposerState:   raftpb.StateCandidate,
+			expRejection:    true,
+			expRejectionMsg: raftutil.LocalReplicaNotLeader.String(),
 		},
 		{
-			name:               "leader, no progress for target",
-			proposerState:      raftpb.StateLeader,
-			targetState:        math.MaxUint64,
-			expRejection:       true,
-			expRejectionReason: raftutil.ReplicaUnknown,
+			name:            "leader, no progress for target",
+			proposerState:   raftpb.StateLeader,
+			targetState:     math.MaxUint64,
+			expRejection:    true,
+			expRejectionMsg: raftutil.ReplicaUnknown.String(),
 		},
 		{
-			name:               "leader, target state probe",
-			proposerState:      raftpb.StateLeader,
-			targetState:        rafttracker.StateProbe,
-			expRejection:       true,
-			expRejectionReason: raftutil.ReplicaStateProbe,
+			name:            "leader, target state probe",
+			proposerState:   raftpb.StateLeader,
+			targetState:     rafttracker.StateProbe,
+			expRejection:    true,
+			expRejectionMsg: raftutil.ReplicaStateProbe.String(),
 		},
 		{
-			name:               "leader, target state snapshot",
-			proposerState:      raftpb.StateLeader,
-			targetState:        rafttracker.StateSnapshot,
-			expRejection:       true,
-			expRejectionReason: raftutil.ReplicaStateSnapshot,
+			name:            "leader, target state snapshot",
+			proposerState:   raftpb.StateLeader,
+			targetState:     rafttracker.StateSnapshot,
+			expRejection:    true,
+			expRejectionMsg: raftutil.ReplicaStateSnapshot.String(),
 		},
 		{
-			name:               "leader, target state replicate, match+1 < firstIndex",
-			proposerState:      raftpb.StateLeader,
-			targetState:        rafttracker.StateReplicate,
-			targetMatch:        proposerCompactedIndex - 1,
-			expRejection:       true,
-			expRejectionReason: raftutil.ReplicaMatchBelowLeadersFirstIndex,
+			name:            "leader, target state replicate, match+1 < firstIndex",
+			proposerState:   raftpb.StateLeader,
+			targetState:     rafttracker.StateReplicate,
+			targetMatch:     proposerCompactedIndex - 1,
+			expRejection:    true,
+			expRejectionMsg: raftutil.ReplicaMatchBelowLeadersFirstIndex.String(),
 		},
 		{
 			name:          "leader, target state replicate, match+1 == firstIndex",
@@ -811,7 +811,7 @@ func TestProposalBufferRejectUnsafeLeaseTransfer(t *testing.T) {
 			require.NoError(t, b.flushLocked(ctx))
 			if tc.expRejection {
 				require.NotNil(t, rejectedErr)
-				require.Contains(t, rejectedErr.Error(), tc.expRejectionReason.String())
+				require.Contains(t, rejectedErr.Error(), tc.expRejectionMsg)
 			} else {
 				require.Nil(t, rejectedErr)
 			}

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -47,6 +47,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/constraint"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvadmission"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/rac2"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/leases"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
@@ -328,6 +329,7 @@ func (p *pendingLeaseRequest) InitOrJoinRequest(
 	status kvserverpb.LeaseStatus,
 	startKey roachpb.Key,
 	bypassSafetyChecks bool,
+	targetHasSendQueue bool,
 	limiter *quotapool.IntPool,
 ) *leaseRequestHandle {
 	if nextLease, ok := p.RequestPending(); ok {
@@ -387,6 +389,12 @@ func (p *pendingLeaseRequest) InitOrJoinRequest(
 		BypassSafetyChecks:    bypassSafetyChecks,
 		DesiredLeaseType:      p.repl.desiredLeaseType(p.repl.descRLocked()),
 	}
+	// For lease transfers, use the pre-fetched send queue status. The caller
+	// must query SendStreamStats before acquiring repl.mu, because
+	// SendStreamStats acquires rcReferenceUpdateMu which is ordered before
+	// repl.mu. When stats are unavailable, the caller passes false to
+	// conservatively allow the transfer.
+	in.TargetHasSendQueue = targetHasSendQueue
 	out, err := leases.VerifyAndBuild(ctx, st, nl, in)
 	if err != nil {
 		if in.Transfer() {
@@ -904,7 +912,7 @@ func (r *Replica) requestLeaseLocked(
 	}
 	return r.mu.pendingLeaseRequest.InitOrJoinRequest(
 		ctx, repDesc, status, r.shMu.state.Desc.StartKey.AsRawKey(),
-		false /* bypassSafetyChecks */, limiter)
+		false /* bypassSafetyChecks */, false /* targetHasSendQueue */, limiter)
 }
 
 // AdminTransferLease transfers the LeaderLease to another replica. Only the
@@ -942,6 +950,16 @@ func (r *Replica) AdminTransferLease(
 	// transfer (if it was successfully initiated).
 	var nextLeaseHolder roachpb.ReplicaDescriptor
 	initTransferHelper := func() (extension, transfer *leaseRequestHandle, err error) {
+		// Query send stream stats before acquiring repl.mu. SendStreamStats
+		// acquires rcReferenceUpdateMu which is ordered before repl.mu, so we
+		// must not call it while holding repl.mu. We pre-fetch the full range
+		// stats here, then look up the target's per-replica stats inside the
+		// lock after resolving the target's ReplicaID.
+		var sendStreamStats rac2.RangeSendStreamStats
+		if !bypassSafetyChecks {
+			r.SendStreamStats(&sendStreamStats)
+		}
+
 		r.mu.Lock()
 		defer r.mu.Unlock()
 
@@ -979,8 +997,21 @@ func (r *Replica) AdminTransferLease(
 				"another transfer to a different store is in progress")
 		}
 
+		// Check whether the target has a send queue using the pre-fetched stats.
+		// Reading from the RangeSendStreamStats struct is a plain data access
+		// with no lock dependencies.
+		var targetHasSendQueue bool
+		if !bypassSafetyChecks {
+			if replStats, ok := sendStreamStats.ReplicaSendStreamStats(
+				nextLeaseHolder.ReplicaID,
+			); ok {
+				targetHasSendQueue = !replStats.IsStateReplicate || replStats.HasSendQueue
+			}
+		}
+
 		transfer = r.mu.pendingLeaseRequest.InitOrJoinRequest(ctx, nextLeaseHolder, status,
-			desc.StartKey.AsRawKey(), bypassSafetyChecks, nil /* limiter */)
+			desc.StartKey.AsRawKey(), bypassSafetyChecks, targetHasSendQueue,
+			nil /* limiter */)
 		return nil, transfer, nil
 	}
 
@@ -1019,11 +1050,15 @@ func (r *Replica) AdminTransferLease(
 			select {
 			case pErr := <-transfer.C():
 				err = pErr.GoError()
-				if IsLeaseTransferRejectedBecauseTargetMayNeedSnapshotError(err) && transferRejectedRetry.Next() {
+				if (IsLeaseTransferRejectedBecauseTargetMayNeedSnapshotError(err) ||
+					IsLeaseTransferRejectedBecauseTargetHasSendQueueError(err)) &&
+					transferRejectedRetry.Next() {
 					// If the lease transfer was rejected because the target may need a
-					// snapshot, try again. After the backoff, we may have become the Raft
-					// leader (through maybeTransferRaftLeadershipToLeaseholderLocked) or
-					// may have learned more about the state of the lease target's log.
+					// snapshot or has a send queue, try again. After the backoff, we may
+					// have become the Raft leader (through
+					// maybeTransferRaftLeadershipToLeaseholderLocked), may have learned
+					// more about the state of the lease target's log, or the send queue
+					// may have drained.
 					log.VEventf(ctx, 2, "retrying lease transfer to store %d after rejection", target)
 					continue
 				}

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -997,9 +997,10 @@ func (r *Replica) AdminTransferLease(
 				"another transfer to a different store is in progress")
 		}
 
-		// Check whether the target has a send queue using the pre-fetched stats.
-		// Reading from the RangeSendStreamStats struct is a plain data access
-		// with no lock dependencies.
+		// Check whether the target has a send queue using the pre-fetched stats
+		// (see the paragraph above about why we pre-fetch before acquiring
+		// repl.mu). Reading from the RangeSendStreamStats struct is a plain data
+		// access with no lock dependencies.
 		var targetHasSendQueue bool
 		if !bypassSafetyChecks {
 			if replStats, ok := sendStreamStats.ReplicaSendStreamStats(


### PR DESCRIPTION
When a lease is transferred to a replica behind on its raft log, the
range becomes unavailable until the new leaseholder catches up. The
allocator paths (replicate queue, lease queue, store rebalancer) filter
out such replicas via `excludeReplicasInNeedOfCatchup`. But several
callers bypass the allocator and call `AdminTransferLease` directly
(store rebalancer, `AdminRelocateRange`, scatter, manual SQL). These
only hit the proposal-buffer check (`verifyTransfer`) which rejects
snapshot-level lag but allows transfers to replicas thousands of entries
behind.

This PR adds a send-queue check to the lease transfer verification path
so it applies uniformly to ALL lease transfers. The check runs
above-raft in `InitOrJoinRequest` (before lease revocation), where
early rejection avoids the more disruptive revoke-then-reject sequence
in the proposal buffer. The proposal buffer retains the airtight
snapshot-level check via `ReplicaMayNeedSnapshot`. The existing
`BypassSafetyChecks` field on `TransferLeaseRequest` serves as the
escape hatch.

Insisting on absence of a send queue is the right signal (not
`Match >= Commit`, which is too strict on busy/WAN ranges). When send
stream stats are unavailable (not the leader, RACv2 not active), we
conservatively allow the transfer — matching the allocator's fallback
behavior in `excludeReplicasInNeedOfCatchup`.

----

**Commit arc:**

1. **Comment-only groundwork.** Update the `verifyTransfer` comment to
   document the replication lag gap and orient the reviewer on the
   problem.

2. **Error infrastructure.** Add the send-queue rejection error
   sentinel, constructor, and detection function following the existing
   `ErrMarkLeaseTransferRejectedBecauseTargetMayNeedSnapshot` pattern.
   Also fix a pre-existing `%d` → `%v` format verb bug in the snapshot
   error constructor.

3. **Core behavioral change.** Add `TargetHasSendQueue` to
   `VerifyInput`/`BuildInput`, thread through `toVerifyInput`, and add
   the rejection check in `verifyTransfer`. Unit tests cover rejection,
   no-rejection, and bypass.

4. **Proposal buffer comment.** Document why the send-queue check is
   intentionally omitted from `verifyLeaseRequestSafetyRLocked`:
   `SendStreamStats` acquires `rcReferenceUpdateMu` which is ordered
   before `repl.mu`, so calling it under `repl.mu` would be a lock
   ordering violation. The proposal buffer retains the airtight
   snapshot check via `ReplicaMayNeedSnapshot`.

5. **Wire above-raft check + retry.** In `AdminTransferLease`, query
   `SendStreamStats` before acquiring `repl.mu` and pass the result
   into `InitOrJoinRequest` as a best-effort early check (before lease
   revocation). In `AdminTransferLease`, update the retry loop to also
   retry on send-queue rejection so the send queue can drain during
   backoff (~6s).

Release note: None
Epic: none