### PR TITLE
backfill: flush progress after non-final merge iteration completion

### DIFF
--- a/pkg/sql/index_backfiller.go
+++ b/pkg/sql/index_backfiller.go
@@ -482,8 +482,12 @@ func (ib *IndexBackfillPlanner) runDistributedMerge(
 		default:
 		}
 
-		// Reset task tracking for this iteration.
+		// Reset task tracking for this iteration and set progress so that we
+		// persist it.
 		progress.MergeIterationCompletedTasks = nil
+		if err := tracker.SetBackfillProgress(ctx, *progress); err != nil {
+			return err
+		}
 
 		genOutputURIAndRecordPrefix := func(instanceID base.SQLInstanceID) (string, error) {
 			// Use nodelocal for temporary storage of merged SSTs. These SSTs are


### PR DESCRIPTION
Call SetBackfillProgress after the first merge iteration completes to persist updated progress.

Previously, fraction_completed was not persisted until tasks began completing in the final merge iteration. If an error occurs in the final merge iteration, or work is slow, the job would remain stuck at 0% for long periods of time.

Closes #164182
Epic: CRDB-48845
Release note: None