### PR TITLE
sql: inherit array type privileges from base type

### DIFF
--- a/pkg/sql/drop_type.go
+++ b/pkg/sql/drop_type.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/errors"
@@ -164,11 +165,25 @@ func (p *planner) addTypeBackReference(
 		return err
 	}
 
-	// Check if this user has USAGE privilege on the type. This function if an
-	// object has a dependency on a type, the user must have USAGE privilege on
-	// the type to create a dependency.
-	if err := p.CheckPrivilege(ctx, mutDesc, privilege.USAGE); err != nil {
-		return err
+	// Check if this user has USAGE privilege on the type. If an object has a
+	// dependency on a type, the user must have USAGE privilege on the type to
+	// create a dependency. For implicit array types (ALIAS), check the
+	// privilege on the base element type instead, matching PostgreSQL behavior.
+	if mutDesc.Kind == descpb.TypeDescriptor_ALIAS &&
+		mutDesc.Alias != nil &&
+		mutDesc.Alias.Family() == types.ArrayFamily {
+		baseTypeID := typedesc.GetUserDefinedTypeDescID(mutDesc.Alias.ArrayContents())
+		baseDesc, err := p.Descriptors().MutableByID(p.txn).Type(ctx, baseTypeID)
+		if err != nil {
+			return err
+		}
+		if err := p.CheckPrivilege(ctx, baseDesc, privilege.USAGE); err != nil {
+			return err
+		}
+	} else {
+		if err := p.CheckPrivilege(ctx, mutDesc, privilege.USAGE); err != nil {
+			return err
+		}
 	}
 
 	if !mutDesc.AddReferencingDescriptorID(ref) {

--- a/pkg/sql/logictest/testdata/logic_test/type_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/type_privileges
@@ -114,3 +114,56 @@ ALTER TYPE test RENAME to test1
 # testuser should be able to drop the type now.
 statement ok
 DROP TYPE test1
+
+subtest array_type_privilege_inheritance
+
+# Regression test for #164470. Array type privileges should inherit from the
+# base type. GRANT/REVOKE on an array type should redirect to the base type.
+
+user root
+
+statement ok
+REVOKE root FROM testuser;
+
+statement ok
+CREATE TYPE myenum AS ENUM ('a', 'b', 'c')
+
+# GRANT on an array type should redirect to the base type with a notice.
+statement notice NOTICE: privileges on array type _myenum are applied to the element type myenum
+GRANT USAGE ON TYPE _myenum TO testuser
+
+# REVOKE on an array type should also redirect to the base type.
+statement notice NOTICE: privileges on array type _myenum are applied to the element type myenum
+REVOKE USAGE ON TYPE _myenum FROM testuser
+
+# Revoke USAGE from public on both the base and array types, then grant only on
+# the base type. Creating a table should still succeed because the array type
+# privilege check delegates to the base type.
+statement ok
+REVOKE USAGE ON TYPE myenum FROM public
+
+statement notice NOTICE: privileges on array type _myenum are applied to the element type myenum
+REVOKE USAGE ON TYPE _myenum FROM public
+
+statement ok
+GRANT USAGE ON TYPE myenum TO testuser
+
+user testuser
+
+# Creating a table with the enum column should succeed even though USAGE was not
+# explicitly granted on the array type.
+statement ok
+CREATE TABLE t_enum(x myenum)
+
+# Creating a table with an array column of the enum type should also succeed.
+statement ok
+CREATE TABLE t_enum_arr(x myenum[])
+
+user root
+
+statement ok
+DROP TABLE t_enum;
+DROP TABLE t_enum_arr;
+DROP TYPE myenum;
+
+subtest end

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -26,12 +26,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/syntheticprivilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/metamorphic"
 	"github.com/cockroachdb/errors"
 )
@@ -306,6 +308,27 @@ func (p *planner) getDescriptorsFromTargetListForPrivilegeChange(
 			_, descriptor, err := p.ResolveMutableTypeDescriptor(ctx, typ, required)
 			if err != nil {
 				return nil, err
+			}
+
+			// If the resolved type is an implicit array type (ALIAS), redirect the
+			// privilege change to the base element type. This matches PostgreSQL,
+			// which does not allow setting privileges on array types directly.
+			if descriptor.Kind == descpb.TypeDescriptor_ALIAS &&
+				descriptor.Alias != nil &&
+				descriptor.Alias.Family() == types.ArrayFamily {
+				baseTypeID := typedesc.GetUserDefinedTypeDescID(descriptor.Alias.ArrayContents())
+				baseDesc, err := p.Descriptors().MutableByID(p.txn).Type(ctx, baseTypeID)
+				if err != nil {
+					return nil, err
+				}
+				p.BufferClientNotice(
+					ctx,
+					pgnotice.Newf(
+						"privileges on array type %s are applied to the element type %s",
+						descriptor.GetName(), baseDesc.GetName(),
+					),
+				)
+				descriptor = baseDesc
 			}
 
 			descs = append(descs, DescriptorWithObjectType{


### PR DESCRIPTION
Previously, CockroachDB checked privileges on implicit array types (e.g. `_myenum`) independently from their base types. This meant that granting USAGE on a user-defined type was not sufficient to use it in table columns — the user also needed USAGE on the implicit array type. This diverged from PostgreSQL, which treats array type privileges as inherited from the base type.

This commit makes two changes:

1. GRANT/REVOKE on array types now redirects to the base element type, with a client notice informing the user.

2. The USAGE privilege check in addTypeBackReference now delegates to the base element type for implicit array types, so granting USAGE on the base type is sufficient.

Resolves: #164470

Release note (bug fix): Fixed a bug where creating a table with a user-defined type column failed when the user had USAGE privilege on the base type but not on its implicit array type. Array type privileges are now inherited from the base type, matching PostgreSQL behavior.