### PR TITLE
backup: skip TestStrictPartitionedBackup

### DIFF
--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -11280,6 +11280,7 @@ func TestStrictLocalityAwareBackup(t *testing.T) {
 func TestStrictPartitionedBackup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.WithIssue(t, 163998)
 	skip.UnderDuress(t, "takes too long under duress")
 
 	knobs := base.TestingKnobs{


### PR DESCRIPTION
## Summary
- Skip `TestStrictPartitionedBackup` due to flakiness.

Fixes #163998

Release note: None

🤖 Generated with [Claude Code](https://claude.com/claude-code)