### PR TITLE
catalog/replication: deflake TestReaderCatalogAutoStatsDisabled

### DIFF
--- a/pkg/sql/catalog/replication/BUILD.bazel
+++ b/pkg/sql/catalog/replication/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
 
 go_test(
     name = "replication_test",
+    size = "large",
     srcs = ["reader_catalog_test.go"],
     deps = [
         ":replication",


### PR DESCRIPTION
Before TestReaderCatalogAutoStatsDisabled could deflake because the package timeout wasn't sufficient to run all the test. This patch bumps the package timeout.

Fixes: #164469

Release note: None