### PR TITLE
colexec: fix data race in TestSimpleProjectOpWithUnorderedSynchronizer

### DIFF
--- a/pkg/sql/colexec/colexecbase/simple_project_test.go
+++ b/pkg/sql/colexec/colexecbase/simple_project_test.go
@@ -6,6 +6,7 @@
 package colexecbase_test
 
 import (
+	"context"
 	"sync"
 	"testing"
 
@@ -14,10 +15,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexectestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
+	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/stretchr/testify/require"
 )
 
@@ -97,6 +100,21 @@ func TestSimpleProjectOp(t *testing.T) {
 func TestSimpleProjectOpWithUnorderedSynchronizer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	// Simulate the production vectorized flow setup where each input gets its
+	// own streaming allocator, etc.
+	memAccs := [2]mon.BoundAccount{
+		testMemMonitor.MakeBoundAccount(),
+		testMemMonitor.MakeBoundAccount(),
+	}
+	defer memAccs[0].Close(ctx)
+	defer memAccs[1].Close(ctx)
+	allocators := [2]*colmem.Allocator{
+		colmem.NewAllocator(ctx, &memAccs[0], testColumnFactory),
+		colmem.NewAllocator(ctx, &memAccs[1], testColumnFactory),
+	}
+
 	inputTypes := []*types.T{types.Bytes, types.Float}
 	constVal := int64(42)
 	var wg sync.WaitGroup
@@ -115,6 +133,11 @@ func TestSimpleProjectOpWithUnorderedSynchronizer(t *testing.T) {
 			var input colexecop.Operator
 			parallelUnorderedSynchronizerInputs := make([]colexecargs.OpWithMetaInfo, len(inputs))
 			for i := range parallelUnorderedSynchronizerInputs {
+				// Currently, both inputs as well as the root of the operator
+				// tree reference the testAllocator, but that will lead to the
+				// data race. In production, each would have their own allocator
+				// so we update the inputs with their separate ones.
+				inputs[i].(colexectestutils.AllocatorHolder).SetAllocator(allocators[i])
 				parallelUnorderedSynchronizerInputs[i].Root = inputs[i]
 			}
 			input = colexec.NewParallelUnorderedSynchronizer(&execinfra.FlowCtx{Local: true, Gateway: true}, 0 /* processorID */, testAllocator, inputTypes, parallelUnorderedSynchronizerInputs, &wg)

--- a/pkg/sql/colexec/colexectestutils/utils.go
+++ b/pkg/sql/colexec/colexectestutils/utils.go
@@ -891,6 +891,16 @@ func newOpTestSelInput(
 	return ret
 }
 
+type AllocatorHolder interface {
+	SetAllocator(allocator *colmem.Allocator)
+}
+
+var _ AllocatorHolder = &opTestInput{}
+
+func (s *opTestInput) SetAllocator(allocator *colmem.Allocator) {
+	s.allocator = allocator
+}
+
 func (s *opTestInput) Init(context.Context) {
 	if s.typs == nil {
 		if len(s.tuples) == 0 {


### PR DESCRIPTION
With the recent refactor of the parallel unordered synchronizer, `TestSimpleProjectOpWithUnorderedSynchronizer` became subject to an expected data race. In particular, currently there is a data race accessing the testAllocator between inputs when they are `Init`ialized (this data race wasn't there before because previously all initialization happened in the "main" PUS goroutine sequentially for each input); there is also another data race between the main goroutine and any of the input goroutines accessing the same testAllocator (this data race existed before, it's just the allocator wasn't actually used on `Next` calls in the input goroutines).

I believe that this is just an artifact of how our RunTests test harness is set up - it only takes a single allocator object that is used for everything. However, in the production setup, each operator would have its own streaming allocator, etc, avoiding any reference sharing.

Thus, this commit makes surgical incisions to give each of the two input operators in the test their own allocators - which simulates the production setup.

Fixes: #164651.
Release note: None