### PR TITLE
build: ignore sharding on nightly extra stress tests

### DIFF
--- a/build/teamcity/cockroach/nightlies/cockroach_nightly_extra_stress_impl.sh
+++ b/build/teamcity/cockroach/nightlies/cockroach_nightly_extra_stress_impl.sh
@@ -72,6 +72,7 @@ $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci -- test $TEST_PACKAGE_TARGETS \
                                       --test_env TC_SERVER_URL \
                                       $TEST_ARGS \
                                       --test_filter="$test_filter" \
+                                      --test_sharding_strategy=disabled \
     || exit_status=$?
 
 exit $exit_status


### PR DESCRIPTION
Our larger test packages specify a `shard_count` in their `BUILD.bazel`, which combined with the 1000 runs per test in our nightly extra stress, results in massive BEP logs that can exceed the gRPC message limit. This teaches the script to ignore the shard counts for our extra stress tests, as they only run a very small subset of tests.

Fixes: #162142

Release note: None