### PR TITLE
release-26.1: kvserver: create a fresh context per-store-rebalancer loop iteration

### DIFF
--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -300,12 +300,12 @@ func (sr *StoreRebalancer) Start(ctx context.Context, stopper *stop.Stopper) {
 			}
 			objective := sr.RebalanceObjective()
 			sr.AddLogTag("obj", objective)
-			ctx = sr.AnnotateCtx(ctx)
+			sCtx := sr.AnnotateCtx(ctx)
 
 			hottestRanges := sr.replicaRankings.TopLoad(objective.ToDimension())
-			options := sr.scorerOptions(ctx, objective.ToDimension())
-			rctx := sr.NewRebalanceContext(ctx, options, hottestRanges, sr.RebalanceMode())
-			sr.rebalanceStore(ctx, rctx)
+			options := sr.scorerOptions(sCtx, objective.ToDimension())
+			rctx := sr.NewRebalanceContext(sCtx, options, hottestRanges, sr.RebalanceMode())
+			sr.rebalanceStore(sCtx, rctx)
 		}
 	})
 }


### PR DESCRIPTION
Backport 1/1 commits from #164202 on behalf of @arulajmani.

----

We've seen this cause issues in older versions of CRDB, where we don't have fastValueCtxs. There, the depth of the context chain increases once per-iteration, which is unecessary.

Epic: none

Release note: None

----

Release justification: