### PR TITLE
release-25.4: kvadmission: rate limit "unable to find queue for store" log

### DIFF
--- a/pkg/kv/kvserver/kvadmission/kvadmission.go
+++ b/pkg/kv/kvserver/kvadmission/kvadmission.go
@@ -550,11 +550,17 @@ func (n *controllerImpl) FollowerStoreWriteBytes(
 
 var _ replica_rac2.ACWorkQueue = &controllerImpl{}
 
+var logUnableToFindQueueForStore = log.Every(time.Second)
+
 // Admit implements replica_rac2.ACWorkQueue. It is only used for the RACv2 protocol.
 func (n *controllerImpl) Admit(ctx context.Context, entry replica_rac2.EntryForAdmission) bool {
 	storeAdmissionQ := n.storeGrantCoords.TryGetQueueForStore(entry.StoreID)
 	if storeAdmissionQ == nil {
-		log.KvDistribution.Errorf(ctx, "unable to find queue for store: %s", entry.StoreID)
+		// This can happen during node startup before
+		// StoreGrantCoordinators.SetPebbleMetricsProvider has run.
+		if logUnableToFindQueueForStore.ShouldLog() {
+			log.KvDistribution.VInfof(ctx, 1, "unable to find queue for store: %s", entry.StoreID)
+		}
 		return false // nothing to do
 	}
 


### PR DESCRIPTION
Backport 1/1 commits from #164162 on behalf of @arulajmani.

----

This log can fire frequently during node startup before
`StoreGrantCoordinators.SetPebbleMetricsProvider` has run, causing log
spam. Rate limit it to once per second.

Fixes #164075

Release note: None

🤖 Generated with [Claude Code](https://claude.ai/code)

----

Release justification: low risk obs fixes