### PR TITLE
colexecbuiltins: support crdb_internal.datums_to_bytes

### DIFF
--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -1939,7 +1939,7 @@ func (r opResult) planAndMaybeWrapFilter(
 	factory coldata.ColumnFactory,
 ) error {
 	err := r.planFilterExpr(
-		ctx, flowCtx, args.SemaCtx, filter, getStreamingAllocator(ctx, args, flowCtx),
+		ctx, flowCtx, args.SemaCtx, filter, getStreamingAllocator(ctx, args, flowCtx), args.CloserRegistry,
 	)
 	if err != nil {
 		// Filter expression planning failed. Fall back to planning the filter
@@ -2072,7 +2072,7 @@ func (r *postProcessResult) planPostProcessSpec(
 		for _, expr := range exprs {
 			var outputIdx int
 			r.Op, outputIdx, r.ColumnTypes, err = planProjectionOperators(
-				ctx, flowCtx.EvalCtx, expr, r.ColumnTypes, r.Op, getStreamingAllocator(ctx, args, flowCtx), releasables,
+				ctx, flowCtx.EvalCtx, expr, r.ColumnTypes, r.Op, getStreamingAllocator(ctx, args, flowCtx), releasables, args.CloserRegistry,
 			)
 			if err != nil {
 				if log.ExpensiveLogEnabled(ctx, 1) {
@@ -2155,6 +2155,7 @@ func (r opResult) planFilterExpr(
 	semaCtx *tree.SemaContext,
 	filter execinfrapb.Expression,
 	allocator *colmem.Allocator,
+	closerRegistry *colexecargs.CloserRegistry,
 ) error {
 	expr, err := processExpr(ctx, filter, flowCtx.EvalCtx, semaCtx, r.ColumnTypes)
 	if err != nil {
@@ -2167,7 +2168,7 @@ func (r opResult) planFilterExpr(
 		return nil
 	}
 	op, _, filterColumnTypes, err := planSelectionOperators(
-		ctx, flowCtx.EvalCtx, expr, r.ColumnTypes, r.Root, allocator, &r.Releasables,
+		ctx, flowCtx.EvalCtx, expr, r.ColumnTypes, r.Root, allocator, &r.Releasables, closerRegistry,
 	)
 	if err != nil {
 		if log.ExpensiveLogEnabled(ctx, 1) {
@@ -2202,6 +2203,7 @@ func planSelectionOperators(
 	input colexecop.Operator,
 	allocator *colmem.Allocator,
 	releasables *[]execreleasable.Releasable,
+	closerRegistry *colexecargs.CloserRegistry,
 ) (op colexecop.Operator, resultIdx int, typs []*types.T, err error) {
 	switch t := expr.(type) {
 	case *tree.AndExpr:
@@ -2211,18 +2213,18 @@ func planSelectionOperators(
 		// tuples that are true on the right side.
 		var leftOp, rightOp colexecop.Operator
 		leftOp, _, typs, err = planSelectionOperators(
-			ctx, evalCtx, t.TypedLeft(), columnTypes, input, allocator, releasables,
+			ctx, evalCtx, t.TypedLeft(), columnTypes, input, allocator, releasables, closerRegistry,
 		)
 		if err != nil {
 			return nil, resultIdx, typs, err
 		}
 		rightOp, resultIdx, typs, err = planSelectionOperators(
-			ctx, evalCtx, t.TypedRight(), typs, leftOp, allocator, releasables,
+			ctx, evalCtx, t.TypedRight(), typs, leftOp, allocator, releasables, closerRegistry,
 		)
 		return rightOp, resultIdx, typs, err
 	case *tree.CaseExpr, *tree.CastExpr, *tree.CoalesceExpr:
 		op, resultIdx, typs, err = planProjectionOperators(
-			ctx, evalCtx, expr, columnTypes, input, allocator, releasables,
+			ctx, evalCtx, expr, columnTypes, input, allocator, releasables, closerRegistry,
 		)
 		if err != nil {
 			return op, resultIdx, typs, err
@@ -2232,7 +2234,7 @@ func planSelectionOperators(
 	case *tree.ComparisonExpr:
 		cmpOp := t.Operator
 		leftOp, leftIdx, ct, err := planProjectionOperators(
-			ctx, evalCtx, t.TypedLeft(), columnTypes, input, allocator, releasables,
+			ctx, evalCtx, t.TypedLeft(), columnTypes, input, allocator, releasables, closerRegistry,
 		)
 		if err != nil {
 			return nil, resultIdx, ct, err
@@ -2289,7 +2291,7 @@ func planSelectionOperators(
 			return op, resultIdx, ct, err
 		}
 		rightOp, rightIdx, ct, err := planProjectionOperators(
-			ctx, evalCtx, t.TypedRight(), ct, leftOp, allocator, releasables,
+			ctx, evalCtx, t.TypedRight(), ct, leftOp, allocator, releasables, closerRegistry,
 		)
 		if err != nil {
 			return nil, resultIdx, ct, err
@@ -2306,7 +2308,7 @@ func planSelectionOperators(
 		return op, -1, columnTypes, err
 	case *tree.IsNotNullExpr:
 		op, resultIdx, typs, err = planProjectionOperators(
-			ctx, evalCtx, t.TypedInnerExpr(), columnTypes, input, allocator, releasables,
+			ctx, evalCtx, t.TypedInnerExpr(), columnTypes, input, allocator, releasables, closerRegistry,
 		)
 		if err != nil {
 			return op, resultIdx, typs, err
@@ -2317,7 +2319,7 @@ func planSelectionOperators(
 		return op, resultIdx, typs, err
 	case *tree.IsNullExpr:
 		op, resultIdx, typs, err = planProjectionOperators(
-			ctx, evalCtx, t.TypedInnerExpr(), columnTypes, input, allocator, releasables,
+			ctx, evalCtx, t.TypedInnerExpr(), columnTypes, input, allocator, releasables, closerRegistry,
 		)
 		if err != nil {
 			return op, resultIdx, typs, err
@@ -2328,7 +2330,7 @@ func planSelectionOperators(
 		return op, resultIdx, typs, err
 	case *tree.NotExpr:
 		op, resultIdx, typs, err = planProjectionOperators(
-			ctx, evalCtx, t.TypedInnerExpr(), columnTypes, input, allocator, releasables,
+			ctx, evalCtx, t.TypedInnerExpr(), columnTypes, input, allocator, releasables, closerRegistry,
 		)
 		if err != nil {
 			return op, resultIdx, typs, err
@@ -2357,7 +2359,7 @@ func planSelectionOperators(
 			return nil, resultIdx, typs, err
 		}
 		op, resultIdx, typs, err = planProjectionOperators(
-			ctx, evalCtx, caseExpr, columnTypes, input, allocator, releasables,
+			ctx, evalCtx, caseExpr, columnTypes, input, allocator, releasables, closerRegistry,
 		)
 		if err != nil {
 			return nil, resultIdx, typs, err
@@ -2404,6 +2406,7 @@ func planProjectionOperators(
 	input colexecop.Operator,
 	allocator *colmem.Allocator,
 	releasables *[]execreleasable.Releasable,
+	closerRegistry *colexecargs.CloserRegistry,
 ) (op colexecop.Operator, resultIdx int, typs []*types.T, err error) {
 	// projectDatum is a helper function that adds a new constant projection
 	// operator for the given datum. typs are updated accordingly.
@@ -2422,7 +2425,7 @@ func planProjectionOperators(
 	resultIdx = -1
 	switch t := expr.(type) {
 	case *tree.AndExpr:
-		return planLogicalProjectionOp(ctx, evalCtx, expr, columnTypes, input, allocator, releasables)
+		return planLogicalProjectionOp(ctx, evalCtx, expr, columnTypes, input, allocator, releasables, closerRegistry)
 	case *tree.BinaryExpr:
 		if err = checkSupportedBinaryExpr(t.TypedLeft(), t.TypedRight(), t.ResolvedType()); err != nil {
 			return op, resultIdx, typs, err
@@ -2450,7 +2453,7 @@ func planProjectionOperators(
 		}
 		return planProjectionExpr(
 			ctx, evalCtx, t.Operator, t.ResolvedType(), leftExpr, rightExpr,
-			columnTypes, input, allocator, t.Op.EvalOp, nil /* cmpExpr */, releasables, t.Op.CalledOnNullInput,
+			columnTypes, input, allocator, t.Op.EvalOp, nil /* cmpExpr */, releasables, closerRegistry, t.Op.CalledOnNullInput,
 		)
 	case *tree.CaseExpr:
 		caseOutputType := t.ResolvedType()
@@ -2481,7 +2484,7 @@ func planProjectionOperators(
 			// final result of the case projection.
 			whenTyped := when.Cond.(tree.TypedExpr)
 			caseOps[i], resultIdx, typs, err = planProjectionOperators(
-				ctx, evalCtx, whenTyped, typs, buffer, allocator, releasables,
+				ctx, evalCtx, whenTyped, typs, buffer, allocator, releasables, closerRegistry,
 			)
 			if err != nil {
 				return nil, resultIdx, typs, err
@@ -2499,7 +2502,7 @@ func planProjectionOperators(
 				right := tree.NewTypedOrdinalReference(resultIdx, whenTyped.ResolvedType())
 				cmpExpr := tree.NewTypedComparisonExpr(treecmp.MakeComparisonOperator(treecmp.EQ), left, right)
 				caseOps[i], resultIdx, typs, err = planProjectionOperators(
-					ctx, evalCtx, cmpExpr, typs, caseOps[i], allocator, releasables,
+					ctx, evalCtx, cmpExpr, typs, caseOps[i], allocator, releasables, closerRegistry,
 				)
 				if err != nil {
 					return nil, resultIdx, typs, err
@@ -2512,7 +2515,7 @@ func planProjectionOperators(
 
 			// Run the "then" clause on those tuples that were selected.
 			caseOps[i], thenIdxs[i], typs, err = planProjectionOperators(
-				ctx, evalCtx, when.Val.(tree.TypedExpr), typs, caseOps[i], allocator, releasables,
+				ctx, evalCtx, when.Val.(tree.TypedExpr), typs, caseOps[i], allocator, releasables, closerRegistry,
 			)
 			if err != nil {
 				return nil, resultIdx, typs, err
@@ -2537,7 +2540,7 @@ func planProjectionOperators(
 			elseExpr = tree.DNull
 		}
 		elseOp, thenIdxs[len(t.Whens)], typs, err = planProjectionOperators(
-			ctx, evalCtx, elseExpr.(tree.TypedExpr), typs, buffer, allocator, releasables,
+			ctx, evalCtx, elseExpr.(tree.TypedExpr), typs, buffer, allocator, releasables, closerRegistry,
 		)
 		if err != nil {
 			return nil, resultIdx, typs, err
@@ -2562,7 +2565,7 @@ func planProjectionOperators(
 	case *tree.CastExpr:
 		expr := t.Expr.(tree.TypedExpr)
 		op, resultIdx, typs, err = planProjectionOperators(
-			ctx, evalCtx, expr, columnTypes, input, allocator, releasables,
+			ctx, evalCtx, expr, columnTypes, input, allocator, releasables, closerRegistry,
 		)
 		if err != nil {
 			return nil, 0, nil, err
@@ -2598,14 +2601,14 @@ func planProjectionOperators(
 		if err != nil {
 			return nil, resultIdx, typs, err
 		}
-		return planProjectionOperators(ctx, evalCtx, caseExpr, columnTypes, input, allocator, releasables)
+		return planProjectionOperators(ctx, evalCtx, caseExpr, columnTypes, input, allocator, releasables, closerRegistry)
 	case *tree.ComparisonExpr:
 		if err = checkSupportedComparisonExpr(t.TypedLeft(), t.TypedRight()); err != nil {
 			return op, resultIdx, typs, err
 		}
 		return planProjectionExpr(
 			ctx, evalCtx, t.Operator, t.ResolvedType(), t.TypedLeft(), t.TypedRight(),
-			columnTypes, input, allocator, nil /* binFn */, t, releasables, t.Op.CalledOnNullInput,
+			columnTypes, input, allocator, nil /* binFn */, t, releasables, closerRegistry, t.Op.CalledOnNullInput,
 		)
 	case tree.Datum:
 		op, err = projectDatum(t)
@@ -2621,7 +2624,7 @@ func planProjectionOperators(
 			// of constant arguments, because the vectorized engine right now
 			// creates a new column full of the constant value.
 			op, resultIdx, typs, err = planProjectionOperators(
-				ctx, evalCtx, e.(tree.TypedExpr), typs, op, allocator, releasables,
+				ctx, evalCtx, e.(tree.TypedExpr), typs, op, allocator, releasables, closerRegistry,
 			)
 			if err != nil {
 				return nil, resultIdx, nil, err
@@ -2634,6 +2637,9 @@ func planProjectionOperators(
 		)
 		if r, ok := op.(execreleasable.Releasable); ok {
 			*releasables = append(*releasables, r)
+		}
+		if c, ok := op.(colexecop.Closer); ok {
+			closerRegistry.AddCloser(c)
 		}
 		typs = append(typs, t.ResolvedType())
 		return op, resultIdx, typs, err
@@ -2649,16 +2655,16 @@ func planProjectionOperators(
 		if err != nil {
 			return nil, resultIdx, typs, err
 		}
-		return planProjectionOperators(ctx, evalCtx, caseExpr, columnTypes, input, allocator, releasables)
+		return planProjectionOperators(ctx, evalCtx, caseExpr, columnTypes, input, allocator, releasables, closerRegistry)
 	case *tree.IndexedVar:
 		return input, t.Idx, columnTypes, nil
 	case *tree.IsNotNullExpr:
-		return planIsNullProjectionOp(ctx, evalCtx, t.ResolvedType(), t.TypedInnerExpr(), columnTypes, input, allocator, true /* negate */, releasables)
+		return planIsNullProjectionOp(ctx, evalCtx, t.ResolvedType(), t.TypedInnerExpr(), columnTypes, input, allocator, true /* negate */, releasables, closerRegistry)
 	case *tree.IsNullExpr:
-		return planIsNullProjectionOp(ctx, evalCtx, t.ResolvedType(), t.TypedInnerExpr(), columnTypes, input, allocator, false /* negate */, releasables)
+		return planIsNullProjectionOp(ctx, evalCtx, t.ResolvedType(), t.TypedInnerExpr(), columnTypes, input, allocator, false /* negate */, releasables, closerRegistry)
 	case *tree.NotExpr:
 		op, resultIdx, typs, err = planProjectionOperators(
-			ctx, evalCtx, t.TypedInnerExpr(), columnTypes, input, allocator, releasables,
+			ctx, evalCtx, t.TypedInnerExpr(), columnTypes, input, allocator, releasables, closerRegistry,
 		)
 		if err != nil {
 			return op, resultIdx, typs, err
@@ -2692,9 +2698,9 @@ func planProjectionOperators(
 		if err != nil {
 			return nil, resultIdx, typs, err
 		}
-		return planProjectionOperators(ctx, evalCtx, caseExpr, columnTypes, input, allocator, releasables)
+		return planProjectionOperators(ctx, evalCtx, caseExpr, columnTypes, input, allocator, releasables, closerRegistry)
 	case *tree.OrExpr:
-		return planLogicalProjectionOp(ctx, evalCtx, expr, columnTypes, input, allocator, releasables)
+		return planLogicalProjectionOp(ctx, evalCtx, expr, columnTypes, input, allocator, releasables, closerRegistry)
 	case *tree.Tuple:
 		tuple, isConstTuple := evalTupleIfConst(ctx, evalCtx, t)
 		if isConstTuple {
@@ -2709,7 +2715,7 @@ func planProjectionOperators(
 		tupleContentsIdxs := make([]int, len(t.Exprs))
 		for i, expr := range t.Exprs {
 			input, tupleContentsIdxs[i], typs, err = planProjectionOperators(
-				ctx, evalCtx, expr.(tree.TypedExpr), typs, input, allocator, releasables,
+				ctx, evalCtx, expr.(tree.TypedExpr), typs, input, allocator, releasables, closerRegistry,
 			)
 			if err != nil {
 				return nil, resultIdx, typs, err
@@ -2816,6 +2822,7 @@ func planProjectionExpr(
 	binOp tree.BinaryEvalOp,
 	cmpExpr *tree.ComparisonExpr,
 	releasables *[]execreleasable.Releasable,
+	closerRegistry *colexecargs.CloserRegistry,
 	calledOnNullInput bool,
 ) (op colexecop.Operator, resultIdx int, typs []*types.T, err error) {
 	resultIdx = -1
@@ -2840,7 +2847,7 @@ func planProjectionExpr(
 		// this case.
 		var rightIdx int
 		input, rightIdx, typs, err = planProjectionOperators(
-			ctx, evalCtx, right, columnTypes, input, allocator, releasables,
+			ctx, evalCtx, right, columnTypes, input, allocator, releasables, closerRegistry,
 		)
 		if err != nil {
 			return nil, resultIdx, typs, err
@@ -2861,7 +2868,7 @@ func planProjectionExpr(
 	} else {
 		var leftIdx int
 		input, leftIdx, typs, err = planProjectionOperators(
-			ctx, evalCtx, left, columnTypes, input, allocator, releasables,
+			ctx, evalCtx, left, columnTypes, input, allocator, releasables, closerRegistry,
 		)
 		if err != nil {
 			return nil, resultIdx, typs, err
@@ -2949,7 +2956,7 @@ func planProjectionExpr(
 			// Case 3: neither are constant.
 			var rightIdx int
 			input, rightIdx, typs, err = planProjectionOperators(
-				ctx, evalCtx, right, typs, input, allocator, releasables,
+				ctx, evalCtx, right, typs, input, allocator, releasables, closerRegistry,
 			)
 			if err != nil {
 				return nil, resultIdx, nil, err
@@ -2981,6 +2988,7 @@ func planLogicalProjectionOp(
 	input colexecop.Operator,
 	allocator *colmem.Allocator,
 	releasables *[]execreleasable.Releasable,
+	closerRegistry *colexecargs.CloserRegistry,
 ) (op colexecop.Operator, resultIdx int, typs []*types.T, err error) {
 	// Add a new boolean column that will store the result of the projection.
 	resultIdx = len(columnTypes)
@@ -3003,13 +3011,13 @@ func planLogicalProjectionOp(
 		colexecerror.InternalError(errors.AssertionFailedf("unexpected logical expression type %s", t.String()))
 	}
 	leftProjOpChain, leftIdx, typs, err = planProjectionOperators(
-		ctx, evalCtx, typedLeft, typs, leftFeedOp, allocator, releasables,
+		ctx, evalCtx, typedLeft, typs, leftFeedOp, allocator, releasables, closerRegistry,
 	)
 	if err != nil {
 		return nil, resultIdx, typs, err
 	}
 	rightProjOpChain, rightIdx, typs, err = planProjectionOperators(
-		ctx, evalCtx, typedRight, typs, rightFeedOp, allocator, releasables,
+		ctx, evalCtx, typedRight, typs, rightFeedOp, allocator, releasables, closerRegistry,
 	)
 	if err != nil {
 		return nil, resultIdx, typs, err
@@ -3048,9 +3056,10 @@ func planIsNullProjectionOp(
 	allocator *colmem.Allocator,
 	negate bool,
 	releasables *[]execreleasable.Releasable,
+	closerRegistry *colexecargs.CloserRegistry,
 ) (op colexecop.Operator, resultIdx int, typs []*types.T, err error) {
 	op, resultIdx, typs, err = planProjectionOperators(
-		ctx, evalCtx, expr, columnTypes, input, allocator, releasables,
+		ctx, evalCtx, expr, columnTypes, input, allocator, releasables, closerRegistry,
 	)
 	if err != nil {
 		return op, resultIdx, typs, err

--- a/pkg/sql/colexec/colexecbuiltins/BUILD.bazel
+++ b/pkg/sql/colexec/colexecbuiltins/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     name = "colexecbuiltins",
     srcs = [
         "builtin_funcs.go",
+        "datums_to_bytes.go",
         "fnv64.go",
         "range_stats.go",
         ":gen-exec",  # keep
@@ -15,6 +16,7 @@ go_library(
         "//pkg/col/coldata",
         "//pkg/roachpb",
         "//pkg/sql/colconv",
+        "//pkg/sql/colexec/colexecspan",
         "//pkg/sql/colexec/colexecutils",
         "//pkg/sql/colexecerror",
         "//pkg/sql/colexecop",

--- a/pkg/sql/colexec/colexecbuiltins/builtin_funcs.go
+++ b/pkg/sql/colexec/colexecbuiltins/builtin_funcs.go
@@ -151,6 +151,8 @@ func NewBuiltinFunctionOperator(
 			hash = fnv.New64a()
 		}
 		return newFNV64Op(argumentCols, outputIdx, input, hash), nil
+	case tree.DatumsToBytes:
+		return newDatumsToBytesOp(allocator, columnTypes, argumentCols, outputIdx, input), nil
 	default:
 		return &defaultBuiltinFuncOperator{
 			OneInputHelper:      colexecop.MakeOneInputHelper(input),

--- a/pkg/sql/colexec/colexecbuiltins/builtin_funcs_test.go
+++ b/pkg/sql/colexec/colexecbuiltins/builtin_funcs_test.go
@@ -48,7 +48,6 @@ func TestBasicBuiltinFunctions(t *testing.T) {
 	testCases := []struct {
 		desc         string
 		expr         string
-		inputCols    []int
 		inputTuples  colexectestutils.Tuples
 		inputTypes   []*types.T
 		outputTuples colexectestutils.Tuples
@@ -56,7 +55,6 @@ func TestBasicBuiltinFunctions(t *testing.T) {
 		{
 			desc:         "AbsVal",
 			expr:         "abs(@1)",
-			inputCols:    []int{0},
 			inputTuples:  colexectestutils.Tuples{{1}, {-2}},
 			inputTypes:   []*types.T{types.Int},
 			outputTuples: colexectestutils.Tuples{{1, 1}, {-2, 2}},
@@ -64,15 +62,13 @@ func TestBasicBuiltinFunctions(t *testing.T) {
 		{
 			desc:         "StringLen",
 			expr:         "length(@1)",
-			inputCols:    []int{0},
 			inputTuples:  colexectestutils.Tuples{{"Hello"}, {"The"}},
 			inputTypes:   []*types.T{types.String},
 			outputTuples: colexectestutils.Tuples{{"Hello", 5}, {"The", 3}},
 		},
 		{
-			desc:      "Substr",
-			expr:      "substr(@1, @2, @3)",
-			inputCols: []int{0},
+			desc: "Substr",
+			expr: "substr(@1, @2, @3)",
 			inputTuples: colexectestutils.Tuples{
 				{"Hello", 1, 4},
 				{"Hello", 4, 2},
@@ -108,7 +104,6 @@ func TestBasicBuiltinFunctions(t *testing.T) {
 		{
 			desc:         "FNV64",
 			expr:         "fnv64(@1)",
-			inputCols:    []int{0},
 			inputTuples:  colexectestutils.Tuples{{"abc"}, {""}, {"hello world"}, {"x"}, {"123"}},
 			inputTypes:   []*types.T{types.String},
 			outputTuples: colexectestutils.Tuples{{"abc", int64(-2820157060406071861)}, {"", int64(-3750763034362895579)}, {"hello world", int64(9065573210506989167)}, {"x", int64(-5808590958014384217)}, {"123", int64(-2774223862635011909)}},
@@ -116,7 +111,6 @@ func TestBasicBuiltinFunctions(t *testing.T) {
 		{
 			desc:         "FNV64a",
 			expr:         "fnv64a(@1)",
-			inputCols:    []int{0},
 			inputTuples:  colexectestutils.Tuples{{"abc"}, {""}, {"hello world"}, {"x"}, {"123"}},
 			inputTypes:   []*types.T{types.String},
 			outputTuples: colexectestutils.Tuples{{"abc", int64(-1792535898324117685)}, {"", int64(-3750763034362895579)}, {"hello world", int64(8618312879776256743)}, {"x", int64(-5808529385363204345)}, {"123", int64(5003431119771845851)}},
@@ -124,7 +118,6 @@ func TestBasicBuiltinFunctions(t *testing.T) {
 		{
 			desc:         "FNV64 with 3 values",
 			expr:         "fnv64(@1, @2, @3)",
-			inputCols:    []int{0, 1, 2},
 			inputTuples:  colexectestutils.Tuples{{"a", "b", "c"}, {"hello", "world", "test"}, {"", "", ""}, {"x", "", "y"}},
 			inputTypes:   []*types.T{types.String, types.String, types.String},
 			outputTuples: colexectestutils.Tuples{{"a", "b", "c", int64(-2820157060406071861)}, {"hello", "world", "test", int64(1178316459888765213)}, {"", "", "", int64(-3750763034362895579)}, {"x", "", "y", int64(590622495169253564)}},
@@ -132,10 +125,23 @@ func TestBasicBuiltinFunctions(t *testing.T) {
 		{
 			desc:         "FNV64a with 3 values",
 			expr:         "fnv64a(@1, @2, @3)",
-			inputCols:    []int{0, 1, 2},
 			inputTuples:  colexectestutils.Tuples{{"a", "b", "c"}, {"hello", "world", "test"}, {"", "", ""}, {"x", "", "y"}},
 			inputTypes:   []*types.T{types.String, types.String, types.String},
 			outputTuples: colexectestutils.Tuples{{"a", "b", "c", int64(-1792535898324117685)}, {"hello", "world", "test", int64(7507279486104997145)}, {"", "", "", int64(-3750763034362895579)}, {"x", "", "y", int64(644383116220033818)}},
+		},
+		{
+			desc:         "DatumsToBytes single int",
+			expr:         "crdb_internal.datums_to_bytes(@1)",
+			inputTuples:  colexectestutils.Tuples{{1}, {2}, {-1}},
+			inputTypes:   []*types.T{types.Int},
+			outputTuples: colexectestutils.Tuples{{1, []byte{0x89}}, {2, []byte{0x8A}}, {-1, []byte{0x87, 0xFF}}},
+		},
+		{
+			desc:         "DatumsToBytes multiple args",
+			expr:         "crdb_internal.datums_to_bytes(@1, @3)",
+			inputTuples:  colexectestutils.Tuples{{1, 0, "a"}, {2, 0, "b"}},
+			inputTypes:   []*types.T{types.Int, types.Int, types.String},
+			outputTuples: colexectestutils.Tuples{{1, 0, "a", []byte{0x89, 0x12, 'a', 0x00, 0x01}}, {2, 0, "b", []byte{0x8A, 0x12, 'b', 0x00, 0x01}}},
 		},
 	}
 

--- a/pkg/sql/colexec/colexecbuiltins/datums_to_bytes.go
+++ b/pkg/sql/colexec/colexecbuiltins/datums_to_bytes.go
@@ -1,0 +1,101 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package colexecbuiltins
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecspan"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
+	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+)
+
+type datumsToBytesOp struct {
+	colexecop.OneInputHelper
+	allocator *colmem.Allocator
+	outputIdx int
+
+	// encoders is an ordered list of utility operators that encode each
+	// argument column in the vectorized fashion.
+	encoders []colexecspan.SpanEncoder
+	// encCols stores the encoded vector for each argument column. It
+	// corresponds one-to-one with encoders.
+	encCols []*coldata.Bytes
+
+	scratch []byte
+}
+
+var _ colexecop.ClosableOperator = (*datumsToBytesOp)(nil)
+
+func newDatumsToBytesOp(
+	allocator *colmem.Allocator,
+	columnTypes []*types.T,
+	argumentCols []int,
+	outputIdx int,
+	input colexecop.Operator,
+) colexecop.Operator {
+	op := &datumsToBytesOp{
+		OneInputHelper: colexecop.MakeOneInputHelper(input),
+		allocator:      allocator,
+		outputIdx:      outputIdx,
+		encoders:       make([]colexecspan.SpanEncoder, len(argumentCols)),
+		encCols:        make([]*coldata.Bytes, len(argumentCols)),
+	}
+	// Create a span encoder for each argument column. All encodings use
+	// ascending direction since we're just concatenating bytes.
+	for i, argumentCol := range argumentCols {
+		op.encoders[i] = colexecspan.NewSpanEncoder(
+			allocator, columnTypes[argumentCol], true /* asc */, argumentCol,
+		)
+	}
+	return op
+}
+
+func (d *datumsToBytesOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := d.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch, nil
+	}
+
+	for i, encoder := range d.encoders {
+		d.encCols[i] = encoder.Next(batch, 0 /* startIdx */, n)
+	}
+
+	inSel := batch.Selection()
+	outVec := batch.ColVec(d.outputIdx)
+	outBytes := outVec.Bytes()
+	d.allocator.PerformOperation([]*coldata.Vec{outVec}, func() {
+		for i := 0; i < batch.Length(); i++ {
+			d.scratch = d.scratch[:0]
+			for _, enc := range d.encCols {
+				// Note that because SpanEncoder.Next performs the deselection
+				// step, we always use 'i' and ignore the selection vector - if
+				// set - on the batch.
+				d.scratch = append(d.scratch, enc.Get(i)...)
+			}
+			outIdx := i
+			if inSel != nil {
+				outIdx = inSel[i]
+			}
+			outBytes.Set(outIdx, d.scratch)
+		}
+	})
+	return batch, nil
+}
+
+func (d *datumsToBytesOp) Close(context.Context) error {
+	for _, encoder := range d.encoders {
+		encoder.Close()
+	}
+	return nil
+}

--- a/pkg/sql/colexec/colexecspan/span_assembler.go
+++ b/pkg/sql/colexec/colexecspan/span_assembler.go
@@ -61,7 +61,7 @@ func NewColSpanAssembler(
 	keyColumns := fetchSpec.KeyColumns()
 	for i := range keyColumns {
 		asc := keyColumns[i].Direction == catenumpb.IndexColumn_ASC
-		sa.spanEncoders = append(sa.spanEncoders, newSpanEncoder(allocator, inputTypes[i], asc, i))
+		sa.spanEncoders = append(sa.spanEncoders, NewSpanEncoder(allocator, inputTypes[i], asc, i))
 	}
 	if cap(sa.spanCols) < len(sa.spanEncoders) {
 		sa.spanCols = make([]*coldata.Bytes, len(sa.spanEncoders))
@@ -143,7 +143,7 @@ type spanAssembler struct {
 
 	// spanEncoders is an ordered list of utility operators that encode each key
 	// column in vectorized fashion.
-	spanEncoders []spanEncoder
+	spanEncoders []SpanEncoder
 
 	// spanCols is used to iterate through the input columns that contain the
 	// key encodings during span construction.
@@ -173,7 +173,7 @@ func (sa *spanAssembler) ConsumeBatch(batch coldata.Batch, startIdx, endIdx int)
 	}
 
 	for i := range sa.spanEncoders {
-		sa.spanCols[i] = sa.spanEncoders[i].next(batch, startIdx, endIdx)
+		sa.spanCols[i] = sa.spanEncoders[i].Next(batch, startIdx, endIdx)
 	}
 
 	oldKeyBytes := sa.keyBytes
@@ -271,7 +271,7 @@ func (sa *spanAssembler) AccountForSpans() {
 // Close implements the ColSpanAssembler interface.
 func (sa *spanAssembler) Close() {
 	for i := range sa.spanEncoders {
-		sa.spanEncoders[i].close()
+		sa.spanEncoders[i].Close()
 	}
 }
 

--- a/pkg/sql/colexec/colexecspan/span_encoder.eg.go
+++ b/pkg/sql/colexec/colexecspan/span_encoder.eg.go
@@ -25,12 +25,12 @@ var (
 	_ tree.Datum
 )
 
-// newSpanEncoder creates a new utility operator that, given input batches,
+// NewSpanEncoder creates a new utility operator that, given input batches,
 // generates the encoding for the given key column. It is used by SpanAssembler
 // operators to generate spans for index joins and lookup joins.
-func newSpanEncoder(
+func NewSpanEncoder(
 	allocator *colmem.Allocator, typ *types.T, asc bool, encodeColIdx int,
-) spanEncoder {
+) SpanEncoder {
 	base := spanEncoderBase{
 		allocator:    allocator,
 		encodeColIdx: encodeColIdx,
@@ -163,16 +163,22 @@ func newSpanEncoder(
 	return nil
 }
 
-type spanEncoder interface {
-	// next generates the encoding for the current key column for each row from
+// SpanEncoder generates the encoding for a key column for each row from a
+// batch.
+type SpanEncoder interface {
+	// Next generates the encoding for the current key column for each row from
 	// the given batch in the range [startIdx, endIdx), then returns each row's
 	// encoding as a value in a Bytes column. The returned Bytes column is owned
-	// by the spanEncoder operator and should not be modified. Calling next
-	// invalidates previous calls to next. next assumes that startIdx and endIdx
+	// by the SpanEncoder operator and should not be modified. Calling Next
+	// invalidates previous calls to Next. Next assumes that startIdx and endIdx
 	// constitute a valid range of the given batch.
-	next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes
+	// NB: Next performs the deselection step (meaning that all output encodings
+	// are contiguous in the output Bytes vector).
+	// TODO(yuzefovich): consider switching to value receiver.
+	Next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes
 
-	close()
+	// Close releases any resources held by the encoder.
+	Close()
 }
 
 type spanEncoderBase struct {
@@ -193,10 +199,10 @@ type spanEncoderBoolAsc struct {
 	spanEncoderBase
 }
 
-var _ spanEncoder = &spanEncoderBoolAsc{}
+var _ SpanEncoder = &spanEncoderBoolAsc{}
 
-// next implements the spanEncoder interface.
-func (op *spanEncoderBoolAsc) next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
+// Next implements the SpanEncoder interface.
+func (op *spanEncoderBoolAsc) Next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
 	oldBytesSize := op.outputBytes.Size()
 	if op.outputBytes == nil || op.outputBytes.Len() < endIdx-startIdx {
 		op.outputBytes = coldata.NewBytes(endIdx - startIdx)
@@ -302,10 +308,10 @@ type spanEncoderBytesAsc struct {
 	spanEncoderBase
 }
 
-var _ spanEncoder = &spanEncoderBytesAsc{}
+var _ SpanEncoder = &spanEncoderBytesAsc{}
 
-// next implements the spanEncoder interface.
-func (op *spanEncoderBytesAsc) next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
+// Next implements the SpanEncoder interface.
+func (op *spanEncoderBytesAsc) Next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
 	oldBytesSize := op.outputBytes.Size()
 	if op.outputBytes == nil || op.outputBytes.Len() < endIdx-startIdx {
 		op.outputBytes = coldata.NewBytes(endIdx - startIdx)
@@ -381,10 +387,10 @@ type spanEncoderDecimalAsc struct {
 	spanEncoderBase
 }
 
-var _ spanEncoder = &spanEncoderDecimalAsc{}
+var _ SpanEncoder = &spanEncoderDecimalAsc{}
 
-// next implements the spanEncoder interface.
-func (op *spanEncoderDecimalAsc) next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
+// Next implements the SpanEncoder interface.
+func (op *spanEncoderDecimalAsc) Next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
 	oldBytesSize := op.outputBytes.Size()
 	if op.outputBytes == nil || op.outputBytes.Len() < endIdx-startIdx {
 		op.outputBytes = coldata.NewBytes(endIdx - startIdx)
@@ -462,10 +468,10 @@ type spanEncoderInt16Asc struct {
 	spanEncoderBase
 }
 
-var _ spanEncoder = &spanEncoderInt16Asc{}
+var _ SpanEncoder = &spanEncoderInt16Asc{}
 
-// next implements the spanEncoder interface.
-func (op *spanEncoderInt16Asc) next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
+// Next implements the SpanEncoder interface.
+func (op *spanEncoderInt16Asc) Next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
 	oldBytesSize := op.outputBytes.Size()
 	if op.outputBytes == nil || op.outputBytes.Len() < endIdx-startIdx {
 		op.outputBytes = coldata.NewBytes(endIdx - startIdx)
@@ -543,10 +549,10 @@ type spanEncoderInt32Asc struct {
 	spanEncoderBase
 }
 
-var _ spanEncoder = &spanEncoderInt32Asc{}
+var _ SpanEncoder = &spanEncoderInt32Asc{}
 
-// next implements the spanEncoder interface.
-func (op *spanEncoderInt32Asc) next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
+// Next implements the SpanEncoder interface.
+func (op *spanEncoderInt32Asc) Next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
 	oldBytesSize := op.outputBytes.Size()
 	if op.outputBytes == nil || op.outputBytes.Len() < endIdx-startIdx {
 		op.outputBytes = coldata.NewBytes(endIdx - startIdx)
@@ -624,10 +630,10 @@ type spanEncoderInt64Asc struct {
 	spanEncoderBase
 }
 
-var _ spanEncoder = &spanEncoderInt64Asc{}
+var _ SpanEncoder = &spanEncoderInt64Asc{}
 
-// next implements the spanEncoder interface.
-func (op *spanEncoderInt64Asc) next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
+// Next implements the SpanEncoder interface.
+func (op *spanEncoderInt64Asc) Next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
 	oldBytesSize := op.outputBytes.Size()
 	if op.outputBytes == nil || op.outputBytes.Len() < endIdx-startIdx {
 		op.outputBytes = coldata.NewBytes(endIdx - startIdx)
@@ -705,10 +711,10 @@ type spanEncoderFloat64Asc struct {
 	spanEncoderBase
 }
 
-var _ spanEncoder = &spanEncoderFloat64Asc{}
+var _ SpanEncoder = &spanEncoderFloat64Asc{}
 
-// next implements the spanEncoder interface.
-func (op *spanEncoderFloat64Asc) next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
+// Next implements the SpanEncoder interface.
+func (op *spanEncoderFloat64Asc) Next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
 	oldBytesSize := op.outputBytes.Size()
 	if op.outputBytes == nil || op.outputBytes.Len() < endIdx-startIdx {
 		op.outputBytes = coldata.NewBytes(endIdx - startIdx)
@@ -786,10 +792,10 @@ type spanEncoderTimestampAsc struct {
 	spanEncoderBase
 }
 
-var _ spanEncoder = &spanEncoderTimestampAsc{}
+var _ SpanEncoder = &spanEncoderTimestampAsc{}
 
-// next implements the spanEncoder interface.
-func (op *spanEncoderTimestampAsc) next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
+// Next implements the SpanEncoder interface.
+func (op *spanEncoderTimestampAsc) Next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
 	oldBytesSize := op.outputBytes.Size()
 	if op.outputBytes == nil || op.outputBytes.Len() < endIdx-startIdx {
 		op.outputBytes = coldata.NewBytes(endIdx - startIdx)
@@ -867,10 +873,10 @@ type spanEncoderIntervalAsc struct {
 	spanEncoderBase
 }
 
-var _ spanEncoder = &spanEncoderIntervalAsc{}
+var _ SpanEncoder = &spanEncoderIntervalAsc{}
 
-// next implements the spanEncoder interface.
-func (op *spanEncoderIntervalAsc) next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
+// Next implements the SpanEncoder interface.
+func (op *spanEncoderIntervalAsc) Next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
 	oldBytesSize := op.outputBytes.Size()
 	if op.outputBytes == nil || op.outputBytes.Len() < endIdx-startIdx {
 		op.outputBytes = coldata.NewBytes(endIdx - startIdx)
@@ -972,10 +978,10 @@ type spanEncoderJSONAsc struct {
 	spanEncoderBase
 }
 
-var _ spanEncoder = &spanEncoderJSONAsc{}
+var _ SpanEncoder = &spanEncoderJSONAsc{}
 
-// next implements the spanEncoder interface.
-func (op *spanEncoderJSONAsc) next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
+// Next implements the SpanEncoder interface.
+func (op *spanEncoderJSONAsc) Next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
 	oldBytesSize := op.outputBytes.Size()
 	if op.outputBytes == nil || op.outputBytes.Len() < endIdx-startIdx {
 		op.outputBytes = coldata.NewBytes(endIdx - startIdx)
@@ -1075,10 +1081,10 @@ type spanEncoderDatumAsc struct {
 	spanEncoderBase
 }
 
-var _ spanEncoder = &spanEncoderDatumAsc{}
+var _ SpanEncoder = &spanEncoderDatumAsc{}
 
-// next implements the spanEncoder interface.
-func (op *spanEncoderDatumAsc) next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
+// Next implements the SpanEncoder interface.
+func (op *spanEncoderDatumAsc) Next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
 	oldBytesSize := op.outputBytes.Size()
 	if op.outputBytes == nil || op.outputBytes.Len() < endIdx-startIdx {
 		op.outputBytes = coldata.NewBytes(endIdx - startIdx)
@@ -1178,10 +1184,10 @@ type spanEncoderBoolDesc struct {
 	spanEncoderBase
 }
 
-var _ spanEncoder = &spanEncoderBoolDesc{}
+var _ SpanEncoder = &spanEncoderBoolDesc{}
 
-// next implements the spanEncoder interface.
-func (op *spanEncoderBoolDesc) next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
+// Next implements the SpanEncoder interface.
+func (op *spanEncoderBoolDesc) Next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
 	oldBytesSize := op.outputBytes.Size()
 	if op.outputBytes == nil || op.outputBytes.Len() < endIdx-startIdx {
 		op.outputBytes = coldata.NewBytes(endIdx - startIdx)
@@ -1287,10 +1293,10 @@ type spanEncoderBytesDesc struct {
 	spanEncoderBase
 }
 
-var _ spanEncoder = &spanEncoderBytesDesc{}
+var _ SpanEncoder = &spanEncoderBytesDesc{}
 
-// next implements the spanEncoder interface.
-func (op *spanEncoderBytesDesc) next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
+// Next implements the SpanEncoder interface.
+func (op *spanEncoderBytesDesc) Next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
 	oldBytesSize := op.outputBytes.Size()
 	if op.outputBytes == nil || op.outputBytes.Len() < endIdx-startIdx {
 		op.outputBytes = coldata.NewBytes(endIdx - startIdx)
@@ -1366,10 +1372,10 @@ type spanEncoderDecimalDesc struct {
 	spanEncoderBase
 }
 
-var _ spanEncoder = &spanEncoderDecimalDesc{}
+var _ SpanEncoder = &spanEncoderDecimalDesc{}
 
-// next implements the spanEncoder interface.
-func (op *spanEncoderDecimalDesc) next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
+// Next implements the SpanEncoder interface.
+func (op *spanEncoderDecimalDesc) Next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
 	oldBytesSize := op.outputBytes.Size()
 	if op.outputBytes == nil || op.outputBytes.Len() < endIdx-startIdx {
 		op.outputBytes = coldata.NewBytes(endIdx - startIdx)
@@ -1447,10 +1453,10 @@ type spanEncoderInt16Desc struct {
 	spanEncoderBase
 }
 
-var _ spanEncoder = &spanEncoderInt16Desc{}
+var _ SpanEncoder = &spanEncoderInt16Desc{}
 
-// next implements the spanEncoder interface.
-func (op *spanEncoderInt16Desc) next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
+// Next implements the SpanEncoder interface.
+func (op *spanEncoderInt16Desc) Next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
 	oldBytesSize := op.outputBytes.Size()
 	if op.outputBytes == nil || op.outputBytes.Len() < endIdx-startIdx {
 		op.outputBytes = coldata.NewBytes(endIdx - startIdx)
@@ -1528,10 +1534,10 @@ type spanEncoderInt32Desc struct {
 	spanEncoderBase
 }
 
-var _ spanEncoder = &spanEncoderInt32Desc{}
+var _ SpanEncoder = &spanEncoderInt32Desc{}
 
-// next implements the spanEncoder interface.
-func (op *spanEncoderInt32Desc) next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
+// Next implements the SpanEncoder interface.
+func (op *spanEncoderInt32Desc) Next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
 	oldBytesSize := op.outputBytes.Size()
 	if op.outputBytes == nil || op.outputBytes.Len() < endIdx-startIdx {
 		op.outputBytes = coldata.NewBytes(endIdx - startIdx)
@@ -1609,10 +1615,10 @@ type spanEncoderInt64Desc struct {
 	spanEncoderBase
 }
 
-var _ spanEncoder = &spanEncoderInt64Desc{}
+var _ SpanEncoder = &spanEncoderInt64Desc{}
 
-// next implements the spanEncoder interface.
-func (op *spanEncoderInt64Desc) next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
+// Next implements the SpanEncoder interface.
+func (op *spanEncoderInt64Desc) Next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
 	oldBytesSize := op.outputBytes.Size()
 	if op.outputBytes == nil || op.outputBytes.Len() < endIdx-startIdx {
 		op.outputBytes = coldata.NewBytes(endIdx - startIdx)
@@ -1690,10 +1696,10 @@ type spanEncoderFloat64Desc struct {
 	spanEncoderBase
 }
 
-var _ spanEncoder = &spanEncoderFloat64Desc{}
+var _ SpanEncoder = &spanEncoderFloat64Desc{}
 
-// next implements the spanEncoder interface.
-func (op *spanEncoderFloat64Desc) next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
+// Next implements the SpanEncoder interface.
+func (op *spanEncoderFloat64Desc) Next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
 	oldBytesSize := op.outputBytes.Size()
 	if op.outputBytes == nil || op.outputBytes.Len() < endIdx-startIdx {
 		op.outputBytes = coldata.NewBytes(endIdx - startIdx)
@@ -1771,10 +1777,10 @@ type spanEncoderTimestampDesc struct {
 	spanEncoderBase
 }
 
-var _ spanEncoder = &spanEncoderTimestampDesc{}
+var _ SpanEncoder = &spanEncoderTimestampDesc{}
 
-// next implements the spanEncoder interface.
-func (op *spanEncoderTimestampDesc) next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
+// Next implements the SpanEncoder interface.
+func (op *spanEncoderTimestampDesc) Next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
 	oldBytesSize := op.outputBytes.Size()
 	if op.outputBytes == nil || op.outputBytes.Len() < endIdx-startIdx {
 		op.outputBytes = coldata.NewBytes(endIdx - startIdx)
@@ -1852,10 +1858,10 @@ type spanEncoderIntervalDesc struct {
 	spanEncoderBase
 }
 
-var _ spanEncoder = &spanEncoderIntervalDesc{}
+var _ SpanEncoder = &spanEncoderIntervalDesc{}
 
-// next implements the spanEncoder interface.
-func (op *spanEncoderIntervalDesc) next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
+// Next implements the SpanEncoder interface.
+func (op *spanEncoderIntervalDesc) Next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
 	oldBytesSize := op.outputBytes.Size()
 	if op.outputBytes == nil || op.outputBytes.Len() < endIdx-startIdx {
 		op.outputBytes = coldata.NewBytes(endIdx - startIdx)
@@ -1957,10 +1963,10 @@ type spanEncoderJSONDesc struct {
 	spanEncoderBase
 }
 
-var _ spanEncoder = &spanEncoderJSONDesc{}
+var _ SpanEncoder = &spanEncoderJSONDesc{}
 
-// next implements the spanEncoder interface.
-func (op *spanEncoderJSONDesc) next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
+// Next implements the SpanEncoder interface.
+func (op *spanEncoderJSONDesc) Next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
 	oldBytesSize := op.outputBytes.Size()
 	if op.outputBytes == nil || op.outputBytes.Len() < endIdx-startIdx {
 		op.outputBytes = coldata.NewBytes(endIdx - startIdx)
@@ -2060,10 +2066,10 @@ type spanEncoderDatumDesc struct {
 	spanEncoderBase
 }
 
-var _ spanEncoder = &spanEncoderDatumDesc{}
+var _ SpanEncoder = &spanEncoderDatumDesc{}
 
-// next implements the spanEncoder interface.
-func (op *spanEncoderDatumDesc) next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
+// Next implements the SpanEncoder interface.
+func (op *spanEncoderDatumDesc) Next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
 	oldBytesSize := op.outputBytes.Size()
 	if op.outputBytes == nil || op.outputBytes.Len() < endIdx-startIdx {
 		op.outputBytes = coldata.NewBytes(endIdx - startIdx)
@@ -2159,8 +2165,8 @@ func (op *spanEncoderDatumDesc) next(batch coldata.Batch, startIdx, endIdx int) 
 	return op.outputBytes
 }
 
-// close implements the spanEncoder interface.
-func (b *spanEncoderBase) close() {
+// Close implements the SpanEncoder interface.
+func (b *spanEncoderBase) Close() {
 	*b = spanEncoderBase{}
 }
 

--- a/pkg/sql/colexec/colexecspan/span_encoder_tmpl.go
+++ b/pkg/sql/colexec/colexecspan/span_encoder_tmpl.go
@@ -50,12 +50,12 @@ func _ASSIGN_SPAN_ENCODING(_, _ string) {
 
 // */}}
 
-// newSpanEncoder creates a new utility operator that, given input batches,
+// NewSpanEncoder creates a new utility operator that, given input batches,
 // generates the encoding for the given key column. It is used by SpanAssembler
 // operators to generate spans for index joins and lookup joins.
-func newSpanEncoder(
+func NewSpanEncoder(
 	allocator *colmem.Allocator, typ *types.T, asc bool, encodeColIdx int,
-) spanEncoder {
+) SpanEncoder {
 	base := spanEncoderBase{
 		allocator:    allocator,
 		encodeColIdx: encodeColIdx,
@@ -80,16 +80,23 @@ func newSpanEncoder(
 	return nil
 }
 
-type spanEncoder interface {
-	// next generates the encoding for the current key column for each row from
+// SpanEncoder generates the encoding for a key column for each row from a
+// batch.
+type SpanEncoder interface {
+	// Next generates the encoding for the current key column for each row from
 	// the given batch in the range [startIdx, endIdx), then returns each row's
 	// encoding as a value in a Bytes column. The returned Bytes column is owned
-	// by the spanEncoder operator and should not be modified. Calling next
-	// invalidates previous calls to next. next assumes that startIdx and endIdx
+	// by the SpanEncoder operator and should not be modified. Calling Next
+	// invalidates previous calls to Next. Next assumes that startIdx and endIdx
 	// constitute a valid range of the given batch.
-	next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes
+	//
+	// NB: Next performs the deselection step (meaning that all output encodings
+	// are contiguous in the output Bytes vector).
+	// TODO(yuzefovich): consider switching to value receiver.
+	Next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes
 
-	close()
+	// Close releases any resources held by the encoder.
+	Close()
 }
 
 type spanEncoderBase struct {
@@ -114,10 +121,10 @@ type _OP_STRING struct {
 	spanEncoderBase
 }
 
-var _ spanEncoder = &_OP_STRING{}
+var _ SpanEncoder = &_OP_STRING{}
 
-// next implements the spanEncoder interface.
-func (op *_OP_STRING) next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
+// Next implements the SpanEncoder interface.
+func (op *_OP_STRING) Next(batch coldata.Batch, startIdx, endIdx int) *coldata.Bytes {
 	oldBytesSize := op.outputBytes.Size()
 	if op.outputBytes == nil || op.outputBytes.Len() < endIdx-startIdx {
 		op.outputBytes = coldata.NewBytes(endIdx - startIdx)
@@ -170,8 +177,8 @@ func (op *_OP_STRING) next(batch coldata.Batch, startIdx, endIdx int) *coldata.B
 // {{end}}
 // {{end}}
 
-// close implements the spanEncoder interface.
-func (b *spanEncoderBase) close() {
+// Close implements the SpanEncoder interface.
+func (b *spanEncoderBase) Close() {
 	*b = spanEncoderBase{}
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/inspect
+++ b/pkg/sql/logictest/testdata/logic_test/inspect
@@ -582,6 +582,11 @@ INSERT INTO tsvector_tbl VALUES
   (2, 20, 'foo bar'::TSVECTOR);
 
 # First verify that datums_to_bytes does not support TSVECTOR
+skipif config local-vec-off
+statement error pgcode XX000 pq: internal error: unable to encode table key: \*tree.DTSVector
+SELECT crdb_internal.datums_to_bytes(tsv) FROM tsvector_tbl LIMIT 1;
+
+onlyif config local-vec-off
 statement error pq: illegal argument 0 of type tsvector
 SELECT crdb_internal.datums_to_bytes(tsv) FROM tsvector_tbl LIMIT 1;
 
@@ -609,6 +614,11 @@ INSERT INTO tsquery_tbl VALUES
   (2, 20, 'another | query'::TSQUERY);
 
 # First verify that datums_to_bytes does not support TSQUERY
+skipif config local-vec-off
+statement error pgcode XX000 pq: internal error: unable to encode table key: \*tree.DTSQuery
+SELECT crdb_internal.datums_to_bytes(tsq) FROM tsquery_tbl LIMIT 1;
+
+onlyif config local-vec-off
 statement error pq: illegal argument 0 of type tsquery
 SELECT crdb_internal.datums_to_bytes(tsq) FROM tsquery_tbl LIMIT 1;
 
@@ -636,6 +646,11 @@ INSERT INTO pgvector_tbl VALUES
   (2, 20, '[4.0, 5.0, 6.0]'::VECTOR(3));
 
 # First verify that datums_to_bytes does not support VECTOR
+skipif config local-vec-off
+statement error pgcode XX000 pq: internal error: unable to encode table key: \*tree.DPGVector
+SELECT crdb_internal.datums_to_bytes(vec) FROM pgvector_tbl LIMIT 1;
+
+onlyif config local-vec-off
 statement error pq: illegal argument 0 of type vector
 SELECT crdb_internal.datums_to_bytes(vec) FROM pgvector_tbl LIMIT 1;
 

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -12924,8 +12924,9 @@ var datumsToBytesOverload = tree.Overload{
 	// Note that datums_to_bytes(a) == datums_to_bytes(b) iff (a IS NOT DISTINCT FROM b)
 	Info: "Converts datums into key-encoded bytes. " +
 		"Supports NULLs and all data types which may be used in index keys",
-	Types:      tree.VariadicType{VarType: types.Any},
-	ReturnType: tree.FixedReturnType(types.Bytes),
+	Types:                 tree.VariadicType{VarType: types.Any},
+	ReturnType:            tree.FixedReturnType(types.Bytes),
+	SpecializedVecBuiltin: tree.DatumsToBytes,
 	Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 		var out []byte
 		for i, arg := range args {

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -35,6 +35,7 @@ const (
 	CrdbInternalRangeStatsWithErrors
 	FNV64
 	FNV64a
+	DatumsToBytes
 )
 
 // AggregateOverload is an opaque type which is used to box an eval.AggregateOverload.


### PR DESCRIPTION
This commit introduces the native vectorized support for `crdb_internal.datums_to_bytes` builtin which concatenates the ASC key encoding of its arguments by reusing the SpanEncoders (which is now exported). The new operator is the first builtin op that needs to be `Close`d, so it also required some plumbing to include the op into the CloserRegistry.

```
name                        old time/op    new time/op    delta
FingerprintQueryForIndex-8    48.1ms ± 2%    39.5ms ± 2%  -17.89%  (p=0.000 n=9+10)

name                        old alloc/op   new alloc/op   delta
FingerprintQueryForIndex-8    12.0MB ± 1%     7.2MB ± 2%  -40.14%  (p=0.000 n=8+9)

name                        old allocs/op  new allocs/op  delta
FingerprintQueryForIndex-8      225k ± 1%       19k ± 3%  -91.44%  (p=0.000 n=9+9)
```

Epic: None
Release note: None