### PR TITLE
sql/schemachanger: fix ALTER PRIMARY KEY idempotency for hash-sharded indexes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -1425,6 +1425,78 @@ t1_pkey  id    ASC
 t1_pkey  id2   ASC
 t1_pkey  name  N/A
 
+# Validate ALTER PRIMARY KEY idempotence with USING HASH for #130191.
+statement ok
+DROP TABLE IF EXISTS t1;
+
+statement ok
+CREATE TABLE t1 (j INT NOT NULL);
+
+statement ok
+ALTER TABLE t1 ALTER PRIMARY KEY USING COLUMNS (j) USING HASH;
+
+# Repeating the same ALTER PRIMARY KEY with USING HASH should be a no-op.
+statement ok
+ALTER TABLE t1 ALTER PRIMARY KEY USING COLUMNS (j) USING HASH;
+
+# Confirm no schema change operations are generated for the no-op.
+skipif config local-legacy-schema-changer
+query T
+EXPLAIN (DDL) ALTER TABLE t1 ALTER PRIMARY KEY USING COLUMNS (j) USING HASH;
+----
+Schema change plan for ALTER TABLE test.public.t1 ALTER PRIMARY KEY USING COLUMNS (j) USING HASH;
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ └── PreCommitPhase
+      └── Stage 1 of 1 in PreCommitPhase
+           └── 1 Mutation operation
+                └── UndoAllInTxnImmediateMutationOpSideEffects
+
+skipif config local-legacy-schema-changer
+query TTT
+SELECT index_name, column_name, direction
+  FROM [SHOW INDEXES FROM t1]
+  WHERE index_name LIKE 't1_pkey%'
+  ORDER BY seq_in_index;
+----
+t1_pkey  crdb_internal_j_shard_16  ASC
+t1_pkey  j                         ASC
+
+# Multi-column hash-sharded ALTER PRIMARY KEY idempotence.
+statement ok
+DROP TABLE IF EXISTS t1;
+
+statement ok
+CREATE TABLE t1 (a INT NOT NULL, b INT NOT NULL);
+
+statement ok
+ALTER TABLE t1 ALTER PRIMARY KEY USING COLUMNS (a, b) USING HASH;
+
+# Repeating the same multi-column hash-sharded ALTER should be a no-op.
+statement ok
+ALTER TABLE t1 ALTER PRIMARY KEY USING COLUMNS (a, b) USING HASH;
+
+skipif config local-legacy-schema-changer
+query TTT
+SELECT index_name, column_name, direction
+  FROM [SHOW INDEXES FROM t1]
+  WHERE index_name LIKE 't1_pkey%'
+  ORDER BY seq_in_index;
+----
+t1_pkey  crdb_internal_a_b_shard_16  ASC
+t1_pkey  a                           ASC
+t1_pkey  b                           ASC
+
+# Set up t1 for the next subtest.
+statement ok
+DROP TABLE IF EXISTS t1;
+
+statement ok
+create table t1(id integer not null, id2 integer not null, name varchar(32));
+
+statement ok
+alter table t1 alter primary key using columns(id, id2);
+
 skipif config schema-locked-disabled
 statement ok
 ALTER TABLE t1 SET (schema_locked = false)

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
@@ -396,13 +396,31 @@ func isNewPrimaryKeySameAsOldPrimaryKey(b BuildCtx, tbl *scpb.Table, t alterPrim
 		}
 	}
 
-	// Check whether they have the same number of key columns.
-	if len(oldPrimaryIndexKeyColumns) != len(t.Columns) {
+	// Check whether they are both sharded or both not sharded.
+	if (oldPrimaryIndexElem.Sharding == nil) != (t.Sharded == nil) {
 		return false
 	}
 
-	// Check whether they are both sharded or both not sharded.
-	if (oldPrimaryIndexElem.Sharding == nil) != (t.Sharded == nil) {
+	// If both are sharded, filter out the shard column from the old index's
+	// key columns. The user-specified columns (t.Columns) don't include the
+	// shard column, but the old index's key columns do.
+	if oldPrimaryIndexElem.Sharding != nil {
+		shardColID := getColumnIDFromColumnName(
+			b, tbl.TableID, tree.Name(oldPrimaryIndexElem.Sharding.Name), false,
+		)
+		if shardColID != 0 {
+			filtered := make([]*scpb.IndexColumn, 0, len(oldPrimaryIndexKeyColumns)-1)
+			for _, col := range oldPrimaryIndexKeyColumns {
+				if col.ColumnID != shardColID {
+					filtered = append(filtered, col)
+				}
+			}
+			oldPrimaryIndexKeyColumns = filtered
+		}
+	}
+
+	// Check whether they have the same number of key columns.
+	if len(oldPrimaryIndexKeyColumns) != len(t.Columns) {
 		return false
 	}
 

--- a/pkg/sql/schemachanger/scbuild/testdata/alter_table_alter_primary_key
+++ b/pkg/sql/schemachanger/scbuild/testdata/alter_table_alter_primary_key
@@ -124,3 +124,80 @@ ALTER TABLE defaultdb.bar ALTER PRIMARY KEY USING COLUMNS (i)
   {columnId: 1, indexId: 5, tableId: 105}
 - [[IndexData:{DescID: 105, IndexID: 5}, TRANSIENT_ABSENT], ABSENT]
   {indexId: 5, tableId: 105}
+
+setup
+CREATE TABLE defaultdb.hash_pk (j INT NOT NULL);
+ALTER TABLE defaultdb.hash_pk ALTER PRIMARY KEY USING COLUMNS (j) USING HASH;
+----
+
+# No-op: repeating the same hash-sharded ALTER PRIMARY KEY produces no elements.
+build
+ALTER TABLE defaultdb.hash_pk ALTER PRIMARY KEY USING COLUMNS (j) USING HASH
+----
+
+# Changing the bucket count is not a no-op.
+build
+ALTER TABLE defaultdb.hash_pk ALTER PRIMARY KEY USING COLUMNS (j) USING HASH WITH (bucket_count = 8)
+----
+- [[Column:{DescID: 106, ColumnID: 3}, ABSENT], PUBLIC]
+  {columnId: 3, tableId: 106}
+- [[ColumnName:{DescID: 106, Name: crdb_internal_j_shard_16, ColumnID: 3}, ABSENT], PUBLIC]
+  {columnId: 3, name: crdb_internal_j_shard_16, tableId: 106}
+- [[ColumnComputeExpression:{DescID: 106, ColumnID: 3, ReferencedColumnIDs: [1], Usage: REGULAR}, ABSENT], PUBLIC]
+  {columnId: 3, expr: 'mod(fnv32(md5(crdb_internal.datums_to_bytes(j))), 16:::INT8)', referencedColumnIds: [1], tableId: 106}
+- [[ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3, TypeName: INT8}, ABSENT], PUBLIC]
+  {columnId: 3, elementCreationMetadata: {in261OrLater: true}, isVirtual: true, tableId: 106, type: {family: IntFamily, oid: 20, width: 64}, typeName: INT8}
+- [[ColumnHidden:{DescID: 106, ColumnID: 3}, ABSENT], PUBLIC]
+  {columnId: 3, tableId: 106}
+- [[ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 0}, ABSENT], PUBLIC]
+  {columnId: 3, tableId: 106}
+- [[IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 4}, ABSENT], PUBLIC]
+  {columnId: 3, indexId: 4, tableId: 106}
+- [[IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 4}, ABSENT], PUBLIC]
+  {columnId: 1, indexId: 4, ordinalInKind: 1, tableId: 106}
+- [[PrimaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 5}, ABSENT], PUBLIC]
+  {constraintId: 5, indexId: 4, isCreatedExplicitly: true, isUnique: true, sharding: {columnNames: [j], isSharded: true, name: crdb_internal_j_shard_16, shardBuckets: 16}, tableId: 106}
+- [[IndexName:{DescID: 106, Name: hash_pk_pkey, IndexID: 4}, ABSENT], PUBLIC]
+  {indexId: 4, name: hash_pk_pkey, tableId: 106}
+- [[IndexData:{DescID: 106, IndexID: 4}, ABSENT], PUBLIC]
+  {indexId: 4, tableId: 106}
+- [[CheckConstraint:{DescID: 106, IndexID: 0, ConstraintID: 2, ReferencedColumnIDs: [3]}, ABSENT], PUBLIC]
+  {columnIds: [3], constraintId: 2, expr: 'crdb_internal_j_shard_16 IN (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15)', fromHashShardedColumn: true, referencedColumnIds: [3], tableId: 106}
+- [[ConstraintWithoutIndexName:{DescID: 106, Name: check_crdb_internal_j_shard_16, ConstraintID: 2}, ABSENT], PUBLIC]
+  {constraintId: 2, name: check_crdb_internal_j_shard_16, tableId: 106}
+- [[TableData:{DescID: 106, ReferencedDescID: 100}, PUBLIC], PUBLIC]
+  {databaseId: 100, tableId: 106}
+- [[PrimaryIndex:{DescID: 106, IndexID: 6, ConstraintID: 8, TemporaryIndexID: 7, SourceIndexID: 4}, PUBLIC], ABSENT]
+  {constraintId: 8, indexId: 6, isCreatedExplicitly: true, isUnique: true, sharding: {columnNames: [j], isSharded: true, name: crdb_internal_j_shard_8, shardBuckets: 8}, sourceIndexId: 4, tableId: 106, temporaryIndexId: 7}
+- [[IndexName:{DescID: 106, Name: hash_pk_pkey, IndexID: 6}, PUBLIC], ABSENT]
+  {indexId: 6, name: hash_pk_pkey, tableId: 106}
+- [[IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 6}, PUBLIC], ABSENT]
+  {columnId: 1, indexId: 6, ordinalInKind: 1, tableId: 106}
+- [[IndexData:{DescID: 106, IndexID: 6}, PUBLIC], ABSENT]
+  {indexId: 6, tableId: 106}
+- [[TemporaryIndex:{DescID: 106, IndexID: 7, ConstraintID: 9, SourceIndexID: 4}, TRANSIENT_ABSENT], ABSENT]
+  {constraintId: 9, indexId: 7, isCreatedExplicitly: true, isUnique: true, sharding: {columnNames: [j], isSharded: true, name: crdb_internal_j_shard_8, shardBuckets: 8}, sourceIndexId: 4, tableId: 106}
+- [[IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 7}, TRANSIENT_ABSENT], ABSENT]
+  {columnId: 1, indexId: 7, ordinalInKind: 1, tableId: 106}
+- [[IndexData:{DescID: 106, IndexID: 7}, TRANSIENT_ABSENT], ABSENT]
+  {indexId: 7, tableId: 106}
+- [[Column:{DescID: 106, ColumnID: 4}, PUBLIC], ABSENT]
+  {columnId: 4, tableId: 106}
+- [[ColumnName:{DescID: 106, Name: crdb_internal_j_shard_8, ColumnID: 4}, PUBLIC], ABSENT]
+  {columnId: 4, name: crdb_internal_j_shard_8, tableId: 106}
+- [[ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4, TypeName: INT8}, PUBLIC], ABSENT]
+  {columnId: 4, elementCreationMetadata: {in261OrLater: true}, isVirtual: true, tableId: 106, type: {family: IntFamily, oid: 20, width: 64}, typeName: INT8}
+- [[ColumnComputeExpression:{DescID: 106, ColumnID: 4, ReferencedColumnIDs: [1], Usage: REGULAR}, PUBLIC], ABSENT]
+  {columnId: 4, expr: 'mod(fnv32(md5(crdb_internal.datums_to_bytes(j))), 8:::INT8)', referencedColumnIds: [1], tableId: 106}
+- [[ColumnHidden:{DescID: 106, ColumnID: 4}, PUBLIC], ABSENT]
+  {columnId: 4, tableId: 106}
+- [[ColumnNotNull:{DescID: 106, ColumnID: 4, IndexID: 6}, PUBLIC], ABSENT]
+  {columnId: 4, indexIdForValidation: 6, tableId: 106}
+- [[CheckConstraint:{DescID: 106, IndexID: 6, ConstraintID: 7, ReferencedColumnIDs: [4]}, PUBLIC], ABSENT]
+  {columnIds: [4], constraintId: 7, expr: 'crdb_internal_j_shard_8 IN (0,1,2,3,4,5,6,7)', fromHashShardedColumn: true, indexIdForValidation: 6, referencedColumnIds: [4], tableId: 106}
+- [[ConstraintWithoutIndexName:{DescID: 106, Name: check_crdb_internal_j_shard_8, ConstraintID: 7}, PUBLIC], ABSENT]
+  {constraintId: 7, name: check_crdb_internal_j_shard_8, tableId: 106}
+- [[IndexColumn:{DescID: 106, ColumnID: 4, IndexID: 6}, PUBLIC], ABSENT]
+  {columnId: 4, indexId: 6, tableId: 106}
+- [[IndexColumn:{DescID: 106, ColumnID: 4, IndexID: 7}, TRANSIENT_ABSENT], ABSENT]
+  {columnId: 4, indexId: 7, tableId: 106}


### PR DESCRIPTION

Previously, running `ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j) USING HASH` twice on the same table would fail instead of being recognized as a no-op. The idempotency check in
`isNewPrimaryKeySameAsOldPrimaryKey` compared the old index's key columns (which include the shard column, e.g.
`[crdb_internal_j_shard_16, j]`) against the user-specified columns (`[j]`). The length mismatch caused the function to return false, proceeding with a redundant ALTER that then errored.

Fix this by moving the sharded-vs-not-sharded check earlier and, when both old and new PKs are hash-sharded, filtering out the shard column from the old index's key columns before comparison.

Resolves: #130191
Resolves: #113587

Release note (bug fix): Fixed a bug where running `ALTER TABLE ... ALTER PRIMARY KEY USING COLUMNS (...) USING HASH` a second time on a table that already had the same hash-sharded primary key would fail instead of being treated as a no-op.