### PR TITLE
kvserver: fix stats merge dropping numEmptyEntries

### DIFF
--- a/pkg/kv/kvserver/app_batch.go
+++ b/pkg/kv/kvserver/app_batch.go
@@ -44,7 +44,7 @@ func (s *appBatchStats) merge(ss appBatchStats) {
 	s.numMutations += ss.numMutations
 	s.numEntriesProcessed += ss.numEntriesProcessed
 	s.numEntriesProcessedBytes += ss.numEntriesProcessedBytes
-	ss.numEmptyEntries += ss.numEmptyEntries
+	s.numEmptyEntries += ss.numEmptyEntries
 	s.numWriteAndIngestedBytes += ss.numWriteAndIngestedBytes
 }
 


### PR DESCRIPTION
The appBatchStats.merge method had a typo where it was updating
ss.numEmptyEntries (the source parameter) instead of s.numEmptyEntries
(the receiver). This caused the empty entries count to be silently
dropped when merging statistics, leading to incorrect statistics
tracking.

The bug manifests as a silent loss of the numEmptyEntries statistic
whenever multiple appBatchStats are merged together. While this
doesn't affect correctness of raft log application, it does result
in incorrect metrics and statistics about empty raft log entries.

---

Resolves: #164667
Epic: CRDB-60941

Release note (bug fix): Fixed a bug in appBatchStats.merge where
the numEmptyEntries field was not being properly accumulated when
merging statistics. This could result in incorrect statistics
tracking for empty raft log entries.