### PR TITLE
sql: skip scanning secondary indexes that are being added or recreated

### DIFF
--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr.definition
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr.definition
@@ -1,7 +1,8 @@
 setup
 CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
 CREATE TABLE multiregion_db.public.table_regional_by_row (
-  k INT NOT NULL,
+  k1 INT NOT NULL PRIMARY KEY,
+  k2 INT NOT NULL,
   V STRING
 ) LOCALITY REGIONAL BY ROW;
 CREATE INDEX idx_v on multiregion_db.table_regional_by_row(v);
@@ -9,14 +10,14 @@ CREATE INDEX idx_v on multiregion_db.table_regional_by_row(v);
 
 stage-exec phase=PostCommitPhase stage=:
 USE multiregion_db;
-INSERT INTO multiregion_db.table_regional_by_row(k) VALUES($stageKey);
-INSERT INTO  multiregion_db.table_regional_by_row(k) VALUES($stageKey + 1);
+INSERT INTO multiregion_db.table_regional_by_row(k1, k2) VALUES($stageKey, $stageKey);
+INSERT INTO  multiregion_db.table_regional_by_row(k1, k2) VALUES($stageKey + 1, $stageKey + 1);
 ----
 
 stage-exec phase=PostCommitNonRevertiblePhase stage=:
 USE multiregion_db;
-INSERT INTO multiregion_db.table_regional_by_row(k) VALUES($stageKey);
-INSERT INTO multiregion_db.table_regional_by_row(k) VALUES($stageKey + 1);
+INSERT INTO multiregion_db.table_regional_by_row(k1, k2) VALUES($stageKey, $stageKey);
+INSERT INTO multiregion_db.table_regional_by_row(k1, k2) VALUES($stageKey + 1, $stageKey + 1);
 ----
 
 stage-exec phase=PostCommitPhase stage=:
@@ -50,11 +51,10 @@ stage-query phase=PostCommitNonRevertiblePhase stage=:
 SELECT index_name FROM crdb_internal.table_indexes WHERE descriptor_name='table_regional_by_row' ORDER BY index_name;
 ----
 idx_v
+table_regional_by_row_k1_key
 table_regional_by_row_pkey
-table_regional_by_row_rowid_key
-
 
 
 test
-alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k) USING HASH;
+alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k2) USING HASH;
 ----

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr.explain
@@ -1,15 +1,16 @@
 /* setup */
 CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
 CREATE TABLE multiregion_db.public.table_regional_by_row (
-  k INT NOT NULL,
+  k1 INT NOT NULL PRIMARY KEY,
+  k2 INT NOT NULL,
   V STRING
 ) LOCALITY REGIONAL BY ROW;
 CREATE INDEX idx_v on multiregion_db.table_regional_by_row(v);
 
 /* test */
-EXPLAIN (DDL) alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k) USING HASH;
+EXPLAIN (DDL) alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k2) USING HASH;
 ----
-Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_regional_by_row› ADD COLUMN ‹m› INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (‹k›) USING HASH;
+Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_regional_by_row› ADD COLUMN ‹m› INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (‹k2›) USING HASH;
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 23 elements transitioning toward PUBLIC
@@ -19,18 +20,18 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │         │    ├── ABSENT → PUBLIC           ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m+), Expr: unique_rowid()}
  │         │    ├── ABSENT → BACKFILL_ONLY    PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey+), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey~)}
  │         │    ├── ABSENT → PUBLIC           IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey+)}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 10 (table_regional_by_row_pkey+)}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 10 (table_regional_by_row_pkey+)}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 10 (table_regional_by_row_pkey+)}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 10 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 10 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 10 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 10 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 10 (table_regional_by_row_pkey+)}
  │         │    ├── ABSENT → PUBLIC           IndexData:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey+)}
  │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m+), IndexID: 10 (table_regional_by_row_pkey+)}
- │         │    ├── ABSENT → DELETE_ONLY      Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16+)}
- │         │    ├── ABSENT → PUBLIC           ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k_shard_16", ColumnID: 6 (crdb_internal_k_shard_16+)}
- │         │    ├── ABSENT → PUBLIC           ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16+), TypeName: "INT8"}
- │         │    ├── ABSENT → PUBLIC           ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16+), ReferencedColumnIDs: [1], Usage: REGULAR}
- │         │    ├── ABSENT → PUBLIC           ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16+)}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16+), IndexID: 10 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → DELETE_ONLY      Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16+)}
+ │         │    ├── ABSENT → PUBLIC           ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k2_shard_16", ColumnID: 6 (crdb_internal_k2_shard_16+)}
+ │         │    ├── ABSENT → PUBLIC           ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k2_shard_16+), TypeName: "INT8"}
+ │         │    ├── ABSENT → PUBLIC           ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16+), ReferencedColumnIDs: [2], Usage: REGULAR}
+ │         │    ├── ABSENT → PUBLIC           ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16+)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16+), IndexID: 10 (table_regional_by_row_pkey+)}
  │         │    ├── ABSENT → PUBLIC           TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
  │         │    ├── ABSENT → PUBLIC           TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
  │         │    ├── ABSENT → PUBLIC           TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
@@ -39,17 +40,17 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │         ├── 15 elements transitioning toward TRANSIENT_ABSENT
  │         │    ├── ABSENT → BACKFILL_ONLY    PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey~), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 1 (table_regional_by_row_pkey-)}
  │         │    ├── ABSENT → PUBLIC           IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey~)}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 8 (table_regional_by_row_pkey~)}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 8 (table_regional_by_row_pkey~)}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey~)}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 8 (table_regional_by_row_pkey~)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey~)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 8 (table_regional_by_row_pkey~)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 8 (table_regional_by_row_pkey~)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 8 (table_regional_by_row_pkey~)}
  │         │    ├── ABSENT → PUBLIC           IndexData:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey~)}
  │         │    ├── ABSENT → DELETE_ONLY      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 8, SourceIndexID: 1 (table_regional_by_row_pkey-)}
  │         │    ├── ABSENT → TRANSIENT_ABSENT IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 9}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 9}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 9}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 9}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 9}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 9}
  │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m+), IndexID: 8 (table_regional_by_row_pkey~)}
  │         │    └── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m+), IndexID: 9}
  │         ├── 1 element transitioning toward TRANSIENT_PUBLIC
@@ -62,20 +63,20 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │              ├── AddColumnDefaultExpression {"Default":{"ColumnID":5,"TableID":108}}
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":7,"IndexID":8,"IsUnique":true,"SourceIndexID":1,"TableID":108,"TemporaryIndexID":9}}
  │              ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":8,"TableID":108}}
- │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":8,"TableID":108}
- │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":8,"Ordinal":1,"TableID":108}
- │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":8,"Kind":2,"TableID":108}
- │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
  │              ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":8,"IndexID":9,"IsUnique":true,"SourceIndexID":1,"TableID":108}}
  │              ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":9,"TableID":108}}
- │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":9,"TableID":108}
- │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":9,"Ordinal":1,"TableID":108}
- │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":9,"Kind":2,"TableID":108}
- │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":9,"Kind":2,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
  │              ├── AddColumnToIndex {"ColumnID":5,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":108}
  │              ├── AddColumnToIndex {"ColumnID":5,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":108}
  │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":6,"TableID":108}}
- │              ├── SetColumnName {"ColumnID":6,"Name":"crdb_internal_k_...","TableID":108}
+ │              ├── SetColumnName {"ColumnID":6,"Name":"crdb_internal_k2...","TableID":108}
  │              ├── UpsertColumnType {"ColumnType":{"ColumnID":6,"IsVirtual":true,"TableID":108}}
  │              ├── AddColumnComputeExpression {"ComputeExpression":{"ColumnID":6,"TableID":108}}
  │              ├── MakeColumnHidden {"ColumnID":6,"TableID":108}
@@ -86,12 +87,12 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │              ├── AddTableZoneConfig {"TableID":108}
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":9,"IndexID":10,"IsUnique":true,"SourceIndexID":8,"TableID":108,"TemporaryIndexID":11}}
  │              ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":10,"TableID":108}}
- │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":10,"TableID":108}
- │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":10,"Kind":2,"TableID":108}
- │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":10,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
  │              ├── AddColumnToIndex {"ColumnID":5,"IndexID":10,"Kind":2,"Ordinal":2,"TableID":108}
  │              ├── AddColumnToIndex {"ColumnID":6,"IndexID":10,"Ordinal":1,"TableID":108}
- │              └── AddColumnToIndex {"ColumnID":1,"IndexID":10,"Ordinal":2,"TableID":108}
+ │              └── AddColumnToIndex {"ColumnID":2,"IndexID":10,"Ordinal":2,"TableID":108}
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
  │    │    ├── 23 elements transitioning toward PUBLIC
@@ -101,18 +102,18 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │    │    │    ├── PUBLIC           → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m+), Expr: unique_rowid()}
  │    │    │    ├── BACKFILL_ONLY    → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey+), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey~)}
  │    │    │    ├── PUBLIC           → ABSENT IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey+)}
- │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 10 (table_regional_by_row_pkey+)}
- │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 10 (table_regional_by_row_pkey+)}
- │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 10 (table_regional_by_row_pkey+)}
- │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 10 (table_regional_by_row_pkey+)}
+ │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 10 (table_regional_by_row_pkey+)}
+ │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 10 (table_regional_by_row_pkey+)}
+ │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 10 (table_regional_by_row_pkey+)}
+ │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 10 (table_regional_by_row_pkey+)}
  │    │    │    ├── PUBLIC           → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey+)}
  │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m+), IndexID: 10 (table_regional_by_row_pkey+)}
- │    │    │    ├── DELETE_ONLY      → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16+)}
- │    │    │    ├── PUBLIC           → ABSENT ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k_shard_16", ColumnID: 6 (crdb_internal_k_shard_16+)}
- │    │    │    ├── PUBLIC           → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16+), TypeName: "INT8"}
- │    │    │    ├── PUBLIC           → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16+), ReferencedColumnIDs: [1], Usage: REGULAR}
- │    │    │    ├── PUBLIC           → ABSENT ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16+)}
- │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16+), IndexID: 10 (table_regional_by_row_pkey+)}
+ │    │    │    ├── DELETE_ONLY      → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16+)}
+ │    │    │    ├── PUBLIC           → ABSENT ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k2_shard_16", ColumnID: 6 (crdb_internal_k2_shard_16+)}
+ │    │    │    ├── PUBLIC           → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k2_shard_16+), TypeName: "INT8"}
+ │    │    │    ├── PUBLIC           → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16+), ReferencedColumnIDs: [2], Usage: REGULAR}
+ │    │    │    ├── PUBLIC           → ABSENT ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16+)}
+ │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16+), IndexID: 10 (table_regional_by_row_pkey+)}
  │    │    │    ├── PUBLIC           → ABSENT TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
  │    │    │    ├── PUBLIC           → ABSENT TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
  │    │    │    ├── PUBLIC           → ABSENT TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
@@ -121,17 +122,17 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │    │    ├── 15 elements transitioning toward TRANSIENT_ABSENT
  │    │    │    ├── BACKFILL_ONLY    → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey~), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 1 (table_regional_by_row_pkey-)}
  │    │    │    ├── PUBLIC           → ABSENT IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey~)}
- │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 8 (table_regional_by_row_pkey~)}
- │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 8 (table_regional_by_row_pkey~)}
- │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey~)}
- │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 8 (table_regional_by_row_pkey~)}
+ │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey~)}
+ │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 8 (table_regional_by_row_pkey~)}
+ │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 8 (table_regional_by_row_pkey~)}
+ │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 8 (table_regional_by_row_pkey~)}
  │    │    │    ├── PUBLIC           → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey~)}
  │    │    │    ├── DELETE_ONLY      → ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 8, SourceIndexID: 1 (table_regional_by_row_pkey-)}
  │    │    │    ├── TRANSIENT_ABSENT → ABSENT IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
- │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 9}
- │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 9}
- │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
- │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 9}
+ │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+ │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 9}
+ │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 9}
+ │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 9}
  │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m+), IndexID: 8 (table_regional_by_row_pkey~)}
  │    │    │    └── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m+), IndexID: 9}
  │    │    ├── 1 element transitioning toward TRANSIENT_PUBLIC
@@ -146,18 +147,18 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │         │    ├── ABSENT → PUBLIC           ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m+), Expr: unique_rowid()}
  │         │    ├── ABSENT → BACKFILL_ONLY    PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey+), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey~)}
  │         │    ├── ABSENT → PUBLIC           IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey+)}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 10 (table_regional_by_row_pkey+)}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 10 (table_regional_by_row_pkey+)}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 10 (table_regional_by_row_pkey+)}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 10 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 10 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 10 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 10 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 10 (table_regional_by_row_pkey+)}
  │         │    ├── ABSENT → PUBLIC           IndexData:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey+)}
  │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m+), IndexID: 10 (table_regional_by_row_pkey+)}
- │         │    ├── ABSENT → DELETE_ONLY      Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16+)}
- │         │    ├── ABSENT → PUBLIC           ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k_shard_16", ColumnID: 6 (crdb_internal_k_shard_16+)}
- │         │    ├── ABSENT → PUBLIC           ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16+), TypeName: "INT8"}
- │         │    ├── ABSENT → PUBLIC           ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16+), ReferencedColumnIDs: [1], Usage: REGULAR}
- │         │    ├── ABSENT → PUBLIC           ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16+)}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16+), IndexID: 10 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → DELETE_ONLY      Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16+)}
+ │         │    ├── ABSENT → PUBLIC           ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k2_shard_16", ColumnID: 6 (crdb_internal_k2_shard_16+)}
+ │         │    ├── ABSENT → PUBLIC           ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k2_shard_16+), TypeName: "INT8"}
+ │         │    ├── ABSENT → PUBLIC           ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16+), ReferencedColumnIDs: [2], Usage: REGULAR}
+ │         │    ├── ABSENT → PUBLIC           ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16+)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16+), IndexID: 10 (table_regional_by_row_pkey+)}
  │         │    ├── ABSENT → PUBLIC           TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
  │         │    ├── ABSENT → PUBLIC           TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
  │         │    ├── ABSENT → PUBLIC           TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
@@ -166,17 +167,17 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │         ├── 15 elements transitioning toward TRANSIENT_ABSENT
  │         │    ├── ABSENT → BACKFILL_ONLY    PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey~), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 1 (table_regional_by_row_pkey-)}
  │         │    ├── ABSENT → PUBLIC           IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey~)}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 8 (table_regional_by_row_pkey~)}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 8 (table_regional_by_row_pkey~)}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey~)}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 8 (table_regional_by_row_pkey~)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey~)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 8 (table_regional_by_row_pkey~)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 8 (table_regional_by_row_pkey~)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 8 (table_regional_by_row_pkey~)}
  │         │    ├── ABSENT → PUBLIC           IndexData:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey~)}
  │         │    ├── ABSENT → DELETE_ONLY      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 8, SourceIndexID: 1 (table_regional_by_row_pkey-)}
  │         │    ├── ABSENT → TRANSIENT_ABSENT IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 9}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 9}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 9}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 9}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 9}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 9}
  │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m+), IndexID: 8 (table_regional_by_row_pkey~)}
  │         │    └── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m+), IndexID: 9}
  │         ├── 1 element transitioning toward TRANSIENT_PUBLIC
@@ -190,21 +191,21 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":7,"IndexID":8,"IsUnique":true,"SourceIndexID":1,"TableID":108,"TemporaryIndexID":9}}
  │              ├── MaybeAddSplitForIndex {"IndexID":8,"TableID":108}
  │              ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":8,"TableID":108}}
- │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":8,"TableID":108}
- │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":8,"Ordinal":1,"TableID":108}
- │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":8,"Kind":2,"TableID":108}
- │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
  │              ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":8,"IndexID":9,"IsUnique":true,"SourceIndexID":1,"TableID":108}}
  │              ├── MaybeAddSplitForIndex {"IndexID":9,"TableID":108}
  │              ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":9,"TableID":108}}
- │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":9,"TableID":108}
- │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":9,"Ordinal":1,"TableID":108}
- │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":9,"Kind":2,"TableID":108}
- │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":9,"Kind":2,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
  │              ├── AddColumnToIndex {"ColumnID":5,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":108}
  │              ├── AddColumnToIndex {"ColumnID":5,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":108}
  │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":6,"TableID":108}}
- │              ├── SetColumnName {"ColumnID":6,"Name":"crdb_internal_k_...","TableID":108}
+ │              ├── SetColumnName {"ColumnID":6,"Name":"crdb_internal_k2...","TableID":108}
  │              ├── UpsertColumnType {"ColumnType":{"ColumnID":6,"IsVirtual":true,"TableID":108}}
  │              ├── AddColumnComputeExpression {"ComputeExpression":{"ColumnID":6,"TableID":108}}
  │              ├── MakeColumnHidden {"ColumnID":6,"TableID":108}
@@ -216,20 +217,20 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":9,"IndexID":10,"IsUnique":true,"SourceIndexID":8,"TableID":108,"TemporaryIndexID":11}}
  │              ├── MaybeAddSplitForIndex {"IndexID":10,"TableID":108}
  │              ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":10,"TableID":108}}
- │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":10,"TableID":108}
- │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":10,"Kind":2,"TableID":108}
- │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":10,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
  │              ├── AddColumnToIndex {"ColumnID":5,"IndexID":10,"Kind":2,"Ordinal":2,"TableID":108}
  │              ├── AddColumnToIndex {"ColumnID":6,"IndexID":10,"Ordinal":1,"TableID":108}
- │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":10,"Ordinal":2,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":10,"Ordinal":2,"TableID":108}
  │              ├── SetJobStateOnDescriptor {"DescriptorID":108,"Initialize":true}
  │              └── CreateSchemaChangerJob {"RunningStatus":"Pending: Updatin..."}
  ├── PostCommitPhase
  │    ├── Stage 1 of 24 in PostCommitPhase
  │    │    ├── 3 elements transitioning toward PUBLIC
  │    │    │    ├── DELETE_ONLY → WRITE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m+)}
- │    │    │    ├── DELETE_ONLY → WRITE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16+)}
- │    │    │    └── ABSENT      → WRITE_ONLY ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16+), IndexID: 10 (table_regional_by_row_pkey+)}
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16+)}
+ │    │    │    └── ABSENT      → WRITE_ONLY ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16+), IndexID: 10 (table_regional_by_row_pkey+)}
  │    │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
  │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 8, SourceIndexID: 1 (table_regional_by_row_pkey-)}
  │    │    │    └── ABSENT      → PUBLIC     IndexData:{DescID: 108 (table_regional_by_row), IndexID: 9}
@@ -280,30 +281,30 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │    │         └── ValidateIndex {"IndexID":8,"TableID":108}
  │    ├── Stage 8 of 24 in PostCommitPhase
  │    │    ├── 7 elements transitioning toward PUBLIC
- │    │    │    ├── ABSENT    → BACKFILL_ONLY    SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v+), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+ │    │    │    ├── ABSENT    → BACKFILL_ONLY    SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v+), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
  │    │    │    ├── ABSENT    → PUBLIC           IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v+)}
- │    │    │    ├── ABSENT    → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (idx_v+)}
- │    │    │    ├── ABSENT    → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 4 (idx_v+)}
- │    │    │    ├── ABSENT    → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 4 (idx_v+)}
- │    │    │    ├── ABSENT    → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16+), IndexID: 4 (idx_v+)}
+ │    │    │    ├── ABSENT    → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 4 (idx_v+)}
+ │    │    │    ├── ABSENT    → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 4 (idx_v+)}
+ │    │    │    ├── ABSENT    → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 4 (idx_v+)}
+ │    │    │    ├── ABSENT    → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16+), IndexID: 4 (idx_v+)}
  │    │    │    └── ABSENT    → PUBLIC           IndexData:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v+)}
  │    │    ├── 16 elements transitioning toward TRANSIENT_ABSENT
  │    │    │    ├── VALIDATED → PUBLIC           PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey~), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 1 (table_regional_by_row_pkey-)}
  │    │    │    ├── ABSENT    → PUBLIC           IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 8 (table_regional_by_row_pkey~)}
  │    │    │    ├── ABSENT    → DELETE_ONLY      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 11, ConstraintID: 10, SourceIndexID: 8 (table_regional_by_row_pkey~)}
  │    │    │    ├── ABSENT    → TRANSIENT_ABSENT IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 11}
- │    │    │    ├── ABSENT    → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 11}
- │    │    │    ├── ABSENT    → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 11}
- │    │    │    ├── ABSENT    → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 11}
- │    │    │    ├── ABSENT    → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 11}
+ │    │    │    ├── ABSENT    → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 11}
+ │    │    │    ├── ABSENT    → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 11}
+ │    │    │    ├── ABSENT    → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 11}
+ │    │    │    ├── ABSENT    → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 11}
  │    │    │    ├── ABSENT    → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m+), IndexID: 11}
- │    │    │    ├── ABSENT    → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16+), IndexID: 11}
+ │    │    │    ├── ABSENT    → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16+), IndexID: 11}
  │    │    │    ├── ABSENT    → DELETE_ONLY      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 4, SourceIndexID: 8 (table_regional_by_row_pkey~)}
  │    │    │    ├── ABSENT    → TRANSIENT_ABSENT IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 5}
- │    │    │    ├── ABSENT    → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 5}
- │    │    │    ├── ABSENT    → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 5}
- │    │    │    ├── ABSENT    → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 5}
- │    │    │    └── ABSENT    → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16+), IndexID: 5}
+ │    │    │    ├── ABSENT    → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 5}
+ │    │    │    ├── ABSENT    → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 5}
+ │    │    │    ├── ABSENT    → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 5}
+ │    │    │    └── ABSENT    → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16+), IndexID: 5}
  │    │    ├── 3 elements transitioning toward ABSENT
  │    │    │    ├── PUBLIC    → VALIDATED        PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey-), ConstraintID: 1}
  │    │    │    ├── PUBLIC    → ABSENT           IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey-)}
@@ -315,27 +316,27 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │    │         ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":10,"IndexID":11,"IsUnique":true,"SourceIndexID":8,"TableID":108}}
  │    │         ├── MaybeAddSplitForIndex {"IndexID":11,"TableID":108}
  │    │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":11,"TableID":108}}
- │    │         ├── AddColumnToIndex {"ColumnID":3,"IndexID":11,"TableID":108}
- │    │         ├── AddColumnToIndex {"ColumnID":4,"IndexID":11,"Kind":2,"TableID":108}
- │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":108}
+ │    │         ├── AddColumnToIndex {"ColumnID":4,"IndexID":11,"TableID":108}
+ │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":11,"Kind":2,"TableID":108}
+ │    │         ├── AddColumnToIndex {"ColumnID":3,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":108}
  │    │         ├── AddColumnToIndex {"ColumnID":5,"IndexID":11,"Kind":2,"Ordinal":2,"TableID":108}
  │    │         ├── AddColumnToIndex {"ColumnID":6,"IndexID":11,"Ordinal":1,"TableID":108}
  │    │         ├── MakeAbsentIndexBackfilling {"IsSecondaryIndex":true}
  │    │         ├── MaybeAddSplitForIndex {"IndexID":4,"TableID":108}
  │    │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":4,"TableID":108}}
- │    │         ├── AddColumnToIndex {"ColumnID":3,"IndexID":4,"TableID":108}
- │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":108}
- │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":108}
+ │    │         ├── AddColumnToIndex {"ColumnID":4,"IndexID":4,"TableID":108}
+ │    │         ├── AddColumnToIndex {"ColumnID":3,"IndexID":4,"Ordinal":1,"TableID":108}
+ │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":108}
  │    │         ├── AddColumnToIndex {"ColumnID":6,"IndexID":4,"Kind":1,"Ordinal":1,"TableID":108}
  │    │         ├── MakeAbsentTempIndexDeleteOnly {"IsSecondaryIndex":true}
  │    │         ├── MaybeAddSplitForIndex {"IndexID":5,"TableID":108}
  │    │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":5,"TableID":108}}
- │    │         ├── AddColumnToIndex {"ColumnID":3,"IndexID":5,"TableID":108}
- │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":108}
- │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":108}
+ │    │         ├── AddColumnToIndex {"ColumnID":4,"IndexID":5,"TableID":108}
+ │    │         ├── AddColumnToIndex {"ColumnID":3,"IndexID":5,"Ordinal":1,"TableID":108}
+ │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":108}
  │    │         ├── AddColumnToIndex {"ColumnID":6,"IndexID":5,"Kind":1,"Ordinal":1,"TableID":108}
  │    │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":8,"TableID":108}
- │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":11,"Ordinal":2,"TableID":108}
+ │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":11,"Ordinal":2,"TableID":108}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"Pending: Updatin..."}
  │    ├── Stage 9 of 24 in PostCommitPhase
@@ -352,14 +353,14 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │    ├── Stage 10 of 24 in PostCommitPhase
  │    │    ├── 2 elements transitioning toward PUBLIC
  │    │    │    ├── BACKFILL_ONLY → BACKFILLED PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey+), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey~)}
- │    │    │    └── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v+), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+ │    │    │    └── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v+), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
  │    │    └── 2 Backfill operations
  │    │         ├── BackfillIndex {"IndexID":10,"SourceIndexID":8,"TableID":108}
  │    │         └── BackfillIndex {"IndexID":4,"SourceIndexID":8,"TableID":108}
  │    ├── Stage 11 of 24 in PostCommitPhase
  │    │    ├── 2 elements transitioning toward PUBLIC
  │    │    │    ├── BACKFILLED → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey+), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey~)}
- │    │    │    └── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v+), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+ │    │    │    └── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v+), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
  │    │    └── 4 Mutation operations
  │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":10,"TableID":108}
  │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":4,"TableID":108}
@@ -368,7 +369,7 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │    ├── Stage 12 of 24 in PostCommitPhase
  │    │    ├── 2 elements transitioning toward PUBLIC
  │    │    │    ├── DELETE_ONLY → MERGE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey+), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey~)}
- │    │    │    └── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v+), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+ │    │    │    └── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v+), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
  │    │    └── 4 Mutation operations
  │    │         ├── MakeBackfilledIndexMerging {"IndexID":10,"TableID":108}
  │    │         ├── MakeBackfilledIndexMerging {"IndexID":4,"TableID":108}
@@ -377,14 +378,14 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │    ├── Stage 13 of 24 in PostCommitPhase
  │    │    ├── 2 elements transitioning toward PUBLIC
  │    │    │    ├── MERGE_ONLY → MERGED PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey+), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey~)}
- │    │    │    └── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v+), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+ │    │    │    └── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v+), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
  │    │    └── 2 Backfill operations
  │    │         ├── MergeIndex {"BackfilledIndexID":10,"TableID":108,"TemporaryIndexID":11}
  │    │         └── MergeIndex {"BackfilledIndexID":4,"TableID":108,"TemporaryIndexID":5}
  │    ├── Stage 14 of 24 in PostCommitPhase
  │    │    ├── 2 elements transitioning toward PUBLIC
  │    │    │    ├── MERGED     → WRITE_ONLY            PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey+), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey~)}
- │    │    │    └── MERGED     → WRITE_ONLY            SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v+), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+ │    │    │    └── MERGED     → WRITE_ONLY            SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v+), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
  │    │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
  │    │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 11, ConstraintID: 10, SourceIndexID: 8 (table_regional_by_row_pkey~)}
  │    │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 4, SourceIndexID: 8 (table_regional_by_row_pkey~)}
@@ -398,56 +399,51 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │    ├── Stage 15 of 24 in PostCommitPhase
  │    │    ├── 3 elements transitioning toward PUBLIC
  │    │    │    ├── WRITE_ONLY → VALIDATED PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey+), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey~)}
- │    │    │    ├── WRITE_ONLY → VALIDATED ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16+), IndexID: 10 (table_regional_by_row_pkey+)}
- │    │    │    └── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v+), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+ │    │    │    ├── WRITE_ONLY → VALIDATED ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16+), IndexID: 10 (table_regional_by_row_pkey+)}
+ │    │    │    └── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v+), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
  │    │    └── 3 Validation operations
  │    │         ├── ValidateIndex {"IndexID":10,"TableID":108}
  │    │         ├── ValidateColumnNotNull {"ColumnID":6,"IndexIDForValidation":10,"TableID":108}
  │    │         └── ValidateIndex {"IndexID":4,"TableID":108}
  │    ├── Stage 16 of 24 in PostCommitPhase
  │    │    ├── 11 elements transitioning toward PUBLIC
- │    │    │    ├── VALIDATED → PUBLIC        ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16+), IndexID: 10 (table_regional_by_row_pkey+)}
- │    │    │    ├── VALIDATED → PUBLIC        SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v+), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+ │    │    │    ├── VALIDATED → PUBLIC        ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16+), IndexID: 10 (table_regional_by_row_pkey+)}
+ │    │    │    ├── VALIDATED → PUBLIC        SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v+), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
  │    │    │    ├── ABSENT    → PUBLIC        IndexName:{DescID: 108 (table_regional_by_row), Name: "idx_v", IndexID: 4 (idx_v+)}
- │    │    │    ├── ABSENT    → BACKFILL_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key+), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 10 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
- │    │    │    ├── ABSENT    → PUBLIC        IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key+)}
- │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 6 (table_regional_by_row_rowid_key+)}
- │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 6 (table_regional_by_row_rowid_key+)}
- │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16+), IndexID: 6 (table_regional_by_row_rowid_key+)}
- │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_rowid_key+)}
- │    │    │    ├── ABSENT    → PUBLIC        IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key+)}
- │    │    │    └── ABSENT    → PUBLIC        IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_rowid_key", IndexID: 6 (table_regional_by_row_rowid_key+)}
+ │    │    │    ├── ABSENT    → BACKFILL_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_k1_key+), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 10 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+ │    │    │    ├── ABSENT    → PUBLIC        IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_k1_key+)}
+ │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 6 (table_regional_by_row_k1_key+)}
+ │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 6 (table_regional_by_row_k1_key+)}
+ │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16+), IndexID: 6 (table_regional_by_row_k1_key+)}
+ │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 6 (table_regional_by_row_k1_key+)}
+ │    │    │    ├── ABSENT    → PUBLIC        IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_k1_key+)}
+ │    │    │    └── ABSENT    → PUBLIC        IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_k1_key", IndexID: 6 (table_regional_by_row_k1_key+)}
  │    │    ├── 5 elements transitioning toward TRANSIENT_ABSENT
  │    │    │    ├── ABSENT    → DELETE_ONLY   TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 6, SourceIndexID: 10 (table_regional_by_row_pkey+)}
- │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 7}
- │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 7}
- │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16+), IndexID: 7}
- │    │    │    └── ABSENT    → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
- │    │    ├── 2 elements transitioning toward ABSENT
- │    │    │    ├── PUBLIC    → VALIDATED     SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (idx_v-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
- │    │    │    └── PUBLIC    → ABSENT        IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 2 (idx_v-)}
- │    │    └── 23 Mutation operations
+ │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 7}
+ │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 7}
+ │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16+), IndexID: 7}
+ │    │    │    └── ABSENT    → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 7}
+ │    │    └── 21 Mutation operations
  │    │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":6,"TableID":108}
  │    │         ├── SetIndexName {"IndexID":4,"Name":"idx_v","TableID":108}
  │    │         ├── MakeAbsentIndexBackfilling {"IsSecondaryIndex":true}
  │    │         ├── MaybeAddSplitForIndex {"IndexID":6,"TableID":108}
  │    │         ├── MakeAbsentTempIndexDeleteOnly {"IsSecondaryIndex":true}
  │    │         ├── MaybeAddSplitForIndex {"IndexID":7,"TableID":108}
- │    │         ├── AddColumnToIndex {"ColumnID":3,"IndexID":6,"TableID":108}
- │    │         ├── AddColumnToIndex {"ColumnID":3,"IndexID":7,"TableID":108}
- │    │         ├── AddColumnToIndex {"ColumnID":4,"IndexID":6,"Ordinal":1,"TableID":108}
- │    │         ├── AddColumnToIndex {"ColumnID":4,"IndexID":7,"Ordinal":1,"TableID":108}
+ │    │         ├── AddColumnToIndex {"ColumnID":4,"IndexID":6,"TableID":108}
+ │    │         ├── AddColumnToIndex {"ColumnID":4,"IndexID":7,"TableID":108}
+ │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+ │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
  │    │         ├── AddColumnToIndex {"ColumnID":6,"IndexID":6,"Kind":1,"TableID":108}
  │    │         ├── AddColumnToIndex {"ColumnID":6,"IndexID":7,"Kind":1,"TableID":108}
- │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":108}
- │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":7,"Kind":1,"Ordinal":1,"TableID":108}
+ │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":108}
+ │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":7,"Kind":1,"Ordinal":1,"TableID":108}
  │    │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":6,"TableID":108}}
  │    │         ├── SetIndexName {"IndexID":6,"Name":"table_regional_b...","TableID":108}
- │    │         ├── MarkRecreatedIndexAsInvisible {"IndexID":4,"SetHideIndexFlag":true,"TableID":108,"TargetPrimaryIndexID":8}
+ │    │         ├── MarkRecreatedIndexAsInvisible {"IndexID":4,"SetHideIndexFlag":true,"TableID":108,"TargetPrimaryIndexID":10}
  │    │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":108}
  │    │         ├── RefreshStats {"TableID":108}
- │    │         ├── MarkRecreatedIndexAsVisible {"IndexID":4,"TableID":108}
- │    │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":2,"TableID":108}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"Pending: Updatin..."}
  │    ├── Stage 17 of 24 in PostCommitPhase
@@ -460,31 +456,31 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"Pending: Backfil..."}
  │    ├── Stage 18 of 24 in PostCommitPhase
  │    │    ├── 1 element transitioning toward PUBLIC
- │    │    │    └── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key+), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 10 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+ │    │    │    └── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_k1_key+), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 10 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
  │    │    └── 1 Backfill operation
  │    │         └── BackfillIndex {"IndexID":6,"SourceIndexID":10,"TableID":108}
  │    ├── Stage 19 of 24 in PostCommitPhase
  │    │    ├── 1 element transitioning toward PUBLIC
- │    │    │    └── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key+), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 10 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+ │    │    │    └── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_k1_key+), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 10 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
  │    │    └── 3 Mutation operations
  │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":6,"TableID":108}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"Pending: Updatin..."}
  │    ├── Stage 20 of 24 in PostCommitPhase
  │    │    ├── 1 element transitioning toward PUBLIC
- │    │    │    └── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key+), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 10 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+ │    │    │    └── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_k1_key+), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 10 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
  │    │    └── 3 Mutation operations
  │    │         ├── MakeBackfilledIndexMerging {"IndexID":6,"TableID":108}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"Pending: Merging..."}
  │    ├── Stage 21 of 24 in PostCommitPhase
  │    │    ├── 1 element transitioning toward PUBLIC
- │    │    │    └── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key+), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 10 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+ │    │    │    └── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_k1_key+), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 10 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
  │    │    └── 1 Backfill operation
  │    │         └── MergeIndex {"BackfilledIndexID":6,"TableID":108,"TemporaryIndexID":7}
  │    ├── Stage 22 of 24 in PostCommitPhase
  │    │    ├── 1 element transitioning toward PUBLIC
- │    │    │    └── MERGED     → WRITE_ONLY            SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key+), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 10 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+ │    │    │    └── MERGED     → WRITE_ONLY            SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_k1_key+), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 10 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
  │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
  │    │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 6, SourceIndexID: 10 (table_regional_by_row_pkey+)}
  │    │    └── 4 Mutation operations
@@ -494,12 +490,12 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"Pending: Validat..."}
  │    ├── Stage 23 of 24 in PostCommitPhase
  │    │    ├── 1 element transitioning toward PUBLIC
- │    │    │    └── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key+), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 10 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+ │    │    │    └── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_k1_key+), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 10 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
  │    │    └── 1 Validation operation
  │    │         └── ValidateIndex {"IndexID":6,"TableID":108}
  │    └── Stage 24 of 24 in PostCommitPhase
  │         ├── 1 element transitioning toward PUBLIC
- │         │    └── VALIDATED → PUBLIC SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key+), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 10 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+ │         │    └── VALIDATED → PUBLIC SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_k1_key+), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 10 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
  │         └── 4 Mutation operations
  │              ├── MakeValidatedSecondaryIndexPublic {"IndexID":6,"TableID":108}
  │              ├── RefreshStats {"TableID":108}
@@ -509,73 +505,63 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
       ├── Stage 1 of 6 in PostCommitNonRevertiblePhase
       │    ├── 23 elements transitioning toward TRANSIENT_ABSENT
       │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 8, SourceIndexID: 1 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 9}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 9}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 9}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 9}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 9}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 9}
       │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 11, ConstraintID: 10, SourceIndexID: 8 (table_regional_by_row_pkey~)}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 11}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 11}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 11}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 11}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 11}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 11}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 11}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 11}
       │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m+), IndexID: 9}
       │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m+), IndexID: 11}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16+), IndexID: 11}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16+), IndexID: 11}
       │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 4, SourceIndexID: 8 (table_regional_by_row_pkey~)}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 5}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 5}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 5}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16+), IndexID: 5}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 5}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 5}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 5}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16+), IndexID: 5}
       │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 6, SourceIndexID: 10 (table_regional_by_row_pkey+)}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 7}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 7}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16+), IndexID: 7}
-      │    │    └── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
-      │    ├── 10 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 1 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 1 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 1 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 1 (table_regional_by_row_pkey-)}
-      │    │    ├── VALIDATED             → DELETE_ONLY      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey-), ConstraintID: 1}
-      │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 2 (idx_v-)}
-      │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 2 (idx_v-)}
-      │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 2 (idx_v-)}
-      │    │    ├── VALIDATED             → DELETE_ONLY      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (idx_v-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
-      │    │    └── PUBLIC                → ABSENT           IndexName:{DescID: 108 (table_regional_by_row), Name: "idx_v", IndexID: 2 (idx_v-)}
-      │    └── 35 Mutation operations
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Ordinal":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":108}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 7}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16+), IndexID: 7}
+      │    │    └── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 7}
+      │    ├── 5 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 1 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 1 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 1 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 1 (table_regional_by_row_pkey-)}
+      │    │    └── VALIDATED             → DELETE_ONLY      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey-), ConstraintID: 1}
+      │    └── 30 Mutation operations
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":11,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":11,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":5,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":5,"Kind":1,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":7,"Kind":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":1,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":108}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":108}
-      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":1,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"Kind":2,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":2,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":1,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 6 in PostCommitNonRevertiblePhase
@@ -583,19 +569,21 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
       │    │    ├── WRITE_ONLY  → PUBLIC              Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m+)}
       │    │    ├── VALIDATED   → PUBLIC              PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey+), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey~)}
       │    │    ├── ABSENT      → PUBLIC              IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 10 (table_regional_by_row_pkey+)}
-      │    │    ├── WRITE_ONLY  → PUBLIC              Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16+)}
-      │    │    ├── ABSENT      → WRITE_ONLY          CheckConstraint:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey+), ConstraintID: 2 (check_crdb_internal_k_shard_16+), ReferencedColumnIDs: [6]}
-      │    │    └── ABSENT      → PUBLIC              ConstraintWithoutIndexName:{DescID: 108 (table_regional_by_row), Name: "check_crdb_internal_k_shard_16", ConstraintID: 2 (check_crdb_internal_k_shard_16+)}
+      │    │    ├── WRITE_ONLY  → PUBLIC              Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16+)}
+      │    │    ├── ABSENT      → WRITE_ONLY          CheckConstraint:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey+), ConstraintID: 2 (check_crdb_internal_k2_shard_16+), ReferencedColumnIDs: [6]}
+      │    │    └── ABSENT      → PUBLIC              ConstraintWithoutIndexName:{DescID: 108 (table_regional_by_row), Name: "check_crdb_internal_k2_shard_16", ConstraintID: 2 (check_crdb_internal_k2_shard_16+)}
       │    ├── 3 elements transitioning toward TRANSIENT_ABSENT
       │    │    ├── PUBLIC      → TRANSIENT_VALIDATED PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey~), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 1 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC      → TRANSIENT_ABSENT    IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 8 (table_regional_by_row_pkey~)}
       │    │    └── PUBLIC      → TRANSIENT_ABSENT    IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey~)}
-      │    ├── 2 elements transitioning toward ABSENT
+      │    ├── 3 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT              PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey-), ConstraintID: 1}
-      │    │    └── DELETE_ONLY → ABSENT              SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (idx_v-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
-      │    └── 14 Mutation operations
+      │    │    ├── PUBLIC      → VALIDATED           SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (idx_v-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+      │    │    └── PUBLIC      → ABSENT              IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 2 (idx_v-)}
+      │    └── 15 Mutation operations
       │         ├── MakeIndexAbsent {"IndexID":1,"TableID":108}
-      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":108}
+      │         ├── MarkRecreatedIndexAsVisible {"IndexID":4,"TableID":108}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":2,"TableID":108}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":8,"TableID":108}
       │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":108}
       │         ├── SetIndexName {"IndexID":10,"Name":"table_regional_b...","TableID":108}
@@ -604,33 +592,44 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
       │         ├── RefreshStats {"TableID":108}
       │         ├── MakeWriteOnlyColumnPublic {"ColumnID":6,"TableID":108}
       │         ├── RefreshStats {"TableID":108}
-      │         ├── AddCheckConstraint {"CheckExpr":"crdb_internal_k_...","ConstraintID":2,"FromHashShardedColumn":true,"TableID":108,"Validity":2}
+      │         ├── AddCheckConstraint {"CheckExpr":"crdb_internal_k2...","ConstraintID":2,"FromHashShardedColumn":true,"TableID":108,"Validity":2}
       │         ├── SetConstraintName {"ConstraintID":2,"Name":"check_crdb_inter...","TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Validat..."}
       ├── Stage 3 of 6 in PostCommitNonRevertiblePhase
       │    ├── 1 element transitioning toward PUBLIC
-      │    │    └── WRITE_ONLY → VALIDATED CheckConstraint:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey+), ConstraintID: 2 (check_crdb_internal_k_shard_16+), ReferencedColumnIDs: [6]}
+      │    │    └── WRITE_ONLY → VALIDATED CheckConstraint:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey+), ConstraintID: 2 (check_crdb_internal_k2_shard_16+), ReferencedColumnIDs: [6]}
       │    └── 1 Validation operation
       │         └── ValidateConstraint {"ConstraintID":2,"IndexIDForValidation":10,"TableID":108}
       ├── Stage 4 of 6 in PostCommitNonRevertiblePhase
       │    ├── 1 element transitioning toward PUBLIC
-      │    │    └── VALIDATED           → PUBLIC                CheckConstraint:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey+), ConstraintID: 2 (check_crdb_internal_k_shard_16+), ReferencedColumnIDs: [6]}
+      │    │    └── VALIDATED           → PUBLIC                CheckConstraint:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey+), ConstraintID: 2 (check_crdb_internal_k2_shard_16+), ReferencedColumnIDs: [6]}
       │    ├── 6 elements transitioning toward TRANSIENT_ABSENT
       │    │    ├── TRANSIENT_VALIDATED → TRANSIENT_DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey~), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 1 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC              → TRANSIENT_ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 8 (table_regional_by_row_pkey~)}
-      │    │    ├── PUBLIC              → TRANSIENT_ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 8 (table_regional_by_row_pkey~)}
-      │    │    ├── PUBLIC              → TRANSIENT_ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey~)}
-      │    │    ├── PUBLIC              → TRANSIENT_ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 8 (table_regional_by_row_pkey~)}
+      │    │    ├── PUBLIC              → TRANSIENT_ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey~)}
+      │    │    ├── PUBLIC              → TRANSIENT_ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 8 (table_regional_by_row_pkey~)}
+      │    │    ├── PUBLIC              → TRANSIENT_ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 8 (table_regional_by_row_pkey~)}
+      │    │    ├── PUBLIC              → TRANSIENT_ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 8 (table_regional_by_row_pkey~)}
       │    │    └── PUBLIC              → TRANSIENT_ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m+), IndexID: 8 (table_regional_by_row_pkey~)}
-      │    └── 9 Mutation operations
+      │    ├── 5 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC              → ABSENT                IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 2 (idx_v-)}
+      │    │    ├── PUBLIC              → ABSENT                IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 2 (idx_v-)}
+      │    │    ├── PUBLIC              → ABSENT                IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 2 (idx_v-)}
+      │    │    ├── VALIDATED           → DELETE_ONLY           SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (idx_v-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+      │    │    └── PUBLIC              → ABSENT                IndexName:{DescID: 108 (table_regional_by_row), Name: "idx_v", IndexID: 2 (idx_v-)}
+      │    └── 14 Mutation operations
       │         ├── MakeValidatedCheckConstraintPublic {"ConstraintID":2,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":108}
+      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 5 of 6 in PostCommitNonRevertiblePhase
@@ -641,11 +640,13 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
       │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 11}
       │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 5}
       │    │    └── PUBLIC                → TRANSIENT_ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
-      │    ├── 2 elements transitioning toward ABSENT
+      │    ├── 3 elements transitioning toward ABSENT
       │    │    ├── PUBLIC                → ABSENT           IndexData:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey-)}
+      │    │    ├── DELETE_ONLY           → ABSENT           SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (idx_v-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
       │    │    └── PUBLIC                → ABSENT           IndexData:{DescID: 108 (table_regional_by_row), IndexID: 2 (idx_v-)}
-      │    └── 10 Mutation operations
+      │    └── 11 Mutation operations
       │         ├── CreateGCJobForIndex {"IndexID":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":108}
       │         ├── CreateGCJobForIndex {"IndexID":2,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":8,"TableID":108}
       │         ├── CreateGCJobForIndex {"IndexID":5,"TableID":108}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr.explain_shape
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr.explain_shape
@@ -1,18 +1,19 @@
 /* setup */
 CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
 CREATE TABLE multiregion_db.public.table_regional_by_row (
-  k INT NOT NULL,
+  k1 INT NOT NULL PRIMARY KEY,
+  k2 INT NOT NULL,
   V STRING
 ) LOCALITY REGIONAL BY ROW;
 CREATE INDEX idx_v on multiregion_db.table_regional_by_row(v);
 
 /* test */
-EXPLAIN (DDL, SHAPE) alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k) USING HASH;
+EXPLAIN (DDL, SHAPE) alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k2) USING HASH;
 ----
-Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_regional_by_row› ADD COLUMN ‹m› INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (‹k›) USING HASH;
+Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_regional_by_row› ADD COLUMN ‹m› INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (‹k2›) USING HASH;
  ├── execute 2 system table mutations transactions
  ├── backfill using primary index table_regional_by_row_pkey- in relation table_regional_by_row
- │    └── into table_regional_by_row_pkey~ (rowid, crdb_region; m+, k, v)
+ │    └── into table_regional_by_row_pkey~ (k1, crdb_region; m+, k2, v)
  ├── execute 2 system table mutations transactions
  ├── merge temporary indexes into backfilled indexes in relation table_regional_by_row
  │    └── from table_regional_by_row@[9] into table_regional_by_row_pkey~
@@ -20,24 +21,24 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  ├── validate UNIQUE constraint backed by index table_regional_by_row_pkey~ in relation table_regional_by_row
  ├── execute 2 system table mutations transactions
  ├── backfill using primary index table_regional_by_row_pkey~ in relation table_regional_by_row
- │    ├── into idx_v+ (crdb_region, v: k, crdb_internal_k_shard_16+)
- │    └── into table_regional_by_row_pkey+ (crdb_internal_k_shard_16+, k, crdb_region; rowid, v, m+)
+ │    ├── into idx_v+ (crdb_region, v: k2, crdb_internal_k2_shard_16+)
+ │    └── into table_regional_by_row_pkey+ (crdb_internal_k2_shard_16+, k2, crdb_region; k1, v, m+)
  ├── execute 2 system table mutations transactions
  ├── merge temporary indexes into backfilled indexes in relation table_regional_by_row
  │    ├── from table_regional_by_row@[5] into idx_v+
  │    └── from table_regional_by_row@[11] into table_regional_by_row_pkey+
  ├── execute 1 system table mutations transaction
  ├── validate UNIQUE constraint backed by index table_regional_by_row_pkey+ in relation table_regional_by_row
- ├── validate NOT NULL constraint on column crdb_internal_k_shard_16+ in index table_regional_by_row_pkey+ in relation table_regional_by_row
+ ├── validate NOT NULL constraint on column crdb_internal_k2_shard_16+ in index table_regional_by_row_pkey+ in relation table_regional_by_row
  ├── validate UNIQUE constraint backed by index idx_v+ in relation table_regional_by_row
  ├── execute 2 system table mutations transactions
  ├── backfill using primary index table_regional_by_row_pkey+ in relation table_regional_by_row
- │    └── into table_regional_by_row_rowid_key+ (rowid, crdb_region: crdb_internal_k_shard_16+, k)
+ │    └── into table_regional_by_row_k1_key+ (k1, crdb_region: crdb_internal_k2_shard_16+, k2)
  ├── execute 2 system table mutations transactions
  ├── merge temporary indexes into backfilled indexes in relation table_regional_by_row
- │    └── from table_regional_by_row@[7] into table_regional_by_row_rowid_key+
+ │    └── from table_regional_by_row@[7] into table_regional_by_row_k1_key+
  ├── execute 1 system table mutations transaction
- ├── validate UNIQUE constraint backed by index table_regional_by_row_rowid_key+ in relation table_regional_by_row
+ ├── validate UNIQUE constraint backed by index table_regional_by_row_k1_key+ in relation table_regional_by_row
  ├── execute 3 system table mutations transactions
- ├── validate non-index-backed constraint check_crdb_internal_k_shard_16+ in relation table_regional_by_row
+ ├── validate non-index-backed constraint check_crdb_internal_k2_shard_16+ in relation table_regional_by_row
  └── execute 3 system table mutations transactions

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr.side_effects
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr.side_effects
@@ -1,7 +1,8 @@
 /* setup */
 CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
 CREATE TABLE multiregion_db.public.table_regional_by_row (
-  k INT NOT NULL,
+  k1 INT NOT NULL PRIMARY KEY,
+  k2 INT NOT NULL,
   V STRING
 ) LOCALITY REGIONAL BY ROW;
 CREATE INDEX idx_v on multiregion_db.table_regional_by_row(v);
@@ -14,7 +15,7 @@ CREATE INDEX idx_v on multiregion_db.table_regional_by_row(v);
 +object {104 105 table_regional_by_row} -> 108
 
 /* test */
-alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k) USING HASH;
+alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k2) USING HASH;
 ----
 begin transaction #1
 # begin StatementPhase
@@ -28,7 +29,7 @@ write *eventpb.AlterTable to event log:
   mutationId: 1
   sql:
     descriptorId: 108
-    statement: ALTER TABLE ‹multiregion_db›.‹public›.‹table_regional_by_row› ADD COLUMN ‹m› INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (‹k›) USING HASH
+    statement: ALTER TABLE ‹multiregion_db›.‹public›.‹table_regional_by_row› ADD COLUMN ‹m› INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (‹k2›) USING HASH
     tag: ALTER TABLE
     user: root
   tableName: multiregion_db.public.table_regional_by_row
@@ -36,7 +37,7 @@ write *eventpb.AlterTable to event log:
   mutationId: 1
   sql:
     descriptorId: 108
-    statement: ALTER TABLE ‹multiregion_db›.‹public›.‹table_regional_by_row› ADD COLUMN ‹m› INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (‹k›) USING HASH
+    statement: ALTER TABLE ‹multiregion_db›.‹public›.‹table_regional_by_row› ADD COLUMN ‹m› INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (‹k2›) USING HASH
     tag: ALTER TABLE
     user: root
   tableName: multiregion_db.public.table_regional_by_row
@@ -47,10 +48,10 @@ upsert descriptor #108
        - 4
   +    - 5
        columnNames:
-       - k
+       - k1
   ...
+       - v
        - crdb_region
-       - rowid
   +    - m
        name: primary
      formatVersion: 3
@@ -83,11 +84,11 @@ upsert descriptor #108
   +      - ASC
   +      - ASC
   +      keyColumnIds:
-  +      - 3
   +      - 4
+  +      - 1
   +      keyColumnNames:
   +      - crdb_region
-  +      - rowid
+  +      - k1
   +      name: crdb_internal_index_8_name_placeholder
   +      partitioning:
   +        list:
@@ -107,11 +108,11 @@ upsert descriptor #108
   +        numImplicitColumns: 1
   +      sharded: {}
   +      storeColumnIds:
-  +      - 1
   +      - 2
+  +      - 3
   +      - 5
   +      storeColumnNames:
-  +      - k
+  +      - k2
   +      - v
   +      - m
   +      unique: true
@@ -132,11 +133,11 @@ upsert descriptor #108
   +      - ASC
   +      - ASC
   +      keyColumnIds:
-  +      - 3
   +      - 4
+  +      - 1
   +      keyColumnNames:
   +      - crdb_region
-  +      - rowid
+  +      - k1
   +      name: crdb_internal_index_9_name_placeholder
   +      partitioning:
   +        list:
@@ -156,11 +157,11 @@ upsert descriptor #108
   +        numImplicitColumns: 1
   +      sharded: {}
   +      storeColumnIds:
-  +      - 1
   +      - 2
+  +      - 3
   +      - 5
   +      storeColumnNames:
-  +      - k
+  +      - k2
   +      - v
   +      - m
   +      unique: true
@@ -170,10 +171,10 @@ upsert descriptor #108
   +    mutationId: 1
   +    state: DELETE_ONLY
   +  - column:
-  +      computeExpr: mod(fnv32(md5(crdb_internal.datums_to_bytes(k))), 16:::INT8)
+  +      computeExpr: mod(fnv32(md5(crdb_internal.datums_to_bytes(k2))), 16:::INT8)
   +      hidden: true
   +      id: 6
-  +      name: crdb_internal_k_shard_16
+  +      name: crdb_internal_k2_shard_16
   +      nullable: true
   +      type:
   +        family: IntFamily
@@ -197,13 +198,13 @@ upsert descriptor #108
   +      - ASC
   +      - ASC
   +      keyColumnIds:
-  +      - 3
+  +      - 4
   +      - 6
-  +      - 1
+  +      - 2
   +      keyColumnNames:
   +      - crdb_region
-  +      - crdb_internal_k_shard_16
-  +      - k
+  +      - crdb_internal_k2_shard_16
+  +      - k2
   +      name: crdb_internal_index_10_name_placeholder
   +      partitioning:
   +        list:
@@ -223,16 +224,16 @@ upsert descriptor #108
   +        numImplicitColumns: 1
   +      sharded:
   +        columnNames:
-  +        - k
+  +        - k2
   +        isSharded: true
-  +        name: crdb_internal_k_shard_16
+  +        name: crdb_internal_k2_shard_16
   +        shardBuckets: 16
   +      storeColumnIds:
-  +      - 4
-  +      - 2
+  +      - 1
+  +      - 3
   +      - 5
   +      storeColumnNames:
-  +      - rowid
+  +      - k1
   +      - v
   +      - m
   +      unique: true
@@ -275,30 +276,30 @@ upsert descriptor #108
   +    jobId: "1"
   +    nameMapping:
   +      columns:
-  +        "1": k
-  +        "2": v
-  +        "3": crdb_region
-  +        "4": rowid
+  +        "1": k1
+  +        "2": k2
+  +        "3": v
+  +        "4": crdb_region
   +        "5": m
-  +        "6": crdb_internal_k_shard_16
+  +        "6": crdb_internal_k2_shard_16
   +        "4294967292": crdb_internal_origin_timestamp
   +        "4294967293": crdb_internal_origin_id
   +        "4294967294": tableoid
   +        "4294967295": crdb_internal_mvcc_timestamp
   +      constraints:
-  +        "2": check_crdb_internal_k_shard_16
+  +        "2": check_crdb_internal_k2_shard_16
   +      families:
   +        "0": primary
   +      id: 108
   +      indexes:
   +        "4": idx_v
-  +        "6": table_regional_by_row_rowid_key
+  +        "6": table_regional_by_row_k1_key
   +        "10": table_regional_by_row_pkey
   +      name: table_regional_by_row
   +    relevantStatements:
   +    - statement:
-  +        redactedStatement: ALTER TABLE ‹multiregion_db›.‹public›.‹table_regional_by_row› ADD COLUMN ‹m› INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (‹k›) USING HASH
-  +        statement: ALTER TABLE multiregion_db.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k) USING HASH
+  +        redactedStatement: ALTER TABLE ‹multiregion_db›.‹public›.‹table_regional_by_row› ADD COLUMN ‹m› INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (‹k2›) USING HASH
+  +        statement: ALTER TABLE multiregion_db.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k2) USING HASH
   +        statementTag: ALTER TABLE
   +    revertible: true
   +    targetRanks: <redacted>
@@ -310,10 +311,10 @@ upsert descriptor #108
        - 4
   +    - 5
        columnNames:
-       - k
+       - k1
   ...
+       - v
        - crdb_region
-       - rowid
   +    - m
        name: primary
      formatVersion: 3
@@ -346,11 +347,11 @@ upsert descriptor #108
   +      - ASC
   +      - ASC
   +      keyColumnIds:
-  +      - 3
   +      - 4
+  +      - 1
   +      keyColumnNames:
   +      - crdb_region
-  +      - rowid
+  +      - k1
   +      name: crdb_internal_index_8_name_placeholder
   +      partitioning:
   +        list:
@@ -370,11 +371,11 @@ upsert descriptor #108
   +        numImplicitColumns: 1
   +      sharded: {}
   +      storeColumnIds:
-  +      - 1
   +      - 2
+  +      - 3
   +      - 5
   +      storeColumnNames:
-  +      - k
+  +      - k2
   +      - v
   +      - m
   +      unique: true
@@ -395,11 +396,11 @@ upsert descriptor #108
   +      - ASC
   +      - ASC
   +      keyColumnIds:
-  +      - 3
   +      - 4
+  +      - 1
   +      keyColumnNames:
   +      - crdb_region
-  +      - rowid
+  +      - k1
   +      name: crdb_internal_index_9_name_placeholder
   +      partitioning:
   +        list:
@@ -419,11 +420,11 @@ upsert descriptor #108
   +        numImplicitColumns: 1
   +      sharded: {}
   +      storeColumnIds:
-  +      - 1
   +      - 2
+  +      - 3
   +      - 5
   +      storeColumnNames:
-  +      - k
+  +      - k2
   +      - v
   +      - m
   +      unique: true
@@ -433,10 +434,10 @@ upsert descriptor #108
   +    mutationId: 1
   +    state: DELETE_ONLY
   +  - column:
-  +      computeExpr: mod(fnv32(md5(crdb_internal.datums_to_bytes(k))), 16:::INT8)
+  +      computeExpr: mod(fnv32(md5(crdb_internal.datums_to_bytes(k2))), 16:::INT8)
   +      hidden: true
   +      id: 6
-  +      name: crdb_internal_k_shard_16
+  +      name: crdb_internal_k2_shard_16
   +      nullable: true
   +      type:
   +        family: IntFamily
@@ -460,13 +461,13 @@ upsert descriptor #108
   +      - ASC
   +      - ASC
   +      keyColumnIds:
-  +      - 3
+  +      - 4
   +      - 6
-  +      - 1
+  +      - 2
   +      keyColumnNames:
   +      - crdb_region
-  +      - crdb_internal_k_shard_16
-  +      - k
+  +      - crdb_internal_k2_shard_16
+  +      - k2
   +      name: crdb_internal_index_10_name_placeholder
   +      partitioning:
   +        list:
@@ -486,16 +487,16 @@ upsert descriptor #108
   +        numImplicitColumns: 1
   +      sharded:
   +        columnNames:
-  +        - k
+  +        - k2
   +        isSharded: true
-  +        name: crdb_internal_k_shard_16
+  +        name: crdb_internal_k2_shard_16
   +        shardBuckets: 16
   +      storeColumnIds:
-  +      - 4
-  +      - 2
+  +      - 1
+  +      - 3
   +      - 5
   +      storeColumnNames:
-  +      - rowid
+  +      - k1
   +      - v
   +      - m
   +      unique: true
@@ -522,7 +523,7 @@ upsert descriptor #108
   +  version: "9"
 upsert zone config for #108
 persist all catalog changes to storage
-create job #1 (non-cancelable: false): "ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k) USING HASH"
+create job #1 (non-cancelable: false): "ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k2) USING HASH"
   descriptor IDs: [108]
 # end PreCommitPhase
 commit transaction #1
@@ -537,9 +538,9 @@ upsert descriptor #108
   +  checks:
   +  - columnIds:
   +    - 6
-  +    expr: crdb_internal_k_shard_16 IS NOT NULL
+  +    expr: crdb_internal_k2_shard_16 IS NOT NULL
   +    isNonNullConstraint: true
-  +    name: crdb_internal_k_shard_16_auto_not_null
+  +    name: crdb_internal_k2_shard_16_auto_not_null
   +    validity: Validating
      columns:
      - id: 1
@@ -556,7 +557,7 @@ upsert descriptor #108
   -    state: DELETE_ONLY
   +    state: WRITE_ONLY
      - column:
-         computeExpr: mod(fnv32(md5(crdb_internal.datums_to_bytes(k))), 16:::INT8)
+         computeExpr: mod(fnv32(md5(crdb_internal.datums_to_bytes(k2))), 16:::INT8)
   ...
        direction: ADD
        mutationId: 1
@@ -571,13 +572,13 @@ upsert descriptor #108
   +      check:
   +        columnIds:
   +        - 6
-  +        expr: crdb_internal_k_shard_16 IS NOT NULL
+  +        expr: crdb_internal_k2_shard_16 IS NOT NULL
   +        isNonNullConstraint: true
-  +        name: crdb_internal_k_shard_16_auto_not_null
+  +        name: crdb_internal_k2_shard_16_auto_not_null
   +        validity: Validating
   +      constraintType: NOT_NULL
   +      foreignKey: {}
-  +      name: crdb_internal_k_shard_16_auto_not_null
+  +      name: crdb_internal_k2_shard_16_auto_not_null
   +      notNullColumn: 6
   +      uniqueWithoutIndexConstraint: {}
   +    direction: ADD
@@ -655,7 +656,7 @@ upsert descriptor #108
   -    state: WRITE_ONLY
   +    state: DELETE_ONLY
      - column:
-         computeExpr: mod(fnv32(md5(crdb_internal.datums_to_bytes(k))), 16:::INT8)
+         computeExpr: mod(fnv32(md5(crdb_internal.datums_to_bytes(k2))), 16:::INT8)
   ...
        time: {}
      unexposedParentSchemaId: 105
@@ -689,7 +690,7 @@ upsert descriptor #108
          keyColumnDirections:
   ...
          - crdb_region
-         - rowid
+         - k1
   -      name: crdb_internal_index_8_name_placeholder
   +      name: crdb_internal_index_9_name_placeholder
          partitioning:
@@ -703,10 +704,10 @@ upsert descriptor #108
        mutationId: 1
   +    state: DELETE_ONLY
   +  - column:
-  +      computeExpr: mod(fnv32(md5(crdb_internal.datums_to_bytes(k))), 16:::INT8)
+  +      computeExpr: mod(fnv32(md5(crdb_internal.datums_to_bytes(k2))), 16:::INT8)
   +      hidden: true
   +      id: 6
-  +      name: crdb_internal_k_shard_16
+  +      name: crdb_internal_k2_shard_16
   +      nullable: true
   +      type:
   +        family: IntFamily
@@ -733,13 +734,13 @@ upsert descriptor #108
          - ASC
   +      - ASC
          keyColumnIds:
-         - 3
+         - 4
   +      - 6
-  +      - 1
+  +      - 2
   +      keyColumnNames:
   +      - crdb_region
-  +      - crdb_internal_k_shard_16
-  +      - k
+  +      - crdb_internal_k2_shard_16
+  +      - k2
   +      name: crdb_internal_index_10_name_placeholder
   +      partitioning:
   +        list:
@@ -759,16 +760,16 @@ upsert descriptor #108
   +        numImplicitColumns: 1
   +      sharded:
   +        columnNames:
-  +        - k
+  +        - k2
   +        isSharded: true
-  +        name: crdb_internal_k_shard_16
+  +        name: crdb_internal_k2_shard_16
   +        shardBuckets: 16
   +      storeColumnIds:
-         - 4
-  +      - 2
+         - 1
+  +      - 3
   +      - 5
   +      storeColumnNames:
-  +      - rowid
+  +      - k1
   +      - v
   +      - m
   +      unique: true
@@ -780,13 +781,13 @@ upsert descriptor #108
   +      check:
   +        columnIds:
   +        - 6
-  +        expr: crdb_internal_k_shard_16 IS NOT NULL
+  +        expr: crdb_internal_k2_shard_16 IS NOT NULL
   +        isNonNullConstraint: true
-  +        name: crdb_internal_k_shard_16_auto_not_null
+  +        name: crdb_internal_k2_shard_16_auto_not_null
   +        validity: Validating
   +      constraintType: NOT_NULL
   +      foreignKey: {}
-  +      name: crdb_internal_k_shard_16_auto_not_null
+  +      name: crdb_internal_k2_shard_16_auto_not_null
   +      notNullColumn: 6
   +      uniqueWithoutIndexConstraint: {}
   +    direction: ADD
@@ -805,21 +806,21 @@ upsert descriptor #108
   +      - ASC
   +      - ASC
   +      keyColumnIds:
-  +      - 3
   +      - 4
+  +      - 1
          keyColumnNames:
          - crdb_region
-         - rowid
+         - k1
   -      name: crdb_internal_index_9_name_placeholder
   +      name: crdb_internal_index_1_name_placeholder
          partitioning:
            list:
   ...
-         - 1
          - 2
+         - 3
   -      - 5
          storeColumnNames:
-         - k
+         - k2
          - v
   -      - m
          unique: true
@@ -829,10 +830,10 @@ upsert descriptor #108
        mutationId: 1
   -    state: DELETE_ONLY
   -  - column:
-  -      computeExpr: mod(fnv32(md5(crdb_internal.datums_to_bytes(k))), 16:::INT8)
+  -      computeExpr: mod(fnv32(md5(crdb_internal.datums_to_bytes(k2))), 16:::INT8)
   -      hidden: true
   -      id: 6
-  -      name: crdb_internal_k_shard_16
+  -      name: crdb_internal_k2_shard_16
   -      nullable: true
   -      type:
   -        family: IntFamily
@@ -855,8 +856,8 @@ upsert descriptor #108
          interleave: {}
          keyColumnDirections:
   ...
-         - crdb_internal_k_shard_16
-         - k
+         - crdb_internal_k2_shard_16
+         - k2
   -      name: crdb_internal_index_10_name_placeholder
   +      name: crdb_internal_index_11_name_placeholder
          partitioning:
@@ -882,13 +883,13 @@ upsert descriptor #108
   +      - ASC
   +      - ASC
   +      keyColumnIds:
+  +      - 4
   +      - 3
-  +      - 2
   +      keyColumnNames:
   +      - crdb_region
   +      - v
   +      keySuffixColumnIds:
-  +      - 1
+  +      - 2
   +      - 6
   +      name: crdb_internal_index_4_name_placeholder
   +      partitioning:
@@ -917,9 +918,9 @@ upsert descriptor #108
   -      check:
   -        columnIds:
   -        - 6
-  -        expr: crdb_internal_k_shard_16 IS NOT NULL
+  -        expr: crdb_internal_k2_shard_16 IS NOT NULL
   -        isNonNullConstraint: true
-  -        name: crdb_internal_k_shard_16_auto_not_null
+  -        name: crdb_internal_k2_shard_16_auto_not_null
   -        validity: Validating
   -      constraintType: NOT_NULL
   +  - direction: ADD
@@ -927,7 +928,7 @@ upsert descriptor #108
   +      constraintId: 4
   +      createdExplicitly: true
          foreignKey: {}
-  -      name: crdb_internal_k_shard_16_auto_not_null
+  -      name: crdb_internal_k2_shard_16_auto_not_null
   -      notNullColumn: 6
   -      uniqueWithoutIndexConstraint: {}
   -    direction: ADD
@@ -938,13 +939,13 @@ upsert descriptor #108
   +      - ASC
   +      - ASC
   +      keyColumnIds:
+  +      - 4
   +      - 3
-  +      - 2
   +      keyColumnNames:
   +      - crdb_region
   +      - v
   +      keySuffixColumnIds:
-  +      - 1
+  +      - 2
   +      - 6
   +      name: crdb_internal_index_5_name_placeholder
   +      partitioning:
@@ -994,11 +995,11 @@ upsert descriptor #108
        interleave: {}
        keyColumnDirections:
   ...
-       - 1
        - 2
+       - 3
   +    - 5
        storeColumnNames:
-       - k
+       - k2
        - v
   +    - m
        unique: true
@@ -1145,52 +1146,73 @@ commit transaction #16
 begin transaction #17
 ## PostCommitPhase stage 15 of 24 with 3 ValidationType ops
 validate forward indexes [10 4] in table #108
-validate CHECK constraint crdb_internal_k_shard_16_auto_not_null in table #108
+validate CHECK constraint crdb_internal_k2_shard_16_auto_not_null in table #108
 commit transaction #17
 begin transaction #18
-## PostCommitPhase stage 16 of 24 with 23 MutationType ops
+## PostCommitPhase stage 16 of 24 with 21 MutationType ops
 upsert descriptor #108
    table:
   -  checks:
   -  - columnIds:
   -    - 6
-  -    expr: crdb_internal_k_shard_16 IS NOT NULL
+  -    expr: crdb_internal_k2_shard_16 IS NOT NULL
   -    isNonNullConstraint: true
-  -    name: crdb_internal_k_shard_16_auto_not_null
+  -    name: crdb_internal_k2_shard_16_auto_not_null
   -    validity: Validating
   +  checks: []
      columns:
      - id: 1
   ...
-     id: 108
-     indexes:
-  -  - createdAtNanos: "1640995200000000000"
-  +  - constraintId: 3
-  +    createdAtNanos: "1640998800000000000"
-       createdExplicitly: true
-       foreignKey: {}
-       geoConfig: {}
-  -    id: 2
-  +    id: 4
-       interleave: {}
-       keyColumnDirections:
-  ...
-       - v
-       keySuffixColumnIds:
-  -    - 4
-  +    - 1
-  +    - 6
-       name: idx_v
-       partitioning:
-  ...
-         numImplicitColumns: 1
-       sharded: {}
-  +    storeColumnNames: []
        vecConfig: {}
        version: 4
+  +  - constraintId: 3
+  +    createdAtNanos: "1640998800000000000"
+  +    createdExplicitly: true
+  +    foreignKey: {}
+  +    geoConfig: {}
+  +    hideForPrimaryKeyRecreate: true
+  +    id: 4
+  +    interleave: {}
+  +    invisibility: 1
+  +    keyColumnDirections:
+  +    - ASC
+  +    - ASC
+  +    keyColumnIds:
+  +    - 4
+  +    - 3
+  +    keyColumnNames:
+  +    - crdb_region
+  +    - v
+  +    keySuffixColumnIds:
+  +    - 2
+  +    - 6
+  +    name: crdb_internal_idx_v_recreated
+  +    notVisible: true
+  +    partitioning:
+  +      list:
+  +      - name: us-east1
+  +        subpartitioning: {}
+  +        values:
+  +        - BgFA
+  +      - name: us-east2
+  +        subpartitioning: {}
+  +        values:
+  +        - BgGA
+  +      - name: us-east3
+  +        subpartitioning: {}
+  +        values:
+  +        - BgHA
+  +      numColumns: 1
+  +      numImplicitColumns: 1
+  +    sharded: {}
+  +    storeColumnNames: []
+  +    vecConfig: {}
+  +    version: 4
+     localityConfig:
+       regionalByRow: {}
   ...
          id: 6
-         name: crdb_internal_k_shard_16
+         name: crdb_internal_k2_shard_16
   -      nullable: true
          type:
            family: IntFamily
@@ -1201,13 +1223,13 @@ upsert descriptor #108
   -      check:
   -        columnIds:
   -        - 6
-  -        expr: crdb_internal_k_shard_16 IS NOT NULL
+  -        expr: crdb_internal_k2_shard_16 IS NOT NULL
   -        isNonNullConstraint: true
-  -        name: crdb_internal_k_shard_16_auto_not_null
+  -        name: crdb_internal_k2_shard_16_auto_not_null
   -        validity: Validating
   -      constraintType: NOT_NULL
   -      foreignKey: {}
-  -      name: crdb_internal_k_shard_16_auto_not_null
+  -      name: crdb_internal_k2_shard_16_auto_not_null
   -      notNullColumn: 6
   -      uniqueWithoutIndexConstraint: {}
   -    direction: ADD
@@ -1232,7 +1254,7 @@ upsert descriptor #108
          interleave: {}
          keyColumnDirections:
   ...
-         - 1
+         - 2
          - 6
   -      name: crdb_internal_index_4_name_placeholder
   +      name: crdb_internal_index_5_name_placeholder
@@ -1262,19 +1284,19 @@ upsert descriptor #108
          keyColumnDirections:
   ...
          keyColumnIds:
-         - 3
-  -      - 2
-  +      - 4
+         - 4
+  -      - 3
+  +      - 1
          keyColumnNames:
          - crdb_region
   -      - v
-  +      - rowid
+  +      - k1
          keySuffixColumnIds:
-  -      - 1
+  -      - 2
          - 6
   -      name: crdb_internal_index_5_name_placeholder
-  +      - 1
-  +      name: table_regional_by_row_rowid_key
+  +      - 2
+  +      name: table_regional_by_row_k1_key
          partitioning:
            list:
   ...
@@ -1297,14 +1319,14 @@ upsert descriptor #108
   +      - ASC
   +      - ASC
   +      keyColumnIds:
-  +      - 3
   +      - 4
+  +      - 1
   +      keyColumnNames:
   +      - crdb_region
-  +      - rowid
+  +      - k1
   +      keySuffixColumnIds:
   +      - 6
-  +      - 1
+  +      - 2
   +      name: crdb_internal_index_7_name_placeholder
   +      partitioning: {}
   +      sharded: {}
@@ -1312,52 +1334,6 @@ upsert descriptor #108
   +      unique: true
          useDeletePreservingEncoding: true
          vecConfig: {}
-  ...
-       mutationId: 1
-       state: DELETE_ONLY
-  +  - direction: DROP
-  +    index:
-  +      createdAtNanos: "1640995200000000000"
-  +      createdExplicitly: true
-  +      foreignKey: {}
-  +      geoConfig: {}
-  +      id: 2
-  +      interleave: {}
-  +      keyColumnDirections:
-  +      - ASC
-  +      - ASC
-  +      keyColumnIds:
-  +      - 3
-  +      - 2
-  +      keyColumnNames:
-  +      - crdb_region
-  +      - v
-  +      keySuffixColumnIds:
-  +      - 4
-  +      name: idx_v
-  +      partitioning:
-  +        list:
-  +        - name: us-east1
-  +          subpartitioning: {}
-  +          values:
-  +          - BgFA
-  +        - name: us-east2
-  +          subpartitioning: {}
-  +          values:
-  +          - BgGA
-  +        - name: us-east3
-  +          subpartitioning: {}
-  +          values:
-  +          - BgHA
-  +        numColumns: 1
-  +        numImplicitColumns: 1
-  +      sharded: {}
-  +      vecConfig: {}
-  +      version: 4
-  +    mutationId: 1
-  +    state: WRITE_ONLY
-     name: table_regional_by_row
-     nextColumnId: 7
   ...
        time: {}
      unexposedParentSchemaId: 105
@@ -1375,8 +1351,8 @@ upsert descriptor #108
        mutationId: 1
   -    state: DELETE_ONLY
   +    state: WRITE_ONLY
-     - direction: DROP
-       index:
+     name: table_regional_by_row
+     nextColumnId: 7
   ...
        time: {}
      unexposedParentSchemaId: 105
@@ -1446,8 +1422,8 @@ upsert descriptor #108
        mutationId: 1
   -    state: WRITE_ONLY
   +    state: DELETE_ONLY
-     - direction: DROP
-       index:
+     name: table_regional_by_row
+     nextColumnId: 7
   ...
        time: {}
      unexposedParentSchemaId: 105
@@ -1464,7 +1440,7 @@ begin transaction #26
 ## PostCommitPhase stage 24 of 24 with 4 MutationType ops
 upsert descriptor #108
   ...
-           statement: ALTER TABLE multiregion_db.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k) USING HASH
+           statement: ALTER TABLE multiregion_db.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k2) USING HASH
            statementTag: ALTER TABLE
   -    revertible: true
        targetRanks: <redacted>
@@ -1483,15 +1459,15 @@ upsert descriptor #108
   +    - ASC
   +    - ASC
   +    keyColumnIds:
-  +    - 3
   +    - 4
+  +    - 1
   +    keyColumnNames:
   +    - crdb_region
-  +    - rowid
+  +    - k1
   +    keySuffixColumnIds:
   +    - 6
-  +    - 1
-  +    name: table_regional_by_row_rowid_key
+  +    - 2
+  +    name: table_regional_by_row_k1_key
   +    partitioning:
   +      list:
   +      - name: us-east1
@@ -1531,15 +1507,15 @@ upsert descriptor #108
   -      - ASC
   -      - ASC
   -      keyColumnIds:
-  -      - 3
   -      - 4
+  -      - 1
   -      keyColumnNames:
   -      - crdb_region
-  -      - rowid
+  -      - k1
   -      keySuffixColumnIds:
   -      - 6
-  -      - 1
-  -      name: table_regional_by_row_rowid_key
+  -      - 2
+  -      name: table_regional_by_row_k1_key
   -      partitioning:
   -        list:
   -        - name: us-east1
@@ -1572,11 +1548,11 @@ upsert descriptor #108
   +  version: "24"
 persist all catalog changes to storage
 adding table for stats refresh: 108
-update progress of schema change job #1: "Pending: Updating schema metadata (33 operations) — PostCommitNonRevertible phase (stage 1 of 6)."
+update progress of schema change job #1: "Pending: Updating schema metadata (28 operations) — PostCommitNonRevertible phase (stage 1 of 6)."
 set schema change job #1 to non-cancellable
 commit transaction #26
 begin transaction #27
-## PostCommitNonRevertiblePhase stage 1 of 6 with 35 MutationType ops
+## PostCommitNonRevertiblePhase stage 1 of 6 with 30 MutationType ops
 upsert descriptor #108
   ...
        mutationId: 1
@@ -1594,11 +1570,11 @@ upsert descriptor #108
   -      - ASC
   -      - ASC
   -      keyColumnIds:
-  -      - 3
   -      - 4
+  -      - 1
   -      keyColumnNames:
   -      - crdb_region
-  -      - rowid
+  -      - k1
   -      name: crdb_internal_index_9_name_placeholder
   -      partitioning:
   -        list:
@@ -1618,11 +1594,11 @@ upsert descriptor #108
   -        numImplicitColumns: 1
   -      sharded: {}
   -      storeColumnIds:
-  -      - 1
   -      - 2
+  -      - 3
   -      - 5
   -      storeColumnNames:
-  -      - k
+  -      - k2
   -      - v
   -      - m
   -      unique: true
@@ -1632,7 +1608,7 @@ upsert descriptor #108
   -    mutationId: 1
   -    state: DELETE_ONLY
      - column:
-         computeExpr: mod(fnv32(md5(crdb_internal.datums_to_bytes(k))), 16:::INT8)
+         computeExpr: mod(fnv32(md5(crdb_internal.datums_to_bytes(k2))), 16:::INT8)
   ...
          version: 4
        mutationId: 1
@@ -1651,13 +1627,13 @@ upsert descriptor #108
   -      - ASC
   -      - ASC
   -      keyColumnIds:
-  -      - 3
+  -      - 4
   -      - 6
-  -      - 1
+  -      - 2
   -      keyColumnNames:
   -      - crdb_region
-  -      - crdb_internal_k_shard_16
-  -      - k
+  -      - crdb_internal_k2_shard_16
+  -      - k2
   -      name: crdb_internal_index_11_name_placeholder
   -      partitioning:
   -        list:
@@ -1677,16 +1653,16 @@ upsert descriptor #108
   -        numImplicitColumns: 1
   -      sharded:
   -        columnNames:
-  -        - k
+  -        - k2
   -        isSharded: true
-  -        name: crdb_internal_k_shard_16
+  -        name: crdb_internal_k2_shard_16
   -        shardBuckets: 16
   -      storeColumnIds:
-  -      - 4
-  -      - 2
+  -      - 1
+  -      - 3
   -      - 5
   -      storeColumnNames:
-  -      - rowid
+  -      - k1
   -      - v
   -      - m
   -      unique: true
@@ -1695,8 +1671,8 @@ upsert descriptor #108
   -      version: 4
   -    mutationId: 1
        state: DELETE_ONLY
-     - direction: DROP
-       index:
+  -  - direction: DROP
+  -    index:
   -      constraintId: 4
   -      createdExplicitly: true
   -      foreignKey: {}
@@ -1707,13 +1683,13 @@ upsert descriptor #108
   -      - ASC
   -      - ASC
   -      keyColumnIds:
+  -      - 4
   -      - 3
-  -      - 2
   -      keyColumnNames:
   -      - crdb_region
   -      - v
   -      keySuffixColumnIds:
-  -      - 1
+  -      - 2
   -      - 6
   -      name: crdb_internal_index_5_name_placeholder
   -      partitioning:
@@ -1751,14 +1727,14 @@ upsert descriptor #108
   -      - ASC
   -      - ASC
   -      keyColumnIds:
-  -      - 3
   -      - 4
+  -      - 1
   -      keyColumnNames:
   -      - crdb_region
-  -      - rowid
+  -      - k1
   -      keySuffixColumnIds:
   -      - 6
-  -      - 1
+  -      - 2
   -      name: crdb_internal_index_7_name_placeholder
   -      partitioning: {}
   -      sharded: {}
@@ -1769,22 +1745,6 @@ upsert descriptor #108
   -      version: 4
   -    mutationId: 1
   -    state: DELETE_ONLY
-  -  - direction: DROP
-  -    index:
-         createdAtNanos: "1640995200000000000"
-         createdExplicitly: true
-  ...
-         keySuffixColumnIds:
-         - 4
-  -      name: idx_v
-  +      name: crdb_internal_index_2_name_placeholder
-         partitioning:
-           list:
-  ...
-         version: 4
-       mutationId: 1
-  -    state: WRITE_ONLY
-  +    state: DELETE_ONLY
      name: table_regional_by_row
      nextColumnId: 7
   ...
@@ -1793,10 +1753,10 @@ upsert descriptor #108
   -  version: "24"
   +  version: "25"
 persist all catalog changes to storage
-update progress of schema change job #1: "Pending: Updating schema metadata (12 operations) — PostCommitNonRevertible phase (stage 2 of 6)."
+update progress of schema change job #1: "Pending: Updating schema metadata (13 operations) — PostCommitNonRevertible phase (stage 2 of 6)."
 commit transaction #27
 begin transaction #28
-## PostCommitNonRevertiblePhase stage 2 of 6 with 14 MutationType ops
+## PostCommitNonRevertiblePhase stage 2 of 6 with 15 MutationType ops
 upsert descriptor #108
    table:
   -  checks: []
@@ -1804,15 +1764,15 @@ upsert descriptor #108
   +  - columnIds:
   +    - 6
   +    constraintId: 2
-  +    expr: crdb_internal_k_shard_16 IN (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15)
+  +    expr: crdb_internal_k2_shard_16 IN (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15)
   +    fromHashShardedColumn: true
-  +    name: check_crdb_internal_k_shard_16
+  +    name: check_crdb_internal_k2_shard_16
   +    validity: Validating
      columns:
      - id: 1
   ...
-         oid: 20
-         width: 64
+         udtMetadata:
+           arrayTypeOid: 100107
   +  - defaultExpr: unique_rowid()
   +    id: 5
   +    name: m
@@ -1821,10 +1781,10 @@ upsert descriptor #108
   +      family: IntFamily
   +      oid: 20
   +      width: 64
-  +  - computeExpr: mod(fnv32(md5(crdb_internal.datums_to_bytes(k))), 16:::INT8)
+  +  - computeExpr: mod(fnv32(md5(crdb_internal.datums_to_bytes(k2))), 16:::INT8)
   +    hidden: true
   +    id: 6
-  +    name: crdb_internal_k_shard_16
+  +    name: crdb_internal_k2_shard_16
   +    type:
   +      family: IntFamily
   +      oid: 20
@@ -1832,6 +1792,65 @@ upsert descriptor #108
   +    virtual: true
      createAsOfTime:
        wallTime: "1640995200000000000"
+  ...
+     id: 108
+     indexes:
+  -  - createdAtNanos: "1640995200000000000"
+  -    createdExplicitly: true
+  -    foreignKey: {}
+  -    geoConfig: {}
+  -    id: 2
+  -    interleave: {}
+  -    keyColumnDirections:
+  -    - ASC
+  -    - ASC
+  -    keyColumnIds:
+  -    - 4
+  -    - 3
+  -    keyColumnNames:
+  -    - crdb_region
+  -    - v
+  -    keySuffixColumnIds:
+  -    - 1
+  -    name: idx_v
+  -    partitioning:
+  -      list:
+  -      - name: us-east1
+  -        subpartitioning: {}
+  -        values:
+  -        - BgFA
+  -      - name: us-east2
+  -        subpartitioning: {}
+  -        values:
+  -        - BgGA
+  -      - name: us-east3
+  -        subpartitioning: {}
+  -        values:
+  -        - BgHA
+  -      numColumns: 1
+  -      numImplicitColumns: 1
+  -    sharded: {}
+  -    vecConfig: {}
+  -    version: 4
+     - constraintId: 3
+       createdAtNanos: "1640998800000000000"
+  ...
+       foreignKey: {}
+       geoConfig: {}
+  -    hideForPrimaryKeyRecreate: true
+       id: 4
+       interleave: {}
+  -    invisibility: 1
+       keyColumnDirections:
+       - ASC
+  ...
+       - 2
+       - 6
+  -    name: crdb_internal_idx_v_recreated
+  -    notVisible: true
+  +    name: idx_v
+       partitioning:
+         list:
   ...
      modificationTime: {}
      mutations:
@@ -1848,10 +1867,10 @@ upsert descriptor #108
   -    mutationId: 1
   -    state: WRITE_ONLY
   -  - column:
-  -      computeExpr: mod(fnv32(md5(crdb_internal.datums_to_bytes(k))), 16:::INT8)
+  -      computeExpr: mod(fnv32(md5(crdb_internal.datums_to_bytes(k2))), 16:::INT8)
   -      hidden: true
   -      id: 6
-  -      name: crdb_internal_k_shard_16
+  -      name: crdb_internal_k2_shard_16
   -      type:
   -        family: IntFamily
   -        oid: 20
@@ -1864,90 +1883,82 @@ upsert descriptor #108
   +  - direction: DROP
        index:
   -      constraintId: 9
-  +      constraintId: 7
+  +      createdAtNanos: "1640995200000000000"
          createdExplicitly: true
-         encodingType: 1
+  -      encodingType: 1
          foreignKey: {}
          geoConfig: {}
   -      id: 10
-  +      id: 8
+  +      id: 2
          interleave: {}
          keyColumnDirections:
          - ASC
          - ASC
   -      - ASC
          keyColumnIds:
-         - 3
+         - 4
   -      - 6
-  -      - 1
-  -      keyColumnNames:
-  -      - crdb_region
-  -      - crdb_internal_k_shard_16
-  -      - k
+  -      - 2
+  +      - 3
+         keyColumnNames:
+         - crdb_region
+  -      - crdb_internal_k2_shard_16
+  -      - k2
   -      name: crdb_internal_index_10_name_placeholder
-  -      partitioning:
-  -        list:
-  -        - name: us-east1
-  -          subpartitioning: {}
-  -          values:
-  -          - BgFA
-  -        - name: us-east2
-  -          subpartitioning: {}
-  -          values:
-  -          - BgGA
-  -        - name: us-east3
-  -          subpartitioning: {}
-  -          values:
-  -          - BgHA
-  -        numColumns: 1
-  -        numImplicitColumns: 1
+  +      - v
+  +      keySuffixColumnIds:
+  +      - 1
+  +      name: idx_v
+         partitioning:
+           list:
+  ...
+           numColumns: 1
+           numImplicitColumns: 1
   -      sharded:
   -        columnNames:
-  -        - k
+  -        - k2
   -        isSharded: true
-  -        name: crdb_internal_k_shard_16
+  -        name: crdb_internal_k2_shard_16
   -        shardBuckets: 16
   -      storeColumnIds:
-         - 4
-  -      - 2
+  -      - 1
+  -      - 3
   -      - 5
   -      storeColumnNames:
-  -      - rowid
+  -      - k1
   -      - v
   -      - m
   -      unique: true
-  -      vecConfig: {}
-  -      version: 4
-  -    mutationId: 1
-  -    state: WRITE_ONLY
-  -  - direction: DROP
-  -    index:
+  +      sharded: {}
+         vecConfig: {}
+         version: 4
+  ...
+     - direction: DROP
+       index:
   -      constraintId: 1
   -      createdAtNanos: "1640995200000000000"
-  -      encodingType: 1
-  -      foreignKey: {}
-  -      geoConfig: {}
+  +      constraintId: 7
+  +      createdExplicitly: true
+         encodingType: 1
+         foreignKey: {}
+         geoConfig: {}
   -      id: 1
-  -      interleave: {}
-  -      keyColumnDirections:
-  -      - ASC
-  -      - ASC
-  -      keyColumnIds:
-  -      - 3
-  -      - 4
-         keyColumnNames:
+  +      id: 8
+         interleave: {}
+         keyColumnDirections:
+  ...
          - crdb_region
-         - rowid
+         - k1
   -      name: crdb_internal_index_1_name_placeholder
   +      name: crdb_internal_index_8_name_placeholder
          partitioning:
            list:
   ...
-         - 1
          - 2
+         - 3
   +      - 5
          storeColumnNames:
-         - k
+         - k2
          - v
   +      - m
          unique: true
@@ -1955,60 +1966,21 @@ upsert descriptor #108
          version: 4
        mutationId: 1
   -    state: DELETE_ONLY
-  -  - direction: DROP
-  -    index:
-  -      createdAtNanos: "1640995200000000000"
-  -      createdExplicitly: true
   +    state: WRITE_ONLY
   +  - constraint:
   +      check:
   +        columnIds:
   +        - 6
   +        constraintId: 2
-  +        expr: crdb_internal_k_shard_16 IN (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15)
+  +        expr: crdb_internal_k2_shard_16 IN (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15)
   +        fromHashShardedColumn: true
   +        name: crdb_internal_constraint_2_name_placeholder
   +        validity: Validating
-         foreignKey: {}
-  -      geoConfig: {}
-  -      id: 2
-  -      interleave: {}
-  -      keyColumnDirections:
-  -      - ASC
-  -      - ASC
-  -      keyColumnIds:
-  -      - 3
-  -      - 2
-  -      keyColumnNames:
-  -      - crdb_region
-  -      - v
-  -      keySuffixColumnIds:
-  -      - 4
-  -      name: crdb_internal_index_2_name_placeholder
-  -      partitioning:
-  -        list:
-  -        - name: us-east1
-  -          subpartitioning: {}
-  -          values:
-  -          - BgFA
-  -        - name: us-east2
-  -          subpartitioning: {}
-  -          values:
-  -          - BgGA
-  -        - name: us-east3
-  -          subpartitioning: {}
-  -          values:
-  -          - BgHA
-  -        numColumns: 1
-  -        numImplicitColumns: 1
-  -      sharded: {}
-  -      vecConfig: {}
-  -      version: 4
+  +      foreignKey: {}
   +      name: crdb_internal_constraint_2_name_placeholder
   +      uniqueWithoutIndexConstraint: {}
   +    direction: ADD
-       mutationId: 1
-  -    state: DELETE_ONLY
+  +    mutationId: 1
   +    state: WRITE_ONLY
      name: table_regional_by_row
      nextColumnId: 7
@@ -2029,15 +2001,15 @@ upsert descriptor #108
        - ASC
   +    - ASC
        keyColumnIds:
-       - 3
-  -    - 4
+       - 4
+  -    - 1
   +    - 6
-  +    - 1
+  +    - 2
        keyColumnNames:
        - crdb_region
-  -    - rowid
-  +    - crdb_internal_k_shard_16
-  +    - k
+  -    - k1
+  +    - crdb_internal_k2_shard_16
+  +    - k2
        name: table_regional_by_row_pkey
        partitioning:
   ...
@@ -2046,18 +2018,18 @@ upsert descriptor #108
   -    sharded: {}
   +    sharded:
   +      columnNames:
-  +      - k
+  +      - k2
   +      isSharded: true
-  +      name: crdb_internal_k_shard_16
+  +      name: crdb_internal_k2_shard_16
   +      shardBuckets: 16
        storeColumnIds:
-  -    - 1
-  +    - 4
-       - 2
+  -    - 2
+  +    - 1
+       - 3
        - 5
        storeColumnNames:
-  -    - k
-  +    - rowid
+  -    - k2
+  +    - k1
        - v
        - m
   ...
@@ -2071,17 +2043,31 @@ update progress of schema change job #1: "Pending: Validating CHECK constraint (
 commit transaction #28
 begin transaction #29
 ## PostCommitNonRevertiblePhase stage 3 of 6 with 1 ValidationType op
-validate CHECK constraint check_crdb_internal_k_shard_16 in table #108
+validate CHECK constraint check_crdb_internal_k2_shard_16 in table #108
 commit transaction #29
 begin transaction #30
-## PostCommitNonRevertiblePhase stage 4 of 6 with 9 MutationType ops
+## PostCommitNonRevertiblePhase stage 4 of 6 with 14 MutationType ops
 upsert descriptor #108
   ...
        fromHashShardedColumn: true
-       name: check_crdb_internal_k_shard_16
+       name: check_crdb_internal_k2_shard_16
   -    validity: Validating
      columns:
      - id: 1
+  ...
+         keySuffixColumnIds:
+         - 1
+  -      name: idx_v
+  +      name: crdb_internal_index_2_name_placeholder
+         partitioning:
+           list:
+  ...
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     - direction: DROP
+       index:
   ...
          version: 4
        mutationId: 1
@@ -2091,7 +2077,7 @@ upsert descriptor #108
   -        columnIds:
   -        - 6
   -        constraintId: 2
-  -        expr: crdb_internal_k_shard_16 IN (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15)
+  -        expr: crdb_internal_k2_shard_16 IN (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15)
   -        fromHashShardedColumn: true
   -        name: crdb_internal_constraint_2_name_placeholder
   -        validity: Validating
@@ -2110,15 +2096,56 @@ upsert descriptor #108
   -  version: "26"
   +  version: "27"
 persist all catalog changes to storage
-update progress of schema change job #1: "Pending: Updating schema metadata (8 operations) — PostCommitNonRevertible phase (stage 5 of 6)."
+update progress of schema change job #1: "Pending: Updating schema metadata (9 operations) — PostCommitNonRevertible phase (stage 5 of 6)."
 commit transaction #30
 begin transaction #31
-## PostCommitNonRevertiblePhase stage 5 of 6 with 10 MutationType ops
+## PostCommitNonRevertiblePhase stage 5 of 6 with 11 MutationType ops
 upsert descriptor #108
   ...
        regionalByRow: {}
      modificationTime: {}
   -  mutations:
+  -  - direction: DROP
+  -    index:
+  -      createdAtNanos: "1640995200000000000"
+  -      createdExplicitly: true
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 2
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      - ASC
+  -      keyColumnIds:
+  -      - 4
+  -      - 3
+  -      keyColumnNames:
+  -      - crdb_region
+  -      - v
+  -      keySuffixColumnIds:
+  -      - 1
+  -      name: crdb_internal_index_2_name_placeholder
+  -      partitioning:
+  -        list:
+  -        - name: us-east1
+  -          subpartitioning: {}
+  -          values:
+  -          - BgFA
+  -        - name: us-east2
+  -          subpartitioning: {}
+  -          values:
+  -          - BgGA
+  -        - name: us-east3
+  -          subpartitioning: {}
+  -          values:
+  -          - BgHA
+  -        numColumns: 1
+  -        numImplicitColumns: 1
+  -      sharded: {}
+  -      vecConfig: {}
+  -      version: 4
+  -    mutationId: 1
+  -    state: DELETE_ONLY
   -  - direction: DROP
   -    index:
   -      constraintId: 7
@@ -2132,11 +2159,11 @@ upsert descriptor #108
   -      - ASC
   -      - ASC
   -      keyColumnIds:
-  -      - 3
   -      - 4
+  -      - 1
   -      keyColumnNames:
   -      - crdb_region
-  -      - rowid
+  -      - k1
   -      name: crdb_internal_index_8_name_placeholder
   -      partitioning:
   -        list:
@@ -2156,11 +2183,11 @@ upsert descriptor #108
   -        numImplicitColumns: 1
   -      sharded: {}
   -      storeColumnIds:
-  -      - 1
   -      - 2
+  -      - 3
   -      - 5
   -      storeColumnNames:
-  -      - k
+  -      - k2
   -      - v
   -      - m
   -      unique: true
@@ -2177,7 +2204,7 @@ upsert descriptor #108
   -  version: "27"
   +  version: "28"
 persist all catalog changes to storage
-create job #2 (non-cancelable: true): "GC for ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k) USING HASH"
+create job #2 (non-cancelable: true): "GC for ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k2) USING HASH"
   descriptor IDs: [108]
 update progress of schema change job #1: "Pending: Updating schema metadata (1 operation) — PostCommitNonRevertible phase (stage 6 of 6)."
 commit transaction #31
@@ -2195,30 +2222,30 @@ upsert descriptor #108
   -    jobId: "1"
   -    nameMapping:
   -      columns:
-  -        "1": k
-  -        "2": v
-  -        "3": crdb_region
-  -        "4": rowid
+  -        "1": k1
+  -        "2": k2
+  -        "3": v
+  -        "4": crdb_region
   -        "5": m
-  -        "6": crdb_internal_k_shard_16
+  -        "6": crdb_internal_k2_shard_16
   -        "4294967292": crdb_internal_origin_timestamp
   -        "4294967293": crdb_internal_origin_id
   -        "4294967294": tableoid
   -        "4294967295": crdb_internal_mvcc_timestamp
   -      constraints:
-  -        "2": check_crdb_internal_k_shard_16
+  -        "2": check_crdb_internal_k2_shard_16
   -      families:
   -        "0": primary
   -      id: 108
   -      indexes:
   -        "4": idx_v
-  -        "6": table_regional_by_row_rowid_key
+  -        "6": table_regional_by_row_k1_key
   -        "10": table_regional_by_row_pkey
   -      name: table_regional_by_row
   -    relevantStatements:
   -    - statement:
-  -        redactedStatement: ALTER TABLE ‹multiregion_db›.‹public›.‹table_regional_by_row› ADD COLUMN ‹m› INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (‹k›) USING HASH
-  -        statement: ALTER TABLE multiregion_db.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k) USING HASH
+  -        redactedStatement: ALTER TABLE ‹multiregion_db›.‹public›.‹table_regional_by_row› ADD COLUMN ‹m› INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (‹k2›) USING HASH
+  -        statement: ALTER TABLE multiregion_db.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k2) USING HASH
   -        statementTag: ALTER TABLE
   -    targetRanks: <redacted>
   -    targets: <redacted>

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_10_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_10_of_24.explain
@@ -1,16 +1,17 @@
 /* setup */
 CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
 CREATE TABLE multiregion_db.public.table_regional_by_row (
-  k INT NOT NULL,
+  k1 INT NOT NULL PRIMARY KEY,
+  k2 INT NOT NULL,
   V STRING
 ) LOCALITY REGIONAL BY ROW;
 CREATE INDEX idx_v on multiregion_db.table_regional_by_row(v);
 
 /* test */
-alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k) USING HASH;
+alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k2) USING HASH;
 EXPLAIN (DDL) rollback at post-commit stage 10 of 24;
 ----
-Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k) USING HASH;
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k2) USING HASH;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
       │    ├── 3 elements transitioning toward PUBLIC
@@ -25,43 +26,43 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 8, SourceIndexID: 1 (table_regional_by_row_pkey+)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 9}
       │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 11, ConstraintID: 10, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 11}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 11}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k_shard_16", ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 11}
-      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k2_shard_16", ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 11}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 4 (idx_v-)}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 4, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
@@ -73,19 +74,19 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":8,"TableID":108}
       │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":11,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Ordinal":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":11,"Kind":2,"Ordinal":2,"TableID":108}
@@ -94,14 +95,14 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── MakeColumnVisible {"ColumnID":6,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":10,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":11,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":4,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":4,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":5,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":5,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
@@ -119,25 +120,25 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
       │    ├── 11 elements transitioning toward ABSENT
       │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 1 (table_regional_by_row_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 11, ConstraintID: 10, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC      → ABSENT      ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16-), TypeName: "INT8"}
-      │    │    ├── PUBLIC      → ABSENT      ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), ReferencedColumnIDs: [1], Usage: REGULAR}
+      │    │    ├── DELETE_ONLY → ABSENT      Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC      → ABSENT      ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k2_shard_16-), TypeName: "INT8"}
+      │    │    ├── PUBLIC      → ABSENT      ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), ReferencedColumnIDs: [2], Usage: REGULAR}
       │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 4, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    └── 12 Mutation operations
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":108}
       │         ├── RemoveColumnComputeExpression {"ColumnID":6,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":6,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_11_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_11_of_24.explain
@@ -1,16 +1,17 @@
 /* setup */
 CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
 CREATE TABLE multiregion_db.public.table_regional_by_row (
-  k INT NOT NULL,
+  k1 INT NOT NULL PRIMARY KEY,
+  k2 INT NOT NULL,
   V STRING
 ) LOCALITY REGIONAL BY ROW;
 CREATE INDEX idx_v on multiregion_db.table_regional_by_row(v);
 
 /* test */
-alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k) USING HASH;
+alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k2) USING HASH;
 EXPLAIN (DDL) rollback at post-commit stage 11 of 24;
 ----
-Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k) USING HASH;
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k2) USING HASH;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
       │    ├── 3 elements transitioning toward PUBLIC
@@ -25,43 +26,43 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 8, SourceIndexID: 1 (table_regional_by_row_pkey+)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 9}
       │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 11, ConstraintID: 10, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 11}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 11}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k_shard_16", ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 11}
-      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k2_shard_16", ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 11}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 4 (idx_v-)}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 4, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
@@ -73,19 +74,19 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":8,"TableID":108}
       │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":11,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Ordinal":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":11,"Kind":2,"Ordinal":2,"TableID":108}
@@ -94,14 +95,14 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── MakeColumnVisible {"ColumnID":6,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":10,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":11,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":4,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":4,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":5,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":5,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
@@ -119,25 +120,25 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
       │    ├── 11 elements transitioning toward ABSENT
       │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 1 (table_regional_by_row_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 11, ConstraintID: 10, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC      → ABSENT      ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16-), TypeName: "INT8"}
-      │    │    ├── PUBLIC      → ABSENT      ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), ReferencedColumnIDs: [1], Usage: REGULAR}
+      │    │    ├── DELETE_ONLY → ABSENT      Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC      → ABSENT      ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k2_shard_16-), TypeName: "INT8"}
+      │    │    ├── PUBLIC      → ABSENT      ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), ReferencedColumnIDs: [2], Usage: REGULAR}
       │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 4, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    └── 12 Mutation operations
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":108}
       │         ├── RemoveColumnComputeExpression {"ColumnID":6,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":6,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_12_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_12_of_24.explain
@@ -1,16 +1,17 @@
 /* setup */
 CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
 CREATE TABLE multiregion_db.public.table_regional_by_row (
-  k INT NOT NULL,
+  k1 INT NOT NULL PRIMARY KEY,
+  k2 INT NOT NULL,
   V STRING
 ) LOCALITY REGIONAL BY ROW;
 CREATE INDEX idx_v on multiregion_db.table_regional_by_row(v);
 
 /* test */
-alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k) USING HASH;
+alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k2) USING HASH;
 EXPLAIN (DDL) rollback at post-commit stage 12 of 24;
 ----
-Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k) USING HASH;
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k2) USING HASH;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
       │    ├── 3 elements transitioning toward PUBLIC
@@ -25,43 +26,43 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 8, SourceIndexID: 1 (table_regional_by_row_pkey+)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 9}
       │    │    ├── DELETE_ONLY           → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 11, ConstraintID: 10, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 11}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 11}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k_shard_16", ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 11}
-      │    │    ├── DELETE_ONLY           → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k2_shard_16", ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 11}
+      │    │    ├── DELETE_ONLY           → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 4 (idx_v-)}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 4, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
@@ -73,19 +74,19 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":8,"TableID":108}
       │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":11,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Ordinal":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":11,"Kind":2,"Ordinal":2,"TableID":108}
@@ -94,14 +95,14 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── MakeColumnVisible {"ColumnID":6,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":10,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":11,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":4,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":4,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":5,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":5,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
@@ -119,25 +120,25 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
       │    ├── 11 elements transitioning toward ABSENT
       │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 1 (table_regional_by_row_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 11, ConstraintID: 10, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC      → ABSENT      ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16-), TypeName: "INT8"}
-      │    │    ├── PUBLIC      → ABSENT      ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), ReferencedColumnIDs: [1], Usage: REGULAR}
+      │    │    ├── DELETE_ONLY → ABSENT      Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC      → ABSENT      ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k2_shard_16-), TypeName: "INT8"}
+      │    │    ├── PUBLIC      → ABSENT      ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), ReferencedColumnIDs: [2], Usage: REGULAR}
       │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 4, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    └── 12 Mutation operations
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":108}
       │         ├── RemoveColumnComputeExpression {"ColumnID":6,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":6,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_13_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_13_of_24.explain
@@ -1,16 +1,17 @@
 /* setup */
 CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
 CREATE TABLE multiregion_db.public.table_regional_by_row (
-  k INT NOT NULL,
+  k1 INT NOT NULL PRIMARY KEY,
+  k2 INT NOT NULL,
   V STRING
 ) LOCALITY REGIONAL BY ROW;
 CREATE INDEX idx_v on multiregion_db.table_regional_by_row(v);
 
 /* test */
-alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k) USING HASH;
+alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k2) USING HASH;
 EXPLAIN (DDL) rollback at post-commit stage 13 of 24;
 ----
-Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k) USING HASH;
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k2) USING HASH;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
       │    ├── 3 elements transitioning toward PUBLIC
@@ -25,43 +26,43 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 8, SourceIndexID: 1 (table_regional_by_row_pkey+)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 9}
       │    │    ├── MERGE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 11, ConstraintID: 10, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 11}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 11}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k_shard_16", ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 11}
-      │    │    ├── MERGE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k2_shard_16", ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 11}
+      │    │    ├── MERGE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 4 (idx_v-)}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 4, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
@@ -73,15 +74,15 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":8,"TableID":108}
       │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":11,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Ordinal":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":11,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":6,"TableID":108}
@@ -89,9 +90,9 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── MakeColumnVisible {"ColumnID":6,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":11,"Ordinal":1,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":5,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":5,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
@@ -101,17 +102,17 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnNotNull {"ColumnID":6,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":10,"Ordinal":1,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":4,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":4,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
@@ -119,17 +120,17 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
       │    ├── 13 elements transitioning toward ABSENT
       │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 1 (table_regional_by_row_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 11, ConstraintID: 10, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC      → ABSENT      ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16-), TypeName: "INT8"}
-      │    │    ├── PUBLIC      → ABSENT      ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), ReferencedColumnIDs: [1], Usage: REGULAR}
-      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── DELETE_ONLY → ABSENT      Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC      → ABSENT      ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k2_shard_16-), TypeName: "INT8"}
+      │    │    ├── PUBLIC      → ABSENT      ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), ReferencedColumnIDs: [2], Usage: REGULAR}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 4, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    └── 14 Mutation operations
       │         ├── MakeIndexAbsent {"IndexID":10,"TableID":108}
@@ -138,10 +139,10 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":6,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_14_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_14_of_24.explain
@@ -1,16 +1,17 @@
 /* setup */
 CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
 CREATE TABLE multiregion_db.public.table_regional_by_row (
-  k INT NOT NULL,
+  k1 INT NOT NULL PRIMARY KEY,
+  k2 INT NOT NULL,
   V STRING
 ) LOCALITY REGIONAL BY ROW;
 CREATE INDEX idx_v on multiregion_db.table_regional_by_row(v);
 
 /* test */
-alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k) USING HASH;
+alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k2) USING HASH;
 EXPLAIN (DDL) rollback at post-commit stage 14 of 24;
 ----
-Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k) USING HASH;
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k2) USING HASH;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
       │    ├── 3 elements transitioning toward PUBLIC
@@ -25,43 +26,43 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 8, SourceIndexID: 1 (table_regional_by_row_pkey+)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 9}
       │    │    ├── MERGE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 11, ConstraintID: 10, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 11}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 11}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k_shard_16", ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 11}
-      │    │    ├── MERGE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k2_shard_16", ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 11}
+      │    │    ├── MERGE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 4 (idx_v-)}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 4, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
@@ -73,15 +74,15 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":8,"TableID":108}
       │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":11,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Ordinal":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":11,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":6,"TableID":108}
@@ -89,9 +90,9 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── MakeColumnVisible {"ColumnID":6,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":11,"Ordinal":1,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":5,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":5,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
@@ -101,17 +102,17 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnNotNull {"ColumnID":6,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":10,"Ordinal":1,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":4,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":4,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
@@ -119,17 +120,17 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
       │    ├── 13 elements transitioning toward ABSENT
       │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 1 (table_regional_by_row_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 11, ConstraintID: 10, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC      → ABSENT      ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16-), TypeName: "INT8"}
-      │    │    ├── PUBLIC      → ABSENT      ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), ReferencedColumnIDs: [1], Usage: REGULAR}
-      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── DELETE_ONLY → ABSENT      Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC      → ABSENT      ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k2_shard_16-), TypeName: "INT8"}
+      │    │    ├── PUBLIC      → ABSENT      ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), ReferencedColumnIDs: [2], Usage: REGULAR}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 4, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    └── 14 Mutation operations
       │         ├── MakeIndexAbsent {"IndexID":10,"TableID":108}
@@ -138,10 +139,10 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":6,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_15_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_15_of_24.explain
@@ -1,16 +1,17 @@
 /* setup */
 CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
 CREATE TABLE multiregion_db.public.table_regional_by_row (
-  k INT NOT NULL,
+  k1 INT NOT NULL PRIMARY KEY,
+  k2 INT NOT NULL,
   V STRING
 ) LOCALITY REGIONAL BY ROW;
 CREATE INDEX idx_v on multiregion_db.table_regional_by_row(v);
 
 /* test */
-alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k) USING HASH;
+alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k2) USING HASH;
 EXPLAIN (DDL) rollback at post-commit stage 15 of 24;
 ----
-Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k) USING HASH;
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k2) USING HASH;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
       │    ├── 3 elements transitioning toward PUBLIC
@@ -25,43 +26,43 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 8, SourceIndexID: 1 (table_regional_by_row_pkey+)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 9}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 11, ConstraintID: 10, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 11}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 11}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k_shard_16", ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 11}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k2_shard_16", ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 11}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 4 (idx_v-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 4, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
@@ -73,19 +74,19 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":8,"TableID":108}
       │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Ordinal":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":11,"Kind":2,"Ordinal":2,"TableID":108}
@@ -95,13 +96,13 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":10,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":11,"Ordinal":1,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":4,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":4,"Kind":1,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":5,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":5,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
@@ -119,25 +120,25 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
       │    ├── 11 elements transitioning toward ABSENT
       │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 1 (table_regional_by_row_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC      → ABSENT      ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16-), TypeName: "INT8"}
-      │    │    ├── PUBLIC      → ABSENT      ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), ReferencedColumnIDs: [1], Usage: REGULAR}
-      │    │    └── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── DELETE_ONLY → ABSENT      Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC      → ABSENT      ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k2_shard_16-), TypeName: "INT8"}
+      │    │    ├── PUBLIC      → ABSENT      ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), ReferencedColumnIDs: [2], Usage: REGULAR}
+      │    │    └── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    └── 12 Mutation operations
       │         ├── MakeIndexAbsent {"IndexID":10,"TableID":108}
       │         ├── RemoveColumnComputeExpression {"ColumnID":6,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":6,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_16_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_16_of_24.explain
@@ -1,16 +1,17 @@
 /* setup */
 CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
 CREATE TABLE multiregion_db.public.table_regional_by_row (
-  k INT NOT NULL,
+  k1 INT NOT NULL PRIMARY KEY,
+  k2 INT NOT NULL,
   V STRING
 ) LOCALITY REGIONAL BY ROW;
 CREATE INDEX idx_v on multiregion_db.table_regional_by_row(v);
 
 /* test */
-alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k) USING HASH;
+alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k2) USING HASH;
 EXPLAIN (DDL) rollback at post-commit stage 16 of 24;
 ----
-Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k) USING HASH;
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k2) USING HASH;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
       │    ├── 3 elements transitioning toward PUBLIC
@@ -25,43 +26,43 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 8, SourceIndexID: 1 (table_regional_by_row_pkey+)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 9}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 11, ConstraintID: 10, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 11}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 11}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k_shard_16", ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 11}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k2_shard_16", ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 11}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 4 (idx_v-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 4, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
@@ -73,19 +74,19 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":8,"TableID":108}
       │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Ordinal":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":11,"Kind":2,"Ordinal":2,"TableID":108}
@@ -95,13 +96,13 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":10,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":11,"Ordinal":1,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":4,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":4,"Kind":1,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":5,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":5,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
@@ -119,25 +120,25 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
       │    ├── 11 elements transitioning toward ABSENT
       │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 1 (table_regional_by_row_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC      → ABSENT      ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16-), TypeName: "INT8"}
-      │    │    ├── PUBLIC      → ABSENT      ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), ReferencedColumnIDs: [1], Usage: REGULAR}
-      │    │    └── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── DELETE_ONLY → ABSENT      Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC      → ABSENT      ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k2_shard_16-), TypeName: "INT8"}
+      │    │    ├── PUBLIC      → ABSENT      ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), ReferencedColumnIDs: [2], Usage: REGULAR}
+      │    │    └── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    └── 12 Mutation operations
       │         ├── MakeIndexAbsent {"IndexID":10,"TableID":108}
       │         ├── RemoveColumnComputeExpression {"ColumnID":6,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":6,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_17_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_17_of_24.explain
@@ -1,24 +1,23 @@
 /* setup */
 CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
 CREATE TABLE multiregion_db.public.table_regional_by_row (
-  k INT NOT NULL,
+  k1 INT NOT NULL PRIMARY KEY,
+  k2 INT NOT NULL,
   V STRING
 ) LOCALITY REGIONAL BY ROW;
 CREATE INDEX idx_v on multiregion_db.table_regional_by_row(v);
 
 /* test */
-alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k) USING HASH;
+alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k2) USING HASH;
 EXPLAIN (DDL) rollback at post-commit stage 17 of 24;
 ----
-Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k) USING HASH;
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k2) USING HASH;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 5 elements transitioning toward PUBLIC
+      │    ├── 3 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+), ConstraintID: 1}
       │    │    ├── ABSENT                → PUBLIC      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+)}
-      │    │    ├── ABSENT                → PUBLIC      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 1 (table_regional_by_row_pkey+)}
-      │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (idx_v+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
-      │    │    └── ABSENT                → PUBLIC      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 2 (idx_v+)}
+      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 1 (table_regional_by_row_pkey+)}
       │    ├── 57 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 5 (m-)}
@@ -27,71 +26,70 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 8, SourceIndexID: 1 (table_regional_by_row_pkey+)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 9}
       │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 11, ConstraintID: 10, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 11}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 11}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k_shard_16", ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 11}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k2_shard_16", ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 11}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 4, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
-      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 10 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_k1_key-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 10 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
       │    │    ├── DELETE_ONLY           → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 6, SourceIndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 6 (table_regional_by_row_rowid_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 7}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 6 (table_regional_by_row_rowid_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 7}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 6 (table_regional_by_row_rowid_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 7}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_rowid_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
-      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 6 (table_regional_by_row_k1_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 6 (table_regional_by_row_k1_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 6 (table_regional_by_row_k1_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 6 (table_regional_by_row_k1_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_k1_key-)}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 4}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_rowid_key", IndexID: 6 (table_regional_by_row_rowid_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_k1_key", IndexID: 6 (table_regional_by_row_k1_key-)}
       │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 5}
-      │    └── 58 Mutation operations
+      │    └── 55 Mutation operations
       │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
-      │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":2,"TableID":108}}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
       │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":8,"TableID":108}
       │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Ordinal":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":11,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":6,"TableID":108}
@@ -100,33 +98,31 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── MakePublicColumnNotNullValidated {"ColumnID":6,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":11,"Ordinal":1,"TableID":108}
       │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":4,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":5,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":5,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":6,"Kind":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":7,"Kind":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":1,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
-      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":108}
-      │         ├── RefreshStats {"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":10,"Ordinal":1,"TableID":108}
@@ -139,33 +135,33 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
       │    ├── 14 elements transitioning toward ABSENT
       │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 1 (table_regional_by_row_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "idx_v", IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 4 (idx_v-)}
-      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 4 (idx_v-)}
+      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 4 (idx_v-)}
       │    └── 16 Mutation operations
       │         ├── MakeIndexAbsent {"IndexID":10,"TableID":108}
       │         ├── RemoveColumnNotNull {"ColumnID":6,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":108}
       │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":4,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":4,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
@@ -179,13 +175,13 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 9}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 11}
-      │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16-), TypeName: "INT8"}
-      │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), ReferencedColumnIDs: [1], Usage: REGULAR}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k2_shard_16-), TypeName: "INT8"}
+      │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), ReferencedColumnIDs: [2], Usage: REGULAR}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 5}
-      │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key-)}
+      │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_k1_key-)}
       │    └── 15 Mutation operations
       │         ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":8,"TableID":108}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_18_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_18_of_24.explain
@@ -1,24 +1,23 @@
 /* setup */
 CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
 CREATE TABLE multiregion_db.public.table_regional_by_row (
-  k INT NOT NULL,
+  k1 INT NOT NULL PRIMARY KEY,
+  k2 INT NOT NULL,
   V STRING
 ) LOCALITY REGIONAL BY ROW;
 CREATE INDEX idx_v on multiregion_db.table_regional_by_row(v);
 
 /* test */
-alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k) USING HASH;
+alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k2) USING HASH;
 EXPLAIN (DDL) rollback at post-commit stage 18 of 24;
 ----
-Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k) USING HASH;
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k2) USING HASH;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 5 elements transitioning toward PUBLIC
+      │    ├── 3 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+), ConstraintID: 1}
       │    │    ├── ABSENT                → PUBLIC      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+)}
-      │    │    ├── ABSENT                → PUBLIC      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 1 (table_regional_by_row_pkey+)}
-      │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (idx_v+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
-      │    │    └── ABSENT                → PUBLIC      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 2 (idx_v+)}
+      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 1 (table_regional_by_row_pkey+)}
       │    ├── 57 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 5 (m-)}
@@ -27,71 +26,70 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 8, SourceIndexID: 1 (table_regional_by_row_pkey+)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 9}
       │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 11, ConstraintID: 10, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 11}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 11}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k_shard_16", ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 11}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k2_shard_16", ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 11}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 4, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
-      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 10 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_k1_key-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 10 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 6, SourceIndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 6 (table_regional_by_row_rowid_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 7}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 6 (table_regional_by_row_rowid_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 7}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 6 (table_regional_by_row_rowid_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 7}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_rowid_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
-      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 6 (table_regional_by_row_k1_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 6 (table_regional_by_row_k1_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 6 (table_regional_by_row_k1_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 6 (table_regional_by_row_k1_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_k1_key-)}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 4}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_rowid_key", IndexID: 6 (table_regional_by_row_rowid_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_k1_key", IndexID: 6 (table_regional_by_row_k1_key-)}
       │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 5}
-      │    └── 58 Mutation operations
+      │    └── 55 Mutation operations
       │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
-      │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":2,"TableID":108}}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
       │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":8,"TableID":108}
       │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Ordinal":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":11,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":6,"TableID":108}
@@ -100,34 +98,32 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── MakePublicColumnNotNullValidated {"ColumnID":6,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":11,"Ordinal":1,"TableID":108}
       │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":4,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":5,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":5,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":6,"Kind":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":7,"Kind":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":1,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
-      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":108}
-      │         ├── RefreshStats {"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":10,"Ordinal":1,"TableID":108}
@@ -139,35 +135,35 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
       │    ├── 15 elements transitioning toward ABSENT
       │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 1 (table_regional_by_row_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "idx_v", IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 4 (idx_v-)}
       │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 6, SourceIndexID: 10 (table_regional_by_row_pkey-)}
       │    └── 17 Mutation operations
       │         ├── MakeIndexAbsent {"IndexID":10,"TableID":108}
       │         ├── RemoveColumnNotNull {"ColumnID":6,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":108}
       │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":4,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":4,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
@@ -181,13 +177,13 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 9}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 11}
-      │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16-), TypeName: "INT8"}
-      │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), ReferencedColumnIDs: [1], Usage: REGULAR}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k2_shard_16-), TypeName: "INT8"}
+      │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), ReferencedColumnIDs: [2], Usage: REGULAR}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 5}
-      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key-)}
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_k1_key-)}
       │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
       │    └── 16 Mutation operations
       │         ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_19_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_19_of_24.explain
@@ -1,24 +1,23 @@
 /* setup */
 CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
 CREATE TABLE multiregion_db.public.table_regional_by_row (
-  k INT NOT NULL,
+  k1 INT NOT NULL PRIMARY KEY,
+  k2 INT NOT NULL,
   V STRING
 ) LOCALITY REGIONAL BY ROW;
 CREATE INDEX idx_v on multiregion_db.table_regional_by_row(v);
 
 /* test */
-alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k) USING HASH;
+alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k2) USING HASH;
 EXPLAIN (DDL) rollback at post-commit stage 19 of 24;
 ----
-Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k) USING HASH;
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k2) USING HASH;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 5 elements transitioning toward PUBLIC
+      │    ├── 3 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+), ConstraintID: 1}
       │    │    ├── ABSENT                → PUBLIC      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+)}
-      │    │    ├── ABSENT                → PUBLIC      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 1 (table_regional_by_row_pkey+)}
-      │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (idx_v+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
-      │    │    └── ABSENT                → PUBLIC      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 2 (idx_v+)}
+      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 1 (table_regional_by_row_pkey+)}
       │    ├── 57 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 5 (m-)}
@@ -27,71 +26,70 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 8, SourceIndexID: 1 (table_regional_by_row_pkey+)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 9}
       │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 11, ConstraintID: 10, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 11}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 11}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k_shard_16", ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 11}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k2_shard_16", ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 11}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 4, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
-      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 10 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_k1_key-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 10 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 6, SourceIndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 6 (table_regional_by_row_rowid_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 7}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 6 (table_regional_by_row_rowid_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 7}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 6 (table_regional_by_row_rowid_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 7}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_rowid_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
-      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 6 (table_regional_by_row_k1_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 6 (table_regional_by_row_k1_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 6 (table_regional_by_row_k1_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 6 (table_regional_by_row_k1_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_k1_key-)}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 4}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_rowid_key", IndexID: 6 (table_regional_by_row_rowid_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_k1_key", IndexID: 6 (table_regional_by_row_k1_key-)}
       │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 5}
-      │    └── 58 Mutation operations
+      │    └── 55 Mutation operations
       │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
-      │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":2,"TableID":108}}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
       │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":8,"TableID":108}
       │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Ordinal":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":11,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":6,"TableID":108}
@@ -100,34 +98,32 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── MakePublicColumnNotNullValidated {"ColumnID":6,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":11,"Ordinal":1,"TableID":108}
       │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":4,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":5,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":5,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":6,"Kind":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":7,"Kind":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":1,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
-      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":108}
-      │         ├── RefreshStats {"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":10,"Ordinal":1,"TableID":108}
@@ -139,35 +135,35 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
       │    ├── 15 elements transitioning toward ABSENT
       │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 1 (table_regional_by_row_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "idx_v", IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 4 (idx_v-)}
       │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 6, SourceIndexID: 10 (table_regional_by_row_pkey-)}
       │    └── 17 Mutation operations
       │         ├── MakeIndexAbsent {"IndexID":10,"TableID":108}
       │         ├── RemoveColumnNotNull {"ColumnID":6,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":108}
       │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":4,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":4,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
@@ -181,13 +177,13 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 9}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 11}
-      │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16-), TypeName: "INT8"}
-      │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), ReferencedColumnIDs: [1], Usage: REGULAR}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k2_shard_16-), TypeName: "INT8"}
+      │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), ReferencedColumnIDs: [2], Usage: REGULAR}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 5}
-      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key-)}
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_k1_key-)}
       │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
       │    └── 16 Mutation operations
       │         ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_1_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_1_of_24.explain
@@ -1,16 +1,17 @@
 /* setup */
 CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
 CREATE TABLE multiregion_db.public.table_regional_by_row (
-  k INT NOT NULL,
+  k1 INT NOT NULL PRIMARY KEY,
+  k2 INT NOT NULL,
   V STRING
 ) LOCALITY REGIONAL BY ROW;
 CREATE INDEX idx_v on multiregion_db.table_regional_by_row(v);
 
 /* test */
-alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k) USING HASH;
+alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k2) USING HASH;
 EXPLAIN (DDL) rollback at post-commit stage 1 of 24;
 ----
-Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k) USING HASH;
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k2) USING HASH;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
       │    ├── 38 elements transitioning toward ABSENT
@@ -20,33 +21,33 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC           → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), Expr: unique_rowid()}
       │    │    ├── BACKFILL_ONLY    → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 1 (table_regional_by_row_pkey+)}
       │    │    ├── PUBLIC           → ABSENT IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC           → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── DELETE_ONLY      → ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 8, SourceIndexID: 1 (table_regional_by_row_pkey+)}
       │    │    ├── TRANSIENT_ABSENT → ABSENT IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
-      │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 9}
-      │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 9}
-      │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
-      │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 9}
+      │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+      │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 9}
+      │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 9}
+      │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 9}
       │    │    ├── BACKFILL_ONLY    → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC           → ABSENT IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC           → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 9}
       │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── DELETE_ONLY      → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC           → ABSENT ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k_shard_16", ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC           → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16-), TypeName: "INT8"}
-      │    │    ├── PUBLIC           → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), ReferencedColumnIDs: [1], Usage: REGULAR}
-      │    │    ├── PUBLIC           → ABSENT ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── DELETE_ONLY      → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC           → ABSENT ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k2_shard_16", ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC           → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k2_shard_16-), TypeName: "INT8"}
+      │    │    ├── PUBLIC           → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), ReferencedColumnIDs: [2], Usage: REGULAR}
+      │    │    ├── PUBLIC           → ABSENT ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC           → ABSENT TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
       │    │    ├── PUBLIC           → ABSENT TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
       │    │    ├── PUBLIC           → ABSENT TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
@@ -54,18 +55,18 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    └── PUBLIC           → ABSENT TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 5}
       │    └── 35 Mutation operations
       │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"Kind":2,"Ordinal":2,"TableID":108}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_20_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_20_of_24.explain
@@ -1,24 +1,23 @@
 /* setup */
 CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
 CREATE TABLE multiregion_db.public.table_regional_by_row (
-  k INT NOT NULL,
+  k1 INT NOT NULL PRIMARY KEY,
+  k2 INT NOT NULL,
   V STRING
 ) LOCALITY REGIONAL BY ROW;
 CREATE INDEX idx_v on multiregion_db.table_regional_by_row(v);
 
 /* test */
-alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k) USING HASH;
+alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k2) USING HASH;
 EXPLAIN (DDL) rollback at post-commit stage 20 of 24;
 ----
-Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k) USING HASH;
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k2) USING HASH;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 5 elements transitioning toward PUBLIC
+      │    ├── 3 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+), ConstraintID: 1}
       │    │    ├── ABSENT                → PUBLIC      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+)}
-      │    │    ├── ABSENT                → PUBLIC      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 1 (table_regional_by_row_pkey+)}
-      │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (idx_v+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
-      │    │    └── ABSENT                → PUBLIC      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 2 (idx_v+)}
+      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 1 (table_regional_by_row_pkey+)}
       │    ├── 57 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 5 (m-)}
@@ -27,71 +26,70 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 8, SourceIndexID: 1 (table_regional_by_row_pkey+)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 9}
       │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 11, ConstraintID: 10, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 11}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 11}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k_shard_16", ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 11}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k2_shard_16", ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 11}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 4, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
-      │    │    ├── DELETE_ONLY           → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 10 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+      │    │    ├── DELETE_ONLY           → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_k1_key-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 10 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 6, SourceIndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 6 (table_regional_by_row_rowid_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 7}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 6 (table_regional_by_row_rowid_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 7}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 6 (table_regional_by_row_rowid_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 7}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_rowid_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
-      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 6 (table_regional_by_row_k1_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 6 (table_regional_by_row_k1_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 6 (table_regional_by_row_k1_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 6 (table_regional_by_row_k1_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_k1_key-)}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 4}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_rowid_key", IndexID: 6 (table_regional_by_row_rowid_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_k1_key", IndexID: 6 (table_regional_by_row_k1_key-)}
       │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 5}
-      │    └── 58 Mutation operations
+      │    └── 55 Mutation operations
       │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
-      │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":2,"TableID":108}}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
       │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":8,"TableID":108}
       │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Ordinal":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":11,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":6,"TableID":108}
@@ -100,34 +98,32 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── MakePublicColumnNotNullValidated {"ColumnID":6,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":11,"Ordinal":1,"TableID":108}
       │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":4,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":5,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":5,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":6,"Kind":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":7,"Kind":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":1,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
-      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":108}
-      │         ├── RefreshStats {"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":10,"Ordinal":1,"TableID":108}
@@ -139,35 +135,35 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
       │    ├── 15 elements transitioning toward ABSENT
       │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 1 (table_regional_by_row_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "idx_v", IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 4 (idx_v-)}
       │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 6, SourceIndexID: 10 (table_regional_by_row_pkey-)}
       │    └── 17 Mutation operations
       │         ├── MakeIndexAbsent {"IndexID":10,"TableID":108}
       │         ├── RemoveColumnNotNull {"ColumnID":6,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":108}
       │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":4,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":4,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
@@ -181,13 +177,13 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 9}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 11}
-      │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16-), TypeName: "INT8"}
-      │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), ReferencedColumnIDs: [1], Usage: REGULAR}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k2_shard_16-), TypeName: "INT8"}
+      │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), ReferencedColumnIDs: [2], Usage: REGULAR}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 5}
-      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key-)}
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_k1_key-)}
       │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
       │    └── 16 Mutation operations
       │         ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_21_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_21_of_24.explain
@@ -1,24 +1,23 @@
 /* setup */
 CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
 CREATE TABLE multiregion_db.public.table_regional_by_row (
-  k INT NOT NULL,
+  k1 INT NOT NULL PRIMARY KEY,
+  k2 INT NOT NULL,
   V STRING
 ) LOCALITY REGIONAL BY ROW;
 CREATE INDEX idx_v on multiregion_db.table_regional_by_row(v);
 
 /* test */
-alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k) USING HASH;
+alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k2) USING HASH;
 EXPLAIN (DDL) rollback at post-commit stage 21 of 24;
 ----
-Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k) USING HASH;
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k2) USING HASH;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 5 elements transitioning toward PUBLIC
+      │    ├── 3 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+), ConstraintID: 1}
       │    │    ├── ABSENT                → PUBLIC      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+)}
-      │    │    ├── ABSENT                → PUBLIC      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 1 (table_regional_by_row_pkey+)}
-      │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (idx_v+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
-      │    │    └── ABSENT                → PUBLIC      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 2 (idx_v+)}
+      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 1 (table_regional_by_row_pkey+)}
       │    ├── 57 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 5 (m-)}
@@ -27,71 +26,70 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 8, SourceIndexID: 1 (table_regional_by_row_pkey+)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 9}
       │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 11, ConstraintID: 10, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 11}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 11}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k_shard_16", ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 11}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k2_shard_16", ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 11}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 4, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
-      │    │    ├── MERGE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 10 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+      │    │    ├── MERGE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_k1_key-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 10 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 6, SourceIndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 6 (table_regional_by_row_rowid_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 7}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 6 (table_regional_by_row_rowid_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 7}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 6 (table_regional_by_row_rowid_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 7}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_rowid_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
-      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 6 (table_regional_by_row_k1_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 6 (table_regional_by_row_k1_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 6 (table_regional_by_row_k1_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 6 (table_regional_by_row_k1_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_k1_key-)}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 4}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_rowid_key", IndexID: 6 (table_regional_by_row_rowid_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_k1_key", IndexID: 6 (table_regional_by_row_k1_key-)}
       │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 5}
-      │    └── 58 Mutation operations
+      │    └── 55 Mutation operations
       │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
-      │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":2,"TableID":108}}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
       │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":8,"TableID":108}
       │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Ordinal":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":11,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":6,"TableID":108}
@@ -100,38 +98,36 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── MakePublicColumnNotNullValidated {"ColumnID":6,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":11,"Ordinal":1,"TableID":108}
       │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":4,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":5,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":5,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":7,"Kind":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":1,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
-      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":108}
-      │         ├── RefreshStats {"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":10,"Ordinal":1,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":6,"Kind":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
@@ -139,20 +135,20 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
       │    ├── 16 elements transitioning toward ABSENT
       │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 1 (table_regional_by_row_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "idx_v", IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 4 (idx_v-)}
-      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 10 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 4 (idx_v-)}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_k1_key-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 10 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
       │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 6, SourceIndexID: 10 (table_regional_by_row_pkey-)}
       │    └── 18 Mutation operations
       │         ├── MakeIndexAbsent {"IndexID":10,"TableID":108}
@@ -160,16 +156,16 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":108}
       │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":4,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":4,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
@@ -183,13 +179,13 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 9}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 11}
-      │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16-), TypeName: "INT8"}
-      │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), ReferencedColumnIDs: [1], Usage: REGULAR}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k2_shard_16-), TypeName: "INT8"}
+      │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), ReferencedColumnIDs: [2], Usage: REGULAR}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 5}
-      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key-)}
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_k1_key-)}
       │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
       │    └── 16 Mutation operations
       │         ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_22_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_22_of_24.explain
@@ -1,24 +1,23 @@
 /* setup */
 CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
 CREATE TABLE multiregion_db.public.table_regional_by_row (
-  k INT NOT NULL,
+  k1 INT NOT NULL PRIMARY KEY,
+  k2 INT NOT NULL,
   V STRING
 ) LOCALITY REGIONAL BY ROW;
 CREATE INDEX idx_v on multiregion_db.table_regional_by_row(v);
 
 /* test */
-alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k) USING HASH;
+alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k2) USING HASH;
 EXPLAIN (DDL) rollback at post-commit stage 22 of 24;
 ----
-Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k) USING HASH;
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k2) USING HASH;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 5 elements transitioning toward PUBLIC
+      │    ├── 3 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+), ConstraintID: 1}
       │    │    ├── ABSENT                → PUBLIC      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+)}
-      │    │    ├── ABSENT                → PUBLIC      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 1 (table_regional_by_row_pkey+)}
-      │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (idx_v+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
-      │    │    └── ABSENT                → PUBLIC      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 2 (idx_v+)}
+      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 1 (table_regional_by_row_pkey+)}
       │    ├── 57 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 5 (m-)}
@@ -27,71 +26,70 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 8, SourceIndexID: 1 (table_regional_by_row_pkey+)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 9}
       │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 11, ConstraintID: 10, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 11}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 11}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k_shard_16", ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 11}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k2_shard_16", ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 11}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 4, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
-      │    │    ├── MERGE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 10 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+      │    │    ├── MERGE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_k1_key-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 10 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 6, SourceIndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 6 (table_regional_by_row_rowid_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 7}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 6 (table_regional_by_row_rowid_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 7}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 6 (table_regional_by_row_rowid_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 7}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_rowid_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
-      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 6 (table_regional_by_row_k1_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 6 (table_regional_by_row_k1_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 6 (table_regional_by_row_k1_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 6 (table_regional_by_row_k1_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_k1_key-)}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 4}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_rowid_key", IndexID: 6 (table_regional_by_row_rowid_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_k1_key", IndexID: 6 (table_regional_by_row_k1_key-)}
       │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 5}
-      │    └── 58 Mutation operations
+      │    └── 55 Mutation operations
       │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
-      │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":2,"TableID":108}}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
       │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":8,"TableID":108}
       │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Ordinal":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":11,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":6,"TableID":108}
@@ -100,38 +98,36 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── MakePublicColumnNotNullValidated {"ColumnID":6,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":11,"Ordinal":1,"TableID":108}
       │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":4,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":5,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":5,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":7,"Kind":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":1,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
-      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":108}
-      │         ├── RefreshStats {"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":10,"Ordinal":1,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":6,"Kind":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
@@ -139,20 +135,20 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
       │    ├── 16 elements transitioning toward ABSENT
       │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 1 (table_regional_by_row_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "idx_v", IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 4 (idx_v-)}
-      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 10 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 4 (idx_v-)}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_k1_key-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 10 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
       │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 6, SourceIndexID: 10 (table_regional_by_row_pkey-)}
       │    └── 18 Mutation operations
       │         ├── MakeIndexAbsent {"IndexID":10,"TableID":108}
@@ -160,16 +156,16 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":108}
       │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":4,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":4,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
@@ -183,13 +179,13 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 9}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 11}
-      │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16-), TypeName: "INT8"}
-      │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), ReferencedColumnIDs: [1], Usage: REGULAR}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k2_shard_16-), TypeName: "INT8"}
+      │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), ReferencedColumnIDs: [2], Usage: REGULAR}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 5}
-      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key-)}
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_k1_key-)}
       │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
       │    └── 16 Mutation operations
       │         ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_23_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_23_of_24.explain
@@ -1,24 +1,23 @@
 /* setup */
 CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
 CREATE TABLE multiregion_db.public.table_regional_by_row (
-  k INT NOT NULL,
+  k1 INT NOT NULL PRIMARY KEY,
+  k2 INT NOT NULL,
   V STRING
 ) LOCALITY REGIONAL BY ROW;
 CREATE INDEX idx_v on multiregion_db.table_regional_by_row(v);
 
 /* test */
-alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k) USING HASH;
+alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k2) USING HASH;
 EXPLAIN (DDL) rollback at post-commit stage 23 of 24;
 ----
-Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k) USING HASH;
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k2) USING HASH;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 5 elements transitioning toward PUBLIC
+      │    ├── 3 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+), ConstraintID: 1}
       │    │    ├── ABSENT                → PUBLIC      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+)}
-      │    │    ├── ABSENT                → PUBLIC      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 1 (table_regional_by_row_pkey+)}
-      │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (idx_v+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
-      │    │    └── ABSENT                → PUBLIC      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 2 (idx_v+)}
+      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 1 (table_regional_by_row_pkey+)}
       │    ├── 57 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 5 (m-)}
@@ -27,71 +26,70 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 8, SourceIndexID: 1 (table_regional_by_row_pkey+)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 9}
       │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 11, ConstraintID: 10, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 11}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 11}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k_shard_16", ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 11}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k2_shard_16", ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 11}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 4, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 10 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_k1_key-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 10 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 6, SourceIndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 6 (table_regional_by_row_rowid_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 7}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 6 (table_regional_by_row_rowid_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 7}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 6 (table_regional_by_row_rowid_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 7}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_rowid_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
-      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 6 (table_regional_by_row_k1_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 6 (table_regional_by_row_k1_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 6 (table_regional_by_row_k1_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 6 (table_regional_by_row_k1_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_k1_key-)}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 4}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_rowid_key", IndexID: 6 (table_regional_by_row_rowid_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_k1_key", IndexID: 6 (table_regional_by_row_k1_key-)}
       │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 5}
-      │    └── 58 Mutation operations
+      │    └── 55 Mutation operations
       │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
-      │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":2,"TableID":108}}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
       │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":8,"TableID":108}
       │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Ordinal":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":11,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":6,"TableID":108}
@@ -100,34 +98,32 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── MakePublicColumnNotNullValidated {"ColumnID":6,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":11,"Ordinal":1,"TableID":108}
       │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":4,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":5,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":5,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":6,"Kind":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":7,"Kind":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":1,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
-      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":108}
-      │         ├── RefreshStats {"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":10,"Ordinal":1,"TableID":108}
@@ -139,35 +135,35 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
       │    ├── 15 elements transitioning toward ABSENT
       │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 1 (table_regional_by_row_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "idx_v", IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 4 (idx_v-)}
-      │    │    └── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 10 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 4 (idx_v-)}
+      │    │    └── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_k1_key-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 10 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
       │    └── 17 Mutation operations
       │         ├── MakeIndexAbsent {"IndexID":10,"TableID":108}
       │         ├── RemoveColumnNotNull {"ColumnID":6,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":108}
       │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":4,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":4,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
@@ -181,13 +177,13 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 9}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 11}
-      │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16-), TypeName: "INT8"}
-      │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), ReferencedColumnIDs: [1], Usage: REGULAR}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k2_shard_16-), TypeName: "INT8"}
+      │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), ReferencedColumnIDs: [2], Usage: REGULAR}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 5}
-      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key-)}
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_k1_key-)}
       │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
       │    └── 16 Mutation operations
       │         ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_24_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_24_of_24.explain
@@ -1,24 +1,23 @@
 /* setup */
 CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
 CREATE TABLE multiregion_db.public.table_regional_by_row (
-  k INT NOT NULL,
+  k1 INT NOT NULL PRIMARY KEY,
+  k2 INT NOT NULL,
   V STRING
 ) LOCALITY REGIONAL BY ROW;
 CREATE INDEX idx_v on multiregion_db.table_regional_by_row(v);
 
 /* test */
-alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k) USING HASH;
+alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k2) USING HASH;
 EXPLAIN (DDL) rollback at post-commit stage 24 of 24;
 ----
-Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k) USING HASH;
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k2) USING HASH;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 5 elements transitioning toward PUBLIC
+      │    ├── 3 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+), ConstraintID: 1}
       │    │    ├── ABSENT                → PUBLIC      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+)}
-      │    │    ├── ABSENT                → PUBLIC      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 1 (table_regional_by_row_pkey+)}
-      │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (idx_v+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
-      │    │    └── ABSENT                → PUBLIC      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 2 (idx_v+)}
+      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 1 (table_regional_by_row_pkey+)}
       │    ├── 57 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 5 (m-)}
@@ -27,71 +26,70 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 8, SourceIndexID: 1 (table_regional_by_row_pkey+)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 9}
       │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 11, ConstraintID: 10, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 11}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 11}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k_shard_16", ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 11}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k2_shard_16", ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 11}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 4, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 10 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_k1_key-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 10 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 6, SourceIndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 6 (table_regional_by_row_rowid_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 7}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 6 (table_regional_by_row_rowid_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 7}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 6 (table_regional_by_row_rowid_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 7}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_rowid_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
-      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 6 (table_regional_by_row_k1_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 6 (table_regional_by_row_k1_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 6 (table_regional_by_row_k1_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 6 (table_regional_by_row_k1_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_k1_key-)}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 4}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_rowid_key", IndexID: 6 (table_regional_by_row_rowid_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_k1_key", IndexID: 6 (table_regional_by_row_k1_key-)}
       │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 5}
-      │    └── 58 Mutation operations
+      │    └── 55 Mutation operations
       │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
-      │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":2,"TableID":108}}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
       │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":8,"TableID":108}
       │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Ordinal":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":11,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":6,"TableID":108}
@@ -100,34 +98,32 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── MakePublicColumnNotNullValidated {"ColumnID":6,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":11,"Ordinal":1,"TableID":108}
       │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":4,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":5,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":5,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":6,"Kind":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":7,"Kind":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":1,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
-      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":108}
-      │         ├── RefreshStats {"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":10,"Ordinal":1,"TableID":108}
@@ -139,35 +135,35 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
       │    ├── 15 elements transitioning toward ABSENT
       │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 1 (table_regional_by_row_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "idx_v", IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 4 (idx_v-)}
-      │    │    └── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 10 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 4 (idx_v-)}
+      │    │    └── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_k1_key-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 10 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
       │    └── 17 Mutation operations
       │         ├── MakeIndexAbsent {"IndexID":10,"TableID":108}
       │         ├── RemoveColumnNotNull {"ColumnID":6,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":108}
       │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":4,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":4,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
@@ -181,13 +177,13 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 9}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 11}
-      │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16-), TypeName: "INT8"}
-      │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), ReferencedColumnIDs: [1], Usage: REGULAR}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k2_shard_16-), TypeName: "INT8"}
+      │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), ReferencedColumnIDs: [2], Usage: REGULAR}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 5}
-      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key-)}
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_k1_key-)}
       │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
       │    └── 16 Mutation operations
       │         ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_2_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_2_of_24.explain
@@ -1,16 +1,17 @@
 /* setup */
 CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
 CREATE TABLE multiregion_db.public.table_regional_by_row (
-  k INT NOT NULL,
+  k1 INT NOT NULL PRIMARY KEY,
+  k2 INT NOT NULL,
   V STRING
 ) LOCALITY REGIONAL BY ROW;
 CREATE INDEX idx_v on multiregion_db.table_regional_by_row(v);
 
 /* test */
-alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k) USING HASH;
+alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k2) USING HASH;
 EXPLAIN (DDL) rollback at post-commit stage 2 of 24;
 ----
-Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k) USING HASH;
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k2) USING HASH;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
       │    ├── 33 elements transitioning toward ABSENT
@@ -18,30 +19,30 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC           → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 5 (m-)}
       │    │    ├── BACKFILL_ONLY    → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 1 (table_regional_by_row_pkey+)}
       │    │    ├── PUBLIC           → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── WRITE_ONLY       → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 8, SourceIndexID: 1 (table_regional_by_row_pkey+)}
       │    │    ├── TRANSIENT_ABSENT → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 9}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 9}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 9}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 9}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 9}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 9}
       │    │    ├── BACKFILL_ONLY    → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC           → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 9}
       │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── WRITE_ONLY       → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC           → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k_shard_16", ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC           → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── WRITE_ONLY       → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── WRITE_ONLY       → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC           → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k2_shard_16", ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC           → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── WRITE_ONLY       → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
       │    │    ├── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
       │    │    ├── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
@@ -50,19 +51,19 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    └── 32 Mutation operations
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
       │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"Kind":2,"Ordinal":2,"TableID":108}
@@ -89,9 +90,9 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 8, SourceIndexID: 1 (table_regional_by_row_pkey+)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 9}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16-), TypeName: "INT8"}
-      │    │    └── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), ReferencedColumnIDs: [1], Usage: REGULAR}
+      │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k2_shard_16-), TypeName: "INT8"}
+      │    │    └── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), ReferencedColumnIDs: [2], Usage: REGULAR}
       │    └── 10 Mutation operations
       │         ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
       │         ├── CreateGCJobForIndex {"IndexID":8,"TableID":108}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_3_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_3_of_24.explain
@@ -1,16 +1,17 @@
 /* setup */
 CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
 CREATE TABLE multiregion_db.public.table_regional_by_row (
-  k INT NOT NULL,
+  k1 INT NOT NULL PRIMARY KEY,
+  k2 INT NOT NULL,
   V STRING
 ) LOCALITY REGIONAL BY ROW;
 CREATE INDEX idx_v on multiregion_db.table_regional_by_row(v);
 
 /* test */
-alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k) USING HASH;
+alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k2) USING HASH;
 EXPLAIN (DDL) rollback at post-commit stage 3 of 24;
 ----
-Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k) USING HASH;
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k2) USING HASH;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
       │    ├── 33 elements transitioning toward ABSENT
@@ -18,30 +19,30 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC           → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 5 (m-)}
       │    │    ├── BACKFILL_ONLY    → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 1 (table_regional_by_row_pkey+)}
       │    │    ├── PUBLIC           → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── WRITE_ONLY       → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 8, SourceIndexID: 1 (table_regional_by_row_pkey+)}
       │    │    ├── TRANSIENT_ABSENT → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 9}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 9}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 9}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 9}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 9}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 9}
       │    │    ├── BACKFILL_ONLY    → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC           → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 9}
       │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── WRITE_ONLY       → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC           → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k_shard_16", ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC           → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── WRITE_ONLY       → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── WRITE_ONLY       → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC           → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k2_shard_16", ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC           → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── WRITE_ONLY       → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
       │    │    ├── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
       │    │    ├── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
@@ -50,19 +51,19 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    └── 32 Mutation operations
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
       │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"Kind":2,"Ordinal":2,"TableID":108}
@@ -89,9 +90,9 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 8, SourceIndexID: 1 (table_regional_by_row_pkey+)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 9}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16-), TypeName: "INT8"}
-      │    │    └── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), ReferencedColumnIDs: [1], Usage: REGULAR}
+      │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k2_shard_16-), TypeName: "INT8"}
+      │    │    └── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), ReferencedColumnIDs: [2], Usage: REGULAR}
       │    └── 10 Mutation operations
       │         ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
       │         ├── CreateGCJobForIndex {"IndexID":8,"TableID":108}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_4_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_4_of_24.explain
@@ -1,16 +1,17 @@
 /* setup */
 CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
 CREATE TABLE multiregion_db.public.table_regional_by_row (
-  k INT NOT NULL,
+  k1 INT NOT NULL PRIMARY KEY,
+  k2 INT NOT NULL,
   V STRING
 ) LOCALITY REGIONAL BY ROW;
 CREATE INDEX idx_v on multiregion_db.table_regional_by_row(v);
 
 /* test */
-alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k) USING HASH;
+alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k2) USING HASH;
 EXPLAIN (DDL) rollback at post-commit stage 4 of 24;
 ----
-Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k) USING HASH;
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k2) USING HASH;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
       │    ├── 33 elements transitioning toward ABSENT
@@ -18,30 +19,30 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC           → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 5 (m-)}
       │    │    ├── DELETE_ONLY      → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 1 (table_regional_by_row_pkey+)}
       │    │    ├── PUBLIC           → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── WRITE_ONLY       → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 8, SourceIndexID: 1 (table_regional_by_row_pkey+)}
       │    │    ├── TRANSIENT_ABSENT → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 9}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 9}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 9}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 9}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 9}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 9}
       │    │    ├── BACKFILL_ONLY    → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC           → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 9}
       │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── WRITE_ONLY       → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC           → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k_shard_16", ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC           → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── WRITE_ONLY       → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── WRITE_ONLY       → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC           → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k2_shard_16", ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC           → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── WRITE_ONLY       → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
       │    │    ├── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
       │    │    ├── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
@@ -50,19 +51,19 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    └── 32 Mutation operations
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
       │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"Kind":2,"Ordinal":2,"TableID":108}
@@ -89,9 +90,9 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 8, SourceIndexID: 1 (table_regional_by_row_pkey+)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 9}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16-), TypeName: "INT8"}
-      │    │    └── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), ReferencedColumnIDs: [1], Usage: REGULAR}
+      │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k2_shard_16-), TypeName: "INT8"}
+      │    │    └── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), ReferencedColumnIDs: [2], Usage: REGULAR}
       │    └── 10 Mutation operations
       │         ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
       │         ├── CreateGCJobForIndex {"IndexID":8,"TableID":108}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_5_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_5_of_24.explain
@@ -1,16 +1,17 @@
 /* setup */
 CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
 CREATE TABLE multiregion_db.public.table_regional_by_row (
-  k INT NOT NULL,
+  k1 INT NOT NULL PRIMARY KEY,
+  k2 INT NOT NULL,
   V STRING
 ) LOCALITY REGIONAL BY ROW;
 CREATE INDEX idx_v on multiregion_db.table_regional_by_row(v);
 
 /* test */
-alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k) USING HASH;
+alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k2) USING HASH;
 EXPLAIN (DDL) rollback at post-commit stage 5 of 24;
 ----
-Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k) USING HASH;
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k2) USING HASH;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
       │    ├── 33 elements transitioning toward ABSENT
@@ -18,30 +19,30 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC           → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 5 (m-)}
       │    │    ├── MERGE_ONLY       → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 1 (table_regional_by_row_pkey+)}
       │    │    ├── PUBLIC           → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── WRITE_ONLY       → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 8, SourceIndexID: 1 (table_regional_by_row_pkey+)}
       │    │    ├── TRANSIENT_ABSENT → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 9}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 9}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 9}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 9}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 9}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 9}
       │    │    ├── BACKFILL_ONLY    → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC           → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 9}
       │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── WRITE_ONLY       → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC           → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k_shard_16", ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC           → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── WRITE_ONLY       → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── WRITE_ONLY       → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC           → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k2_shard_16", ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC           → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── WRITE_ONLY       → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
       │    │    ├── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
       │    │    ├── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
@@ -51,14 +52,14 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
       │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":6,"TableID":108}
@@ -71,10 +72,10 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":10,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnNotNull {"ColumnID":6,"TableID":108}
@@ -90,9 +91,9 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 8, SourceIndexID: 1 (table_regional_by_row_pkey+)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 9}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16-), TypeName: "INT8"}
-      │    │    └── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), ReferencedColumnIDs: [1], Usage: REGULAR}
+      │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k2_shard_16-), TypeName: "INT8"}
+      │    │    └── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), ReferencedColumnIDs: [2], Usage: REGULAR}
       │    └── 11 Mutation operations
       │         ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":8,"TableID":108}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_6_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_6_of_24.explain
@@ -1,16 +1,17 @@
 /* setup */
 CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
 CREATE TABLE multiregion_db.public.table_regional_by_row (
-  k INT NOT NULL,
+  k1 INT NOT NULL PRIMARY KEY,
+  k2 INT NOT NULL,
   V STRING
 ) LOCALITY REGIONAL BY ROW;
 CREATE INDEX idx_v on multiregion_db.table_regional_by_row(v);
 
 /* test */
-alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k) USING HASH;
+alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k2) USING HASH;
 EXPLAIN (DDL) rollback at post-commit stage 6 of 24;
 ----
-Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k) USING HASH;
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k2) USING HASH;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
       │    ├── 33 elements transitioning toward ABSENT
@@ -18,30 +19,30 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC           → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 5 (m-)}
       │    │    ├── MERGE_ONLY       → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 1 (table_regional_by_row_pkey+)}
       │    │    ├── PUBLIC           → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── WRITE_ONLY       → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 8, SourceIndexID: 1 (table_regional_by_row_pkey+)}
       │    │    ├── TRANSIENT_ABSENT → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 9}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 9}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 9}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 9}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 9}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 9}
       │    │    ├── BACKFILL_ONLY    → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC           → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 9}
       │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── WRITE_ONLY       → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC           → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k_shard_16", ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC           → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── WRITE_ONLY       → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── WRITE_ONLY       → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC           → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k2_shard_16", ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC           → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── WRITE_ONLY       → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
       │    │    ├── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
       │    │    ├── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
@@ -51,14 +52,14 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
       │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":6,"TableID":108}
@@ -71,10 +72,10 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":10,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnNotNull {"ColumnID":6,"TableID":108}
@@ -90,9 +91,9 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 8, SourceIndexID: 1 (table_regional_by_row_pkey+)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 9}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16-), TypeName: "INT8"}
-      │    │    └── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), ReferencedColumnIDs: [1], Usage: REGULAR}
+      │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k2_shard_16-), TypeName: "INT8"}
+      │    │    └── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), ReferencedColumnIDs: [2], Usage: REGULAR}
       │    └── 11 Mutation operations
       │         ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":8,"TableID":108}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_7_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_7_of_24.explain
@@ -1,16 +1,17 @@
 /* setup */
 CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
 CREATE TABLE multiregion_db.public.table_regional_by_row (
-  k INT NOT NULL,
+  k1 INT NOT NULL PRIMARY KEY,
+  k2 INT NOT NULL,
   V STRING
 ) LOCALITY REGIONAL BY ROW;
 CREATE INDEX idx_v on multiregion_db.table_regional_by_row(v);
 
 /* test */
-alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k) USING HASH;
+alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k2) USING HASH;
 EXPLAIN (DDL) rollback at post-commit stage 7 of 24;
 ----
-Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k) USING HASH;
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k2) USING HASH;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
       │    ├── 33 elements transitioning toward ABSENT
@@ -18,30 +19,30 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 5 (m-)}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 1 (table_regional_by_row_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 8, SourceIndexID: 1 (table_regional_by_row_pkey+)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 9}
       │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k_shard_16", ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k2_shard_16", ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
@@ -51,18 +52,18 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
       │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"Kind":2,"Ordinal":2,"TableID":108}
@@ -89,9 +90,9 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 9}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16-), TypeName: "INT8"}
-      │    │    └── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), ReferencedColumnIDs: [1], Usage: REGULAR}
+      │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k2_shard_16-), TypeName: "INT8"}
+      │    │    └── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), ReferencedColumnIDs: [2], Usage: REGULAR}
       │    └── 10 Mutation operations
       │         ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":8,"TableID":108}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_8_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_8_of_24.explain
@@ -1,16 +1,17 @@
 /* setup */
 CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
 CREATE TABLE multiregion_db.public.table_regional_by_row (
-  k INT NOT NULL,
+  k1 INT NOT NULL PRIMARY KEY,
+  k2 INT NOT NULL,
   V STRING
 ) LOCALITY REGIONAL BY ROW;
 CREATE INDEX idx_v on multiregion_db.table_regional_by_row(v);
 
 /* test */
-alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k) USING HASH;
+alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k2) USING HASH;
 EXPLAIN (DDL) rollback at post-commit stage 8 of 24;
 ----
-Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k) USING HASH;
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k2) USING HASH;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
       │    ├── 33 elements transitioning toward ABSENT
@@ -18,30 +19,30 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 5 (m-)}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 1 (table_regional_by_row_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 8, SourceIndexID: 1 (table_regional_by_row_pkey+)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 9}
       │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k_shard_16", ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k2_shard_16", ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
@@ -51,18 +52,18 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
       │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"Kind":2,"Ordinal":2,"TableID":108}
@@ -89,9 +90,9 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 9}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16-), TypeName: "INT8"}
-      │    │    └── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), ReferencedColumnIDs: [1], Usage: REGULAR}
+      │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k2_shard_16-), TypeName: "INT8"}
+      │    │    └── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), ReferencedColumnIDs: [2], Usage: REGULAR}
       │    └── 10 Mutation operations
       │         ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":8,"TableID":108}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_9_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_9_of_24.explain
@@ -1,16 +1,17 @@
 /* setup */
 CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
 CREATE TABLE multiregion_db.public.table_regional_by_row (
-  k INT NOT NULL,
+  k1 INT NOT NULL PRIMARY KEY,
+  k2 INT NOT NULL,
   V STRING
 ) LOCALITY REGIONAL BY ROW;
 CREATE INDEX idx_v on multiregion_db.table_regional_by_row(v);
 
 /* test */
-alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k) USING HASH;
+alter table multiregion_db.table_regional_by_row add column m int8 default unique_rowid(), alter primary key using columns(k2) USING HASH;
 EXPLAIN (DDL) rollback at post-commit stage 9 of 24;
 ----
-Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k) USING HASH;
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (k2) USING HASH;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
       │    ├── 3 elements transitioning toward PUBLIC
@@ -25,43 +26,43 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 8, SourceIndexID: 1 (table_regional_by_row_pkey+)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 9}
       │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── DELETE_ONLY           → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 11, ConstraintID: 10, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 11}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 11}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 11}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k_shard_16", ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC                → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 11}
-      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "crdb_internal_k2_shard_16", ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnHidden:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 11}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 4 (idx_v-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 4 (idx_v-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 4 (idx_v-)}
       │    │    ├── DELETE_ONLY           → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 4, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
       │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
@@ -73,18 +74,18 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":8,"TableID":108}
       │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Ordinal":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":11,"Kind":2,"Ordinal":2,"TableID":108}
@@ -93,13 +94,13 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── MakeColumnVisible {"ColumnID":6,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":10,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":11,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":4,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":4,"Kind":1,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":5,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":5,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
@@ -119,21 +120,21 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
       │    ├── 9 elements transitioning toward ABSENT
       │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 1 (table_regional_by_row_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (rowid), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k1), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (k2), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (v), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 8 (table_regional_by_row_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
-      │    │    ├── PUBLIC      → ABSENT      ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16-), TypeName: "INT8"}
-      │    │    └── PUBLIC      → ABSENT      ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), ReferencedColumnIDs: [1], Usage: REGULAR}
+      │    │    ├── DELETE_ONLY → ABSENT      Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-)}
+      │    │    ├── PUBLIC      → ABSENT      ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k2_shard_16-), TypeName: "INT8"}
+      │    │    └── PUBLIC      → ABSENT      ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k2_shard_16-), ReferencedColumnIDs: [2], Usage: REGULAR}
       │    └── 10 Mutation operations
       │         ├── RemoveColumnComputeExpression {"ColumnID":6,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Ordinal":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":108}
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":6,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}

--- a/pkg/sql/catalog/tabledesc/index.go
+++ b/pkg/sql/catalog/tabledesc/index.go
@@ -49,6 +49,12 @@ func (w index) IndexDescDeepCopy() descpb.IndexDescriptor {
 	return *protoutil.Clone(w.desc).(*descpb.IndexDescriptor)
 }
 
+// Adding returns true if this index is not yet usable for reads. This is
+// the case either when the index is in an ADD mutation (not yet public) or
+// when it is a secondary index being recreated during an ALTER PRIMARY KEY
+// operation and the new primary key has not yet become public. In the
+// latter case, the recreated index may lack key columns from the old
+// primary key and cannot serve correct results.
 func (w index) Adding() bool {
 	// Either the index is adding or is a recreated index that needs
 	// to be temporarily hidden.

--- a/pkg/sql/opt/cat/table.go
+++ b/pkg/sql/opt/cat/table.go
@@ -69,6 +69,9 @@ type Table interface {
 	// This method should be used when mutation columns can be ignored (the common
 	// case). The returned indexes include the primary index, so the count is
 	// always >= 1.
+	// This count excludes secondary indexes that are not ready for reads yet.
+	// Those are indexes that are created during a primary index swap and are not
+	// usable until the new primary index goes public.
 	IndexCount() int
 
 	// WritableIndexCount returns the number of public and write-only indexes

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -903,6 +903,11 @@ type optTable struct {
 	// indexes.
 	indexes []optIndex
 
+	// readableIndexCount is the number of indexes usable for reads. Non-readable
+	// public indexes (e.g. those being recreated during ALTER PRIMARY KEY) are
+	// reordered past this boundary.
+	readableIndexCount int
+
 	// codec is capable of encoding sql table keys.
 	codec keys.SQLCodec
 
@@ -1086,7 +1091,37 @@ func newOptTable(
 		}
 	}
 
-	// Build the indexes.
+	// Build the indexes. Reorder public secondary indexes so that readable
+	// indexes (those not being added or recreated) come before non-readable
+	// ones. This allows IndexCount to only include indexes that can be used
+	// for reads.
+	// Non-readable indexes are the secondary indexes that are recreated
+	// during a primary key swap that may lack key columns from the old
+	// primary key and cannot be used for look ups.
+	numPublicSecondary := len(desc.ActiveIndexes()) - 1
+	readableCount := 0
+	for i := 0; i < numPublicSecondary; i++ {
+		if !secondaryIndexes[i].Adding() {
+			readableCount++
+		}
+	}
+	if readableCount < numPublicSecondary {
+		reordered := make([]catalog.Index, len(secondaryIndexes))
+		ri, ni := 0, readableCount
+		for i := 0; i < numPublicSecondary; i++ {
+			if !secondaryIndexes[i].Adding() {
+				reordered[ri] = secondaryIndexes[i]
+				ri++
+			} else {
+				reordered[ni] = secondaryIndexes[i]
+				ni++
+			}
+		}
+		copy(reordered[numPublicSecondary:], secondaryIndexes[numPublicSecondary:])
+		secondaryIndexes = reordered
+	}
+	ot.readableIndexCount = 1 + readableCount
+
 	ot.indexes = make([]optIndex, 1+len(secondaryIndexes))
 	// partZones is allocated lazily and is reused for all indexes.
 	var partZones map[string]cat.Zone
@@ -1427,8 +1462,7 @@ func (ot *optTable) getCol(i int) catalog.Column {
 
 // IndexCount is part of the cat.Table interface.
 func (ot *optTable) IndexCount() int {
-	// Primary index is always present, so count is always >= 1.
-	return len(ot.desc.ActiveIndexes())
+	return ot.readableIndexCount
 }
 
 // WritableIndexCount is part of the cat.Table interface.

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
@@ -1722,14 +1722,6 @@ func (pic *primaryIndexChain) deflate(b BuildCtx) {
 		redundants = append(redundants, idxSpec)
 		redundantIDs[idxSpec] = true
 	}
-	hasRedundantID := func(id catid.IndexID) bool {
-		for _, r := range redundants {
-			if r.indexID() == id {
-				return true
-			}
-		}
-		return false
-	}
 
 	if haveSameIndexCols(b, tableID, pic.oldSpec.primary.IndexID, pic.inter1Spec.primary.IndexID) {
 		markAsRedundant(&pic.inter1Spec)
@@ -1771,24 +1763,12 @@ func (pic *primaryIndexChain) deflate(b BuildCtx) {
 	// primary index will cause us to fail to retrieve the element to drop).
 	for _, redundant := range redundants {
 		// For new replacement secondary indexes we need to select the index to
-		// publish this index with. The source index ID is an excellent candidate
-		// as long as its not the old primary index (i.e. we folded all earlier
-		// primary indexes).
-		recreateTargetID := redundant.SourceIndexID()
-		if recreateTargetID == pic.oldSpec.primary.IndexID || hasRedundantID(recreateTargetID) {
-			// Otherwise, we need to select the next valid index in the chain, that
-			// follows the redundant one.
-			firstMatch := false
-			specs := pic.allPrimaryIndexSpecs(func(spec *indexSpec) bool {
-				if spec.indexID() == recreateTargetID {
-					firstMatch = true
-					return false
-				}
-				return !redundantIDs[spec] && firstMatch
-			})
-			if len(specs) > 0 {
-				recreateTargetID = specs[0].indexID()
-			}
+		// publish this index with. The final index ID is an excellent candidate
+		// because it is guaranteed to have the new key columns. If the final index
+		// is also redundant, we can use old primary index ID as the replacement.
+		recreateTargetID := pic.finalSpec.indexID()
+		if redundantIDs[&pic.finalSpec] {
+			recreateTargetID = pic.oldSpec.indexID()
 		}
 		updateElementsToDependOnNewFromOld(b, tableID,
 			redundant.indexID(), redundant.SourceIndexID(), recreateTargetID, catid.IndexSet{} /* excludes */)


### PR DESCRIPTION
Previously, the optimizer considered all secondary indexes (including the invisible ones) when checking constraints. This caused an issue during alter primary key because the recreated secondary index is not ready to use. This change adds an additional check in the optimizer to ensure these indexes are not used too soon.

Fixes #164309