### PR TITLE
sql: fix panic in pg_policies when policy references a dropped role

### DIFF
--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -4431,9 +4431,13 @@ https://www.postgresql.org/docs/17/view-pg-policies.html`,
 				permissive = "restrictive"
 			}
 
-			// Create a NAME array for roles
+			// Create a NAME array for roles. Skip NULL elements which can
+			// appear when a policy references a role that has been dropped.
 			roleNames := tree.NewDArray(types.Name)
 			for _, role := range roles.Array {
+				if role == tree.DNull {
+					continue
+				}
 				roleName := tree.MustBeDString(role)
 				if err := roleNames.Append(tree.NewDName(string(roleName))); err != nil {
 					return err


### PR DESCRIPTION
The pg_policies virtual table query uses LEFT JOINs to resolve role OIDs to names. When a policy references a dropped role, the join produces NULL, which causes MustBeDString to panic. Skip NULL elements in the roles array instead.

Fixes: #160547

Release note: None