### PR TITLE
kvserver: use MVCCBlindPutProto for LastReplicaGCTimestamp

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -1350,13 +1350,13 @@ func splitTriggerHelper(
 
 	// Copy the last replica GC timestamp. This value is unreplicated,
 	// which is why the MVCC stats are set to nil on calls to
-	// MVCCPutProto.
+	// MVCCBlindPutProto.
 	replicaGCTS, err := rec.GetLastReplicaGCTimestamp(ctx)
 	if err != nil {
 		return enginepb.MVCCStats{}, result.Result{}, errors.Wrap(err, "unable to fetch last replica GC timestamp")
 	}
 
-	if err := storage.MVCCPutProto(
+	if err := storage.MVCCBlindPutProto(
 		ctx, spanset.DisableForbiddenSpanAssertions(batch),
 		keys.RangeLastReplicaGCTimestampKey(split.RightDesc.RangeID), hlc.Timestamp{},
 		&replicaGCTS, storage.MVCCWriteOptions{Category: fs.BatchEvalReadCategory}); err != nil {

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1822,7 +1822,7 @@ func (r *Replica) GetLastReplicaGCTimestamp(ctx context.Context) (hlc.Timestamp,
 
 func (r *Replica) setLastReplicaGCTimestamp(ctx context.Context, timestamp hlc.Timestamp) error {
 	key := keys.RangeLastReplicaGCTimestampKey(r.RangeID)
-	return storage.MVCCPutProto(
+	return storage.MVCCBlindPutProto(
 		ctx, r.store.LogEngine(), key, hlc.Timestamp{}, &timestamp, storage.MVCCWriteOptions{})
 }
 

--- a/pkg/kv/kvserver/store_init.go
+++ b/pkg/kv/kvserver/store_init.go
@@ -182,7 +182,7 @@ func WriteInitialClusterData(
 			}
 
 			// Replica GC timestamp.
-			if err := storage.MVCCPutProto(
+			if err := storage.MVCCBlindPutProto(
 				ctx, batch, keys.RangeLastReplicaGCTimestampKey(desc.RangeID),
 				hlc.Timestamp{}, &now, storage.MVCCWriteOptions{},
 			); err != nil {


### PR DESCRIPTION
All writers of `LastReplicaGCTimestamp` key do not track `MVCCStats` because this is an unreplicated key in `LogStorage`. Downgrade the call to `MVCCBlindPutProto` so that these calls can use `storage.Writer` instead of `storage.ReadWriter`.

Epic: none
Release note: none