### PR TITLE
util/metric, server/status: fix +Inf in GaugeFloat64 JSON marshaling

### DIFF
--- a/pkg/server/status/recorder.go
+++ b/pkg/server/status/recorder.go
@@ -892,7 +892,11 @@ func extractValue(name string, mtr interface{}, fn func(string, float64)) error 
 		// NB: this branch is intentionally at the bottom since all metrics implement it.
 		m := mtr.ToPrometheusMetric()
 		if m.Gauge != nil {
-			fn(name, *m.Gauge.Value)
+			v := *m.Gauge.Value
+			if math.IsInf(v, 0) || math.IsNaN(v) {
+				v = 0
+			}
+			fn(name, v)
 		} else if m.Counter != nil {
 			fn(name, *m.Counter.Value)
 		}

--- a/pkg/util/metric/metric.go
+++ b/pkg/util/metric/metric.go
@@ -1182,7 +1182,11 @@ func (g *GaugeFloat64) Inspect(f func(interface{})) { f(g) }
 
 // MarshalJSON marshals to JSON.
 func (g *GaugeFloat64) MarshalJSON() ([]byte, error) {
-	return json.Marshal(g.Value())
+	v := g.Value()
+	if math.IsInf(v, 0) || math.IsNaN(v) {
+		v = 0
+	}
+	return json.Marshal(v)
 }
 
 // ToPrometheusMetric returns a filled-in prometheus metric of the right type.

--- a/pkg/util/metric/metric_test.go
+++ b/pkg/util/metric/metric_test.go
@@ -119,6 +119,22 @@ func TestGaugeFloat64(t *testing.T) {
 	}
 }
 
+func TestGaugeFloat64MarshalInfNaN(t *testing.T) {
+	g := NewGaugeFloat64(emptyMetadata)
+
+	g.Update(math.Inf(1))
+	testMarshal(t, g, "0")
+
+	g.Update(math.Inf(-1))
+	testMarshal(t, g, "0")
+
+	g.Update(math.NaN())
+	testMarshal(t, g, "0")
+
+	g.Update(42.5)
+	testMarshal(t, g, "42.5")
+}
+
 func TestCounter(t *testing.T) {
 	c := NewCounter(emptyMetadata)
 	c.Inc(90)


### PR DESCRIPTION
GaugeFloat64.MarshalJSON() could produce a JSON marshaling error when
the gauge's value was +Inf, -Inf, or NaN, since Go's encoding/json
rejects these values. This caused the /_status/metrics/local endpoint
to return HTTP 500, which is the root cause of the TestStopServer
flake.

The most likely source of +Inf was division by zero in
RuntimeStatSampler.SampleEnvironment() when the elapsed duration
between two samples was zero (possible under the race detector).
Several rate computations (CPU usage, GC pause ratio, runnable
goroutines, cgo call rate) divided by the elapsed duration without
guarding against zero.

Fix both the source and the symptom:
- Guard all divisions by elapsed duration in SampleEnvironment()
  against dur <= 0.
- Sanitize +Inf/-Inf/NaN to 0 in GaugeFloat64.MarshalJSON() as
  defense in depth, matching the pattern already used for histogram
  avg computed metrics.
- Sanitize +Inf/-Inf/NaN gauge values in extractValue() to prevent
  non-finite floats from reaching TSDB recording.

Fixes https://github.com/cockroachdb/cockroach/issues/164147
Fixes https://github.com/cockroachdb/cockroach/issues/163932

Release note: None