### PR TITLE
pkg/cli: sanitize non-finite floats before JSON encoding in debug zip

### DIFF
--- a/pkg/cli/zip_helpers.go
+++ b/pkg/cli/zip_helpers.go
@@ -10,8 +10,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -94,6 +96,7 @@ func (z *zipper) createJSON(s *zipReporter, name string, m interface{}) (err err
 	if err != nil {
 		return s.fail(err)
 	}
+	sanitizeNonFiniteFloats(reflect.ValueOf(m))
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	if err := enc.Encode(m); err != nil {
@@ -101,6 +104,44 @@ func (z *zipper) createJSON(s *zipReporter, name string, m interface{}) (err err
 	}
 	s.done()
 	return nil
+}
+
+// sanitizeNonFiniteFloats recursively walks v and replaces any +Inf, -Inf, or
+// NaN float64 values with 0, since encoding/json cannot marshal non-finite
+// floats. Only map values can be replaced in place; struct fields with
+// non-finite floats that are not settable are skipped.
+func sanitizeNonFiniteFloats(v reflect.Value) {
+	switch v.Kind() {
+	case reflect.Ptr, reflect.Interface:
+		if !v.IsNil() {
+			sanitizeNonFiniteFloats(v.Elem())
+		}
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			f := v.Field(i)
+			if f.Kind() == reflect.Float64 && f.CanSet() {
+				if math.IsInf(f.Float(), 0) || math.IsNaN(f.Float()) {
+					f.SetFloat(0)
+				}
+			} else {
+				sanitizeNonFiniteFloats(f)
+			}
+		}
+	case reflect.Slice:
+		for i := 0; i < v.Len(); i++ {
+			sanitizeNonFiniteFloats(v.Index(i))
+		}
+	case reflect.Map:
+		for _, key := range v.MapKeys() {
+			elem := v.MapIndex(key)
+			if (elem.Kind() == reflect.Float64 || elem.Kind() == reflect.Float32) &&
+				(math.IsInf(elem.Float(), 0) || math.IsNaN(elem.Float())) {
+				v.SetMapIndex(key, reflect.Zero(elem.Type()))
+			} else {
+				sanitizeNonFiniteFloats(elem)
+			}
+		}
+	}
 }
 
 // createError reports an error payload.

--- a/pkg/cli/zip_helpers_test.go
+++ b/pkg/cli/zip_helpers_test.go
@@ -6,11 +6,15 @@
 package cli
 
 import (
+	"fmt"
+	"math"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFileSelection(t *testing.T) {
@@ -282,6 +286,61 @@ func TestNodeSelection(t *testing.T) {
 				t.Errorf("incl=%s, excl=%s: mistakenly includes %d", &sel.inclusive, &sel.exclusive, n)
 			}
 		}
+	}
+}
+
+func TestCreateJSONWithNonFiniteFloats(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	f, err := os.CreateTemp("", "test-zip-*.zip")
+	require.NoError(t, err)
+	defer func() { _ = os.Remove(f.Name()) }()
+	z := newZipper(f)
+	defer func() { _ = z.close() }()
+
+	reporter := &zipReporter{
+		flowing: true,
+		prefix:  "[test]",
+		newline: true,
+		inItem:  false,
+	}
+
+	tests := []struct {
+		name    string
+		payload interface{}
+	}{
+		{
+			name:    "map with +Inf",
+			payload: map[string]float64{"metric": math.Inf(1)},
+		},
+		{
+			name:    "map with -Inf",
+			payload: map[string]float64{"metric": math.Inf(-1)},
+		},
+		{
+			name:    "map with NaN",
+			payload: map[string]float64{"metric": math.NaN()},
+		},
+		{
+			name: "struct with Metrics map containing +Inf",
+			payload: struct {
+				Name    string
+				Metrics map[string]float64
+			}{
+				Name:    "node1",
+				Metrics: map[string]float64{"requests": 100, "rate": math.Inf(1)},
+			},
+		},
+	}
+
+	for i, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := reporter.start("test item")
+			err := z.createJSON(s, fmt.Sprintf("test%d.json", i), tc.payload)
+			if err != nil {
+				t.Errorf("createJSON failed on %s: %v", tc.name, err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
The `debug zip` command uses `encoding/json` to serialize protobuf payloads (node status, range info, etc.) into JSON files within the zip archive. Go's `encoding/json` does not support non-finite float values (+Inf, -Inf, NaN) and fails with `json: unsupported value: +Inf` when it encounters them. This error propagates up and aborts the entire zip collection.

The Metrics map[string]float64 fields on NodeStatus and StoreStatus are populated from Prometheus gauges, counters, and histogram-derived values via eachRecordableValue/extractValue. In certain conditions (e.g. edge cases in histogram quantile interpolation, division by zero in rate computations, or gauge values set to infinity), these maps can contain +Inf or NaN values.

The fix adds a sanitizeNonFiniteFloats helper that uses reflection to walk the payload before JSON encoding and replaces any +Inf, -Inf, or NaN float values with 0. This is applied in createJSON, which is the sole JSON encoding point for all debug zip file creation. A unit test is added that confirms the previous failure and validates the fix.

Fixes: #164490
Part of: CRDB-60842
Epic: none
Release note: none