### PR TITLE
kvstorage: sep engines in WriteInitialClusterData

### DIFF
--- a/pkg/kv/kvserver/kvstorage/initial.go
+++ b/pkg/kv/kvserver/kvstorage/initial.go
@@ -133,8 +133,8 @@ func WriteInitialRangeState(
 		return err
 	}
 
-	// TODO(sep-raft-log): when the log storage is separated, raft state must be
-	// written separately.
+	// TODO(sep-raft-log): when the log storage is separated, write a WAG node
+	// here, for crash recovery.
 	return WriteInitialRaftState(ctx, raftWO, desc.RangeID)
 }
 

--- a/pkg/kv/kvserver/kvstorage/storage.go
+++ b/pkg/kv/kvserver/kvstorage/storage.go
@@ -248,9 +248,9 @@ func (e *Engines) SetStoreID(ctx context.Context, id roachpb.StoreID) error {
 // NewWriteBatch creates a new write batch to storage. If engines are separated,
 // it consists of two batches, one per engine.
 // TODO(sep-raft-log): generalize this so that the LogEngine batch is lazy.
-func (e *Engines) NewWriteBatch() WriteBatch {
+func (e *Engines) NewWriteBatch() Batch[storage.WriteBatch] {
 	if e.Separated() {
-		return WriteBatch{
+		return Batch[storage.WriteBatch]{
 			state:     e.StateEngine().NewWriteBatch(),
 			raft:      e.LogEngine().NewWriteBatch(),
 			separated: true,
@@ -259,37 +259,64 @@ func (e *Engines) NewWriteBatch() WriteBatch {
 	// With a single engine, create one batch, and reference it by both pointers.
 	b := e.Engine().NewWriteBatch()
 	if !spanset.EnableAssertions {
-		return WriteBatch{state: b, raft: b}
+		return Batch[storage.WriteBatch]{state: b, raft: b}
 	}
 	// Additionally, if assertions are enabled, enclose the batch into the
 	// corresponding per-engine wrappers. With EnableAssertions, State/LogEngine
 	// are always wrapped, so we don't use conditional type assertions.
-	type wrapper interface {
-		WrapWriteBatch(wb storage.WriteBatch) storage.WriteBatch
-	}
-	return WriteBatch{
-		state: e.StateEngine().(wrapper).WrapWriteBatch(b),
-		raft:  e.LogEngine().(wrapper).WrapWriteBatch(b),
+	return Batch[storage.WriteBatch]{
+		state: e.StateEngine().(batchWrapper).WrapWriteBatch(b),
+		raft:  e.LogEngine().(batchWrapper).WrapWriteBatch(b),
 	}
 }
 
-// WriteBatch is a write batch to storage which is aware whether the log and
-// state machine engines are separated.
-type WriteBatch struct {
-	state     storage.WriteBatch
+// NewBatch is like NewWriteBatch, but the StateEngine batch is a read-write
+// storage.Batch rather than a write-only storage.WriteBatch.
+func (e *Engines) NewBatch() Batch[storage.Batch] {
+	if e.Separated() {
+		return Batch[storage.Batch]{
+			state:     e.StateEngine().NewBatch(),
+			raft:      e.LogEngine().NewWriteBatch(),
+			separated: true,
+		}
+	}
+	// With a single engine, create one batch, and reference it by both pointers.
+	b := e.Engine().NewBatch()
+	if !spanset.EnableAssertions {
+		return Batch[storage.Batch]{state: b, raft: b}
+	}
+	// Additionally, if assertions are enabled, enclose the batch into the
+	// corresponding per-engine wrappers. With EnableAssertions, State/LogEngine
+	// are always wrapped, so we don't use conditional type assertions.
+	return Batch[storage.Batch]{
+		state: e.StateEngine().(batchWrapper).WrapBatch(b),
+		raft:  e.LogEngine().(batchWrapper).WrapWriteBatch(b),
+	}
+}
+
+// Batch is a write batch to storage which is aware whether the log and state
+// machine engines are separated. It supports any wrapper around
+// storage.WriteBatch, in particular a read-write storage.Batch.
+type Batch[B storage.WriteBatch] struct {
+	state     B
 	raft      storage.WriteBatch
 	separated bool
 }
 
-// Writers returns the state machine and raft engine writer into this batch.
-func (b *WriteBatch) Writers() (StateWO, RaftWO) {
-	return b.state, b.raft
+// State returns the StateEngine batch.
+func (b *Batch[B]) State() B {
+	return b.state
+}
+
+// Raft returns the LogEngine writer.
+func (b *Batch[B]) Raft() RaftWO {
+	return b.raft
 }
 
 // CommitAndSync commits and syncs the batch to storage. When engines are
 // separated, only the LogEngine batch is synced, and the StateEngine part is
 // expected to be replayable from the LogEngine batch.
-func (b *WriteBatch) CommitAndSync() error {
+func (b *Batch[B]) CommitAndSync() error {
 	if !b.separated {
 		return b.state.Commit(true /* sync */)
 	}
@@ -300,7 +327,7 @@ func (b *WriteBatch) CommitAndSync() error {
 }
 
 // Close closes the batch.
-func (b *WriteBatch) Close() {
+func (b *Batch[B]) Close() {
 	b.state.Close()
 	if b.separated {
 		b.raft.Close()
@@ -430,4 +457,11 @@ func validateIsRaftEngineSpan(span spanset.TrickySpan) error {
 	}
 
 	return nil
+}
+
+// batchWrapper is a sub-interface of storage.Engine wrapper in the spanset
+// package used here for engine access assertions.
+type batchWrapper interface {
+	WrapWriteBatch(storage.WriteBatch) storage.WriteBatch
+	WrapBatch(storage.Batch) storage.Batch
 }

--- a/pkg/kv/kvserver/replica_destroy.go
+++ b/pkg/kv/kvserver/replica_destroy.go
@@ -89,7 +89,7 @@ func (r *Replica) destroyRaftMuLocked(ctx context.Context, nextReplicaID roachpb
 	batch := r.store.internalEngines.NewWriteBatch()
 	defer batch.Close()
 
-	stateWO, raftWO := batch.Writers()
+	stateWO, raftWO := kvstorage.StateWO(batch.State()), batch.Raft()
 	if err := kvstorage.DestroyReplica(
 		ctx, kvstorage.ReadWriter{
 			State: kvstorage.State{RO: r.store.StateEngine(), WO: stateWO},

--- a/pkg/kv/kvserver/spanset/engine.go
+++ b/pkg/kv/kvserver/spanset/engine.go
@@ -147,6 +147,20 @@ func (s *spanSetEngine) WrapWriteBatch(wb storage.WriteBatch) storage.WriteBatch
 	}
 }
 
+// WrapBatch associates the given Batch with this Engine, and returns a wrapped
+// Batch. This enables the corresponding assertions, e.g. checking that the
+// batch accesses only the keys allowed by this Engine.
+func (s *spanSetEngine) WrapBatch(b storage.Batch) storage.Batch {
+	return &spanSetBatch{
+		spanSetReader: spanSetReader{r: b, spans: s.spans, spansOnly: true},
+		spanSetWriteBatch: spanSetWriteBatch{
+			spanSetWriter: spanSetWriter{w: b, spans: s.spans, spansOnly: true},
+			wb:            b,
+		},
+		b: b, spans: s.spans, spansOnly: true,
+	}
+}
+
 // Attrs implements the storage.EngineWithoutRW interface.
 func (s *spanSetEngine) Attrs() roachpb.Attributes {
 	return s.e.Attrs()

--- a/pkg/kv/kvserver/store_init.go
+++ b/pkg/kv/kvserver/store_init.go
@@ -153,6 +153,9 @@ func WriteInitialClusterData(
 			ctx, 2, "creating range %d [%s, %s). Initial values: %d",
 			desc.RangeID, desc.StartKey, desc.EndKey, len(rangeInitialValues))
 
+		// TODO(#97616): the ranges are written one by one, so it is possible to end
+		// up with a partially initialized store if there is a crash in the middle.
+		// Write through a single batch, or find another way to make this atomic.
 		err := func() error {
 			batch := eng.NewBatch()
 			defer batch.Close()
@@ -249,6 +252,10 @@ func WriteInitialClusterData(
 			); err != nil {
 				return err
 			}
+
+			// TODO(sep-raft-log): the computed stats much be reflected in the WAG
+			// node written in WriteInitialRangeState, before the write is committed.
+			// Decompose WriteInitialRangeState to make it possible.
 			computedStats, err := rditer.ComputeStatsForRange(
 				ctx, desc, batch.State(), fs.UnknownReadCategory, now.WallTime)
 			if err != nil {

--- a/pkg/kv/kvserver/store_init.go
+++ b/pkg/kv/kvserver/store_init.go
@@ -39,7 +39,7 @@ import (
 // nowNanos: the timestamp at which to write the initial engine data.
 func WriteInitialClusterData(
 	ctx context.Context,
-	eng storage.Engine,
+	eng kvstorage.Engines,
 	initialValues []roachpb.KeyValue,
 	bootstrapVersion roachpb.Version,
 	numStores int,
@@ -168,14 +168,14 @@ func WriteInitialClusterData(
 			// If requested, write an MVCC range tombstone at the bottom of the
 			// keyspace, for performance and correctness testing.
 			if knobs.GlobalMVCCRangeTombstone {
-				if err := writeGlobalMVCCRangeTombstone(ctx, batch, desc, now.Prev()); err != nil {
+				if err := writeGlobalMVCCRangeTombstone(ctx, batch.State(), desc, now.Prev()); err != nil {
 					return err
 				}
 			}
 
 			// Range descriptor.
 			if err := storage.MVCCPutProto(
-				ctx, batch, keys.RangeDescriptorKey(desc.StartKey),
+				ctx, batch.State(), keys.RangeDescriptorKey(desc.StartKey),
 				now, desc, storage.MVCCWriteOptions{},
 			); err != nil {
 				return err
@@ -183,7 +183,7 @@ func WriteInitialClusterData(
 
 			// Replica GC timestamp.
 			if err := storage.MVCCBlindPutProto(
-				ctx, batch, keys.RangeLastReplicaGCTimestampKey(desc.RangeID),
+				ctx, batch.Raft(), keys.RangeLastReplicaGCTimestampKey(desc.RangeID),
 				hlc.Timestamp{}, &now, storage.MVCCWriteOptions{},
 			); err != nil {
 				return err
@@ -197,7 +197,7 @@ func WriteInitialClusterData(
 			// should improve the performance in workloads that cause many range
 			// splits by delaying the consistency checker.
 			if err := storage.MVCCPutProto(
-				ctx, batch, keys.QueueLastProcessedKey(desc.StartKey, "consistencyChecker"),
+				ctx, batch.State(), keys.QueueLastProcessedKey(desc.StartKey, "consistencyChecker"),
 				hlc.Timestamp{}, &now, storage.MVCCWriteOptions{},
 			); err != nil {
 				return err
@@ -210,7 +210,7 @@ func WriteInitialClusterData(
 			// liveness.
 			metaKey := keys.RangeMetaKey(endKey)
 			if err := storage.MVCCPutProto(
-				ctx, batch, metaKey.AsRawKey(),
+				ctx, batch.State(), metaKey.AsRawKey(),
 				now, desc, storage.MVCCWriteOptions{Stats: meta2RangeMS},
 			); err != nil {
 				return err
@@ -226,7 +226,7 @@ func WriteInitialClusterData(
 				// The range descriptor is stored in meta1.
 				meta1Key := keys.RangeMetaKey(keys.RangeMetaKey(roachpb.RKeyMax)) // range addressing for meta1
 				if err := storage.MVCCPutProto(
-					ctx, batch, meta1Key.AsRawKey(), now, desc, storage.MVCCWriteOptions{},
+					ctx, batch.State(), meta1Key.AsRawKey(), now, desc, storage.MVCCWriteOptions{},
 				); err != nil {
 					return err
 				}
@@ -237,29 +237,30 @@ func WriteInitialClusterData(
 				// Initialize the checksums.
 				kv.Value.InitChecksum(kv.Key)
 				if _, err := storage.MVCCPut(
-					ctx, batch, kv.Key, now, kv.Value, storage.MVCCWriteOptions{},
+					ctx, batch.State(), kv.Key, now, kv.Value, storage.MVCCWriteOptions{},
 				); err != nil {
 					return err
 				}
 			}
 
 			if err := kvstorage.WriteInitialRangeState(
-				ctx, batch, batch,
+				ctx, batch.State(), batch.Raft(),
 				*desc, firstReplicaID, initialReplicaVersion,
 			); err != nil {
 				return err
 			}
-			computedStats, err := rditer.ComputeStatsForRange(ctx, desc, batch, fs.UnknownReadCategory, now.WallTime)
+			computedStats, err := rditer.ComputeStatsForRange(
+				ctx, desc, batch.State(), fs.UnknownReadCategory, now.WallTime)
 			if err != nil {
 				return err
 			}
 
 			sl := kvstorage.MakeStateLoader(rangeID)
-			if err := sl.SetMVCCStats(ctx, batch, &computedStats); err != nil {
+			if err := sl.SetMVCCStats(ctx, batch.State(), &computedStats); err != nil {
 				return err
 			}
 
-			return batch.Commit(true /* sync */)
+			return batch.CommitAndSync()
 		}()
 		if err != nil {
 			return err

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -308,7 +308,7 @@ func createTestStoreWithoutStart(
 
 	kvs, splits := opts.splits()
 	if err := WriteInitialClusterData(
-		ctx, eng.TODOEngine(), kvs /* initialValues */, cv.Version,
+		ctx, eng, kvs /* initialValues */, cv.Version,
 		1 /* numStores */, splits, cfg.Clock.PhysicalNow(), cfg.TestingKnobs,
 	); err != nil {
 		t.Fatal(err)

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -544,7 +544,7 @@ func bootstrapCluster(
 				storeKnobs = *kn
 			}
 			if err := kvserver.WriteInitialClusterData(
-				ctx, eng.TODOEngine(), initialValues,
+				ctx, eng, initialValues,
 				bootstrapVersion.Version, len(engines), splits,
 				timeutil.Now().UnixNano(), storeKnobs,
 			); err != nil {

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -297,7 +297,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, initFactory InitFactoryFn) {
 
 	if err := kvserver.WriteInitialClusterData(
 		ctx,
-		ltc.Eng.TODOEngine(),
+		ltc.Eng,
 		initialValues,
 		clusterversion.Latest.Version(),
 		1, /* numStores */


### PR DESCRIPTION
This PR changes `WriteInitialClusterData` to use `Engines.NewBatch` which transparently handles separated engines.

Part of #97627