### PR TITLE
release-25.4: Revert "sql: remove AllowUnsafeInternals deserialization workaround"

### DIFF
--- a/pkg/sql/session_state.go
+++ b/pkg/sql/session_state.go
@@ -134,6 +134,15 @@ func (p *planner) DeserializeSessionState(
 	sd.SessionData = m.SessionData
 	sd.LocalUnmigratableSessionData = evalCtx.SessionData().LocalUnmigratableSessionData
 	sd.LocalOnlySessionData = m.LocalOnlySessionData
+
+	// Note(davidh): The line below is mitigation for an issue with
+	// upgrades to 25.4 where the `AllowUnsafeInternals` field was
+	// introduced. The default value of this is `true` and setting it to
+	// `false` will incorrectly block executions that access internals on
+	// migrated sessions.
+	// TODO(davidh): Remove after 25.4 is rolled out everywhere. (CRDB-57952)
+	sd.LocalOnlySessionData.AllowUnsafeInternals = true
+
 	if sd.SessionUser().Normalized() != evalCtx.SessionData().SessionUser().Normalized() {
 		return nil, pgerror.Newf(
 			pgcode.InsufficientPrivilege,

--- a/pkg/sql/testdata/session_migration/session_migration
+++ b/pkg/sql/testdata/session_migration/session_migration
@@ -68,3 +68,30 @@ query
 EXECUTE stmt
 ----
 1
+
+reset
+----
+
+exec
+SET allow_unsafe_internals = false;
+----
+
+let $x
+SELECT encode(crdb_internal.serialize_session(), 'hex')
+----
+
+exec
+SET allow_unsafe_internals = true;
+----
+
+exec
+SELECT crdb_internal.deserialize_session( decode('$x', 'hex') )
+----
+
+# Demonstrate that `allow_unsafe_internals` will always get
+# deserialized in `on` state in order to avoid the deserialization bug
+# which sets the setting to `off` by default.
+query
+SHOW allow_unsafe_internals
+----
+on


### PR DESCRIPTION
This reverts commit 32d9056d21b which removed the workaround that forces `AllowUnsafeInternals` to `true` during session deserialization.

The workaround is still needed because multi-tenant clusters may still be running mixed versions where older pods serialize sessions without the `AllowUnsafeInternals` field. When such a session is deserialized on a 25.4 node, protobuf sets the field to its zero value (`false`), which incorrectly blocks access to internal tables.

Fixes: CRDB-57952
Epic: None
Release note: None

Release justification: Prevents the accidental deserialization of a zero value for a non-zero default session var in a mixed-version multi-tenant cluster.