### PR TITLE
concurrency: preserve status of previously pushed txns for VIR

### DIFF
--- a/pkg/kv/kvserver/concurrency/concurrency_control.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_control.go
@@ -518,6 +518,10 @@ type Guard interface {
 	// IntentsToResolveVirtually delegates listing the locks to be resolved to the
 	// lock table guard.
 	IntentsToResolveVirtually() []roachpb.LockUpdate
+
+	// PrepareForLockConflictRetry called on the lock conflict error path, before
+	// the guard is re-sequenced.
+	PrepareForLockConflictRetry(context.Context)
 }
 
 // guardImpl implements the Guard interface.
@@ -894,6 +898,11 @@ type lockTableGuard interface {
 	// VirtuallyResolvesIntents returns true if the guard will resolve intents
 	// virtually during evaluation rather than physically before re-scanning.
 	VirtuallyResolvesIntents() bool
+
+	// PrepareForLockConflictRetry is called when handling a LockConflictError
+	// after an evaluation. If VIR is in use, it collapses the guard's point
+	// resolve entries into range entries that persist across re-sequencing.
+	PrepareForLockConflictRetry(context.Context)
 
 	// CheckOptimisticNoConflicts uses the LockSpanSet representing the spans that
 	// were actually read, to check for conflicting locks, after an optimistic

--- a/pkg/kv/kvserver/concurrency/concurrency_control.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_control.go
@@ -359,6 +359,10 @@ type TestingAccessor interface {
 
 	// TestingTxnWaitQueue returns the concurrency manager's txnWaitQueue.
 	TestingTxnWaitQueue() *txnwait.Queue
+
+	// TestingPushedTransactionUpdated exposes PushedTransactionUpdated on the
+	// underlying lock table for use in tests.
+	TestingPushedTransactionUpdated(txn *roachpb.Transaction, clockObs roachpb.ObservedTimestamp)
 }
 
 ///////////////////////////////////
@@ -519,8 +523,9 @@ type Guard interface {
 	// lock table guard.
 	IntentsToResolveVirtually() []roachpb.LockUpdate
 
-	// PrepareForLockConflictRetry called on the lock conflict error path, before
-	// the guard is re-sequenced.
+	// PrepareForLockConflictRetry is called on the lock conflict error path,
+	// before the guard is re-sequenced. It condenses point resolve entries into
+	// range entries that persist across re-sequencing.
 	PrepareForLockConflictRetry(context.Context)
 }
 
@@ -900,8 +905,8 @@ type lockTableGuard interface {
 	VirtuallyResolvesIntents() bool
 
 	// PrepareForLockConflictRetry is called when handling a LockConflictError
-	// after an evaluation. If VIR is in use, it collapses the guard's point
-	// resolve entries into range entries that persist across re-sequencing.
+	// after evaluation. It condenses point resolve entries into range entries
+	// that persist across re-sequencing.
 	PrepareForLockConflictRetry(context.Context)
 
 	// CheckOptimisticNoConflicts uses the LockSpanSet representing the spans that

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -597,9 +597,9 @@ func (m *managerImpl) HandleLockConflictError(
 	// Either way, there is no possibility of the request entering an infinite
 	// loop without making progress.
 
-	// If VIR was used, collapse point resolve entries into persistent range
-	// entries before they are cleared by the next ScanAndEnqueue. This prevents
-	// livelock when the lock table evicts entries under memory pressure.
+	// Condense point resolve entries into range entries before they are cleared
+	// by the next ScanAndEnqueue. This prevents livelock when the lock table
+	// evicts entries under memory pressure.
 	g.PrepareForLockConflictRetry(ctx)
 
 	consultTxnStatusCache :=
@@ -831,6 +831,13 @@ func (m *managerImpl) TestingTxnWaitQueue() *txnwait.Queue {
 	return m.twq.(*txnwait.Queue)
 }
 
+// TestingPushedTransactionUpdated implements the TestingAccessor interface.
+func (m *managerImpl) TestingPushedTransactionUpdated(
+	txn *roachpb.Transaction, clockObs roachpb.ObservedTimestamp,
+) {
+	m.lt.PushedTransactionUpdated(txn, clockObs)
+}
+
 // SetMaxLockTableSize implements the LockManager interface.
 func (m *managerImpl) SetMaxLockTableSize(maxLocks int64) {
 	m.lt.SetMaxLockTableSize(maxLocks)
@@ -905,6 +912,7 @@ func (g *guardImpl) HoldingLatches() bool {
 	return g != nil && g.lg != nil
 }
 
+// PrepareForLockConflictRetry implements the Guard interface.
 func (g *guardImpl) PrepareForLockConflictRetry(ctx context.Context) {
 	if g != nil && g.ltg != nil {
 		g.ltg.PrepareForLockConflictRetry(ctx)

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -596,6 +596,12 @@ func (m *managerImpl) HandleLockConflictError(
 	//
 	// Either way, there is no possibility of the request entering an infinite
 	// loop without making progress.
+
+	// If VIR was used, collapse point resolve entries into persistent range
+	// entries before they are cleared by the next ScanAndEnqueue. This prevents
+	// livelock when the lock table evicts entries under memory pressure.
+	g.PrepareForLockConflictRetry(ctx)
+
 	consultTxnStatusCache :=
 		int64(len(t.Locks)) > DiscoveredLocksThresholdToConsultTxnStatusCache.Get(&m.st.SV)
 	var numAdded int
@@ -897,6 +903,12 @@ func (g *guardImpl) TakeSpanSets() (*spanset.SpanSet, *lockspanset.LockSpanSet) 
 // HoldingLatches implements the Guard interface.
 func (g *guardImpl) HoldingLatches() bool {
 	return g != nil && g.lg != nil
+}
+
+func (g *guardImpl) PrepareForLockConflictRetry(ctx context.Context) {
+	if g != nil && g.ltg != nil {
+		g.ltg.PrepareForLockConflictRetry(ctx)
+	}
 }
 
 // AssertLatches implements the Guard interface.

--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -412,6 +412,7 @@ type lockTableGuardImpl struct {
 	// PushUsingCachedClockObservation cluster setting at the this request.
 	pushUsingCachedClockObs bool
 	maxWaitQueueLength      int
+	maxToResolveRangeTxns   int
 
 	// Snapshot of the tree for which this request has some spans. Note that
 	// the lockStates in this snapshot may have been removed from
@@ -518,6 +519,10 @@ type lockTableGuardImpl struct {
 	// toResolveUnreplicated is used instead.
 	toResolve []roachpb.LockUpdate
 
+	// toResolveRange maps txn IDs to range LockUpdates that persist across scan
+	// attempts. It is only used when virtual intent resolution is enabled.
+	toResolveRange map[uuid.UUID]roachpb.LockUpdate
+
 	// toResolveUnreplicated is a list of locks (only held with durability
 	// unreplicated) that are known to belong to finalized transactions. Such
 	// locks may be cleared from the lock table (and some requests queueing in the
@@ -596,17 +601,38 @@ func (g *lockTableGuardImpl) ResolveBeforeScanning() []roachpb.LockUpdate {
 }
 
 // IntentsToResolveVirtually implements the lockTableGuard interface. The locks
-// to resolve are returned only if virtualized resolution is enabled.
+// to resolve are returned only if virtualized resolution is enabled. Returns
+// both point entries from toResolve and range entries from toResolveRange.
 func (g *lockTableGuardImpl) IntentsToResolveVirtually() []roachpb.LockUpdate {
-	if g.virtuallyResolveIntents {
+	if !g.virtuallyResolveIntents {
+		return nil
+	}
+	if len(g.toResolveRange) == 0 {
 		return g.toResolve
 	}
-	return nil
+	combined := make([]roachpb.LockUpdate, 0, len(g.toResolve)+len(g.toResolveRange))
+	combined = append(combined, g.toResolve...)
+	for _, up := range g.toResolveRange {
+		combined = append(combined, up)
+	}
+	return combined
 }
 
 // VirtuallyResolvesIntents implements the lockTableGuard interface.
 func (g *lockTableGuardImpl) VirtuallyResolvesIntents() bool {
 	return g.virtuallyResolveIntents
+}
+
+// keyAlreadyCoveredByRangeResolve returns true if the given key for the given
+// txn is already covered by a range entry in toResolveRange.
+func (g *lockTableGuardImpl) keyAlreadyCoveredByRangeResolve(
+	txnID uuid.UUID, key roachpb.Key,
+) bool {
+	if g.toResolveRange == nil {
+		return false
+	}
+	rangeUp, ok := g.toResolveRange[txnID]
+	return ok && rangeUp.Span.ContainsKey(key)
 }
 
 func (g *lockTableGuardImpl) NewStateChan() chan struct{} {
@@ -949,8 +975,9 @@ func (g *lockTableGuardImpl) conflictsWithHeldLock(
 				// block on Exclusive locks. Once non-locking reads start only
 				// blocking on intents, it can be removed and asserted against.
 				g.toResolveUnreplicated = append(g.toResolveUnreplicated, up)
-			} else {
-				// Resolve to push the replicated intent.
+			} else if !g.keyAlreadyCoveredByRangeResolve(lockHolderTxn.ID, key) {
+				// Resolve to push the replicated intent, unless this key
+				// is already covered by a range resolve range request.
 				g.toResolve = append(g.toResolve, up)
 			}
 			return false // No conflict on a lock we are going to resolve.
@@ -1137,6 +1164,57 @@ func (g *lockTableGuardImpl) resumeScan(notify bool) error {
 		g.notify()
 	}
 	return nil
+}
+
+// defaultMaxToResolveRangeTxns is the default maximum number of distinct txns
+// tracked in toResolveRange. If exceeded, VIR is disabled for the remainder of
+// this guard's lifetime to bound memory usage.
+const defaultMaxToResolveRangeTxns = 128
+
+// PrepareForLockConflictRetry implements the lockTableGuard interface.
+//
+// It collapses all point entries in toResolve into range entries in
+// toResolveRange, keyed by txn ID. This ensures that virtually resolved intents
+// are not forgotten if the lock table evicts their entries under memory
+// pressure.
+//
+// If the number of distinct txns in toResolveRange exceeds a safety bound, VIR
+// is disabled for this guard to prevent unbounded memory growth.
+func (g *lockTableGuardImpl) PrepareForLockConflictRetry(ctx context.Context) {
+	if !g.virtuallyResolveIntents || len(g.toResolve) == 0 {
+		return
+	}
+	g.collapseToResolveIntoRange(ctx)
+	if len(g.toResolveRange) > g.maxToResolveRangeTxns {
+		log.VEventf(ctx, 2,
+			"disabling virtual intent resolution: resolve range request count exceeds maximum: %d > %d",
+			len(g.toResolveRange), g.maxToResolveRangeTxns)
+		g.virtuallyResolveIntents = false
+		g.toResolveRange = nil
+	}
+}
+
+// collapseToResolveIntoRange moves all point entries from toResolve into
+// toResolveRange, extending existing entries if they exist.
+func (g *lockTableGuardImpl) collapseToResolveIntoRange(ctx context.Context) {
+	if g.toResolveRange == nil {
+		g.toResolveRange = make(map[uuid.UUID]roachpb.LockUpdate)
+	}
+	for i := range g.toResolve {
+		up := g.toResolve[i]
+		txnID := up.Txn.ID
+		existing, ok := g.toResolveRange[txnID]
+		if !ok {
+			up.Span.EndKey = up.Key.Next()
+			g.toResolveRange[txnID] = up
+		} else {
+			existing.Span = existing.Combine(up.Span)
+			g.toResolveRange[txnID] = existing
+		}
+	}
+	log.VEventf(ctx, 2, "collapsing %d point intent resolution requests into %d ranged intent resolution requests",
+		len(g.toResolve), len(g.toResolveRange))
+	g.toResolve = g.toResolve[:0]
 }
 
 func (g *lockTableGuardImpl) String() string {
@@ -4358,6 +4436,7 @@ func (t *lockTableImpl) newGuardForReq(req Request) *lockTableGuardImpl {
 	g.spans = req.LockSpans
 	g.waitPolicy = req.WaitPolicy
 	g.maxWaitQueueLength = req.MaxLockWaitQueueLength
+	g.maxToResolveRangeTxns = defaultMaxToResolveRangeTxns
 	g.str = lock.MaxStrength
 	g.index = -1
 	g.pushUsingCachedClockObs = PushUsingCachedClockObservation.Get(&g.lt.settings.SV)
@@ -4459,7 +4538,9 @@ func (t *lockTableImpl) AddDiscoveredLock(
 	}
 	if consultTxnStatusCache {
 		if canResolve, up := g.canResolveKeyForHoldingTransaction(&foundLock.Txn, str, key); canResolve {
-			g.toResolve = append(g.toResolve, up)
+			if !g.keyAlreadyCoveredByRangeResolve(foundLock.Txn.ID, key) {
+				g.toResolve = append(g.toResolve, up)
+			}
 			return true, nil
 		}
 	}

--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/lockspanset"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/container/list"
@@ -413,6 +414,7 @@ type lockTableGuardImpl struct {
 	pushUsingCachedClockObs bool
 	maxWaitQueueLength      int
 	maxToResolveRangeTxns   int
+	condenseOnScanThreshold int
 
 	// Snapshot of the tree for which this request has some spans. Note that
 	// the lockStates in this snapshot may have been removed from
@@ -511,17 +513,14 @@ type lockTableGuardImpl struct {
 		mustComputeWaitingState bool
 		startWait               bool
 	}
+
 	// Locks to resolve before scanning again. Doesn't need to be protected by
-	// mu since should only be read after the caller has already synced with mu
-	// in realizing that it is doneWaiting.
+	// mu since should only be read after the caller has already synced with mu in
+	// realizing that it is doneWaiting.
 	//
 	// toResolve should only include replicated locks; for unreplicated locks,
 	// toResolveUnreplicated is used instead.
-	toResolve []roachpb.LockUpdate
-
-	// toResolveRange maps txn IDs to range LockUpdates that persist across scan
-	// attempts. It is only used when virtual intent resolution is enabled.
-	toResolveRange map[uuid.UUID]roachpb.LockUpdate
+	toResolve resolvableLocks
 
 	// toResolveUnreplicated is a list of locks (only held with durability
 	// unreplicated) that are known to belong to finalized transactions. Such
@@ -536,6 +535,168 @@ type lockTableGuardImpl struct {
 	// on locks belonging to finalized transactions, we wouldn't need to bother
 	// scanning requests.
 	toResolveUnreplicated []roachpb.LockUpdate
+}
+
+// resolvableLocks tracks replicated locks that a guard has determined are
+// resolvable. Point entries accumulate in toResolve during lock table scans.
+//
+// When VIR is enabled and toResolve grows beyond condenseThreshold, point
+// entries are condensed into range entries in toResolveRange. The range entries
+// and resolvableTxns persist across scans so the guard does not re-conflict on
+// locks whose txnStatusCache entry has been evicted.
+type resolvableLocks struct {
+	// toResolve holds point LockUpdates accumulated during scanning. This is
+	// cleared on every entry to ScanAndEnqueue.
+	//
+	// For VIR transactions, we rely on previously encountered transactions being
+	// in resolvableTxns
+	toResolve []roachpb.LockUpdate
+
+	// toResolveRange maps txn IDs to range LockUpdates that persist across
+	// scan attempts. Populated by condensing toResolve. Only used when
+	// virtual intent resolution is enabled.
+	//
+	// This is not cleared across ScanAndEnqueue calls.
+	toResolveRange map[uuid.UUID]roachpb.LockUpdate
+
+	// resolvableTxns maps txn IDs to a partial LockUpdate representing that
+	// transaction's last addition to toResolve. This is not cleared across
+	// ScanAndEnqueue.
+	resolvableTxns map[uuid.UUID]roachpb.LockUpdate
+
+	// virEnabled controls whether resolvableLocks should actually use toResolveRange
+	// and resolvableTxns.
+	virEnabled bool
+}
+
+// condense moves all point entries from toResolve into toResolveRange,
+// extending existing range entries per txn ID.
+func (rl *resolvableLocks) condense() {
+	if len(rl.toResolve) == 0 || !rl.virEnabled {
+		return
+	}
+
+	if rl.toResolveRange == nil {
+		rl.toResolveRange = make(map[uuid.UUID]roachpb.LockUpdate)
+	}
+	for i := range rl.toResolve {
+		up := rl.toResolve[i]
+		txnID := up.Txn.ID
+		existing, ok := rl.toResolveRange[txnID]
+		if !ok {
+			up.Span.EndKey = up.Key.Next()
+			rl.toResolveRange[txnID] = up
+		} else if !existing.Span.ContainsKey(up.Key) {
+			existing.Span = existing.Combine(up.Span)
+			rl.toResolveRange[txnID] = existing
+		}
+	}
+	rl.toResolve = rl.toResolve[:0]
+}
+
+// maybeCondense condenses point entries into range entries if toResolve has
+// grown beyond the configured threshold.
+func (rl *resolvableLocks) maybeCondense(threshold int) bool {
+	if rl.virEnabled && len(rl.toResolve) > threshold {
+		rl.condense()
+		return true
+	}
+	return false
+}
+
+// collect returns all resolvable locks — both point and range entries.
+func (rl *resolvableLocks) collect() []roachpb.LockUpdate {
+	if len(rl.toResolveRange) == 0 {
+		return rl.toResolve
+	}
+	combined := make([]roachpb.LockUpdate, 0, len(rl.toResolve)+len(rl.toResolveRange))
+	combined = append(combined, rl.toResolve...)
+	for _, up := range rl.toResolveRange {
+		combined = append(combined, up)
+	}
+	return combined
+}
+
+// contains returns true if the given (txnID, key) pair is already tracked
+// as resolvable via the range entries. Point entries in toResolve are not
+// checked; duplicates are tolerated and eliminated on condensing.
+func (rl *resolvableLocks) contains(txnID uuid.UUID, key roachpb.Key) bool {
+	if rl.toResolveRange != nil {
+		rangeUp, ok := rl.toResolveRange[txnID]
+		return ok && rangeUp.Span.ContainsKey(key)
+	}
+	return false
+}
+
+func (rl *resolvableLocks) isResolvableTxn(txnID uuid.UUID) (bool, roachpb.LockUpdate) {
+	if !rl.virEnabled {
+		return false, roachpb.LockUpdate{}
+	}
+
+	if lu, ok := rl.resolvableTxns[txnID]; ok {
+		return true, lu
+	}
+	return false, roachpb.LockUpdate{}
+}
+
+// add appends a point LockUpdate. If the key is already covered by a range
+// entry for the same txn, the add is skipped. Duplicate point entries for
+// the same (txn, key) are tolerated.
+func (rl *resolvableLocks) add(lu roachpb.LockUpdate) {
+	// We only track resolvableTxns for VIR-enabled txns.
+	if !rl.virEnabled {
+		rl.toResolve = append(rl.toResolve, lu)
+		return
+	}
+
+	if rl.toResolveRange != nil {
+		existing, ok := rl.toResolveRange[lu.Txn.ID]
+		if ok && existing.Span.ContainsKey(lu.Key) {
+			return
+		}
+	}
+	rl.toResolve = append(rl.toResolve, lu)
+
+	if rl.resolvableTxns == nil {
+		rl.resolvableTxns = make(map[uuid.UUID]roachpb.LockUpdate)
+	}
+	cacheEntry := lu
+	cacheEntry.Span = roachpb.Span{}
+	rl.resolvableTxns[cacheEntry.Txn.ID] = cacheEntry
+}
+
+// filterPointResolves removes point entries for which fn returns false.
+func (rl *resolvableLocks) filterPointResolves(fn func(roachpb.LockUpdate) bool) {
+	if len(rl.toResolve) == 0 {
+		return
+	}
+	j := 0
+	for i := range rl.toResolve {
+		if fn(rl.toResolve[i]) {
+			rl.toResolve[j] = rl.toResolve[i]
+			j++
+		}
+	}
+	rl.toResolve = rl.toResolve[:j]
+}
+
+func (rl *resolvableLocks) rangeResolves() int {
+	return len(rl.toResolveRange)
+}
+
+func (rl *resolvableLocks) len() int {
+	return len(rl.toResolve) + len(rl.toResolveRange)
+}
+
+func (rl *resolvableLocks) clear() {
+	rl.toResolve = rl.toResolve[:0]
+}
+
+func (rl *resolvableLocks) reset(virEnabled bool) {
+	rl.toResolve = rl.toResolve[:0]
+	rl.resolvableTxns = nil
+	rl.toResolveRange = nil
+	rl.virEnabled = virEnabled
 }
 
 var _ lockTableGuard = &lockTableGuardImpl{}
@@ -588,14 +749,14 @@ func (g *lockTableGuardImpl) ShouldWait() bool {
 	// resolution is enabled, these locks will be resolved during evaluation (on
 	// a temporary batch) rather than before re-scanning, so the request does not
 	// need to wait.
-	return g.mu.startWait || (!g.virtuallyResolveIntents && len(g.toResolve) > 0)
+	return g.mu.startWait || (!g.virtuallyResolveIntents && g.toResolve.len() > 0)
 }
 
 // ResolveBeforeScanning implements the lockTableGuard interface. The locks to
 // resolve are returned only if virtualized resolution is disabled.
 func (g *lockTableGuardImpl) ResolveBeforeScanning() []roachpb.LockUpdate {
 	if !g.virtuallyResolveIntents {
-		return g.toResolve
+		return g.toResolve.collect()
 	}
 	return nil
 }
@@ -607,32 +768,12 @@ func (g *lockTableGuardImpl) IntentsToResolveVirtually() []roachpb.LockUpdate {
 	if !g.virtuallyResolveIntents {
 		return nil
 	}
-	if len(g.toResolveRange) == 0 {
-		return g.toResolve
-	}
-	combined := make([]roachpb.LockUpdate, 0, len(g.toResolve)+len(g.toResolveRange))
-	combined = append(combined, g.toResolve...)
-	for _, up := range g.toResolveRange {
-		combined = append(combined, up)
-	}
-	return combined
+	return g.toResolve.collect()
 }
 
 // VirtuallyResolvesIntents implements the lockTableGuard interface.
 func (g *lockTableGuardImpl) VirtuallyResolvesIntents() bool {
 	return g.virtuallyResolveIntents
-}
-
-// keyAlreadyCoveredByRangeResolve returns true if the given key for the given
-// txn is already covered by a range entry in toResolveRange.
-func (g *lockTableGuardImpl) keyAlreadyCoveredByRangeResolve(
-	txnID uuid.UUID, key roachpb.Key,
-) bool {
-	if g.toResolveRange == nil {
-		return false
-	}
-	rangeUp, ok := g.toResolveRange[txnID]
-	return ok && rangeUp.Span.ContainsKey(key)
 }
 
 func (g *lockTableGuardImpl) NewStateChan() chan struct{} {
@@ -896,6 +1037,13 @@ func (g *lockTableGuardImpl) hasObservationAtOrBefore(o roachpb.ObservedTimestam
 func (g *lockTableGuardImpl) canResolveKeyForHoldingTransaction(
 	lockHolderTxn *enginepb.TxnMeta, str lock.Strength, key roachpb.Key,
 ) (bool, roachpb.LockUpdate) {
+	// If we already know about this txn in our toResolve set but it has just been
+	// pushed, then we can use it from there.
+	if resolvable, up := g.toResolve.isResolvableTxn(lockHolderTxn.ID); resolvable {
+		up.Span = roachpb.Span{Key: key}
+		return true, up
+	}
+
 	// If the transaction is known to be finalized, then we are good to go.
 	finalizedTxn, ok := g.lt.txnStatusCache.finalizedTxns.get(lockHolderTxn.ID)
 	if ok {
@@ -914,6 +1062,7 @@ func (g *lockTableGuardImpl) canResolveKeyForHoldingTransaction(
 			return true, up
 		}
 	}
+
 	return false, roachpb.LockUpdate{}
 }
 
@@ -960,6 +1109,10 @@ func (g *lockTableGuardImpl) conflictsWithHeldLock(
 		return false // no conflict with a lock held by our own transaction
 	}
 
+	if g.toResolve.contains(lockHolderTxn.ID, key) {
+		return false // No conflict for a lock we are going to resolve.
+	}
+
 	if canResolve, up := g.canResolveKeyForHoldingTransaction(lockHolderTxn, g.curStrength(), key); canResolve {
 		// We share this code with a couple of contexts. For now, we want to avoid waking up
 		// readers who are not going to virtually resolve their intents.
@@ -975,10 +1128,10 @@ func (g *lockTableGuardImpl) conflictsWithHeldLock(
 				// block on Exclusive locks. Once non-locking reads start only
 				// blocking on intents, it can be removed and asserted against.
 				g.toResolveUnreplicated = append(g.toResolveUnreplicated, up)
-			} else if !g.keyAlreadyCoveredByRangeResolve(lockHolderTxn.ID, key) {
+			} else {
 				// Resolve to push the replicated intent, unless this key
 				// is already covered by a range resolve range request.
-				g.toResolve = append(g.toResolve, up)
+				g.toResolve.add(up)
 			}
 			return false // No conflict on a lock we are going to resolve.
 		}
@@ -1126,8 +1279,7 @@ func (g *lockTableGuardImpl) resumeScan(notify bool) error {
 		span = stepToNextSpan(g)
 	}
 
-	if len(g.toResolve) > 0 && !g.virtuallyResolveIntents {
-		j := 0
+	if !g.virtuallyResolveIntents {
 		// Some of the locks in g.toResolve may already have been claimed by
 		// another concurrent request and removed, or intent resolution could have
 		// happened while this request was waiting (after releasing latches). So
@@ -1143,19 +1295,13 @@ func (g *lockTableGuardImpl) resumeScan(notify bool) error {
 		//
 		// We skip updating the lock table if virtual intent resolution is enabled
 		// since this request won't be committing its intent resolution.
-		for i := range g.toResolve {
-			var doResolve bool
-			if g.toResolve[i].Status.IsFinalized() {
-				doResolve = g.lt.updateLockInternal(&g.toResolve[i])
+		g.toResolve.filterPointResolves(func(lu roachpb.LockUpdate) bool {
+			if lu.Status.IsFinalized() {
+				return g.lt.updateLockInternal(&lu)
 			} else {
-				doResolve = true
+				return true
 			}
-			if doResolve {
-				g.toResolve[j] = g.toResolve[i]
-				j++
-			}
-		}
-		g.toResolve = g.toResolve[:j]
+		})
 	}
 	g.mu.Lock()
 	defer g.mu.Unlock()
@@ -1166,55 +1312,26 @@ func (g *lockTableGuardImpl) resumeScan(notify bool) error {
 	return nil
 }
 
-// defaultMaxToResolveRangeTxns is the default maximum number of distinct txns
-// tracked in toResolveRange. If exceeded, VIR is disabled for the remainder of
-// this guard's lifetime to bound memory usage.
-const defaultMaxToResolveRangeTxns = 128
-
 // PrepareForLockConflictRetry implements the lockTableGuard interface.
-//
-// It collapses all point entries in toResolve into range entries in
-// toResolveRange, keyed by txn ID. This ensures that virtually resolved intents
-// are not forgotten if the lock table evicts their entries under memory
-// pressure.
-//
-// If the number of distinct txns in toResolveRange exceeds a safety bound, VIR
-// is disabled for this guard to prevent unbounded memory growth.
-func (g *lockTableGuardImpl) PrepareForLockConflictRetry(ctx context.Context) {
-	if !g.virtuallyResolveIntents || len(g.toResolve) == 0 {
-		return
-	}
-	g.collapseToResolveIntoRange(ctx)
-	if len(g.toResolveRange) > g.maxToResolveRangeTxns {
-		log.VEventf(ctx, 2,
-			"disabling virtual intent resolution: resolve range request count exceeds maximum: %d > %d",
-			len(g.toResolveRange), g.maxToResolveRangeTxns)
-		g.virtuallyResolveIntents = false
-		g.toResolveRange = nil
-	}
+func (g *lockTableGuardImpl) PrepareForLockConflictRetry(_ context.Context) {
+	// If we encountered a LockConflict during evaluation, we need to consider the
+	// possibility that we _won't_ encounter the lock again from the lock table.
+	//
+	// We handle that by condensing _everything_ into resolve ranges. We could
+	// have alternatively handled this by keep toResolve across invocations of
+	// ScanAndEnqueue. If we find that overzealous range resolutions are a
+	// problem, we can re-consider that decision.
+	g.toResolve.maybeCondense(0)
 }
 
-// collapseToResolveIntoRange moves all point entries from toResolve into
-// toResolveRange, extending existing entries if they exist.
-func (g *lockTableGuardImpl) collapseToResolveIntoRange(ctx context.Context) {
-	if g.toResolveRange == nil {
-		g.toResolveRange = make(map[uuid.UUID]roachpb.LockUpdate)
+func (g *lockTableGuardImpl) maybeDisableVIR(ctx context.Context) {
+	if l := g.toResolve.rangeResolves(); l > g.maxToResolveRangeTxns {
+		log.VEventf(ctx, 2,
+			"disabling virtual intent resolution: resolve range request count exceeds maximum: %d > %d",
+			l, g.maxToResolveRangeTxns)
+		g.virtuallyResolveIntents = false
+		g.toResolve.reset(g.virtuallyResolveIntents)
 	}
-	for i := range g.toResolve {
-		up := g.toResolve[i]
-		txnID := up.Txn.ID
-		existing, ok := g.toResolveRange[txnID]
-		if !ok {
-			up.Span.EndKey = up.Key.Next()
-			g.toResolveRange[txnID] = up
-		} else {
-			existing.Span = existing.Combine(up.Span)
-			g.toResolveRange[txnID] = existing
-		}
-	}
-	log.VEventf(ctx, 2, "collapsing %d point intent resolution requests into %d ranged intent resolution requests",
-		len(g.toResolve), len(g.toResolveRange))
-	g.toResolve = g.toResolve[:0]
 }
 
 func (g *lockTableGuardImpl) String() string {
@@ -4399,7 +4516,16 @@ func (t *lockTableImpl) ScanAndEnqueue(
 		g.mu.state = waitingState{}
 		g.mu.mustComputeWaitingState = false
 		g.mu.Unlock()
-		g.toResolve = g.toResolve[:0]
+		if g.virtuallyResolveIntents {
+			// Condense accumulated point entries into range entries if the list has
+			// grown large.
+			//
+			// If we've also accumulated too many range resolves, give up trying to
+			// virtually resolve.
+			g.toResolve.maybeCondense(g.condenseOnScanThreshold)
+			g.maybeDisableVIR(ctx)
+		}
+		g.toResolve.clear()
 	}
 	t.doSnapshotForGuard(g)
 
@@ -4427,6 +4553,10 @@ func (t *lockTableImpl) ScanAndEnqueue(
 	return g, nil
 }
 
+// defaultMaxToResolveRangeTxns is the default maximum number of distinct txns
+// tracked in toResolveRange.
+const defaultMaxToResolveRangeTxns = 128
+
 func (t *lockTableImpl) newGuardForReq(req Request) *lockTableGuardImpl {
 	g := newLockTableGuardImpl()
 	g.seqNum = t.seqNum.Add(1)
@@ -4437,10 +4567,12 @@ func (t *lockTableImpl) newGuardForReq(req Request) *lockTableGuardImpl {
 	g.waitPolicy = req.WaitPolicy
 	g.maxWaitQueueLength = req.MaxLockWaitQueueLength
 	g.maxToResolveRangeTxns = defaultMaxToResolveRangeTxns
+	g.condenseOnScanThreshold = int(storage.MaxConflictsPerLockConflictError.Get(&g.lt.settings.SV))
 	g.str = lock.MaxStrength
 	g.index = -1
 	g.pushUsingCachedClockObs = PushUsingCachedClockObservation.Get(&g.lt.settings.SV)
 	g.virtuallyResolveIntents = VirtualIntentResolution.Get(&g.lt.settings.SV) && req.canVirtuallyResolve()
+	g.toResolve.virEnabled = g.virtuallyResolveIntents
 	return g
 }
 
@@ -4538,9 +4670,7 @@ func (t *lockTableImpl) AddDiscoveredLock(
 	}
 	if consultTxnStatusCache {
 		if canResolve, up := g.canResolveKeyForHoldingTransaction(&foundLock.Txn, str, key); canResolve {
-			if !g.keyAlreadyCoveredByRangeResolve(foundLock.Txn.ID, key) {
-				g.toResolve = append(g.toResolve, up)
-			}
+			g.toResolve.add(up)
 			return true, nil
 		}
 	}

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -2215,14 +2215,168 @@ func TestKeyLocksSafeFormatWaitQueue(t *testing.T) {
 		redact.Sprint(kl).Redact())
 }
 
-// TestPrepareForLockConflictRetry exercises the guard's collapse and VIR
-// disable behavior. Point entries in toResolve are collapsed into range entries
-// in toResolveRange on each lock conflict retry. When the number of distinct
-// txns in toResolveRange exceeds the configured threshold, VIR is disabled
-// stickily for the guard's lifetime.
-func TestPrepareForLockConflictRetry(t *testing.T) {
+// TestResolvableLocks exercises the condense, contains, collect, and
+// isResolvableTxn behavior of resolvableLocks.
+func TestResolvableLocks(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	makeTxnMeta := func(name string) enginepb.TxnMeta {
+		return enginepb.TxnMeta{
+			ID:             uuid.MakeV4(),
+			WriteTimestamp: hlc.Timestamp{WallTime: 10},
+			Key:            roachpb.Key(name),
+		}
+	}
+	makeLockUpdate := func(txn enginepb.TxnMeta, key roachpb.Key) roachpb.LockUpdate {
+		return roachpb.LockUpdate{
+			Span:   roachpb.Span{Key: key},
+			Txn:    txn,
+			Status: roachpb.PENDING,
+		}
+	}
+	makeRL := func(vir bool, updates ...roachpb.LockUpdate) resolvableLocks {
+		rl := resolvableLocks{virEnabled: vir}
+		for _, lu := range updates {
+			rl.add(lu)
+		}
+		return rl
+	}
+	txn := makeTxnMeta("txn1")
+
+	t.Run("condense noop when VIR disabled", func(t *testing.T) {
+		rl := makeRL(false, makeLockUpdate(txn, roachpb.Key("a")))
+		require.False(t, rl.maybeCondense(0))
+		require.Len(t, rl.toResolve, 1)
+		require.Nil(t, rl.toResolveRange)
+	})
+
+	t.Run("condense noop when empty", func(t *testing.T) {
+		rl := makeRL(true)
+		require.False(t, rl.maybeCondense(0))
+		require.Nil(t, rl.toResolveRange)
+	})
+
+	t.Run("condense single txn", func(t *testing.T) {
+		rl := makeRL(true,
+			makeLockUpdate(txn, roachpb.Key("b")),
+			makeLockUpdate(txn, roachpb.Key("d")),
+			makeLockUpdate(txn, roachpb.Key("a")),
+		)
+		require.True(t, rl.maybeCondense(0))
+		require.Empty(t, rl.toResolve)
+		require.Len(t, rl.toResolveRange, 1)
+		// Range should span [a, d.Next()).
+		rangeUp := rl.toResolveRange[txn.ID]
+		require.Equal(t, roachpb.Key("a"), rangeUp.Key)
+		require.Equal(t, roachpb.Key("d").Next(), rangeUp.EndKey)
+	})
+
+	t.Run("extend existing range", func(t *testing.T) {
+		rl := makeRL(true,
+			makeLockUpdate(txn, roachpb.Key("b")),
+			makeLockUpdate(txn, roachpb.Key("c")),
+		)
+		// First round: condense "b" and "c".
+		rl.condense()
+		require.Empty(t, rl.toResolve)
+		require.Equal(t, roachpb.Key("b"), rl.toResolveRange[txn.ID].Key)
+		require.Equal(t, roachpb.Key("c").Next(), rl.toResolveRange[txn.ID].EndKey)
+
+		// Second round: extend left with "a" and right with "e".
+		rl.add(makeLockUpdate(txn, roachpb.Key("a")))
+		rl.add(makeLockUpdate(txn, roachpb.Key("e")))
+		rl.condense()
+		require.Len(t, rl.toResolveRange, 1)
+		rangeUp := rl.toResolveRange[txn.ID]
+		require.Equal(t, roachpb.Key("a"), rangeUp.Key)
+		require.Equal(t, roachpb.Key("e").Next(), rangeUp.EndKey)
+	})
+
+	t.Run("covered keys skipped on add", func(t *testing.T) {
+		rl := makeRL(true,
+			makeLockUpdate(txn, roachpb.Key("a")),
+			makeLockUpdate(txn, roachpb.Key("c")),
+		)
+		rl.condense()
+		// "b" is inside the range [a, c.Next()) and should be covered.
+		require.True(t, rl.contains(txn.ID, roachpb.Key("b")))
+		// "d" is outside.
+		require.False(t, rl.contains(txn.ID, roachpb.Key("d")))
+		// Unknown txn is not covered.
+		require.False(t, rl.contains(uuid.MakeV4(), roachpb.Key("b")))
+
+		// Adding a key already covered by the range should be a no-op.
+		rl.add(makeLockUpdate(txn, roachpb.Key("b")))
+		require.Empty(t, rl.toResolve)
+	})
+
+	t.Run("isResolvableTxn tracks added txns", func(t *testing.T) {
+		rl := makeRL(true, makeLockUpdate(txn, roachpb.Key("a")))
+		ok, _ := rl.isResolvableTxn(txn.ID)
+		require.True(t, ok)
+		ok, _ = rl.isResolvableTxn(uuid.MakeV4())
+		require.False(t, ok)
+	})
+
+	t.Run("isResolvableTxn noop when VIR disabled", func(t *testing.T) {
+		rl := makeRL(false, makeLockUpdate(txn, roachpb.Key("a")))
+		ok, _ := rl.isResolvableTxn(txn.ID)
+		require.False(t, ok)
+	})
+
+	t.Run("isResolvableTxn persists across clear", func(t *testing.T) {
+		rl := makeRL(true, makeLockUpdate(txn, roachpb.Key("a")))
+		rl.clear()
+		require.Empty(t, rl.toResolve)
+		ok, _ := rl.isResolvableTxn(txn.ID)
+		require.True(t, ok)
+	})
+
+	t.Run("collect combines point and range", func(t *testing.T) {
+		txn2 := makeTxnMeta("txn2")
+		rl := makeRL(true, makeLockUpdate(txn, roachpb.Key("a")))
+		// Condense txn into toResolveRange.
+		rl.condense()
+		// Add a point entry for txn2 (not yet condensed).
+		rl.add(makeLockUpdate(txn2, roachpb.Key("x")))
+
+		combined := rl.collect()
+		require.Len(t, combined, 2)
+		// One point (txn2) and one range (txn).
+		var hasPoint, hasRange bool
+		for _, up := range combined {
+			if len(up.EndKey) > 0 {
+				hasRange = true
+				require.Equal(t, txn.ID, up.Txn.ID)
+			} else {
+				hasPoint = true
+				require.Equal(t, txn2.ID, up.Txn.ID)
+			}
+		}
+		require.True(t, hasPoint)
+		require.True(t, hasRange)
+	})
+
+	t.Run("reset clears everything", func(t *testing.T) {
+		rl := makeRL(true,
+			makeLockUpdate(txn, roachpb.Key("a")),
+			makeLockUpdate(makeTxnMeta("txn2"), roachpb.Key("b")),
+		)
+		rl.condense()
+		rl.reset(false)
+		require.Empty(t, rl.toResolve)
+		require.Nil(t, rl.toResolveRange)
+		require.Nil(t, rl.resolvableTxns)
+		require.False(t, rl.virEnabled)
+	})
+}
+
+// TestMaybeDisableVIR exercises the maybeDisableVIR logic on lockTableGuardImpl.
+func TestMaybeDisableVIR(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
 	ctx := context.Background()
 
 	makeTxnMeta := func(name string) enginepb.TxnMeta {
@@ -2239,157 +2393,45 @@ func TestPrepareForLockConflictRetry(t *testing.T) {
 			Status: roachpb.PENDING,
 		}
 	}
-	txn := makeTxnMeta("txn1")
 
-	t.Run("noop when VIR disabled", func(t *testing.T) {
-		g := &lockTableGuardImpl{
-			virtuallyResolveIntents: false,
-			maxToResolveRangeTxns:   2,
-			toResolve: []roachpb.LockUpdate{
-				makeLockUpdate(txn, roachpb.Key("a")),
-			},
-		}
-		g.PrepareForLockConflictRetry(ctx)
-		// toResolve should be untouched since VIR is disabled.
-		require.Len(t, g.toResolve, 1)
-		require.Nil(t, g.toResolveRange)
-	})
+	t.Run("does not disable when under limit", func(t *testing.T) {
+		g := newLockTableGuardImpl()
+		defer releaseLockTableGuardImpl(g)
+		g.virtuallyResolveIntents = true
+		g.toResolve.virEnabled = true
+		g.maxToResolveRangeTxns = 2
 
-	t.Run("noop when toResolve is empty", func(t *testing.T) {
-		g := &lockTableGuardImpl{
-			virtuallyResolveIntents: true,
-			maxToResolveRangeTxns:   2,
-		}
-		g.PrepareForLockConflictRetry(ctx)
-		require.Nil(t, g.toResolveRange)
-	})
+		// Add and condense one txn — under the limit.
+		txn1 := makeTxnMeta("txn1")
+		g.toResolve.add(makeLockUpdate(txn1, roachpb.Key("a")))
+		g.toResolve.condense()
+		require.Equal(t, 1, g.toResolve.rangeResolves())
 
-	t.Run("collapse single txn", func(t *testing.T) {
-		g := &lockTableGuardImpl{
-			virtuallyResolveIntents: true,
-			maxToResolveRangeTxns:   10,
-			toResolve: []roachpb.LockUpdate{
-				makeLockUpdate(txn, roachpb.Key("b")),
-				makeLockUpdate(txn, roachpb.Key("d")),
-				makeLockUpdate(txn, roachpb.Key("a")),
-			},
-		}
-		g.PrepareForLockConflictRetry(ctx)
-		require.Empty(t, g.toResolve)
-		require.Len(t, g.toResolveRange, 1)
-		// Range should span [a, d.Next()).
-		rangeUp := g.toResolveRange[txn.ID]
-		require.Equal(t, roachpb.Key("a"), rangeUp.Key)
-		require.Equal(t, roachpb.Key("d").Next(), rangeUp.EndKey)
+		g.maybeDisableVIR(ctx)
 		require.True(t, g.virtuallyResolveIntents)
 	})
 
-	t.Run("extend existing range", func(t *testing.T) {
-		g := &lockTableGuardImpl{
-			virtuallyResolveIntents: true,
-			maxToResolveRangeTxns:   10,
-			toResolve: []roachpb.LockUpdate{
-				makeLockUpdate(txn, roachpb.Key("b")),
-				makeLockUpdate(txn, roachpb.Key("c")),
-			},
-		}
-		// First round: collapse "b" and "c".
-		g.PrepareForLockConflictRetry(ctx)
-		require.Empty(t, g.toResolve)
-		require.Equal(t, roachpb.Key("b"), g.toResolveRange[txn.ID].Key)
-		require.Equal(t, roachpb.Key("c").Next(), g.toResolveRange[txn.ID].EndKey)
+	t.Run("disables when over limit", func(t *testing.T) {
+		g := newLockTableGuardImpl()
+		defer releaseLockTableGuardImpl(g)
+		g.virtuallyResolveIntents = true
+		g.toResolve.virEnabled = true
+		g.maxToResolveRangeTxns = 1
 
-		// Second round: extend left with "a" and right with "e".
-		g.toResolve = append(g.toResolve,
-			makeLockUpdate(txn, roachpb.Key("a")),
-			makeLockUpdate(txn, roachpb.Key("e")),
-		)
-		g.PrepareForLockConflictRetry(ctx)
-		require.Len(t, g.toResolveRange, 1)
-		rangeUp := g.toResolveRange[txn.ID]
-		require.Equal(t, roachpb.Key("a"), rangeUp.Key)
-		require.Equal(t, roachpb.Key("e").Next(), rangeUp.EndKey)
-	})
-
-	t.Run("covered keys skipped", func(t *testing.T) {
-		g := &lockTableGuardImpl{
-			virtuallyResolveIntents: true,
-			maxToResolveRangeTxns:   10,
-			toResolve: []roachpb.LockUpdate{
-				makeLockUpdate(txn, roachpb.Key("a")),
-				makeLockUpdate(txn, roachpb.Key("c")),
-			},
-		}
-		g.PrepareForLockConflictRetry(ctx)
-		// "b" is inside the range [a, c.Next()) and should be covered.
-		require.True(t, g.keyAlreadyCoveredByRangeResolve(txn.ID, roachpb.Key("b")))
-		// "d" is outside.
-		require.False(t, g.keyAlreadyCoveredByRangeResolve(txn.ID, roachpb.Key("d")))
-		// Unknown txn is not covered.
-		require.False(t, g.keyAlreadyCoveredByRangeResolve(uuid.MakeV4(), roachpb.Key("b")))
-	})
-
-	t.Run("VIR disabled when threshold exceeded", func(t *testing.T) {
-		g := &lockTableGuardImpl{
-			virtuallyResolveIntents: true,
-			maxToResolveRangeTxns:   2,
-			toResolve: []roachpb.LockUpdate{
-				makeLockUpdate(txn, roachpb.Key("a")),
-				makeLockUpdate(makeTxnMeta("txn2"), roachpb.Key("b")),
-				makeLockUpdate(makeTxnMeta("txn3"), roachpb.Key("c")),
-			},
-		}
-		g.PrepareForLockConflictRetry(ctx)
-		require.False(t, g.virtuallyResolveIntents)
-		require.Nil(t, g.toResolveRange)
-		require.Empty(t, g.toResolve)
-	})
-
-	t.Run("below threshold no disable", func(t *testing.T) {
-		g := &lockTableGuardImpl{
-			virtuallyResolveIntents: true,
-			maxToResolveRangeTxns:   3,
-			toResolve: []roachpb.LockUpdate{
-				makeLockUpdate(txn, roachpb.Key("a")),
-				makeLockUpdate(makeTxnMeta("txn2"), roachpb.Key("b")),
-				makeLockUpdate(makeTxnMeta("txn3"), roachpb.Key("c")),
-			},
-		}
-		// 3 txns at threshold of 3 — should not disable.
-		g.PrepareForLockConflictRetry(ctx)
-		require.True(t, g.virtuallyResolveIntents)
-		require.Len(t, g.toResolveRange, 3)
-	})
-
-	t.Run("IntentsToResolveVirtually combines point and range", func(t *testing.T) {
+		// Add and condense two txns — over the limit.
+		txn1 := makeTxnMeta("txn1")
 		txn2 := makeTxnMeta("txn2")
-		g := &lockTableGuardImpl{
-			virtuallyResolveIntents: true,
-			maxToResolveRangeTxns:   10,
-			toResolve: []roachpb.LockUpdate{
-				makeLockUpdate(txn, roachpb.Key("a")),
-			},
-		}
-		// Collapse txn into toResolveRange.
-		g.PrepareForLockConflictRetry(ctx)
-		// Add a point entry for txn2 (not yet collapsed).
-		g.toResolve = append(g.toResolve, makeLockUpdate(txn2, roachpb.Key("x")))
+		g.toResolve.add(makeLockUpdate(txn1, roachpb.Key("a")))
+		g.toResolve.add(makeLockUpdate(txn2, roachpb.Key("b")))
+		g.toResolve.condense()
+		require.Equal(t, 2, g.toResolve.rangeResolves())
 
-		combined := g.IntentsToResolveVirtually()
-		require.Len(t, combined, 2)
-		// One point (txn2) and one range (txn).
-		var hasPoint, hasRange bool
-		for _, up := range combined {
-			if len(up.EndKey) > 0 {
-				hasRange = true
-				require.Equal(t, txn.ID, up.Txn.ID)
-			} else {
-				hasPoint = true
-				require.Equal(t, txn2.ID, up.Txn.ID)
-			}
-		}
-		require.True(t, hasPoint)
-		require.True(t, hasRange)
+		g.maybeDisableVIR(ctx)
+		require.False(t, g.virtuallyResolveIntents)
+		// reset should have been called, clearing everything.
+		require.Empty(t, g.toResolve.toResolve)
+		require.Nil(t, g.toResolve.toResolveRange)
+		require.Nil(t, g.toResolve.resolvableTxns)
 	})
 }
 
@@ -2424,5 +2466,65 @@ func TestCanElideWaitingStateUpdateConsidersAllFields(t *testing.T) {
 			t.Fatalf("%s field not considered", fieldName)
 		}
 		typ.Field(i)
+	}
+}
+
+// BenchmarkResolvableLocksAdd benchmarks the add path of resolvableLocks with
+// and without VIR enabled, varying the number of locks, distinct transactions,
+// and key sizes.
+func BenchmarkResolvableLocksAdd(b *testing.B) {
+	const maxTxns = 64
+	const maxKeysPerTxn = 256
+	txns := make([]enginepb.TxnMeta, maxTxns)
+	for i := range txns {
+		txns[i] = enginepb.TxnMeta{
+			ID:             uuid.MakeV4(),
+			WriteTimestamp: hlc.Timestamp{WallTime: 10},
+		}
+	}
+
+	makeKey := func(keySize, idx int) roachpb.Key {
+		k := make(roachpb.Key, keySize)
+		// Write the index into the last 8 bytes to ensure uniqueness.
+		s := strconv.AppendInt(k[:0], int64(idx), 10)
+		copy(k[keySize-len(s):], s)
+		return k
+	}
+
+	makeUpdate := func(txn enginepb.TxnMeta, key roachpb.Key) roachpb.LockUpdate {
+		return roachpb.LockUpdate{
+			Span:   roachpb.Span{Key: key},
+			Txn:    txn,
+			Status: roachpb.COMMITTED,
+		}
+	}
+
+	for _, keySize := range []int{32, 64, 128} {
+		keys := make([]roachpb.Key, maxKeysPerTxn)
+		for i := range keys {
+			keys[i] = makeKey(keySize, i)
+		}
+		for _, numTxns := range []int{1, 8, 64} {
+			for _, keysPerTxn := range []int{1, 32, 256} {
+				updates := make([]roachpb.LockUpdate, 0, numTxns*keysPerTxn)
+				for t := 0; t < numTxns; t++ {
+					for k := 0; k < keysPerTxn; k++ {
+						updates = append(updates, makeUpdate(txns[t], keys[k]))
+					}
+				}
+				for _, vir := range []bool{false, true} {
+					name := fmt.Sprintf("keySize=%d/txns=%d/keys=%d/vir=%t",
+						keySize, numTxns, keysPerTxn, vir)
+					b.Run(name, func(b *testing.B) {
+						for i := 0; i < b.N; i++ {
+							rl := resolvableLocks{virEnabled: vir}
+							for j := range updates {
+								rl.add(updates[j])
+							}
+						}
+					})
+				}
+			}
+		}
 	}
 }

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -2215,6 +2215,184 @@ func TestKeyLocksSafeFormatWaitQueue(t *testing.T) {
 		redact.Sprint(kl).Redact())
 }
 
+// TestPrepareForLockConflictRetry exercises the guard's collapse and VIR
+// disable behavior. Point entries in toResolve are collapsed into range entries
+// in toResolveRange on each lock conflict retry. When the number of distinct
+// txns in toResolveRange exceeds the configured threshold, VIR is disabled
+// stickily for the guard's lifetime.
+func TestPrepareForLockConflictRetry(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	makeTxnMeta := func(name string) enginepb.TxnMeta {
+		return enginepb.TxnMeta{
+			ID:             uuid.MakeV4(),
+			WriteTimestamp: hlc.Timestamp{WallTime: 10},
+			Key:            roachpb.Key(name),
+		}
+	}
+	makeLockUpdate := func(txn enginepb.TxnMeta, key roachpb.Key) roachpb.LockUpdate {
+		return roachpb.LockUpdate{
+			Span:   roachpb.Span{Key: key},
+			Txn:    txn,
+			Status: roachpb.PENDING,
+		}
+	}
+	txn := makeTxnMeta("txn1")
+
+	t.Run("noop when VIR disabled", func(t *testing.T) {
+		g := &lockTableGuardImpl{
+			virtuallyResolveIntents: false,
+			maxToResolveRangeTxns:   2,
+			toResolve: []roachpb.LockUpdate{
+				makeLockUpdate(txn, roachpb.Key("a")),
+			},
+		}
+		g.PrepareForLockConflictRetry(ctx)
+		// toResolve should be untouched since VIR is disabled.
+		require.Len(t, g.toResolve, 1)
+		require.Nil(t, g.toResolveRange)
+	})
+
+	t.Run("noop when toResolve is empty", func(t *testing.T) {
+		g := &lockTableGuardImpl{
+			virtuallyResolveIntents: true,
+			maxToResolveRangeTxns:   2,
+		}
+		g.PrepareForLockConflictRetry(ctx)
+		require.Nil(t, g.toResolveRange)
+	})
+
+	t.Run("collapse single txn", func(t *testing.T) {
+		g := &lockTableGuardImpl{
+			virtuallyResolveIntents: true,
+			maxToResolveRangeTxns:   10,
+			toResolve: []roachpb.LockUpdate{
+				makeLockUpdate(txn, roachpb.Key("b")),
+				makeLockUpdate(txn, roachpb.Key("d")),
+				makeLockUpdate(txn, roachpb.Key("a")),
+			},
+		}
+		g.PrepareForLockConflictRetry(ctx)
+		require.Empty(t, g.toResolve)
+		require.Len(t, g.toResolveRange, 1)
+		// Range should span [a, d.Next()).
+		rangeUp := g.toResolveRange[txn.ID]
+		require.Equal(t, roachpb.Key("a"), rangeUp.Key)
+		require.Equal(t, roachpb.Key("d").Next(), rangeUp.EndKey)
+		require.True(t, g.virtuallyResolveIntents)
+	})
+
+	t.Run("extend existing range", func(t *testing.T) {
+		g := &lockTableGuardImpl{
+			virtuallyResolveIntents: true,
+			maxToResolveRangeTxns:   10,
+			toResolve: []roachpb.LockUpdate{
+				makeLockUpdate(txn, roachpb.Key("b")),
+				makeLockUpdate(txn, roachpb.Key("c")),
+			},
+		}
+		// First round: collapse "b" and "c".
+		g.PrepareForLockConflictRetry(ctx)
+		require.Empty(t, g.toResolve)
+		require.Equal(t, roachpb.Key("b"), g.toResolveRange[txn.ID].Key)
+		require.Equal(t, roachpb.Key("c").Next(), g.toResolveRange[txn.ID].EndKey)
+
+		// Second round: extend left with "a" and right with "e".
+		g.toResolve = append(g.toResolve,
+			makeLockUpdate(txn, roachpb.Key("a")),
+			makeLockUpdate(txn, roachpb.Key("e")),
+		)
+		g.PrepareForLockConflictRetry(ctx)
+		require.Len(t, g.toResolveRange, 1)
+		rangeUp := g.toResolveRange[txn.ID]
+		require.Equal(t, roachpb.Key("a"), rangeUp.Key)
+		require.Equal(t, roachpb.Key("e").Next(), rangeUp.EndKey)
+	})
+
+	t.Run("covered keys skipped", func(t *testing.T) {
+		g := &lockTableGuardImpl{
+			virtuallyResolveIntents: true,
+			maxToResolveRangeTxns:   10,
+			toResolve: []roachpb.LockUpdate{
+				makeLockUpdate(txn, roachpb.Key("a")),
+				makeLockUpdate(txn, roachpb.Key("c")),
+			},
+		}
+		g.PrepareForLockConflictRetry(ctx)
+		// "b" is inside the range [a, c.Next()) and should be covered.
+		require.True(t, g.keyAlreadyCoveredByRangeResolve(txn.ID, roachpb.Key("b")))
+		// "d" is outside.
+		require.False(t, g.keyAlreadyCoveredByRangeResolve(txn.ID, roachpb.Key("d")))
+		// Unknown txn is not covered.
+		require.False(t, g.keyAlreadyCoveredByRangeResolve(uuid.MakeV4(), roachpb.Key("b")))
+	})
+
+	t.Run("VIR disabled when threshold exceeded", func(t *testing.T) {
+		g := &lockTableGuardImpl{
+			virtuallyResolveIntents: true,
+			maxToResolveRangeTxns:   2,
+			toResolve: []roachpb.LockUpdate{
+				makeLockUpdate(txn, roachpb.Key("a")),
+				makeLockUpdate(makeTxnMeta("txn2"), roachpb.Key("b")),
+				makeLockUpdate(makeTxnMeta("txn3"), roachpb.Key("c")),
+			},
+		}
+		g.PrepareForLockConflictRetry(ctx)
+		require.False(t, g.virtuallyResolveIntents)
+		require.Nil(t, g.toResolveRange)
+		require.Empty(t, g.toResolve)
+	})
+
+	t.Run("below threshold no disable", func(t *testing.T) {
+		g := &lockTableGuardImpl{
+			virtuallyResolveIntents: true,
+			maxToResolveRangeTxns:   3,
+			toResolve: []roachpb.LockUpdate{
+				makeLockUpdate(txn, roachpb.Key("a")),
+				makeLockUpdate(makeTxnMeta("txn2"), roachpb.Key("b")),
+				makeLockUpdate(makeTxnMeta("txn3"), roachpb.Key("c")),
+			},
+		}
+		// 3 txns at threshold of 3 — should not disable.
+		g.PrepareForLockConflictRetry(ctx)
+		require.True(t, g.virtuallyResolveIntents)
+		require.Len(t, g.toResolveRange, 3)
+	})
+
+	t.Run("IntentsToResolveVirtually combines point and range", func(t *testing.T) {
+		txn2 := makeTxnMeta("txn2")
+		g := &lockTableGuardImpl{
+			virtuallyResolveIntents: true,
+			maxToResolveRangeTxns:   10,
+			toResolve: []roachpb.LockUpdate{
+				makeLockUpdate(txn, roachpb.Key("a")),
+			},
+		}
+		// Collapse txn into toResolveRange.
+		g.PrepareForLockConflictRetry(ctx)
+		// Add a point entry for txn2 (not yet collapsed).
+		g.toResolve = append(g.toResolve, makeLockUpdate(txn2, roachpb.Key("x")))
+
+		combined := g.IntentsToResolveVirtually()
+		require.Len(t, combined, 2)
+		// One point (txn2) and one range (txn).
+		var hasPoint, hasRange bool
+		for _, up := range combined {
+			if len(up.EndKey) > 0 {
+				hasRange = true
+				require.Equal(t, txn.ID, up.Txn.ID)
+			} else {
+				hasPoint = true
+				require.Equal(t, txn2.ID, up.Txn.ID)
+			}
+		}
+		require.True(t, hasPoint)
+		require.True(t, hasRange)
+	})
+}
+
 // TestElideWaitingStateUpdatesConsidersAllFields ensures all fields in the
 // waitingState struct have been considered for inclusion/non-inclusion in the
 // logic of canElideWaitingStateUpdate. The test doesn't check if the

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
@@ -89,6 +89,7 @@ func (g *mockLockTableGuard) VirtuallyResolvesIntents() bool {
 func (g *mockLockTableGuard) CheckOptimisticNoConflicts(*lockspanset.LockSpanSet) (ok bool) {
 	return true
 }
+func (g *mockLockTableGuard) PrepareForLockConflictRetry(context.Context) {}
 func (g *mockLockTableGuard) IsKeyLockedByConflictingTxn(
 	context.Context, roachpb.Key, lock.Strength,
 ) (bool, *enginepb.TxnMeta, error) {

--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -92,7 +92,6 @@ func (r *Replica) executeReadOnlyBatch(
 	defer rw.Close()
 
 	if len(intentsToResolveVirtually) > 0 {
-
 		log.Eventf(
 			ctx, "resolving %d intents virtually before executing read",
 			len(intentsToResolveVirtually),
@@ -108,21 +107,37 @@ func (r *Replica) executeReadOnlyBatch(
 		// below. Depending on the result of the intent resolution, the read-only
 		// batch request may not conflict with the intents anymore.
 		for _, intent := range intentsToResolveVirtually {
-			ir := kvpb.ResolveIntentRequest{
-				RequestHeader:     kvpb.RequestHeaderFromSpan(intent.Span),
-				IntentTxn:         intent.Txn,
-				Status:            intent.Status,
-				IgnoredSeqNums:    intent.IgnoredSeqNums,
-				ClockWhilePending: intent.ClockWhilePending,
+			var (
+				// It's ok to pass an empty header since during intent resolution it's only
+				// used to ensure that this is not a transactional request, and to apply
+				// MaxTargetBytes (which we don't need because the batch is not committed).
+				h kvpb.Header
+				// The reply coming from evaluation is discarded below.
+				reply kvpb.Response
+				req   kvpb.Request
+			)
+			if len(intent.EndKey) > 0 {
+				// Range LockUpdate: resolve all intents for this txn in the span.
+				req = &kvpb.ResolveIntentRangeRequest{
+					RequestHeader:     kvpb.RequestHeaderFromSpan(intent.Span),
+					IntentTxn:         intent.Txn,
+					Status:            intent.Status,
+					IgnoredSeqNums:    intent.IgnoredSeqNums,
+					ClockWhilePending: intent.ClockWhilePending,
+				}
+				reply = &kvpb.ResolveIntentRangeResponse{}
+			} else {
+				req = &kvpb.ResolveIntentRequest{
+					RequestHeader:     kvpb.RequestHeaderFromSpan(intent.Span),
+					IntentTxn:         intent.Txn,
+					Status:            intent.Status,
+					IgnoredSeqNums:    intent.IgnoredSeqNums,
+					ClockWhilePending: intent.ClockWhilePending,
+				}
+				reply = &kvpb.ResolveIntentResponse{}
 			}
-			// The reply coming from evaluation is discarded below.
-			reply := &kvpb.ResolveIntentResponse{}
-			// It's ok to pass an empty header since during intent resolution it's only
-			// used to ensure that this is not a transactional request, and to apply
-			// MaxTargetBytes (which we don't need because the batch is not committed).
-			h := kvpb.Header{}
 			_, err = evaluateCommand(
-				ctx, rwNoAssert, rec, nil /* ms */, nil /* ss */, h, &ir,
+				ctx, rwNoAssert, rec, nil /* ms */, nil /* ss */, h, req,
 				reply, g, &st, ui, readWrite, false, /* omitInRangefeeds */
 			)
 			if err != nil {

--- a/pkg/kv/kvserver/replica_read_test.go
+++ b/pkg/kv/kvserver/replica_read_test.go
@@ -110,49 +110,57 @@ func TestVirtualizedIntentResolution(t *testing.T) {
 		{readTs: ts300, readGUL: ts600, toResolve: &toResolve{txnStatus: roachpb.PENDING, txnWriteTs: ts500, obsTs: ts400, obsNode: 2}, exp: res{error: "uncertainty interval"}},
 	}
 
-	for _, c := range testCases {
-		// Build a mock guard, injecting any intents to resolve virtually.
-		var intents []roachpb.LockUpdate
-		if c.toResolve != nil {
-			writeTxn.TxnMeta.WriteTimestamp = c.toResolve.txnWriteTs
-			status := c.toResolve.txnStatus
-			obs := roachpb.ObservedTimestamp{Timestamp: hlc.ClockTimestamp(c.toResolve.obsTs), NodeID: roachpb.NodeID(c.toResolve.obsNode)}
-			intents = []roachpb.LockUpdate{{Span: roachpb.Span{Key: k}, Status: status, Txn: writeTxn.TxnMeta, ClockWhilePending: obs}}
-		}
-		g := mockGuard{
-			req: concurrency.Request{
-				LatchSpans: allSpans(),
-				LockSpans:  lockspanset.New(),
-			},
-			intentsToResolveVirtually: intents,
-		}
-		// Construct the read-only request.
-		ba := &kvpb.BatchRequest{}
-		ba.Timestamp = c.readTs
-		// If the read wants to set a GUL, use a transactional read.
-		if !c.readGUL.IsEmpty() {
-			readTxn := newTransaction("readTxn", k, 1, nil)
-			readTxn.ReadTimestamp = c.readTs
-			readTxn.GlobalUncertaintyLimit = c.readGUL
-			// We need a fairly old observation here to make sure the read's local
-			// uncertainty limit lets it read under the intent with a clock
-			// observation while pending. This observation needs to be lower than the
-			// local timestamp set on the intent (set using ClockWhilePending).
-			// The txn's observed timestamp is usually set when the request is first
-			// received by the store, so here we'll record it as the read's ts.
-			readTxn.UpdateObservedTimestamp(roachpb.NodeID(1), c.readTs.UnsafeToClockTimestamp())
-			ba.Txn = readTxn
-		}
-		gArgs := getArgs(k)
-		ba.Add(&gArgs)
-		br, _, _, pErr := tc.repl.executeReadOnlyBatch(ctx, ba, g, kvadmission.AdmissionInfo{})
+	for _, resolveRange := range []bool{true, false} {
+		for _, c := range testCases {
+			// Build a mock guard, injecting any intents to resolve virtually.
+			var intents []roachpb.LockUpdate
+			if c.toResolve != nil {
+				writeTxn.TxnMeta.WriteTimestamp = c.toResolve.txnWriteTs
+				status := c.toResolve.txnStatus
+				obs := roachpb.ObservedTimestamp{Timestamp: hlc.ClockTimestamp(c.toResolve.obsTs), NodeID: roachpb.NodeID(c.toResolve.obsNode)}
+				var span roachpb.Span
+				if resolveRange {
+					span = roachpb.Span{Key: k, EndKey: k.Next()}
+				} else {
+					span = roachpb.Span{Key: k}
+				}
+				intents = []roachpb.LockUpdate{{Span: span, Status: status, Txn: writeTxn.TxnMeta, ClockWhilePending: obs}}
+			}
+			g := mockGuard{
+				req: concurrency.Request{
+					LatchSpans: allSpans(),
+					LockSpans:  lockspanset.New(),
+				},
+				intentsToResolveVirtually: intents,
+			}
+			// Construct the read-only request.
+			ba := &kvpb.BatchRequest{}
+			ba.Timestamp = c.readTs
+			// If the read wants to set a GUL, use a transactional read.
+			if !c.readGUL.IsEmpty() {
+				readTxn := newTransaction("readTxn", k, 1, nil)
+				readTxn.ReadTimestamp = c.readTs
+				readTxn.GlobalUncertaintyLimit = c.readGUL
+				// We need a fairly old observation here to make sure the read's local
+				// uncertainty limit lets it read under the intent with a clock
+				// observation while pending. This observation needs to be lower than the
+				// local timestamp set on the intent (set using ClockWhilePending).
+				// The txn's observed timestamp is usually set when the request is first
+				// received by the store, so here we'll record it as the read's ts.
+				readTxn.UpdateObservedTimestamp(roachpb.NodeID(1), c.readTs.UnsafeToClockTimestamp())
+				ba.Txn = readTxn
+			}
+			gArgs := getArgs(k)
+			ba.Add(&gArgs)
+			br, _, _, pErr := tc.repl.executeReadOnlyBatch(ctx, ba, g, kvadmission.AdmissionInfo{})
 
-		if c.exp.error == "" {
-			require.NoError(t, pErr.GoError())
-			require.Regexp(t, c.exp.value, string(br.Responses[0].GetGet().Value.RawBytes))
-		} else {
-			require.Nil(t, br)
-			require.Regexp(t, c.exp.error, pErr.GoError())
+			if c.exp.error == "" {
+				require.NoError(t, pErr.GoError())
+				require.Regexp(t, c.exp.value, string(br.Responses[0].GetGet().Value.RawBytes))
+			} else {
+				require.Nil(t, br)
+				require.Regexp(t, c.exp.error, pErr.GoError())
+			}
 		}
 	}
 }

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -124,6 +124,7 @@ func (mg mockGuard) IsKeyLockedByConflictingTxn(
 func (mg mockGuard) IntentsToResolveVirtually() []roachpb.LockUpdate {
 	return mg.intentsToResolveVirtually
 }
+func (mg mockGuard) PrepareForLockConflictRetry(context.Context) {}
 
 var _ concurrency.Guard = (*mockGuard)(nil)
 

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -58,7 +58,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/gossiputil"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
-	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -66,6 +65,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -2370,7 +2370,7 @@ func TestStoreScanIntentsRespectsLimit(t *testing.T) {
 //     3-5. Added to lock table (now 6 > max 4), evicting intents 0-2.
 //  3. Re-sequence clears toResolve, repopulates from lock table (only 3-5).
 //     VIR resolves 3-5, rediscovers evicted 0-2. Cycle repeats.
-func TestVirtualIntentResolutionLivelock(t *testing.T) {
+func TestVirtualIntentResolutionReentryAfterEvaluationLiveLock(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
@@ -2432,18 +2432,186 @@ func TestVirtualIntentResolutionLivelock(t *testing.T) {
 	)
 	readerTxnID.Store(readerTxn.ID)
 
+	readerCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+
+	tracer := tc.Server(0).TracerI().(*tracing.Tracer)
+	traceCtx, finishAndGetRecording := tracing.ContextWithRecordingSpan(
+		readerCtx, tracer, "test-vir-livelock",
+	)
+	defer func() {
+		recording := finishAndGetRecording()
+		if t.Failed() {
+			t.Logf("full trace:\n%s", recording)
+		}
+	}()
+
+	defer cancel()
+	_, pErr := kv.SendWrappedWith(traceCtx, store.TestSender(), kvpb.Header{
+		Txn: readerTxn,
+	}, scanArgs(startKey, endKey))
+	require.NoError(t, pErr.GoError(), "reader failed (%d lock conflicts observed)", lockConflictCount.Load())
+}
+
+// TestVirtualIntentResolutionReentryBeforeEvaluationLiveLock demonstrates that
+// we don't livelock in the ScanAndEnqueue -> WaitOn -> re-ScanAndEnqueue cycle
+// for VIR-enabled requests when the pending txn cache loses entries between
+// re-scans.
+//
+// Test Setup:
+//
+//  1. Two writers (low priority) each create an intent on separate keys.
+//  2. Reader 1 (high priority) scans, discovering both intents and adding them
+//     as contended entries in the lock table.
+//  3. Reader 2 (high priority, VIR enabled) scans. Its first ScanAndEnqueue
+//     finds both locks already in the lock table and enters WaitOn.
+//  4. While reader 2 is pushing the second writer, the shared txnStatusCache
+//     overflows.
+//
+// Currently, we prevent this from livelocking by maintaining a per-request
+// cache of resolvable txns that survives ScanAndEnqueue Reentry.
+func TestVirtualIntentResolutionReentryBeforeEvaluationLiveLock(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	// Track push count for our writers from reader 2.
+	var pushCount atomic.Int32
+	var reader2TxnID atomic.Value
+	reader2TxnID.Store(uuid.Nil)
+
+	// writerIDs tracks the two writer txn IDs so we can identify pushes
+	// targeting them.
+	exists := &struct{}{}
+	var writerIDs syncutil.Map[uuid.UUID, struct{}]
+
+	// repl will be set after cluster start so the response filter can access
+	// the concurrency manager.
+	var repl atomic.Pointer[Replica]
+
+	tc := serverutils.StartCluster(t, 1, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				Store: &StoreTestingKnobs{
+					TestingResponseFilter: func(
+						ctx context.Context, ba *kvpb.BatchRequest, br *kvpb.BatchResponse,
+					) *kvpb.Error {
+						if br == nil || len(ba.Requests) != 1 {
+							return nil
+						}
+						pushReq, ok := ba.Requests[0].GetInner().(*kvpb.PushTxnRequest)
+						if !ok {
+							return nil
+						}
+						// Only intercept pushes from reader 2 targeting our writers.
+						if pushReq.PusherTxn.ID != reader2TxnID.Load().(uuid.UUID) {
+							return nil
+						}
+						if _, isOurWriter := writerIDs.Load(pushReq.PusheeTxn.ID); !isOurWriter {
+							return nil
+						}
+
+						pushCount.Add(1)
+
+						// Flood the pending txn cache with dummy entries to evict
+						// whatever was there before this push's result is recorded.
+						r := repl.Load()
+						if r == nil {
+							return nil
+						}
+						cm := r.GetConcurrencyManager()
+						ts := pushReq.PusherTxn.WriteTimestamp
+						for i := 0; i < 8; i++ {
+							cm.TestingPushedTransactionUpdated(&roachpb.Transaction{
+								TxnMeta: enginepb.TxnMeta{ID: uuid.MakeV4(), WriteTimestamp: ts},
+								Status:  roachpb.PENDING,
+							}, roachpb.ObservedTimestamp{NodeID: 1, Timestamp: hlc.ClockTimestamp(ts)})
+						}
+
+						return nil
+					},
+				},
+			},
+		},
+	})
+	defer tc.Stopper().Stop(ctx)
+
+	st := tc.Server(0).ClusterSettings()
+	concurrency.VirtualIntentResolution.Override(ctx, &st.SV, true)
+
+	store, err := tc.Server(0).GetStores().(*Stores).GetStore(tc.Server(0).GetFirstStoreID())
+	require.NoError(t, err)
+
+	// Look up the replica for the scratch range and stash it for the filter.
+	r := store.LookupReplica(keys.MustAddr(keys.ScratchRangeMin))
+	require.NotNil(t, r)
+	repl.Store(r)
+
+	// Two writers create intents on separate keys.
+	keyA := append(keys.ScratchRangeMin.Clone(), 'a')
+	keyB := append(keys.ScratchRangeMin.Clone(), 'b')
+
+	writerTxn1 := newTransaction(
+		"writer1", keys.ScratchRangeMin, roachpb.NormalUserPriority, tc.Server(0).Clock(),
+	)
+	writerIDs.Store(writerTxn1.ID, exists)
+	putReq := putArgs(keyA, []byte("val-a"))
+	assignSeqNumsForReqs(writerTxn1, &putReq)
+	_, pErr := kv.SendWrappedWith(
+		ctx, store.TestSender(), kvpb.Header{Txn: writerTxn1}, &putReq,
+	)
+	require.Nil(t, pErr)
+
+	writerTxn2 := newTransaction(
+		"writer2", keys.ScratchRangeMin, roachpb.NormalUserPriority, tc.Server(0).Clock(),
+	)
+	writerIDs.Store(writerTxn2.ID, exists)
+	putReq = putArgs(keyB, []byte("val-b"))
+	assignSeqNumsForReqs(writerTxn2, &putReq)
+	_, pErr = kv.SendWrappedWith(
+		ctx, store.TestSender(), kvpb.Header{Txn: writerTxn2}, &putReq,
+	)
+	require.Nil(t, pErr)
+
+	// Reader 1 scans to discover both intents and create contended lock table
+	// entries.
+	readerTxn1 := newTransaction(
+		"reader1", keys.ScratchRangeMin, roachpb.MaxUserPriority, tc.Server(0).Clock(),
+	)
+	scanReq := scanArgs(keys.ScratchRangeMin, keys.ScratchRangeMax)
+	_, pErr = kv.SendWrappedWith(
+		ctx, store.TestSender(), kvpb.Header{Txn: readerTxn1}, scanReq,
+	)
+	require.Nil(t, pErr)
+
+	// Reader 2 scans with VIR. The response filter will sabotage the pending
+	// txn cache on every push, causing a livelock.
+	readerTxn2 := newTransaction(
+		"reader2", keys.ScratchRangeMin, roachpb.MaxUserPriority, tc.Server(0).Clock(),
+	)
+	reader2TxnID.Store(readerTxn2.ID)
+
 	readCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
-	g := ctxgroup.WithContext(readCtx)
-	g.GoCtx(func(ctx context.Context) error {
-		_, pErr := kv.SendWrappedWith(ctx, store.TestSender(), kvpb.Header{
-			Txn: readerTxn,
-		}, scanArgs(startKey, endKey))
-		return pErr.GoError()
-	})
-	require.NoError(t, g.Wait(), "reader failed (%d lock conflicts observed)", lockConflictCount.Load())
-	count := lockConflictCount.Load()
-	t.Logf("reader completed with %d lock conflict retries", count)
+
+	tracer := tc.Server(0).TracerI().(*tracing.Tracer)
+	traceCtx, finishAndGetRecording := tracing.ContextWithRecordingSpan(
+		readCtx, tracer, "test-vir-livelock",
+	)
+
+	scanReq = scanArgs(keys.ScratchRangeMin, keys.ScratchRangeMax)
+	_, pErr = kv.SendWrappedWith(
+		traceCtx, store.TestSender(), kvpb.Header{Txn: readerTxn2}, scanReq,
+	)
+
+	defer func() {
+		recording := finishAndGetRecording()
+		if t.Failed() {
+			t.Logf("full trace:\n%s", recording)
+		}
+	}()
+
+	require.NoError(t, pErr.GoError())
+	require.Equal(t, pushCount.Load(), int32(2), "unexpected number of txn pushes")
 }
 
 // TestStoreScanInconsistentResolvesIntents lays down 10 intents,

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -58,6 +58,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/gossiputil"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -2349,6 +2350,100 @@ func TestStoreScanIntentsRespectsLimit(t *testing.T) {
 	}()
 
 	wg.Wait()
+}
+
+// TestVirtualIntentResolutionLivelock demonstrates that virtual intent
+// resolution (VIR) can livelock under lock table memory pressure when a reader
+// must discover intents across multiple evaluation rounds (#163924).
+//
+// # Test Setup
+//
+// - VIR is enabled, Low lock table size limit (4), and a low MaxConflictsPerLockConflictError (3) is set.
+// - A writer creates 6 intents.
+// - High-priority reader scans the range.
+//
+// Hazard before the fix:
+//
+//  1. Reader discovers intents 0-2 (truncated at MaxConflicts=3), adds to lock
+//     table, pushes writer, proceeds with VIR.
+//  2. VIR resolves 0-2 on ephemeral batch (discarded). Scan discovers intents
+//     3-5. Added to lock table (now 6 > max 4), evicting intents 0-2.
+//  3. Re-sequence clears toResolve, repopulates from lock table (only 3-5).
+//     VIR resolves 3-5, rediscovers evicted 0-2. Cycle repeats.
+func TestVirtualIntentResolutionLivelock(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	var lockConflictCount atomic.Int32
+	var readerTxnID atomic.Value // uuid.UUID
+	readerTxnID.Store(uuid.Nil)
+
+	tc := serverutils.StartCluster(t, 1, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				Store: &StoreTestingKnobs{
+					TestingConcurrencyRetryFilter: func(
+						_ context.Context, ba *kvpb.BatchRequest, pErr *kvpb.Error,
+					) {
+						if ba.Txn == nil || ba.Txn.ID != readerTxnID.Load().(uuid.UUID) {
+							return // not our reader
+						}
+						if errors.HasType(pErr.GoError(), (*kvpb.LockConflictError)(nil)) {
+							lockConflictCount.Add(1)
+						}
+					},
+				},
+			},
+		},
+	})
+	defer tc.Stopper().Stop(ctx)
+
+	// Enable VIR, set low lock table size, and low max conflicts per error to
+	// force multi-round intent discovery with frequent lock table eviction.
+	st := tc.Server(0).ClusterSettings()
+	concurrency.VirtualIntentResolution.Override(ctx, &st.SV, true)
+	concurrency.DefaultLockTableSize.Override(ctx, &st.SV, 4)
+	storage.MaxConflictsPerLockConflictError.Override(ctx, &st.SV, 3)
+
+	store, err := tc.Server(0).GetStores().(*Stores).GetStore(tc.Server(0).GetFirstStoreID())
+	require.NoError(t, err)
+
+	// Writer creates 6 intents (more than MaxConflictsPerLockConflictError but
+	// more than the lock table can hold simultaneously).
+	const numIntents = 6
+	writerTxn := newTransaction(
+		"writer", keys.ScratchRangeMin, roachpb.NormalUserPriority, tc.Server(0).Clock(),
+	)
+	for i := 0; i < numIntents; i++ {
+		key := append(keys.ScratchRangeMin.Clone(), []byte(fmt.Sprintf("%04d", i))...)
+		args := putArgs(key, []byte(fmt.Sprintf("value%d", i)))
+		assignSeqNumsForReqs(writerTxn, &args)
+		_, pErr := kv.SendWrappedWith(ctx, store.TestSender(), kvpb.Header{Txn: writerTxn}, &args)
+		require.Nil(t, pErr)
+	}
+
+	// High-priority scan to push the writer.
+	startKey := keys.ScratchRangeMin
+	endKey := keys.ScratchRangeMax
+
+	readerTxn := newTransaction(
+		"reader", startKey, roachpb.MaxUserPriority, tc.Server(0).Clock(),
+	)
+	readerTxnID.Store(readerTxn.ID)
+
+	readCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	g := ctxgroup.WithContext(readCtx)
+	g.GoCtx(func(ctx context.Context) error {
+		_, pErr := kv.SendWrappedWith(ctx, store.TestSender(), kvpb.Header{
+			Txn: readerTxn,
+		}, scanArgs(startKey, endKey))
+		return pErr.GoError()
+	})
+	require.NoError(t, g.Wait(), "reader failed (%d lock conflicts observed)", lockConflictCount.Load())
+	count := lockConflictCount.Load()
+	t.Logf("reader completed with %d lock conflict retries", count)
 }
 
 // TestStoreScanInconsistentResolvesIntents lays down 10 intents,


### PR DESCRIPTION
We recently added PrepareForLockConflictRetry to the concurrency
manager which, for VIR-enabled requests, condenses the previous set of
LockUpdates into a smaller set of ranged LockUpdates. This solved a
situation in which upon re-entering ScanAndEnqueue after a
LockConflictError, we did not depend on those same locks being in the
lock table.

This, however, overlooked another, perhaps even more common, case:

- Request enters ScanAndEnqueue

- Request encounters some number of locks and pushes their holders

- Other requests push at least one of our updated transaction statuses
  out of txnStatusCache.

- Request re-enters ScanAndEnqueue, encounters the same locks, but
  now must re-push it.

This commit introduces a request-scoped map of transaction statuses to
ensure we never have to re-push a request we previously pushed.

Along the way, it refactors our handling of toResolve condensing.

We are also considering other alternatives:

- Using a much larger txnStatusCache to avoid this issue in practice
  most of the time.

- Preserving toResolve across calls of ScanAndEnqueue for VIR-enabled
  requests. This is a bit tricky to do efficiently since without care
  it would result in duplicates in toResolve or excessive allocations
  to maintain our set.

Epic: CRDB-49120

Release note: none