### PR TITLE
db-console: convert email subscription and input components to functional components

### DIFF
--- a/pkg/ui/workspaces/db-console/src/components/input/passwordInput.tsx
+++ b/pkg/ui/workspaces/db-console/src/components/input/passwordInput.tsx
@@ -4,7 +4,7 @@
 // included in the /LICENSE file.
 
 import cn from "classnames";
-import React from "react";
+import React, { useState } from "react";
 
 import EyeOff from "assets/eye-off.svg";
 import Eye from "assets/eye.svg";
@@ -21,63 +21,50 @@ interface PasswordInputProps {
   label?: string;
 }
 
-interface PasswordInputState {
-  showPassword?: boolean;
-}
+export const PasswordInput: React.FC<PasswordInputProps> = ({
+  onChange,
+  value,
+  placeholder,
+  className,
+  name,
+  label,
+}) => {
+  const [showPassword, setShowPassword] = useState(false);
 
-export class PasswordInput extends React.Component<
-  PasswordInputProps,
-  PasswordInputState
-> {
-  state = {
-    showPassword: false,
+  const handleOnTextChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    onChange(event.target.value);
   };
 
-  handleOnTextChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const value = event.target.value;
-    this.props.onChange(value);
+  const togglePassword = () => {
+    setShowPassword(prev => !prev);
   };
 
-  togglePassword = () => {
-    this.setState({
-      showPassword: !this.state.showPassword,
-    });
-  };
+  const inputType = showPassword ? "text" : "password";
+  const classes = cn(className, "crl-input", "crl-input__password");
 
-  renderPasswordIcon = (showPassword: boolean) => (
-    <Button
-      tabIndex={-1}
-      type="flat"
-      onClick={this.togglePassword}
-      className="crl-button__show-password"
-    >
-      <img src={showPassword ? EyeOff : Eye} alt="Toggle Password" />
-    </Button>
+  return (
+    <div className="crl-input__wrapper">
+      {label && (
+        <label htmlFor={name} className="crl-input__label">
+          {label}
+        </label>
+      )}
+      <input
+        name={name}
+        type={inputType}
+        value={value}
+        placeholder={placeholder}
+        className={classes}
+        onChange={handleOnTextChange}
+      />
+      <Button
+        tabIndex={-1}
+        type="flat"
+        onClick={togglePassword}
+        className="crl-button__show-password"
+      >
+        <img src={showPassword ? EyeOff : Eye} alt="Toggle Password" />
+      </Button>
+    </div>
   );
-
-  render() {
-    const { placeholder, className, name, label, value } = this.props;
-    const { showPassword } = this.state;
-    const inputType = showPassword ? "text" : "password";
-
-    const classes = cn(className, "crl-input", "crl-input__password");
-    return (
-      <div className="crl-input__wrapper">
-        {label && (
-          <label htmlFor={name} className="crl-input__label">
-            {label}
-          </label>
-        )}
-        <input
-          name={name}
-          type={inputType}
-          value={value}
-          placeholder={placeholder}
-          className={classes}
-          onChange={this.handleOnTextChange}
-        />
-        {this.renderPasswordIcon(showPassword)}
-      </div>
-    );
-  }
-}
+};

--- a/pkg/ui/workspaces/db-console/src/components/input/textInput.tsx
+++ b/pkg/ui/workspaces/db-console/src/components/input/textInput.tsx
@@ -4,7 +4,7 @@
 // included in the /LICENSE file.
 
 import cn from "classnames";
-import React from "react";
+import React, { useState } from "react";
 
 import { Text, TextTypes } from "src/components";
 import "./input.scss";
@@ -22,99 +22,78 @@ interface TextInputProps {
   validate?: (value: string) => string | undefined;
 }
 
-interface TextInputState {
-  validationMessage: string;
-  isValid: boolean;
-  isDirty: boolean;
-  isTouched: boolean;
-  needValidation: boolean;
-}
+const defaultValidate = () => undefined as string | undefined;
 
-export class TextInput extends React.Component<TextInputProps, TextInputState> {
-  static defaultProps = {
-    initialValue: "",
-    validate: () => false,
+export const TextInput: React.FC<TextInputProps> = ({
+  onChange,
+  value,
+  initialValue = "",
+  placeholder,
+  className,
+  name,
+  label,
+  validate = defaultValidate,
+}) => {
+  const [isValid, setIsValid] = useState(true);
+  const [validationMessage, setValidationMessage] = useState<
+    string | undefined
+  >(undefined);
+  const [isDirty, setIsDirty] = useState(false);
+  const [needValidation, setNeedValidation] = useState(false);
+
+  const validateInput = (val: string) => {
+    const msg = validate(val);
+    setIsValid(!msg);
+    setValidationMessage(msg);
   };
 
-  constructor(props: TextInputProps) {
-    super(props);
-
-    this.state = {
-      isValid: true,
-      validationMessage: undefined,
-      isDirty: false,
-      isTouched: false,
-      needValidation: false,
-    };
-  }
-
-  validateInput = (value: string) => {
-    const { validate } = this.props;
-    const validationMessage = validate(value);
-    this.setState({
-      isValid: !validationMessage,
-      validationMessage,
-    });
-  };
-
-  handleOnTextChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const value = event.target.value;
-    const { needValidation, isValid } = this.state;
+  const handleOnTextChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const val = event.target.value;
     if (needValidation && !isValid) {
-      this.validateInput(value);
+      validateInput(val);
     }
-    this.setState({
-      isDirty: true,
-    });
-    this.props.onChange(value);
+    setIsDirty(true);
+    onChange(val);
   };
 
-  handleOnBlur = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const value = event.target.value;
-    this.validateInput(value);
-    this.setState({
-      isTouched: true,
-      needValidation: true,
-    });
+  const handleOnBlur = (event: React.ChangeEvent<HTMLInputElement>) => {
+    validateInput(event.target.value);
+    setNeedValidation(true);
   };
 
-  render() {
-    const { initialValue, placeholder, className, name, value, label } =
-      this.props;
-    const { isDirty, isValid, validationMessage } = this.state;
-    const textValue = isDirty ? value : initialValue;
+  const textValue = isDirty ? value : initialValue;
 
-    const classes = cn(className, "crl-input", "crl-input__text", {
-      "crl-input__text--invalid": !isValid,
-    });
-    return (
-      <div className="crl-input__wrapper">
-        {label && (
-          <label htmlFor={name} className="crl-input__label">
-            {label}
-          </label>
-        )}
-        <input
-          name={name}
-          type="text"
-          value={textValue}
-          placeholder={placeholder}
-          className={classes}
-          onChange={this.handleOnTextChange}
-          onBlur={this.handleOnBlur}
-          autoComplete="off"
-        />
-        {!isValid && (
-          <div className="crl-input__text--validation-container">
-            <Text
-              textType={TextTypes.Caption}
-              className="crl-input__text--error-message"
-            >
-              {validationMessage}
-            </Text>
-          </div>
-        )}
-      </div>
-    );
-  }
-}
+  const classes = cn(className, "crl-input", "crl-input__text", {
+    "crl-input__text--invalid": !isValid,
+  });
+
+  return (
+    <div className="crl-input__wrapper">
+      {label && (
+        <label htmlFor={name} className="crl-input__label">
+          {label}
+        </label>
+      )}
+      <input
+        name={name}
+        type="text"
+        value={textValue}
+        placeholder={placeholder}
+        className={classes}
+        onChange={handleOnTextChange}
+        onBlur={handleOnBlur}
+        autoComplete="off"
+      />
+      {!isValid && (
+        <div className="crl-input__text--validation-container">
+          <Text
+            textType={TextTypes.Caption}
+            className="crl-input__text--error-message"
+          >
+            {validationMessage}
+          </Text>
+        </div>
+      )}
+    </div>
+  );
+};


### PR DESCRIPTION
Convert the following class components to functional style:
- EmailSubscription:
    1. connect → useSelector + useDispatch
    2. componentDidMount/componentWillUnmount → useEffect with cleanup return
- PasswordInput (components/input/passwordInput.tsx):
    1. Replace `showPassword` class state with `useState`
    2. Inline `renderPasswordIcon` helper into JSX
    3. Convert `handleOnTextChange` and `togglePassword` to local functions
- TextInput (components/input/textInput.tsx):
    1. Replace 5 class state vars with individual `useState` hooks
    2. Replace `static defaultProps` with default parameter values
    3. Convert `validateInput`, `handleOnTextChange`, `handleOnBlur` to local functions

Epic: CRDB-58145
Release note: None