### PR TITLE
sql/regions: omit secondary region from super region lease preferences

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/super_regions
+++ b/pkg/ccl/logictestccl/testdata/logic_test/super_regions
@@ -835,3 +835,79 @@ query TTT
 SHOW SUPER REGIONS FROM DATABASE mr3
 ----
 mr3  r1  {ap-southeast-2,ca-central-1,us-central-1,us-east-1,us-west-1}
+
+# Verify that a secondary region outside a super region does not leak into
+# lease_preferences or voter_constraints for tables in the super region.
+subtest secondary_region_outside_super_region
+
+statement ok
+CREATE DATABASE sr_sec
+  PRIMARY REGION "ap-southeast-2"
+  REGIONS "us-east-1", "us-west-1", "us-central-1", "ca-central-1"
+
+statement ok
+ALTER DATABASE sr_sec ADD SUPER REGION "east" VALUES "us-east-1", "us-west-1", "us-central-1"
+
+statement ok
+ALTER DATABASE sr_sec SET SECONDARY REGION "ca-central-1"
+
+statement ok
+ALTER DATABASE sr_sec SURVIVE REGION FAILURE
+
+# REGIONAL BY TABLE inside the super region.
+statement ok
+CREATE TABLE sr_sec.rbt_in_sr(k INT PRIMARY KEY) LOCALITY REGIONAL BY TABLE IN "us-east-1"
+
+# The lease_preferences must reference only us-east-1 (the home region inside
+# the super region). The secondary region ca-central-1 is outside the super
+# region and must NOT appear.
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE sr_sec.rbt_in_sr
+----
+TABLE sr_sec.public.rbt_in_sr  ALTER TABLE sr_sec.public.rbt_in_sr CONFIGURE ZONE USING
+                                 range_min_bytes = 134217728,
+                                 range_max_bytes = 536870912,
+                                 gc.ttlseconds = 14400,
+                                 num_replicas = 5,
+                                 num_voters = 5,
+                                 constraints = '{+region=us-central-1: 2, +region=us-east-1: 2, +region=us-west-1: 1}',
+                                 voter_constraints = '{+region=us-east-1: 2}',
+                                 lease_preferences = '[[+region=us-east-1]]'
+
+# REGIONAL BY ROW table for testing per-partition zone configs.
+statement ok
+CREATE TABLE sr_sec.rbr_sr(k INT PRIMARY KEY) LOCALITY REGIONAL BY ROW
+
+# Partition inside the super region: no secondary region in lease_preferences.
+query TT
+SHOW ZONE CONFIGURATION FOR PARTITION "us-east-1" OF TABLE sr_sec.rbr_sr
+----
+PARTITION "us-east-1" OF TABLE sr_sec.public.rbr_sr  ALTER PARTITION "us-east-1" OF TABLE sr_sec.public.rbr_sr CONFIGURE ZONE USING
+                                                       range_min_bytes = 134217728,
+                                                       range_max_bytes = 536870912,
+                                                       gc.ttlseconds = 14400,
+                                                       num_replicas = 5,
+                                                       num_voters = 5,
+                                                       constraints = '{+region=us-central-1: 2, +region=us-east-1: 2, +region=us-west-1: 1}',
+                                                       voter_constraints = '{+region=us-east-1: 2}',
+                                                       lease_preferences = '[[+region=us-east-1]]'
+
+# Partition outside the super region: secondary region SHOULD appear in
+# lease_preferences and voter_constraints.
+query TT
+SHOW ZONE CONFIGURATION FOR PARTITION "ap-southeast-2" OF TABLE sr_sec.rbr_sr
+----
+PARTITION "ap-southeast-2" OF TABLE sr_sec.public.rbr_sr  ALTER PARTITION "ap-southeast-2" OF TABLE sr_sec.public.rbr_sr CONFIGURE ZONE USING
+                                                            range_min_bytes = 134217728,
+                                                            range_max_bytes = 536870912,
+                                                            gc.ttlseconds = 14400,
+                                                            num_replicas = 7,
+                                                            num_voters = 5,
+                                                            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-central-1: 1, +region=us-east-1: 1, +region=us-west-1: 1}',
+                                                            voter_constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2}',
+                                                            lease_preferences = '[[+region=ap-southeast-2], [+region=ca-central-1]]'
+
+statement ok
+SELECT crdb_internal.validate_multi_region_zone_configs()
+
+subtest end

--- a/pkg/config/zonepb/zone.go
+++ b/pkg/config/zonepb/zone.go
@@ -845,6 +845,38 @@ func (z *ZoneConfig) DiffWithZone(
 					}
 				}
 			}
+			if len(z.Constraints) != len(other.Constraints) {
+				expected, err := json.Marshal(other.Constraints)
+				if err != nil {
+					return false, DiffWithZoneMismatch{}, err
+				}
+				actual, err := json.Marshal(z.Constraints)
+				if err != nil {
+					return false, DiffWithZoneMismatch{}, err
+				}
+				return false, DiffWithZoneMismatch{
+					Field:    "constraints",
+					Expected: string(expected),
+					Actual:   string(actual),
+				}, nil
+			}
+			for i := range z.Constraints {
+				if len(z.Constraints[i].Constraints) != len(other.Constraints[i].Constraints) {
+					expected, err := json.Marshal(other.Constraints)
+					if err != nil {
+						return false, DiffWithZoneMismatch{}, err
+					}
+					actual, err := json.Marshal(z.Constraints)
+					if err != nil {
+						return false, DiffWithZoneMismatch{}, err
+					}
+					return false, DiffWithZoneMismatch{
+						Field:    "constraints",
+						Expected: string(expected),
+						Actual:   string(actual),
+					}, nil
+				}
+			}
 		case "voter_constraints":
 			if other.VoterConstraints == nil && z.VoterConstraints == nil {
 				continue
@@ -887,6 +919,38 @@ func (z *ZoneConfig) DiffWithZone(
 					}
 				}
 			}
+			if len(z.VoterConstraints) != len(other.VoterConstraints) {
+				expected, err := json.Marshal(other.VoterConstraints)
+				if err != nil {
+					return false, DiffWithZoneMismatch{}, err
+				}
+				actual, err := json.Marshal(z.VoterConstraints)
+				if err != nil {
+					return false, DiffWithZoneMismatch{}, err
+				}
+				return false, DiffWithZoneMismatch{
+					Field:    "voter_constraints",
+					Expected: string(expected),
+					Actual:   string(actual),
+				}, nil
+			}
+			for i := range z.VoterConstraints {
+				if len(z.VoterConstraints[i].Constraints) != len(other.VoterConstraints[i].Constraints) {
+					expected, err := json.Marshal(other.VoterConstraints)
+					if err != nil {
+						return false, DiffWithZoneMismatch{}, err
+					}
+					actual, err := json.Marshal(z.VoterConstraints)
+					if err != nil {
+						return false, DiffWithZoneMismatch{}, err
+					}
+					return false, DiffWithZoneMismatch{
+						Field:    "voter_constraints",
+						Expected: string(expected),
+						Actual:   string(actual),
+					}, nil
+				}
+			}
 		case "lease_preferences":
 			if other.LeasePreferences == nil && z.LeasePreferences == nil {
 				continue
@@ -927,6 +991,38 @@ func (z *ZoneConfig) DiffWithZone(
 							Actual:   string(actual),
 						}, nil
 					}
+				}
+			}
+			if len(z.LeasePreferences) != len(other.LeasePreferences) {
+				expected, err := json.Marshal(other.LeasePreferences)
+				if err != nil {
+					return false, DiffWithZoneMismatch{}, err
+				}
+				actual, err := json.Marshal(z.LeasePreferences)
+				if err != nil {
+					return false, DiffWithZoneMismatch{}, err
+				}
+				return false, DiffWithZoneMismatch{
+					Field:    "lease_preferences",
+					Expected: string(expected),
+					Actual:   string(actual),
+				}, nil
+			}
+			for i := range z.LeasePreferences {
+				if len(z.LeasePreferences[i].Constraints) != len(other.LeasePreferences[i].Constraints) {
+					expected, err := json.Marshal(other.LeasePreferences)
+					if err != nil {
+						return false, DiffWithZoneMismatch{}, err
+					}
+					actual, err := json.Marshal(z.LeasePreferences)
+					if err != nil {
+						return false, DiffWithZoneMismatch{}, err
+					}
+					return false, DiffWithZoneMismatch{
+						Field:    "lease_preferences",
+						Expected: string(expected),
+						Actual:   string(actual),
+					}, nil
 				}
 			}
 		default:

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -1166,11 +1166,14 @@ func (n *alterDatabasePrimaryRegionNode) setInitialPrimaryRegion(params runParam
 		return err
 	}
 
-	// Check we are writing valid zone configurations.
+	// Check we are writing valid zone configurations. Pass an empty
+	// RegionConfig because no super regions or secondary region exist yet
+	// during initial primary region setup.
 	if err := params.p.validateAllMultiRegionZoneConfigsInDatabase(
 		params.ctx,
 		n.desc,
 		&zoneConfigForMultiRegionValidatorSetInitialRegion{},
+		multiregion.RegionConfig{},
 	); err != nil {
 		return err
 	}

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -781,6 +781,7 @@ func (p *planner) ValidateAllMultiRegionZoneConfigsInCurrentDatabase(ctx context
 				regionConfig: regionConfig,
 			},
 		},
+		regionConfig,
 	)
 }
 
@@ -870,6 +871,7 @@ func (p *planner) validateAllMultiRegionZoneConfigsInDatabase(
 	ctx context.Context,
 	dbDesc catalog.DatabaseDescriptor,
 	zoneConfigForMultiRegionValidator zoneConfigForMultiRegionValidator,
+	regionConfig multiregion.RegionConfig,
 ) error {
 	var ids []descpb.ID
 	if err := p.forEachMutableTableInDatabase(
@@ -914,6 +916,7 @@ func (p *planner) validateAllMultiRegionZoneConfigsInDatabase(
 				tbDesc,
 				tbZoneConfig,
 				zoneConfigForMultiRegionValidator,
+				regionConfig,
 			)
 		},
 	)
@@ -1573,13 +1576,15 @@ func (p *planner) validateZoneConfigForMultiRegionTableWasNotModifiedByUser(
 				regionConfig: regionConfig,
 			},
 		},
+		regionConfig,
 	)
 }
 
 // multiRegionTableValidatorData implements zoneconfig.MultiRegionTableValidatorData for legacy schema changer.
 type multiRegionTableValidatorData struct {
-	desc   catalog.TableDescriptor
-	dbDesc catalog.DatabaseDescriptor
+	desc         catalog.TableDescriptor
+	dbDesc       catalog.DatabaseDescriptor
+	regionConfig multiregion.RegionConfig
 }
 
 var _ regions.MultiRegionTableValidatorData = (*multiRegionTableValidatorData)(nil)
@@ -1640,6 +1645,13 @@ func (v *multiRegionTableValidatorData) GetDatabaseSecondaryRegion() catpb.Regio
 	return regionConfig.SecondaryRegion
 }
 
+// IsSecondaryRegionOutsideSuperRegion implements regions.MultiRegionTableValidatorData.
+func (v *multiRegionTableValidatorData) IsSecondaryRegionOutsideSuperRegion(
+	region catpb.RegionName,
+) bool {
+	return regions.SecondaryRegionOutsideSuperRegion(region, v.regionConfig)
+}
+
 func (v *multiRegionTableValidatorData) GetTableLocalitySecondaryRegion() *catpb.RegionName {
 	regionConfig := v.dbDesc.GetRegionConfig()
 	if regionConfig == nil || regionConfig.SecondaryRegion == "" {
@@ -1662,6 +1674,7 @@ func (p *planner) validateZoneConfigForMultiRegionTable(
 	desc catalog.TableDescriptor,
 	currentZoneConfig *zonepb.ZoneConfig,
 	zoneConfigForMultiRegionValidator zoneConfigForMultiRegionValidator,
+	regionConfig multiregion.RegionConfig,
 ) error {
 	if currentZoneConfig == nil {
 		currentZoneConfig = zonepb.NewZoneConfig()
@@ -1677,8 +1690,9 @@ func (p *planner) validateZoneConfigForMultiRegionTable(
 	}
 
 	validatorData := multiRegionTableValidatorData{
-		desc:   desc,
-		dbDesc: dbDesc,
+		desc:         desc,
+		dbDesc:       dbDesc,
+		regionConfig: regionConfig,
 	}
 
 	return regions.ValidateZoneConfigForMultiRegionTable(

--- a/pkg/sql/regions/region_util.go
+++ b/pkg/sql/regions/region_util.go
@@ -531,6 +531,11 @@ type MultiRegionTableValidatorData interface {
 
 	// GetDatabaseSecondaryRegion returns the database secondary region name
 	GetDatabaseSecondaryRegion() catpb.RegionName
+
+	// IsSecondaryRegionOutsideSuperRegion returns true when the given region
+	// belongs to a super region and the database's secondary region is NOT a
+	// member of that same super region.
+	IsSecondaryRegionOutsideSuperRegion(region catpb.RegionName) bool
 }
 
 // ValidateZoneConfigForMultiRegionTable validates that the multi-region fields
@@ -708,10 +713,17 @@ func buildValidationError(
 func synthesizeLeasePreferencesForTable(
 	tableData MultiRegionTableValidatorData,
 ) []zonepb.LeasePreference {
+	var affinityRegion catpb.RegionName
 	if rbtSecondaryRegion := tableData.GetTableLocalitySecondaryRegion(); rbtSecondaryRegion != nil {
-		return SynthesizeLeasePreferences(*rbtSecondaryRegion, tableData.GetDatabaseSecondaryRegion())
+		affinityRegion = *rbtSecondaryRegion
+	} else {
+		affinityRegion = tableData.GetDatabasePrimaryRegion()
 	}
-	return SynthesizeLeasePreferences(tableData.GetDatabasePrimaryRegion(), tableData.GetDatabaseSecondaryRegion())
+	secondaryRegion := tableData.GetDatabaseSecondaryRegion()
+	if tableData.IsSecondaryRegionOutsideSuperRegion(affinityRegion) {
+		secondaryRegion = ""
+	}
+	return SynthesizeLeasePreferences(affinityRegion, secondaryRegion)
 }
 
 // distributeReplicasAcrossRegions distributes numReplicas across the given

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/zone_config_helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/zone_config_helpers.go
@@ -1993,6 +1993,13 @@ func (v *multiRegionTableValidatorData) GetDatabaseSecondaryRegion() catpb.Regio
 	return v.regionConfig.SecondaryRegion()
 }
 
+// IsSecondaryRegionOutsideSuperRegion implements regions.MultiRegionTableValidatorData.
+func (v *multiRegionTableValidatorData) IsSecondaryRegionOutsideSuperRegion(
+	region catpb.RegionName,
+) bool {
+	return regions.SecondaryRegionOutsideSuperRegion(region, v.regionConfig)
+}
+
 // validateZoneConfigForMultiRegionTable validates that the multi-region
 // fields of the table's zone configuration match what is expected for
 // the given table.


### PR DESCRIPTION
PR #164513 only partially fixed secondary region leaking out of the super region abstraction. There was a bug with `DiffWithZone` that prevented the zone config validation finding cases with the `lease_preferences` leaking. `DiffWithZone` performed a subset check rather than an equality check for constraints, `voter_constraints`, and `lease_preferences`. The loops iterated over the receiver and indexed into other, so extra elements in other were silently ignored. This masked downstream bugs where the expected and actual zone configs differed in slice length but were reported as matching.

With the asymmetry fixed, a latent bug in `synthesizeLeasePreferencesForTable` was exposed: it always included the database secondary region in lease preferences, even for super-region-confined tables where the secondary region falls outside the super region. The write path already handled this correctly; the validation path did not.

Fixes: #164422
Fixes #163403
Epic: CRDB-58694
