### PR TITLE
release-26.1: restore: deflake or empty database test

### DIFF
--- a/pkg/backup/testdata/backup-restore/online-restore-empty-database
+++ b/pkg/backup/testdata/backup-restore/online-restore-empty-database
@@ -22,4 +22,4 @@ RESTORE DATABASE d FROM LATEST IN 'nodelocal://1/cluster/' with EXPERIMENTAL DEF
 query-sql retry
 SELECT count(*) FROM [SHOW JOBS] WHERE job_type='RESTORE' and status='succeeded';
 ----
-1
+2


### PR DESCRIPTION
Backport 1/1 commits from #164183 on behalf of @msbutler.

----

Gotta wait for both the link and download job to complete!

Fixes #164153

Release note: none

----

Release justification: