### PR TITLE
storage: return error from SyncWait instead of panicking

### DIFF
--- a/pkg/kv/kvserver/logstore/BUILD.bazel
+++ b/pkg/kv/kvserver/logstore/BUILD.bazel
@@ -59,6 +59,7 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":logstore"],
     deps = [
+        "//pkg/cli/exit",
         "//pkg/keys",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver/kvserverbase",

--- a/pkg/kv/kvserver/logstore/sync_waiter_test.go
+++ b/pkg/kv/kvserver/logstore/sync_waiter_test.go
@@ -7,12 +7,16 @@ package logstore
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/cli/exit"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSyncWaiterLoop(t *testing.T) {
@@ -78,6 +82,45 @@ func BenchmarkSyncWaiterLoop(b *testing.B) {
 		<-c
 	}
 }
+
+// TestSyncWaiterLoopError verifies that a SyncWait error (e.g. a WAL write
+// failure) triggers a fatal log for graceful shutdown rather than a panic.
+func TestSyncWaiterLoopError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Intercept log.Fatalf to prevent the test process from exiting.
+	var fatalCalled atomic.Bool
+	log.SetExitFunc(true /* hideStack */, func(exit.Code) {
+		fatalCalled.Store(true)
+	})
+	defer log.ResetExitFunc()
+
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	w := NewSyncWaiterLoop()
+	w.Start(ctx, stopper)
+
+	// Enqueue a waiter whose SyncWait returns an error.
+	injectedErr := errors.New("permission denied")
+	wg := &errSyncWaiter{err: injectedErr}
+	cb := funcSyncWaiterCallback(func() {})
+	w.enqueue(ctx, wg, cb)
+
+	// Verify that the error triggers a fatal log, not a panic.
+	require.Eventually(t, func() bool {
+		return fatalCalled.Load()
+	}, time.Second, time.Millisecond)
+}
+
+// errSyncWaiter implements the syncWaiter interface and returns an error.
+type errSyncWaiter struct {
+	err error
+}
+
+func (e *errSyncWaiter) SyncWait() error { return e.err }
+func (e *errSyncWaiter) Close()          {}
 
 // chanSyncWaiter implements the syncWaiter interface.
 type chanSyncWaiter chan struct{}

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -1180,6 +1180,11 @@ type WriteBatch interface {
 	CommitNoSyncWait() error
 	// SyncWait waits for the disk write initiated by a call to CommitNoSyncWait
 	// to complete.
+	//
+	// An error means the WAL write or fsync failed; the data was already applied
+	// to the memtable and is visible, but durability is not guaranteed. After an
+	// error the batch must not be reused and the caller should treat the error
+	// as fatal.
 	SyncWait() error
 	// Empty returns whether the batch has been written to or not.
 	Empty() bool

--- a/pkg/storage/pebble_batch.go
+++ b/pkg/storage/pebble_batch.go
@@ -401,14 +401,10 @@ func (wb *writeBatch) SyncWait() error {
 	}
 	err := wb.batch.SyncWait()
 	if err != nil {
-		// TODO(storage): ensure that these errors are only ever due to invariant
-		// violations and never due to unrecoverable Pebble states. Then switch to
-		// returning the error instead of panicking.
-		//
-		// Once we do that, document on the storage.Batch interface the meaning of
-		// an error returned from this method and the guarantees that callers have
-		// or don't have after they receive an error from this method.
-		panic(err)
+		// SyncWait can fail due to environmental causes such as permission
+		// denied or disk I/O errors. See the WriteBatch.SyncWait interface
+		// doc for error semantics.
+		return err
 	}
 	wb.batchStatsReporter.aggregateBatchCommitStats(
 		BatchCommitStats{wb.batch.CommitStats()})


### PR DESCRIPTION
`writeBatch.SyncWait()` panicked on any error from the underlying Pebble `SyncWait`, including environmental failures like EPERM or EIO on WAL writes. This caused an ungraceful process crash, bypassing the `log.Fatalf` handler in `SyncWaiterLoop.waitLoop` that provides structured logging, crash reporting, and graceful shutdown.

Change SyncWait to return the error instead. Document the error semantics on the `WriteBatch.SyncWait` interface: an error means the WAL write or fsync failed, the data is already applied to the memtable but durability is not guaranteed, and the caller should treat it as fatal.

Fixes #163906

Release note: None