### PR TITLE
fix: upgrade Go to 1.26.0 to resolve Go standard library CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cockroachdb/cockroach
 
-go 1.25.5
+go 1.26.0
 
 // golang.org/x/* packages are maintained and curated by the go project, just
 // without the backwards compatibility promises the standard library, and thus


### PR DESCRIPTION
## Summary
Upgrades Go version to 1.26.0 to fix critical vulnerabilities in the Go standard library.

## CVEs Fixed
- CVE-2025-68121 (CRITICAL): crypto/tls session resumption vulnerability
- CVE-2025-61726 (HIGH): net/url memory exhaustion
- CVE-2025-61728 (HIGH): archive/zip CPU consumption

This is a minimal version bump fix.