### PR TITLE
sql: add telemetry counters and metric for row-level security

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -1417,6 +1417,22 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+    - name: sql.rls.policies_applied.count
+      exported_name: sql_rls_policies_applied_count
+      description: Number of SQL statements where row-level security policies were applied
+      y_axis_label: SQL Statements
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: sql.rls.policies_applied.count.internal
+      exported_name: sql_rls_policies_applied_count_internal
+      description: Number of SQL statements where row-level security policies were applied (internal queries)
+      y_axis_label: SQL Internal Statements
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
     - name: sql.routine.delete.count
       exported_name: sql_routine_delete_count
       labeled_name: 'sql.count{query_type: routine_delete}'

--- a/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
+++ b/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
@@ -2542,6 +2542,8 @@ sql_restart_savepoint_rollback_started_count: sql.restart_savepoint.rollback.sta
 sql_restart_savepoint_rollback_started_count_internal: sql.restart_savepoint.rollback.started.internal
 sql_restart_savepoint_started_count: sql.restart_savepoint.started.count
 sql_restart_savepoint_started_count_internal: sql.restart_savepoint.started.internal
+sql_rls_policies_applied_count: sql.rls.policies_applied.count
+sql_rls_policies_applied_count_internal: sql.rls.policies_applied.count.internal
 sql_routine_delete_count: sql.routine.delete.count
 sql_routine_delete_count_internal: sql.routine.delete.count.internal
 sql_routine_delete_started_count: sql.routine.delete.started.count

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -662,6 +662,7 @@ func makeMetrics(internal bool, sv *settings.Values) Metrics {
 			StatementIndexRowsWritten:         metric.NewCounter(getMetricMeta(MetaStatementIndexRowsWritten, internal)),
 			StatementIndexBytesWritten:        metric.NewCounter(getMetricMeta(MetaStatementIndexBytesWritten, internal)),
 			QueryWithStatementHintsCount:      metric.NewCounter(getMetricMeta(MetaQueryWithStatementHints, internal)),
+			RLSPoliciesAppliedCount:           metric.NewCounter(getMetricMeta(MetaRLSPoliciesApplied, internal)),
 		},
 		StartedStatementCounters:  makeStartedStatementCounters(internal),
 		ExecutedStatementCounters: makeExecutedStatementCounters(internal),

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -3435,6 +3435,10 @@ func (ex *connExecutor) makeExecPlan(
 		ex.metrics.EngineMetrics.FullTableOrIndexScanCount.Inc(1, ex.sessionData().Database, ex.sessionData().ApplicationName)
 	}
 
+	if flags.IsSet(planFlagUsesRLS) {
+		ex.metrics.EngineMetrics.RLSPoliciesAppliedCount.Inc(1)
+	}
+
 	// TODO(knz): Remove this accounting if/when savepoint rollbacks
 	// support rolling back over DDL.
 	if flags.IsSet(planFlagIsDDL) {

--- a/pkg/sql/exec_factory_util.go
+++ b/pkg/sql/exec_factory_util.go
@@ -120,6 +120,9 @@ func constructPlan(
 	if flags.IsSet(exec.PlanFlagContainsUpsert) {
 		res.flags.Set(planFlagContainsUpsert)
 	}
+	if flags.IsSet(exec.PlanFlagUsesRLS) {
+		res.flags.Set(planFlagUsesRLS)
+	}
 
 	return res, nil
 }

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -914,6 +914,13 @@ var (
 		Unit:        metric.Unit_COUNT,
 		Category:    metric.Metadata_SQL,
 	}
+	MetaRLSPoliciesApplied = metric.Metadata{
+		Name:        "sql.rls.policies_applied.count",
+		Help:        "Number of SQL statements where row-level security policies were applied",
+		Measurement: "SQL Statements",
+		Unit:        metric.Unit_COUNT,
+		Category:    metric.Metadata_SQL,
+	}
 	MetaTxnAbort = metric.Metadata{
 		Name:        "sql.txn.abort.count",
 		Help:        "Number of SQL transaction abort errors",

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -102,6 +102,10 @@ type EngineMetrics struct {
 
 	// QueryWithStatementHintsCount counts queries executed with external statement hints.
 	QueryWithStatementHintsCount *metric.Counter
+
+	// RLSPoliciesAppliedCount counts the number of SQL statements where
+	// row-level security policies were applied during query planning.
+	RLSPoliciesAppliedCount *metric.Counter
 }
 
 // EngineMetrics implements the metric.Struct interface.

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -90,6 +90,9 @@ const (
 	// PlanFlagContainsUpsert is set if at least one UPSERT stmt is found in the
 	// whole plan.
 	PlanFlagContainsUpsert
+
+	// PlanFlagUsesRLS is set if the plan applies row-level security policies.
+	PlanFlagUsesRLS
 )
 
 // IsSet returns true if the receiver has all of the given flags set.

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -691,6 +691,9 @@ const (
 	planFlagContainsInsert
 	planFlagContainsUpdate
 	planFlagContainsUpsert
+
+	// planFlagUsesRLS is set if the plan applies row-level security policies.
+	planFlagUsesRLS
 )
 
 // IsSet returns true if the receiver has all of the given flags set.

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_set_rls_mode.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_set_rls_mode.go
@@ -6,8 +6,10 @@
 package scbuildstmt
 
 import (
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 )
 
 func alterTableSetRLSMode(
@@ -26,18 +28,22 @@ func alterTableSetRLSMode(
 
 	switch n.Mode {
 	case tree.TableRLSEnable:
+		telemetry.Inc(sqltelemetry.EnableRLSCounter)
 		b.Add(&scpb.RowLevelSecurityEnabled{
 			TableID: tbl.TableID,
 		})
 	case tree.TableRLSDisable:
+		telemetry.Inc(sqltelemetry.DisableRLSCounter)
 		b.Drop(&scpb.RowLevelSecurityEnabled{
 			TableID: tbl.TableID,
 		})
 	case tree.TableRLSForce:
+		telemetry.Inc(sqltelemetry.ForceRLSCounter)
 		b.Add(&scpb.RowLevelSecurityForced{
 			TableID: tbl.TableID,
 		})
 	case tree.TableRLSNoForce:
+		telemetry.Inc(sqltelemetry.NoForceRLSCounter)
 		b.Drop(&scpb.RowLevelSecurityForced{
 			TableID: tbl.TableID,
 		})

--- a/pkg/sql/sqltelemetry/schema.go
+++ b/pkg/sql/sqltelemetry/schema.go
@@ -231,3 +231,21 @@ var DDLOnlyTransactionSuccessCounter = telemetry.GetCounterOnce("sql.schema.tran
 // DDLOnlyTransactionFailureCounter is incremented whenever an explicit
 // transaction that has only DDL statements fails.
 var DDLOnlyTransactionFailureCounter = telemetry.GetCounterOnce("sql.schema.transaction.ddl_only.failure")
+
+var (
+	// EnableRLSCounter is incremented when row-level security is enabled on a
+	// table via ALTER TABLE ... ENABLE ROW LEVEL SECURITY.
+	EnableRLSCounter = telemetry.GetCounterOnce("sql.schema.enable_rls")
+
+	// DisableRLSCounter is incremented when row-level security is disabled on a
+	// table via ALTER TABLE ... DISABLE ROW LEVEL SECURITY.
+	DisableRLSCounter = telemetry.GetCounterOnce("sql.schema.disable_rls")
+
+	// ForceRLSCounter is incremented when row-level security is forced on a
+	// table via ALTER TABLE ... FORCE ROW LEVEL SECURITY.
+	ForceRLSCounter = telemetry.GetCounterOnce("sql.schema.force_rls")
+
+	// NoForceRLSCounter is incremented when row-level security force is removed
+	// from a table via ALTER TABLE ... NO FORCE ROW LEVEL SECURITY.
+	NoForceRLSCounter = telemetry.GetCounterOnce("sql.schema.no_force_rls")
+)


### PR DESCRIPTION
Add instrumentation for RLS usage tracking:

DDL telemetry counters for the four RLS mode changes (ENABLE/DISABLE/FORCE/NO FORCE ROW LEVEL SECURITY) are incremented via the diagnostics reporting system, matching the pattern used by other schema change operations.

A new counter metric `sql.rls.policies_applied.count` tracks when RLS policies are actually applied during query planning. This uses the established planFlags pattern: the execbuilder checks the optimizer's RLSMeta for tables with filter or check policies, sets PlanFlagUsesRLS, which bridges through to planFlagUsesRLS and increments the metric in the connExecutor.

Resolves: #148087

Release note (ops change): Added a new metric
`sql.rls.policies_applied.count` that tracks the number of SQL statements where row-level security policies were applied during query planning.