### PR TITLE
sql: check view owner privileges on underlying tables

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -1951,3 +1951,153 @@ show session allow_view_with_security_invoker_clause;
 on
 
 subtest end
+
+# Regression test for #164426. When selecting from a view, verify that the view
+# owner still has SELECT privilege on the underlying tables.
+subtest view_owner_privilege_check
+
+statement ok
+USE test
+
+statement ok
+CREATE TABLE t_vop (a INT PRIMARY KEY, b INT);
+INSERT INTO t_vop VALUES (1, 10), (2, 20);
+
+statement ok
+CREATE USER view_owner;
+GRANT ALL ON TABLE t_vop TO view_owner;
+GRANT CREATE ON SCHEMA public TO view_owner;
+
+# Create a view as view_owner (root can SET ROLE to any role).
+statement ok
+SET ROLE view_owner
+
+statement ok
+CREATE VIEW v_vop AS SELECT a, b FROM t_vop
+
+statement ok
+SET ROLE root
+
+# Grant SELECT on the view to testuser so they can query through it.
+statement ok
+GRANT SELECT ON v_vop TO testuser
+
+# Verify the view works initially.
+user testuser
+
+query II
+SELECT * FROM v_vop ORDER BY a
+----
+1  10
+2  20
+
+user root
+
+# Revoke view owner's SELECT on the underlying table.
+statement ok
+REVOKE SELECT ON t_vop FROM view_owner
+
+# Now querying through the view should fail because the view owner no longer
+# has SELECT on the underlying table.
+user testuser
+
+statement error pgcode 42501 user view_owner does not have SELECT privilege on relation t_vop
+SELECT * FROM v_vop
+
+user root
+
+# Re-grant SELECT to the view owner. The view should work again.
+statement ok
+GRANT SELECT ON t_vop TO view_owner
+
+user testuser
+
+query II
+SELECT * FROM v_vop ORDER BY a
+----
+1  10
+2  20
+
+user root
+
+# Verify that the cluster setting can disable the check.
+statement ok
+REVOKE SELECT ON t_vop FROM view_owner
+
+statement ok
+SET CLUSTER SETTING sql.auth.check_view_owner_privileges.enabled = false
+
+user testuser
+
+query II
+SELECT * FROM v_vop ORDER BY a
+----
+1  10
+2  20
+
+user root
+
+statement ok
+SET CLUSTER SETTING sql.auth.check_view_owner_privileges.enabled = true
+
+user testuser
+
+statement error pgcode 42501 user view_owner does not have SELECT privilege on relation t_vop
+SELECT * FROM v_vop
+
+user root
+
+# Test nested views: each level checks its own owner's privileges.
+statement ok
+CREATE USER view_owner2;
+GRANT SELECT ON t_vop TO view_owner;
+GRANT SELECT ON v_vop TO view_owner2;
+GRANT CREATE ON SCHEMA public TO view_owner2;
+
+statement ok
+SET ROLE view_owner2
+
+statement ok
+CREATE VIEW v_vop_nested AS SELECT a FROM v_vop
+
+statement ok
+SET ROLE root
+
+statement ok
+GRANT SELECT ON v_vop_nested TO testuser
+
+# Both owners have SELECT, so nested view works.
+user testuser
+
+query I
+SELECT * FROM v_vop_nested ORDER BY a
+----
+1
+2
+
+user root
+
+# Revoke the inner view owner's SELECT on the underlying table. The nested
+# view should fail because the inner view's owner lost access.
+statement ok
+REVOKE SELECT ON t_vop FROM view_owner
+
+user testuser
+
+statement error pgcode 42501 user view_owner does not have SELECT privilege on relation t_vop
+SELECT * FROM v_vop_nested
+
+user root
+
+# Clean up.
+statement ok
+GRANT SELECT ON t_vop TO view_owner;
+DROP VIEW v_vop_nested;
+DROP VIEW v_vop;
+DROP TABLE t_vop;
+REVOKE CREATE ON SCHEMA public FROM view_owner;
+REVOKE CREATE ON SCHEMA public FROM view_owner2;
+DROP USER view_owner2;
+DROP USER view_owner;
+
+subtest end

--- a/pkg/sql/opt/cat/view.go
+++ b/pkg/sql/opt/cat/view.go
@@ -8,6 +8,7 @@ package cat
 import (
 	"bytes"
 
+	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
 )
@@ -33,6 +34,10 @@ type View interface {
 	// IsSystemView returns true if this view is a system view (like
 	// crdb_internal.ranges).
 	IsSystemView() bool
+
+	// Owner returns the owner of this view. This is used to check that the
+	// view owner retains SELECT privilege on underlying tables.
+	Owner() username.SQLUsername
 
 	// TriggerCount returns the number of triggers present on the view.
 	TriggerCount() int

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -119,6 +119,13 @@ type Builder struct {
 	// be used with care.
 	skipSelectPrivilegeChecks bool
 
+	// viewOwnerForSelectChecks stores the view owner when building within a
+	// view body. When skipSelectPrivilegeChecks is true and this is set, we
+	// perform a build-time privilege check as the view owner on underlying
+	// tables. This ensures the view owner still has SELECT privilege on the
+	// tables the view references.
+	viewOwnerForSelectChecks username.SQLUsername
+
 	// views contains a cache of views that have already been parsed, in case they
 	// are referenced multiple times in the same query.
 	views map[cat.View]*tree.Select

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -33,6 +34,15 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/intsets"
 	"github.com/cockroachdb/errors"
+)
+
+var checkViewOwnerPrivileges = settings.RegisterBoolSetting(
+	settings.ApplicationLevel,
+	"sql.auth.check_view_owner_privileges.enabled",
+	"if true, verify that the view owner retains SELECT privilege on "+
+		"underlying tables when a query uses the view",
+	true,
+	settings.WithPublic,
 )
 
 // buildDataSource builds a set of memo groups that represent the given table
@@ -352,6 +362,17 @@ func (b *Builder) buildView(
 	if !b.skipSelectPrivilegeChecks {
 		b.skipSelectPrivilegeChecks = true
 		defer func() { b.skipSelectPrivilegeChecks = false }()
+	}
+	// Even though we skip the session user's SELECT privilege check above, we
+	// still need to verify that the view owner retains SELECT on the underlying
+	// tables. This mirrors PostgreSQL behavior: if the view owner's SELECT is
+	// revoked, queries through the view fail. Save/restore per view level so
+	// nested views each check their own owner.
+	if !view.IsSystemView() &&
+		checkViewOwnerPrivileges.Get(&b.evalCtx.Settings.SV) {
+		savedOwner := b.viewOwnerForSelectChecks
+		b.viewOwnerForSelectChecks = view.Owner()
+		defer func() { b.viewOwnerForSelectChecks = savedOwner }()
 	}
 	// We are only interested in the direct dependency on this view descriptor.
 	// Any further dependency by the view's query should not be tracked.

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -722,7 +722,14 @@ func (b *Builder) resolveDataSourceRef(
 func (b *Builder) checkPrivilege(name opt.MDDepName, ds cat.DataSource, privs ...privilege.Kind) {
 	priv := privs[0]
 	if priv == privilege.SELECT && b.skipSelectPrivilegeChecks {
-		// The check is skipped, so don't recheck when dependencies are checked.
+		// We skip the session user's SELECT check, but if we're inside a view,
+		// verify that the view owner still has SELECT on this data source.
+		if !b.viewOwnerForSelectChecks.Undefined() {
+			if err := b.catalog.CheckPrivilege(b.ctx, ds, b.viewOwnerForSelectChecks, priv); err != nil {
+				panic(err)
+			}
+		}
+		// Don't recheck session user privileges when dependencies are checked.
 		b.factory.Metadata().AddDependency(name, ds, 0)
 		return
 	}

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -797,6 +797,9 @@ type View struct {
 	ColumnNames tree.NameList
 	Triggers    []Trigger
 
+	// ViewOwner is the owner of this view.
+	ViewOwner username.SQLUsername
+
 	// If Revoked is true, then the user has had privileges on the view revoked.
 	Revoked bool
 }
@@ -846,6 +849,14 @@ func (tv *View) fqName() cat.DataSourceName {
 // IsSystemView is part of the cat.View interface.
 func (tv *View) IsSystemView() bool {
 	return false
+}
+
+// Owner is part of the cat.View interface.
+func (tv *View) Owner() username.SQLUsername {
+	if tv.ViewOwner.Undefined() {
+		return username.RootUserName()
+	}
+	return tv.ViewOwner
 }
 
 // Query is part of the cat.View interface.

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -805,6 +805,11 @@ func (ov *optView) IsSystemView() bool {
 	return ov.desc.IsVirtualTable()
 }
 
+// Owner is part of the cat.View interface.
+func (ov *optView) Owner() username.SQLUsername {
+	return ov.desc.GetPrivileges().Owner()
+}
+
 // Query is part of the cat.View interface.
 func (ov *optView) Query() string {
 	return ov.desc.GetViewQuery()


### PR DESCRIPTION
Previously, when selecting from a view, CockroachDB unconditionally skipped all privilege checks on underlying tables. This meant that if the view owner's SELECT privilege was revoked on an underlying table, queries through the view would still succeed. PostgreSQL correctly returns "permission denied" in this case.

The root cause was in buildView(), which set skipSelectPrivilegeChecks unconditionally without any view-owner-level check.

This commit adds a build-time privilege check that verifies the view owner retains SELECT privilege on underlying tables. A new Builder field viewOwnerForSelectChecks is saved/restored per view level, so nested views each check their own owner's privileges. The session user's privileges are still not checked (that's the purpose of views).

A cluster setting sql.auth.check_view_owner_privileges.enabled (default true) is provided as an escape hatch.

Resolves: 164426

Release note (bug fix): Fixed a bug where queries through a view would succeed even after the view owner's SELECT privilege on an underlying table was revoked. CockroachDB now checks that the view owner retains SELECT on all referenced tables, matching PostgreSQL behavior. A new cluster setting
sql.auth.check_view_owner_privileges.enabled (default true) controls this check.