### PR TITLE
sql/internal: add more logging to smither setup

### DIFF
--- a/pkg/cmd/roachtest/tests/query_comparison_util.go
+++ b/pkg/cmd/roachtest/tests/query_comparison_util.go
@@ -366,6 +366,7 @@ func runOneRoundQueryComparison(
 			sqlsmith.SetComplexity(.3),
 			sqlsmith.SetScalarComplexity(.1),
 			sqlsmith.SimpleNames(),
+			sqlsmith.SetLogger(t.L().Printf),
 		)
 		if err != nil {
 			t.Fatal(err)
@@ -445,6 +446,7 @@ func newMutatingSmither(
 		sqlsmith.SetComplexity(.05),
 		sqlsmith.SetScalarComplexity(.01),
 		sqlsmith.SimpleNames(),
+		sqlsmith.SetLogger(t.L().Printf),
 	)
 	if disableDelete {
 		smitherOpts = append(smitherOpts, sqlsmith.InsUpdOnly())

--- a/pkg/internal/sqlsmith/sqlsmith.go
+++ b/pkg/internal/sqlsmith/sqlsmith.go
@@ -129,6 +129,10 @@ type Smither struct {
 	bulkFiles   map[string][]byte
 	bulkBackups map[string]tree.BackupTargetList
 	bulkExports []string
+
+	// logFn, if set, is called to emit progress messages during schema loading
+	// and other potentially slow operations.
+	logFn func(format string, args ...interface{})
 }
 
 type (
@@ -627,6 +631,18 @@ var DisableDoBlocks = simpleOption("disable do block", func(s *Smither) {
 var DisableIsolationChange = simpleOption("disable isolation change", func(s *Smither) {
 	s.disableIsolationChange = true
 })
+
+// SetLogger configures a logging function for the Smither. The function is
+// called to emit progress messages during schema loading and other potentially
+// slow operations.
+func SetLogger(logFn func(format string, args ...interface{})) SmitherOption {
+	return option{
+		name: "set logger",
+		apply: func(s *Smither) {
+			s.logFn = logFn
+		},
+	}
+}
 
 // CompareMode causes the Smither to generate statements that have
 // deterministic output.


### PR DESCRIPTION
Informs: #163484

We recently see a frequent timeout of the unoptimized-query-oracle roachtest in a multiregion set up. We had the theory that it's the queries that extracts indexes while resetting the smither timed out, and this commit is to have more logging to prove and disprove this guess.

Release note: None