### PR TITLE
release-26.1: pkg/cli: support full zip path matching in --include-files/--exclude-files

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -1699,8 +1699,17 @@ The default is to not exclude any node.`,
 List of glob patterns that determine files that can be included
 in the output. The list can be specified as a comma-delimited
 list of patterns, or by using the flag multiple times.
-The patterns apply to the base name of the file, without
-a path prefix.
+<PRE>
+
+</PRE>
+Patterns without '/' apply to the base name of the file (e.g. '*.json').
+Patterns containing '/' are matched against the full path within the zip
+archive (e.g. 'debug/nodes/1/*.json' or 'debug/nodes/*/ranges.json').
+The path matching uses Go's filepath.Match syntax, where '*' matches
+any sequence of non-separator characters within a single path component.
+<PRE>
+
+</PRE>
 The default is to include all files.
 <PRE>
 
@@ -1722,8 +1731,14 @@ List of glob patterns that determine files that are to
 be excluded from the output. The list can be specified
 as a comma-delimited list of patterns, or by using the
 flag multiple times.
-The patterns apply to the base name of the file, without
-a path prefix.
+<PRE>
+
+</PRE>
+Patterns without '/' apply to the base name of the file (e.g. '*.log').
+Patterns containing '/' are matched against the full path within the zip
+archive (e.g. 'debug/nodes/*/ranges.json').
+The path matching uses Go's filepath.Match syntax, where '*' matches
+any sequence of non-separator characters within a single path component.
 <PRE>
 
 </PRE>

--- a/pkg/cli/testdata/zip/file-filters/testzip_file_filters
+++ b/pkg/cli/testdata/zip/file-filters/testzip_file_filters
@@ -669,3 +669,49 @@ debug/nodes/1/stacks.txt
 debug/nodes/1/stacks_with_labels.txt
 debug/pprof-summary.sh
 debug/tenant_ranges.err.txt
+
+#path-based include: only node 1 json files
+--include-files=debug/nodes/1/*.json
+----
+debug/debug_zip_command_flags.txt
+debug/hot-ranges-tenant.sh
+debug/hot-ranges.sh
+debug/nodes/1/details.json
+debug/nodes/1/gossip.json
+debug/nodes/1/ranges.json
+debug/nodes/1/status.json
+debug/pprof-summary.sh
+debug/tenant_ranges.err.txt
+
+#path-based exclude: include all json but exclude per-node ranges
+--include-files=*.json --exclude-files=debug/nodes/*/ranges.json
+----
+debug/debug_zip_command_flags.txt
+debug/events.json
+debug/hot-ranges-tenant.sh
+debug/hot-ranges.sh
+debug/liveness.json
+debug/nodes.json
+debug/nodes/1/details.json
+debug/nodes/1/gossip.json
+debug/nodes/1/status.json
+debug/pprof-summary.sh
+debug/rangelog.json
+debug/reports/problemranges.json
+debug/settings.json
+debug/tenant_ranges.err.txt
+
+#path-based exclude: include all json but exclude all node-level json files
+--include-files=*.json --exclude-files=debug/nodes/*/*.json
+----
+debug/debug_zip_command_flags.txt
+debug/events.json
+debug/hot-ranges-tenant.sh
+debug/hot-ranges.sh
+debug/liveness.json
+debug/nodes.json
+debug/pprof-summary.sh
+debug/rangelog.json
+debug/reports/problemranges.json
+debug/settings.json
+debug/tenant_ranges.err.txt

--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -559,8 +559,7 @@ func (zc *debugZipContext) dumpTableDataForZip(
 	ctx := context.Background()
 	fileName := sanitizeFilename(table)
 	baseName := path.Join(base, fileName)
-	fileNameWithExtension := fileName + "." + zc.clusterPrinter.sqlOutputFilenameExtension
-	if !zipCtx.files.shouldIncludeFile(fileNameWithExtension) {
+	if !zipCtx.files.shouldIncludeFile(baseName + "." + zc.clusterPrinter.sqlOutputFilenameExtension) {
 		zr.info("skipping table data for %s due to file filters", table)
 		return nil
 	}

--- a/pkg/cli/zip_helpers_test.go
+++ b/pkg/cli/zip_helpers_test.go
@@ -17,6 +17,7 @@ func TestFileSelection(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	type s = string
+	// Tests for base-name-only patterns (just filename, no directory).
 	testCases := []struct {
 		incl    []s
 		excl    []s
@@ -44,6 +45,142 @@ func TestFileSelection(t *testing.T) {
 				t.Errorf("incl=%+v, excl=%+v: mistakenly includes %q", sel.includePatterns, sel.excludePatterns, f)
 			}
 		}
+	}
+}
+
+func TestFileSelectionWithPaths(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	type s = string
+	var zt time.Time
+
+	testCases := []struct {
+		name     string
+		incl     []s
+		excl     []s
+		zipPath  s
+		included bool
+	}{
+		{
+			name:     "path include with wildcard node",
+			incl:     []s{"debug/nodes/*/*.json"},
+			zipPath:  "debug/nodes/1/details.json",
+			included: true,
+		},
+		{
+			name:     "path include rejects wrong node",
+			incl:     []s{"debug/nodes/1/*.json"},
+			zipPath:  "debug/nodes/2/details.json",
+			included: false,
+		},
+		{
+			name:     "path exclude on per-node spares cluster-wide same name",
+			excl:     []s{"debug/nodes/*/ranges.json"},
+			zipPath:  "debug/ranges.json",
+			included: true,
+		},
+		{
+			name:     "base include with path exclude removes targeted file",
+			incl:     []s{"*.json"},
+			excl:     []s{"debug/nodes/*/ranges.json"},
+			zipPath:  "debug/nodes/1/ranges.json",
+			included: false,
+		},
+		{
+			name:     "path include distinguishes cluster-wide vs per-node",
+			incl:     []s{"debug/events.json"},
+			zipPath:  "debug/nodes/1/events.json",
+			included: false,
+		},
+		{
+			name:     "path pattern does not match bare filename",
+			incl:     []s{"debug/nodes/*/cpu.pprof"},
+			zipPath:  "cpu.pprof",
+			included: false,
+		},
+		{
+			name:     "base-only zipPath with base pattern",
+			incl:     []s{"*.pprof"},
+			zipPath:  "cpu.pprof",
+			included: true,
+		},
+		{
+			name:     "mixed base and path include rejects non-matching node",
+			incl:     []s{"*.txt", "debug/nodes/1/*.json"},
+			zipPath:  "debug/nodes/2/details.json",
+			included: false,
+		},
+		{
+			name:     "deep path include matches heapprof subdirectory",
+			incl:     []s{"debug/nodes/*/heapprof/*.pprof"},
+			zipPath:  "debug/nodes/1/heapprof/memprof.2026-02-10.pprof",
+			included: true,
+		},
+		{
+			name:     "deep path exclude spares non-matching files in same dir",
+			excl:     []s{"debug/nodes/*/heapprof/*.pprof"},
+			zipPath:  "debug/nodes/1/heapprof/memmonitoring.2026-02-10.txt",
+			included: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sel := fileSelection{includePatterns: tc.incl, excludePatterns: tc.excl}
+			actual := sel.isIncluded(tc.zipPath, zt, zt)
+			if actual != tc.included {
+				t.Errorf("incl=%+v, excl=%+v, path=%q: expected included=%v, got %v",
+					sel.includePatterns, sel.excludePatterns, tc.zipPath, tc.included, actual)
+			}
+		})
+	}
+}
+
+func TestRetrievalPatternsWithPaths(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	type s = string
+	testCases := []struct {
+		name     string
+		incl     []s
+		expected []s
+	}{
+		{
+			name:     "no patterns returns wildcard",
+			incl:     nil,
+			expected: []s{"*"},
+		},
+		{
+			name:     "base-name patterns returned as-is",
+			incl:     []s{"*.json", "*.txt"},
+			expected: []s{"*.json", "*.txt"},
+		},
+		{
+			name:     "path patterns filtered out, only base-name sent to server",
+			incl:     []s{"*.json", "debug/nodes/1/*.txt"},
+			expected: []s{"*.json"},
+		},
+		{
+			name:     "all path patterns returns wildcard",
+			incl:     []s{"debug/nodes/1/*.json", "debug/nodes/*/stacks.txt"},
+			expected: []s{"*"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sel := fileSelection{includePatterns: tc.incl}
+			actual := sel.retrievalPatterns()
+			if len(actual) != len(tc.expected) {
+				t.Fatalf("expected %v, got %v", tc.expected, actual)
+			}
+			for i := range actual {
+				if actual[i] != tc.expected[i] {
+					t.Errorf("expected %v, got %v", tc.expected, actual)
+					break
+				}
+			}
+		})
 	}
 }
 

--- a/pkg/cli/zip_per_node.go
+++ b/pkg/cli/zip_per_node.go
@@ -77,7 +77,7 @@ func (zc *debugZipContext) collectPerNodeData(
 
 	nodePrinter := zipCtx.newZipReporter(redact.Sprintf("node %d", nodeID))
 	id := fmt.Sprintf("%d", nodeID)
-	prefix := fmt.Sprintf("%s%s/%s", zc.prefix, nodesPrefix, id)
+	prefix := path.Join(zc.prefix, nodesPrefix, id)
 
 	if !zipCtx.nodes.isIncluded(nodeID) {
 		nodePrinter.info("skipping excluded node")
@@ -137,7 +137,7 @@ func makePerNodeZipRequests(
 ) []zipRequest {
 	var zipRequests []zipRequest
 
-	if zipCtx.files.shouldIncludeFile(detailsFileName) {
+	if zipCtx.files.shouldIncludeFile(path.Join(prefix, detailsFileName)) {
 		zipRequests = append(zipRequests, zipRequest{
 			fn: func(ctx context.Context) (interface{}, error) {
 				return status.Details(ctx, &serverpb.DetailsRequest{NodeId: id, Redact: zipCtx.redact})
@@ -149,7 +149,7 @@ func makePerNodeZipRequests(
 		zr.info("skipping %s due to file filters", detailsFileName)
 	}
 
-	if zipCtx.files.shouldIncludeFile(gossipFileName) {
+	if zipCtx.files.shouldIncludeFile(path.Join(prefix, gossipFileName)) {
 		zipRequests = append(zipRequests, zipRequest{
 			fn: func(ctx context.Context) (interface{}, error) {
 				return status.Gossip(ctx, &serverpb.GossipRequest{NodeId: id, Redact: zipCtx.redact})
@@ -187,10 +187,6 @@ func (zc *debugZipContext) collectCPUProfiles(
 	}
 
 	zc.clusterPrinter.info("requesting CPU profiles")
-	if !zipCtx.files.shouldIncludeFile(cpuProfileFileName) {
-		zc.clusterPrinter.info("skipping %s due to file filters", cpuProfileFileName)
-		return nil
-	}
 
 	if ni == nil {
 		return errors.AssertionFailedf("nodes list is empty; nothing to do")
@@ -206,6 +202,13 @@ func (zc *debugZipContext) collectCPUProfiles(
 		}
 		if !zipCtx.nodes.isIncluded(nodeID) {
 			zc.clusterPrinter.info("skipping excluded node %d", nodeID)
+			continue
+		}
+		// Per-node check with the full zip path so that path-based
+		// patterns like 'debug/nodes/1/cpu.pprof' are respected.
+		nodePrefix := path.Join(zc.prefix, nodesPrefix, fmt.Sprintf("%d", nodeID))
+		if !zipCtx.files.shouldIncludeFile(path.Join(nodePrefix, cpuProfileFileName)) {
+			zc.clusterPrinter.info("skipping %s for node %d due to file filters", cpuProfileFileName, nodeID)
 			continue
 		}
 		wg.Add(1)
@@ -247,9 +250,9 @@ func (zc *debugZipContext) collectCPUProfiles(
 			continue // skipped node
 		}
 		nodeID := nodeList[i].NodeID
-		prefix := fmt.Sprintf("%s%s/%s", zc.prefix, nodesPrefix, fmt.Sprintf("%d", nodeID))
+		prefix := path.Join(zc.prefix, nodesPrefix, fmt.Sprintf("%d", nodeID))
 		s := zc.clusterPrinter.start(redact.Sprintf("profile for node %d", nodeID))
-		if err := zc.z.createRawOrError(s, prefix+"/"+cpuProfileFileName, pd.data, pd.err); err != nil {
+		if err := zc.z.createRawOrError(s, path.Join(prefix, cpuProfileFileName), pd.data, pd.err); err != nil {
 			return err
 		}
 	}
@@ -310,7 +313,7 @@ func (zc *debugZipContext) collectFileList(
 		nodePrinter.info("%d %ss found", len(files.Files), fileKind)
 		for _, file := range files.Files {
 			ctime := extractTimeFromFileName(file.Name)
-			if !zipCtx.files.isIncluded(file.Name, ctime, ctime) {
+			if !zipCtx.files.isIncluded(path.Join(prefix, file.Name), ctime, ctime) {
 				nodePrinter.info("skipping excluded %s: %s due to file filters", fileKind, file.Name)
 				continue
 			}
@@ -354,7 +357,7 @@ func (zc *debugZipContext) getRangeInformation(
 	ctx context.Context, nodePrinter *zipReporter, id string, prefix string,
 ) error {
 	if zipCtx.includeRangeInfo {
-		if !zipCtx.files.shouldIncludeFile(rangesInfoFileName) {
+		if !zipCtx.files.shouldIncludeFile(path.Join(prefix, rangesInfoFileName)) {
 			nodePrinter.info("skipping %s due to file filters", rangesInfoFileName)
 			return nil
 		}
@@ -419,7 +422,7 @@ func (zc *debugZipContext) getLogFiles(
 		for _, file := range logs.Files {
 			ctime := extractTimeFromFileName(file.Name)
 			mtime := timeutil.Unix(0, file.ModTimeNanos)
-			if !zipCtx.files.isIncluded(file.Name, ctime, mtime) {
+			if !zipCtx.files.isIncluded(path.Join(prefix, "logs", file.Name), ctime, mtime) {
 				nodePrinter.info("skipping excluded log file: %s due to file filters", file.Name)
 				continue
 			}
@@ -530,7 +533,7 @@ func (zc *debugZipContext) getProfiles(
 func (zc *debugZipContext) getEngineStats(
 	ctx context.Context, nodePrinter *zipReporter, id string, prefix string,
 ) error {
-	if !zipCtx.files.shouldIncludeFile(lsmFileName) {
+	if !zipCtx.files.shouldIncludeFile(path.Join(prefix, lsmFileName)) {
 		nodePrinter.info("skipping %s due to file filters", lsmFileName)
 		return nil
 	}
@@ -554,7 +557,7 @@ func (zc *debugZipContext) getEngineStats(
 func (zc *debugZipContext) getCurrentHeapProfile(
 	ctx context.Context, nodePrinter *zipReporter, id string, prefix string,
 ) error {
-	if !zipCtx.files.shouldIncludeFile(heapPprofFileName) {
+	if !zipCtx.files.shouldIncludeFile(path.Join(prefix, heapPprofFileName)) {
 		nodePrinter.info("skipping %s due to file filters", heapPprofFileName)
 		return nil
 	}
@@ -587,7 +590,7 @@ func (zc *debugZipContext) getStackInformation(
 	// binary goroutine profile (debug=3 or debug=0), as these do not have that
 	// same stop-the-world disruption.
 	if zipCtx.includeStacks {
-		if zipCtx.files.shouldIncludeFile(stacksFileName) {
+		if zipCtx.files.shouldIncludeFile(path.Join(prefix, stacksFileName)) {
 			var stacksData []byte
 			s := nodePrinter.start("requesting stacks")
 			requestErr := zc.runZipFn(ctx, s,
@@ -612,7 +615,7 @@ func (zc *debugZipContext) getStackInformation(
 	}
 
 	var stacksDataWithLabels []byte
-	if zipCtx.files.shouldIncludeFile(stacksWithLabelFileName) {
+	if zipCtx.files.shouldIncludeFile(path.Join(prefix, stacksWithLabelFileName)) {
 		s := nodePrinter.start("requesting stacks with labels")
 		requestErr := zc.runZipFn(ctx, s,
 			func(ctx context.Context) error {
@@ -635,7 +638,7 @@ func (zc *debugZipContext) getStackInformation(
 		nodePrinter.info("skipping %s due to file filters", stacksWithLabelFileName)
 	}
 
-	if zipCtx.files.shouldIncludeFile(stacksPprofFileName) {
+	if zipCtx.files.shouldIncludeFile(path.Join(prefix, stacksPprofFileName)) {
 		var stacksPprofData []byte
 		s := nodePrinter.start("requesting goroutine profile")
 		requestErr := zc.runZipFn(ctx, s,
@@ -706,7 +709,7 @@ func (zc *debugZipContext) getNodeStatus(
 	prefix string,
 	redactedNodeDetails serverpb.NodeDetails,
 ) error {
-	if !zipCtx.files.shouldIncludeFile(statusFileName) {
+	if !zipCtx.files.shouldIncludeFile(path.Join(prefix, statusFileName)) {
 		nodePrinter.info("skipping %s due to file filters", statusFileName)
 		return nil
 	}


### PR DESCRIPTION
Backport 1/1 commits from #163266.

/cc @cockroachdb/release

---

Previously, the --include-files and --exclude-files flags in `debug zip` 
only matched against the base file name (e.g. "details.json"). This made 
it impossible to filter by location within the zip archive, for example 
including only a specific node's files, or excluding per-node ranges.json 
while keeping the cluster-wide copy.

This commit extends the file filter flags to support full zip path 
matching. Patterns without '/' continue to match the base file name, 
preserving the backward compatibility. Patterns with '/' are matched 
against the full path within the zip archive using filepath.Match 
semantics (e.g. "debug/nodes/1/*.json" or "debug/nodes/*/ranges.json").

The core change adds a zipPath parameter to shouldIncludeFile and 
isIncluded, with a matchPattern helper that routes each pattern to the 
appropriate match target. Server-side retrieval patterns only forward 
base-name patterns since the server does not know the zip directory 
layout.

Fixes: #158450
Part of: CRDB-57302
Epic: none
Release note (cli change): The `cockroach debug zip` command's 
`--include-files` and `--exclude-files` flags now support full zip path 
patterns. Patterns containing '/' are matched against the full path 
within the zip archive (e.g. `--include-files='debug/nodes/1/*.json'`). 
Patterns without '/' continue to match the base file name as before.

Release justification: This change is needed to unblock an active customer investigation 
runbook. The current workaround for collecting faster "lite" debug zips uses `--exclude-files='*.pprof'`, 
but this over-excludes: it drops per-node cpu.pprof and heap.pprof (<1% of zip size) which are 
critical for diagnosing cluster behavior at collection time. The actual bloat comes from historical 
profiles in heapprof/ folders (49% of zip size). Without path-based filtering there is no way to 
exclude heapprof/* while retaining the current profiles -- the only option is the blunt `*.pprof`
which sacrifices essential diagnostic data. This change enables surgical patterns like --exclude-files='debug/nodes/*/heapprof/*' to target the bulk data. The change is backward compatible and 
additive only.
