### PR TITLE
*: remove enterprise license checks

### DIFF
--- a/pkg/backup/BUILD.bazel
+++ b/pkg/backup/BUILD.bazel
@@ -51,7 +51,6 @@ go_library(
         "//pkg/backup/backuputils",
         "//pkg/base",
         "//pkg/build",
-        "//pkg/ccl/multiregionccl",
         "//pkg/cloud",
         "//pkg/cloud/cloudpb",
         "//pkg/cloud/externalconn",

--- a/pkg/backup/restore_planning.go
+++ b/pkg/backup/restore_planning.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/backup/backupinfo"
 	"github.com/cockroachdb/cockroach/pkg/backup/backuppb"
 	"github.com/cockroachdb/cockroach/pkg/backup/backuputils"
-	"github.com/cockroachdb/cockroach/pkg/ccl/multiregionccl"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/featureflag"
@@ -2364,16 +2363,6 @@ func planDatabaseModifiersForRestore(
 	if defaultPrimaryRegion == "" {
 		return nil, nil, nil
 	}
-	if err := multiregionccl.CheckClusterSupportsMultiRegion(
-		p.ExecCfg().Settings,
-	); err != nil {
-		return nil, nil, errors.WithHintf(
-			err,
-			"try disabling the default PRIMARY REGION by using RESET CLUSTER SETTING %s",
-			sqlclustersettings.DefaultPrimaryRegionClusterSettingName,
-		)
-	}
-
 	l, err := sql.GetLiveClusterRegions(ctx, p)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/base/license.go
+++ b/pkg/base/license.go
@@ -26,13 +26,6 @@ var CheckEnterpriseEnabled = func(_ *cluster.Settings, feature string) error {
 	return errEnterpriseNotEnabled // nb: this is squarely in the hot path on OSS builds
 }
 
-// CCLDistributionAndEnterpriseEnabled is a simpler version of
-// CheckEnterpriseEnabled which doesn't take in feature-related info and doesn't
-// return an error with a nice message.
-var CCLDistributionAndEnterpriseEnabled = func(st *cluster.Settings) bool {
-	return CheckEnterpriseEnabled(st, "" /* feature */) == nil
-}
-
 var LicenseTTLMetadata = metric.Metadata{
 	// This metric name isn't namespaced for backwards
 	// compatibility. The prior version of this metric was manually

--- a/pkg/base/license.go
+++ b/pkg/base/license.go
@@ -12,19 +12,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"github.com/cockroachdb/errors"
 )
-
-var errEnterpriseNotEnabled = errors.New("OSS binaries do not include enterprise features")
-
-// CheckEnterpriseEnabled returns a non-nil error if the requested enterprise
-// feature is not enabled, including information or a link explaining how to
-// enable it.
-//
-// This function is overridden by an init hook in CCL builds.
-var CheckEnterpriseEnabled = func(_ *cluster.Settings, feature string) error {
-	return errEnterpriseNotEnabled // nb: this is squarely in the hot path on OSS builds
-}
 
 var LicenseTTLMetadata = metric.Metadata{
 	// This metric name isn't namespaced for backwards

--- a/pkg/ccl/ccl_init.go
+++ b/pkg/ccl/ccl_init.go
@@ -34,7 +34,6 @@ func init() {
 	// functions we bind is in utilccl, but license checks only work once
 	// utilccl.AllCCLCodeImported is set, above; that's why this hookup is done in
 	// this `ccl` pkg.
-	base.CheckEnterpriseEnabled = utilccl.CheckEnterpriseEnabled
 	base.LicenseType = utilccl.GetLicenseType
 	base.GetLicenseTTL = utilccl.GetLicenseTTL
 	license.RegisterCallbackOnLicenseChange = utilccl.RegisterCallbackOnLicenseChange

--- a/pkg/ccl/changefeedccl/scheduled_changefeed.go
+++ b/pkg/ccl/changefeedccl/scheduled_changefeed.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedpb"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedvalidators"
-	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
@@ -334,15 +333,6 @@ func makeScheduledChangefeedSpec(
 			return nil, err
 		}
 		spec.recurrence = &rec
-	}
-
-	enterpriseCheckErr := utilccl.CheckEnterpriseEnabled(
-		p.ExecCfg().Settings,
-		opName)
-
-	if !(enterpriseCheckErr == nil) {
-		// Cannot use SCHEDULED CHANGEFEED w/out enterprise license.
-		return nil, enterpriseCheckErr
 	}
 
 	spec.scheduleOpts, err = exprEval.KVOptions(

--- a/pkg/ccl/gssapiccl/gssapi.go
+++ b/pkg/ccl/gssapiccl/gssapi.go
@@ -16,7 +16,6 @@ import (
 	"crypto/tls"
 	"strings"
 
-	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -96,12 +95,7 @@ func authGSS(
 				return errors.New("GSSAPI did not return realm but realm matching was requested")
 			}
 		}
-
-		// Do the license check last so that administrators are able to test whether
-		// their GSS configuration is correct. That is, the presence of this error
-		// message means they have a correctly functioning GSS/Kerberos setup,
-		// but now need to enable enterprise features.
-		return utilccl.CheckEnterpriseEnabled(execCfg.Settings, "GSS authentication")
+		return nil
 	})
 	return behaviors, nil
 }

--- a/pkg/ccl/jwtauthccl/BUILD.bazel
+++ b/pkg/ccl/jwtauthccl/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/ccl/securityccl/jwthelper",
-        "//pkg/ccl/utilccl",
         "//pkg/security/username",
         "//pkg/server/telemetry",
         "//pkg/settings",

--- a/pkg/ccl/jwtauthccl/authentication_jwt.go
+++ b/pkg/ccl/jwtauthccl/authentication_jwt.go
@@ -13,7 +13,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -221,10 +220,6 @@ func (authenticator *jwtAuthenticator) ValidateJWTLogin(
 		return "", errors.WithDetailf(
 			errors.Newf("JWT authentication: invalid audience"),
 			"token issued with an audience of %s", parsedToken.Audience())
-	}
-
-	if err = utilccl.CheckEnterpriseEnabled(st, "JWT authentication"); err != nil {
-		return "", err
 	}
 
 	telemetry.Inc(loginSuccessUseCounter)

--- a/pkg/ccl/ldapccl/BUILD.bazel
+++ b/pkg/ccl/ldapccl/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/ldapccl",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/ccl/utilccl",
         "//pkg/security",
         "//pkg/security/distinguishedname",
         "//pkg/security/username",

--- a/pkg/ccl/ldapccl/authentication_ldap.go
+++ b/pkg/ccl/ldapccl/authentication_ldap.go
@@ -8,7 +8,6 @@ package ldapccl
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/security/distinguishedname"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
@@ -53,10 +52,6 @@ func (authManager *ldapAuthManager) FetchLDAPUserDN(
 	entry *hba.Entry,
 	_ *identmap.Conf,
 ) (retrievedUserDN *ldap.DN, detailedErrorMsg redact.RedactableString, authError error) {
-	if err := utilccl.CheckEnterpriseEnabled(st, "LDAP authentication"); err != nil {
-		return nil, "", err
-	}
-
 	authManager.mu.Lock()
 	defer authManager.mu.Unlock()
 	if !authManager.mu.enabled {
@@ -131,10 +126,6 @@ func (authManager *ldapAuthManager) ValidateLDAPLogin(
 	entry *hba.Entry,
 	_ *identmap.Conf,
 ) (detailedErrorMsg redact.RedactableString, authError error) {
-	if err := utilccl.CheckEnterpriseEnabled(st, "LDAP authentication"); err != nil {
-		return "", err
-	}
-
 	authManager.mu.Lock()
 	defer authManager.mu.Unlock()
 

--- a/pkg/ccl/ldapccl/authorization_ldap.go
+++ b/pkg/ccl/ldapccl/authorization_ldap.go
@@ -8,7 +8,6 @@ package ldapccl
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/security/distinguishedname"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
@@ -54,10 +53,6 @@ func (authManager *ldapAuthManager) FetchLDAPGroups(
 	entry *hba.Entry,
 	_ *identmap.Conf,
 ) (_ []*ldap.DN, detailedErrorMsg redact.RedactableString, authError error) {
-	if err := utilccl.CheckEnterpriseEnabled(st, "LDAP authorization"); err != nil {
-		return nil, "", err
-	}
-
 	authManager.mu.Lock()
 	defer authManager.mu.Unlock()
 

--- a/pkg/ccl/multiregionccl/BUILD.bazel
+++ b/pkg/ccl/multiregionccl/BUILD.bazel
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/multiregionccl",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/ccl/utilccl",
         "//pkg/settings/cluster",
         "//pkg/sql",
         "//pkg/sql/catalog/catpb",

--- a/pkg/ccl/multiregionccl/multiregion.go
+++ b/pkg/ccl/multiregionccl/multiregion.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"sort"
 
-	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
@@ -38,12 +37,6 @@ func initializeMultiRegionMetadata(
 	dataPlacement tree.DataPlacement,
 	secondaryRegion catpb.RegionName,
 ) (*multiregion.RegionConfig, error) {
-	if err := CheckClusterSupportsMultiRegion(
-		settings,
-	); err != nil {
-		return nil, err
-	}
-
 	survivalGoal, err := sql.TranslateSurvivalGoal(goal)
 	if err != nil {
 		return nil, err
@@ -122,25 +115,9 @@ func initializeMultiRegionMetadata(
 	return &regionConfig, nil
 }
 
-// CheckClusterSupportsMultiRegion returns whether the current cluster supports
-// multi-region features.
-func CheckClusterSupportsMultiRegion(settings *cluster.Settings) error {
-	return utilccl.CheckEnterpriseEnabled(
-		settings,
-		"multi-region features",
-	)
-}
-
 func getMultiRegionEnumAddValuePlacement(
 	execCfg *sql.ExecutorConfig, typeDesc *typedesc.Mutable, region tree.Name,
 ) (tree.AlterTypeAddValue, error) {
-	if err := utilccl.CheckEnterpriseEnabled(
-		execCfg.Settings,
-		"ADD REGION",
-	); err != nil {
-		return tree.AlterTypeAddValue{}, err
-	}
-
 	// Find the location in the enum where we should insert the new value. We much search
 	// for the location (and not append to the end), as we want to keep the values in sorted
 	// order.

--- a/pkg/ccl/oidcccl/BUILD.bazel
+++ b/pkg/ccl/oidcccl/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//pkg/ccl/jwtauthccl",
         "//pkg/ccl/securityccl/jwthelper",
-        "//pkg/ccl/utilccl",
         "//pkg/roachpb",
         "//pkg/security/provisioning",
         "//pkg/security/username",

--- a/pkg/ccl/oidcccl/authentication_oidc.go
+++ b/pkg/ccl/oidcccl/authentication_oidc.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/jwtauthccl"
-	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/provisioning"
 	secuser "github.com/cockroachdb/cockroach/pkg/security/username"
@@ -692,11 +691,6 @@ var ConfigureOIDC = func(
 		if err != nil {
 			log.Dev.Errorf(ctx, "OIDC: failed to complete authentication: unable to create session for %s: %v", username, err)
 			http.Error(w, genericCallbackHTTPError, http.StatusForbidden)
-			return
-		}
-
-		if err := utilccl.CheckEnterpriseEnabled(st, "OIDC"); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 

--- a/pkg/ccl/partitionccl/BUILD.bazel
+++ b/pkg/ccl/partitionccl/BUILD.bazel
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/partitionccl",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/ccl/utilccl",
         "//pkg/config/zonepb",
         "//pkg/settings/cluster",
         "//pkg/sql",

--- a/pkg/ccl/partitionccl/partition.go
+++ b/pkg/ccl/partitionccl/partition.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"strings"
 
-	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -335,10 +334,6 @@ func createPartitioning(
 	allowedNewColumnNames []tree.Name,
 	allowImplicitPartitioning bool,
 ) (newImplicitCols []catalog.Column, newPartitioning catpb.PartitioningDescriptor, err error) {
-	if err := utilccl.CheckEnterpriseEnabled(st, "partitions"); err != nil {
-		return nil, newPartitioning, err
-	}
-
 	// Truncate existing implicitly partitioned column names.
 	newIdxColumnNames := oldKeyColumnNames[oldNumImplicitColumns:]
 

--- a/pkg/ccl/securityccl/fipsccl/sql.go
+++ b/pkg/ccl/securityccl/fipsccl/sql.go
@@ -24,11 +24,6 @@ func init() {
 		Types:      tree.ParamTypes{},
 		ReturnType: tree.FixedReturnType(types.Bool),
 		Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-			if err := utilccl.CheckEnterpriseEnabled(
-				evalCtx.Settings, "fips_ready",
-			); err != nil {
-				return nil, err
-			}
 			// It's debatable whether we need a permission check here at all.
 			// It's not very sensitive and is (currently) a very cheap function
 			// call. However, it's something that regular users should have no

--- a/pkg/ccl/utilccl/license_check.go
+++ b/pkg/ccl/utilccl/license_check.go
@@ -80,15 +80,6 @@ func TestingDisableEnterprise() func() {
 	return func() {}
 }
 
-// CheckEnterpriseEnabled previously returned a non-nil error if the requested enterprise
-// feature was not enabled. It is now deprecated and always returns nil. Callers should
-// remove any usage of this function.
-//
-// Deprecated
-func CheckEnterpriseEnabled(*cluster.Settings, string) error {
-	return nil
-}
-
 // GetLicenseTTL is a function which returns the TTL for the active cluster.
 // This is done by reading the license information from the cluster settings
 // and subtracting the epoch from the expiry timestamp.

--- a/pkg/ccl/utilccl/license_check_test.go
+++ b/pkg/ccl/utilccl/license_check_test.go
@@ -26,39 +26,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSettingAndCheckingLicense(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	ctx := context.Background()
-	t0 := timeutil.Unix(0, 0)
-
-	licA, _ := (&licenseccl.License{
-		Type:              licenseccl.License_Enterprise,
-		ValidUntilUnixSec: t0.AddDate(0, 1, 0).Unix(),
-	}).Encode()
-
-	st := cluster.MakeTestingClusterSettings()
-
-	for _, tc := range []struct {
-		lic string
-	}{
-		// NB: we're observing the update manifest as changed behavior -- detailed
-		// testing of that behavior is left to licenseccl's own tests.
-		{""},
-		// adding a valid lic.
-		{licA},
-		// clearing an existing lic.
-		{""},
-	} {
-		updater := st.MakeUpdater()
-		if err := setLicense(ctx, updater, tc.lic); err != nil {
-			t.Fatal(err)
-		}
-		err := CheckEnterpriseEnabled(st, "")
-		require.NoError(t, err)
-	}
-}
-
 func TestGetLicenseTypePresent(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 

--- a/pkg/crosscluster/logical/BUILD.bazel
+++ b/pkg/crosscluster/logical/BUILD.bazel
@@ -27,7 +27,6 @@ go_library(
         "//pkg/base",
         "//pkg/ccl/changefeedccl/cdcevent",
         "//pkg/ccl/changefeedccl/changefeedbase",
-        "//pkg/ccl/utilccl",
         "//pkg/cloud",
         "//pkg/clusterversion",
         "//pkg/crosscluster",

--- a/pkg/crosscluster/logical/create_logical_replication_stmt.go
+++ b/pkg/crosscluster/logical/create_logical_replication_stmt.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/crosscluster"
@@ -95,13 +94,6 @@ func createLogicalReplicationStreamPlanHook(
 		}()
 		ctx, span := tracing.ChildSpan(ctx, stmt.StatementTag())
 		defer span.Finish()
-
-		if err := utilccl.CheckEnterpriseEnabled(
-			p.ExecCfg().Settings,
-			"CREATE LOGICAL REPLICATION",
-		); err != nil {
-			return err
-		}
 
 		if stmt.From.Database != "" {
 			return errors.UnimplementedErrorf(errors.IssueLink{}, "logical replication streams on databases are unsupported")

--- a/pkg/crosscluster/physical/BUILD.bazel
+++ b/pkg/crosscluster/physical/BUILD.bazel
@@ -23,7 +23,6 @@ go_library(
     deps = [
         "//pkg/backup",
         "//pkg/base",
-        "//pkg/ccl/utilccl",
         "//pkg/cloud",
         "//pkg/cloud/externalconn",
         "//pkg/cloud/externalconn/connectionpb",

--- a/pkg/crosscluster/physical/alter_replication_job.go
+++ b/pkg/crosscluster/physical/alter_replication_job.go
@@ -11,7 +11,6 @@ import (
 	"math"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/crosscluster/replicationutils"
 	"github.com/cockroachdb/cockroach/pkg/crosscluster/streamclient"
@@ -211,13 +210,6 @@ func alterReplicationJobHook(
 	}
 
 	fn := func(ctx context.Context, resultsCh chan<- tree.Datums) error {
-		if err := utilccl.CheckEnterpriseEnabled(
-			p.ExecCfg().Settings,
-			alterReplicationJobOp,
-		); err != nil {
-			return err
-		}
-
 		if err := sql.CanManageTenant(ctx, p); err != nil {
 			return err
 		}

--- a/pkg/crosscluster/physical/stream_ingest_manager.go
+++ b/pkg/crosscluster/physical/stream_ingest_manager.go
@@ -8,7 +8,6 @@ package physical
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/crosscluster/replicationutils"
 	"github.com/cockroachdb/cockroach/pkg/crosscluster/streamclient"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
@@ -20,8 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/clusterunique"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/syntheticprivilege"
@@ -54,13 +51,6 @@ func newStreamIngestManagerWithPrivilegesCheck(
 	ctx context.Context, evalCtx *eval.Context, txn isql.Txn, sessionID clusterunique.ID,
 ) (eval.StreamIngestManager, error) {
 	execCfg := evalCtx.Planner.ExecutorConfig().(*sql.ExecutorConfig)
-	enterpriseCheckErr := utilccl.CheckEnterpriseEnabled(
-		execCfg.Settings, "REPLICATION")
-	if enterpriseCheckErr != nil {
-		return nil, pgerror.Wrap(enterpriseCheckErr,
-			pgcode.CCLValidLicenseRequired, "physical replication requires an enterprise license on the secondary (and primary) cluster")
-	}
-
 	if err := evalCtx.SessionAccessor.CheckPrivilege(ctx,
 		syntheticprivilege.GlobalPrivilegeObject,
 		privilege.MANAGEVIRTUALCLUSTER); err != nil {

--- a/pkg/crosscluster/physical/stream_ingestion_planning.go
+++ b/pkg/crosscluster/physical/stream_ingestion_planning.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"math"
 
-	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/crosscluster/streamclient"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
@@ -132,13 +131,6 @@ func ingestionPlanHook(
 		}()
 		ctx, span := tracing.ChildSpan(ctx, stmt.StatementTag())
 		defer span.Finish()
-
-		if err := utilccl.CheckEnterpriseEnabled(
-			p.ExecCfg().Settings,
-			"CREATE VIRTUAL CLUSTER FROM REPLICATION",
-		); err != nil {
-			return err
-		}
 
 		if err := sql.CanManageTenant(ctx, p); err != nil {
 			return err

--- a/pkg/crosscluster/producer/BUILD.bazel
+++ b/pkg/crosscluster/producer/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/crosscluster/producer",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/ccl/utilccl",
         "//pkg/clusterversion",
         "//pkg/crosscluster",
         "//pkg/crosscluster/replicationutils",

--- a/pkg/crosscluster/producer/replication_manager.go
+++ b/pkg/crosscluster/producer/replication_manager.go
@@ -10,7 +10,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/crosscluster/replicationutils"
 	"github.com/cockroachdb/cockroach/pkg/crosscluster/streamclient"
@@ -55,9 +54,7 @@ type replicationStreamManagerImpl struct {
 func (r *replicationStreamManagerImpl) StartReplicationStream(
 	ctx context.Context, tenantName roachpb.TenantName, req streampb.ReplicationProducerRequest,
 ) (streampb.ReplicationProducerSpec, error) {
-	if err := r.checkLicense(); err != nil {
-		return streampb.ReplicationProducerSpec{}, err
-	}
+
 	if err := r.Authorized("StartReplicationStream"); err != nil {
 		return streampb.ReplicationProducerSpec{}, err
 	}
@@ -68,9 +65,7 @@ func (r *replicationStreamManagerImpl) StartReplicationStream(
 func (r *replicationStreamManagerImpl) StartReplicationStreamForTables(
 	ctx context.Context, req streampb.ReplicationProducerRequest,
 ) (streampb.ReplicationProducerSpec, error) {
-	if err := r.checkLicense(); err != nil {
-		return streampb.ReplicationProducerSpec{}, err
-	}
+
 	if err := r.Authorized("StartReplicationStreamForTables"); err != nil {
 		return streampb.ReplicationProducerSpec{}, err
 	}
@@ -292,9 +287,7 @@ func (r *replicationStreamManagerImpl) PlanLogicalReplication(
 func (r *replicationStreamManagerImpl) HeartbeatReplicationStream(
 	ctx context.Context, streamID streampb.StreamID, frontier hlc.Timestamp,
 ) (streampb.StreamReplicationStatus, error) {
-	if err := r.checkLicense(); err != nil {
-		return streampb.StreamReplicationStatus{}, err
-	}
+
 	if err := r.Authorized("HeartbeatReplicationStream"); err != nil {
 		return streampb.StreamReplicationStatus{}, err
 	}
@@ -305,9 +298,7 @@ func (r *replicationStreamManagerImpl) HeartbeatReplicationStream(
 func (r *replicationStreamManagerImpl) StreamPartition(
 	ctx context.Context, streamID streampb.StreamID, opaqueSpec []byte,
 ) (eval.ValueGenerator, error) {
-	if err := r.checkLicense(); err != nil {
-		return nil, err
-	}
+
 	if err := r.Authorized("StreamPartition"); err != nil {
 		return nil, err
 	}
@@ -337,9 +328,7 @@ func (r *replicationStreamManagerImpl) StreamPartition(
 func (r *replicationStreamManagerImpl) GetPhysicalReplicationStreamSpec(
 	ctx context.Context, streamID streampb.StreamID,
 ) (*streampb.ReplicationStreamSpec, error) {
-	if err := r.checkLicense(); err != nil {
-		return nil, err
-	}
+
 	if err := r.Authorized("GetPhysicalReplicationStreamSpec"); err != nil {
 		return nil, err
 	}
@@ -350,9 +339,7 @@ func (r *replicationStreamManagerImpl) GetPhysicalReplicationStreamSpec(
 func (r *replicationStreamManagerImpl) CompleteReplicationStream(
 	ctx context.Context, streamID streampb.StreamID, successfulIngestion bool,
 ) error {
-	if err := r.checkLicense(); err != nil {
-		return err
-	}
+
 	if err := r.Authorized("CompleteReplicationStream"); err != nil {
 		return err
 	}
@@ -362,9 +349,7 @@ func (r *replicationStreamManagerImpl) CompleteReplicationStream(
 func (r *replicationStreamManagerImpl) SetupSpanConfigsStream(
 	ctx context.Context, tenantName roachpb.TenantName,
 ) (eval.ValueGenerator, error) {
-	if err := r.checkLicense(); err != nil {
-		return nil, err
-	}
+
 	if err := r.Authorized("SetupSpanConfigStream"); err != nil {
 		return nil, err
 	}
@@ -532,14 +517,6 @@ func newReplicationStreamManager(
 	knobs := execCfg.StreamingTestingKnobs
 
 	return &replicationStreamManagerImpl{evalCtx: evalCtx, txn: txn, sessionID: sessionID, resolver: sc, knobs: knobs}, nil
-}
-
-func (r *replicationStreamManagerImpl) checkLicense() error {
-	if err := utilccl.CheckEnterpriseEnabled(r.evalCtx.Settings, "REPLICATION"); err != nil {
-		return pgerror.Wrap(err,
-			pgcode.CCLValidLicenseRequired, "physical replication requires an enterprise license on the primary (and secondary) cluster")
-	}
-	return nil
 }
 
 func init() {

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	apd "github.com/cockroachdb/apd/v3"
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
@@ -2041,18 +2040,11 @@ func (s *adminServer) Cluster(
 		return nil, grpcstatus.Errorf(codes.Unavailable, "cluster ID not yet available")
 	}
 
-	// Check if enterprise features are enabled.  We currently test for the
-	// feature "BACKUP", although enterprise licenses do not yet distinguish
-	// between different features.
-	enterpriseEnabled := base.CheckEnterpriseEnabled(
-		s.st,
-		"BACKUP") == nil
-
 	return &serverpb.ClusterResponse{
 		// TODO(knz): Respond with the logical cluster ID as well.
 		ClusterID:         storageClusterID.String(),
 		ReportingEnabled:  logcrash.DiagnosticsReportingEnabled.Get(&s.st.SV),
-		EnterpriseEnabled: enterpriseEnabled,
+		EnterpriseEnabled: true,
 	}, nil
 }
 

--- a/pkg/settings/cluster/cluster_settings.go
+++ b/pkg/settings/cluster/cluster_settings.go
@@ -46,7 +46,7 @@ type Settings struct {
 	Version clusterversion.Handle
 
 	// Cache can be used for arbitrary caching, e.g. to cache decoded
-	// enterprises licenses for utilccl.CheckEnterpriseEnabled().
+	// enterprises licenses.
 	Cache syncutil.Map[any, any]
 
 	// OverridesInformer can be nil.

--- a/pkg/sql/catalog/zone/BUILD.bazel
+++ b/pkg/sql/catalog/zone/BUILD.bazel
@@ -9,10 +9,8 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/catalog/zone",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/base",
         "//pkg/config",
         "//pkg/config/zonepb",
-        "//pkg/settings/cluster",
         "//pkg/sql/catalog",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",

--- a/pkg/sql/logictest/testdata/logic_test/role
+++ b/pkg/sql/logictest/testdata/logic_test/role
@@ -1929,18 +1929,6 @@ DROP ROLE creator_of_databases
 
 subtest end
 
-subtest subject
-
-skipif config 3node-tenant
-statement error OSS binaries do not include enterprise features
-CREATE ROLE role_with_subject SUBJECT 'foo'
-
-skipif config 3node-tenant
-statement error OSS binaries do not include enterprise features
-ALTER ROLE testuser SUBJECT 'foo'
-
-subtest end
-
 subtest provisionsrc
 
 skipif config 3node-tenant

--- a/pkg/sql/logictest/testdata/logic_test/txn
+++ b/pkg/sql/logictest/testdata/logic_test/txn
@@ -219,16 +219,9 @@ SQLSTATE: 25P01
 statement ok
 BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ; COMMIT
 
-onlyif config enterprise-configs
 query T noticetrace
 BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED
 ----
-
-skipif config enterprise-configs
-query T noticetrace
-BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED
-----
-NOTICE: READ COMMITTED isolation level is not allowed without an enterprise license; upgrading to SERIALIZABLE
 
 statement ok
 COMMIT
@@ -245,16 +238,9 @@ BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL SERIALIZABLE; COMMIT
 statement ok
 BEGIN TRANSACTION
 
-onlyif config enterprise-configs
 query T noticetrace
 SET TRANSACTION ISOLATION LEVEL READ COMMITTED
 ----
-
-skipif config enterprise-configs
-query T noticetrace
-SET TRANSACTION ISOLATION LEVEL READ COMMITTED
-----
-NOTICE: READ COMMITTED isolation level is not allowed without an enterprise license; upgrading to SERIALIZABLE
 
 statement ok
 COMMIT
@@ -267,7 +253,6 @@ BEGIN TRANSACTION
 statement ok
 UPDATE kv SET v = 'b' WHERE k in ('a')
 
-onlyif config enterprise-configs
 skipif config weak-iso-level-configs
 statement error pgcode 25001 cannot change the isolation level of a running transaction
 SET TRANSACTION ISOLATION LEVEL READ COMMITTED
@@ -285,7 +270,6 @@ BEGIN TRANSACTION
 statement ok
 SELECT * FROM kv LIMIT 1
 
-onlyif config enterprise-configs
 skipif config weak-iso-level-configs
 statement error pgcode 25001 cannot change the isolation level of a running transaction
 SET transaction_isolation = 'READ COMMITTED'
@@ -383,32 +367,19 @@ SET CLUSTER SETTING sql.txn.repeatable_read_isolation.enabled = true
 statement ok
 SET default_transaction_isolation = 'read committed'
 
-onlyif config enterprise-configs
 query T
 SHOW default_transaction_isolation
 ----
 repeatable read
-
-skipif config enterprise-configs
-query T
-SHOW default_transaction_isolation
-----
-serializable
 
 statement ok
 SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL READ COMMITTED
 
-onlyif config enterprise-configs
 query T
 SHOW DEFAULT_TRANSACTION_ISOLATION
 ----
 repeatable read
 
-skipif config enterprise-configs
-query T
-SHOW DEFAULT_TRANSACTION_ISOLATION
-----
-serializable
 
 # Since repeatable_read_isolation.enabled is true, REPEATABLE READ can be used.
 statement ok
@@ -417,29 +388,15 @@ BEGIN
 statement ok
 SET TRANSACTION ISOLATION LEVEL REPEATABLE READ
 
-onlyif config enterprise-configs
 query T
 SHOW TRANSACTION ISOLATION LEVEL
 ----
 repeatable read
 
-onlyif config enterprise-configs
 query T
 SHOW transaction_isolation
 ----
 repeatable read
-
-skipif config enterprise-configs
-query T
-SHOW TRANSACTION ISOLATION LEVEL
-----
-serializable
-
-skipif config enterprise-configs
-query T
-SHOW transaction_isolation
-----
-serializable
 
 statement ok
 COMMIT
@@ -453,17 +410,10 @@ SET transaction_isolation = 'this is made up'
 statement ok
 BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ
 
-onlyif config enterprise-configs
 query T
 SHOW TRANSACTION ISOLATION LEVEL
 ----
 repeatable read
-
-skipif config enterprise-configs
-query T
-SHOW TRANSACTION ISOLATION LEVEL
-----
-serializable
 
 statement ok
 SET TRANSACTION ISOLATION LEVEL SERIALIZABLE
@@ -485,17 +435,10 @@ SET CLUSTER SETTING sql.txn.read_committed_isolation.enabled = true
 statement ok
 BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED
 
-onlyif config enterprise-configs
 query T
 SHOW TRANSACTION ISOLATION LEVEL
 ----
 read committed
-
-skipif config enterprise-configs
-query T
-SHOW TRANSACTION ISOLATION LEVEL
-----
-serializable
 
 statement ok
 SET TRANSACTION ISOLATION LEVEL SERIALIZABLE
@@ -509,29 +452,15 @@ serializable
 statement ok
 SET transaction_isolation = 'READ COMMITTED'
 
-onlyif config enterprise-configs
 query T
 SHOW TRANSACTION ISOLATION LEVEL
 ----
 read committed
 
-skipif config enterprise-configs
-query T
-SHOW TRANSACTION ISOLATION LEVEL
-----
-serializable
-
-onlyif config enterprise-configs
 query T
 SHOW transaction_isolation
 ----
 read committed
-
-skipif config enterprise-configs
-query T
-SHOW transaction_isolation
-----
-serializable
 
 statement ok
 COMMIT
@@ -842,7 +771,6 @@ SET CLUSTER SETTING sql.txn.repeatable_read_isolation.enabled = true
 statement ok
 BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ, PRIORITY LOW
 
-onlyif config enterprise-configs
 query T
 SHOW TRANSACTION ISOLATION LEVEL
 ----
@@ -870,32 +798,18 @@ statement ok
 COMMIT
 
 # With the repeatable_read_isolation.enabled cluster setting set to true,
-# REPEATABLE READ can be used if there is a valid license.
-onlyif config enterprise-configs
+# REPEATABLE READ can be used.
 query T noticetrace
 SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL REPEATABLE READ
 ----
-
-skipif config enterprise-configs
-query T noticetrace
-SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL REPEATABLE READ
-----
-NOTICE: REPEATABLE READ isolation level is not allowed without an enterprise license; upgrading to SERIALIZABLE
 
 statement ok
 SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL REPEATABLE READ
 
-onlyif config enterprise-configs
 query T
 SHOW DEFAULT_TRANSACTION_ISOLATION
 ----
 repeatable read
-
-skipif config enterprise-configs
-query T
-SHOW DEFAULT_TRANSACTION_ISOLATION
-----
-serializable
 
 statement ok
 SET CLUSTER SETTING sql.txn.repeatable_read_isolation.enabled = false
@@ -903,17 +817,10 @@ SET CLUSTER SETTING sql.txn.repeatable_read_isolation.enabled = false
 statement ok
 SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL READ UNCOMMITTED
 
-onlyif config enterprise-configs
 query T
 SHOW DEFAULT_TRANSACTION_ISOLATION
 ----
 read committed
-
-skipif config enterprise-configs
-query T
-SHOW DEFAULT_TRANSACTION_ISOLATION
-----
-serializable
 
 statement ok
 SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL REPEATABLE READ
@@ -940,14 +847,12 @@ serializable
 statement ok
 SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL READ COMMITTED
 
-onlyif config enterprise-configs
 query T
 SHOW DEFAULT_TRANSACTION_ISOLATION
 ----
 read committed
 
 # SHOW without a transaction should create an auto-transaction with the new default level
-onlyif config enterprise-configs
 query T
 SHOW TRANSACTION ISOLATION LEVEL
 ----
@@ -964,40 +869,19 @@ serializable
 statement ok
 SET default_transaction_isolation = 'read uncommitted'
 
-onlyif config enterprise-configs
 query T
 SHOW default_transaction_isolation
 ----
 read committed
 
-skipif config enterprise-configs
-query T
-SHOW default_transaction_isolation
-----
-serializable
-
-onlyif config enterprise-configs
 query T noticetrace
 SET default_transaction_isolation = 'read committed'
 ----
 
-skipif config enterprise-configs
-query T noticetrace
-SET default_transaction_isolation = 'read committed'
-----
-NOTICE: READ COMMITTED isolation level is not allowed without an enterprise license; upgrading to SERIALIZABLE
-
-onlyif config enterprise-configs
 query T
 SHOW default_transaction_isolation
 ----
 read committed
-
-skipif config enterprise-configs
-query T
-SHOW default_transaction_isolation
-----
-serializable
 
 statement ok
 SET CLUSTER SETTING sql.txn.repeatable_read_isolation.enabled = true
@@ -1007,32 +891,18 @@ SET CLUSTER SETTING sql.txn.repeatable_read_isolation.enabled = true
 statement ok
 SET default_transaction_isolation = 'snapshot'
 
-onlyif config enterprise-configs
 query T
 SHOW default_transaction_isolation
 ----
 repeatable read
-
-skipif config enterprise-configs
-query T
-SHOW default_transaction_isolation
-----
-serializable
 
 statement ok
 SET DEFAULT_TRANSACTION_ISOLATION TO 'REPEATABLE READ'
 
-onlyif config enterprise-configs
 query T
 SHOW DEFAULT_TRANSACTION_ISOLATION
 ----
 repeatable read
-
-skipif config enterprise-configs
-query T
-SHOW default_transaction_isolation
-----
-serializable
 
 statement ok
 SET CLUSTER SETTING sql.txn.repeatable_read_isolation.enabled = false
@@ -1073,7 +943,6 @@ COMMIT
 statement ok
 BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED
 
-onlyif config enterprise-configs
 query T
 SHOW TRANSACTION ISOLATION LEVEL
 ----
@@ -1852,7 +1721,6 @@ ROLLBACK
 statement ok
 BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
 
-onlyif config enterprise-configs
 statement error pq: unsupported in READ COMMITTED isolation
 SELECT cluster_logical_timestamp();
 

--- a/pkg/sql/logictest/testdata/logic_test/zone_config_system_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config_system_tenant
@@ -26,11 +26,6 @@ ALTER TABLE t CONFIGURE ZONE USING num_replicas = 3;
 statement ok
 CREATE TABLE a(id INT PRIMARY KEY)
 
-# Check that global_reads cannot be set without a CCL binary and enterprise license.
-skipif config enterprise-configs
-statement error OSS binaries do not include enterprise features
-ALTER TABLE a CONFIGURE ZONE USING global_reads = true
-
 query IT
 SELECT zone_id, target FROM crdb_internal.zones ORDER BY 1
 ----

--- a/pkg/sql/roleoption/BUILD.bazel
+++ b/pkg/sql/roleoption/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/roleoption",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/base",
         "//pkg/cli/cliflags",
         "//pkg/clusterversion",
         "//pkg/security/distinguishedname",

--- a/pkg/sql/roleoption/role_option.go
+++ b/pkg/sql/roleoption/role_option.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"strings"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/cli/cliflags"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/security/distinguishedname"
@@ -237,9 +236,6 @@ func MakeListFromKVOptions(
 		switch option {
 		case SUBJECT:
 			roleOptions[i].Validate = func(settings *cluster.Settings, u username.SQLUsername, s string) error {
-				if err := base.CheckEnterpriseEnabled(settings, "SUBJECT role option"); err != nil {
-					return err
-				}
 				if u.IsRootUser() {
 					return errors.WithDetailf(
 						pgerror.Newf(pgcode.InvalidParameterValue, "role %q cannot have a SUBJECT", u),

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/zone_config_helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/zone_config_helpers.go
@@ -382,13 +382,7 @@ func evaluateZoneOptions(
 					pgerror.Newf(pgcode.InvalidParameterValue, "unsupported NULL value for %q",
 						tree.ErrString(name))
 			}
-			opt := zone.SupportedZoneConfigOptions[*name]
-			if opt.CheckAllowed != nil {
-				if err := opt.CheckAllowed(b, b.ClusterSettings(), datum); err != nil {
-					return nil, nil, nil, err
-				}
-			}
-			setter := opt.Setter
+			setter := zone.SupportedZoneConfigOptions[*name].Setter
 			setters = append(setters, func(c *zonepb.ZoneConfig) { setter(c, datum) })
 			optionsStr = append(optionsStr, fmt.Sprintf("%s = %s", name, datum))
 		}

--- a/pkg/sql/sem/tree/txn_test.go
+++ b/pkg/sql/sem/tree/txn_test.go
@@ -64,63 +64,39 @@ func TestUpgradeToEnabledLevel(t *testing.T) {
 	const SER = tree.SerializableIsolation
 
 	testCases := []struct {
-		in                      tree.IsolationLevel
-		allowRC                 bool
-		allowRR                 bool
-		license                 bool
-		expOut                  tree.IsolationLevel
-		expUpgraded             bool
-		expUpgradedDueToLicense bool
+		in          tree.IsolationLevel
+		allowRC     bool
+		allowRR     bool
+		expOut      tree.IsolationLevel
+		expUpgraded bool
 	}{
-		{in: RU, allowRC: false, allowRR: false, license: false, expOut: SER, expUpgraded: true, expUpgradedDueToLicense: false},
-		{in: RU, allowRC: true, allowRR: false, license: false, expOut: SER, expUpgraded: true, expUpgradedDueToLicense: true},
-		{in: RU, allowRC: false, allowRR: true, license: false, expOut: SER, expUpgraded: true, expUpgradedDueToLicense: true},
-		{in: RU, allowRC: true, allowRR: true, license: false, expOut: SER, expUpgraded: true, expUpgradedDueToLicense: true},
-		{in: RU, allowRC: false, allowRR: false, license: true, expOut: SER, expUpgraded: true, expUpgradedDueToLicense: false},
-		{in: RU, allowRC: true, allowRR: false, license: true, expOut: RC, expUpgraded: true, expUpgradedDueToLicense: false},
-		{in: RU, allowRC: false, allowRR: true, license: true, expOut: RR, expUpgraded: true, expUpgradedDueToLicense: false},
-		{in: RU, allowRC: true, allowRR: true, license: true, expOut: RC, expUpgraded: true, expUpgradedDueToLicense: false},
-		{in: RC, allowRC: false, allowRR: false, license: false, expOut: SER, expUpgraded: true, expUpgradedDueToLicense: false},
-		{in: RC, allowRC: true, allowRR: false, license: false, expOut: SER, expUpgraded: true, expUpgradedDueToLicense: true},
-		{in: RC, allowRC: false, allowRR: true, license: false, expOut: SER, expUpgraded: true, expUpgradedDueToLicense: true},
-		{in: RC, allowRC: true, allowRR: true, license: false, expOut: SER, expUpgraded: true, expUpgradedDueToLicense: true},
-		{in: RC, allowRC: false, allowRR: false, license: true, expOut: SER, expUpgraded: true, expUpgradedDueToLicense: false},
-		{in: RC, allowRC: true, allowRR: false, license: true, expOut: RC, expUpgraded: false, expUpgradedDueToLicense: false},
-		{in: RC, allowRC: false, allowRR: true, license: true, expOut: RR, expUpgraded: true, expUpgradedDueToLicense: false},
-		{in: RC, allowRC: true, allowRR: true, license: true, expOut: RC, expUpgraded: false, expUpgradedDueToLicense: false},
-		{in: RR, allowRC: false, allowRR: false, license: false, expOut: SER, expUpgraded: true, expUpgradedDueToLicense: false},
-		{in: RR, allowRC: true, allowRR: false, license: false, expOut: SER, expUpgraded: true, expUpgradedDueToLicense: false},
-		{in: RR, allowRC: false, allowRR: true, license: false, expOut: SER, expUpgraded: true, expUpgradedDueToLicense: true},
-		{in: RR, allowRC: true, allowRR: true, license: false, expOut: SER, expUpgraded: true, expUpgradedDueToLicense: true},
-		{in: RR, allowRC: false, allowRR: false, license: true, expOut: SER, expUpgraded: true, expUpgradedDueToLicense: false},
-		{in: RR, allowRC: true, allowRR: false, license: true, expOut: SER, expUpgraded: true, expUpgradedDueToLicense: false},
-		{in: RR, allowRC: false, allowRR: true, license: true, expOut: RR, expUpgraded: false, expUpgradedDueToLicense: false},
-		{in: RR, allowRC: true, allowRR: true, license: true, expOut: RR, expUpgraded: false, expUpgradedDueToLicense: false},
-		{in: SI, allowRC: false, allowRR: false, license: false, expOut: SER, expUpgraded: true, expUpgradedDueToLicense: false},
-		{in: SI, allowRC: true, allowRR: false, license: false, expOut: SER, expUpgraded: true, expUpgradedDueToLicense: false},
-		{in: SI, allowRC: false, allowRR: true, license: false, expOut: SER, expUpgraded: true, expUpgradedDueToLicense: true},
-		{in: SI, allowRC: true, allowRR: true, license: false, expOut: SER, expUpgraded: true, expUpgradedDueToLicense: true},
-		{in: SI, allowRC: false, allowRR: false, license: true, expOut: SER, expUpgraded: true, expUpgradedDueToLicense: false},
-		{in: SI, allowRC: true, allowRR: false, license: true, expOut: SER, expUpgraded: true, expUpgradedDueToLicense: false},
-		{in: SI, allowRC: false, allowRR: true, license: true, expOut: RR, expUpgraded: false, expUpgradedDueToLicense: false},
-		{in: SI, allowRC: true, allowRR: true, license: true, expOut: RR, expUpgraded: false, expUpgradedDueToLicense: false},
-		{in: SER, allowRC: false, allowRR: false, license: false, expOut: SER, expUpgraded: false, expUpgradedDueToLicense: false},
-		{in: SER, allowRC: true, allowRR: false, license: false, expOut: SER, expUpgraded: false, expUpgradedDueToLicense: false},
-		{in: SER, allowRC: false, allowRR: true, license: false, expOut: SER, expUpgraded: false, expUpgradedDueToLicense: false},
-		{in: SER, allowRC: true, allowRR: true, license: false, expOut: SER, expUpgraded: false, expUpgradedDueToLicense: false},
-		{in: SER, allowRC: false, allowRR: false, license: true, expOut: SER, expUpgraded: false, expUpgradedDueToLicense: false},
-		{in: SER, allowRC: true, allowRR: false, license: true, expOut: SER, expUpgraded: false, expUpgradedDueToLicense: false},
-		{in: SER, allowRC: false, allowRR: true, license: true, expOut: SER, expUpgraded: false, expUpgradedDueToLicense: false},
-		{in: SER, allowRC: true, allowRR: true, license: true, expOut: SER, expUpgraded: false, expUpgradedDueToLicense: false},
+		{in: RU, allowRC: false, allowRR: false, expOut: SER, expUpgraded: true},
+		{in: RU, allowRC: true, allowRR: false, expOut: RC, expUpgraded: true},
+		{in: RU, allowRC: false, allowRR: true, expOut: RR, expUpgraded: true},
+		{in: RU, allowRC: true, allowRR: true, expOut: RC, expUpgraded: true},
+		{in: RC, allowRC: false, allowRR: false, expOut: SER, expUpgraded: true},
+		{in: RC, allowRC: true, allowRR: false, expOut: RC, expUpgraded: false},
+		{in: RC, allowRC: false, allowRR: true, expOut: RR, expUpgraded: true},
+		{in: RC, allowRC: true, allowRR: true, expOut: RC, expUpgraded: false},
+		{in: RR, allowRC: false, allowRR: false, expOut: SER, expUpgraded: true},
+		{in: RR, allowRC: true, allowRR: false, expOut: SER, expUpgraded: true},
+		{in: RR, allowRC: false, allowRR: true, expOut: RR, expUpgraded: false},
+		{in: RR, allowRC: true, allowRR: true, expOut: RR, expUpgraded: false},
+		{in: SI, allowRC: false, allowRR: false, expOut: SER, expUpgraded: true},
+		{in: SI, allowRC: true, allowRR: false, expOut: SER, expUpgraded: true},
+		{in: SI, allowRC: false, allowRR: true, expOut: RR, expUpgraded: false},
+		{in: SI, allowRC: true, allowRR: true, expOut: RR, expUpgraded: false},
+		{in: SER, allowRC: false, allowRR: false, expOut: SER, expUpgraded: false},
+		{in: SER, allowRC: true, allowRR: false, expOut: SER, expUpgraded: false},
+		{in: SER, allowRC: false, allowRR: true, expOut: SER, expUpgraded: false},
+		{in: SER, allowRC: true, allowRR: true, expOut: SER, expUpgraded: false},
 	}
 
 	for _, tc := range testCases {
 		t.Run("", func(t *testing.T) {
-			res, upgraded, upgradedDueToLicense := tc.in.UpgradeToEnabledLevel(
-				tc.allowRC, tc.allowRR, tc.license)
+			res, upgraded := tc.in.UpgradeToEnabledLevel(tc.allowRC, tc.allowRR)
 			require.Equal(t, tc.expOut, res)
 			require.Equal(t, tc.expUpgraded, upgraded)
-			require.Equal(t, tc.expUpgradedDueToLicense, upgradedDueToLicense)
 		})
 	}
 }

--- a/pkg/sql/sessionmutator/mutator.go
+++ b/pkg/sql/sessionmutator/mutator.go
@@ -88,7 +88,7 @@ type SessionDataMutatorCallbacks struct {
 	// session variable is configured and the isolation level is automatically
 	// upgraded to a stronger one. It's also used when the isolation level is
 	// upgraded in BEGIN or SET TRANSACTION statements.
-	UpgradedIsolationLevel func(ctx context.Context, upgradedFrom tree.IsolationLevel, requiresNotice bool)
+	UpgradedIsolationLevel func(ctx context.Context, upgradedFrom tree.IsolationLevel)
 	// OnTempSchemaCreation is called when the temporary schema is set
 	// on the search path (the first and only time).
 	// It can be nil, in which case nothing triggers on execution.

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -296,13 +296,8 @@ func evaluateZoneOptions(
 				return nil, nil, nil, pgerror.Newf(pgcode.InvalidParameterValue,
 					"unsupported NULL value for %q", tree.ErrString(name))
 			}
-			opt := zone.SupportedZoneConfigOptions[*name]
-			if opt.CheckAllowed != nil {
-				if err := opt.CheckAllowed(params.ctx, params.ExecCfg().Settings, datum); err != nil {
-					return nil, nil, nil, err
-				}
-			}
-			setter := opt.Setter
+
+			setter := zone.SupportedZoneConfigOptions[*name].Setter
 			setters = append(setters, func(c *zonepb.ZoneConfig) { setter(c, datum) })
 			optionsStr = append(optionsStr, fmt.Sprintf("%s = %s", name, datum))
 		}

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
@@ -430,7 +429,6 @@ var varGen = map[string]sessionVar{
 		Set: func(ctx context.Context, m sessionmutator.SessionDataMutator, s string) error {
 			allowReadCommitted := allowReadCommittedIsolation.Get(&m.Settings.SV)
 			allowRepeatableRead := allowRepeatableReadIsolation.Get(&m.Settings.SV)
-			hasLicense := base.CCLDistributionAndEnterpriseEnabled(m.Settings)
 			var allowedValues = []string{"serializable"}
 			if allowRepeatableRead {
 				allowedValues = append(allowedValues, "repeatable read")
@@ -443,10 +441,10 @@ var varGen = map[string]sessionVar{
 				return newVarValueError(`default_transaction_isolation`, s, allowedValues...)
 			}
 			originalLevel := level
-			level, upgraded, upgradedDueToLicense := level.UpgradeToEnabledLevel(
-				allowReadCommitted, allowRepeatableRead, hasLicense)
+			level, upgraded := level.UpgradeToEnabledLevel(
+				allowReadCommitted, allowRepeatableRead)
 			if f := m.UpgradedIsolationLevel; upgraded && f != nil {
-				f(ctx, originalLevel, upgradedDueToLicense)
+				f(ctx, originalLevel)
 			}
 			m.SetDefaultTransactionIsolationLevel(level)
 			return nil

--- a/pkg/upgrade/migrationstable/migrations_table.go
+++ b/pkg/upgrade/migrationstable/migrations_table.go
@@ -80,15 +80,10 @@ const (
 //
 // staleOpt dictates whether the check will run a consistent read or a stale,
 // follower read. If txn is not nil, only ConsistentRead can be specified. If
-// enterpriseEnabled is set and the StaleRead option is passed, then AS OF
-// SYSTEM TIME with_max_staleness('1h') is used for the query.
+// the StaleRead option is passed, then AS OF SYSTEM TIME
+// with_max_staleness('1h') is used for the query.
 func CheckIfMigrationCompleted(
-	ctx context.Context,
-	v roachpb.Version,
-	txn *kv.Txn,
-	ex isql.Executor,
-	enterpriseEnabled bool,
-	staleOpt StaleReadOpt,
+	ctx context.Context, v roachpb.Version, txn *kv.Txn, ex isql.Executor, staleOpt StaleReadOpt,
 ) (alreadyCompleted bool, _ error) {
 	if txn != nil && staleOpt == StaleRead {
 		return false, errors.AssertionFailedf(
@@ -104,7 +99,7 @@ SELECT count(*)
 	 AND internal = $4
 `
 	var query string
-	if staleOpt == StaleRead && enterpriseEnabled {
+	if staleOpt == StaleRead {
 		query = fmt.Sprintf(queryFormat, "AS OF SYSTEM TIME with_max_staleness('1h')")
 	} else {
 		query = fmt.Sprintf(queryFormat, "")

--- a/pkg/upgrade/upgradejob/BUILD.bazel
+++ b/pkg/upgrade/upgradejob/BUILD.bazel
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/upgrade/upgradejob",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/base",
         "//pkg/clusterversion",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",

--- a/pkg/upgrade/upgradejob/upgrade_job.go
+++ b/pkg/upgrade/upgradejob/upgrade_job.go
@@ -10,7 +10,6 @@ package upgradejob
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
@@ -61,11 +60,9 @@ func (r resumer) Resume(ctx context.Context, execCtxI interface{}) error {
 	v := pl.GetMigration().ClusterVersion.Version
 	db := execCtx.ExecCfg().InternalDB
 	ex := db.Executor()
-	enterpriseEnabled := base.CCLDistributionAndEnterpriseEnabled(
-		execCtx.ExecCfg().Settings)
+
 	alreadyCompleted, err := migrationstable.CheckIfMigrationCompleted(
-		ctx, v, nil /* txn */, ex,
-		enterpriseEnabled, migrationstable.ConsistentRead,
+		ctx, v, nil /* txn */, ex, migrationstable.ConsistentRead,
 	)
 	if alreadyCompleted || err != nil {
 		return errors.Wrapf(err, "checking migration completion for %v", v)


### PR DESCRIPTION
This removes all enterprise license checks and the associated functions. Such checks were only exercised in tests since OSS build targets have been removed.

Note that removal of ccl.TestingEnableEnterprise and ccl.TestingDisableEnterprise will happen in follow-up PRs as I'm trying to limit the number of test failures I need to deal with at once.