### PR TITLE
parquet: fix ValidateDatum to handle BIT(0) arrays

### DIFF
--- a/pkg/sql/export/exportparquet_test.go
+++ b/pkg/sql/export/exportparquet_test.go
@@ -229,22 +229,6 @@ func TestRandomParquetExports(t *testing.T) {
 					require.NoError(t, err)
 
 					for _, col := range cols {
-						// Skip tables with BIT(0) columns (or arrays of BIT(0)).
-						// The testutils parquet decoder cannot decode these as
-						// into the expected empty bit array and decodes the as
-						// nil. Ignore these to avoid these flakes.
-						colTyp := col.Typ
-						if colTyp.Family() == types.ArrayFamily {
-							colTyp = colTyp.ArrayContents()
-						}
-						if colTyp.Family() == types.BitFamily && colTyp.Width() == 0 {
-							// We skip these because of the aforementioned
-							// decoder issue.
-							t.Logf("skipping table '%s' because it has BIT(0) column '%s' (type: %s)",
-								tableName, col.Name, colTyp.String())
-							return fmt.Errorf("table has BIT(0) column")
-						}
-
 						// TODO(#104278): don't call this function to check if a type is supported.
 						// We should explicitly use the ones supported by  util/parquet).
 						_, err := parquet.NewSchema([]string{"test"}, []*types.T{col.Typ})

--- a/pkg/util/parquet/testutils.go
+++ b/pkg/util/parquet/testutils.go
@@ -419,6 +419,12 @@ func ValidateDatum(t *testing.T, expected tree.Datum, actual tree.Datum) {
 		require.Equal(t, expected.(*tree.DEnum).LogicalRep, actual.(*tree.DEnum).LogicalRep)
 	case types.CollatedStringFamily:
 		require.Equal(t, expected.(*tree.DCollatedString).Contents, actual.(*tree.DCollatedString).Contents)
+	case types.BitFamily:
+		// Compare using string representation to avoid nil vs empty slice
+		// mismatch. BIT(0) produces a BitArray with an empty words slice from
+		// SQL, but the parquet decoder's bitarray.Parse("") returns a nil words
+		// slice. Both are semantically equivalent.
+		require.Equal(t, expected.String(), actual.String())
 	case types.OidFamily:
 		require.Equal(t, expected.(*tree.DOid).Oid, actual.(*tree.DOid).Oid)
 	default:


### PR DESCRIPTION
The parquet test utility's ValidateDatum used deep equality to compare DBitArray values. For BIT(0) columns, the SQL layer produces a BitArray with a non-nil empty words slice, but the parquet decoder's bitarray.Parse("") returns a nil words slice. These are semantically equivalent but fail deep equality. Compare using string representation instead, matching the pattern used for other types like JSON and Date.

Also remove the workaround in TestRandomParquetExports that skipped tables with BIT(0) columns, and add a dedicated test case for empty bit array round-tripping.

Fixes #137757