### PR TITLE
admission: set minimums on cpu time granter buckets

### DIFF
--- a/pkg/util/admission/cpu_time_token_filler.go
+++ b/pkg/util/admission/cpu_time_token_filler.go
@@ -231,6 +231,10 @@ type rates [numResourceTiers][numBurstQualifications]int64
 // buckets, one per bucket in cpuTimeTokenGranter.
 type capacities [numResourceTiers][numBurstQualifications]int64
 
+// minimums stores the minimum number of tokens that can be in the
+// buckets, one per bucket in cpuTimeTokenGranter.
+type minimums [numResourceTiers][numBurstQualifications]int64
+
 // tokenCounts stores unit-less token counts, one per bucket in
 // cpuTimeTokenGranter.
 type tokenCounts [numResourceTiers][numBurstQualifications]int64
@@ -239,6 +243,44 @@ type tokenCounts [numResourceTiers][numBurstQualifications]int64
 // 0.8 for 80% CPU utilization), one per bucket in CPUTimeTokenGranter. This
 // is aggregate CPU usage, so 0.8 means 80% of CPU time across all cores.
 type targetUtilizations [numResourceTiers][numBurstQualifications]float64
+
+// computeMinimums computes per-bucket minimums from refill rates. These
+// minimums prevent higher priority work from putting lower priority buckets
+// into unbounded token debt.
+//
+// The top priority bucket (tier0/canBurst) has a floor of 0. Each subsequent
+// bucket's floor is its rate minus the top priority rate, which is always
+// negative. For example, with refill rates of 100, 95, 80, 75, the minimums
+// are 0, -5, -20, -25.
+//
+// Any choice of minimums must respect the invariants in cpuTimeTokenGranter
+// that higher priority buckets always have more tokens than lower priority
+// ones (see Invariant #1 and #2 on cpuTimeTokenGranter.mu.buckets). The
+// approach here satisfies these invariants because the minimums are derived
+// from the refill rates, which are themselves ordered by priority.
+//
+// An alternative would be to set all minimums to 0. We go with the
+// rate-derived minimums instead because they preserve the same delta
+// in token counts between buckets that cpuTimeTokenLinearModel
+// establishes during normal operation. That is, the spacing between
+// bucket token counts is consistent regardless of whether buckets are
+// full, partially drained, or at their minimum. One concrete benefit:
+// during overload, when all buckets are at their minimums, the higher
+// priority buckets recover to positive first, which means burstable
+// work is naturally prioritized over non-burstable work (and, less
+// importantly, system tenant work over app tenant work). With all-zero
+// minimums, all buckets would recover roughly simultaneously, losing
+// this prioritization at an important moment.
+func computeMinimums(r rates) minimums {
+	var m minimums
+	topRate := r[0][0]
+	for tier := range r {
+		for qual := range r[tier] {
+			m[tier][qual] = r[tier][qual] - topRate
+		}
+	}
+	return m
+}
 
 // allocateTokens allocates tokens to a cpuTimeTokenGranter. allocateTokens
 // adds the desired number of tokens every interval, while respecting the bucket
@@ -278,7 +320,11 @@ func (a *cpuTimeTokenAllocator) allocateTokens(expectedRemainingTicksInInterval 
 	// one second worth of tokens at the current refill rate. This is a fairly
 	// arbitrary decision.
 	bucketCapacities := capacities(a.refillRates)
-	a.granter.refill(allocations, bucketCapacities)
+	// Each bucket has a minimum allowed token count. This prevents
+	// higher priority work from putting lower priority buckets into
+	// unbounded token debt.
+	bucketMinimums := computeMinimums(a.refillRates)
+	a.granter.refill(allocations, bucketCapacities, bucketMinimums)
 
 	// Refill per-tenant burst buckets in the WorkQueues. The burst bucket
 	// refill rate and capacity should be 1/4th of the noBurst refill rate
@@ -335,9 +381,10 @@ func (a *cpuTimeTokenAllocator) resetInterval(ctx context.Context) {
 		}
 	}
 	// See comment above the call to refill in allocateTokens for a discussion of
-	// bucketCapacities.
+	// bucketCapacities and bucketMinimums.
 	bucketCapacities := capacities(newRefillRates)
-	a.granter.refill(deltaRefillRates, bucketCapacities)
+	bucketMinimums := computeMinimums(newRefillRates)
+	a.granter.refill(deltaRefillRates, bucketCapacities, bucketMinimums)
 	a.refillRates = newRefillRates
 
 	// Apply the delta to the per-tenant burst buckets also.

--- a/pkg/util/admission/cpu_time_token_filler_test.go
+++ b/pkg/util/admission/cpu_time_token_filler_test.go
@@ -104,6 +104,9 @@ func (m *testBurstManager) refillBurstBuckets(toAdd int64, capacity int64) {
 	if m.tokens > capacity {
 		m.tokens = capacity
 	}
+	if m.tokens < -capacity/4 {
+		m.tokens = -capacity / 4
+	}
 }
 
 func (m *testModel) init() {}
@@ -206,13 +209,15 @@ func TestCPUTimeTokenAllocator(t *testing.T) {
 			d.ScanArgs(t, "remaining", &remainingTicks)
 			allocator.allocateTokens(remainingTicks)
 			return flushAndReset()
-		case "clear":
-			granter.mu.buckets[testTier0][canBurst].tokens = 0
-			granter.mu.buckets[testTier0][noBurst].tokens = 0
-			granter.mu.buckets[testTier1][canBurst].tokens = 0
-			granter.mu.buckets[testTier1][noBurst].tokens = 0
-			burstMgrs[testTier0].tokens = 0
-			burstMgrs[testTier1].tokens = 0
+		case "set-tokens":
+			var v int64
+			d.ScanArgs(t, "v", &v)
+			granter.mu.buckets[testTier0][canBurst].tokens = v
+			granter.mu.buckets[testTier0][noBurst].tokens = v
+			granter.mu.buckets[testTier1][canBurst].tokens = v
+			granter.mu.buckets[testTier1][noBurst].tokens = v
+			burstMgrs[testTier0].tokens = v
+			burstMgrs[testTier1].tokens = v
 			return flushAndReset()
 		case "setClusterSettings":
 			ctx := context.Background()

--- a/pkg/util/admission/cpu_time_token_granter.go
+++ b/pkg/util/admission/cpu_time_token_granter.go
@@ -21,8 +21,6 @@ import (
 //
 // The tier determination for a request happens at a layer outside the admission package.
 //
-// TODO(josh): Add docs re: tentative usage after a discussion with Sumeer.
-//
 // NB: Inter-tenant fair sharing only works within a tier.
 //
 // TODO(josh): Move this definition to admission.go. Export publicly.
@@ -110,29 +108,22 @@ func (cg *cpuTimeTokenChildGranter) continueGrantChain(grantChainID grantChainID
 // 6.4 seconds of CPU time per second. In limiting CPU usage to some max, goroutine
 // scheduling latency can be kept low.
 //
-// TODO(josh): Add docs about resourceTier after a discussion with Sumeer.
-//
 // Note that cpuTimeTokenGranter does not handle replenishing the buckets.
 //
 // For more, see the initial design sketch:
 // https://docs.google.com/document/d/1-Kr2gRFTk0QV8kBs7AXRXUwFpK2ZxR1cqIwWCuOx22Q/edit?tab=t.0
-// TODO(josh): Turn into a proper design documnet.
 type cpuTimeTokenGranter struct {
 	requester [numResourceTiers]requester
 	mu        struct {
-		// TODO(josh): I suspect putting the mutex here is better than in
-		// CPUTimeTokenGrantCoordinator, but for now the decision is tentative.
-		// Think better to decice when I put up a PR that introduces
-		// CPUTimeTokenGrantCoordinator & cpuTimeTokenAdjusterNew.
 		syncutil.Mutex
 		// Invariant #1: For any two buckets A & B, if A has a lower ordinal resourceTier,
 		// then A must have more tokens than B.
 		// Invariant #2: For any two buckets A & B, if A & B have the same resourceTier,
 		// and if A has a lower ordinal burstQualification, then A must have more tokens than B.
 		//
-		// Since admission deducts from all buckets, these invariants are true, so long as token bucket
-		// replenishing respects it also. Token bucket replenishing is not yet implemented. See
-		// tryGrantLocked for a situation where invariant #1 is relied on.
+		// Since admission deducts from all buckets, these invariants are true, so long as token
+		// bucket replenishing respects it also. See tryGrantLocked for a situation where
+		// invariant #1 is relied on.
 		buckets    [numResourceTiers][numBurstQualifications]tokenBucket
 		tokensUsed int64
 	}
@@ -274,11 +265,16 @@ func (stg *cpuTimeTokenGranter) resetTokensUsedInInterval() int64 {
 }
 
 // refill adds toAdd tokens to the corresponding buckets, while respecting
-// the capacity info stored in bucketCapacities. That is, tokens that would
-// bring the bucket above capacity will be discarded instead. refill attempts
-// to grant admission to waiting requests in case where tokens are added to
-// some bucket.
-func (stg *cpuTimeTokenGranter) refill(toAdd tokenCounts, bucketCapacities capacities) {
+// the capacity info stored in bucketCapacities and enforcing per-bucket
+// minimums from bucketMinimums. Tokens that would bring the bucket above
+// capacity will be discarded, and if the token count is below the minimum,
+// it will be raised to the minimum. The minimums bound recovery time after
+// periods of overuse, preventing a bucket from accumulating unbounded token
+// debt. refill attempts to grant admission to waiting requests in case
+// where tokens are added to some bucket.
+func (stg *cpuTimeTokenGranter) refill(
+	toAdd tokenCounts, bucketCapacities capacities, bucketMinimums minimums,
+) {
 	stg.mu.Lock()
 	defer stg.mu.Unlock()
 
@@ -289,9 +285,8 @@ func (stg *cpuTimeTokenGranter) refill(toAdd tokenCounts, bucketCapacities capac
 				shouldGrant = true
 			}
 			newTokenCount := stg.mu.buckets[wc][kind].tokens + toAdd[wc][kind]
-			if newTokenCount > bucketCapacities[wc][kind] {
-				newTokenCount = bucketCapacities[wc][kind]
-			}
+			newTokenCount = min(newTokenCount, bucketCapacities[wc][kind])
+			newTokenCount = max(newTokenCount, bucketMinimums[wc][kind])
 			stg.mu.buckets[wc][kind].tokens = newTokenCount
 		}
 	}

--- a/pkg/util/admission/cpu_time_token_granter_test.go
+++ b/pkg/util/admission/cpu_time_token_granter_test.go
@@ -150,25 +150,31 @@ func TestCPUTimeTokenGranter(t *testing.T) {
 			return flushAndReset(false /* init */)
 
 		case "refill":
-			// The delta & the bucket capacity are hard-coded. It is unwiedly
-			// to make them data-driven arguments, and the payoff would be
-			// low anyway.
+			// The delta, bucket capacity, & bucket minimums are hard-coded.
+			// It is unwieldy to make them data-driven arguments, and the
+			// payoff would be low anyway.
 			var delta [numResourceTiers][numBurstQualifications]int64
 			delta[testTier0][canBurst] = 5
 			delta[testTier0][noBurst] = 4
 			delta[testTier1][canBurst] = 3
 			delta[testTier1][noBurst] = 1
 			var bucketCapacity [numResourceTiers][numBurstQualifications]int64
-			bucketCapacity[testTier0][canBurst] = 4
-			bucketCapacity[testTier0][noBurst] = 3
-			bucketCapacity[testTier1][canBurst] = 10
-			bucketCapacity[testTier1][noBurst] = 1
-			granter.refill(delta, bucketCapacity)
+			bucketCapacity[testTier0][canBurst] = 20
+			bucketCapacity[testTier0][noBurst] = 16
+			bucketCapacity[testTier1][canBurst] = 12
+			bucketCapacity[testTier1][noBurst] = 8
+			var bucketMins [numResourceTiers][numBurstQualifications]int64
+			bucketMins[testTier0][canBurst] = 0
+			bucketMins[testTier0][noBurst] = -4
+			bucketMins[testTier1][canBurst] = -8
+			bucketMins[testTier1][noBurst] = -12
+			granter.refill(delta, bucketCapacity, bucketMins)
 			fmt.Fprint(&buf, "refill(\n")
-			for tier := int(numResourceTiers - 1); tier >= 0; tier-- {
-				for qual := int(numBurstQualifications - 1); qual >= 0; qual-- {
-					fmt.Fprintf(&buf, "\ttier%d %s -> delta: %v, cap: %v\n",
-						tier, burstQualification(qual).String(), delta[tier][qual], bucketCapacity[tier][qual])
+			for tier := 0; tier < int(numResourceTiers); tier++ {
+				for qual := 0; qual < int(numBurstQualifications); qual++ {
+					fmt.Fprintf(&buf, "\ttier%d %s -> delta: %v, cap: %v, min: %v\n",
+						tier, burstQualification(qual).String(), delta[tier][qual],
+						bucketCapacity[tier][qual], bucketMins[tier][qual])
 				}
 			}
 			fmt.Fprint(&buf, ")\n")

--- a/pkg/util/admission/testdata/cpu_time_token_allocator
+++ b/pkg/util/admission/testdata/cpu_time_token_allocator
@@ -24,8 +24,8 @@ burstM
 tier0  1000
 tier1  500
 
-# clear simulates tokens being taken due to admitted work.
-clear
+# set-tokens v=0 simulates tokens being taken due to admitted work.
+set-tokens v=0
 ----
 cpuTTG canBurst noBurst
 tier0  0        0
@@ -128,7 +128,7 @@ burstM
 tier0  1000
 tier1  500
 
-clear
+set-tokens v=0
 ----
 cpuTTG canBurst noBurst
 tier0  0        0
@@ -180,7 +180,7 @@ burstM
 tier0  800
 tier1  400
 
-clear
+set-tokens v=0
 ----
 cpuTTG canBurst noBurst
 tier0  0        0
@@ -216,7 +216,7 @@ burstM
 tier0  1000
 tier1  500
 
-clear
+set-tokens v=0
 ----
 cpuTTG canBurst noBurst
 tier0  0        0
@@ -266,7 +266,7 @@ burstM
 tier0  1000
 tier1  500
 
-clear
+set-tokens v=0
 ----
 cpuTTG canBurst noBurst
 tier0  0        0
@@ -304,7 +304,7 @@ burstM
 tier0  999
 tier1  499
 
-clear
+set-tokens v=0
 ----
 cpuTTG canBurst noBurst
 tier0  0        0
@@ -324,7 +324,7 @@ burstM
 tier0  999
 tier1  499
 
-clear
+set-tokens v=0
 ----
 cpuTTG canBurst noBurst
 tier0  0        0
@@ -364,3 +364,62 @@ tier1  0        0
 burstM
 tier0  0
 tier1  0
+
+# Test that both allocateTokens and resetInterval clamp bucket token counts to
+# their per-bucket minimums. The granter minimums are computed from the current
+# refill rates {4999, 3999, 2999, 1999}:
+#   tier0 canBurst: 0              (top priority, floor is 0)
+#   tier0 noBurst:  3999 - 4999 = -1000
+#   tier1 canBurst: 2999 - 4999 = -2000
+#   tier1 noBurst:  1999 - 4999 = -3000
+#
+# The burst buckets also have minimums. The burst bucket capacity for each tier
+# is noBurstRate/4 (tier0: 3999/4 = 999, tier1: 1999/4 = 499), and the burst
+# bucket minimum is -capacity/4 (tier0: -999/4 = -249, tier1: -499/4 = -124).
+
+# Test allocateTokens path. Drive buckets deeply negative, then allocate. The
+# added tokens (the full refill rates) are far too small to overcome the deficit,
+# so each bucket clamps to its minimum.
+set-tokens v=-10000000
+----
+cpuTTG canBurst   noBurst
+tier0  -10000000 -10000000
+tier1  -10000000 -10000000
+burstM
+tier0  -10000000
+tier1  -10000000
+
+allocate remaining=1
+----
+cpuTTG canBurst noBurst
+tier0  0        -1000
+tier1  -2000    -3000
+burstM
+tier0  -249
+tier1  -124
+
+# Test resetInterval path. Drive buckets deeply negative again. resetInterval
+# has delta=0 (rates unchanged), but the floor still clamps.
+set-tokens v=-10000000
+----
+cpuTTG canBurst   noBurst
+tier0  -10000000 -10000000
+tier1  -10000000 -10000000
+burstM
+tier0  -10000000
+tier1  -10000000
+
+resetInterval
+----
+fit(
+	tier1 noBurst -> 50%
+	tier1 canBurst -> 60%
+	tier0 noBurst -> 75%
+	tier0 canBurst -> 85%
+)
+cpuTTG canBurst noBurst
+tier0  0        -1000
+tier1  -2000    -3000
+burstM
+tier0  -249
+tier1  -124

--- a/pkg/util/admission/testdata/cpu_time_token_granter
+++ b/pkg/util/admission/testdata/cpu_time_token_granter
@@ -275,24 +275,25 @@ tier1requester: waitingRequests: true, returnValueFromHasWaitingRequests: noBurs
 
 # The arguments to refill are hard-coded in the test code, but they are also
 # shown in the below output. The corresponding entry in delta is added to every
-# bucket, subject to a max capacity of the corresponding entry in cap. Note as
-# per the call init above, there is one tier1 non-burstable request waiting for
-# admission. Due to the call to refill, it is granted admission, as can be seen
-# in the output below. So one token is deducted from all buckets, post the deltas
-# being added to the buckets. For example, tier0 canBurst was 0, then 3 is added
-# to it subject to a cap of 10 (so cap is applied), then 1 token is deducted, so
-# the final state of the bucket is 3-1 = 2.
+# bucket, subject to a max capacity of the corresponding entry in cap and a min
+# floor of the corresponding entry in min. Note as per the call init above,
+# there is one tier1 non-burstable request waiting for admission. Due to the
+# call to refill, it is granted admission, as can be seen in the output below.
+# So one token is deducted from all buckets, post the deltas being added to the
+# buckets. For example, tier0 canBurst was 0, then 5 is added to it (cap of 20
+# is not applied), then 1 token is deducted, so the final state of the bucket is
+# 5-1 = 4.
 refill
 ----
 kvtier1: granted in chain 0, and returning 1
 refill(
-	tier1 noBurst -> delta: 1, cap: 1
-	tier1 canBurst -> delta: 3, cap: 10
-	tier0 noBurst -> delta: 4, cap: 3
-	tier0 canBurst -> delta: 5, cap: 4
+	tier0 canBurst -> delta: 5, cap: 20, min: 0
+	tier0 noBurst -> delta: 4, cap: 16, min: -4
+	tier1 canBurst -> delta: 3, cap: 12, min: -8
+	tier1 noBurst -> delta: 1, cap: 8, min: -12
 )
 cpuTTG canBurst noBurst
-tier0  3        2
+tier0  4        3
 tier1  2        0
 
 # Refilling the buckets does not count as token usage. The only usage that happens
@@ -301,3 +302,27 @@ tier1  2        0
 reset-tokens-used
 ----
 reset-tokens-used-in-interval() returned 1
+
+# Test that refill enforces both ceiling and floor. tier0 canBurst starts at 16,
+# so 16 + delta(5) = 21 > cap(20), demonstrating the ceiling. The other three
+# buckets start deeply negative, so they are clamped to their respective floors:
+# tier0 noBurst to -4, tier1 canBurst to -8, tier1 noBurst to -12.
+init tier0=-100 tier0burst=16 tier1=-100 tier1burst=-100
+----
+cpuTTG canBurst noBurst
+tier0  16       -100
+tier1  -100     -100
+tier0requester: waitingRequests: false, returnValueFromHasWaitingRequests: noBurst, returnValueFromGranted: 0
+tier1requester: waitingRequests: false, returnValueFromHasWaitingRequests: noBurst, returnValueFromGranted: 0
+
+refill
+----
+refill(
+	tier0 canBurst -> delta: 5, cap: 20, min: 0
+	tier0 noBurst -> delta: 4, cap: 16, min: -4
+	tier1 canBurst -> delta: 3, cap: 12, min: -8
+	tier1 noBurst -> delta: 1, cap: 8, min: -12
+)
+cpuTTG canBurst noBurst
+tier0  20       -4
+tier1  -8       -12


### PR DESCRIPTION
**admission: set minimums on cpu time granter buckets**

This commit introduces minimums on all the token buckets in cpu time token AC's granter. This prevents higher priority work from putting lower priority buckets into unbounded token debt.

Fixes: #158539

Release note: None