### PR TITLE
admission: add env var kill switch for CPU time token AC

### DIFF
--- a/pkg/util/admission/BUILD.bazel
+++ b/pkg/util/admission/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
         "//pkg/util/admission/admissionpb",
         "//pkg/util/buildutil",
         "//pkg/util/ctxutil",
+        "//pkg/util/envutil",
         "//pkg/util/goschedstats",
         "//pkg/util/grunning",
         "//pkg/util/humanizeutil",

--- a/pkg/util/admission/cpu_time_token_grant_coordinator.go
+++ b/pkg/util/admission/cpu_time_token_grant_coordinator.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/goschedstats"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
@@ -24,6 +25,19 @@ var cpuTimeTokenACEnabled = settings.RegisterBoolSetting(
 	"if true, CPU time token AC will be used for foreground KVWork, instead of slots-based AC -- "+
 		"note that this is not supported in production except on multi-tenant Serverless clusters",
 	false)
+
+// cpuTimeTokenACKillSwitch is an env var kill switch that disables CPU time
+// token AC regardless of the cluster setting. This is useful when SQL is
+// unavailable, preventing the cluster setting from being changed.
+var cpuTimeTokenACKillSwitch = envutil.EnvOrDefaultBool(
+	"COCKROACH_DISABLE_CPU_TIME_TOKEN_AC", false)
+
+// cpuTimeTokenACIsEnabled returns true if CPU time token AC is enabled. It
+// checks both the cluster setting and the env var kill switch. The kill switch
+// takes precedence over the cluster setting.
+func cpuTimeTokenACIsEnabled(sv *settings.Values) bool {
+	return !cpuTimeTokenACKillSwitch && cpuTimeTokenACEnabled.Get(sv)
+}
 
 // CPUGrantCoordinators's main purpose is to act as a shim. Depending on
 // whether admission.cpu_time_tokens.enabled is true or false, a WorkQueue
@@ -45,7 +59,7 @@ type CPUGrantCoordinators struct {
 // tenant WorkQueue. This is a prioritization scheme. For details regarding
 // the granters, see cpu_time_token_granter.go.
 func (coord *CPUGrantCoordinators) GetKVWorkQueue(isSystemTenant bool) *WorkQueue {
-	if !cpuTimeTokenACEnabled.Get(&coord.st.SV) {
+	if !cpuTimeTokenACIsEnabled(&coord.st.SV) {
 		return coord.slotsCoord.GetWorkQueue(KVWork)
 	}
 	if isSystemTenant {
@@ -146,13 +160,13 @@ func makeCPUTimeTokenGrantCoordinator(
 	// https://github.com/cockroachdb/cockroach/issues/161945
 	if !knobs.DisableCPUTimeTokenFillerGoroutine {
 		var once sync.Once
-		if cpuTimeTokenACEnabled.Get(&settings.SV) {
+		if cpuTimeTokenACIsEnabled(&settings.SV) {
 			once.Do(func() {
 				filler.start(ambientCtx.AnnotateCtx(context.Background()))
 			})
 		}
 		cpuTimeTokenACEnabled.SetOnChange(&settings.SV, func(ctx context.Context) {
-			if cpuTimeTokenACEnabled.Get(&settings.SV) {
+			if cpuTimeTokenACIsEnabled(&settings.SV) {
 				once.Do(func() {
 					filler.start(ambientCtx.AnnotateCtx(context.Background()))
 				})

--- a/pkg/util/admission/cpu_time_token_grant_coordinator_test.go
+++ b/pkg/util/admission/cpu_time_token_grant_coordinator_test.go
@@ -48,4 +48,21 @@ func TestCPUTimeTokenACEnableAndDisable(t *testing.T) {
 	// If CPU time token AC is enabled, we use one WorkQueue for system
 	// tenant work & a second WorkQueue for app tenant work.
 	require.NotEqual(t, cpuCoords.GetKVWorkQueue(false /* isSystemTenant */), cpuCoords.GetKVWorkQueue(true /* isSystemTenant */))
+
+	// Test that the env var kill switch overrides the cluster setting.
+	// Even with the setting enabled, the kill switch forces slot-based AC.
+	defer func(prev bool) {
+		cpuTimeTokenACKillSwitch = prev
+	}(cpuTimeTokenACKillSwitch)
+	cpuTimeTokenACKillSwitch = true
+	require.Equal(t, usesSlots, cpuCoords.GetKVWorkQueue(false /* isSystemTenant */).mode)
+	require.Equal(t, usesSlots, cpuCoords.GetKVWorkQueue(true /* isSystemTenant */).mode)
+	require.Equal(t, cpuCoords.GetKVWorkQueue(false /* isSystemTenant */), cpuCoords.GetKVWorkQueue(true /* isSystemTenant */))
+
+	// Disabling the kill switch restores CPU time token AC (setting is
+	// still enabled).
+	cpuTimeTokenACKillSwitch = false
+	require.Equal(t, usesCPUTimeTokens, cpuCoords.GetKVWorkQueue(false /* isSystemTenant */).mode)
+	require.Equal(t, usesCPUTimeTokens, cpuCoords.GetKVWorkQueue(true /* isSystemTenant */).mode)
+	require.NotEqual(t, cpuCoords.GetKVWorkQueue(false /* isSystemTenant */), cpuCoords.GetKVWorkQueue(true /* isSystemTenant */))
 }

--- a/pkg/util/admission/grant_coordinator.go
+++ b/pkg/util/admission/grant_coordinator.go
@@ -195,7 +195,7 @@ func NewGrantCoordinators(
 		sqlKVWorkQueue := slotsCoord.GetWorkQueue(SQLKVResponseWork)
 		sqlSQLWorkQueue := slotsCoord.GetWorkQueue(SQLSQLResponseWork)
 		setLatestOverride := func() {
-			override := cpuTimeTokenACEnabled.Get(&st.SV)
+			override := cpuTimeTokenACIsEnabled(&st.SV)
 			sqlKVWorkQueue.SetOverrideAllToBypassAdmission(override)
 			sqlSQLWorkQueue.SetOverrideAllToBypassAdmission(override)
 		}


### PR DESCRIPTION
**admission: add env var kill switch for CPU time token AC**

This commit adds an env var that is by default false. The env
var disables CPU time token AC. The standard approach for enabling
& disabling CPU time token AC is a cluster setting. But in case of
a serious bug, SQL may be unavailable. So we have this env var also.

Fixes: #158540

Release note: None.