### PR TITLE
server: clean up DeprecatedStoreClusterVersionKey

### DIFF
--- a/pkg/keys/keys_test.go
+++ b/pkg/keys/keys_test.go
@@ -29,7 +29,6 @@ func TestStoreKeyEncodeDecode(t *testing.T) {
 	}{
 		{key: StoreIdentKey(), expSuffix: localStoreIdentSuffix, expDetail: nil},
 		{key: StoreGossipKey(), expSuffix: localStoreGossipSuffix, expDetail: nil},
-		{key: DeprecatedStoreClusterVersionKey(), expSuffix: localStoreClusterVersionSuffix, expDetail: nil},
 		{key: StoreLastUpKey(), expSuffix: localStoreLastUpSuffix, expDetail: nil},
 		{key: StoreHLCUpperBoundKey(), expSuffix: localStoreHLCUpperBoundSuffix, expDetail: nil},
 	}

--- a/pkg/keys/printer.go
+++ b/pkg/keys/printer.go
@@ -143,7 +143,6 @@ var constSubKeyDict = []struct {
 }{
 	{"/storeIdent", localStoreIdentSuffix},
 	{"/gossipBootstrap", localStoreGossipSuffix},
-	{"/clusterVersion", localStoreClusterVersionSuffix},
 	{"/nodeTombstone", localStoreNodeTombstoneSuffix},
 	{"/cachedSettings", localStoreCachedSettingsSuffix},
 	{"/wag", localStoreWAGNodeSuffix},

--- a/pkg/keys/printer_test.go
+++ b/pkg/keys/printer_test.go
@@ -230,7 +230,6 @@ func TestPrettyPrint(t *testing.T) {
 		// local
 		{keys.StoreIdentKey(), "/Local/Store/storeIdent", revertSupportUnknown},
 		{keys.StoreGossipKey(), "/Local/Store/gossipBootstrap", revertSupportUnknown},
-		{keys.DeprecatedStoreClusterVersionKey(), "/Local/Store/clusterVersion", revertSupportUnknown},
 		{keys.StoreNodeTombstoneKey(123), "/Local/Store/nodeTombstone/n123", revertSupportUnknown},
 		{keys.StoreCachedSettingsKey(roachpb.Key("a")), `/Local/Store/cachedSettings/"a"`, revertSupportUnknown},
 		{keys.StoreUnsafeReplicaRecoveryKey(loqRecoveryID), fmt.Sprintf(`/Local/Store/lossOfQuorumRecovery/applied/%s`, loqRecoveryID), revertSupportUnknown},

--- a/pkg/kv/kvserver/kvstorage/init.go
+++ b/pkg/kv/kvserver/kvstorage/init.go
@@ -89,13 +89,10 @@ func checkCanInitializeEngine(ctx context.Context, eng storage.Engine) error {
 	} else if !errors.HasType(err, (*NotBootstrappedError)(nil)) {
 		return errors.Wrap(err, "unable to read store ident")
 	}
-	// Engine is not bootstrapped yet (i.e. no StoreIdent). Does it contain a
-	// cluster version, cached settings and nothing else? Note that there is one
-	// cluster version key and many cached settings key, and the cluster version
-	// key precedes the cached settings.
-	//
-	// We use an EngineIterator to ensure that there are no keys that cannot be
-	// parsed as MVCCKeys (e.g. lock table keys) in the engine.
+	// Engine is not bootstrapped yet (i.e. no StoreIdent). It may contain cached
+	// settings, but nothing else. Use EngineIterator to ensure that there are no
+	// keys that cannot be parsed as MVCCKeys (e.g. lock table keys) in the
+	// engine.
 	iter, err := eng.NewEngineIterator(ctx, storage.IterOptions{
 		KeyTypes:   storage.IterKeyTypePointsAndRanges,
 		UpperBound: roachpb.KeyMax,
@@ -133,12 +130,9 @@ func checkCanInitializeEngine(ctx context.Context, eng storage.Engine) error {
 		if k, err = getMVCCKey(); err != nil {
 			return err
 		}
-		// Only allowed to find cluster version and cached cluster settings on an
-		// uninitialized engine.
-		if !k.Key.Equal(keys.DeprecatedStoreClusterVersionKey()) {
-			if _, err := keys.DecodeStoreCachedSettingsKey(k.Key); err != nil {
-				return errors.Errorf("engine cannot be bootstrapped, contains key:\n%s", k.String())
-			}
+		// Only allowed to find cached cluster settings on an uninitialized engine.
+		if _, err := keys.DecodeStoreCachedSettingsKey(k.Key); err != nil {
+			return errors.Errorf("engine cannot be bootstrapped, contains key:\n%s", k.String())
 		}
 		valid, err = iter.NextEngineKey()
 	}

--- a/pkg/kv/kvserver/obsolete_code_test.go
+++ b/pkg/kv/kvserver/obsolete_code_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
@@ -30,4 +31,13 @@ func TestObsoleteCode(t *testing.T) {
 	//		_ = some.Type{}.DeprecatedField
 	//		t.Fatalf("DeprecatedField can be removed")
 	//	}
+
+	// When MinSupported is bumped above V26_2, the deprecated store cluster
+	// version key cleanup code in pkg/server/init.go can be removed, as well as
+	// the DeprecatedStoreClusterVersionKey and its uses.
+	v26dot2 := clusterversion.RemoveDevOffset(clusterversion.V26_2.Version())
+	if !msv.LessEq(v26dot2) {
+		_ = keys.DeprecatedStoreClusterVersionKey()
+		t.Fatalf("DeprecatedStoreClusterVersionKey and its uses can be removed")
+	}
 }

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -528,8 +528,6 @@ func (s *initServer) initializeFirstStoreAfterJoin(
 }
 
 func assertEnginesEmpty(engines []kvstorage.Engines) error {
-	// TODO(pav-kv): remove this key, it's not used.
-	storeClusterVersionKey := keys.DeprecatedStoreClusterVersionKey()
 	// TODO(sumeer): plumb a context if necessary.
 	ctx := context.Background()
 
@@ -544,19 +542,7 @@ func assertEnginesEmpty(engines []kvstorage.Engines) error {
 		defer iter.Close()
 
 		valid, err := iter.SeekEngineKeyGE(storage.EngineKey{Key: roachpb.KeyMin})
-		for ; valid && err == nil; valid, err = iter.NextEngineKey() {
-			k, err := iter.UnsafeEngineKey()
-			if err != nil {
-				return err
-			}
-			hasPoint, hasRange := iter.HasPointAndRange()
-
-			// The store cluster version key is written multiple times,
-			// including before bootstrapping or joining a cluster.
-			// Skip it if it exists.
-			if hasPoint && !hasRange && storeClusterVersionKey.Equal(k.Key) {
-				continue
-			}
+		if valid && err == nil {
 			return errors.New("engine is not empty")
 		}
 		return err

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -527,40 +527,42 @@ func (s *initServer) initializeFirstStoreAfterJoin(
 }
 
 func assertEnginesEmpty(engines []kvstorage.Engines) error {
+	// TODO(pav-kv): remove this key, it's not used.
 	storeClusterVersionKey := keys.DeprecatedStoreClusterVersionKey()
-
 	// TODO(sumeer): plumb a context if necessary.
 	ctx := context.Background()
-	for _, engine := range engines {
-		err := func() error {
-			iter, err := engine.TODOEngine().NewEngineIterator(ctx, storage.IterOptions{
-				KeyTypes:   storage.IterKeyTypePointsAndRanges,
-				UpperBound: roachpb.KeyMax,
-			})
+
+	assertEmpty := func(eng kvstorage.Engines) error {
+		iter, err := eng.TODOEngine().NewEngineIterator(ctx, storage.IterOptions{
+			KeyTypes:   storage.IterKeyTypePointsAndRanges,
+			UpperBound: roachpb.KeyMax,
+		})
+		if err != nil {
+			return err
+		}
+		defer iter.Close()
+
+		valid, err := iter.SeekEngineKeyGE(storage.EngineKey{Key: roachpb.KeyMin})
+		for ; valid && err == nil; valid, err = iter.NextEngineKey() {
+			k, err := iter.UnsafeEngineKey()
 			if err != nil {
 				return err
 			}
-			defer iter.Close()
+			hasPoint, hasRange := iter.HasPointAndRange()
 
-			valid, err := iter.SeekEngineKeyGE(storage.EngineKey{Key: roachpb.KeyMin})
-			for ; valid && err == nil; valid, err = iter.NextEngineKey() {
-				k, err := iter.UnsafeEngineKey()
-				if err != nil {
-					return err
-				}
-				hasPoint, hasRange := iter.HasPointAndRange()
-
-				// The store cluster version key is written multiple times,
-				// including before bootstrapping or joining a cluster.
-				// Skip it if it exists.
-				if hasPoint && !hasRange && storeClusterVersionKey.Equal(k.Key) {
-					continue
-				}
-				return errors.New("engine is not empty")
+			// The store cluster version key is written multiple times,
+			// including before bootstrapping or joining a cluster.
+			// Skip it if it exists.
+			if hasPoint && !hasRange && storeClusterVersionKey.Equal(k.Key) {
+				continue
 			}
-			return err
-		}()
-		if err != nil {
+			return errors.New("engine is not empty")
+		}
+		return err
+	}
+
+	for _, engine := range engines {
+		if err := assertEmpty(engine); err != nil {
 			return err
 		}
 	}

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -755,12 +755,14 @@ func inspectEngines(
 		initializedEngines = append(initializedEngines, eng)
 	}
 
-	// Clean up the deprecated store cluster version key from all engines.
-	//
-	// TODO(pav-kv): make it conditional on version, so that this code can be
-	// eventually removed.
-	if err := removeDeprecatedStoreClusterVersionKey(ctx, engines); err != nil {
-		return nil, err
+	// Clean up the deprecated store cluster version key from all engines if we
+	// are on v26.2 or less.
+	// TODO(pav-kv): Remove this cleanup when MinSupported is bumped above V26_2,
+	// as all clusters will have gone through this cleanup by then.
+	if v26dot2 := clusterversion.V26_2.Version(); !v26dot2.Less(minSupportedVersion) {
+		if err := removeDeprecatedStoreClusterVersionKey(ctx, engines); err != nil {
+			return nil, err
+		}
 	}
 
 	clusterVersion, err := kvstorage.SynthesizeClusterVersionFromEngines(

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -682,6 +683,39 @@ func newInitServerConfig(
 	}
 }
 
+// removeDeprecatedStoreClusterVersionKey removes the deprecated store cluster
+// version key from the given engines if it exists. This key was deprecated in
+// v23.1 and is no longer needed.
+func removeDeprecatedStoreClusterVersionKey(ctx context.Context, engines Engines) error {
+	deprecatedKey := keys.DeprecatedStoreClusterVersionKey()
+	cleanup := func(eng kvstorage.Engines) error {
+		// Check if the key exists before attempting to delete it.
+		if val, err := storage.MVCCGet(
+			ctx, eng.LogEngine(), deprecatedKey, hlc.Timestamp{}, storage.MVCCGetOptions{},
+		); err != nil {
+			return errors.Wrap(err, "checking for deprecated store cluster version key")
+		} else if !val.Value.IsPresent() {
+			return nil // key doesn't exist, nothing to clean up
+		}
+		// Key exists, delete it.
+		batch := eng.LogEngine().NewWriteBatch()
+		defer batch.Close()
+		if err := batch.ClearUnversioned(deprecatedKey, storage.ClearOptions{}); err != nil {
+			return errors.Wrap(err, "clearing deprecated store cluster version key")
+		}
+		if err := batch.Commit(true /* sync */); err != nil {
+			return errors.Wrap(err, "committing deprecated key cleanup")
+		}
+		return nil
+	}
+	for _, eng := range engines {
+		if err := cleanup(eng); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // inspectEngines goes through engines and constructs an initState. The
 // initState returned by this method will reflect a zero NodeID if none has
 // been assigned yet (i.e. if none of the engines is initialized). See
@@ -734,6 +768,15 @@ func inspectEngines(
 
 		initializedEngines = append(initializedEngines, eng)
 	}
+
+	// Clean up the deprecated store cluster version key from all engines.
+	//
+	// TODO(pav-kv): make it conditional on version, so that this code can be
+	// eventually removed.
+	if err := removeDeprecatedStoreClusterVersionKey(ctx, engines); err != nil {
+		return nil, err
+	}
+
 	clusterVersion, err := kvstorage.SynthesizeClusterVersionFromEngines(
 		ctx, initializedEngines, latestVersion, minSupportedVersion,
 	)

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -471,9 +471,7 @@ func GetBootstrapSchemaForTest(
 func bootstrapCluster(
 	ctx context.Context, engines Engines, initCfg initServerCfg,
 ) (*initState, error) {
-	// We expect all the stores to be empty at this point, except for
-	// the store cluster version key. Assert so.
-	//
+	// We expect all the stores to be empty at this point.
 	// TODO(jackson): Eventually we should be able to avoid opening the
 	// engines altogether until here.
 	if err := assertEnginesEmpty(engines); err != nil {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/ui"
@@ -1041,6 +1042,63 @@ func TestAssertEnginesEmpty(t *testing.T) {
 	require.NoError(t, batch.PutMVCC(key, value))
 	require.NoError(t, batch.Commit(false))
 	require.Error(t, assertEnginesEmpty(engs))
+}
+
+func TestDeprecatedStoreClusterVersionKeyCleanup(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	// Create sticky VFS registry for in-memory storage.
+	vfsRegistry := fs.NewStickyRegistry()
+	storeSpec := base.DefaultTestStoreSpec
+	storeSpec.StickyVFSID = "deprecated-key-cleanup-test"
+
+	// Open engine and write deprecated key before server startup.
+	env, err := fs.InitEnvFromStoreSpec(ctx, storeSpec,
+		fs.EnvConfig{}, vfsRegistry, nil /* diskWriteStats */)
+	require.NoError(t, err)
+	eng, err := storage.Open(ctx, env, cluster.MakeTestingClusterSettings())
+	require.NoError(t, err)
+
+	// TODO(pav-kv): rm this test when DeprecatedStoreClusterVersionKey is gone.
+	deprecatedKey := keys.DeprecatedStoreClusterVersionKey()
+	require.NoError(t, storage.MVCCPutProto(ctx, eng, deprecatedKey,
+		hlc.Timestamp{}, &roachpb.Version{Major: 22, Minor: 2, Internal: 0},
+		storage.MVCCWriteOptions{}))
+
+	// Verify key exists before server startup.
+	val, err := storage.MVCCGet(ctx, eng, deprecatedKey,
+		hlc.Timestamp{}, storage.MVCCGetOptions{})
+	require.NoError(t, err)
+	require.True(t, val.Value.IsPresent(), "deprecated key should exist before cleanup")
+
+	eng.Close()
+
+	// Start TestServer with the pre-populated engine.
+	// Server startup calls inspectEngines() which triggers cleanup.
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{
+		StoreSpecs: []base.StoreSpec{storeSpec},
+		Knobs: base.TestingKnobs{
+			Server: &TestingKnobs{
+				StickyVFSRegistry: vfsRegistry,
+			},
+		},
+	})
+	defer srv.Stopper().Stop(ctx)
+
+	// Access the store's engine and verify the key has been removed.
+	storeID := srv.StorageLayer().GetFirstStoreID()
+	store, err := srv.StorageLayer().GetStores().(*kvserver.Stores).GetStore(storeID)
+	require.NoError(t, err)
+
+	// Verify the key has been removed by reading from the engine.
+	val, err = storage.MVCCGet(ctx, store.LogEngine(), deprecatedKey,
+		hlc.Timestamp{}, storage.MVCCGetOptions{})
+	require.NoError(t, err)
+	// TODO(pav-kv): this should become false.
+	require.True(t, val.Value.IsPresent(), "deprecated key removed after server init")
 }
 
 // TestAssertExternalStorageInitializedBeforeJobSchedulerStart is a

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1097,8 +1097,7 @@ func TestDeprecatedStoreClusterVersionKeyCleanup(t *testing.T) {
 	val, err = storage.MVCCGet(ctx, store.LogEngine(), deprecatedKey,
 		hlc.Timestamp{}, storage.MVCCGetOptions{})
 	require.NoError(t, err)
-	// TODO(pav-kv): this should become false.
-	require.True(t, val.Value.IsPresent(), "deprecated key removed after server init")
+	require.False(t, val.Value.IsPresent(), "deprecated key present after server init")
 }
 
 // TestAssertExternalStorageInitializedBeforeJobSchedulerStart is a

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1029,6 +1029,8 @@ func TestAssertEnginesEmpty(t *testing.T) {
 
 	require.NoError(t, storage.MVCCPutProto(ctx, eng, keys.DeprecatedStoreClusterVersionKey(),
 		hlc.Timestamp{}, &roachpb.Version{Major: 21, Minor: 1, Internal: 122}, storage.MVCCWriteOptions{}))
+	require.Error(t, assertEnginesEmpty(engs))
+	require.NoError(t, removeDeprecatedStoreClusterVersionKey(ctx, engs))
 	require.NoError(t, assertEnginesEmpty(engs))
 
 	batch := eng.NewBatch()


### PR DESCRIPTION
`DeprecatedStoreClusterVersionKey` was deprecated in v23.1 (c1b7c2e0) when cluster version storage moved to a separate `COCKROACHDB_MIN_VERSION` file. It is no longer written since fddd2623.

Clusters no longer need to maintain compatibility with v22.2 where this key was used. However, it remains on disk on older installations and is still skipped in engine validation.

This commit adds cleanup logic in `inspectEngines` to automatically remove this key from all engines during server startup. The operation is idempotent and safe to run on every startup:

- First startup after upgrade: removes the key if present
- Subsequent startups: no-op (key already removed)
- New engines: no-op (key never existed)

The cleanup runs before normal operations begin, and has access to all engines that need cleanup. The implementation uses `MVCCGet` to check for key existence before deletion, and `ClearUnversioned` to clear it if so.

Epic: none
Release note: none