### PR TITLE
release-25.4: roachtest: fix psycopg test by installing python3.10

### DIFF
--- a/pkg/cmd/roachtest/tests/psycopg.go
+++ b/pkg/cmd/roachtest/tests/psycopg.go
@@ -79,7 +79,7 @@ func registerPsycopg(r registry.Registry) {
 		if err := repeatRunE(
 			ctx, t, c, node,
 			"install dependencies",
-			`sudo apt-get -qq install make python3 libpq-dev python3-dev gcc python3-virtualenv python3-setuptools python-setuptools`,
+			`sudo apt-get -qq install make python3.10 libpq-dev python3.10-dev gcc python3-virtualenv python3-setuptools python-setuptools python3.10-distutils`,
 		); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Backport 1/1 commits from #164434 on behalf of @rafiss.

----

The psycopg test was updated to use python3.10 for pip and update-alternatives, but the apt-get install command was not updated to include the python3.10 packages. This caused the test to fail on FIPS images (Ubuntu 20.04) which ship with Python 3.8, not 3.10.

Install python3.10, python3.10-dev, and python3.10-distutils explicitly, matching the pattern used by the asyncpg, django, and sqlalchemy tests.

Resolves: #164150
Resolves: #164086

Release note: None

----

Release justification: Fixes test that fails during init.