### PR TITLE
cancelchecker: fix data race in GoroutineCPUHandle registration

### DIFF
--- a/pkg/util/cancelchecker/cancel_checker.go
+++ b/pkg/util/cancelchecker/cancel_checker.go
@@ -31,7 +31,13 @@ type CancelChecker struct {
 	// The number of Check() calls to skip the context cancellation check.
 	checkInterval uint32
 
-	cpuHandle *admission.GoroutineCPUHandle
+	// sqlCPUHandle is the SQL-level CPU handle from which a per-goroutine
+	// handle is lazily registered on the first Check call. Registration is
+	// deferred from Reset to the first Check because Reset and Check may run
+	// on different goroutines (e.g. when a Columnarizer wrapping a row-based
+	// processor runs inside a ParallelUnorderedSynchronizer).
+	sqlCPUHandle *admission.SQLCPUHandle
+	cpuHandle    *admission.GoroutineCPUHandle
 }
 
 // The default interval of Check() calls to wait between checks for context
@@ -50,6 +56,9 @@ func (c *CancelChecker) Check() error {
 			// to Check().
 			return QueryCanceledError
 		default:
+		}
+		if c.cpuHandle == nil && c.sqlCPUHandle != nil {
+			c.cpuHandle = c.sqlCPUHandle.RegisterGoroutine()
 		}
 		if c.cpuHandle != nil {
 			err := c.cpuHandle.MeasureAndAdmit(c.ctx)
@@ -78,10 +87,7 @@ func (c *CancelChecker) Reset(ctx context.Context, checkInterval ...uint32) {
 	} else {
 		c.checkInterval = cancelCheckInterval
 	}
-	cpuHandle := admission.SQLCPUHandleFromContext(ctx)
-	if cpuHandle != nil {
-		c.cpuHandle = cpuHandle.RegisterGoroutine()
-	}
+	c.sqlCPUHandle = admission.SQLCPUHandleFromContext(ctx)
 }
 
 // QueryCanceledError is an error representing query cancellation.


### PR DESCRIPTION
Fixes #164346
Fixes #164347
Fixes #164348
Fixes #164349
Fixes #164350
Fixes #164352
Fixes #164353
Fixes #164354
Fixes #164355
Fixes #164594

The row-based CancelChecker.Reset() was eagerly calling SQLCPUHandle.RegisterGoroutine() during Reset(), which runs on the main goroutine. The resulting GoroutineCPUHandle was keyed to the main goroutine's ID. When the CancelChecker was later used inside a ParallelUnorderedSynchronizer worker goroutine (via a Columnarizer wrapping a row-based processor), it called measureAndAdmit() on the main goroutine's handle. Meanwhile, the main goroutine's vectorized CancelChecker lazily registered and obtained the same handle (same goroutine ID). Both goroutines then called measureAndAdmit() concurrently on unsynchronized fields (cpuAccounted, pauseDur, etc.), triggering a data race detected by the race detector.

The fix defers RegisterGoroutine() from Reset() to the first Check() call, matching the pattern already used in the vectorized cancel checker (colexecutils.CancelChecker) since PR #163771. This ensures each goroutine registers its own handle on the goroutine that actually uses it.

Release note: None

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>