### PR TITLE
loqrecovery: fix Recv error being swallowed by forwardReplicaFilter

### DIFF
--- a/pkg/cli/debug_recover_loss_of_quorum_test.go
+++ b/pkg/cli/debug_recover_loss_of_quorum_test.go
@@ -486,7 +486,7 @@ func TestHalfOnlineLossOfQuorumRecovery(t *testing.T) {
 				},
 				LOQRecovery: &loqrecovery.TestingKnobs{
 					MetadataScanTimeout: 15 * time.Second,
-					ForwardReplicaFilter: func(
+					MaybeInjectError: func(
 						response *serverpb.RecoveryCollectLocalReplicaInfoResponse,
 					) error {
 						// Artificially add an error that would cause the server to retry

--- a/pkg/kv/kvserver/loqrecovery/server.go
+++ b/pkg/kv/kvserver/loqrecovery/server.go
@@ -77,7 +77,7 @@ type Server struct {
 	decommissionFn     func(context.Context, roachpb.NodeID) error
 
 	metadataQueryTimeout time.Duration
-	forwardReplicaFilter func(*serverpb.RecoveryCollectLocalReplicaInfoResponse) error
+	maybeInjectError     func(*serverpb.RecoveryCollectLocalReplicaInfoResponse) error
 }
 
 func NewServer(
@@ -95,12 +95,12 @@ func NewServer(
 	// effort operations where cluster info collection as an operation succeeds
 	// even if some parts of it time out.
 	metadataQueryTimeout := 1 * time.Minute
-	var forwardReplicaFilter func(*serverpb.RecoveryCollectLocalReplicaInfoResponse) error
+	var maybeInjectError func(*serverpb.RecoveryCollectLocalReplicaInfoResponse) error
 	if rk, ok := knobs.(*TestingKnobs); ok {
 		if rk.MetadataScanTimeout > 0 {
 			metadataQueryTimeout = rk.MetadataScanTimeout
 		}
-		forwardReplicaFilter = rk.ForwardReplicaFilter
+		maybeInjectError = rk.MaybeInjectError
 	}
 	return &Server{
 		nodeIDContainer:      nodeIDContainer,
@@ -112,7 +112,7 @@ func NewServer(
 		planStore:            planStore,
 		decommissionFn:       decommission,
 		metadataQueryTimeout: metadataQueryTimeout,
-		forwardReplicaFilter: forwardReplicaFilter,
+		maybeInjectError:     maybeInjectError,
 	}
 }
 
@@ -221,13 +221,13 @@ func (s Server) ServeClusterReplicas(
 		fanOutConnectionRetryOptions,
 		req.MaxConcurrency,
 		allNodes,
-		serveClusterReplicasParallelFn(ctx, syncOutStream, s.forwardReplicaFilter, &replicas, &nodes))
+		serveClusterReplicasParallelFn(ctx, syncOutStream, s.maybeInjectError, &replicas, &nodes))
 }
 
 func serveClusterReplicasParallelFn(
 	ctx context.Context,
 	outStream *threadSafeStream[*serverpb.RecoveryCollectReplicaInfoResponse],
-	forwardReplicaFilter func(*serverpb.RecoveryCollectLocalReplicaInfoResponse) error,
+	maybeInjectError func(*serverpb.RecoveryCollectLocalReplicaInfoResponse) error,
 	replicas, nodes *atomic.Int64,
 ) visitNodeAdminFn {
 	return func(nodeID roachpb.NodeID, client serverpb.RPCAdminClient) error {
@@ -244,8 +244,8 @@ func serveClusterReplicasParallelFn(
 			if err == io.EOF {
 				break
 			}
-			if forwardReplicaFilter != nil {
-				err = forwardReplicaFilter(r)
+			if err == nil && maybeInjectError != nil {
+				err = maybeInjectError(r)
 			}
 			if err != nil {
 				// Some replicas were already sent back, need to notify client of stream

--- a/pkg/kv/kvserver/loqrecovery/server_integration_test.go
+++ b/pkg/kv/kvserver/loqrecovery/server_integration_test.go
@@ -143,7 +143,7 @@ func TestStreamRestart(t *testing.T) {
 			Knobs: base.TestingKnobs{
 				LOQRecovery: &loqrecovery.TestingKnobs{
 					MetadataScanTimeout: 15 * time.Second,
-					ForwardReplicaFilter: func(response *serverpb.RecoveryCollectLocalReplicaInfoResponse) error {
+					MaybeInjectError: func(response *serverpb.RecoveryCollectLocalReplicaInfoResponse) error {
 						if response.ReplicaInfo.NodeID == 2 && response.ReplicaInfo.Desc.RangeID == 14 && failCount.Add(1) < 3 {
 							return errors.New("rpc stream stopped")
 						}

--- a/pkg/kv/kvserver/loqrecovery/testing_knobs.go
+++ b/pkg/kv/kvserver/loqrecovery/testing_knobs.go
@@ -17,9 +17,10 @@ type TestingKnobs struct {
 	// behaviors when meta ranges are unavailable.
 	MetadataScanTimeout time.Duration
 
-	// Replica filter for forwarded replica info when collecting fan-out data.
-	// It can be called concurrently, so must be safe for concurrent use.
-	ForwardReplicaFilter func(*serverpb.RecoveryCollectLocalReplicaInfoResponse) error
+	// MaybeInjectError can be used to inject an error after replica info is
+	// received when collecting fan-out data. It can be called concurrently,
+	// so must be safe for concurrent use.
+	MaybeInjectError func(*serverpb.RecoveryCollectLocalReplicaInfoResponse) error
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.


### PR DESCRIPTION
- When `inStream.Recv()` returned a non-EOF error during fan-out replica collection, the error was passed to `forwardReplicaFilter` (via the overwrite `err = forwardReplicaFilter(r)`). Since `r` is `nil` on `Recv` error, the filter would return `nil`, silently discarding the original error. This caused the code to fall through to `r.ReplicaInfo` access, panicking on the `nil` response. The fix guards the filter call with `err == nil` so that `Recv` errors propagate to the retry logic unchanged. 
- [Claude's analysis](https://github.com/cockroachdb/cockroach/issues/162609#issuecomment-3988899504)
- **Note:**  This bug only manifests when `forwardReplicaFilter` is set, which only happens via the `TestingKnobs` so it can't trigger in production (where `forwardReplicaFilter` is nil and the original `err` from `Recv()`flows through correctly). 
- The fix also renames the testing knob `ForwardReplicaFilter` to `MaybeInjectError` to be consistent with its existing usage ([slack discussion](https://cockroachlabs.slack.com/archives/C0KB9Q03D/p1772613557241359?thread_ts=1772598003.618319&cid=C0KB9Q03D)). 

Fixes: #162609
Epic: none

Release note: None