### PR TITLE
changefeedccl: support top-level compression option for Kafka sinks

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -7865,9 +7865,20 @@ func TestChangefeedErrors(t *testing.T) {
 		`webhook-https://fake-host`,
 	)
 	sqlDB.ExpectErrWithTimeout(
-		t, `unknown compression: invalid, valid values are 'gzip' and 'zstd'`,
+		t, `unsupported compression algorithm "invalid"`,
 		`CREATE CHANGEFEED FOR foo INTO $1 WITH compression='invalid'`,
 		`webhook-https://fake-host`,
+	)
+	// Kafka-only codecs are rejected by non-Kafka sinks at creation time.
+	sqlDB.ExpectErrWithTimeout(
+		t, `unsupported compression algorithm "snappy"`,
+		`CREATE CHANGEFEED FOR foo INTO $1 WITH compression='snappy'`,
+		`webhook-https://fake-host`,
+	)
+	sqlDB.ExpectErrWithTimeout(
+		t, `unsupported compression algorithm "lz4"`,
+		`CREATE CHANGEFEED FOR foo INTO $1 WITH compression='lz4'`,
+		`experimental-nodelocal://1/bar`,
 	)
 	sqlDB.ExpectErrWithTimeout(
 		t, `Retry.Max must be either a positive int or 'inf' for infinite retries.`,
@@ -7910,10 +7921,20 @@ func TestChangefeedErrors(t *testing.T) {
 		`CREATE CHANGEFEED FOR foo into $1 WITH on_error='not_valid'`,
 		`kafka://nope`)
 
-	// Sanity check for options compatibility validation.
+	// Sanity check Kafka compression options.
 	sqlDB.ExpectErrWithTimeout(
-		t, `this sink is incompatible with option compression`,
-		`CREATE CHANGEFEED FOR foo into $1 WITH compression='gzip'`,
+		t, `unsupported compression codec "invalid" for Kafka sink`,
+		`CREATE CHANGEFEED FOR foo into $1 WITH compression='invalid'`,
+		`kafka://nope`)
+	sqlDB.ExpectErrWithTimeout(
+		t, `conflicts with kafka_sink_config`,
+		`CREATE CHANGEFEED FOR foo into $1 WITH compression='gzip', kafka_sink_config='{"Compression":"ZSTD"}'`,
+		`kafka://nope`)
+	// An explicit "NONE" in kafka_sink_config conflicts with a top-level
+	// compression option, same as any other mismatched codec.
+	sqlDB.ExpectErrWithTimeout(
+		t, `conflicts with kafka_sink_config`,
+		`CREATE CHANGEFEED FOR foo into $1 WITH compression='gzip', kafka_sink_config='{"Compression":"NONE"}'`,
 		`kafka://nope`)
 
 	sqlDB.ExpectErrWithTimeout(

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -413,7 +413,7 @@ var ChangefeedOptionExpectValues = map[string]OptionPermittedValues{
 	OptUpdatedTimestamps:                  flagOption,
 	OptMVCCTimestamps:                     flagOption,
 	OptDiff:                               flagOption,
-	OptCompression:                        enum("gzip", "zstd"),
+	OptCompression:                        stringOption,
 	OptSchemaChangeEvents:                 enum("column_changes", "default"),
 	OptSchemaChangePolicy:                 enum("backfill", "nobackfill", "stop", "ignore"),
 	OptSplitColumnFamilies:                flagOption,
@@ -464,7 +464,7 @@ var CommonOptions = makeStringSet(OptCursor, OptEndTime, OptEnvelope,
 var SQLValidOptions map[string]struct{} = nil
 
 // KafkaValidOptions is options exclusive to Kafka sink
-var KafkaValidOptions = makeStringSet(OptAvroSchemaPrefix, OptConfluentSchemaRegistry, OptKafkaSinkConfig, OptHeadersJSONColumnName, OptExtraHeaders, OptPartitionAlg, OptCreateKafkaTopics)
+var KafkaValidOptions = makeStringSet(OptAvroSchemaPrefix, OptConfluentSchemaRegistry, OptKafkaSinkConfig, OptHeadersJSONColumnName, OptExtraHeaders, OptPartitionAlg, OptCreateKafkaTopics, OptCompression)
 
 // CloudStorageValidOptions is options exclusive to cloud storage sink
 var CloudStorageValidOptions = makeStringSet(OptCompression, OptCsvHeader)
@@ -1204,6 +1204,10 @@ type KafkaSinkOptions struct {
 	// PartitionAlg is the hash function to use for Kafka partitioning.
 	// Valid values are "fnv-1a" (default) and "murmur2".
 	PartitionAlg string
+
+	// Compression is the top-level compression option (e.g. "gzip", "snappy",
+	// "lz4", "zstd"). Must match kafka_sink_config.Compression if both are set.
+	Compression string
 }
 
 func (s StatementOptions) GetKafkaSinkOptions() (KafkaSinkOptions, error) {
@@ -1221,6 +1225,7 @@ func (s StatementOptions) GetKafkaSinkOptions() (KafkaSinkOptions, error) {
 		JSONConfig:   s.getJSONValue(OptKafkaSinkConfig),
 		Headers:      headersMap,
 		PartitionAlg: partitionAlg,
+		Compression:  s.m[OptCompression],
 	}
 	return o, nil
 }

--- a/pkg/ccl/changefeedccl/compression.go
+++ b/pkg/ccl/changefeedccl/compression.go
@@ -234,5 +234,5 @@ func compressionFromString(algo string) (_ compressionAlgo, ext string, _ error)
 	if strings.EqualFold(algo, string(sinkCompressionZstd)) {
 		return sinkCompressionZstd, ".zst", nil
 	}
-	return "", "", errors.AssertionFailedf("unsupported compression algorithm %q", algo)
+	return "", "", errors.Errorf("unsupported compression algorithm %q; supported values are 'gzip' and 'zstd'", algo)
 }

--- a/pkg/ccl/changefeedccl/sink_kafka.go
+++ b/pkg/ccl/changefeedccl/sink_kafka.go
@@ -176,6 +176,58 @@ func getValidCompressionCodecs() (codecs string) {
 	return codecs
 }
 
+// resolveTopLevelCompression reconciles the top-level compression changefeed
+// option with the Compression field of kafka_sink_config. If only one of the
+// two is set, it wins; if both are set they must agree (an explicit
+// "Compression": "NONE" in the JSON config counts as set), otherwise the
+// configuration is ambiguous and an error is returned. Both the v1 (sarama)
+// and v2 (kgo) Kafka sinks resolve compression through this function.
+func resolveTopLevelCompression(
+	jsonStr changefeedbase.SinkSpecificJSONConfig,
+	jsonCodec sarama.CompressionCodec,
+	topLevelCompression string,
+) (sarama.CompressionCodec, error) {
+	if topLevelCompression == "" {
+		return jsonCodec, nil
+	}
+	topCodec, ok := saramaCompressionCodecOptions[strings.ToUpper(topLevelCompression)]
+	if !ok {
+		return 0, errors.Errorf(
+			`unsupported compression codec %q for Kafka sink; valid options are %s`,
+			topLevelCompression, getValidCompressionCodecs())
+	}
+	jsonSetsCompression, err := jsonConfigSetsCompression(jsonStr)
+	if err != nil {
+		return 0, err
+	}
+	if jsonSetsCompression && jsonCodec != topCodec {
+		return 0, errors.Newf(
+			`compression option %q conflicts with kafka_sink_config Compression %q; `+
+				`remove one or make them match`,
+			topLevelCompression, strings.ToUpper(jsonCodec.String()))
+	}
+	return topCodec, nil
+}
+
+// jsonConfigSetsCompression reports whether the kafka_sink_config JSON object
+// explicitly sets the Compression field. Key matching is case-insensitive to
+// mirror Go's JSON field matching, which getSaramaConfig relies on.
+func jsonConfigSetsCompression(jsonStr changefeedbase.SinkSpecificJSONConfig) (bool, error) {
+	if jsonStr == "" {
+		return false, nil
+	}
+	var keys map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(jsonStr), &keys); err != nil {
+		return false, errors.Wrap(err, "error unmarshalling json")
+	}
+	for k := range keys {
+		if strings.EqualFold(k, "Compression") {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func (j *compressionCodec) UnmarshalText(b []byte) error {
 	var c sarama.CompressionCodec
 	if err := c.UnmarshalText(bytes.ToLower(b)); err != nil {
@@ -1133,6 +1185,7 @@ func buildKafkaConfig(
 	ctx context.Context,
 	u *changefeedbase.SinkURL,
 	jsonStr changefeedbase.SinkSpecificJSONConfig,
+	topLevelCompression string,
 	kafkaThrottlingMetrics metrics.Histogram,
 	netMetrics *cidr.NetMetrics,
 ) (*sarama.Config, error) {
@@ -1211,6 +1264,13 @@ func buildKafkaConfig(
 		return nil, errors.Wrap(err, "invalid sarama configuration")
 	}
 
+	codec, err := resolveTopLevelCompression(
+		jsonStr, sarama.CompressionCodec(saramaCfg.Compression), topLevelCompression)
+	if err != nil {
+		return nil, err
+	}
+	saramaCfg.Compression = compressionCodec(codec)
+
 	// Apply configures config based on saramaCfg.
 	if err := saramaCfg.Apply(config); err != nil {
 		return nil, errors.Wrap(err, "failed to apply kafka client configuration")
@@ -1245,7 +1305,7 @@ func makeKafkaSink(
 	}
 
 	m := mb(requiresResourceAccounting)
-	config, err := buildKafkaConfig(ctx, u, jsonStr, m.getKafkaThrottlingMetrics(settings), m.netMetrics())
+	config, err := buildKafkaConfig(ctx, u, jsonStr, sinkOpts.Compression, m.getKafkaThrottlingMetrics(settings), m.netMetrics())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/changefeedccl/sink_kafka_connection_test.go
+++ b/pkg/ccl/changefeedccl/sink_kafka_connection_test.go
@@ -497,7 +497,7 @@ func TestAzureKafkaDefaults(t *testing.T) {
 			u := &changefeedbase.SinkURL{URL: url}
 
 			t.Run(tc.name, func(t *testing.T) {
-				cfg, err := buildKafkaConfig(ctx, u, `{}`, nil, nil)
+				cfg, err := buildKafkaConfig(ctx, u, `{}`, "", nil, nil)
 				require.NoError(t, err)
 				assertExpectedSaramaCfg(tc.expected, cfg)
 			})
@@ -511,7 +511,7 @@ func TestAzureKafkaDefaults(t *testing.T) {
 			u := &changefeedbase.SinkURL{URL: url}
 
 			t.Run(tc.name, func(t *testing.T) {
-				opts, err := buildKgoConfig(ctx, u, `{}`, nil)
+				opts, err := buildKgoConfig(ctx, u, `{}`, "", nil)
 				require.NoError(t, err)
 				assertExpectedKgoOpts(tc.expected, opts)
 			})

--- a/pkg/ccl/changefeedccl/sink_kafka_v2.go
+++ b/pkg/ccl/changefeedccl/sink_kafka_v2.go
@@ -403,7 +403,7 @@ func makeKafkaSinkV2(
 		return nil, errors.Errorf(`%s is not yet supported`, changefeedbase.SinkParamSchemaTopic)
 	}
 
-	clientOpts, err := buildKgoConfig(ctx, u, jsonConfig, mb(true).netMetrics())
+	clientOpts, err := buildKgoConfig(ctx, u, jsonConfig, sinkOpts.Compression, mb(true).netMetrics())
 	if err != nil {
 		return nil, err
 	}
@@ -435,6 +435,7 @@ func buildKgoConfig(
 	ctx context.Context,
 	u *changefeedbase.SinkURL,
 	jsonStr changefeedbase.SinkSpecificJSONConfig,
+	topLevelCompression string,
 	netMetrics *cidr.NetMetrics,
 ) ([]kgo.Opt, error) {
 	var opts []kgo.Opt
@@ -543,8 +544,14 @@ func buildKgoConfig(
 
 	// TODO(#126991): Remove this sarama dependency.
 	// NOTE: kgo lets you give multiple compression options in preference order, which is cool but the config json doesnt support that. Should we?
+	effectiveCompression, err := resolveTopLevelCompression(
+		jsonStr, sarama.CompressionCodec(sinkCfg.Compression), topLevelCompression)
+	if err != nil {
+		return nil, err
+	}
+
 	var comp kgo.CompressionCodec
-	switch sarama.CompressionCodec(sinkCfg.Compression) {
+	switch effectiveCompression {
 	case sarama.CompressionNone:
 	case sarama.CompressionGZIP:
 		comp = kgo.GzipCompression()
@@ -555,7 +562,7 @@ func buildKgoConfig(
 	case sarama.CompressionZSTD:
 		comp = kgo.ZstdCompression()
 	default:
-		return nil, errors.Errorf(`unknown compression codec: %v`, sinkCfg.Compression)
+		return nil, errors.Errorf(`unknown compression codec: %v`, effectiveCompression)
 	}
 
 	if level := sinkCfg.CompressionLevel; level != sarama.CompressionLevelDefault {

--- a/pkg/ccl/changefeedccl/sink_test.go
+++ b/pkg/ccl/changefeedccl/sink_test.go
@@ -856,6 +856,129 @@ func TestSaramaConfigOptionParsing(t *testing.T) {
 	})
 }
 
+func TestKafkaTopLevelCompression(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	u, err := url.Parse("kafka://localhost:9092")
+	require.NoError(t, err)
+	sinkURL := &changefeedbase.SinkURL{URL: u}
+
+	tests := []struct {
+		name          string
+		jsonConfig    changefeedbase.SinkSpecificJSONConfig
+		compression   string
+		expectedCodec sarama.CompressionCodec // verified on the v1 sink only
+		expectedErr   string
+	}{
+		{name: "gzip", jsonConfig: `{}`, compression: "gzip", expectedCodec: sarama.CompressionGZIP},
+		{name: "snappy", jsonConfig: `{}`, compression: "snappy", expectedCodec: sarama.CompressionSnappy},
+		{name: "lz4", jsonConfig: `{}`, compression: "lz4", expectedCodec: sarama.CompressionLZ4},
+		{name: "zstd", jsonConfig: `{}`, compression: "zstd", expectedCodec: sarama.CompressionZSTD},
+		{
+			name:          "option value is case-insensitive",
+			jsonConfig:    `{}`,
+			compression:   "GZIP",
+			expectedCodec: sarama.CompressionGZIP,
+		},
+		{
+			name:        "invalid codec",
+			jsonConfig:  `{}`,
+			compression: "invalid",
+			expectedErr: "unsupported compression codec",
+		},
+		{
+			name:        "conflict with json codec",
+			jsonConfig:  `{"Compression":"ZSTD"}`,
+			compression: "gzip",
+			expectedErr: "conflicts with kafka_sink_config",
+		},
+		{
+			name:        "conflict with explicit json NONE",
+			jsonConfig:  `{"Compression":"NONE"}`,
+			compression: "gzip",
+			expectedErr: "conflicts with kafka_sink_config",
+		},
+		{
+			// Go's JSON decoding matches struct fields case-insensitively, so
+			// conflict detection must too.
+			name:        "conflict with lowercase json key",
+			jsonConfig:  `{"compression":"NONE"}`,
+			compression: "gzip",
+			expectedErr: "conflicts with kafka_sink_config",
+		},
+		{
+			name:          "matching json codec",
+			jsonConfig:    `{"Compression":"GZIP"}`,
+			compression:   "gzip",
+			expectedCodec: sarama.CompressionGZIP,
+		},
+		{
+			name:          "json codec alone is unaffected",
+			jsonConfig:    `{"Compression":"ZSTD"}`,
+			compression:   "",
+			expectedCodec: sarama.CompressionZSTD,
+		},
+		{
+			name:          "explicit json NONE alone disables compression",
+			jsonConfig:    `{"Compression":"NONE"}`,
+			compression:   "",
+			expectedCodec: sarama.CompressionNone,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run("v1/"+tc.name, func(t *testing.T) {
+			cfg, err := buildKafkaConfig(ctx, sinkURL, tc.jsonConfig, tc.compression, nil, nil)
+			if tc.expectedErr != "" {
+				require.ErrorContains(t, err, tc.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedCodec, cfg.Producer.Compression)
+		})
+		t.Run("v2/"+tc.name, func(t *testing.T) {
+			_, err := buildKgoConfig(ctx, sinkURL, tc.jsonConfig, tc.compression, nil)
+			if tc.expectedErr != "" {
+				require.ErrorContains(t, err, tc.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestKafkaCompressionOptionOnOlderNode documents the mixed-version behavior
+// of the top-level compression option on Kafka sinks. Nodes that predate the
+// option's addition to KafkaValidOptions reject it during sink construction,
+// which happens both at CREATE CHANGEFEED time and when a node resumes the
+// changefeed job. A changefeed created on a new-version node can therefore
+// fail sink construction when adopted by an older node; that failure is
+// marked retryable by the change aggregator (see the getEventSink error
+// handling in changefeed_processors.go), so the changefeed retries rather
+// than failing permanently, and recovers once the flow lands on new-version
+// nodes.
+func TestKafkaCompressionOptionOnOlderNode(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// KafkaValidOptions as of v26.1, before the compression option was
+	// permitted on Kafka sinks.
+	oldKafkaValidOptions := make(map[string]struct{})
+	for opt := range changefeedbase.KafkaValidOptions {
+		if opt != changefeedbase.OptCompression {
+			oldKafkaValidOptions[opt] = struct{}{}
+		}
+	}
+
+	opts := map[string]string{changefeedbase.OptCompression: "gzip"}
+	err := validateSinkOptions(opts, oldKafkaValidOptions)
+	require.ErrorContains(t, err, "this sink is incompatible with option compression")
+
+	require.NoError(t, validateSinkOptions(opts, changefeedbase.KafkaValidOptions))
+}
+
 func TestKafkaSinkTracksMemory(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)


### PR DESCRIPTION
Fixes #113495

Previously, the compression changefeed option was incompatible with
Kafka sinks. Users had to configure compression through the
kafka_sink_config JSON option, which was inconsistent with other sinks
(cloud storage, webhook) that support the top-level compression option
directly.

This PR permits the compression option on Kafka sinks, accepting all
Kafka-supported codecs: gzip, snappy, lz4, and zstd. Both the v1
(sarama) and v2 (kgo) Kafka sinks resolve the option through a shared
helper. If both the top-level option and kafka_sink_config.Compression
are set — including an explicit `"Compression": "NONE"` in the JSON
config — they must match, or an error is returned at CREATE CHANGEFEED
time to avoid ambiguous configuration.

The compression option validation also changes from a fixed enum
(gzip, zstd) to a free-form string, since valid codecs are
sink-dependent (Kafka supports snappy and lz4 in addition to gzip and
zstd). Each sink validates the compression value it receives during
sink construction, so invalid values still fail at CREATE CHANGEFEED
time; non-Kafka sinks continue to reject snappy and lz4.

In a mixed-version cluster, a changefeed created with this option on a
new-version node fails sink construction if adopted by an older node
that does not permit the option on Kafka sinks. That failure is marked
retryable by the change aggregator (see the getEventSink error handling
in changefeed_processors.go), so the changefeed retries rather than
failing permanently and recovers once the flow runs on new-version
nodes.

Epic: none
