### PR TITLE
toolchains: fix darwin cross-compilation with clang-20

### DIFF
--- a/build/toolchains/darwin/BUILD.tmpl
+++ b/build/toolchains/darwin/BUILD.tmpl
@@ -50,6 +50,7 @@ filegroup(
     srcs = [
         "bin/%{target}-apple-darwin21.2-cc",
         "bin/%{target}-apple-darwin21.2-ld",
+        "bin/ld",
         "bin/xcrun",
     ],
 )

--- a/build/toolchains/darwin/cc_toolchain_config.bzl.tmpl
+++ b/build/toolchains/darwin/cc_toolchain_config.bzl.tmpl
@@ -196,12 +196,12 @@ def _impl(ctx):
         target_cpu = "%{target}-apple-darwin21.2",
         target_libc = "glibc-2.14",
         compiler = "clang",
-        abi_version = "clang-10.0.0",
+        abi_version = "clang-20.0.0",
         abi_libc_version = "%{target}-apple-darwin21.2",
         tool_paths = tool_paths,
         cxx_builtin_include_directories = [
             "%sysroot%/usr/include",
-            "/usr/lib/llvm-10/lib/clang/10.0.0/include",
+            "/usr/lib/llvm-20/lib/clang/20/include",
         ],
         builtin_sysroot = "external/%{repo_name}/SDK/MacOSX12.1.sdk",
     )

--- a/build/toolchains/darwin/toolchain.bzl
+++ b/build/toolchains/darwin/toolchain.bzl
@@ -11,6 +11,20 @@ def _impl(rctx):
         stripPrefix = "x-tools/x86_64-apple-darwin21.2/",
     )
 
+    # Create a plain "ld" wrapper that delegates to the target-prefixed linker.
+    # Clang searches for a linker named "ld" in the compiler's tool directories.
+    # The osxcross toolchain only ships target-prefixed binaries (e.g.
+    # arm64-apple-darwin21.2-ld), so without this wrapper clang falls back to
+    # the system /bin/ld (GNU ld), which fails on Ubuntu 24.04+ with
+    # "unrecognised emulation mode".
+    rctx.file(
+        "bin/ld",
+        content = '#!/bin/bash\nexec "$(dirname "$0")/{}-apple-darwin21.2-ld" "$@"\n'.format(
+            rctx.attr.target,
+        ),
+        executable = True,
+    )
+
     rctx.template(
         "BUILD",
         Label("@com_github_cockroachdb_cockroach//build:toolchains/darwin/BUILD.tmpl"),


### PR DESCRIPTION
The Ubuntu 24.04 builder upgrade changed the system clang from version 10 to 20. The osxcross cross-compiler wrappers invoke the system clang, which then searches for a linker binary named "ld". The osxcross toolchain only ships target-prefixed binaries (e.g. arm64-apple-darwin21.2-ld), so clang-20 cannot find "ld" in the toolchain's bin directory and falls back to /bin/ld (GNU ld), which fails with "unrecognised emulation mode: llvm".

Fix by generating a plain "ld" wrapper script in the osxcross repository rule that delegates to the target-prefixed linker. This wrapper is declared in the linker_files filegroup so it's available in the Bazel sandbox. Also update abi_version and
cxx_builtin_include_directories to reference clang-20 instead of the now-absent clang-10.

Part of: DEVINF-1703
Release note: None
Epic: DEVINF-1704