### PR TITLE
claude: add crlfmt post-edit hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "FILE=$(grep -o '\"file_path\" *: *\"[^\"]*\"' | sed 's/\"file_path\" *: *\"//;s/\"$//'); if [[ \"$FILE\" == *.go ]]; then crlfmt -w -tab 2 \"$FILE\"; fi"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,13 +72,6 @@ good starting point if the overall architecture is relevant to the task.
 
 ## Coding Guidelines
 
-### Code Formatting
-
-After editing Go files, run `crlfmt -w -tab 2 <filename>.go` to format them.
-`crlfmt` is CockroachDB's custom formatter (not `gofmt`); it enforces 100-column
-code lines, 80-column comments, and CockroachDB-specific signature wrapping.
-It also handles import grouping. `crlfmt` only accepts one filename at a time.
-
 ### Engineering Standards
 
 CockroachDB is a complex system and you should write code under the assumption


### PR DESCRIPTION
We already tell Claude to run crlfmt after editing Go files in CLAUDE.md,
but instructions are just instructions -- they're easy to forget, especially
when working through a multi-commit arc where the agent is juggling a lot of
context. We learned this the hard way when a rename commit shipped with bad
alignment and CI caught it instead of us.

A hook is strictly better here. It fires automatically after every Edit/Write
tool call, so formatting issues get fixed at the source. No discipline
required, no relying on the agent to remember step N of some checklist buried
in a markdown file. The same argument applies to putting this in a skill --
skills are contextual guidance, not guardrails. A hook is a guardrail.

This is the first `.claude/settings.json` in the repo. Unlike
`settings.local.json` (which is gitignored and per-developer), this file is
checked in and shared with the team, so everyone gets the hook for free.

While here, the crlfmt section in CLAUDE.md is removed since the hook
supersedes it.