### PR TITLE
dev-inf: fix pr-autosolve-comments workflow for fork PRs

### DIFF
--- a/.github/workflows/pr-autosolve-comments.yml
+++ b/.github/workflows/pr-autosolve-comments.yml
@@ -482,6 +482,18 @@ Co-Authored-By: Claude <noreply@anthropic.com>"
           } > "$COMMENT_FILE"
           gh pr comment "$PR_NUMBER" --body-file "$COMMENT_FILE"
 
+      - name: Re-request review from commenter
+        if: steps.commit.outputs.pushed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.context.outputs.pr_number }}
+          REVIEWER: ${{ steps.context.outputs.actor }}
+        run: |
+          # Re-request review so the reviewer is notified that their feedback was addressed
+          gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/requested_reviewers" \
+            -f "reviewers[]=${REVIEWER}" 2>/dev/null || \
+            echo "::warning::Could not re-request review from ${REVIEWER}"
+
       - name: Post no-changes comment
         if: |
           steps.claude_result.outputs.changes_status == 'SUCCESS' &&

--- a/.github/workflows/pr-autosolve-comments.yml
+++ b/.github/workflows/pr-autosolve-comments.yml
@@ -318,9 +318,14 @@ jobs:
 
             Provide a concise summary of changes made to address each comment.
 
-            **OUTPUT REQUIREMENT**: End your response with a single line containing only:
-            - `CHANGES_RESULT - SUCCESS` if you successfully addressed the feedback (with or without code changes)
-            - `CHANGES_RESULT - FAILED` if you were unable to address the feedback
+            CRITICAL - You MUST end your response with EXACTLY one of these two lines:
+            CHANGES_RESULT - SUCCESS
+            CHANGES_RESULT - FAILED
+
+            Use SUCCESS if you addressed the feedback (with or without code changes).
+            Use FAILED only if you were unable to address the feedback.
+            This line MUST be the very last line of your response. Do NOT omit it.
+            The automation pipeline depends on this marker to proceed.
             </task>
 
       - name: Extract Claude Result


### PR DESCRIPTION
This PR contains two fixes for the pr-autosolve-comments workflow:

- **strengthen CHANGES_RESULT marker prompt**: Claude was completing work
  successfully but omitting the required CHANGES_RESULT marker, causing
  the pipeline to treat success as failure and skip the commit/push step.

- **re-request review after addressing comments**: After the autosolve bot
  pushes changes that address review feedback, re-request review from
  the commenter so they are notified and the PR review state is refreshed.

Epic: none
Release note: None