### PR TITLE
Revert "workload/tpcc: disable TCP user timeout during consistency"

### DIFF
--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -630,31 +630,6 @@ func (w *tpcc) Hooks() workload.Hooks {
 			return nil
 		},
 		CheckConsistency: func(ctx context.Context, db *gosql.DB) error {
-			// Temporarily disable the server.sql_tcp_user.timeout setting while
-			// running consistency checks. The setting was introduced in #164037
-			// with a 30s default, which causes long-running check queries
-			// (especially the expensive order table checks) to be killed with
-			// "connection reset by peer". We disable it for the duration of the
-			// checks and restore the previous value afterward.
-			var prevTimeout string
-			if err := db.QueryRowContext(ctx,
-				`SHOW CLUSTER SETTING server.sql_tcp_user.timeout`,
-			).Scan(&prevTimeout); err != nil {
-				return errors.Wrap(err, "reading server.sql_tcp_user.timeout")
-			}
-			if _, err := db.ExecContext(ctx,
-				`SET CLUSTER SETTING server.sql_tcp_user.timeout = '0s'`,
-			); err != nil {
-				return errors.Wrap(err, "disabling server.sql_tcp_user.timeout")
-			}
-			defer func() {
-				if _, err := db.ExecContext(ctx,
-					`SET CLUSTER SETTING server.sql_tcp_user.timeout = $1`, prevTimeout,
-				); err != nil {
-					log.Dev.Warningf(ctx, "failed to restore server.sql_tcp_user.timeout: %v", err)
-				}
-			}()
-
 			for _, check := range AllChecks() {
 				if !w.expensiveChecks && check.Expensive {
 					continue


### PR DESCRIPTION
Reverts the changes to to TPCC workload (#164493) to change the `server.sql_tcp_user.timeout` cluster setting before doing the checks.

This unfortunately broke some mixed version tests due to the cluster setting only being available in the latest version.

I reran my stress test on a test where this was failing, and with this change I managed to get a failure again on the 10th run, so this change did not fix the problem, hence the revert.

Epic: None
Release note: None