### PR TITLE
concurrency: release waiting readers on lock re-discovery at higher ts

### DIFF
--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -3376,7 +3376,7 @@ func (kl *keyLocks) acquireLock(
 	//
 	// TODO(arul): Replace the call to releaseLockingRequestsFromTxn with
 	// recomputeWaitQueue, and push the responsibility of re-ordering the wait
-	// queue into there. Ditto for the call in addDiscoveredLock.
+	// queue into there. Ditto for the call in discoveredLock.
 	kl.releaseLockingRequestsFromTxn(&acq.Txn)
 
 	// Sanity check that there aren't any waiting readers on this lock. There
@@ -3485,17 +3485,14 @@ func (kl *keyLocks) discoveredLock(
 	}
 
 	var tl *txnLock
+	var writeTSAdvanced bool
 	if kl.isLockedBy(foundLock.Txn.ID) {
 		e := kl.heldBy[foundLock.Txn.ID]
 		tl = e.Value
 
-		beforeTs := tl.writeTS()
-
+		beforeWriteTS := tl.writeTS()
 		tl.replicatedInfo.acquire(foundLock.Strength, foundLock.Txn.WriteTimestamp)
-
-		if beforeTs.Less(tl.writeTS()) {
-			kl.recomputeWaitQueues(st)
-		}
+		writeTSAdvanced = beforeWriteTS.Less(tl.writeTS())
 		// TODO(arul): If the discovered lock indicates a newer epoch than what's
 		// being tracked, should we clear out unreplicatedLockInfo here?
 	} else {
@@ -3550,8 +3547,16 @@ func (kl *keyLocks) discoveredLock(
 	// If there are waiting requests from the same txn, they no longer need to wait.
 	kl.releaseLockingRequestsFromTxn(&foundLock.Txn)
 
-	// Active waiters need to be told about who they are waiting for.
-	kl.informActiveWaiters()
+	if writeTSAdvanced {
+		// The lock holder's write timestamp advanced, which may allow some waiting
+		// readers to proceed (their read timestamps may now fall below the intent's
+		// timestamp). Recompute wait queues to release them; this also calls
+		// informActiveWaiters for remaining waiters.
+		kl.recomputeWaitQueues(st)
+	} else {
+		// Active waiters need to be told about who they are waiting for.
+		kl.informActiveWaiters()
+	}
 	return nil
 }
 

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/add_discovered
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/add_discovered
@@ -295,3 +295,111 @@ dequeue r=req5
 num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 12.000000000,0, info: repl [Intent]
+
+# -------------------------------------------------------------
+# When a lock is re-discovered at a higher timestamp (e.g.,
+# because the intent was rewritten after the transaction was
+# pushed), discoveredLock must call recomputeWaitQueues to
+# release waiting readers whose read timestamps fall below
+# the updated intent timestamp.
+#
+# Setup: txn2 discovers txn1's intent on "a" at ts=10
+#        txn3 (reader at ts=15) waits on the intent
+#
+# Test:  txn1 is pushed to ts=20
+#        txn4 discovers the intent at ts=20
+#        txn3 should stop waiting because ts=20 > ts=15
+# -------------------------------------------------------------
+
+new-lock-table maxlocks=10000
+----
+
+new-txn txn=txn1 ts=10 epoch=0
+----
+
+new-txn txn=txn2 ts=25 epoch=0
+----
+
+new-txn txn=txn3 ts=15 epoch=0
+----
+
+new-txn txn=txn4 ts=25 epoch=0
+----
+
+# txn4's request scans the lock table before any locks exist. In a real system,
+# this could happen after a lease transfer clears the in-memory lock table while
+# txn1's replicated intent still exists in MVCC.
+new-request r=req1 txn=txn4 ts=25 spans=none@a
+----
+
+scan r=req1
+----
+start-waiting: false
+
+# txn2's request also scans before any locks exist.
+new-request r=req2 txn=txn2 ts=25 spans=none@a
+----
+
+scan r=req2
+----
+start-waiting: false
+
+# txn2 discovers txn1's intent on "a" at ts=10 during evaluation. This adds
+# the intent to the lock table.
+add-discovered r=req2 k=a txn=txn1
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]
+
+dequeue r=req2
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]
+
+# txn3 (reader at ts=15) scans and waits on the intent at ts=10 (10 ≤ 15).
+new-request r=req3 txn=txn3 ts=15 spans=none@a
+----
+
+scan r=req3
+----
+start-waiting: true
+
+guard-state r=req3
+----
+new: state=waitFor txn=txn1 key="a" held=true guard-strength=None
+
+# --------------------------------
+# Setup complete, test starts here
+# --------------------------------
+
+# Simulate txn1 being pushed to ts=20.
+update-txn-not-observed txn=txn1 ts=20 epoch=0
+----
+
+# txn4 discovers the intent from txn1, now at ts=20. This advances the lock
+# table's tracked intent timestamp from 10 to 20.
+add-discovered r=req1 k=a txn=txn1
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 20.000000000,0, info: repl [Intent]
+
+# txn3 (reader at ts=15) should be released because the intent at ts=20 no
+# longer conflicts with a read at ts=15.
+guard-state r=req3
+----
+new: state=doneWaiting
+
+dequeue r=req1
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 20.000000000,0, info: repl [Intent]
+
+dequeue r=req3
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 20.000000000,0, info: repl [Intent]


### PR DESCRIPTION
Previously, `discoveredLock` called `recomputeWaitQueues` inside the `isLockedBy` branch — before same-txn queued requests were removed and before the discovering request was handled. It then unconditionally called `informActiveWaiters` at the end. This meant that when a lock was re-discovered at a higher timestamp (e.g., after the holder was pushed), the final `informActiveWaiters` call would update waiter state but would not release waiting readers whose read timestamps now fell below the updated intent timestamp.

This commit moves the `recomputeWaitQueues` call to after all state mutations (enqueuing, `releaseLockingRequestsFromTxn`) are complete, and makes it conditional on the write timestamp having advanced. When the timestamp hasn't changed, `informActiveWaiters` is still called to update push targets.

Part of: https://github.com/cockroachdb/cockroach/issues/122156

Release note: None