### PR TITLE
kvserver: use mock guard instead of knob for VIR test

### DIFF
--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -70,9 +70,6 @@ func (r *Replica) executeReadOnlyBatch(
 
 	var rw storage.ReadWriter
 	intentsToResolveVirtually := g.IntentsToResolveVirtually()
-	if itrv := r.store.TestingKnobs().InjectIntentsToResolveVirtually; itrv != nil {
-		intentsToResolveVirtually = itrv()
-	}
 	// If there are intents to be resolved virtually, use a storage batch in which
 	// the intent resolution will be evaluated before the read-only batch request.
 	if len(intentsToResolveVirtually) > 0 {

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -86,7 +86,8 @@ import (
 )
 
 type mockGuard struct {
-	req concurrency.Request
+	req                       concurrency.Request
+	intentsToResolveVirtually []roachpb.LockUpdate
 }
 
 func (mg mockGuard) Req() concurrency.Request {
@@ -121,7 +122,7 @@ func (mg mockGuard) IsKeyLockedByConflictingTxn(
 	return false, nil, nil
 }
 func (mg mockGuard) IntentsToResolveVirtually() []roachpb.LockUpdate {
-	return nil
+	return mg.intentsToResolveVirtually
 }
 
 var _ concurrency.Guard = (*mockGuard)(nil)

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -595,11 +595,6 @@ type StoreTestingKnobs struct {
 	// BeforeSplitAcquiresLocksOnRHS is invoked during a split application before
 	// we start acquiring locks on the right hand side.
 	BeforeSplitAcquiresLocksOnRHS func(context.Context, *Replica)
-
-	// InjectIntentsToResolveVirtually is called while executing read-only
-	// requests; it helps inject intents to be resolved virtually, usually passed
-	// in by the lock table guard.
-	InjectIntentsToResolveVirtually func() []roachpb.LockUpdate
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.


### PR DESCRIPTION
After 6d85411, the `TestVirtualizedIntentResolution` test can now use the mock guard instead of the testing knob to inject intents to resolve virtually.

Part of: #162204

Release note: None