### PR TITLE
sql: add pgcode to home region enum value removal error

### DIFF
--- a/pkg/sql/type_change.go
+++ b/pkg/sql/type_change.go
@@ -1083,7 +1083,8 @@ func (t *typeSchemaChanger) canRemoveEnumValueFromTable(
 			return err
 		}
 		if catpb.RegionName(member.LogicalRepresentation) == homedRegion {
-			return errors.Newf("could not remove enum value %q as it is the home region for table %q",
+			return pgerror.Newf(pgcode.DependentObjectsStillExist,
+				"could not remove enum value %q as it is the home region for table %q",
 				member.LogicalRepresentation, desc.GetName())
 		}
 	}


### PR DESCRIPTION
The error returned when attempting to remove an enum value that is the home region for a regional by table table was missing a pgcode. This caused the jobs framework to log it as an "unexpected error" rather than a clean user-facing failure. Add pgcode.DependentObjectsStillExist to match the pattern used by the adjacent enum-value-in-use check.

Epic: None

Release note: None