### PR TITLE
changefeedccl: return error from Drain when context cancelled

### DIFF
--- a/pkg/ccl/changefeedccl/kvevent/blocking_buffer.go
+++ b/pkg/ccl/changefeedccl/kvevent/blocking_buffer.go
@@ -341,7 +341,13 @@ func (b *blockingBuffer) Drain(ctx context.Context) (err error) {
 		}
 	}
 
-	return nil
+	// Check if context was cancelled even if buffer is already empty.
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		return nil
+	}
 }
 
 // CloseWithReason implements Writer interface.


### PR DESCRIPTION
changefeedccl: return error from Drain when context cancelled
Previously, blockingBuffer.Drain() would return nil when the buffer
was already empty, even if the context was cancelled. This could lead
to improper resource cleanup since the kvfeed would proceed to close
its writer with a "normal restart" reason when it should have failed
due to context cancellation.

Now Drain checks for context cancellation even when the buffer is
empty, preventing the cleanup issue we saw in the failing test.

We think we saw this in the test failure https://github.com/cockroachdb/cockroach/issues/158130 which didn't see
an error it was expecting and therefore failed.

Informs: https://github.com/cockroachdb/cockroach/issues/158130

Epic: none

Release note: None