### PR TITLE
sql: support security_invoker for views

### DIFF
--- a/docs/generated/sql/bnf/BUILD.bazel
+++ b/docs/generated/sql/bnf/BUILD.bazel
@@ -67,6 +67,8 @@ FILES = [
     "alter_type",
     "alter_view",
     "alter_view_owner_stmt",
+    "alter_view_set_options_stmt",
+    "alter_view_reset_options_stmt",
     "alter_view_set_schema_stmt",
     "alter_virtual_cluster_capability",
     "alter_virtual_cluster",

--- a/docs/generated/sql/bnf/alter_view.bnf
+++ b/docs/generated/sql/bnf/alter_view.bnf
@@ -11,3 +11,5 @@ alter_view_stmt ::=
 	| 'ALTER' 'MATERIALIZED' 'VIEW' view_name 'OWNER' 'TO' role_spec
 	| 'ALTER' 'VIEW' 'IF' 'EXISTS' view_name 'OWNER' 'TO' role_spec
 	| 'ALTER' 'MATERIALIZED' 'VIEW' 'IF' 'EXISTS' view_name 'OWNER' 'TO' role_spec
+	| alter_view_set_options_stmt
+	| alter_view_reset_options_stmt

--- a/docs/generated/sql/bnf/alter_view_reset_options_stmt.bnf
+++ b/docs/generated/sql/bnf/alter_view_reset_options_stmt.bnf
@@ -1,0 +1,3 @@
+alter_view_reset_options_stmt ::=
+	'ALTER' 'VIEW' relation_expr 'RESET' '(' 'SECURITY_INVOKER' ')'
+	| 'ALTER' 'VIEW' 'IF' 'EXISTS' relation_expr 'RESET' '(' 'SECURITY_INVOKER' ')'

--- a/docs/generated/sql/bnf/alter_view_set_options_stmt.bnf
+++ b/docs/generated/sql/bnf/alter_view_set_options_stmt.bnf
@@ -1,0 +1,9 @@
+alter_view_set_options_stmt ::=
+	'ALTER' 'VIEW' relation_expr 'SET' '(' 'SECURITY_INVOKER' '=' 'TRUE' ')'
+	| 'ALTER' 'VIEW' relation_expr 'SET' '(' 'SECURITY_INVOKER' '=' 'FALSE' ')'
+	| 'ALTER' 'VIEW' relation_expr 'SET' '(' 'SECURITY_INVOKER' '=' 'ICONST' ')'
+	| 'ALTER' 'VIEW' relation_expr 'SET' '(' 'SECURITY_INVOKER' ')'
+	| 'ALTER' 'VIEW' 'IF' 'EXISTS' relation_expr 'SET' '(' 'SECURITY_INVOKER' '=' 'TRUE' ')'
+	| 'ALTER' 'VIEW' 'IF' 'EXISTS' relation_expr 'SET' '(' 'SECURITY_INVOKER' '=' 'FALSE' ')'
+	| 'ALTER' 'VIEW' 'IF' 'EXISTS' relation_expr 'SET' '(' 'SECURITY_INVOKER' '=' 'ICONST' ')'
+	| 'ALTER' 'VIEW' 'IF' 'EXISTS' relation_expr 'SET' '(' 'SECURITY_INVOKER' ')'

--- a/docs/generated/sql/bnf/create_view_stmt.bnf
+++ b/docs/generated/sql/bnf/create_view_stmt.bnf
@@ -1,10 +1,10 @@
 create_view_stmt ::=
-	'CREATE' opt_temp 'VIEW' view_name '(' name_list ')' 'AS' select_stmt
-	| 'CREATE' opt_temp 'VIEW' view_name  'AS' select_stmt
-	| 'CREATE' 'OR' 'REPLACE' opt_temp 'VIEW' view_name '(' name_list ')' 'AS' select_stmt
-	| 'CREATE' 'OR' 'REPLACE' opt_temp 'VIEW' view_name  'AS' select_stmt
-	| 'CREATE' opt_temp 'VIEW' 'IF' 'NOT' 'EXISTS' view_name '(' name_list ')' 'AS' select_stmt
-	| 'CREATE' opt_temp 'VIEW' 'IF' 'NOT' 'EXISTS' view_name  'AS' select_stmt
+	'CREATE' opt_temp 'VIEW' view_name '(' name_list ')' opt_view_with 'AS' select_stmt
+	| 'CREATE' opt_temp 'VIEW' view_name  opt_view_with 'AS' select_stmt
+	| 'CREATE' 'OR' 'REPLACE' opt_temp 'VIEW' view_name '(' name_list ')' opt_view_with 'AS' select_stmt
+	| 'CREATE' 'OR' 'REPLACE' opt_temp 'VIEW' view_name  opt_view_with 'AS' select_stmt
+	| 'CREATE' opt_temp 'VIEW' 'IF' 'NOT' 'EXISTS' view_name '(' name_list ')' opt_view_with 'AS' select_stmt
+	| 'CREATE' opt_temp 'VIEW' 'IF' 'NOT' 'EXISTS' view_name  opt_view_with 'AS' select_stmt
 	| 'CREATE' 'MATERIALIZED' 'VIEW' view_name '(' name_list ')' 'AS' select_stmt opt_with_data
 	| 'CREATE' 'MATERIALIZED' 'VIEW' view_name  'AS' select_stmt opt_with_data
 	| 'CREATE' 'MATERIALIZED' 'VIEW' 'IF' 'NOT' 'EXISTS' view_name '(' name_list ')' 'AS' select_stmt opt_with_data

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1775,6 +1775,8 @@ alter_view_stmt ::=
 	alter_rename_view_stmt
 	| alter_view_set_schema_stmt
 	| alter_view_owner_stmt
+	| alter_view_set_options_stmt
+	| alter_view_reset_options_stmt
 
 alter_sequence_stmt ::=
 	alter_rename_sequence_stmt
@@ -1936,9 +1938,9 @@ create_type_stmt ::=
 	| 'CREATE' 'TYPE' 'IF' 'NOT' 'EXISTS' type_name 'AS' '(' opt_composite_type_list ')'
 
 create_view_stmt ::=
-	'CREATE' opt_temp 'VIEW' view_name opt_column_list 'AS' select_stmt
-	| 'CREATE' 'OR' 'REPLACE' opt_temp 'VIEW' view_name opt_column_list 'AS' select_stmt
-	| 'CREATE' opt_temp 'VIEW' 'IF' 'NOT' 'EXISTS' view_name opt_column_list 'AS' select_stmt
+	'CREATE' opt_temp 'VIEW' view_name opt_column_list opt_view_with 'AS' select_stmt
+	| 'CREATE' 'OR' 'REPLACE' opt_temp 'VIEW' view_name opt_column_list opt_view_with 'AS' select_stmt
+	| 'CREATE' opt_temp 'VIEW' 'IF' 'NOT' 'EXISTS' view_name opt_column_list opt_view_with 'AS' select_stmt
 	| 'CREATE' 'MATERIALIZED' 'VIEW' view_name opt_column_list 'AS' select_stmt opt_with_data
 	| 'CREATE' 'MATERIALIZED' 'VIEW' 'IF' 'NOT' 'EXISTS' view_name opt_column_list 'AS' select_stmt opt_with_data
 
@@ -2487,6 +2489,20 @@ alter_view_owner_stmt ::=
 	| 'ALTER' 'VIEW' 'IF' 'EXISTS' relation_expr 'OWNER' 'TO' role_spec
 	| 'ALTER' 'MATERIALIZED' 'VIEW' 'IF' 'EXISTS' relation_expr 'OWNER' 'TO' role_spec
 
+alter_view_set_options_stmt ::=
+	'ALTER' 'VIEW' relation_expr 'SET' '(' 'SECURITY_INVOKER' '=' 'TRUE' ')'
+	| 'ALTER' 'VIEW' relation_expr 'SET' '(' 'SECURITY_INVOKER' '=' 'FALSE' ')'
+	| 'ALTER' 'VIEW' relation_expr 'SET' '(' 'SECURITY_INVOKER' '=' 'ICONST' ')'
+	| 'ALTER' 'VIEW' relation_expr 'SET' '(' 'SECURITY_INVOKER' ')'
+	| 'ALTER' 'VIEW' 'IF' 'EXISTS' relation_expr 'SET' '(' 'SECURITY_INVOKER' '=' 'TRUE' ')'
+	| 'ALTER' 'VIEW' 'IF' 'EXISTS' relation_expr 'SET' '(' 'SECURITY_INVOKER' '=' 'FALSE' ')'
+	| 'ALTER' 'VIEW' 'IF' 'EXISTS' relation_expr 'SET' '(' 'SECURITY_INVOKER' '=' 'ICONST' ')'
+	| 'ALTER' 'VIEW' 'IF' 'EXISTS' relation_expr 'SET' '(' 'SECURITY_INVOKER' ')'
+
+alter_view_reset_options_stmt ::=
+	'ALTER' 'VIEW' relation_expr 'RESET' '(' 'SECURITY_INVOKER' ')'
+	| 'ALTER' 'VIEW' 'IF' 'EXISTS' relation_expr 'RESET' '(' 'SECURITY_INVOKER' ')'
+
 alter_rename_sequence_stmt ::=
 	'ALTER' 'SEQUENCE' relation_expr 'RENAME' 'TO' sequence_name
 	| 'ALTER' 'SEQUENCE' 'IF' 'EXISTS' relation_expr 'RENAME' 'TO' sequence_name
@@ -2827,6 +2843,12 @@ opt_temp ::=
 	'TEMPORARY'
 	| 'TEMP'
 	| 
+
+opt_view_with ::=
+	'WITH' '(' 'SECURITY_INVOKER' ')'
+	| 'WITH' '(' 'SECURITY_INVOKER' '=' 'TRUE' ')'
+	| 'WITH' '(' 'SECURITY_INVOKER' '=' 'FALSE' ')'
+	| 'WITH' '(' 'SECURITY_INVOKER' '=' 'ICONST' ')'
 
 opt_with_data ::=
 	'WITH' 'DATA'

--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -1845,6 +1845,13 @@ func TestTenantLogic_secondary_index_column_families(
 	runLogicTest(t, "secondary_index_column_families")
 }
 
+func TestTenantLogic_security_invoker_view(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "security_invoker_view")
+}
+
 func TestTenantLogic_select(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
@@ -1850,6 +1850,13 @@ func TestReadCommittedLogic_secondary_index_column_families(
 	runLogicTest(t, "secondary_index_column_families")
 }
 
+func TestReadCommittedLogic_security_invoker_view(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "security_invoker_view")
+}
+
 func TestReadCommittedLogic_select(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
@@ -1809,6 +1809,13 @@ func TestRepeatableReadLogic_secondary_index_column_families(
 	runLogicTest(t, "secondary_index_column_families")
 }
 
+func TestRepeatableReadLogic_security_invoker_view(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "security_invoker_view")
+}
+
 func TestRepeatableReadLogic_select(
 	t *testing.T,
 ) {

--- a/pkg/gen/bnf.bzl
+++ b/pkg/gen/bnf.bzl
@@ -67,6 +67,8 @@ BNF_SRCS = [
     "//docs/generated/sql/bnf:alter_type.bnf",
     "//docs/generated/sql/bnf:alter_view.bnf",
     "//docs/generated/sql/bnf:alter_view_owner_stmt.bnf",
+    "//docs/generated/sql/bnf:alter_view_reset_options_stmt.bnf",
+    "//docs/generated/sql/bnf:alter_view_set_options_stmt.bnf",
     "//docs/generated/sql/bnf:alter_view_set_schema_stmt.bnf",
     "//docs/generated/sql/bnf:alter_virtual_cluster.bnf",
     "//docs/generated/sql/bnf:alter_virtual_cluster_capability.bnf",

--- a/pkg/gen/diagrams.bzl
+++ b/pkg/gen/diagrams.bzl
@@ -67,6 +67,8 @@ DIAGRAMS_SRCS = [
     "//docs/generated/sql/bnf:alter_type.html",
     "//docs/generated/sql/bnf:alter_view.html",
     "//docs/generated/sql/bnf:alter_view_owner.html",
+    "//docs/generated/sql/bnf:alter_view_reset_options.html",
+    "//docs/generated/sql/bnf:alter_view_set_options.html",
     "//docs/generated/sql/bnf:alter_view_set_schema.html",
     "//docs/generated/sql/bnf:alter_virtual_cluster.html",
     "//docs/generated/sql/bnf:alter_virtual_cluster_capability.html",

--- a/pkg/gen/docs.bzl
+++ b/pkg/gen/docs.bzl
@@ -77,6 +77,8 @@ DOCS_SRCS = [
     "//docs/generated/sql/bnf:alter_type.bnf",
     "//docs/generated/sql/bnf:alter_view.bnf",
     "//docs/generated/sql/bnf:alter_view_owner_stmt.bnf",
+    "//docs/generated/sql/bnf:alter_view_reset_options_stmt.bnf",
+    "//docs/generated/sql/bnf:alter_view_set_options_stmt.bnf",
     "//docs/generated/sql/bnf:alter_view_set_schema_stmt.bnf",
     "//docs/generated/sql/bnf:alter_virtual_cluster.bnf",
     "//docs/generated/sql/bnf:alter_virtual_cluster_capability.bnf",

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "alter_table_owner.go",
         "alter_table_set_schema.go",
         "alter_type.go",
+        "alter_view_set_options.go",
         "analyze_expr.go",
         "apply_join.go",
         "audit_logging.go",

--- a/pkg/sql/alter_view_set_options.go
+++ b/pkg/sql/alter_view_set_options.go
@@ -1,0 +1,158 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
+	"github.com/gogo/protobuf/proto"
+)
+
+type alterViewSetOptionsNode struct {
+	zeroInputPlanNode
+	n      *tree.AlterViewSetOptions
+	desc   *tabledesc.Mutable
+	prefix catalog.ResolvedObjectPrefix
+}
+
+// AlterViewSetOptions sets options on a view.
+func (p *planner) AlterViewSetOptions(
+	ctx context.Context, n *tree.AlterViewSetOptions,
+) (planNode, error) {
+	if err := checkSchemaChangeEnabled(
+		ctx,
+		p.ExecCfg(),
+		"ALTER VIEW SET",
+	); err != nil {
+		return nil, err
+	}
+
+	if !p.execCfg.Settings.Version.IsActive(ctx, clusterversion.V26_2) {
+		return nil, pgerror.Newf(pgcode.FeatureNotSupported,
+			"security invoker views are not supported")
+	}
+
+	tn := n.Name.ToTableName()
+	prefix, viewDesc, err := p.ResolveMutableTableDescriptor(
+		ctx, &tn, !n.IfExists, tree.ResolveRequireViewDesc)
+	if err != nil {
+		return nil, err
+	}
+	if viewDesc == nil {
+		return newZeroNode(nil /* columns */), nil
+	}
+
+	if err := checkViewMatchesMaterialized(viewDesc, true /* requireView */, false /* wantMaterialized */); err != nil {
+		return nil, err
+	}
+
+	hasOwnership, err := p.HasOwnership(ctx, viewDesc)
+	if err != nil {
+		return nil, err
+	}
+	if !hasOwnership {
+		return nil, pgerror.Newf(pgcode.InsufficientPrivilege,
+			"must be owner of view %s", tree.Name(viewDesc.GetName()))
+	}
+
+	return &alterViewSetOptionsNode{
+		n:      n,
+		desc:   viewDesc,
+		prefix: prefix,
+	}, nil
+}
+
+func (n *alterViewSetOptionsNode) startExec(params runParams) error {
+	telemetry.Inc(sqltelemetry.SchemaChangeAlterCounterWithExtra(
+		"view", n.n.TelemetryName(),
+	))
+
+	n.desc.SecurityInvoker = proto.Bool(n.n.Options.SecurityInvoker)
+
+	return params.p.writeSchemaChange(
+		params.ctx, n.desc, descpb.InvalidMutationID,
+		tree.AsStringWithFQNames(n.n, params.Ann()),
+	)
+}
+
+func (n *alterViewSetOptionsNode) Next(runParams) (bool, error) { return false, nil }
+func (n *alterViewSetOptionsNode) Values() tree.Datums          { return tree.Datums{} }
+func (n *alterViewSetOptionsNode) Close(context.Context)        {}
+
+type alterViewResetOptionsNode struct {
+	zeroInputPlanNode
+	n      *tree.AlterViewResetOptions
+	desc   *tabledesc.Mutable
+	prefix catalog.ResolvedObjectPrefix
+}
+
+// AlterViewResetOptions resets options on a view to their defaults.
+func (p *planner) AlterViewResetOptions(
+	ctx context.Context, n *tree.AlterViewResetOptions,
+) (planNode, error) {
+	if err := checkSchemaChangeEnabled(
+		ctx,
+		p.ExecCfg(),
+		"ALTER VIEW RESET",
+	); err != nil {
+		return nil, err
+	}
+
+	tn := n.Name.ToTableName()
+	prefix, viewDesc, err := p.ResolveMutableTableDescriptor(
+		ctx, &tn, !n.IfExists, tree.ResolveRequireViewDesc)
+	if err != nil {
+		return nil, err
+	}
+	if viewDesc == nil {
+		return newZeroNode(nil /* columns */), nil
+	}
+
+	if err := checkViewMatchesMaterialized(viewDesc, true /* requireView */, false /* wantMaterialized */); err != nil {
+		return nil, err
+	}
+
+	hasOwnership, err := p.HasOwnership(ctx, viewDesc)
+	if err != nil {
+		return nil, err
+	}
+	if !hasOwnership {
+		return nil, pgerror.Newf(pgcode.InsufficientPrivilege,
+			"must be owner of view %s", tree.Name(viewDesc.GetName()))
+	}
+
+	return &alterViewResetOptionsNode{
+		n:      n,
+		desc:   viewDesc,
+		prefix: prefix,
+	}, nil
+}
+
+func (n *alterViewResetOptionsNode) startExec(params runParams) error {
+	telemetry.Inc(sqltelemetry.SchemaChangeAlterCounterWithExtra(
+		"view", n.n.TelemetryName(),
+	))
+
+	n.desc.SecurityInvoker = nil
+
+	return params.p.writeSchemaChange(
+		params.ctx, n.desc, descpb.InvalidMutationID,
+		tree.AsStringWithFQNames(n.n, params.Ann()),
+	)
+}
+
+func (n *alterViewResetOptionsNode) Next(runParams) (bool, error) { return false, nil }
+func (n *alterViewResetOptionsNode) Values() tree.Datums          { return tree.Datums{} }
+func (n *alterViewResetOptionsNode) Close(context.Context)        {}

--- a/pkg/sql/catalog/descpb/structured.go
+++ b/pkg/sql/catalog/descpb/structured.go
@@ -231,6 +231,11 @@ func (desc *TableDescriptor) MaterializedView() bool {
 	return desc.IsMaterializedView
 }
 
+// IsSecurityInvoker implements the TableDescriptor interface.
+func (desc *TableDescriptor) IsSecurityInvoker() bool {
+	return desc.SecurityInvoker != nil && *desc.SecurityInvoker
+}
+
 // IsReadOnly implements the TableDescriptor interface.
 func (desc *TableDescriptor) IsReadOnly() bool {
 	return desc.IsMaterializedView || desc.GetExternal() != nil

--- a/pkg/sql/catalog/descpb/structured.proto
+++ b/pkg/sql/catalog/descpb/structured.proto
@@ -1111,6 +1111,12 @@ message TableDescriptor {
   // RefreshViewRequired indicates if the materialized view needs to be refreshed
   // prior to access.
   optional bool refresh_view_required = 53 [(gogoproto.nullable) = false];
+  // SecurityInvoker indicates whether the view uses SECURITY INVOKER semantics.
+  // When true, the view executes with the privileges and the RLS of the user
+  // invoking it rather than the view definer. The field is optional to match
+  // PostgreSQL behavior. `SHOW CREATE VIEW` and `pg_catalog` only show this
+  // option when it's explicitly set by the user.
+  optional bool security_invoker = 72 [(gogoproto.nullable) = true];
   // The IDs of all relations that this depends on.
   // Only ever populated if this descriptor is for a view.
   repeated uint32 dependsOn = 25 [(gogoproto.customname) = "DependsOn",
@@ -1398,7 +1404,7 @@ message TableDescriptor {
   // before new statistics are fully deployed to all queries throughout the
   // cluster.
   optional int64 stats_canary_window = 71 [(gogoproto.nullable) = false, (gogoproto.casttype)="time.Duration"];
-  // Next ID: 72
+  // Next ID: 73
 }
 
 // ExternalRowData indicates that the row data for this object is stored outside

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -372,6 +372,9 @@ type TableDescriptor interface {
 	IsPhysicalTable() bool
 	// MaterializedView returns whether this TableDescriptor is a MaterializedView.
 	MaterializedView() bool
+	// IsSecurityInvoker returns true if security_invoker option is set to true.
+	// The function should only be called on a view descriptor.
+	IsSecurityInvoker() bool
 	// IsReadOnly returns if this table descriptor has external data, and cannot
 	// be written to.
 	IsReadOnly() bool
@@ -818,6 +821,8 @@ type TableDescriptor interface {
 	GetExcludeDataFromBackup() bool
 	// GetStorageParams returns a list of storage parameters for the table.
 	GetStorageParams(spaceBetweenEqual bool) ([]string, error)
+	// GetViewOptions returns a list of options for the view.
+	GetViewOptions(spaceBetweenEqual bool) ([]string, error)
 	// NoAutoStatsSettingsOverrides is true if no auto stats related settings are
 	// set at the table level for the given table.
 	NoAutoStatsSettingsOverrides() bool

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -2667,6 +2667,27 @@ func (desc *wrapper) GetStorageParams(spaceBetweenEqual bool) ([]string, error) 
 	return storageParams, nil
 }
 
+// GetViewOptions implements the TableDescriptor interface.
+func (desc *wrapper) GetViewOptions(spaceBetweenEqual bool) ([]string, error) {
+	var viewOptions []string
+	var spacing string
+	if spaceBetweenEqual {
+		spacing = ` `
+	}
+	appendViewOptions := func(key, value string) {
+		viewOptions = append(viewOptions, key+spacing+`=`+spacing+value)
+	}
+
+	if desc.SecurityInvoker != nil {
+		if *desc.SecurityInvoker {
+			appendViewOptions(`security_invoker`, `true`)
+		} else {
+			appendViewOptions(`security_invoker`, `false`)
+		}
+	}
+	return viewOptions, nil
+}
+
 // GetMultiRegionEnumDependency returns true if the given table has an "implicit"
 // dependency on the multi-region enum. An implicit dependency exists for
 // REGIONAL BY TABLE table's which are homed in an explicit region

--- a/pkg/sql/catalog/tabledesc/validate_test.go
+++ b/pkg/sql/catalog/tabledesc/validate_test.go
@@ -102,6 +102,7 @@ var validationMap = []struct {
 				status: todoIAmKnowinglyAddingTechDebt,
 				reason: "initial import: TODO(features): add validation"},
 			"IsMaterializedView":  {status: thisFieldReferencesNoObjects},
+			"SecurityInvoker":     {status: thisFieldReferencesNoObjects},
 			"RefreshViewRequired": {status: thisFieldReferencesNoObjects},
 			"DependsOn":           {status: iSolemnlySwearThisFieldIsValidated},
 			"DependsOnTypes":      {status: iSolemnlySwearThisFieldIsValidated},

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/docs"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
@@ -37,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/errors"
+	"github.com/gogo/protobuf/proto"
 )
 
 // createViewNode represents a CREATE VIEW statement.
@@ -78,7 +80,8 @@ func (n *createViewNode) startExec(params runParams) error {
 	}
 	createView := n.createView
 
-	if !params.SessionData().AllowViewWithSecurityInvokerClause && createView.Options != nil && createView.Options.SecurityInvoker {
+	if !params.p.execCfg.Settings.Version.IsActive(params.ctx, clusterversion.V26_2) &&
+		createView.Options != nil && createView.Options.SecurityInvoker {
 		return pgerror.Newf(pgcode.FeatureNotSupported,
 			"security invoker views are not supported")
 	}
@@ -289,6 +292,11 @@ func (n *createViewNode) startExec(params runParams) error {
 						desc.SetTableLocalityGlobal()
 						applyGlobalMultiRegionZoneConfig = true
 					}
+				}
+
+				// Set view options if specified.
+				if createView.Options != nil {
+					desc.SecurityInvoker = proto.Bool(createView.Options.SecurityInvoker)
 				}
 
 				// Collect all the tables/views this view depends on.
@@ -745,6 +753,13 @@ func (p *planner) replaceViewDesc(
 		return nil, err
 	}
 	toReplace.ViewQuery = typeReplacedQuery
+
+	// Update view options if specified in the replacement.
+	if n.createView.Options != nil {
+		toReplace.SecurityInvoker = proto.Bool(n.createView.Options.SecurityInvoker)
+	} else {
+		toReplace.SecurityInvoker = nil
+	}
 
 	// Check that the new view has at least as many columns as the old view before
 	// adding result columns.

--- a/pkg/sql/logictest/testdata/logic_test/row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_security
@@ -5703,29 +5703,6 @@ DROP FUNCTION fail, divbyzero;
 statement ok
 DROP ROLE alice;
 
-subtest unimplemented_alter_view_with_security_invoker
-
-statement ok
-CREATE TABLE roach_pg_table ( count INT )
-
-statement ok
-SET allow_view_with_security_invoker_clause = on
-
-statement ok
-CREATE VIEW security_invoker_view WITH ( security_invoker = true ) AS SELECT * FROM roach_pg_table
-
-statement error pq: at or near "\)": syntax error: unimplemented: this syntax\nHINT: You have attempted to use a feature that is not yet implemented\.\n\nPlease check the public issue tracker to check whether this problem is\nalready tracked\. If you cannot find it there, please report the error\nwith details by creating a new issue\.\n\nIf you would rather not post publicly, please contact us directly\nusing the support form\.\n\nWe appreciate your feedback\.\n\nDETAIL: source SQL:\nALTER VIEW security_invoker_view SET \( security_invoker = false \)
-ALTER VIEW security_invoker_view SET ( security_invoker = false )
-
-statement ok
-DROP VIEW security_invoker_view
-
-statement ok
-DROP TABLE roach_pg_table
-
-statement ok
-SET allow_view_with_security_invoker_clause = off
-
 subtest end
 
 subtest row_security_off

--- a/pkg/sql/logictest/testdata/logic_test/security_invoker_view
+++ b/pkg/sql/logictest/testdata/logic_test/security_invoker_view
@@ -1,0 +1,1437 @@
+# LogicTest: !local-legacy-schema-changer !local-mixed-25.4 !local-mixed-26.1
+
+# Comprehensive tests for security_invoker view option.
+# Tests privilege checks and RLS policy application with security_invoker
+# on and off (security definer).
+
+subtest setup
+
+statement ok
+CREATE DATABASE sidb;
+
+statement ok
+USE sidb;
+
+# Create roles:
+# - table_owner: owns the base table
+# - view_owner: owns the views (different from table_owner for some tests)
+# - invoker_user: the user querying the views
+statement ok
+CREATE ROLE table_owner;
+
+statement ok
+CREATE ROLE view_owner;
+
+statement ok
+CREATE ROLE invoker_user;
+
+statement ok
+GRANT ALL ON DATABASE sidb TO table_owner;
+
+statement ok
+GRANT ALL ON DATABASE sidb TO view_owner;
+
+statement ok
+GRANT ALL ON DATABASE sidb TO invoker_user;
+
+subtest end
+
+# ---------------------------------------------------------------------------
+# Part 1: DDL tests — CREATE VIEW, SHOW CREATE, pg_catalog, CREATE OR REPLACE
+# ---------------------------------------------------------------------------
+subtest ddl_create_and_metadata
+
+statement ok
+CREATE TABLE base_t (
+  id INT PRIMARY KEY,
+  username TEXT,
+  data TEXT
+);
+
+statement ok
+INSERT INTO base_t VALUES
+  (1, 'table_owner', 'owner-data'),
+  (2, 'view_owner', 'vowner-data'),
+  (3, 'invoker_user', 'invoker-data'),
+  (4, 'other', 'other-data');
+
+# Create view with security_invoker = true
+statement ok
+CREATE VIEW si_view WITH (security_invoker = true) AS
+  SELECT id, username, data FROM base_t;
+
+statement ok
+CREATE VIEW si_view_default WITH (security_invoker) AS
+  SELECT id, username, data FROM base_t;
+
+# Create view with security_invoker = false (explicit definer)
+statement ok
+CREATE VIEW sd_view WITH (security_invoker = false) AS
+  SELECT id, username, data FROM base_t;
+
+# Create view without any option (defaults to definer)
+statement ok
+CREATE VIEW default_view AS
+  SELECT id, username, data FROM base_t;
+
+# SHOW CREATE should show security_invoker when explicitly included in the CREATE VIEW
+query TT
+SHOW CREATE VIEW si_view;
+----
+si_view  CREATE VIEW public.si_view (
+           id,
+           username,
+           data
+         ) WITH (security_invoker = true) AS SELECT id, username, data FROM sidb.public.base_t;
+
+query TT
+SHOW CREATE VIEW si_view_default;
+----
+si_view_default  CREATE VIEW public.si_view_default (
+                  id,
+                  username,
+                  data
+                ) WITH (security_invoker = true) AS SELECT id, username, data FROM sidb.public.base_t;
+
+query TT
+SHOW CREATE VIEW sd_view;
+----
+sd_view  CREATE VIEW public.sd_view (
+           id,
+           username,
+           data
+         ) WITH (security_invoker = false) AS SELECT id, username, data FROM sidb.public.base_t;
+
+query TT
+SHOW CREATE VIEW default_view;
+----
+default_view  CREATE VIEW public.default_view (
+                id,
+                username,
+                data
+              ) AS SELECT id, username, data FROM sidb.public.base_t;
+
+# Verify reloptions in pg_catalog.pg_class
+query TT
+SELECT relname, reloptions FROM pg_catalog.pg_class
+WHERE relname IN ('si_view', 'si_view_default', 'sd_view', 'default_view')
+ORDER BY relname;
+----
+default_view     NULL
+sd_view          {security_invoker=false}
+si_view          {security_invoker=true}
+si_view_default  {security_invoker=true}
+
+subtest end
+
+# ---------------------------------------------------------------------------
+subtest ddl_create_or_replace
+
+# CREATE OR REPLACE resets security_invoker
+statement ok
+CREATE OR REPLACE VIEW si_view AS
+  SELECT id, username, data FROM base_t;
+
+query TT
+SELECT relname, reloptions FROM pg_catalog.pg_class
+WHERE relname = 'si_view';
+----
+si_view  NULL
+
+statement ok
+CREATE OR REPLACE VIEW si_view WITH (security_invoker) AS
+  SELECT id, username, data FROM base_t;
+
+query TT
+SELECT relname, reloptions FROM pg_catalog.pg_class
+WHERE relname = 'si_view';
+----
+si_view  {security_invoker=true}
+
+# CREATE OR REPLACE can add security_invoker to an existing definer view
+statement ok
+CREATE OR REPLACE VIEW sd_view WITH (security_invoker = true) AS
+  SELECT id, username, data FROM base_t;
+
+query TT
+SELECT relname, reloptions FROM pg_catalog.pg_class
+WHERE relname = 'sd_view';
+----
+sd_view  {security_invoker=true}
+
+# Change it back to definer
+statement ok
+CREATE OR REPLACE VIEW sd_view WITH (security_invoker = false) AS
+  SELECT id, username, data FROM base_t;
+
+query TT
+SELECT relname, reloptions FROM pg_catalog.pg_class
+WHERE relname = 'sd_view';
+----
+sd_view  {security_invoker=false}
+
+subtest end
+
+# ---------------------------------------------------------------------------
+# Part 2: Privilege checks without RLS
+# ---------------------------------------------------------------------------
+subtest privileges_no_rls
+
+# Revoke direct table access from invoker_user.
+statement ok
+REVOKE ALL ON base_t FROM invoker_user;
+
+# Grant SELECT on the views to invoker_user.
+statement ok
+GRANT SELECT ON si_view TO invoker_user;
+
+statement ok
+GRANT SELECT ON sd_view TO invoker_user;
+
+statement ok
+GRANT SELECT ON default_view TO invoker_user;
+
+statement ok
+SET ROLE invoker_user;
+
+statement ok
+USE sidb;
+
+# SECURITY INVOKER view: should fail because invoker_user does not have
+# SELECT on base_t. The view checks invoker privileges.
+statement error pgcode 42501 user invoker_user does not have SELECT privilege on relation base_t
+SELECT * FROM si_view;
+
+# SECURITY DEFINER view: should succeed because the view owner (root)
+# has access to base_t.
+query ITT rowsort
+SELECT * FROM sd_view;
+----
+1  table_owner   owner-data
+2  view_owner    vowner-data
+3  invoker_user  invoker-data
+4  other         other-data
+
+# Default view (no option): behaves as definer, should succeed.
+query ITT rowsort
+SELECT * FROM default_view;
+----
+1  table_owner   owner-data
+2  view_owner    vowner-data
+3  invoker_user  invoker-data
+4  other         other-data
+
+statement ok
+SET ROLE root;
+
+subtest end
+
+# ---------------------------------------------------------------------------
+subtest privileges_after_grant
+
+# Grant SELECT on base_t to invoker_user.
+statement ok
+GRANT SELECT ON base_t TO invoker_user;
+
+statement ok
+SET ROLE invoker_user;
+
+# Now SECURITY INVOKER should succeed since invoker has table access.
+query ITT rowsort
+SELECT * FROM si_view;
+----
+1  table_owner   owner-data
+2  view_owner    vowner-data
+3  invoker_user  invoker-data
+4  other         other-data
+
+# Definer view still works.
+query ITT rowsort
+SELECT * FROM sd_view;
+----
+1  table_owner   owner-data
+2  view_owner    vowner-data
+3  invoker_user  invoker-data
+4  other         other-data
+
+statement ok
+SET ROLE root;
+
+# Revoke again for later tests.
+statement ok
+REVOKE ALL ON base_t FROM invoker_user;
+
+subtest end
+
+# ---------------------------------------------------------------------------
+# Part 3: View owner != table owner (privilege checks without RLS)
+# ---------------------------------------------------------------------------
+subtest different_owners_privileges
+
+# Give table_owner access to base_t.
+statement ok
+ALTER TABLE base_t OWNER TO table_owner;
+
+# Let view_owner create views. Grant view_owner access to base_t so they
+# can create views referencing it.
+statement ok
+GRANT SELECT ON base_t TO view_owner;
+
+statement ok
+SET ROLE view_owner;
+
+statement ok
+CREATE VIEW vo_si_view WITH (security_invoker = true) AS
+  SELECT id, username, data FROM base_t;
+
+statement ok
+CREATE VIEW vo_sd_view WITH (security_invoker = false) AS
+  SELECT id, username, data FROM base_t;
+
+statement ok
+SET ROLE root;
+
+statement ok
+GRANT SELECT ON vo_si_view TO invoker_user;
+
+statement ok
+GRANT SELECT ON vo_sd_view TO invoker_user;
+
+statement ok
+SET ROLE invoker_user;
+
+# SECURITY INVOKER: fails because invoker_user has no SELECT on base_t.
+statement error pgcode 42501 user invoker_user does not have SELECT privilege on relation base_t
+SELECT * FROM vo_si_view;
+
+# SECURITY DEFINER: succeeds because view_owner has SELECT on base_t.
+query ITT rowsort
+SELECT * FROM vo_sd_view;
+----
+1  table_owner   owner-data
+2  view_owner    vowner-data
+3  invoker_user  invoker-data
+4  other         other-data
+
+statement ok
+SET ROLE root;
+
+# Grant base_t SELECT to invoker_user, now invoker view works.
+statement ok
+GRANT SELECT ON base_t TO invoker_user;
+
+statement ok
+SET ROLE invoker_user;
+
+query ITT rowsort
+SELECT * FROM vo_si_view;
+----
+1  table_owner   owner-data
+2  view_owner    vowner-data
+3  invoker_user  invoker-data
+4  other         other-data
+
+statement ok
+SET ROLE root;
+
+# Revoke view_owner's SELECT on base_t. The definer view should now fail
+# when queried even by root because the view owner (view_owner) lost access.
+statement ok
+REVOKE SELECT ON base_t FROM view_owner;
+
+# Query as invoker_user: invoker view still works (invoker has access).
+statement ok
+SET ROLE invoker_user;
+
+query ITT rowsort
+SELECT * FROM vo_si_view;
+----
+1  table_owner   owner-data
+2  view_owner    vowner-data
+3  invoker_user  invoker-data
+4  other         other-data
+
+# Definer view fails because view_owner lost access to base_t.
+statement error pgcode 42501 user view_owner does not have SELECT privilege on relation base_t
+SELECT * FROM vo_sd_view;
+
+statement ok
+SET ROLE root;
+
+# Restore view_owner's access for later tests.
+statement ok
+GRANT SELECT ON base_t TO view_owner;
+
+subtest end
+
+# ---------------------------------------------------------------------------
+# Part 4: RLS with security_invoker — different policies for different users
+# ---------------------------------------------------------------------------
+subtest rls_basic
+
+# Enable RLS on base_t.
+statement ok
+ALTER TABLE base_t ENABLE ROW LEVEL SECURITY;
+
+# Create per-user policies:
+# - table_owner sees all rows (owns the table, so RLS is bypassed for owner)
+# - view_owner sees the 'view_owner' row
+# - invoker_user sees the 'invoker_user' row
+statement ok
+CREATE POLICY p_view_owner ON base_t
+  FOR SELECT
+  TO view_owner
+  USING (username = 'view_owner');
+
+statement ok
+CREATE POLICY p_invoker ON base_t
+  FOR SELECT
+  TO invoker_user
+  USING (username = 'invoker_user');
+
+# Ensure both users have SELECT on the table itself.
+statement ok
+GRANT SELECT ON base_t TO view_owner;
+
+statement ok
+GRANT SELECT ON base_t TO invoker_user;
+
+# Create views owned by view_owner with RLS-enabled table.
+statement ok
+SET ROLE view_owner;
+
+statement ok
+CREATE VIEW rls_si_view WITH (security_invoker = true) AS
+  SELECT id, username, data FROM base_t;
+
+statement ok
+CREATE VIEW rls_sd_view WITH (security_invoker = false) AS
+  SELECT id, username, data FROM base_t;
+
+statement ok
+CREATE VIEW rls_default_view AS
+  SELECT id, username, data FROM base_t;
+
+statement ok
+SET ROLE root;
+
+statement ok
+GRANT SELECT ON rls_si_view TO invoker_user;
+
+statement ok
+GRANT SELECT ON rls_sd_view TO invoker_user;
+
+statement ok
+GRANT SELECT ON rls_default_view TO invoker_user;
+
+# ---- Query as view_owner (the view owner) ----
+statement ok
+SET ROLE view_owner;
+
+query ITT
+SELECT * FROM rls_si_view ORDER BY id;
+----
+2  view_owner  vowner-data
+
+query ITT
+SELECT * FROM rls_sd_view ORDER BY id;
+----
+2  view_owner  vowner-data
+
+query ITT
+SELECT * FROM rls_default_view ORDER BY id;
+----
+2  view_owner  vowner-data
+
+# ---- Query as invoker_user ----
+statement ok
+SET ROLE invoker_user;
+
+query ITT
+SELECT * FROM rls_si_view ORDER BY id;
+----
+3  invoker_user  invoker-data
+
+query ITT
+SELECT * FROM rls_sd_view ORDER BY id;
+----
+2  view_owner  vowner-data
+
+query ITT
+SELECT * FROM rls_default_view ORDER BY id;
+----
+2  view_owner  vowner-data
+
+statement ok
+SET ROLE root;
+
+subtest end
+
+# ---------------------------------------------------------------------------
+# Part 5: RLS with current_user based policies
+# ---------------------------------------------------------------------------
+subtest rls_current_user
+
+# Create a table where each user sees only their own rows.
+statement ok
+CREATE TABLE user_data (
+  id INT PRIMARY KEY,
+  owner_name TEXT,
+  secret TEXT
+);
+
+statement ok
+INSERT INTO user_data VALUES
+  (1, 'view_owner', 'vo-secret'),
+  (2, 'invoker_user', 'inv-secret'),
+  (3, 'table_owner', 'to-secret'),
+  (4, 'invoker_user', 'inv-secret-2');
+
+statement ok
+ALTER TABLE user_data ENABLE ROW LEVEL SECURITY;
+
+statement ok
+CREATE POLICY see_own ON user_data
+  FOR SELECT
+  TO view_owner, invoker_user
+  USING (owner_name = current_user());
+
+statement ok
+GRANT SELECT ON user_data TO view_owner;
+
+statement ok
+GRANT SELECT ON user_data TO invoker_user;
+
+statement ok
+SET ROLE view_owner;
+
+statement ok
+CREATE VIEW ud_si_view WITH (security_invoker = true) AS
+  SELECT * FROM user_data;
+
+statement ok
+CREATE VIEW ud_sd_view WITH (security_invoker = false) AS
+  SELECT * FROM user_data;
+
+statement ok
+SET ROLE root;
+
+statement ok
+GRANT SELECT ON ud_si_view TO invoker_user;
+
+statement ok
+GRANT SELECT ON ud_sd_view TO invoker_user;
+
+# As view_owner: both views show view_owner's rows.
+statement ok
+SET ROLE view_owner;
+
+query ITT
+SELECT * FROM ud_si_view ORDER BY id;
+----
+1  view_owner  vo-secret
+
+query ITT
+SELECT * FROM ud_sd_view ORDER BY id;
+----
+1  view_owner  vo-secret
+
+# As invoker_user: both views show invoker_user's rows.
+statement ok
+SET ROLE invoker_user;
+
+# SECURITY INVOKER: current_user = invoker_user → sees invoker_user's rows.
+query ITT
+SELECT * FROM ud_si_view ORDER BY id;
+----
+2  invoker_user  inv-secret
+4  invoker_user  inv-secret-2
+
+# SECURITY DEFINER: current_user is still invoker_user → sees invoker_user's rows.
+query ITT
+SELECT * FROM ud_sd_view ORDER BY id;
+----
+2  invoker_user  inv-secret
+4  invoker_user  inv-secret-2
+
+statement ok
+SET ROLE root;
+
+subtest end
+
+# ---------------------------------------------------------------------------
+# Part 6: RLS with FORCE ROW LEVEL SECURITY (table owner affected)
+# ---------------------------------------------------------------------------
+subtest rls_force
+
+# With FORCE ROW LEVEL SECURITY, even the table owner is subject to policies.
+statement ok
+CREATE TABLE force_t (
+  id INT PRIMARY KEY,
+  val TEXT
+);
+
+statement ok
+INSERT INTO force_t VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd');
+
+statement ok
+ALTER TABLE force_t ENABLE ROW LEVEL SECURITY;
+
+statement ok
+ALTER TABLE force_t FORCE ROW LEVEL SECURITY;
+
+statement ok
+CREATE POLICY p_even ON force_t FOR SELECT USING (id % 2 = 0);
+
+statement ok
+GRANT SELECT ON force_t TO view_owner;
+
+statement ok
+GRANT SELECT ON force_t TO invoker_user;
+
+# Table owner (root) is also subject to policy because of FORCE.
+# But root has admin so it bypasses RLS regardless.
+query IT
+SELECT * FROM force_t ORDER BY id;
+----
+1  a
+2  b
+3  c
+4  d
+
+# Transfer ownership to table_owner.
+statement ok
+ALTER TABLE force_t OWNER TO table_owner;
+
+statement ok
+SET ROLE table_owner;
+
+# Table owner with FORCE RLS: sees only even rows.
+query IT
+SELECT * FROM force_t ORDER BY id;
+----
+2  b
+4  d
+
+statement ok
+SET ROLE root;
+
+# Create views owned by view_owner.
+statement ok
+SET ROLE view_owner;
+
+statement ok
+CREATE VIEW force_si_view WITH (security_invoker = true) AS
+  SELECT * FROM force_t;
+
+statement ok
+CREATE VIEW force_sd_view WITH (security_invoker = false) AS
+  SELECT * FROM force_t;
+
+statement ok
+SET ROLE root;
+
+statement ok
+GRANT SELECT ON force_si_view TO table_owner;
+
+statement ok
+GRANT SELECT ON force_sd_view TO table_owner;
+
+statement ok
+GRANT SELECT ON force_si_view TO invoker_user;
+
+statement ok
+GRANT SELECT ON force_sd_view TO invoker_user;
+
+statement ok
+SET ROLE invoker_user;
+
+query IT
+SELECT * FROM force_si_view ORDER BY id;
+----
+2  b
+4  d
+
+query IT
+SELECT * FROM force_sd_view ORDER BY id;
+----
+2  b
+4  d
+
+statement ok
+SET ROLE table_owner;
+
+query IT
+SELECT * FROM force_si_view ORDER BY id;
+----
+2  b
+4  d
+
+query IT
+SELECT * FROM force_sd_view ORDER BY id;
+----
+2  b
+4  d
+
+statement ok
+SET ROLE root;
+
+subtest end
+
+# ---------------------------------------------------------------------------
+# Part 7: Nested views with security_invoker
+# ---------------------------------------------------------------------------
+subtest nested_views
+
+# A security_invoker view on top of another security_invoker view.
+# The privilege/RLS check should follow the invoker at each level.
+
+statement ok
+GRANT SELECT ON base_t TO view_owner;
+
+statement ok
+GRANT SELECT ON base_t TO invoker_user;
+
+statement ok
+SET ROLE view_owner;
+
+# Inner view: security_invoker
+statement ok
+CREATE VIEW inner_si WITH (security_invoker = true) AS
+  SELECT id, username, data FROM base_t;
+
+# Outer view: security_invoker, on top of inner_si
+statement ok
+CREATE VIEW outer_si WITH (security_invoker = true) AS
+  SELECT * FROM inner_si;
+
+# Outer view: security definer, on top of inner_si
+statement ok
+CREATE VIEW outer_sd WITH (security_invoker = false) AS
+  SELECT * FROM inner_si;
+
+statement ok
+SET ROLE root;
+
+statement ok
+GRANT SELECT ON inner_si TO invoker_user;
+
+statement ok
+GRANT SELECT ON outer_si TO invoker_user;
+
+statement ok
+GRANT SELECT ON outer_sd TO invoker_user;
+
+statement ok
+SET ROLE invoker_user;
+
+# As invoker_user: outer_si (invoker) → inner_si (invoker) → base_t
+query ITT
+SELECT * FROM outer_si ORDER BY id;
+----
+3  invoker_user  invoker-data
+
+# outer_sd (definer=view_owner) → inner_si (invoker, but invoker is now
+# view_owner because outer is definer) → base_t
+query ITT
+SELECT * FROM outer_sd ORDER BY id;
+----
+2  view_owner   vowner-data
+
+statement ok
+SET ROLE root;
+
+statement ok
+DROP VIEW outer_si;
+DROP VIEW outer_sd;
+DROP VIEW inner_si;
+
+subtest end
+
+# ---------------------------------------------------------------------------
+# Part 8: Switching security_invoker on an existing view with RLS
+# ---------------------------------------------------------------------------
+subtest toggle_security_invoker
+
+# Start with a definer view.
+statement ok
+SET ROLE view_owner;
+
+statement ok
+CREATE VIEW toggle_view AS
+  SELECT id, username, data FROM base_t;
+
+statement ok
+SET ROLE root;
+
+statement ok
+GRANT SELECT ON toggle_view TO invoker_user;
+
+statement ok
+SET ROLE invoker_user;
+
+# Default (definer): view_owner policy → view_owner row
+query ITT
+SELECT * FROM toggle_view ORDER BY id;
+----
+2  view_owner   vowner-data
+
+statement ok
+SET ROLE view_owner;
+
+# Switch to security_invoker.
+statement ok
+CREATE OR REPLACE VIEW toggle_view WITH (security_invoker = true) AS
+  SELECT id, username, data FROM base_t;
+
+statement ok
+SET ROLE invoker_user;
+
+# Now invoker_user policy applies → invoker_user row
+query ITT
+SELECT * FROM toggle_view ORDER BY id;
+----
+3  invoker_user  invoker-data
+
+statement ok
+SET ROLE view_owner;
+
+# Switch back to definer.
+statement ok
+CREATE OR REPLACE VIEW toggle_view WITH (security_invoker = false) AS
+  SELECT id, username, data FROM base_t;
+
+statement ok
+SET ROLE invoker_user;
+
+# Back to view_owner policy → odd IDs.
+query ITT
+SELECT * FROM toggle_view ORDER BY id;
+----
+2  view_owner   vowner-data
+
+statement ok
+SET ROLE root;
+
+subtest end
+
+# ---------------------------------------------------------------------------
+# Part 9: RLS with restrictive policies and security_invoker
+# ---------------------------------------------------------------------------
+subtest rls_restrictive
+
+statement ok
+CREATE TABLE restrict_t (
+  id INT PRIMARY KEY,
+  category TEXT,
+  val TEXT
+);
+
+statement ok
+INSERT INTO restrict_t VALUES
+  (1, 'public', 'pub-1'),
+  (2, 'public', 'pub-2'),
+  (3, 'secret', 'sec-3'),
+  (4, 'secret', 'sec-4'),
+  (5, 'public', 'pub-5');
+
+statement ok
+ALTER TABLE restrict_t ENABLE ROW LEVEL SECURITY;
+
+# Permissive policy: both users can see all rows.
+statement ok
+CREATE POLICY perm ON restrict_t
+  FOR SELECT
+  TO view_owner, invoker_user
+  USING (true);
+
+# Restrictive policy only for invoker_user: cannot see 'secret' rows.
+statement ok
+CREATE POLICY restrict ON restrict_t
+  AS RESTRICTIVE
+  FOR SELECT
+  TO invoker_user
+  USING (category = 'public');
+
+statement ok
+GRANT SELECT ON restrict_t TO view_owner;
+
+statement ok
+GRANT SELECT ON restrict_t TO invoker_user;
+
+statement ok
+SET ROLE view_owner;
+
+statement ok
+CREATE VIEW restrict_si WITH (security_invoker = true) AS
+  SELECT * FROM restrict_t;
+
+statement ok
+CREATE VIEW restrict_sd WITH (security_invoker = false) AS
+  SELECT * FROM restrict_t;
+
+statement ok
+SET ROLE root;
+
+statement ok
+GRANT SELECT ON restrict_si TO invoker_user;
+
+statement ok
+GRANT SELECT ON restrict_sd TO invoker_user;
+
+# As invoker_user through invoker view: restrictive policy applies.
+statement ok
+SET ROLE invoker_user;
+
+query ITT
+SELECT * FROM restrict_si ORDER BY id;
+----
+1  public  pub-1
+2  public  pub-2
+5  public  pub-5
+
+# Through definer view: view_owner policies apply (no restrictive policy
+# for view_owner), sees all rows.
+query ITT
+SELECT * FROM restrict_sd ORDER BY id;
+----
+1  public  pub-1
+2  public  pub-2
+3  secret  sec-3
+4  secret  sec-4
+5  public  pub-5
+
+statement ok
+SET ROLE root;
+
+# Disable RLS: should see all rows in the invoker view.
+statement ok
+ALTER TABLE restrict_t DISABLE ROW LEVEL SECURITY;
+
+statement ok
+SET ROLE invoker_user;
+
+query ITT
+SELECT * FROM restrict_si ORDER BY id;
+----
+1  public  pub-1
+2  public  pub-2
+3  secret  sec-3
+4  secret  sec-4
+5  public  pub-5
+
+statement ok
+SET ROLE root;
+
+subtest end
+
+# ---------------------------------------------------------------------------
+# Part 10: Multiple policies with security_invoker
+# ---------------------------------------------------------------------------
+subtest rls_multiple_policies
+
+statement ok
+CREATE TABLE multi_pol_t (
+  id INT PRIMARY KEY,
+  department TEXT,
+  data TEXT
+);
+
+statement ok
+INSERT INTO multi_pol_t VALUES
+  (1, 'eng', 'eng-1'),
+  (2, 'sales', 'sales-2'),
+  (3, 'eng', 'eng-3'),
+  (4, 'hr', 'hr-4'),
+  (5, 'sales', 'sales-5');
+
+statement ok
+ALTER TABLE multi_pol_t ENABLE ROW LEVEL SECURITY;
+
+# invoker_user has two permissive policies (union): eng OR sales
+statement ok
+CREATE POLICY inv_eng ON multi_pol_t
+  FOR SELECT TO invoker_user
+  USING (department = 'eng');
+
+statement ok
+CREATE POLICY inv_sales ON multi_pol_t
+  FOR SELECT TO invoker_user
+  USING (department = 'sales');
+
+# view_owner only sees hr
+statement ok
+CREATE POLICY vo_hr ON multi_pol_t
+  FOR SELECT TO view_owner
+  USING (department = 'hr');
+
+statement ok
+GRANT SELECT ON multi_pol_t TO view_owner;
+
+statement ok
+GRANT SELECT ON multi_pol_t TO invoker_user;
+
+statement ok
+SET ROLE view_owner;
+
+statement ok
+CREATE VIEW multi_si WITH (security_invoker = true) AS
+  SELECT * FROM multi_pol_t;
+
+statement ok
+CREATE VIEW multi_sd WITH (security_invoker = false) AS
+  SELECT * FROM multi_pol_t;
+
+statement ok
+SET ROLE root;
+
+statement ok
+GRANT SELECT ON multi_si TO invoker_user;
+
+statement ok
+GRANT SELECT ON multi_sd TO invoker_user;
+
+statement ok
+SET ROLE invoker_user;
+
+# Invoker view: invoker_user's policies → eng + sales rows.
+query ITT
+SELECT * FROM multi_si ORDER BY id;
+----
+1  eng    eng-1
+2  sales  sales-2
+3  eng    eng-3
+5  sales  sales-5
+
+# Definer view: view_owner's policy → hr only.
+query ITT
+SELECT * FROM multi_sd ORDER BY id;
+----
+4  hr  hr-4
+
+statement ok
+SET ROLE root;
+
+subtest end
+
+# ---------------------------------------------------------------------------
+# Part 11: ALTER VIEW SET/RESET (security_invoker)
+# ---------------------------------------------------------------------------
+subtest alter_view_set_security_invoker
+
+statement ok
+SET ROLE root;
+
+# Create a basic view without security_invoker.
+statement ok
+CREATE VIEW alter_test_view AS SELECT id, username FROM base_t;
+
+# Verify it does not have security_invoker set.
+query TT
+SHOW CREATE VIEW alter_test_view;
+----
+alter_test_view  CREATE VIEW public.alter_test_view (
+                   id,
+                   username
+                 ) AS SELECT id, username FROM sidb.public.base_t;
+
+# ALTER VIEW to enable security_invoker.
+statement ok
+ALTER VIEW alter_test_view SET (security_invoker = true)
+
+query TT
+SHOW CREATE VIEW alter_test_view;
+----
+alter_test_view  CREATE VIEW public.alter_test_view (
+                   id,
+                   username
+                 ) WITH (security_invoker = true) AS SELECT id, username FROM sidb.public.base_t;
+
+# ALTER VIEW to disable security_invoker.
+statement ok
+ALTER VIEW alter_test_view SET (security_invoker = false)
+
+query TT
+SHOW CREATE VIEW alter_test_view;
+----
+alter_test_view  CREATE VIEW public.alter_test_view (
+                   id,
+                   username
+                 ) WITH (security_invoker = false) AS SELECT id, username FROM sidb.public.base_t;
+
+# IF EXISTS on a nonexistent view should be a no-op.
+statement ok
+ALTER VIEW IF EXISTS nonexistent_view SET (security_invoker = true)
+
+# Without IF EXISTS on a nonexistent view should error.
+statement error pgcode 42P01 relation "nonexistent_view" does not exist
+ALTER VIEW nonexistent_view SET (security_invoker = true)
+
+# ALTER VIEW on a table should error.
+statement error pgcode 42809 "base_t" is not a view
+ALTER VIEW base_t SET (security_invoker = true)
+
+# Test integer values: 1 = true, 0 = false.
+statement ok
+ALTER VIEW alter_test_view SET (security_invoker = 1)
+
+query TT
+SHOW CREATE VIEW alter_test_view;
+----
+alter_test_view  CREATE VIEW public.alter_test_view (
+                   id,
+                   username
+                 ) WITH (security_invoker = true) AS SELECT id, username FROM sidb.public.base_t;
+
+statement ok
+ALTER VIEW alter_test_view SET (security_invoker = 0)
+
+query TT
+SHOW CREATE VIEW alter_test_view;
+----
+alter_test_view  CREATE VIEW public.alter_test_view (
+                   id,
+                   username
+                 ) WITH (security_invoker = false) AS SELECT id, username FROM sidb.public.base_t;
+
+# Test security_invoker without values
+statement ok
+ALTER VIEW alter_test_view SET (security_invoker)
+
+query TT
+SHOW CREATE VIEW alter_test_view;
+----
+alter_test_view  CREATE VIEW public.alter_test_view (
+                   id,
+                   username
+                 ) WITH (security_invoker = true) AS SELECT id, username FROM sidb.public.base_t;
+
+# Test privilege check: non-owner without CREATE should fail.
+statement ok
+GRANT SELECT ON alter_test_view TO invoker_user
+
+statement ok
+SET ROLE invoker_user
+
+statement error pgcode 42501 must be owner of view alter_test_view
+ALTER VIEW alter_test_view SET (security_invoker = true)
+
+statement ok
+SET ROLE root
+
+# Verify that toggling security_invoker changes privilege behavior.
+# Enable security_invoker and check that invoker_user needs SELECT on base table.
+statement ok
+ALTER VIEW alter_test_view SET (security_invoker = true)
+
+statement ok
+REVOKE ALL on base_t FROM invoker_user
+
+statement ok
+GRANT SELECT ON alter_test_view TO invoker_user
+
+statement ok
+SET ROLE invoker_user
+
+statement error pgcode 42501 user invoker_user does not have SELECT privilege on relation base_t
+SELECT * FROM alter_test_view
+
+statement ok
+SET ROLE root
+
+# Disable security_invoker and verify invoker_user can query via the view.
+statement ok
+ALTER VIEW alter_test_view SET (security_invoker = false)
+
+statement ok
+SET ROLE invoker_user
+
+query IT
+SELECT id, username FROM alter_test_view ORDER BY id
+----
+1  table_owner
+2  view_owner
+3  invoker_user
+4  other
+
+statement ok
+SET ROLE root
+
+# Re-enable security_invoker, then RESET to restore the default (definer).
+statement ok
+ALTER VIEW alter_test_view SET (security_invoker = true)
+
+query TT
+SHOW CREATE VIEW alter_test_view;
+----
+alter_test_view  CREATE VIEW public.alter_test_view (
+                   id,
+                   username
+                 ) WITH (security_invoker = true) AS SELECT id, username FROM sidb.public.base_t;
+
+statement ok
+ALTER VIEW alter_test_view RESET (security_invoker)
+
+# After RESET, security_invoker is false (definer), so SHOW CREATE should
+# not include the WITH clause.
+query TT
+SHOW CREATE VIEW alter_test_view;
+----
+alter_test_view  CREATE VIEW public.alter_test_view (
+                   id,
+                   username
+                 ) AS SELECT id, username FROM sidb.public.base_t;
+
+# Verify the view behaves as definer after RESET: invoker_user can query
+# even without SELECT on the base table.
+statement ok
+SET ROLE invoker_user
+
+query IT
+SELECT id, username FROM alter_test_view ORDER BY id
+----
+1  table_owner
+2  view_owner
+3  invoker_user
+4  other
+
+statement ok
+SET ROLE root
+
+# Create a materialized view. We should see an error for set/reset security_invoker on it.
+statement error pgcode 42601 at or near "with": syntax error
+CREATE MATERIALIZED VIEW mat_view WITH (security_invoker = false) AS SELECT id, username, data FROM base_t;
+
+statement ok
+CREATE MATERIALIZED VIEW mat_view AS SELECT id, username, data FROM base_t;
+
+# Setting security_invoker on a materialized view should fail.
+statement error pgcode 42809 "mat_view" is a materialized view
+ALTER VIEW mat_view SET (security_invoker = true)
+
+# Resetting security_invoker on a materialized view should also fail.
+statement error pgcode 42809 "mat_view" is a materialized view
+ALTER VIEW mat_view RESET (security_invoker)
+
+# SHOW CREATE should not show security_invoker.
+query TT
+SHOW CREATE mat_view;
+----
+mat_view  CREATE MATERIALIZED VIEW public.mat_view (
+            id,
+            username,
+            data,
+            rowid
+          ) AS SELECT id, username, data FROM sidb.public.base_t;
+
+# Verify pg_catalog.pg_class shows NULL in reloptions.
+query TT
+SELECT relname, reloptions FROM pg_catalog.pg_class
+WHERE relname = 'mat_view';
+----
+mat_view  NULL
+
+
+# Clean up alter test view.
+statement ok
+DROP VIEW alter_test_view
+
+statement ok
+DROP MATERIALIZED VIEW mat_view;
+
+subtest end
+
+# ---------------------------------------------------------------------------
+# Part 12: Nested views — all combinations of invoker/definer
+# ---------------------------------------------------------------------------
+subtest nested_views
+
+# Create a base table for nested view tests.
+statement ok
+CREATE TABLE nested_t (
+  id INT PRIMARY KEY,
+  username TEXT,
+  data TEXT
+);
+
+statement ok
+INSERT INTO nested_t VALUES
+  (1, 'view_owner', 'vo-data'),
+  (2, 'invoker_user', 'inv-data'),
+  (3, 'other', 'other-data');
+
+# Grant view_owner access so they can create views referencing nested_t.
+statement ok
+GRANT SELECT ON nested_t TO view_owner;
+
+# Create inner views owned by view_owner.
+statement ok
+SET ROLE view_owner;
+
+statement ok
+CREATE VIEW inner_si WITH (security_invoker = true) AS
+  SELECT id, username, data FROM nested_t;
+
+statement ok
+CREATE VIEW inner_sd WITH (security_invoker = false) AS
+  SELECT id, username, data FROM nested_t;
+
+# Create outer views for all four combinations.
+statement ok
+CREATE VIEW outer_si_si WITH (security_invoker = true) AS
+  SELECT id, username, data FROM inner_si;
+
+statement ok
+CREATE VIEW outer_si_sd WITH (security_invoker = true) AS
+  SELECT id, username, data FROM inner_sd;
+
+statement ok
+CREATE VIEW outer_sd_si WITH (security_invoker = false) AS
+  SELECT id, username, data FROM inner_si;
+
+statement ok
+CREATE VIEW outer_sd_sd WITH (security_invoker = false) AS
+  SELECT id, username, data FROM inner_sd;
+
+statement ok
+SET ROLE root;
+
+# Grant invoker_user SELECT on all views but NOT on nested_t.
+statement ok
+GRANT SELECT ON inner_si TO invoker_user;
+
+statement ok
+GRANT SELECT ON inner_sd TO invoker_user;
+
+statement ok
+GRANT SELECT ON outer_si_si TO invoker_user;
+
+statement ok
+GRANT SELECT ON outer_si_sd TO invoker_user;
+
+statement ok
+GRANT SELECT ON outer_sd_si TO invoker_user;
+
+statement ok
+GRANT SELECT ON outer_sd_sd TO invoker_user;
+
+# Privilege checks 
+statement ok
+SET ROLE invoker_user;
+
+# invoker(invoker): FAIL — privilege check reaches nested_t as invoker_user.
+statement error pgcode 42501 user invoker_user does not have SELECT privilege on relation nested_t
+SELECT * FROM outer_si_si;
+
+# invoker(definer): PASS — inner definer checks nested_t as view_owner.
+query ITT rowsort
+SELECT * FROM outer_si_sd;
+----
+1  view_owner    vo-data
+2  invoker_user  inv-data
+3  other         other-data
+
+# definer(invoker): PASS — outer definer sets privilege user to view_owner,
+# inner invoker inherits that.
+query ITT rowsort
+SELECT * FROM outer_sd_si;
+----
+1  view_owner    vo-data
+2  invoker_user  inv-data
+3  other         other-data
+
+# definer(definer): PASS — inner definer checks nested_t as view_owner.
+query ITT rowsort
+SELECT * FROM outer_sd_sd;
+----
+1  view_owner    vo-data
+2  invoker_user  inv-data
+3  other         other-data
+
+statement ok
+SET ROLE root;
+
+# RLS checks
+statement ok
+ALTER TABLE nested_t ENABLE ROW LEVEL SECURITY;
+
+# view_owner can see all rows.
+statement ok
+CREATE POLICY view_owner_all ON nested_t
+  FOR SELECT TO view_owner USING (true);
+
+# invoker_user can only see their own rows.
+statement ok
+CREATE POLICY invoker_own_rows ON nested_t
+  FOR SELECT TO invoker_user USING (username = current_user);
+
+statement ok
+GRANT SELECT ON nested_t TO invoker_user;
+
+statement ok
+SET ROLE invoker_user;
+
+# invoker(invoker): RLS evaluated as invoker_user — sees only own rows.
+query ITT
+SELECT * FROM outer_si_si;
+----
+2  invoker_user  inv-data
+
+# invoker(definer): RLS evaluated as view_owner — sees all rows.
+query ITT rowsort
+SELECT * FROM outer_si_sd;
+----
+1  view_owner    vo-data
+2  invoker_user  inv-data
+3  other         other-data
+
+# definer(invoker): outer definer sets current_user to view_owner, inner
+# invoker inherits it — RLS evaluated as view_owner, sees all rows.
+query ITT rowsort
+SELECT * FROM outer_sd_si;
+----
+1  view_owner    vo-data
+2  invoker_user  inv-data
+3  other         other-data
+
+# definer(definer): RLS evaluated as view_owner — sees all rows.
+query ITT rowsort
+SELECT * FROM outer_sd_sd;
+----
+1  view_owner    vo-data
+2  invoker_user  inv-data
+3  other         other-data
+
+statement ok
+SET ROLE root;
+
+# Clean up nested view test objects.
+statement ok
+DROP VIEW outer_si_si, outer_si_sd, outer_sd_si, outer_sd_sd;
+
+statement ok
+DROP VIEW inner_si, inner_sd;
+
+statement ok
+DROP TABLE nested_t;
+
+subtest end
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+subtest cleanup
+
+statement ok
+DROP DATABASE IF EXISTS sidb CASCADE;
+
+statement ok
+DROP ROLE IF EXISTS table_owner;
+
+statement ok
+DROP ROLE IF EXISTS view_owner;
+
+statement ok
+DROP ROLE IF EXISTS invoker_user;
+
+subtest end

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -1798,6 +1798,13 @@ func TestLogic_secondary_index_column_families(
 	runLogicTest(t, "secondary_index_column_families")
 }
 
+func TestLogic_security_invoker_view(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "security_invoker_view")
+}
+
 func TestLogic_select(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -1798,6 +1798,13 @@ func TestLogic_secondary_index_column_families(
 	runLogicTest(t, "secondary_index_column_families")
 }
 
+func TestLogic_security_invoker_view(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "security_invoker_view")
+}
+
 func TestLogic_select(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -1819,6 +1819,13 @@ func TestLogic_secondary_index_column_families(
 	runLogicTest(t, "secondary_index_column_families")
 }
 
+func TestLogic_security_invoker_view(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "security_invoker_view")
+}
+
 func TestLogic_select(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-prepared/generated_test.go
+++ b/pkg/sql/logictest/tests/local-prepared/generated_test.go
@@ -1273,6 +1273,13 @@ func TestLogic_secondary_index_column_families(
 	runLogicTest(t, "secondary_index_column_families")
 }
 
+func TestLogic_security_invoker_view(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "security_invoker_view")
+}
+
 func TestLogic_select_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -1819,6 +1819,13 @@ func TestLogic_secondary_index_column_families(
 	runLogicTest(t, "secondary_index_column_families")
 }
 
+func TestLogic_security_invoker_view(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "security_invoker_view")
+}
+
 func TestLogic_select(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -2036,6 +2036,13 @@ func TestLogic_secondary_index_column_families(
 	runLogicTest(t, "secondary_index_column_families")
 }
 
+func TestLogic_security_invoker_view(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "security_invoker_view")
+}
+
 func TestLogic_select(
 	t *testing.T,
 ) {

--- a/pkg/sql/opaque.go
+++ b/pkg/sql/opaque.go
@@ -132,6 +132,10 @@ func planOpaque(ctx context.Context, p *planner, stmt tree.Statement) (planNode,
 		return p.AlterTableSetLogged(ctx, n)
 	case *tree.AlterTableSetSchema:
 		return p.AlterTableSetSchema(ctx, n)
+	case *tree.AlterViewSetOptions:
+		return p.AlterViewSetOptions(ctx, n)
+	case *tree.AlterViewResetOptions:
+		return p.AlterViewResetOptions(ctx, n)
 	case *tree.AlterTenantCapability:
 		return p.AlterTenantCapability(ctx, n)
 	case *tree.AlterTenantSetClusterSetting:
@@ -362,6 +366,8 @@ func init() {
 		&tree.AlterTableOwner{},
 		&tree.AlterTableSetLogged{},
 		&tree.AlterTableSetSchema{},
+		&tree.AlterViewSetOptions{},
+		&tree.AlterViewResetOptions{},
 		&tree.AlterTenantCapability{},
 		&tree.AlterTenantRename{},
 		&tree.AlterTenantSetClusterSetting{},

--- a/pkg/sql/opt/cat/view.go
+++ b/pkg/sql/opt/cat/view.go
@@ -41,8 +41,11 @@ type View interface {
 	// Trigger returns the ith trigger, where i < TriggerCount.
 	Trigger(i int) Trigger
 
+	// IsSecurityInvoker returns true if the view uses SECURITY INVOKER semantics.
+	IsSecurityInvoker() bool
+
 	// Owner returns the username of the view owner.
-	// Used to check view select privileges.
+	// Used for SECURITY DEFINER semantics when security_invoker is false.
 	Owner() username.SQLUsername
 }
 

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -374,10 +374,12 @@ func (b *Builder) buildView(
 			defer func() { b.skipSelectPrivilegeChecks = false }()
 		}
 	} else {
-		defer func(dataSourcePrivilegeUserOverride username.SQLUsername) {
-			b.dataSourcePrivilegeUserOverride = dataSourcePrivilegeUserOverride
-		}(b.dataSourcePrivilegeUserOverride)
-		b.dataSourcePrivilegeUserOverride = view.Owner()
+		if !view.IsSecurityInvoker() {
+			defer func(dataSourcePrivilegeUserOverride username.SQLUsername) {
+				b.dataSourcePrivilegeUserOverride = dataSourcePrivilegeUserOverride
+			}(b.dataSourcePrivilegeUserOverride)
+			b.dataSourcePrivilegeUserOverride = view.Owner()
+		}
 		defer b.DisableUnsafeInternalCheck()()
 		if b.skipSelectPrivilegeChecks {
 			b.skipSelectPrivilegeChecks = false

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -878,6 +878,11 @@ func (tv *View) Trigger(i int) cat.Trigger {
 	return &tv.Triggers[i]
 }
 
+// IsSecurityInvoker is part of the cat.View interface.
+func (tv *View) IsSecurityInvoker() bool {
+	return false
+}
+
 // Owner is part of the cat.View interface.
 func (tv *View) Owner() username.SQLUsername {
 	return username.MakeSQLUsernameFromPreNormalizedString("root")

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -845,6 +845,11 @@ func (ov *optView) Trigger(i int) cat.Trigger {
 	return &ov.triggers[i]
 }
 
+// IsSecurityInvoker is part of the cat.View interface.
+func (ov *optView) IsSecurityInvoker() bool {
+	return ov.desc.IsSecurityInvoker()
+}
+
 // Owner is part of the cat.View interface.
 func (ov *optView) Owner() username.SQLUsername {
 	return ov.desc.GetPrivileges().Owner()

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1237,6 +1237,7 @@ func (u *sqlSymUnion) filterType() tree.FilterType {
 %type <tree.Statement> alter_view_set_schema_stmt
 %type <tree.Statement> alter_view_owner_stmt
 %type <tree.Statement> alter_view_set_options_stmt
+%type <tree.Statement> alter_view_reset_options_stmt
 
 // ALTER SEQUENCE
 %type <tree.Statement> alter_rename_sequence_stmt
@@ -2110,6 +2111,7 @@ alter_view_stmt:
 | alter_view_set_schema_stmt
 | alter_view_owner_stmt
 | alter_view_set_options_stmt
+| alter_view_reset_options_stmt
 // ALTER VIEW has its error help token here because the ALTER VIEW
 // prefix is spread over multiple non-terminals.
 | ALTER VIEW error // SHOW HELP: ALTER VIEW
@@ -12656,23 +12658,19 @@ opt_view_with:
   }
 | WITH '(' SECURITY_INVOKER ')'
   {
-    /* SKIP DOC */
     // security_invoker without value defaults to true
     $$.val = &tree.ViewOptions{SecurityInvoker: true}
   }
 | WITH '(' SECURITY_INVOKER '=' TRUE ')'
   {
-    /* SKIP DOC */
     $$.val = &tree.ViewOptions{SecurityInvoker: true}
   }
 | WITH '(' SECURITY_INVOKER '=' FALSE ')'
   {
-    /* SKIP DOC */
     $$.val = &tree.ViewOptions{SecurityInvoker: false}
   }
 | WITH '(' SECURITY_INVOKER '=' ICONST ')'
   {
-    /* SKIP DOC */
     // Handle integer values: 1 = true, 0 = false
     val, err := $5.numVal().AsInt64()
     if err != nil {
@@ -13301,13 +13299,103 @@ alter_view_owner_stmt:
   }
 
 alter_view_set_options_stmt:
-  ALTER VIEW relation_expr SET '(' SECURITY_INVOKER '=' var_value ')'
+  ALTER VIEW relation_expr SET '(' SECURITY_INVOKER '=' TRUE ')'
   {
-    return unimplemented(sqllex, "ALTER VIEW ... SET (security_invoker = ...) is not yet implemented.")
+    $$.val = &tree.AlterViewSetOptions{
+      Name: $3.unresolvedObjectName(),
+      IfExists: false,
+      Options: &tree.ViewOptions{SecurityInvoker: true},
+    }
   }
-| ALTER VIEW IF EXISTS relation_expr SET '(' SECURITY_INVOKER '=' var_value ')'
+| ALTER VIEW relation_expr SET '(' SECURITY_INVOKER '=' FALSE ')'
   {
-    return unimplemented(sqllex, "ALTER VIEW ... IF EXISTS SET (security_invoker = ...) is not yet implemented.")
+    $$.val = &tree.AlterViewSetOptions{
+      Name: $3.unresolvedObjectName(),
+      IfExists: false,
+      Options: &tree.ViewOptions{SecurityInvoker: false},
+    }
+  }
+| ALTER VIEW relation_expr SET '(' SECURITY_INVOKER '=' ICONST ')'
+  {
+    val, err := $8.numVal().AsInt64()
+    if err != nil { return setErr(sqllex, err) }
+    var si bool
+    if val == 1 {
+      si = true
+    } else if val == 0 {
+      si = false
+    } else {
+      return setErr(sqllex, errors.New("security_invoker accepts only true/false or 1/0"))
+    }
+    $$.val = &tree.AlterViewSetOptions{
+      Name: $3.unresolvedObjectName(),
+      IfExists: false,
+      Options: &tree.ViewOptions{SecurityInvoker: si},
+    }
+  }
+| ALTER VIEW relation_expr SET '(' SECURITY_INVOKER ')'
+  {
+    $$.val = &tree.AlterViewSetOptions{
+      Name: $3.unresolvedObjectName(),
+      IfExists: false,
+      Options: &tree.ViewOptions{SecurityInvoker: true},
+    }
+  }
+| ALTER VIEW IF EXISTS relation_expr SET '(' SECURITY_INVOKER '=' TRUE ')'
+  {
+    $$.val = &tree.AlterViewSetOptions{
+      Name: $5.unresolvedObjectName(),
+      IfExists: true,
+      Options: &tree.ViewOptions{SecurityInvoker: true},
+    }
+  }
+| ALTER VIEW IF EXISTS relation_expr SET '(' SECURITY_INVOKER '=' FALSE ')'
+  {
+    $$.val = &tree.AlterViewSetOptions{
+      Name: $5.unresolvedObjectName(),
+      IfExists: true,
+      Options: &tree.ViewOptions{SecurityInvoker: false},
+    }
+  }
+| ALTER VIEW IF EXISTS relation_expr SET '(' SECURITY_INVOKER '=' ICONST ')'
+  {
+    val, err := $10.numVal().AsInt64()
+    if err != nil { return setErr(sqllex, err) }
+    var si bool
+    if val == 1 {
+      si = true
+    } else if val == 0 {
+      si = false
+    } else {
+      return setErr(sqllex, errors.New("security_invoker accepts only true/false or 1/0"))
+    }
+    $$.val = &tree.AlterViewSetOptions{
+      Name: $5.unresolvedObjectName(),
+      IfExists: true,
+      Options: &tree.ViewOptions{SecurityInvoker: si},
+    }
+  }
+| ALTER VIEW IF EXISTS relation_expr SET '(' SECURITY_INVOKER ')'
+  {
+    $$.val = &tree.AlterViewSetOptions{
+      Name: $5.unresolvedObjectName(),
+      IfExists: true,
+      Options: &tree.ViewOptions{SecurityInvoker: true},
+    }
+  }
+alter_view_reset_options_stmt:
+  ALTER VIEW relation_expr RESET '(' SECURITY_INVOKER ')'
+  {
+    $$.val = &tree.AlterViewResetOptions{
+      Name: $3.unresolvedObjectName(),
+    }
+  }
+| ALTER VIEW IF EXISTS relation_expr RESET '(' SECURITY_INVOKER ')'
+  {
+    $$.val = &tree.AlterViewResetOptions{
+      Name: $5.unresolvedObjectName(),
+      IfExists: true,
+    }
   }
 
 alter_sequence_set_schema_stmt:

--- a/pkg/sql/parser/testdata/alter_view
+++ b/pkg/sql/parser/testdata/alter_view
@@ -62,23 +62,26 @@ ALTER MATERIALIZED VIEW IF EXISTS v RENAME TO v -- fully parenthesized
 ALTER MATERIALIZED VIEW IF EXISTS v RENAME TO v -- literals removed
 ALTER MATERIALIZED VIEW IF EXISTS _ RENAME TO _ -- identifiers removed
 
-error
+parse
 ALTER VIEW v SET (security_invoker = true)
 ----
-----
-at or near ")": syntax error: unimplemented: this syntax
-DETAIL: source SQL:
 ALTER VIEW v SET (security_invoker = true)
-                                         ^
-HINT: You have attempted to use a feature that is not yet implemented.
+ALTER VIEW v SET (security_invoker = true) -- fully parenthesized
+ALTER VIEW v SET (security_invoker = true) -- literals removed
+ALTER VIEW _ SET (security_invoker = true) -- identifiers removed
 
-Please check the public issue tracker to check whether this problem is
-already tracked. If you cannot find it there, please report the error
-with details by creating a new issue.
-
-If you would rather not post publicly, please contact us directly
-using the support form.
-
-We appreciate your feedback.
+parse
+ALTER VIEW v RESET (security_invoker)
 ----
+ALTER VIEW v RESET (security_invoker)
+ALTER VIEW v RESET (security_invoker) -- fully parenthesized
+ALTER VIEW v RESET (security_invoker) -- literals removed
+ALTER VIEW _ RESET (security_invoker) -- identifiers removed
+
+parse
+ALTER VIEW IF EXISTS v RESET (security_invoker)
 ----
+ALTER VIEW IF EXISTS v RESET (security_invoker)
+ALTER VIEW IF EXISTS v RESET (security_invoker) -- fully parenthesized
+ALTER VIEW IF EXISTS v RESET (security_invoker) -- literals removed
+ALTER VIEW IF EXISTS _ RESET (security_invoker) -- identifiers removed

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -815,14 +815,22 @@ https://www.postgresql.org/docs/9.5/catalog-pg-class.html`,
 			relPersistence = relPersistenceTemporary
 		}
 		var relOptions tree.Datum = tree.DNull
-		storageParams, err := table.GetStorageParams(false /* spaceBetweenEqual */)
+		var withOptions []string
+		var err error
+		if table.IsView() && !table.MaterializedView() {
+			// Show view options in reloptions.
+			withOptions, err = table.GetViewOptions(false /* spaceBetweenEqual */)
+		} else {
+			// Show table storage parameters in reloptions.
+			withOptions, err = table.GetStorageParams(false /* spaceBetweenEqual */)
+		}
 		if err != nil {
 			return err
 		}
-		if len(storageParams) > 0 {
+		if len(withOptions) > 0 {
 			relOptionsArr := tree.NewDArray(types.String)
-			for _, storageParam := range storageParams {
-				if err := relOptionsArr.Append(tree.NewDString(storageParam)); err != nil {
+			for _, opt := range withOptions {
+				if err := relOptionsArr.Append(tree.NewDString(opt)); err != nil {
 					return err
 				}
 			}

--- a/pkg/sql/plan_names.go
+++ b/pkg/sql/plan_names.go
@@ -73,6 +73,8 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&alterTableOwnerNode{}):                     "alter table owner",
 	reflect.TypeOf(&alterTableSetLocalityNode{}):               "alter table set locality",
 	reflect.TypeOf(&alterTableSetSchemaNode{}):                 "alter table set schema",
+	reflect.TypeOf(&alterViewSetOptionsNode{}):                 "alter view set options",
+	reflect.TypeOf(&alterViewResetOptionsNode{}):               "alter view reset options",
 	reflect.TypeOf(&alterTenantCapabilityNode{}):               "alter tenant capability",
 	reflect.TypeOf(&alterTenantSetClusterSettingNode{}):        "alter tenant set cluster setting",
 	reflect.TypeOf(&alterTenantServiceNode{}):                  "alter tenant service",

--- a/pkg/sql/sem/tree/alter_table.go
+++ b/pkg/sql/sem/tree/alter_table.go
@@ -800,6 +800,53 @@ func (node *AlterTableOwner) Format(ctx *FmtCtx) {
 	ctx.FormatNode(&node.Owner)
 }
 
+// AlterViewSetOptions represents an ALTER VIEW SET (...) command.
+type AlterViewSetOptions struct {
+	Name     *UnresolvedObjectName
+	IfExists bool
+	Options  *ViewOptions
+}
+
+// TelemetryName returns the telemetry counter to increment
+// when this command is used.
+func (node *AlterViewSetOptions) TelemetryName() string {
+	return "set_options"
+}
+
+// Format implements the NodeFormatter interface.
+func (node *AlterViewSetOptions) Format(ctx *FmtCtx) {
+	ctx.WriteString("ALTER VIEW ")
+	if node.IfExists {
+		ctx.WriteString("IF EXISTS ")
+	}
+	ctx.FormatNode(node.Name)
+	ctx.WriteString(" SET (")
+	node.Options.Format(ctx)
+	ctx.WriteString(")")
+}
+
+// AlterViewResetOptions represents an ALTER VIEW RESET (...) command.
+type AlterViewResetOptions struct {
+	Name     *UnresolvedObjectName
+	IfExists bool
+}
+
+// TelemetryName returns the telemetry counter to increment
+// when this command is used.
+func (node *AlterViewResetOptions) TelemetryName() string {
+	return "reset_options"
+}
+
+// Format implements the NodeFormatter interface.
+func (node *AlterViewResetOptions) Format(ctx *FmtCtx) {
+	ctx.WriteString("ALTER VIEW ")
+	if node.IfExists {
+		ctx.WriteString("IF EXISTS ")
+	}
+	ctx.FormatNode(node.Name)
+	ctx.WriteString(" RESET (security_invoker)")
+}
+
 // AlterTableAddIdentity represents commands to alter a column to an identity.
 type AlterTableAddIdentity struct {
 	Column        Name

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -526,6 +526,28 @@ func (*AlterTableOwner) StatementTag() string { return "ALTER TABLE" }
 
 func (*AlterTableOwner) hiddenFromShowQueries() {}
 
+// StatementReturnType implements the Statement interface.
+func (*AlterViewSetOptions) StatementReturnType() StatementReturnType { return DDL }
+
+// StatementType implements the Statement interface.
+func (*AlterViewSetOptions) StatementType() StatementType { return TypeDDL }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*AlterViewSetOptions) StatementTag() string { return "ALTER VIEW" }
+
+func (*AlterViewSetOptions) hiddenFromShowQueries() {}
+
+// StatementReturnType implements the Statement interface.
+func (*AlterViewResetOptions) StatementReturnType() StatementReturnType { return DDL }
+
+// StatementType implements the Statement interface.
+func (*AlterViewResetOptions) StatementType() StatementType { return TypeDDL }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*AlterViewResetOptions) StatementTag() string { return "ALTER VIEW" }
+
+func (*AlterViewResetOptions) hiddenFromShowQueries() {}
+
 // StatementType implements the Statement interface.
 func (*AlterTableSetLogged) StatementReturnType() StatementReturnType { return DDL }
 
@@ -2600,6 +2622,8 @@ func (n *AlterTableSetNotNull) String() string                { return AsString(
 func (n *AlterTableOwner) String() string                     { return AsString(n) }
 func (n *AlterTableSetLogged) String() string                 { return AsString(n) }
 func (n *AlterTableSetSchema) String() string                 { return AsString(n) }
+func (n *AlterViewSetOptions) String() string                 { return AsString(n) }
+func (n *AlterViewResetOptions) String() string               { return AsString(n) }
 func (n *AlterTenantCapability) String() string               { return AsString(n) }
 func (n *AlterTenantSetClusterSetting) String() string        { return AsString(n) }
 func (n *AlterTenantReset) String() string                    { return AsString(n) }

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -682,8 +682,7 @@ message LocalOnlySessionData {
   // procedure is executed via a portal in the extended wire protocol.
   bool use_proc_txn_control_extended_protocol_fix = 175;
   reserved 176;
-  // AllowViewWithSecurityInvokerClause indicates whether security invoker for views is enabled
-  bool allow_view_with_security_invoker_clause = 177;
+  reserved 177;
   // VectorSearchRerankMultiplier controls how many of the initial search results
   // can be reranked using exact distance calculations with the original
   // full-size vectors. It acts as a multiplier on a base limit derived from the

--- a/pkg/sql/sessionmutator/mutator.go
+++ b/pkg/sql/sessionmutator/mutator.go
@@ -576,10 +576,6 @@ func (m *SessionDataMutator) SetAlterColumnTypeGeneral(val bool) {
 	m.Data.AlterColumnTypeGeneralEnabled = val
 }
 
-func (m *SessionDataMutator) SetAllowViewWithSecurityInvokerClause(val bool) {
-	m.Data.AllowViewWithSecurityInvokerClause = val
-}
-
 func (m *SessionDataMutator) SetEnableOverrideAlterPrimaryRegionInSuperRegion(val bool) {
 	m.Data.OverrideAlterPrimaryRegionInSuperRegion = val
 }

--- a/pkg/sql/show_create_clauses.go
+++ b/pkg/sql/show_create_clauses.go
@@ -135,8 +135,20 @@ func ShowCreateView(
 			f.WriteRune(',')
 		}
 	}
-	f.WriteString(") AS ")
+	f.WriteString(")")
 
+	// Add view options if any exist
+	viewOptions, err := desc.GetViewOptions(true /* spaceBetweenEqual */)
+	if err != nil {
+		return "", err
+	}
+	if len(viewOptions) > 0 {
+		f.WriteString(" WITH (")
+		f.WriteString(strings.Join(viewOptions, ", "))
+		f.WriteString(")")
+	}
+
+	f.WriteString(" AS ")
 	cfg := tree.DefaultPrettyCfg()
 	cfg.UseTabs = true
 	cfg.LineWidth = 100 - cfg.TabWidth

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -2167,22 +2167,8 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
-	`allow_view_with_security_invoker_clause`: {
-		Hidden:       true,
-		GetStringVal: makePostgresBoolGetStringValFn(`allow_view_with_security_invoker_clause`),
-		Set: func(_ context.Context, m sessionmutator.SessionDataMutator, s string) error {
-			b, err := paramparse.ParseBoolVar("allow_view_with_security_invoker_clause", s)
-			if err != nil {
-				return err
-			}
-			m.SetAllowViewWithSecurityInvokerClause(b)
-			return nil
-		},
-		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
-			return formatBoolAsPostgresSetting(evalCtx.SessionData().AllowViewWithSecurityInvokerClause), nil
-		},
-		GlobalDefault: globalFalse,
-	},
+	// This is only kept for backwards compatibility and no longer has any effect.
+	`allow_view_with_security_invoker_clause`: makeBackwardsCompatBoolVar("allow_view_with_security_invoker_clause", true),
 
 	// TODO(rytaft): remove this once unique without index constraints are fully
 	// supported.


### PR DESCRIPTION
Previously, CRDB did not support setting security_invoker for viewes.
This led to inconsistent behaviour for privileges and RLS on viewes
where the view would use the creator's privileges and the invoker's RLS.
With this change, security_invoker is stored in the view descriptor as
an option, and it will be used to query views.

Part of: https://github.com/cockroachdb/cockroach/issues/138918

Release note: None