### PR TITLE
sql,kv: plumb workloadID for ASH sampling

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
@@ -4129,6 +4129,8 @@ func TestBatchHeaderFieldsAreAccountedForInBufferedWrites(t *testing.T) {
 		"HasBufferedAllPrecedingWrites": iSwearFieldDoesNotNeedHandling,
 		// Our flush should never need isReverse.
 		"IsReverse": fieldIsHandledByBatchSplitting,
+		// Observability label, doesn't affect batch processing.
+		"WorkloadID": iSwearFieldDoesNotNeedHandling,
 	}
 
 	header := kvpb.Header{}

--- a/pkg/kv/kvclient/kvstreamer/streamer.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer.go
@@ -403,6 +403,7 @@ func NewStreamer(
 	lockStrength lock.Strength,
 	lockDurability lock.Durability,
 	reverse bool,
+	workloadID uint64,
 ) *Streamer {
 	if txn.Type() != kv.LeafTxn {
 		panic(errors.AssertionFailedf("RootTxn is given to the Streamer"))
@@ -447,6 +448,7 @@ func NewStreamer(
 		lockWaitPolicy:         lockWaitPolicy,
 		requestAdmissionHeader: txn.AdmissionHeader(),
 		responseAdmissionQ:     txn.DB().SQLKVResponseAdmissionQ,
+		workloadID:             workloadID,
 	}
 	s.coordinator.asyncSem = quotapool.NewIntPool(
 		"single Streamer async concurrency",
@@ -918,6 +920,9 @@ type workerCoordinator struct {
 	// For request and response admission control.
 	requestAdmissionHeader kvpb.AdmissionHeader
 	responseAdmissionQ     *admission.WorkQueue
+	// workloadID is the identifier for the workload that triggered this
+	// request (e.g. statement fingerprint ID) for ASH sampling.
+	workloadID uint64
 }
 
 // mainLoop runs throughout the lifetime of the Streamer (from the first Enqueue
@@ -1557,6 +1562,7 @@ func (w *workerCoordinator) performRequestAsync(
 				TenantID:   roachpb.SystemTenantID,
 				Priority:   admissionpb.WorkPriority(w.requestAdmissionHeader.Priority),
 				CreateTime: w.requestAdmissionHeader.CreateTime,
+				WorkloadID: w.workloadID,
 			}
 			if _, err = w.responseAdmissionQ.Admit(ctx, responseAdmission); err != nil {
 				log.VEventf(ctx, 2, "dropping response: admission control: %v", err)

--- a/pkg/kv/kvclient/kvstreamer/streamer_accounting_test.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer_accounting_test.go
@@ -104,6 +104,7 @@ func TestStreamerMemoryAccounting(t *testing.T) {
 			lock.None,
 			lock.Unreplicated,
 			reverse,
+			0, /* workloadID */
 		)
 		s.Init(OutOfOrder, Hints{UniqueRequests: true}, 1 /* maxKeysPerRow */, nil /* diskBuffer */)
 		return s

--- a/pkg/kv/kvclient/kvstreamer/streamer_test.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer_test.go
@@ -74,6 +74,7 @@ func getStreamer(
 		lock.None,
 		lock.Unreplicated,
 		reverse,
+		0, /* workloadID */
 	)
 }
 
@@ -136,6 +137,7 @@ func TestStreamerLimitations(t *testing.T) {
 				lock.None,
 				lock.Unreplicated,
 				false, /* reverse */
+				0,     /* workloadID */
 			)
 		})
 	})

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -3022,9 +3022,13 @@ message Header {
   // evaluated in descending range order.
   bool is_reverse = 38;
 
+  // workload_id identifies the workload that triggered this batch (statement
+  // fingerprint ID, job ID, etc.). Used for ASH sampling and profiling.
+  uint64 workload_id = 39 [(gogoproto.customname) = "WorkloadID"];
+
   reserved 7, 10, 12, 14, 20, 24;
 
-  // Next ID: 39
+  // Next ID: 40
 }
 
 message WriteOptions {

--- a/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
@@ -62,6 +62,7 @@ func ReverseScan(
 		DontInterleaveIntents:   cArgs.DontInterleaveIntents,
 		ReadCategory:            readCategory,
 		ReturnRawMVCCValues:     args.ReturnRawMVCCValues,
+		WorkloadID:              h.WorkloadID,
 	}
 
 	switch args.ScanFormat {

--- a/pkg/kv/kvserver/batcheval/cmd_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_scan.go
@@ -64,6 +64,7 @@ func Scan(
 		DontInterleaveIntents:   cArgs.DontInterleaveIntents,
 		ReadCategory:            readCategory,
 		ReturnRawMVCCValues:     args.ReturnRawMVCCValues,
+		WorkloadID:              h.WorkloadID,
 	}
 
 	switch args.ScanFormat {

--- a/pkg/kv/kvserver/kvadmission/kvadmission.go
+++ b/pkg/kv/kvserver/kvadmission/kvadmission.go
@@ -726,6 +726,7 @@ func workInfoForBatch(
 		Priority:        admissionpb.WorkPriority(ba.AdmissionHeader.Priority),
 		CreateTime:      createTime,
 		BypassAdmission: bypassAdmission,
+		WorkloadID:      ba.Header.WorkloadID,
 	}
 	return admissionInfo
 }

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -82,6 +82,16 @@ type Txn struct {
 	// It will be attached to all requests sent through this transaction.
 	gatewayNodeID roachpb.NodeID
 
+	// workloadID, if != 0, is the identifier for the workload that is using
+	// this transaction (e.g., statement fingerprint ID, job ID). It will be
+	// attached to all requests sent through this transaction.
+	// Note(alyshan): This field can change during the lifetime of the Txn, this
+	// is safe to do since the only use case of doing so involves no concurrent
+	// access of this field. This is when the connExecutor is serving a multi-statement
+	// transaction. In that case, statements are executed sequentially, and the
+	// workloadID is updated after each statement.
+	workloadID uint64
+
 	// The following fields are not safe for concurrent modification.
 	// They should be set before operating on the transaction.
 
@@ -439,6 +449,12 @@ func (txn *Txn) DebugName() string {
 
 func (txn *Txn) debugNameLocked() string {
 	return fmt.Sprintf("%s (id: %s)", txn.mu.debugName, txn.mu.ID)
+}
+
+// SetWorkloadID sets the workload ID for ASH sampling.
+// Automatically propagated to all BatchRequests sent through this transaction.
+func (txn *Txn) SetWorkloadID(workloadID uint64) {
+	txn.workloadID = workloadID
 }
 
 // SetBufferedWritesEnabled toggles whether the writes are buffered on the
@@ -1351,6 +1367,10 @@ func (txn *Txn) Send(
 	// place I found to set this field.
 	if txn.gatewayNodeID != 0 {
 		ba.Header.GatewayNodeID = txn.gatewayNodeID
+	}
+
+	if txn.workloadID != 0 && ba.Header.WorkloadID == 0 {
+		ba.Header.WorkloadID = txn.workloadID
 	}
 
 	// Requests with a bounded staleness header should use NegotiateAndSend.

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -782,6 +782,7 @@ go_test(
         "values_test.go",
         "virtual_schema_test.go",
         "virtual_table_test.go",
+        "workload_id_test.go",
         "zone_test.go",
     ],
     data = glob(["testdata/**"]) + [

--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -224,6 +224,8 @@ type cFetcherArgs struct {
 
 	// tenantID is required in some places for AC/bookkeeping.
 	tenantID roachpb.TenantID
+	// workloadID is used for ASH sampling.
+	workloadID uint64
 }
 
 // noOutputColumn is a sentinel value to denote that a system column is not
@@ -566,7 +568,10 @@ func (cf *cFetcher) Init(
 			cf.pacer = cf.txn.DB().AdmissionPacerFactory.NewPacer(
 				50*time.Millisecond, // Request a realistic per-batch amount.
 				admission.WorkInfo{
-					TenantID: cf.tenantID, Priority: pri, CreateTime: timeutil.Now().UnixNano(),
+					TenantID:   cf.tenantID,
+					Priority:   pri,
+					CreateTime: timeutil.Now().UnixNano(),
+					WorkloadID: cf.workloadID,
 				},
 			)
 		}

--- a/pkg/sql/colfetcher/cfetcher_wrapper.go
+++ b/pkg/sql/colfetcher/cfetcher_wrapper.go
@@ -177,6 +177,7 @@ func newCFetcherWrapper(
 	nextKVer storage.NextKVer,
 	startKey roachpb.Key,
 	mustSerialize bool,
+	workloadID uint64,
 ) (_ storage.CFetcherWrapper, retErr error) {
 	// At the moment, we always serialize the columnar batches if they contain
 	// enums, so it is safe to handle enum types without proper hydration - we
@@ -239,6 +240,7 @@ func newCFetcherWrapper(
 		alwaysReallocate,
 		nil, /* txn; TODO(dt): this means no AC priority info is passed. */
 		tenantID,
+		workloadID,
 	}
 
 	// This memory monitor is not connected to the memory accounting system

--- a/pkg/sql/colfetcher/colbatch_direct_scan.go
+++ b/pkg/sql/colfetcher/colbatch_direct_scan.go
@@ -238,6 +238,7 @@ func NewColBatchDirectScan(
 		kvFetcherMemAcc,
 		flowCtx.EvalCtx.TestingKnobs.ForceProductionValues,
 		spec.FetchSpec.External,
+		flowCtx.EvalCtx.WorkloadID,
 	)
 	var hasDatumVec bool
 	for _, t := range tableArgs.typs {

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -380,6 +380,7 @@ func NewColBatchScan(
 		kvFetcherMemAcc,
 		flowCtx.EvalCtx.TestingKnobs.ForceProductionValues,
 		spec.FetchSpec.External,
+		flowCtx.EvalCtx.WorkloadID,
 	)
 	fetcher := cFetcherPool.Get().(*cFetcher)
 	shouldCollectStats := execstats.ShouldCollectStats(ctx, flowCtx.CollectStats)
@@ -392,6 +393,7 @@ func NewColBatchScan(
 		false, /* alwaysReallocate */
 		flowCtx.Txn,
 		flowCtx.Codec().TenantID,
+		flowCtx.EvalCtx.WorkloadID,
 	}
 	if err = fetcher.Init(fetcherAllocator, kvFetcher, tableArgs); err != nil {
 		fetcher.Release()

--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -637,6 +637,7 @@ func NewColIndexJoin(
 			kvFetcherMemAcc,
 			spec.FetchSpec.External,
 			tableArgs.RequiresRawMVCCValues(),
+			flowCtx.EvalCtx.WorkloadID,
 		)
 	} else {
 		kvFetcher = row.NewKVFetcher(
@@ -652,6 +653,7 @@ func NewColIndexJoin(
 			kvFetcherMemAcc,
 			flowCtx.EvalCtx.TestingKnobs.ForceProductionValues,
 			spec.FetchSpec.External,
+			flowCtx.EvalCtx.WorkloadID,
 		)
 	}
 
@@ -668,6 +670,7 @@ func NewColIndexJoin(
 		false, /* alwaysReallocate */
 		txn,
 		flowCtx.Codec().TenantID,
+		flowCtx.EvalCtx.WorkloadID,
 	}
 	if err = fetcher.Init(
 		fetcherAllocator, kvFetcher, tableArgs,

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -513,6 +513,10 @@ type admissionOptions struct {
 
 // remoteComponentCreator is an interface that abstracts the constructors for
 // several components in a remote flow. Mostly for testing purposes.
+// TODO(alyshan): #164542 Will need to plumb workload info through to these
+// interface methods so remote components can instrument their work. Why does
+// outbox get the flowCtx but not inbox? Workload info will be present in
+// flowCtx.EvalCtx.
 type remoteComponentCreator interface {
 	newOutbox(
 		flowCtx *execinfra.FlowCtx,

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -656,6 +656,13 @@ func (ex *connExecutor) execStmtInOpenState(
 	ctx = ih.Setup(ctx, ex, p, &stmt, os.ImplicitTxn.Get(),
 		ex.state.mu.priority, ex.state.mu.autoRetryCounter)
 
+	// Set workload ID for ASH sampling. ih.Setup already computed the
+	// statement fingerprint ID, so reuse it here.
+	p.extendedEvalCtx.WorkloadID = uint64(ih.fingerprintId)
+	if p.txn != nil {
+		p.txn.SetWorkloadID(uint64(ih.fingerprintId))
+	}
+
 	// Note that here we always unconditionally defer a function that takes care
 	// of finishing the instrumentation helper. This is needed since in order to
 	// support plan-gist-matching of the statement diagnostics we might not know
@@ -1726,6 +1733,13 @@ func (ex *connExecutor) execStmtInOpenStateWithPausablePortal(
 	p.extendedEvalCtx.Annotations = &p.semaCtx.Annotations
 	p.semaCtx.Placeholders.Assign(pinfo, vars.stmt.NumPlaceholders)
 	p.extendedEvalCtx.Placeholders = &p.semaCtx.Placeholders
+
+	// Set workload ID for ASH sampling. ih.Setup already computed the
+	// statement fingerprint ID, so reuse it here.
+	p.extendedEvalCtx.WorkloadID = uint64(ih.fingerprintId)
+	if p.txn != nil {
+		p.txn.SetWorkloadID(uint64(ih.fingerprintId))
+	}
 
 	if buildutil.CrdbTestBuild {
 		// Ensure that each statement is formatted regardless of logging

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -281,7 +281,9 @@ func (ds *ServerImpl) setupFlow(
 		// The flow will run in a LeafTxn because we do not want each distributed
 		// Txn to heartbeat the transaction.
 		nodeID := roachpb.NodeID(req.Flow.Gateway)
-		return kv.NewLeafTxn(ctx, ds.DB.KV(), nodeID, tis, &req.LeafTxnAdmissionHeader), nil
+		leafTxn := kv.NewLeafTxn(ctx, ds.DB.KV(), nodeID, tis, &req.LeafTxnAdmissionHeader)
+		leafTxn.SetWorkloadID(req.EvalContext.WorkloadID)
+		return leafTxn, nil
 	}
 
 	var evalCtx *eval.Context
@@ -378,6 +380,7 @@ func (ds *ServerImpl) setupFlow(
 		evalCtx.SetStmtTimestamp(timeutil.Unix(0 /* sec */, req.EvalContext.StmtTimestampNanos))
 		evalCtx.SetTxnTimestamp(timeutil.Unix(0 /* sec */, req.EvalContext.TxnTimestampNanos))
 		evalCtx.TestingKnobs.ForceProductionValues = req.EvalContext.TestingKnobsForceProductionValues
+		evalCtx.WorkloadID = req.EvalContext.WorkloadID
 
 		if ds.SQLCPUProvider != nil {
 			var cpuHandle *admission.SQLCPUHandle

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -395,6 +395,7 @@ func serializeEvalContext(evalCtx *eval.Context) execinfrapb.EvalContext {
 		StmtTimestampNanos:                evalCtx.StmtTimestamp.UnixNano(),
 		TxnTimestampNanos:                 evalCtx.TxnTimestamp.UnixNano(),
 		TestingKnobsForceProductionValues: evalCtx.TestingKnobs.ForceProductionValues,
+		WorkloadID:                        evalCtx.WorkloadID,
 	}
 }
 
@@ -474,9 +475,10 @@ func (dsp *DistSQLPlanner) setupFlows(
 		StatementSQL:      statementSQL,
 	}
 	if localState.IsLocal {
-		// VectorizeMode is the only field that the setup code expects to be set
+		// VectorizeMode, and workloadID are the only fields that the setup code expects to be set
 		// in the local flows.
 		setupReq.EvalContext.SessionData.VectorizeMode = evalCtx.SessionData().VectorizeMode
+		setupReq.EvalContext.WorkloadID = evalCtx.WorkloadID
 	} else {
 		// In distributed plans populate some extra state.
 		setupReq.EvalContext = serializeEvalContext(evalCtx)

--- a/pkg/sql/execinfrapb/api.proto
+++ b/pkg/sql/execinfrapb/api.proto
@@ -87,6 +87,9 @@ message EvalContext {
   reserved 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14;
   optional sessiondatapb.SessionData session_data = 15 [(gogoproto.nullable) = false];
   optional bool testing_knobs_force_production_values = 16  [(gogoproto.nullable) = false];
+  // WorkloadID for ASH sampling.
+  optional uint64 workload_id = 17 [(gogoproto.nullable) = false,
+    (gogoproto.customname) = "WorkloadID"];
 }
 
 message SimpleResponse {

--- a/pkg/sql/flowinfra/flow.go
+++ b/pkg/sql/flowinfra/flow.go
@@ -331,6 +331,7 @@ func NewFlowBase(
 	// within SQL (not KV), so using an arbitrary tenant is ok -- we choose to
 	// use SystemTenantID since it is already defined.
 	admissionInfo := admission.WorkInfo{TenantID: roachpb.SystemTenantID}
+	admissionInfo.WorkloadID = flowCtx.EvalCtx.WorkloadID
 	if flowCtx.Txn == nil {
 		admissionInfo.Priority = admissionpb.NormalPri
 		admissionInfo.CreateTime = timeutil.Now().UnixNano()

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -353,6 +353,9 @@ type FetcherInitArgs struct {
 	// row is being processed. In practice, this means that span IDs must be
 	// passed in when SpansCanOverlap is true.
 	SpansCanOverlap bool
+	// WorkloadID is the identifier for the workload that triggered this fetch
+	// (e.g. statement fingerprint ID, job ID) for ASH sampling.
+	WorkloadID uint64
 }
 
 // Init sets up a Fetcher for a given table and index.
@@ -518,6 +521,7 @@ func (rf *Fetcher) Init(ctx context.Context, args FetcherInitArgs) error {
 			kvPairsRead:                &kvPairsRead,
 			batchRequestsIssued:        &batchRequestsIssued,
 			kvCPUTime:                  &kvCPUTime,
+			workloadID:                 args.WorkloadID,
 		}
 		if args.Txn != nil {
 			fetcherArgs.sendFn = makeSendFunc(args.Txn, args.Spec.External, &batchRequestsIssued, &kvCPUTime)

--- a/pkg/sql/row/kv_batch_fetcher.go
+++ b/pkg/sql/row/kv_batch_fetcher.go
@@ -216,6 +216,8 @@ type txnKVFetcher struct {
 	requestAdmissionHeader kvpb.AdmissionHeader
 	responseAdmissionQ     *admission.WorkQueue
 	admissionPacer         *admission.Pacer
+	// workloadID is the statement fingerprint ID or job ID for ASH sampling.
+	workloadID uint64
 }
 
 var _ KVBatchFetcher = &txnKVFetcher{}
@@ -368,6 +370,7 @@ type newTxnKVFetcherArgs struct {
 	batchRequestsIssued        *int64
 	kvCPUTime                  *int64
 	rawMVCCValues              bool
+	workloadID                 uint64
 
 	admission struct { // groups AC-related fields
 		requestHeader  kvpb.AdmissionHeader
@@ -398,6 +401,7 @@ func newTxnKVFetcherInternal(args newTxnKVFetcherArgs) *txnKVFetcher {
 		forceProductionKVBatchSize: args.forceProductionKVBatchSize,
 		requestAdmissionHeader:     args.admission.requestHeader,
 		responseAdmissionQ:         args.admission.responseQ,
+		workloadID:                 args.workloadID,
 	}
 
 	f.maybeInitAdmissionPacer(
@@ -446,6 +450,7 @@ func (f *txnKVFetcher) maybeInitAdmissionPacer(
 				TenantID:   roachpb.SystemTenantID,
 				Priority:   admissionPri,
 				CreateTime: admissionHeader.CreateTime,
+				WorkloadID: f.workloadID,
 			})
 	}
 }
@@ -776,6 +781,7 @@ func (f *txnKVFetcher) maybeAdmitBatchResponse(ctx context.Context, br *kvpb.Bat
 			TenantID:   roachpb.SystemTenantID,
 			Priority:   admissionpb.WorkPriority(f.requestAdmissionHeader.Priority),
 			CreateTime: f.requestAdmissionHeader.CreateTime,
+			WorkloadID: f.workloadID,
 		}
 		if _, err := f.responseAdmissionQ.Admit(ctx, responseAdmission); err != nil {
 			return err

--- a/pkg/sql/row/kv_fetcher.go
+++ b/pkg/sql/row/kv_fetcher.go
@@ -61,6 +61,7 @@ func newTxnKVFetcher(
 	acc *mon.BoundAccount,
 	forceProductionKVBatchSize bool,
 	ext *fetchpb.IndexFetchSpec_ExternalRowData,
+	workloadID uint64,
 ) *txnKVFetcher {
 	alloc := new(struct {
 		batchRequestsIssued int64
@@ -117,6 +118,7 @@ func newTxnKVFetcher(
 		kvPairsRead:                &alloc.kvPairsRead,
 		batchRequestsIssued:        &alloc.batchRequestsIssued,
 		kvCPUTime:                  &alloc.kvCPUTime,
+		workloadID:                 workloadID,
 	}
 	fetcherArgs.admission.requestHeader = txn.AdmissionHeader()
 	fetcherArgs.admission.responseQ = txn.DB().SQLKVResponseAdmissionQ
@@ -148,10 +150,11 @@ func NewDirectKVBatchFetcher(
 	acc *mon.BoundAccount,
 	forceProductionKVBatchSize bool,
 	ext *fetchpb.IndexFetchSpec_ExternalRowData,
+	workloadID uint64,
 ) KVBatchFetcher {
 	f := newTxnKVFetcher(
 		txn, bsHeader, reverse, rawMVCCValues, lockStrength, lockWaitPolicy, lockDurability,
-		lockTimeout, deadlockTimeout, acc, forceProductionKVBatchSize, ext,
+		lockTimeout, deadlockTimeout, acc, forceProductionKVBatchSize, ext, workloadID,
 	)
 	f.scanFormat = kvpb.COL_BATCH_RESPONSE
 	f.indexFetchSpec = spec
@@ -177,10 +180,11 @@ func NewKVFetcher(
 	acc *mon.BoundAccount,
 	forceProductionKVBatchSize bool,
 	ext *fetchpb.IndexFetchSpec_ExternalRowData,
+	workloadID uint64,
 ) *KVFetcher {
 	return newKVFetcher(newTxnKVFetcher(
 		txn, bsHeader, reverse, rawMVCCValues, lockStrength, lockWaitPolicy, lockDurability,
-		lockTimeout, deadlockTimeout, acc, forceProductionKVBatchSize, ext,
+		lockTimeout, deadlockTimeout, acc, forceProductionKVBatchSize, ext, workloadID,
 	))
 }
 
@@ -208,6 +212,7 @@ func NewStreamingKVFetcher(
 	kvFetcherMemAcc *mon.BoundAccount,
 	ext *fetchpb.IndexFetchSpec_ExternalRowData,
 	rawMVCCValues bool,
+	workloadID uint64,
 ) *KVFetcher {
 	var kvPairsRead int64
 	var batchRequestsIssued int64
@@ -229,6 +234,7 @@ func NewStreamingKVFetcher(
 		GetKeyLockingStrength(lockStrength),
 		GetKeyLockingDurability(lockDurability),
 		reverse,
+		workloadID,
 	)
 	mode := kvstreamer.OutOfOrder
 	if maintainOrdering {

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -307,6 +307,7 @@ func newInvertedJoiner(
 			Spec:                       &spec.FetchSpec,
 			TraceKV:                    flowCtx.TraceKV,
 			ForceProductionKVBatchSize: flowCtx.EvalCtx.TestingKnobs.ForceProductionValues,
+			WorkloadID:                 flowCtx.EvalCtx.WorkloadID,
 		},
 	); err != nil {
 		return nil, err

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -595,6 +595,7 @@ func newJoinReader(
 			&jr.streamerInfo.txnKVStreamerMemAcc,
 			spec.FetchSpec.External,
 			row.FetchSpecRequiresRawMVCCValues(spec.FetchSpec),
+			flowCtx.EvalCtx.WorkloadID,
 		)
 	} else {
 		// When not using the Streamer API, we want to limit the batch size hint
@@ -624,6 +625,7 @@ func newJoinReader(
 			TraceKV:                    flowCtx.TraceKV,
 			ForceProductionKVBatchSize: flowCtx.EvalCtx.TestingKnobs.ForceProductionValues,
 			SpansCanOverlap:            jr.spansCanOverlap,
+			WorkloadID:                 flowCtx.EvalCtx.WorkloadID,
 		},
 	); err != nil {
 		return nil, err

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -151,6 +151,7 @@ func newTableReader(
 			Spec:                       &spec.FetchSpec,
 			TraceKV:                    flowCtx.TraceKV,
 			ForceProductionKVBatchSize: flowCtx.EvalCtx.TestingKnobs.ForceProductionValues,
+			WorkloadID:                 flowCtx.EvalCtx.WorkloadID,
 		},
 	); err != nil {
 		return nil, err

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -477,6 +477,7 @@ func (z *zigzagJoiner) setupInfo(
 			Spec:                       &spec.FetchSpec,
 			TraceKV:                    flowCtx.TraceKV,
 			ForceProductionKVBatchSize: flowCtx.EvalCtx.TestingKnobs.ForceProductionValues,
+			WorkloadID:                 flowCtx.EvalCtx.WorkloadID,
 		},
 	); err != nil {
 		return err

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -360,6 +360,9 @@ type Context struct {
 	// thumb is: the cached memo, either in query cache or prepared stmt,
 	// are always for stable stats.
 	UseCanaryStats bool
+
+	// WorkloadID for ASH sampling.
+	WorkloadID uint64
 }
 
 // RoutineStatementCounters encapsulates metrics for tracking the execution

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -92,6 +92,8 @@ type tableWriterBase struct {
 	// originally written with before being replicated via Logical Data
 	// Replication.
 	originTimestamp hlc.Timestamp
+	// workloadID is the statement fingerprint ID or job ID for ASH sampling.
+	workloadID uint64
 }
 
 var maxBatchBytes = settings.RegisterByteSizeSetting(
@@ -119,6 +121,7 @@ func (tb *tableWriterBase) init(
 		tb.deadlockTimeout = evalCtx.SessionData().DeadlockTimeout
 		tb.originID = evalCtx.SessionData().OriginIDForLogicalDataReplication
 		tb.originTimestamp = evalCtx.SessionData().OriginTimestampForLogicalDataReplication
+		tb.workloadID = evalCtx.WorkloadID
 	}
 	tb.forceProductionBatchSizes = evalCtx != nil && evalCtx.TestingKnobs.ForceProductionValues
 	tb.maxBatchSize = mutations.MaxBatchSize(tb.forceProductionBatchSizes)
@@ -211,6 +214,7 @@ func (tb *tableWriterBase) tryDoResponseAdmission(ctx context.Context) error {
 			TenantID:   roachpb.SystemTenantID,
 			Priority:   admissionpb.WorkPriority(requestAdmissionHeader.Priority),
 			CreateTime: requestAdmissionHeader.CreateTime,
+			WorkloadID: tb.workloadID,
 		}
 		if _, err := responseAdmissionQ.Admit(ctx, responseAdmission); err != nil {
 			return err

--- a/pkg/sql/workload_id_test.go
+++ b/pkg/sql/workload_id_test.go
@@ -1,0 +1,284 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package sql_test
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilitiespb"
+	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/admission"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWorkloadIDPropagation verifies that workload IDs (statement fingerprint
+// IDs) are correctly propagated through three paths:
+//
+//  1. Transaction → KV BatchRequest headers (tested via TestingRequestFilter).
+//  2. Row fetcher / KV streamer → admission control WorkInfo (tested via
+//     WorkQueueAdmitInterceptor). This verifies that the fetcher and streamer
+//     init args correctly pass workloadID to admission.
+//  3. DistSQL remote flows → leaf transaction via EvalContext serialization
+//     (tested via TestingRequestFilter on a multi-node cluster).
+func TestWorkloadIDPropagation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	var batchMu syncutil.Mutex
+	seenBatchIDs := make(map[uint64]struct{})
+
+	var admissionMu syncutil.Mutex
+	seenAdmissionIDs := make(map[uint64]struct{})
+
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			Store: &kvserver.StoreTestingKnobs{
+				TestingRequestFilter: func(_ context.Context, ba *kvpb.BatchRequest) *kvpb.Error {
+					if ba.Header.WorkloadID != 0 {
+						batchMu.Lock()
+						seenBatchIDs[ba.Header.WorkloadID] = struct{}{}
+						batchMu.Unlock()
+					}
+					return nil
+				},
+			},
+			AdmissionControl: &admission.TestingKnobs{
+				WorkQueueAdmitInterceptor: func(info admission.WorkInfo) {
+					if info.WorkloadID != 0 {
+						admissionMu.Lock()
+						seenAdmissionIDs[info.WorkloadID] = struct{}{}
+						admissionMu.Unlock()
+					}
+				},
+			},
+			SQLStatsKnobs: &sqlstats.TestingKnobs{
+				SynchronousSQLStats: true,
+			},
+		},
+	})
+	defer s.Stopper().Stop(ctx)
+
+	runner := sqlutils.MakeSQLRunner(db)
+
+	const appName = "workload_id_test"
+	runner.Exec(t, "SET application_name = $1", appName)
+	runner.Exec(t, "CREATE TABLE t (id INT PRIMARY KEY, v INT)")
+	runner.Exec(t, "INSERT INTO t VALUES (1, 10), (2, 20), (3, 30)")
+
+	clearBatchIDs := func() {
+		batchMu.Lock()
+		seenBatchIDs = make(map[uint64]struct{})
+		batchMu.Unlock()
+	}
+	getBatchIDs := func() map[uint64]struct{} {
+		batchMu.Lock()
+		defer batchMu.Unlock()
+		result := make(map[uint64]struct{}, len(seenBatchIDs))
+		maps.Copy(result, seenBatchIDs)
+		return result
+	}
+	clearAdmissionIDs := func() {
+		admissionMu.Lock()
+		seenAdmissionIDs = make(map[uint64]struct{})
+		admissionMu.Unlock()
+	}
+	getAdmissionIDs := func() map[uint64]struct{} {
+		admissionMu.Lock()
+		defer admissionMu.Unlock()
+		result := make(map[uint64]struct{}, len(seenAdmissionIDs))
+		maps.Copy(result, seenAdmissionIDs)
+		return result
+	}
+
+	// assertWorkloadIDMatch verifies that at least one captured workload ID
+	// matches a fingerprint from statement_statistics for the given query
+	// substring.
+	assertWorkloadIDMatch := func(
+		t *testing.T,
+		r *sqlutils.SQLRunner,
+		app string,
+		querySubstring string,
+		captured map[uint64]struct{},
+	) {
+		t.Helper()
+		require.NotEmpty(t, captured, "expected non-zero workload IDs for %q", querySubstring)
+
+		rows := r.Query(t,
+			`SELECT encode(fingerprint_id, 'hex')
+			 FROM crdb_internal.cluster_statement_statistics
+			 WHERE app_name = $1
+			   AND strpos(metadata->>'query', $2) > 0`,
+			app, querySubstring,
+		)
+		defer rows.Close()
+		var hexFPs []string
+		for rows.Next() {
+			var hexFP string
+			require.NoError(t, rows.Scan(&hexFP))
+			hexFPs = append(hexFPs, hexFP)
+		}
+		require.NotEmpty(t, hexFPs,
+			"no matching fingerprints in statement_statistics for %q", querySubstring)
+
+		statsFingerprints := make(map[string]struct{}, len(hexFPs))
+		for _, fp := range hexFPs {
+			statsFingerprints[fp] = struct{}{}
+		}
+		found := false
+		for wid := range captured {
+			encoded := sqlstatsutil.EncodeStmtFingerprintIDToString(
+				appstatspb.StmtFingerprintID(wid),
+			)
+			if _, ok := statsFingerprints[encoded]; ok {
+				found = true
+				break
+			}
+		}
+		require.True(t, found,
+			"no captured workload ID matched any fingerprint in statement_statistics; "+
+				"stats fingerprints: %v, captured IDs: %s",
+			hexFPs, capturedIDsString(captured))
+	}
+
+	// Verify that txn.SetWorkloadID propagates to KV BatchRequest headers.
+	// All fetcher/streamer variants share this same txn-level path, so a
+	// single SELECT suffices.
+	t.Run("batch_request", func(t *testing.T) {
+		clearBatchIDs()
+		runner.Exec(t, "SELECT * FROM t WHERE id = 1")
+		captured := getBatchIDs()
+		assertWorkloadIDMatch(t, runner, appName, "SELECT * FROM t WHERE", captured)
+	})
+
+	// Verify that fetcher and streamer init args correctly propagate
+	// workloadID into admission control WorkInfo structs. This is distinct
+	// from the batch_request test: the txn already carries workloadID
+	// regardless of the fetcher, but the admission WorkInfo is only populated
+	// if the fetcher/streamer received workloadID through its init args.
+	t.Run("response_admission", func(t *testing.T) {
+		// Row fetcher path: a basic scan goes through
+		// txnKVFetcher.responseAdmissionQ.Admit() with WorkInfo.WorkloadID.
+		t.Run("row_fetcher", func(t *testing.T) {
+			clearAdmissionIDs()
+			runner.Exec(t, "SELECT * FROM t WHERE v > 0")
+			captured := getAdmissionIDs()
+			assertWorkloadIDMatch(t, runner, appName,
+				"SELECT * FROM t WHERE v", captured)
+		})
+
+		// Streamer path: a lookup join goes through the KV streamer's
+		// responseAdmissionQ.Admit() with WorkInfo.WorkloadID.
+		t.Run("streamer", func(t *testing.T) {
+			runner.Exec(t, "CREATE TABLE IF NOT EXISTS t2 (id INT PRIMARY KEY, data INT)")
+			runner.Exec(t, "INSERT INTO t2 VALUES (10, 100), (20, 200), (30, 300)")
+			clearAdmissionIDs()
+			runner.Exec(t, "SELECT count(*) FROM t INNER LOOKUP JOIN t2 ON t.v = t2.id")
+			captured := getAdmissionIDs()
+			assertWorkloadIDMatch(t, runner, appName, "LOOKUP JOIN t2", captured)
+		})
+	})
+
+	// Test that DistSQL remote flows propagate the workload ID through leaf
+	// txn creation in distsql/server.go. This exercises a genuinely different
+	// code path: the workloadID is serialized in the EvalContext protobuf,
+	// transmitted to remote nodes, and set on the leaf transaction.
+	t.Run("distsql_remote", func(t *testing.T) {
+		var clusterMu syncutil.Mutex
+		clusterSeenIDs := make(map[uint64]struct{})
+
+		clusterFilter := func(_ context.Context, ba *kvpb.BatchRequest) *kvpb.Error {
+			if ba.Header.WorkloadID != 0 {
+				clusterMu.Lock()
+				clusterSeenIDs[ba.Header.WorkloadID] = struct{}{}
+				clusterMu.Unlock()
+			}
+			return nil
+		}
+
+		tc := serverutils.StartCluster(t, 3, base.TestClusterArgs{
+			ReplicationMode: base.ReplicationManual,
+			ServerArgs: base.TestServerArgs{
+				Knobs: base.TestingKnobs{
+					Store: &kvserver.StoreTestingKnobs{
+						TestingRequestFilter: clusterFilter,
+					},
+					SQLStatsKnobs: &sqlstats.TestingKnobs{
+						SynchronousSQLStats: true,
+					},
+				},
+			},
+		})
+		defer tc.Stopper().Stop(ctx)
+
+		if tc.DefaultTenantDeploymentMode().IsExternal() {
+			tc.GrantTenantCapabilities(ctx, t, serverutils.TestTenantID(),
+				map[tenantcapabilitiespb.ID]string{tenantcapabilitiespb.CanAdminRelocateRange: "true"})
+		}
+
+		clusterDB := tc.ServerConn(0)
+		clusterRunner := sqlutils.MakeSQLRunner(clusterDB)
+
+		const clusterAppName = "workload_id_test_distsql"
+		clusterRunner.Exec(t, "SET application_name = $1", clusterAppName)
+		clusterRunner.Exec(t, "CREATE TABLE td (id INT PRIMARY KEY, v INT)")
+		clusterRunner.Exec(t, "INSERT INTO td SELECT generate_series(1, 30), generate_series(1, 30)")
+
+		// Split the table into 3 ranges and relocate them to different nodes.
+		clusterRunner.Exec(t, "ALTER TABLE td SPLIT AT VALUES (10), (20)")
+		clusterRunner.ExecSucceedsSoon(t, fmt.Sprintf(
+			"ALTER TABLE td EXPERIMENTAL_RELOCATE VALUES (ARRAY[%d], 1), (ARRAY[%d], 10), (ARRAY[%d], 20)",
+			tc.Server(0).GetFirstStoreID(),
+			tc.Server(1).GetFirstStoreID(),
+			tc.Server(2).GetFirstStoreID(),
+		))
+
+		// Populate the range cache so the gateway knows where the ranges are.
+		clusterRunner.Exec(t, "SELECT count(*) FROM td")
+
+		// Force DistSQL to create remote flows with leaf txns.
+		clusterRunner.Exec(t, "SET distsql = always")
+
+		clusterMu.Lock()
+		clusterSeenIDs = make(map[uint64]struct{})
+		clusterMu.Unlock()
+
+		clusterRunner.Exec(t, "SELECT * FROM td WHERE v > 0")
+
+		clusterMu.Lock()
+		captured := make(map[uint64]struct{}, len(clusterSeenIDs))
+		maps.Copy(captured, clusterSeenIDs)
+		clusterMu.Unlock()
+
+		assertWorkloadIDMatch(t, clusterRunner, clusterAppName,
+			"SELECT * FROM td WHERE v", captured)
+	})
+}
+
+// capturedIDsString formats captured workload IDs for diagnostic output.
+func capturedIDsString(ids map[uint64]struct{}) string {
+	parts := make([]string, 0, len(ids))
+	for id := range ids {
+		hex := sqlstatsutil.EncodeStmtFingerprintIDToString(appstatspb.StmtFingerprintID(id))
+		parts = append(parts, fmt.Sprintf("%d(%s)", id, hex))
+	}
+	return strings.Join(parts, ", ")
+}

--- a/pkg/storage/col_mvcc.go
+++ b/pkg/storage/col_mvcc.go
@@ -162,6 +162,7 @@ var GetCFetcherWrapper func(
 	nextKVer NextKVer,
 	startKey roachpb.Key,
 	mustSerialize bool,
+	workloadID uint64,
 ) (CFetcherWrapper, error)
 
 // onNextKVFn represents the transition that the mvccScanFetchAdapter needs to
@@ -460,6 +461,7 @@ func mvccScanToCols(
 		&adapter,
 		key,
 		mustSerialize,
+		opts.WorkloadID,
 	)
 	if err != nil {
 		return MVCCScanResult{}, err

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -4940,6 +4940,9 @@ type MVCCScanOptions struct {
 	// roachpb.Value whose RawBytes may contain MVCCValueHeader
 	// data.
 	ReturnRawMVCCValues bool
+	// WorkloadID identifies the workload that triggered the scan (e.g.
+	// statement fingerprint ID, job ID). Used for ASH sampling.
+	WorkloadID uint64
 }
 
 func (opts *MVCCScanOptions) validate() error {

--- a/pkg/util/admission/elastic_cpu_grant_coordinator.go
+++ b/pkg/util/admission/elastic_cpu_grant_coordinator.go
@@ -15,7 +15,10 @@ import (
 )
 
 func makeElasticCPUGrantCoordinator(
-	ambientCtx log.AmbientContext, st *cluster.Settings, registry *metric.Registry,
+	ambientCtx log.AmbientContext,
+	st *cluster.Settings,
+	registry *metric.Registry,
+	knobs *TestingKnobs,
 ) *ElasticCPUGrantCoordinator {
 	schedulerLatencyListenerMetrics := makeSchedulerLatencyListenerMetrics()
 	registry.AddMetricStruct(schedulerLatencyListenerMetrics)
@@ -30,7 +33,7 @@ func makeElasticCPUGrantCoordinator(
 	elasticCPUInternalWorkQueue := &WorkQueue{}
 	initWorkQueue(elasticCPUInternalWorkQueue, ambientCtx, KVWork, "kv-elastic-cpu-queue", elasticCPUGranter, st,
 		elasticWorkQueueMetrics,
-		workQueueOptions{mode: usesTokens}, nil /* knobs */) // will be closed by the embedding *ElasticCPUWorkQueue
+		workQueueOptions{mode: usesTokens}, knobs.observeOnlyKnobs()) // will be closed by the embedding *ElasticCPUWorkQueue
 	elasticCPUWorkQueue := makeElasticCPUWorkQueue(st, elasticCPUInternalWorkQueue, elasticCPUGranter, elasticCPUGranterMetrics)
 	elasticCPUGrantCoordinator := newElasticCPUGrantCoordinator(elasticCPUGranter, elasticCPUWorkQueue, schedulerLatencyListener)
 	elasticCPUGranter.setRequester(elasticCPUInternalWorkQueue)

--- a/pkg/util/admission/grant_coordinator.go
+++ b/pkg/util/admission/grant_coordinator.go
@@ -213,7 +213,7 @@ func NewGrantCoordinators(
 			slotsCoord:   slotsCoord,
 			cpuTimeCoord: cpuTimeTokenCoord,
 		},
-		ElasticCPU: makeElasticCPUGrantCoordinator(ambientCtx, st, registry),
+		ElasticCPU: makeElasticCPUGrantCoordinator(ambientCtx, st, registry, knobs),
 	}
 }
 
@@ -263,7 +263,9 @@ func makeRegularGrantCoordinator(
 
 	kvSlotAdjuster.granter = kvg
 	wqMetrics := makeWorkQueueMetrics(KVWork.String(), registry)
-	req := makeRequester(ambientCtx, KVWork, kvg, st, wqMetrics, makeWorkQueueOptions(KVWork))
+	kvOpts := makeWorkQueueOptions(KVWork)
+	kvOpts.knobs = knobs.observeOnlyKnobs()
+	req := makeRequester(ambientCtx, KVWork, kvg, st, wqMetrics, kvOpts)
 	coord.queues[KVWork] = req
 	kvg.requester = req
 	coord.granters[KVWork] = kvg
@@ -276,8 +278,9 @@ func makeRegularGrantCoordinator(
 		cpuOverload:          kvSlotAdjuster,
 	}
 	wqMetrics = makeWorkQueueMetrics(SQLKVResponseWork.String(), registry)
-	req = makeRequester(
-		ambientCtx, SQLKVResponseWork, tg, st, wqMetrics, makeWorkQueueOptions(SQLKVResponseWork))
+	sqlKVOpts := makeWorkQueueOptions(SQLKVResponseWork)
+	sqlKVOpts.knobs = knobs.observeOnlyKnobs()
+	req = makeRequester(ambientCtx, SQLKVResponseWork, tg, st, wqMetrics, sqlKVOpts)
 	coord.queues[SQLKVResponseWork] = req
 	tg.requester = req
 	coord.granters[SQLKVResponseWork] = tg
@@ -290,8 +293,9 @@ func makeRegularGrantCoordinator(
 		cpuOverload:          kvSlotAdjuster,
 	}
 	wqMetrics = makeWorkQueueMetrics(SQLSQLResponseWork.String(), registry)
-	req = makeRequester(ambientCtx,
-		SQLSQLResponseWork, tg, st, wqMetrics, makeWorkQueueOptions(SQLSQLResponseWork))
+	sqlSQLOpts := makeWorkQueueOptions(SQLSQLResponseWork)
+	sqlSQLOpts.knobs = knobs.observeOnlyKnobs()
+	req = makeRequester(ambientCtx, SQLSQLResponseWork, tg, st, wqMetrics, sqlSQLOpts)
 	coord.queues[SQLSQLResponseWork] = req
 	tg.requester = req
 	coord.granters[SQLSQLResponseWork] = tg

--- a/pkg/util/admission/testing_knobs.go
+++ b/pkg/util/admission/testing_knobs.go
@@ -27,6 +27,12 @@ type TestingKnobs struct {
 		createTime int64,
 	)
 
+	// WorkQueueAdmitInterceptor, if set, is called at the start of every
+	// WorkQueue.Admit call with the WorkInfo being submitted. Tests can use
+	// this to observe what workload information reaches admission control
+	// (e.g. to verify WorkloadID propagation).
+	WorkQueueAdmitInterceptor func(info WorkInfo)
+
 	// DisableWorkQueueFastPath disables the fast-path in work queues.
 	DisableWorkQueueFastPath bool
 
@@ -50,6 +56,24 @@ type TestingKnobs struct {
 	// DisableCPUTimeTokenSQLBypass disables the functionality which
 	// has SQL work bypass AC, in case CPU time token AC is enabled.
 	DisableCPUTimeTokenSQLBypass bool
+}
+
+// observeOnlyKnobs returns a TestingKnobs that includes only observation
+// hooks (like WorkQueueAdmitInterceptor) without behavioral overrides (like
+// DisableWorkQueueGranting and DisableWorkQueueFastPath). This is used for
+// non-store work queues (regular CPU, elastic CPU) where behavioral knobs
+// intended for store-level flow control tests would interfere with cluster
+// startup and normal operation.
+func (t *TestingKnobs) observeOnlyKnobs() *TestingKnobs {
+	if t == nil {
+		return nil
+	}
+	if t.WorkQueueAdmitInterceptor == nil {
+		return nil
+	}
+	return &TestingKnobs{
+		WorkQueueAdmitInterceptor: t.WorkQueueAdmitInterceptor,
+	}
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -187,6 +187,8 @@ type WorkInfo struct {
 	// ReplicatedWorkInfo groups everything needed to admit replicated writes, done
 	// so asynchronously below-raft as part of replication admission control.
 	ReplicatedWorkInfo ReplicatedWorkInfo
+	// WorkloadID is used for ASH sampling.
+	WorkloadID uint64
 }
 
 // ReplicatedWorkInfo groups everything needed to admit replicated writes, done
@@ -327,6 +329,8 @@ type workQueueOptions struct {
 	// The background resetting of used and GC'ing of tenants can be disabled
 	// for tests.
 	disableGCTenantsAndResetUsed bool
+	// knobs, if set, provides testing knobs to the work queue.
+	knobs *TestingKnobs
 }
 
 func makeWorkQueueOptions(workKind WorkKind) workQueueOptions {
@@ -356,7 +360,7 @@ func makeWorkQueue(
 	if workKind == KVWork {
 		queueKind = "kv-regular-cpu-queue"
 	}
-	initWorkQueue(q, ambientCtx, workKind, queueKind, granter, settings, metrics, opts, nil)
+	initWorkQueue(q, ambientCtx, workKind, queueKind, granter, settings, metrics, opts, opts.knobs)
 	return q
 }
 
@@ -627,6 +631,9 @@ type AdmitResponse struct {
 // AdmitResponse.Enabled=true && error==nil, and the WorkKind for this
 // queue is KVWork.
 func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, error) {
+	if fn := q.knobs.WorkQueueAdmitInterceptor; fn != nil {
+		fn(info)
+	}
 	if !info.ReplicatedWorkInfo.Enabled {
 		enabledSetting := admissionControlEnabledSettings[q.workKind]
 		if enabledSetting != nil && !enabledSetting.Get(&q.settings.SV) {


### PR DESCRIPTION
Propagate the statement fingerprint ID (workloadID) from SQL execution
through DistSQL flows, row/columnar fetchers, KV streamer, and
transactions into BatchRequest headers. On the KV server side, thread
workloadID from the batch header through MVCCScanOptions into the
cFetcherWrapper so that KV-server-side direct columnar scans (via
cmd_scan and cmd_reverse_scan) also carry the correct workloadID.

The workloadID originates in the connExecutor, which sets it in two
places: the eval context (evalCtx.WorkloadID) and the transaction
(txn.SetWorkloadID). The eval context carries the ID into DistSQL via
the flow context (flowCtx), where individual operators — table readers,
join readers, inverted joiners, zigzag joiners, columnar batch scans,
index joins, and table writers — can use it to instrument their own
work and to pass it down to their underlying fetchers. The
transaction is the centralized point for issuing BatchRequests, so
setting the workloadID there ensures every KV request carries it
without each caller needing to propagate it individually.

This enables all the components (including admission control) involved
in SQL execution to attribute their work to specific statements for ASH
sampling. The workloadID is threaded into admission control at three levels:

- SQL-side CPU admission: DistSQL flow setup sets it on the flow's
  admissionInfo.
- SQL-side response admission: row fetchers, the KV streamer, and
  table writers set it on response admission WorkInfo.
- KV-side request admission: kvadmission reads it from the
  BatchRequest header.

Resolves: https://github.com/cockroachdb/cockroach/issues/164198
Release note: None

For more infomation about ASH, see the design doc: https://docs.google.com/document/d/164fCBKytBGiRDPPMezQDGGiQClVW0wJLAzCEmwb2QKo/edit?usp=sharing