### PR TITLE
release-25.2: workload/schemachanger: fix dependency detection for DROP COLUMN

### DIFF
--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -125,7 +125,7 @@ func (og *operationGenerator) tableHasDependencies(
 }
 
 func (og *operationGenerator) columnIsDependedOn(
-	ctx context.Context, tx pgx.Tx, tableName *tree.TableName, columnName tree.Name,
+	ctx context.Context, tx pgx.Tx, tableName *tree.TableName, columnName tree.Name, includeFKs bool,
 ) (bool, error) {
 	// To see if a column is depended on, the ordinal_position of the column is looked up in
 	// information_schema.columns. Then, this position is used to see if that column has view dependencies
@@ -162,6 +162,7 @@ func (og *operationGenerator) columnIsDependedOn(
 			            WHERE fd.descriptor_id
 			                  = $1::REGCLASS
                     AND fd.dependedonby_type != 'sequence'
+										AND ($5::BOOL || fd.dependedonby_type != 'fk')
 			          )
 			   UNION  (
 			           SELECT unnest(confkey) AS column_id
@@ -183,7 +184,7 @@ func (og *operationGenerator) columnIsDependedOn(
 			      AND column_name = $4
 			  ) AS source ON source.column_id = cons.column_id
 )
-`, tableName.String(), tableName.Schema(), tableName.Object(), columnName)
+`, tableName.String(), tableName.Schema(), tableName.Object(), columnName, includeFKs)
 }
 
 // colIsRefByComputed determines if a column is referenced by a computed column.

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -1674,7 +1674,7 @@ func (og *operationGenerator) dropColumn(ctx context.Context, tx pgx.Tx) (*opStm
 	if err != nil {
 		return nil, err
 	}
-	columnIsDependedOn, err := og.columnIsDependedOn(ctx, tx, tableName, columnName)
+	columnIsDependedOn, err := og.columnIsDependedOn(ctx, tx, tableName, columnName, false /* includeFKs */)
 	if err != nil {
 		return nil, err
 	}
@@ -2594,7 +2594,7 @@ func (og *operationGenerator) setColumnType(ctx context.Context, tx pgx.Tx) (*op
 		return nil, err
 	}
 
-	columnHasDependencies, err := og.columnIsDependedOn(ctx, tx, tableName, columnForTypeChange.name)
+	columnHasDependencies, err := og.columnIsDependedOn(ctx, tx, tableName, columnForTypeChange.name, true /* includeFKs */)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Backport 1/1 commits from #160659.

/cc @cockroachdb/release

---

Previously, the DROP COLUMN operation in the schema changer could fail, since it detected self referential foreign key dependencies as external ones. To address this, this patch excludes them from the detection.

Fixes: #160318
Fixes: #159952
Fixes: #164583

Release note: None

Release justification:  test only change
