### PR TITLE
sql: support statement hint in routine body with SQL language

### DIFF
--- a/pkg/sql/hints/hint_table.go
+++ b/pkg/sql/hints/hint_table.go
@@ -263,6 +263,77 @@ func DeleteHintFromDB(
 	return rowIDs, fingerprints, hintBytes, nil
 }
 
+// TryInjectHints attempts to apply hint injection to the given AST
+// using the provided hints. It returns the rewritten AST if a hint was
+// successfully injected, or nil if no hints were applied. The
+// wrapperAST is the original (possibly wrapper) AST used to re-wrap the
+// injected AST when the original was a wrapper statement (e.g. CopyTo,
+// Explain, ExplainAnalyze and Prepare). nil for wrapperAST when no
+// re-wrapping is needed (e.g. routine bodies).
+func TryInjectHints(
+	ctx context.Context,
+	stmtHints []Hint,
+	hintIDs []int64,
+	ast tree.Statement,
+	wrapperAST tree.Statement,
+	fmtFlags tree.FmtFlags,
+) tree.Statement {
+	for i, hint := range stmtHints {
+		if !hint.Enabled || hint.Err != nil {
+			continue
+		}
+		hd := hint.HintInjectionDonor
+		if hd == nil {
+			continue
+		}
+		if err := hd.Validate(ast, fmtFlags); err != nil {
+			log.Eventf(
+				ctx, "failed to validate hint injection donor from external statement hint %v: %v",
+				hintIDs[i], err,
+			)
+			// Do not return the error. Instead we'll simply execute the query
+			// without this hint.
+			continue
+		}
+		injectedAST, injected, err := hd.InjectHints(ast)
+		if err != nil {
+			log.Eventf(
+				ctx, "failed to inject hints from external statement hint %v: %v", hintIDs[i], err,
+			)
+			// Do not return the error. Instead we'll simply execute the query
+			// without this hint.
+			continue
+		}
+		if !injected {
+			continue
+		}
+		log.Eventf(ctx, "injected hints from external statement hint %v", hintIDs[i])
+		// Re-wrap the injected AST if the original was a wrapper statement.
+		if wrapperAST != nil {
+			switch e := wrapperAST.(type) {
+			case *tree.CopyTo:
+				copyTo := *e
+				copyTo.Statement = injectedAST
+				return &copyTo
+			case *tree.Explain:
+				explain := *e
+				explain.Statement = injectedAST
+				return &explain
+			case *tree.ExplainAnalyze:
+				explain := *e
+				explain.Statement = injectedAST
+				return &explain
+			case *tree.Prepare:
+				prepare := *e
+				prepare.Statement = injectedAST
+				return &prepare
+			}
+		}
+		return injectedAST
+	}
+	return nil
+}
+
 // Size returns an estimate of the memory usage of the Hint in bytes.
 func (hint *Hint) Size() int64 {
 	res := int64(unsafe.Sizeof(*hint))

--- a/pkg/sql/opt/cat/catalog.go
+++ b/pkg/sql/opt/cat/catalog.go
@@ -234,6 +234,11 @@ type Catalog interface {
 	// returns an error.
 	CheckExecutionPrivilege(ctx context.Context, oid oid.Oid, user username.SQLUsername) error
 
+	// TryRewriteWithStmtHints looks up statement hints for the given
+	// fingerprint and returns a rewritten AST with injected hints. If no
+	// hints match, it returns the original AST.
+	TryRewriteWithStmtHints(ctx context.Context, fingerprint string, ast tree.Statement, fmtFlags tree.FmtFlags) tree.Statement
+
 	// HasAdminRole checks that the current user has admin privileges. If yes,
 	// returns true. Returns an error if query on the `system.users` table failed
 	HasAdminRole(ctx context.Context) (bool, error)

--- a/pkg/sql/opt/exec/execbuilder/testdata/statement_hint_builtins
+++ b/pkg/sql/opt/exec/execbuilder/testdata/statement_hint_builtins
@@ -1564,3 +1564,90 @@ FROM system.statement_hints
 WHERE row_id = $inject_db_hint_id
 ----
 mydb  |  SELECT y FROM xy WHERE y = _
+
+subtest within_routine_hints
+
+statement ok
+CREATE TABLE drivers (
+  id INT PRIMARY KEY,
+  name STRING,
+  team STRING,
+  INDEX drivers_name_idx (name) STORING (team)
+)
+
+statement ok
+CREATE FUNCTION op() RETURNS STRING LANGUAGE SQL STABLE AS $$
+SELECT team FROM drivers WHERE name = 'oscar piastri';
+$$;
+
+statement ok
+SELECT information_schema.crdb_rewrite_inline_hints(
+  'SELECT team FROM drivers WHERE name = _',
+  'SELECT team FROM drivers@drivers_pkey WHERE name = _'
+)
+
+statement ok
+SELECT crdb_internal.await_statement_hints_cache()
+
+# Routine body statements use fully-qualified table names, so the hint
+# fingerprint must also use fully-qualified names. So though with hints,
+# we still use the drivers_name_idx, since the table name is not fully
+# qualified in the added hint.
+query T
+EXPLAIN SELECT op();
+----
+distribution: local
+·
+• root
+│
+├── • values
+│     size: 1 column, 1 row
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: <unknown>
+    │ exec mode: one row
+    │
+    └── • scan
+          missing stats
+          table: drivers@drivers_name_idx
+          spans: [/'oscar piastri' - /'oscar piastri']
+          limit: 1
+
+# Insert statement hint with fully qualified table name.
+statement ok
+SELECT information_schema.crdb_rewrite_inline_hints(
+  'SELECT team FROM test.public.drivers WHERE name = _',
+  'SELECT team FROM test.public.drivers@drivers_pkey WHERE name = _'
+)
+
+statement ok
+SELECT crdb_internal.await_statement_hints_cache()
+
+query T
+EXPLAIN SELECT op();
+----
+distribution: local
+·
+• root
+│
+├── • values
+│     size: 1 column, 1 row
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: <unknown>
+    │ exec mode: one row
+    │
+    └── • limit
+        │ count: 1
+        │
+        └── • filter
+            │ filter: name = 'oscar piastri'
+            │
+            └── • scan
+                  missing stats
+                  table: drivers@drivers_pkey
+                  spans: FULL SCAN (SOFT LIMIT)
+
+subtest end

--- a/pkg/sql/opt/optbuilder/routine.go
+++ b/pkg/sql/opt/optbuilder/routine.go
@@ -450,10 +450,11 @@ func (b *Builder) buildRoutine(
 		bodyProps = make([]*physical.Required, len(stmts))
 		bodyTags = make([]string, len(stmts))
 		bodyASTs = make([]tree.Statement, len(stmts))
+		fmtFlags := tree.FmtHideConstants | tree.FmtFlags(tree.QueryFormattingForFingerprintsMask.Get(&b.evalCtx.Settings.SV))
 		for i := range stmts {
-			// TODO(michae2): We should be checking the statement hints cache here to
-			// find any external statement hints that could apply to this statement.
-			stmtScope := b.buildStmtAtRootWithScope(stmts[i].AST, nil /* desiredTypes */, bodyScope)
+			hintStmtFingerprint := tree.FormatStatementHideConstants(stmts[i].AST, fmtFlags)
+			maybeHintedStmt := b.catalog.TryRewriteWithStmtHints(b.ctx, hintStmtFingerprint, stmts[i].AST, fmtFlags)
+			stmtScope := b.buildStmtAtRootWithScope(maybeHintedStmt, nil /* desiredTypes */, bodyScope)
 
 			// The last statement produces the output of the UDF.
 			if i == len(stmts)-1 {
@@ -468,7 +469,7 @@ func (b *Builder) buildRoutine(
 			if appendedNullForVoidReturn && i == len(stmts)-1 {
 				bodyTags[i] = ""
 			} else {
-				bodyTags[i] = stmts[i].AST.StatementTag()
+				bodyTags[i] = maybeHintedStmt.StatementTag()
 			}
 
 		}

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -322,6 +322,13 @@ func (tc *Catalog) CheckAnyPrivilege(ctx context.Context, o cat.Object) error {
 	return nil
 }
 
+// TryRewriteWithStmtHints is part of the cat.Catalog interface.
+func (tc *Catalog) TryRewriteWithStmtHints(
+	ctx context.Context, fingerprint string, ast tree.Statement, fmtFlags tree.FmtFlags,
+) tree.Statement {
+	return ast
+}
+
 // CheckExecutionPrivilege is part of the cat.Catalog interface.
 func (tc *Catalog) CheckExecutionPrivilege(
 	ctx context.Context, oid oid.Oid, user username.SQLUsername,

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/resolver"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/hints"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/indexrec"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -476,6 +477,23 @@ func (oc *optCatalog) CheckExecutionPrivilege(
 		return errors.WithAssertionFailure(err)
 	}
 	return oc.planner.CheckPrivilegeForUser(ctx, desc, privilege.EXECUTE, user)
+}
+
+// TryRewriteWithStmtHints is part of the cat.Catalog interface.
+func (oc *optCatalog) TryRewriteWithStmtHints(
+	ctx context.Context, fingerprint string, ast tree.Statement, fmtFlags tree.FmtFlags,
+) tree.Statement {
+	hintCache := oc.planner.execCfg.StatementHintsCache
+	if hintCache == nil {
+		return ast
+	}
+	stmtHints, hintIDs := hintCache.MaybeGetStatementHints(ctx, fingerprint, fmtFlags)
+	if injected := hints.TryInjectHints(
+		ctx, stmtHints, hintIDs, ast, nil /* wrapperAST */, fmtFlags,
+	); injected != nil {
+		return injected
+	}
+	return ast
 }
 
 // HasAdminRole is part of the cat.Catalog interface.

--- a/pkg/sql/statement.go
+++ b/pkg/sql/statement.go
@@ -138,7 +138,7 @@ func (s Statement) String() string {
 func (s *Statement) ReloadHintsIfStale(
 	ctx context.Context, fmtFlags tree.FmtFlags, statementHintsCache *hints.StatementHintsCache,
 ) bool {
-	var hints []hints.Hint
+	var stmtHints []hints.Hint
 	var hintIDs []int64
 	var hintsGeneration int64
 	if statementHintsCache != nil {
@@ -167,69 +167,20 @@ func (s *Statement) ReloadHintsIfStale(
 			ast = e.Statement
 			hintStmtFingerprint = tree.FormatStatementHideConstants(ast, fmtFlags)
 		}
-		hints, hintIDs = statementHintsCache.MaybeGetStatementHints(ctx, hintStmtFingerprint, fmtFlags)
+		stmtHints, hintIDs = statementHintsCache.MaybeGetStatementHints(ctx, hintStmtFingerprint, fmtFlags)
 	}
 	if slices.Equal(hintIDs, s.HintIDs) {
 		return false
 	}
-	s.Hints = hints
+	s.Hints = stmtHints
 	s.HintIDs = hintIDs
 	s.HintsGeneration = hintsGeneration
-	s.ASTWithInjectedHints = nil
 
 	log.Eventf(
 		ctx, "loaded %d external statement hints from the statement hints cache: %v",
 		len(s.Hints), s.HintIDs,
 	)
 
-	for i, hint := range s.Hints {
-		if !hint.Enabled || hint.Err != nil {
-			continue
-		}
-		if hd := hint.HintInjectionDonor; hd != nil && s.ASTWithInjectedHints == nil {
-			if err := hd.Validate(ast, fmtFlags); err != nil {
-				log.Eventf(
-					ctx, "failed to validate hint injection donor from external statement hint %v: %v",
-					s.HintIDs[i], err,
-				)
-				// Do not return the error. Instead we'll simply execute the query
-				// without this hint.
-				continue
-			}
-			injectedAST, injected, err := hd.InjectHints(ast)
-			if err != nil {
-				log.Eventf(
-					ctx, "failed to inject hints from external statement hint %v: %v", s.HintIDs[i], err,
-				)
-				// Do not return the error. Instead we'll simply execute the query
-				// without this hint.
-				continue
-			}
-			if injected {
-				log.Eventf(ctx, "injected hints from external statement hint %v", s.HintIDs[i])
-				// If we unwrapped the AST above, we need to re-wrap the rewritten AST here.
-				s.ASTWithInjectedHints = injectedAST
-				switch e := s.AST.(type) {
-				case *tree.CopyTo:
-					copyTo := *e
-					copyTo.Statement = injectedAST
-					s.ASTWithInjectedHints = &copyTo
-				case *tree.Explain:
-					explain := *e
-					explain.Statement = injectedAST
-					s.ASTWithInjectedHints = &explain
-				case *tree.ExplainAnalyze:
-					explain := *e
-					explain.Statement = injectedAST
-					s.ASTWithInjectedHints = &explain
-				case *tree.Prepare:
-					prepare := *e
-					prepare.Statement = injectedAST
-					s.ASTWithInjectedHints = &prepare
-				}
-				break
-			}
-		}
-	}
+	s.ASTWithInjectedHints = hints.TryInjectHints(ctx, s.Hints, s.HintIDs, ast, s.AST, fmtFlags)
 	return true
 }


### PR DESCRIPTION
informs: https://github.com/cockroachdb/cockroach/pull/162627

This commit is to ensure statements within routines defined by SQL
language respect hint injections.

Note that the routines written in PLpgSQL language are not covered in
this commit.

Release note (bug fix): ensure statements within routines body defined by SQL
language respect hint injections.