### PR TITLE
[DNM] kvserver: repro for context depth accumulation in store rebalancer

### DIFF
--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -296,8 +296,21 @@ func (r *RebalanceContext) logRemainingHotRanges(ctx context.Context) {
 func (sr *StoreRebalancer) Start(ctx context.Context, stopper *stop.Stopper) {
 	ctx = sr.AnnotateCtx(ctx)
 
-	// Start a goroutine that watches and proactively renews certain
-	// expiration-based leases.
+	_ = stopper.RunAsyncTask(ctx, "store-rebalancer-ctx-depth", func(ctx context.Context) {
+		for i := 0; i < 250_000; i++ {
+			sr.AddLogTag("obj", i)
+			ctx = sr.AnnotateCtx(ctx)
+		}
+		for {
+			sr.AddLogTag("obj", "test")
+			ctx = sr.AnnotateCtx(ctx)
+
+			_, cancel := context.WithTimeout(ctx, time.Second) // nolint:context
+			cancel()
+			time.Sleep(10 * time.Millisecond)
+		}
+	})
+
 	_ = stopper.RunAsyncTask(ctx, "store-rebalancer", func(ctx context.Context) {
 		var timer timeutil.Timer
 		defer timer.Stop()


### PR DESCRIPTION
## Summary

Repro for a performance issue where `AnnotateCtx` in the store rebalancer loop
accumulates `valueCtx` wrappers on `release-24.3` (where `logtags.AddTags` uses
`context.WithValue`). After enough loop iterations, context operations like
`Deadline()` have to walk the entire chain, causing severe slowdowns.

Builds a 200K-deep context chain at startup and then repeatedly calls
`context.WithTimeout` on it to make the issue observable.

Do not merge.

Epic: none
Release note: None


Made with [Cursor](https://cursor.com)