### PR TITLE
mmaprototype: add MMA investigator Claude Code skill

### DIFF
--- a/pkg/kv/kvserver/allocator/mmaprototype/.claude/skills/mma-investigator/DATADOG_QUERIES.md
+++ b/pkg/kv/kvserver/allocator/mmaprototype/.claude/skills/mma-investigator/DATADOG_QUERIES.md
@@ -1,0 +1,336 @@
+# Datadog Query Templates for MMA Investigation
+
+Pre-built query templates for investigating MMA behavior. Replace `{cluster}`
+with the actual cluster name/tag and adjust time ranges as needed.
+
+For guidance on Datadog MCP tools vs pup CLI, Flex tier usage, and tool
+selection, use the built-in `datadog` skill.
+
+**Important:** All CockroachDB metrics in Datadog use the `cockroachdb.`
+prefix (e.g. `cockroachdb.mma.store.cpu.utilization`).
+
+## Reference Dashboard
+
+The team uses the **MMA Enriched** dashboard to monitor MMA behavior:
+
+- **Dashboard ID:** `a7p-9t8-pyf`
+- **Template variables:** `cluster`, `node_id`, `store`, `upload_id`
+- **Link template:**
+  ```
+  https://us5.datadoghq.com/dashboard/a7p-9t8-pyf/mma-enriched?tpl_var_cluster%5B0%5D={cluster}&from_ts={from_ms}&to_ts={to_ms}&live=false
+  ```
+
+When presenting findings, always link to this dashboard filtered to the
+cluster and time window under investigation.
+
+## Metric Queries
+
+Use the Datadog MCP `get_datadog_metric` tool for timeseries data. All metric
+queries support `from`/`to` parameters for time scoping.
+
+### 1. Resource Balance Across Stores (Start Here)
+
+These are the primary metrics for assessing cluster balance — the same metrics
+used in the MMA Enriched dashboard.
+
+**CPU balance:**
+```
+# CPU load per node (nanos/sec of CPU attributed to KV work)
+avg:cockroachdb.rebalancing.cpunanospersecond{cluster:{cluster}} by {node_id}
+
+# System CPU utilization per node (normalized %)
+avg:cockroachdb.sys.cpu.combined.percent.normalized{cluster:{cluster}} by {node_id}
+
+# System CPU per store (weighted, used in dashboard)
+sum:cockroachdb.sys.cpu.combined.percent.normalized{cluster:{cluster}} by {node_id,store}.weighted()
+
+# MMA's view of CPU utilization per store
+avg:cockroachdb.mma.store.cpu.utilization{cluster:{cluster}} by {store}
+
+# Per-replica CPU distribution (p90, p95, p99 — identifies hot replicas)
+p90:cockroachdb.rebalancing.replicas.cpunanospersecond{cluster:{cluster}} by {instance}
+p99:cockroachdb.rebalancing.replicas.cpunanospersecond{cluster:{cluster}} by {instance}
+
+# Cluster-wide CPU mean (single line for reference)
+avg:cockroachdb.rebalancing.cpunanospersecond{cluster:{cluster}} by {cluster}
+```
+
+**Write bandwidth balance:**
+```
+# Write bandwidth per node/store (weighted — what MMA sees)
+sum:cockroachdb.rebalancing.writebytespersecond{cluster:{cluster}} by {node_id,store}.weighted()
+
+# Write bandwidth per node (aggregate view)
+sum:cockroachdb.rebalancing.writebytespersecond{cluster:{cluster}} by {node_id}.weighted()
+
+# Host-level disk write bytes (physical I/O, includes write amp)
+avg:cockroachdb.sys.host.disk.write.bytes{cluster:{cluster}} by {node_id}.as_rate()
+
+# Storage engine disk writes per store (physical I/O by store)
+sum:cockroachdb.storage.disk.write.bytes{cluster:{cluster}} by {node_id,store}.as_rate()
+```
+
+**Disk balance:**
+```
+# Disk capacity used per node
+avg:cockroachdb.capacity.used{cluster:{cluster}} by {node_id}
+
+# Disk capacity available per node
+avg:cockroachdb.capacity.available{cluster:{cluster}} by {node_id}
+
+# Disk capacity available per store
+avg:cockroachdb.capacity.available{cluster:{cluster}} by {store}
+
+# Total disk capacity per node
+avg:cockroachdb.capacity.total{cluster:{cluster}} by {node_id}
+```
+
+**Replica and lease distribution:**
+```
+# Replica count per store
+sum:cockroachdb.replicas.total{cluster:{cluster}} by {instance}
+
+# Leaseholder count per store
+sum:cockroachdb.replicas.leaseholders{cluster:{cluster}} by {instance}
+
+# Leaseholder count per node
+avg:cockroachdb.replicas.leaseholders{cluster:{cluster}} by {node_id}
+
+# Leader count per node
+avg:cockroachdb.replicas.leaders{cluster:{cluster}} by {node_id}
+```
+
+**Query load:**
+```
+# QPS per node
+avg:cockroachdb.rebalancing.queriespersecond{cluster:{cluster}} by {node_id}
+
+# Cluster-wide QPS mean
+avg:cockroachdb.rebalancing.queriespersecond{cluster:{cluster}} by {cluster}
+
+# Read bandwidth per node
+avg:cockroachdb.rebalancing.readbytespersecond{cluster:{cluster}} by {node_id}
+```
+
+### 2. MMA Rebalancing Activity
+
+**MMA-initiated operations:**
+```
+# Replica move outcomes
+sum:cockroachdb.mma.change.rebalance.replica.success{cluster:{cluster}} by {node_id,store}.as_rate()
+sum:cockroachdb.mma.change.rebalance.replica.failure{cluster:{cluster}} by {node_id,store}.as_rate()
+
+# Lease transfer outcomes
+sum:cockroachdb.mma.change.rebalance.lease.success{cluster:{cluster}} by {node_id,store}.as_rate()
+sum:cockroachdb.mma.change.rebalance.lease.failure{cluster:{cluster}} by {node_id,store}.as_rate()
+```
+
+**External (non-MMA) operations registered with MMA:**
+```
+sum:cockroachdb.mma.change.external.replica.success{cluster:{cluster}} by {node_id,store}.as_rate()
+sum:cockroachdb.mma.change.external.replica.failure{cluster:{cluster}} by {node_id,store}.as_rate()
+sum:cockroachdb.mma.change.external.lease.success{cluster:{cluster}} by {node_id,store}.as_rate()
+sum:cockroachdb.mma.change.external.lease.failure{cluster:{cluster}} by {node_id,store}.as_rate()
+```
+
+**Overloaded store tracking:**
+```
+# By duration bucket — indicates how long stores stay overloaded
+sum:cockroachdb.mma.overloaded_store.lease_grace.success{cluster:{cluster}} by {node_id,store}
+sum:cockroachdb.mma.overloaded_store.lease_grace.failure{cluster:{cluster}} by {node_id,store}
+sum:cockroachdb.mma.overloaded_store.short_dur.success{cluster:{cluster}} by {node_id,store}
+sum:cockroachdb.mma.overloaded_store.short_dur.failure{cluster:{cluster}} by {node_id,store}
+sum:cockroachdb.mma.overloaded_store.medium_dur.success{cluster:{cluster}} by {node_id,store}
+sum:cockroachdb.mma.overloaded_store.medium_dur.failure{cluster:{cluster}} by {node_id,store}
+sum:cockroachdb.mma.overloaded_store.long_dur.success{cluster:{cluster}} by {node_id,store}
+sum:cockroachdb.mma.overloaded_store.long_dur.failure{cluster:{cluster}} by {node_id,store}
+```
+
+Duration buckets indicate desperation level:
+- `lease_grace` — remote store still in lease shedding grace period (~2 min)
+- `short_dur` — recently overloaded, conservative candidate selection
+- `medium_dur` — overloaded ~5+ min, relaxed candidate selection
+- `long_dur` — overloaded ~8+ min, most aggressive candidate selection
+
+**Rebalancing rates (general — includes both MMA and non-MMA):**
+```
+# Lease transfer rate per node
+sum:cockroachdb.rebalancing.lease.transfers{cluster:{cluster}} by {node_id}.as_rate()
+
+# Range rebalance rate per node
+avg:cockroachdb.rebalancing.range.rebalances{cluster:{cluster}} by {node_id}.as_rate()
+
+# Snapshot data movement (indicates replica moves in progress)
+avg:cockroachdb.range.snapshots.sent_bytes{cluster:{cluster}} by {node_id}.as_rate()
+sum:cockroachdb.range.snapshots.rebalancing.rcvd_bytes{cluster:{cluster}} by {cluster}.as_rate()
+```
+
+### 3. Other Rebalancing Components
+
+These help distinguish MMA activity from other rebalancing sources.
+
+```
+# Replicate queue activity
+avg:cockroachdb.queue.replicate.process.success{cluster:{cluster}} by {node_id}.as_rate()
+avg:cockroachdb.queue.replicate.process.failure{cluster:{cluster}} by {node_id}.as_rate()
+avg:cockroachdb.queue.replicate.pending{cluster:{cluster}} by {node_id}
+
+# Replicate queue operation types
+sum:cockroachdb.queue.replicate.addreplica{cluster:{cluster}} by {node_id}.as_rate()
+sum:cockroachdb.queue.replicate.removereplica{cluster:{cluster}} by {node_id}.as_rate()
+sum:cockroachdb.queue.replicate.rebalancereplica{cluster:{cluster}} by {node_id}.as_rate()
+sum:cockroachdb.queue.replicate.transferlease{cluster:{cluster}} by {node_id}.as_rate()
+
+# Lease preference health
+avg:cockroachdb.leases.preferences.violating{cluster:{cluster}} by {node_id}
+avg:cockroachdb.leases.preferences.less_preferred{cluster:{cluster}} by {node_id}
+
+# Lease transfer errors
+avg:cockroachdb.leases.transfers.error{cluster:{cluster}} by {node_id}.as_rate()
+
+# Follow-the-workload lease transfers
+avg:cockroachdb.kv.allocator.load_based_lease_transfers.follow_the_workload{cluster:{cluster}} by {node_id}.as_rate()
+```
+
+### 4. Cluster and System Health
+
+```
+# Range health
+avg:cockroachdb.ranges.underreplicated{cluster:{cluster}} by {node_id}
+avg:cockroachdb.ranges.overreplicated{cluster:{cluster}} by {node_id}
+avg:cockroachdb.ranges.unavailable{cluster:{cluster}} by {node_id}
+
+# Node liveness
+sum:cockroachdb.liveness.livenodes{cluster:{cluster}} by {node_id,store}
+
+# LSM health
+avg:cockroachdb.storage.l0_sublevels{cluster:{cluster}} by {node_id}
+
+# IO admission control
+avg:cockroachdb.admission.io.overload{cluster:{cluster}} by {node_id}
+
+# Disk latency
+p99:cockroachdb.storage.wal.fsync.latency{cluster:{cluster}} by {instance}
+
+# Query latency
+p99.9:cockroachdb.sql.service.latency{cluster:{cluster}} by {node_id}
+p99.9:cockroachdb.exec.latency{cluster:{cluster}} by {node_id}
+```
+
+### 5. MMA Operational Health
+
+```
+# Operations dropped (state inconsistency)
+sum:cockroachdb.mma.dropped{cluster:{cluster}} by {node_id,store}.as_rate()
+
+# External operation registration
+sum:cockroachdb.mma.external.registration.success{cluster:{cluster}} by {node_id,store}.as_rate()
+sum:cockroachdb.mma.external.registration.failure{cluster:{cluster}} by {node_id,store}.as_rate()
+
+# Span config normalization issues
+sum:cockroachdb.mma.span_config.normalization.error{cluster:{cluster}} by {node_id,store}
+max:cockroachdb.mma.span_config.normalization.soft_error{cluster:{cluster}} by {node_id}
+```
+
+## Log Queries
+
+Use the Datadog MCP `search_datadog_logs` tool. **Always set
+`storage_tier: "flex"`** — most logs are in Flex storage.
+
+### General MMA Log Search
+
+```
+# All MMA rebalancing logs for a cluster
+host:{host} "rebalanceStores begins"
+
+# Rebalancing pass summaries (Infof level — always visible)
+host:{host} "rebalancing pass"
+```
+
+Note: filter by `host:` (the specific host name, e.g. `wenyi-skew-0006`) or
+`service:` depending on how the cluster's logs are tagged. Try both if one
+returns no results.
+
+### Overload State Transitions
+
+```
+host:{host} "overload-start"
+host:{host} "overload-end"
+host:{host} "overload-continued"
+host:{host} "was added to shedding store list"
+host:{host} "skipping overloaded store"
+```
+
+### Candidate Evaluation and Outcomes
+
+```
+host:{host} "considering lease-transfer"
+host:{host} "considering replica-transfer"
+host:{host} "no candidates found"
+host:{host} "no suitable target found"
+host:{host} "result(success)"
+host:{host} "result(failed)"
+```
+
+### Grace Periods and Limits
+
+```
+host:{host} "in lease shedding grace period"
+host:{host} "reached max range move count"
+host:{host} "reached pending decrease threshold"
+host:{host} "too soon after failed change"
+```
+
+### Tracing a Specific Pass
+
+```
+host:{host} mmaid={N}
+```
+
+## SQL Log Analytics
+
+Use the Datadog MCP `analyze_datadog_logs` tool for aggregation. Always set
+`storage_tier: "flex"`. Keep filters narrow to avoid Flex tier timeouts.
+
+```sql
+-- Count rebalancing passes over time
+SELECT DATE_TRUNC('hour', timestamp) as hour, count(*)
+FROM logs
+WHERE message LIKE '%rebalanceStores begins%'
+GROUP BY DATE_TRUNC('hour', timestamp)
+ORDER BY DATE_TRUNC('hour', timestamp)
+
+-- Count successes vs failures
+SELECT
+  CASE
+    WHEN message LIKE '%result(success)%' THEN 'success'
+    WHEN message LIKE '%result(failed)%' THEN 'failure'
+  END as outcome,
+  count(*)
+FROM logs
+WHERE message LIKE '%result(%'
+GROUP BY CASE
+    WHEN message LIKE '%result(success)%' THEN 'success'
+    WHEN message LIKE '%result(failed)%' THEN 'failure'
+  END
+```
+
+Note: set the `filter` parameter to `host:{host}` to scope these queries.
+
+## Metric Discovery
+
+If the predefined queries don't cover your case:
+
+```
+# Find all MMA metrics
+name_filter: "cockroachdb.mma.*"
+
+# Find rebalancing metrics
+name_filter: "cockroachdb.rebalancing.*"
+
+# Find queue metrics
+name_filter: "cockroachdb.queue.*"
+```
+
+Use `get_datadog_metric` (metadata mode) with `include_tag_values: true` to
+discover available tag values for scoping.

--- a/pkg/kv/kvserver/allocator/mmaprototype/.claude/skills/mma-investigator/DATADOG_QUERIES.md
+++ b/pkg/kv/kvserver/allocator/mmaprototype/.claude/skills/mma-investigator/DATADOG_QUERIES.md
@@ -3,8 +3,7 @@
 Pre-built query templates for investigating MMA behavior. Replace `{cluster}`
 with the actual cluster name/tag and adjust time ranges as needed.
 
-For guidance on Datadog MCP tools vs pup CLI, Flex tier usage, and tool
-selection, use the built-in `datadog` skill.
+Use the built-in `datadog` skill for reading from to Datadog.
 
 **Important:** All CockroachDB metrics in Datadog use the `cockroachdb.`
 prefix (e.g. `cockroachdb.mma.store.cpu.utilization`).
@@ -294,11 +293,11 @@ Use the Datadog MCP `analyze_datadog_logs` tool for aggregation. Always set
 
 ```sql
 -- Count rebalancing passes over time
-SELECT DATE_TRUNC('hour', timestamp) as hour, count(*)
+SELECT date_trunc('hour', timestamp) as hour, count(*)
 FROM logs
 WHERE message LIKE '%rebalanceStores begins%'
-GROUP BY DATE_TRUNC('hour', timestamp)
-ORDER BY DATE_TRUNC('hour', timestamp)
+GROUP BY date_trunc('hour', timestamp)
+ORDER BY date_trunc('hour', timestamp)
 
 -- Count successes vs failures
 SELECT

--- a/pkg/kv/kvserver/allocator/mmaprototype/.claude/skills/mma-investigator/MMA_REFERENCE.md
+++ b/pkg/kv/kvserver/allocator/mmaprototype/.claude/skills/mma-investigator/MMA_REFERENCE.md
@@ -1,0 +1,349 @@
+# MMA Reference Guide
+
+This document provides architectural context for investigating MMA (Multi-Metric
+Allocator) behavior on CockroachDB clusters. It covers big-picture concepts and
+points to source code for implementation details. Since MMA is under active
+development, **always read the source code for exact thresholds, constants, and
+algorithmic details** rather than relying on hard-coded values in this document.
+
+All source paths are relative to the CockroachDB repository root. The MMA
+prototype lives under `pkg/kv/kvserver/allocator/mmaprototype/`.
+
+## CockroachDB Rebalancing System Overview
+
+MMA is one of several components that affect replica and lease placement.
+Understanding MMA behavior requires understanding how it fits alongside the
+others. Several of these components run simultaneously and independently, which
+means rebalancing activity you observe may not be caused by MMA.
+
+### Component Summary
+
+| Component | Role |
+|-----------|------|
+| **Replica Scanner** | Periodically scans each store's replicas and enqueues them to registered queues. Active in both SMA and MMA modes. |
+| **Replicate Queue** | Handles under/over-replicated ranges, dead/decommissioning replicas, range count convergence, diversity/constraint satisfaction, full disk shedding. Active in both modes. |
+| **Lease Queue** | Handles invalid leases, lease count convergence, lease preferences from span configs, IO overload. Active in both modes. |
+| **Allocator** | Stateless decision-making library. Does not initiate rebalancing. Called by the store rebalancer, replicate queue, and lease queue. |
+| **Store Rebalancer (SMA)** | Load-based, single metric. **Disabled when MMA is enabled.** Only acts when local store exceeds cluster mean by a threshold. Attempts lease transfers first, then replicas. |
+| **MMA** | Multi-metric. Replaces the Store Rebalancer. Computes `storeLoadSummary` per store, identifies overloaded stores, attempts lease transfers then replica moves. |
+
+### What MMA Replaces vs What Still Runs
+
+When MMA is enabled:
+- The **Store Rebalancer** (SMA's load-based component) is **disabled**.
+- The **Replicate Queue** and **Lease Queue** still run independently. They
+  handle count-based convergence, constraint satisfaction, IO overload, lease
+  preferences, etc. — concerns orthogonal to MMA's load-based rebalancing.
+- The **Replica Scanner** still runs and enqueues to those queues.
+
+This means observed replica/lease movement may come from MMA or from the queues.
+Use MMA metrics (`mma.change.rebalance.*`) vs queue metrics to distinguish.
+
+### Enabling MMA
+
+MMA is controlled by the cluster setting `kv.allocator.load_based_rebalancing`:
+- `off` — no load-based rebalancing
+- `leases` — SMA: lease-only rebalancing
+- `leases and replicas` — SMA: lease and replica rebalancing (default)
+- `multi-metric only` — MMA enabled, replaces SMA store rebalancer
+- `multi-metric and count` — MMA enabled, also does count-based convergence
+
+See: `pkg/kv/kvserver/kvserverbase/base.go` for the setting definition.
+
+## MMA Architecture
+
+### Key Types and Data Flow
+
+```
+StoreLoadMsg (via gossip)         StoreLeaseholderMsg (from local store)
+        |                                     |
+        v                                     v
+  ProcessStoreLoadMsg()              ComputeChanges()
+        |                                     |
+        v                                     v
+  allocatorState.cs (clusterState)  ------>  rebalanceStores()
+                                              |
+                                              v
+                                       []ExternalRangeChange
+                                              |
+                                              v
+                                    mmaStoreRebalancer applies changes
+                                              |
+                                              v
+                                    AdjustPendingChangeDisposition() (feedback)
+```
+
+- **`allocatorState`** — Top-level struct, holds a mutex and the `clusterState`.
+  All `Allocator` interface methods acquire this mutex.
+  See: `pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go`
+
+- **`clusterState`** — Holds per-store state (`storeState`), per-range state
+  (`rangeState`), per-node state, and the `meansMemo` for caching load means.
+  See: `pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go`
+
+- **`rebalanceEnv`** — Created fresh for each `rebalanceStores()` invocation.
+  Holds the `clusterState`, limits, thresholds, and accumulated changes.
+  See: `pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go`
+
+- **`mmaStoreRebalancer`** — Integration layer in `kvserver`. Runs a periodic
+  loop, calls `ComputeChanges()`, and applies the returned changes.
+  See: `pkg/kv/kvserver/mma_store_rebalancer.go`
+
+- **`AllocatorSync`** — Coordinates between MMA and the replicate/lease queues
+  to prevent conflicting concurrent decisions.
+  See: `pkg/kv/kvserver/mmaintegration/allocator_sync.go`
+
+### The Rebalancing Loop
+
+`mmaStoreRebalancer.run()` ticks on a jittered interval controlled by
+`kv.allocator.load_based_rebalance.interval`. On each tick:
+
+1. Calls `rebalance()` with `periodicCall=true`.
+2. If changes were made, immediately calls `rebalance()` again with
+   `periodicCall=false` (tight loop to drain pending work).
+3. Stops when no changes are computed.
+
+Each `rebalance()` call invokes `ComputeChanges()` on the allocator, which
+calls `rebalanceStores()`.
+
+## Load Dimensions
+
+MMA tracks multiple load dimensions per store. Each dimension has a load value
+and optionally a capacity, allowing MMA to compute utilization.
+
+See: `pkg/kv/kvserver/allocator/mmaprototype/load.go` for `LoadDimension`,
+`LoadVector`, capacity handling, and related types.
+
+### Utilization vs Equal-Load Balancing
+
+- When **capacity is known** (e.g. CPU, disk), MMA balances on **utilization**
+  (load/capacity). This handles heterogeneous clusters correctly — all stores
+  should run at similar utilization regardless of size.
+- When **capacity is unknown**, MMA balances towards **equal absolute load**
+  across stores.
+- Capacity-weighted mean: computed as `sum(load)/sum(capacity)`, not the
+  average of individual utilizations.
+
+### Secondary Dimensions (Not Yet Active)
+
+`LeaseCount` and `ReplicaCount` are defined as `SecondaryLoadDimension` but are
+not yet hooked up to the main rebalancing loop. The plan is for MMA to
+eventually replace the replicate and lease queues' count-based convergence.
+
+## Store Load Classification
+
+Each store's load is classified per dimension and then aggregated into a
+`storeLoadSummary`. This is the key data structure for understanding MMA's
+decisions.
+
+### Load Summary Levels
+
+The `loadSummary` enum classifies each store's load on a spectrum from
+underloaded to urgently overloaded. The classification considers both
+distance from the cluster mean and absolute utilization (when capacity is
+known). Some dimensions apply additional caps to avoid thrashing when
+utilization is low.
+
+See: `loadSummaryForDimension()` in `load.go` for the exact thresholds and
+classification logic.
+
+### storeLoadSummary
+
+The `storeLoadSummary` struct (in `store_load_summary.go`) aggregates:
+- `sls` — overall store load summary (worst across all dimensions)
+- `nls` — node-level load summary (CPU only, since CPU is shared across stores)
+- `worstDim` — which dimension drove the overall `sls`
+- `dimSummary[dim]` — per-dimension breakdown
+- `maxFractionPendingIncrease/Decrease` — pending change fraction
+
+## The Rebalancing Algorithm
+
+`rebalanceStores()` in `cluster_state_rebalance_stores.go` is the core
+algorithm. Read the source and its comments for exact details. The high-level
+phases are:
+
+### Phase 1: Identify Overloaded Stores
+
+Compute cluster means, classify each store via `storeLoadSummary`, and
+identify shedding candidates — stores that are overloaded and not already
+at their pending-change limits.
+
+### Phase 2: Track Overload Duration
+
+Each store tracks how long it has been continuously overloaded, with a grace
+period before the overload timer resets. The duration determines how
+aggressively MMA picks targets (see ignore levels below).
+
+See: `allocator_state.go` for the overload tracking constants.
+
+### Phase 3: Sort and Process Shedding Stores
+
+Shedding stores are sorted by severity (local store first, then by overload
+level). For each shedding store, MMA attempts to shed load.
+
+### Phase 4: Lease Transfers (Local Store Only)
+
+If the local store is CPU-overloaded, attempt lease transfers first. Leases
+can only be transferred from the local store (it holds them). If any leases
+were transferred, skip replica moves for this store (wait for the next tick
+to see the effect).
+
+### Phase 5: Replica Moves
+
+For each range in the store's top-K list (sorted by load on the worst
+dimension), evaluate candidate target stores using constraint analysis,
+pre-means filtering, post-means filtering, and diversity/lease-preference
+ranking.
+
+MMA limits the number of replica moves and lease transfers per invocation.
+See: `newRebalanceEnv()` in `cluster_state_rebalance_stores.go` for the
+per-invocation limits and other constants.
+
+### Ignore Levels (Desperation)
+
+As overload duration increases, MMA becomes more willing to accept suboptimal
+targets. The ignore level progresses through stages that increasingly relax
+which candidate stores are acceptable.
+
+See: `allocator_state.go` for the ignore level definitions and the duration
+thresholds that trigger each level.
+
+### Remote Store Lease Shedding Grace Period
+
+For remote stores that are CPU-overloaded, MMA waits a grace period before
+shedding replicas. This gives the remote store's own leaseholder a chance to
+shed leases first (which is cheaper than moving replicas).
+
+See: `remoteStoreLeaseSheddingGraceDuration` in `allocator_state.go`.
+
+## Candidate Filtering
+
+### Pre-Means Filtering
+
+Excludes stores before computing the mean for the candidate set:
+- Stores with non-OK disposition (draining, dead, suspect, decommissioning,
+  high disk utilization)
+- Rationale: these stores can't accept work and shouldn't skew the mean
+
+### Post-Means Filtering
+
+Excludes candidates after computing the mean:
+- Stores already hosting a replica of the range
+- The shedding store itself
+- Stores whose load summary (relative to the candidate-set mean) is worse than
+  the source store's, to prevent thrashing
+- Stores with too much pending inflight work
+
+### Diversity and Lease Preferences
+
+After filtering, candidates are further ranked by:
+- **Diversity score** — prefer targets that improve locality diversity
+- **Lease preference** — when moving a leaseholder, prefer targets matching
+  the range's lease preference configuration
+
+See: `sortTargetCandidateSetAndPick()` in `cluster_state_rebalance_stores.go`.
+
+## Disk Utilization
+
+Disk utilization gets special treatment. Stores above configurable thresholds
+are given dispositions that cause them to actively shed replicas or refuse new
+ones. When a store's disk utilization exceeds the shedding threshold, ByteSize
+becomes the priority dimension for the top-K range selection regardless of
+other load dimensions.
+
+See: `highDiskSpaceUtilization()` in `load.go` and `updateStoreStatuses()`
+in `cluster_state.go` for threshold logic. The thresholds are configured via
+the cluster settings `kv.allocator.max_disk_utilization_threshold` and
+`kv.allocator.rebalance_to_max_disk_utilization_threshold`.
+
+## Pending Changes and Rate Limiting
+
+MMA tracks pending changes to avoid piling up inaccurate estimates. It
+enforces per-invocation limits on replica moves and lease transfers, a
+pending-fraction threshold beyond which no further shedding occurs, a delay
+after failed changes before retrying the same range, and a grace period
+after a store drops below overload before resetting overload tracking.
+
+See: `newRebalanceEnv()` in `cluster_state_rebalance_stores.go` for the
+constant definitions.
+
+## Logging
+
+MMA logs on the `KvDistribution` channel. Most detailed logs are at verbosity
+level 2 (`VEventf(ctx, 2, ...)`); candidate-level detail at level 3.
+
+### Key Log Patterns
+
+See `cluster_state_rebalance_stores.go` and `mma_store_rebalancer.go` for the
+exact format strings. The important patterns are:
+
+- **Pass start**: `"rebalanceStores begins"`
+- **Cluster means**: `"cluster means: (stores-load ...) ..."`
+- **Store evaluation**: `"evaluating s%d: node load %s, store load %s, worst dim %s"`
+- **Overload transitions**: `"overload-start"`, `"overload-end"`, `"overload-continued"`
+- **Shedding store added**: `"store s%v was added to shedding store list"`
+- **Skipped (pending)**: `"skipping overloaded store s%d ..."`
+- **Top-K ranges**: `"top-K[%s] ranges for s%d ..."`
+- **Candidate evaluation**: `"considering replica-transfer r%v from s%v ..."`
+- **Failures**: `"result(failed): no candidates found ..."`, `"result(failed): no suitable target ..."`
+- **Successes**: `"result(success): ..."`
+- **Pass summary**: logged at `Infof` level with shed successes, failures by
+  reason, and skipped stores.
+
+The `mmaid` tag is incremented per `rebalanceStores()` call and added to the
+context, so all log messages within a single pass share the same `mmaid` value.
+
+## Key Source Files
+
+| File | Description |
+|------|-------------|
+| `pkg/kv/kvserver/allocator/mmaprototype/doc.go` | Package documentation, links to origin PR |
+| `pkg/kv/kvserver/allocator/mmaprototype/allocator.go` | `Allocator` interface definition |
+| `pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go` | Top-level state, mutex, `ComputeChanges`, ignore levels and grace period constants |
+| `pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go` | Per-store/range/node state, constraint matching, disposition management |
+| `pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go` | **Core rebalancing algorithm**: `rebalanceStores()`, candidate filtering, lease and replica shedding |
+| `pkg/kv/kvserver/allocator/mmaprototype/load.go` | `LoadDimension`, `LoadVector`, `loadSummary` enum, `loadSummaryForDimension()`, means computation, disk utilization checks |
+| `pkg/kv/kvserver/allocator/mmaprototype/store_load_summary.go` | `storeLoadSummary` struct |
+| `pkg/kv/kvserver/allocator/mmaprototype/mma_metrics.go` | All MMA metric definitions |
+| `pkg/kv/kvserver/allocator/mmaprototype/top_k_replicas.go` | Top-K range selection for shedding |
+| `pkg/kv/kvserver/allocator/mmaprototype/constraint.go` | Constraint analysis and normalization |
+| `pkg/kv/kvserver/allocator/mmaprototype/rebalance_advisor.go` | `MMARebalanceAdvisor` for conflict detection with SMA |
+| `pkg/kv/kvserver/allocator/mmaprototype/store_status.go` | Store disposition and health status types |
+| `pkg/kv/kvserver/mma_store_rebalancer.go` | Integration: periodic loop, applies changes |
+| `pkg/kv/kvserver/mmaintegration/allocator_sync.go` | Coordination between MMA and replicate/lease queues |
+| `pkg/kv/kvserver/mmaintegration/store_load_msg.go` | Building `StoreLoadMsg` from store state |
+| `pkg/kv/kvserver/mmaintegration/store_status.go` | Building store status updates for MMA |
+| `pkg/kv/kvserver/kvserverbase/base.go` | Cluster setting `kv.allocator.load_based_rebalancing` |
+
+## Common Investigation Scenarios
+
+### "Stores are imbalanced on CPU but MMA isn't doing anything"
+
+Check in order:
+1. Is MMA enabled? (`kv.allocator.load_based_rebalancing` must be `multi-metric*`)
+2. Does MMA see the imbalance? Check `mma.store.cpu.utilization` metrics.
+3. Is the overloaded store classified as `overloadSlow` or higher? Check logs
+   for `"evaluating s%d"` to see the `storeLoadSummary`.
+4. Is the store stuck at pending threshold? Check for `"skipping overloaded store"` logs.
+5. Are there viable targets? Check for `"no candidates found"` or
+   `"no suitable target"` in logs.
+6. Is the store in grace period? Check for `"in lease shedding grace period"`.
+
+### "MMA is rebalancing but the imbalance isn't improving"
+
+Check:
+1. Is MMA succeeding? Check `mma.change.rebalance.*.success` vs `*.failure`.
+2. Is something else counteracting MMA? Check replicate queue and lease queue
+   activity.
+3. Is a single hot range causing the imbalance? If so, MMA won't move it if
+   it would just shift the problem (candidate filtering prevents this).
+4. Are pending change limits preventing more aggressive action? Check the
+   `mma.overloaded_store.*` duration buckets — if stores stay in
+   `lease_grace` or `short_dur`, MMA is being conservative.
+
+### "Unexpected replica/lease movement"
+
+1. Distinguish MMA moves from queue moves using metrics.
+2. Check MMA logs for the specific range movement.
+3. Check if the store was classified as overloaded on a dimension you didn't
+   expect (e.g., WriteBandwidth might trigger shedding even if CPU looks fine).

--- a/pkg/kv/kvserver/allocator/mmaprototype/.claude/skills/mma-investigator/SKILL.md
+++ b/pkg/kv/kvserver/allocator/mmaprototype/.claude/skills/mma-investigator/SKILL.md
@@ -1,0 +1,293 @@
+---
+name: mma-investigator
+description: Expert system for investigating MMA (Multi-Metric Allocator) behavior on CockroachDB clusters. Helps oncall engineers diagnose load imbalances, understand rebalancing decisions, and identify why MMA did or didn't act.
+---
+
+# CockroachDB MMA Investigator
+
+You are an expert at investigating MMA (Multi-Metric Allocator) behavior on
+CockroachDB clusters. Your primary goal is to **understand and explain the
+state of the system** — how balanced the cluster is across dimensions, what
+rebalancing activity occurred, and what drove it. You should also note
+potential bugs or opportunities for improvement when there is strong evidence,
+but the focus is on understanding what happened and why, not on finding fault.
+
+## Scoping
+
+Every investigation targets **a single cluster over a specific timeframe**.
+Your first action is always to establish:
+
+1. **Cluster identifier** (cluster name or Datadog tag)
+2. **Time window** (e.g. "last 2 hours", "2026-02-10 14:00 to 16:00 UTC")
+
+If the user hasn't provided these, ask for them before proceeding. All
+subsequent Datadog queries must be scoped to this cluster and time window.
+
+## General Guidelines
+
+- Be honest. Guessing is okay, but jumping to conclusions is not. Multiple
+  rounds of back-and-forth are normal and expected.
+- Be thorough but avoid going in circles. If you're stuck, return to the user
+  with a status update and explain the difficulty.
+- Perform "cheap" actions first: start with metrics (fast overview), then logs
+  (detailed), then source code (deep dive).
+- **Focus on understanding, not diagnosing bugs.** Your job is to explain what
+  the system did and why, in the context of how it's designed to work. If
+  something looks wrong, note it with the supporting evidence, but don't lead
+  with "this is a bug."
+- **Link to evidence.** When referencing specific metrics, logs, or dashboards,
+  include Datadog URLs or excerpts so the user can verify your findings.
+
+## Using Datadog
+
+Use the built-in `datadog` skill (available via roachdev) for guidance on
+Datadog MCP tool usage.
+
+MMA-specific Datadog tips:
+- Always query the **Flex tier** for logs (`storage_tier: "flex"` or
+  `"flex_and_indexes"`).
+- All CockroachDB metrics in Datadog use the `cockroachdb.` prefix.
+  For example, the MMA CPU utilization metric is `cockroachdb.mma.store.cpu.utilization`,
+  not `mma.store.cpu.utilization`.
+- Prefer MCP tools for logs and metrics.
+
+Pre-built query templates for MMA investigations are in the companion file
+`DATADOG_QUERIES.md`. Use these as starting points and adapt as needed.
+
+### Reference Dashboard
+
+The team uses the **MMA Enriched** dashboard (ID: `a7p-9t8-pyf`) to monitor
+MMA behavior. It is filterable by cluster, node_id, store, and upload_id.
+
+Link template:
+```
+https://us5.datadoghq.com/dashboard/a7p-9t8-pyf/mma-enriched?tpl_var_cluster%5B0%5D={cluster}&from_ts={from_ms}&to_ts={to_ms}&live=false
+```
+
+When presenting findings, link to this dashboard filtered to the cluster and
+time window. Also link to specific metric graphs and log searches where they
+support your analysis.
+
+## Troubleshooting Missing Data
+
+If metrics or logs return empty/zero results where you'd expect data, check
+these common causes before concluding the data doesn't exist:
+
+1. **Missing `cockroachdb.` prefix on metrics.** All CockroachDB metrics in
+   Datadog are prefixed with `cockroachdb.` (e.g. `cockroachdb.mma.store.cpu.utilization`,
+   not `mma.store.cpu.utilization`). This is the most common cause of
+   all-zero metric results.
+2. **Wrong storage tier for logs.** Most CockroachDB logs are only in
+   Flex storage. If `search_datadog_logs` returns nothing, make sure you're
+   using `storage_tier: "flex_and_indexes"`.
+3. **Incorrect tag names or values.** Verify tag names with the dashboard or
+   `get_datadog_metric_context`. Common pitfalls:
+   - `cluster` vs `cluster_name`
+   - `store` vs `store_id` (check which tag key the metric actually uses)
+   - `node_id` vs `instance`
+4. **Time range mismatch.** Double-check that `from` and `to` match the
+   investigation window. ISO 8601 timestamps must include timezone (use `Z`
+   for UTC).
+5. **Aggregation hiding signal.** A `sum` or `avg` across all stores may wash
+   out per-store spikes. Try grouping by `store` or `node_id` to see
+   individual series.
+6. **Metric not yet emitted.** Some MMA metrics (e.g. `medium_dur`, `long_dur`
+   overload buckets) only emit non-zero values when a store has been
+   continuously overloaded for several minutes. Zero values may be correct.
+
+When in doubt, check the MMA Enriched dashboard (ID: `a7p-9t8-pyf`) filtered
+to the same cluster and time window — if the dashboard shows data but your
+query doesn't, you have a query issue.
+
+## Investigation Workflow
+
+### Step 1: Gather Context
+
+Establish the cluster and time window. Understand the symptom:
+- Which dimension appears imbalanced? (CPU, write bandwidth, disk, range count)
+- Which stores or nodes are affected?
+- Is MMA enabled on this cluster? If any `cockroachdb.mma.change.*` metrics
+  are non-zero in the time window, MMA is enabled. Otherwise, check the
+  `kv.allocator.load_based_rebalancing` cluster setting (must be
+  `multi-metric only` or `multi-metric and count`).
+- How long has the imbalance persisted?
+
+Accept input via:
+- Datadog links / cluster identifier + time range
+- User-uploaded or pasted logs
+- Description of observed behavior
+
+### Step 2: Assess Cluster State via Metrics
+
+**This is the most important step.** Build a comprehensive picture of how
+balanced the cluster is before looking at anything else. Use the same metrics
+from the MMA Enriched dashboard (see `DATADOG_QUERIES.md`).
+
+Query these metric groups in order:
+
+**1. Resource balance across stores** (primary view):
+- `cockroachdb.rebalancing.cpunanospersecond` by node_id — CPU load per node
+- `cockroachdb.sys.cpu.combined.percent.normalized` by node_id — system CPU %
+- `cockroachdb.rebalancing.writebytespersecond` by node_id/store — write bandwidth
+- `cockroachdb.capacity.{used,available}` by node_id — disk usage
+- `cockroachdb.mma.store.cpu.utilization` — MMA's view of CPU balance
+- `cockroachdb.replicas.total` by instance — replica count distribution
+- `cockroachdb.replicas.leaseholders` by instance — lease distribution
+- `cockroachdb.rebalancing.queriespersecond` by node_id — query rate
+- `cockroachdb.rebalancing.readbytespersecond` by node_id — read bandwidth
+
+**2. MMA rebalancing activity**:
+- `cockroachdb.mma.change.rebalance.{replica,lease}.{success,failure}` — MMA outcomes
+- `cockroachdb.mma.change.external.{replica,lease}.{success,failure}` — non-MMA changes
+- `cockroachdb.mma.overloaded_store.*` — overload tracking by duration bucket
+- `cockroachdb.rebalancing.lease.transfers` — lease transfer rate
+- `cockroachdb.rebalancing.range.rebalances` — range rebalance rate
+- `cockroachdb.range.snapshots.{sent_bytes,rebalancing.rcvd_bytes}` — data movement
+
+**3. Other rebalancing components** (to distinguish from MMA):
+- `cockroachdb.queue.replicate.*` — replicate queue activity
+- `cockroachdb.queue.replicate.transferlease` — queue-driven lease transfers
+- `cockroachdb.leases.preferences.{violating,less_preferred}` — lease preference health
+- `cockroachdb.ranges.{underreplicated,overreplicated,unavailable}` — range health
+
+**4. System health context**:
+- `cockroachdb.liveness.livenodes` — cluster membership
+- `cockroachdb.storage.l0_sublevels` — LSM health
+- `cockroachdb.admission.io.overload` — IO admission control
+- `cockroachdb.storage.wal.fsync.latency` — disk latency
+- `cockroachdb.sql.service.latency` / `cockroachdb.exec.latency` — query latency
+
+From this data, characterize:
+- How balanced is each dimension (CPU, writes, disk, replicas, leases)?
+- Did the balance change over the time window? When?
+- Is there a clear imbalance, or is the cluster roughly in equilibrium?
+
+### Step 3: Identify Rebalancing Timeline
+
+Look at the metrics over time to identify **periods of significant change**:
+
+- When did notable rebalancing activity start or stop?
+- What might have triggered it? Common triggers:
+  - MMA being enabled (cluster setting change)
+  - Workload shift (QPS/CPU change on specific nodes)
+  - Node addition/removal
+  - Cluster setting change
+  - Store going suspect/draining
+- What type of rebalancing primarily occurred? (lease transfers vs replica
+  moves, from which stores/nodes)
+- At what point did the cluster appear to stabilize?
+
+Present this as a timeline with evidence (metric graphs, timestamps).
+
+### Step 4: Check Logs via Datadog
+
+Search for MMA logs on the KvDistribution channel to understand decision-level
+detail. Always use Flex tier.
+
+Key log patterns (see `DATADOG_QUERIES.md` for query syntax):
+
+- **Rebalancing pass summaries**: `"rebalancing pass"` — successes, failures
+  by reason, and skipped stores.
+- **Overload state transitions**: `"overload-start"`, `"overload-end"`,
+  `"overload-continued"`.
+- **Candidate evaluation**: `"considering lease-transfer"`,
+  `"considering replica-transfer"`.
+- **Outcomes**: `"result(success)"`, `"result(failed)"`,
+  `"no candidates found"`.
+
+Use the `mmaid` tag to trace individual rebalancing passes. Include links to
+specific log searches that illustrate key findings.
+
+### Step 5: Analyze User-Provided Logs
+
+If the user uploads or pastes log output directly:
+
+- Parse rebalancing pass summaries to identify shed successes, failures, and
+  skipped stores.
+- Identify which stores were classified as overloaded and on which dimension
+  (look for `worst dim` in the log output).
+- Trace candidate evaluation: for each overloaded store, see which ranges were
+  considered and why candidates were excluded.
+- Map `mmaid` values to group related log entries into individual passes.
+- Look at `storeLoadSummary` values — per-dimension classification and worst
+  dimension for each store.
+
+### Step 6: Read Source Code (If Needed)
+
+When observational data (metrics + logs) doesn't fully explain the behavior,
+consult the source code. Read `MMA_REFERENCE.md` first for architecture
+overview and file pointers.
+
+Use `Grep`, `Glob`, and `Read` tools for navigating the source code. For
+broader codebase searches, use the `Explore` agent via the Task tool.
+
+### Step 7: Search GitHub for Related Issues/PRs (If Needed)
+
+**Only do this after you understand the cluster state.** Search GitHub when you
+have a specific behavior to look up — not speculatively.
+
+Use the built-in `github` skill (available via roachdev) for searching issues
+and PRs. Useful search terms:
+
+- MMA-related issues: `mma`, `multi-metric allocator`, `mmaprototype`
+- Label-based: `label:A-kv-allocator`
+- Specific error messages or behaviors observed in logs
+- Recent PRs modifying `mmaprototype/` or `mmaintegration/`
+
+### Step 8: Synthesize Findings
+
+Structure your findings around **understanding the system state**, not
+diagnosing problems. Use this template:
+
+```markdown
+# MMA Investigation Summary
+
+**Date:** <date>
+**Cluster:** <cluster-name>
+**Time Window:** <from> to <to>
+**Dashboard:** [MMA Enriched](<link filtered to cluster and time window>)
+
+## Cluster Balance Assessment
+
+For each dimension, describe how balanced the cluster is across stores/nodes.
+Include links to the relevant metric graphs.
+
+| Dimension | Balance | Notes |
+|-----------|---------|-------|
+| CPU | e.g. "Well balanced" / "Moderate imbalance" / "Severe hotspot" | specifics |
+| Write Bandwidth | ... | ... |
+| Disk Usage | ... | ... |
+| Replica Count | ... | ... |
+| Lease Count | ... | ... |
+
+## Rebalancing Timeline
+
+Describe the key periods of rebalancing activity, ordered chronologically:
+
+### <Time Period 1>: <Description>
+- **Trigger:** <what started this period — workload shift, MMA enabled, etc.>
+- **Activity:** <what rebalancing occurred — lease transfers from sX, replica
+  moves to nY, etc.>
+- **Evidence:** <links to metrics/logs showing this>
+
+### <Time Period 2>: <Stabilization / Continued Activity>
+- ...
+
+## How MMA Performed
+
+- Was MMA active? Success vs failure rates?
+- What were the primary failure reasons?
+- Were there stores MMA couldn't help? Why?
+
+## Observations
+
+<Any notable behaviors, potential improvements, or suspected issues —
+only if supported by strong evidence. Frame as observations, not bugs.>
+
+## Evidence Links
+
+- [MMA Enriched Dashboard](<link>)
+- [Example rebalancing log](<link or excerpt>)
+- [CPU utilization graph](<link or description>)
+- ...
+```

--- a/pkg/kv/kvserver/allocator/mmaprototype/.claude/skills/mma-investigator/SKILL.md
+++ b/pkg/kv/kvserver/allocator/mmaprototype/.claude/skills/mma-investigator/SKILL.md
@@ -40,8 +40,7 @@ subsequent Datadog queries must be scoped to this cluster and time window.
 
 ## Using Datadog
 
-Use the built-in `datadog` skill (available via roachdev) for guidance on
-Datadog MCP tool usage.
+Use the built-in `datadog` skill for guidance on Datadog MCP tool usage.
 
 MMA-specific Datadog tips:
 - Always query the **Flex tier** for logs (`storage_tier: "flex"` or
@@ -82,7 +81,7 @@ these common causes before concluding the data doesn't exist:
    using `storage_tier: "flex_and_indexes"`.
 3. **Incorrect tag names or values.** Verify tag names with the dashboard or
    `get_datadog_metric_context`. Common pitfalls:
-   - `cluster` vs `cluster_name`
+   - The cluster name should be in `cluster`, or sometimes a substring of `hostname`
    - `store` vs `store_id` (check which tag key the metric actually uses)
    - `node_id` vs `instance`
 4. **Time range mismatch.** Double-check that `from` and `to` match the
@@ -226,8 +225,7 @@ broader codebase searches, use the `Explore` agent via the Task tool.
 **Only do this after you understand the cluster state.** Search GitHub when you
 have a specific behavior to look up — not speculatively.
 
-Use the built-in `github` skill (available via roachdev) for searching issues
-and PRs. Useful search terms:
+Use the built-in `github` skill for searching issues and PRs. Useful search terms:
 
 - MMA-related issues: `mma`, `multi-metric allocator`, `mmaprototype`
 - Label-based: `label:A-kv-allocator`


### PR DESCRIPTION
Add a Claude Code skill for investigating MMA (Multi-Metric Allocator) behavior on CockroachDB clusters. The skill guides oncall engineers through a structured workflow: scoping to a cluster and time window, assessing balance via Datadog metrics, analyzing rebalancing timelines, checking logs, and reading source code when needed.

The skill is placed under the mmaprototype package's `.claude/skills/` directory so it is automatically discovered when working with MMA code. It references companion files for Datadog query templates and MMA architecture context, and delegates to the built-in `datadog` and `github` skills for tool-specific guidance.

Release note: None
Epic: None