### PR TITLE
backup: deflake CompactionTriggeringCompaction test

### DIFF
--- a/pkg/backup/compaction_test.go
+++ b/pkg/backup/compaction_test.go
@@ -504,7 +504,7 @@ func TestCompactionTriggeringCompaction(t *testing.T) {
 		th.waitForSuccessfulScheduledJob(t, inc.ScheduleID())
 	}
 
-	for range 12 {
+	for range 5 {
 		executeIncremental()
 	}
 


### PR DESCRIPTION
The `TestCompactionTriggerCompaction` test was creating 12 incrementals, which would trigger 5 compactions for a total of 18 backup jobs. Under sufficient CI load and the 45 second time limit for `testutils.SucceedsSoon`, this may have led to the timeout seen in #164176. This commit reduces the amount of backups taken to the minimum number of backups that would result in multiple compactions being taken.

Fixes: #164176

Release note: None