### PR TITLE
schemachanger: fix flaky DML injection test for drop column with NOT NULL

### DIFF
--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -100,20 +100,20 @@ var LeaseMonitorRangeFeedResetTime = settings.RegisterDurationSetting(
 	time.Minute*25,
 )
 
-// diableLeasedDescriptorsByDefaultThreshold any value above this is considered
+// disableLeasedDescriptorsByDefaultThreshold any value above this is considered
 // disabled, making it 10% odds of disabled.
-const diableLeasedDescriptorsByDefaultThreshold = 90
+const disableLeasedDescriptorsByDefaultThreshold = 90
 
 // disableLeasedDescriptorThresholdDefault, by default, leased descriptors
 // are enabled.
 const disableLeasedDescriptorThresholdDefault = 0
 
-// UseLeasedDescriptorsForCatalogDefault determines if leased descrptor are used for catalog
+// UseLeasedDescriptorsForCatalogDefault determines if leased descriptors are used for catalog
 // views.
 var UseLeasedDescriptorsForCatalogDefault = metamorphic.ConstantWithTestRange("disable-catalog-leased-descriptors-threshold",
 	disableLeasedDescriptorThresholdDefault,
 	0,
-	100) < diableLeasedDescriptorsByDefaultThreshold
+	100) < disableLeasedDescriptorsByDefaultThreshold
 
 var WaitForInitialVersion = settings.RegisterBoolSetting(settings.ApplicationLevel,
 	"sql.catalog.descriptor_wait_for_initial_version.enabled",

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_with_null_constraint/drop_column_with_null_constraint.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_with_null_constraint/drop_column_with_null_constraint.definition
@@ -8,12 +8,12 @@ create table t (i int primary key, j int not null);
 stage-exec phase=PostCommitPhase stage=:
 INSERT INTO t (i) VALUES($stageKey);
 ----
-pq: failed to satisfy CHECK constraint \(j IS NOT NULL\)
+pq: (failed to satisfy CHECK constraint \(j IS NOT NULL\)|null value in column "j" violates not-null constraint)
 
 stage-exec phase=PostCommitNonRevertiblePhase stage=1
 INSERT INTO t (i) VALUES($stageKey);
 ----
-pq: failed to satisfy CHECK constraint \(j IS NOT NULL\)
+pq: (failed to satisfy CHECK constraint \(j IS NOT NULL\)|null value in column "j" violates not-null constraint)
 
 
 stage-exec phase=PostCommitNonRevertiblePhase stage=2:


### PR DESCRIPTION
## Summary

- Fix flaky `TestExecuteWithDMLInjection_drop_column_with_null_constraint` by accepting both NOT NULL error message variants in the expected error regex.
- When metamorphic locked leasing is enabled (~90% of test runs), the DML injection may see a stale descriptor where the native NOT NULL constraint hasn't yet been converted to a synthetic CHECK constraint, producing a different but semantically equivalent error message.
- Fix typos in `pkg/sql/catalog/lease/lease.go`: `diable` → `disable` in variable name, `descrptor` → `descriptors` in comment.

Fixes: #160985

Release note: None