### PR TITLE
sql/regions: omit secondary region from super region zone configs

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/secondary_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/secondary_region
@@ -646,3 +646,98 @@ non_mr         {}                                                              N
 postgres       {}                                                              NULL            NULL
 system         {}                                                              NULL            NULL
 test           {}                                                              NULL            NULL
+
+# Verify that the secondary region does not leak into lease_preferences and
+# voter_constraints for tables/partitions confined to a super region when the
+# secondary region is outside that super region.
+#
+# mr2 was created earlier with:
+#   Primary: ap-southeast-2 (outside any super region)
+#   Secondary: ca-central-1 (set above, also outside any super region)
+#   Super region test1: us-east-1, us-west-1
+subtest secondary_super_region_leak
+
+statement ok
+USE mr2;
+
+# Expand super region test1 to 3 regions so it meets the minimum for SURVIVE
+# REGION FAILURE.
+statement ok
+ALTER DATABASE mr2 ALTER SUPER REGION "test1" VALUES "us-east-1", "us-west-1", "us-central-1"
+
+statement ok
+ALTER DATABASE mr2 SURVIVE REGION FAILURE
+
+# REGIONAL BY TABLE inside super region: the secondary region (ca-central-1)
+# is outside the super region and must NOT appear in lease_preferences or
+# voter_constraints.
+statement ok
+CREATE TABLE mr2.rbt_in_sr() LOCALITY REGIONAL BY TABLE IN "us-east-1"
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE mr2.rbt_in_sr
+----
+TABLE mr2.public.rbt_in_sr  ALTER TABLE mr2.public.rbt_in_sr CONFIGURE ZONE USING
+                               range_min_bytes = 134217728,
+                               range_max_bytes = 536870912,
+                               gc.ttlseconds = 14400,
+                               num_replicas = 5,
+                               num_voters = 5,
+                               constraints = '{+region=us-central-1: 2, +region=us-east-1: 2, +region=us-west-1: 1}',
+                               voter_constraints = '{+region=us-east-1: 2}',
+                               lease_preferences = '[[+region=us-east-1]]'
+
+# Control: REGIONAL BY TABLE outside super region. The secondary region
+# (ca-central-1) SHOULD appear in lease_preferences and voter_constraints.
+statement ok
+CREATE TABLE mr2.rbt_outside_sr() LOCALITY REGIONAL BY TABLE IN "ap-southeast-2"
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE mr2.rbt_outside_sr
+----
+TABLE mr2.public.rbt_outside_sr  ALTER TABLE mr2.public.rbt_outside_sr CONFIGURE ZONE USING
+                                   range_min_bytes = 134217728,
+                                   range_max_bytes = 536870912,
+                                   gc.ttlseconds = 14400,
+                                   num_replicas = 7,
+                                   num_voters = 5,
+                                   constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-central-1: 1, +region=us-east-1: 1, +region=us-west-1: 1}',
+                                   voter_constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2}',
+                                   lease_preferences = '[[+region=ap-southeast-2], [+region=ca-central-1]]'
+
+# REGIONAL BY ROW table to test partitions.
+statement ok
+CREATE TABLE mr2.rbr_sr(k INT PRIMARY KEY) LOCALITY REGIONAL BY ROW
+
+# Partition inside super region: no secondary region leak.
+query TT
+SHOW ZONE CONFIGURATION FOR PARTITION "us-east-1" OF TABLE mr2.rbr_sr
+----
+PARTITION "us-east-1" OF TABLE mr2.public.rbr_sr  ALTER PARTITION "us-east-1" OF TABLE mr2.public.rbr_sr CONFIGURE ZONE USING
+                                                     range_min_bytes = 134217728,
+                                                     range_max_bytes = 536870912,
+                                                     gc.ttlseconds = 14400,
+                                                     num_replicas = 5,
+                                                     num_voters = 5,
+                                                     constraints = '{+region=us-central-1: 2, +region=us-east-1: 2, +region=us-west-1: 1}',
+                                                     voter_constraints = '{+region=us-east-1: 2}',
+                                                     lease_preferences = '[[+region=us-east-1]]'
+
+# Partition outside super region: secondary region should be present.
+query TT
+SHOW ZONE CONFIGURATION FOR PARTITION "ap-southeast-2" OF TABLE mr2.rbr_sr
+----
+PARTITION "ap-southeast-2" OF TABLE mr2.public.rbr_sr  ALTER PARTITION "ap-southeast-2" OF TABLE mr2.public.rbr_sr CONFIGURE ZONE USING
+                                                         range_min_bytes = 134217728,
+                                                         range_max_bytes = 536870912,
+                                                         gc.ttlseconds = 14400,
+                                                         num_replicas = 7,
+                                                         num_voters = 5,
+                                                         constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-central-1: 1, +region=us-east-1: 1, +region=us-west-1: 1}',
+                                                         voter_constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2}',
+                                                         lease_preferences = '[[+region=ap-southeast-2], [+region=ca-central-1]]'
+
+statement ok
+SELECT crdb_internal.validate_multi_region_zone_configs()
+
+subtest end

--- a/pkg/ccl/multiregionccl/multiregion_test.go
+++ b/pkg/ccl/multiregionccl/multiregion_test.go
@@ -276,7 +276,7 @@ func TestSuperRegionConstraintConformance(t *testing.T) {
 	skip.UnderShort(t)
 	skip.UnderDuress(t)
 
-	// The topology uses 4 regions across 8 nodes (2 per region):
+	// The topology uses 5 regions across 10 nodes (2 per region):
 	//
 	//   - Super region "americas": {us-east-1, us-central-1, us-west-1} — a
 	//     non-primary super region, exercising the AddConstraintsForSuperRegion
@@ -284,6 +284,9 @@ func TestSuperRegionConstraintConformance(t *testing.T) {
 	//   - Primary region: {ap-southeast-1} — outside any super region, which
 	//     also ensures RBR partitions and RBT tables homing here get normal
 	//     inherited constraints rather than super-region-confined ones.
+	//   - Secondary region: {eu-west-1} — outside any super region, used to
+	//     verify that super-region-confined partitions do not leak this region
+	//     into their lease_preferences (#164422).
 	//
 	// With exactly 3 regions per super region + SURVIVE REGION FAILURE, we get
 	// 5 voters and 0 non-voters — the tightest possible constraint configuration
@@ -292,6 +295,7 @@ func TestSuperRegionConstraintConformance(t *testing.T) {
 	regionNames := []string{
 		"ap-southeast-1",                         // primary (standalone)
 		"us-east-1", "us-central-1", "us-west-1", // super region "americas"
+		"eu-west-1", // secondary region (standalone)
 	}
 	tc, sqlDB, cleanup :=
 		multiregionccltestutils.TestingCreateMultiRegionClusterWithRegionList(
@@ -310,22 +314,23 @@ func TestSuperRegionConstraintConformance(t *testing.T) {
 	tdb.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '10ms'")
 	tdb.Exec(t, "SET CLUSTER SETTING kv.rangefeed.closed_timestamp_refresh_interval = '10ms'")
 
-	// Setup MR database with all 4 regions.
+	// Setup MR database with all 5 regions.
 	tdb.Exec(t, `CREATE DATABASE testdb PRIMARY REGION "ap-southeast-1"
-		REGIONS "us-east-1", "us-central-1", "us-west-1"`)
+		REGIONS "us-east-1", "us-central-1", "us-west-1", "eu-west-1"`)
 	tdb.Exec(t, `SET enable_super_regions = 'on'`)
 	tdb.Exec(t, `ALTER DATABASE testdb ADD SUPER REGION "americas"
 		VALUES "us-east-1", "us-central-1", "us-west-1"`)
+	tdb.Exec(t, `ALTER DATABASE testdb SET SECONDARY REGION "eu-west-1"`) // Set a secondary outside the super region.
 	tdb.Exec(t, `ALTER DATABASE testdb SURVIVE REGION FAILURE`)
 
-	// Create a REGIONAL BY ROW table with rows in all 4 regions, exercising
+	// Create a REGIONAL BY ROW table with rows in all 5 regions, exercising
 	// every partition's subzone config — both super-region-confined and normal.
 	tdb.Exec(t,
 		`CREATE TABLE testdb.rbr(k INT PRIMARY KEY, v INT)
 		 LOCALITY REGIONAL BY ROW`)
 	tdb.Exec(t, `INSERT INTO testdb.rbr(crdb_region, k, v) VALUES
 		('us-east-1', 1, 10), ('us-central-1', 2, 20), ('us-west-1', 3, 30),
-		('ap-southeast-1', 4, 40)`)
+		('ap-southeast-1', 4, 40), ('eu-west-1', 5, 50)`)
 
 	// RBT in a super region (non-primary). Tests AddConstraintsForSuperRegion
 	// at the table level.
@@ -361,20 +366,30 @@ func TestSuperRegionConstraintConformance(t *testing.T) {
 		}
 	}
 	// RBT in super region: all replicas confined to americas super region.
+	// The secondary region (eu-west-1) must NOT appear in lease_preferences
+	// because no replica can exist outside the super region.
 	verifyZoneConfig(
 		`SHOW ZONE CONFIGURATION FOR TABLE testdb.rbt_sr`,
 		[]string{
 			"voter_constraints", "us-east-1",
 			"constraints", "us-central-1", "us-west-1",
+			"lease_preferences = '[[+region=us-east-1]]'",
 		},
 	)
 	// RBT in primary region (standalone): voters in ap-southeast-1, no super
-	// region confinement.
+	// region confinement. The secondary region correctly appears here.
 	verifyZoneConfig(
 		`SHOW ZONE CONFIGURATION FOR TABLE testdb.rbt_standalone`,
-		[]string{"voter_constraints", "ap-southeast-1"},
+		[]string{
+			"voter_constraints", "ap-southeast-1",
+			"lease_preferences = '[[+region=ap-southeast-1], [+region=eu-west-1]]'",
+		},
 	)
-	// RBR partitions inside the super region.
+	// RBR partitions inside the super region. The secondary region
+	// (eu-west-1) must NOT appear in lease_preferences because no replica
+	// can exist outside the super region (#164422). The exact
+	// lease_preferences assertion ensures only the partition's own region
+	// is listed.
 	for _, region := range []string{"us-east-1", "us-central-1", "us-west-1"} {
 		verifyZoneConfig(
 			fmt.Sprintf(
@@ -383,13 +398,30 @@ func TestSuperRegionConstraintConformance(t *testing.T) {
 			[]string{
 				"voter_constraints", region,
 				"constraints", "us-east-1", "us-central-1", "us-west-1",
+				fmt.Sprintf(
+					"lease_preferences = '[[+region=%s]]'", region),
 			},
 		)
 	}
-	// RBR partition outside any super region.
+	// RBR partition outside any super region. The secondary region
+	// (eu-west-1) correctly appears in lease_preferences here because this
+	// partition is not confined to a super region.
 	verifyZoneConfig(
 		`SHOW ZONE CONFIGURATION FOR PARTITION "ap-southeast-1" OF TABLE testdb.rbr`,
-		[]string{"voter_constraints", "ap-southeast-1"},
+		[]string{
+			"voter_constraints", "ap-southeast-1",
+			"lease_preferences = '[[+region=ap-southeast-1], [+region=eu-west-1]]'",
+		},
+	)
+	// RBR partition for the secondary region itself, outside any super
+	// region. The secondary region is the partition's own region so
+	// lease_preferences list it once.
+	verifyZoneConfig(
+		`SHOW ZONE CONFIGURATION FOR PARTITION "eu-west-1" OF TABLE testdb.rbr`,
+		[]string{
+			"voter_constraints", "eu-west-1",
+			"lease_preferences = '[[+region=eu-west-1]]'",
+		},
 	)
 
 	forceProcess := func() error {

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -350,13 +350,16 @@ func prepareZoneConfigForMultiRegionTable(
 	}
 
 	if regionConfig.HasSecondaryRegion() {
-
 		var newLeasePreferences []zonepb.LeasePreference
 		switch {
 		case table.IsLocalityRegionalByTable():
 			localityConfig := table.TableDesc().LocalityConfig.GetRegionalByTable()
 			if region := localityConfig.Region; region != nil {
-				newLeasePreferences = regions.SynthesizeLeasePreferences(*region, regionConfig.SecondaryRegion())
+				secondaryRegion := regionConfig.SecondaryRegion()
+				if regions.SecondaryRegionOutsideSuperRegion(*region, regionConfig) {
+					secondaryRegion = ""
+				}
+				newLeasePreferences = regions.SynthesizeLeasePreferences(*region, secondaryRegion)
 			} else {
 				newLeasePreferences = regions.SynthesizeLeasePreferences(regionConfig.PrimaryRegion(), regionConfig.SecondaryRegion())
 			}

--- a/pkg/sql/region_util_test.go
+++ b/pkg/sql/region_util_test.go
@@ -2077,6 +2077,101 @@ func TestZoneConfigForMultiRegionPartition(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc:   "3-region super region, zone survival, secondary INSIDE super region",
+			region: "region_a",
+			regionConfig: multiregion.MakeRegionConfig(
+				catpb.RegionNames{"region_a", "region_b", "region_c"},
+				"region_a",
+				descpb.SurvivalGoal_ZONE_FAILURE,
+				descpb.InvalidID,
+				descpb.DataPlacement_DEFAULT,
+				[]descpb.SuperRegion{{
+					SuperRegionName: "sr1",
+					Regions:         []catpb.RegionName{"region_a", "region_b", "region_c"},
+				}},
+				descpb.ZoneConfigExtensions{},
+				multiregion.WithSecondaryRegion("region_b"),
+			),
+			expected: zonepb.ZoneConfig{
+				NumReplicas: proto.Int32(5),
+				NumVoters:   proto.Int32(3),
+				Constraints: []zonepb.ConstraintsConjunction{
+					{NumReplicas: 2, Constraints: []zonepb.Constraint{
+						{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_a"},
+					}},
+					{NumReplicas: 2, Constraints: []zonepb.Constraint{
+						{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_b"},
+					}},
+					{NumReplicas: 1, Constraints: []zonepb.Constraint{
+						{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_c"},
+					}},
+				},
+				NullVoterConstraintsIsEmpty: true,
+				VoterConstraints: []zonepb.ConstraintsConjunction{
+					{Constraints: []zonepb.Constraint{
+						{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_a"},
+					}},
+				},
+				LeasePreferences: []zonepb.LeasePreference{
+					{Constraints: []zonepb.Constraint{
+						{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_a"},
+					}},
+					{Constraints: []zonepb.Constraint{
+						{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_b"},
+					}},
+				},
+			},
+		},
+		{
+			desc:   "3-region super region, region survival, secondary INSIDE super region",
+			region: "region_c",
+			regionConfig: multiregion.MakeRegionConfig(
+				catpb.RegionNames{"region_a", "region_b", "region_c"},
+				"region_a",
+				descpb.SurvivalGoal_REGION_FAILURE,
+				descpb.InvalidID,
+				descpb.DataPlacement_DEFAULT,
+				[]descpb.SuperRegion{{
+					SuperRegionName: "sr1",
+					Regions:         []catpb.RegionName{"region_a", "region_b", "region_c"},
+				}},
+				descpb.ZoneConfigExtensions{},
+				multiregion.WithSecondaryRegion("region_b"),
+			),
+			expected: zonepb.ZoneConfig{
+				NumReplicas: proto.Int32(5),
+				NumVoters:   proto.Int32(5),
+				Constraints: []zonepb.ConstraintsConjunction{
+					{NumReplicas: 2, Constraints: []zonepb.Constraint{
+						{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_a"},
+					}},
+					{NumReplicas: 1, Constraints: []zonepb.Constraint{
+						{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_b"},
+					}},
+					{NumReplicas: 2, Constraints: []zonepb.Constraint{
+						{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_c"},
+					}},
+				},
+				NullVoterConstraintsIsEmpty: true,
+				VoterConstraints: []zonepb.ConstraintsConjunction{
+					{NumReplicas: 2, Constraints: []zonepb.Constraint{
+						{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_c"},
+					}},
+					{NumReplicas: 2, Constraints: []zonepb.Constraint{
+						{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_b"},
+					}},
+				},
+				LeasePreferences: []zonepb.LeasePreference{
+					{Constraints: []zonepb.Constraint{
+						{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_c"},
+					}},
+					{Constraints: []zonepb.Constraint{
+						{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_b"},
+					}},
+				},
+			},
+		},
 	}
 	testCases = append(testCases, superRegionTestCases...)
 

--- a/pkg/sql/regions/region_util.go
+++ b/pkg/sql/regions/region_util.go
@@ -113,9 +113,19 @@ func ZoneConfigForMultiRegionTable(
 		if err != nil {
 			return zonepb.ZoneConfig{}, err
 		}
+		secondaryRegion := regionConfig.SecondaryRegion()
+		if SecondaryRegionOutsideSuperRegion(affinityRegion, regionConfig) {
+			// Remove the secondary region voter constraint; it references a
+			// region outside the super region where no replica can exist.
+			voterConstraints, err = removeSecondaryVoterConstraint(voterConstraints)
+			if err != nil {
+				return zonepb.ZoneConfig{}, err
+			}
+			secondaryRegion = ""
+		}
 		zc.VoterConstraints = voterConstraints
 		zc.NullVoterConstraintsIsEmpty = true
-		zc.LeasePreferences = SynthesizeLeasePreferences(affinityRegion, "" /* secondaryRegion */)
+		zc.LeasePreferences = SynthesizeLeasePreferences(affinityRegion, secondaryRegion)
 		zc.InheritedLeasePreferences = false
 
 		return regionConfig.ExtendZoneConfigWithRegionalIn(zc, affinityRegion)
@@ -163,16 +173,79 @@ func ZoneConfigForMultiRegionPartition(
 		zc.InheritedConstraints = false
 	}
 
+	// For partitions that are confined to a super region, the secondary region
+	// must not appear in voter_constraints or lease_preferences if it lies
+	// outside the super region, because all replicas are confined to the super
+	// region. We clear the secondary region for both.
+	secondaryOutside := SecondaryRegionOutsideSuperRegion(partitionRegion, regionConfig)
 	voterConstraints, err := SynthesizeVoterConstraints(partitionRegion, regionConfig)
 	if err != nil {
 		return zonepb.ZoneConfig{}, err
 	}
+	if secondaryOutside {
+		// Remove the secondary region voter constraint that
+		// SynthesizeVoterConstraints added; it references a region
+		// outside the super region where no replica can exist.
+		voterConstraints, err = removeSecondaryVoterConstraint(voterConstraints)
+		if err != nil {
+			return zonepb.ZoneConfig{}, err
+		}
+	}
 	zc.VoterConstraints = voterConstraints
 	zc.NullVoterConstraintsIsEmpty = true
-	zc.LeasePreferences = SynthesizeLeasePreferences(partitionRegion, regionConfig.SecondaryRegion())
+	secondaryRegion := regionConfig.SecondaryRegion()
+	if secondaryOutside {
+		secondaryRegion = ""
+	}
+	zc.LeasePreferences = SynthesizeLeasePreferences(partitionRegion, secondaryRegion)
 	zc.InheritedLeasePreferences = false
 
 	return regionConfig.ExtendZoneConfigWithRegionalIn(zc, partitionRegion)
+}
+
+// SecondaryRegionOutsideSuperRegion returns true when the given region belongs
+// to a super region and the database's secondary region is set but is NOT a
+// member of that same super region.
+func SecondaryRegionOutsideSuperRegion(
+	region catpb.RegionName, regionConfig multiregion.RegionConfig,
+) bool {
+	if !regionConfig.HasSecondaryRegion() {
+		return false
+	}
+	superRegionMembers, ok := regionConfig.GetSuperRegionRegionsForRegion(region)
+	if !ok {
+		return false
+	}
+	secondary := regionConfig.SecondaryRegion()
+	for _, r := range superRegionMembers {
+		if r == secondary {
+			return false
+		}
+	}
+	return true
+}
+
+// removeSecondaryVoterConstraint strips the secondary-region entry that
+// SynthesizeVoterConstraints appends when a secondary region is configured.
+// This is needed for super-region-confined tables/partitions where the
+// secondary region lies outside the super region and no replica can exist
+// there.
+//
+// SynthesizeVoterConstraints returns at most two elements (one under zone
+// survival, up to two under region survival): the first for the home region,
+// and an optional second for the secondary region. We keep only the first.
+func removeSecondaryVoterConstraint(
+	vc []zonepb.ConstraintsConjunction,
+) ([]zonepb.ConstraintsConjunction, error) {
+	switch len(vc) {
+	case 1:
+		return vc, nil
+	case 2:
+		return vc[:1], nil
+	default:
+		return nil, errors.AssertionFailedf(
+			"expected 1 or 2 voter constraints, got %d", len(vc))
+	}
 }
 
 // IsPlaceholderZoneConfigForMultiRegion returns whether a given zone config


### PR DESCRIPTION
REGIONAL BY ROW partitions and REGIONAL BY TABLE tables inside a super region incorrectly included the database secondary region in their voter_constraints and lease_preferences, even when that secondary region was outside the super region.

This resulted in zone configs referencing a region where no replica could
exist.

Super-region-confined partitions and tables now exclude the secondary region when it is not part of the same super region. Secondary regions within the super region continue to be applied as before.

Informs: #164422
Epic: CRDB-58694

Release note (bug fix): Fixed a bug where REGIONAL BY ROW partitions and REGIONAL BY TABLE tables inside a super region could include a secondary region outside that super region in their zone config, causing voter_constraints and lease_preferences to reference a region where no replicas can exist.