### PR TITLE
ci: run canary test under `stress`

### DIFF
--- a/.github/workflows/github-actions-essential-ci.yml
+++ b/.github/workflows/github-actions-essential-ci.yml
@@ -261,6 +261,27 @@ jobs:
       - name: clean up
         run: ./build/github/cleanup-engflow-keys.sh
         if: always()
+  race_canary:
+    runs-on: [self-hosted, ubuntu_2404]
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+      - name: compute metadata
+        run: echo GITHUB_ACTIONS_BRANCH=${{ github.event.pull_request.number || github.ref_name}} >> "$GITHUB_ENV"
+      - run: ./build/github/get-engflow-keys.sh
+      - run: ./build/github/prepare-summarize-build.sh
+      - name: run race canary test
+        run: ./build/github/race-canary.sh
+      - name: upload build results
+        run: ./build/github/summarize-build.sh bes.bin
+        if: always()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: clean up
+        run: ./build/github/cleanup-engflow-keys.sh
+        if: always()
   unit_tests:
     runs-on: [self-hosted, ubuntu_2404]
     timeout-minutes: 120

--- a/build/github/race-canary.sh
+++ b/build/github/race-canary.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+# Runs a canary test under the race detector unconditionally to catch
+# race conditions that the selective stressrace job might miss. See
+# the Slack thread at:
+# https://cockroachlabs.slack.com/archives/C023S0V4YEB/p1770903351769809
+
+set -euxo pipefail
+
+bazel test //pkg/server:server_test \
+    --config crosslinux --config race \
+    --test_filter=TestSpanStatsFanOut \
+    --jobs 100 $(./build/github/engflow-args.sh) \
+    --remote_download_minimal \
+    --test_timeout=300 \
+    --runs_per_test=10 \
+    --bes_keywords ci-race-canary \
+    --build_event_binary_file=bes.bin


### PR DESCRIPTION
This will become a required check. The goal here is to catch obvious `--race` failures before they're merged.

Part of: DEVINF-1698
Release note: none
Epic: DEVINF-1582