### PR TITLE
sql: fix panic in SHOW CREATE SCHEDULE with non-existent ID

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/show_create_schedule
+++ b/pkg/sql/logictest/testdata/logic_test/show_create_schedule
@@ -1,0 +1,20 @@
+# LogicTest: local
+
+# SHOW CREATE SCHEDULE requires the VIEWCLUSTERMETADATA privilege.
+
+statement error user testuser does not have VIEWCLUSTERMETADATA privilege
+SHOW CREATE SCHEDULE 123
+
+user root
+
+# Regression test: SHOW CREATE SCHEDULE should return an error for
+# non-existent schedule IDs instead of panicking (#164710).
+statement error schedule with id 999999 does not exist
+SHOW CREATE SCHEDULE 999999
+
+# SHOW CREATE ALL SCHEDULES should return empty results when there
+# are no schedules.
+query IT colnames
+SHOW CREATE ALL SCHEDULES
+----
+schedule_id  create_statement

--- a/pkg/sql/show_create_schedule.go
+++ b/pkg/sql/show_create_schedule.go
@@ -34,7 +34,7 @@ const (
 )
 
 func loadSchedules(params runParams, n *tree.ShowCreateSchedules) ([]*jobs.ScheduledJob, error) {
-	env := jobs.JobSchedulerEnv(params.ExecCfg().JobsKnobs())
+	env := JobSchedulerEnv(params.ExecCfg().JobsKnobs())
 	var schedules []*jobs.ScheduledJob
 	var rows []tree.Datums
 	var cols colinfo.ResultColumns

--- a/pkg/sql/show_create_schedule.go
+++ b/pkg/sql/show_create_schedule.go
@@ -13,6 +13,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/scheduledjobs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -32,7 +34,7 @@ const (
 )
 
 func loadSchedules(params runParams, n *tree.ShowCreateSchedules) ([]*jobs.ScheduledJob, error) {
-	env := JobSchedulerEnv(params.ExecCfg().JobsKnobs())
+	env := jobs.JobSchedulerEnv(params.ExecCfg().JobsKnobs())
 	var schedules []*jobs.ScheduledJob
 	var rows []tree.Datums
 	var cols colinfo.ResultColumns
@@ -51,6 +53,9 @@ func loadSchedules(params runParams, n *tree.ShowCreateSchedules) ([]*jobs.Sched
 			tree.NewDInt(tree.DInt(sjID)))
 		if err != nil {
 			return nil, err
+		}
+		if datums == nil {
+			return nil, pgerror.Newf(pgcode.UndefinedObject, "schedule with id %d does not exist", sjID)
 		}
 		rows = append(rows, datums)
 		cols = columns


### PR DESCRIPTION
When `SHOW CREATE SCHEDULE <id>` is executed with a non-existent schedule ID, `QueryRowExWithCols` returns `nil` for the row datums. Previously, this `nil` was unconditionally appended to the `rows` slice, causing a panic (nil pointer dereference or index out of bounds) when `InitFromDatums` later attempted to access elements of the `nil` row.

### Root cause

In `loadSchedules()` (`pkg/sql/show_create_schedule.go`), the single-schedule-ID path calls `QueryRowExWithCols` and appends `datums` to `rows` without checking for `nil`:

```go
datums, columns, err := params.p.InternalSQLTxn().QueryRowExWithCols(...)
if err != nil {
    return nil, err
}
rows = append(rows, datums)  // datums is nil when schedule doesn't exist
```

Later, iterating over `rows` calls `schedule.InitFromDatums(row, cols)` on the `nil` row → **panic**.

### Fix

Add a nil check for `datums` before appending, returning a `pgcode.UndefinedObject` error. This is consistent with the existing pattern in `control_schedules.go`'s `loadSchedule` function, which already handles the same case:

```go
if datums == nil {
    return nil, pgerror.Newf(pgcode.UndefinedObject, "schedule with id %d does not exist", sjID)
}
```

### Reproduction

```sql
SHOW CREATE SCHEDULE 999999;  -- non-existent schedule ID → panic before fix, clean error after
```

Fixes: #164711

Epic: None