### PR TITLE
indexbackfiller: populate RowSample in checkpointed manifests

### DIFF
--- a/pkg/sql/index_backfiller.go
+++ b/pkg/sql/index_backfiller.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -591,6 +592,13 @@ func (ib *IndexBackfillPlanner) runDistributedMerge(
 				URI:      sst.URI,
 				Span:     &span,
 				KeyCount: sst.KeyCount,
+				// Populate RowSample so CombineFileInfo can split schema spans on
+				// resume. StartKey is already a row prefix (family suffix stripped
+				// by SSTWriter.Flush), but CombineFileInfo passes samples through
+				// keys.EnsureSafeSplitKey which expects a full key including the
+				// column family suffix. Re-appending family 0 makes the key valid
+				// for that function.
+				RowSample: keys.MakeFamilyKey(append(roachpb.Key(nil), sst.StartKey...), 0),
 			})
 		}
 		progress.SSTManifests = newManifests

--- a/pkg/sql/indexbackfiller_test.go
+++ b/pkg/sql/indexbackfiller_test.go
@@ -1672,6 +1672,15 @@ func TestDistributedMergeResumePreservesProgress(t *testing.T) {
 					state.manifestCountByIteration[iteration] = len(manifests)
 					t.Logf("[%s] after distributed merge iteration %d, manifests count: %d", state.currentTestName, iteration, len(manifests))
 
+					if len(manifests) > 0 {
+						for i, m := range manifests {
+							if len(m.RowSample) == 0 {
+								t.Errorf("[%s] iteration %d: manifest %d has empty RowSample",
+									state.currentTestName, iteration, i)
+							}
+						}
+					}
+
 					if len(manifests) == 0 {
 						t.Logf("[%s] final iteration %d completed (direct KV ingest)", state.currentTestName, iteration)
 						state.finalIterationCompleted.Store(true)
@@ -1937,6 +1946,16 @@ func TestDistributedMergeResumePreservesProgress(t *testing.T) {
 				require.True(t, state.finalIterationCompleted.Load(),
 					"expected final iteration (KV ingest) to complete after pause/resume at iteration %d",
 					tc.pauseAfterIteration)
+
+				// Verify that the paused iteration produced multiple manifests. Combined
+				// with the RowSample assertion in AfterDistributedMergeIteration, this
+				// guarantees that CombineFileInfo can split work into multiple merge spans
+				// on resume, preserving parallelism.
+				manifestCount := state.manifestCountByIteration[tc.pauseAfterIteration]
+				require.Greater(t, manifestCount, 1,
+					"expected multiple manifests from iteration %d for parallelism on resume",
+					tc.pauseAfterIteration)
+
 				t.Logf("resumption from iteration %d completed with final KV ingest (total iterations: %d)",
 					tc.pauseAfterIteration, state.currentIteration.Load())
 			}


### PR DESCRIPTION
When a non-final merge iteration completes, its output SSTs are converted to manifests and checkpointed in job progress. On a fresh run, the loop continues to the next iteration using in-memory state, so the checkpointed manifests are never re-read. On restart, however, runDistributedMerge is called fresh with the checkpointed manifests, which are fed through CombineFileInfo to split schema spans into parallel merge tasks using RowSamples.

Without RowSample populated, CombineFileInfo has no split points and produces a single merge span, silently reducing the final KV-ingest iteration to a single task and losing all parallelism.

This fixes it by populating the RowSample in the checkpoint.

Epic: CRDB-48845
Closes #164256
Release note: None