### PR TITLE
disk: add collectInstantaneous to defaultCollector

### DIFF
--- a/pkg/storage/disk/platform_default.go
+++ b/pkg/storage/disk/platform_default.go
@@ -20,6 +20,12 @@ func (defaultCollector) collect(disks []*monitoredDisk, time time.Time) (int, er
 	return len(disks), nil
 }
 
+func (defaultCollector) collectInstantaneous(
+	disks []*monitoredDisk, now time.Time, recorder func(traceEvent), buf []byte,
+) (countCollected int, _ []byte, err error) {
+	return len(disks), buf, nil
+}
+
 func newStatsCollector(fs vfs.FS) (*defaultCollector, error) {
 	return &defaultCollector{}, nil
 }


### PR DESCRIPTION
The `statsCollector` interface requires both `collect` and `collectInstantaneous` methods. The `collectInstantaneous` method was added to the interface and implemented on `linuxStatsCollector` and `darwinCollector` in PR #163208, but was not added to `defaultCollector` (used for `!linux && !darwin` builds, including Windows).

This caused the win-amd64 release build to fail with:
```
cannot use collector (variable of type *defaultCollector) as
statsCollector value: missing method collectInstantaneous
```

This commit adds a stub implementation of `collectInstantaneous` to `defaultCollector`, following the same pattern as the darwin implementation.

Fixes #164356

Epic: None
Release note: None