### PR TITLE
restore: use normal target span size for dist online restore

### DIFF
--- a/pkg/backup/restore_job.go
+++ b/pkg/backup/restore_job.go
@@ -489,7 +489,7 @@ func restore(
 	defer introducedSpanFrontier.Release()
 
 	targetSize := targetRestoreSpanSize.Get(&execCtx.ExecCfg().Settings.SV)
-	if details.OnlineImpl() {
+	if details.OnlineImpl() && !onlineRestoreUseDistFlow.Get(&execCtx.ExecCfg().Settings.SV) {
 		targetSize = targetOnlineRestoreSpanSize.Get(&execCtx.ExecCfg().Settings.SV)
 	}
 	maxFileCount := maxFileCount.Get(&execCtx.ExecCfg().Settings.SV)


### PR DESCRIPTION
Previously this was using the online-restore 'coarse split' size, which is 16gb on the assumption that the goroutines doing fine splits would then split to 400mb. But in distSQL online restore, the split and scatter processor expects to get the 'fine' splits directly from span generation and then chunks them. So when using the DistSQL path we should gnerate fine splits here, not coarse ones.

Release note: none.
Epic: none.