### PR TITLE
backup: support `RESTORE ... WITH GRANTS` option

### DIFF
--- a/docs/generated/sql/bnf/restore_options.bnf
+++ b/docs/generated/sql/bnf/restore_options.bnf
@@ -19,3 +19,4 @@ restore_options ::=
 	| 'EXPERIMENTAL' 'DEFERRED' 'COPY'
 	| 'EXPERIMENTAL' 'COPY'
 	| 'REMOVE_REGIONS'
+	| 'GRANTS'

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -3132,6 +3132,7 @@ restore_options ::=
 	| 'EXPERIMENTAL' 'DEFERRED' 'COPY'
 	| 'EXPERIMENTAL' 'COPY'
 	| 'REMOVE_REGIONS'
+	| 'GRANTS'
 
 scrub_option_list ::=
 	( scrub_option ) ( ( ',' scrub_option ) )*

--- a/pkg/backup/restore_job.go
+++ b/pkg/backup/restore_job.go
@@ -1799,7 +1799,6 @@ func createImportingDescriptors(
 	return p.ExecCfg().InternalDB.DescsTxn(ctx, func(
 		ctx context.Context, txn descs.Txn,
 	) error {
-
 		descsCol := txn.Descriptors()
 		includePublicSchemaCreatePriv := sqlclustersettings.PublicSchemaCreatePrivilegeEnabled.Get(&p.ExecCfg().Settings.SV)
 		if err := ingesting.WriteDescriptors(
@@ -2029,6 +2028,60 @@ func createImportingDescriptors(
 	})
 }
 
+// getUsersToPreserve finds the intersection of usernames which have privileges on, or are an owner
+// of, a descriptor in backupDescs, and currently exist in the restoring cluster.
+// It returns this intersection as a set, and is intended for use with `RESTORE ... WITH GRANTS`.
+func getUsersToPreserve(
+	ctx context.Context, txn isql.Txn, backupDescs []catalog.Descriptor,
+) (map[username.SQLUsername]struct{}, error) {
+	preserveUsers := make(map[username.SQLUsername]struct{})
+
+	// Collect and dedup users which have privileges on our descriptors.
+	for _, backupDesc := range backupDescs {
+		backupDescPrivs := backupDesc.GetPrivileges()
+
+		// Include owner.
+		owner := backupDescPrivs.Owner()
+		if !owner.IsReserved() && !owner.IsAdminRole() && !owner.IsRootUser() {
+			preserveUsers[owner] = struct{}{}
+		}
+
+		// Include users with explicit privileges.
+		for _, userPrivs := range backupDescPrivs.Users {
+			sqlUser := userPrivs.User()
+			if sqlUser.IsReserved() || sqlUser.IsAdminRole() || sqlUser.IsRootUser() {
+				continue
+			}
+			preserveUsers[sqlUser] = struct{}{}
+		}
+	}
+
+	// Query for the intersection of our backed up users and existing users.
+	allBackedUpUsers := make([]string, 0, len(preserveUsers))
+	for username := range preserveUsers {
+		allBackedUpUsers = append(allBackedUpUsers, username.SQLIdentifier())
+	}
+	rows, err := txn.QueryBufferedEx(ctx, "restore-with-grants-select-existing-users",
+		txn.KV(), sessiondata.NoSessionDataOverride,
+		"SELECT username FROM system.users WHERE username = ANY($1)",
+		allBackedUpUsers,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Collect intersection into our final output set.
+	clear(preserveUsers)
+	for _, row := range rows {
+		username := username.MakeSQLUsernameFromPreNormalizedString(
+			string(tree.MustBeDString(row[0])),
+		)
+		preserveUsers[username] = struct{}{}
+	}
+
+	return preserveUsers, nil
+}
+
 // protectRestoreTargets issues a protected timestamp over the targets we seek
 // to restore and writes the pts record to the job record. If a pts already
 // exists in the job record, due to previous call of this function, this noops.
@@ -2186,7 +2239,7 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 	defer mem.Close(ctx)
 	// Note that we ignore memSize because the memory account is closed in a
 	// defer anyway.
-	backupManifests, latestBackupManifest, sqlDescs, _, err := loadBackupSQLDescs(
+	backupManifests, latestBackupManifest, backupDescs, _, err := loadBackupSQLDescs(
 		ctx, &mem, p, details, details.Encryption, &kmsEnv,
 	)
 	if err != nil {
@@ -2211,10 +2264,10 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 	if err != nil {
 		return err
 	}
-	if err := createImportingDescriptors(ctx, p, sqlDescs, r); err != nil {
+	if err := createImportingDescriptors(ctx, p, backupDescs, r); err != nil {
 		return err
 	}
-	preData, preValidateData, mainData, err := createRestoreFlows(ctx, r, backupCodec, sqlDescs)
+	preData, preValidateData, mainData, err := createRestoreFlows(ctx, r, backupCodec, backupDescs)
 	if err != nil {
 		return err
 	}
@@ -2267,7 +2320,8 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 		// the first place, as a special case.
 		publishDescriptors := func(ctx context.Context, txn descs.Txn) error {
 			return r.publishDescriptors(
-				ctx, p.ExecCfg().JobRegistry, p.ExecCfg().JobsKnobs(), txn, p.User(), details, sqlDescs, p.ExecCfg().NodeInfo.LogicalClusterID(),
+				ctx, p.ExecCfg().JobRegistry, p.ExecCfg().JobsKnobs(),
+				txn, p.User(), details, backupDescs, p.ExecCfg().NodeInfo.LogicalClusterID(),
 			)
 		}
 		if err := r.execCfg.InternalDB.DescsTxn(ctx, publishDescriptors); err != nil {
@@ -2431,7 +2485,7 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 	publishDescriptors := func(ctx context.Context, txn descs.Txn) (err error) {
 		return r.publishDescriptors(
 			ctx, p.ExecCfg().JobRegistry, p.ExecCfg().JobsKnobs(), txn, p.User(),
-			details, sqlDescs, p.ExecCfg().NodeInfo.LogicalClusterID(),
+			details, backupDescs, p.ExecCfg().NodeInfo.LogicalClusterID(),
 		)
 	}
 	if err := r.execCfg.InternalDB.DescsTxn(ctx, publishDescriptors); err != nil {
@@ -2940,7 +2994,7 @@ func (r *restoreResumer) publishDescriptors(
 	txn descs.Txn,
 	user username.SQLUsername,
 	details jobspb.RestoreDetails,
-	sqlDesc []catalog.Descriptor,
+	backupDescs []catalog.Descriptor,
 	clusterID uuid.UUID,
 ) (err error) {
 	if details.DescriptorsPublished {
@@ -2970,7 +3024,9 @@ func (r *restoreResumer) publishDescriptors(
 	}
 
 	// Add type descriptors referenced by schema change targets.
-	all, err = addReferencedTypeDescriptorsFromSchemaChangeState(ctx, txn, all, sqlDesc, details.DescriptorRewrites)
+	all, err = addReferencedTypeDescriptorsFromSchemaChangeState(
+		ctx, txn, all, backupDescs, details.DescriptorRewrites,
+	)
 	if err != nil {
 		return err
 	}
@@ -3087,9 +3143,57 @@ func (r *restoreResumer) publishDescriptors(
 		fn := all.LookupDescriptor(details.FunctionDescs[i].GetID()).(catalog.FunctionDescriptor)
 		newFunctions = append(newFunctions, fn.FuncDesc())
 	}
+
+	// Build helper maps for restore with grants.
+	//
+	// Note that this feature could be implemented inside createImportingDescriptors,
+	// however, if we intend to extend the feature to restore users as well, we wouldn't be able
+	// to implement it in createImportingDescriptors, as we need the temp system db for that
+	// functionality, so keeping this logic here gives us a much more simple foundation for future
+	// extensions.
+	var usersToPreserve map[username.SQLUsername]struct{}
+	var newToOld map[descpb.ID]catalog.Descriptor
+	if details.Grants {
+		usersToPreserve, err = getUsersToPreserve(ctx, txn, backupDescs)
+		if err != nil {
+			return errors.Wrap(err, "finding users to preserve for restore with grants")
+		}
+		newToOld = make(map[descpb.ID]catalog.Descriptor)
+		for _, desc := range backupDescs {
+			oldID := desc.GetID()
+			rewrite, ok := details.DescriptorRewrites[oldID]
+			if !ok {
+				return errors.AssertionFailedf("backup descriptor ID not in descriptor rewrite map")
+			}
+			newToOld[rewrite.ID] = desc
+		}
+	}
+
 	b := txn.KV().NewBatch()
 	if err := all.ForEachDescriptor(func(desc catalog.Descriptor) error {
 		d := desc.(catalog.MutableDescriptor)
+
+		if details.Grants {
+			oldDesc, ok := newToOld[d.GetID()]
+			if !ok {
+				return errors.AssertionFailedf("new descriptor ID not in new to old ID map")
+			}
+			updatedPrivileges := d.GetPrivileges()
+
+			for _, userPrivs := range oldDesc.GetPrivileges().Users {
+				if _, ok := usersToPreserve[userPrivs.User()]; ok {
+					userEntry := updatedPrivileges.FindOrCreateUser(userPrivs.User())
+					userEntry.Privileges = userPrivs.Privileges
+					userEntry.WithGrantOption = userPrivs.WithGrantOption
+				}
+			}
+
+			originalOwner := oldDesc.GetPrivileges().Owner()
+			if _, ok := usersToPreserve[originalOwner]; ok {
+				updatedPrivileges.SetOwner(originalOwner)
+			}
+		}
+
 		if details.OnlineImpl() && epochBasedInProgressImport(desc) {
 			log.Dev.Infof(ctx, "table %q (%d) with in-progress IMPORT remaining offline", desc.GetName(), desc.GetID())
 		} else {

--- a/pkg/backup/restore_planning.go
+++ b/pkg/backup/restore_planning.go
@@ -1236,6 +1236,7 @@ func resolveOptionsForRestoreJobDescription(
 		ExperimentalOnline:               opts.ExperimentalOnline,
 		ExperimentalCopy:                 opts.ExperimentalCopy,
 		RemoveRegions:                    opts.RemoveRegions,
+		Grants:                           opts.Grants,
 	}
 
 	if opts.EncryptionPassphrase != nil {
@@ -1434,6 +1435,24 @@ func restorePlanHook(
 
 	if restoreStmt.Options.OnlineImpl() && restoreStmt.Options.VerifyData {
 		return nil, nil, false, errors.New("cannot run online restore with verify_backup_table_data")
+	}
+
+	if restoreStmt.Options.Grants {
+		if !p.ExecCfg().Settings.Version.ActiveVersion(ctx).AtLeast(clusterversion.V26_2.Version()) {
+			return nil, nil, false, errors.New(
+				"RESTORE ... WITH GRANTS is only supported on clusters with version 26.2 or later",
+			)
+		}
+		switch restoreStmt.DescriptorCoverage {
+		case tree.AllDescriptors:
+			return nil, nil, false, errors.New(
+				"RESTORE ... WITH GRANTS is only supported for database and table level restores",
+			)
+		case tree.SystemUsers:
+			return nil, nil, false, errors.New(
+				"RESTORE SYSTEM USERS does not support the WITH GRANTS option",
+			)
+		}
 	}
 
 	var newTenantID *roachpb.TenantID
@@ -2141,6 +2160,7 @@ func doRestorePlan(
 		RemoveRegions:                    restoreStmt.Options.RemoveRegions,
 		UnsafeRestoreIncompatibleVersion: restoreStmt.Options.UnsafeRestoreIncompatibleVersion,
 		TempSystemID:                     tempSysDBID,
+		Grants:                           restoreStmt.Options.Grants,
 	}
 
 	jr := jobs.Record{

--- a/pkg/backup/restore_planning_test.go
+++ b/pkg/backup/restore_planning_test.go
@@ -79,6 +79,7 @@ func TestRestoreResolveOptionsForJobDescription(t *testing.T) {
 		NewDBName:            tree.NewDString("test expr"),
 		DecryptionKMSURI:     []tree.Expr{tree.NewDString("http://example.com")},
 		EncryptionPassphrase: tree.NewDString("test expr"),
+		Grants:               true,
 	}
 
 	ensureAllStructFieldsSet := func(s tree.RestoreOptions, name string) {

--- a/pkg/backup/restore_test.go
+++ b/pkg/backup/restore_test.go
@@ -587,3 +587,360 @@ func TestRestorePausepointSkipsRetries(t *testing.T) {
 		t, 1, mu.attemptCount, "expected only 1 restore attempt since pausepoint should skip retries",
 	)
 }
+
+func TestRestoreWithGrants(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	_, db, _, cleanup := backuptestutils.StartBackupRestoreTestCluster(t, 1)
+	defer cleanup()
+
+	tests := []struct {
+		name              string
+		setupStmts        []string
+		grantStmts        []string
+		backupStmt        string
+		dropBeforeRestore []string
+		restoreStmt       string
+		ownerChecks       []ownerCheck
+		privilegeChecks   []privilegeCheck
+		expectError       string // if non-empty, expect this error message
+	}{
+		// Database ownership tests
+		{
+			name: "owner-preserved-database",
+			setupStmts: []string{
+				"CREATE DATABASE testdb",
+				"CREATE USER testowner",
+			},
+			grantStmts: []string{
+				"ALTER DATABASE testdb OWNER TO testowner",
+			},
+			backupStmt:  "BACKUP DATABASE testdb INTO 'nodelocal://1/test-owner-db'",
+			restoreStmt: "RESTORE DATABASE testdb FROM LATEST IN 'nodelocal://1/test-owner-db' WITH GRANTS, new_db_name = newtestdb",
+			ownerChecks: []ownerCheck{
+				{objectType: "database", objectName: "newtestdb", expectedOwner: "testowner"},
+			},
+		},
+		{
+			name: "owner-not-preserved",
+			setupStmts: []string{
+				"CREATE DATABASE testdb2",
+				"CREATE USER testowner2",
+			},
+			grantStmts: []string{
+				"ALTER DATABASE testdb2 OWNER TO testowner2",
+			},
+			backupStmt: "BACKUP DATABASE testdb2 INTO 'nodelocal://1/test-owner-dropped'",
+			dropBeforeRestore: []string{
+				"DROP DATABASE testdb2",
+				"DROP USER testowner2",
+			},
+			restoreStmt: "RESTORE DATABASE testdb2 FROM LATEST IN 'nodelocal://1/test-owner-dropped' WITH GRANTS",
+			ownerChecks: []ownerCheck{
+				{objectType: "database", objectName: "testdb2", expectedOwner: "root"},
+			},
+		},
+
+		// Grant option tests
+		{
+			name: "grant-option-on-select",
+			setupStmts: []string{
+				"CREATE DATABASE grantoptdb",
+				"CREATE TABLE grantoptdb.t (id INT PRIMARY KEY)",
+				"CREATE USER user1",
+			},
+			grantStmts: []string{
+				"GRANT SELECT ON TABLE grantoptdb.t TO user1 WITH GRANT OPTION",
+				"GRANT INSERT ON TABLE grantoptdb.t TO user1",
+			},
+			backupStmt:  "BACKUP DATABASE grantoptdb INTO 'nodelocal://1/test-grant-option'",
+			restoreStmt: "RESTORE DATABASE grantoptdb FROM LATEST IN 'nodelocal://1/test-grant-option' WITH GRANTS, new_db_name = newgrantoptdb",
+			privilegeChecks: []privilegeCheck{
+				hasGrantablePriv("user1", "TABLE", "newgrantoptdb.t", "SELECT"),
+				hasPriv("user1", "TABLE", "newgrantoptdb.t", "INSERT"),
+			},
+		},
+
+		// Multi-privilege tests
+		{
+			name: "multiple-table-privileges",
+			setupStmts: []string{
+				"CREATE DATABASE multiprivdb",
+				"CREATE TABLE multiprivdb.t (id INT PRIMARY KEY)",
+				"CREATE USER user3",
+			},
+			grantStmts: []string{
+				"GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE multiprivdb.t TO user3",
+			},
+			backupStmt:      "BACKUP DATABASE multiprivdb INTO 'nodelocal://1/test-multi-priv'",
+			restoreStmt:     "RESTORE TABLE multiprivdb.t FROM LATEST IN 'nodelocal://1/test-multi-priv' WITH GRANTS, into_db = testdb",
+			privilegeChecks: hasPrivs("user3", "TABLE", "testdb.t", "SELECT", "INSERT", "UPDATE", "DELETE"),
+		},
+
+		// Object type privilege tests
+		{
+			name: "multi-desc-types",
+			setupStmts: []string{
+				"CREATE DATABASE descdb",
+				"CREATE SCHEMA descdb.testschema",
+				"CREATE TYPE descdb.myenum AS ENUM ('a', 'b', 'c')",
+				"CREATE USER user5",
+			},
+			grantStmts: []string{
+				"GRANT CREATE ON DATABASE descdb TO user5",
+				"GRANT CREATE ON SCHEMA descdb.testschema TO user5",
+				"GRANT USAGE ON TYPE descdb.myenum TO user5",
+			},
+			backupStmt:  "BACKUP DATABASE descdb INTO 'nodelocal://1/test-multi-desc'",
+			restoreStmt: "RESTORE DATABASE descdb FROM LATEST IN 'nodelocal://1/test-multi-desc' WITH GRANTS, new_db_name = newdescdb",
+			privilegeChecks: []privilegeCheck{
+				hasPriv("user5", "DATABASE", "newdescdb", "CREATE"),
+				hasPriv("user5", "SCHEMA", "newdescdb.testschema", "CREATE"),
+				hasPriv("user5", "TYPE", "newdescdb.myenum", "USAGE"),
+			},
+		},
+
+		// Multi-user scenarios
+		{
+			name: "multiple-users",
+			setupStmts: []string{
+				"CREATE DATABASE multiuserdb",
+				"CREATE USER alice",
+				"CREATE USER bob",
+				"CREATE USER charlie",
+			},
+			grantStmts: []string{
+				"GRANT CREATE ON DATABASE multiuserdb TO alice",
+				"GRANT CONNECT ON DATABASE multiuserdb TO bob",
+				"GRANT CREATE ON DATABASE multiuserdb TO charlie",
+			},
+			backupStmt: "BACKUP DATABASE multiuserdb INTO 'nodelocal://1/test-multi-user'",
+			dropBeforeRestore: []string{
+				"DROP DATABASE multiuserdb",
+				"DROP USER bob",
+			},
+			restoreStmt: "RESTORE DATABASE multiuserdb FROM LATEST IN 'nodelocal://1/test-multi-user' WITH GRANTS",
+			privilegeChecks: []privilegeCheck{
+				hasPriv("alice", "DATABASE", "multiuserdb", "CREATE"),
+				lacksPriv("bob", "DATABASE", "multiuserdb", "CONNECT"),
+				hasPriv("charlie", "DATABASE", "multiuserdb", "CREATE"),
+			},
+		},
+
+		// Edge cases and error conditions
+		{
+			name: "without-grants-option",
+			setupStmts: []string{
+				"CREATE DATABASE nograntdb",
+				"CREATE USER user7",
+			},
+			grantStmts: []string{
+				"GRANT CREATE ON DATABASE nograntdb TO user7",
+			},
+			backupStmt:  "BACKUP DATABASE nograntdb INTO 'nodelocal://1/test-no-grants'",
+			restoreStmt: "RESTORE DATABASE nograntdb FROM LATEST IN 'nodelocal://1/test-no-grants' WITH new_db_name = newnograntdb",
+			privilegeChecks: []privilegeCheck{
+				lacksPriv("user7", "DATABASE", "newnograntdb", "CREATE"),
+			},
+		},
+		{
+			name: "cluster-restore-rejected",
+			setupStmts: []string{
+				"CREATE DATABASE clusterdb",
+			},
+			backupStmt:  "BACKUP INTO 'nodelocal://1/test-cluster'",
+			restoreStmt: "RESTORE FROM LATEST IN 'nodelocal://1/test-cluster' WITH GRANTS",
+			expectError: "only supported for database and table level restores",
+		},
+		{
+			name: "system-users-restore-rejected",
+			setupStmts: []string{
+				"CREATE DATABASE systemusersdb",
+			},
+			backupStmt:  "BACKUP INTO 'nodelocal://1/test-system-users'",
+			restoreStmt: "RESTORE SYSTEM USERS FROM LATEST IN 'nodelocal://1/test-system-users' WITH GRANTS",
+			expectError: "does not support the WITH GRANTS option",
+		},
+
+		// Table-level operations
+		{
+			name: "table-level-backup",
+			setupStmts: []string{
+				"CREATE DATABASE tablebackupdb",
+				"CREATE TABLE tablebackupdb.t1 (id INT PRIMARY KEY)",
+				"CREATE USER user8",
+			},
+			grantStmts: []string{
+				"GRANT SELECT, INSERT ON TABLE tablebackupdb.t1 TO user8",
+			},
+			backupStmt: "BACKUP TABLE tablebackupdb.t1 INTO 'nodelocal://1/test-table-backup'",
+			dropBeforeRestore: []string{
+				"DROP TABLE tablebackupdb.t1",
+			},
+			restoreStmt:     "RESTORE TABLE tablebackupdb.t1 FROM LATEST IN 'nodelocal://1/test-table-backup' WITH GRANTS",
+			privilegeChecks: hasPrivs("user8", "TABLE", "tablebackupdb.t1", "SELECT", "INSERT"),
+		},
+
+		// Complex scenarios
+		{
+			name: "nested-objects",
+			setupStmts: []string{
+				"CREATE DATABASE nesteddb",
+				"CREATE SCHEMA nesteddb.myschema",
+				"CREATE TABLE nesteddb.myschema.t1 (id INT PRIMARY KEY)",
+				"CREATE USER user9",
+			},
+			grantStmts: []string{
+				"GRANT CREATE ON DATABASE nesteddb TO user9",
+				"GRANT USAGE ON SCHEMA nesteddb.myschema TO user9",
+				"GRANT SELECT ON TABLE nesteddb.myschema.t1 TO user9",
+			},
+			backupStmt:  "BACKUP DATABASE nesteddb INTO 'nodelocal://1/test-nested'",
+			restoreStmt: "RESTORE DATABASE nesteddb FROM LATEST IN 'nodelocal://1/test-nested' WITH GRANTS, new_db_name = newnesteddb",
+			privilegeChecks: []privilegeCheck{
+				hasPriv("user9", "DATABASE", "newnesteddb", "CREATE"),
+				hasPriv("user9", "SCHEMA", "newnesteddb.myschema", "USAGE"),
+				hasPriv("user9", "TABLE", "newnesteddb.myschema.t1", "SELECT"),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup.
+			for _, stmt := range tc.setupStmts {
+				db.Exec(t, stmt)
+			}
+			for _, stmt := range tc.grantStmts {
+				db.Exec(t, stmt)
+			}
+
+			// Backup.
+			db.Exec(t, tc.backupStmt)
+
+			// Drop before restore.
+			for _, stmt := range tc.dropBeforeRestore {
+				db.Exec(t, stmt)
+			}
+
+			// Restore.
+			if tc.expectError != "" {
+				db.ExpectErr(t, tc.expectError, tc.restoreStmt)
+				return
+			}
+			db.Exec(t, tc.restoreStmt)
+
+			// Verify ownership.
+			for _, check := range tc.ownerChecks {
+				verifyOwner(t, db, check)
+			}
+
+			// Verify privileges.
+			for _, check := range tc.privilegeChecks {
+				verifyPrivilege(t, db, check)
+			}
+		})
+	}
+}
+
+// hasPriv creates a privilege check expecting a non-grantable privilege to be present.
+func hasPriv(grantee, objectType, objectName, privilege string) privilegeCheck {
+	return privilegeCheck{
+		grantee:         grantee,
+		objectType:      objectType,
+		objectName:      objectName,
+		privilege:       privilege,
+		expectPresent:   true,
+		expectGrantable: false,
+	}
+}
+
+func hasPrivs(grantee, objectType, objectName string, privileges ...string) []privilegeCheck {
+	checks := make([]privilegeCheck, len(privileges))
+	for i, priv := range privileges {
+		checks[i] = hasPriv(grantee, objectType, objectName, priv)
+	}
+	return checks
+}
+
+// hasGrantablePriv creates a privilege check expecting a grantable privilege to be present.
+func hasGrantablePriv(grantee, objectType, objectName, privilege string) privilegeCheck {
+	return privilegeCheck{
+		grantee:         grantee,
+		objectType:      objectType,
+		objectName:      objectName,
+		privilege:       privilege,
+		expectPresent:   true,
+		expectGrantable: true,
+	}
+}
+
+// lacksPriv creates a privilege check expecting a privilege to be absent.
+func lacksPriv(grantee, objectType, objectName, privilege string) privilegeCheck {
+	return privilegeCheck{
+		grantee:       grantee,
+		objectType:    objectType,
+		objectName:    objectName,
+		privilege:     privilege,
+		expectPresent: false,
+	}
+}
+
+// ownerCheck specifies an ownership verification.
+type ownerCheck struct {
+	objectType    string // "database", "table", "schema", "type"
+	objectName    string
+	expectedOwner string
+}
+
+// privilegeCheck specifies a privilege verification.
+type privilegeCheck struct {
+	grantee         string
+	objectType      string // "DATABASE", "TABLE", "SCHEMA", "TYPE"
+	objectName      string
+	privilege       string // "SELECT", "INSERT", "CREATE", etc.
+	expectPresent   bool
+	expectGrantable bool // only checked if expectPresent is true
+}
+
+// verifyOwner checks that an object has the expected owner.
+func verifyOwner(t *testing.T, db *sqlutils.SQLRunner, check ownerCheck) {
+	t.Helper()
+	var query string
+	switch check.objectType {
+	case "database":
+		query = fmt.Sprintf("SELECT owner FROM [SHOW DATABASES] WHERE database_name = '%s'", check.objectName)
+	case "table":
+		// objectName format is "database.table" or "database.schema.table"
+		query = fmt.Sprintf("SELECT owner FROM [SHOW TABLES] WHERE table_name = '%s'", check.objectName)
+	case "schema":
+		// objectName format is "database.schema"
+		query = fmt.Sprintf("SELECT owner FROM [SHOW SCHEMAS] WHERE schema_name = '%s'", check.objectName)
+	default:
+		t.Fatalf("unknown object type: %s", check.objectType)
+	}
+
+	var owner string
+	db.QueryRow(t, query).Scan(&owner)
+	require.Equal(t, check.expectedOwner, owner, "owner mismatch for %s %s", check.objectType, check.objectName)
+}
+
+// verifyPrivilege checks that a privilege is present or absent as expected.
+func verifyPrivilege(t *testing.T, db *sqlutils.SQLRunner, check privilegeCheck) {
+	t.Helper()
+	query := fmt.Sprintf(
+		"SELECT is_grantable FROM [SHOW GRANTS ON %s %s] WHERE grantee = '%s' AND privilege_type = '%s'",
+		check.objectType, check.objectName, check.grantee, check.privilege)
+
+	rows := db.Query(t, query)
+	defer rows.Close()
+
+	require.Equal(t, check.expectPresent, rows.Next())
+
+	if check.expectPresent {
+		var isGrantable bool
+		require.NoError(t, rows.Scan(&isGrantable))
+		require.Equal(t, check.expectGrantable, isGrantable)
+	}
+}

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -669,7 +669,11 @@ message RestoreDetails {
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb.ID"
   ];
 
-  // NEXT ID: 39.
+  // Grants, when true, directs the restore job to restore privileges on descriptors it restores
+  // for users that are in the restoring cluster.
+  bool grants = 39;
+
+  // NEXT ID: 40.
 }
 
 

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -4240,6 +4240,10 @@ restore_options:
   {
     $$.val = &tree.RestoreOptions{RemoveRegions: true, SkipLocalitiesCheck: true}
   }
+| GRANTS
+  {
+    $$.val = &tree.RestoreOptions{Grants: true}
+  }
 
 virtual_cluster_opt:
   TENANT  { /* SKIP DOC */ }

--- a/pkg/sql/parser/testdata/backup_restore
+++ b/pkg/sql/parser/testdata/backup_restore
@@ -570,6 +570,15 @@ RESTORE DATABASE _ FROM 'latest' IN '*****' WITH OPTIONS (experimental copy) -- 
 RESTORE DATABASE foo FROM 'latest' IN 'bar' WITH OPTIONS (experimental copy) -- passwords exposed
 
 parse
+RESTORE DATABASE foo FROM LATEST IN 'bar' WITH GRANTS
+----
+RESTORE DATABASE foo FROM 'latest' IN '*****' WITH OPTIONS (grants) -- normalized!
+RESTORE DATABASE foo FROM ('latest') IN ('*****') WITH OPTIONS (grants) -- fully parenthesized
+RESTORE DATABASE foo FROM '_' IN '_' WITH OPTIONS (grants) -- literals removed
+RESTORE DATABASE _ FROM 'latest' IN '*****' WITH OPTIONS (grants) -- identifiers removed
+RESTORE DATABASE foo FROM 'latest' IN 'bar' WITH OPTIONS (grants) -- passwords exposed
+
+parse
 RESTORE DATABASE foo, baz FROM LATEST IN 'bar' AS OF SYSTEM TIME '1'
 ----
 RESTORE DATABASE foo, baz FROM 'latest' IN '*****' AS OF SYSTEM TIME '1' -- normalized!

--- a/pkg/sql/sem/tree/backup.go
+++ b/pkg/sql/sem/tree/backup.go
@@ -128,6 +128,7 @@ type RestoreOptions struct {
 	ExperimentalOnline               bool
 	ExperimentalCopy                 bool
 	RemoveRegions                    bool
+	Grants                           bool
 }
 
 func (opts *RestoreOptions) OnlineImpl() bool {
@@ -496,6 +497,11 @@ func (o *RestoreOptions) Format(ctx *FmtCtx) {
 		maybeAddSep()
 		ctx.WriteString("remove_regions")
 	}
+
+	if o.Grants {
+		maybeAddSep()
+		ctx.WriteString("grants")
+	}
 }
 
 // CombineWith merges other backup options into this backup options struct.
@@ -647,6 +653,14 @@ func (o *RestoreOptions) CombineWith(other *RestoreOptions) error {
 		o.RemoveRegions = other.RemoveRegions
 	}
 
+	if o.Grants {
+		if other.Grants {
+			return errors.New("grants specified multiple times")
+		}
+	} else {
+		o.Grants = other.Grants
+	}
+
 	return nil
 }
 
@@ -672,7 +686,8 @@ func (o RestoreOptions) IsDefault() bool {
 		o.ExecutionLocality == options.ExecutionLocality &&
 		o.ExperimentalOnline == options.ExperimentalOnline &&
 		o.ExperimentalCopy == options.ExperimentalCopy &&
-		o.RemoveRegions == options.RemoveRegions
+		o.RemoveRegions == options.RemoveRegions &&
+		o.Grants == options.Grants
 }
 
 // BackupTargetList represents a list of targets.


### PR DESCRIPTION
This patch adds support for a `WITH GRANTS` option to restore, which restores any grants on the restore targets for users that exist in the restoring cluster.

Informs: #45359

Release note (sql): RESTORE TABLE/DATABASE now supports the WITH GRANTS option, which restores grants on restore targets for users in the restoring cluster. Note that using this option with `new_db_name` will cause the new database to inherit the privileges in the backed up database.