### PR TITLE
multiregionccl: add super region constraint conformance regression test

### DIFF
--- a/pkg/ccl/multiregionccl/multiregion_test.go
+++ b/pkg/ccl/multiregionccl/multiregion_test.go
@@ -7,6 +7,7 @@ package multiregionccl_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -14,12 +15,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/multiregionccl/multiregionccltestutils"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/ctpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -256,6 +259,216 @@ func TestReplicaClosedTSPolicyWithPolicyRefresher(t *testing.T) {
 		for _, policy := range snapshot.AddedOrUpdated {
 			if isLatencyBasedPolicy(policy.Policy) {
 				return errors.Errorf("range %d has latency based policy %s", policy.RangeID, policy.Policy)
+			}
+		}
+		return nil
+	})
+}
+
+// TestSuperRegionConstraintConformance is a regression test for #108127. It
+// verifies that REGIONAL BY ROW and REGIONAL BY TABLE tables in a database
+// with super regions and SURVIVE REGION FAILURE eventually reach full
+// constraint conformance.
+func TestSuperRegionConstraintConformance(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	skip.UnderShort(t)
+	skip.UnderDuress(t)
+
+	// The topology uses 4 regions across 8 nodes (2 per region):
+	//
+	//   - Super region "americas": {us-east-1, us-central-1, us-west-1} — a
+	//     non-primary super region, exercising the AddConstraintsForSuperRegion
+	//     code path where the primary region lives outside the super region.
+	//   - Primary region: {ap-southeast-1} — outside any super region, which
+	//     also ensures RBR partitions and RBT tables homing here get normal
+	//     inherited constraints rather than super-region-confined ones.
+	//
+	// With exactly 3 regions per super region + SURVIVE REGION FAILURE, we get
+	// 5 voters and 0 non-voters — the tightest possible constraint configuration
+	// where every replica is doubly constrained. This is the specific scenario
+	// that triggered the original bug.
+	regionNames := []string{
+		"ap-southeast-1",                         // primary (standalone)
+		"us-east-1", "us-central-1", "us-west-1", // super region "americas"
+	}
+	tc, sqlDB, cleanup :=
+		multiregionccltestutils.TestingCreateMultiRegionClusterWithRegionList(
+			t,
+			regionNames,
+			2, /* serversPerRegion */
+			base.TestingKnobs{},
+		)
+	defer cleanup()
+
+	tdb := sqlutils.MakeSQLRunner(sqlDB)
+
+	// Speed up replication reporting and closed timestamps.
+	tdb.Exec(t, "SET CLUSTER SETTING kv.replication_reports.interval = '1ms'")
+	tdb.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.target_duration = '10ms'")
+	tdb.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '10ms'")
+	tdb.Exec(t, "SET CLUSTER SETTING kv.rangefeed.closed_timestamp_refresh_interval = '10ms'")
+
+	// Setup MR database with all 4 regions.
+	tdb.Exec(t, `CREATE DATABASE testdb PRIMARY REGION "ap-southeast-1"
+		REGIONS "us-east-1", "us-central-1", "us-west-1"`)
+	tdb.Exec(t, `SET enable_super_regions = 'on'`)
+	tdb.Exec(t, `ALTER DATABASE testdb ADD SUPER REGION "americas"
+		VALUES "us-east-1", "us-central-1", "us-west-1"`)
+	tdb.Exec(t, `ALTER DATABASE testdb SURVIVE REGION FAILURE`)
+
+	// Create a REGIONAL BY ROW table with rows in all 4 regions, exercising
+	// every partition's subzone config — both super-region-confined and normal.
+	tdb.Exec(t,
+		`CREATE TABLE testdb.rbr(k INT PRIMARY KEY, v INT)
+		 LOCALITY REGIONAL BY ROW`)
+	tdb.Exec(t, `INSERT INTO testdb.rbr(crdb_region, k, v) VALUES
+		('us-east-1', 1, 10), ('us-central-1', 2, 20), ('us-west-1', 3, 30),
+		('ap-southeast-1', 4, 40)`)
+
+	// RBT in a super region (non-primary). Tests AddConstraintsForSuperRegion
+	// at the table level.
+	tdb.Exec(t,
+		`CREATE TABLE testdb.rbt_sr(k INT PRIMARY KEY, v INT)
+		 LOCALITY REGIONAL BY TABLE IN "us-east-1"`)
+	tdb.Exec(t, `INSERT INTO testdb.rbt_sr(k, v) VALUES (1, 10)`)
+
+	// RBT in the primary region (outside any super region). Tests that
+	// table-level constraints work correctly without super region confinement.
+	tdb.Exec(t,
+		`CREATE TABLE testdb.rbt_standalone(k INT PRIMARY KEY, v INT)
+		 LOCALITY REGIONAL BY TABLE IN "ap-southeast-1"`)
+	tdb.Exec(t, `INSERT INTO testdb.rbt_standalone(k, v) VALUES (1, 10)`)
+
+	// Look up zone_ids for all 3 tables.
+	var rbrZoneID, rbtSRZoneID, rbtStandaloneZoneID int
+	tdb.QueryRow(t, "SELECT zone_id FROM crdb_internal.zones WHERE table_name = 'rbr'").Scan(&rbrZoneID)
+	tdb.QueryRow(t, "SELECT zone_id FROM crdb_internal.zones WHERE table_name = 'rbt_sr'").Scan(&rbtSRZoneID)
+	tdb.QueryRow(t, "SELECT zone_id FROM crdb_internal.zones WHERE table_name = 'rbt_standalone'").Scan(&rbtStandaloneZoneID)
+	zoneIDs := []int{rbrZoneID, rbtSRZoneID, rbtStandaloneZoneID}
+
+	// Verify that zone configs themselves have the expected constraints, so
+	// the conformance check below cannot pass vacuously due to misconfigured
+	// zones.
+	verifyZoneConfig := func(query string, expectedFragments []string) {
+		t.Helper()
+		var target, rawSQL string
+		tdb.QueryRow(t, query).Scan(&target, &rawSQL)
+		for _, frag := range expectedFragments {
+			require.Contains(t, rawSQL, frag,
+				"zone config for %s missing expected fragment", target)
+		}
+	}
+	// RBT in super region: all replicas confined to americas super region.
+	verifyZoneConfig(
+		`SHOW ZONE CONFIGURATION FOR TABLE testdb.rbt_sr`,
+		[]string{
+			"voter_constraints", "us-east-1",
+			"constraints", "us-central-1", "us-west-1",
+		},
+	)
+	// RBT in primary region (standalone): voters in ap-southeast-1, no super
+	// region confinement.
+	verifyZoneConfig(
+		`SHOW ZONE CONFIGURATION FOR TABLE testdb.rbt_standalone`,
+		[]string{"voter_constraints", "ap-southeast-1"},
+	)
+	// RBR partitions inside the super region.
+	for _, region := range []string{"us-east-1", "us-central-1", "us-west-1"} {
+		verifyZoneConfig(
+			fmt.Sprintf(
+				`SHOW ZONE CONFIGURATION FOR PARTITION "%s" OF TABLE testdb.rbr`,
+				region),
+			[]string{
+				"voter_constraints", region,
+				"constraints", "us-east-1", "us-central-1", "us-west-1",
+			},
+		)
+	}
+	// RBR partition outside any super region.
+	verifyZoneConfig(
+		`SHOW ZONE CONFIGURATION FOR PARTITION "ap-southeast-1" OF TABLE testdb.rbr`,
+		[]string{"voter_constraints", "ap-southeast-1"},
+	)
+
+	forceProcess := func() error {
+		for i := 0; i < tc.NumServers(); i++ {
+			if err := tc.Server(i).GetStores().(*kvserver.Stores).VisitStores(
+				func(s *kvserver.Store) error {
+					return s.ForceReplicationScanAndProcess()
+				},
+			); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	// First, wait for the constraint stats report to have been generated for
+	// all zones. Without this gate the subsequent zero-violations check could
+	// pass vacuously before the report has ever run.
+	testutils.SucceedsSoon(t, func() error {
+		if err := forceProcess(); err != nil {
+			return err
+		}
+		for _, zid := range zoneIDs {
+			var count int
+			if err := sqlDB.QueryRow(
+				`SELECT count(*) FROM system.replication_constraint_stats
+				  WHERE zone_id = $1`, zid,
+			).Scan(&count); err != nil {
+				return err
+			}
+			if count == 0 {
+				return fmt.Errorf(
+					"constraint stats report not yet generated for zone %d", zid)
+			}
+		}
+		return nil
+	})
+
+	// Now verify that every reported constraint has zero violating ranges for
+	// all locality types.
+	testutils.SucceedsSoon(t, func() error {
+		if err := forceProcess(); err != nil {
+			return err
+		}
+		checkZone := func(zid int) error {
+			rows, err := sqlDB.Query(
+				`SELECT type, violating_ranges
+				   FROM system.replication_constraint_stats
+				  WHERE zone_id = $1 AND violating_ranges > 0`,
+				zid,
+			)
+			if err != nil {
+				return err
+			}
+			defer rows.Close()
+
+			var violations []string
+			for rows.Next() {
+				var cType string
+				var count int
+				if err := rows.Scan(&cType, &count); err != nil {
+					return err
+				}
+				violations = append(violations,
+					fmt.Sprintf("%s: %d violating ranges", cType, count))
+			}
+			if err := rows.Err(); err != nil {
+				return err
+			}
+			if len(violations) > 0 {
+				return fmt.Errorf(
+					"constraint violations still present for zone %d: %v",
+					zid, violations)
+			}
+			return nil
+		}
+		for _, zid := range zoneIDs {
+			if err := checkZone(zid); err != nil {
+				return err
 			}
 		}
 		return nil


### PR DESCRIPTION
Add TestSuperRegionConstraintConformance as a regression test for #108127 (allocator bug #106559). The test creates an 8-node cluster across 4 regions — one 3-region super region and one standalone region — with SURVIVE REGION FAILURE, then verifies that RBR and RBT tables reach zero constraint violations in system.replication_constraint_stats.

Closes #162479

Release note: None
Epic: CRDB-58694