### PR TITLE
dev-inf: use targeted tests and increase timeout in issue-autosolve

### DIFF
--- a/.github/workflows/issue-autosolve.yml
+++ b/.github/workflows/issue-autosolve.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   auto-solve-issue:
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 180
     if: github.event.label.name == 'c-autosolve'
     permissions:
       contents: write
@@ -210,7 +210,12 @@ jobs:
           2. Read and understand the issue
           3. Implement the minimal fix required
           4. Add or update tests to verify the fix
-          5. Run tests with ./dev test or ./dev testlogic
+          5. Run ONLY targeted tests for the packages/files you changed:
+             - For Go tests: ./dev test <package> -f=<TestName> -v
+             - For logic tests: ./dev testlogic --files=<testfile> -v
+             Do NOT run broad test suites (e.g. ./dev test pkg/sql or
+             ./dev testlogic without --files). Only test the specific
+             packages and files affected by your changes.
           6. Stage all changes with git add
 
           When formatting commits and PRs, follow the guidelines in CLAUDE.md.


### PR DESCRIPTION
## Summary

- **Targeted tests**: Update the Stage 2 prompt to instruct Claude to run only
  tests for the specific packages/files it changed (e.g. `./dev test <pkg>
  -f=<Test>`, `./dev testlogic --files=<file>`), rather than broad suites like
  `./dev test pkg/sql` or `./dev testlogic` without `--files` that can run for
  hours.
- **Timeout bump**: Increase the job timeout from 120 to 180 minutes as a safety
  net, since even targeted tests require initial Bazel compilation on a fresh
  runner.

Release note: None

Epic: None


🤖 Generated with [Claude Code](https://claude.com/claude-code)