### PR TITLE
dev-inf: fix jq parsing of claude CLI output in issue-autosolve

### DIFF
--- a/.github/workflows/issue-autosolve.yml
+++ b/.github/workflows/issue-autosolve.yml
@@ -259,7 +259,7 @@ jobs:
             fi
 
             # Extract session ID for potential retry
-            NEW_SESSION_ID=$(jq -r '.[] | select(.type == "system") | .session_id // empty' "$EXECUTION_FILE" 2>/dev/null | head -1 || true)
+            NEW_SESSION_ID=$(jq -r 'select(.type == "result") | .session_id // empty' "$EXECUTION_FILE" 2>/dev/null | head -1 || true)
             if [ -n "$NEW_SESSION_ID" ]; then
               SESSION_ID="$NEW_SESSION_ID"
               echo "Session ID: $SESSION_ID"
@@ -267,7 +267,7 @@ jobs:
 
             # Check if implementation succeeded by looking for SUCCESS marker in result
             # Allow flexible formatting: IMPLEMENTATION_RESULT - SUCCESS, IMPLEMENTATION_RESULT: SUCCESS, etc.
-            RESULT=$(jq -r '.[] | select(.type == "result") | .result // empty' "$EXECUTION_FILE" 2>/dev/null || true)
+            RESULT=$(jq -r 'select(.type == "result") | .result // empty' "$EXECUTION_FILE" 2>/dev/null || true)
             if echo "$RESULT" | grep -qiE 'IMPLEMENTATION_RESULT[[:space:]]*[-:][[:space:]]*SUCCESS'; then
               echo "Implementation succeeded on attempt $ATTEMPT"
               EXIT_CODE=0
@@ -306,7 +306,7 @@ jobs:
             exit 1
           fi
 
-          RESULT=$(jq -r '.[] | select(.type == "result") | .result' "$EXECUTION_FILE") || {
+          RESULT=$(jq -r 'select(.type == "result") | .result' "$EXECUTION_FILE") || {
             echo "::error::Failed to parse execution file with jq"
             exit 1
           }


### PR DESCRIPTION
## Summary

The Stage 2 implementation step in `issue-autosolve.yml` invokes `claude --print
--output-format json` directly (not via `claude-code-action`). The CLI outputs
JSONL (one JSON object per line), not a JSON array. The jq queries used `.[]`
which iterates over an object's **values** rather than array elements, so
`select(.type == "result")` never matched.

This caused two problems:
- **Result extraction always empty**: every retry reported "No result marker
  found" regardless of what Claude actually output, looping until the 2-hour job
  timeout was hit.
- **Session ID never extracted**: retries started fresh sessions instead of
  resuming, wasting time re-reading the issue and codebase from scratch.

Additionally, the session ID extraction looked for a `type: "system"` object,
but the CLI puts `session_id` on the `type: "result"` object.

Release note: None

Epic: None


🤖 Generated with [Claude Code](https://claude.com/claude-code)