### PR TITLE
kvserver: skip TestLeaseTransferReplicatesLocks under duress

### DIFF
--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -5868,6 +5868,7 @@ func TestOptimisticEvalWithConcurrentWriters(t *testing.T) {
 func TestLeaseTransferReplicatesLocks(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.UnderDuress(t, "can cause uncooperative lease change under leader leases")
 
 	testutils.SetVModule(t, "cmd_lease=2")
 


### PR DESCRIPTION
This test was flaky because under metamorphic leader lease testing,
a Raft election (common under race/stress) causes an uncooperative
lease change that clears the lock table without exporting unreplicated
locks. The subsequent cooperative transfer then finds no locks to
export, causing the metric assertion to fail.

Skip the test under duress to avoid this. Suppressing elections via
high RaftElectionTimeoutTicks was considered, but that approach is
fragile: if store liveness blips long enough after a leader is
established, the leader is lost permanently since the high election
timeout prevents a timely re-election.

Fixes: https://github.com/cockroachdb/cockroach/issues/164262

Release note: None

Made-with: Cursor