### PR TITLE
dev-inf: fix invalid --prompt flag in issue-autosolve workflow

### DIFF
--- a/.github/workflows/issue-autosolve.yml
+++ b/.github/workflows/issue-autosolve.yml
@@ -231,11 +231,10 @@ jobs:
             if [ -z "$SESSION_ID" ]; then
               # First attempt - start new session
               echo "Starting new Claude session..."
-              claude --print \
+              echo "$PROMPT" | claude --print \
                 --model claude-opus-4-6 \
                 --output-format json \
                 --allowedTools "Read,Write,Edit,Grep,Glob,Bash(gh issue view:*),Bash(./dev test:*),Bash(./dev testlogic:*),Bash(./dev build:*),Bash(./dev generate:*),Bash(git add:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*)" \
-                --prompt "$PROMPT" \
                 > "$EXECUTION_FILE" 2> "$STDERR_FILE" || CLAUDE_EXIT_CODE=$?
             else
               # Retry - resume existing session


### PR DESCRIPTION
## Summary

- `--prompt` is not a valid `claude` CLI option, causing the auto-solver to fail with `error: unknown option '--prompt'`
- Pass the prompt via stdin instead, which also avoids the variadic `--allowedTools` flag consuming the prompt as a tool name

🤖 Generated with [Claude Code](https://claude.com/claude-code)