### PR TITLE
workloadccl: fix scan of nullable inspect_job_id in fixture import

### DIFF
--- a/pkg/ccl/workloadccl/fixture.go
+++ b/pkg/ccl/workloadccl/fixture.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"context"
 	gosql "database/sql"
-	"database/sql/driver"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -490,7 +489,7 @@ func importFixtureTable(
 		fmt.Fprintf(&buf, `, transform=$%d`, len(params))
 	}
 	var rows, index, tableBytes int64
-	var discard driver.Value
+	var discard any
 	res, err := sqlDB.Query(buf.String(), params...)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
The previous fix (445b9bacc6f) corrected the scan order but the discard variable was declared as `driver.Value`. Go's database/sql scan has a fast-path for `*any` that handles NULL by assigning nil, but `*driver.Value` (a named type alias for `any`) doesn't match that case. When inspect_job_id is NULL, the scan falls through to reflection-based conversion which can't store nil into an interface kind, producing:
```
  unsupported Scan, storing driver.Value type <nil> into type
  *driver.Value
```
Change the discard variable to `any` so the `*any` fast-path handles NULL correctly.

Resolves: #164019
Resolves: #164017
Resolves: https://github.com/cockroachdb/cockroach/issues/164098

Release note: None