### PR TITLE
release-24.3: crosscluster/logical: switch ownership to CDC

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -255,6 +255,7 @@
 /pkg/ccl/changefeedccl/      @cockroachdb/cdc-prs
 
 /pkg/ccl/crosscluster/       @cockroachdb/disaster-recovery
+/pkg/ccl/crosscluster/logical/    @cockroachdb/cdc-prs
 /pkg/ccl/backupccl/          @cockroachdb/disaster-recovery
 /pkg/ccl/backupccl/*_job.go  @cockroachdb/disaster-recovery @cockroachdb/jobs-prs
 /pkg/ccl/revertccl/          @cockroachdb/disaster-recovery

--- a/pkg/cmd/roachtest/tests/logical_data_replication.go
+++ b/pkg/cmd/roachtest/tests/logical_data_replication.go
@@ -178,7 +178,7 @@ func registerLogicalDataReplicationTests(r registry.Registry) {
 
 		r.Add(registry.TestSpec{
 			Name:             sp.name,
-			Owner:            registry.OwnerDisasterRecovery,
+			Owner:            registry.OwnerCDC,
 			Timeout:          60 * time.Minute,
 			CompatibleClouds: registry.OnlyGCE,
 			Suites:           registry.Suites(registry.Nightly),


### PR DESCRIPTION
Backport 2/2 commits from #163935.

/cc @cockroachdb/release

---

Epic: none

Release note: none

Release justification: test-only changes
