### PR TITLE
roachtest: enable VIR for kv/long-running-writer/nodes=4

### DIFF
--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -498,6 +498,12 @@ func registerKVLongRunningTxn(r registry.Registry) {
 			`); err != nil {
 				t.Fatal(err)
 			}
+			// Enable virtual intent resolution.
+			if _, err := conn.Exec(`
+				SET CLUSTER SETTING kv.concurrency.virtual_intent_resolution.enabled = true;
+			`); err != nil {
+				t.Fatal(err)
+			}
 
 			t.Status("running workload")
 			const duration = time.Hour


### PR DESCRIPTION
This test sets up a perfect scenario to highlight the benefits of virtualized intent resolution. While VIR is still off by default, enabling it for this test would let us see a clear increase in throughput.

Part of: #158348

Release note: None