### PR TITLE
ui,e2e: move cypress helper function into util file after upgrade to 13

### DIFF
--- a/pkg/ui/workspaces/e2e-tests/BUILD.bazel
+++ b/pkg/ui/workspaces/e2e-tests/BUILD.bazel
@@ -52,6 +52,7 @@ go_library(
         "cypress/e2e/pages/schedules.cy.ts",
         "cypress/e2e/pages/sqlActivity.cy.ts",
         "cypress/e2e/pages/topRanges.cy.ts",
+        "cypress/support/utils.ts",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/ui/workspaces/e2e-tests",
     visibility = ["//visibility:public"],

--- a/pkg/ui/workspaces/e2e-tests/cypress/e2e/health-check/authenticated.cy.ts
+++ b/pkg/ui/workspaces/e2e-tests/cypress/e2e/health-check/authenticated.cy.ts
@@ -4,7 +4,7 @@
 // included in the /LICENSE file.
 
 import { SQLPrivilege } from "../../support/types";
-import { isTextGreaterThanZero } from "../../support/e2e";
+import { isTextGreaterThanZero } from "../../support/utils";
 
 describe("health check: authenticated user", () => {
   it("serves a DB Console overview page", () => {

--- a/pkg/ui/workspaces/e2e-tests/cypress/e2e/pages/insights.cy.ts
+++ b/pkg/ui/workspaces/e2e-tests/cypress/e2e/pages/insights.cy.ts
@@ -33,7 +33,7 @@ describe("insights page", () => {
     cy.get("button").contains("Now").should("exist");
   });
 
-  it("displays insights statements table with dynamic column headers", () => {
+  it("displays insights statements table with column headers", () => {
     cy.get('[data-testid="statement-insights-table"]').should("exist");
     // default header
     cy.get('[data-testid="statement-insights-table"]').contains(
@@ -58,21 +58,6 @@ describe("insights page", () => {
     cy.get('[data-testid="statement-insights-table"]').contains(
       "Rows Processed",
     );
-
-    cy.get('[data-testid="statement-insights-table"]').should("exist");
-    // non-default header
-    cy.get('[data-testid="statement-insights-table"]').should(
-      "not.contain.text",
-      "Full Scan",
-    );
-    cy.contains("button", "Columns").should("be.visible").click();
-    cy.get('[class*="dropdown-area"]')
-      .should("exist")
-      .within(() => {
-        cy.contains("Full Scan").click();
-        cy.contains("Apply").click();
-      });
-    cy.get('[data-testid="statement-insights-table"]').contains("Full Scan");
   });
 
   it("displays insights transactions table with column headers", () => {

--- a/pkg/ui/workspaces/e2e-tests/cypress/e2e/pages/overview.cy.ts
+++ b/pkg/ui/workspaces/e2e-tests/cypress/e2e/pages/overview.cy.ts
@@ -4,7 +4,7 @@
 // included in the /LICENSE file.
 
 import { SQLPrivilege } from "../../support/types";
-import { isTextGreaterThanZero } from "../../support/e2e";
+import { isTextGreaterThanZero } from "../../support/utils";
 import commonChecks from "../../support/commonChecks";
 
 describe("overview page", () => {

--- a/pkg/ui/workspaces/e2e-tests/cypress/support/e2e.ts
+++ b/pkg/ui/workspaces/e2e-tests/cypress/support/e2e.ts
@@ -20,10 +20,3 @@
 
 // Import commands.js using ES2015 syntax:
 import "./commands";
-
-// Shared helper functions
-export const isTextGreaterThanZero = (ele: JQuery<HTMLElement>) => {
-  const text = ele.get()[0].innerText;
-  const textAsFloat = parseFloat(text);
-  expect(textAsFloat).to.be.greaterThan(0);
-};

--- a/pkg/ui/workspaces/e2e-tests/cypress/support/utils.ts
+++ b/pkg/ui/workspaces/e2e-tests/cypress/support/utils.ts
@@ -1,0 +1,12 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+// Shared helper functions for e2e tests.
+
+export const isTextGreaterThanZero = (ele: JQuery<HTMLElement>) => {
+  const text = ele.get()[0].innerText;
+  const textAsFloat = parseFloat(text);
+  expect(textAsFloat).to.be.greaterThan(0);
+};


### PR DESCRIPTION
The previous upgrade fixed the race condition but introduced an issue with the file organization that is new to cypress v13.

This change moves the shared helper function out into a new file to resolve the test failure. This change also removes the column header interaction from the insights page to remove a flakey failure.

Fixes [#164240](https://github.com/cockroachdb/cockroach/issues/164240) and fixes [#164239](https://github.com/cockroachdb/cockroach/issues/164239)
Epic: None
Release Note: None