### PR TITLE
sql/regions: fix replica leak in super region constraint generation

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region
@@ -407,7 +407,7 @@ TABLE regional_primary_region_table  ALTER TABLE regional_primary_region_table C
                                        gc.ttlseconds = 14400,
                                        num_replicas = 5,
                                        num_voters = 5,
-                                       constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                       constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',
                                        voter_constraints = '{+region=ca-central-1: 2}',
                                        lease_preferences = '[[+region=ca-central-1]]'
 
@@ -442,7 +442,7 @@ TABLE regional_implicit_primary_region_table  ALTER TABLE regional_implicit_prim
                                                 gc.ttlseconds = 14400,
                                                 num_replicas = 5,
                                                 num_voters = 5,
-                                                constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',
                                                 voter_constraints = '{+region=ca-central-1: 2}',
                                                 lease_preferences = '[[+region=ca-central-1]]'
 
@@ -467,7 +467,7 @@ TABLE "regional_us-east-1_table"  ALTER TABLE "regional_us-east-1_table" CONFIGU
                                     gc.ttlseconds = 14400,
                                     num_replicas = 5,
                                     num_voters = 5,
-                                    constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                    constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 2}',
                                     voter_constraints = '{+region=us-east-1: 2}',
                                     lease_preferences = '[[+region=us-east-1]]'
 
@@ -939,7 +939,7 @@ TABLE t_no_locality  ALTER TABLE t_no_locality CONFIGURE ZONE USING
                        gc.ttlseconds = 14400,
                        num_replicas = 5,
                        num_voters = 5,
-                       constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                       constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',
                        voter_constraints = '{+region=ca-central-1: 2}',
                        lease_preferences = '[[+region=ca-central-1]]'
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_survival_goal
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_survival_goal
@@ -51,7 +51,7 @@ TABLE alter_survive_db.public.t  ALTER TABLE alter_survive_db.public.t CONFIGURE
                                    gc.ttlseconds = 14400,
                                    num_replicas = 5,
                                    num_voters = 5,
-                                   constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                   constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',
                                    voter_constraints = '{+region=ca-central-1: 2}',
                                    lease_preferences = '[[+region=ca-central-1]]'
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_config_extensions
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_config_extensions
@@ -44,7 +44,7 @@ TABLE tbl  ALTER TABLE tbl CONFIGURE ZONE USING
              gc.ttlseconds = 14400,
              num_replicas = 5,
              num_voters = 5,
-             constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
+             constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',
              voter_constraints = '{+region=ca-central-1: 2}',
              lease_preferences = '[[+region=ca-central-1]]'
 
@@ -76,7 +76,7 @@ TABLE tbl  ALTER TABLE tbl CONFIGURE ZONE USING
              gc.ttlseconds = 14400,
              num_replicas = 9,
              num_voters = 5,
-             constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
+             constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',
              voter_constraints = '{+region=ca-central-1: 2}',
              lease_preferences = '[[+region=ca-central-1]]'
 
@@ -113,7 +113,7 @@ TABLE tbl  ALTER TABLE tbl CONFIGURE ZONE USING
              gc.ttlseconds = 14400,
              num_replicas = 9,
              num_voters = 5,
-             constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
+             constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',
              voter_constraints = '{+region=ca-central-1: 2}',
              lease_preferences = '[[+region=ca-central-1], [+region=ap-southeast-2]]'
 
@@ -135,7 +135,7 @@ TABLE tbl  ALTER TABLE tbl CONFIGURE ZONE USING
              gc.ttlseconds = 14400,
              num_replicas = 9,
              num_voters = 5,
-             constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
+             constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',
              voter_constraints = '{+region=ca-central-1: 2}',
              lease_preferences = '[[+region=ca-central-1], [+region=ap-southeast-2]]'
 
@@ -157,7 +157,7 @@ TABLE tbl  ALTER TABLE tbl CONFIGURE ZONE USING
              gc.ttlseconds = 14400,
              num_replicas = 9,
              num_voters = 5,
-             constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',
+             constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',
              voter_constraints = '{+region=ap-southeast-2: 2}',
              lease_preferences = '[[+region=ap-southeast-2], [+region=us-east-1]]'
 
@@ -179,7 +179,7 @@ TABLE tbl  ALTER TABLE tbl CONFIGURE ZONE USING
              gc.ttlseconds = 14400,
              num_replicas = 9,
              num_voters = 5,
-             constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
+             constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 2}',
              voter_constraints = '{+region=us-east-1: 2}',
              lease_preferences = '[[+region=us-east-1]]'
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -117,9 +117,9 @@ query TTT
 SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row_table_explicit_crdb_region_column]
 ORDER BY partition_name, index_name
 ----
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_table_explicit_crdb_region_column@regional_by_row_table_explicit_crdb_region_column_pkey  ap-southeast-2
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'      regional_by_row_table_explicit_crdb_region_column@regional_by_row_table_explicit_crdb_region_column_pkey  ca-central-1
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'            regional_by_row_table_explicit_crdb_region_column@regional_by_row_table_explicit_crdb_region_column_pkey  us-east-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_table_explicit_crdb_region_column@regional_by_row_table_explicit_crdb_region_column_pkey  ap-southeast-2
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'      regional_by_row_table_explicit_crdb_region_column@regional_by_row_table_explicit_crdb_region_column_pkey  ca-central-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 2}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'            regional_by_row_table_explicit_crdb_region_column@regional_by_row_table_explicit_crdb_region_column_pkey  us-east-1
 
 query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_table_explicit_crdb_region_column
@@ -188,18 +188,18 @@ query TTT
 SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row_table]
 ORDER BY partition_name, index_name
 ----
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_table@regional_by_row_table_a_idx  ap-southeast-2
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_table@regional_by_row_table_b_key  ap-southeast-2
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_table@regional_by_row_table_j_idx  ap-southeast-2
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_table@regional_by_row_table_pkey   ap-southeast-2
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'      regional_by_row_table@regional_by_row_table_a_idx  ca-central-1
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'      regional_by_row_table@regional_by_row_table_b_key  ca-central-1
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'      regional_by_row_table@regional_by_row_table_j_idx  ca-central-1
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'      regional_by_row_table@regional_by_row_table_pkey   ca-central-1
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'            regional_by_row_table@regional_by_row_table_a_idx  us-east-1
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'            regional_by_row_table@regional_by_row_table_b_key  us-east-1
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'            regional_by_row_table@regional_by_row_table_j_idx  us-east-1
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'            regional_by_row_table@regional_by_row_table_pkey   us-east-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_table@regional_by_row_table_a_idx  ap-southeast-2
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_table@regional_by_row_table_b_key  ap-southeast-2
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_table@regional_by_row_table_j_idx  ap-southeast-2
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_table@regional_by_row_table_pkey   ap-southeast-2
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'      regional_by_row_table@regional_by_row_table_a_idx  ca-central-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'      regional_by_row_table@regional_by_row_table_b_key  ca-central-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'      regional_by_row_table@regional_by_row_table_j_idx  ca-central-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'      regional_by_row_table@regional_by_row_table_pkey   ca-central-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 2}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'            regional_by_row_table@regional_by_row_table_a_idx  us-east-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 2}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'            regional_by_row_table@regional_by_row_table_b_key  us-east-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 2}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'            regional_by_row_table@regional_by_row_table_j_idx  us-east-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 2}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'            regional_by_row_table@regional_by_row_table_pkey   us-east-1
 
 query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_table
@@ -308,21 +308,21 @@ query TTT
 SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row_table]
 ORDER BY partition_name, index_name
 ----
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'             regional_by_row_table@regional_by_row_table_a_idx           ap-southeast-2
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'             regional_by_row_table@regional_by_row_table_b_key           ap-southeast-2
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'             regional_by_row_table@regional_by_row_table_j_idx           ap-southeast-2
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'             regional_by_row_table@regional_by_row_table_pkey            ap-southeast-2
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'             regional_by_row_table@regional_by_row_table_unique_col_key  ap-southeast-2
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'                 regional_by_row_table@regional_by_row_table_a_idx           ca-central-1
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'                 regional_by_row_table@regional_by_row_table_b_key           ca-central-1
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'                 regional_by_row_table@regional_by_row_table_j_idx           ca-central-1
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'                 regional_by_row_table@regional_by_row_table_pkey            ca-central-1
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'                 regional_by_row_table@regional_by_row_table_unique_col_key  ca-central-1
-gc.ttlseconds = 10,\nnum_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'  regional_by_row_table@regional_by_row_table_a_idx           us-east-1
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'                       regional_by_row_table@regional_by_row_table_b_key           us-east-1
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'                       regional_by_row_table@regional_by_row_table_j_idx           us-east-1
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'                       regional_by_row_table@regional_by_row_table_pkey            us-east-1
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'                       regional_by_row_table@regional_by_row_table_unique_col_key  us-east-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'             regional_by_row_table@regional_by_row_table_a_idx           ap-southeast-2
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'             regional_by_row_table@regional_by_row_table_b_key           ap-southeast-2
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'             regional_by_row_table@regional_by_row_table_j_idx           ap-southeast-2
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'             regional_by_row_table@regional_by_row_table_pkey            ap-southeast-2
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'             regional_by_row_table@regional_by_row_table_unique_col_key  ap-southeast-2
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'                 regional_by_row_table@regional_by_row_table_a_idx           ca-central-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'                 regional_by_row_table@regional_by_row_table_b_key           ca-central-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'                 regional_by_row_table@regional_by_row_table_j_idx           ca-central-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'                 regional_by_row_table@regional_by_row_table_pkey            ca-central-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'                 regional_by_row_table@regional_by_row_table_unique_col_key  ca-central-1
+gc.ttlseconds = 10,\nnum_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 2}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'  regional_by_row_table@regional_by_row_table_a_idx           us-east-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 2}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'                       regional_by_row_table@regional_by_row_table_b_key           us-east-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 2}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'                       regional_by_row_table@regional_by_row_table_j_idx           us-east-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 2}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'                       regional_by_row_table@regional_by_row_table_pkey            us-east-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 2}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'                       regional_by_row_table@regional_by_row_table_unique_col_key  us-east-1
 
 statement ok
 ALTER TABLE regional_by_row_table DROP COLUMN unique_col
@@ -492,7 +492,7 @@ PARTITION "ap-southeast-2" OF INDEX regional_by_row_table@regional_by_row_table_
                                                                                         gc.ttlseconds = 14400,
                                                                                         num_replicas = 5,
                                                                                         num_voters = 5,
-                                                                                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',
+                                                                                        constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',
                                                                                         voter_constraints = '{+region=ap-southeast-2: 2}',
                                                                                         lease_preferences = '[[+region=ap-southeast-2]]'
 
@@ -505,7 +505,7 @@ PARTITION "ap-southeast-2" OF INDEX regional_by_row_table@regional_by_row_table_
                                                                                           gc.ttlseconds = 14400,
                                                                                           num_replicas = 5,
                                                                                           num_voters = 5,
-                                                                                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',
+                                                                                          constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',
                                                                                           voter_constraints = '{+region=ap-southeast-2: 2}',
                                                                                           lease_preferences = '[[+region=ap-southeast-2]]'
 
@@ -518,7 +518,7 @@ PARTITION "ap-southeast-2" OF INDEX regional_by_row_table@unique_b_a  ALTER PART
                                                                         gc.ttlseconds = 14400,
                                                                         num_replicas = 5,
                                                                         num_voters = 5,
-                                                                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',
+                                                                        constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',
                                                                         voter_constraints = '{+region=ap-southeast-2: 2}',
                                                                         lease_preferences = '[[+region=ap-southeast-2]]'
 
@@ -583,15 +583,15 @@ query TTT
 SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row_table_as]
 ORDER BY partition_name, index_name
 ----
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_table_as@regional_by_row_table_as_a_idx  ap-southeast-2
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_table_as@regional_by_row_table_as_b_key  ap-southeast-2
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_table_as@regional_by_row_table_as_pkey   ap-southeast-2
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'      regional_by_row_table_as@regional_by_row_table_as_a_idx  ca-central-1
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'      regional_by_row_table_as@regional_by_row_table_as_b_key  ca-central-1
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'      regional_by_row_table_as@regional_by_row_table_as_pkey   ca-central-1
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'            regional_by_row_table_as@regional_by_row_table_as_a_idx  us-east-1
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'            regional_by_row_table_as@regional_by_row_table_as_b_key  us-east-1
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'            regional_by_row_table_as@regional_by_row_table_as_pkey   us-east-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_table_as@regional_by_row_table_as_a_idx  ap-southeast-2
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_table_as@regional_by_row_table_as_b_key  ap-southeast-2
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_table_as@regional_by_row_table_as_pkey   ap-southeast-2
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'      regional_by_row_table_as@regional_by_row_table_as_a_idx  ca-central-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'      regional_by_row_table_as@regional_by_row_table_as_b_key  ca-central-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'      regional_by_row_table_as@regional_by_row_table_as_pkey   ca-central-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 2}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'            regional_by_row_table_as@regional_by_row_table_as_a_idx  us-east-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 2}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'            regional_by_row_table_as@regional_by_row_table_as_b_key  us-east-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 2}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'            regional_by_row_table_as@regional_by_row_table_as_pkey   us-east-1
 
 query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_table_as
@@ -646,7 +646,7 @@ PARTITION "us-east-1" OF TABLE t_regional_by_row  ALTER PARTITION "us-east-1" OF
                                                     gc.ttlseconds = 14400,
                                                     num_replicas = 5,
                                                     num_voters = 5,
-                                                    constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                    constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 2}',
                                                     voter_constraints = '{+region=us-east-1: 2}',
                                                     lease_preferences = '[[+region=us-east-1]]'
 
@@ -654,17 +654,17 @@ query TTT
 SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE t_regional_by_row]
 ORDER BY partition_name, index_name
 ----
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'  t_regional_by_row@t_regional_by_row_pkey  ap-southeast-2
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'      t_regional_by_row@t_regional_by_row_pkey  ca-central-1
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'            t_regional_by_row@t_regional_by_row_pkey  us-east-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'  t_regional_by_row@t_regional_by_row_pkey  ap-southeast-2
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'      t_regional_by_row@t_regional_by_row_pkey  ca-central-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 2}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'            t_regional_by_row@t_regional_by_row_pkey  us-east-1
 
 query TTT
 SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE t_regional_by_row]
 ORDER BY partition_name, index_name
 ----
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'  t_regional_by_row@t_regional_by_row_pkey  ap-southeast-2
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'      t_regional_by_row@t_regional_by_row_pkey  ca-central-1
-num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'            t_regional_by_row@t_regional_by_row_pkey  us-east-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'  t_regional_by_row@t_regional_by_row_pkey  ap-southeast-2
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'      t_regional_by_row@t_regional_by_row_pkey  ca-central-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 2}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'            t_regional_by_row@t_regional_by_row_pkey  us-east-1
 
 query TT
 SHOW ZONE CONFIGURATION FROM TABLE t_regional_by_row

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
@@ -67,7 +67,7 @@ TABLE regional_by_row_table
  │         │    │    └── ('ap-southeast-2')
  │         │    └── ZONE
  │         │         ├── replica constraints
- │         │         │    ├── 1 replicas: [+region=ap-southeast-2]
+ │         │         │    ├── 2 replicas: [+region=ap-southeast-2]
  │         │         │    ├── 2 replicas: [+region=ca-central-1]
  │         │         │    └── 1 replicas: [+region=us-east-1]
  │         │         ├── voter constraints: [+region=ap-southeast-2]
@@ -78,7 +78,7 @@ TABLE regional_by_row_table
  │         │    └── ZONE
  │         │         ├── replica constraints
  │         │         │    ├── 2 replicas: [+region=ap-southeast-2]
- │         │         │    ├── 1 replicas: [+region=ca-central-1]
+ │         │         │    ├── 2 replicas: [+region=ca-central-1]
  │         │         │    └── 1 replicas: [+region=us-east-1]
  │         │         ├── voter constraints: [+region=ca-central-1]
  │         │         └── lease preference: [+region=ca-central-1]
@@ -89,7 +89,7 @@ TABLE regional_by_row_table
  │                   ├── replica constraints
  │                   │    ├── 2 replicas: [+region=ap-southeast-2]
  │                   │    ├── 1 replicas: [+region=ca-central-1]
- │                   │    └── 1 replicas: [+region=us-east-1]
+ │                   │    └── 2 replicas: [+region=us-east-1]
  │                   ├── voter constraints: [+region=us-east-1]
  │                   └── lease preference: [+region=us-east-1]
  ├── INDEX regional_by_row_table_a_idx
@@ -109,7 +109,7 @@ TABLE regional_by_row_table
  │         │    │    └── ('ap-southeast-2')
  │         │    └── ZONE
  │         │         ├── replica constraints
- │         │         │    ├── 1 replicas: [+region=ap-southeast-2]
+ │         │         │    ├── 2 replicas: [+region=ap-southeast-2]
  │         │         │    ├── 2 replicas: [+region=ca-central-1]
  │         │         │    └── 1 replicas: [+region=us-east-1]
  │         │         ├── voter constraints: [+region=ap-southeast-2]
@@ -120,7 +120,7 @@ TABLE regional_by_row_table
  │         │    └── ZONE
  │         │         ├── replica constraints
  │         │         │    ├── 2 replicas: [+region=ap-southeast-2]
- │         │         │    ├── 1 replicas: [+region=ca-central-1]
+ │         │         │    ├── 2 replicas: [+region=ca-central-1]
  │         │         │    └── 1 replicas: [+region=us-east-1]
  │         │         ├── voter constraints: [+region=ca-central-1]
  │         │         └── lease preference: [+region=ca-central-1]
@@ -131,7 +131,7 @@ TABLE regional_by_row_table
  │                   ├── replica constraints
  │                   │    ├── 2 replicas: [+region=ap-southeast-2]
  │                   │    ├── 1 replicas: [+region=ca-central-1]
- │                   │    └── 1 replicas: [+region=us-east-1]
+ │                   │    └── 2 replicas: [+region=us-east-1]
  │                   ├── voter constraints: [+region=us-east-1]
  │                   └── lease preference: [+region=us-east-1]
  ├── UNIQUE INDEX regional_by_row_table_b_key
@@ -151,7 +151,7 @@ TABLE regional_by_row_table
  │         │    │    └── ('ap-southeast-2')
  │         │    └── ZONE
  │         │         ├── replica constraints
- │         │         │    ├── 1 replicas: [+region=ap-southeast-2]
+ │         │         │    ├── 2 replicas: [+region=ap-southeast-2]
  │         │         │    ├── 2 replicas: [+region=ca-central-1]
  │         │         │    └── 1 replicas: [+region=us-east-1]
  │         │         ├── voter constraints: [+region=ap-southeast-2]
@@ -162,7 +162,7 @@ TABLE regional_by_row_table
  │         │    └── ZONE
  │         │         ├── replica constraints
  │         │         │    ├── 2 replicas: [+region=ap-southeast-2]
- │         │         │    ├── 1 replicas: [+region=ca-central-1]
+ │         │         │    ├── 2 replicas: [+region=ca-central-1]
  │         │         │    └── 1 replicas: [+region=us-east-1]
  │         │         ├── voter constraints: [+region=ca-central-1]
  │         │         └── lease preference: [+region=ca-central-1]
@@ -173,7 +173,7 @@ TABLE regional_by_row_table
  │                   ├── replica constraints
  │                   │    ├── 2 replicas: [+region=ap-southeast-2]
  │                   │    ├── 1 replicas: [+region=ca-central-1]
- │                   │    └── 1 replicas: [+region=us-east-1]
+ │                   │    └── 2 replicas: [+region=us-east-1]
  │                   ├── voter constraints: [+region=us-east-1]
  │                   └── lease preference: [+region=us-east-1]
  ├── INVERTED INDEX regional_by_row_table_j_idx
@@ -193,7 +193,7 @@ TABLE regional_by_row_table
  │         │    │    └── ('ap-southeast-2')
  │         │    └── ZONE
  │         │         ├── replica constraints
- │         │         │    ├── 1 replicas: [+region=ap-southeast-2]
+ │         │         │    ├── 2 replicas: [+region=ap-southeast-2]
  │         │         │    ├── 2 replicas: [+region=ca-central-1]
  │         │         │    └── 1 replicas: [+region=us-east-1]
  │         │         ├── voter constraints: [+region=ap-southeast-2]
@@ -204,7 +204,7 @@ TABLE regional_by_row_table
  │         │    └── ZONE
  │         │         ├── replica constraints
  │         │         │    ├── 2 replicas: [+region=ap-southeast-2]
- │         │         │    ├── 1 replicas: [+region=ca-central-1]
+ │         │         │    ├── 2 replicas: [+region=ca-central-1]
  │         │         │    └── 1 replicas: [+region=us-east-1]
  │         │         ├── voter constraints: [+region=ca-central-1]
  │         │         └── lease preference: [+region=ca-central-1]
@@ -215,7 +215,7 @@ TABLE regional_by_row_table
  │                   ├── replica constraints
  │                   │    ├── 2 replicas: [+region=ap-southeast-2]
  │                   │    ├── 1 replicas: [+region=ca-central-1]
- │                   │    └── 1 replicas: [+region=us-east-1]
+ │                   │    └── 2 replicas: [+region=us-east-1]
  │                   ├── voter constraints: [+region=us-east-1]
  │                   └── lease preference: [+region=us-east-1]
  ├── UNIQUE WITHOUT INDEX (pk)

--- a/pkg/ccl/logictestccl/testdata/logic_test/secondary_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/secondary_region
@@ -230,7 +230,7 @@ TABLE db.public.rbt_in_primary  ALTER TABLE db.public.rbt_in_primary CONFIGURE Z
                                   gc.ttlseconds = 14400,
                                   num_replicas = 5,
                                   num_voters = 5,
-                                  constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                  constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',
                                   voter_constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2}',
                                   lease_preferences = '[[+region=ap-southeast-2], [+region=ca-central-1]]'
 
@@ -243,7 +243,7 @@ TABLE db.public.rbt_in_us_east  ALTER TABLE db.public.rbt_in_us_east CONFIGURE Z
                                   gc.ttlseconds = 14400,
                                   num_replicas = 5,
                                   num_voters = 5,
-                                  constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                  constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 2}',
                                   voter_constraints = '{+region=ca-central-1: 2, +region=us-east-1: 2}',
                                   lease_preferences = '[[+region=us-east-1], [+region=ca-central-1]]'
 
@@ -256,7 +256,7 @@ TABLE db.public.rbt_in_ca_central  ALTER TABLE db.public.rbt_in_ca_central CONFI
                                      gc.ttlseconds = 14400,
                                      num_replicas = 5,
                                      num_voters = 5,
-                                     constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                     constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',
                                      voter_constraints = '{+region=ca-central-1: 2}',
                                      lease_preferences = '[[+region=ca-central-1]]'
 
@@ -270,7 +270,7 @@ PARTITION "us-east-1" OF TABLE db.public.rbr  ALTER PARTITION "us-east-1" OF TAB
                                                 gc.ttlseconds = 14400,
                                                 num_replicas = 5,
                                                 num_voters = 5,
-                                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 2}',
                                                 voter_constraints = '{+region=ca-central-1: 2, +region=us-east-1: 2}',
                                                 lease_preferences = '[[+region=us-east-1], [+region=ca-central-1]]'
 
@@ -283,7 +283,7 @@ PARTITION "ap-southeast-2" OF TABLE db.public.rbr  ALTER PARTITION "ap-southeast
                                                      gc.ttlseconds = 14400,
                                                      num_replicas = 5,
                                                      num_voters = 5,
-                                                     constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                     constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',
                                                      voter_constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2}',
                                                      lease_preferences = '[[+region=ap-southeast-2], [+region=ca-central-1]]'
 
@@ -296,7 +296,7 @@ PARTITION "ca-central-1" OF TABLE db.public.rbr  ALTER PARTITION "ca-central-1" 
                                                    gc.ttlseconds = 14400,
                                                    num_replicas = 5,
                                                    num_voters = 5,
-                                                   constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                   constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',
                                                    voter_constraints = '{+region=ca-central-1: 2}',
                                                    lease_preferences = '[[+region=ca-central-1]]'
 
@@ -330,7 +330,7 @@ TABLE db.public.rbt_in_us_east  ALTER TABLE db.public.rbt_in_us_east CONFIGURE Z
                                   gc.ttlseconds = 14400,
                                   num_replicas = 5,
                                   num_voters = 5,
-                                  constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                  constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 2}',
                                   voter_constraints = '{+region=ca-central-1: 2, +region=us-east-1: 2}',
                                   lease_preferences = '[[+region=us-east-1], [+region=ca-central-1]]'
 
@@ -343,7 +343,7 @@ TABLE db.public.rbt_in_ca_central  ALTER TABLE db.public.rbt_in_ca_central CONFI
                                      gc.ttlseconds = 14400,
                                      num_replicas = 5,
                                      num_voters = 5,
-                                     constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                     constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',
                                      voter_constraints = '{+region=ca-central-1: 2}',
                                      lease_preferences = '[[+region=ca-central-1]]'
 
@@ -357,7 +357,7 @@ PARTITION "us-east-1" OF TABLE db.public.rbr  ALTER PARTITION "us-east-1" OF TAB
                                                 gc.ttlseconds = 14400,
                                                 num_replicas = 5,
                                                 num_voters = 5,
-                                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 2}',
                                                 voter_constraints = '{+region=ca-central-1: 2, +region=us-east-1: 2}',
                                                 lease_preferences = '[[+region=us-east-1], [+region=ca-central-1]]'
 
@@ -370,7 +370,7 @@ PARTITION "ap-southeast-2" OF TABLE db.public.rbr  ALTER PARTITION "ap-southeast
                                                      gc.ttlseconds = 14400,
                                                      num_replicas = 5,
                                                      num_voters = 5,
-                                                     constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                     constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',
                                                      voter_constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2}',
                                                      lease_preferences = '[[+region=ap-southeast-2], [+region=ca-central-1]]'
 
@@ -383,7 +383,7 @@ PARTITION "ca-central-1" OF TABLE db.public.rbr  ALTER PARTITION "ca-central-1" 
                                                    gc.ttlseconds = 14400,
                                                    num_replicas = 5,
                                                    num_voters = 5,
-                                                   constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                   constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',
                                                    voter_constraints = '{+region=ca-central-1: 2}',
                                                    lease_preferences = '[[+region=ca-central-1]]'
 
@@ -415,7 +415,7 @@ TABLE db.public.rbt_in_us_east  ALTER TABLE db.public.rbt_in_us_east CONFIGURE Z
                                   gc.ttlseconds = 14400,
                                   num_replicas = 5,
                                   num_voters = 5,
-                                  constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                  constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 2}',
                                   voter_constraints = '{+region=us-east-1: 2}',
                                   lease_preferences = '[[+region=us-east-1]]'
 
@@ -428,7 +428,7 @@ PARTITION "ap-southeast-2" OF TABLE db.public.rbr  ALTER PARTITION "ap-southeast
                                                      gc.ttlseconds = 14400,
                                                      num_replicas = 5,
                                                      num_voters = 5,
-                                                     constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',
+                                                     constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',
                                                      voter_constraints = '{+region=ap-southeast-2: 2}',
                                                      lease_preferences = '[[+region=ap-southeast-2]]'
 
@@ -441,7 +441,7 @@ PARTITION "ca-central-1" OF TABLE db.public.rbr  ALTER PARTITION "ca-central-1" 
                                                    gc.ttlseconds = 14400,
                                                    num_replicas = 5,
                                                    num_voters = 5,
-                                                   constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                   constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',
                                                    voter_constraints = '{+region=ca-central-1: 2}',
                                                    lease_preferences = '[[+region=ca-central-1]]'
 
@@ -472,7 +472,7 @@ TABLE db.public.rbt_in_us_east  ALTER TABLE db.public.rbt_in_us_east CONFIGURE Z
                                   gc.ttlseconds = 14400,
                                   num_replicas = 5,
                                   num_voters = 5,
-                                  constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                  constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 2}',
                                   voter_constraints = '{+region=us-east-1: 2}',
                                   lease_preferences = '[[+region=us-east-1]]'
 
@@ -485,7 +485,7 @@ TABLE db.public.rbt_in_ca_central  ALTER TABLE db.public.rbt_in_ca_central CONFI
                                      gc.ttlseconds = 14400,
                                      num_replicas = 5,
                                      num_voters = 5,
-                                     constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                     constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',
                                      voter_constraints = '{+region=ca-central-1: 2}',
                                      lease_preferences = '[[+region=ca-central-1]]'
 
@@ -518,7 +518,7 @@ TABLE db.public.rbt_in_us_east  ALTER TABLE db.public.rbt_in_us_east CONFIGURE Z
                                   gc.ttlseconds = 14400,
                                   num_replicas = 5,
                                   num_voters = 5,
-                                  constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                  constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 2}',
                                   voter_constraints = '{+region=us-east-1: 2}',
                                   lease_preferences = '[[+region=us-east-1]]'
 
@@ -531,7 +531,7 @@ TABLE db.public.rbt_in_ca_central  ALTER TABLE db.public.rbt_in_ca_central CONFI
                                      gc.ttlseconds = 14400,
                                      num_replicas = 5,
                                      num_voters = 5,
-                                     constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                     constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',
                                      voter_constraints = '{+region=ca-central-1: 2, +region=us-east-1: 2}',
                                      lease_preferences = '[[+region=ca-central-1], [+region=us-east-1]]'
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/super_regions
+++ b/pkg/ccl/logictestccl/testdata/logic_test/super_regions
@@ -21,7 +21,7 @@ TABLE oncreate.public.rbt  ALTER TABLE oncreate.public.rbt CONFIGURE ZONE USING
                              gc.ttlseconds = 14400,
                              num_replicas = 4,
                              num_voters = 3,
-                             constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                             constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
                              voter_constraints = '[+region=us-east-1]',
                              lease_preferences = '[[+region=us-east-1]]'
 
@@ -34,7 +34,7 @@ PARTITION "us-east-1" OF TABLE oncreate.public.rbr  ALTER PARTITION "us-east-1" 
                                                       gc.ttlseconds = 14400,
                                                       num_replicas = 4,
                                                       num_voters = 3,
-                                                      constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                                                      constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
                                                       voter_constraints = '[+region=us-east-1]',
                                                       lease_preferences = '[[+region=us-east-1]]'
 
@@ -85,7 +85,7 @@ TABLE mr1.public.rbt  ALTER TABLE mr1.public.rbt CONFIGURE ZONE USING
                         gc.ttlseconds = 14400,
                         num_replicas = 3,
                         num_voters = 3,
-                        constraints = '{+region=us-east-1: 1}',
+                        constraints = '{+region=us-east-1: 3}',
                         voter_constraints = '[+region=us-east-1]',
                         lease_preferences = '[[+region=us-east-1]]'
 
@@ -112,7 +112,7 @@ PARTITION "us-east-1" OF TABLE mr1.public.rbr  ALTER PARTITION "us-east-1" OF TA
                                                  gc.ttlseconds = 14400,
                                                  num_replicas = 3,
                                                  num_voters = 3,
-                                                 constraints = '{+region=us-east-1: 1}',
+                                                 constraints = '{+region=us-east-1: 3}',
                                                  voter_constraints = '[+region=us-east-1]',
                                                  lease_preferences = '[[+region=us-east-1]]'
 
@@ -158,7 +158,7 @@ TABLE mr2.public.t_rt_us_east_1  ALTER TABLE mr2.public.t_rt_us_east_1 CONFIGURE
                                    gc.ttlseconds = 14400,
                                    num_replicas = 4,
                                    num_voters = 3,
-                                   constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                                   constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
                                    voter_constraints = '[+region=us-east-1]',
                                    lease_preferences = '[[+region=us-east-1]]'
 
@@ -171,7 +171,7 @@ TABLE mr2.public.t_rt_primary_region  ALTER TABLE mr2.public.t_rt_primary_region
                                         gc.ttlseconds = 14400,
                                         num_replicas = 4,
                                         num_voters = 3,
-                                        constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                                        constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
                                         voter_constraints = '[+region=us-east-1]',
                                         lease_preferences = '[[+region=us-east-1]]'
 
@@ -184,7 +184,7 @@ TABLE mr2.public.t_rt  ALTER TABLE mr2.public.t_rt CONFIGURE ZONE USING
                          gc.ttlseconds = 14400,
                          num_replicas = 4,
                          num_voters = 3,
-                         constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                         constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
                          voter_constraints = '[+region=ap-southeast-2]',
                          lease_preferences = '[[+region=ap-southeast-2]]'
 
@@ -197,7 +197,7 @@ TABLE mr2.public.t_rt_with_idx  ALTER TABLE mr2.public.t_rt_with_idx CONFIGURE Z
                                   gc.ttlseconds = 14400,
                                   num_replicas = 4,
                                   num_voters = 3,
-                                  constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                                  constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
                                   voter_constraints = '[+region=ap-southeast-2]',
                                   lease_preferences = '[[+region=ap-southeast-2]]'
 
@@ -210,7 +210,7 @@ TABLE mr2.public.t_rt_with_idx  ALTER TABLE mr2.public.t_rt_with_idx CONFIGURE Z
                                   gc.ttlseconds = 14400,
                                   num_replicas = 4,
                                   num_voters = 3,
-                                  constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                                  constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
                                   voter_constraints = '[+region=ap-southeast-2]',
                                   lease_preferences = '[[+region=ap-southeast-2]]'
 
@@ -223,7 +223,7 @@ PARTITION "us-east-1" OF TABLE mr2.public.t_rbr  ALTER PARTITION "us-east-1" OF 
                                                    gc.ttlseconds = 14400,
                                                    num_replicas = 4,
                                                    num_voters = 3,
-                                                   constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                                                   constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
                                                    voter_constraints = '[+region=us-east-1]',
                                                    lease_preferences = '[[+region=us-east-1]]'
 
@@ -236,7 +236,7 @@ PARTITION "ap-southeast-2" OF TABLE mr2.public.t_rbr_with_idx  ALTER PARTITION "
                                                                  gc.ttlseconds = 14400,
                                                                  num_replicas = 4,
                                                                  num_voters = 3,
-                                                                 constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                                                                 constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
                                                                  voter_constraints = '[+region=ap-southeast-2]',
                                                                  lease_preferences = '[[+region=ap-southeast-2]]'
 
@@ -263,7 +263,7 @@ PARTITION "ap-southeast-2" OF INDEX mr2.public.t_rbr_with_idx@idx  ALTER PARTITI
                                                                      gc.ttlseconds = 14400,
                                                                      num_replicas = 4,
                                                                      num_voters = 3,
-                                                                     constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                                                                     constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
                                                                      voter_constraints = '[+region=ap-southeast-2]',
                                                                      lease_preferences = '[[+region=ap-southeast-2]]'
 
@@ -289,7 +289,7 @@ TABLE mr2.public.t_rt2  ALTER TABLE mr2.public.t_rt2 CONFIGURE ZONE USING
                           gc.ttlseconds = 14400,
                           num_replicas = 4,
                           num_voters = 3,
-                          constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                          constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
                           voter_constraints = '[+region=ap-southeast-2]',
                           lease_preferences = '[[+region=ap-southeast-2]]'
 
@@ -302,7 +302,7 @@ TABLE mr2.public.t_rt_with_idx2  ALTER TABLE mr2.public.t_rt_with_idx2 CONFIGURE
                                    gc.ttlseconds = 14400,
                                    num_replicas = 4,
                                    num_voters = 3,
-                                   constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                                   constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
                                    voter_constraints = '[+region=ap-southeast-2]',
                                    lease_preferences = '[[+region=ap-southeast-2]]'
 
@@ -315,7 +315,7 @@ TABLE mr2.public.t_rt_with_idx2  ALTER TABLE mr2.public.t_rt_with_idx2 CONFIGURE
                                    gc.ttlseconds = 14400,
                                    num_replicas = 4,
                                    num_voters = 3,
-                                   constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                                   constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
                                    voter_constraints = '[+region=ap-southeast-2]',
                                    lease_preferences = '[[+region=ap-southeast-2]]'
 
@@ -328,7 +328,7 @@ PARTITION "us-east-1" OF TABLE mr2.public.t_rbr2  ALTER PARTITION "us-east-1" OF
                                                     gc.ttlseconds = 14400,
                                                     num_replicas = 4,
                                                     num_voters = 3,
-                                                    constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                                                    constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
                                                     voter_constraints = '[+region=us-east-1]',
                                                     lease_preferences = '[[+region=us-east-1]]'
 
@@ -341,7 +341,7 @@ PARTITION "ap-southeast-2" OF TABLE mr2.public.t_rbr_with_idx2  ALTER PARTITION 
                                                                   gc.ttlseconds = 14400,
                                                                   num_replicas = 4,
                                                                   num_voters = 3,
-                                                                  constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                                                                  constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
                                                                   voter_constraints = '[+region=ap-southeast-2]',
                                                                   lease_preferences = '[[+region=ap-southeast-2]]'
 
@@ -355,7 +355,7 @@ PARTITION "ap-southeast-2" OF INDEX mr2.public.t_rbr_with_idx2@idx  ALTER PARTIT
                                                                       gc.ttlseconds = 14400,
                                                                       num_replicas = 4,
                                                                       num_voters = 3,
-                                                                      constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                                                                      constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
                                                                       voter_constraints = '[+region=ap-southeast-2]',
                                                                       lease_preferences = '[[+region=ap-southeast-2]]'
 
@@ -368,7 +368,7 @@ PARTITION "us-east-1" OF INDEX mr2.public.t_rbr_with_idx2@idx  ALTER PARTITION "
                                                                  gc.ttlseconds = 14400,
                                                                  num_replicas = 4,
                                                                  num_voters = 3,
-                                                                 constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                                                                 constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
                                                                  voter_constraints = '[+region=us-east-1]',
                                                                  lease_preferences = '[[+region=us-east-1]]'
 
@@ -418,7 +418,7 @@ TABLE mr2.public.t_rt_ca_central_1  ALTER TABLE mr2.public.t_rt_ca_central_1 CON
                                       gc.ttlseconds = 14400,
                                       num_replicas = 3,
                                       num_voters = 3,
-                                      constraints = '{+region=ca-central-1: 1}',
+                                      constraints = '{+region=ca-central-1: 3}',
                                       voter_constraints = '[+region=ca-central-1]',
                                       lease_preferences = '[[+region=ca-central-1]]'
 
@@ -446,7 +446,7 @@ PARTITION "us-east-1" OF TABLE mr3.public.rt  ALTER PARTITION "us-east-1" OF TAB
                                                 gc.ttlseconds = 14400,
                                                 num_replicas = 4,
                                                 num_voters = 3,
-                                                constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                                                constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
                                                 voter_constraints = '[+region=us-east-1]',
                                                 lease_preferences = '[[+region=us-east-1]]'
 
@@ -459,7 +459,7 @@ PARTITION "ap-southeast-2" OF TABLE mr3.public.rt  ALTER PARTITION "ap-southeast
                                                      gc.ttlseconds = 14400,
                                                      num_replicas = 4,
                                                      num_voters = 3,
-                                                     constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                                                     constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
                                                      voter_constraints = '[+region=ap-southeast-2]',
                                                      lease_preferences = '[[+region=ap-southeast-2]]'
 
@@ -472,7 +472,7 @@ PARTITION "ca-central-1" OF TABLE mr3.public.rt  ALTER PARTITION "ca-central-1" 
                                                    gc.ttlseconds = 14400,
                                                    num_replicas = 5,
                                                    num_voters = 3,
-                                                   constraints = '{+region=ca-central-1: 1, +region=us-central-1: 1, +region=us-west-1: 1}',
+                                                   constraints = '{+region=ca-central-1: 2, +region=us-central-1: 2, +region=us-west-1: 1}',
                                                    voter_constraints = '[+region=ca-central-1]',
                                                    lease_preferences = '[[+region=ca-central-1]]'
 
@@ -485,7 +485,7 @@ PARTITION "us-west-1" OF TABLE mr3.public.rt  ALTER PARTITION "us-west-1" OF TAB
                                                 gc.ttlseconds = 14400,
                                                 num_replicas = 5,
                                                 num_voters = 3,
-                                                constraints = '{+region=ca-central-1: 1, +region=us-central-1: 1, +region=us-west-1: 1}',
+                                                constraints = '{+region=ca-central-1: 2, +region=us-central-1: 1, +region=us-west-1: 2}',
                                                 voter_constraints = '[+region=us-west-1]',
                                                 lease_preferences = '[[+region=us-west-1]]'
 
@@ -498,7 +498,7 @@ PARTITION "us-central-1" OF TABLE mr3.public.rt  ALTER PARTITION "us-central-1" 
                                                    gc.ttlseconds = 14400,
                                                    num_replicas = 5,
                                                    num_voters = 3,
-                                                   constraints = '{+region=ca-central-1: 1, +region=us-central-1: 1, +region=us-west-1: 1}',
+                                                   constraints = '{+region=ca-central-1: 2, +region=us-central-1: 2, +region=us-west-1: 1}',
                                                    voter_constraints = '[+region=us-central-1]',
                                                    lease_preferences = '[[+region=us-central-1]]'
 
@@ -580,9 +580,9 @@ us-east-1       primary
 us-west-1       other
 
 # In the case where we have 3 regions within the super region under
-# survive region failure mode, the first non-primary region constraint should
-# have 2 replicas, this is so all replicas are accounted for.
-# ap-southeast-2 in the example below should have 2 replicas because of this.
+# survive region failure mode, replicas are distributed evenly across regions
+# with the affinity region receiving priority for any extra replicas.
+# This ensures all replicas are accounted for within the super region.
 query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "us-central-1" OF TABLE mr3.rt
 ----
@@ -592,7 +592,7 @@ PARTITION "us-central-1" OF TABLE mr3.public.rt  ALTER PARTITION "us-central-1" 
                                                    gc.ttlseconds = 14400,
                                                    num_replicas = 5,
                                                    num_voters = 5,
-                                                   constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-central-1: 1}',
+                                                   constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-central-1: 2}',
                                                    voter_constraints = '{+region=us-central-1: 2}',
                                                    lease_preferences = '[[+region=us-central-1]]'
 
@@ -605,7 +605,7 @@ PARTITION "ap-southeast-2" OF TABLE mr3.public.rt  ALTER PARTITION "ap-southeast
                                                      gc.ttlseconds = 14400,
                                                      num_replicas = 5,
                                                      num_voters = 5,
-                                                     constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-central-1: 1}',
+                                                     constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-central-1: 1}',
                                                      voter_constraints = '{+region=ap-southeast-2: 2}',
                                                      lease_preferences = '[[+region=ap-southeast-2]]'
 
@@ -625,7 +625,7 @@ PARTITION "us-central-1" OF TABLE mr3.public.rt  ALTER PARTITION "us-central-1" 
                                                    gc.ttlseconds = 14400,
                                                    num_replicas = 6,
                                                    num_voters = 5,
-                                                   constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-central-1: 1, +region=us-east-1: 1, +region=us-west-1: 1}',
+                                                   constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-central-1: 2, +region=us-east-1: 1, +region=us-west-1: 1}',
                                                    voter_constraints = '{+region=us-central-1: 2}',
                                                    lease_preferences = '[[+region=us-central-1]]'
 
@@ -638,7 +638,7 @@ PARTITION "ap-southeast-2" OF TABLE mr3.public.rt  ALTER PARTITION "ap-southeast
                                                      gc.ttlseconds = 14400,
                                                      num_replicas = 6,
                                                      num_voters = 5,
-                                                     constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-central-1: 1, +region=us-east-1: 1, +region=us-west-1: 1}',
+                                                     constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-central-1: 1, +region=us-east-1: 1, +region=us-west-1: 1}',
                                                      voter_constraints = '{+region=ap-southeast-2: 2}',
                                                      lease_preferences = '[[+region=ap-southeast-2]]'
 
@@ -680,7 +680,7 @@ TABLE db3.public.t  ALTER TABLE db3.public.t CONFIGURE ZONE USING
                       gc.ttlseconds = 14400,
                       num_replicas = 4,
                       num_voters = 3,
-                      constraints = '{+region=ca-central-1: 1, +region=us-west-1: 1}',
+                      constraints = '{+region=ca-central-1: 2, +region=us-west-1: 2}',
                       voter_constraints = '[+region=ca-central-1]',
                       lease_preferences = '[[+region=ca-central-1]]'
 
@@ -712,7 +712,7 @@ TABLE db3.public.t  ALTER TABLE db3.public.t CONFIGURE ZONE USING
                       gc.ttlseconds = 14400,
                       num_replicas = 3,
                       num_voters = 3,
-                      constraints = '{+region=us-east-1: 1}',
+                      constraints = '{+region=us-east-1: 3}',
                       voter_constraints = '[+region=us-east-1]',
                       lease_preferences = '[[+region=us-east-1]]'
 
@@ -734,7 +734,7 @@ TABLE db3.public.t  ALTER TABLE db3.public.t CONFIGURE ZONE USING
                       gc.ttlseconds = 14400,
                       num_replicas = 4,
                       num_voters = 3,
-                      constraints = '{+region=ca-central-1: 1, +region=us-west-1: 1}',
+                      constraints = '{+region=ca-central-1: 2, +region=us-west-1: 2}',
                       voter_constraints = '[+region=us-west-1]',
                       lease_preferences = '[[+region=us-west-1]]'
 
@@ -769,7 +769,7 @@ TABLE db3.public.t  ALTER TABLE db3.public.t CONFIGURE ZONE USING
                       gc.ttlseconds = 14400,
                       num_replicas = 5,
                       num_voters = 3,
-                      constraints = '{+region=ca-central-1: 1, +region=us-east-1: 1, +region=us-west-1: 1}',
+                      constraints = '{+region=ca-central-1: 2, +region=us-east-1: 1, +region=us-west-1: 2}',
                       voter_constraints = '[+region=us-west-1]',
                       lease_preferences = '[[+region=us-west-1]]'
 
@@ -785,7 +785,7 @@ TABLE db3.public.t  ALTER TABLE db3.public.t CONFIGURE ZONE USING
                       gc.ttlseconds = 14400,
                       num_replicas = 3,
                       num_voters = 3,
-                      constraints = '{+region=us-west-1: 1}',
+                      constraints = '{+region=us-west-1: 3}',
                       voter_constraints = '[+region=us-west-1]',
                       lease_preferences = '[[+region=us-west-1]]'
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/super_regions_backup
+++ b/pkg/ccl/logictestccl/testdata/logic_test/super_regions_backup
@@ -65,7 +65,7 @@ PARTITION "us-east-1" OF TABLE mr1.public.t2  ALTER PARTITION "us-east-1" OF TAB
                                                 gc.ttlseconds = 14400,
                                                 num_replicas = 4,
                                                 num_voters = 3,
-                                                constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                                                constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
                                                 voter_constraints = '[+region=us-east-1]',
                                                 lease_preferences = '[[+region=us-east-1]]'
 
@@ -103,7 +103,7 @@ PARTITION "us-east-1" OF TABLE mr1.public.t2  ALTER PARTITION "us-east-1" OF TAB
                                                 gc.ttlseconds = 14400,
                                                 num_replicas = 4,
                                                 num_voters = 3,
-                                                constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                                                constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
                                                 voter_constraints = '[+region=us-east-1]',
                                                 lease_preferences = '[[+region=us-east-1]]'
 

--- a/pkg/ccl/schemachangerccl/testdata/decomp/multiregion
+++ b/pkg/ccl/schemachangerccl/testdata/decomp/multiregion
@@ -898,7 +898,7 @@ ElementState:
         - key: region
           type: REQUIRED
           value: us-east2
-        numReplicas: 1
+        numReplicas: 2
       - constraints:
         - key: region
           type: REQUIRED
@@ -1393,7 +1393,7 @@ ElementState:
           - key: region
             type: REQUIRED
             value: us-east1
-          numReplicas: 1
+          numReplicas: 2
         - constraints:
           - key: region
             type: REQUIRED
@@ -1451,7 +1451,7 @@ ElementState:
           - key: region
             type: REQUIRED
             value: us-east2
-          numReplicas: 1
+          numReplicas: 2
         - constraints:
           - key: region
             type: REQUIRED
@@ -1509,7 +1509,7 @@ ElementState:
           - key: region
             type: REQUIRED
             value: us-east3
-          numReplicas: 1
+          numReplicas: 2
         gc: null
         globalReads: null
         inheritedConstraints: false
@@ -1615,7 +1615,7 @@ ElementState:
             - key: region
               type: REQUIRED
               value: us-east1
-            numReplicas: 1
+            numReplicas: 2
           - constraints:
             - key: region
               type: REQUIRED
@@ -1661,7 +1661,7 @@ ElementState:
             - key: region
               type: REQUIRED
               value: us-east2
-            numReplicas: 1
+            numReplicas: 2
           - constraints:
             - key: region
               type: REQUIRED
@@ -1707,7 +1707,7 @@ ElementState:
             - key: region
               type: REQUIRED
               value: us-east3
-            numReplicas: 1
+            numReplicas: 2
           gc: null
           globalReads: null
           inheritedConstraints: false

--- a/pkg/sql/regions/BUILD.bazel
+++ b/pkg/sql/regions/BUILD.bazel
@@ -31,14 +31,19 @@ go_library(
 
 go_test(
     name = "regions_test",
-    srcs = ["region_provider_test.go"],
+    srcs = [
+        "region_provider_test.go",
+        "region_util_test.go",
+    ],
+    embed = [":regions"],
     deps = [
-        ":regions",
+        "//pkg/config/zonepb",
         "//pkg/keys",
         "//pkg/kv",
         "//pkg/roachpb",
         "//pkg/server/serverpb",
         "//pkg/sql/catalog",
+        "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/catsessiondata",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/descs",

--- a/pkg/sql/regions/region_util_test.go
+++ b/pkg/sql/regions/region_util_test.go
@@ -1,0 +1,109 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package regions
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDistributeReplicasAcrossRegions(t *testing.T) {
+	mkConstraint := func(region catpb.RegionName, n int32) zonepb.ConstraintsConjunction {
+		return zonepb.ConstraintsConjunction{
+			NumReplicas: n,
+			Constraints: []zonepb.Constraint{MakeRequiredConstraintForRegion(region)},
+		}
+	}
+
+	tests := []struct {
+		name           string
+		numReplicas    int32
+		regions        catpb.RegionNames
+		affinityRegion catpb.RegionName
+		expected       []zonepb.ConstraintsConjunction
+		expectErr      string
+	}{{
+		name:           "even distribution",
+		numReplicas:    6,
+		regions:        catpb.RegionNames{"us-east", "us-west", "eu-west"},
+		affinityRegion: "us-east",
+		expected: []zonepb.ConstraintsConjunction{
+			mkConstraint("us-east", 2),
+			mkConstraint("us-west", 2),
+			mkConstraint("eu-west", 2),
+		},
+	}, {
+		name:           "remainder goes to affinity region first",
+		numReplicas:    5,
+		regions:        catpb.RegionNames{"us-east", "us-west", "eu-west"},
+		affinityRegion: "us-east",
+		expected: []zonepb.ConstraintsConjunction{
+			mkConstraint("us-east", 2),
+			mkConstraint("us-west", 2),
+			mkConstraint("eu-west", 1),
+		},
+	}, {
+		name:           "two extras distributed to affinity then next",
+		numReplicas:    5,
+		regions:        catpb.RegionNames{"us-east", "us-west", "eu-west"},
+		affinityRegion: "us-west",
+		expected: []zonepb.ConstraintsConjunction{
+			mkConstraint("us-east", 2),
+			mkConstraint("us-west", 2),
+			mkConstraint("eu-west", 1),
+		},
+	}, {
+		name:           "single region",
+		numReplicas:    5,
+		regions:        catpb.RegionNames{"us-east"},
+		affinityRegion: "us-east",
+		expected: []zonepb.ConstraintsConjunction{
+			mkConstraint("us-east", 5),
+		},
+	}, {
+		name:           "more regions than replicas",
+		numReplicas:    2,
+		regions:        catpb.RegionNames{"us-east", "us-west", "eu-west", "ap-south"},
+		affinityRegion: "us-west",
+		expected: []zonepb.ConstraintsConjunction{
+			mkConstraint("us-east", 1),
+			mkConstraint("us-west", 1),
+		},
+	}, {
+		name:           "zero replicas",
+		numReplicas:    0,
+		regions:        catpb.RegionNames{"us-east", "us-west"},
+		affinityRegion: "us-east",
+		expected:       nil,
+	}, {
+		name:           "empty regions returns error",
+		numReplicas:    5,
+		regions:        catpb.RegionNames{},
+		affinityRegion: "us-east",
+		expectErr:      "cannot distribute replicas across empty region set",
+	}, {
+		name:           "affinity region not in regions returns error",
+		numReplicas:    5,
+		regions:        catpb.RegionNames{"us-east", "us-west"},
+		affinityRegion: "eu-west",
+		expectErr:      "affinity region eu-west must be a member of the region set",
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := distributeReplicasAcrossRegions(tt.numReplicas, tt.regions, tt.affinityRegion)
+			if tt.expectErr != "" {
+				require.ErrorContains(t, err, tt.expectErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
Previously, AddConstraintsForSuperRegion used a switch statement that only assigned 1 replica per region (with a shouldDoubleUp flag for the first non-affinity region in certain cases). This left replicas unconstrained and free to float outside the super region, defeating the purpose of data domiciling.

Replace the switch with distributeReplicasAcrossRegions, which evenly distributes all replicas across super region members with the affinity region receiving priority for any remainder. The same 3-region case now produces {affinity: 2, next: 2, last: 1}, accounting for all 5 replicas.

Closes #163428
Epic: CRDB-58694
Release note (bug fix): Fixed a bug where super region zone configurations did not constrain all replicas to regions within the super region.