### PR TITLE
release-26.1: sql: deflake TestIndexBackfillAfterGC

### DIFF
--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -4149,6 +4149,7 @@ func TestSchemaChangeErrorOnCommit(t *testing.T) {
 func TestIndexBackfillAfterGC(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.UnderDuress(t, "flaky under race")
 
 	var tc serverutils.TestClusterInterface
 	ctx := context.Background()


### PR DESCRIPTION
Backport 1/1 commits from #164297 on behalf of @fqazi.

----

Skip TestIndexBackfillAfterGC under race, since it can be timing sensitive.

Fixes: #161759

Release note: None

----

Release justification: test only change