### PR TITLE
sql: uniqueness check for complex keys

### DIFF
--- a/pkg/sql/inspect/check_helpers.go
+++ b/pkg/sql/inspect/check_helpers.go
@@ -143,7 +143,8 @@ func extractRegionFromSpan(
 	return regionEnum.LogicalRep, nil
 }
 
-// spanForRegion returns an equivalent span with the region column set to the specific region.
+// spanForRegion returns an equivalent span with the region column set to the
+// specific region.
 func spanForRegion(
 	ctx context.Context,
 	cfg *execinfra.ServerConfig,
@@ -168,16 +169,11 @@ func spanForRegion(
 		return roachpb.Span{}, err
 	}
 
-	regionDatum, err := tree.MakeDEnumFromLogicalRepresentation(regionCol.GetType(), region)
+	regionSpan, err := spanForFullRegion(cfg, tableDesc, region)
 	if err != nil {
-		return roachpb.Span{}, errors.Wrapf(err, "invalid region %q", region)
+		return roachpb.Span{}, err
 	}
-
-	regionPrefixBytes, err := keyside.Encode(indexPrefix, &regionDatum, encoding.Ascending)
-	if err != nil {
-		return roachpb.Span{}, errors.Wrap(err, "encoding region")
-	}
-	regionPrefix := roachpb.Key(regionPrefixBytes)
+	regionPrefix := regionSpan.Key
 
 	startKeyAfterIndex := span.Key[len(indexPrefix):]
 	endKeyAfterIndex := span.EndKey[len(indexPrefix):]
@@ -209,6 +205,40 @@ func spanForRegion(
 		Key:    key,
 		EndKey: endKey,
 	}, nil
+}
+
+// spanForFullRegion returns a span that covers the full region of a regional by
+// row table.
+func spanForFullRegion(
+	cfg *execinfra.ServerConfig, tableDesc catalog.TableDescriptor, region string,
+) (roachpb.Span, error) {
+	priIndex := tableDesc.GetPrimaryIndex()
+
+	indexPrefix := cfg.Codec.IndexPrefix(uint32(tableDesc.GetID()), uint32(priIndex.GetID()))
+
+	regionColID := priIndex.GetKeyColumnID(0)
+	regionCol, err := catalog.MustFindColumnByID(tableDesc, regionColID)
+	if err != nil {
+		return roachpb.Span{}, err
+	}
+
+	regionDatum, err := tree.MakeDEnumFromLogicalRepresentation(regionCol.GetType(), region)
+	if err != nil {
+		return roachpb.Span{}, errors.Wrapf(err, "invalid region %q", region)
+	}
+
+	regionPrefixBytes, err := keyside.Encode(indexPrefix, &regionDatum, encoding.Ascending)
+	if err != nil {
+		return roachpb.Span{}, errors.Wrap(err, "encoding region")
+	}
+	regionPrefix := roachpb.Key(regionPrefixBytes)
+
+	span := roachpb.Span{
+		Key:    regionPrefix,
+		EndKey: regionPrefix.PrefixEnd(),
+	}
+
+	return span, nil
 }
 
 // getPredicateAndQueryArgs generates query bounds from the span to limit the query to the specified range.

--- a/pkg/sql/inspect/uniqueness_check.go
+++ b/pkg/sql/inspect/uniqueness_check.go
@@ -149,11 +149,11 @@ func (c *uniquenessCheck) Start(
 	colList := strings.Join(encodedColNames, ", ")
 
 	queryWithRemoteRegionsGrouped := fmt.Sprintf(`
-WITH sub AS (
+WITH all_regions AS (
   %s
 )
 SELECT %s, array_agg(remote_region) as remote_regions
-FROM sub
+FROM all_regions
 GROUP BY %s
 `,
 		query, colList, colList)
@@ -218,9 +218,18 @@ func (c *uniquenessCheck) getRemotePredicatesAndQueryArgs(
 	endPlaceholderOffset int,
 ) (remotePredicates []string, remoteArgs []interface{}, err error) {
 	for _, region := range remoteRegions {
-		remoteSpan, err := spanForRegion(ctx, cfg, span, c.tableDesc, region)
-		if err != nil {
-			return nil, nil, errors.Wrapf(err, "creating span for region %q", region)
+		var remoteSpan roachpb.Span
+		// Limit the scan of the remote region if possible
+		if c.uniqueColIdx == 1 {
+			remoteSpan, err = spanForRegion(ctx, cfg, span, c.tableDesc, region)
+			if err != nil {
+				return nil, nil, errors.Wrapf(err, "creating span for region %q", region)
+			}
+		} else {
+			remoteSpan, err = spanForFullRegion(cfg, c.tableDesc, region)
+			if err != nil {
+				return nil, nil, errors.Wrapf(err, "creating span for full region %q", region)
+			}
 		}
 
 		rPredicate, rQueryArgs, err := getPredicateAndQueryArgs(
@@ -430,11 +439,6 @@ func (c *uniquenessCheck) loadCatalogInfo(ctx context.Context) error {
 		return errors.AssertionFailedf("index has no `unique_rowid()` or `unordered_unique_rowid()` column to be unique checked")
 	} else if len(uniqueColIdxs) > 1 {
 		return errors.AssertionFailedf("uniqueness check for indexes with multiple `unique_rowid()` or `unordered_unique_rowid()` columns is not supported")
-	}
-
-	// TODO(154551): Support full scans of the remote regions.
-	if uniqueColIdxs[0] != 1 {
-		return errors.AssertionFailedf("the unique column must be immediately after the regionality column")
 	}
 
 	c.index = index

--- a/pkg/sql/inspect/uniqueness_check_test.go
+++ b/pkg/sql/inspect/uniqueness_check_test.go
@@ -255,8 +255,59 @@ func TestUniquenessCheck(t *testing.T) {
 				data TEXT,
 				PRIMARY KEY (crdb_region, filler, id)
 				)`,
-			// TODO(154551): Add support for this case.
-			expectError: "the unique column must be immediately after the regionality column",
+			createSpan: func(cfg *execinfra.ServerConfig, tableDesc catalog.TableDescriptor) roachpb.Span {
+				index := tableDesc.GetPrimaryIndex()
+
+				indexPrefix := cfg.Codec.IndexPrefix(uint32(tableDesc.GetID()), uint32(index.GetID()))
+
+				regionColID := index.GetKeyColumnID(0)
+				regionCol, err := catalog.MustFindColumnByID(tableDesc, regionColID)
+				require.NoError(t, err)
+
+				// Use the faked "us-east1" region for testing then the filler
+				// column and the unique-constrained INT64 [1, 10000).
+
+				testRegion := "us-east1"
+				regionDatum, err := tree.MakeDEnumFromLogicalRepresentation(regionCol.GetType(), testRegion)
+				require.NoError(t, err)
+
+				regionPrefixBytes, err := keyside.Encode(indexPrefix, &regionDatum, encoding.Ascending)
+				require.NoError(t, err)
+
+				// Create a tight bound for the second column in the key. The test will use a filler outside this range.
+				startFillerDatum := tree.NewDString("colombo")
+				startKey, err := keyside.Encode(slices.Clone(regionPrefixBytes), startFillerDatum, encoding.Ascending)
+				require.NoError(t, err)
+				endFillerDatum := tree.NewDString("dhaka")
+				endKey, err := keyside.Encode(slices.Clone(regionPrefixBytes), endFillerDatum, encoding.Ascending)
+				require.NoError(t, err)
+
+				startID := tree.NewDInt(1)
+				startKey, err = keyside.Encode(startKey, startID, encoding.Ascending)
+				require.NoError(t, err)
+				endID := tree.NewDInt(10000)
+				endKey, err = keyside.Encode(endKey, endID, encoding.Ascending)
+				require.NoError(t, err)
+
+				span := roachpb.Span{
+					Key:    roachpb.Key(startKey),
+					EndKey: roachpb.Key(endKey),
+				}
+
+				return span
+			},
+			insertStmts: []string{
+				// The test region row is inside the filler range.
+				`INSERT INTO test.%s (crdb_region, filler, id, data) VALUES ('us-east1', 'dakar', 100, 'foo')`,
+				// The remote region is outside and should be found.
+				`INSERT INTO test.%s (crdb_region, filler, id, data) VALUES ('us-west1', 'paris', 100, 'bar')`,
+
+				// These are not duplicated and should yield no issues.
+				`INSERT INTO test.%s (crdb_region, filler, id, data) VALUES ('us-east1', 'damascus', 200, 'toto')`,
+				`INSERT INTO test.%s (crdb_region, filler, id, data) VALUES ('us-west4', 'rome', 300, 'toto')`,
+			},
+			expectDuplicates: true,
+			expectedCount:    1,
 		},
 	}
 


### PR DESCRIPTION
Previously the uniqueness check for RBR tables only supported tables
with a `(crdb_region, unique_rowid, ... )` key format. This change
allows check to run when the unique column is in other positions in the
key. When the unique column isn't immediately after the region column,
a full scan of the remote region is necessary.

Epic: CRDB-58692

Part of: #154551

Release note: None
