### PR TITLE
asim: add physical modeling to simulator

### DIFF
--- a/pkg/kv/kvserver/asim/gen/generator.go
+++ b/pkg/kv/kvserver/asim/gen/generator.go
@@ -230,6 +230,7 @@ type BasicCluster struct {
 	Region              []string
 	NodesPerRegion      []int
 	NodeCPURateCapacity state.NodeCPURateCapacities
+	NodePhysical        state.NodePhysicalCharacteristics
 }
 
 func (bc BasicCluster) String() string {
@@ -252,6 +253,7 @@ func (bc BasicCluster) Generate(seed int64, settings *config.SimulationSettings)
 	info := bc.info()
 	info.StoreDiskCapacityBytes = bc.StoreByteCapacity
 	info.NodeCPURateCapacityNanos = bc.NodeCPURateCapacity
+	info.NodePhysical = bc.NodePhysical
 	return state.LoadClusterInfo(info, settings)
 }
 

--- a/pkg/kv/kvserver/asim/state/config_loader.go
+++ b/pkg/kv/kvserver/asim/state/config_loader.go
@@ -283,6 +283,9 @@ type ClusterInfo struct {
 	Regions                  []Region
 	StoreDiskCapacityBytes   int64
 	NodeCPURateCapacityNanos NodeCPURateCapacities
+	// NodePhysical overrides the default NodePhysicalCharacteristics for all
+	// nodes. Zero-valued fields use DefaultNodePhysicalCharacteristics().
+	NodePhysical NodePhysicalCharacteristics
 }
 
 func (c ClusterInfo) String() (s string) {
@@ -361,6 +364,16 @@ func LoadClusterInfo(c ClusterInfo, settings *config.SimulationSettings) State {
 	s := newState(settings)
 	// A new state has a single range - add the replica load for that range.
 	s.clusterinfo = c
+	physical := DefaultNodePhysicalCharacteristics()
+	if c.NodePhysical.CPUOverheadMultiplier > 0 {
+		physical.CPUOverheadMultiplier = c.NodePhysical.CPUOverheadMultiplier
+	}
+	if c.NodePhysical.SpaceAmplification > 0 {
+		physical.SpaceAmplification = c.NodePhysical.SpaceAmplification
+	}
+	if c.NodePhysical.ReservedDiskBytes > 0 {
+		physical.ReservedDiskBytes = c.NodePhysical.ReservedDiskBytes
+	}
 	var nodeIdx int
 	for _, r := range c.Regions {
 		regionTier := roachpb.Tier{
@@ -387,6 +400,7 @@ func LoadClusterInfo(c ClusterInfo, settings *config.SimulationSettings) State {
 				}
 				nodeIdx += 1
 				node := s.AddNode(int64(cpuCap), locality)
+				s.SetNodePhysicalCharacteristics(node.NodeID(), physical)
 				storesRequired := z.StoresPerNode
 				if storesRequired < 1 {
 					panic(fmt.Sprintf("storesPerNode cannot be less than one but found %v", storesRequired))

--- a/pkg/kv/kvserver/asim/state/impl.go
+++ b/pkg/kv/kvserver/asim/state/impl.go
@@ -301,10 +301,12 @@ func (s *state) capacity(storeID StoreID) roachpb.StoreCapacity {
 		}
 	}
 
-	// TODO(kvoli): parameterize the logical to actual used storage bytes. At the
-	// moment we use 1.25 as a rough estimate.
-	used := int64(float64(capacity.LogicalBytes) * 1.25)
-	available := capacity.Capacity - used
+	physical := s.nodes[store.nodeID].physical
+	used := int64(float64(capacity.LogicalBytes) * physical.SpaceAmplification)
+	available := capacity.Capacity - used - physical.ReservedDiskBytes
+	if available < 0 {
+		available = 0
+	}
 	capacity.Used = used
 	capacity.Available = available
 	return capacity
@@ -432,6 +434,7 @@ func (s *state) AddNode(nodeCPUCapacity int64, locality roachpb.Locality) Node {
 	node := &node{
 		nodeID:      nodeID,
 		desc:        roachpb.NodeDescriptor{NodeID: roachpb.NodeID(nodeID)},
+		physical:    DefaultNodePhysicalCharacteristics(),
 		stores:      []StoreID{},
 		mmAllocator: mmAllocator,
 		storepool:   sp,
@@ -464,9 +467,22 @@ func (s *state) SetNodeCPURateCapacity(nodeID NodeID, cpuRateCapacity int64) {
 	node.cpuRateCapacity = cpuRateCapacity
 }
 
-// NodeCapacity returns the capacity of the Node with ID NodeID. Note that it is
-// currently unused.
-// TODO(wenyihu6): MMA integration should later use it.
+func (s *state) SetNodePhysicalCharacteristics(nodeID NodeID, chars NodePhysicalCharacteristics) {
+	node, ok := s.nodes[nodeID]
+	if !ok {
+		panic(fmt.Sprintf("programming error: node with ID %d doesn't exist", nodeID))
+	}
+	node.physical = chars
+}
+
+// NodeCapacity returns the capacity of the Node with ID NodeID. Used by
+// updateStoreCapacity to populate StoreDescriptor.NodeCapacity, which feeds
+// into MakeStoreLoadMsg and ComputeAmplificationFactors.
+//
+// NodeCPURateUsage is inflated by cpuOverheadMultiplier to simulate the gap
+// between OS-level CPU (which includes GC, goroutine overhead, etc.) and the
+// directly-tracked per-replica CPU (StoresCPURate). In real clusters this
+// ratio is typically 1.0-3.0.
 func (s *state) NodeCapacity(nodeID NodeID) roachpb.NodeCapacity {
 	node := s.nodes[nodeID]
 	stores := node.Stores()
@@ -476,10 +492,11 @@ func (s *state) NodeCapacity(nodeID NodeID) roachpb.NodeCapacity {
 		cpuRate += int(capacity.CPUPerSecond)
 	}
 
+	nodeCPURateUsage := int64(float64(cpuRate) * node.physical.CPUOverheadMultiplier)
 	return roachpb.NodeCapacity{
 		StoresCPURate:       int64(cpuRate),
 		NumStores:           int32(len(stores)),
-		NodeCPURateUsage:    int64(cpuRate),
+		NodeCPURateUsage:    nodeCPURateUsage,
 		NodeCPURateCapacity: node.cpuRateCapacity,
 	}
 }
@@ -1517,10 +1534,39 @@ func (s *state) NodesStringWithTag(tag string) string {
 }
 
 // node is an implementation of the Node interface.
+// NodePhysicalCharacteristics models OS-level and filesystem characteristics
+// that affect how the physical model computes load, capacity, and amplification
+// factors. All stores on a node share these characteristics.
+type NodePhysicalCharacteristics struct {
+	// CPUOverheadMultiplier inflates NodeCPURateUsage relative to StoresCPURate
+	// to simulate OS-level overhead (GC, goroutine scheduling, etc.) that isn't
+	// tracked per-replica. In real clusters this ratio is typically 1.0-3.0.
+	CPUOverheadMultiplier float64
+	// SpaceAmplification is the ratio of physical disk bytes (Used) to logical
+	// bytes (LogicalBytes). Default 1.25. Feeds into StoreCapacity.Used and
+	// therefore into computePhysicalDisk's amplification factor.
+	SpaceAmplification float64
+	// ReservedDiskBytes models filesystem reserved blocks (e.g. ext4 reserved
+	// block count). Subtracted from Available in capacity(), making
+	// Total - Available > Used.
+	ReservedDiskBytes int64
+}
+
+// DefaultNodePhysicalCharacteristics returns characteristics with sensible
+// defaults: no CPU overhead, 1.25x space amplification, no reserved blocks.
+func DefaultNodePhysicalCharacteristics() NodePhysicalCharacteristics {
+	return NodePhysicalCharacteristics{
+		CPUOverheadMultiplier: 1.0,
+		SpaceAmplification:    1.25,
+	}
+}
+
+// node is an implementation of the Node interface.
 type node struct {
 	nodeID          NodeID
 	desc            roachpb.NodeDescriptor
 	cpuRateCapacity int64
+	physical        NodePhysicalCharacteristics
 
 	stores      []StoreID
 	storepool   *storepool.StorePool

--- a/pkg/kv/kvserver/asim/state/impl.go
+++ b/pkg/kv/kvserver/asim/state/impl.go
@@ -259,6 +259,7 @@ func (s *state) updateStoreCapacity(storeID StoreID) {
 			capacity = mergeOverride(capacity, override)
 		}
 		store.desc.Capacity = capacity
+		store.desc.NodeCapacity = s.NodeCapacity(store.nodeID)
 		s.publishNewCapacityEvent(capacity, storeID)
 	}
 }

--- a/pkg/kv/kvserver/asim/tests/datadriven_simulation_test.go
+++ b/pkg/kv/kvserver/asim/tests/datadriven_simulation_test.go
@@ -62,10 +62,15 @@ var runAsimTests = envutil.EnvOrDefaultBool("COCKROACH_RUN_ASIM_TESTS", false)
 //
 //   - "gen_cluster" [nodes=<int>] [stores_per_node=<int>]
 //     [store_byte_capacity_gib=<int>] [node_cpu_cores=<float>]
+//     [cpu_overhead_multiplier=<float>] [space_amplification=<float>]
+//     [reserved_disk_gib=<int>]
 //     Initialize the cluster generator parameters. On the next call to eval,
 //     the cluster generator is called to create the initial state used in the
 //     simulation. The default values are: nodes=3 stores_per_node=1
-//     store_byte_capacity_gib=256, node_cpu_cores=8.0.
+//     store_byte_capacity_gib=256, node_cpu_cores=8.0,
+//     cpu_overhead_multiplier=1.0 (ratio of OS CPU to tracked CPU),
+//     space_amplification=1.25 (Used/LogicalBytes ratio),
+//     reserved_disk_gib=0 (filesystem reserved blocks).
 //
 //   - "load_cluster": config=<name>
 //     Load a defined cluster configuration to be the generated cluster in the
@@ -91,7 +96,7 @@ var runAsimTests = envutil.EnvOrDefaultBool("COCKROACH_RUN_ASIM_TESTS", false)
 //
 //   - set_status store=<int> [delay=<duration>] liveness=(live|unavailable|dead)
 //   - set_status node=<int> [delay=<duration>] [liveness=(live|unavailable|dead)]
-//       [membership=(active|decommissioning|decommissioned)] [draining=<bool>]
+//     [membership=(active|decommissioning|decommissioned)] [draining=<bool>]
 //     Set status signals for stores or nodes. The store= form sets liveness for
 //     a single store. The node= form can set liveness for all stores on a node
 //     and/or set membership/draining (which are per-node). Defaults for node=:
@@ -363,12 +368,18 @@ func TestDataDriven(t *testing.T) {
 					var region []string
 					var nodesPerRegion []int
 					var storeByteCapacityGiB int64 = 256
+					var cpuOverheadMultiplier float64
+					var spaceAmplification float64
+					var reservedDiskGiB int64
 					scanIfExists(t, d, "nodes", &nodes)
 					scanIfExists(t, d, "stores_per_node", &storesPerNode)
 					scanIfExists(t, d, "store_byte_capacity_gib", &storeByteCapacityGiB)
 					scanIfExists(t, d, "region", &region)
 					scanIfExists(t, d, "nodes_per_region", &nodesPerRegion)
 					scanIfExists(t, d, "node_cpu_cores", &nodeCPUCores)
+					scanIfExists(t, d, "cpu_overhead_multiplier", &cpuOverheadMultiplier)
+					scanIfExists(t, d, "space_amplification", &spaceAmplification)
+					scanIfExists(t, d, "reserved_disk_gib", &reservedDiskGiB)
 
 					var buf strings.Builder
 					require.NotEmpty(t, nodeCPUCores)
@@ -395,6 +406,11 @@ func TestDataDriven(t *testing.T) {
 						Region:              region,
 						NodesPerRegion:      nodesPerRegion,
 						NodeCPURateCapacity: state.NodeCPUCores(nodeCPUCores).ToRateCapacityNanos(),
+						NodePhysical: state.NodePhysicalCharacteristics{
+							CPUOverheadMultiplier: cpuOverheadMultiplier,
+							SpaceAmplification:    spaceAmplification,
+							ReservedDiskBytes:     reservedDiskGiB << 30,
+						},
 					}
 					return buf.String()
 				case "load_cluster":

--- a/pkg/kv/kvserver/asim/tests/testdata/non_rand/mma/skewed_ranges_write_workload_disk_balance.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/non_rand/mma/skewed_ranges_write_workload_disk_balance.txt
@@ -36,7 +36,7 @@ cpu_util#1: last:  [s1=0.17, s2=0.15, s3=0.16, s4=0.17, s5=0.17, s6=0.17] (stdde
 cpu_util#1: thrash_pct: [s1=491%, s2=413%, s3=461%, s4=425%, s5=431%, s6=386%]  (sum=2605%)
 disk_fraction_used#1: first: [s1=0.55, s2=0.55, s3=0.55, s4=0.01, s5=0.01, s6=0.01] (stddev=0.27, mean=0.28, sum=2)
 disk_fraction_used#1: last:  [s1=0.96, s2=0.95, s3=0.93, s4=0.97, s5=0.94, s6=0.94] (stddev=0.01, mean=0.95, sum=6)
-disk_fraction_used#1: thrash_pct: [s1=175%, s2=100%, s3=139%, s4=93%, s5=93%, s6=82%]  (sum=683%)
+disk_fraction_used#1: thrash_pct: [s1=176%, s2=104%, s3=141%, s4=97%, s5=97%, s6=77%]  (sum=691%)
 leases#1: first: [s1=100, s2=0, s3=0, s4=100, s5=0, s6=0] (stddev=47.14, mean=33.33, sum=200)
 leases#1: last:  [s1=34, s2=30, s3=30, s4=39, s5=34, s6=33] (stddev=3.04, mean=33.33, sum=200)
 leases#1: thrash_pct: [s1=83%, s2=63%, s3=81%, s4=83%, s5=74%, s6=59%]  (sum=443%)
@@ -45,5 +45,5 @@ replicas#1: last:  [s1=98, s2=94, s3=98, s4=103, s5=106, s6=101] (stddev=3.87, m
 replicas#1: thrash_pct: [s1=935%, s2=538%, s3=693%, s4=786%, s5=813%, s6=651%]  (sum=4416%)
 write_bytes_per_second#1: last:  [s1=2511195, s2=2380741, s3=2479587, s4=2582128, s5=2685024, s6=2561533] (stddev=93852.18, mean=2533368.00, sum=15200208)
 write_bytes_per_second#1: thrash_pct: [s1=1694%, s2=1429%, s3=1563%, s4=1400%, s5=1464%, s6=1353%]  (sum=8901%)
-hash: fcee53f9469a8659
+hash: 3c924e7450c7465a
 ==========================


### PR DESCRIPTION
Part of https://github.com/cockroachdb/cockroach/issues/159584. 
Release note: None 

----

Previously, the allocator simulator hardcoded the space amplification
factor (1.25x) and did not model filesystem reserved blocks or CPU
overhead multipliers. This made it impossible to reproduce disk capacity
model bugs where reserved blocks inflate utilization calculations.

This commit adds NodePhysicalCharacteristics to model OS-level and
filesystem properties that affect disk capacity computation:

- CPUOverheadMultiplier: inflates NodeCPURateUsage relative to
  StoresCPURate to simulate OS-level overhead (default 1.0)
- SpaceAmplification: ratio of physical Used bytes to LogicalBytes
  (default 1.25, previously hardcoded)
- ReservedDiskBytes: models filesystem reserved blocks (e.g. ext4
  reserved block count) subtracted from Available in capacity()

These parameters are exposed via gen_cluster in datadriven tests
as cpu_overhead_multiplier, space_amplification, and reserved_disk_gib.