### PR TITLE
server: resolve TODOEngine in addStore

### DIFF
--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3073,6 +3073,11 @@ func (s *Store) StoreID() roachpb.StoreID { return s.Ident.StoreID }
 // Clock accessor.
 func (s *Store) Clock() *hlc.Clock { return s.cfg.Clock }
 
+// EnginesSeparated returns true iff the Store uses separated engines.
+func (s *Store) EnginesSeparated() bool {
+	return s.internalEngines.Separated()
+}
+
 // StateEngine returns the state machine engine.
 func (s *Store) StateEngine() storage.Engine {
 	return s.internalEngines.StateEngine()

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -861,18 +861,27 @@ func (n *Node) SetHLCUpperBound(ctx context.Context, hlcUpperBound int64) error 
 }
 
 func (n *Node) addStore(ctx context.Context, store *kvserver.Store) {
-	cv := store.TODOEngine().MinVersion()
-	if cv == (roachpb.Version{}) {
+	// NB: both engines have the same MinVersion, check any.
+	if cv := store.StateEngine().MinVersion(); cv == (roachpb.Version{}) {
 		// The store should have had a version written to it during the store
 		// initialization process.
 		log.Dev.Fatal(ctx, "attempting to add a store without a version")
 	}
-	store.TODOEngine().RegisterDiskSlowCallback(func(info pebble.DiskSlowInfo) {
-		n.onStoreDiskSlow(n.AnnotateCtx(context.Background()), store.StoreID(), info)
-	})
-	store.TODOEngine().RegisterLowDiskSpaceCallback(func(info pebble.LowDiskSpaceInfo) {
-		n.onLowDiskSpace(n.AnnotateCtx(context.Background()), store.StoreID(), info)
-	})
+
+	// Register all storage engines for disk slow and low disk space callbacks.
+	register := func(eng storage.Engine) {
+		eng.RegisterDiskSlowCallback(func(info pebble.DiskSlowInfo) {
+			n.onStoreDiskSlow(n.AnnotateCtx(context.Background()), store.StoreID(), info)
+		})
+		eng.RegisterLowDiskSpaceCallback(func(info pebble.LowDiskSpaceInfo) {
+			n.onLowDiskSpace(n.AnnotateCtx(context.Background()), store.StoreID(), info)
+		})
+	}
+	register(store.StateEngine())
+	if store.EnginesSeparated() {
+		register(store.LogEngine())
+	}
+
 	n.stores.AddStore(store)
 	n.recorder.AddStore(store)
 }


### PR DESCRIPTION
Register both engines for disk slow and low disk space callbacks. There might be some redundancy when both engines reside on the same FS, but there is no harm in getting this signal / logging twice.

Alternatively, we could register "low disk space" only for one engine (assuming the other one gives a duplicate signal), but that bakes in an assumption that engines are collocated. Err on the side of generality instead.

Part of #97627