### PR TITLE
obs/clustermetrics: add delete support to cmwriter

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -6962,7 +6962,7 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
     - name: obs.clustermetrics.flush.errors
       exported_name: obs_clustermetrics_flush_errors
-      description: Number of cluster metrics flush errors
+      description: Number of flush errors (write or delete failures)
       y_axis_label: Errors
       type: COUNTER
       unit: COUNT
@@ -6976,6 +6976,14 @@ layers:
       unit: NANOSECONDS
       aggregation: AVG
       derivative: NONE
+    - name: obs.clustermetrics.flush.metrics_deleted
+      exported_name: obs_clustermetrics_flush_metrics_deleted
+      description: Number of individual metrics deleted per flush
+      y_axis_label: Metrics
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
     - name: obs.clustermetrics.flush.metrics_written
       exported_name: obs_clustermetrics_flush_metrics_written
       description: Number of individual metrics written per flush

--- a/pkg/obs/clustermetrics/cmmetrics/api.go
+++ b/pkg/obs/clustermetrics/cmmetrics/api.go
@@ -65,6 +65,13 @@ type Metric interface {
 	WritableMetric
 	// IsDirty returns true if the metric has changed since the last flush.
 	IsDirty() bool
+	// IsDeleted returns true if the metric has been permanently marked
+	// for deletion. A deleted metric is collected for removal on the
+	// next flush, after which the Writer removes it from its tracked
+	// map. Delete takes precedence over dirty: if both are set, the
+	// metric is deleted rather than written. All mutations on a
+	// deleted metric are silently ignored.
+	IsDeleted() bool
 	// Reset resets the metric's state after a successful flush.
 	// For counters, this resets the count to zero and clears the dirty flag.
 	// For gauges, this clears the dirty flag (value is retained).
@@ -84,6 +91,13 @@ type MetricVec interface {
 	Each(f func(WritableMetric))
 	// Reset clears all children. Called after a successful flush.
 	Reset()
+	// CollectDeleted returns snapshots of children that have been
+	// deleted since the last collection and clears the pending list
+	// (drain semantics). Returns nil when no deletions are pending.
+	// The returned WritableMetric values carry the metric name and
+	// labels needed to identify the row; value and type are ignored
+	// by the delete path.
+	CollectDeleted() []WritableMetric
 }
 
 // MetricTypeString returns the type string stored in the

--- a/pkg/obs/clustermetrics/cmmetrics/metric.go
+++ b/pkg/obs/clustermetrics/cmmetrics/metric.go
@@ -28,11 +28,16 @@ var (
 
 // Counter wraps a metric.Counter to satisfy the Metric interface.
 // Tracks whether it has been updated since the last flush via a dirty flag.
+//
+// Once Delete() is called, the counter is permanently marked for deletion.
+// All subsequent mutations (Inc) are silently ignored, and the Writer
+// removes the metric from its tracked map after a successful flush.
 type Counter struct {
 	*metric.Counter
 	metric.IsNonExportableMetric
 	IsClusterMetric
-	dirty atomic.Bool
+	dirty   atomic.Bool
+	deleted atomic.Bool
 }
 
 // NewCounter creates a new Counter with the given metadata. The
@@ -45,8 +50,12 @@ func NewCounter(metadata metric.Metadata) *Counter {
 	}
 }
 
-// Inc increments the counter and marks it as dirty.
+// Inc increments the counter and marks it as dirty. If the counter
+// has been deleted, the call is a no-op.
 func (c *Counter) Inc(i int64) {
+	if c.deleted.Load() {
+		return
+	}
 	c.Counter.Inc(i)
 	c.dirty.Store(true)
 }
@@ -61,11 +70,12 @@ func (c *Counter) IsDirty() bool {
 	return c.dirty.Load()
 }
 
-// Reset resets the counter to zero and clears the dirty flag.
-// Called after a successful flush.
+// Reset resets the counter to zero and clears the dirty and deleted
+// flags. Called after a successful flush.
 func (c *Counter) Reset() {
 	c.Counter.Clear()
 	c.dirty.Store(false)
+	c.deleted.Store(false)
 }
 
 // Inspect calls the given closure with the Counter itself.
@@ -80,14 +90,33 @@ func (c *Counter) GetLabels() map[string]string {
 	return nil
 }
 
+// Delete permanently marks the counter for deletion on the next
+// flush. After Delete, all mutations are no-ops and the Writer
+// removes the counter from its tracked map once the delete is
+// flushed.
+func (c *Counter) Delete() {
+	c.deleted.Store(true)
+}
+
+// IsDeleted returns true if the counter has been marked for deletion.
+func (c *Counter) IsDeleted() bool {
+	return c.deleted.Load()
+}
+
 // Gauge wraps a metric.Gauge to track whether it has been updated
 // since the last flush. Only gauges that have been explicitly updated will
 // be written to the store.
+//
+// Once Delete() is called, the gauge is permanently marked for deletion.
+// All subsequent mutations (Update, Inc, Dec) are silently ignored,
+// and the Writer removes the metric from its tracked map after a
+// successful flush.
 type Gauge struct {
 	*metric.Gauge
 	metric.IsNonExportableMetric
 	IsClusterMetric
-	dirty atomic.Bool
+	dirty   atomic.Bool
+	deleted atomic.Bool
 }
 
 // NewGauge creates a new Gauge with the given metadata. The
@@ -100,20 +129,32 @@ func NewGauge(metadata metric.Metadata) *Gauge {
 	}
 }
 
-// Update updates the gauge's value and marks it as dirty.
+// Update updates the gauge's value and marks it as dirty. If the gauge
+// has been deleted, the call is a no-op.
 func (g *Gauge) Update(v int64) {
+	if g.deleted.Load() {
+		return
+	}
 	g.Gauge.Update(v)
 	g.dirty.Store(true)
 }
 
-// Inc increments the gauge's value and marks it as dirty.
+// Inc increments the gauge's value and marks it as dirty. If the gauge
+// has been deleted, the call is a no-op.
 func (g *Gauge) Inc(i int64) {
+	if g.deleted.Load() {
+		return
+	}
 	g.Gauge.Inc(i)
 	g.dirty.Store(true)
 }
 
-// Dec decrements the gauge's value and marks it as dirty.
+// Dec decrements the gauge's value and marks it as dirty. If the gauge
+// has been deleted, the call is a no-op.
 func (g *Gauge) Dec(i int64) {
+	if g.deleted.Load() {
+		return
+	}
 	g.Gauge.Dec(i)
 	g.dirty.Store(true)
 }
@@ -128,10 +169,11 @@ func (g *Gauge) IsDirty() bool {
 	return g.dirty.Load()
 }
 
-// Reset clears the dirty flag. Called after a successful flush.
-// This does not reset the gauge value itself.
+// Reset clears the dirty and deleted flags. Called after a successful
+// flush. This does not reset the gauge value itself.
 func (g *Gauge) Reset() {
 	g.dirty.Store(false)
+	g.deleted.Store(false)
 }
 
 // Inspect calls the given closure with the Gauge itself.
@@ -146,15 +188,34 @@ func (g *Gauge) GetLabels() map[string]string {
 	return nil
 }
 
+// Delete permanently marks the gauge for deletion on the next
+// flush. After Delete, all mutations are no-ops and the Writer
+// removes the gauge from its tracked map once the delete is
+// flushed.
+func (g *Gauge) Delete() {
+	g.deleted.Store(true)
+}
+
+// IsDeleted returns true if the gauge has been marked for deletion.
+func (g *Gauge) IsDeleted() bool {
+	return g.deleted.Load()
+}
+
 // WriteStopwatch wraps a metric.Gauge to record the unix-second
 // timestamp at which Start() was called. The stored value is the
 // timestamp itself, not elapsed time. Dirty tracking ensures that
 // only updated stopwatches are flushed to storage.
+//
+// Once Delete() is called, the stopwatch is permanently marked for
+// deletion. All subsequent mutations (SetStartTime) are silently
+// ignored, and the Writer removes the metric from its tracked map
+// after a successful flush.
 type WriteStopwatch struct {
 	*metric.Gauge
 	metric.IsNonExportableMetric
 	IsClusterMetric
 	dirty      atomic.Bool
+	deleted    atomic.Bool
 	timeSource timeutil.TimeSource
 }
 
@@ -170,8 +231,11 @@ func NewWriteStopwatch(metadata metric.Metadata, timeSource timeutil.TimeSource)
 }
 
 // SetStartTime records the current time as the start time and marks
-// dirty.
+// dirty. If the stopwatch has been deleted, the call is a no-op.
 func (s *WriteStopwatch) SetStartTime() {
+	if s.deleted.Load() {
+		return
+	}
 	s.Gauge.Update(s.timeSource.Now().Unix())
 	s.dirty.Store(true)
 }
@@ -186,9 +250,11 @@ func (s *WriteStopwatch) IsDirty() bool {
 	return s.dirty.Load()
 }
 
-// Reset clears the dirty flag. Called after a successful flush.
+// Reset clears the dirty and deleted flags. Called after a successful
+// flush.
 func (s *WriteStopwatch) Reset() {
 	s.dirty.Store(false)
+	s.deleted.Store(false)
 }
 
 // Inspect calls the given closure with the WriteStopwatch itself.
@@ -207,4 +273,17 @@ func (s *WriteStopwatch) GetType() *prometheusgo.MetricType {
 // GetLabels returns nil for unlabeled stopwatches.
 func (s *WriteStopwatch) GetLabels() map[string]string {
 	return nil
+}
+
+// Delete permanently marks the stopwatch for deletion on the next
+// flush. After Delete, all mutations are no-ops and the Writer
+// removes the stopwatch from its tracked map once the delete is
+// flushed.
+func (s *WriteStopwatch) Delete() {
+	s.deleted.Store(true)
+}
+
+// IsDeleted returns true if the stopwatch has been marked for deletion.
+func (s *WriteStopwatch) IsDeleted() bool {
+	return s.deleted.Load()
 }

--- a/pkg/obs/clustermetrics/cmmetrics/vector.go
+++ b/pkg/obs/clustermetrics/cmmetrics/vector.go
@@ -14,6 +14,7 @@ package cmmetrics
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	prometheusgo "github.com/prometheus/client_model/go"
 )
@@ -48,6 +49,10 @@ type GaugeVec struct {
 	*metric.GaugeVec
 	metric.IsNonExportableMetric
 	IsClusterMetric
+	mu struct {
+		syncutil.Mutex
+		deleted []map[string]string
+	}
 }
 
 // NewGaugeVec creates a new GaugeVec with the given metadata and label
@@ -78,6 +83,37 @@ func (v *GaugeVec) Reset() {
 // Inspect passes the GaugeVec itself (not the embedded metric.GaugeVec).
 func (v *GaugeVec) Inspect(f func(interface{})) { f(v) }
 
+// Delete removes a child from the underlying prometheus vec and queues
+// the label set for deletion from the store on the next flush.
+func (v *GaugeVec) Delete(labels map[string]string) {
+	v.GaugeVec.Delete(labels)
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.mu.deleted = append(v.mu.deleted, labels)
+}
+
+// CollectDeleted returns snapshots of deleted children and clears
+// the pending list (drain semantics).
+func (v *GaugeVec) CollectDeleted() []WritableMetric {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if len(v.mu.deleted) == 0 {
+		return nil
+	}
+	result := make([]WritableMetric, len(v.mu.deleted))
+	for i, labels := range v.mu.deleted {
+		result[i] = &metricSnapshot{
+			VecChildSnapshot: &metric.VecChildSnapshot{
+				Metadata: v.GaugeVec.Metadata,
+				Labels:   labels,
+			},
+			metricType: prometheusgo.MetricType_GAUGE.Enum(),
+		}
+	}
+	v.mu.deleted = nil
+	return result
+}
+
 // CounterVec wraps metric.CounterVec for the cluster metrics writer.
 // All children present at flush time are written; Reset clears all
 // children so only the delta since the last flush is emitted.
@@ -85,6 +121,10 @@ type CounterVec struct {
 	*metric.CounterVec
 	metric.IsNonExportableMetric
 	IsClusterMetric
+	mu struct {
+		syncutil.Mutex
+		deleted []map[string]string
+	}
 }
 
 // NewCounterVec creates a new CounterVec with the given metadata and
@@ -117,6 +157,37 @@ func (v *CounterVec) Reset() {
 // Inspect passes the CounterVec itself (not the embedded metric.CounterVec).
 func (v *CounterVec) Inspect(f func(interface{})) { f(v) }
 
+// Delete removes a child from the underlying prometheus vec and queues
+// the label set for deletion from the store on the next flush.
+func (v *CounterVec) Delete(labels map[string]string) {
+	v.CounterVec.Delete(labels)
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.mu.deleted = append(v.mu.deleted, labels)
+}
+
+// CollectDeleted returns snapshots of deleted children and clears
+// the pending list (drain semantics).
+func (v *CounterVec) CollectDeleted() []WritableMetric {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if len(v.mu.deleted) == 0 {
+		return nil
+	}
+	result := make([]WritableMetric, len(v.mu.deleted))
+	for i, labels := range v.mu.deleted {
+		result[i] = &metricSnapshot{
+			VecChildSnapshot: &metric.VecChildSnapshot{
+				Metadata: v.CounterVec.Metadata,
+				Labels:   labels,
+			},
+			metricType: prometheusgo.MetricType_COUNTER.Enum(),
+		}
+	}
+	v.mu.deleted = nil
+	return result
+}
+
 // WriteStopwatchVec wraps metric.GaugeVec for labeled stopwatch
 // metrics. Each child records a unix-second timestamp set via
 // SetStartTime. All children present at flush time are written;
@@ -127,6 +198,10 @@ type WriteStopwatchVec struct {
 	metric.IsNonExportableMetric
 	IsClusterMetric
 	timeSource timeutil.TimeSource
+	mu         struct {
+		syncutil.Mutex
+		deleted []map[string]string
+	}
 }
 
 // NewWriteStopwatchVec creates a new WriteStopwatchVec with the
@@ -165,3 +240,35 @@ func (v *WriteStopwatchVec) Reset() {
 
 // Inspect passes the WriteStopwatchVec itself.
 func (v *WriteStopwatchVec) Inspect(f func(interface{})) { f(v) }
+
+// Delete removes a child from the underlying prometheus vec and queues
+// the label set for deletion from the store on the next flush.
+func (v *WriteStopwatchVec) Delete(labels map[string]string) {
+	v.GaugeVec.Delete(labels)
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.mu.deleted = append(v.mu.deleted, labels)
+}
+
+// CollectDeleted returns snapshots of deleted children and clears
+// the pending list (drain semantics).
+func (v *WriteStopwatchVec) CollectDeleted() []WritableMetric {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if len(v.mu.deleted) == 0 {
+		return nil
+	}
+	result := make([]WritableMetric, len(v.mu.deleted))
+	for i, labels := range v.mu.deleted {
+		result[i] = &metricSnapshot{
+			VecChildSnapshot: &metric.VecChildSnapshot{
+				Metadata: v.GaugeVec.Metadata,
+				Labels:   labels,
+			},
+			metricType: prometheusgo.MetricType_GAUGE.Enum(),
+			typeString: "STOPWATCH",
+		}
+	}
+	v.mu.deleted = nil
+	return result
+}

--- a/pkg/obs/clustermetrics/cmwriter/sql_store.go
+++ b/pkg/obs/clustermetrics/cmwriter/sql_store.go
@@ -47,6 +47,9 @@ func newSQLStore(db isql.DB, sqlIDContainer *base.SQLIDContainer, st *cluster.Se
 // added to the existing stored value. Gauges and stopwatches replace:
 // the stored value is overwritten.
 func (s *SQLStore) Write(ctx context.Context, metrics []cmmetrics.WritableMetric) error {
+	if len(metrics) == 0 {
+		return nil
+	}
 	if !s.st.Version.IsActive(ctx, clusterversion.V26_2_AddSystemClusterMetricsTable) {
 		return nil
 	}
@@ -102,6 +105,48 @@ func (s *SQLStore) Write(ctx context.Context, metrics []cmmetrics.WritableMetric
 		   node_id = excluded.node_id, last_updated = now()`
 
 		_, err := txn.ExecEx(ctx, "upsert-cluster-metrics", txn.KV(),
+			sessiondata.NodeUserSessionDataOverride,
+			stmt, args...,
+		)
+		return err
+	})
+}
+
+// Delete removes the given metrics from the system.cluster_metrics
+// table in a single batched DELETE. Each metric identifies a row by
+// its (name, labels) unique index; value and type are ignored.
+func (s *SQLStore) Delete(ctx context.Context, metrics []cmmetrics.WritableMetric) error {
+	if len(metrics) == 0 {
+		return nil
+	}
+	if !s.st.Version.IsActive(ctx, clusterversion.V26_2_AddSystemClusterMetricsTable) {
+		return nil
+	}
+
+	return s.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+		var buf strings.Builder
+		args := make([]interface{}, 0, len(metrics)*2)
+		for i, m := range metrics {
+			if i > 0 {
+				buf.WriteString(" OR ")
+			}
+			p := i*2 + 1
+			fmt.Fprintf(&buf, "(name = $%d AND labels = $%d::JSONB)", p, p+1)
+
+			labels := m.GetLabels()
+			labelsJSON := "{}"
+			if len(labels) > 0 {
+				b, err := json.Marshal(labels)
+				if err != nil {
+					return err
+				}
+				labelsJSON = string(b)
+			}
+			args = append(args, m.GetName(false /* useStaticLabels */), labelsJSON)
+		}
+
+		stmt := `DELETE FROM system.cluster_metrics WHERE ` + buf.String()
+		_, err := txn.ExecEx(ctx, "delete-cluster-metrics", txn.KV(),
 			sessiondata.NodeUserSessionDataOverride,
 			stmt, args...,
 		)

--- a/pkg/obs/clustermetrics/cmwriter/sql_store_test.go
+++ b/pkg/obs/clustermetrics/cmwriter/sql_store_test.go
@@ -180,3 +180,77 @@ func TestSQLStore_Write(t *testing.T) {
 		require.Equal(t, int64(200), gm.Value())
 	})
 }
+
+func TestSQLStore_Delete(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	defer cmmetrics.TestingAllowNonInitConstruction()()
+
+	t.Run("delete scalar", func(t *testing.T) {
+		env := newSQLStoreTestEnv(t)
+		c := cmmetrics.NewCounter(metric.Metadata{Name: "test.del.counter"})
+		c.Inc(42)
+		require.NoError(t, env.store.Write(env.ctx, []cmmetrics.WritableMetric{c}))
+
+		// Pass the metric itself to Delete.
+		require.NoError(t, env.store.Delete(env.ctx, []cmmetrics.WritableMetric{c}))
+
+		metrics, err := env.store.Get(env.ctx)
+		require.NoError(t, err)
+		require.Empty(t, metrics)
+	})
+
+	t.Run("delete labeled metric", func(t *testing.T) {
+		env := newSQLStoreTestEnv(t)
+		gv := cmmetrics.NewGaugeVec(metric.Metadata{Name: "test.del.gv"}, "region")
+
+		// Write two children.
+		var children []cmmetrics.WritableMetric
+		gv.Update(map[string]string{"region": "us-east"}, 10)
+		gv.Update(map[string]string{"region": "us-west"}, 20)
+		gv.Each(func(m cmmetrics.WritableMetric) {
+			children = append(children, m)
+		})
+		require.NoError(t, env.store.Write(env.ctx, children))
+
+		// Delete one child via CollectDeleted snapshot.
+		gv.Delete(map[string]string{"region": "us-east"})
+		deleted := gv.CollectDeleted()
+		require.Len(t, deleted, 1)
+		require.NoError(t, env.store.Delete(env.ctx, deleted))
+
+		metrics, err := env.store.Get(env.ctx)
+		require.NoError(t, err)
+		require.Len(t, metrics, 1)
+		require.Equal(t, int64(20), metrics[0].Value())
+	})
+
+	t.Run("delete nonexistent", func(t *testing.T) {
+		env := newSQLStoreTestEnv(t)
+
+		// Deleting a metric that doesn't exist should not error.
+		c := cmmetrics.NewCounter(metric.Metadata{Name: "nonexistent.metric"})
+		require.NoError(t, env.store.Delete(env.ctx, []cmmetrics.WritableMetric{c}))
+	})
+
+	t.Run("delete multiple", func(t *testing.T) {
+		env := newSQLStoreTestEnv(t)
+		c1 := cmmetrics.NewCounter(metric.Metadata{Name: "test.del.m1"})
+		c2 := cmmetrics.NewCounter(metric.Metadata{Name: "test.del.m2"})
+		g := cmmetrics.NewGauge(metric.Metadata{Name: "test.del.m3"})
+		c1.Inc(1)
+		c2.Inc(2)
+		g.Update(3)
+
+		require.NoError(t, env.store.Write(env.ctx, []cmmetrics.WritableMetric{c1, c2, g}))
+
+		// Delete c1 and g, keep c2.
+		require.NoError(t, env.store.Delete(env.ctx, []cmmetrics.WritableMetric{c1, g}))
+
+		metrics, err := env.store.Get(env.ctx)
+		require.NoError(t, err)
+		require.Len(t, metrics, 1)
+		require.Equal(t, "test.del.m2", metrics[0].GetName(false))
+		require.Equal(t, int64(2), metrics[0].Value())
+	})
+}

--- a/pkg/obs/clustermetrics/cmwriter/writer.go
+++ b/pkg/obs/clustermetrics/cmwriter/writer.go
@@ -28,6 +28,9 @@ import (
 type MetricStore interface {
 	// Write writes the given metrics to storage.
 	Write(ctx context.Context, metrics []cmmetrics.WritableMetric) error
+	// Delete removes the given metrics from storage, identified by
+	// their name and labels. Value and type are ignored.
+	Delete(ctx context.Context, metrics []cmmetrics.WritableMetric) error
 }
 
 // Writer manages registered cluster metrics and periodically flushes their
@@ -114,21 +117,34 @@ type resettable interface {
 	Reset()
 }
 
-// collectDirty returns the dirty metrics and their resetters under the lock.
+// collectDirty returns dirty metrics to write, metrics to delete,
+// items to reset after a fully successful flush, and scalar metric
+// names to remove from the tracked map after a successful delete.
 func (w *Writer) collectDirty(
 	ctx context.Context,
-) (toWrite []cmmetrics.WritableMetric, toReset []resettable) {
+) (
+	toWrite []cmmetrics.WritableMetric,
+	toDelete []cmmetrics.WritableMetric,
+	toReset []resettable,
+	toUntrack []string,
+) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	for _, tracked := range w.mu.tracked {
+	for name, tracked := range w.mu.tracked {
 		tracked.Inspect(func(val interface{}) {
 			switch m := val.(type) {
 			case cmmetrics.Metric:
-				if m.IsDirty() {
+				if m.IsDeleted() {
+					toDelete = append(toDelete, m)
+					toUntrack = append(toUntrack, name)
+				} else if m.IsDirty() {
 					toWrite = append(toWrite, m)
 					toReset = append(toReset, m)
 				}
 			case cmmetrics.MetricVec:
+				// Collect deleted children first.
+				toDelete = append(toDelete, m.CollectDeleted()...)
+				// Then collect dirty children for writing.
 				shouldReset := false
 				m.Each(func(snap cmmetrics.WritableMetric) {
 					toWrite = append(toWrite, snap)
@@ -143,41 +159,78 @@ func (w *Writer) collectDirty(
 			}
 		})
 	}
-	return toWrite, toReset
+	return toWrite, toDelete, toReset, toUntrack
 }
 
 // Flush triggers an immediate flush of all registered metrics to the store.
-// Only metrics that have changed since the last flush are written.
+// Only metrics that have changed since the last flush are written. Deleted
+// metrics are removed from the store before writes so that a delete-then-
+// re-add in the same cycle produces the correct final state.
 //
 // Scalar metrics (Metric) are collected when their dirty flag is set.
 // Vector metrics (MetricVec) yield read-only snapshots of all children;
 // the parent vec is cleared after a successful write so only values set
 // since the last flush appear next time.
+//
+// Deleted scalar metrics are removed from the tracked map after a
+// successful flush. Their deleted flag remains set so that any
+// subsequent mutations on the metric instance are silently ignored.
+//
+// If either the delete or write call fails, the flush returns early
+// without resetting any state. Scalar metrics retry naturally on the
+// next flush because their dirty/deleted flags remain set. Vec
+// deletions use drain semantics and may be lost on failure; this is
+// acceptable because cluster metrics have an implicit TTL that will
+// eventually clean up stale rows.
 func (w *Writer) Flush(ctx context.Context) {
 	startTime := timeutil.Now()
-	toWrite, toReset := w.collectDirty(ctx)
+	toWrite, toDelete, toReset, toUntrack := w.collectDirty(ctx)
 
-	if len(toWrite) == 0 {
+	if len(toWrite) == 0 && len(toDelete) == 0 {
 		return
 	}
 
-	// Write the metrics to the downstream store.
-	err := w.store.Write(ctx, toWrite)
+	defer func() {
+		elapsed := timeutil.Since(startTime)
+		w.metrics.FlushLatency.Update(elapsed.Nanoseconds())
+		w.metrics.FlushCount.Inc(1)
+	}()
 
-	// Record meta metrics.
-	elapsed := timeutil.Since(startTime)
-	w.metrics.FlushLatency.Update(elapsed.Nanoseconds())
-	w.metrics.FlushCount.Inc(1)
-	if err != nil {
+	// Execute deletes before writes so that a vec child deleted and
+	// re-added in the same flush cycle ends up with the new value
+	// (UPSERT after DELETE).
+	if err := w.store.Delete(ctx, toDelete); err != nil {
+		w.metrics.FlushErrors.Inc(1)
+		log.Ops.Warningf(ctx, "failed to delete cluster metrics: %v", err)
+		return
+	}
+
+	if err := w.store.Write(ctx, toWrite); err != nil {
 		w.metrics.FlushErrors.Inc(1)
 		log.Ops.Warningf(ctx, "failed to flush cluster metrics: %v", err)
 		return
 	}
-	w.metrics.MetricsWritten.Inc(int64(len(toWrite)))
 
-	// Reset metrics after successful write.
+	// Both operations succeeded — reset all state and record counts.
+	w.metrics.MetricsDeleted.Inc(int64(len(toDelete)))
+	w.metrics.MetricsWritten.Inc(int64(len(toWrite)))
 	for _, r := range toReset {
 		r.Reset()
+	}
+
+	// Remove deleted scalar metrics from the tracked map. The deleted
+	// flag on each metric remains set so future mutations are no-ops.
+	if len(toUntrack) > 0 {
+		w.untrack(toUntrack)
+	}
+}
+
+// untrack removes the named metrics from the tracked map.
+func (w *Writer) untrack(names []string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for _, name := range names {
+		delete(w.mu.tracked, name)
 	}
 }
 

--- a/pkg/obs/clustermetrics/cmwriter/writer_metrics.go
+++ b/pkg/obs/clustermetrics/cmwriter/writer_metrics.go
@@ -22,13 +22,19 @@ var (
 	}
 	metaFlushErrors = metric.Metadata{
 		Name:        "obs.clustermetrics.flush.errors",
-		Help:        "Number of cluster metrics flush errors",
+		Help:        "Number of flush errors (write or delete failures)",
 		Measurement: "Errors",
 		Unit:        metric.Unit_COUNT,
 	}
 	metaMetricsWritten = metric.Metadata{
 		Name:        "obs.clustermetrics.flush.metrics_written",
 		Help:        "Number of individual metrics written per flush",
+		Measurement: "Metrics",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaMetricsDeleted = metric.Metadata{
+		Name:        "obs.clustermetrics.flush.metrics_deleted",
+		Help:        "Number of individual metrics deleted per flush",
 		Measurement: "Metrics",
 		Unit:        metric.Unit_COUNT,
 	}
@@ -40,6 +46,7 @@ type WriterMetrics struct {
 	FlushCount     *metric.Counter
 	FlushErrors    *metric.Counter
 	MetricsWritten *metric.Counter
+	MetricsDeleted *metric.Counter
 }
 
 // MetricStruct implements the metric.Struct interface.
@@ -52,5 +59,6 @@ func NewWriterMetrics() *WriterMetrics {
 		FlushCount:     metric.NewCounter(metaFlushCount),
 		FlushErrors:    metric.NewCounter(metaFlushErrors),
 		MetricsWritten: metric.NewCounter(metaMetricsWritten),
+		MetricsDeleted: metric.NewCounter(metaMetricsDeleted),
 	}
 }

--- a/pkg/obs/clustermetrics/cmwriter/writer_test.go
+++ b/pkg/obs/clustermetrics/cmwriter/writer_test.go
@@ -70,6 +70,15 @@ func (s *mapStore) Write(_ context.Context, metrics []cmmetrics.WritableMetric) 
 	return nil
 }
 
+func (s *mapStore) Delete(_ context.Context, metrics []cmmetrics.WritableMetric) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, m := range metrics {
+		delete(s.mu.metrics, storeKey(m))
+	}
+	return nil
+}
+
 func (s *mapStore) get(name string) (storedMetric, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -594,5 +603,323 @@ func TestWriter_VecMetrics(t *testing.T) {
 		sv.SetStartTime(map[string]string{"job": "backup"})
 		env.writer.Flush(env.ctx)
 		require.Equal(t, int64(2), env.writerMetrics.MetricsWritten.Count())
+	})
+}
+
+// errorStore wraps a mapStore and allows injecting errors for Delete
+// and/or Write calls.
+type errorStore struct {
+	*mapStore
+	mu struct {
+		syncutil.Mutex
+		writeErr  error
+		deleteErr error
+	}
+}
+
+func newErrorStore() *errorStore {
+	return &errorStore{mapStore: newMapStore()}
+}
+
+func (s *errorStore) setDeleteErr(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.mu.deleteErr = err
+}
+
+func (s *errorStore) Write(ctx context.Context, metrics []cmmetrics.WritableMetric) error {
+	s.mu.Lock()
+	err := s.mu.writeErr
+	s.mu.Unlock()
+	if err != nil {
+		return err
+	}
+	return s.mapStore.Write(ctx, metrics)
+}
+
+func (s *errorStore) Delete(ctx context.Context, metrics []cmmetrics.WritableMetric) error {
+	s.mu.Lock()
+	err := s.mu.deleteErr
+	s.mu.Unlock()
+	if err != nil {
+		return err
+	}
+	return s.mapStore.Delete(ctx, metrics)
+}
+
+func TestWriter_Delete(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	defer cmmetrics.TestingAllowNonInitConstruction()()
+
+	t.Run("scalar counter delete", func(t *testing.T) {
+		env := newTestEnv()
+		c := cmmetrics.NewCounter(metric.Metadata{Name: "c"})
+		env.writer.AddMetric(c)
+
+		c.Inc(5)
+		env.writer.Flush(env.ctx)
+		_, ok := env.store.get("c")
+		require.True(t, ok, "counter should be stored after write")
+
+		c.Delete()
+		env.writer.Flush(env.ctx)
+		_, ok = env.store.get("c")
+		require.False(t, ok, "counter should be removed after delete")
+		require.Equal(t, int64(1), env.writerMetrics.MetricsDeleted.Count())
+	})
+
+	t.Run("scalar gauge delete", func(t *testing.T) {
+		env := newTestEnv()
+		g := cmmetrics.NewGauge(metric.Metadata{Name: "g"})
+		env.writer.AddMetric(g)
+
+		g.Update(42)
+		env.writer.Flush(env.ctx)
+		_, ok := env.store.get("g")
+		require.True(t, ok, "gauge should be stored after write")
+
+		g.Delete()
+		env.writer.Flush(env.ctx)
+		_, ok = env.store.get("g")
+		require.False(t, ok, "gauge should be removed after delete")
+		require.Equal(t, int64(1), env.writerMetrics.MetricsDeleted.Count())
+	})
+
+	t.Run("scalar inc then delete before flush", func(t *testing.T) {
+		env := newTestEnv()
+		c := cmmetrics.NewCounter(metric.Metadata{Name: "c"})
+		env.writer.AddMetric(c)
+
+		c.Inc(5)
+		c.Delete()
+		env.writer.Flush(env.ctx)
+
+		// Delete after Inc: deletion wins, value should not be written.
+		_, ok := env.store.get("c")
+		require.False(t, ok, "deleted metric should not be written")
+		require.Equal(t, int64(0), env.writerMetrics.MetricsWritten.Count())
+		require.Equal(t, int64(1), env.writerMetrics.MetricsDeleted.Count())
+	})
+
+	t.Run("scalar delete then inc before flush", func(t *testing.T) {
+		env := newTestEnv()
+		c := cmmetrics.NewCounter(metric.Metadata{Name: "c"})
+		env.writer.AddMetric(c)
+
+		c.Delete()
+		c.Inc(5) // no-op: metric is deleted
+		env.writer.Flush(env.ctx)
+
+		// Inc after Delete is a no-op; the metric is deleted.
+		_, ok := env.store.get("c")
+		require.False(t, ok, "deleted metric should not be written")
+		require.Equal(t, int64(0), env.writerMetrics.MetricsWritten.Count())
+		require.Equal(t, int64(1), env.writerMetrics.MetricsDeleted.Count())
+	})
+
+	t.Run("scalar delete then update gauge", func(t *testing.T) {
+		env := newTestEnv()
+		g := cmmetrics.NewGauge(metric.Metadata{Name: "g"})
+		env.writer.AddMetric(g)
+
+		g.Update(10)
+		env.writer.Flush(env.ctx)
+
+		g.Delete()
+		g.Update(42) // no-op: gauge is deleted
+		env.writer.Flush(env.ctx)
+
+		// Update after Delete is a no-op; the metric is deleted.
+		_, ok := env.store.get("g")
+		require.False(t, ok, "deleted gauge should be removed from store")
+		require.Equal(t, int64(1), env.writerMetrics.MetricsDeleted.Count())
+	})
+
+	t.Run("vec single child delete", func(t *testing.T) {
+		env := newTestEnv()
+		gv := cmmetrics.NewGaugeVec(metric.Metadata{Name: "gv"}, "region")
+		env.writer.AddMetric(gv)
+
+		gv.Update(map[string]string{"region": "us-east"}, 10)
+		gv.Update(map[string]string{"region": "us-west"}, 20)
+		env.writer.Flush(env.ctx)
+		require.Equal(t, 2, env.store.count())
+
+		gv.Delete(map[string]string{"region": "us-east"})
+		env.writer.Flush(env.ctx)
+
+		_, ok := env.store.getByLabels("gv", map[string]string{"region": "us-east"})
+		require.False(t, ok, "deleted child should be removed")
+		_, ok = env.store.getByLabels("gv", map[string]string{"region": "us-west"})
+		require.True(t, ok, "non-deleted child should remain")
+		require.Equal(t, int64(1), env.writerMetrics.MetricsDeleted.Count())
+	})
+
+	t.Run("vec all children deleted", func(t *testing.T) {
+		env := newTestEnv()
+		gv := cmmetrics.NewGaugeVec(metric.Metadata{Name: "gv"}, "region")
+		env.writer.AddMetric(gv)
+
+		gv.Update(map[string]string{"region": "us-east"}, 10)
+		env.writer.Flush(env.ctx)
+		require.Equal(t, 1, env.store.count())
+
+		gv.Delete(map[string]string{"region": "us-east"})
+		env.writer.Flush(env.ctx)
+
+		require.Equal(t, 0, env.store.count())
+		require.Equal(t, int64(1), env.writerMetrics.MetricsDeleted.Count())
+	})
+
+	t.Run("vec delete and re-add same cycle", func(t *testing.T) {
+		env := newTestEnv()
+		gv := cmmetrics.NewGaugeVec(metric.Metadata{Name: "gv"}, "region")
+		env.writer.AddMetric(gv)
+
+		gv.Update(map[string]string{"region": "us-east"}, 10)
+		env.writer.Flush(env.ctx)
+
+		// Delete and re-add with new value in the same cycle.
+		gv.Delete(map[string]string{"region": "us-east"})
+		gv.Update(map[string]string{"region": "us-east"}, 99)
+		env.writer.Flush(env.ctx)
+
+		// UPSERT after DELETE means the new value should survive.
+		stored, ok := env.store.getByLabels("gv", map[string]string{"region": "us-east"})
+		require.True(t, ok, "re-added child should be present")
+		require.Equal(t, int64(99), stored.StoredValue)
+	})
+
+	t.Run("counter vec delete", func(t *testing.T) {
+		env := newTestEnv()
+		cv := cmmetrics.NewCounterVec(metric.Metadata{Name: "cv"}, "method")
+		env.writer.AddMetric(cv)
+
+		cv.Inc(map[string]string{"method": "GET"}, 5)
+		cv.Inc(map[string]string{"method": "POST"}, 3)
+		env.writer.Flush(env.ctx)
+		require.Equal(t, 2, env.store.count())
+
+		cv.Delete(map[string]string{"method": "GET"})
+		env.writer.Flush(env.ctx)
+
+		_, ok := env.store.getByLabels("cv", map[string]string{"method": "GET"})
+		require.False(t, ok, "deleted counter vec child should be removed")
+		_, ok = env.store.getByLabels("cv", map[string]string{"method": "POST"})
+		require.True(t, ok, "non-deleted counter vec child should remain")
+	})
+
+	t.Run("stopwatch vec delete", func(t *testing.T) {
+		env := newTestEnv()
+		sv := cmmetrics.NewWriteStopwatchVec(
+			metric.Metadata{Name: "sv"}, timeutil.DefaultTimeSource{}, "job",
+		)
+		env.writer.AddMetric(sv)
+
+		sv.SetStartTime(map[string]string{"job": "backup"})
+		sv.SetStartTime(map[string]string{"job": "restore"})
+		env.writer.Flush(env.ctx)
+		require.Equal(t, 2, env.store.count())
+
+		sv.Delete(map[string]string{"job": "backup"})
+		env.writer.Flush(env.ctx)
+
+		_, ok := env.store.getByLabels("sv", map[string]string{"job": "backup"})
+		require.False(t, ok, "deleted stopwatch vec child should be removed")
+		_, ok = env.store.getByLabels("sv", map[string]string{"job": "restore"})
+		require.True(t, ok, "non-deleted stopwatch vec child should remain")
+	})
+
+	t.Run("scalar stopwatch delete", func(t *testing.T) {
+		env := newTestEnv()
+		sw := cmmetrics.NewWriteStopwatch(
+			metric.Metadata{Name: "sw"}, timeutil.DefaultTimeSource{},
+		)
+		env.writer.AddMetric(sw)
+
+		sw.SetStartTime()
+		env.writer.Flush(env.ctx)
+		_, ok := env.store.get("sw")
+		require.True(t, ok, "stopwatch should be stored after write")
+
+		sw.Delete()
+		env.writer.Flush(env.ctx)
+		_, ok = env.store.get("sw")
+		require.False(t, ok, "stopwatch should be removed after delete")
+		require.Equal(t, int64(1), env.writerMetrics.MetricsDeleted.Count())
+	})
+
+	t.Run("scalar inc after flushed delete is noop", func(t *testing.T) {
+		env := newTestEnv()
+		c := cmmetrics.NewCounter(metric.Metadata{Name: "c"})
+		env.writer.AddMetric(c)
+
+		c.Inc(5)
+		env.writer.Flush(env.ctx)
+		_, ok := env.store.get("c")
+		require.True(t, ok)
+
+		// Delete and flush — row removed from store, metric
+		// removed from tracked map.
+		c.Delete()
+		env.writer.Flush(env.ctx)
+		_, ok = env.store.get("c")
+		require.False(t, ok)
+
+		// Inc after the delete has been flushed — metric is no
+		// longer tracked and Inc is a no-op.
+		c.Inc(3)
+		env.writer.Flush(env.ctx)
+		_, ok = env.store.get("c")
+		require.False(t, ok, "inc after flushed delete should be a no-op")
+		require.Equal(t, int64(1), env.writerMetrics.MetricsWritten.Count(),
+			"only the original write should be counted")
+	})
+
+	t.Run("delete with failed store", func(t *testing.T) {
+		ctx := context.Background()
+		es := newErrorStore()
+		writerMetrics := NewWriterMetrics()
+		w := NewWriterWithStore(es, writerMetrics)
+
+		c := cmmetrics.NewCounter(metric.Metadata{Name: "c"})
+		w.AddMetric(c)
+		c.Inc(5)
+		w.Flush(ctx)
+
+		// Inject delete error.
+		es.setDeleteErr(errors.New("delete failed"))
+		c.Delete()
+		w.Flush(ctx)
+
+		// Metric should still be in the store because delete failed.
+		_, ok := es.mapStore.get("c")
+		require.True(t, ok, "metric should remain after failed delete")
+		require.Equal(t, int64(0), writerMetrics.MetricsDeleted.Count())
+		require.Equal(t, int64(1), writerMetrics.FlushErrors.Count())
+
+		// Scalar delete is retried because IsDeleted stays set.
+		es.setDeleteErr(nil)
+		w.Flush(ctx)
+		_, ok = es.mapStore.get("c")
+		require.False(t, ok, "metric should be removed after retry")
+		require.Equal(t, int64(1), writerMetrics.MetricsDeleted.Count())
+	})
+
+	t.Run("operational metrics", func(t *testing.T) {
+		env := newTestEnv()
+		gv := cmmetrics.NewGaugeVec(metric.Metadata{Name: "gv"}, "region")
+		env.writer.AddMetric(gv)
+
+		gv.Update(map[string]string{"region": "us-east"}, 10)
+		gv.Update(map[string]string{"region": "us-west"}, 20)
+		env.writer.Flush(env.ctx)
+
+		gv.Delete(map[string]string{"region": "us-east"})
+		gv.Delete(map[string]string{"region": "us-west"})
+		env.writer.Flush(env.ctx)
+
+		require.Equal(t, int64(2), env.writerMetrics.MetricsDeleted.Count())
 	})
 }

--- a/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
+++ b/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
@@ -1789,6 +1789,7 @@ node_id: node_id
 obs_clustermetrics_flush_count: obs.clustermetrics.flush.count
 obs_clustermetrics_flush_errors: obs.clustermetrics.flush.errors
 obs_clustermetrics_flush_latency: obs.clustermetrics.flush.latency
+obs_clustermetrics_flush_metrics_deleted: obs.clustermetrics.flush.metrics_deleted
 obs_clustermetrics_flush_metrics_written: obs.clustermetrics.flush.metrics_written
 obs_tablemetadata_update_job_duration: obs.tablemetadata.update_job.duration
 obs_tablemetadata_update_job_duration_bucket: obs.tablemetadata.update_job.duration.bucket


### PR DESCRIPTION
The cluster metrics write path (cmwriter) could upsert metrics to system.cluster_metrics but had no mechanism to delete rows. When a metric or vector child should be removed, there was no way to propagate that deletion to the table.

This change mirrors the existing dirty tracking pattern with a "deleted" sentinel that the writer picks up during flush and translates into DELETE SQL:

- Scalar metrics (Counter, Gauge, WriteStopwatch) gain an atomic deleted flag with Delete()/IsDeleted(). Delete takes precedence over dirty: if both are set, the metric is deleted rather than written. Failed deletes are retried on the next flush since IsDeleted stays set.

- Vector metrics (GaugeVec, CounterVec, WriteStopwatchVec) gain a mutex-protected deleted list with Delete(labels)/CollectDeleted(). Delete removes the child from the prometheus vec immediately and queues the label set for collection during flush. CollectDeleted uses drain semantics matching the existing vec snapshot pattern.

- The MetricStore interface gains a Delete(ctx, keys) method. SQLStore.Delete builds a batched DELETE WHERE (name, labels) statement.

- Flush executes deletes before writes so that a vec child deleted and re-added in the same cycle produces the correct final state (DELETE then UPSERT). Successfully deleted scalars are untracked so they can be re-registered as fresh metrics.

- A MetricsDeleted operational counter tracks successful deletions.

Resolves: CRDB-60770
Epic: CRDB-58342

Release note: None