### PR TITLE
release-26.1: util/metric, server/status: fix +Inf in GaugeFloat64 JSON marshaling

### DIFF
--- a/pkg/server/status/recorder.go
+++ b/pkg/server/status/recorder.go
@@ -846,7 +846,11 @@ func extractValue(name string, mtr interface{}, fn func(string, float64)) error 
 		// NB: this branch is intentionally at the bottom since all metrics implement it.
 		m := mtr.ToPrometheusMetric()
 		if m.Gauge != nil {
-			fn(name, *m.Gauge.Value)
+			v := *m.Gauge.Value
+			if math.IsInf(v, 0) || math.IsNaN(v) {
+				v = 0
+			}
+			fn(name, v)
 		} else if m.Counter != nil {
 			fn(name, *m.Counter.Value)
 		}

--- a/pkg/server/status/runtime.go
+++ b/pkg/server/status/runtime.go
@@ -1153,7 +1153,7 @@ func (rsr *RuntimeStatSampler) SampleEnvironment(ctx context.Context, cs *CGoMem
 	hostNiceTime := int64(cpuUsage.Nice * 1.e9)
 
 	var procUrate, procSrate, hostUrate, hostSrate, hostIrqrate, hostSoftIrqrate, hostNiceRate float64
-	if rsr.last.now != 0 { // We cannot compute these rates on the first iteration.
+	if rsr.last.now != 0 && dur > 0 { // We cannot compute these rates on the first iteration or if no time elapsed.
 		procUrate = float64(procUtime-rsr.last.procUtime) / dur
 		procSrate = float64(procStime-rsr.last.procStime) / dur
 		hostUrate = float64(hostUtime-rsr.last.hostUtime) / dur
@@ -1175,14 +1175,20 @@ func (rsr *RuntimeStatSampler) SampleEnvironment(ctx context.Context, cs *CGoMem
 	gcStopTotalNs := int64(gcStopTotal * 1.e9)
 	nonGcStopTotalNs := int64(nonGcStopTotal * 1.e9)
 	gcCount := rsr.goRuntimeSampler.uint64(runtimeMetricGCCount)
-	gcPauseRatio := float64(gcPauseTotalNs-rsr.last.gcPauseTime) / dur
+	var gcPauseRatio float64
+	if dur > 0 {
+		gcPauseRatio = float64(gcPauseTotalNs-rsr.last.gcPauseTime) / dur
+	}
 	runnableSum := goschedstats.CumulativeNormalizedRunnableGoroutines()
 	gcAssistSeconds := rsr.goRuntimeSampler.float64(runtimeMetricGCAssist)
 	gcAssistNS := int64(gcAssistSeconds * 1e9)
 	// The number of runnable goroutines per CPU is a count, but it can vary
 	// quickly. We don't just want to get a current snapshot of it, we want the
 	// average value since the last sampling.
-	runnableAvg := (runnableSum - rsr.last.runnableSum) * 1e9 / dur
+	var runnableAvg float64
+	if dur > 0 {
+		runnableAvg = (runnableSum - rsr.last.runnableSum) * 1e9 / dur
+	}
 	rsr.last.now = now
 	rsr.last.procUtime = procUtime
 	rsr.last.procStime = procStime
@@ -1196,7 +1202,10 @@ func (rsr *RuntimeStatSampler) SampleEnvironment(ctx context.Context, cs *CGoMem
 
 	// Log summary of statistics to console.
 	osStackBytes := rsr.goRuntimeSampler.uint64(runtimeMetricMemStackOSBytes)
-	cgoRate := float64((numCgoCall-rsr.last.cgoCall)*int64(time.Second)) / dur
+	var cgoRate float64
+	if dur > 0 {
+		cgoRate = float64((numCgoCall-rsr.last.cgoCall)*int64(time.Second)) / dur
+	}
 	goAlloc := rsr.goRuntimeSampler.uint64(runtimeMetricHeapAlloc)
 	goTotal := rsr.goRuntimeSampler.uint64(runtimeMetricGoTotal) -
 		rsr.goRuntimeSampler.uint64(runtimeMetricHeapReleasedBytes)

--- a/pkg/util/metric/metric.go
+++ b/pkg/util/metric/metric.go
@@ -1181,7 +1181,11 @@ func (g *GaugeFloat64) Inspect(f func(interface{})) { f(g) }
 
 // MarshalJSON marshals to JSON.
 func (g *GaugeFloat64) MarshalJSON() ([]byte, error) {
-	return json.Marshal(g.Value())
+	v := g.Value()
+	if math.IsInf(v, 0) || math.IsNaN(v) {
+		v = 0
+	}
+	return json.Marshal(v)
 }
 
 // ToPrometheusMetric returns a filled-in prometheus metric of the right type.

--- a/pkg/util/metric/metric_test.go
+++ b/pkg/util/metric/metric_test.go
@@ -119,6 +119,22 @@ func TestGaugeFloat64(t *testing.T) {
 	}
 }
 
+func TestGaugeFloat64MarshalInfNaN(t *testing.T) {
+	g := NewGaugeFloat64(emptyMetadata)
+
+	g.Update(math.Inf(1))
+	testMarshal(t, g, "0")
+
+	g.Update(math.Inf(-1))
+	testMarshal(t, g, "0")
+
+	g.Update(math.NaN())
+	testMarshal(t, g, "0")
+
+	g.Update(42.5)
+	testMarshal(t, g, "42.5")
+}
+
 func TestCounter(t *testing.T) {
 	c := NewCounter(emptyMetadata)
 	c.Inc(90)


### PR DESCRIPTION
Backport 1/1 commits from #164280 on behalf of @dhartunian.

----

GaugeFloat64.MarshalJSON() could produce a JSON marshaling error when
the gauge's value was +Inf, -Inf, or NaN, since Go's encoding/json
rejects these values. This caused the /_status/metrics/local endpoint
to return HTTP 500, which is the root cause of the TestStopServer
flake.

The most likely source of +Inf was division by zero in
RuntimeStatSampler.SampleEnvironment() when the elapsed duration
between two samples was zero (possible under the race detector).
Several rate computations (CPU usage, GC pause ratio, runnable
goroutines, cgo call rate) divided by the elapsed duration without
guarding against zero.

Fix both the source and the symptom:
- Guard all divisions by elapsed duration in SampleEnvironment()
  against dur <= 0.
- Sanitize +Inf/-Inf/NaN to 0 in GaugeFloat64.MarshalJSON() as
  defense in depth, matching the pattern already used for histogram
  avg computed metrics.
- Sanitize +Inf/-Inf/NaN gauge values in extractValue() to prevent
  non-finite floats from reaching TSDB recording.

Fixes https://github.com/cockroachdb/cockroach/issues/164147
Fixes https://github.com/cockroachdb/cockroach/issues/163932

Release note: None

----

Release justification: bugfix for a divide by zero error.