### PR TITLE
builder: revert image back to Ubuntu 20.04

### DIFF
--- a/build/.bazelbuilderversion
+++ b/build/.bazelbuilderversion
@@ -1,1 +1,1 @@
-us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel:20260226-163400
+us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel:20250717-170828

--- a/build/bazelbuilder/Dockerfile
+++ b/build/bazelbuilder/Dockerfile
@@ -1,23 +1,6 @@
 # We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.
 # See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
-
-# Download external keys on the build host's native platform to avoid QEMU
-# user-mode emulation bugs that cause SSL_ERROR_SYSCALL during TLS handshakes
-# on cross-architecture builds. See https://github.com/tonistiigi/binfmt/issues/215.
-FROM --platform=$BUILDPLATFORM us-east1-docker.pkg.dev/crl-docker-sync/docker-io/library/ubuntu:noble AS fetch
-ARG TARGETPLATFORM
-SHELL ["/usr/bin/bash", "-c"]
-RUN if [[ ${TARGETPLATFORM} != "linux/s390x" ]]; then \
- apt-get update \
- && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    ca-certificates \
-    curl \
-    gnupg2 \
- && apt-get clean \
- && curl -fsLS https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /microsoft.gpg ; \
- fi
-
-FROM us-east1-docker.pkg.dev/crl-docker-sync/docker-io/library/ubuntu:noble
+FROM us-east1-docker.pkg.dev/crl-docker-sync/docker-io/library/ubuntu:focal
 ARG TARGETPLATFORM
 
 SHELL ["/usr/bin/bash", "-c"]
@@ -28,7 +11,7 @@ RUN apt-get update \
     autoconf \
     bison \
     ca-certificates \
-    clang-20 \
+    clang-10 \
     cmake \
     curl \
     flex \
@@ -45,11 +28,11 @@ RUN apt-get update \
     openssh-client \
     python-is-python3 \
     python3 \
-    python3.12-venv \
+    python3.8-venv \
     unzip \
     zip \
- && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-20 100 \
-    --slave /usr/bin/clang++ clang++ /usr/bin/clang++-20 \
+ && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-10 100 \
+    --slave /usr/bin/clang++ clang++ /usr/bin/clang++-10 \
  && apt-get clean
 
 # We need a newer version of cmake.
@@ -95,12 +78,9 @@ RUN apt-get update && \
     rm -rf git-2.29.2.zip git-2.29.2
 
 # NB: Don't install the azure CLI on s390x which doesn't support it.
-# The GPG key is fetched in the "fetch" stage on the native build platform to
-# work around QEMU SSL failures during cross-arch builds.
-COPY --from=fetch /microsoft.gpg* /tmp/
 RUN if [[ ${TARGETPLATFORM} != "linux/s390x" ]]; then \
- mv /tmp/microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg \
- && echo "deb https://packages.microsoft.com/repos/azure-cli/ noble main" > /etc/apt/sources.list.d/azure-cli.list \
+ curl -fsLS https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | apt-key add - \
+ && echo "deb https://packages.microsoft.com/repos/azure-cli/ focal main" > /etc/apt/sources.list.d/azure-cli.list \
  && apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends azure-cli \
  && apt-get clean ; \
@@ -109,8 +89,8 @@ RUN if [[ ${TARGETPLATFORM} != "linux/s390x" ]]; then \
 # NB: As above, this is not available on `s390x`.
 RUN if [[ ${TARGETPLATFORM} != "linux/s390x" ]]; then \
  case ${TARGETPLATFORM} in \
-     "linux/amd64") ARCH=x86_64; SHASUM=080dc67647ba765295a2045aa0d75364121889b712a98e2c6c7eab93f333015d ;; \
-     "linux/arm64") ARCH=arm; SHASUM=6bb473ed86f23bb3a117398e5dd9039d0412c26ca1595c344146d1a1d4a5e335 ;; \
+     "linux/amd64") ARCH=x86_64; SHASUM=8ba7e746ca05f225e5a73952bbc03f4086a5f65fd94f3717df6f75f212587159 ;; \
+     "linux/arm64") ARCH=arm; SHASUM=e6153461e3154ebce61d35b73005bdd14a0ecacd42e5008f66e25b4ad231e5c9 ;; \
  esac  \
  && curl -fsSL "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-$ARCH.tar.gz" -o gcloud.tar.gz \
  && echo "$SHASUM gcloud.tar.gz" | sha256sum -c - \
@@ -203,11 +183,6 @@ RUN if [[ ${TARGETPLATFORM} == "linux/s390x" ]]; then \
   && tar xzf autouseradd.tar.gz --strip-components 1 \
   && rm autouseradd.tar.gz ; \
   fi
-
-# Avoid errors that look like:
-#    roach's uid 108 outside of the UID_MIN 1000 and UID_MAX 60000 range.
-RUN sed -i 's/^UID_MIN.*/UID_MIN 100/' /etc/login.defs && \
-  sed -i 's/^UID_MAX.*/UID_MAX 1000000000/' /etc/login.defs
 
 ENTRYPOINT ["autouseradd", "--user", "roach", "--no-create-home"]
 CMD ["/usr/bin/bash"]

--- a/build/toolchains/BUILD.bazel
+++ b/build/toolchains/BUILD.bazel
@@ -32,7 +32,7 @@ platform(
         "@platforms//cpu:x86_64",
     ],
     exec_properties = {
-        "container-image": "docker://us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel@sha256:777de92cc32790cd8dfd6bedbf6c9ca9fad594552f18265db5bca9d1e357c7dc",
+        "container-image": "docker://us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel@sha256:8e28252850bdd6f996d3d4087839be7a2e37d441f6f1e0d5c0a08fae82feacc3",
         "dockerReuse": "True",
     },
 )
@@ -136,7 +136,7 @@ platform(
         "@platforms//cpu:arm64",
     ],
     exec_properties = {
-        "container-image": "docker://us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel@sha256:342d5589ba69ca9f57efc964fb1142c7e8667402403c8ed91fd887739a3e3d4e",
+        "container-image": "docker://us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel@sha256:a60cd34ece7f75930169653ce55eb6825775a5204152fb563276e6eb25c73ed1",
         "dockerReuse": "True",
     },
 )


### PR DESCRIPTION
There are breakages in CI for now. We should be able to re-apply this soon. When we do, we should make sure to install `patch` in the container.

Reverts `a4f5fccfb5c2e98cc209cfe8fe14d4d9afbcdc5a`

Release note: none
Epic: none