### PR TITLE
db-console: convert raft devtools components to functional components

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/devtools/containers/raft/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/devtools/containers/raft/index.tsx
@@ -10,32 +10,32 @@ import { NavLink } from "react-router-dom";
 /**
  * Renders the layout of the nodes page.
  */
-export default class Layout extends React.Component<{}, {}> {
-  render() {
-    // TODO(mrtracy): this outer div is used to spare the children
-    // `nav-container's styling. Should those styles apply only to `nav`?
-    return (
-      <div>
-        <Helmet title="Raft | Debug" />
-        <section className="section">
-          <h1 className="base-heading">Raft</h1>
-        </section>
-        <div className="nav-container">
-          <ul className="nav">
-            <li className="normal">
-              <NavLink to="/raft/ranges" activeClassName="active">
-                Ranges
-              </NavLink>
-            </li>
-            <li className="normal">
-              <NavLink to="/raft/messages/all" activeClassName="active">
-                Messages
-              </NavLink>
-            </li>
-          </ul>
-        </div>
-        {this.props.children}
+const Layout: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
+  // TODO(mrtracy): this outer div is used to spare the children
+  // `nav-container's styling. Should those styles apply only to `nav`?
+  return (
+    <div>
+      <Helmet title="Raft | Debug" />
+      <section className="section">
+        <h1 className="base-heading">Raft</h1>
+      </section>
+      <div className="nav-container">
+        <ul className="nav">
+          <li className="normal">
+            <NavLink to="/raft/ranges" activeClassName="active">
+              Ranges
+            </NavLink>
+          </li>
+          <li className="normal">
+            <NavLink to="/raft/messages/all" activeClassName="active">
+              Messages
+            </NavLink>
+          </li>
+        </ul>
       </div>
-    );
-  }
-}
+      {children}
+    </div>
+  );
+};
+
+export default Layout;

--- a/pkg/ui/workspaces/db-console/src/views/devtools/containers/raftMessages/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/devtools/containers/raftMessages/index.tsx
@@ -3,21 +3,18 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
-import { TimeScale } from "@cockroachlabs/cluster-ui";
 import isString from "lodash/isString";
 import map from "lodash/map";
-import React from "react";
-import { connect } from "react-redux";
-import { RouteComponentProps, withRouter } from "react-router-dom";
+import React, { useCallback, useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { useHistory, useRouteMatch } from "react-router-dom";
 import { createSelector } from "reselect";
 
-import { PayloadAction } from "src/interfaces/action";
 import { refreshLiveness, refreshNodes } from "src/redux/apiReducers";
 import {
   hoverOff as hoverOffAction,
   hoverOn as hoverOnAction,
   hoverStateSelector,
-  HoverState,
 } from "src/redux/hover";
 import {
   nodeDisplayNameByIDSelector,
@@ -25,9 +22,9 @@ import {
   selectStoreIDsByNodeID,
   nodeIDsSelector,
 } from "src/redux/nodes";
-import { AdminUIState } from "src/redux/state";
+import { AdminUIState, AppDispatch } from "src/redux/state";
 import { setGlobalTimeScaleAction } from "src/redux/statements";
-import { TimeWindow, setMetricsFixedWindow } from "src/redux/timeScale";
+import { setMetricsFixedWindow } from "src/redux/timeScale";
 import { nodeIDAttr } from "src/util/constants";
 import { getMatchParamByName } from "src/util/query";
 import {
@@ -43,152 +40,6 @@ import {
 import { MetricsDataProvider } from "src/views/shared/containers/metricDataProvider";
 
 import messagesDashboard from "./messages";
-
-interface NodeGraphsOwnProps {
-  refreshNodes: typeof refreshNodes;
-  refreshLiveness: typeof refreshLiveness;
-  hoverOn: typeof hoverOnAction;
-  hoverOff: typeof hoverOffAction;
-  nodesQueryValid: boolean;
-  livenessQueryValid: boolean;
-  nodeDropdownOptions: ReturnType<
-    typeof nodeDropdownOptionsSelector.resultFunc
-  >;
-  storeIDsByNodeID: ReturnType<typeof selectStoreIDsByNodeID.resultFunc>;
-  hoverState: HoverState;
-  setMetricsFixedWindow: (tw: TimeWindow) => PayloadAction<TimeWindow>;
-  setTimeScale: (ts: TimeScale) => PayloadAction<TimeScale>;
-
-  nodeIds: string[];
-  nodeDisplayNameByID: ReturnType<
-    typeof nodeDisplayNameByIDSelector.resultFunc
-  >;
-}
-
-type RaftMessagesProps = NodeGraphsOwnProps & RouteComponentProps;
-
-export class RaftMessages extends React.Component<RaftMessagesProps> {
-  /**
-   * Selector to compute node dropdown options from the current node summary
-   * collection.
-   */
-
-  refresh(props = this.props) {
-    if (!props.nodesQueryValid) {
-      props.refreshNodes();
-    }
-    if (!props.livenessQueryValid) {
-      props.refreshLiveness();
-    }
-  }
-
-  setClusterPath(nodeID: string) {
-    const push = this.props.history.push;
-    if (!isString(nodeID) || nodeID === "") {
-      push("/raft/messages/all/");
-    } else {
-      push(`/raft/messages/node/${nodeID}`);
-    }
-  }
-
-  nodeChange = (selected: DropdownOption) => {
-    this.setClusterPath(selected.value);
-  };
-
-  componentDidMount() {
-    this.refresh();
-  }
-
-  componentDidUpdate(props: RaftMessagesProps) {
-    this.refresh(props);
-  }
-
-  render() {
-    const {
-      match,
-      hoverState,
-      hoverOn,
-      hoverOff,
-      storeIDsByNodeID,
-      nodeIds,
-      nodeDisplayNameByID,
-    } = this.props;
-
-    const selectedNode = getMatchParamByName(match, nodeIDAttr) || "";
-    const nodeSources = selectedNode !== "" ? [selectedNode] : null;
-
-    // When "all" is the selected source, some graphs display a line for every
-    // node in the cluster using the nodeIDs collection. However, if a specific
-    // node is already selected, these per-node graphs should only display data
-    // only for the selected node.
-    const nodeIDs = nodeSources ? nodeSources : nodeIds;
-
-    // If a single node is selected, we need to restrict the set of stores
-    // queried for per-store metrics (only stores that belong to that node will
-    // be queried).
-    const storeSources = nodeSources
-      ? storeIDsForNode(storeIDsByNodeID, nodeSources[0])
-      : null;
-
-    // tooltipSelection is a string used in tooltips to reference the currently
-    // selected nodes. This is a prepositional phrase, currently either "across
-    // all nodes" or "on node X".
-    const tooltipSelection =
-      nodeSources && nodeSources.length === 1
-        ? `on node ${nodeSources[0]}`
-        : "across all nodes";
-
-    const dashboardProps: GraphDashboardProps = {
-      nodeIDs,
-      nodeSources,
-      storeSources,
-      tooltipSelection,
-      nodeDisplayNameByID,
-      storeIDsByNodeID,
-    };
-
-    // Generate graphs for the current dashboard, wrapping each one in a
-    // MetricsDataProvider with a unique key.
-    const graphs = messagesDashboard(dashboardProps);
-    const graphComponents = map(graphs, (graph, idx) => {
-      const key = `nodes.raftMessages.${idx}`;
-      return (
-        <div key={key}>
-          <MetricsDataProvider
-            id={key}
-            key={key}
-            setMetricsFixedWindow={this.props.setMetricsFixedWindow}
-            setTimeScale={this.props.setTimeScale}
-            history={this.props.history}
-          >
-            {React.cloneElement(graph, { hoverOn, hoverOff, hoverState })}
-          </MetricsDataProvider>
-        </div>
-      );
-    });
-
-    return (
-      <div>
-        <PageConfig>
-          <PageConfigItem>
-            <Dropdown
-              title="Graph"
-              options={this.props.nodeDropdownOptions}
-              selected={selectedNode}
-              onChange={this.nodeChange}
-            />
-          </PageConfigItem>
-          <PageConfigItem>
-            <TimeScaleDropdown />
-          </PageConfigItem>
-        </PageConfig>
-        <div className="section l-columns">
-          <div className="chart-group l-columns__left">{graphComponents}</div>
-        </div>
-      </div>
-    );
-  }
-}
 
 const nodeDropdownOptionsSelector = createSelector(
   nodeIDsSelector,
@@ -206,25 +57,121 @@ const nodeDropdownOptionsSelector = createSelector(
   },
 );
 
-const mapStateToProps = (state: AdminUIState) => ({
-  nodesQueryValid: state.cachedData.nodes.valid,
-  livenessQueryValid: state.cachedData.nodes.valid,
-  hoverState: hoverStateSelector(state),
-  nodeIds: nodeIDsStringifiedSelector(state),
-  storeIDsByNodeID: selectStoreIDsByNodeID(state),
-  nodeDropdownOptions: nodeDropdownOptionsSelector(state),
-  nodeDisplayNameByID: nodeDisplayNameByIDSelector(state),
-});
+const RaftMessages: React.FC = () => {
+  const dispatch: AppDispatch = useDispatch();
+  const history = useHistory();
+  const match = useRouteMatch();
 
-const mapDispatchToProps = {
-  refreshNodes,
-  refreshLiveness,
-  hoverOn: hoverOnAction,
-  hoverOff: hoverOffAction,
-  setMetricsFixedWindow: setMetricsFixedWindow,
-  setTimeScale: setGlobalTimeScaleAction,
+  const nodesQueryValid = useSelector(
+    (state: AdminUIState) => state.cachedData.nodes.valid,
+  );
+  const livenessQueryValid = useSelector(
+    (state: AdminUIState) => state.cachedData.nodes.valid,
+  );
+  const hoverState = useSelector(hoverStateSelector);
+  const nodeIds = useSelector(nodeIDsStringifiedSelector);
+  const storeIDsByNodeID = useSelector(selectStoreIDsByNodeID);
+  const nodeDropdownOptions = useSelector(nodeDropdownOptionsSelector);
+  const nodeDisplayNameByID = useSelector(nodeDisplayNameByIDSelector);
+
+  useEffect(() => {
+    if (!nodesQueryValid) {
+      dispatch(refreshNodes());
+    }
+    if (!livenessQueryValid) {
+      dispatch(refreshLiveness());
+    }
+  }, [dispatch, nodesQueryValid, livenessQueryValid]);
+
+  const nodeChange = useCallback(
+    (selected: DropdownOption) => {
+      if (!isString(selected.value) || selected.value === "") {
+        history.push("/raft/messages/all/");
+      } else {
+        history.push(`/raft/messages/node/${selected.value}`);
+      }
+    },
+    [history],
+  );
+
+  const selectedNode = getMatchParamByName(match, nodeIDAttr) || "";
+  const nodeSources = selectedNode !== "" ? [selectedNode] : null;
+
+  // When "all" is the selected source, some graphs display a line for every
+  // node in the cluster using the nodeIDs collection. However, if a specific
+  // node is already selected, these per-node graphs should only display data
+  // only for the selected node.
+  const nodeIDs = nodeSources ? nodeSources : nodeIds;
+
+  // If a single node is selected, we need to restrict the set of stores
+  // queried for per-store metrics (only stores that belong to that node will
+  // be queried).
+  const storeSources = nodeSources
+    ? storeIDsForNode(storeIDsByNodeID, nodeSources[0])
+    : null;
+
+  // tooltipSelection is a string used in tooltips to reference the currently
+  // selected nodes. This is a prepositional phrase, currently either "across
+  // all nodes" or "on node X".
+  const tooltipSelection =
+    nodeSources && nodeSources.length === 1
+      ? `on node ${nodeSources[0]}`
+      : "across all nodes";
+
+  const dashboardProps: GraphDashboardProps = {
+    nodeIDs,
+    nodeSources,
+    storeSources,
+    tooltipSelection,
+    nodeDisplayNameByID,
+    storeIDsByNodeID,
+  };
+
+  // Generate graphs for the current dashboard, wrapping each one in a
+  // MetricsDataProvider with a unique key.
+  const graphs = messagesDashboard(dashboardProps);
+  const graphComponents = map(graphs, (graph, idx) => {
+    const key = `nodes.raftMessages.${idx}`;
+    return (
+      <div key={key}>
+        <MetricsDataProvider
+          id={key}
+          key={key}
+          setMetricsFixedWindow={tw => dispatch(setMetricsFixedWindow(tw))}
+          setTimeScale={ts => dispatch(setGlobalTimeScaleAction(ts))}
+          history={history}
+        >
+          {React.cloneElement(graph, {
+            hoverOn: (...args: Parameters<typeof hoverOnAction>) =>
+              dispatch(hoverOnAction(...args)),
+            hoverOff: () => dispatch(hoverOffAction()),
+            hoverState,
+          })}
+        </MetricsDataProvider>
+      </div>
+    );
+  });
+
+  return (
+    <div>
+      <PageConfig>
+        <PageConfigItem>
+          <Dropdown
+            title="Graph"
+            options={nodeDropdownOptions}
+            selected={selectedNode}
+            onChange={nodeChange}
+          />
+        </PageConfigItem>
+        <PageConfigItem>
+          <TimeScaleDropdown />
+        </PageConfigItem>
+      </PageConfig>
+      <div className="section l-columns">
+        <div className="chart-group l-columns__left">{graphComponents}</div>
+      </div>
+    </div>
+  );
 };
 
-export default withRouter(
-  connect(mapStateToProps, mapDispatchToProps)(RaftMessages),
-);
+export default RaftMessages;

--- a/pkg/ui/workspaces/db-console/src/views/devtools/containers/raftRanges/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/devtools/containers/raftRanges/index.tsx
@@ -13,15 +13,15 @@ import sortBy from "lodash/sortBy";
 import uniq from "lodash/uniq";
 import values from "lodash/values";
 import moment from "moment-timezone";
-import React from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import ReactPaginate from "react-paginate";
-import { connect } from "react-redux";
-import { Link, RouteComponentProps, withRouter } from "react-router-dom";
+import { useDispatch, useSelector } from "react-redux";
+import { Link } from "react-router-dom";
 
 import * as protos from "src/js/protos";
 import { refreshRaft } from "src/redux/apiReducers";
 import { CachedDataReducerState } from "src/redux/cachedDataReducer";
-import { AdminUIState } from "src/redux/state";
+import { AdminUIState, AppDispatch } from "src/redux/state";
 import { FixLong } from "src/util/fixLong";
 import Print from "src/views/reports/containers/range/print";
 import { ToolTipWrapper } from "src/views/shared/components/toolTip";
@@ -34,68 +34,42 @@ import RaftDebugResponse = cockroach.server.serverpb.RaftDebugResponse;
 
 const RANGES_PER_PAGE = 100;
 
-/**
- * RangesMainData are the data properties which should be passed to the RangesMain
- * container.
- */
-interface RangesMainData {
-  state: CachedDataReducerState<protos.cockroach.server.serverpb.RaftDebugResponse>;
-}
+const selectRaftState = (
+  state: AdminUIState,
+): CachedDataReducerState<protos.cockroach.server.serverpb.RaftDebugResponse> =>
+  state.cachedData.raft;
 
-/**
- * RangesMainActions are the action dispatchers which should be passed to the
- * RangesMain container.
- */
-interface RangesMainActions {
-  // Call if the ranges statuses are stale and need to be refreshed.
-  refreshRaft: typeof refreshRaft;
-}
+const RangesMain: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
+  const dispatch: AppDispatch = useDispatch();
+  const raftState = useSelector(selectRaftState);
 
-interface RangesMainState {
-  showState?: boolean;
-  showReplicas?: boolean;
-  showPending?: boolean;
-  showOnlyErrors?: boolean;
-  pageNum?: number;
-  offset?: number;
-}
+  const [showState, setShowState] = useState(true);
+  const [showReplicas, setShowReplicas] = useState(true);
+  const [showPending, setShowPending] = useState(true);
+  const [showOnlyErrors, setShowOnlyErrors] = useState(false);
+  const [offset, setOffset] = useState(0);
 
-/**
- * RangesMainProps is the type of the props object that must be passed to
- * RangesMain component.
- */
-type RangesMainProps = RangesMainData & RangesMainActions;
-
-/**
- * Renders the main content of the raft ranges page, which is primarily a data
- * table of all ranges and their replicas.
- */
-export class RangesMain extends React.Component<
-  RangesMainProps,
-  RangesMainState
-> {
-  state: RangesMainState = {
-    showState: true,
-    showReplicas: true,
-    showPending: true,
-    showOnlyErrors: false,
-    offset: 0,
-  };
-
-  componentDidMount() {
+  useEffect(() => {
     // Refresh nodes status query when mounting.
-    this.props.refreshRaft();
-  }
+    dispatch(refreshRaft());
+  }, [dispatch]);
 
-  componentDidUpdate() {
+  useEffect(() => {
     // Refresh ranges when props are received; this will immediately
     // trigger a new request if previous results are invalidated.
-    if (!this.props.state.valid) {
-      this.props.refreshRaft();
+    if (!raftState.valid) {
+      dispatch(refreshRaft());
     }
-  }
+  }, [dispatch, raftState.valid]);
 
-  renderPagination(pageCount: number): React.ReactNode {
+  const handlePageClick = useCallback((data: any) => {
+    const selected = data.selected;
+    const newOffset = Math.ceil(selected * RANGES_PER_PAGE);
+    setOffset(newOffset);
+    window.scroll(0, 0);
+  }, []);
+
+  const renderPagination = (pageCount: number): React.ReactNode => {
     return (
       <ReactPaginate
         previousLabel={"previous"}
@@ -104,267 +78,55 @@ export class RangesMain extends React.Component<
         pageCount={pageCount}
         marginPagesDisplayed={2}
         pageRangeDisplayed={5}
-        onPageChange={this.handlePageClick.bind(this)}
+        onPageChange={handlePageClick}
         containerClassName={"pagination"}
         activeClassName={"active"}
       />
     );
-  }
-
-  handlePageClick(data: any) {
-    const selected = data.selected;
-    const offset = Math.ceil(selected * RANGES_PER_PAGE);
-    this.setState({ offset });
-    window.scroll(0, 0);
-  }
+  };
 
   // renderFilterSettings renders the filter settings box.
-  renderFilterSettings(): React.ReactNode {
+  const renderFilterSettings = (): React.ReactNode => {
     return (
       <div className="section raft-filters">
         <b>Filters</b>
         <label>
           <input
             type="checkbox"
-            checked={this.state.showState}
-            onChange={() => this.setState({ showState: !this.state.showState })}
+            checked={showState}
+            onChange={() => setShowState(prev => !prev)}
           />
           State
         </label>
         <label>
           <input
             type="checkbox"
-            checked={this.state.showReplicas}
-            onChange={() =>
-              this.setState({ showReplicas: !this.state.showReplicas })
-            }
+            checked={showReplicas}
+            onChange={() => setShowReplicas(prev => !prev)}
           />
           Replicas
         </label>
         <label>
           <input
             type="checkbox"
-            checked={this.state.showPending}
-            onChange={() =>
-              this.setState({ showPending: !this.state.showPending })
-            }
+            checked={showPending}
+            onChange={() => setShowPending(prev => !prev)}
           />
           Pending
         </label>
         <label>
           <input
             type="checkbox"
-            checked={this.state.showOnlyErrors}
-            onChange={() =>
-              this.setState({ showOnlyErrors: !this.state.showOnlyErrors })
-            }
+            checked={showOnlyErrors}
+            onChange={() => setShowOnlyErrors(prev => !prev)}
           />
           Only Error Ranges
         </label>
       </div>
     );
-  }
+  };
 
-  render() {
-    const statuses = this.props.state.data;
-    let content: React.ReactNode = null;
-    let errors: string[] = [];
-
-    if (this.props.state.lastError) {
-      errors.push(this.props.state.lastError.message);
-    }
-
-    if (!this.props.state.data) {
-      content = <div className="section">Loading...</div>;
-    } else if (statuses) {
-      errors = errors.concat(statuses.errors.map(err => err.message));
-
-      // Build list of all nodes for static ordering.
-      const nodeIDs = flow(
-        (ranges: RaftDebugResponse["ranges"]) => flatMap(ranges, r => r.nodes),
-        nodes => map(nodes, node => node.node_id),
-        nodeIds => uniq(nodeIds),
-        nodeIds => sortBy(nodeIds),
-      )(statuses.ranges);
-
-      const nodeIDIndex: { [nodeID: number]: number } = {};
-      const columns = [<th key={-1}>Range</th>];
-      nodeIDs.forEach((id, i) => {
-        nodeIDIndex[id] = i + 1;
-        columns.push(
-          <th key={i}>
-            <Link className="debug-link" to={"/nodes/" + id}>
-              Node {id}
-            </Link>
-          </th>,
-        );
-      });
-
-      // Filter ranges and paginate
-      const justRanges = values(statuses.ranges);
-      const filteredRanges = filter(justRanges, range => {
-        return !this.state.showOnlyErrors || range.errors.length > 0;
-      });
-      let offset = this.state.offset;
-      if (this.state.offset > filteredRanges.length) {
-        offset = 0;
-      }
-      const ranges = filteredRanges.slice(offset, offset + RANGES_PER_PAGE);
-      const rows: React.ReactNode[][] = [];
-      map(ranges, (range, i) => {
-        const hasErrors = range.errors.length > 0;
-        const rangeErrors = (
-          <ul>
-            {map(range.errors, (error, j) => {
-              return <li key={j}>{error.message}</li>;
-            })}
-          </ul>
-        );
-        const row = [
-          <td key="row{i}">
-            <Link
-              className="debug-link"
-              to={`/reports/range/${range.range_id.toString()}`}
-            >
-              r{range.range_id.toString()}
-            </Link>
-            {hasErrors ? (
-              <span style={{ position: "relative" }}>
-                <ToolTipWrapper text={rangeErrors}>
-                  <div className="viz-info-icon">
-                    <div className="icon-warning" />
-                  </div>
-                </ToolTipWrapper>
-              </span>
-            ) : (
-              ""
-            )}
-          </td>,
-        ];
-        rows[i] = row;
-
-        // Render each replica into a cell
-        range.nodes.forEach(node => {
-          const nodeRange = node.range;
-          const replicaLocations =
-            nodeRange.state.state.desc.internal_replicas.map(
-              replica =>
-                "(Node " +
-                replica.node_id.toString() +
-                " Store " +
-                replica.store_id.toString() +
-                " ReplicaID " +
-                replica.replica_id.toString() +
-                ")",
-            );
-          const display = (l?: Long): string => {
-            if (l) {
-              return l.toString();
-            }
-            return "N/A";
-          };
-
-          const displayTimestamp = (
-            timestamp: protos.cockroach.util.hlc.ITimestamp,
-            now: moment.Moment,
-          ): string => {
-            if (isNil(timestamp) || isNil(timestamp.wall_time)) {
-              return "nil";
-            }
-
-            if (FixLong(timestamp.wall_time).isZero()) {
-              return "empty";
-            }
-
-            const humanized = Print.Timestamp(timestamp);
-            const delta = Print.TimestampDeltaFromNow(timestamp, now);
-            return humanized.concat(", ", delta);
-          };
-
-          const now = moment();
-          const index = nodeIDIndex[node.node_id];
-          const raftState = nodeRange.raft_state;
-          const cell = (
-            <td key={index}>
-              {this.state.showState ? (
-                <div>
-                  State: {raftState.state}&nbsp; ReplicaID=
-                  {display(raftState.replica_id)}&nbsp; Term=
-                  {display(raftState.hard_state.term)}&nbsp; Lead=
-                  {display(raftState.lead)}&nbsp; LeadSupportUntil=
-                  {displayTimestamp(raftState.lead_support_until, now)}&nbsp;
-                </div>
-              ) : (
-                ""
-              )}
-              {this.state.showReplicas ? (
-                <div>
-                  <div>Replica On: {replicaLocations.join(", ")}</div>
-                  <div>
-                    Next Replica ID:{" "}
-                    {nodeRange.state.state.desc.next_replica_id}
-                  </div>
-                </div>
-              ) : (
-                ""
-              )}
-              {this.state.showPending ? (
-                <div>
-                  Pending Command Count:{" "}
-                  {(nodeRange.state.num_pending || 0).toString()}
-                </div>
-              ) : (
-                ""
-              )}
-            </td>
-          );
-          row[index] = cell;
-        });
-
-        // Fill empty spaces in table with td elements.
-        for (let j = 1; j <= nodeIDs.length; j++) {
-          if (!row[j]) {
-            row[j] = <td key={j}></td>;
-          }
-        }
-      });
-
-      // Build the final display table
-      if (columns.length > 1) {
-        content = (
-          <div>
-            {this.renderFilterSettings()}
-            <table>
-              <thead>
-                <tr>{columns}</tr>
-              </thead>
-              <tbody>
-                {values(rows).map((row: React.ReactNode[], i: number) => {
-                  return <tr key={i}>{row}</tr>;
-                })}
-              </tbody>
-            </table>
-            <div className="section">
-              {this.renderPagination(
-                Math.ceil(filteredRanges.length / RANGES_PER_PAGE),
-              )}
-            </div>
-          </div>
-        );
-      }
-    }
-    return (
-      <div className="section table">
-        {this.props.children}
-        <div className="stats-table">
-          {this.renderErrors(errors)}
-          {content}
-        </div>
-      </div>
-    );
-  }
-
-  renderErrors(errors: string[]) {
+  const renderErrors = (errors: string[]) => {
     if (!errors || errors.length === 0) {
       return;
     }
@@ -375,31 +137,206 @@ export class RangesMain extends React.Component<
         })}
       </div>
     );
+  };
+
+  const statuses = raftState.data;
+  let content: React.ReactNode = null;
+  let errors: string[] = [];
+
+  if (raftState.lastError) {
+    errors.push(raftState.lastError.message);
   }
-}
 
-/******************************
- *         SELECTORS
- */
+  if (!raftState.data) {
+    content = <div className="section">Loading...</div>;
+  } else if (statuses) {
+    errors = errors.concat(statuses.errors.map(err => err.message));
 
-// Base selectors to extract data from redux state.
-const selectRaftState = (
-  state: AdminUIState,
-): CachedDataReducerState<protos.cockroach.server.serverpb.RaftDebugResponse> =>
-  state.cachedData.raft;
+    // Build list of all nodes for static ordering.
+    const nodeIDs = flow(
+      (ranges: RaftDebugResponse["ranges"]) => flatMap(ranges, r => r.nodes),
+      nodes => map(nodes, node => node.node_id),
+      nodeIds => uniq(nodeIds),
+      nodeIds => sortBy(nodeIds),
+    )(statuses.ranges);
 
-const mapStateToProps = (state: AdminUIState, _: RouteComponentProps) => ({
-  // RootState contains declaration for whole state
-  state: selectRaftState(state),
-});
+    const nodeIDIndex: { [nodeID: number]: number } = {};
+    const columns = [<th key={-1}>Range</th>];
+    nodeIDs.forEach((id, i) => {
+      nodeIDIndex[id] = i + 1;
+      columns.push(
+        <th key={i}>
+          <Link className="debug-link" to={"/nodes/" + id}>
+            Node {id}
+          </Link>
+        </th>,
+      );
+    });
 
-const mapDispatchToProps = {
-  refreshRaft,
+    // Filter ranges and paginate
+    const justRanges = values(statuses.ranges);
+    const filteredRanges = filter(justRanges, range => {
+      return !showOnlyErrors || range.errors.length > 0;
+    });
+    let currentOffset = offset;
+    if (offset > filteredRanges.length) {
+      currentOffset = 0;
+    }
+    const ranges = filteredRanges.slice(
+      currentOffset,
+      currentOffset + RANGES_PER_PAGE,
+    );
+    const rows: React.ReactNode[][] = [];
+    map(ranges, (range, i) => {
+      const hasErrors = range.errors.length > 0;
+      const rangeErrors = (
+        <ul>
+          {map(range.errors, (error, j) => {
+            return <li key={j}>{error.message}</li>;
+          })}
+        </ul>
+      );
+      const row = [
+        <td key="row{i}">
+          <Link
+            className="debug-link"
+            to={`/reports/range/${range.range_id.toString()}`}
+          >
+            r{range.range_id.toString()}
+          </Link>
+          {hasErrors ? (
+            <span style={{ position: "relative" }}>
+              <ToolTipWrapper text={rangeErrors}>
+                <div className="viz-info-icon">
+                  <div className="icon-warning" />
+                </div>
+              </ToolTipWrapper>
+            </span>
+          ) : (
+            ""
+          )}
+        </td>,
+      ];
+      rows[i] = row;
+
+      // Render each replica into a cell
+      range.nodes.forEach(node => {
+        const nodeRange = node.range;
+        const replicaLocations =
+          nodeRange.state.state.desc.internal_replicas.map(
+            replica =>
+              "(Node " +
+              replica.node_id.toString() +
+              " Store " +
+              replica.store_id.toString() +
+              " ReplicaID " +
+              replica.replica_id.toString() +
+              ")",
+          );
+        const display = (l?: Long): string => {
+          if (l) {
+            return l.toString();
+          }
+          return "N/A";
+        };
+
+        const displayTimestamp = (
+          timestamp: protos.cockroach.util.hlc.ITimestamp,
+          now: moment.Moment,
+        ): string => {
+          if (isNil(timestamp) || isNil(timestamp.wall_time)) {
+            return "nil";
+          }
+
+          if (FixLong(timestamp.wall_time).isZero()) {
+            return "empty";
+          }
+
+          const humanized = Print.Timestamp(timestamp);
+          const delta = Print.TimestampDeltaFromNow(timestamp, now);
+          return humanized.concat(", ", delta);
+        };
+
+        const now = moment();
+        const index = nodeIDIndex[node.node_id];
+        const raftNodeState = nodeRange.raft_state;
+        const cell = (
+          <td key={index}>
+            {showState ? (
+              <div>
+                State: {raftNodeState.state}&nbsp; ReplicaID=
+                {display(raftNodeState.replica_id)}&nbsp; Term=
+                {display(raftNodeState.hard_state.term)}&nbsp; Lead=
+                {display(raftNodeState.lead)}&nbsp; LeadSupportUntil=
+                {displayTimestamp(raftNodeState.lead_support_until, now)}&nbsp;
+              </div>
+            ) : (
+              ""
+            )}
+            {showReplicas ? (
+              <div>
+                <div>Replica On: {replicaLocations.join(", ")}</div>
+                <div>
+                  Next Replica ID: {nodeRange.state.state.desc.next_replica_id}
+                </div>
+              </div>
+            ) : (
+              ""
+            )}
+            {showPending ? (
+              <div>
+                Pending Command Count:{" "}
+                {(nodeRange.state.num_pending || 0).toString()}
+              </div>
+            ) : (
+              ""
+            )}
+          </td>
+        );
+        row[index] = cell;
+      });
+
+      // Fill empty spaces in table with td elements.
+      for (let j = 1; j <= nodeIDs.length; j++) {
+        if (!row[j]) {
+          row[j] = <td key={j}></td>;
+        }
+      }
+    });
+
+    // Build the final display table
+    if (columns.length > 1) {
+      content = (
+        <div>
+          {renderFilterSettings()}
+          <table>
+            <thead>
+              <tr>{columns}</tr>
+            </thead>
+            <tbody>
+              {values(rows).map((row: React.ReactNode[], i: number) => {
+                return <tr key={i}>{row}</tr>;
+              })}
+            </tbody>
+          </table>
+          <div className="section">
+            {renderPagination(
+              Math.ceil(filteredRanges.length / RANGES_PER_PAGE),
+            )}
+          </div>
+        </div>
+      );
+    }
+  }
+  return (
+    <div className="section table">
+      {children}
+      <div className="stats-table">
+        {renderErrors(errors)}
+        {content}
+      </div>
+    </div>
+  );
 };
 
-// Connect the RangesMain class with our redux store.
-const rangesMainConnected = withRouter(
-  connect(mapStateToProps, mapDispatchToProps)(RangesMain),
-);
-
-export { rangesMainConnected as default };
+export default RangesMain;


### PR DESCRIPTION
Convert the following class components to functional style:
- Raft Layout:
    1. stateless class → plain FC, no hooks needed
- RaftMessages:
    1. connect + withRouter → useSelector + useDispatch + useHistory + useRouteMatch
    2. componentDidMount/componentDidUpdate refresh → useEffect
    3. nodeChange → useCallback
    4. removed connect-only interfaces (NodeGraphsOwnProps, etc.)
- RangesMain:
    1. connect + withRouter → useSelector + useDispatch
    2. five class state fields → individual useState hooks
    3. componentDidMount + componentDidUpdate → useEffect
    4. handlePageClick.bind(this) → useCallback
    5. removed connect-only interfaces

Epic: CRDB-58145
Release note: None