### PR TITLE
release-26.1: kvserver: pin RHS lease after transfer in TestClosedTimestampFrozenAf…

### DIFF
--- a/pkg/kv/kvserver/closed_timestamp_test.go
+++ b/pkg/kv/kvserver/closed_timestamp_test.go
@@ -790,6 +790,10 @@ SET CLUSTER SETTING kv.closed_timestamp.follower_reads.enabled = true;
 				// Transfer the RHS lease while the RHS is subsumed.
 				log.KvDistribution.Infof(ctx, "test: transferring RHS lease...")
 				rightLeaseholder, rhsLeaseStart = test.transferLease(ctx, t, tc, rightDesc, rightLeaseholder, manual)
+				// Pin the RHS lease to the new leaseholder to prevent it from
+				// bouncing back to the original leaseholder due to clock advancement
+				// in MoveRangeLeaseNonCooperatively's retry loop.
+				pinnedLeases.PinLease(rightDesc.RangeID, rightLeaseholder.StoreID)
 				// Sanity check.
 				require.True(t, freezeStartTimestamp.Less(rhsLeaseStart))
 				log.KvDistribution.Infof(ctx, "test: transferring RHS lease... done")


### PR DESCRIPTION
Backport 1/1 commits from #164454 on behalf of @wenyihu6.

----

Previously, the `rhs_lease_transfer_while_subsumed` subtest transferred
the RHS lease via `MoveRangeLeaseNonCooperatively` but did not pin it
to the new leaseholder. The retry loop in `MoveRangeLeaseNonCooperatively`
advances the manual clock past each lease's expiration, which could cause
the newly transferred lease to expire shortly after the function returns.
When n1 re-acquired the RHS lease, the test's `rightLeaseholder` variable
became stale, and the scan intended for a "follower" landed on the actual
leaseholder. Since n1's RHS replica had `mergeInProgress` set from the
earlier Subsume, the scan blocked in `handleMergeInProgressError` waiting
for the merge to complete — but the merge was held by `SuspendMergeTrigger`
waiting for `Unblock()`, which was sequenced after the blocking scan.

This patch pins the RHS lease to the new leaseholder immediately after
the transfer. This prevents the lease from bouncing back to n1 due to
the clock advancement.

Fixes: https://github.com/cockroachdb/cockroach/issues/164404

Release note: None

Made-with: Cursor

----

Release justification: test only changes