### PR TITLE
plpgsql: fix incorrect column resolution for pl/pgsql variables

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_into
+++ b/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_into
@@ -583,3 +583,42 @@ statement ok
 DROP FUNCTION f(xy);
 
 subtest end
+
+subtest regression_162289
+
+statement ok
+CREATE TABLE t162289 (x INT, y INT);
+
+statement ok
+CREATE FUNCTION test_select_into_162289() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$
+  DECLARE
+    v TEXT;
+  BEGIN
+    SELECT TG_NAME INTO v;  -- This fails
+    RAISE NOTICE 'TG_NAME: %', v;
+    RETURN NEW;
+  END
+$$;
+
+statement ok
+CREATE TRIGGER tr_test BEFORE INSERT ON t162289 FOR EACH ROW EXECUTE FUNCTION test_select_into_162289();
+
+statement ok
+INSERT INTO t162289 VALUES (1, 1);
+
+statement ok
+CREATE FUNCTION f162289(x INT) RETURNS INT AS $$
+  DECLARE
+    y INT;
+  BEGIN
+    SELECT x INTO y;
+    RETURN x;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query I
+SELECT f162289(42);
+----
+42
+
+subtest end

--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -2370,11 +2370,29 @@ func (b *plpgsqlBuilder) makeContinuationArgs(con *continuation, s *scope) memo.
 		}
 		block := &b.blocks[i]
 		for _, name := range block.vars {
-			_, source, _, err := s.FindSourceProvidingColumn(b.ob.ctx, name)
-			if err != nil {
-				panic(err)
+			// The variable may have been updated since the last continuation call,
+			// in which case there will be a column for it in the current scope.
+			// Otherwise, the variable has not been updated, and we should search for
+			// it by param ord.
+			//
+			// This prevents a subtle bug where a user-supplied expression happens to
+			// project a column for one of the variables in an ancestor scope
+			// (e.g. as part of SELECT INTO). Referencing such a column would lead to
+			// an invalid outer column reference. See also #162289.
+			var col *scopeColumn
+			for j := range s.cols {
+				if s.cols[j].name.MatchesReferenceName(name) {
+					col = &s.cols[j]
+					break
+				}
 			}
-			args = append(args, b.ob.factory.ConstructVariable(source.(*scopeColumn).id))
+			if col == nil {
+				col = s.findFuncArgCol(len(args))
+			}
+			if col == nil {
+				panic(errors.AssertionFailedf("variable %s not found", name))
+			}
+			args = append(args, b.ob.factory.ConstructVariable(col.id))
 		}
 		for _, name := range block.hiddenVars {
 			col := s.findFuncArgCol(len(args))


### PR DESCRIPTION
Previously, `makeContinuationArgs` used `FindSourceProvidingColumn` to resolve each variable by walking the entire scope chain. This could find a SQL result column from an intermediate scope (e.g., `stmtScope` from a SELECT INTO) that shared the variable's name but had been projected away by a subsequent projection. Referencing such a column produced an invalid outer column reference.

Fix this by checking only the top-level scope's columns for recently modified variables, and falling back to `findFuncArgCol` (ordinal-based lookup) for variables that weren't modified. This avoids picking up intermediate SQL result columns by name, and unifies the approach with hidden variables which already used ordinal-based lookup.

Fixes #162289

Release note (bug fix): Fixed a bug that could result in an internal error for PL/pgSQL routines (including triggers) that referenced a parameter or variable in a SELECT INTO statement.