### PR TITLE
workloadccl: fix log.Scope() race and enable test sharding

### DIFF
--- a/pkg/ccl/workloadccl/allccl/BUILD.bazel
+++ b/pkg/ccl/workloadccl/allccl/BUILD.bazel
@@ -47,7 +47,7 @@ go_test(
         "main_test.go",
     ],
     embed = [":allccl"],
-    shard_count = 4,
+    shard_count = 5,
     deps = [
         "//pkg/base",
         "//pkg/ccl",


### PR DESCRIPTION
Previously, TestAllRegisteredImportFixture ran all workload tests as
subtests within a single test function. This caused two issues:

1. Race condition: tpcc and tpccmultidb ran in parallel and both used
   log.Scope(), which is not thread-safe as it saves and restores
   global mutable state.

2. No Bazel sharding: All workloads ran in one test function, preventing
   Bazel's test sharding (which works at the test function level, not
   subtest level) from distributing work across shards.

This commit splits the test into two separate test functions:

1. TestImportFixture_TPC: Runs tpcc and tpccmultidb sequentially
   to avoid the log.Scope() race condition.

2. TestImportFixture_Others: Runs all remaining workloads, explicitly
   excluding problematic ones (workload_generator, startrek, roachmart,
   ttlbench, tpch).

Changes:
- Extracted runImportFixtureTest(): Shared test logic to reduce duplication
- Added runIncludedWorkloads(): Wrapper to run only specified workloads
- Added runExcludedWorkloads(): Wrapper to run all except specified workloads
- Added runImportFixtures(): Underlying implementation with include/exclude
  filtering
- Changed BUILD.bazel shard_count from 4 to 5

The three-function wrapper design makes the intent explicit at call sites
and avoids the complexity of having both include and exclude parameters
(which are mutually exclusive) in a single function.

Fixes: #164266
Epic: None

Release note: None