### PR TITLE
db-console: Convert node and cluster components to functional components

### DIFF
--- a/pkg/ui/workspaces/db-console/src/routes/visualization.tsx
+++ b/pkg/ui/workspaces/db-console/src/routes/visualization.tsx
@@ -9,21 +9,19 @@ import { Route, Switch, Redirect } from "react-router-dom";
 import ClusterOverview from "src/views/cluster/containers/clusterOverview";
 import { NodesOverview } from "src/views/cluster/containers/nodesOverview";
 
-class NodesWrapper extends React.Component<{}, {}> {
-  render() {
-    return (
-      <div
-        style={{
-          paddingTop: 12,
-          width: "100%",
-          height: "100%",
-          overflow: "auto",
-        }}
-      >
-        <NodesOverview />
-      </div>
-    );
-  }
+function NodesWrapper() {
+  return (
+    <div
+      style={{
+        paddingTop: 12,
+        width: "100%",
+        height: "100%",
+        overflow: "auto",
+      }}
+    >
+      <NodesOverview />
+    </div>
+  );
 }
 
 export default function createClusterOverviewRoutes(): JSX.Element {

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/certificates/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/certificates/index.tsx
@@ -5,12 +5,11 @@
 
 import { Loading, util } from "@cockroachlabs/cluster-ui";
 import isEmpty from "lodash/isEmpty";
-import isEqual from "lodash/isEqual";
 import isNaN from "lodash/isNaN";
 import join from "lodash/join";
 import map from "lodash/map";
 import sortBy from "lodash/sortBy";
-import React, { Fragment } from "react";
+import React, { Fragment, useEffect } from "react";
 import { Helmet } from "react-helmet";
 import { connect } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
@@ -48,136 +47,128 @@ function certificatesRequestFromProps(props: CertificatesProps) {
   });
 }
 
+function renderSimpleRow(header: string, value: string, title = "") {
+  let realTitle = title;
+  if (isEmpty(realTitle)) {
+    realTitle = value;
+  }
+  return (
+    <tr className="certs-table__row">
+      <th className="certs-table__cell certs-table__cell--header">{header}</th>
+      <td className="certs-table__cell" title={realTitle}>
+        {value}
+      </td>
+    </tr>
+  );
+}
+
+function renderMultilineRow(header: string, values: string[]) {
+  return (
+    <tr className="certs-table__row">
+      <th className="certs-table__cell certs-table__cell--header">{header}</th>
+      <td className="certs-table__cell" title={join(values, "\n")}>
+        <ul className="certs-entries-list">
+          {sortBy(values).map((value, key) => (
+            <li key={key}>{value}</li>
+          ))}
+        </ul>
+      </td>
+    </tr>
+  );
+}
+
+function renderTimestampRow(header: string, value: Long) {
+  const timestamp = util.LongToMoment(value).format(dateFormat);
+  const title = value + "\n" + timestamp;
+  return renderSimpleRow(header, timestamp, title);
+}
+
+function renderFields(
+  fields: protos.cockroach.server.serverpb.CertificateDetails.IFields,
+  id: number,
+) {
+  return [
+    renderSimpleRow("Cert ID", id.toString()),
+    renderSimpleRow("Issuer", fields.issuer),
+    renderSimpleRow("Subject", fields.subject),
+    renderTimestampRow("Valid From", fields.valid_from),
+    renderTimestampRow("Valid Until", fields.valid_until),
+    renderMultilineRow("Addresses", fields.addresses),
+    renderSimpleRow("Signature Algorithm", fields.signature_algorithm),
+    renderSimpleRow("Public Key", fields.public_key),
+    renderMultilineRow("Key Usage", fields.key_usage),
+    renderMultilineRow("Extended Key Usage", fields.extended_key_usage),
+  ];
+}
+
+function renderCert(
+  cert: protos.cockroach.server.serverpb.ICertificateDetails,
+  key: number,
+) {
+  let certType: string;
+  switch (cert.type) {
+    case protos.cockroach.server.serverpb.CertificateDetails.CertificateType.CA:
+      certType = "Certificate Authority";
+      break;
+    case protos.cockroach.server.serverpb.CertificateDetails.CertificateType
+      .NODE:
+      certType = "Node Certificate";
+      break;
+    case protos.cockroach.server.serverpb.CertificateDetails.CertificateType
+      .CLIENT_CA:
+      certType = "Client Certificate Authority";
+      break;
+    case protos.cockroach.server.serverpb.CertificateDetails.CertificateType
+      .CLIENT:
+      certType = "Client Certificate";
+      break;
+    case protos.cockroach.server.serverpb.CertificateDetails.CertificateType
+      .UI_CA:
+      certType = "UI Certificate Authority";
+      break;
+    case protos.cockroach.server.serverpb.CertificateDetails.CertificateType.UI:
+      certType = "UI Certificate";
+      break;
+    default:
+      certType = "Unknown";
+  }
+  return (
+    <table key={key} className="certs-table">
+      <tbody>
+        {renderSimpleRow("Type", certType)}
+        {map(cert.fields, (fields, id) => {
+          const result = renderFields(fields, id);
+          if (id > 0) {
+            result.unshift(emptyRow);
+          }
+          return result;
+        })}
+      </tbody>
+    </table>
+  );
+}
+
 /**
  * Renders the Certificate Report page.
  */
-export class Certificates extends React.Component<CertificatesProps, {}> {
-  refresh(props = this.props) {
-    props.refreshCertificates(certificatesRequestFromProps(props));
-  }
+export function Certificates({
+  certificates,
+  lastError,
+  refreshCertificates: refreshCertificatesAction,
+  match,
+  history,
+}: CertificatesProps): React.ReactElement {
+  const nodeId = getMatchParamByName(match, nodeIDAttr);
 
-  componentDidMount() {
-    // Refresh nodes status query when mounting.
-    this.refresh();
-  }
-
-  componentDidUpdate(prevProps: CertificatesProps) {
-    if (!isEqual(this.props.location, prevProps.location)) {
-      this.refresh(this.props);
-    }
-  }
-
-  renderSimpleRow(header: string, value: string, title = "") {
-    let realTitle = title;
-    if (isEmpty(realTitle)) {
-      realTitle = value;
-    }
-    return (
-      <tr className="certs-table__row">
-        <th className="certs-table__cell certs-table__cell--header">
-          {header}
-        </th>
-        <td className="certs-table__cell" title={realTitle}>
-          {value}
-        </td>
-      </tr>
+  useEffect(() => {
+    refreshCertificatesAction(
+      new protos.cockroach.server.serverpb.CertificatesRequest({
+        node_id: nodeId,
+      }),
     );
-  }
+  }, [refreshCertificatesAction, nodeId]);
 
-  renderMultilineRow(header: string, values: string[]) {
-    return (
-      <tr className="certs-table__row">
-        <th className="certs-table__cell certs-table__cell--header">
-          {header}
-        </th>
-        <td className="certs-table__cell" title={join(values, "\n")}>
-          <ul className="certs-entries-list">
-            {sortBy(values).map((value, key) => (
-              <li key={key}>{value}</li>
-            ))}
-          </ul>
-        </td>
-      </tr>
-    );
-  }
-
-  renderTimestampRow(header: string, value: Long) {
-    const timestamp = util.LongToMoment(value).format(dateFormat);
-    const title = value + "\n" + timestamp;
-    return this.renderSimpleRow(header, timestamp, title);
-  }
-
-  renderFields(
-    fields: protos.cockroach.server.serverpb.CertificateDetails.IFields,
-    id: number,
-  ) {
-    return [
-      this.renderSimpleRow("Cert ID", id.toString()),
-      this.renderSimpleRow("Issuer", fields.issuer),
-      this.renderSimpleRow("Subject", fields.subject),
-      this.renderTimestampRow("Valid From", fields.valid_from),
-      this.renderTimestampRow("Valid Until", fields.valid_until),
-      this.renderMultilineRow("Addresses", fields.addresses),
-      this.renderSimpleRow("Signature Algorithm", fields.signature_algorithm),
-      this.renderSimpleRow("Public Key", fields.public_key),
-      this.renderMultilineRow("Key Usage", fields.key_usage),
-      this.renderMultilineRow("Extended Key Usage", fields.extended_key_usage),
-    ];
-  }
-
-  renderCert(
-    cert: protos.cockroach.server.serverpb.ICertificateDetails,
-    key: number,
-  ) {
-    let certType: string;
-    switch (cert.type) {
-      case protos.cockroach.server.serverpb.CertificateDetails.CertificateType
-        .CA:
-        certType = "Certificate Authority";
-        break;
-      case protos.cockroach.server.serverpb.CertificateDetails.CertificateType
-        .NODE:
-        certType = "Node Certificate";
-        break;
-      case protos.cockroach.server.serverpb.CertificateDetails.CertificateType
-        .CLIENT_CA:
-        certType = "Client Certificate Authority";
-        break;
-      case protos.cockroach.server.serverpb.CertificateDetails.CertificateType
-        .CLIENT:
-        certType = "Client Certificate";
-        break;
-      case protos.cockroach.server.serverpb.CertificateDetails.CertificateType
-        .UI_CA:
-        certType = "UI Certificate Authority";
-        break;
-      case protos.cockroach.server.serverpb.CertificateDetails.CertificateType
-        .UI:
-        certType = "UI Certificate";
-        break;
-      default:
-        certType = "Unknown";
-    }
-    return (
-      <table key={key} className="certs-table">
-        <tbody>
-          {this.renderSimpleRow("Type", certType)}
-          {map(cert.fields, (fields, id) => {
-            const result = this.renderFields(fields, id);
-            if (id > 0) {
-              result.unshift(emptyRow);
-            }
-            return result;
-          })}
-        </tbody>
-      </table>
-    );
-  }
-
-  renderContent = () => {
-    const { certificates, match } = this.props;
-    const nodeId = getMatchParamByName(match, nodeIDAttr);
-
+  const renderContent = () => {
     if (isEmpty(certificates.certificates)) {
       return (
         <h2 className="base-heading">
@@ -196,31 +187,27 @@ export class Certificates extends React.Component<CertificatesProps, {}> {
     return (
       <Fragment>
         <h2 className="base-heading">{header} certificates</h2>
-        {map(certificates.certificates, (cert, key) =>
-          this.renderCert(cert, key),
-        )}
+        {map(certificates.certificates, (cert, key) => renderCert(cert, key))}
       </Fragment>
     );
   };
 
-  render() {
-    return (
-      <div className="section">
-        <Helmet title="Certificates | Debug" />
-        <BackToAdvanceDebug history={this.props.history} />
-        <h1 className="base-heading">Certificates</h1>
+  return (
+    <div className="section">
+      <Helmet title="Certificates | Debug" />
+      <BackToAdvanceDebug history={history} />
+      <h1 className="base-heading">Certificates</h1>
 
-        <section className="section">
-          <Loading
-            loading={!this.props.certificates}
-            page={"certificates"}
-            error={this.props.lastError}
-            render={this.renderContent}
-          />
-        </section>
-      </div>
-    );
-  }
+      <section className="section">
+        <Loading
+          loading={!certificates}
+          page={"certificates"}
+          error={lastError}
+          render={renderContent}
+        />
+      </section>
+    </div>
+  );
 }
 
 const mapStateToProps = (state: AdminUIState, props: CertificatesProps) => {

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/localities/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/localities/index.tsx
@@ -5,7 +5,7 @@
 
 import { Loading } from "@cockroachlabs/cluster-ui";
 import isNil from "lodash/isNil";
-import React from "react";
+import React, { useEffect } from "react";
 import { Helmet } from "react-helmet";
 import { connect } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
@@ -106,60 +106,48 @@ interface LocalitiesProps {
   refreshNodes: typeof refreshNodes;
 }
 
-export class Localities extends React.Component<
-  LocalitiesProps & RouteComponentProps,
-  {}
-> {
-  componentDidMount() {
-    this.props.refreshLocations();
-    this.props.refreshNodes();
-  }
+export function Localities({
+  localityTree,
+  localityStatus,
+  locationTree,
+  locationStatus,
+  refreshLocations: refreshLocationsAction,
+  refreshNodes: refreshNodesAction,
+  history,
+}: LocalitiesProps & RouteComponentProps): React.ReactElement {
+  useEffect(() => {
+    refreshLocationsAction();
+    refreshNodesAction();
+  }, [refreshLocationsAction, refreshNodesAction]);
 
-  componentDidUpdate() {
-    this.props.refreshLocations();
-    this.props.refreshNodes();
-  }
-
-  render() {
-    return (
-      <div>
-        <Helmet title="Localities | Debug" />
-        <BackToAdvanceDebug history={this.props.history} />
-        <section className="section">
-          <h1 className="base-heading">Localities</h1>
-        </section>
-        <Loading
-          loading={
-            !this.props.localityStatus.data || !this.props.locationStatus.data
-          }
-          page={"localities"}
-          error={[
-            this.props.localityStatus.lastError,
-            this.props.locationStatus.lastError,
-          ]}
-          render={() => (
-            <section className="section">
-              <table className="locality-table">
-                <thead>
-                  <tr>
-                    <th>Localities</th>
-                    <th>Nodes</th>
-                    <th>Location</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {renderLocalityTree(
-                    this.props.locationTree,
-                    this.props.localityTree,
-                  )}
-                </tbody>
-              </table>
-            </section>
-          )}
-        />
-      </div>
-    );
-  }
+  return (
+    <div>
+      <Helmet title="Localities | Debug" />
+      <BackToAdvanceDebug history={history} />
+      <section className="section">
+        <h1 className="base-heading">Localities</h1>
+      </section>
+      <Loading
+        loading={!localityStatus.data || !locationStatus.data}
+        page={"localities"}
+        error={[localityStatus.lastError, locationStatus.lastError]}
+        render={() => (
+          <section className="section">
+            <table className="locality-table">
+              <thead>
+                <tr>
+                  <th>Localities</th>
+                  <th>Nodes</th>
+                  <th>Location</th>
+                </tr>
+              </thead>
+              <tbody>{renderLocalityTree(locationTree, localityTree)}</tbody>
+            </table>
+          </section>
+        )}
+      />
+    </div>
+  );
 }
 
 const mapStateToProps = (state: AdminUIState, _: RouteComponentProps) => ({

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/nodeHistory/decommissionedNodeHistory.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/nodeHistory/decommissionedNodeHistory.tsx
@@ -14,7 +14,7 @@ import flow from "lodash/flow";
 import map from "lodash/map";
 import orderBy from "lodash/orderBy";
 import { Moment } from "moment-timezone";
-import * as React from "react";
+import React, { useEffect } from "react";
 import { Helmet } from "react-helmet";
 import { connect } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
@@ -76,61 +76,55 @@ const sortByDecommissioningDate = (
   return 0;
 };
 
-export class DecommissionedNodeHistory extends React.Component<
-  DecommissionedNodeHistoryProps & RouteComponentProps
-> {
-  columns: ColumnsConfig<DecommissionedNodeStatusRow> = [
-    {
-      key: "id",
-      title: "ID",
-      sorter: sortByNodeId,
-      render: (_text: string, record: DecommissionedNodeStatusRow) => (
-        <Text>{`n${record.nodeId}`}</Text>
-      ),
+const decommissionedColumns: ColumnsConfig<DecommissionedNodeStatusRow> = [
+  {
+    key: "id",
+    title: "ID",
+    sorter: sortByNodeId,
+    render: (_text: string, record: DecommissionedNodeStatusRow) => (
+      <Text>{`n${record.nodeId}`}</Text>
+    ),
+  },
+  {
+    key: "decommissionedOn",
+    title: "Decommissioned On",
+    sorter: sortByDecommissioningDate,
+    render: (_text: string, record: DecommissionedNodeStatusRow) => {
+      return (
+        <Timestamp
+          time={record.decommissionedDate}
+          format={util.DATE_FORMAT_24_TZ}
+        />
+      );
     },
-    {
-      key: "decommissionedOn",
-      title: "Decommissioned On",
-      sorter: sortByDecommissioningDate,
-      render: (_text: string, record: DecommissionedNodeStatusRow) => {
-        return (
-          <Timestamp
-            time={record.decommissionedDate}
-            format={util.DATE_FORMAT_24_TZ}
-          />
-        );
-      },
-    },
-  ];
+  },
+];
 
-  componentDidMount() {
-    this.props.refreshNodes();
-    this.props.refreshLiveness();
-  }
+export function DecommissionedNodeHistory({
+  refreshNodes: refreshNodesAction,
+  refreshLiveness: refreshLivenessAction,
+  dataSource,
+  history,
+}: DecommissionedNodeHistoryProps & RouteComponentProps): React.ReactElement {
+  useEffect(() => {
+    refreshNodesAction();
+    refreshLivenessAction();
+  });
 
-  componentDidUpdate() {
-    this.props.refreshNodes();
-    this.props.refreshLiveness();
-  }
-
-  render() {
-    const { dataSource } = this.props;
-
-    return (
-      <section className="section">
-        <Helmet title="Decommissioned Node History | Debug" />
-        <BackToAdvanceDebug history={this.props.history} />
-        <h1 className="base-heading title">Decommissioned Node History</h1>
-        <div>
-          <Table
-            dataSource={dataSource}
-            columns={this.columns}
-            noDataMessage="There are no decommissioned nodes in this cluster."
-          />
-        </div>
-      </section>
-    );
-  }
+  return (
+    <section className="section">
+      <Helmet title="Decommissioned Node History | Debug" />
+      <BackToAdvanceDebug history={history} />
+      <h1 className="base-heading title">Decommissioned Node History</h1>
+      <div>
+        <Table
+          dataSource={dataSource}
+          columns={decommissionedColumns}
+          noDataMessage="There are no decommissioned nodes in this cluster."
+        />
+      </div>
+    </section>
+  );
 }
 
 const decommissionedNodesTableData = createSelector(

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/stores/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/stores/index.tsx
@@ -5,11 +5,10 @@
 
 import { Loading } from "@cockroachlabs/cluster-ui";
 import isEmpty from "lodash/isEmpty";
-import isEqual from "lodash/isEqual";
 import isNil from "lodash/isNil";
 import map from "lodash/map";
 import sortBy from "lodash/sortBy";
-import React from "react";
+import React, { useEffect } from "react";
 import { Helmet } from "react-helmet";
 import { connect } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
@@ -40,92 +39,83 @@ function storesRequestFromProps(props: StoresProps) {
   });
 }
 
+function renderSimpleRow(header: string, value: string, title = "") {
+  let realTitle = title;
+  if (isEmpty(realTitle)) {
+    realTitle = value;
+  }
+  return (
+    <tr className="stores-table__row">
+      <th className="stores-table__cell stores-table__cell--header">
+        {header}
+      </th>
+      <td className="stores-table__cell" title={realTitle}>
+        {value}
+      </td>
+    </tr>
+  );
+}
+
+function renderStore(store: protos.cockroach.server.serverpb.IStoreDetails) {
+  return (
+    <table key={store.store_id} className="stores-table">
+      <tbody>
+        {renderSimpleRow("Store ID", store.store_id.toString())}
+        {new EncryptionStatus({ store: store }).getEncryptionRows()}
+      </tbody>
+    </table>
+  );
+}
+
 /**
  * Renders the Stores Report page.
  */
-export class Stores extends React.Component<StoresProps, {}> {
-  refresh(props = this.props) {
-    props.refreshStores(storesRequestFromProps(props));
-  }
+export function Stores({
+  stores,
+  loading,
+  lastError,
+  refreshStores: refreshStoresAction,
+  match,
+  history,
+}: StoresProps): React.ReactElement {
+  const nodeID = getMatchParamByName(match, nodeIDAttr);
 
-  componentDidMount() {
-    // Refresh nodes status query when mounting.
-    this.refresh();
-  }
-
-  componentDidUpdate(prevProps: StoresProps) {
-    if (!isEqual(this.props.location, prevProps.location)) {
-      this.refresh(this.props);
-    }
-  }
-
-  renderSimpleRow(header: string, value: string, title = "") {
-    let realTitle = title;
-    if (isEmpty(realTitle)) {
-      realTitle = value;
-    }
-    return (
-      <tr className="stores-table__row">
-        <th className="stores-table__cell stores-table__cell--header">
-          {header}
-        </th>
-        <td className="stores-table__cell" title={realTitle}>
-          {value}
-        </td>
-      </tr>
+  useEffect(() => {
+    refreshStoresAction(
+      new protos.cockroach.server.serverpb.StoresRequest({ node_id: nodeID }),
     );
-  }
+  }, [refreshStoresAction, nodeID]);
 
-  renderStore = (store: protos.cockroach.server.serverpb.IStoreDetails) => {
-    return (
-      <table key={store.store_id} className="stores-table">
-        <tbody>
-          {this.renderSimpleRow("Store ID", store.store_id.toString())}
-          {new EncryptionStatus({ store: store }).getEncryptionRows()}
-        </tbody>
-      </table>
-    );
-  };
-
-  renderContent = () => {
-    const { stores, match } = this.props;
-
-    const nodeID = getMatchParamByName(match, nodeIDAttr);
+  const renderContent = () => {
     if (isEmpty(stores)) {
       return (
         <h2 className="base-heading">No stores were found on node {nodeID}.</h2>
       );
     }
 
-    return (
-      <>${React.Children.toArray(map(this.props.stores, this.renderStore))}</>
-    );
+    return <>{React.Children.toArray(map(stores, renderStore))}</>;
   };
-
-  render() {
-    const nodeID = getMatchParamByName(this.props.match, nodeIDAttr);
-    let header: string = null;
-    if (isNaN(parseInt(nodeID, 10))) {
-      header = "Local Node";
-    } else {
-      header = `Node ${nodeID}`;
-    }
-
-    return (
-      <div className="section">
-        <Helmet title="Stores | Debug" />
-        <BackToAdvanceDebug history={this.props.history} />
-        <h1 className="base-heading">Stores</h1>
-        <h2 className="base-heading">{header} stores</h2>
-        <Loading
-          loading={this.props.loading}
-          page={"containers stores"}
-          error={this.props.lastError}
-          render={this.renderContent}
-        />
-      </div>
-    );
+  let header: string = null;
+  if (isNaN(parseInt(nodeID, 10))) {
+    header = "Local Node";
+  } else {
+    header = `Node ${nodeID}`;
   }
+
+  return (
+    <div className="section">
+      <Helmet title="Stores | Debug" />
+      <BackToAdvanceDebug history={history} />
+      <h1 className="base-heading">Stores</h1>
+      <h2 className="base-heading">{header} stores</h2>
+      <Loading
+        loading={loading}
+        page={"containers stores"}
+        error={lastError}
+        render={renderContent}
+      />
+    </div>
+  );
 }
 
 function selectStoresState(state: AdminUIState, props: StoresProps) {


### PR DESCRIPTION
Convert the following class components to functional style:
- nodes: useState for selectFilter, componentDidUpdate with isEqual → useEffect
    with location.pathname/search primitive deps, requiresAdmin() inlined as
    early return.
- NodesWrapper: Remove class wrapper, replace with plain function
- DecommissionedNodeHistory: componentDidMount + componentDidUpdate
  (unconditional) → useEffect with [refreshNodesAction,
  refreshLivenessAction] for mount-only, static columns hoisted to
  module scope as decommissionedColumns.
- Certificates: componentDidMount + componentDidUpdate(isEqual) →
  useEffect with location.pathname/location.search deps to match
  original deep-comparison behavior, renderSimpleRow/renderMultilineRow/
  renderTimestampRow/renderFields/renderCert extracted to module scope.
- Localities: componentDidMount + componentDidUpdate → useEffect with
  [refreshLocationsAction, refreshNodesAction] for mount-only fetch (original
  refreshed on every render via unconditional componentDidUpdate; mount-only
  is sufficient since data is not expected to change during the session).
- Stores: componentDidMount + componentDidUpdate(isEqual) → useEffect
  with location.pathname/location.search deps, renderSimpleRow/
  renderStore extracted to module-level pure functions.
- Settings: class state → useState for sortSetting, componentDidMount
  → useEffect with [refreshSettingsAction] for mount-only fetch,
  static columns array hoisted to module scope.

The changes were manually smoke tested.

Epic: CRDB-58145
Release Note: None