### PR TITLE
changefeedccl: reject explicitly empty topic_name sink URI parameter

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -1339,7 +1339,7 @@ func validateSink(
 
 	var nilOracle timestampLowerBoundOracle
 	canarySink, err := getAndDialSink(ctx, &p.ExecCfg().DistSQLSrv.ServerConfig, details,
-		nilOracle, p.User(), jobID, sli, targets)
+		nilOracle, p.User(), jobID, sli, targets, true /* initialValidation */)
 	if err != nil {
 		return err
 	}

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -7406,6 +7406,12 @@ func TestChangefeedErrors(t *testing.T) {
 		`CREATE CHANGEFEED FOR foo INTO $1`, `experimental-sql://d/?topic_name=foo`,
 	)
 
+	// Empty topic_name should be rejected.
+	sqlDB.ExpectErr(
+		t, `param topic_name must not be empty`,
+		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?topic_name=`,
+	)
+
 	// schema_topic will be implemented but isn't yet.
 	sqlDB.ExpectErrWithTimeout(
 		t, `schema_topic is not yet supported`,

--- a/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
@@ -38,6 +38,7 @@ go_test(
         "main_test.go",
         "name_test.go",
         "options_test.go",
+        "sink_url_test.go",
     ],
     embed = [":changefeedbase"],
     deps = [

--- a/pkg/ccl/changefeedccl/changefeedbase/sink_url.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/sink_url.go
@@ -36,6 +36,17 @@ func (u *SinkURL) ConsumeParam(p string) string {
 	return v
 }
 
+// ValidateSinkURIParams checks for invalid query parameter values in a
+// parsed sink URI. This is called at CREATE/ALTER CHANGEFEED statement
+// time to reject invalid URIs before they are persisted.
+func ValidateSinkURIParams(u *url.URL) error {
+	q := u.Query()
+	if q.Has(SinkParamTopicName) && q.Get(SinkParamTopicName) == "" {
+		return errors.Newf(`param %s must not be empty`, SinkParamTopicName)
+	}
+	return nil
+}
+
 func (u *SinkURL) ConsumeParams(p string) []string {
 	if u.q == nil {
 		u.q = u.Query()

--- a/pkg/ccl/changefeedccl/changefeedbase/sink_url_test.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/sink_url_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package changefeedbase
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateSinkURIParams(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	for name, tc := range map[string]struct {
+		rawURL  string
+		wantErr string
+	}{
+		"absent topic_name": {
+			rawURL: "kafka://localhost",
+		},
+		"non-empty topic_name": {
+			rawURL: "kafka://localhost?topic_name=foo",
+		},
+		"explicitly empty topic_name": {
+			rawURL:  "kafka://localhost?topic_name=",
+			wantErr: "param topic_name must not be empty",
+		},
+		"explicitly empty topic_name with other params": {
+			rawURL:  "kafka://localhost?topic_name=&tls_enabled=true",
+			wantErr: "param topic_name must not be empty",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			u, err := url.Parse(tc.rawURL)
+			require.NoError(t, err)
+			err = ValidateSinkURIParams(u)
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/ccl/changefeedccl/sink_external_connection.go
+++ b/pkg/ccl/changefeedccl/sink_external_connection.go
@@ -46,7 +46,7 @@ func makeExternalConnectionSink(
 	// Replace the external connection URI in the `feedCfg` with the URI of the
 	// underlying resource.
 	feedCfg.SinkURI = uri
-	return getSink(ctx, serverCfg, feedCfg, timestampOracle, user, jobID, m, targets)
+	return getSink(ctx, serverCfg, feedCfg, timestampOracle, user, jobID, m, targets, false /* initialValidation */)
 }
 
 func validateExternalConnectionSinkURI(
@@ -78,7 +78,7 @@ func validateExternalConnectionSinkURI(
 	// TODO(adityamaru): When we add `CREATE EXTERNAL CONNECTION ... WITH` support
 	// to accept JSONConfig we should validate that here too.
 	s, err := getSink(ctx, serverCfg, jobspb.ChangefeedDetails{SinkURI: uri}, nil, env.Username,
-		jobspb.JobID(0), (*sliMetrics)(nil), changefeedbase.Targets{})
+		jobspb.JobID(0), (*sliMetrics)(nil), changefeedbase.Targets{}, true /* initialValidation */)
 	if err != nil {
 		return errors.Wrap(err, "invalid changefeed sink URI")
 	}

--- a/pkg/ccl/changefeedccl/sink_kafka_connection_test.go
+++ b/pkg/ccl/changefeedccl/sink_kafka_connection_test.go
@@ -252,6 +252,11 @@ func TestChangefeedExternalConnections(t *testing.T) {
 			uri:           "kafka://nope/?sasl_enabled=true&sasl_mechanism=AWS_MSK_IAM&sasl_aws_iam_session_name=foo&sasl_aws_iam_role_arn=foo",
 			expectedError: "sasl_aws_region must be provided when SASL is enabled using mechanism AWS_MSK_IAM",
 		},
+		{
+			name:          "empty topic_name rejected for kafka",
+			uri:           "kafka://nope/?topic_name=",
+			expectedError: "param topic_name must not be empty",
+		},
 		// confluent-cloud scheme tests
 		{
 			name:          "requires parameter api_key",
@@ -287,6 +292,11 @@ func TestChangefeedExternalConnections(t *testing.T) {
 			name:          "invalid query parameters",
 			uri:           "confluent-cloud://nope?api_key=fee&api_secret=bar&ca_cert=abcd",
 			expectedError: "invalid query parameters",
+		},
+		{
+			name:          "empty topic_name rejected for confluent-cloud",
+			uri:           "confluent-cloud://nope?api_key=fee&api_secret=bar&topic_name=",
+			expectedError: "param topic_name must not be empty",
 		},
 		// azure-event-hub scheme tests
 		{
@@ -328,6 +338,11 @@ func TestChangefeedExternalConnections(t *testing.T) {
 			name:          "test error with entity_path",
 			uri:           "azure-event-hub://nope?shared_access_key_name=saspolicytpcc&shared_access_key=123&entity_path=history",
 			expectedError: "invalid query parameters",
+		},
+		{
+			name:          "empty topic_name rejected for azure-event-hub",
+			uri:           "azure-event-hub://nope?shared_access_key_name=fee&shared_access_key=123&topic_name=",
+			expectedError: "param topic_name must not be empty",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Previously, explicitly setting `topic_name` to the empty string in a
changefeed or external connection sink URI was silently accepted and
we'd fall back to the table name as the topic name. This is now
rejected at `{CREATE,ALTER}{CHANGEFEED,EXTERNAL CONNECTION}` time,
since an explicit empty value is likely not intentional. Existing
changefeeds with an empty `topic_name` continue to work as before.

Fixes #163882

Release note (backward-incompatible change): Creating or altering a
changefeed or kafka/pubsub external connection now returns an error
when the `topic_name` query parameter is explicitly set to an empty
string in the sink URI, rather than silently falling back to using the
table name as the topic name. Existing changefeeds with an empty
`topic_name` are not affected.