### PR TITLE
opt: add rules to eliminate Select/Project over zero-card inputs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/apply_join
+++ b/pkg/sql/logictest/testdata/logic_test/apply_join
@@ -502,8 +502,6 @@ SELECT
         AS tab_130098 (col_218772)
       JOIN (VALUES ('14:54:42.42701':::TIME)) AS tab_130099 (col_218773) ON (tab_130098.col_218772) = (tab_130099.col_218773)
       FULL JOIN (VALUES (tab_130094.col_218765)) AS tab_130100 (col_218774) ON NULL
-    WHERE
-      NULL
     GROUP BY
       tab_130098.col_218772, tab_130100.col_218774
     LIMIT

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -1139,13 +1139,8 @@ EXPLAIN (TYPES) SELECT 2*count(k) as z, v FROM t WHERE v>123 GROUP BY v HAVING v
 distribution: local
 vectorized: true
 ·
-• render
-│ columns: (z int, v int)
-│ render z: ((count)[int] * (2)[int])[int]
-│ render v: (v)[int]
-│
-└── • norows
-      columns: (v int, count int)
+• norows
+  columns: (z int, v int)
 
 query T
 EXPLAIN (TYPES) DELETE FROM t WHERE v > 1

--- a/pkg/sql/opt/exec/explain/testdata/row_level_security
+++ b/pkg/sql/opt/exec/explain/testdata/row_level_security
@@ -290,10 +290,8 @@ UPDATE writer SET key = key * 10;
 │ auto commit
 │ policies: p_select
 │
-└── • render
-    │
-    └── • norows
-          policies: applied (filtered all rows)
+└── • norows
+      policies: applied (filtered all rows)
 
 exec-ddl
 CREATE POLICY p_update1 ON writer FOR UPDATE USING (key = 5)  WITH CHECK (value like 'updater: %')

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -3212,7 +3212,7 @@ inner-join (hash)
 # Regression tests for #116943.
 
 # Semi-joins with right side cardinality of 0 have cardinality of 0.
-norm disable=(EliminateExistsZeroRows,SimplifyZeroCardinalitySemiJoin)
+norm disable=(EliminateExistsZeroRows,SimplifyZeroCardinalitySemiJoin,EliminateZeroCardSelect,EliminateZeroCardProject)
 SELECT * FROM mn WHERE m = 5 AND n::FLOAT IN (SELECT x::FLOAT FROM xysd WHERE false)
 ----
 project
@@ -3277,7 +3277,7 @@ project
                 └── variable: x:11 [type=float]
 
 # Anti-joins with right side cardinality of 0 have cardinality equal to left side cardinality.
-norm disable=(EliminateExistsZeroRows,EliminateAntiJoin)
+norm disable=(EliminateExistsZeroRows,EliminateAntiJoin,EliminateZeroCardSelect,EliminateZeroCardProject)
 SELECT * FROM mn WHERE m = 5 AND n::FLOAT NOT IN (SELECT x::FLOAT FROM xysd WHERE false)
 ----
 anti-join (cross)

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -3246,7 +3246,7 @@ CREATE TABLE t84478 (
 )
 ----
 
-norm disable=SimplifyLeftJoinWithZeroRowsRight
+norm disable=(SimplifyLeftJoinWithZeroRowsRight,EliminateZeroCardSelect,EliminateZeroCardProject)
 SELECT
   NULL, 1
 FROM

--- a/pkg/sql/opt/norm/rules/project.opt
+++ b/pkg/sql/opt/norm/rules/project.opt
@@ -371,3 +371,19 @@ $input
     (Project $input $projections $passthrough)
     $leakproofPermeable
 )
+
+# EliminateZeroCardProject eliminates a Project when its input has zero
+# cardinality. The projection expressions are per-row and will never be
+# evaluated, so it is safe to remove them regardless of volatility. This
+# complements the SimplifyZeroCardinalityGroup rule which requires the entire
+# expression to be leakproof.
+[EliminateZeroCardProject, Normalize]
+(Project
+    $input:* & (HasZeroRows $input) & (IsLeakproof $input)
+    $projections:*
+    $passthrough:*
+)
+=>
+(ConstructEmptyValues
+    (UnionCols $passthrough (ProjectionCols $projections))
+)

--- a/pkg/sql/opt/norm/rules/select.opt
+++ b/pkg/sql/opt/norm/rules/select.opt
@@ -654,3 +654,13 @@ $input
         (IsNot $left (Null (AnyType)))
     )
 )
+
+# EliminateZeroCardSelect eliminates a Select when its input has zero
+# cardinality. The filter expressions are per-row and will never be evaluated,
+# so it is safe to remove them regardless of volatility. This complements the
+# SimplifyZeroCardinalityGroup rule which requires the entire expression to be
+# leakproof.
+[EliminateZeroCardSelect, Normalize]
+(Select $input:* & (HasZeroRows $input) $filters:*)
+=>
+$input

--- a/pkg/sql/opt/norm/testdata/rules/project
+++ b/pkg/sql/opt/norm/testdata/rules/project
@@ -1447,7 +1447,7 @@ CREATE TABLE t74241 (
 )
 ----
 
-norm
+norm disable=(EliminateZeroCardSelect,EliminateZeroCardProject)
 INSERT INTO t74241 (a, b, c)
 SELECT tmp.b, tmp.b, tmp.d FROM t74241 AS tmp
 WHERE false

--- a/pkg/sql/opt/norm/testdata/rules/zero_cardinality
+++ b/pkg/sql/opt/norm/testdata/rules/zero_cardinality
@@ -104,7 +104,7 @@ values
  ├── key: ()
  └── fd: ()-->(1-5)
 
-norm expect=SimplifyZeroCardinalityGroup
+norm expect=SimplifyZeroCardinalityGroup disable=EliminateZeroCardProject
 SELECT * FROM (SELECT CASE WHEN k < 0 THEN 3 / 0 ELSE 3 END FROM b) WHERE false
 ----
 project
@@ -132,3 +132,268 @@ scan c
  │         └── false [constraints=(contradiction; tight)]
  ├── key: (1)
  └── fd: (1)-->(2)
+
+# --------------------------------------------------
+# EliminateZeroCardSelect
+# --------------------------------------------------
+
+# Select with immutable (non-leakproof) filter over zero-cardinality input.
+norm expect=EliminateZeroCardSelect
+SELECT * FROM (SELECT * FROM b WHERE false) WHERE i::FLOAT8 IS NAN
+----
+values
+ ├── columns: k:1!null i:2!null f:3!null s:4!null j:5!null
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1-5)
+
+# Volatile filter over zero-cardinality input. The rule should fire even with
+# volatile expressions like random() since zero rows means the filter is never
+# evaluated.
+norm expect=EliminateZeroCardSelect
+SELECT * FROM (SELECT * FROM b WHERE false) WHERE random() < 0.5
+----
+values
+ ├── columns: k:1!null i:2!null f:3!null s:4!null j:5!null
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1-5)
+
+# Multiple non-leakproof filter conditions (AND).
+norm expect=EliminateZeroCardSelect
+SELECT * FROM (SELECT * FROM b WHERE false) WHERE i::FLOAT8 > 0 AND s::CHAR = 'x'
+----
+values
+ ├── columns: k:1!null i:2!null f:3!null s:4!null j:5!null
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1-5)
+
+# Zero cardinality from LIMIT 0 rather than WHERE false.
+norm expect=EliminateZeroCardSelect
+SELECT * FROM (SELECT * FROM b LIMIT 0) WHERE i::FLOAT8 IS NAN
+----
+values
+ ├── columns: k:1!null i:2!null f:3!null s:4!null j:5!null
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1-5)
+
+# Filter with subquery over zero-cardinality input.
+norm expect=EliminateZeroCardSelect
+SELECT * FROM (SELECT * FROM b WHERE false) WHERE i::FLOAT8 IN (SELECT k::FLOAT8 FROM a)
+----
+values
+ ├── columns: k:1!null i:2!null f:3!null s:4!null j:5!null
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1-5)
+
+# Select does not fire when input is not zero-cardinality.
+norm expect-not=EliminateZeroCardSelect
+SELECT * FROM b WHERE i::FLOAT8 IS NAN
+----
+select
+ ├── columns: k:1!null i:2 f:3 s:4!null j:5
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan b
+ │    ├── columns: k:1!null i:2 f:3 s:4!null j:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters
+      └── i:2::FLOAT8 = NaN [outer=(2), immutable]
+
+# Select does not fire when input is not leakproof.
+norm expect-not=EliminateZeroCardSelect
+SELECT * FROM (SELECT * FROM (SELECT * FROM b FOR UPDATE) WHERE false) WHERE i::FLOAT8 IS NAN
+----
+select
+ ├── columns: k:1!null i:2 f:3 s:4!null j:5
+ ├── cardinality: [0 - 0]
+ ├── volatile
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan b
+ │    ├── columns: k:1!null i:2 f:3 s:4!null j:5
+ │    ├── locking: for-update
+ │    ├── volatile
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters
+      └── false [constraints=(contradiction; tight)]
+
+# Leakproof filter over zero-cardinality input. Both SimplifyZeroCardinalityGroup
+# and EliminateZeroCardSelect fire since EliminateZeroCardSelect has no volatility
+# restriction.
+norm expect=(SimplifyZeroCardinalityGroup,EliminateZeroCardSelect)
+SELECT * FROM (SELECT * FROM b WHERE false) WHERE i > 0
+----
+values
+ ├── columns: k:1!null i:2!null f:3!null s:4!null j:5!null
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1-5)
+
+# --------------------------------------------------
+# EliminateZeroCardProject
+# --------------------------------------------------
+
+# Project with immutable (non-leakproof) projection over zero-cardinality input.
+norm expect=EliminateZeroCardProject
+SELECT i::FLOAT8 FROM (SELECT * FROM b WHERE false)
+----
+values
+ ├── columns: i:8!null
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(8)
+
+# Volatile projection over zero-cardinality input. Volatile expressions like
+# random() should also be eliminated.
+norm expect=EliminateZeroCardProject
+SELECT random() FROM (SELECT * FROM b WHERE false)
+----
+values
+ ├── columns: random:8!null
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(8)
+
+# Projection with passthrough columns. Passthrough columns should be correctly
+# included in the output Values via UnionCols.
+norm expect=EliminateZeroCardProject
+SELECT k, i::FLOAT8 FROM (SELECT * FROM b WHERE false)
+----
+values
+ ├── columns: k:1!null i:8!null
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1,8)
+
+# Multiple non-leakproof projections at once.
+norm expect=EliminateZeroCardProject
+SELECT i::FLOAT8, f::INT, s::CHAR FROM (SELECT * FROM b WHERE false)
+----
+values
+ ├── columns: i:8!null f:9!null s:10!null
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(8-10)
+
+# Zero cardinality from contradictory WHERE clause.
+norm expect=EliminateZeroCardProject
+SELECT i::FLOAT8 FROM b WHERE k < 1 AND k > 2
+----
+values
+ ├── columns: i:8!null
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(8)
+
+# Project does not fire when input is not zero-cardinality.
+norm expect-not=EliminateZeroCardProject
+SELECT i::FLOAT8 FROM b
+----
+project
+ ├── columns: i:8
+ ├── immutable
+ ├── scan b
+ │    └── columns: b.i:2
+ └── projections
+      └── b.i:2::FLOAT8 [as=i:8, outer=(2), immutable]
+
+# Project does not fire when input is not leakproof.
+norm expect-not=EliminateZeroCardProject
+SELECT i::FLOAT8 FROM (SELECT * FROM (SELECT * FROM b FOR UPDATE) WHERE false)
+----
+project
+ ├── columns: i:8
+ ├── cardinality: [0 - 0]
+ ├── volatile
+ ├── select
+ │    ├── columns: b.i:2
+ │    ├── cardinality: [0 - 0]
+ │    ├── volatile
+ │    ├── scan b
+ │    │    ├── columns: b.i:2
+ │    │    ├── locking: for-update
+ │    │    └── volatile
+ │    └── filters
+ │         └── false [constraints=(contradiction; tight)]
+ └── projections
+      └── b.i:2::FLOAT8 [as=i:8, outer=(2), immutable]
+
+# Combined: Select over Project over zero-cardinality input, both non-leakproof.
+norm expect=(EliminateZeroCardSelect,EliminateZeroCardProject)
+SELECT * FROM (SELECT i::FLOAT8 AS x FROM b WHERE false) WHERE x IS NAN
+----
+values
+ ├── columns: x:8!null
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(8)
+
+# Project with non-leakproof projection over Select with non-leakproof filter,
+# both over zero-cardinality input.
+norm expect=(EliminateZeroCardSelect,EliminateZeroCardProject)
+SELECT i::FLOAT8 FROM (SELECT * FROM b WHERE false) WHERE s::CHAR = 'x'
+----
+values
+ ├── columns: i:8!null
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(8)
+
+# Regression test for #162382: redundant filter and render operators remain in
+# the plan when a join folds to norows. The normal SELECT path leaves a Select
+# and Project on top of an empty Values, while the assign-placeholders path
+# (prepared statement) correctly eliminates them.
+
+exec-ddl
+CREATE TABLE t162382_t0 (c0 INTERVAL)
+----
+
+exec-ddl
+CREATE TABLE t162382_t2 (c0 TIMETZ)
+----
+
+# Normal SELECT: the ON false condition folds the join to norows, and then
+# Select is eliminated using EliminateZeroCardSelect.
+opt
+SELECT max(1) FROM t162382_t0 INNER JOIN t162382_t2 ON false WHERE t162382_t0.c0::FLOAT8 IS NAN
+----
+scalar-group-by
+ ├── columns: max:10
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(10)
+ ├── values
+ │    ├── columns: column9:9!null
+ │    ├── cardinality: [0 - 0]
+ │    ├── key: ()
+ │    └── fd: ()-->(9)
+ └── aggregations
+      └── max [as=max:10, outer=(9)]
+           └── column9:9
+
+# Prepared statement path (assign-placeholders-opt): after substituting $1 =
+# false, the optimizer re-normalizes and correctly eliminates the filter and
+# render above norows.
+assign-placeholders-opt query-args=(false)
+SELECT max(1) FROM t162382_t0 INNER JOIN t162382_t2 ON $1 WHERE t162382_t0.c0::FLOAT8 IS NAN
+----
+scalar-group-by
+ ├── columns: max:10
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(10)
+ ├── values
+ │    ├── columns: column9:9!null
+ │    ├── cardinality: [0 - 0]
+ │    ├── key: ()
+ │    └── fd: ()-->(9)
+ └── aggregations
+      └── max [as=max:10, outer=(9)]
+           └── column9:9

--- a/pkg/sql/opt/xform/testdata/physprops/limit_hint
+++ b/pkg/sql/opt/xform/testdata/physprops/limit_hint
@@ -587,7 +587,7 @@ exec-ddl
 CREATE VIEW v44683(c0) AS SELECT 1 FROM t44683 LIMIT -1
 ----
 
-opt
+opt disable=(EliminateZeroCardSelect,EliminateZeroCardProject)
 SELECT DISTINCT t44683.c0 FROM t44683, v44683 LIMIT -1;
 ----
 limit
@@ -634,7 +634,7 @@ CREATE VIEW v0(c0) AS SELECT 0 FROM t1 LIMIT -1
 
 # Regression test for #46187. Ensure that the estimated cost of a lookup join
 # with a limit hint is finite when the number of output rows is 0.
-opt
+opt disable=(EliminateZeroCardSelect,EliminateZeroCardProject)
 SELECT * FROM v0, t0 NATURAL JOIN t1 LIMIT -1
 ----
 project

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -3149,7 +3149,7 @@ CREATE TABLE table2_88649 (
 )
 ----
 
-opt
+opt disable=(EliminateZeroCardSelect,EliminateZeroCardProject)
 SELECT
   CASE WHEN true THEN tab_923.col1_4 ELSE tab_923.col1_3 END AS col_2150
 FROM

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -568,7 +568,7 @@ CREATE TABLE t140019 (
 
 # Regression test for #140019. Do not project unnecessary columns, like i=0,
 # that are held constant by the partial index predicate.
-opt disable=SimplifyZeroCardinalityGroup
+opt disable=(SimplifyZeroCardinalityGroup,EliminateZeroCardSelect,EliminateZeroCardProject)
 SELECT NULL FROM t140019 WHERE false GROUP BY j
 ----
 project


### PR DESCRIPTION
Add two normalization rules, EliminateZeroCardSelect and EliminateZeroCardProject, that remove Select and Project operators when their input has zero cardinality. The filter/projection expressions are per-row and will never be evaluated with zero input rows, so it is safe to remove them regardless of volatility.

This complements the existing SimplifyZeroCardinalityGroup rule, which only fires when the entire expression is leakproof. The new rules handle the case where the Select or Project contains immutable (non-leakproof) scalar expressions.

Fixes: #162382
Fixes: #124832

Release note (performance improvement): The query optimizer now eliminates redundant filter and projection operators over inputs with zero cardinality, even when the filter or projection expressions are not leakproof. This produces simpler, more efficient query plans in cases where joins or other operations fold to zero rows.