### PR TITLE
jobs: refactor `JobUpdater` started function to not clobber job progress

### DIFF
--- a/pkg/cli/debug_job_trace.go
+++ b/pkg/cli/debug_job_trace.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/cli/clierrorplus"
 	"github.com/cockroachdb/cockroach/pkg/cli/clisqlclient"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	tracezipper "github.com/cockroachdb/cockroach/pkg/util/tracing/zipper"
 	"github.com/cockroachdb/errors"
@@ -49,10 +50,9 @@ func runDebugJobTrace(_ *cobra.Command, args []string) (resErr error) {
 
 func getJobTraceID(sqlConn clisqlclient.Conn, jobID int64) (int64, error) {
 	var traceID int64
-	// We normally avoid programatic access to the job's message log, but this is
-	// a debug command so we can allow it here.
+	// Try reading from message storage first, then fall back to legacy Progress proto.
 	for attempt, query := range []string{
-		`SELECT message::int FROM system.job_message WHERE job_id=$1 AND kind = 'trace-id' ORDER BY written DESC LIMIT 1`,
+		fmt.Sprintf(`SELECT message::int FROM system.job_message WHERE job_id=$1 AND kind = '%s' ORDER BY written DESC LIMIT 1`, jobs.MessageKindTraceID),
 		`SELECT trace_id FROM crdb_internal.jobs WHERE job_id=$1`,
 	} {
 		rows, err := sqlConn.Query(context.Background(), query, jobID)

--- a/pkg/jobs/adopt.go
+++ b/pkg/jobs/adopt.go
@@ -599,7 +599,7 @@ func (r *Registry) servePauseAndCancelRequests(ctx context.Context, s sqllivenes
 			stateString := *row[1].(*tree.DString)
 			jobTypeString := *row[2].(*tree.DString)
 
-			if err := job.Messages().Record(ctx, txn, "state", string(stateString)); err != nil {
+			if err := job.Messages().Record(ctx, txn, MessageKindState, string(stateString)); err != nil {
 				return err
 			}
 

--- a/pkg/jobs/job_info_storage.go
+++ b/pkg/jobs/job_info_storage.go
@@ -259,6 +259,16 @@ func (i StatusStorage) Get(ctx context.Context, txn isql.Txn) (string, time.Time
 	return string(*status), written.Time, nil
 }
 
+// Message kinds used in the job message log.
+const (
+	// MessageKindState records job state transitions.
+	MessageKindState = "state"
+	// MessageKindTraceID records the trace ID associated with a job execution.
+	MessageKindTraceID = "trace-id"
+	// MessageKindRetry records retry errors encountered during job execution.
+	MessageKindRetry = "retry"
+)
+
 // MessageStorage stores human-readable messages emitted by the execution of a
 // job, including when it changes states in the job system, when it wishes to
 // communicate its own custom status, or additional messages it wishes to

--- a/pkg/jobs/job_info_storage_test.go
+++ b/pkg/jobs/job_info_storage_test.go
@@ -875,6 +875,10 @@ func TestJobPauseStateTransitionsRecorded(t *testing.T) {
 	cleanup := jobs.TestingRegisterConstructor(jobspb.TypeBackup, func(job *jobs.Job, _ *cluster.Settings) jobs.Resumer {
 		return jobstest.FakeResumer{
 			OnResume: func(ctx context.Context) error {
+				// Simulate job making progress.
+				_ = idb.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+					return job.ProgressStorage().Set(ctx, txn, 0.3, hlc.Timestamp{})
+				})
 				select {
 				case <-ctx.Done():
 					return ctx.Err()
@@ -947,5 +951,20 @@ func TestJobPauseStateTransitionsRecorded(t *testing.T) {
 		)
 		stateMessages := collectStatusMessages(job)
 		require.Equal(t, []string{"succeeded", "running", "paused", "pause-requested"}, stateMessages)
+
+		// Verify job progress was not clobbered during pause/resume.
+		rows := sql.Query(t, fmt.Sprintf(
+			"SELECT fraction FROM system.job_progress_history WHERE job_id = %d ORDER BY written",
+			job.ID()))
+		updates := 0
+		var frac float64
+		for rows.Next() {
+			updates++
+			prevFrac := frac
+			require.NoError(t, rows.Scan(&frac))
+			require.GreaterOrEqual(t, frac, prevFrac)
+		}
+		require.NoError(t, rows.Err())
+		require.Greater(t, updates, 0)
 	})
 }

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strconv"
 	"sync/atomic"
 	"time"
 
@@ -246,7 +247,7 @@ func (u Updater) started(ctx context.Context) error {
 	if sp != nil {
 		traceID = sp.TraceID()
 	}
-	return u.Update(ctx, func(_ isql.Txn, md JobMetadata, ju *JobUpdater) error {
+	return u.Update(ctx, func(txn isql.Txn, md JobMetadata, ju *JobUpdater) error {
 		if md.State != StatePending && md.State != StateRunning {
 			return errors.Errorf("job with state %s cannot be marked started", md.State)
 		}
@@ -255,9 +256,12 @@ func (u Updater) started(ctx context.Context) error {
 			md.Payload.StartedMicros = timeutil.ToUnixMicros(u.now())
 			ju.UpdatePayload(md.Payload)
 		}
-		if traceID != 0 && md.Progress != nil && md.Progress.TraceID != traceID {
-			md.Progress.TraceID = traceID
-			ju.UpdateProgress(md.Progress)
+		// Write trace ID to message storage instead of Progress proto.
+		// This avoids clobbering progress updates made via ProgressStorage.
+		if traceID != 0 {
+			if err := u.j.Messages().Record(ctx, txn, MessageKindTraceID, fmt.Sprintf("%d", traceID)); err != nil {
+				return err
+			}
 		}
 		return nil
 	})
@@ -409,9 +413,11 @@ func (u Updater) reverted(
 			}
 			ju.UpdateState(StateReverting)
 		}
-		if traceID != 0 && md.Progress != nil && md.Progress.TraceID != traceID {
-			md.Progress.TraceID = traceID
-			ju.UpdateProgress(md.Progress)
+		// Write trace ID to message storage instead of Progress proto.
+		if traceID != 0 {
+			if err := u.j.Messages().Record(ctx, txn, MessageKindTraceID, fmt.Sprintf("%d", traceID)); err != nil {
+				return err
+			}
 		}
 		return nil
 	})
@@ -894,10 +900,37 @@ func (sj *StartableJob) recordStart() (alreadyStarted bool) {
 	return atomic.AddInt64(&sj.starts, 1) != 1
 }
 
-// GetJobTraceID returns the current trace ID of the job from the job progress.
+// GetJobTraceID returns the current trace ID of the job, reading from message
+// storage with fallback to legacy Progress proto for old jobs.
 func GetJobTraceID(ctx context.Context, db isql.DB, jobID jobspb.JobID) (tracingpb.TraceID, error) {
 	var traceID tracingpb.TraceID
 	if err := db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+		// Try reading from message storage first (new location).
+		row, err := txn.QueryRowEx(
+			ctx, "get-job-trace-id", txn.KV(),
+			sessiondata.NodeUserSessionDataOverride,
+			`SELECT message FROM system.job_message
+			 WHERE job_id = $1 AND kind = $2
+			 ORDER BY written DESC LIMIT 1`,
+			jobID, MessageKindTraceID,
+		)
+		if err != nil {
+			return err
+		}
+		if row != nil {
+			message, ok := row[0].(*tree.DString)
+			if !ok {
+				return errors.Errorf("unexpected type %T for trace ID message", row[0])
+			}
+			id, err := strconv.ParseUint(string(*message), 10, 64)
+			if err != nil {
+				return errors.Wrap(err, "failed to parse trace ID from message storage")
+			}
+			traceID = tracingpb.TraceID(id)
+			return nil
+		}
+
+		// Fallback to legacy Progress proto for backwards compatibility.
 		jobInfo := InfoStorageForJob(txn, jobID)
 		progressBytes, exists, err := jobInfo.GetLegacyProgress(ctx, "GetJobTraceID")
 		if err != nil {

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -1923,7 +1923,7 @@ func (r *Registry) maybeRecordExecutionFailure(ctx context.Context, err error, j
 		if err != nil || v.Less(clusterversion.V25_1.Version()) {
 			return err
 		}
-		return j.Messages().Record(ctx, txn, "retry", efe.cause.Error())
+		return j.Messages().Record(ctx, txn, MessageKindRetry, efe.cause.Error())
 	})
 	if ctx.Err() != nil {
 		return

--- a/pkg/jobs/update.go
+++ b/pkg/jobs/update.go
@@ -239,7 +239,7 @@ WHERE id = $1
 	}
 
 	if ju.md.State != "" && ju.md.State != state {
-		if err := j.Messages().Record(ctx, u.txn, "state", string(ju.md.State)); err != nil {
+		if err := j.Messages().Record(ctx, u.txn, MessageKindState, string(ju.md.State)); err != nil {
 			return err
 		}
 		// If we are changing state, we should clear out the status, unless
@@ -275,7 +275,7 @@ WHERE id = $1
 		}
 
 		if progress.TraceID != beforeProgress.TraceID {
-			if err := j.Messages().Record(ctx, u.txn, "trace-id", fmt.Sprintf("%d", progress.TraceID)); err != nil {
+			if err := j.Messages().Record(ctx, u.txn, MessageKindTraceID, fmt.Sprintf("%d", progress.TraceID)); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Previously, jobs using `ProgressStorage` for progress updates would briefly drop down to 0 `fraction_completed` on resume, as the `JobUpdater` `started` function would clobber the job's progress in order to set the trace id. This patch refactors trace id updates to use message storage instead, and leave progress untouched.

Fixes: #164160

Release note: None