### PR TITLE
schemachange: fix width validation during ALTER COLUMN ... SET TYPE for unbounded string/bit types

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_column_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_column_type
@@ -2003,3 +2003,107 @@ statement ok
 SET use_declarative_schema_changer = $schema_changer_state
 
 subtest end
+
+# Regression test: altering an unbounded STRING, BYTES, or VARBIT column to a
+# bounded type must validate existing data. Previously, classifierWidth treated
+# width 0 as 64-bit (integer semantics) for all families, so going from
+# unbounded (width 0) to bounded with width >= 64 (e.g., STRING(100)) was
+# incorrectly classified as trivial, skipping the validation scan.
+subtest unbounded_to_bounded_width_validation
+
+statement ok
+CREATE TABLE t_unbounded_string (
+  id INT PRIMARY KEY,
+  s STRING,
+  FAMILY f (id, s)
+) WITH (schema_locked = false)
+
+statement ok
+INSERT INTO t_unbounded_string VALUES (1, repeat('x', 200))
+
+# Altering to STRING(100) must fail because the existing 200-char value
+# exceeds the new limit.
+statement error validation of CHECK
+ALTER TABLE t_unbounded_string ALTER COLUMN s SET DATA TYPE STRING(100)
+
+# Confirm no schema change occurred: the column is still unbounded STRING.
+query TT
+SHOW CREATE TABLE t_unbounded_string
+----
+t_unbounded_string  CREATE TABLE public.t_unbounded_string (
+                      id INT8 NOT NULL,
+                      s STRING NULL,
+                      CONSTRAINT t_unbounded_string_pkey PRIMARY KEY (id ASC),
+                      FAMILY f (id, s)
+                    );
+
+# Altering to a limit that fits the data should succeed.
+statement ok
+ALTER TABLE t_unbounded_string ALTER COLUMN s SET DATA TYPE STRING(200)
+
+query TT
+SHOW CREATE TABLE t_unbounded_string
+----
+t_unbounded_string  CREATE TABLE public.t_unbounded_string (
+                      id INT8 NOT NULL,
+                      s STRING(200) NULL,
+                      CONSTRAINT t_unbounded_string_pkey PRIMARY KEY (id ASC),
+                      FAMILY f (id, s)
+                    );
+
+statement ok
+DROP TABLE t_unbounded_string
+
+# Same test for VARBIT.
+statement ok
+CREATE TABLE t_unbounded_varbit (
+  id INT PRIMARY KEY,
+  v VARBIT,
+  FAMILY f (id, v)
+) WITH (schema_locked = false)
+
+statement ok
+INSERT INTO t_unbounded_varbit VALUES (1, repeat('1', 200)::VARBIT)
+
+statement error validation of CHECK
+ALTER TABLE t_unbounded_varbit ALTER COLUMN v SET DATA TYPE VARBIT(100)
+
+# Confirm the column is still unbounded.
+query TT
+SHOW CREATE TABLE t_unbounded_varbit
+----
+t_unbounded_varbit  CREATE TABLE public.t_unbounded_varbit (
+                      id INT8 NOT NULL,
+                      v VARBIT NULL,
+                      CONSTRAINT t_unbounded_varbit_pkey PRIMARY KEY (id ASC),
+                      FAMILY f (id, v)
+                    );
+
+statement ok
+ALTER TABLE t_unbounded_varbit ALTER COLUMN v SET DATA TYPE VARBIT(200)
+
+statement ok
+DROP TABLE t_unbounded_varbit
+
+# Verify that bounded-to-wider-bounded STRING conversions still work trivially.
+statement ok
+CREATE TABLE t_bounded_string (
+  id INT PRIMARY KEY,
+  s VARCHAR(10),
+  FAMILY f (id, s)
+) WITH (schema_locked = false)
+
+statement ok
+INSERT INTO t_bounded_string VALUES (1, 'hello')
+
+statement ok
+ALTER TABLE t_bounded_string ALTER COLUMN s SET DATA TYPE VARCHAR(20)
+
+# And bounded-to-narrower requires validation.
+statement error validation of CHECK
+ALTER TABLE t_bounded_string ALTER COLUMN s SET DATA TYPE VARCHAR(3)
+
+statement ok
+DROP TABLE t_bounded_string
+
+subtest end

--- a/pkg/sql/schemachange/alter_column_type.go
+++ b/pkg/sql/schemachange/alter_column_type.go
@@ -85,7 +85,7 @@ var classifiers = map[types.Family]map[types.Family]classifier{
 	},
 	types.IntFamily: {
 		types.IntFamily: func(from *types.T, to *types.T) ColumnConversionKind {
-			return classifierWidth(from, to)
+			return classifierIntWidth(from, to)
 		},
 	},
 	types.BitFamily: {
@@ -194,14 +194,32 @@ func classifierDecimalPrecision(oldType *types.T, newType *types.T) ColumnConver
 	}
 }
 
-// classifierWidth returns trivial only if the new type has a width
-// greater than the existing width.  If they are the same, it returns
-// no-op.  Otherwise, it returns validate.
-func classifierWidth(oldType *types.T, newType *types.T) ColumnConversionKind {
+// classifierIntWidth handles width changes for integer types.
+// For integers, a width of 0 means 64-bit (INT8), so narrowing from
+// width 0 to width < 64 requires validation, while going to 64 is trivial.
+func classifierIntWidth(oldType *types.T, newType *types.T) ColumnConversionKind {
 	switch {
 	case oldType.Width() == newType.Width():
 		return ColumnConversionTrivial
 	case oldType.Width() == 0 && newType.Width() < 64:
+		return ColumnConversionValidate
+	case newType.Width() == 0 || newType.Width() > oldType.Width():
+		return ColumnConversionTrivial
+	default:
+		return ColumnConversionValidate
+	}
+}
+
+// classifierWidth handles width changes for string, bytes, and bit types.
+// For these families, a width of 0 means unbounded (e.g., STRING without a
+// length limit). Going from unbounded to any bounded type always requires
+// validation, since existing values may exceed the new limit.
+func classifierWidth(oldType *types.T, newType *types.T) ColumnConversionKind {
+	switch {
+	case oldType.Width() == newType.Width():
+		return ColumnConversionTrivial
+	case oldType.Width() == 0 && newType.Width() > 0:
+		// Unbounded to bounded always requires validation.
 		return ColumnConversionValidate
 	case newType.Width() == 0 || newType.Width() > oldType.Width():
 		return ColumnConversionTrivial

--- a/pkg/sql/schemachange/alter_column_type_test.go
+++ b/pkg/sql/schemachange/alter_column_type_test.go
@@ -83,10 +83,11 @@ func TestColumnConversions(t *testing.T) {
 		},
 
 		"VARBIT": {
-			"INT":    ColumnConversionGeneral,
-			"STRING": ColumnConversionGeneral,
-			"BYTES":  ColumnConversionImpossible,
-			"BIT(4)": ColumnConversionValidate,
+			"INT":      ColumnConversionGeneral,
+			"STRING":   ColumnConversionGeneral,
+			"BYTES":    ColumnConversionImpossible,
+			"BIT(4)":   ColumnConversionValidate,
+			"BIT(100)": ColumnConversionValidate,
 		},
 		"BIT(4)": {
 			"BIT(2)": ColumnConversionValidate,
@@ -94,8 +95,9 @@ func TestColumnConversions(t *testing.T) {
 		},
 
 		"STRING": {
-			"BIT":   ColumnConversionGeneral,
-			"BYTES": ColumnConversionValidate,
+			"BIT":         ColumnConversionGeneral,
+			"BYTES":       ColumnConversionValidate,
+			"STRING(100)": ColumnConversionValidate,
 		},
 		"STRING(5)": {
 			"BYTES": ColumnConversionValidate,
@@ -453,7 +455,17 @@ func TestVirtualColumnConversions(t *testing.T) {
 		{"BIT(4)", "BIT(1)", ColumnConversionValidate},
 		{"BIT(4)", "BIT(0)", ColumnConversionTrivial},
 		{"VARCHAR(10)", "CHAR(5)", ColumnConversionValidate},
+		{"VARCHAR(10)", "VARCHAR(20)", ColumnConversionTrivial},
+		{"VARCHAR(10)", "VARCHAR(5)", ColumnConversionValidate},
+		{"VARCHAR(10)", "TEXT", ColumnConversionTrivial},
 		{"CHAR(15)", "TEXT", ColumnConversionTrivial},
+		// Unbounded string to bounded requires validation since existing data
+		// may exceed the new limit.
+		{"TEXT", "VARCHAR(100)", ColumnConversionValidate},
+		{"TEXT", "VARCHAR(10)", ColumnConversionValidate},
+		// Unbounded bit to bounded requires validation.
+		{"VARBIT", "BIT(100)", ColumnConversionValidate},
+		{"VARBIT", "BIT(10)", ColumnConversionValidate},
 		{"TIMESTAMP(6)", "TIMESTAMP(4)", ColumnConversionTrivial},
 		{"TIMESTAMP(4)", "TIMESTAMP(6)", ColumnConversionTrivial},
 		{"TIMESTAMP(4)", "TIMESTAMPTZ(2)", ColumnConversionTrivial},


### PR DESCRIPTION
classifierWidth was shared by IntFamily, StringFamily, BytesFamily, and BitFamily, but contained a special case designed only for integers: when oldType.Width() == 0 (meaning 64-bit for INT), it only triggered validation if newType.Width() < 64. For string and bit families, Width() == 0 means unbounded (no length limit), so altering from unbounded to bounded with width >= 64 (e.g., STRING -> STRING(100)) was incorrectly classified as trivial, skipping the validation scan. This allowed existing data exceeding the new limit to remain, silently violating schema constraints.

Split classifierWidth into classifierIntWidth (retains integer semantics where 0 means 64-bit) and classifierWidth (for string/bytes/bit families where 0 means unbounded, so any unbounded-to-bounded conversion always requires validation).

Resolves: #164721

Release note (bug fix): Fixed a bug where ALTER TABLE ... ALTER COLUMN ... SET DATA TYPE from an unbounded string or bit type to a bounded type with a length >= 64 (e.g., STRING to STRING(100)) would skip validating existing data against the new length constraint. This could leave rows in the table that violate the column's type, with values longer than the specified limit.