### PR TITLE
sql/copy: deflake TestLargeCopy by setting session var on correct connection

### DIFF
--- a/pkg/sql/copy/copy_test.go
+++ b/pkg/sql/copy/copy_test.go
@@ -726,7 +726,7 @@ func TestLargeCopy(t *testing.T) {
 
 	atomicCopy := true
 	if rng.Float64() < 0.5 {
-		_, err = sqlDB.Exec("SET copy_from_atomic_enabled = false")
+		err = conn.Exec(ctx, "SET copy_from_atomic_enabled = false")
 		require.NoError(t, err)
 		atomicCopy = false
 	}


### PR DESCRIPTION
TestLargeCopy randomly chooses between atomic and non-atomic COPY mode.
In non-atomic mode, the test sets `copy_from_atomic_enabled = false` on
`sqlDB`, which is a `*sql.DB` connection pool. However, the COPY itself
runs on `conn`, a separate `clisqlclient` connection. The SET therefore
has no effect on the COPY, which always runs in atomic mode (the default).

When the test thinks it's in non-atomic mode (`atomicCopy = false`), its
`ignoreErr` function does not forgive SerializationFailure errors — it
expects the COPY retry mechanism to handle them. But since the COPY is
actually running in atomic mode (where retries are not automatic), the
40001 error propagates to the test and causes a failure.

Fix this by executing the SET on `conn` so it actually affects the COPY
session. The previous attempt (PR #164320) to also set
`copy_from_retries_enabled = true` was a no-op since its default is
already true.

Fixes: #164185
Epic: CRDB-60677
Release note: None