### PR TITLE
sql: make uniqueness checks available from `INSPECT` command

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/inspect
+++ b/pkg/ccl/logictestccl/testdata/logic_test/inspect
@@ -1,0 +1,38 @@
+# LogicTest: multiregion-9node-3region-3azs
+# knob-opt: allow-unsafe
+
+statement ok
+CREATE DATABASE mr_db PRIMARY REGION "ca-central-1" REGIONS "ap-southeast-2", "us-east-1"
+
+subtest uniqueness_check
+
+statement ok
+USE mr_db
+
+statement ok
+CREATE TABLE uniqueness_check (
+  id INT64 DEFAULT unordered_unique_rowid(),
+  data TEXT,
+  PRIMARY KEY (id)
+) LOCALITY REGIONAL BY ROW;
+
+statement ok
+INSERT INTO uniqueness_check (crdb_region, id, data) VALUES ('ap-southeast-2', 100, 'foo');
+INSERT INTO uniqueness_check (crdb_region, id, data) VALUES ('ap-southeast-2', 200, 'titi');
+INSERT INTO uniqueness_check (crdb_region, id, data) VALUES ('ca-central-1', 300, 'bar');
+INSERT INTO uniqueness_check (crdb_region, id, data) VALUES ('ca-central-1', 400, 'toto');
+INSERT INTO uniqueness_check (crdb_region, id, data) VALUES ('us-east-1', 500, 'baz');
+
+statement ok
+INSPECT TABLE uniqueness_check WITH OPTIONS INDEX (uniqueness_check_pkey);
+
+statement ok
+DROP TABLE uniqueness_check;
+
+statement ok
+USE system
+
+subtest end
+
+statement ok
+DROP DATABASE mr_db CASCADE;

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 33,
+    shard_count = 34,
     tags = ["cpu:4"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs/generated_test.go
@@ -86,6 +86,13 @@ func TestCCLLogic_global_placement_restricted(
 	runCCLLogicTest(t, "global_placement_restricted")
 }
 
+func TestCCLLogic_inspect(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "inspect")
+}
+
 func TestCCLLogic_multi_region(
 	t *testing.T,
 ) {

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -1556,6 +1556,9 @@ message InspectDetails {
 
       // INSPECT_CHECK_ROW_COUNT validates a table has the expected number of rows.
       INSPECT_CHECK_ROW_COUNT = 2 [(gogoproto.enumvalue_customname) = "InspectCheckRowCount"];
+
+      // INSPECT_CHECK_UNIQUENESS validates an index's unique column is unique across regions.
+      INSPECT_CHECK_UNIQUENESS = 3 [(gogoproto.enumvalue_customname) = "InspectCheckUniqueness"];
     }
 
     // Type is the kind of validation to perform.

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -408,12 +408,12 @@ func (r *importResumer) Resume(ctx context.Context, execCtx interface{}) error {
 			if creationVersion := r.job.Payload().CreationClusterVersion; !details.Table.WasEmpty && creationVersion.Less(clusterversion.V26_2.Version()) {
 				log.Eventf(ctx, "skipping row count on table %q: the table was not empty and the job was started in an unsupported version", tableName)
 
-				checks, err = inspect.ChecksForTable(ctx, nil /* p */, tblDesc, nil /* expectedRowCount */)
+				checks, err = inspect.ChecksForTable(ctx, p.ExecCfg(), nil /* p */, tblDesc, nil /* expectedRowCount */)
 				return err
 			}
 
 			expectedRowCount := uint64(r.res.Rows + previouslyImportedRows + int64(table.InitialRowCount) + r.testingKnobs.expectedRowCountOffset)
-			checks, err = inspect.ChecksForTable(ctx, nil /* p */, tblDesc, &expectedRowCount)
+			checks, err = inspect.ChecksForTable(ctx, p.ExecCfg(), nil /* p */, tblDesc, &expectedRowCount)
 			return err
 		}); err != nil {
 			return err

--- a/pkg/sql/inspect/check_helpers.go
+++ b/pkg/sql/inspect/check_helpers.go
@@ -102,10 +102,8 @@ func extractRegionFromSpan(
 	span roachpb.Span,
 	tableDesc catalog.TableDescriptor,
 ) (string, error) {
-	if !tableDesc.IsLocalityRegionalByRow() {
-		if !buildutil.CrdbTestBuild && !testing.Testing() { // For ease of testing, allow faked multi-region databases.
-			return "", errors.AssertionFailedf("table is not REGIONAL BY ROW, cannot extract region from span")
-		}
+	if !isRegionalByRow(tableDesc) {
+		return "", errors.AssertionFailedf("table is not REGIONAL BY ROW, cannot extract region from span")
 	}
 
 	priIndex := tableDesc.GetPrimaryIndex()
@@ -389,10 +387,8 @@ func findUniqueColIdxs(tableDesc catalog.TableDescriptor, index catalog.Index) (
 
 // getRegionsForTable retrieves the list of regions from an RBR table.
 func getRegionsForTable(ctx context.Context, tableDesc catalog.TableDescriptor) ([]string, error) {
-	if !tableDesc.IsLocalityRegionalByRow() {
-		if !buildutil.CrdbTestBuild && !testing.Testing() { // For ease of testing, allow faked multi-region databases.
-			return nil, errors.AssertionFailedf("table is not REGIONAL BY ROW")
-		}
+	if !isRegionalByRow(tableDesc) {
+		return nil, errors.AssertionFailedf("table is not REGIONAL BY ROW")
 	}
 
 	regionColID := tableDesc.GetPrimaryIndex().GetKeyColumnID(0)
@@ -408,4 +404,24 @@ func getRegionsForTable(ctx context.Context, tableDesc catalog.TableDescriptor) 
 	allRegions := regionType.TypeMeta.EnumData.LogicalRepresentations
 
 	return allRegions, nil
+}
+
+func isTesting() bool {
+	return buildutil.CrdbTestBuild || testing.Testing()
+}
+
+// isRegionalByRow checks whether a table is regional by row or if it's a mock
+// RBR table run under test.
+//
+// Mocked RBR tables (in unit and base logic tests) allow for duplicated values
+// in unique columns whereas the genuine articles (in CCL logic tests) are
+// blocked by the uniqueness constraints. Single-node mock RBR tables are used
+// to test the duplicated uniques case; multi-node RBR tables are used to test
+// the unduplicated case.
+func isRegionalByRow(table catalog.TableDescriptor) bool {
+	priIndex := table.GetPrimaryIndex()
+
+	isMockedRegionalByRow := isTesting() && priIndex.IndexDesc().KeyColumnNames[0] == tree.RegionalByRowRegionDefaultCol
+
+	return table.IsLocalityRegionalByRow() || isMockedRegionalByRow
 }

--- a/pkg/sql/inspect/inspect_job_entry.go
+++ b/pkg/sql/inspect/inspect_job_entry.go
@@ -8,6 +8,7 @@ package inspect
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
@@ -94,7 +95,7 @@ func checksForDatabase(
 	checks := []*jobspb.InspectDetails_Check{}
 
 	if err := tables.ForEachDescriptor(func(desc catalog.Descriptor) error {
-		tableChecks, err := ChecksForTable(ctx, p, desc.(catalog.TableDescriptor), nil /* rowCount */)
+		tableChecks, err := ChecksForTable(ctx, p.ExecCfg(), p, desc.(catalog.TableDescriptor), nil /* rowCount */)
 		if err != nil {
 			return err
 		}
@@ -109,13 +110,32 @@ func checksForDatabase(
 
 // ChecksForTable generates checks on every supported index on the given table.
 func ChecksForTable(
-	ctx context.Context, p sql.PlanHookState, table catalog.TableDescriptor, expectedRowCount *uint64,
+	ctx context.Context,
+	execCfg *sql.ExecutorConfig,
+	p sql.PlanHookState,
+	table catalog.TableDescriptor,
+	expectedRowCount *uint64,
 ) ([]*jobspb.InspectDetails_Check, error) {
 	checks := []*jobspb.InspectDetails_Check{}
 
 	// Skip non-physical tables that don't have physical storage to inspect.
 	if !table.IsPhysicalTable() {
 		return checks, nil
+	}
+
+	priIndex := table.GetPrimaryIndex()
+
+	if execCfg.Settings.Version.IsActive(ctx, clusterversion.V26_2) {
+		if uniqueColIdxs, err := findUniqueColIdxs(table, priIndex); err != nil {
+			return nil, err
+		} else if isRegionalByRow(table) && len(uniqueColIdxs) == 1 {
+			checks = append(checks, &jobspb.InspectDetails_Check{
+				Type:         jobspb.InspectCheckUniqueness,
+				TableID:      table.GetID(),
+				IndexID:      priIndex.GetID(),
+				TableVersion: table.GetVersion(),
+			})
+		}
 	}
 
 	for _, index := range table.PublicNonPrimaryIndexes() {
@@ -147,41 +167,73 @@ func ChecksForTable(
 	return checks, nil
 }
 
-type indexKey struct {
-	descpb.ID
-	descpb.IndexID
-}
-
 // checksByIndexNames generates checks for the specified index names.
 // If index names are not found or are not supported for inspection, an error is returned.
 // Index names are deduplicated.
 func checksByIndexNames(
-	ctx context.Context, p sql.PlanHookState, names tree.TableIndexNames,
+	ctx context.Context, execCfg *sql.ExecutorConfig, p sql.PlanHookState, names tree.TableIndexNames,
 ) ([]*jobspb.InspectDetails_Check, error) {
 	checks := []*jobspb.InspectDetails_Check{}
 
+	// Collect the indexes and dedupe them.
+	type indexKey struct {
+		descpb.ID
+		descpb.IndexID
+	}
+	type index struct {
+		catalog.TableDescriptor
+		catalog.Index
+	}
+
+	var indexes []index
 	var seenIndexes = make(map[indexKey]struct{})
 	for _, indexName := range names {
-		_, table, index, err := p.GetTableAndIndex(ctx, indexName, privilege.INSPECT, false /* skipCache */)
+		_, tableDesc, indexDesc, err := p.GetTableAndIndex(ctx, indexName, privilege.INSPECT, false /* skipCache */)
 		if err != nil {
 			return nil, err
 		}
 
-		if _, ok := seenIndexes[indexKey{table.GetID(), index.GetID()}]; ok {
-			continue
+		key := indexKey{tableDesc.GetID(), indexDesc.GetID()}
+		if _, ok := seenIndexes[key]; !ok {
+			indexes = append(indexes, index{tableDesc, indexDesc})
 		}
-		seenIndexes[indexKey{table.GetID(), index.GetID()}] = struct{}{}
+		seenIndexes[key] = struct{}{}
+	}
 
-		if reason := isSupportedIndexForIndexConsistencyCheck(index, table); reason != "" {
-			return nil, pgerror.Newf(pgcode.InvalidName, "index %q on table %q is not supported for index consistency checking", index.GetName(), table.GetName())
+	for _, idx := range indexes {
+		index := idx.Index
+		table := idx.TableDescriptor
+
+		var isIndexSupportedForChecks bool
+		if reason := isSupportedIndexForIndexConsistencyCheck(index, table); reason == "" {
+			isIndexSupportedForChecks = true
+			checks = append(checks,
+				&jobspb.InspectDetails_Check{
+					Type:         jobspb.InspectCheckIndexConsistency,
+					TableID:      table.GetID(),
+					IndexID:      index.GetID(),
+					TableVersion: table.GetVersion(),
+				})
+		}
+		if execCfg.Settings.Version.IsActive(ctx, clusterversion.V26_2) {
+			if index.Primary() {
+				if uniqueColIdxs, err := findUniqueColIdxs(table, index); err != nil {
+					return nil, err
+				} else if isRegionalByRow(table) && len(uniqueColIdxs) == 1 {
+					isIndexSupportedForChecks = true
+					checks = append(checks, &jobspb.InspectDetails_Check{
+						Type:         jobspb.InspectCheckUniqueness,
+						TableID:      table.GetID(),
+						IndexID:      index.GetID(),
+						TableVersion: table.GetVersion(),
+					})
+				}
+			}
 		}
 
-		checks = append(checks, &jobspb.InspectDetails_Check{
-			Type:         jobspb.InspectCheckIndexConsistency,
-			TableID:      table.GetID(),
-			IndexID:      index.GetID(),
-			TableVersion: table.GetVersion(),
-		})
+		if !isIndexSupportedForChecks {
+			return nil, pgerror.Newf(pgcode.InvalidParameterValue, "index %q on table %q is not supported by INSPECT checks", index.GetName(), table.GetName())
+		}
 	}
 
 	return checks, nil

--- a/pkg/sql/inspect/inspect_plan.go
+++ b/pkg/sql/inspect/inspect_plan.go
@@ -109,7 +109,7 @@ func newInspectRun(
 		// No INDEX options or INDEX ALL specified - inspect all indexes.
 		switch stmt.Typ {
 		case tree.InspectTable:
-			checks, err := ChecksForTable(ctx, p, run.table, nil /* rowCount */)
+			checks, err := ChecksForTable(ctx, p.ExecCfg(), p, run.table, nil /* rowCount */)
 			if err != nil {
 				return inspectRun{}, err
 			}
@@ -152,7 +152,7 @@ func newInspectRun(
 			}
 		}
 
-		if checks, err := checksByIndexNames(ctx, p, run.namedIndexes); err != nil {
+		if checks, err := checksByIndexNames(ctx, p.ExecCfg(), p, run.namedIndexes); err != nil {
 			return inspectRun{}, err
 		} else {
 			run.checks = checks

--- a/pkg/sql/inspect/inspect_processor.go
+++ b/pkg/sql/inspect/inspect_processor.go
@@ -542,6 +542,18 @@ func buildInspectCheckFactories(
 					expected: specCheck.RowCount,
 				}
 			})
+		case jobspb.InspectCheckUniqueness:
+			checkFactories = append(checkFactories, func(asOf hlc.Timestamp) inspectCheck {
+				return &uniquenessCheck{
+					uniquenessCheckApplicability: uniquenessCheckApplicability{
+						tableID: tableID,
+					},
+					execCfg:      execCfg,
+					indexID:      indexID,
+					tableVersion: tableVersion,
+					asOf:         asOf,
+				}
+			})
 		default:
 			return nil, errors.AssertionFailedf("unsupported inspect check type: %v", specCheck.Type)
 		}

--- a/pkg/sql/inspect/inspect_resumer.go
+++ b/pkg/sql/inspect/inspect_resumer.go
@@ -174,8 +174,7 @@ func (c *inspectResumer) getSpans(
 	// Get the primary index spans. For RBR tables, partition them to region-specific spans.
 	spans := make([]roachpb.Span, 0, len(uniqueTableIDs))
 	for _, desc := range tableDescs {
-		if !desc.IsLocalityRegionalByRow() ||
-			c.job.Payload().CreationClusterVersion.Less(clusterversion.V26_2_Start.Version()) {
+		if c.job.Payload().CreationClusterVersion.Less(clusterversion.V26_2_Start.Version()) || !isRegionalByRow(desc) {
 			spans = append(spans, desc.PrimaryIndexSpan(execCfg.Codec))
 		} else {
 			regions, err := getRegionsForTable(ctx, desc)
@@ -403,6 +402,10 @@ func buildApplicabilityCheckers(
 			})
 		case jobspb.InspectCheckRowCount:
 			checkers = append(checkers, &rowCountCheckApplicability{
+				tableID: specCheck.TableID,
+			})
+		case jobspb.InspectCheckUniqueness:
+			checkers = append(checkers, &uniquenessCheckApplicability{
 				tableID: specCheck.TableID,
 			})
 		default:

--- a/pkg/sql/inspect/row_count_check_test.go
+++ b/pkg/sql/inspect/row_count_check_test.go
@@ -135,7 +135,7 @@ func TestRowCountCheck(t *testing.T) {
 
 			for _, tc := range matchCases {
 				t.Run(tc.name, func(t *testing.T) {
-					checks, err := ChecksForTable(ctx, nil /* PlanHookState */, tableDesc, &tc.expectedRowCount)
+					checks, err := ChecksForTable(ctx, &execCfg, nil /* PlanHookState */, tableDesc, &tc.expectedRowCount)
 					require.NoError(t, err)
 					require.Len(t, checks, expectedCheckCount)
 

--- a/pkg/sql/inspect/uniqueness_check.go
+++ b/pkg/sql/inspect/uniqueness_check.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"slices"
 	"strings"
-	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -22,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
-	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
@@ -404,10 +402,8 @@ func (c *uniquenessCheck) loadCatalogInfo(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	if !tableDesc.IsLocalityRegionalByRow() {
-		if !buildutil.CrdbTestBuild && !testing.Testing() { // For ease of testing, allow faked multi-region databases.
-			return errors.AssertionFailedf("uniqueness check is only supported for tables with REGIONAL BY ROW locality")
-		}
+	if !isRegionalByRow(tableDesc) {
+		return errors.AssertionFailedf("uniqueness check is only supported for tables with REGIONAL BY ROW locality")
 	}
 	c.tableDesc = tableDesc
 

--- a/pkg/sql/logictest/testdata/logic_test/inspect
+++ b/pkg/sql/logictest/testdata/logic_test/inspect
@@ -264,22 +264,22 @@ SELECT * FROM last_inspect_job;
 ----
 succeeded  2
 
-statement error pq: index "t2_pkey" on table "t2" is not supported for index consistency checking
+statement error pq: index "t2_pkey" on table "t2" is not supported by INSPECT checks
 INSPECT TABLE t2 WITH OPTIONS INDEX (t2@t2_pkey);
 
-statement error pq: index "hash_idx" on table "t2" is not supported for index consistency checking
+statement error pq: index "hash_idx" on table "t2" is not supported by INSPECT checks
 INSPECT TABLE t2 WITH OPTIONS INDEX (hash_idx);
 
-statement error pq: index "expr_idx" on table "t2" is not supported for index consistency checking
+statement error pq: index "expr_idx" on table "t2" is not supported by INSPECT checks
 INSPECT TABLE t2 WITH OPTIONS INDEX (expr_idx);
 
-statement error pq: index "vector_idx" on table "t2" is not supported for index consistency checking
+statement error pq: index "vector_idx" on table "t2" is not supported by INSPECT checks
 INSPECT TABLE t2 WITH OPTIONS INDEX (vector_idx);
 
-statement error pq: index "partial_idx" on table "t2" is not supported for index consistency checking
+statement error pq: index "partial_idx" on table "t2" is not supported by INSPECT checks
 INSPECT TABLE t2 WITH OPTIONS INDEX (partial_idx);
 
-statement error pq: index "inverted_idx" on table "t2" is not supported for index consistency checking
+statement error pq: index "inverted_idx" on table "t2" is not supported by INSPECT checks
 INSPECT TABLE t2 WITH OPTIONS INDEX (inverted_idx);
 
 # Confirm no jobs were run.
@@ -321,7 +321,7 @@ SELECT * FROM last_inspect_job;
 succeeded  1
 
 # Explicitly specifying the virtual column index should fail.
-statement error pq: index "idx_c2" on table "t_virtual" is not supported for index consistency checking
+statement error pq: index "idx_c2" on table "t_virtual" is not supported by INSPECT checks
 INSPECT TABLE t_virtual WITH OPTIONS INDEX (idx_c2);
 
 # Explicitly specifying the regular index should succeed.
@@ -357,7 +357,7 @@ SELECT * FROM last_inspect_job;
 succeeded  1
 
 # Explicitly specifying the index with virtual columns should fail.
-statement error pq: index "idx_virtual_combo" on table "t_multi_virtual" is not supported for index consistency checking
+statement error pq: index "idx_virtual_combo" on table "t_multi_virtual" is not supported by INSPECT checks
 INSPECT TABLE t_multi_virtual WITH OPTIONS INDEX (idx_virtual_combo);
 
 statement ok
@@ -714,5 +714,41 @@ DROP TABLE pgvector_tbl;
 
 statement ok
 DROP TABLE multi_type_tbl;
+
+subtest end
+
+subtest uniqueness_check
+
+statement ok
+CREATE TYPE test.region_enum AS ENUM ('eu-central1', 'us-east1', 'us-west1', 'us-west4');
+CREATE TABLE uniqueness_check (
+  crdb_region test.region_enum NOT NULL,
+  id INT64 DEFAULT unordered_unique_rowid(),
+  data TEXT,
+  PRIMARY KEY (crdb_region, id)
+);
+
+statement ok
+INSERT INTO uniqueness_check (crdb_region, id, data) VALUES ('us-east1', 100, 'foo');
+INSERT INTO uniqueness_check (crdb_region, id, data) VALUES ('us-west1', 100, 'biz');
+INSERT INTO uniqueness_check (crdb_region, id, data) VALUES ('us-west4', 100, 'toto');
+
+statement ok
+INSERT INTO uniqueness_check (crdb_region, id, data) VALUES ('us-east1', 200, 'bar');
+INSERT INTO uniqueness_check (crdb_region, id, data) VALUES ('us-west1', 200, 'baz');
+
+statement ok
+INSERT INTO uniqueness_check (crdb_region, id, data) VALUES ('us-west1', 300, 'titi');
+INSERT INTO uniqueness_check (crdb_region, id, data) VALUES ('us-west4', 300, 'tata');
+
+onlyif config local
+statement error pq: INSPECT found inconsistencies
+INSPECT TABLE uniqueness_check WITH OPTIONS INDEX (uniqueness_check_pkey);
+
+onlyif config local
+query TI retry
+SELECT * FROM last_inspect_job
+----
+failed  1
 
 subtest end


### PR DESCRIPTION
Adds the uniqueness check to the job specs for `INSPECT` commands.

Epic: CRDB-58692

Fixes: #154551

Release note (sql change): On an `INSPECT` run a new check validates
unique column values in regional by row tables.

**Part of a stack.**