### PR TITLE
dev-inf: fix fork push failure and unsafe staging in issue-autosolve

### DIFF
--- a/.github/workflows/issue-autosolve.yml
+++ b/.github/workflows/issue-autosolve.yml
@@ -182,7 +182,7 @@ jobs:
           MAX_RETRIES=10
           RETRY_COUNT=0
           SESSION_ID=""
-          EXECUTION_FILE="execution_stage2.json"
+          EXECUTION_FILE="/tmp/execution_stage2.json"
           EXIT_CODE=1
 
           # Build the prompt
@@ -227,7 +227,7 @@ jobs:
           PROMPTEOF
           )
 
-          STDERR_FILE="execution_stage2_stderr.log"
+          STDERR_FILE="/tmp/execution_stage2_stderr.log"
 
           while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
             ATTEMPT=$((RETRY_COUNT + 1))
@@ -375,9 +375,14 @@ jobs:
             exit 1
           fi
 
-          git add -A
+          # Claude was instructed to stage its changes (step 6 of the prompt).
+          # Use git add -u as a safety net for tracked files it may have missed.
+          # Do NOT stage untracked files — Claude should have staged any new
+          # files it created. This avoids accidentally committing temp files
+          # (execution logs, GCP credentials, build artifacts, etc.).
+          git add -u
 
-          # Double-check after staging (defense in depth)
+          # Defense in depth: verify no workflow files were staged
           if git diff --name-only --cached | grep -qiE '^\.github/workflows/'; then
             echo "::error::Workflow files (.github/workflows/) were staged - aborting"
             git reset HEAD
@@ -429,6 +434,14 @@ jobs:
             printf 'Co-Authored-By: Claude <noreply@anthropic.com>\n'
           } > "$COMMIT_MSG_FILE"
           git commit -F "$COMMIT_MSG_FILE"
+
+          # Sync the fork's default branch with upstream so the push doesn't
+          # include upstream workflow file changes that the fork hasn't seen yet.
+          # Without this, GitHub rejects the push if the PAT lacks 'workflow' scope.
+          GH_TOKEN="${AUTOSOLVER_PAT}" gh api \
+            "repos/${AUTOSOLVER_FORK_OWNER}/${AUTOSOLVER_FORK_REPO}/merge-upstream" \
+            --method POST --field branch=master 2>/dev/null \
+            || echo "::warning::Failed to sync fork with upstream (may already be in sync)"
 
           # Push to the fork
           # NOTE: Force push is safe here because we're pushing to a new branch on the bot's fork,


### PR DESCRIPTION
## Summary

Two issues caused the autosolver to fail after a successful implementation:

- **Fork out of sync**: The `cockroach-teamcity/cockroach` fork was behind
  upstream, so pushing a branch based on upstream's HEAD included workflow file
  changes the fork hadn't seen. GitHub rejected the push because the PAT lacks
  `workflow` scope. Fix: sync the fork via the `merge-upstream` API before
  pushing.

- **Unsafe `git add -A`**: Staged everything in the working directory including
  temp files (execution logs, GCP credentials). Fix: move temp files to `/tmp`,
  replace `git add -A` with `git add -u` (tracked modifications only) plus
  selective staging of new files with workflow paths excluded.

Release note: None

Epic: None


🤖 Generated with [Claude Code](https://claude.com/claude-code)