### PR TITLE
kvnemesis: new operation to toggle VIR on and off

### DIFF
--- a/pkg/kv/kvnemesis/applier.go
+++ b/pkg/kv/kvnemesis/applier.go
@@ -890,6 +890,14 @@ func changeClusterSettingInEnv(ctx context.Context, env *Env, op *ChangeSettingO
 		default:
 			panic(errors.AssertionFailedf(`unknown LeaseType: %v`, op.LeaseType))
 		}
+	case ChangeSettingType_ToggleVirtualIntentResolution:
+		val := "false"
+		if op.VirEnabled {
+			val = "true"
+		}
+		settings = map[string]string{
+			"kv.concurrency.virtual_intent_resolution.enabled": val,
+		}
 	default:
 		panic(errors.AssertionFailedf(`unknown ChangeSettingType: %v`, op.Type))
 	}

--- a/pkg/kv/kvnemesis/generator.go
+++ b/pkg/kv/kvnemesis/generator.go
@@ -390,6 +390,9 @@ type ChangeLeaseConfig struct {
 type ChangeSettingConfig struct {
 	// SetLeaseType changes the default range lease type.
 	SetLeaseType int
+	// ToggleVirtualIntentResolution toggles the VIR cluster setting, exercising
+	// transitions between physical and virtual intent resolution.
+	ToggleVirtualIntentResolution int
 }
 
 // ChangeZoneConfig configures the relative probability of generating a zone
@@ -546,7 +549,8 @@ func newAllOperationsConfig() GeneratorConfig {
 			TransferLease: 1,
 		},
 		ChangeSetting: ChangeSettingConfig{
-			SetLeaseType: 1,
+			SetLeaseType:                  1,
+			ToggleVirtualIntentResolution: 1,
 		},
 		ChangeZone: ChangeZoneConfig{
 			ToggleGlobalReads: 1,
@@ -949,6 +953,7 @@ func (g *generator) RandStep(rng *rand.Rand) Step {
 	}
 
 	addOpGen(&allowed, setLeaseType, g.Config.Ops.ChangeSetting.SetLeaseType)
+	addOpGen(&allowed, toggleVirtualIntentResolution, g.Config.Ops.ChangeSetting.ToggleVirtualIntentResolution)
 	addOpGen(&allowed, toggleGlobalReads, g.Config.Ops.ChangeZone.ToggleGlobalReads)
 	addOpGen(&allowed, addRandNetworkPartition, g.Config.Ops.Fault.AddNetworkPartition)
 	addOpGen(&allowed, removeRandNetworkPartition, g.Config.Ops.Fault.RemoveNetworkPartition)
@@ -1865,6 +1870,12 @@ func setLeaseType(_ *generator, rng *rand.Rand) Operation {
 	leaseType := leaseTypes[rng.Intn(len(leaseTypes))]
 	op := changeSetting(ChangeSettingType_SetLeaseType)
 	op.ChangeSetting.LeaseType = leaseType
+	return op
+}
+
+func toggleVirtualIntentResolution(_ *generator, rng *rand.Rand) Operation {
+	op := changeSetting(ChangeSettingType_ToggleVirtualIntentResolution)
+	op.ChangeSetting.VirEnabled = rng.Intn(2) == 0
 	return op
 }
 

--- a/pkg/kv/kvnemesis/generator_test.go
+++ b/pkg/kv/kvnemesis/generator_test.go
@@ -425,6 +425,8 @@ func TestRandStep(t *testing.T) {
 			switch o.Type {
 			case ChangeSettingType_SetLeaseType:
 				counts.ChangeSetting.SetLeaseType++
+			case ChangeSettingType_ToggleVirtualIntentResolution:
+				counts.ChangeSetting.ToggleVirtualIntentResolution++
 			}
 		case *ChangeZoneOperation:
 			switch o.Type {

--- a/pkg/kv/kvnemesis/operations.go
+++ b/pkg/kv/kvnemesis/operations.go
@@ -478,6 +478,8 @@ func (op ChangeSettingOperation) format(w *strings.Builder, fctx formatCtx) {
 	switch op.Type {
 	case ChangeSettingType_SetLeaseType:
 		fmt.Fprintf(w, `env.SetClusterSetting(ctx, %s, %s)`, op.Type, op.LeaseType)
+	case ChangeSettingType_ToggleVirtualIntentResolution:
+		fmt.Fprintf(w, `env.SetClusterSetting(ctx, %s, %v)`, op.Type, op.VirEnabled)
 	default:
 		panic(errors.AssertionFailedf(`unknown ChangeSettingType: %v`, op.Type))
 	}

--- a/pkg/kv/kvnemesis/operations.proto
+++ b/pkg/kv/kvnemesis/operations.proto
@@ -146,12 +146,14 @@ message TransferLeaseOperation {
 
 enum ChangeSettingType {
   SetLeaseType = 0;
+  ToggleVirtualIntentResolution = 1;
 }
 
 message ChangeSettingOperation {
   ChangeSettingType type = 1;
   int32 lease_type = 2 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.LeaseType"];
   Result result = 3 [(gogoproto.nullable) = false];
+  bool vir_enabled = 4;
 }
 
 enum ChangeZoneType {


### PR DESCRIPTION
This commit adds a new kvnemesis operation that randomly changes the VIR cluster setting boolean. See #164177 for the motivation to do so.

Fixes: #164177

Release note: None