### PR TITLE
roachtest: mark gce only for multitenant/sqlproxy

### DIFF
--- a/pkg/cmd/roachtest/tests/multitenant.go
+++ b/pkg/cmd/roachtest/tests/multitenant.go
@@ -419,7 +419,7 @@ func registerMultiTenantSQLProxy(r registry.Registry) {
 		Owner:             registry.OwnerTestEng,
 		Cluster:           r.MakeClusterSpec(3),
 		EncryptionSupport: registry.EncryptionMetamorphic,
-		CompatibleClouds:  registry.AllClouds,
+		CompatibleClouds:  registry.OnlyGCE,
 		Leases:            registry.MetamorphicLeases,
 		Suites:            registry.Suites(registry.Weekly),
 		Run:               runMultiTenantSQLProxy,


### PR DESCRIPTION
Separate process requires port registration, which is only supported in GCE for non local clouds.

Fixes: #164581
Release note: none