### PR TITLE
dev-inf: fix autosolve workflow failures

### DIFF
--- a/.github/workflows/issue-autosolve.yml
+++ b/.github/workflows/issue-autosolve.yml
@@ -173,6 +173,7 @@ jobs:
         id: implement
         if: steps.assess_result.outputs.assessment == 'PROCEED'
         env:
+          CLAUDE_CODE_USE_VERTEX: "1"
           ANTHROPIC_VERTEX_PROJECT_ID: vertex-model-runners
           CLOUD_ML_REGION: us-east5
           ISSUE_TITLE: ${{ github.event.issue.title }}
@@ -237,9 +238,9 @@ jobs:
                 --allowedTools "Read,Write,Edit,Grep,Glob,Bash(gh issue view:*),Bash(./dev test:*),Bash(./dev testlogic:*),Bash(./dev build:*),Bash(./dev generate:*),Bash(git add:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*)" \
                 > "$EXECUTION_FILE" 2> "$STDERR_FILE" || CLAUDE_EXIT_CODE=$?
             else
-              # Retry - resume existing session
+              # Retry - resume existing session with a retry prompt
               echo "Resuming session $SESSION_ID..."
-              claude --print \
+              echo "The previous attempt did not succeed. Please try again to fix the issue. Remember to end your response with IMPLEMENTATION_RESULT - SUCCESS or IMPLEMENTATION_RESULT - FAILED." | claude --print \
                 --resume "$SESSION_ID" \
                 --model claude-opus-4-6 \
                 --output-format json \
@@ -528,6 +529,7 @@ jobs:
 
       - name: Comment on issue - Failed
         if: |
+          always() &&
           (steps.implement.conclusion == 'failure' ||
            steps.implement_result.outputs.implementation == 'FAILED') &&
           steps.assess_result.outputs.assessment != 'SKIP'

--- a/.github/workflows/pr-autosolve-comments.yml
+++ b/.github/workflows/pr-autosolve-comments.yml
@@ -445,7 +445,10 @@ Co-Authored-By: Claude <noreply@anthropic.com>"
           gh pr comment ${{ github.event.pull_request.number }} --body-file "$COMMENT_FILE"
 
       - name: Post failure comment
-        if: steps.claude_result.outputs.changes_status == 'FAILED'
+        if: |
+          always() &&
+          (steps.claude_result.outputs.changes_status == 'FAILED' ||
+           (steps.address.conclusion == 'failure' && steps.claude_result.conclusion != 'success'))
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CLAUDE_RESULT: ${{ steps.claude_result.outputs.result }}


### PR DESCRIPTION
## Summary

Fixes several issues causing the issue-autosolve workflow to fail silently:

- **Add missing `CLAUDE_CODE_USE_VERTEX` env var** — Stage 2 invokes the Claude CLI directly (not via `claude-code-action`), but was missing the env var that tells the CLI to use Vertex AI. Without it, the CLI defaults to the direct Anthropic API, finds no `ANTHROPIC_API_KEY`, and exits immediately with code 1 on every retry.

- **Add `always()` to failure comment steps** — Both `issue-autosolve.yml` and `pr-autosolve-comments.yml` had failure-notification steps that were unreachable. In GitHub Actions, `if:` conditions without a status check function are implicitly prefixed with `success() &&`, which short-circuits to false after a step failure.

- **Pipe retry prompt on session resume** — The retry path used `claude --print --resume $SESSION_ID` without providing any stdin input. The CLI would receive EOF and fail immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)