### PR TITLE
roachtest: bump backup perturbation threshold from 5x to 15x

### DIFF
--- a/pkg/cmd/roachtest/tests/perturbation/backup.go
+++ b/pkg/cmd/roachtest/tests/perturbation/backup.go
@@ -25,7 +25,7 @@ type backup struct{}
 var _ perturbation = backup{}
 
 func (b backup) setup() variations {
-	return setup(b, 5.0)
+	return setup(b, 15.0)
 }
 
 // TODO(baptist): Add variation for incremental backup.


### PR DESCRIPTION
The perturbation/full/backup test has been flaking across all branches
since at least August 2025 (https://github.com/cockroachdb/cockroach/issues/151594, https://github.com/cockroachdb/cockroach/issues/156744, https://github.com/cockroachdb/cockroach/issues/160192, https://github.com/cockroachdb/cockroach/issues/163552,
https://github.com/cockroachdb/cockroach/issues/163749, https://github.com/cockroachdb/cockroach/issues/164499). The failure pattern is consistent: read and
follower-read latencies spike during the backup while writes stay
within tolerance.

The flakiness is due to that a full backup creates significant I/O pressure
competing with foreground reads, and the degree of contention depends
on cloud I/O variability outside CockroachDB's control. The observed
failure ratios range from marginal (5.2x-11.3x) to severe (49x-57x),
meaning the 5.0x threshold was sitting right at the edge of normal
GCE I/O variance. Bumping to 15.0x moves the threshold above the
noise band while still catching catastrophic regressions.

Informs: https://github.com/cockroachdb/cockroach/issues/156744

Release note: None

Made-with: Cursor