### PR TITLE
ui,e2e: fix cypress failure after docker removal

### DIFF
--- a/pkg/ui/pnpm-lock.yaml
+++ b/pkg/ui/pnpm-lock.yaml
@@ -33,11 +33,11 @@ overrides:
   '@cockroachlabs/cluster-ui>yargs-parser': 13.1.2
   analytics-node>axios-retry: 3.1.9
 
-packageExtensionsChecksum: f03a6ac29a2e646ae57bda3f9fc03971
+packageExtensionsChecksum: sha256-02fFnGGwSjfYK/rXie5PGkAvEEzXSPuaxyYtaA0W/7E=
 
 patchedDependencies:
   topojson@3.0.2:
-    hash: wpfs36vhb2v7nm6ekzrirgbci4
+    hash: be4a1a6184740cb5b3e06c729ecbea528e2f1a80d531f66c1e4c07553c3f6ced
     path: patches/topojson@3.0.2.patch
 
 importers:
@@ -732,10 +732,6 @@ importers:
       whatwg-fetch:
         specifier: ^2.0.3
         version: 2.0.3
-    optionalDependencies:
-      timers-browserify:
-        specifier: ^2.0.12
-        version: 2.0.12
     devDependencies:
       '@babel/core':
         specifier: ^7.7.7
@@ -1087,7 +1083,7 @@ importers:
         version: 0.0.33
       topojson:
         specifier: ^3.0.2
-        version: 3.0.2(patch_hash=wpfs36vhb2v7nm6ekzrirgbci4)
+        version: 3.0.2(patch_hash=be4a1a6184740cb5b3e06c729ecbea528e2f1a80d531f66c1e4c07553c3f6ced)
       ts-jest:
         specifier: 27.1.3
         version: 27.1.3(@babel/core@7.8.3)(@types/jest@27.5.2)(babel-jest@27.5.1(@babel/core@7.8.3))(esbuild@0.14.43)(jest@27.5.1(@babel/runtime@7.12.13))(typescript@5.1.6)
@@ -1124,6 +1120,10 @@ importers:
       world-atlas:
         specifier: ^1.1.4
         version: 1.1.4
+    optionalDependencies:
+      timers-browserify:
+        specifier: ^2.0.12
+        version: 2.0.12
 
   workspaces/db-console/ccl/src/js:
     dependencies:
@@ -1209,8 +1209,8 @@ importers:
         specifier: 0.1.11
         version: 0.1.11(@typescript-eslint/eslint-plugin@4.29.1(@typescript-eslint/parser@2.34.0(eslint@7.29.0)(typescript@5.1.6))(eslint@7.29.0)(typescript@5.1.6))(eslint-plugin-prettier@3.4.1(eslint-config-prettier@8.8.0(eslint@7.29.0))(eslint@7.29.0)(prettier@2.6.2))(eslint-plugin-react-hooks@4.2.0(eslint@7.29.0))(eslint-plugin-react@7.24.0(eslint@7.29.0))(eslint@7.29.0)(typescript@5.1.6)
       '@testing-library/cypress':
-        specifier: ^8.0.2
-        version: 8.0.2(cypress@10.3.0)
+        specifier: ^10.0.0
+        version: 10.1.0(cypress@13.17.0)
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.3
@@ -1218,8 +1218,8 @@ importers:
         specifier: 2.34.0
         version: 2.34.0(eslint@7.29.0)(typescript@5.1.6)
       cypress:
-        specifier: ^10.3.0
-        version: 10.3.0
+        specifier: ^13.13.2
+        version: 13.17.0
       eslint:
         specifier: 7.29.0
         version: 7.29.0
@@ -2237,14 +2237,6 @@ packages:
   '@babel/runtime@7.12.13':
     resolution: {integrity: sha512-8+3UMPBrjFa/6TtKi/7sehPKqfAm4g6K+YQjyyFOLUTxzOngcRZTlAVY8sc2CORJYqdHQY8gRPHmn+qo15rCBw==}
 
-  '@babel/runtime@7.22.6':
-    resolution: {integrity: sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/runtime@7.24.5':
-    resolution: {integrity: sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/runtime@7.28.6':
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
     engines: {node: '>=6.9.0'}
@@ -2347,8 +2339,8 @@ packages:
     resolution: {integrity: sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==}
     engines: {node: '>=10'}
 
-  '@cypress/request@2.88.11':
-    resolution: {integrity: sha512-M83/wfQ1EkspjkE2lNWNV5ui2Cv7UCv1swW1DqljahbzLVWltcsexQh8jYtuS/vzFXP+HySntGM83ZXA9fn17w==}
+  '@cypress/request@3.0.10':
+    resolution: {integrity: sha512-hauBrOdvu08vOsagkZ/Aju5XuiZx6ldsLfByg1htFeldhex+PeMrYauANzFsMJeAA0+dyPLbDoX2OYuvVoLDkQ==}
     engines: {node: '>= 6'}
 
   '@cypress/xvfb@1.2.4':
@@ -2698,36 +2690,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.4':
     resolution: {integrity: sha512-kGO8RPvVrcAotV4QcWh8kZuHr9bXi9a3bSZw7kFarYR0+fGliU7hd/zevhjw8fnvIKG3J9EO5G6sXNGCSNMYPQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.4':
     resolution: {integrity: sha512-KU75aooXhqGFY2W5/p8DYYHt4hrjHZod8AhcGAmhzPn/etTa+lYCDB2b1sJy3sWJ8ahFVTdy+EbqSBvMx3iFlw==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.4':
     resolution: {integrity: sha512-Qx8uNiIekVutnzbVdrgSanM+cbpDD3boB1f8vMtnuG5Zau4/bdDbXyKwIn0ToqFhIuob73bcxV9NwRm04/hzHQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.4':
     resolution: {integrity: sha512-UYBQvhYmgAv61LNUn24qGQdjtycFBKSK3EXr72DbJqX9aaLbtCOO8+1SkKhD/GNiJ97ExgcHBrukcYhVjrnogA==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.4':
     resolution: {integrity: sha512-YoRWCVgxv8akZrMhdyVi6/TyoeeMkQ0PGGOf2E4omODrvd1wxniXP+DBynKoHryStks7l+fDAMUBRzqNHrVOpg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.4':
     resolution: {integrity: sha512-iby+D/YNXWkiQNYcIhg8P5hSjzXEHaQrk2SLrWOUD7VeC4Ohu0WQvmV+HDJokZVJ2UjJ4AGXW3bx7Lls9Ln4TQ==}
@@ -3180,11 +3178,15 @@ packages:
       react: 16.12.0
       react-dom: 16.12.0
 
-  '@testing-library/cypress@8.0.2':
-    resolution: {integrity: sha512-KVdm7n37sg/A4e3wKMD4zUl0NpzzVhx06V9Tf0hZHZ7nrZ4yFva6Zwg2EFF1VzHkEfN/ahUzRtT1qiW+vuWnJw==}
+  '@testing-library/cypress@10.1.0':
+    resolution: {integrity: sha512-tNkNtYRqPQh71xXKuMizr146zlellawUfDth7A/urYU4J66g0VGZ063YsS0gqS79Z58u1G/uo9UxN05qvKXMag==}
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
-      cypress: ^2.1.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
+      cypress: ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0
+
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
 
   '@testing-library/dom@8.11.1':
     resolution: {integrity: sha512-3KQDyx9r0RKYailW2MiYrSSKEfH0GTkI51UGEvJenvcoDoeRYs0PZpi2SXqtnMClQvCqdtTTpOfFETDTVADpAg==}
@@ -3229,6 +3231,9 @@ packages:
 
   '@types/aria-query@4.2.2':
     resolution: {integrity: sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/assert@1.4.0':
     resolution: {integrity: sha512-VUHsfGbKXGjCa0yanF3woz+a1hW72knNw/bumzeVQ4qH+znsQxdLhJf14QcyM1c7yOdjyIHmIX0cbbf1IgrhhA==}
@@ -4938,6 +4943,10 @@ packages:
     resolution: {integrity: sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==}
     engines: {node: '>=8'}
 
+  ci-info@4.4.0:
+    resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
+    engines: {node: '>=8'}
+
   cipher-base@1.0.4:
     resolution: {integrity: sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==}
 
@@ -5075,10 +5084,6 @@ packages:
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
-    engines: {node: '>= 6'}
-
-  commander@5.1.0:
-    resolution: {integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==}
     engines: {node: '>= 6'}
 
   commander@6.2.1:
@@ -5359,9 +5364,9 @@ packages:
   cyclist@1.0.2:
     resolution: {integrity: sha512-0sVXIohTfLqVIW3kb/0n6IiWF3Ifj5nm2XaSrLq2DI6fKIGa2fYAZdk917rUneaeLVpYfFcyXE2ft0fe3remsA==}
 
-  cypress@10.3.0:
-    resolution: {integrity: sha512-txkQWKzvBVnWdCuKs5Xc08gjpO89W2Dom2wpZgT9zWZT5jXxqPIxqP/NC1YArtkpmp3fN5HW8aDjYBizHLUFvg==}
-    engines: {node: '>=12.0.0'}
+  cypress@13.17.0:
+    resolution: {integrity: sha512-5xWkaPurwkIljojFidhw8lFScyxhtiFHl/i/3zov+1Z5CmY4t9tjIdvSXfu82Y3w7wt0uR9KkucbhkVvJZLQSA==}
+    engines: {node: ^16.0.0 || ^18.0.0 || >=20.0.0}
     hasBin: true
 
   d3-array@3.2.4:
@@ -5468,9 +5473,6 @@ packages:
 
   dayjs@1.11.19:
     resolution: {integrity: sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==}
-
-  dayjs@1.11.9:
-    resolution: {integrity: sha512-QvzAURSbQ0pKdIye2txOzNaHmxtUBXerpY0FJsFXUMKbIZeFm5ht1LS/jFsrncjnmtv8HsG0W2g6c0zUjZWmpA==}
 
   debug@2.6.1:
     resolution: {integrity: sha512-BmFi/QgceF1MztznXEqbZXATlMwzrsfWR9Iahbp4j7vTK+Sel84Mt3SZ/btENs22PSm0bw6NOoZOd2fbOczPRQ==}
@@ -5950,6 +5952,10 @@ packages:
     resolution: {integrity: sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==}
     engines: {node: '>= 0.4'}
 
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
   es-shim-unscopables@1.0.0:
     resolution: {integrity: sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==}
 
@@ -6378,8 +6384,8 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
-  eventemitter2@6.4.9:
-    resolution: {integrity: sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==}
+  eventemitter2@6.4.7:
+    resolution: {integrity: sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg==}
 
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
@@ -6705,12 +6711,12 @@ packages:
       vue-template-compiler:
         optional: true
 
-  form-data@2.3.3:
-    resolution: {integrity: sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==}
-    engines: {node: '>= 0.12'}
-
   form-data@3.0.1:
     resolution: {integrity: sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==}
+    engines: {node: '>= 6'}
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
   format@0.2.2:
@@ -6907,15 +6913,15 @@ packages:
 
   glob@7.1.1:
     resolution: {integrity: sha512-mRyN/EsN2SyNhKWykF3eEGhDpeNplMWaW18Bmh76tnOqk5TbELAVwFAYOCmKVssOYFrYvvLMguiA+NXO3ZTuVA==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@7.1.3:
     resolution: {integrity: sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-dirs@3.0.1:
     resolution: {integrity: sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==}
@@ -7216,8 +7222,8 @@ packages:
     resolution: {integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==}
     engines: {node: '>=8.0.0'}
 
-  http-signature@1.3.6:
-    resolution: {integrity: sha512-3adrsD6zqo4GsTqtO7FyrejHNv+NgiIfAfv68+jVlFmSr9OGy7zrxONceFRLKvnnZA5jbxQBX1u9PpB6Wi32Gw==}
+  http-signature@1.4.0:
+    resolution: {integrity: sha512-G5akfn7eKbpDN+8nPS/cb57YeA1jLTVxjpCj7tmm3QKPdyDy7T+qSC40e9ptydSWvkwjSXw1VbkpyEm39ukeAg==}
     engines: {node: '>=0.10'}
 
   http2-client@1.3.5:
@@ -7472,10 +7478,6 @@ packages:
   is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
-
-  is-ci@3.0.1:
-    resolution: {integrity: sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==}
-    hasBin: true
 
   is-core-module@2.12.1:
     resolution: {integrity: sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==}
@@ -9555,10 +9557,6 @@ packages:
     resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
     engines: {node: '>=6'}
 
-  qs@6.10.4:
-    resolution: {integrity: sha512-OQiU+C+Ds5qiH91qh/mg0w+8nwQuLjM4F4M/PbmhDOoYehPh+Fb0bDjtR1sOvy7YKxvj28Y/M0PhP5uVX0kB+g==}
-    engines: {node: '>=0.6'}
-
   qs@6.11.0:
     resolution: {integrity: sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==}
     engines: {node: '>=0.6'}
@@ -9569,6 +9567,10 @@ packages:
 
   qs@6.14.0:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
+    engines: {node: '>=0.6'}
+
+  qs@6.14.2:
+    resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
     engines: {node: '>=0.6'}
 
   qs@6.4.0:
@@ -10252,9 +10254,6 @@ packages:
   regenerator-runtime@0.13.11:
     resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
 
-  regenerator-runtime@0.14.1:
-    resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
-
   regenerator-transform@0.15.1:
     resolution: {integrity: sha512-knzmNAcuyxV+gQCufkYcvOqX/qIIfHLv0u5x79kRxuGojfYVky1f15TzZEu2Avte8QGepvUNTnLskf8E6X6Vyg==}
 
@@ -10525,48 +10524,56 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: glibc
 
   sass-embedded-linux-arm@1.97.3:
     resolution: {integrity: sha512-2lPQ7HQQg4CKsH18FTsj2hbw5GJa6sBQgDsls+cV7buXlHjqF8iTKhAQViT6nrpLK/e8nFCoaRgSqEC8xMnXuA==}
     engines: {node: '>=14.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: glibc
 
   sass-embedded-linux-musl-arm64@1.97.3:
     resolution: {integrity: sha512-Lij0SdZCsr+mNRSyDZ7XtJpXEITrYsaGbOTz5e6uFLJ9bmzUbV7M8BXz2/cA7bhfpRPT7/lwRKPdV4+aR9Ozcw==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: musl
 
   sass-embedded-linux-musl-arm@1.97.3:
     resolution: {integrity: sha512-cBTMU68X2opBpoYsSZnI321gnoaiMBEtc+60CKCclN6PCL3W3uXm8g4TLoil1hDD6mqU9YYNlVG6sJ+ZNef6Lg==}
     engines: {node: '>=14.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: musl
 
   sass-embedded-linux-musl-riscv64@1.97.3:
     resolution: {integrity: sha512-sBeLFIzMGshR4WmHAD4oIM7WJVkSoCIEwutzptFtGlSlwfNiijULp+J5hA2KteGvI6Gji35apR5aWj66wEn/iA==}
     engines: {node: '>=14.0.0'}
     cpu: [riscv64]
     os: [linux]
+    libc: musl
 
   sass-embedded-linux-musl-x64@1.97.3:
     resolution: {integrity: sha512-/oWJ+OVrDg7ADDQxRLC/4g1+Nsz1g4mkYS2t6XmyMJKFTFK50FVI2t5sOdFH+zmMp+nXHKM036W94y9m4jjEcw==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: musl
 
   sass-embedded-linux-riscv64@1.97.3:
     resolution: {integrity: sha512-l3IfySApLVYdNx0Kjm7Zehte1CDPZVcldma3dZt+TfzvlAEerM6YDgsk5XEj3L8eHBCgHgF4A0MJspHEo2WNfA==}
     engines: {node: '>=14.0.0'}
     cpu: [riscv64]
     os: [linux]
+    libc: glibc
 
   sass-embedded-linux-x64@1.97.3:
     resolution: {integrity: sha512-Kwqwc/jSSlcpRjULAOVbndqEy2GBzo6OBmmuBVINWUaJLJ8Kczz3vIsDUWLfWz/kTEw9FHBSiL0WCtYLVAXSLg==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: glibc
 
   sass-embedded-unknown-all@1.97.3:
     resolution: {integrity: sha512-/GHajyYJmvb0IABUQHbVHf1nuHPtIDo/ClMZ81IDr59wT5CNcMe7/dMNujXwWugtQVGI5UGmqXWZQCeoGnct8Q==}
@@ -10974,8 +10981,8 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
-  sshpk@1.17.0:
-    resolution: {integrity: sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==}
+  sshpk@1.18.0:
+    resolution: {integrity: sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==}
     engines: {node: '>=0.10.0'}
     hasBin: true
 
@@ -11274,6 +11281,7 @@ packages:
   tar@6.1.15:
     resolution: {integrity: sha512-/zKt9UyngnxIT/EAGYuxaMYgOIJiP81ab9ZfkILq4oNLPFX50qyYmu7jRj9qeXoxmJHjGlbH0+cm2uy1WCs10A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   telejson@5.3.3:
     resolution: {integrity: sha512-PjqkJZpzEggA9TBpVtJi1LVptP7tYtXB6rEubwlHap76AMjzvOdKX41CxyaW7ahhzDU1aftXnMCx5kAPDZTQBA==}
@@ -11378,13 +11386,20 @@ packages:
   tiny-warning@1.0.3:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
 
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
   tmp@0.0.33:
     resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
     engines: {node: '>=0.6.0'}
 
-  tmp@0.2.1:
-    resolution: {integrity: sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==}
-    engines: {node: '>=8.17.0'}
+  tmp@0.2.5:
+    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+    engines: {node: '>=14.14'}
 
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
@@ -11440,13 +11455,13 @@ packages:
     deprecated: Use topojson-client, topojson-server or topojson-simplify directly.
     hasBin: true
 
-  tough-cookie@2.5.0:
-    resolution: {integrity: sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==}
-    engines: {node: '>=0.8'}
-
   tough-cookie@4.1.3:
     resolution: {integrity: sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==}
     engines: {node: '>=6'}
+
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
@@ -11463,6 +11478,10 @@ packages:
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
 
   trim-trailing-lines@1.1.4:
     resolution: {integrity: sha512-rjUWSqnfTNrjbB9NQWfPMH/xRK1deHeGsHoVfpxJ++XeYXE0d6B1En37AHfw3jtfTU7dzMzZL2jjpe8Qb5gLIQ==}
@@ -12082,6 +12101,7 @@ packages:
 
   whatwg-encoding@1.0.5:
     resolution: {integrity: sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-fetch@2.0.3:
     resolution: {integrity: sha512-SA2KdOXATOroD3EBUYvcdugsusXS5YiQFqwskSbsp5b1gK8HpNi/YP0jcy/BDpdllp305HMnrsVf9K7Be9GiEQ==}
@@ -12418,7 +12438,7 @@ snapshots:
 
   '@babel/core@7.12.9':
     dependencies:
-      '@babel/code-frame': 7.22.5
+      '@babel/code-frame': 7.27.1
       '@babel/generator': 7.22.7
       '@babel/helper-module-transforms': 7.22.5
       '@babel/helpers': 7.22.6
@@ -12427,7 +12447,7 @@ snapshots:
       '@babel/traverse': 7.22.8
       '@babel/types': 7.22.5
       convert-source-map: 1.9.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@10.2.2)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       lodash: 4.17.20
@@ -12440,7 +12460,7 @@ snapshots:
   '@babel/core@7.22.8':
     dependencies:
       '@ampproject/remapping': 2.2.1
-      '@babel/code-frame': 7.22.5
+      '@babel/code-frame': 7.27.1
       '@babel/generator': 7.22.7
       '@babel/helper-compilation-targets': 7.22.6(@babel/core@7.22.8)
       '@babel/helper-module-transforms': 7.22.5
@@ -12451,7 +12471,7 @@ snapshots:
       '@babel/types': 7.22.5
       '@nicolo-ribaudo/semver-v6': 6.3.3
       convert-source-map: 1.9.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@10.2.2)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
     transitivePeerDependencies:
@@ -12467,7 +12487,7 @@ snapshots:
       '@babel/traverse': 7.22.6
       '@babel/types': 7.22.5
       convert-source-map: 1.9.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@10.2.2)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       lodash: 4.17.20
@@ -12488,7 +12508,7 @@ snapshots:
       '@babel/traverse': 7.22.8
       '@babel/types': 7.22.5
       convert-source-map: 1.9.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@10.2.2)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       lodash: 4.17.20
@@ -12620,7 +12640,7 @@ snapshots:
       '@babel/helper-module-imports': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/traverse': 7.22.8
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@10.2.2)
       lodash.debounce: 4.0.8
       resolve: 1.22.8
       semver: 6.3.1
@@ -12634,7 +12654,7 @@ snapshots:
       '@babel/helper-module-imports': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/traverse': 7.22.8
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@10.2.2)
       lodash.debounce: 4.0.8
       resolve: 1.22.2
       semver: 6.3.1
@@ -12646,7 +12666,7 @@ snapshots:
       '@babel/core': 7.22.8
       '@babel/helper-compilation-targets': 7.22.6(@babel/core@7.22.8)
       '@babel/helper-plugin-utils': 7.22.5
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@10.2.2)
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -12657,7 +12677,7 @@ snapshots:
       '@babel/core': 7.8.3
       '@babel/helper-compilation-targets': 7.22.6(@babel/core@7.8.3)
       '@babel/helper-plugin-utils': 7.22.5
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@10.2.2)
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -14807,14 +14827,6 @@ snapshots:
     dependencies:
       regenerator-runtime: 0.13.11
 
-  '@babel/runtime@7.22.6':
-    dependencies:
-      regenerator-runtime: 0.13.11
-
-  '@babel/runtime@7.24.5':
-    dependencies:
-      regenerator-runtime: 0.14.1
-
   '@babel/runtime@7.28.6': {}
 
   '@babel/runtime@7.9.0':
@@ -14837,7 +14849,7 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/parser': 7.22.7
       '@babel/types': 7.22.5
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@10.2.2)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -14852,7 +14864,7 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/parser': 7.22.7
       '@babel/types': 7.22.5
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@10.2.2)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -14965,7 +14977,7 @@ snapshots:
 
   '@ctrl/tinycolor@3.6.1': {}
 
-  '@cypress/request@2.88.11':
+  '@cypress/request@3.0.10':
     dependencies:
       aws-sign2: 0.7.0
       aws4: 1.12.0
@@ -14973,16 +14985,16 @@ snapshots:
       combined-stream: 1.0.8
       extend: 3.0.2
       forever-agent: 0.6.1
-      form-data: 2.3.3
-      http-signature: 1.3.6
+      form-data: 4.0.5
+      http-signature: 1.4.0
       is-typedarray: 1.0.0
       isstream: 0.1.2
       json-stringify-safe: 5.0.1
       mime-types: 2.1.35
       performance-now: 2.1.0
-      qs: 6.10.4
+      qs: 6.14.2
       safe-buffer: 5.2.1
-      tough-cookie: 2.5.0
+      tough-cookie: 5.1.2
       tunnel-agent: 0.6.0
       uuid: 8.3.2
 
@@ -15054,7 +15066,7 @@ snapshots:
 
   '@emotion/react@11.11.1(@types/react@16.14.8)(react@16.12.0)':
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.28.6
       '@emotion/babel-plugin': 11.11.0
       '@emotion/cache': 11.11.0
       '@emotion/serialize': 1.1.2
@@ -15130,7 +15142,7 @@ snapshots:
   '@eslint/eslintrc@0.4.3':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@10.2.2)
       espree: 7.3.1
       globals: 13.20.0
       ignore: 4.0.6
@@ -15144,7 +15156,7 @@ snapshots:
   '@eslint/eslintrc@1.4.1':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@10.2.2)
       espree: 9.6.0
       globals: 13.20.0
       ignore: 5.2.4
@@ -15158,7 +15170,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@10.2.2)
       espree: 9.6.1
       globals: 13.20.0
       ignore: 5.2.4
@@ -15178,7 +15190,7 @@ snapshots:
   '@humanwhocodes/config-array@0.11.14':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@10.2.2)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -15186,7 +15198,7 @@ snapshots:
   '@humanwhocodes/config-array@0.9.5':
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@10.2.2)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -15555,7 +15567,7 @@ snapshots:
       webpack: 4.46.0(webpack-cli@5.1.4)
     optionalDependencies:
       '@types/webpack': 4.41.33
-      sockjs-client: 1.4.0
+      sockjs-client: 1.4.0(supports-color@6.1.0)
       webpack-dev-server: 3.10.1(webpack-cli@5.1.4)(webpack@5.103.0)
       webpack-hot-middleware: 2.25.4
 
@@ -15571,7 +15583,7 @@ snapshots:
       webpack: 4.46.0(webpack-cli@5.1.4)
     optionalDependencies:
       '@types/webpack': 4.41.33
-      sockjs-client: 1.4.0
+      sockjs-client: 1.4.0(supports-color@6.1.0)
       webpack-dev-server: 5.2.2(webpack-cli@5.1.4)(webpack@5.103.0)
       webpack-hot-middleware: 2.25.4
 
@@ -15638,7 +15650,7 @@ snapshots:
 
   '@rc-component/portal@1.1.2(react-dom@16.12.0(react@16.12.0))(react@16.12.0)':
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.28.6
       classnames: 2.3.2
       rc-util: 5.39.3(react-dom@16.12.0(react@16.12.0))(react@16.12.0)
       react: 16.12.0
@@ -15663,7 +15675,7 @@ snapshots:
 
   '@rc-component/trigger@1.18.3(react-dom@16.12.0(react@16.12.0))(react@16.12.0)':
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.28.6
       '@rc-component/portal': 1.1.2(react-dom@16.12.0(react@16.12.0))(react@16.12.0)
       classnames: 2.3.2
       rc-motion: 2.9.0(react-dom@16.12.0(react@16.12.0))(react@16.12.0)
@@ -16008,7 +16020,7 @@ snapshots:
       '@storybook/core-events': 6.3.1
       core-js: 3.31.1
       global: 4.4.0
-      qs: 6.11.2
+      qs: 6.14.0
       telejson: 5.3.3
 
   '@storybook/channels@6.3.1':
@@ -16037,7 +16049,7 @@ snapshots:
       global: 4.4.0
       lodash: 4.17.20
       memoizerific: 1.11.3
-      qs: 6.11.2
+      qs: 6.14.0
       react: 16.12.0
       react-dom: 16.12.0(react@16.12.0)
       regenerator-runtime: 0.13.11
@@ -16114,7 +16126,7 @@ snapshots:
       core-js: 3.31.1
       global: 4.4.0
       lodash: 4.17.20
-      qs: 6.11.2
+      qs: 6.14.0
       react: 16.12.0
       react-dom: 16.12.0(react@16.12.0)
       regenerator-runtime: 0.13.11
@@ -16358,7 +16370,7 @@ snapshots:
 
   '@storybook/react-docgen-typescript-plugin@1.0.2-canary.3c70e01.0(typescript@5.1.6)(webpack@4.46.0(webpack-cli@5.1.4))':
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@10.2.2)
       endent: 2.1.0
       find-cache-dir: 3.3.2
       flat-cache: 3.0.4
@@ -16546,7 +16558,7 @@ snapshots:
       markdown-to-jsx: 6.11.4(react@16.12.0)
       memoizerific: 1.11.3
       polished: 4.2.2
-      qs: 6.11.2
+      qs: 6.14.0
       react: 16.12.0
       react-dom: 16.12.0(react@16.12.0)
       react-draggable: 4.4.5(react-dom@16.12.0(react@16.12.0))(react@16.12.0)
@@ -16558,11 +16570,22 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@testing-library/cypress@8.0.2(cypress@10.3.0)':
+  '@testing-library/cypress@10.1.0(cypress@13.17.0)':
     dependencies:
-      '@babel/runtime': 7.22.6
-      '@testing-library/dom': 8.11.1
-      cypress: 10.3.0
+      '@babel/runtime': 7.28.6
+      '@testing-library/dom': 10.4.1
+      cypress: 13.17.0
+
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/runtime': 7.12.13
+      '@types/aria-query': 5.0.4
+      aria-query: 5.0.1
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
 
   '@testing-library/dom@8.11.1':
     dependencies:
@@ -16615,6 +16638,8 @@ snapshots:
   '@types/analytics-node@0.0.32': {}
 
   '@types/aria-query@4.2.2': {}
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/assert@1.4.0': {}
 
@@ -17117,7 +17142,7 @@ snapshots:
       '@typescript-eslint/experimental-utils': 4.29.1(eslint@7.29.0)(typescript@5.1.6)
       '@typescript-eslint/parser': 2.34.0(eslint@7.29.0)(typescript@5.1.6)
       '@typescript-eslint/scope-manager': 4.29.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@10.2.2)
       eslint: 7.29.0
       functional-red-black-tree: 1.0.1
       regexpp: 3.2.0
@@ -17135,7 +17160,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.0)(typescript@5.1.6)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@5.1.6)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@10.2.2)
       eslint: 8.57.0
       graphemer: 1.4.0
       ignore: 5.2.4
@@ -17188,7 +17213,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.0.0
       '@typescript-eslint/types': 5.0.0
       '@typescript-eslint/typescript-estree': 5.0.0(typescript@5.1.6)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@10.2.2)
       eslint: 8.16.0
     optionalDependencies:
       typescript: 5.1.6
@@ -17200,7 +17225,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.1.6)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@10.2.2)
       eslint: 8.57.0
     optionalDependencies:
       typescript: 5.1.6
@@ -17213,7 +17238,7 @@ snapshots:
       '@typescript-eslint/types': 6.7.0
       '@typescript-eslint/typescript-estree': 6.7.0(typescript@5.1.6)
       '@typescript-eslint/visitor-keys': 6.7.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@10.2.2)
       eslint: 8.57.0
     optionalDependencies:
       typescript: 5.1.6
@@ -17249,7 +17274,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.1.6)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@5.1.6)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@10.2.2)
       eslint: 8.57.0
       tsutils: 3.21.0(typescript@5.1.6)
     optionalDependencies:
@@ -17269,7 +17294,7 @@ snapshots:
 
   '@typescript-eslint/typescript-estree@2.34.0(typescript@5.1.6)':
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@10.2.2)
       eslint-visitor-keys: 1.3.0
       glob: 7.2.3
       is-glob: 4.0.3
@@ -17285,7 +17310,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 4.29.1
       '@typescript-eslint/visitor-keys': 4.29.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@10.2.2)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.3
@@ -17299,7 +17324,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.0.0
       '@typescript-eslint/visitor-keys': 5.0.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@10.2.2)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.3
@@ -17313,7 +17338,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.26.0
       '@typescript-eslint/visitor-keys': 5.26.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@10.2.2)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.3
@@ -17327,7 +17352,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@10.2.2)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.3
@@ -17341,7 +17366,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 6.7.0
       '@typescript-eslint/visitor-keys': 6.7.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@10.2.2)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.6.2
@@ -17406,7 +17431,7 @@ snapshots:
 
   '@typescript/vfs@1.5.0':
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -17665,7 +17690,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -18284,7 +18309,7 @@ snapshots:
       '@babel/compat-data': 7.22.6
       '@babel/core': 7.8.3
       '@babel/helper-define-polyfill-provider': 0.2.4(@babel/core@7.8.3)
-      semver: 6.3.0
+      semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
@@ -18946,6 +18971,8 @@ snapshots:
 
   ci-info@3.8.0: {}
 
+  ci-info@4.4.0: {}
+
   cipher-base@1.0.4:
     dependencies:
       inherits: 2.0.4
@@ -19084,8 +19111,6 @@ snapshots:
   commander@2.20.3: {}
 
   commander@4.1.1: {}
-
-  commander@5.1.0: {}
 
   commander@6.2.1: {}
 
@@ -19447,11 +19472,10 @@ snapshots:
 
   cyclist@1.0.2: {}
 
-  cypress@10.3.0:
+  cypress@13.17.0:
     dependencies:
-      '@cypress/request': 2.88.11
+      '@cypress/request': 3.0.10
       '@cypress/xvfb': 1.2.4(supports-color@8.1.1)
-      '@types/node': 14.18.53
       '@types/sinonjs__fake-timers': 8.1.1
       '@types/sizzle': 2.3.3
       arch: 2.2.0
@@ -19461,21 +19485,21 @@ snapshots:
       cachedir: 2.3.0
       chalk: 4.1.2
       check-more-types: 2.24.0
+      ci-info: 4.4.0
       cli-cursor: 3.1.0
       cli-table3: 0.6.3
-      commander: 5.1.0
+      commander: 6.2.1
       common-tags: 1.8.2
-      dayjs: 1.11.9
+      dayjs: 1.11.19
       debug: 4.3.4(supports-color@8.1.1)
       enquirer: 2.3.6
-      eventemitter2: 6.4.9
+      eventemitter2: 6.4.7
       execa: 4.1.0
       executable: 4.1.1
       extract-zip: 2.0.1(supports-color@8.1.1)
       figures: 3.2.0
       fs-extra: 9.1.0
       getos: 3.2.1
-      is-ci: 3.0.1
       is-installed-globally: 0.4.0
       lazy-ass: 1.6.0
       listr2: 3.14.0(enquirer@2.3.6)
@@ -19484,11 +19508,13 @@ snapshots:
       minimist: 1.2.8
       ospath: 1.2.2
       pretty-bytes: 5.6.0
+      process: 0.11.10
       proxy-from-env: 1.0.0
       request-progress: 3.0.0
       semver: 7.5.3
       supports-color: 8.1.1
-      tmp: 0.2.1
+      tmp: 0.2.5
+      tree-kill: 1.2.2
       untildify: 4.0.0
       yauzl: 2.10.0
 
@@ -19600,8 +19626,6 @@ snapshots:
 
   dayjs@1.11.19: {}
 
-  dayjs@1.11.9: {}
-
   debug@2.6.1:
     dependencies:
       ms: 0.7.2
@@ -19623,7 +19647,6 @@ snapshots:
       ms: 2.1.3
     optionalDependencies:
       supports-color: 6.1.0
-    optional: true
 
   debug@3.2.7(supports-color@8.1.1):
     dependencies:
@@ -19777,7 +19800,7 @@ snapshots:
   detect-port@1.5.1:
     dependencies:
       address: 1.2.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -20213,6 +20236,13 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.2
 
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
+
   es-shim-unscopables@1.0.0:
     dependencies:
       has: 1.0.3
@@ -20388,7 +20418,7 @@ snapshots:
 
   eslint-import-resolver-node@0.3.9:
     dependencies:
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7(supports-color@6.1.0)
       is-core-module: 2.13.1
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -20396,7 +20426,7 @@ snapshots:
 
   eslint-module-utils@2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
     dependencies:
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7(supports-color@6.1.0)
     optionalDependencies:
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.1.6)
       eslint: 8.57.0
@@ -20410,7 +20440,7 @@ snapshots:
       array.prototype.findlastindex: 1.2.5
       array.prototype.flat: 1.3.2
       array.prototype.flatmap: 1.3.2
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7(supports-color@6.1.0)
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
@@ -20546,7 +20576,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@10.2.2)
       doctrine: 3.0.0
       enquirer: 2.3.6
       escape-string-regexp: 4.0.0
@@ -20590,7 +20620,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@10.2.2)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.0
@@ -20636,7 +20666,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@10.2.2)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -20729,7 +20759,7 @@ snapshots:
 
   etag@1.8.1: {}
 
-  eventemitter2@6.4.9: {}
+  eventemitter2@6.4.7: {}
 
   eventemitter3@4.0.7: {}
 
@@ -21030,7 +21060,7 @@ snapshots:
     dependencies:
       babel-runtime: 6.26.0
       core-js: 3.31.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@10.2.2)
       glob-to-regexp: 0.4.1
       is-subset: 0.1.1
       lodash.isequal: 4.5.0
@@ -21214,7 +21244,7 @@ snapshots:
 
   fork-ts-checker-webpack-plugin@4.1.6(eslint@8.57.0)(typescript@5.1.6)(webpack@4.46.0(webpack-cli@5.1.4)):
     dependencies:
-      '@babel/code-frame': 7.22.5
+      '@babel/code-frame': 7.27.1
       chalk: 2.4.2
       micromatch: 3.1.10(supports-color@6.1.0)
       minimatch: 3.1.2
@@ -21230,7 +21260,7 @@ snapshots:
 
   fork-ts-checker-webpack-plugin@6.5.3(eslint@8.57.0)(typescript@5.1.6)(webpack@4.46.0(webpack-cli@5.1.4)):
     dependencies:
-      '@babel/code-frame': 7.22.5
+      '@babel/code-frame': 7.27.1
       '@types/json-schema': 7.0.15
       chalk: 4.1.2
       chokidar: 3.5.2
@@ -21248,16 +21278,18 @@ snapshots:
     optionalDependencies:
       eslint: 8.57.0
 
-  form-data@2.3.3:
+  form-data@3.0.1:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.35
 
-  form-data@3.0.1:
+  form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
       mime-types: 2.1.35
 
   format@0.2.2: {}
@@ -21864,7 +21896,7 @@ snapshots:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -21908,11 +21940,11 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  http-signature@1.3.6:
+  http-signature@1.4.0:
     dependencies:
       assert-plus: 1.0.0
       jsprim: 2.0.2
-      sshpk: 1.17.0
+      sshpk: 1.18.0
 
   http2-client@1.3.5: {}
 
@@ -21921,7 +21953,7 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -22128,10 +22160,6 @@ snapshots:
   is-buffer@2.0.5: {}
 
   is-callable@1.2.7: {}
-
-  is-ci@3.0.1:
-    dependencies:
-      ci-info: 3.8.0
 
   is-core-module@2.12.1:
     dependencies:
@@ -22399,7 +22427,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@10.2.2)
       istanbul-lib-coverage: 3.2.0
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -22688,7 +22716,7 @@ snapshots:
 
   jest-message-util@27.5.1:
     dependencies:
-      '@babel/code-frame': 7.22.5
+      '@babel/code-frame': 7.27.1
       '@jest/types': 27.5.1
       '@types/stack-utils': 2.0.1
       chalk: 4.1.2
@@ -24188,7 +24216,7 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.22.5
+      '@babel/code-frame': 7.27.1
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -24334,7 +24362,7 @@ snapshots:
 
   polished@4.2.2:
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.28.6
 
   popper.js@1.14.4: {}
 
@@ -24638,19 +24666,19 @@ snapshots:
 
   punycode@2.3.0: {}
 
-  qs@6.10.4:
-    dependencies:
-      side-channel: 1.0.4
-
   qs@6.11.0:
     dependencies:
-      side-channel: 1.0.4
+      side-channel: 1.1.0
 
   qs@6.11.2:
     dependencies:
       side-channel: 1.0.4
 
   qs@6.14.0:
+    dependencies:
+      side-channel: 1.1.0
+
+  qs@6.14.2:
     dependencies:
       side-channel: 1.1.0
 
@@ -25132,7 +25160,7 @@ snapshots:
 
   rc-util@5.39.3(react-dom@16.12.0(react@16.12.0))(react@16.12.0):
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.28.6
       react: 16.12.0
       react-dom: 16.12.0(react@16.12.0)
       react-is: 18.2.0
@@ -25632,8 +25660,6 @@ snapshots:
   regenerator-runtime@0.11.1: {}
 
   regenerator-runtime@0.13.11: {}
-
-  regenerator-runtime@0.14.1: {}
 
   regenerator-transform@0.15.1:
     dependencies:
@@ -26406,18 +26432,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  sockjs-client@1.4.0:
-    dependencies:
-      debug: 3.2.7(supports-color@8.1.1)
-      eventsource: 1.1.2
-      faye-websocket: 0.11.4
-      inherits: 2.0.4
-      json3: 3.3.3
-      url-parse: 1.5.1
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   sockjs-client@1.4.0(supports-color@6.1.0):
     dependencies:
       debug: 3.2.7(supports-color@6.1.0)
@@ -26506,7 +26520,7 @@ snapshots:
 
   spdy-transport@3.0.0:
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@10.2.2)
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -26529,7 +26543,7 @@ snapshots:
 
   spdy@4.0.2:
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@10.2.2)
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
@@ -26554,7 +26568,7 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
-  sshpk@1.17.0:
+  sshpk@1.18.0:
     dependencies:
       asn1: 0.2.6
       assert-plus: 1.0.0
@@ -27046,13 +27060,17 @@ snapshots:
 
   tiny-warning@1.0.3: {}
 
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
   tmp@0.0.33:
     dependencies:
       os-tmpdir: 1.0.2
 
-  tmp@0.2.1:
-    dependencies:
-      rimraf: 3.0.2
+  tmp@0.2.5: {}
 
   tmpl@1.0.5: {}
 
@@ -27103,16 +27121,11 @@ snapshots:
       commander: 2.20.3
       topojson-client: 3.0.0
 
-  topojson@3.0.2(patch_hash=wpfs36vhb2v7nm6ekzrirgbci4):
+  topojson@3.0.2(patch_hash=be4a1a6184740cb5b3e06c729ecbea528e2f1a80d531f66c1e4c07553c3f6ced):
     dependencies:
       topojson-client: 3.0.0
       topojson-server: 3.0.0
       topojson-simplify: 3.0.2
-
-  tough-cookie@2.5.0:
-    dependencies:
-      psl: 1.9.0
-      punycode: 2.3.0
 
   tough-cookie@4.1.3:
     dependencies:
@@ -27120,6 +27133,10 @@ snapshots:
       punycode: 2.3.0
       universalify: 0.2.0
       url-parse: 1.5.1
+
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
 
   tr46@0.0.3: {}
 
@@ -27134,6 +27151,8 @@ snapshots:
   tree-dump@1.1.0(tslib@2.6.3):
     dependencies:
       tslib: 2.6.3
+
+  tree-kill@1.2.2: {}
 
   trim-trailing-lines@1.1.4: {}
 
@@ -27485,7 +27504,7 @@ snapshots:
   url@0.11.1:
     dependencies:
       punycode: 1.4.1
-      qs: 6.11.2
+      qs: 6.14.0
 
   us-atlas@1.0.2: {}
 
@@ -27854,7 +27873,7 @@ snapshots:
 
   webpack-virtual-modules@0.2.2:
     dependencies:
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7(supports-color@6.1.0)
     transitivePeerDependencies:
       - supports-color
 

--- a/pkg/ui/workspaces/e2e-tests/cypress/e2e/pages/insights.cy.ts
+++ b/pkg/ui/workspaces/e2e-tests/cypress/e2e/pages/insights.cy.ts
@@ -65,7 +65,7 @@ describe("insights page", () => {
       "not.contain.text",
       "Full Scan",
     );
-    cy.contains("Columns").click();
+    cy.contains("button", "Columns").should("be.visible").click();
     cy.get('[class*="dropdown-area"]')
       .should("exist")
       .within(() => {

--- a/pkg/ui/workspaces/e2e-tests/cypress/e2e/pages/jobs.cy.ts
+++ b/pkg/ui/workspaces/e2e-tests/cypress/e2e/pages/jobs.cy.ts
@@ -69,7 +69,6 @@ describe("jobs page", () => {
     cy.get('[class*="summary--card"]').contains("Status");
     cy.get('[class*="summary--card"]').contains("Creation Time");
     cy.get('[class*="summary--card"]').contains("Last Modified Time");
-    cy.get('[class*="summary--card"]').contains("Completed Time");
     cy.get('[class*="summary--card"]').contains("User Name");
     cy.get('[class*="summary--card"]').contains("Coordinator Node");
 

--- a/pkg/ui/workspaces/e2e-tests/package.json
+++ b/pkg/ui/workspaces/e2e-tests/package.json
@@ -16,10 +16,10 @@
   },
   "devDependencies": {
     "@cockroachlabs/eslint-config": "0.1.11",
-    "@testing-library/cypress": "^8.0.2",
+    "@testing-library/cypress": "^10.0.0",
     "@types/node": "^22.0.0",
     "@typescript-eslint/parser": "2.34.0",
-    "cypress": "^10.3.0",
+    "cypress": "^13.13.2",
     "eslint": "7.29.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-prettier": "3.4.1",


### PR DESCRIPTION
The cypress version previously ran in the docker containers was v13 and
since 164000 removed the docker build, this revealed a rare race condition leading to an element detaching from the DOM.

This is fixed by guarding the line of code with a `should("be.visible")` as well as a bump in the cypress version.
This change also fixes a flake in the jobs page test where we check the job status

Fixes: https://github.com/cockroachdb/cockroach/issues/163525
Epic: None
Release Note: None