### PR TITLE
roachtest: add --skip flag to exclude operations by regex

### DIFF
--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -225,7 +225,7 @@ Check --parallelism, --run-forever and --wait-before-next-execution flags`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Printf("\nRunning operation %s on %s.\n\n", args[1], args[0])
 			cmd.SilenceUsage = true
-			return runOperations(operations.RegisterOperations, args[1], args[0])
+			return runOperations(operations.RegisterOperations, args[1], roachtestflags.SkipOperations, args[0])
 		},
 	}
 	roachtestflags.AddRunOpsFlags(runOperationCmd.Flags())
@@ -246,12 +246,21 @@ Example:
 
    roachtest list-operations
    roachtest list-operations node-kill/.*m$
+   roachtest list-operations --skip disk-stall
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			r := makeTestRegistry()
 			operations.RegisterOperations(&r)
 
-			ops := r.FilteredOperations(registry.MergeRegEx(args))
+			var skipRegex *regexp.Regexp
+			if roachtestflags.SkipOperations != "" {
+				var err error
+				skipRegex, err = regexp.Compile(roachtestflags.SkipOperations)
+				if err != nil {
+					return err
+				}
+			}
+			ops := r.FilteredOperations(registry.MergeRegEx(args), skipRegex)
 			for _, op := range ops {
 				fmt.Printf("%s\n", op.Name)
 			}
@@ -259,6 +268,7 @@ Example:
 			return nil
 		},
 	}
+	roachtestflags.AddRunOpsFlags(listOperationCmd.Flags())
 	rootCmd.AddCommand(listOperationCmd)
 
 	var err error
@@ -455,12 +465,19 @@ func testShouldBeSkipped(
 	return td != nil && !td.Selected
 }
 
-func opsToRun(r testRegistryImpl, filter string) ([]registry.OperationSpec, error) {
+func opsToRun(r testRegistryImpl, filter string, skip string) ([]registry.OperationSpec, error) {
 	regex, err := regexp.Compile(filter)
 	if err != nil {
 		return nil, err
 	}
-	filteredOps := r.FilteredOperations(regex)
+	var skipRegex *regexp.Regexp
+	if skip != "" {
+		skipRegex, err = regexp.Compile(skip)
+		if err != nil {
+			return nil, err
+		}
+	}
+	filteredOps := r.FilteredOperations(regex, skipRegex)
 	if len(filteredOps) == 0 {
 		return nil, errors.New("no matching operations to run")
 	}

--- a/pkg/cmd/roachtest/roachtestflags/flags.go
+++ b/pkg/cmd/roachtest/roachtestflags/flags.go
@@ -404,6 +404,12 @@ var (
 		Usage: "Interval to wait before the operation next execution after the previous run.",
 	})
 
+	SkipOperations string = ""
+	_                     = registerRunOpsFlag(&SkipOperations, FlagInfo{
+		Name:  "skip",
+		Usage: "A regex pattern for operations to exclude from running.",
+	})
+
 	RunForever bool = false
 	_               = registerRunOpsFlag(&RunForever, FlagInfo{
 		Name:  "run-forever",

--- a/pkg/cmd/roachtest/run_operation.go
+++ b/pkg/cmd/roachtest/run_operation.go
@@ -63,10 +63,10 @@ type opsRunner struct {
 }
 
 // runOperations spins `parallelism` workers to run operations.
-func runOperations(register func(registry.Registry), filter, clusterName string) error {
+func runOperations(register func(registry.Registry), filter, skip, clusterName string) error {
 	r := makeTestRegistry()
 	register(&r)
-	opSpecs, err := opsToRun(r, filter)
+	opSpecs, err := opsToRun(r, filter, skip)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/roachtest/test_registry.go
+++ b/pkg/cmd/roachtest/test_registry.go
@@ -182,12 +182,19 @@ func (r testRegistryImpl) AllOperations() []registry.OperationSpec {
 }
 
 // FilteredOperations returns operations filtered by the given regex.
-func (r testRegistryImpl) FilteredOperations(regex *regexp.Regexp) []registry.OperationSpec {
+// If skipRegex is non-nil, operations matching it are excluded.
+func (r testRegistryImpl) FilteredOperations(
+	regex *regexp.Regexp, skipRegex *regexp.Regexp,
+) []registry.OperationSpec {
 	var filteredOps []registry.OperationSpec
 	for _, opSpec := range r.AllOperations() {
-		if regex.MatchString(opSpec.Name) {
-			filteredOps = append(filteredOps, opSpec)
+		if !regex.MatchString(opSpec.Name) {
+			continue
 		}
+		if skipRegex != nil && skipRegex.MatchString(opSpec.Name) {
+			continue
+		}
+		filteredOps = append(filteredOps, opSpec)
 	}
 	return filteredOps
 }


### PR DESCRIPTION
## Summary
- Adds a `--skip` flag to `run-operation` and `list-operations` commands that accepts a regex pattern to exclude matching operations.
- Useful for temporarily skipping consistently failing or buggy operations during DRT runs.

Fixes #163591

## Usage Examples
```bash
# Run all operations except disk-stall
roachtest run-operation my-cluster '.*' --skip disk-stall

# Exclude multiple operations
roachtest run-operation my-cluster '.*' --skip 'disk-stall|network-partition'

# List operations excluding a pattern
roachtest list-operations --skip disk-stall
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)