### PR TITLE
dev-inf: add EngFlow artifact support to investigate workflow

### DIFF
--- a/.claude/skills/engflow-artifacts/SKILL.md
+++ b/.claude/skills/engflow-artifacts/SKILL.md
@@ -21,7 +21,8 @@ engflow_auth export mesolite.cluster.engflow.com
 
 ## Quick Reference
 
-The script is at `.claude/skills/engflow-artifacts/engflow_artifacts.py`.
+The script is at `.claude/skills/engflow-artifacts/engflow_artifacts.py` and is
+directly executable (has a shebang). Run it from the repo root:
 
 | Command | Purpose |
 |---------|---------|
@@ -34,17 +35,17 @@ The script is at `.claude/skills/engflow-artifacts/engflow_artifacts.py`.
 ## Typical Investigation Workflow
 
 ```bash
-SCRIPT=.claude/skills/engflow-artifacts/engflow_artifacts.py
+EF=.claude/skills/engflow-artifacts/engflow_artifacts.py
 
 # 1. Find what failed
-python3 $SCRIPT targets daa807a0-3589-40a5-94b5-3440c7490d6a
+./$EF targets daa807a0-3589-40a5-94b5-3440c7490d6a
 
 # 2. List shards for the failed target
-python3 $SCRIPT list daa807a0-3589-40a5-94b5-3440c7490d6a \
+./$EF list daa807a0-3589-40a5-94b5-3440c7490d6a \
   --target '//pkg/sql/ttl:ttl_test'
 
 # 3. Download the failing shard's logs
-python3 $SCRIPT download daa807a0-3589-40a5-94b5-3440c7490d6a \
+./$EF download daa807a0-3589-40a5-94b5-3440c7490d6a \
   --target '//pkg/sql/ttl:ttl_test' --shard 100 --outdir /tmp/engflow-test
 
 # 4. Read the test log

--- a/.claude/skills/engflow-artifacts/engflow_artifacts.py
+++ b/.claude/skills/engflow-artifacts/engflow_artifacts.py
@@ -1,14 +1,15 @@
+#!/usr/bin/env python3
 # Copyright 2026 The Cockroach Authors.
 #
 # Use of this software is governed by the CockroachDB Software License
 # included in the /LICENSE file.
-
-#!/usr/bin/env python3
 """
 EngFlow artifact downloader.
 
-Uses engflow_auth CLI for authentication and curl for downloads.
-No browser needed.
+Authentication (in priority order):
+  1. mTLS certificates: set ENGFLOW_CERT_FILE and ENGFLOW_KEY_FILE env vars
+  2. JWT from env: set ENGFLOW_TOKEN env var
+  3. JWT from CLI: uses engflow_auth export (requires prior login)
 
 Usage:
     # List all targets and their artifacts for an invocation
@@ -40,18 +41,57 @@ CAS_API = f"{ENGFLOW_URL}/api/contentaddressablestorage/v1/instances/default/blo
 GRPC_URL = f"{ENGFLOW_URL}/engflow.resultstore.v1alpha.ResultStore"
 
 
-def get_token():
-    """Get auth token from engflow_auth CLI."""
-    result = subprocess.run(
-        ["engflow_auth", "export", ENGFLOW_HOST],
-        capture_output=True, text=True
-    )
-    if result.returncode != 0:
-        print(f"Error: engflow_auth export failed: {result.stderr}", file=sys.stderr)
-        print("Run: engflow_auth login mesolite.cluster.engflow.com", file=sys.stderr)
-        sys.exit(1)
-    data = json.loads(result.stdout)
-    return data["token"]["access_token"]
+def get_curl_auth_args():
+    """Return curl arguments for EngFlow authentication.
+
+    Tries, in order:
+      1. mTLS — ENGFLOW_CERT_FILE and ENGFLOW_KEY_FILE env vars
+      2. JWT from env — ENGFLOW_TOKEN env var
+      3. JWT from CLI — engflow_auth export (interactive login required)
+    """
+    cert = os.environ.get("ENGFLOW_CERT_FILE")
+    key = os.environ.get("ENGFLOW_KEY_FILE")
+    if cert and key:
+        return ["--cert", cert, "--key", key]
+
+    token = os.environ.get("ENGFLOW_TOKEN")
+    if not token:
+        try:
+            result = subprocess.run(
+                ["engflow_auth", "export", ENGFLOW_HOST],
+                capture_output=True, text=True,
+            )
+        except FileNotFoundError:
+            print("Error: engflow_auth not found on PATH.", file=sys.stderr)
+            print(
+                "Install engflow_auth, or set ENGFLOW_TOKEN, or configure "
+                "ENGFLOW_CERT_FILE and ENGFLOW_KEY_FILE.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        if result.returncode != 0:
+            print(f"Error: engflow_auth export failed: {result.stderr}", file=sys.stderr)
+            print("Run: engflow_auth login mesolite.cluster.engflow.com", file=sys.stderr)
+            sys.exit(1)
+
+        try:
+            data = json.loads(result.stdout)
+            token = data["token"]["access_token"]
+        except (json.JSONDecodeError, KeyError):
+            print("Error: Failed to parse access token from engflow_auth output.", file=sys.stderr)
+            print(
+                "Try running: engflow_auth login mesolite.cluster.engflow.com "
+                "or set ENGFLOW_TOKEN directly.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+    return [
+        "-H", f"x-engflow-auth-method: jwt-v0",
+        "-H", f"x-engflow-auth-token: {token}",
+        "-H", f"Cookie: x-engflow-auth={token}",
+    ]
 
 
 def encode_varint(val):
@@ -82,7 +122,7 @@ def make_grpc_frame(proto_bytes):
     return struct.pack(">BI", 0, len(proto_bytes)) + proto_bytes
 
 
-def grpc_call(token, method, proto_bytes):
+def grpc_call(auth_args, method, proto_bytes):
     """Make a gRPC-web call via curl and return the response protobuf bytes.
 
     Python's urllib mangles headers in a way that EngFlow's server rejects
@@ -101,11 +141,7 @@ def grpc_call(token, method, proto_bytes):
                 "curl", "-s", "--data-binary", f"@{tmp_path}",
                 "-H", "Content-Type: application/grpc-web+proto",
                 "-H", "x-grpc-web: 1",
-                "-H", f"x-engflow-auth-method: jwt-v0",
-                "-H", f"x-engflow-auth-token: {token}",
-                "-H", f"Cookie: x-engflow-auth={token}",
-                url,
-            ],
+            ] + auth_args + [url],
             capture_output=True,
         )
     finally:
@@ -128,18 +164,11 @@ def grpc_call(token, method, proto_bytes):
     return data[5:5 + payload_len]
 
 
-def download_blob(token, blob_hash, blob_size, outfile):
+def download_blob(auth_args, blob_hash, blob_size, outfile):
     """Download a blob from the CAS API via curl."""
     url = f"{CAS_API}/{blob_hash}/{blob_size}"
     result = subprocess.run(
-        [
-            "curl", "-s",
-            "-H", f"Cookie: x-engflow-auth={token}",
-            "-H", f"x-engflow-auth-method: jwt-v0",
-            "-H", f"x-engflow-auth-token: {token}",
-            "-o", outfile,
-            url,
-        ],
+        ["curl", "-s"] + auth_args + ["-o", outfile, url],
         capture_output=True,
     )
     if result.returncode != 0:
@@ -148,7 +177,7 @@ def download_blob(token, blob_hash, blob_size, outfile):
     return os.path.getsize(outfile)
 
 
-def get_target_labels_by_status(token, instance, invocation_id, status_code):
+def get_target_labels_by_status(auth_args, instance, invocation_id, status_code):
     """Call GetTargetLabelsByStatus and return target labels.
 
     Status codes observed from the EngFlow UI:
@@ -161,19 +190,19 @@ def get_target_labels_by_status(token, instance, invocation_id, status_code):
     proto += encode_bytes_field(3, bytes([status_code]))
     # Field 4 is a varint limit.
     proto += bytes([(4 << 3) | 0]) + encode_varint(100)
-    resp = grpc_call(token, "GetTargetLabelsByStatus", proto)
+    resp = grpc_call(auth_args, "GetTargetLabelsByStatus", proto)
     if not resp:
         return []
     text = resp.decode("latin-1")
     return [s for s in re.findall(r"//[^\x00-\x1f]+", text) if not s.startswith("///")]
 
 
-def get_target(token, instance, invocation_id, target_label):
+def get_target(auth_args, instance, invocation_id, target_label):
     """Call GetTarget and return the raw protobuf response."""
     proto = encode_string_field(1, instance)
     proto += encode_string_field(2, invocation_id)
     proto += encode_string_field(3, target_label)
-    return grpc_call(token, "GetTarget", proto)
+    return grpc_call(auth_args, "GetTarget", proto)
 
 
 def decode_varint(data, pos):
@@ -307,18 +336,18 @@ def parse_invocation_url(url):
 
 def cmd_targets(args):
     """List targets for an invocation, optionally filtered by status."""
-    token = get_token()
+    auth_args = get_curl_auth_args()
     invocation_id = args.invocation_id
 
     if args.all:
         # Try both passed (0x08) and failed (0x09).
         labels = set()
         for code in [0x08, 0x09]:
-            labels.update(get_target_labels_by_status(token, "default", invocation_id, code))
+            labels.update(get_target_labels_by_status(auth_args, "default", invocation_id, code))
         labels = sorted(labels)
         print(f"All targets ({len(labels)}):")
     else:
-        labels = get_target_labels_by_status(token, "default", invocation_id, 0x09)
+        labels = get_target_labels_by_status(auth_args, "default", invocation_id, 0x09)
         if not labels:
             print("No failed targets found. Use --all to list all targets.")
             return
@@ -330,7 +359,7 @@ def cmd_targets(args):
 
 def cmd_list(args):
     """List artifacts for a target."""
-    token = get_token()
+    auth_args = get_curl_auth_args()
 
     if args.url:
         invocation_id, target_label, shard, _, _ = parse_invocation_url(args.url)
@@ -343,7 +372,7 @@ def cmd_list(args):
         target_label = args.target
         shard = args.shard
 
-    proto = get_target(token, "default", invocation_id, target_label)
+    proto = get_target(auth_args, "default", invocation_id, target_label)
     if not proto:
         print("Error: GetTarget returned empty response", file=sys.stderr)
         sys.exit(1)
@@ -366,7 +395,7 @@ def cmd_list(args):
 
 def cmd_download(args):
     """Download artifacts for a target shard."""
-    token = get_token()
+    auth_args = get_curl_auth_args()
 
     if args.url:
         invocation_id, target_label, shard, _, _ = parse_invocation_url(args.url)
@@ -386,7 +415,7 @@ def cmd_download(args):
               file=sys.stderr)
         sys.exit(1)
 
-    proto = get_target(token, "default", invocation_id, target_label)
+    proto = get_target(auth_args, "default", invocation_id, target_label)
     if not proto:
         print("Error: GetTarget returned empty response", file=sys.stderr)
         sys.exit(1)
@@ -410,7 +439,7 @@ def cmd_download(args):
         blob_hash, size = shard_data[name]
         outfile = os.path.join(outdir, name)
         print(f"  Downloading {name} ({size:,} bytes)...")
-        downloaded = download_blob(token, blob_hash, size, outfile)
+        downloaded = download_blob(auth_args, blob_hash, size, outfile)
         print(f"  Saved to {outfile} ({downloaded:,} bytes)")
 
     # Auto-extract outputs.zip
@@ -425,18 +454,18 @@ def cmd_download(args):
 
 def cmd_blob(args):
     """Download a specific blob by hash and size."""
-    token = get_token()
+    auth_args = get_curl_auth_args()
     outfile = args.outfile or f"/tmp/engflow-artifacts/{args.hash[:12]}"
     os.makedirs(os.path.dirname(outfile), exist_ok=True)
 
     print(f"Downloading blob {args.hash}/{args.size}...")
-    downloaded = download_blob(token, args.hash, args.size, outfile)
+    downloaded = download_blob(auth_args, args.hash, args.size, outfile)
     print(f"Saved to {outfile} ({downloaded:,} bytes)")
 
 
 def cmd_url(args):
     """Download artifacts directly from an EngFlow invocation URL."""
-    token = get_token()
+    auth_args = get_curl_auth_args()
     invocation_id, target_label, shard, _, _ = parse_invocation_url(args.url)
 
     if not target_label:
@@ -453,7 +482,7 @@ def cmd_url(args):
     print(f"Shard: {shard}")
     print()
 
-    proto = get_target(token, "default", invocation_id, target_label)
+    proto = get_target(auth_args, "default", invocation_id, target_label)
     if not proto:
         print("Error: GetTarget returned empty response", file=sys.stderr)
         sys.exit(1)
@@ -475,7 +504,7 @@ def cmd_url(args):
         blob_hash, size = shard_data[name]
         outfile = os.path.join(outdir, name)
         print(f"  Downloading {name} ({size:,} bytes)...")
-        downloaded = download_blob(token, blob_hash, size, outfile)
+        downloaded = download_blob(auth_args, blob_hash, size, outfile)
         print(f"  Saved to {outfile} ({downloaded:,} bytes)")
 
     # Auto-extract outputs.zip

--- a/.github/prompts/investigate.md
+++ b/.github/prompts/investigate.md
@@ -190,8 +190,44 @@ Log files are generally large. Prefer searching them with grep first
 to find interesting sections, but `test.log` is often worth reading
 in full.
 
-If there is no TeamCity build ID (e.g. EngFlow builds), note this in
-your findings and work with what is available in the issue.
+**EngFlow artifacts:**
+
+Some CI builds run on EngFlow (mesolite.cluster.engflow.com) instead
+of TeamCity. You can recognize these by:
+- EngFlow invocation URLs in the issue:
+  `https://mesolite.cluster.engflow.com/invocations/default/<ID>`
+- Bazel target labels like `//pkg/sql/...`
+- Issues that mention EngFlow but have no TeamCity build ID
+
+Use the [`engflow_artifacts.py`](../.claude/skills/engflow-artifacts/engflow_artifacts.py)
+script to download artifacts. Authentication is handled via environment
+variables set by the workflow — no manual login needed. Example:
+
+```bash
+EF=.claude/skills/engflow-artifacts/engflow_artifacts.py
+
+# 1. Discover failed targets
+python3 $EF targets <invocation_id>
+
+# 2. List artifacts for a target
+python3 $EF list <invocation_id> --target <target_label>
+
+# 3. Download artifacts for a shard
+python3 $EF download <invocation_id> \
+  --target <target_label> --shard <N> --outdir /tmp/engflow-artifacts
+```
+
+Key artifacts per shard:
+- `test.log` — test stdout/stderr (start here)
+- `test.xml` — JUnit results
+- `outputs.zip` — CockroachDB server logs (auto-extracted on download)
+
+If EngFlow certificates are unavailable (e.g. on a personal fork or
+if IAM permissions are not yet configured), note this limitation in
+your findings rather than failing the investigation.
+
+If there is no TeamCity build ID and no EngFlow invocation URL, work
+with what is available in the issue.
 
 ### Step 5: Write Your Findings
 

--- a/.github/workflows/investigate.yml
+++ b/.github/workflows/investigate.yml
@@ -134,6 +134,23 @@ jobs:
           service_account: 'ai-review@dev-inf-prod.iam.gserviceaccount.com'
           workload_identity_provider: 'projects/72497726731/locations/global/workloadIdentityPools/ai-review/providers/ai-review'
 
+      - name: Retrieve EngFlow certificates
+        if: env.HAS_API_KEY != 'true'
+        id: engflow-certs
+        run: |
+          CERT_DIR=$(mktemp -d)
+          if gcloud secrets versions access 2 --secret=engflow-mesolite-key --project=crl-github-actions > "$CERT_DIR/engflow.key" 2>/dev/null &&
+             gcloud secrets versions access 2 --secret=engflow-mesolite-crt --project=crl-github-actions > "$CERT_DIR/engflow.crt" 2>/dev/null; then
+            chmod 600 "$CERT_DIR/engflow.key" "$CERT_DIR/engflow.crt"
+            echo "ENGFLOW_CERT_FILE=$CERT_DIR/engflow.crt" >> "$GITHUB_ENV"
+            echo "ENGFLOW_KEY_FILE=$CERT_DIR/engflow.key" >> "$GITHUB_ENV"
+            echo "has_engflow=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::Could not retrieve EngFlow certificates — EngFlow artifact access will be unavailable"
+            echo "has_engflow=false" >> "$GITHUB_OUTPUT"
+            rm -rf "$CERT_DIR"
+          fi
+
       - name: Investigate
         uses: cockroachdb/claude-code-action@v1
         env:
@@ -151,7 +168,7 @@ jobs:
           # based permissions may work after upgrading the action.
           claude_args: |
             --model ${{ inputs.cheap == true && 'claude-sonnet-4-5' || 'claude-opus-4-6' }}
-            --allowedTools "Write,Read,Grep,Glob,WebFetch,Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(grep:*),Bash(rg:*),Bash(awk:*),Bash(cut:*),Bash(tr:*),Bash(sort:*),Bash(uniq:*),Bash(wc:*),Bash(tee:*),Bash(diff:*),Bash(file:*),Bash(strings:*),Bash(jq:*),Bash(ls:*),Bash(find:*),Bash(tree:*),Bash(stat:*),Bash(du:*),Bash(mkdir:*),Bash(git:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr diff:*),Bash(gh search:*),Bash(fetch-url:*),Bash(unzip:*),Bash(tar x*),Bash(tar -x*),Bash(tar --extract:*),Bash(go mod download:*),Bash(go env:*)"
+            --allowedTools "Write,Read,Grep,Glob,WebFetch,Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(grep:*),Bash(rg:*),Bash(awk:*),Bash(cut:*),Bash(tr:*),Bash(sort:*),Bash(uniq:*),Bash(wc:*),Bash(tee:*),Bash(diff:*),Bash(file:*),Bash(strings:*),Bash(jq:*),Bash(ls:*),Bash(find:*),Bash(tree:*),Bash(stat:*),Bash(du:*),Bash(mkdir:*),Bash(git:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr diff:*),Bash(gh search:*),Bash(fetch-url:*),Bash(unzip:*),Bash(tar x*),Bash(tar -x*),Bash(tar --extract:*),Bash(go mod download:*),Bash(go env:*),Bash(python3 .claude/skills/engflow-artifacts/engflow_artifacts.py:*)"
           prompt: |
             Read and follow the instructions in the prompt file
             `.github/prompts/${{ inputs.smoke_test == true && 'investigate-smoke' || 'investigate' }}.md`.
@@ -183,3 +200,9 @@ jobs:
               --repo ${{ github.repository }} \
               --body "Investigation did not produce findings. Check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details."
           fi
+
+      - name: Clean up EngFlow certificates
+        if: always() && steps.engflow-certs.outputs.has_engflow == 'true'
+        run: |
+          rm -f "$ENGFLOW_CERT_FILE" "$ENGFLOW_KEY_FILE"
+          rmdir "$(dirname "$ENGFLOW_CERT_FILE")" 2>/dev/null || true


### PR DESCRIPTION
The investigate workflow could only download artifacts from TeamCity. When it encountered an EngFlow-based failure, it had to skip artifact analysis entirely. This commit adds EngFlow support:

- engflow_artifacts.py: replace get_token() with get_curl_auth_args() that supports mTLS certificates (via ENGFLOW_CERT_FILE/ENGFLOW_KEY_FILE env vars), JWT from env (ENGFLOW_TOKEN), and the existing engflow_auth CLI fallback. All callers updated to thread auth_args through.

- investigate.yml: add a step to retrieve EngFlow mTLS certs from Google Cloud Secret Manager after OIDC auth, with graceful fallback if access is denied. Add python3:* to allowedTools. Add a cleanup step to remove temp cert files.

- investigate.md: replace the "EngFlow not supported" fallback text with full instructions for discovering failed targets, listing artifacts, and downloading test.log/outputs.zip via the script.

The mTLS path requires the ai-review service account to have secretmanager.versions.access on the engflow-mesolite-key/crt secrets, which is an IAM change outside this PR. The workflow fails gracefully if that access is not yet granted.

fixes #163955
Epic: CRDB-60540
Release note: None