### PR TITLE
leaktest: remove TLS handshake goroutine leak exclusion

### DIFF
--- a/pkg/util/leaktest/leaktest.go
+++ b/pkg/util/leaktest/leaktest.go
@@ -59,11 +59,6 @@ func interestingGoroutines() map[int64]string {
 			strings.Contains(stack, "github.com/jackc/pgconn/internal/ctxwatch.(*ContextWatcher).Watch.func1") ||
 			// Ignore pq goroutine that watches for context cancellation.
 			strings.Contains(stack, "github.com/lib/pq.(*conn).watchCancel") ||
-			// Ignore TLS handshake related goroutine.
-			// TODO(pritesh-lahoti): Revisit this once Go is updated to 1.23, as this seems to have been
-			// fixed: https://github.com/golang/go/pull/62227.
-			strings.Contains(stack, "net/http.(*persistConn).addTLS") ||
-			strings.Contains(stack, "crypto/tls.(*Conn).handshakeContext") ||
 			// Seems to be gccgo specific.
 			(runtime.Compiler == "gccgo" && strings.Contains(stack, "testing.T.Parallel")) ||
 			// Ignore intentionally long-running logging goroutines that live for the


### PR DESCRIPTION
## Summary

- Remove the `net/http.(*persistConn).addTLS` and `crypto/tls.(*Conn).handshakeContext` goroutine leak exclusions from `leaktest.go`
- These were workarounds for a Go stdlib memory leak (golang/go#43966, golang/go#50798) fixed in Go 1.23 via CL 522095
- We are now on Go 1.25.5, so these exclusions are dead code

Closes #142448

Release note: None