### PR TITLE
colexec: fix just added bug in the unordered sync

### DIFF
--- a/pkg/sql/colexec/parallel_unordered_synchronizer.go
+++ b/pkg/sql/colexec/parallel_unordered_synchronizer.go
@@ -327,6 +327,9 @@ func (s *ParallelUnorderedSynchronizer) workerRun(input colexecargs.OpWithMetaIn
 	case <-s.blockWorkersCh:
 	case <-s.exitWorkersCh:
 		return
+	case <-s.Ctx.Done():
+		s.workerSendErr(s.Ctx.Err())
+		return
 	}
 	msg := &unorderedSynchronizerMsg{
 		inputIdx: inputIdx,


### PR DESCRIPTION
We just saw a test timeout due to just merged refactor of the parallel unordered synchronizer where one of the input goroutines is stuck waiting for "block" and "exit" channels to be closed which never happens. I don't immediately see the sequence of events that can lead to this state, yet we should always respect the context cancellation which is added in this commit.

Fixes: #164622.
Release note: None