### PR TITLE
sql/inspect: partition table spans by region

### DIFF
--- a/pkg/sql/inspect/check_helpers.go
+++ b/pkg/sql/inspect/check_helpers.go
@@ -179,7 +179,7 @@ func spanForRegion(
 	endKeyAfterIndex := span.EndKey[len(indexPrefix):]
 
 	// Decode and skip the region column from the original span
-	_, startSuffix, err := keyside.Decode(
+	startRegionDatum, startSuffix, err := keyside.Decode(
 		nil, /* alloc */
 		regionCol.GetType(),
 		startKeyAfterIndex,
@@ -189,6 +189,23 @@ func spanForRegion(
 		return roachpb.Span{}, errors.Wrap(err, "decoding region from start key")
 	}
 
+	// If the original span uses the `PrefixEnd` of the region value, the updated
+	// span does as well.
+	startRegionEncoded, err := keyside.Encode(nil, startRegionDatum, encoding.Ascending)
+	if err != nil {
+		return roachpb.Span{}, errors.Wrap(err, "encoding start region")
+	}
+
+	if isPrefixEnd := bytes.Equal(endKeyAfterIndex, roachpb.Key(startRegionEncoded).PrefixEnd()); isPrefixEnd {
+		key := append(slices.Clone(regionPrefix), startSuffix...)
+		endKey := regionSpan.EndKey
+		return roachpb.Span{
+			Key:    key,
+			EndKey: endKey,
+		}, nil
+	}
+
+	// Decode the end key normally
 	_, endSuffix, err := keyside.Decode(
 		nil, /* alloc */
 		regionCol.GetType(),
@@ -368,4 +385,27 @@ func findUniqueColIdxs(tableDesc catalog.TableDescriptor, index catalog.Index) (
 
 	}
 	return uniqueColIdxs, nil
+}
+
+// getRegionsForTable retrieves the list of regions from an RBR table.
+func getRegionsForTable(ctx context.Context, tableDesc catalog.TableDescriptor) ([]string, error) {
+	if !tableDesc.IsLocalityRegionalByRow() {
+		if !buildutil.CrdbTestBuild && !testing.Testing() { // For ease of testing, allow faked multi-region databases.
+			return nil, errors.AssertionFailedf("table is not REGIONAL BY ROW")
+		}
+	}
+
+	regionColID := tableDesc.GetPrimaryIndex().GetKeyColumnID(0)
+	regionCol, err := catalog.MustFindColumnByID(tableDesc, regionColID)
+	if err != nil {
+		return nil, err
+	}
+
+	regionType := regionCol.GetType()
+	if regionType.TypeMeta.EnumData == nil {
+		return nil, errors.AssertionFailedf("region column is not an enum type")
+	}
+	allRegions := regionType.TypeMeta.EnumData.LogicalRepresentations
+
+	return allRegions, nil
 }

--- a/pkg/sql/inspect/inspect_resumer.go
+++ b/pkg/sql/inspect/inspect_resumer.go
@@ -8,6 +8,7 @@ package inspect
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts/ptpb"
@@ -49,7 +50,7 @@ func (c *inspectResumer) Resume(ctx context.Context, execCtx interface{}) error 
 		return nil
 	}
 
-	pkSpans, err := c.getPrimaryIndexSpans(ctx, execCfg)
+	allSpans, err := c.getSpans(ctx, execCfg)
 	if err != nil {
 		return err
 	}
@@ -70,7 +71,7 @@ func (c *inspectResumer) Resume(ctx context.Context, execCtx interface{}) error 
 	}
 	defer cleanupProgress()
 
-	remainingSpans := c.filterCompletedSpans(pkSpans, completedSpans)
+	remainingSpans := c.filterCompletedSpans(allSpans, completedSpans)
 
 	if len(remainingSpans) > 0 {
 		plan, planCtx, err := c.planInspectProcessors(ctx, jobExecCtx, remainingSpans)
@@ -140,9 +141,9 @@ func (c *inspectResumer) maybeRunAfterProtectedTimestampHook(execCfg *sql.Execut
 	return execCfg.InspectTestingKnobs.OnInspectAfterProtectedTimestamp()
 }
 
-// getPrimaryIndexSpans returns the primary index spans for all tables involved in
-// the INSPECT job's checks.
-func (c *inspectResumer) getPrimaryIndexSpans(
+// getSpans returns the spans for all tables involved in the INSPECT
+// job's checks.
+func (c *inspectResumer) getSpans(
 	ctx context.Context, execCfg *sql.ExecutorConfig,
 ) ([]roachpb.Span, error) {
 	details := c.job.Details().(jobspb.InspectDetails)
@@ -154,18 +155,44 @@ func (c *inspectResumer) getPrimaryIndexSpans(
 		uniqueTableIDs[details.Checks[i].TableID] = struct{}{}
 	}
 
-	spans := make([]roachpb.Span, 0, len(uniqueTableIDs))
+	// Collect the table descriptors.
+	tableDescs := make([]catalog.TableDescriptor, 0, len(uniqueTableIDs))
 	err := execCfg.InternalDB.DescsTxn(ctx, func(ctx context.Context, txn descs.Txn) error {
 		for tableID := range uniqueTableIDs {
 			desc, err := txn.Descriptors().ByIDWithLeased(txn.KV()).WithoutNonPublic().Get().Table(ctx, tableID)
 			if err != nil {
 				return err
 			}
-			spans = append(spans, desc.PrimaryIndexSpan(execCfg.Codec))
+			tableDescs = append(tableDescs, desc)
 		}
 		return nil
 	})
-	return spans, err
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the primary index spans. For RBR tables, partition them to region-specific spans.
+	spans := make([]roachpb.Span, 0, len(uniqueTableIDs))
+	for _, desc := range tableDescs {
+		if !desc.IsLocalityRegionalByRow() ||
+			c.job.Payload().CreationClusterVersion.Less(clusterversion.V26_2_Start.Version()) {
+			spans = append(spans, desc.PrimaryIndexSpan(execCfg.Codec))
+		} else {
+			regions, err := getRegionsForTable(ctx, desc)
+			if err != nil {
+				return nil, err
+			}
+			for _, region := range regions {
+				regionSpan, err := spanForFullRegion(&execCfg.DistSQLSrv.ServerConfig, desc, region)
+				if err != nil {
+					return nil, err
+				}
+				spans = append(spans, regionSpan)
+			}
+		}
+	}
+
+	return spans, nil
 }
 
 // planInspectProcessors constructs the physical plan for the INSPECT job by

--- a/pkg/sql/inspect/uniqueness_check.go
+++ b/pkg/sql/inspect/uniqueness_check.go
@@ -185,17 +185,10 @@ GROUP BY %s
 func (c *uniquenessCheck) getRemoteRegions(
 	ctx context.Context, localRegion string,
 ) ([]string, error) {
-	regionColID := c.tableDesc.GetPrimaryIndex().GetKeyColumnID(0)
-	regionCol, err := catalog.MustFindColumnByID(c.tableDesc, regionColID)
+	allRegions, err := getRegionsForTable(ctx, c.tableDesc)
 	if err != nil {
 		return nil, err
 	}
-
-	regionType := regionCol.GetType()
-	if regionType.TypeMeta.EnumData == nil {
-		return nil, errors.AssertionFailedf("region column is not an enum type")
-	}
-	allRegions := regionType.TypeMeta.EnumData.LogicalRepresentations
 
 	var remoteRegions []string
 	for _, region := range allRegions {

--- a/pkg/sql/inspect/uniqueness_check_test.go
+++ b/pkg/sql/inspect/uniqueness_check_test.go
@@ -246,6 +246,52 @@ func TestUniquenessCheck(t *testing.T) {
 			expectedCount:    2,
 		},
 		{
+			name: "span_covers_full_index",
+			insertStmts: []string{
+				// Insert rows in us-east1 with specific IDs
+				`INSERT INTO test.%s (crdb_region, id, data) VALUES ('us-east1', 100, 'foo')`,
+				`INSERT INTO test.%s (crdb_region, id, data) VALUES ('us-east1', 200, 'titi')`,
+				// "Unsafe" inserts to duplicate IDs in a second region
+				`INSERT INTO test.%s (crdb_region, id, data) VALUES ('us-west1', 100, 'bar')`,
+				`INSERT INTO test.%s (crdb_region, id, data) VALUES ('us-west1', 200, 'toto')`,
+				// "Unsafe" insert to duplicate ID in a third region
+				`INSERT INTO test.%s (crdb_region, id, data) VALUES ('us-west4', 100, 'baz')`,
+			},
+			createSpan: func(cfg *execinfra.ServerConfig, tableDesc catalog.TableDescriptor) roachpb.Span {
+				index := tableDesc.GetPrimaryIndex()
+
+				indexPrefix := cfg.Codec.IndexPrefix(uint32(tableDesc.GetID()), uint32(index.GetID()))
+
+				span := roachpb.Span{
+					Key:    indexPrefix,
+					EndKey: indexPrefix.PrefixEnd(),
+				}
+
+				return span
+			},
+			expectError: "extracting local region from span: span does not contain region column data",
+		},
+		{
+			name: "span_covers_full_region",
+			insertStmts: []string{
+				// Insert rows in us-east1 with specific IDs
+				`INSERT INTO test.%s (crdb_region, id, data) VALUES ('us-east1', 100, 'foo')`,
+				`INSERT INTO test.%s (crdb_region, id, data) VALUES ('us-east1', 200, 'titi')`,
+				// "Unsafe" inserts to duplicate IDs in a second region
+				`INSERT INTO test.%s (crdb_region, id, data) VALUES ('us-west1', 100, 'bar')`,
+				`INSERT INTO test.%s (crdb_region, id, data) VALUES ('us-west1', 200, 'toto')`,
+				// "Unsafe" insert to duplicate ID in a third region
+				`INSERT INTO test.%s (crdb_region, id, data) VALUES ('us-west4', 100, 'baz')`,
+			},
+			createSpan: func(cfg *execinfra.ServerConfig, tableDesc catalog.TableDescriptor) roachpb.Span {
+				span, err := spanForFullRegion(cfg, tableDesc, "us-east1")
+				require.NoError(t, err)
+				return span
+			},
+			expectDuplicates: true,
+			expectedCount:    2,
+		},
+		{
 			// The unique column is not immediately after the region column
 			name: "complex_primary_key",
 			createTableStmt: `CREATE TABLE test.%s (


### PR DESCRIPTION
Previously, the uniqueness check assumed spans included the region
column and would fail on spans that ranged the full index (i.e. did not
include the region column). This change has the resumer partition spans
on RBR tables into regional spans to satisfy the check's assumption.

Epic: CRDB-58692

Part of: #154551

Release note: None

**Part of a stack.**