### PR TITLE
release-25.4: workload/schemachange: disable triggers testing

### DIFF
--- a/pkg/workload/schemachange/optype.go
+++ b/pkg/workload/schemachange/optype.go
@@ -305,7 +305,7 @@ var opWeights = []int{
 	createSequence:                    1,
 	createTable:                       10,
 	createTableAs:                     1,
-	createTrigger:                     1,
+	createTrigger:                     0, /* Not GA and breaks with DROP TABLE CASCADE */
 	createTypeEnum:                    1,
 	createTypeComposite:               1,
 	createView:                        1,
@@ -315,7 +315,7 @@ var opWeights = []int{
 	dropSchema:                        1,
 	dropSequence:                      1,
 	dropTable:                         1,
-	dropTrigger:                       1,
+	dropTrigger:                       0, /* Not GA and breaks with DROP TABLE CASCADE */
 	dropView:                          1,
 	renameIndex:                       1,
 	renameSequence:                    1,


### PR DESCRIPTION
Previously, we could run into errors dropping objects because the triggers implementation on 25.4 has bugs during cascaded drop scenarios. Since this work is not GA in this release, we are going to opt to have the workload skip CREATE TRIGGER / DROP TRIGGER operations in the random workload.

Fixes: #163474

Release note: None
Release justification: test only change 