### PR TITLE
pgwire: deflake TestTCPKeepAliveConnectionInit

### DIFF
--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -2096,7 +2096,13 @@ func TestTCPKeepAliveConnectionInit(t *testing.T) {
 		)
 		defer cleanup()
 		q := pgURL.Query()
-		q.Set("options", "-c tcp_keepalives_idle=25 -c tcp_keepalives_interval=8 -c tcp_keepalives_count=4 -c tcp_user_timeout=15000")
+		// Append to existing options to preserve any cluster routing set by PGUrl.
+		opts := q.Get("options")
+		if opts != "" {
+			opts += " "
+		}
+		opts += "-c tcp_keepalives_idle=25 -c tcp_keepalives_interval=8 -c tcp_keepalives_count=4 -c tcp_user_timeout=15000"
+		q.Set("options", opts)
 		pgURL.RawQuery = q.Encode()
 
 		conn, err := pgx.Connect(ctx, pgURL.String())
@@ -2147,7 +2153,13 @@ func TestTCPKeepAliveConnectionInit(t *testing.T) {
 		)
 		defer cleanup()
 		q := pgURL.Query()
-		q.Set("options", "-c tcp_keepalives_idle=30")
+		// Append to existing options to preserve any cluster routing set by PGUrl.
+		opts := q.Get("options")
+		if opts != "" {
+			opts += " "
+		}
+		opts += "-c tcp_keepalives_idle=30"
+		q.Set("options", opts)
 		pgURL.RawQuery = q.Encode()
 
 		conn, err := pgx.Connect(ctx, pgURL.String())


### PR DESCRIPTION
The test used `q.Set("options", ...)` to set connection string options like `tcp_keepalives_idle`, which replaced the entire `options` query parameter. When PGUrl adds `-ccluster=<tenant>` for virtual cluster routing, this replacement dropped the cluster routing, causing the connection to reach the system tenant where `testuser` doesn't exist.

Fix by appending to the existing options value instead of replacing it.

Fixes: #164396

Release note: None