### PR TITLE
concurrency: disable VIR metamorphic testing

### DIFF
--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -168,7 +168,12 @@ var VirtualIntentResolution = settings.RegisterBoolSetting(
 	settings.SystemOnly,
 	"kv.concurrency.virtual_intent_resolution.enabled",
 	"whether read-only, non-locking requests should virtually resolve intents",
-	metamorphic.ConstantWithTestBool("kv.concurrency.virtual_intent_resolution.enabled", false),
+	false,
+	// TODO(ssd): Re-enable after
+	// https://github.com/cockroachdb/cockroach/issues/164175 is diagnosed and
+	// solved.
+	// metamorphic.ConstantWithTestBool("kv.concurrency.virtual_intent_resolution.enabled",
+	// false),
 	settings.WithValidateBool(func(_ *settings.Values, b bool) error {
 		if b && !buildutil.CrdbTestBuild {
 			return errors.New("kv.concurrency.virtual_intent_resolution.enabled is not supported in production builds")


### PR DESCRIPTION
Metamorphic testing has revealed a problem that we are currently diagnosing. We will re-enable this once this issue is resolved.

Informs #164175

Release note: None