### PR TITLE
sql: skip collecting histogram for json column if in partial index

### DIFF
--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -637,10 +637,10 @@ const maxNonIndexCols = 100
 // If nonIndexJsonHistograms is true, 2-bucket histograms are collected for
 // non-indexed JSON columns.
 //
-// If partialStats is true, we only collect statistics on single columns that
-// are prefixes of forward indexes, and skip over partial, sharded, and
-// implicitly partitioned indexes. Partial statistic creation only supports
-// these columns.
+// If partialStatsUsingExtremes is true, we only collect statistics on
+// single columns that are prefixes of forward indexes, and skip over
+// partial, sharded, and implicitly partitioned indexes. Partial
+// statistic creation only supports these columns.
 //
 // In addition to the index columns, we collect stats on up to maxNonIndexCols
 // other columns from the table. We only collect histograms for index columns,
@@ -648,7 +648,7 @@ const maxNonIndexCols = 100
 func createStatsDefaultColumns(
 	ctx context.Context,
 	desc catalog.TableDescriptor,
-	virtColEnabled, multiColEnabled, nonIndexJSONHistograms, partialStats bool,
+	virtColEnabled, multiColEnabled, nonIndexJSONHistograms, partialStatsUsingExtremes bool,
 	defaultHistogramBuckets uint32,
 	evalCtx *eval.Context,
 ) ([]jobspb.CreateStatsDetails_ColStat, error) {
@@ -701,6 +701,18 @@ func createStatsDefaultColumns(
 		return false
 	}
 
+	// nonIndexColHasHistogram returns whether a non-indexed column should
+	// have a histogram collected.
+	nonIndexColHasHistogram := func(col catalog.Column) bool {
+		if colinfo.ColumnTypeIsOnlyInvertedIndexable(col.GetType()) {
+			return false
+		}
+		if col.GetType().Family() == types.JsonFamily {
+			return nonIndexJSONHistograms
+		}
+		return true
+	}
+
 	// addIndexColumnStatsIfNotExists appends column stats for the given column
 	// ID if they have not already been added. Histogram stats are collected for
 	// every indexed column.
@@ -748,10 +760,10 @@ func createStatsDefaultColumns(
 		return nil
 	}
 
-	// Only collect statistics on single columns that are prefixes of forward
-	// indexes for partial statistics, and skip over partial, sharded, and
-	// implicitly partitioned indexes.
-	if partialStats {
+	// Only collect statistics on single columns that are prefixes of
+	// forward indexes for USING EXTREMES partial statistics, and skip over
+	// partial, sharded, and implicitly partitioned indexes.
+	if partialStatsUsingExtremes {
 		for _, idx := range desc.ActiveIndexes() {
 			if idx.GetType() != idxtype.FORWARD ||
 				idx.IsPartial() ||
@@ -878,6 +890,9 @@ func createStatsDefaultColumns(
 		}
 
 		// Add columns referenced in partial index predicate expressions.
+		// These columns are not directly indexed, so they should not get
+		// inverted index stats, and json type columns should respect the
+		// sql.stats.non_indexed_json_histograms.enabled cluster setting.
 		if idx.IsPartial() {
 			expr, err := parser.ParseExpr(idx.GetPredicate())
 			if err != nil {
@@ -896,10 +911,21 @@ func createStatsDefaultColumns(
 				if err != nil {
 					return nil, err
 				}
-				isInverted := colinfo.ColumnTypeIsOnlyInvertedIndexable(col.GetType())
-				if err := addIndexColumnStatsIfNotExists(colID, isInverted); err != nil {
-					return nil, err
+				if !col.Public() {
+					continue
 				}
+				if isUnsupportedVirtual(col) {
+					continue
+				}
+				cIDs := []descpb.ColumnID{colID}
+				if ok := sortAndTrackStatsExists(cIDs); ok {
+					continue
+				}
+				colStats = append(colStats, jobspb.CreateStatsDetails_ColStat{
+					ColumnIDs:           cIDs,
+					HasHistogram:        nonIndexColHasHistogram(col),
+					HistogramMaxBuckets: defaultHistogramBuckets,
+				})
 			}
 		}
 	}
@@ -929,13 +955,9 @@ func createStatsDefaultColumns(
 		if col.GetType().Family() == types.BoolFamily || col.GetType().Family() == types.EnumFamily {
 			maxHistBuckets = defaultHistogramBuckets
 		}
-		hasHistogram := !colinfo.ColumnTypeIsOnlyInvertedIndexable(col.GetType())
-		if col.GetType().Family() == types.JsonFamily {
-			hasHistogram = nonIndexJSONHistograms
-		}
 		colStats = append(colStats, jobspb.CreateStatsDetails_ColStat{
 			ColumnIDs:           colIDs,
-			HasHistogram:        hasHistogram,
+			HasHistogram:        nonIndexColHasHistogram(col),
 			HistogramMaxBuckets: maxHistBuckets,
 		})
 		nonIdxCols++

--- a/pkg/sql/logictest/testdata/logic_test/stats
+++ b/pkg/sql/logictest/testdata/logic_test/stats
@@ -69,6 +69,52 @@ ALTER TYPE greeting ADD VALUE 'hey';
 SELECT * FROM t122312 WHERE g = 'hi';
 COMMIT;
 
+subtest json_col_histogram
+# The histogram generation for JSON columns requires special handling
+# in certain scenarios.
+# - Forward indexed JSON columns, in primary or secondary index: always generate histogram.
+# - Non-indexed JSON columns always respect sql.stats.non_indexed_json_histograms.enabled.
+
+statement ok
+RESET CLUSTER SETTING sql.stats.non_indexed_json_histograms.enabled;
+
+# JSON column as a key column in a forward secondary index. Since this column
+# is now directly indexed, it should always get a histogram.
+statement ok
+CREATE TABLE t163346_fwd_idx (
+    k INT PRIMARY KEY,
+    j JSONB,
+    INDEX (j)
+);
+
+statement ok
+ANALYZE t163346_fwd_idx
+
+query TT rowsort
+SELECT column_names, IF(histogram_id IS NOT NULL, 'histogram_collected', 'no_histogram_collected')
+FROM [SHOW STATISTICS FOR TABLE t163346_fwd_idx]
+----
+{k}  histogram_collected
+{j}  histogram_collected
+
+statement ok
+CREATE TABLE t163346_pk (
+    k INT,
+    j JSONB,
+    PRIMARY KEY (k, j)
+);
+
+statement ok
+ANALYZE t163346_pk
+
+query TT rowsort
+SELECT column_names, IF(histogram_id IS NOT NULL, 'histogram_collected', 'no_histogram_collected')
+FROM [SHOW STATISTICS FOR TABLE t163346_pk]
+----
+{k}    histogram_collected
+{k,j}  no_histogram_collected
+{j}    histogram_collected
+
 # Regression test related to #139381. Do not collect histograms on non-indexed
 # JSON columns by default.
 statement ok
@@ -110,6 +156,107 @@ FROM [SHOW STATISTICS FOR TABLE t139381]
 {k}  histogram_collected
 {j}  histogram_collected
 {v}  histogram_collected
+
+# Regression test related to #163346. Do not collect histograms on non-indexed
+# JSON columns by default if referenced only in a partial index predicate.
+statement ok
+RESET CLUSTER SETTING sql.stats.non_indexed_json_histograms.enabled;
+
+statement ok
+CREATE TABLE t163346_partial (
+    k INT PRIMARY KEY,
+    j JSONB
+);
+
+statement ok
+CREATE INDEX ON t163346_partial (k) WHERE j->>'a' = '1';
+
+statement ok
+ANALYZE t163346_partial
+
+query TT rowsort
+SELECT column_names, IF(histogram_id IS NOT NULL, 'histogram_collected', 'no_histogram_collected')
+FROM [SHOW STATISTICS FOR TABLE t163346_partial]
+----
+{k}  histogram_collected
+{j}  no_histogram_collected
+
+statement ok
+SET CLUSTER SETTING sql.stats.non_indexed_json_histograms.enabled = true
+
+statement ok
+ANALYZE t163346_partial
+
+query TT rowsort
+SELECT column_names, IF(histogram_id IS NOT NULL, 'histogram_collected', 'no_histogram_collected')
+FROM [SHOW STATISTICS FOR TABLE t163346_partial]
+----
+{k}  histogram_collected
+{j}  histogram_collected
+
+statement ok
+RESET CLUSTER SETTING sql.stats.non_indexed_json_histograms.enabled;
+
+# USING EXTREMES partial stats only collect stats on forward index
+# prefix columns. A JSON column that is not a forward index prefix should not
+# get stats. Once it becomes a forward index prefix, it should get a histogram
+# because it is now an indexed column.
+statement ok
+CREATE TABLE t163346_partial_stats (
+    k INT PRIMARY KEY,
+    j JSONB
+);
+
+statement ok
+INSERT INTO t163346_partial_stats VALUES (1, '{"a": 1}'), (2, '{"a": 2}');
+
+# Collect full stats first, since partial stats needs to merge with
+# existing full stats.
+statement ok
+ANALYZE t163346_partial_stats
+
+statement ok
+INSERT INTO t163346_partial_stats VALUES (3, '{"a": 3}');
+
+statement ok
+SELECT crdb_internal.clear_table_stats_cache();
+
+# No forward index on j, so partial stats should only collect stats for k.
+statement ok
+CREATE STATISTICS s1 FROM t163346_partial_stats USING EXTREMES
+
+query empty
+SELECT column_names, IF(histogram_id IS NOT NULL, 'histogram_collected', 'no_histogram_collected')
+FROM [SHOW STATISTICS FOR TABLE t163346_partial_stats]
+WHERE statistics_name = 's2'
+----
+
+# Add a forward index with j as the prefix and refresh full stats so that
+# partial stats have a base to merge with.
+statement ok
+CREATE INDEX ON t163346_partial_stats (j)
+
+statement ok
+ANALYZE t163346_partial_stats
+
+statement ok
+INSERT INTO t163346_partial_stats VALUES (4, '{"a": 4}');
+
+statement ok
+SELECT crdb_internal.clear_table_stats_cache();
+
+statement ok
+CREATE STATISTICS s2 FROM t163346_partial_stats USING EXTREMES
+
+query TT rowsort
+SELECT column_names, IF(histogram_id IS NOT NULL, 'histogram_collected', 'no_histogram_collected')
+FROM [SHOW STATISTICS FOR TABLE t163346_partial_stats]
+WHERE statistics_name = 's2'
+----
+{k}  histogram_collected
+{j}  histogram_collected
+
+subtest end
 
 # Regression test for inflating the distinct count due to including column ID
 # delta in the sketch (#141448).


### PR DESCRIPTION
Fixes #163346

We already skip collecting histogram for json columns used in a non-inverted index, but we don't do it if the json column is in a partial index. This commit is to fix it.

Release note (bug fix): skip collection histogram for json column if in partial index, except when the cluster setting
sql.stats.non_indexed_json_histograms.enabled is `true` (default false).