### PR TITLE
sql/copy: deflake TestLargeCopy by enabling retries in non-atomic mode

### DIFF
--- a/pkg/sql/copy/copy_test.go
+++ b/pkg/sql/copy/copy_test.go
@@ -728,6 +728,8 @@ func TestLargeCopy(t *testing.T) {
 	if rng.Float64() < 0.5 {
 		_, err = sqlDB.Exec("SET copy_from_atomic_enabled = false")
 		require.NoError(t, err)
+		_, err = sqlDB.Exec("SET copy_from_retries_enabled = true")
+		require.NoError(t, err)
 		atomicCopy = false
 	}
 


### PR DESCRIPTION
`TestLargeCopy` randomly chooses between atomic and non-atomic COPY mode.
In non-atomic mode, the test disables `copy_from_atomic_enabled` but does
not enable `copy_from_retries_enabled`. This means retryable errors
(`TransactionRetryWithProtoRefreshError` / SQLSTATE 40001) are not handled
by the internal COPY retry mechanism, and the test's `ignoreErr` function
only ignores `SerializationFailure` in atomic mode.

Enable `copy_from_retries_enabled` alongside disabling atomic mode so that
the per-batch retry mechanism handles transient conflicts automatically.

Fixes: #164185
Epic: CRDB-60677
Release note: None