### PR TITLE
goexectrace,debug: embed metadata in Go execution traces

### DIFF
--- a/pkg/server/debug/BUILD.bazel
+++ b/pkg/server/debug/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "logspy.go",
         "queries_writer.go",
         "server.go",
+        "trace.go",
         "vmodule.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/server/debug",

--- a/pkg/server/debug/server.go
+++ b/pkg/server/debug/server.go
@@ -72,6 +72,7 @@ func setupProcessWideRoutes(
 	authorizer tenantcapabilities.Authorizer,
 	vsrv *vmoduleServer,
 	profiler pprofui.Profiler,
+	logMetadata func(ctx context.Context, source string),
 ) {
 	authzCheck := func(w http.ResponseWriter, r *http.Request) bool {
 		if err := authorizer.HasProcessDebugCapability(r.Context(), tenantID); err != nil {
@@ -97,7 +98,9 @@ func setupProcessWideRoutes(
 		CPUProfileHandler(st, w, r)
 	}))
 	mux.HandleFunc("/debug/pprof/symbol", authzFunc(pprof.Symbol))
-	mux.HandleFunc("/debug/pprof/trace", authzFunc(pprof.Trace))
+	mux.HandleFunc("/debug/pprof/trace", authzFunc(func(w http.ResponseWriter, r *http.Request) {
+		ExecutionTraceHandler(logMetadata, w, r)
+	}))
 
 	// Cribbed straight from trace's `init()` method. See:
 	// https://github.com/golang/net/blob/master/trace/trace.go
@@ -144,7 +147,9 @@ func setupProcessWideRoutes(
 	mux.HandleFunc("/debug/pprof/fgprof", authzFunc(fgprof.Handler().ServeHTTP))
 }
 
-// NewServer sets up a debug server.
+// NewServer sets up a debug server. The logMetadata callback, if non-nil, is
+// called when serving /debug/pprof/trace to embed CRDB metadata (node ID,
+// version, wallclock) into Go execution traces.
 func NewServer(
 	ambientContext log.AmbientContext,
 	st *cluster.Settings,
@@ -152,6 +157,7 @@ func NewServer(
 	profiler pprofui.Profiler,
 	tenantID roachpb.TenantID,
 	authorizer tenantcapabilities.Authorizer,
+	logMetadata func(ctx context.Context, source string),
 ) *Server {
 	mux := http.NewServeMux()
 
@@ -160,7 +166,7 @@ func NewServer(
 
 	// Debug routes that retrieve process-wide state.
 	vsrv := &vmoduleServer{}
-	setupProcessWideRoutes(mux, st, tenantID, authorizer, vsrv, profiler)
+	setupProcessWideRoutes(mux, st, tenantID, authorizer, vsrv, profiler, logMetadata)
 
 	if hbaConfDebugFn != nil {
 		// Expose the processed HBA configuration through the debug

--- a/pkg/server/debug/trace.go
+++ b/pkg/server/debug/trace.go
@@ -1,0 +1,69 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package debug
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	rttrace "runtime/trace"
+	"strconv"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+// ExecutionTraceHandler serves Go execution traces with embedded CRDB metadata.
+// It reimplements net/http/pprof.Trace (based on Go 1.24) to inject a
+// runtime/trace.Log event containing node identity and version information
+// immediately after starting the trace. If upgrading Go versions, diff this
+// function against the upstream net/http/pprof.Trace implementation.
+//
+// The logMetadata callback is invoked with source="pprof_endpoint" to emit the
+// metadata event into the trace buffer.
+func ExecutionTraceHandler(
+	logMetadata func(ctx context.Context, source string), w http.ResponseWriter, r *http.Request,
+) {
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	sec, err := strconv.ParseFloat(r.FormValue("seconds"), 64)
+	if sec <= 0 || err != nil {
+		sec = 1
+	}
+
+	// Extend the server's write deadline to accommodate the trace duration,
+	// matching the behavior of net/http/pprof.Trace.
+	if srv, ok := r.Context().Value(http.ServerContextKey).(*http.Server); ok && srv.WriteTimeout > 0 {
+		rc := http.NewResponseController(w)
+		timeout := srv.WriteTimeout + time.Duration(sec*float64(time.Second))
+		_ = rc.SetWriteDeadline(timeutil.Now().Add(timeout))
+	}
+
+	// Set Content-Type before starting the trace, since trace.Start will
+	// begin writing binary data to w immediately.
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Content-Disposition", `attachment; filename="trace"`)
+	if err := rttrace.Start(w); err != nil {
+		// Clean up the success-path headers before sending the error.
+		w.Header().Del("Content-Disposition")
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		http.Error(w,
+			fmt.Sprintf("Could not enable tracing: %s", err),
+			http.StatusInternalServerError)
+		return
+	}
+	defer rttrace.Stop()
+
+	if logMetadata != nil {
+		logMetadata(r.Context(), "pprof_endpoint")
+	}
+
+	timer := time.NewTimer(time.Duration(sec * float64(time.Second)))
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+	case <-r.Context().Done():
+	}
+}

--- a/pkg/server/env_sampler.go
+++ b/pkg/server/env_sampler.go
@@ -66,6 +66,7 @@ func startSampleEnvironment(
 	goroutineDumper *goroutinedumper.GoroutineDumper,
 	sessionRegistry *sql.SessionRegistry,
 	rootMemMonitor *mon.BytesMonitor,
+	logMetadata func(ctx context.Context, source string),
 ) error {
 	metricsSampleInterval := base.DefaultMetricsSampleInterval
 	if p, ok := srvCfg.TestingKnobs.Server.(*TestingKnobs); ok && p.EnvironmentSampleInterval != time.Duration(0) {
@@ -132,7 +133,7 @@ func startSampleEnvironment(
 		}
 	}
 
-	simpleFlightRecorder, err := goexectrace.NewFlightRecorder(cfg.st, 10*time.Second, cfg.executionTraceDirName)
+	simpleFlightRecorder, err := goexectrace.NewFlightRecorder(cfg.st, 10*time.Second, cfg.executionTraceDirName, logMetadata)
 	if err != nil {
 		log.Dev.Warningf(ctx, "failed to initialize flight recorder: %v", err)
 	} else {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -136,6 +136,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil/ptp"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing/goexectrace"
 	"github.com/cockroachdb/cockroach/pkg/util/unique"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
@@ -1367,6 +1368,10 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 	)
 	drain.serverCtl = sc
 
+	// Create the callback for embedding metadata in Go execution traces,
+	// used by the debug server's trace endpoint.
+	logMetadata := goexectrace.NewLogMetadataFn(cfg.BaseConfig.IDContainer)
+
 	// Create the debug API server.
 	debugServer := debug.NewServer(
 		cfg.BaseConfig.AmbientCtx,
@@ -1375,6 +1380,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		sqlServer.execCfg.SQLStatusServer,
 		roachpb.SystemTenantID,
 		authorizer,
+		logMetadata,
 	)
 
 	recoveryServer := loqrecovery.NewServer(
@@ -2059,6 +2065,7 @@ func (s *topLevelServer) PreStart(ctx context.Context) error {
 		s.goroutineDumper,
 		s.status.sessionRegistry,
 		s.sqlServer.execCfg.RootMemoryMonitor,
+		goexectrace.NewLogMetadataFn(s.cfg.BaseConfig.IDContainer),
 	); err != nil {
 		return err
 	}

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -78,6 +78,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/schedulerlatency"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing/goexectrace"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
@@ -513,6 +514,10 @@ func newTenantServer(
 		processCapAuthz = lsi.SameProcessCapabilityAuthorizer
 	}
 
+	// Create the callback for embedding metadata in Go execution traces,
+	// used by the debug server's trace endpoint.
+	logMetadata := goexectrace.NewLogMetadataFn(baseCfg.IDContainer)
+
 	// Create the debug API server.
 	debugServer := debug.NewServer(
 		baseCfg.AmbientCtx,
@@ -521,6 +526,7 @@ func newTenantServer(
 		sqlServer.execCfg.SQLStatusServer,
 		sqlCfg.TenantID,
 		processCapAuthz,
+		logMetadata,
 	)
 
 	return &SQLServerWrapper{
@@ -803,6 +809,7 @@ func (s *SQLServerWrapper) PreStart(ctx context.Context) error {
 			goroutineDumper,
 			s.tenantStatus.sessionRegistry,
 			s.sqlServer.execCfg.RootMemoryMonitor,
+			goexectrace.NewLogMetadataFn(s.cfg.IDContainer),
 		); err != nil {
 			return err
 		}

--- a/pkg/util/tracing/goexectrace/BUILD.bazel
+++ b/pkg/util/tracing/goexectrace/BUILD.bazel
@@ -2,10 +2,16 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "goexectrace",
-    srcs = ["simple_flight_recorder.go"],
+    srcs = [
+        "exectrace_meta.go",
+        "simple_flight_recorder.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/util/tracing/goexectrace",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/base",
+        "//pkg/build",
+        "//pkg/roachpb",
         "//pkg/server/dumpstore",
         "//pkg/settings",
         "//pkg/settings/cluster",
@@ -28,5 +34,6 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/stop",
         "@com_github_stretchr_testify//require",
+        "@org_golang_x_exp//trace",
     ],
 )

--- a/pkg/util/tracing/goexectrace/exectrace_meta.go
+++ b/pkg/util/tracing/goexectrace/exectrace_meta.go
@@ -1,0 +1,52 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package goexectrace
+
+import (
+	"context"
+	"encoding/json"
+	rttrace "runtime/trace"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/build"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+// execTraceMetadata is the JSON-serializable structure embedded into Go
+// execution traces via runtime/trace.Log.
+type execTraceMetadata struct {
+	// TODO(jasonlmfong): consider adding TenantID for multi-tenant deployments.
+	// The tenant ID is available at both call sites (server.go and tenant.go)
+	// via roachpb.SystemTenantID and sqlCfg.TenantID respectively.
+	Wallclock string         `json:"wallclock"`
+	NodeID    roachpb.NodeID `json:"node_id"`
+	Version   string         `json:"version"`
+	Source    string         `json:"source"`
+}
+
+// NewLogMetadataFn returns a callback that embeds metadata into a Go execution
+// trace via runtime/trace.Log. The metadata includes the current wall-clock
+// time, node ID, build version, and the source of the trace capture. The
+// returned function is safe to call from any goroutine.
+func NewLogMetadataFn(idContainer *base.NodeIDContainer) func(ctx context.Context, source string) {
+	return func(ctx context.Context, source string) {
+		meta := execTraceMetadata{
+			Wallclock: timeutil.Now().Format(time.RFC3339Nano),
+			NodeID:    idContainer.Get(),
+			Version:   build.GetInfo().Tag,
+			Source:    source,
+		}
+		var payload string
+		if b, err := json.Marshal(meta); err != nil {
+			payload = "marshal error: " + err.Error()
+		} else {
+			payload = string(b)
+		}
+		rttrace.Log(ctx, "crdb.exectrace.meta", payload)
+	}
+}

--- a/pkg/util/tracing/goexectrace/simple_flight_recorder.go
+++ b/pkg/util/tracing/goexectrace/simple_flight_recorder.go
@@ -64,6 +64,12 @@ type SimpleFlightRecorder struct {
 	// checks to see if the feature has been enabled if it's disabled.
 	enabledCheckInterval time.Duration
 	enabled              atomic.Bool
+
+	// logMetadata, if set, is called just before each WriteTo to embed
+	// metadata (e.g. wallclock, node ID, version) into the execution trace
+	// via runtime/trace.Log. This ensures the metadata event is in the
+	// flight recorder's ring buffer at snapshot time.
+	logMetadata func(ctx context.Context, source string)
 }
 
 // A `Dumper` implementation is needed to run `DumpStore.GC` periodically. This
@@ -72,7 +78,10 @@ type SimpleFlightRecorder struct {
 var _ dumpstore.Dumper = &SimpleFlightRecorder{}
 
 func NewFlightRecorder(
-	st *cluster.Settings, enabledCheckInterval time.Duration, directory string,
+	st *cluster.Settings,
+	enabledCheckInterval time.Duration,
+	directory string,
+	logMetadata func(ctx context.Context, source string),
 ) (*SimpleFlightRecorder, error) {
 	fr := trace.NewFlightRecorder()
 	if directory == "" {
@@ -90,6 +99,7 @@ func NewFlightRecorder(
 		sv:                   &st.SV,
 		directory:            directory,
 		enabledCheckInterval: enabledCheckInterval,
+		logMetadata:          logMetadata,
 	}, nil
 }
 
@@ -176,6 +186,9 @@ func (sfr *SimpleFlightRecorder) Start(ctx context.Context, stopper *stop.Stoppe
 					log.Dev.Warningf(ctx, "unable to open file %s to dump flight record, will try again: %v", filename, err)
 					t.Reset(max(interval-timeutil.Since(startTime), 0))
 					continue
+				}
+				if sfr.logMetadata != nil {
+					sfr.logMetadata(ctx, "flight_recorder")
 				}
 				_, err = sfr.fr.WriteTo(destFile)
 				if err != nil {

--- a/pkg/util/tracing/goexectrace/simple_flight_recorder_test.go
+++ b/pkg/util/tracing/goexectrace/simple_flight_recorder_test.go
@@ -8,8 +8,11 @@ package goexectrace
 import (
 	"context"
 	"errors"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	rttrace "runtime/trace"
 	"testing"
 	"time"
 
@@ -19,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/stretchr/testify/require"
+	exptrace "golang.org/x/exp/trace"
 )
 
 func TestSimpleFlightRecorder(t *testing.T) {
@@ -28,7 +32,17 @@ func TestSimpleFlightRecorder(t *testing.T) {
 	dir := t.TempDir()
 	st := cluster.MakeTestingClusterSettings()
 
-	fr, err := NewFlightRecorder(st, 1*time.Second, dir)
+	// The logMetadata callback emits a runtime/trace.Log event with a known
+	// category. We verify below that this event actually appears in the
+	// flight recorder's snapshot, confirming that the flight recorder
+	// captures runtime/trace.Log events.
+	const metaCategory = "crdb.exectrace.meta.test"
+	const metaMessage = "test-metadata-payload"
+	logMetadata := func(ctx context.Context, _ string) {
+		rttrace.Log(ctx, metaCategory, metaMessage)
+	}
+
+	fr, err := NewFlightRecorder(st, 1*time.Second, dir, logMetadata)
 	require.NoError(t, err)
 
 	stopper := stop.NewStopper()
@@ -73,6 +87,57 @@ func TestSimpleFlightRecorder(t *testing.T) {
 				return errors.New("file name does not match expected pattern")
 			}
 			return nil
+		})
+	})
+
+	t.Run("metadata log event appears in trace snapshot", func(t *testing.T) {
+		// Parse trace files and verify that the runtime/trace.Log event
+		// emitted by logMetadata is present. We retry because the most
+		// recent file may have been created (os.Create) but not yet
+		// written to (WriteTo) by the flight recorder goroutine.
+		testutils.SucceedsSoon(t, func() error {
+			files, err := os.ReadDir(dir)
+			if err != nil {
+				return err
+			}
+			if len(files) == 0 {
+				return errors.New("no trace files found")
+			}
+
+			// Use the last file. os.ReadDir returns entries sorted by name,
+			// and filenames contain timestamps, so the last entry is the
+			// most recent.
+			latestFile := filepath.Join(dir, files[len(files)-1].Name())
+			f, err := os.Open(latestFile)
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+
+			reader, err := exptrace.NewReader(f)
+			if err != nil {
+				return err
+			}
+
+			for {
+				ev, err := reader.ReadEvent()
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					return err
+				}
+				if ev.Kind() == exptrace.EventLog {
+					logEv := ev.Log()
+					if logEv.Category == metaCategory && logEv.Message == metaMessage {
+						return nil
+					}
+				}
+			}
+			return fmt.Errorf(
+				"no trace.Log event with category=%q found in the flight recorder snapshot %s",
+				metaCategory, latestFile,
+			)
 		})
 	})
 


### PR DESCRIPTION
Go execution traces captured by CockroachDB (via the flight recorder or
/debug/pprof/trace) contain no embedded metadata, making it difficult to
correlate traces with wall-clock time, identify which node produced them,
or determine the CRDB version when traces are shared without context.

Embed a JSON-encoded metadata event into traces via runtime/trace.Log with
the category "crdb.exectrace.meta". The payload includes wallclock time,
node ID, build version, and capture source (flight_recorder or pprof_endpoint).

For the flight recorder, the metadata is logged just before WriteTo so it
lands in the ring buffer at snapshot time. For the pprof endpoint, the
stdlib pprof.Trace handler is reimplemented (based on Go 1.24) because
the metadata must be injected between trace.Start and trace.Stop, which
are both internal to pprof.Trace — a simple wrapper cannot inject at
that point.

Closes: cockroachdb#161503
Epic: None
Release note: None