### PR TITLE
release-24.3.28-rc: build: use docker buildx imagetools for multi-arch manifest creation

### DIFF
--- a/build/release/teamcity-support.sh
+++ b/build/release/teamcity-support.sh
@@ -135,6 +135,28 @@ function is_release_or_master_build(){
   # We don't strictly match the suffix to allow different ones, e.g. "rc" or have none.
 }
 
+# create_and_push_multi_arch_manifest creates a multi-architecture manifest
+# (image index) and pushes it to the registry. Uses `docker buildx imagetools
+# create` which handles both plain manifests and OCI image indexes as sources
+# (newer Docker versions produce the latter even for single-arch builds).
+# Falls back to `docker manifest create` for environments without buildx.
+#
+# Usage: create_and_push_multi_arch_manifest TARGET SOURCE1 SOURCE2 ...
+create_and_push_multi_arch_manifest() {
+  local target=$1
+  shift
+  local sources=("$@")
+
+  if docker buildx imagetools create -t "$target" "${sources[@]}"; then
+    return
+  fi
+
+  echo "Falling back to docker manifest create..."
+  docker manifest rm "$target" || :
+  docker manifest create "$target" "${sources[@]}"
+  docker manifest push "$target"
+}
+
 # Compare the passed version to the latest published version. Returns 0 if the
 # passed version is the latest. Supports stable versions only.
 function is_latest() {

--- a/build/teamcity/internal/cockroach/release/publish/publish-staged-cockroach-release.sh
+++ b/build/teamcity/internal/cockroach/release/publish/publish-staged-cockroach-release.sh
@@ -137,23 +137,8 @@ done
 
 docker_login_gcr "$gcr_repository" "$gcr_credentials"
 
-docker manifest rm "${gcr_tag}" || :
-docker manifest create "${gcr_tag}" "${gcr_arch_tags[@]}"
-docker manifest push "${gcr_tag}"
-
-docker manifest rm "${dockerhub_tag}" || :
-docker manifest create "${dockerhub_tag}" "${dockerhub_arch_tags[@]}"
-docker manifest push "${dockerhub_tag}"
-
-docker manifest rm "${gcr_repository}:latest" || :
-docker manifest create "${gcr_repository}:latest" "${gcr_arch_tags[@]}"
-docker manifest rm "${gcr_repository}:latest-${release_branch}" || :
-docker manifest create "${gcr_repository}:latest-${release_branch}" "${gcr_arch_tags[@]}"
-
-docker manifest rm "${dockerhub_repository}:latest" || :
-docker manifest create "${dockerhub_repository}:latest" "${dockerhub_arch_tags[@]}"
-docker manifest rm "${dockerhub_repository}:latest-${release_branch}" || :
-docker manifest create "${dockerhub_repository}:latest-${release_branch}" "${dockerhub_arch_tags[@]}"
+create_and_push_multi_arch_manifest "${gcr_tag}" "${gcr_arch_tags[@]}"
+create_and_push_multi_arch_manifest "${dockerhub_tag}" "${dockerhub_arch_tags[@]}"
 tc_end_block "Make and push multiarch docker images"
 
 
@@ -208,7 +193,7 @@ tc_end_block "Publish binaries and archive as latest"
 
 tc_start_block "Tag docker image as latest-RELEASE_BRANCH"
 if [[ $prerelease == false ]]; then
-  docker manifest push "${dockerhub_repository}:latest-${release_branch}"
+  create_and_push_multi_arch_manifest "${dockerhub_repository}:latest-${release_branch}" "${dockerhub_arch_tags[@]}"
 else
   echo "The ${dockerhub_repository}:latest-${release_branch} docker image tags were _not_ pushed."
 fi
@@ -221,7 +206,7 @@ tc_start_block "Tag docker images as latest"
 # https://github.com/cockroachdb/cockroach/issues/41067
 # https://github.com/cockroachdb/cockroach/issues/48309
 if [[ -n "${PUBLISH_LATEST}" || $prerelease == true ]]; then
-  docker manifest push "${dockerhub_repository}:latest"
+  create_and_push_multi_arch_manifest "${dockerhub_repository}:latest" "${dockerhub_arch_tags[@]}"
 else
   echo "The ${dockerhub_repository}:latest docker image tags were _not_ pushed."
 fi

--- a/build/teamcity/internal/release/process/build-cockroach-release-cloud-only.sh
+++ b/build/teamcity/internal/release/process/build-cockroach-release-cloud-only.sh
@@ -63,13 +63,9 @@ docker tag \
 docker push "${gcr_repository}:amd64-${version_cloudonly}"
 docker push "${gcr_repository}:arm64-${version_cloudonly}"
 
-docker manifest rm "$manifest" || :
-docker manifest create \
-  "$manifest" \
+create_and_push_multi_arch_manifest "$manifest" \
   "${gcr_repository}:amd64-${version_cloudonly}" \
   "${gcr_repository}:arm64-${version_cloudonly}"
-
-docker manifest push "$manifest" 
 echo "==========="
 echo "published to"
 echo "$manifest"

--- a/build/teamcity/internal/release/process/build-cockroach-release-docker.sh
+++ b/build/teamcity/internal/release/process/build-cockroach-release-docker.sh
@@ -32,9 +32,7 @@ tc_end_block "Variable Setup"
 
 gcr_tag="${gcr_staged_repository}:${version}"
 docker_login_gcr "$gcr_staged_repository" "$gcr_credentials"
-docker manifest rm "${gcr_tag}" || :
-docker manifest create "${gcr_tag}" "${gcr_staged_repository}:amd64-${version}" "${gcr_staged_repository}:arm64-${version}"
-docker manifest push "${gcr_tag}"
+create_and_push_multi_arch_manifest "${gcr_tag}" "${gcr_staged_repository}:amd64-${version}" "${gcr_staged_repository}:arm64-${version}"
 
 tc_start_block "Verify docker images"
 error=0

--- a/build/teamcity/internal/release/process/make-and-publish-build-artifacts-docker.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-artifacts-docker.sh
@@ -53,7 +53,5 @@ tc_end_block "Variable Setup"
 tc_start_block "Make and push multi-arch docker image"
 docker_login_with_google
 gcr_tag="${gcr_repository}:${build_name}"
-docker manifest rm "${gcr_tag}" || :
-docker manifest create "${gcr_tag}" "${gcr_repository}:amd64-${build_name}" "${gcr_repository}:arm64-${build_name}"
-docker manifest push "${gcr_tag}"
+create_and_push_multi_arch_manifest "${gcr_tag}" "${gcr_repository}:amd64-${build_name}" "${gcr_repository}:arm64-${build_name}"
 tc_end_block "Make and push multi-arch docker images"


### PR DESCRIPTION
Backport 1/1 commits from #164559.

/cc @cockroachdb/release

---

Newer Docker versions (as shipped with Ubuntu 24.04) create OCI image indexes even for single-architecture builds. `docker manifest create` refuses to accept a manifest list as a source, causing failures like:

  us-docker.pkg.dev/.../cockroach:amd64-v26.1.0-rc.1-... is a manifest list

Add a `create_and_push_multi_arch_manifest` helper to teamcity-support.sh that uses `docker buildx imagetools create`, which handles both plain manifests and OCI image indexes as sources. Falls back to the old `docker manifest create` flow if buildx is unavailable.

Update all release scripts to use the new helper. In publish-staged-cockroach-release.sh, also drop GCR latest/latest-branch manifests that were created but never pushed (dead code), and restructure DockerHub latest/latest-branch creation to only happen when the manifest will actually be pushed, since buildx imagetools create pushes immediately.

Epic: None
Release note: None

Release justification: release automation changes
