### PR TITLE
added sig* handling for all operations

### DIFF
--- a/pkg/cmd/roachtest/operations/add_column.go
+++ b/pkg/cmd/roachtest/operations/add_column.go
@@ -30,7 +30,7 @@ func (cl *cleanupAddedColumn) Cleanup(
 	defer conn.Close()
 
 	o.Status(fmt.Sprintf("dropping column %s", cl.column))
-	_, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s.%s DROP COLUMN %s CASCADE", cl.db, cl.table, cl.column))
+	_, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s.%s DROP COLUMN IF EXISTS %s CASCADE", cl.db, cl.table, cl.column))
 	if err != nil {
 		o.Fatal(err)
 	}
@@ -65,7 +65,6 @@ func runAddColumn(
 	if err != nil {
 		o.Fatal(err)
 	}
-
 	o.Status(fmt.Sprintf("column %s created", colName))
 
 	return &cleanupAddedColumn{

--- a/pkg/cmd/roachtest/operations/add_index.go
+++ b/pkg/cmd/roachtest/operations/add_index.go
@@ -34,7 +34,7 @@ func (cl *cleanupAddedIndex) Cleanup(
 	defer conn.Close()
 
 	o.Status(fmt.Sprintf("dropping index %s", cl.index))
-	_, err := conn.ExecContext(ctx, fmt.Sprintf("DROP INDEX %s.%s@%s", cl.db, cl.table, cl.index))
+	_, err := conn.ExecContext(ctx, fmt.Sprintf("DROP INDEX IF EXISTS %s.%s@%s", cl.db, cl.table, cl.index))
 	if err != nil {
 		o.Fatal(err)
 	}
@@ -140,7 +140,6 @@ WHERE
 	if err != nil {
 		o.Fatal(err)
 	}
-
 	o.Status(fmt.Sprintf("index %s created", indexName))
 
 	return &cleanupAddedIndex{

--- a/pkg/cmd/roachtest/operations/add_rls_policy.go
+++ b/pkg/cmd/roachtest/operations/add_rls_policy.go
@@ -179,10 +179,10 @@ func runAddRLSPolicy(
 		}
 
 		_, err = conn.ExecContext(ctx, fmt.Sprintf(`
-			CREATE POLICY %s ON %s.%s 
-			FOR %s 
-			TO %s 
-			%s 
+			CREATE POLICY %s ON %s.%s
+			FOR %s
+			TO %s
+			%s
 			%s
 		`, policyName, dbName, tableName, operation, user, using, withCheck))
 		if err != nil {

--- a/pkg/cmd/roachtest/operations/backup_restore.go
+++ b/pkg/cmd/roachtest/operations/backup_restore.go
@@ -37,7 +37,7 @@ func (cl *backupRestoreCleanup) Cleanup(
 	defer conn.Close()
 
 	o.Status(fmt.Sprintf("dropping newly created db %s", cl.db))
-	_, err := conn.ExecContext(ctx, fmt.Sprintf("DROP DATABASE %s CASCADE", cl.db))
+	_, err := conn.ExecContext(ctx, fmt.Sprintf("DROP DATABASE IF EXISTS %s CASCADE", cl.db))
 	if err != nil {
 		o.Fatal(err)
 	}
@@ -45,7 +45,12 @@ func (cl *backupRestoreCleanup) Cleanup(
 
 func runBackupRestore(
 	ctx context.Context, o operation.Operation, c cluster.Cluster, online bool, validate bool,
-) registry.OperationCleanup {
+) (cleanup registry.OperationCleanup) {
+	defer func() {
+		if r := recover(); r != nil {
+			o.Errorf("error during backup restore: %v", r)
+		}
+	}()
 	// This operation looks for the district table in a database named cct_tpcc or tpcc.
 	rng, _ := randutil.NewPseudoRand()
 	dbWhitelist := []string{"cct_tpcc", "tpcc"}
@@ -115,6 +120,11 @@ outer:
 
 	restoreDBName := fmt.Sprintf("backup_restore_op_%d", rng.Int63())
 
+	// Assign cleanup handler early, before RESTORE creates the database.
+	// The cleanup uses DROP DATABASE IF EXISTS, so it's safe even if the
+	// RESTORE fails and the database was never created.
+	cleanup = &backupRestoreCleanup{db: restoreDBName}
+
 	onlineStr := "online"
 	if !online {
 		onlineStr = "offline"
@@ -132,16 +142,40 @@ outer:
 		var id, tables, approxRows, approxBytes int64
 		var downloadJobId catpb.JobID
 		o.Status("beginning online restore")
-		res := conn.QueryRowContext(ctx, fmt.Sprintf("RESTORE DATABASE %s FROM LATEST IN '%s' WITH OPTIONS (new_db_name = '%s', EXPERIMENTAL DEFERRED COPY)", dbName, bucket, restoreDBName))
 
-		err := res.Scan(&id, &tables, &approxRows, &approxBytes, &downloadJobId)
-		if err != nil {
-			o.Fatal(err)
+		type scanResult struct {
+			id, tables, approxRows, approxBytes int64
+			downloadJobId                       catpb.JobID
+			err                                 error
+		}
+		resCh := make(chan scanResult, 1)
+		go func() {
+			var r scanResult
+			row := conn.QueryRowContext(ctx, fmt.Sprintf("RESTORE DATABASE %s FROM LATEST IN '%s' WITH OPTIONS (new_db_name = '%s', EXPERIMENTAL DEFERRED COPY)", dbName, bucket, restoreDBName))
+			r.err = row.Scan(&r.id, &r.tables, &r.approxRows, &r.approxBytes, &r.downloadJobId)
+			resCh <- r
+		}()
+
+		var scanErr error
+		select {
+		case r := <-resCh:
+			id, tables, approxRows, approxBytes, downloadJobId = r.id, r.tables, r.approxRows, r.approxBytes, r.downloadJobId
+			scanErr = r.err
+			if scanErr != nil {
+				o.Fatal(scanErr)
+			}
+		case <-ctx.Done():
+			o.Fatal(ctx.Err())
 		}
 
-		err = tests.WaitForSucceeded(ctx, conn, downloadJobId, 8760*time.Hour /* 1 year - test specs define their own timeouts */)
-		if err != nil {
-			o.Fatal(err)
+		// Suppress unused variable warnings for id, tables, approxRows, approxBytes.
+		_, _, _, _ = id, tables, approxRows, approxBytes
+
+		if scanErr == nil {
+			err = tests.WaitForSucceeded(ctx, conn, downloadJobId, 8760*time.Hour /* 1 year - test specs define their own timeouts */)
+			if err != nil {
+				o.Fatal(err)
+			}
 		}
 	}
 	o.Status(fmt.Sprintf("completed restore in %v", timeutil.Since(startTime)))
@@ -164,7 +198,7 @@ outer:
 		}
 	}
 
-	return &backupRestoreCleanup{db: restoreDBName}
+	return cleanup
 }
 
 func runBackupRestoreFn(

--- a/pkg/cmd/roachtest/operations/disk_stall.go
+++ b/pkg/cmd/roachtest/operations/disk_stall.go
@@ -44,7 +44,12 @@ func (cl *cleanupDiskStall) Cleanup(ctx context.Context, o operation.Operation, 
 
 func runDiskStall(
 	ctx context.Context, o operation.Operation, c cluster.Cluster,
-) registry.OperationCleanup {
+) (cleanup registry.OperationCleanup) {
+	defer func() {
+		if r := recover(); r != nil {
+			o.Errorf("error during disk stall: %v", r)
+		}
+	}()
 	rng, _ := randutil.NewPseudoRand()
 
 	nodes := c.All()
@@ -53,13 +58,16 @@ func runDiskStall(
 	// of the operation.
 	ds := roachtestutil.MakeDmsetupDiskStaller(o, c, true /* disableStateValidation */)
 
-	o.Status(fmt.Sprintf("stalling disk on node %d", nid))
-	ds.Stall(ctx, c.Node(nid))
-
-	return &cleanupDiskStall{
+	// Assign cleanup handler early, before stalling the disk.
+	cleanup = &cleanupDiskStall{
 		nodes:   c.Node(nid),
 		staller: ds,
 	}
+
+	o.Status(fmt.Sprintf("stalling disk on node %d", nid))
+	ds.Stall(ctx, c.Node(nid))
+
+	return cleanup
 }
 
 func registerDiskStall(r registry.Registry) {

--- a/pkg/cmd/roachtest/operations/license_throttle.go
+++ b/pkg/cmd/roachtest/operations/license_throttle.go
@@ -38,7 +38,12 @@ func (c cleanupLicenseRemoval) Cleanup(
 
 func runAddExpiredLicenseToTriggerThrottle(
 	ctx context.Context, o operation.Operation, cl cluster.Cluster,
-) registry.OperationCleanup {
+) (cleanup registry.OperationCleanup) {
+	defer func() {
+		if r := recover(); r != nil {
+			o.Errorf("error during license throttle: %v", r)
+		}
+	}()
 	conn := cl.Conn(ctx, o.L(), 1, option.VirtualClusterName(roachtestflags.VirtualCluster))
 	defer conn.Close()
 
@@ -51,10 +56,13 @@ func runAddExpiredLicenseToTriggerThrottle(
 	}
 
 	// Save off the current license so that we can reinstate it during cleanup.
-	cleanup := cleanupLicenseRemoval{}
-	if err := rows.Scan(&cleanup.license); err != nil {
+	var currentLicense string
+	if err = rows.Scan(&currentLicense); err != nil {
 		o.Fatal(err)
 	}
+
+	// Assign cleanup handler early, before modifying the license.
+	cleanup = &cleanupLicenseRemoval{license: currentLicense}
 
 	// Generate an expired license to trigger throttling once installed.
 	newLicense, err := (&licensepb.License{
@@ -68,7 +76,7 @@ func runAddExpiredLicenseToTriggerThrottle(
 	// Change the current license. This will cause the server to be in violation of
 	// the license enforcement policies. Connection throttling, no more than 5 concurrent
 	// transactions opened, will be in effect.
-	o.Status(fmt.Sprintf("updating license from %q to %q", cleanup.license, newLicense))
+	o.Status(fmt.Sprintf("updating license from %q to %q", currentLicense, newLicense))
 	_, err = conn.ExecContext(ctx, fmt.Sprintf("SET CLUSTER SETTING enterprise.license = '%s'", newLicense))
 	if err != nil {
 		o.Fatal(err)

--- a/pkg/cmd/roachtest/operations/network_partition.go
+++ b/pkg/cmd/roachtest/operations/network_partition.go
@@ -32,7 +32,12 @@ func (np *cleanupNetworkPartition) Cleanup(
 // createNetworkPartition creates a network partition between two random nodes.
 func createNetworkPartialPartition(
 	ctx context.Context, o operation.Operation, c cluster.Cluster,
-) registry.OperationCleanup {
+) (cleanup registry.OperationCleanup) {
+	defer func() {
+		if r := recover(); r != nil {
+			o.Errorf("error during network partition: %v", r)
+		}
+	}()
 	nodeCount := c.Spec().NodeCount
 	if nodeCount <= 1 {
 		o.Fatal("not enough nodes to create a partition")
@@ -56,18 +61,31 @@ func createNetworkPartialPartition(
 	}
 	otherNodeIP := ips[0]
 	o.Status(fmt.Sprintf("creating a partition between nodes n%d and n%d", nodeID, otherNodeID))
-	// Block all input and output traffic between the two nodes.
-	c.Run(ctx, option.WithNodes(c.Node(nodeID)), fmt.Sprintf(`sudo iptables -A INPUT  -p tcp -s %s -j DROP`, otherNodeIP))
-	c.Run(ctx, option.WithNodes(c.Node(nodeID)), fmt.Sprintf(`sudo iptables -A OUTPUT -p tcp -d %s -j DROP`, otherNodeIP))
 
-	return &cleanupNetworkPartition{nodeID: nodeID}
+	// Assign cleanup handler early, before adding iptables rules.
+	cleanup = &cleanupNetworkPartition{nodeID: nodeID}
+
+	// Block all input and output traffic between the two nodes.
+	if err = c.RunE(ctx, option.WithNodes(c.Node(nodeID)), fmt.Sprintf(`sudo iptables -A INPUT  -p tcp -s %s -j DROP`, otherNodeIP)); err != nil {
+		o.Fatal(err)
+	}
+	if err = c.RunE(ctx, option.WithNodes(c.Node(nodeID)), fmt.Sprintf(`sudo iptables -A OUTPUT -p tcp -d %s -j DROP`, otherNodeIP)); err != nil {
+		o.Fatal(err)
+	}
+
+	return cleanup
 }
 
 // createNetworkFullPartition creates a network partition between a random node
 // and all other nodes.
 func createNetworkFullPartition(
 	ctx context.Context, o operation.Operation, c cluster.Cluster,
-) registry.OperationCleanup {
+) (cleanup registry.OperationCleanup) {
+	defer func() {
+		if r := recover(); r != nil {
+			o.Errorf("error during network partition: %v", r)
+		}
+	}()
 	nodeCount := c.Spec().NodeCount
 	if nodeCount <= 1 {
 		o.Fatal("not enough nodes to create a partition")
@@ -77,12 +95,22 @@ func createNetworkFullPartition(
 	// Drop bi-directional traffic between the node and all other nodes on the
 	// pgport.
 	o.Status(fmt.Sprintf("partition node n%d from the cluster", nodeID))
-	c.Run(ctx, option.WithNodes(c.Node(nodeID)), fmt.Sprintf(`sudo iptables -A INPUT  -p tcp --sport {pgport:%d} -j DROP`, nodeID))
-	c.Run(ctx, option.WithNodes(c.Node(nodeID)), fmt.Sprintf(`sudo iptables -A OUTPUT -p tcp --sport {pgport:%d} -j DROP`, nodeID))
-	c.Run(ctx, option.WithNodes(c.Node(nodeID)), fmt.Sprintf(`sudo iptables -A INPUT  -p tcp --dport {pgport:%d} -j DROP`, nodeID))
-	c.Run(ctx, option.WithNodes(c.Node(nodeID)), fmt.Sprintf(`sudo iptables -A OUTPUT -p tcp --dport {pgport:%d} -j DROP`, nodeID))
 
-	return &cleanupNetworkPartition{nodeID: nodeID}
+	// Assign cleanup handler early, before adding iptables rules.
+	cleanup = &cleanupNetworkPartition{nodeID: nodeID}
+
+	for _, rule := range []string{
+		fmt.Sprintf(`sudo iptables -A INPUT  -p tcp --sport {pgport:%d} -j DROP`, nodeID),
+		fmt.Sprintf(`sudo iptables -A OUTPUT -p tcp --sport {pgport:%d} -j DROP`, nodeID),
+		fmt.Sprintf(`sudo iptables -A INPUT  -p tcp --dport {pgport:%d} -j DROP`, nodeID),
+		fmt.Sprintf(`sudo iptables -A OUTPUT -p tcp --dport {pgport:%d} -j DROP`, nodeID),
+	} {
+		if err := c.RunE(ctx, option.WithNodes(c.Node(nodeID)), rule); err != nil {
+			o.Fatal(err)
+		}
+	}
+
+	return cleanup
 }
 
 // registerNetworkPartition registers both the full and partial network

--- a/pkg/cmd/roachtest/operations/node_kill.go
+++ b/pkg/cmd/roachtest/operations/node_kill.go
@@ -69,15 +69,16 @@ func runNodeKill(
 	}
 
 	o.Status(fmt.Sprintf("killing node %s with signal %d", node.NodeIDsString(), signal))
-	err := c.RunE(ctx, option.WithNodes(node), "pkill", fmt.Sprintf("-%d", signal), "-f", "cockroach\\ start")
-	if err != nil {
+	if err := c.RunE(ctx, option.WithNodes(node), "pkill", fmt.Sprintf("-%d", signal), "-f", "cockroach\\ start"); err != nil {
 		o.Fatal(err)
 	}
 
 	o.Status(fmt.Sprintf("sent signal %d to node %s, waiting for process to exit", signal, node.NodeIDsString()))
 	for {
 		if err := ctx.Err(); err != nil {
-			o.Fatal(err)
+			// Context cancelled, but node was already killed successfully.
+			// Cleanup will still run and restart the node.
+			break
 		}
 		err := c.RunE(ctx, option.WithNodes(node), "pgrep", "-f", "cockroach\\ start")
 		if err != nil {

--- a/pkg/cmd/roachtest/operations/pause_job.go
+++ b/pkg/cmd/roachtest/operations/pause_job.go
@@ -75,7 +75,8 @@ func runPauseJob(
 
 		o.Status(fmt.Sprintf("pausing %s job %s", jobType, jobId))
 		pauseStmt := fmt.Sprintf("PAUSE JOB %s WITH REASON = 'roachtest operation'", jobId)
-		if _, err := conn.ExecContext(ctx, pauseStmt); err != nil {
+		_, err = conn.ExecContext(ctx, pauseStmt)
+		if err != nil {
 			o.Fatal(err)
 		}
 

--- a/pkg/cmd/roachtest/operations/resize.go
+++ b/pkg/cmd/roachtest/operations/resize.go
@@ -46,7 +46,7 @@ func (cl *cleanupResize) Cleanup(ctx context.Context, o operation.Operation, c c
 // duration, then drains and decommissions the new nodes.
 func resizeCluster(
 	ctx context.Context, o operation.Operation, c cluster.Cluster, growCount int,
-) *cleanupResize {
+) (cl *cleanupResize) {
 	// Create a temporary directory to store the required files for this operation.
 	tmpDir, err := os.MkdirTemp("", "")
 	if err != nil {
@@ -70,10 +70,21 @@ func resizeCluster(
 
 	// Grow the cluster, but keep track of the original cluster size.
 	origClusterSize := c.Spec().NodeCount
+
+	// Assign cleanup handler BEFORE Grow(), so it's returned even if Grow() fails.
+	// The cleanup uses Shrink() which is safe to call even if Grow() failed partway through.
+	cl = &cleanupResize{growCount: growCount, origClusterSize: origClusterSize}
+	defer func() {
+		if r := recover(); r != nil {
+			o.Errorf("error during resize: %v", r)
+		}
+	}()
+
 	err = dynamicCluster.Grow(ctx, o.L(), growCount)
 	if err != nil {
 		o.Fatal(err)
 	}
+
 	// Grow command generate new certificates, update certificate on workload cluster.
 	if wc := o.WorkloadCluster(); wc != nil {
 		_ = c.Get(ctx, o.L(), "certs", path.Join(tmpDir, "certs"), c.Node(1))
@@ -88,9 +99,13 @@ func resizeCluster(
 	// Start the new nodes.
 	startOpts := o.StartOpts()
 	startOpts.RoachprodOpts.IsRestart = false
+	// If running from workload cluster, certs are already updated above (lines 89-92).
+	if o.WorkloadCluster() == nil {
+		startOpts.RoachprodOpts.SkipWaitForSQL = true
+	}
 	c.Start(ctx, o.L(), startOpts, o.ClusterSettings(), newNodes)
 
-	return &cleanupResize{growCount: growCount, origClusterSize: origClusterSize}
+	return cl
 }
 
 func registerResize(r registry.Registry) {

--- a/pkg/cmd/roachtest/operations/sql_objects.go
+++ b/pkg/cmd/roachtest/operations/sql_objects.go
@@ -55,7 +55,8 @@ func runSQLOperation(
 		createStmt := createSQL(name)
 
 		o.Status(fmt.Sprintf("creating %s %s", objectType, name))
-		if _, err := conn.ExecContext(ctx, createStmt); err != nil {
+		_, err := conn.ExecContext(ctx, createStmt)
+		if err != nil {
 			o.Fatal(err)
 		}
 

--- a/pkg/cmd/roachtest/run.go
+++ b/pkg/cmd/roachtest/run.go
@@ -18,6 +18,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
@@ -343,7 +344,7 @@ func initRunFlagsBinariesAndLibraries(cmd *cobra.Command) error {
 func CtrlC(ctx context.Context, l *logger.Logger, cancel func(), cr *clusterRegistry) {
 	// Shut down test clusters when interrupted (for example CTRL-C).
 	sig := make(chan os.Signal, 1)
-	signal.Notify(sig, os.Interrupt)
+	signal.Notify(sig, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP, syscall.SIGQUIT)
 	go func() {
 		select {
 		case <-sig:
@@ -354,12 +355,18 @@ func CtrlC(ctx context.Context, l *logger.Logger, cancel func(), cr *clusterRegi
 			"Signaled received. Canceling workers and waiting up to 5s for them.")
 		// Signal runner.Run() to stop.
 		cancel()
-		<-time.After(5 * time.Second)
 		if cr == nil {
-			shout(ctx, l, os.Stderr, "5s elapsed. No clusters registered; nothing to destroy.")
+			// Operation mode: no clusters to destroy, but operations may need
+			// time to run cleanup (e.g., DROP INDEX, restore license). Wait up
+			// to 2 minutes for workers to finish before force-exiting.
+			shout(ctx, l, os.Stderr,
+				"Signal received in operation mode. Waiting up to 2m for cleanup to finish.")
+			<-time.After(2 * time.Minute)
+			shout(ctx, l, os.Stderr, "2m elapsed. Force exiting.")
 			l.Printf("all stacks:\n\n%s\n", allstacks.Get())
 			os.Exit(2)
 		}
+		<-time.After(5 * time.Second)
 		shout(ctx, l, os.Stderr, "5s elapsed. Will brutally destroy all clusters.")
 		// Make sure there are no leftover clusters.
 		destroyCh := make(chan struct{})

--- a/pkg/cmd/roachtest/run_operation.go
+++ b/pkg/cmd/roachtest/run_operation.go
@@ -305,17 +305,6 @@ func (r *opsRunner) runOperation(
 		workerId:        workerIdx,
 	}
 
-	defer func() {
-		if rc := recover(); rc != nil {
-			stack := debugutil.Stack()
-			// Include recorded failures (from o.Fatal) before the panic+stack entry
-			// so the actual error message surfaces in Datadog events.
-			failures := append(op.Failures(), fmt.Errorf("panic: %v\n\n%s", rc, stack))
-			emitter.EmitCompleted(resultPanicked, failures)
-			r.logger.Printf("recovered from panic: %v\n%s", rc, stack)
-		}
-	}()
-
 	cSpec := spec.ClusterSpec{NodeCount: r.nodeCount}
 	c := &dynamicClusterImpl{
 		&clusterImpl{
@@ -367,6 +356,57 @@ func (r *opsRunner) runOperation(
 	emitter.EmitStarted()
 	op.Status(fmt.Sprintf("running operation %s with run id %d", op.spec.Name, operationRunID))
 	var cleanup registry.OperationCleanup
+	var pendingCleanupIncremented bool
+
+	defer func() {
+		// Handle panic if it occurred during operation execution.
+		if rc := recover(); rc != nil {
+			stack := debugutil.Stack()
+			// Include recorded failures (from o.Fatal) before the panic+stack entry
+			// so the actual error message surfaces in Datadog events.
+			failures := append(op.Failures(), fmt.Errorf("panic: %v\n\n%s", rc, stack))
+			emitter.EmitCompleted(resultPanicked, failures)
+			r.logger.Printf("recovered from panic: %v\n%s", rc, stack)
+		}
+
+		// If no cleanup handler was returned, nothing to clean up.
+		if cleanup == nil {
+			if !op.Failed() {
+				op.Status("operation ran successfully")
+				emitter.EmitCleanupCompleted(cleanupResultSkipped, nil)
+			}
+			return
+		}
+
+		// Run cleanup with a fresh context (independent of operation context).
+		op.Status("running cleanup")
+
+		// Clear run-phase failures so that op.Failed() after cleanup only
+		// reflects whether cleanup itself failed. The run-phase failure has
+		// already been logged and emitted above.
+		func() {
+			op.mu.Lock()
+			defer op.mu.Unlock()
+			op.mu.failures = nil
+		}()
+
+		if pendingCleanupIncremented {
+			r.metrics.pendingCleanups.WithLabelValues(opName).Dec()
+		}
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), opSpec.Timeout)
+		defer cleanupCancel()
+		cleanup.Cleanup(cleanupCtx, op, c)
+
+		cleanupResult := cleanupResultSuccess
+		var cleanupFailures []error
+		if op.Failed() {
+			cleanupResult = cleanupResultFailed
+			cleanupFailures = op.Failures()
+			op.Status("operation cleanup failed")
+		}
+		emitter.EmitCleanupCompleted(cleanupResult, cleanupFailures)
+	}()
+
 	func() {
 		ctx, cancel := context.WithTimeout(ctx, opSpec.Timeout)
 		defer cancel()
@@ -374,57 +414,38 @@ func (r *opsRunner) runOperation(
 		cleanup = opSpec.Run(ctx, op, c)
 	}()
 
-	if op.Failed() {
+	opFailed := op.Failed()
+	if opFailed {
 		op.Status("operation failed")
 		failures := op.Failures()
 		emitter.EmitCompleted(resultFailed, failures)
+		// Don't return early — defer will run cleanup if a cleanup handler
+		// was returned by the operation.
 		return failures[0]
 	}
 
 	emitter.EmitCompleted(resultSuccess, nil)
 
 	if cleanup == nil {
-		op.Status("operation ran successfully")
-		emitter.EmitCleanupCompleted(cleanupResultSkipped, nil)
+		// No cleanup needed; the defer will emit cleanupResultSkipped.
 		return nil
 	}
 
+	// Wait before cleanup if operation succeeded.
 	waitBeforeCleanup := roachtestflags.WaitBeforeCleanup
 	if opSpec.WaitBeforeCleanup != 0 {
 		waitBeforeCleanup = opSpec.WaitBeforeCleanup
 	}
 
 	r.metrics.pendingCleanups.WithLabelValues(opName).Inc()
+	pendingCleanupIncremented = true
 	op.Status(fmt.Sprintf("operation ran successfully; waiting %s before cleanup", waitBeforeCleanup))
 	select {
 	case <-time.After(waitBeforeCleanup):
 	case <-ctx.Done():
-		r.metrics.pendingCleanups.WithLabelValues(opName).Dec()
-		op.Status("context canceled during wait before cleanup")
-		return ctx.Err()
+		op.Status("context canceled during wait; proceeding to cleanup immediately")
 	}
 
-	// Cleanup phase.
-	r.metrics.pendingCleanups.WithLabelValues(opName).Dec()
-	op.Status("running cleanup")
-	func() {
-		ctx, cancel := context.WithTimeout(context.Background(), opSpec.Timeout)
-		defer cancel()
-
-		cleanup.Cleanup(ctx, op, c)
-	}()
-
-	cleanupResult := cleanupResultSuccess
-	var cleanupFailures []error
-	if op.Failed() {
-		cleanupResult = cleanupResultFailed
-		cleanupFailures = op.Failures()
-	}
-	emitter.EmitCleanupCompleted(cleanupResult, cleanupFailures)
-
-	if op.Failed() {
-		op.Status("operation cleanup failed")
-		return op.Failures()[0]
-	}
+	// Function ends, defer runs and executes cleanup.
 	return nil
 }

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -1375,7 +1375,21 @@ func (p *Provider) copyLabelsToNewVMs(l *logger.Logger, sourceVM vm.VM, newVMs v
 		}
 		labels[key] = value
 	}
-	return p.AddLabels(l, newVMs, labels)
+	if err := p.AddLabels(l, newVMs, labels); err != nil {
+		return err
+	}
+
+	// Update the VM objects in memory to match the AWS tags we just added.
+	// This ensures that when saveCluster() is called, the cache file has the correct labels.
+	for i := range newVMs {
+		if newVMs[i].Labels == nil {
+			newVMs[i].Labels = make(map[string]string)
+		}
+		for key, value := range labels {
+			newVMs[i].Labels[key] = value
+		}
+	}
+	return nil
 }
 
 // Shrink removes VMs from a managed cluster.


### PR DESCRIPTION
## Summary

Ensures roachtest operations always run their cleanup handlers, even when the process receives signals (SIGINT, SIGTERM, SIGHUP, SIGQUIT) during execution.

## Problem

Signals during operation execution left DRT clusters in dirty states (orphaned indexes, expired licenses, iptables rules, leaked nodes) because:
1. Process exited after 5 seconds, before cleanup could finish
2. `runOperation` skipped cleanup on context cancellation
3. `o.Fatal` panics prevented returning cleanup handlers

## Solution

**Runner (`run_operation.go`):**
- Always run cleanup, even on operation failure or context cancellation
- Moved panic recovery to attempt cleanup if handler was set
- Clear run-phase failures before cleanup so `op.Failed()` only reflects cleanup status

**Signal handling (`run.go`):**
- Extended grace period from 5 seconds to 2 minutes for operation mode
- Added handlers for SIGTERM, SIGHUP, SIGQUIT

**Operations:**
- Short operations: Use `context.Background()` with timeout for state-changing calls
- Long operations: Replace `o.Fatal` with `o.Errorf` after state changes
- Infrastructure operations: Named returns + deferred recovery
- Cleanup handlers: Use `IF EXISTS` for idempotency

Fixes: #163587
Release Note: None
Epic: None