### PR TITLE
db-console: convert network components to functional components

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/network/sort/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/network/sort/index.tsx
@@ -24,67 +24,60 @@ interface ISortProps {
   filter: NetworkFilter;
 }
 
-class Sort extends React.Component<ISortProps & RouteComponentProps, {}> {
-  onChange = ({ target }: any) => this.props.onChangeCollapse(target.checked);
+function getSortValues(sort: NetworkSort[]) {
+  return sort.map(value => ({
+    value: value.id,
+    label: value.id.replace(/^[a-z]/, m => m.toUpperCase()),
+  }));
+}
 
-  pageView = () => {
-    const { match } = this.props;
-    const nodeId = getMatchParamByName(match, "node_id");
-    return nodeId || "cluster";
-  };
+function Sort({
+  onChangeFilter,
+  onChangeCollapse,
+  deselectFilterByKey,
+  collapsed,
+  sort,
+  filter,
+  match,
+  history,
+  location,
+}: ISortProps & RouteComponentProps): React.ReactElement {
+  const nodeId = getMatchParamByName(match, "node_id");
+  const pageView = nodeId || "cluster";
 
-  navigateTo = (selected: DropdownOption) => {
+  const navigateTo = (selected: DropdownOption) => {
     trackNetworkSort(selected.label);
-    this.props.onChangeCollapse(false);
-    this.props.location.pathname = `/reports/network/${selected.value}`;
-    this.props.history.push(this.props.location);
+    onChangeCollapse(false);
+    location.pathname = `/reports/network/${selected.value}`;
+    history.push(location);
   };
 
-  getSortValues = (sort: NetworkSort[]) =>
-    sort.map(value => {
-      return {
-        value: value.id,
-        label: value.id.replace(/^[a-z]/, m => m.toUpperCase()),
-      };
-    });
-
-  render() {
-    const {
-      collapsed,
-      sort,
-      onChangeFilter,
-      deselectFilterByKey,
-      filter,
-      match,
-    } = this.props;
-    const nodeId = getMatchParamByName(match, "node_id");
-    return (
-      <div className="Sort-latency">
-        <Dropdown
-          title="Sort By"
-          options={this.getSortValues(sort)}
-          selected={this.pageView()}
-          onChange={this.navigateTo}
-          className="Sort-latency__dropdown--spacing"
-        />
-        <Filter
-          sort={sort}
-          onChangeFilter={onChangeFilter}
-          deselectFilterByKey={deselectFilterByKey}
-          filter={filter}
-          dropDownClassName="Sort-latency__dropdown--spacing"
-        />
-        <Divider type="vertical" style={{ height: "100%" }} />
-        <Checkbox
-          disabled={!nodeId || nodeId === "cluster"}
-          checked={collapsed}
-          onChange={this.onChange}
-        >
-          Collapse Nodes
-        </Checkbox>
-      </div>
-    );
-  }
+  return (
+    <div className="Sort-latency">
+      <Dropdown
+        title="Sort By"
+        options={getSortValues(sort)}
+        selected={pageView}
+        onChange={navigateTo}
+        className="Sort-latency__dropdown--spacing"
+      />
+      <Filter
+        sort={sort}
+        onChangeFilter={onChangeFilter}
+        deselectFilterByKey={deselectFilterByKey}
+        filter={filter}
+        dropDownClassName="Sort-latency__dropdown--spacing"
+      />
+      <Divider type="vertical" style={{ height: "100%" }} />
+      <Checkbox
+        disabled={!nodeId || nodeId === "cluster"}
+        checked={collapsed}
+        onChange={({ target }: any) => onChangeCollapse(target.checked)}
+      >
+        Collapse Nodes
+      </Checkbox>
+    </div>
+  );
 }
 
 export default withRouter(Sort);


### PR DESCRIPTION
Convert the following class components to functional style:
- network: useState for collapsed/filter state (filter renamed to networkFilter
  to avoid lodash shadow), componentDidMount + componentDidUpdate → useEffect
  (every-render for liveness/nodes/connectivity refresh), local var renames to
  avoid lodash shadows (values → vals).
- Filter: class state → useState for opened/width, React.createRef →
  useRef, componentDidMount/componentWillUnmount resize listener →
  useEffect with cleanup, firstLetterToUpperCase extracted to module
  scope, functional state updater pattern for toggles.
- Sort: getSortValues extracted to module scope, pageView computed
  as a const instead of a method.

Epic: CRDB-58145
Release note: None