### PR TITLE
logictest: improve scalar replacement and enable local-prepared

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -1,4 +1,3 @@
-# LogicTest: !local-prepared
 # We've seen this test hit a timeout in fakedist configs under race.
 skip under race
 

--- a/pkg/sql/logictest/testdata/logic_test/apply_join
+++ b/pkg/sql/logictest/testdata/logic_test/apply_join
@@ -1,4 +1,3 @@
-# LogicTest: !local-prepared
 statement ok
 CREATE TABLE t (k INT PRIMARY KEY, str STRING);
 CREATE TABLE u (l INT PRIMARY KEY, str2 STRING);

--- a/pkg/sql/logictest/testdata/logic_test/citext
+++ b/pkg/sql/logictest/testdata/logic_test/citext
@@ -1,4 +1,3 @@
-# LogicTest: !local-prepared
 
 query T
 SELECT pg_typeof(CITEXT 'Foo')

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring
@@ -1,4 +1,3 @@
-# LogicTest: !local-prepared
 statement error pq: invalid locale bad_locale: language: subtag "locale" is well-formed but unknown
 SELECT 'a' COLLATE bad_locale
 

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_normalization
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_normalization
@@ -1,4 +1,3 @@
-# LogicTest: !local-prepared
 statement ok
 CREATE TABLE t (
   a STRING COLLATE fr PRIMARY KEY

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -1,4 +1,4 @@
-# LogicTest: default-configs 3node-tenant !local-prepared local-dist-merge-backfill-declarative-schema-changer
+# LogicTest: default-configs 3node-tenant local-dist-merge-backfill-declarative-schema-changer
 
 # Note: this file does not contain tests for virtual computed columns; those
 # are in a separate test file.

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -1,4 +1,4 @@
-# LogicTest: !weak-iso-level-configs !local-prepared
+# LogicTest: !weak-iso-level-configs
 # This test is skipped under READ COMMITTED and REPEATABLE READ, since it
 # asserts on the NOTICE output, and weak isolation level schema changes always
 # send out extra notices.

--- a/pkg/sql/logictest/testdata/logic_test/cursor
+++ b/pkg/sql/logictest/testdata/logic_test/cursor
@@ -1,4 +1,3 @@
-# LogicTest: !local-prepared
 statement ok
 SET autocommit_before_ddl = false
 

--- a/pkg/sql/logictest/testdata/logic_test/custom_escape_character
+++ b/pkg/sql/logictest/testdata/logic_test/custom_escape_character
@@ -1,4 +1,3 @@
-# LogicTest: !local-prepared
 query B
 SELECT '%' LIKE 't%' ESCAPE CASE WHEN (SELECT '-A' SIMILAR TO '--A' ESCAPE '-') THEN 't' ELSE 'f' END
 ----

--- a/pkg/sql/logictest/testdata/logic_test/decimal
+++ b/pkg/sql/logictest/testdata/logic_test/decimal
@@ -1,4 +1,3 @@
-# LogicTest: !local-prepared
 
 # The following tests have results equivalent to Postgres (differences
 # in string representation and number of decimals returned, but otherwise

--- a/pkg/sql/logictest/testdata/logic_test/inverted_filter_geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_filter_geospatial
@@ -1,4 +1,3 @@
-# LogicTest: !local-prepared
 # Test cases for using invertedFilterer on an inverted geospatial index.
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/jsonb_path_exists
+++ b/pkg/sql/logictest/testdata/logic_test/jsonb_path_exists
@@ -1,4 +1,3 @@
-# LogicTest: !local-prepared
 query B
 SELECT jsonb_path_exists('{}', '$');
 ----

--- a/pkg/sql/logictest/testdata/logic_test/jsonb_path_query_array
+++ b/pkg/sql/logictest/testdata/logic_test/jsonb_path_query_array
@@ -1,4 +1,3 @@
-# LogicTest: !local-prepared
 query T
 SELECT jsonb_path_query_array('{}', '$')
 ----

--- a/pkg/sql/logictest/testdata/logic_test/jsonb_path_query_first
+++ b/pkg/sql/logictest/testdata/logic_test/jsonb_path_query_first
@@ -1,4 +1,3 @@
-# LogicTest: !local-prepared
 query T
 SELECT jsonb_path_query_first('[1, 2, 3]', '$[*]');
 ----

--- a/pkg/sql/logictest/testdata/logic_test/select_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_index
@@ -1,4 +1,3 @@
-# LogicTest: !local-prepared
 
 statement ok
 CREATE TABLE t (

--- a/pkg/sql/logictest/testdata/logic_test/set_local
+++ b/pkg/sql/logictest/testdata/logic_test/set_local
@@ -1,4 +1,3 @@
-# LogicTest: !local-prepared
 
 statement ok
 CREATE TABLE tbl (

--- a/pkg/sql/logictest/testdata/logic_test/udf_observability
+++ b/pkg/sql/logictest/testdata/logic_test/udf_observability
@@ -1,4 +1,3 @@
-# LogicTest: !local-prepared
 subtest event_logging
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/udf_oid_ref
+++ b/pkg/sql/logictest/testdata/logic_test/udf_oid_ref
@@ -1,4 +1,3 @@
-# LogicTest: !local-prepared
 # 1074 is the OID of builtin function "string_to_array" with signature
 # "string_to_array(str: string, delimiter: string) -> string[]".
 query T

--- a/pkg/sql/logictest/testdata/logic_test/where
+++ b/pkg/sql/logictest/testdata/logic_test/where
@@ -1,4 +1,3 @@
-# LogicTest: !local-prepared
 statement ok
 CREATE TABLE kv (
   k INT PRIMARY KEY,

--- a/pkg/sql/logictest/tests/local-prepared/generated_test.go
+++ b/pkg/sql/logictest/tests/local-prepared/generated_test.go
@@ -150,6 +150,13 @@ func TestLogic_alter_default_privileges_with_grant_option(
 	runLogicTest(t, "alter_default_privileges_with_grant_option")
 }
 
+func TestLogic_alter_primary_key(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "alter_primary_key")
+}
+
 func TestLogic_alter_role(
 	t *testing.T,
 ) {
@@ -220,6 +227,13 @@ func TestLogic_and_or(
 	runLogicTest(t, "and_or")
 }
 
+func TestLogic_apply_join(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "apply_join")
+}
+
 func TestLogic_asyncpg(
 	t *testing.T,
 ) {
@@ -283,6 +297,20 @@ func TestLogic_check_constraints(
 	runLogicTest(t, "check_constraints")
 }
 
+func TestLogic_citext(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "citext")
+}
+
+func TestLogic_collatedstring(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "collatedstring")
+}
+
 func TestLogic_collatedstring_constraint(
 	t *testing.T,
 ) {
@@ -302,6 +330,13 @@ func TestLogic_collatedstring_index2(
 ) {
 	defer leaktest.AfterTest(t)()
 	runLogicTest(t, "collatedstring_index2")
+}
+
+func TestLogic_collatedstring_normalization(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "collatedstring_normalization")
 }
 
 func TestLogic_collatedstring_nullinindex(
@@ -332,6 +367,13 @@ func TestLogic_composite_types(
 	runLogicTest(t, "composite_types")
 }
 
+func TestLogic_computed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "computed")
+}
+
 func TestLogic_conditional(
 	t *testing.T,
 ) {
@@ -360,11 +402,32 @@ func TestLogic_crdb_internal_default_privileges(
 	runLogicTest(t, "crdb_internal_default_privileges")
 }
 
+func TestLogic_create_statements(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "create_statements")
+}
+
 func TestLogic_cross_join(
 	t *testing.T,
 ) {
 	defer leaktest.AfterTest(t)()
 	runLogicTest(t, "cross_join")
+}
+
+func TestLogic_cursor(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "cursor")
+}
+
+func TestLogic_custom_escape_character(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "custom_escape_character")
 }
 
 func TestLogic_dangerous_statements(
@@ -379,6 +442,13 @@ func TestLogic_database(
 ) {
 	defer leaktest.AfterTest(t)()
 	runLogicTest(t, "database")
+}
+
+func TestLogic_decimal(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "decimal")
 }
 
 func TestLogic_default(
@@ -766,6 +836,13 @@ func TestLogic_internal_executor(
 	runLogicTest(t, "internal_executor")
 }
 
+func TestLogic_inverted_filter_geospatial(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "inverted_filter_geospatial")
+}
+
 func TestLogic_join(
 	t *testing.T,
 ) {
@@ -773,11 +850,32 @@ func TestLogic_join(
 	runLogicTest(t, "join")
 }
 
+func TestLogic_jsonb_path_exists(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_exists")
+}
+
 func TestLogic_jsonb_path_match(
 	t *testing.T,
 ) {
 	defer leaktest.AfterTest(t)()
 	runLogicTest(t, "jsonb_path_match")
+}
+
+func TestLogic_jsonb_path_query_array(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_query_array")
+}
+
+func TestLogic_jsonb_path_query_first(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_query_first")
 }
 
 func TestLogic_kv_builtin_functions(
@@ -1179,6 +1277,13 @@ func TestLogic_secondary_index_column_families(
 	runLogicTest(t, "secondary_index_column_families")
 }
 
+func TestLogic_select_index(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "select_index")
+}
+
 func TestLogic_select_index_flags(
 	t *testing.T,
 ) {
@@ -1226,6 +1331,13 @@ func TestLogic_serializable_eager_restart(
 ) {
 	defer leaktest.AfterTest(t)()
 	runLogicTest(t, "serializable_eager_restart")
+}
+
+func TestLogic_set_local(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "set_local")
 }
 
 func TestLogic_set_schema(
@@ -1585,6 +1697,20 @@ func TestLogic_udf_insert(
 	runLogicTest(t, "udf_insert")
 }
 
+func TestLogic_udf_observability(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_observability")
+}
+
+func TestLogic_udf_oid_ref(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_oid_ref")
+}
+
 func TestLogic_udf_options(
 	t *testing.T,
 ) {
@@ -1765,6 +1891,13 @@ func TestLogic_void(
 ) {
 	defer leaktest.AfterTest(t)()
 	runLogicTest(t, "void")
+}
+
+func TestLogic_where(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "where")
 }
 
 func TestLogic_with(

--- a/pkg/sql/sem/tree/replace_scalars.go
+++ b/pkg/sql/sem/tree/replace_scalars.go
@@ -5,6 +5,8 @@
 
 package tree
 
+import "github.com/cockroachdb/cockroach/pkg/sql/types"
+
 // TestingReplaceScalarsWithPlaceholders traverses a statement, replacing
 // scalars with placeholders. It returns the new statement and the list of
 // replaced scalars in order.
@@ -17,31 +19,37 @@ func TestingReplaceScalarsWithPlaceholders(s Statement) (Statement, Exprs) {
 
 // scalarReplacer replaces scalar constants with placeholders. It implements
 // ExtendedVisitor so that WalkStmt also walks into table expressions, join
-// conditions, and statement nodes. The VisitStatementPre method collects bare
-// integer literals used as column ordinal references (in ORDER BY, GROUP BY,
-// and DISTINCT ON) so that VisitPre can skip replacing them.
+// conditions, and statement nodes. The VisitStatementPre method collects
+// constant literals used in ORDER BY, GROUP BY, and DISTINCT ON positions
+// so that VisitPre can skip replacing them. This is necessary because
+// integer constants are interpreted as column ordinals, and non-integer
+// constants produce specific error messages that tests may expect.
 type scalarReplacer struct {
 	scalars Exprs
 	// skipExprs tracks specific AST nodes (by pointer identity) that should
-	// not be replaced with placeholders. These are bare integer literals used
-	// as column ordinal references in ORDER BY, GROUP BY, and DISTINCT ON
-	// clauses. Because the map keys are pointers to the original AST nodes,
-	// other NumVal nodes with the same value in different parts of the AST
-	// (e.g. SELECT 1 FROM t ORDER BY 1) are not affected.
+	// not be replaced with placeholders. These are constant literals in
+	// ORDER BY, GROUP BY, and DISTINCT ON positions. Because the map keys
+	// are pointers to the original AST nodes, other nodes with the same
+	// value in different parts of the AST (e.g. SELECT 1 FROM t ORDER BY 1)
+	// are not affected.
 	skipExprs map[Expr]struct{}
 }
 
 var _ ExtendedVisitor = &scalarReplacer{}
 
-// skipOrdinal adds expr to the skip set if it is a bare integer NumVal,
-// matching the optbuilder's colIndex detection logic.
+// skipOrdinal adds expr to the skip set if it is a constant (NumVal,
+// StrVal, or other Constant/Datum). Integer constants in ORDER BY,
+// GROUP BY, and DISTINCT ON are interpreted as column ordinals, and
+// non-integer constants produce specific error messages — both cases
+// require the original literal to be preserved.
 func (s *scalarReplacer) skipOrdinal(expr Expr) {
 	expr = StripParens(expr)
-	if n, ok := expr.(*NumVal); ok && n.ShouldBeInt64() {
+	switch t := expr.(type) {
+	case Constant, Datum:
 		if s.skipExprs == nil {
 			s.skipExprs = make(map[Expr]struct{})
 		}
-		s.skipExprs[n] = struct{}{}
+		s.skipExprs[t] = struct{}{}
 	}
 }
 
@@ -51,6 +59,23 @@ func (s *scalarReplacer) VisitPre(expr Expr) (recurse bool, newExpr Expr) {
 		// Don't try to substitute NULL with placeholders, because Go's database/sql
 		// needs to know the type of the NULL in order to send it properly.
 		return false, expr
+	case *NumVal:
+		if _, skip := s.skipExprs[t]; skip {
+			return false, expr
+		}
+		s.scalars = append(s.scalars, t)
+		placeholder := &Placeholder{Idx: PlaceholderIdx(len(s.scalars) - 1)}
+		if t.ShouldBeInt64() {
+			// Integer literals are left as bare placeholders so their type is
+			// inferred from context. This preserves correct behavior for integer
+			// division, LIMIT/OFFSET, and other contexts where the type of the
+			// literal matters (e.g. pow(decimal, $1) infers $1 as decimal).
+			return false, placeholder
+		}
+		// Fractional literals are cast to DECIMAL to prevent incorrect type
+		// inference from context (e.g. "4.0" being inferred as INT and failing
+		// to parse).
+		return false, &CastExpr{Expr: placeholder, Type: types.Decimal, SyntaxMode: CastExplicit}
 	case Constant, Datum:
 		if _, skip := s.skipExprs[t]; skip {
 			return false, expr

--- a/pkg/sql/sem/tree/replace_scalars_test.go
+++ b/pkg/sql/sem/tree/replace_scalars_test.go
@@ -15,16 +15,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestReplaceScalarsSkipsOrdinals(t *testing.T) {
+func TestReplaceScalarsWithPlaceholders(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
 	testCases := []struct {
-		name string
-		sql  string
-		// expected is the SQL after scalar replacement. Column ordinals in
-		// ORDER BY, GROUP BY, and DISTINCT ON should be preserved, while
-		// other constants should be replaced with placeholders.
+		name     string
+		sql      string
 		expected string
 	}{{
 		name:     "order_by_ordinal_with_select_constant",
@@ -50,6 +47,50 @@ func TestReplaceScalarsSkipsOrdinals(t *testing.T) {
 		name:     "group_by_and_order_by_ordinals",
 		sql:      "SELECT x, count(y) FROM t WHERE x > 5 GROUP BY 1 ORDER BY 1",
 		expected: "SELECT x, count(y) FROM t WHERE x > $1 GROUP BY 1 ORDER BY 1",
+	}, {
+		name:     "fractional_literal_cast_decimal",
+		sql:      "SELECT x FROM t WHERE x < 4.0",
+		expected: "SELECT x FROM t WHERE x < CAST($1 AS DECIMAL)",
+	}, {
+		name:     "integer_literal_bare_placeholder",
+		sql:      "SELECT x FROM t WHERE x < 4",
+		expected: "SELECT x FROM t WHERE x < $1",
+	}, {
+		name:     "limit_bare_placeholder",
+		sql:      "SELECT x FROM t LIMIT 10",
+		expected: "SELECT x FROM t LIMIT $1",
+	}, {
+		name:     "offset_bare_placeholder",
+		sql:      "SELECT x FROM t OFFSET 5",
+		expected: "SELECT x FROM t OFFSET $1",
+	}, {
+		name:     "limit_and_offset_bare_placeholder",
+		sql:      "SELECT x FROM t LIMIT 10 OFFSET 5",
+		expected: "SELECT x FROM t LIMIT $2 OFFSET $1",
+	}, {
+		name:     "limit_with_where_int_constant",
+		sql:      "SELECT x FROM t WHERE x > 5 LIMIT 10",
+		expected: "SELECT x FROM t WHERE x > $1 LIMIT $2",
+	}, {
+		name:     "string_literal_bare_placeholder",
+		sql:      "SELECT x FROM t WHERE x = 'hello'",
+		expected: "SELECT x FROM t WHERE x = $1",
+	}, {
+		name:     "order_by_fractional_not_replaced",
+		sql:      "SELECT * FROM t ORDER BY 2.5",
+		expected: "SELECT * FROM t ORDER BY 2.5",
+	}, {
+		name:     "order_by_string_not_replaced",
+		sql:      "SELECT * FROM t ORDER BY 'a'",
+		expected: "SELECT * FROM t ORDER BY 'a'",
+	}, {
+		name:     "bool_datum_replaced_in_where",
+		sql:      "SELECT x FROM t WHERE true",
+		expected: "SELECT x FROM t WHERE $1",
+	}, {
+		name:     "order_by_bool_datum_not_replaced",
+		sql:      "SELECT * FROM t ORDER BY true",
+		expected: "SELECT * FROM t ORDER BY true",
 	}}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Improve `TestingReplaceScalarsWithPlaceholders` to handle numeric literals
more correctly: integer `NumVal`s are left as bare placeholders (type inferred
from context), while fractional `NumVal`s are cast to `DECIMAL`. String literals
and other constants also use bare placeholders. This approach preserves
correct semantics for integer division, `LIMIT`/`OFFSET`, and other contexts
where the type of the literal matters.

Additionally, skip replacing all constants in `ORDER BY`, `GROUP BY`, and
`DISTINCT ON` positions (not just integer ordinals). Non-integer constants
like `2.5` or `'a'` in these positions produce specific error messages that
must be preserved.

This enables the `local-prepared` config on 19 additional logictest files:
alter_primary_key, apply_join, citext, collatedstring,
collatedstring_normalization, computed, create_statements, cursor,
custom_escape_character, decimal, inverted_filter_geospatial,
jsonb_path_exists, jsonb_path_query_array, jsonb_path_query_first,
select_index, set_local, udf_observability, udf_oid_ref, where.

Informs: #152139