### PR TITLE
cli: merge encode-uri into convert-url

### DIFF
--- a/pkg/cli/cert.go
+++ b/pkg/cli/cert.go
@@ -302,10 +302,11 @@ func runListCerts(cmd *cobra.Command, args []string) error {
 // encodeURICmd creates a PG URI for the given parameters.
 var encodeURICmd = func() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "encode-uri [postgres://][USERNAME[:PASSWORD]@]HOST",
-		Short: "encode a CRDB connection URL",
-		Args:  cobra.ExactArgs(1),
-		RunE:  clierrorplus.MaybeDecorateError(encodeURI),
+		Deprecated: "please use convert-url instead, as encode-uri will be removed in a future release.\n",
+		Use:        "encode-uri [postgres://][USERNAME[:PASSWORD]@]HOST",
+		Short:      "encode a CRDB connection URL",
+		Args:       cobra.ExactArgs(1),
+		RunE:       clierrorplus.MaybeDecorateError(encodeURI),
 	}
 	f := cmd.PersistentFlags()
 	f.BoolVar(&encodeURIOpts.sslInline, "inline", false, "whether to inline certificates (supported by CRDB's Physical Replication feature)")

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"slices"
 	"strconv"
 	"time"
 
@@ -32,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log/logconfig"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
 	isatty "github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -640,6 +642,41 @@ func setSqlfmtContextDefaults() {
 	sqlfmtCtx.execStmts = nil
 }
 
+// convertURLFormat enumerates the supported output formats for the `convert-url`
+// command.
+type convertURLFormat string
+
+const (
+	convertURLFormatAll  convertURLFormat = ""
+	convertURLFormatPQ   convertURLFormat = "pq"
+	convertURLFormatDSN  convertURLFormat = "dsn"
+	convertURLFormatJDBC convertURLFormat = "jdbc"
+	convertURLFormatCRDB convertURLFormat = "crdb"
+)
+
+var convertURLFormats = []convertURLFormat{
+	convertURLFormatPQ,
+	convertURLFormatDSN,
+	convertURLFormatJDBC,
+	convertURLFormatCRDB,
+}
+
+func (f *convertURLFormat) String() string {
+	return string(*f)
+}
+
+func (f *convertURLFormat) Set(s string) error {
+	if slices.Contains(convertURLFormats, convertURLFormat(s)) {
+		*f = convertURLFormat(s)
+		return nil
+	}
+	return errors.Newf("must be one of %s", convertURLFormats)
+}
+
+func (f *convertURLFormat) Type() string {
+	return "string"
+}
+
 // convertCtx captures the command-line parameters of the `convert-url` command.
 // See below for defaults.
 var convertCtx struct {
@@ -653,6 +690,7 @@ var convertCtx struct {
 	caCertPath string
 	certPath   string
 	keyPath    string
+	format     convertURLFormat
 }
 
 // setConvContextDefaults set the default values in convertCtx.  This
@@ -669,6 +707,7 @@ func setConvContextDefaults() {
 	convertCtx.caCertPath = ""
 	convertCtx.certPath = ""
 	convertCtx.keyPath = ""
+	convertCtx.format = ""
 }
 
 // demoCtx captures the command-line parameters of the `demo` command.

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -640,8 +640,19 @@ func setSqlfmtContextDefaults() {
 	sqlfmtCtx.execStmts = nil
 }
 
+// convertCtx captures the command-line parameters of the `convert-url` command.
+// See below for defaults.
 var convertCtx struct {
-	url string
+	url        string
+	sslInline  bool
+	database   string
+	username   string
+	password   string
+	cluster    string
+	certsDir   string
+	caCertPath string
+	certPath   string
+	keyPath    string
 }
 
 // setConvContextDefaults set the default values in convertCtx.  This
@@ -649,6 +660,15 @@ var convertCtx struct {
 // test that exercises command-line parsing.
 func setConvContextDefaults() {
 	convertCtx.url = ""
+	convertCtx.sslInline = false
+	convertCtx.database = ""
+	convertCtx.username = ""
+	convertCtx.password = ""
+	convertCtx.cluster = ""
+	convertCtx.certsDir = ""
+	convertCtx.caCertPath = ""
+	convertCtx.certPath = ""
+	convertCtx.keyPath = ""
 }
 
 // demoCtx captures the command-line parameters of the `demo` command.

--- a/pkg/cli/convert_url.go
+++ b/pkg/cli/convert_url.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/cli/clierrorplus"
+	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/pgurl"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/ttycolor"
 	"github.com/spf13/cobra"
 )
@@ -22,8 +24,9 @@ var convertURLCmd = &cobra.Command{
   convert-url --url postgres://root@localhost:26257/defaultdb
 
   convert-url "postgresql://example.com?sslcert=certs%2Fclient.root.crt&sslkey=certs%2Fclient.root.key&sslmode=verify-full&sslrootcert=certs%2Fca.crt"
-`,
 
+  convert-url --url postgres://localhost --user root --password secret --database mydb --cluster app --certs-dir certs --inline
+	`,
 	Short: "convert a SQL connection string for use with various client drivers",
 	Args:  cobra.NoArgs,
 	RunE:  clierrorplus.MaybeDecorateError(runConvertURL),
@@ -43,13 +46,51 @@ func runConvertURL(cmd *cobra.Command, _ []string) error {
 			return err
 		}
 	}
+	if convertCtx.database != "" {
+		u.WithDatabase(convertCtx.database)
+	}
+	if convertCtx.username != "" {
+		u.WithUsername(convertCtx.username)
+	}
+	if convertCtx.password != "" {
+		u.WithAuthn(pgurl.AuthnPassword(true, convertCtx.password))
+	}
+	if convertCtx.sslInline {
+		if err := u.SetOption("sslinline", "true"); err != nil {
+			return err
+		}
+	}
+	if convertCtx.cluster != "" {
+		if err := u.SetOption("options", "-ccluster="+convertCtx.cluster); err != nil {
+			return err
+		}
+	}
+	// If no username/database were specified in the options, and the URL didn't
+	// specify them either, we set some sensible defaults.
 	u.
 		WithDefaultUsername(username.RootUser).
 		WithDefaultDatabase(catalogkeys.DefaultDatabaseName).
 		WithDefaultHost("localhost").
 		WithDefaultPort(cliCtx.clientOpts.ServerPort)
 
+	// Since the certificate paths are derived from the username, we need to set
+	// it after the username defaults.
+	if err := setURLCertOptions(u); err != nil {
+		return errors.Wrap(err, "cannot load certificates")
+	}
+
 	if err := u.Validate(); err != nil {
+		return err
+	}
+
+	return displayConvertedURL(u)
+}
+
+func displayConvertedURL(u *pgurl.URL) error {
+	// We perform the CRDB conversion first, as this could fail and we do not
+	// want to print to stdout if there is an error.
+	crdbURL, err := u.ToCRDB()
+	if err != nil {
 		return err
 	}
 
@@ -68,6 +109,65 @@ func runConvertURL(cmd *cobra.Command, _ []string) error {
 	fmt.Printf("# Connection URL for JDBC (%[1]sJava%[2]s and %[1]sJVM%[2]s-based languages):\n", yc, rc)
 	fmt.Println(u.ToJDBC())
 	fmt.Println()
+
+	fmt.Printf("# Direct URL to %[1]sCockroachDB%[2]s:\n", yc, rc)
+	fmt.Println(crdbURL)
+
+	return nil
+}
+
+// setURLCertOptions modifies the given URL to include any SSL-options that can
+// be resolved from the command-line options.
+func setURLCertOptions(u *pgurl.URL) error {
+	sqlUser, err := username.MakeSQLUsernameFromPreNormalizedStringChecked(u.GetUsername())
+	if err != nil {
+		return err
+	}
+
+	var sslmode string
+	caCertPath := convertCtx.caCertPath
+	certPath := convertCtx.certPath
+	keyPath := convertCtx.keyPath
+
+	if convertCtx.certsDir != "" {
+		cm, err := security.NewCertificateManager(convertCtx.certsDir, security.CommandTLSSettings{})
+		if err != nil {
+			return err
+		}
+		if caCertPath == "" {
+			caCertPath = cm.CACertPath()
+		}
+		if certPath == "" {
+			certPath = cm.ClientCertPath(sqlUser)
+		}
+		if keyPath == "" {
+			keyPath = cm.ClientKeyPath(sqlUser)
+		}
+	}
+	if caCertPath != "" {
+		sslmode = "verify-full"
+	}
+
+	if caCertPath != "" {
+		if err := u.SetOption("sslrootcert", caCertPath); err != nil {
+			return err
+		}
+	}
+	if certPath != "" {
+		if err := u.SetOption("sslcert", certPath); err != nil {
+			return err
+		}
+	}
+	if keyPath != "" {
+		if err := u.SetOption("sslkey", keyPath); err != nil {
+			return err
+		}
+	}
+	if sslmode != "" {
+		if err := u.SetOption("sslmode", sslmode); err != nil {
+			return err
+		}
+	}
 
 	return nil
 }

--- a/pkg/cli/convert_url.go
+++ b/pkg/cli/convert_url.go
@@ -29,7 +29,16 @@ var convertURLCmd = &cobra.Command{
 	`,
 	Short: "convert a SQL connection string for use with various client drivers",
 	Args:  cobra.NoArgs,
-	RunE:  clierrorplus.MaybeDecorateError(runConvertURL),
+	PreRunE: func(cmd *cobra.Command, _ []string) error {
+		if convertCtx.sslInline {
+			if convertCtx.format != "" && convertCtx.format != convertURLFormatCRDB {
+				return errors.New("--inline only supports --format=crdb")
+			}
+			convertCtx.format = convertURLFormatCRDB
+		}
+		return nil
+	},
+	RunE: clierrorplus.MaybeDecorateError(runConvertURL),
 }
 
 func runConvertURL(cmd *cobra.Command, _ []string) error {
@@ -83,17 +92,40 @@ func runConvertURL(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	return displayConvertedURL(u)
+	return displayConvertedURL(u, convertCtx.format)
 }
 
-func displayConvertedURL(u *pgurl.URL) error {
-	// We perform the CRDB conversion first, as this could fail and we do not
+func displayConvertedURL(u *pgurl.URL, format convertURLFormat) error {
+	// If the user specifies a specific format, we only print the URL without a
+	// header.
+	if format != convertURLFormatAll {
+		switch format {
+		case convertURLFormatPQ:
+			fmt.Println(u.ToPQ())
+		case convertURLFormatDSN:
+			fmt.Println(u.ToDSN())
+		case convertURLFormatJDBC:
+			fmt.Println(u.ToJDBC())
+		case convertURLFormatCRDB:
+			crdbURL, err := u.ToCRDB()
+			if err != nil {
+				return err
+			}
+			fmt.Println(crdbURL)
+		default:
+			return fmt.Errorf("unknown format: %s", format)
+		}
+		return nil
+	}
+
+	// We perform the CRDB converstion first, as this could fail and we do not
 	// want to print to stdout if there is an error.
 	crdbURL, err := u.ToCRDB()
 	if err != nil {
 		return err
 	}
 
+	// The user didn't specify a format, so we display all of them with a header.
 	cp := ttycolor.StdoutProfile
 	yc := cp[ttycolor.Yellow]
 	rc := cp[ttycolor.Reset]

--- a/pkg/cli/convert_url_test.go
+++ b/pkg/cli/convert_url_test.go
@@ -18,6 +18,24 @@ func Example_convert_url() {
 
 	c.RunWithArgs([]string{`convert-url`})
 	c.RunWithArgs([]string{`convert-url`, `--url`, `postgres://foo@bar`, `--cluster`, `app`})
+	c.RunWithArgs([]string{`convert-url`, `--url`, `postgres://foo@bar`, `--format`, `dsn`})
+	c.RunWithArgs([]string{`convert-url`, `--url`, `postgres://foo@bar`, `--format`, `pq`})
+	c.RunWithArgs([]string{`convert-url`, `--url`, `postgres://foo@bar`, `--format`, `jdbc`})
+
+	// --format crdb without --inline includes credentials.
+	c.RunWithArgs([]string{
+		`convert-url`,
+		`--url`, `postgres://bar`,
+		`--user`, `foo`,
+		`--password`, `secret`,
+		`--format`, `crdb`,
+	})
+
+	// Password embedded in the URL is preserved.
+	c.RunWithArgs([]string{`convert-url`, `--url`, `postgres://foo:s3cret@qux`, `--format`, `crdb`})
+
+	// Invalid --format value.
+	c.RunWithArgs([]string{`convert-url`, `--url`, `postgres://foo@bar`, `--format`, `invalid`})
 
 	// Flag overrides take precedence over URL values.
 	c.RunWithArgs([]string{
@@ -54,6 +72,18 @@ func Example_convert_url() {
 	//
 	// # Direct URL to CockroachDB:
 	// postgresql://foo@bar:26257/defaultdb?options=-ccluster%3Dapp
+	// convert-url --url postgres://foo@bar --format dsn
+	// database=defaultdb user=foo host=bar port=26257
+	// convert-url --url postgres://foo@bar --format pq
+	// postgresql://foo@bar:26257/defaultdb
+	// convert-url --url postgres://foo@bar --format jdbc
+	// jdbc:postgresql://bar:26257/defaultdb?user=foo
+	// convert-url --url postgres://bar --user foo --password secret --format crdb
+	// postgresql://foo:secret@bar:26257/defaultdb
+	// convert-url --url postgres://foo:s3cret@qux --format crdb
+	// postgresql://foo:s3cret@qux:26257/defaultdb
+	// convert-url --url postgres://foo@bar --format invalid
+	// ERROR: invalid argument "invalid" for "--format" flag: must be one of [pq dsn jdbc crdb]
 	// convert-url --url postgres://foo@qux/origdb --user baz --database newdb
 	// # Connection URL for libpq (C/C++), psycopg (Python), lib/pq & pgx (Go), node-postgres (JS) and most pq-compatible drivers:
 	// postgresql://baz@qux:26257/newdb
@@ -74,7 +104,7 @@ func Example_convert_url_with_inline() {
 	})
 	defer c.Cleanup()
 
-	cleanup, err := setupTestCertsDir()
+	cleanup, err := setupTestCertsDir("root")
 	if err != nil {
 		fmt.Println("could not set up test certs directory:", err)
 		return
@@ -86,26 +116,62 @@ func Example_convert_url_with_inline() {
 		`convert-url`,
 		`--url`, `postgres://bar`,
 		`--certs-dir`, `certs/`,
-		`--user`, `foo`,
+		`--user`, `root`,
+		`--password`, `secret`,
+		`--database`, `mydb`,
+		`--cluster`, `app`,
+		`--format`, `crdb`,
+		`--inline`,
+	})
+	// Inline defaults to --format crdb
+	c.RunWithArgs([]string{
+		`convert-url`,
+		`--url`, `postgres://bar`,
+		`--certs-dir`, `certs/`,
+		`--user`, `root`,
 		`--password`, `secret`,
 		`--database`, `mydb`,
 		`--cluster`, `app`,
 		`--inline`,
 	})
+	// Inline with explicit cert flags instead of --certs-dir.
+	c.RunWithArgs([]string{
+		`convert-url`,
+		`--url`, `postgres://bar`,
+		`--ca-cert`, `certs/ca.crt`,
+		`--cert`, `certs/client.root.crt`,
+		`--key`, `certs/client.root.key`,
+		`--user`, `root`,
+		`--format`, `crdb`,
+		`--inline`,
+	})
+	// Inline without specifying user should default to root certs.
+	c.RunWithArgs([]string{
+		`convert-url`,
+		`--url`, `postgres://bar`,
+		`--certs-dir`, `certs/`,
+		`--format`, `crdb`,
+		`--inline`,
+	})
+	// Inline fails on other formats
+	c.RunWithArgs([]string{
+		`convert-url`,
+		`--url`, `postgres://bar`,
+		`--format`, `jdbc`,
+		`--inline`,
+	})
 
 	// Output:
-	// convert-url --url postgres://bar --certs-dir certs/ --user foo --password secret --database mydb --cluster app --inline
-	// # Connection URL for libpq (C/C++), psycopg (Python), lib/pq & pgx (Go), node-postgres (JS) and most pq-compatible drivers:
-	// postgresql://foo:secret@bar:26257/mydb?options=-ccluster%3Dapp&sslcert=certs%2Fclient.foo.crt&sslinline=true&sslkey=certs%2Fclient.foo.key&sslmode=verify-full&sslrootcert=certs%2Fca.crt
-	//
-	// # Connection DSN (Data Source Name) for Postgres drivers that accept DSNs - most drivers and also ODBC:
-	// database=mydb user=foo host=bar port=26257 password=secret sslcert=certs/client.foo.crt sslkey=certs/client.foo.key sslrootcert=certs/ca.crt sslmode=verify-full options=-ccluster=app sslinline=true
-	//
-	// # Connection URL for JDBC (Java and JVM-based languages):
-	// jdbc:postgresql://bar:26257/mydb?options=-ccluster%3Dapp&password=secret&sslcert=certs%2Fclient.foo.crt&sslinline=true&sslkey=certs%2Fclient.foo.key&sslmode=verify-full&sslrootcert=certs%2Fca.crt&user=foo
-	//
-	// # Direct URL to CockroachDB:
-	// postgresql://foo:secret@bar:26257/mydb?options=-ccluster%3Dapp&sslcert=clientCertContents&sslinline=true&sslkey=clientKeyContents&sslmode=verify-full&sslrootcert=caCertContents
+	// convert-url --url postgres://bar --certs-dir certs/ --user root --password secret --database mydb --cluster app --format crdb --inline
+	// postgresql://root:secret@bar:26257/mydb?options=-ccluster%3Dapp&sslcert=clientCertContents&sslinline=true&sslkey=clientKeyContents&sslmode=verify-full&sslrootcert=caCertContents
+	// convert-url --url postgres://bar --certs-dir certs/ --user root --password secret --database mydb --cluster app --inline
+	// postgresql://root:secret@bar:26257/mydb?options=-ccluster%3Dapp&sslcert=clientCertContents&sslinline=true&sslkey=clientKeyContents&sslmode=verify-full&sslrootcert=caCertContents
+	// convert-url --url postgres://bar --ca-cert certs/ca.crt --cert certs/client.root.crt --key certs/client.root.key --user root --format crdb --inline
+	// postgresql://root@bar:26257/defaultdb?sslcert=clientCertContents&sslinline=true&sslkey=clientKeyContents&sslmode=verify-full&sslrootcert=caCertContents
+	// convert-url --url postgres://bar --certs-dir certs/ --format crdb --inline
+	// postgresql://root@bar:26257/defaultdb?sslcert=clientCertContents&sslinline=true&sslkey=clientKeyContents&sslmode=verify-full&sslrootcert=caCertContents
+	// convert-url --url postgres://bar --format jdbc --inline
+	// ERROR: --inline only supports --format=crdb
 }
 
 func Example_convert_url_with_certs() {
@@ -114,7 +180,7 @@ func Example_convert_url_with_certs() {
 	})
 	defer c.Cleanup()
 
-	cleanup, err := setupTestCertsDir()
+	cleanup, err := setupTestCertsDir("foo")
 	if err != nil {
 		fmt.Println("could not set up test certs directory:", err)
 		return
@@ -167,7 +233,7 @@ func Example_convert_url_with_certs() {
 }
 
 // setupTestCertsDir sets up a temp working directory with test certs.
-func setupTestCertsDir() (cleanup func(), retErr error) {
+func setupTestCertsDir(user string) (cleanup func(), retErr error) {
 	tmpdir, err := os.MkdirTemp("", "*")
 	if err != nil {
 		return nil, err
@@ -203,8 +269,8 @@ func setupTestCertsDir() (cleanup func(), retErr error) {
 		perm     os.FileMode
 	}{
 		{"certs/ca.crt", "caCertContents", 0644},
-		{"certs/client.foo.key", "clientKeyContents", 0600},
-		{"certs/client.foo.crt", "clientCertContents", 0644},
+		{fmt.Sprintf("certs/client.%s.key", user), "clientKeyContents", 0600},
+		{fmt.Sprintf("certs/client.%s.crt", user), "clientCertContents", 0644},
 	} {
 		if err := os.WriteFile(f.name, []byte(f.contents), f.perm); err != nil {
 			return nil, err

--- a/pkg/cli/convert_url_test.go
+++ b/pkg/cli/convert_url_test.go
@@ -10,6 +10,13 @@ import (
 	"os"
 )
 
+func printHeader(name string) {
+	fmt.Println()
+	fmt.Println("---------------------------------------------")
+	fmt.Println(name)
+	fmt.Println("---------------------------------------------")
+}
+
 func Example_convert_url() {
 	c := NewCLITest(TestCLIParams{
 		NoServer: true,
@@ -17,12 +24,20 @@ func Example_convert_url() {
 	defer c.Cleanup()
 
 	c.RunWithArgs([]string{`convert-url`})
+
+	printHeader("all formats with cluster")
 	c.RunWithArgs([]string{`convert-url`, `--url`, `postgres://foo@bar`, `--cluster`, `app`})
+
+	printHeader("format: dsn")
 	c.RunWithArgs([]string{`convert-url`, `--url`, `postgres://foo@bar`, `--format`, `dsn`})
+
+	printHeader("format: pq")
 	c.RunWithArgs([]string{`convert-url`, `--url`, `postgres://foo@bar`, `--format`, `pq`})
+
+	printHeader("format: jdbc")
 	c.RunWithArgs([]string{`convert-url`, `--url`, `postgres://foo@bar`, `--format`, `jdbc`})
 
-	// --format crdb without --inline includes credentials.
+	printHeader("format: crdb with credentials")
 	c.RunWithArgs([]string{
 		`convert-url`,
 		`--url`, `postgres://bar`,
@@ -31,13 +46,13 @@ func Example_convert_url() {
 		`--format`, `crdb`,
 	})
 
-	// Password embedded in the URL is preserved.
+	printHeader("format: crdb with password in URL")
 	c.RunWithArgs([]string{`convert-url`, `--url`, `postgres://foo:s3cret@qux`, `--format`, `crdb`})
 
-	// Invalid --format value.
+	printHeader("invalid format")
 	c.RunWithArgs([]string{`convert-url`, `--url`, `postgres://foo@bar`, `--format`, `invalid`})
 
-	// Flag overrides take precedence over URL values.
+	printHeader("flag overrides")
 	c.RunWithArgs([]string{
 		`convert-url`,
 		`--url`, `postgres://foo@qux/origdb`,
@@ -60,6 +75,10 @@ func Example_convert_url() {
 	//
 	// # Direct URL to CockroachDB:
 	// postgresql://root@localhost:26257/defaultdb
+	//
+	// ---------------------------------------------
+	// all formats with cluster
+	// ---------------------------------------------
 	// convert-url --url postgres://foo@bar --cluster app
 	// # Connection URL for libpq (C/C++), psycopg (Python), lib/pq & pgx (Go), node-postgres (JS) and most pq-compatible drivers:
 	// postgresql://foo@bar:26257/defaultdb?options=-ccluster%3Dapp
@@ -72,18 +91,46 @@ func Example_convert_url() {
 	//
 	// # Direct URL to CockroachDB:
 	// postgresql://foo@bar:26257/defaultdb?options=-ccluster%3Dapp
+	//
+	// ---------------------------------------------
+	// format: dsn
+	// ---------------------------------------------
 	// convert-url --url postgres://foo@bar --format dsn
 	// database=defaultdb user=foo host=bar port=26257
+	//
+	// ---------------------------------------------
+	// format: pq
+	// ---------------------------------------------
 	// convert-url --url postgres://foo@bar --format pq
 	// postgresql://foo@bar:26257/defaultdb
+	//
+	// ---------------------------------------------
+	// format: jdbc
+	// ---------------------------------------------
 	// convert-url --url postgres://foo@bar --format jdbc
 	// jdbc:postgresql://bar:26257/defaultdb?user=foo
+	//
+	// ---------------------------------------------
+	// format: crdb with credentials
+	// ---------------------------------------------
 	// convert-url --url postgres://bar --user foo --password secret --format crdb
 	// postgresql://foo:secret@bar:26257/defaultdb
+	//
+	// ---------------------------------------------
+	// format: crdb with password in URL
+	// ---------------------------------------------
 	// convert-url --url postgres://foo:s3cret@qux --format crdb
 	// postgresql://foo:s3cret@qux:26257/defaultdb
+	//
+	// ---------------------------------------------
+	// invalid format
+	// ---------------------------------------------
 	// convert-url --url postgres://foo@bar --format invalid
 	// ERROR: invalid argument "invalid" for "--format" flag: must be one of [pq dsn jdbc crdb]
+	//
+	// ---------------------------------------------
+	// flag overrides
+	// ---------------------------------------------
 	// convert-url --url postgres://foo@qux/origdb --user baz --database newdb
 	// # Connection URL for libpq (C/C++), psycopg (Python), lib/pq & pgx (Go), node-postgres (JS) and most pq-compatible drivers:
 	// postgresql://baz@qux:26257/newdb
@@ -123,7 +170,8 @@ func Example_convert_url_with_inline() {
 		`--format`, `crdb`,
 		`--inline`,
 	})
-	// Inline defaults to --format crdb
+
+	printHeader("inline defaults to crdb")
 	c.RunWithArgs([]string{
 		`convert-url`,
 		`--url`, `postgres://bar`,
@@ -134,7 +182,8 @@ func Example_convert_url_with_inline() {
 		`--cluster`, `app`,
 		`--inline`,
 	})
-	// Inline with explicit cert flags instead of --certs-dir.
+
+	printHeader("inline with explicit cert flags")
 	c.RunWithArgs([]string{
 		`convert-url`,
 		`--url`, `postgres://bar`,
@@ -145,7 +194,7 @@ func Example_convert_url_with_inline() {
 		`--format`, `crdb`,
 		`--inline`,
 	})
-	// Inline without specifying user should default to root certs.
+	printHeader("inline without specifying user")
 	c.RunWithArgs([]string{
 		`convert-url`,
 		`--url`, `postgres://bar`,
@@ -153,7 +202,8 @@ func Example_convert_url_with_inline() {
 		`--format`, `crdb`,
 		`--inline`,
 	})
-	// Inline fails on other formats
+
+	printHeader("inline fails on other formats")
 	c.RunWithArgs([]string{
 		`convert-url`,
 		`--url`, `postgres://bar`,
@@ -164,12 +214,28 @@ func Example_convert_url_with_inline() {
 	// Output:
 	// convert-url --url postgres://bar --certs-dir certs/ --user root --password secret --database mydb --cluster app --format crdb --inline
 	// postgresql://root:secret@bar:26257/mydb?options=-ccluster%3Dapp&sslcert=clientCertContents&sslinline=true&sslkey=clientKeyContents&sslmode=verify-full&sslrootcert=caCertContents
+	//
+	// ---------------------------------------------
+	// inline defaults to crdb
+	// ---------------------------------------------
 	// convert-url --url postgres://bar --certs-dir certs/ --user root --password secret --database mydb --cluster app --inline
 	// postgresql://root:secret@bar:26257/mydb?options=-ccluster%3Dapp&sslcert=clientCertContents&sslinline=true&sslkey=clientKeyContents&sslmode=verify-full&sslrootcert=caCertContents
+	//
+	// ---------------------------------------------
+	// inline with explicit cert flags
+	// ---------------------------------------------
 	// convert-url --url postgres://bar --ca-cert certs/ca.crt --cert certs/client.root.crt --key certs/client.root.key --user root --format crdb --inline
 	// postgresql://root@bar:26257/defaultdb?sslcert=clientCertContents&sslinline=true&sslkey=clientKeyContents&sslmode=verify-full&sslrootcert=caCertContents
+	//
+	// ---------------------------------------------
+	// inline without specifying user
+	// ---------------------------------------------
 	// convert-url --url postgres://bar --certs-dir certs/ --format crdb --inline
 	// postgresql://root@bar:26257/defaultdb?sslcert=clientCertContents&sslinline=true&sslkey=clientKeyContents&sslmode=verify-full&sslrootcert=caCertContents
+	//
+	// ---------------------------------------------
+	// inline fails on other formats
+	// ---------------------------------------------
 	// convert-url --url postgres://bar --format jdbc --inline
 	// ERROR: --inline only supports --format=crdb
 }
@@ -196,7 +262,7 @@ func Example_convert_url_with_certs() {
 		`--key`, `path/to/client.key`,
 	})
 
-	// --certs-dir with explicit --ca-cert override.
+	printHeader("certs-dir with ca-cert override")
 	c.RunWithArgs([]string{
 		`convert-url`,
 		`--url`, `postgres://bar`,
@@ -218,6 +284,10 @@ func Example_convert_url_with_certs() {
 	//
 	// # Direct URL to CockroachDB:
 	// postgresql://foo@bar:26257/defaultdb?sslcert=path%2Fto%2Fclient.crt&sslkey=path%2Fto%2Fclient.key&sslmode=verify-full&sslrootcert=path%2Fto%2Fca.crt
+	//
+	// ---------------------------------------------
+	// certs-dir with ca-cert override
+	// ---------------------------------------------
 	// convert-url --url postgres://bar --user foo --certs-dir certs/ --ca-cert custom/ca.crt
 	// # Connection URL for libpq (C/C++), psycopg (Python), lib/pq & pgx (Go), node-postgres (JS) and most pq-compatible drivers:
 	// postgresql://foo@bar:26257/defaultdb?sslcert=certs%2Fclient.foo.crt&sslkey=certs%2Fclient.foo.key&sslmode=verify-full&sslrootcert=custom%2Fca.crt

--- a/pkg/cli/convert_url_test.go
+++ b/pkg/cli/convert_url_test.go
@@ -5,6 +5,11 @@
 
 package cli
 
+import (
+	"fmt"
+	"os"
+)
+
 func Example_convert_url() {
 	c := NewCLITest(TestCLIParams{
 		NoServer: true,
@@ -12,7 +17,15 @@ func Example_convert_url() {
 	defer c.Cleanup()
 
 	c.RunWithArgs([]string{`convert-url`})
-	c.RunWithArgs([]string{`convert-url`, `--url`, `postgres://foo@bar`})
+	c.RunWithArgs([]string{`convert-url`, `--url`, `postgres://foo@bar`, `--cluster`, `app`})
+
+	// Flag overrides take precedence over URL values.
+	c.RunWithArgs([]string{
+		`convert-url`,
+		`--url`, `postgres://foo@qux/origdb`,
+		`--user`, `baz`,
+		`--database`, `newdb`,
+	})
 
 	// Output:
 	// convert-url
@@ -27,14 +40,175 @@ func Example_convert_url() {
 	// # Connection URL for JDBC (Java and JVM-based languages):
 	// jdbc:postgresql://localhost:26257/defaultdb?user=root
 	//
-	// convert-url --url postgres://foo@bar
+	// # Direct URL to CockroachDB:
+	// postgresql://root@localhost:26257/defaultdb
+	// convert-url --url postgres://foo@bar --cluster app
 	// # Connection URL for libpq (C/C++), psycopg (Python), lib/pq & pgx (Go), node-postgres (JS) and most pq-compatible drivers:
-	// postgresql://foo@bar:26257/defaultdb
+	// postgresql://foo@bar:26257/defaultdb?options=-ccluster%3Dapp
 	//
 	// # Connection DSN (Data Source Name) for Postgres drivers that accept DSNs - most drivers and also ODBC:
-	// database=defaultdb user=foo host=bar port=26257
+	// database=defaultdb user=foo host=bar port=26257 options=-ccluster=app
 	//
 	// # Connection URL for JDBC (Java and JVM-based languages):
-	// jdbc:postgresql://bar:26257/defaultdb?user=foo
+	// jdbc:postgresql://bar:26257/defaultdb?options=-ccluster%3Dapp&user=foo
 	//
+	// # Direct URL to CockroachDB:
+	// postgresql://foo@bar:26257/defaultdb?options=-ccluster%3Dapp
+	// convert-url --url postgres://foo@qux/origdb --user baz --database newdb
+	// # Connection URL for libpq (C/C++), psycopg (Python), lib/pq & pgx (Go), node-postgres (JS) and most pq-compatible drivers:
+	// postgresql://baz@qux:26257/newdb
+	//
+	// # Connection DSN (Data Source Name) for Postgres drivers that accept DSNs - most drivers and also ODBC:
+	// database=newdb user=baz host=qux port=26257
+	//
+	// # Connection URL for JDBC (Java and JVM-based languages):
+	// jdbc:postgresql://qux:26257/newdb?user=baz
+	//
+	// # Direct URL to CockroachDB:
+	// postgresql://baz@qux:26257/newdb
+}
+
+func Example_convert_url_with_inline() {
+	c := NewCLITest(TestCLIParams{
+		NoServer: true,
+	})
+	defer c.Cleanup()
+
+	cleanup, err := setupTestCertsDir()
+	if err != nil {
+		fmt.Println("could not set up test certs directory:", err)
+		return
+	}
+	defer cleanup()
+
+	// Happy path
+	c.RunWithArgs([]string{
+		`convert-url`,
+		`--url`, `postgres://bar`,
+		`--certs-dir`, `certs/`,
+		`--user`, `foo`,
+		`--password`, `secret`,
+		`--database`, `mydb`,
+		`--cluster`, `app`,
+		`--inline`,
+	})
+
+	// Output:
+	// convert-url --url postgres://bar --certs-dir certs/ --user foo --password secret --database mydb --cluster app --inline
+	// # Connection URL for libpq (C/C++), psycopg (Python), lib/pq & pgx (Go), node-postgres (JS) and most pq-compatible drivers:
+	// postgresql://foo:secret@bar:26257/mydb?options=-ccluster%3Dapp&sslcert=certs%2Fclient.foo.crt&sslinline=true&sslkey=certs%2Fclient.foo.key&sslmode=verify-full&sslrootcert=certs%2Fca.crt
+	//
+	// # Connection DSN (Data Source Name) for Postgres drivers that accept DSNs - most drivers and also ODBC:
+	// database=mydb user=foo host=bar port=26257 password=secret sslcert=certs/client.foo.crt sslkey=certs/client.foo.key sslrootcert=certs/ca.crt sslmode=verify-full options=-ccluster=app sslinline=true
+	//
+	// # Connection URL for JDBC (Java and JVM-based languages):
+	// jdbc:postgresql://bar:26257/mydb?options=-ccluster%3Dapp&password=secret&sslcert=certs%2Fclient.foo.crt&sslinline=true&sslkey=certs%2Fclient.foo.key&sslmode=verify-full&sslrootcert=certs%2Fca.crt&user=foo
+	//
+	// # Direct URL to CockroachDB:
+	// postgresql://foo:secret@bar:26257/mydb?options=-ccluster%3Dapp&sslcert=clientCertContents&sslinline=true&sslkey=clientKeyContents&sslmode=verify-full&sslrootcert=caCertContents
+}
+
+func Example_convert_url_with_certs() {
+	c := NewCLITest(TestCLIParams{
+		NoServer: true,
+	})
+	defer c.Cleanup()
+
+	cleanup, err := setupTestCertsDir()
+	if err != nil {
+		fmt.Println("could not set up test certs directory:", err)
+		return
+	}
+	defer cleanup()
+
+	// Individual cert flags without --certs-dir.
+	c.RunWithArgs([]string{
+		`convert-url`,
+		`--url`, `postgres://foo@bar`,
+		`--ca-cert`, `path/to/ca.crt`,
+		`--cert`, `path/to/client.crt`,
+		`--key`, `path/to/client.key`,
+	})
+
+	// --certs-dir with explicit --ca-cert override.
+	c.RunWithArgs([]string{
+		`convert-url`,
+		`--url`, `postgres://bar`,
+		`--user`, `foo`,
+		`--certs-dir`, `certs/`,
+		`--ca-cert`, `custom/ca.crt`,
+	})
+
+	// Output:
+	// convert-url --url postgres://foo@bar --ca-cert path/to/ca.crt --cert path/to/client.crt --key path/to/client.key
+	// # Connection URL for libpq (C/C++), psycopg (Python), lib/pq & pgx (Go), node-postgres (JS) and most pq-compatible drivers:
+	// postgresql://foo@bar:26257/defaultdb?sslcert=path%2Fto%2Fclient.crt&sslkey=path%2Fto%2Fclient.key&sslmode=verify-full&sslrootcert=path%2Fto%2Fca.crt
+	//
+	// # Connection DSN (Data Source Name) for Postgres drivers that accept DSNs - most drivers and also ODBC:
+	// database=defaultdb user=foo host=bar port=26257 sslcert=path/to/client.crt sslkey=path/to/client.key sslrootcert=path/to/ca.crt sslmode=verify-full
+	//
+	// # Connection URL for JDBC (Java and JVM-based languages):
+	// jdbc:postgresql://bar:26257/defaultdb?sslcert=path%2Fto%2Fclient.crt&sslkey=path%2Fto%2Fclient.key&sslmode=verify-full&sslrootcert=path%2Fto%2Fca.crt&user=foo
+	//
+	// # Direct URL to CockroachDB:
+	// postgresql://foo@bar:26257/defaultdb?sslcert=path%2Fto%2Fclient.crt&sslkey=path%2Fto%2Fclient.key&sslmode=verify-full&sslrootcert=path%2Fto%2Fca.crt
+	// convert-url --url postgres://bar --user foo --certs-dir certs/ --ca-cert custom/ca.crt
+	// # Connection URL for libpq (C/C++), psycopg (Python), lib/pq & pgx (Go), node-postgres (JS) and most pq-compatible drivers:
+	// postgresql://foo@bar:26257/defaultdb?sslcert=certs%2Fclient.foo.crt&sslkey=certs%2Fclient.foo.key&sslmode=verify-full&sslrootcert=custom%2Fca.crt
+	//
+	// # Connection DSN (Data Source Name) for Postgres drivers that accept DSNs - most drivers and also ODBC:
+	// database=defaultdb user=foo host=bar port=26257 sslcert=certs/client.foo.crt sslkey=certs/client.foo.key sslrootcert=custom/ca.crt sslmode=verify-full
+	//
+	// # Connection URL for JDBC (Java and JVM-based languages):
+	// jdbc:postgresql://bar:26257/defaultdb?sslcert=certs%2Fclient.foo.crt&sslkey=certs%2Fclient.foo.key&sslmode=verify-full&sslrootcert=custom%2Fca.crt&user=foo
+	//
+	// # Direct URL to CockroachDB:
+	// postgresql://foo@bar:26257/defaultdb?sslcert=certs%2Fclient.foo.crt&sslkey=certs%2Fclient.foo.key&sslmode=verify-full&sslrootcert=custom%2Fca.crt
+}
+
+// setupTestCertsDir sets up a temp working directory with test certs.
+func setupTestCertsDir() (cleanup func(), retErr error) {
+	tmpdir, err := os.MkdirTemp("", "*")
+	if err != nil {
+		return nil, err
+	}
+	oldWD, err := os.Getwd()
+	if err != nil {
+		_ = os.RemoveAll(tmpdir)
+		return nil, err
+	}
+	if err := os.Chdir(tmpdir); err != nil {
+		_ = os.RemoveAll(tmpdir)
+		return nil, err
+	}
+	cleanupFn := func() {
+		if err := os.Chdir(oldWD); err != nil {
+			fmt.Println("could not restore working directory:", err)
+		}
+		if err := os.RemoveAll(tmpdir); err != nil {
+			fmt.Println("could not remove temporary directory:", err)
+		}
+	}
+	defer func() {
+		if retErr != nil {
+			cleanupFn()
+		}
+	}()
+	if err := os.Mkdir("certs", 0755); err != nil {
+		return nil, err
+	}
+	for _, f := range []struct {
+		name     string
+		contents string
+		perm     os.FileMode
+	}{
+		{"certs/ca.crt", "caCertContents", 0644},
+		{"certs/client.foo.key", "clientKeyContents", 0600},
+		{"certs/client.foo.crt", "clientCertContents", 0644},
+	} {
+		if err := os.WriteFile(f.name, []byte(f.contents), f.perm); err != nil {
+			return nil, err
+		}
+	}
+	return cleanupFn, nil
 }

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -758,7 +758,7 @@ func init() {
 
 		f.BoolVar(
 			&convertCtx.sslInline, "inline", convertCtx.sslInline,
-			"replace certificate file paths with their contents inline in the URL",
+			"replace certificate file paths with their contents inline in the URL. If set, forces CRDB URL format output (i.e. --format=crdb)",
 		)
 		f.StringVar(
 			&convertCtx.database, "database", convertCtx.database,
@@ -791,6 +791,11 @@ func init() {
 		f.StringVar(
 			&convertCtx.keyPath, "key", convertCtx.keyPath,
 			"path to key for client-cert authentication",
+		)
+		f.Var(
+			&convertCtx.format,
+			"format",
+			fmt.Sprintf("output url format (one of %v). If not specified, all formats will be printed", convertURLFormats),
 		)
 	}
 

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -752,11 +752,46 @@ func init() {
 		cliflagcfg.StringSliceFlag(f, &cliCtx.certPrincipalMap, cliflags.CertPrincipalMap)
 	}
 
-	// convert-url is not really a client command. It just recognizes (some)
-	// client flags.
 	{
 		f := convertURLCmd.PersistentFlags()
 		cliflagcfg.StringFlag(f, &convertCtx.url, cliflags.URL)
+
+		f.BoolVar(
+			&convertCtx.sslInline, "inline", convertCtx.sslInline,
+			"replace certificate file paths with their contents inline in the URL",
+		)
+		f.StringVar(
+			&convertCtx.database, "database", convertCtx.database,
+			"database to connect to",
+		)
+		f.StringVar(
+			&convertCtx.username, "user", convertCtx.username,
+			"username to connect as",
+		)
+		f.StringVar(
+			&convertCtx.password, "password", convertCtx.password,
+			"password to connect with",
+		)
+		f.StringVar(
+			&convertCtx.cluster, "cluster", convertCtx.cluster,
+			"virtual cluster name to connect to",
+		)
+		f.StringVar(
+			&convertCtx.certsDir, "certs-dir", convertCtx.certsDir,
+			"certs directory to automatically load certs from",
+		)
+		f.StringVar(
+			&convertCtx.caCertPath, "ca-cert", convertCtx.caCertPath,
+			"path to CA certificate",
+		)
+		f.StringVar(
+			&convertCtx.certPath, "cert", convertCtx.certPath,
+			"path to certificate for client-cert authentication",
+		)
+		f.StringVar(
+			&convertCtx.keyPath, "key", convertCtx.keyPath,
+			"path to key for client-cert authentication",
+		)
 	}
 
 	// Auth commands.

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -1364,7 +1364,6 @@ Available Commands:
   debug             debugging commands
   sqlfmt            format SQL statements
   workload          generators for data and query loads
-  encode-uri        encode a CRDB connection URL
   help              Help about any command
 
 Flags:

--- a/pkg/server/pgurl/generate.go
+++ b/pkg/server/pgurl/generate.go
@@ -8,6 +8,7 @@ package pgurl
 import (
 	"net"
 	"net/url"
+	"os"
 	"sort"
 	"strings"
 )
@@ -140,6 +141,62 @@ func (u *URL) ToJDBC() *url.URL {
 
 	nu.RawQuery = opts.Encode()
 	return nu
+}
+
+// ToCRDB converts the URL to a connection string for use with CRDB.
+// If sslinline is true, the certificate contents will be inlined
+// in the URL instead of the file paths.
+func (u *URL) ToCRDB() (*url.URL, error) {
+	nu, opts := u.baseURL()
+
+	if u.username != "" {
+		nu.User = url.User(u.username)
+	}
+	switch u.authn {
+	case authnPassword, authnPasswordWithClientCert:
+		if u.hasPassword {
+			nu.User = url.UserPassword(u.username, u.password)
+		}
+	}
+
+	if opts.Get("sslinline") != "true" {
+		nu.RawQuery = opts.Encode()
+		return nu, nil
+	}
+
+	getCert := func(path string) (string, error) {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return "", err
+		}
+		return string(content), err
+	}
+
+	if caCert := opts.Get("sslrootcert"); caCert != "" {
+		caCertContent, err := getCert(caCert)
+		if err != nil {
+			return nil, err
+		}
+		opts.Set("sslrootcert", caCertContent)
+	}
+
+	if cert := opts.Get("sslcert"); cert != "" {
+		certContent, err := getCert(cert)
+		if err != nil {
+			return nil, err
+		}
+		opts.Set("sslcert", certContent)
+	}
+
+	if key := opts.Get("sslkey"); key != "" {
+		keyContent, err := getCert(key)
+		if err != nil {
+			return nil, err
+		}
+		opts.Set("sslkey", keyContent)
+	}
+	nu.RawQuery = opts.Encode()
+	return nu, nil
 }
 
 // baseURL constructs the URL fields common to both

--- a/pkg/server/pgurl/pgurl_test.go
+++ b/pkg/server/pgurl/pgurl_test.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"fmt"
 	"net/url"
+	"os"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
@@ -18,6 +19,27 @@ import (
 )
 
 func TestURL(t *testing.T) {
+	// Create certificate files in a temporary directory for use with --inline.
+	tmpdir := t.TempDir()
+	oldWD, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpdir))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(oldWD))
+	})
+	require.NoError(t, os.Mkdir("certs", 0755))
+	for _, f := range []struct {
+		name     string
+		contents string
+		perm     os.FileMode
+	}{
+		{"certs/ca.crt", "caCertContents", 0644},
+		{"certs/client.root.key", "clientKeyContents", 0600},
+		{"certs/client.root.crt", "clientCertContents", 0644},
+	} {
+		require.NoError(t, os.WriteFile(f.name, []byte(f.contents), f.perm))
+	}
+
 	datadriven.RunTest(t, datapathutils.TestDataPath(t, "url"), func(t *testing.T, td *datadriven.TestData) string {
 		var result bytes.Buffer
 
@@ -45,6 +67,11 @@ func TestURL(t *testing.T) {
 		fmt.Fprintf(&result, "pq URL: %s\n", u.ToPQ())
 		fmt.Fprintf(&result, "DSN:    %s\n", u.ToDSN())
 		fmt.Fprintf(&result, "JDBC:   %s\n", u.ToJDBC())
+		if crdbURL, err := u.ToCRDB(); err == nil {
+			fmt.Fprintf(&result, "CRDB:   %s\n", crdbURL)
+		} else {
+			fmt.Fprintf(&result, "CRDB:   (err: %s)\n", err)
+		}
 
 		u.
 			WithDefaultUsername("defaultuser").
@@ -55,6 +82,11 @@ func TestURL(t *testing.T) {
 		fmt.Fprintf(&result, "pq URL: %s\n", u.ToPQ())
 		fmt.Fprintf(&result, "DSN:    %s\n", u.ToDSN())
 		fmt.Fprintf(&result, "JDBC:   %s\n", u.ToJDBC())
+		if crdbURL, err := u.ToCRDB(); err == nil {
+			fmt.Fprintf(&result, "CRDB:   %s\n", crdbURL)
+		} else {
+			fmt.Fprintf(&result, "CRDB:   (err: %s)\n", err)
+		}
 
 		return result.String()
 	})

--- a/pkg/server/pgurl/testdata/url
+++ b/pkg/server/pgurl/testdata/url
@@ -4,10 +4,12 @@ postgres://somehost
 pq URL: postgresql://somehost/
 DSN:    host=somehost
 JDBC:   jdbc:postgresql://somehost/
+CRDB:   postgresql://somehost/
 --defaults filled--
 pq URL: postgresql://defaultuser@somehost:26257/defaultdb
 DSN:    database=defaultdb user=defaultuser host=somehost port=26257
 JDBC:   jdbc:postgresql://somehost:26257/defaultdb?user=defaultuser
+CRDB:   postgresql://defaultuser@somehost:26257/defaultdb
 
 # Empty host.
 url
@@ -16,10 +18,12 @@ postgres:///somedb
 pq URL: postgresql:///somedb
 DSN:    database=somedb
 JDBC:   jdbc:postgresql:///somedb
+CRDB:   postgresql:///somedb
 --defaults filled--
 pq URL: postgresql://defaultuser@defaulthost:26257/somedb
 DSN:    database=somedb user=defaultuser host=defaulthost port=26257
 JDBC:   jdbc:postgresql://defaulthost:26257/somedb?user=defaultuser
+CRDB:   postgresql://defaultuser@defaulthost:26257/somedb
 
 # Empty everything.
 url
@@ -28,10 +32,12 @@ postgres:///
 pq URL: postgresql:///
 DSN:    
 JDBC:   jdbc:postgresql:///
+CRDB:   postgresql:///
 --defaults filled--
 pq URL: postgresql://defaultuser@defaulthost:26257/defaultdb
 DSN:    database=defaultdb user=defaultuser host=defaulthost port=26257
 JDBC:   jdbc:postgresql://defaulthost:26257/defaultdb?user=defaultuser
+CRDB:   postgresql://defaultuser@defaulthost:26257/defaultdb
 
 url
 postgres://somehost:123/
@@ -39,10 +45,12 @@ postgres://somehost:123/
 pq URL: postgresql://somehost:123/
 DSN:    host=somehost port=123
 JDBC:   jdbc:postgresql://somehost:123/
+CRDB:   postgresql://somehost:123/
 --defaults filled--
 pq URL: postgresql://defaultuser@somehost:123/defaultdb
 DSN:    database=defaultdb user=defaultuser host=somehost port=123
 JDBC:   jdbc:postgresql://somehost:123/defaultdb?user=defaultuser
+CRDB:   postgresql://defaultuser@somehost:123/defaultdb
 
 url
 postgres://somehost/somedb
@@ -50,10 +58,12 @@ postgres://somehost/somedb
 pq URL: postgresql://somehost/somedb
 DSN:    database=somedb host=somehost
 JDBC:   jdbc:postgresql://somehost/somedb
+CRDB:   postgresql://somehost/somedb
 --defaults filled--
 pq URL: postgresql://defaultuser@somehost:26257/somedb
 DSN:    database=somedb user=defaultuser host=somehost port=26257
 JDBC:   jdbc:postgresql://somehost:26257/somedb?user=defaultuser
+CRDB:   postgresql://defaultuser@somehost:26257/somedb
 
 url
 postgres://someuser@somehost/somedb
@@ -61,10 +71,12 @@ postgres://someuser@somehost/somedb
 pq URL: postgresql://someuser@somehost/somedb
 DSN:    database=somedb user=someuser host=somehost
 JDBC:   jdbc:postgresql://somehost/somedb?user=someuser
+CRDB:   postgresql://someuser@somehost/somedb
 --defaults filled--
 pq URL: postgresql://someuser@somehost:26257/somedb
 DSN:    database=somedb user=someuser host=somehost port=26257
 JDBC:   jdbc:postgresql://somehost:26257/somedb?user=someuser
+CRDB:   postgresql://someuser@somehost:26257/somedb
 
 url
 postgres://someuser:somepass@somehost/somedb
@@ -72,10 +84,12 @@ postgres://someuser:somepass@somehost/somedb
 pq URL: postgresql://someuser:somepass@somehost/somedb
 DSN:    database=somedb user=someuser host=somehost password=somepass
 JDBC:   jdbc:postgresql://somehost/somedb?password=somepass&user=someuser
+CRDB:   postgresql://someuser:somepass@somehost/somedb
 --defaults filled--
 pq URL: postgresql://someuser:somepass@somehost:26257/somedb
 DSN:    database=somedb user=someuser host=somehost port=26257 password=somepass
 JDBC:   jdbc:postgresql://somehost:26257/somedb?password=somepass&user=someuser
+CRDB:   postgresql://someuser:somepass@somehost:26257/somedb
 
 url
 postgres://someuser:somepass@somehost/somedb?application_name=myapp
@@ -83,20 +97,24 @@ postgres://someuser:somepass@somehost/somedb?application_name=myapp
 pq URL: postgresql://someuser:somepass@somehost/somedb?application_name=myapp
 DSN:    database=somedb user=someuser host=somehost password=somepass application_name=myapp
 JDBC:   jdbc:postgresql://somehost/somedb?application_name=myapp&password=somepass&user=someuser
+CRDB:   postgresql://someuser:somepass@somehost/somedb?application_name=myapp
 --defaults filled--
 pq URL: postgresql://someuser:somepass@somehost:26257/somedb?application_name=myapp
 DSN:    database=somedb user=someuser host=somehost port=26257 password=somepass application_name=myapp
 JDBC:   jdbc:postgresql://somehost:26257/somedb?application_name=myapp&password=somepass&user=someuser
+CRDB:   postgresql://someuser:somepass@somehost:26257/somedb?application_name=myapp
 
 insecure
 ----
 pq URL: postgresql:///?sslmode=disable
 DSN:    sslmode=disable
 JDBC:   jdbc:postgresql:///?sslmode=disable
+CRDB:   postgresql:///?sslmode=disable
 --defaults filled--
 pq URL: postgresql://defaultuser@defaulthost:26257/defaultdb?sslmode=disable
 DSN:    database=defaultdb user=defaultuser host=defaulthost port=26257 sslmode=disable
 JDBC:   jdbc:postgresql://defaulthost:26257/defaultdb?sslmode=disable&user=defaultuser
+CRDB:   postgresql://defaultuser@defaulthost:26257/defaultdb?sslmode=disable
 
 subtest redundant
 
@@ -106,10 +124,12 @@ postgres://user1@host/?user=user2
 pq URL: postgresql://user2@host/
 DSN:    user=user2 host=host
 JDBC:   jdbc:postgresql://host/?user=user2
+CRDB:   postgresql://user2@host/
 --defaults filled--
 pq URL: postgresql://user2@host:26257/defaultdb
 DSN:    database=defaultdb user=user2 host=host port=26257
 JDBC:   jdbc:postgresql://host:26257/defaultdb?user=user2
+CRDB:   postgresql://user2@host:26257/defaultdb
 
 url
 postgres://user1@host/?user=user2&user=user3
@@ -117,10 +137,12 @@ postgres://user1@host/?user=user2&user=user3
 pq URL: postgresql://user3@host/
 DSN:    user=user3 host=host
 JDBC:   jdbc:postgresql://host/?user=user3
+CRDB:   postgresql://user3@host/
 --defaults filled--
 pq URL: postgresql://user3@host:26257/defaultdb
 DSN:    database=defaultdb user=user3 host=host port=26257
 JDBC:   jdbc:postgresql://host:26257/defaultdb?user=user3
+CRDB:   postgresql://user3@host:26257/defaultdb
 
 url
 postgres://user1:pw1@host/?password=pw2
@@ -128,10 +150,12 @@ postgres://user1:pw1@host/?password=pw2
 pq URL: postgresql://user1:pw2@host/
 DSN:    user=user1 host=host password=pw2
 JDBC:   jdbc:postgresql://host/?password=pw2&user=user1
+CRDB:   postgresql://user1:pw2@host/
 --defaults filled--
 pq URL: postgresql://user1:pw2@host:26257/defaultdb
 DSN:    database=defaultdb user=user1 host=host port=26257 password=pw2
 JDBC:   jdbc:postgresql://host:26257/defaultdb?password=pw2&user=user1
+CRDB:   postgresql://user1:pw2@host:26257/defaultdb
 
 url
 postgres://host1/?host=host2
@@ -139,10 +163,12 @@ postgres://host1/?host=host2
 pq URL: postgresql://host2/
 DSN:    host=host2
 JDBC:   jdbc:postgresql://host2/
+CRDB:   postgresql://host2/
 --defaults filled--
 pq URL: postgresql://defaultuser@host2:26257/defaultdb
 DSN:    database=defaultdb user=defaultuser host=host2 port=26257
 JDBC:   jdbc:postgresql://host2:26257/defaultdb?user=defaultuser
+CRDB:   postgresql://defaultuser@host2:26257/defaultdb
 
 subtest end
 
@@ -154,10 +180,12 @@ postgres://host/?k=v1&k=v2&k=v3
 pq URL: postgresql://host/?k=v1&k=v2&k=v3
 DSN:    host=host k=v1 k=v2 k=v3
 JDBC:   jdbc:postgresql://host/?k=v1&k=v2&k=v3
+CRDB:   postgresql://host/?k=v1&k=v2&k=v3
 --defaults filled--
 pq URL: postgresql://defaultuser@host:26257/defaultdb?k=v1&k=v2&k=v3
 DSN:    database=defaultdb user=defaultuser host=host port=26257 k=v1 k=v2 k=v3
 JDBC:   jdbc:postgresql://host:26257/defaultdb?k=v1&k=v2&k=v3&user=defaultuser
+CRDB:   postgresql://defaultuser@host:26257/defaultdb?k=v1&k=v2&k=v3
 
 subtest end
 
@@ -170,10 +198,12 @@ postgres://user:@foo
 pq URL: postgresql://user:@foo/
 DSN:    user=user host=foo password=
 JDBC:   jdbc:postgresql://foo/?password=&user=user
+CRDB:   postgresql://user:@foo/
 --defaults filled--
 pq URL: postgresql://user:@foo:26257/defaultdb
 DSN:    database=defaultdb user=user host=foo port=26257 password=
 JDBC:   jdbc:postgresql://foo:26257/defaultdb?password=&user=user
+CRDB:   postgresql://user:@foo:26257/defaultdb
 
 # Password with special characters.
 url
@@ -182,10 +212,12 @@ postgres://user:pw%5ca'b@foo
 pq URL: postgresql://user:pw%5Ca%27b@foo/
 DSN:    user=user host=foo password=pw\\a\'b
 JDBC:   jdbc:postgresql://foo/?password=pw%5Ca%27b&user=user
+CRDB:   postgresql://user:pw%5Ca%27b@foo/
 --defaults filled--
 pq URL: postgresql://user:pw%5Ca%27b@foo:26257/defaultdb
 DSN:    database=defaultdb user=user host=foo port=26257 password=pw\\a\'b
 JDBC:   jdbc:postgresql://foo:26257/defaultdb?password=pw%5Ca%27b&user=user
+CRDB:   postgresql://user:pw%5Ca%27b@foo:26257/defaultdb
 
 # DB with special characters.
 url
@@ -194,10 +226,12 @@ postgres://foo/bar%5c-'baz
 pq URL: postgresql://foo/bar%5C-%27baz
 DSN:    database=bar\\-\'baz host=foo
 JDBC:   jdbc:postgresql://foo/bar%5C-%27baz
+CRDB:   postgresql://foo/bar%5C-%27baz
 --defaults filled--
 pq URL: postgresql://defaultuser@foo:26257/bar%5C-%27baz
 DSN:    database=bar\\-\'baz user=defaultuser host=foo port=26257
 JDBC:   jdbc:postgresql://foo:26257/bar%5C-%27baz?user=defaultuser
+CRDB:   postgresql://defaultuser@foo:26257/bar%5C-%27baz
 
 
 # kwarg with special characters.
@@ -207,10 +241,12 @@ postgres://foo/bar?baz=a'-%5ce
 pq URL: postgresql://foo/bar?baz=a%27-%5Ce
 DSN:    database=bar host=foo baz=a\'-\\e
 JDBC:   jdbc:postgresql://foo/bar?baz=a%27-%5Ce
+CRDB:   postgresql://foo/bar?baz=a%27-%5Ce
 --defaults filled--
 pq URL: postgresql://defaultuser@foo:26257/bar?baz=a%27-%5Ce
 DSN:    database=bar user=defaultuser host=foo port=26257 baz=a\'-\\e
 JDBC:   jdbc:postgresql://foo:26257/bar?baz=a%27-%5Ce&user=defaultuser
+CRDB:   postgresql://defaultuser@foo:26257/bar?baz=a%27-%5Ce
 
 subtest end
 
@@ -231,10 +267,12 @@ Username cannot be empty when a password is provided.
 pq URL: postgresql://:pwd@host/
 DSN:    host=host password=pwd
 JDBC:   jdbc:postgresql://host/?password=pwd
+CRDB:   postgresql://:pwd@host/
 --defaults filled--
 pq URL: postgresql://defaultuser:pwd@host:26257/defaultdb
 DSN:    database=defaultdb user=defaultuser host=host port=26257 password=pwd
 JDBC:   jdbc:postgresql://host:26257/defaultdb?password=pwd&user=defaultuser
+CRDB:   postgresql://defaultuser:pwd@host:26257/defaultdb
 
 url
 postgres:///somedb?host=/tmp&sslmode=require
@@ -246,10 +284,12 @@ Cannot specify TLS settings when using unix sockets.
 pq URL: postgresql:///somedb?host=%2Ftmp&sslmode=require
 DSN:    database=somedb host=/tmp sslmode=require
 JDBC:   jdbc:postgresql:///somedb?host=%2Ftmp&sslmode=require
+CRDB:   postgresql:///somedb?host=%2Ftmp&sslmode=require
 --defaults filled--
 pq URL: postgresql://defaultuser@/somedb?host=%2Ftmp&port=26257&sslmode=require
 DSN:    database=somedb user=defaultuser host=/tmp port=26257 sslmode=require
 JDBC:   jdbc:postgresql:///somedb?host=%2Ftmp&port=26257&sslmode=require&user=defaultuser
+CRDB:   postgresql://defaultuser@/somedb?host=%2Ftmp&port=26257&sslmode=require
 
 url
 postgres:///somedb?sslmode=disable&sslcert=/a/b/c
@@ -262,9 +302,53 @@ Client key missing.
 pq URL: postgresql:///somedb?sslcert=%2Fa%2Fb%2Fc&sslkey=&sslmode=disable
 DSN:    database=somedb sslcert=/a/b/c sslkey= sslmode=disable
 JDBC:   jdbc:postgresql:///somedb?sslcert=%2Fa%2Fb%2Fc&sslkey=&sslmode=disable
+CRDB:   postgresql:///somedb?sslcert=%2Fa%2Fb%2Fc&sslkey=&sslmode=disable
 --defaults filled--
 pq URL: postgresql://defaultuser@defaulthost:26257/somedb?sslcert=%2Fa%2Fb%2Fc&sslkey=&sslmode=disable
 DSN:    database=somedb user=defaultuser host=defaulthost port=26257 sslcert=/a/b/c sslkey= sslmode=disable
 JDBC:   jdbc:postgresql://defaulthost:26257/somedb?sslcert=%2Fa%2Fb%2Fc&sslkey=&sslmode=disable&user=defaultuser
+CRDB:   postgresql://defaultuser@defaulthost:26257/somedb?sslcert=%2Fa%2Fb%2Fc&sslkey=&sslmode=disable
+
+# SSLInline with specified CA, client cert, and client key.
+url
+postgres://root@host?sslmode=verify-full&sslrootcert=certs%2Fca.crt&sslcert=certs%2Fclient.root.crt&sslkey=certs%2Fclient.root.key&sslinline=true
+----
+pq URL: postgresql://root@host/?sslcert=certs%2Fclient.root.crt&sslinline=true&sslkey=certs%2Fclient.root.key&sslmode=verify-full&sslrootcert=certs%2Fca.crt
+DSN:    user=root host=host sslcert=certs/client.root.crt sslkey=certs/client.root.key sslrootcert=certs/ca.crt sslmode=verify-full sslinline=true
+JDBC:   jdbc:postgresql://host/?sslcert=certs%2Fclient.root.crt&sslinline=true&sslkey=certs%2Fclient.root.key&sslmode=verify-full&sslrootcert=certs%2Fca.crt&user=root
+CRDB:   postgresql://root@host/?sslcert=clientCertContents&sslinline=true&sslkey=clientKeyContents&sslmode=verify-full&sslrootcert=caCertContents
+--defaults filled--
+pq URL: postgresql://root@host:26257/defaultdb?sslcert=certs%2Fclient.root.crt&sslinline=true&sslkey=certs%2Fclient.root.key&sslmode=verify-full&sslrootcert=certs%2Fca.crt
+DSN:    database=defaultdb user=root host=host port=26257 sslcert=certs/client.root.crt sslkey=certs/client.root.key sslrootcert=certs/ca.crt sslmode=verify-full sslinline=true
+JDBC:   jdbc:postgresql://host:26257/defaultdb?sslcert=certs%2Fclient.root.crt&sslinline=true&sslkey=certs%2Fclient.root.key&sslmode=verify-full&sslrootcert=certs%2Fca.crt&user=root
+CRDB:   postgresql://root@host:26257/defaultdb?sslcert=clientCertContents&sslinline=true&sslkey=clientKeyContents&sslmode=verify-full&sslrootcert=caCertContents
+
+# SSLInline with certs but no CA specified.
+url
+postgres://foo@host?sslmode=verify-full&sslinline=true&sslcert=certs%2Fclient.root.crt&sslkey=certs%2Fclient.root.key
+----
+pq URL: postgresql://foo@host/?sslcert=certs%2Fclient.root.crt&sslinline=true&sslkey=certs%2Fclient.root.key&sslmode=verify-full
+DSN:    user=foo host=host sslcert=certs/client.root.crt sslkey=certs/client.root.key sslmode=verify-full sslinline=true
+JDBC:   jdbc:postgresql://host/?sslcert=certs%2Fclient.root.crt&sslinline=true&sslkey=certs%2Fclient.root.key&sslmode=verify-full&user=foo
+CRDB:   postgresql://foo@host/?sslcert=clientCertContents&sslinline=true&sslkey=clientKeyContents&sslmode=verify-full
+--defaults filled--
+pq URL: postgresql://foo@host:26257/defaultdb?sslcert=certs%2Fclient.root.crt&sslinline=true&sslkey=certs%2Fclient.root.key&sslmode=verify-full
+DSN:    database=defaultdb user=foo host=host port=26257 sslcert=certs/client.root.crt sslkey=certs/client.root.key sslmode=verify-full sslinline=true
+JDBC:   jdbc:postgresql://host:26257/defaultdb?sslcert=certs%2Fclient.root.crt&sslinline=true&sslkey=certs%2Fclient.root.key&sslmode=verify-full&user=foo
+CRDB:   postgresql://foo@host:26257/defaultdb?sslcert=clientCertContents&sslinline=true&sslkey=clientKeyContents&sslmode=verify-full
+
+# SSLInline but certs point to non-existent files.
+url
+postgres://foo@host?sslmode=verify-full&sslinline=true&sslrootcert=certs%2Fca.crt&sslcert=certs%2Fclient.foo.crt&sslkey=certs%2Fclient.foo.key
+----
+pq URL: postgresql://foo@host/?sslcert=certs%2Fclient.foo.crt&sslinline=true&sslkey=certs%2Fclient.foo.key&sslmode=verify-full&sslrootcert=certs%2Fca.crt
+DSN:    user=foo host=host sslcert=certs/client.foo.crt sslkey=certs/client.foo.key sslrootcert=certs/ca.crt sslmode=verify-full sslinline=true
+JDBC:   jdbc:postgresql://host/?sslcert=certs%2Fclient.foo.crt&sslinline=true&sslkey=certs%2Fclient.foo.key&sslmode=verify-full&sslrootcert=certs%2Fca.crt&user=foo
+CRDB:   (err: open certs/client.foo.crt: no such file or directory)
+--defaults filled--
+pq URL: postgresql://foo@host:26257/defaultdb?sslcert=certs%2Fclient.foo.crt&sslinline=true&sslkey=certs%2Fclient.foo.key&sslmode=verify-full&sslrootcert=certs%2Fca.crt
+DSN:    database=defaultdb user=foo host=host port=26257 sslcert=certs/client.foo.crt sslkey=certs/client.foo.key sslrootcert=certs/ca.crt sslmode=verify-full sslinline=true
+JDBC:   jdbc:postgresql://host:26257/defaultdb?sslcert=certs%2Fclient.foo.crt&sslinline=true&sslkey=certs%2Fclient.foo.key&sslmode=verify-full&sslrootcert=certs%2Fca.crt&user=foo
+CRDB:   (err: open certs/client.foo.crt: no such file or directory)
 
 subtest end

--- a/scripts/drtprod
+++ b/scripts/drtprod
@@ -401,8 +401,8 @@ EOF"
         $0 start drt-ua2 --restart=false
 
         # tell the clusters about eachother.
-        ua2="$(roachprod ssh drt-ua2:1 -- ./cockroach convert-url --inline --ca-cert ./certs/ca.crt --key ./certs/client.root.key --cert ./certs/client.root.crt --url {pgurl:1:system} | tail -1)"
-        ua1="$(roachprod ssh drt-ua1:1 -- ./cockroach convert-url --inline --ca-cert ./certs/ca.crt --key ./certs/client.root.key --cert ./certs/client.root.crt --url {pgurl:1:system} | tail -1)"
+        ua2="$(roachprod ssh drt-ua2:1 -- ./cockroach convert-url --inline --ca-cert ./certs/ca.crt --key ./certs/client.root.key --cert ./certs/client.root.crt --url {pgurl:1:system})"
+        ua1="$(roachprod ssh drt-ua1:1 -- ./cockroach convert-url --inline --ca-cert ./certs/ca.crt --key ./certs/client.root.key --cert ./certs/client.root.crt --url {pgurl:1:system})"
         $0 sql drt-ua1:1 --cluster=system -- -e "CREATE EXTERNAL CONNECTION 'drt-ua2' AS '${ua2}'"
         $0 sql drt-ua2:1 --cluster=system -- -e "CREATE EXTERNAL CONNECTION 'drt-ua1' AS '${ua1}'"
 
@@ -558,8 +558,8 @@ EOF"
         $0 ssh drt-ldr2:1 "./cockroach workload init ycsb --workload=A --insert-count=1000 --families=false --insert-start=4511686018427387904 {pgurl:1}"
 
         # tell the clusters about eachother.
-        ldr2="$(roachprod ssh drt-ldr2:1 -- ./cockroach convert-url --inline --ca-cert ./certs/ca.crt --key ./certs/client.root.key --cert ./certs/client.root.crt --database ycsb --user root --url {pgurl:1} | tail -1)"
-        ldr1="$(roachprod ssh drt-ldr1:1 -- ./cockroach convert-url --inline --ca-cert ./certs/ca.crt --key ./certs/client.root.key --cert ./certs/client.root.crt --database ycsb --user root --url {pgurl:1} | tail -1)"
+        ldr2="$(roachprod ssh drt-ldr2:1 -- ./cockroach convert-url --inline --ca-cert ./certs/ca.crt --key ./certs/client.root.key --cert ./certs/client.root.crt --database ycsb --user root --url {pgurl:1})"
+        ldr1="$(roachprod ssh drt-ldr1:1 -- ./cockroach convert-url --inline --ca-cert ./certs/ca.crt --key ./certs/client.root.key --cert ./certs/client.root.crt --database ycsb --user root --url {pgurl:1})"
         $0 sql drt-ldr1:1 -- -e "CREATE EXTERNAL CONNECTION 'drt-ldr2' AS '${ldr2}'"
         $0 sql drt-ldr2:1 -- -e "CREATE EXTERNAL CONNECTION 'drt-ldr1' AS '${ldr1}'"
 

--- a/scripts/drtprod
+++ b/scripts/drtprod
@@ -64,7 +64,7 @@ case $1 in
     if [ "$#" -lt 2 ]; then
       echo "usage: drtprod $1 <cluster> [create]"
       exit 1
-    fi 
+    fi
     # roachprod only manages DNS in ephemeral, so we just do this ourselves.
     # These are very low-churn clusters so this is fine being manual and in a
     # wrapper.
@@ -401,8 +401,8 @@ EOF"
         $0 start drt-ua2 --restart=false
 
         # tell the clusters about eachother.
-        ua2="$(roachprod ssh drt-ua2:1 -- ./cockroach encode-uri --inline --ca-cert ./certs/ca.crt --key ./certs/client.root.key --cert ./certs/client.root.crt {pgurl:1:system} | sed 's,postgresql://postgres://,postgres://,')"
-        ua1="$(roachprod ssh drt-ua1:1 -- ./cockroach encode-uri --inline --ca-cert ./certs/ca.crt --key ./certs/client.root.key --cert ./certs/client.root.crt {pgurl:1:system} | sed 's,postgresql://postgres://,postgres://,')"
+        ua2="$(roachprod ssh drt-ua2:1 -- ./cockroach convert-url --inline --ca-cert ./certs/ca.crt --key ./certs/client.root.key --cert ./certs/client.root.crt --url {pgurl:1:system} | tail -1)"
+        ua1="$(roachprod ssh drt-ua1:1 -- ./cockroach convert-url --inline --ca-cert ./certs/ca.crt --key ./certs/client.root.key --cert ./certs/client.root.crt --url {pgurl:1:system} | tail -1)"
         $0 sql drt-ua1:1 --cluster=system -- -e "CREATE EXTERNAL CONNECTION 'drt-ua2' AS '${ua2}'"
         $0 sql drt-ua2:1 --cluster=system -- -e "CREATE EXTERNAL CONNECTION 'drt-ua1' AS '${ua1}'"
 
@@ -553,13 +553,13 @@ EOF"
 
         $0 sql drt-ldr2:1 -- -e "CREATE DATABASE ycsb"
         $0 sql drt-ldr2:1 -- -e "ALTER DATABASE ycsb CONFIGURE ZONE USING gc.ttlseconds = 600"
-        
+
         $0 ssh drt-ldr1:1 "./cockroach workload init ycsb --workload=A --insert-count=1000 --families=false {pgurl:1}"
         $0 ssh drt-ldr2:1 "./cockroach workload init ycsb --workload=A --insert-count=1000 --families=false --insert-start=4511686018427387904 {pgurl:1}"
 
         # tell the clusters about eachother.
-        ldr2="$(roachprod ssh drt-ldr2:1 -- ./cockroach encode-uri --inline --ca-cert ./certs/ca.crt --key ./certs/client.root.key --cert ./certs/client.root.crt {pgurl:1} | sed 's,postgresql://postgres://,postgres://,' | sed 's/roachprod:cockroachdb/root/' | sed 's/defaultdb/ycsb/')"
-        ldr1="$(roachprod ssh drt-ldr1:1 -- ./cockroach encode-uri --inline --ca-cert ./certs/ca.crt --key ./certs/client.root.key --cert ./certs/client.root.crt {pgurl:1} | sed 's,postgresql://postgres://,postgres://,' | sed 's/roachprod:cockroachdb/root/' | sed 's/defaultdb/ycsb/')"
+        ldr2="$(roachprod ssh drt-ldr2:1 -- ./cockroach convert-url --inline --ca-cert ./certs/ca.crt --key ./certs/client.root.key --cert ./certs/client.root.crt --database ycsb --user root --url {pgurl:1} | tail -1)"
+        ldr1="$(roachprod ssh drt-ldr1:1 -- ./cockroach convert-url --inline --ca-cert ./certs/ca.crt --key ./certs/client.root.key --cert ./certs/client.root.crt --database ycsb --user root --url {pgurl:1} | tail -1)"
         $0 sql drt-ldr1:1 -- -e "CREATE EXTERNAL CONNECTION 'drt-ldr2' AS '${ldr2}'"
         $0 sql drt-ldr2:1 -- -e "CREATE EXTERNAL CONNECTION 'drt-ldr1' AS '${ldr1}'"
 


### PR DESCRIPTION
This commit merges the `cockroach encode-uri` command into the `cockroach convert-url` command so that we have a unified interface for generating connection URLs. `cockroach encode-uri` has been deprecated and will be removed in a later release.

Resolves: https://github.com/cockroachdb/cockroach/issues/154384

Release note (cli): The `cockroach encode-uri` command has been merged into the `cockroach convert-url` command and `encode-uri` has been deprecated. The PCR/LDR docs referencing `encode-uri` should be updated to use `convert-url` instead. As part of this port, additional flags `--inline`, `--database`, `--user`, `--password`, `--cluster`, `--certs-dir`, `--ca-cert`, `--cert`, `--key`, and `--format` have been added to `convert-url`.