### PR TITLE
roachtest: properly set up backup test as benchmark

### DIFF
--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -260,6 +260,7 @@ func registerBackupIntents(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:                      "backup/intents/pending",
 		Owner:                     registry.OwnerKV,
+		Benchmark:                 true,
 		Cluster:                   r.MakeClusterSpec(4),
 		EncryptionSupport:         registry.EncryptionMetamorphic,
 		Leases:                    registry.MetamorphicLeases,
@@ -290,6 +291,7 @@ func registerBackupIntents(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:                      "backup/intents/abandoned",
 		Owner:                     registry.OwnerKV,
+		Benchmark:                 true,
 		Cluster:                   r.MakeClusterSpec(4),
 		EncryptionSupport:         registry.EncryptionMetamorphic,
 		Leases:                    registry.MetamorphicLeases,


### PR DESCRIPTION
Two new roachperf tests were added in 1084a6c, but without the `Benchmark` flag set the results were not getting picked up by the roachperf sync job. This commit sets the flag for both tests.

Part of: #156800

Release note: None