### PR TITLE
batcheval: separate reads from writes in split/merge triggers

### DIFF
--- a/pkg/kv/kvserver/abortspan/abortspan.go
+++ b/pkg/kv/kvserver/abortspan/abortspan.go
@@ -135,6 +135,67 @@ func (sc *AbortSpan) Put(
 	return storage.MVCCPutProto(ctx, readWriter, key, hlc.Timestamp{}, entry, storage.MVCCWriteOptions{Stats: ms})
 }
 
+// Entry pairs a transaction ID with its AbortSpanEntry, representing a single
+// abort span record suitable for copying between ranges.
+type Entry struct {
+	TxnID uuid.UUID
+	roachpb.AbortSpanEntry
+}
+
+// Collect returns the abort span entries that are newer than the GC threshold.
+// Entries older than the threshold are filtered out, as they would be garbage
+// collected. Filtering is important because certain workloads create sizable
+// abort spans, and repeated splitting can blow them up further. Once the abort
+// span reaches approximately the Raft MaxCommandSize, splits become impossible
+// (see #25233).
+func (sc *AbortSpan) Collect(
+	ctx context.Context,
+	r storage.Reader,
+	ts hlc.Timestamp,
+	txnCleanupThreshold time.Duration,
+) ([]Entry, error) {
+	threshold := ts.Add(-txnCleanupThreshold.Nanoseconds(), 0)
+	var entries []Entry
+	var scratch [64]byte
+	var skipped int
+	if err := sc.Iterate(ctx, r, func(k roachpb.Key, entry roachpb.AbortSpanEntry) error {
+		if entry.Timestamp.Less(threshold) {
+			skipped++
+			return nil
+		}
+		txnID, err := keys.DecodeAbortSpanKey(k, scratch[:0])
+		if err != nil {
+			return err
+		}
+		entries = append(entries, Entry{TxnID: txnID, AbortSpanEntry: entry})
+		return nil
+	}); err != nil {
+		return nil, errors.Wrap(err, "AbortSpan.Collect")
+	}
+	log.Eventf(ctx, "abort span: collected %d entries, skipped %d", len(entries), skipped)
+	return entries, nil
+}
+
+// WriteTo writes the given abort span entries into the abort span for
+// targetRangeID.
+func WriteTo(
+	ctx context.Context,
+	w storage.ReadWriter,
+	ms *enginepb.MVCCStats,
+	targetRangeID roachpb.RangeID,
+	entries []Entry,
+) error {
+	for i := range entries {
+		if err := storage.MVCCPutProto(ctx, w,
+			keys.AbortSpanKey(targetRangeID, entries[i].TxnID),
+			hlc.Timestamp{}, &entries[i].AbortSpanEntry, storage.MVCCWriteOptions{Stats: ms},
+		); err != nil {
+			return errors.Wrap(err, "AbortSpan.WriteTo")
+		}
+	}
+	return nil
+}
+
 // CopyTo copies the abort span entries to the abort span for the range
 // identified by newRangeID. Entries are read from r and written to w. It is
 // safe for r and w to be the same object.
@@ -152,37 +213,9 @@ func (sc *AbortSpan) CopyTo(
 	newRangeID roachpb.RangeID,
 	txnCleanupThreshold time.Duration,
 ) error {
-	var abortSpanCopyCount, abortSpanSkipCount int
-	// Abort span entries before this span are eligible for GC, so we don't
-	// copy them into the new range. We could try to delete them from the LHS
-	// as well, but that could create a large Raft command in itself. Plus,
-	// we'd have to adjust the stats computations.
-	threshold := ts.Add(-txnCleanupThreshold.Nanoseconds(), 0)
-	var scratch [64]byte
-	if err := sc.Iterate(ctx, r, func(k roachpb.Key, entry roachpb.AbortSpanEntry) error {
-		if entry.Timestamp.Less(threshold) {
-			// The entry would be garbage collected (if GC had run), so
-			// don't bother copying it. Note that we can't filter on the key,
-			// that is just where the txn record lives, but it doesn't tell
-			// us whether the intents that triggered the abort span record
-			// where on the LHS, RHS, or both.
-			abortSpanSkipCount++
-			return nil
-		}
-
-		abortSpanCopyCount++
-		var txnID uuid.UUID
-		txnID, err := keys.DecodeAbortSpanKey(k, scratch[:0])
-		if err != nil {
-			return err
-		}
-		return storage.MVCCPutProto(ctx, w,
-			keys.AbortSpanKey(newRangeID, txnID),
-			hlc.Timestamp{}, &entry, storage.MVCCWriteOptions{Stats: ms},
-		)
-	}); err != nil {
-		return errors.Wrap(err, "AbortSpan.CopyTo")
+	entries, err := sc.Collect(ctx, r, ts, txnCleanupThreshold)
+	if err != nil {
+		return err
 	}
-	log.Eventf(ctx, "abort span: copied %d entries, skipped %d", abortSpanCopyCount, abortSpanSkipCount)
-	return nil
+	return WriteTo(ctx, w, ms, newRangeID, entries)
 }

--- a/pkg/kv/kvserver/abortspan/abortspan.go
+++ b/pkg/kv/kvserver/abortspan/abortspan.go
@@ -196,26 +196,3 @@ func WriteTo(
 	return nil
 }
 
-// CopyTo copies the abort span entries to the abort span for the range
-// identified by newRangeID. Entries are read from r and written to w. It is
-// safe for r and w to be the same object.
-//
-// CopyTo takes care to only copy records that are required: certain workloads
-// create sizable abort spans, and repeated splitting can blow them up further.
-// Once it reaches approximately the Raft MaxCommandSize, splits become
-// impossible, which is pretty bad (see #25233).
-func (sc *AbortSpan) CopyTo(
-	ctx context.Context,
-	r storage.Reader,
-	w storage.ReadWriter,
-	ms *enginepb.MVCCStats,
-	ts hlc.Timestamp,
-	newRangeID roachpb.RangeID,
-	txnCleanupThreshold time.Duration,
-) error {
-	entries, err := sc.Collect(ctx, r, ts, txnCleanupThreshold)
-	if err != nil {
-		return err
-	}
-	return WriteTo(ctx, w, ms, newRangeID, entries)
-}

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -1254,6 +1254,19 @@ func splitTrigger(
 	return splitTriggerHelper(ctx, rec, batch, in, h, split, ts)
 }
 
+// TestingMergeTrigger is a wrapper around mergeTrigger that is exported for
+// testing purposes.
+func TestingMergeTrigger(
+	ctx context.Context,
+	rec EvalContext,
+	batch storage.Batch,
+	ms *enginepb.MVCCStats,
+	merge *roachpb.MergeTrigger,
+	ts hlc.Timestamp,
+) (result.Result, error) {
+	return mergeTrigger(ctx, rec, batch, ms, merge, ts)
+}
+
 // TestingSplitTrigger is a wrapper around splitTrigger that is exported for
 // testing purposes.
 func TestingSplitTrigger(

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -958,7 +958,20 @@ func RunCommitTrigger(
 		return res, nil
 	}
 	if mt := ct.GetMergeTrigger(); mt != nil {
-		res, err := mergeTrigger(ctx, rec, batch, ms, mt, txn.WriteTimestamp)
+		lhsHint, err := MakeStateLoader(rec).LoadGCHint(ctx, batch)
+		if err != nil {
+			return result.Result{}, maybeWrapReplicaCorruptionError(
+				ctx, errors.Wrap(err, "unable to load LHS GCHint"),
+			)
+		}
+		rhsHint, err := kvstorage.MakeStateLoader(mt.RightDesc.RangeID).LoadGCHint(ctx, batch)
+		if err != nil {
+			return result.Result{}, maybeWrapReplicaCorruptionError(
+				ctx, errors.Wrap(err, "unable to load RHS GCHint"),
+			)
+		}
+		in := MergeTriggerHelperInput{LHSGCHint: lhsHint, RHSGCHint: rhsHint}
+		res, err := mergeTrigger(ctx, rec, batch, ms, mt, txn.WriteTimestamp, in)
 		if err != nil {
 			return result.Result{}, maybeWrapReplicaCorruptionError(ctx, err)
 		}
@@ -1263,8 +1276,9 @@ func TestingMergeTrigger(
 	ms *enginepb.MVCCStats,
 	merge *roachpb.MergeTrigger,
 	ts hlc.Timestamp,
+	in MergeTriggerHelperInput,
 ) (result.Result, error) {
-	return mergeTrigger(ctx, rec, batch, ms, merge, ts)
+	return mergeTrigger(ctx, rec, batch, ms, merge, ts, in)
 }
 
 // TestingSplitTrigger is a wrapper around splitTrigger that is exported for
@@ -1337,6 +1351,12 @@ type SplitTriggerHelperInput struct {
 	GCThreshold    *hlc.Timestamp
 	GCHint         *roachpb.GCHint
 	ReplicaVersion roachpb.Version
+}
+
+// MergeTriggerHelperInput contains metadata required by the mergeTrigger.
+type MergeTriggerHelperInput struct {
+	LHSGCHint *roachpb.GCHint
+	RHSGCHint *roachpb.GCHint
 }
 
 // splitTriggerHelper continues the work begun by splitTrigger, but has a
@@ -1599,6 +1619,7 @@ func mergeTrigger(
 	ms *enginepb.MVCCStats,
 	merge *roachpb.MergeTrigger,
 	ts hlc.Timestamp,
+	in MergeTriggerHelperInput,
 ) (result.Result, error) {
 	desc := rec.Desc()
 	if !bytes.Equal(desc.StartKey, merge.LeftDesc.StartKey) {
@@ -1685,21 +1706,12 @@ func mergeTrigger(
 	pd.Replicated.DoTimelyApplicationToAllReplicas = true
 
 	{
-		// If we have GC hints populated that means we are trying to perform
-		// optimized garbage removal in future.
-		// We will try to merge both hints if possible and set new hint on LHS.
-		lhsLoader := MakeStateLoader(rec)
-		lhsHint, err := lhsLoader.LoadGCHint(ctx, batch)
-		if err != nil {
-			return result.Result{}, err
-		}
-		rhsLoader := kvstorage.MakeStateLoader(merge.RightDesc.RangeID)
-		rhsHint, err := rhsLoader.LoadGCHint(ctx, batch)
-		if err != nil {
-			return result.Result{}, err
-		}
+		// Merge the GC hints from both sides. If the merged hint differs from the
+		// LHS hint, persist the updated hint.
+		lhsHint := in.LHSGCHint
+		rhsHint := in.RHSGCHint
 		if lhsHint.Merge(rhsHint, rec.GetMVCCStats().HasNoUserData(), merge.RightMVCCStats.HasNoUserData()) {
-			if err := lhsLoader.SetGCHint(ctx, batch, ms, lhsHint); err != nil {
+			if err := MakeStateLoader(rec).SetGCHint(ctx, batch, ms, lhsHint); err != nil {
 				return result.Result{}, err
 			}
 			pd.Replicated.State = &kvserverpb.ReplicaState{

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -942,11 +942,21 @@ func RunCommitTrigger(
 				ctx, errors.Wrap(err, "unable to load replica version"),
 			)
 		}
+		lhsAbortSpanEntries, err := rec.AbortSpan().Collect(
+			ctx, batch, txn.WriteTimestamp,
+			gc.TxnCleanupThreshold.Get(&rec.ClusterSettings().SV),
+		)
+		if err != nil {
+			return result.Result{}, maybeWrapReplicaCorruptionError(
+				ctx, errors.Wrap(err, "unable to collect LHS abort span entries"),
+			)
+		}
 		in := SplitTriggerHelperInput{
-			LeftLease:      lhsLease,
-			GCThreshold:    gcThreshold,
-			GCHint:         gcHint,
-			ReplicaVersion: replicaVersion,
+			LeftLease:           lhsLease,
+			GCThreshold:        gcThreshold,
+			GCHint:             gcHint,
+			ReplicaVersion:     replicaVersion,
+			LHSAbortSpanEntries: lhsAbortSpanEntries,
 		}
 
 		newMS, res, err := splitTrigger(
@@ -1368,10 +1378,11 @@ func makeScanStatsFn(
 // SplitTriggerHelperInput contains metadata needed by the RHS when running the
 // splitTriggerHelper.
 type SplitTriggerHelperInput struct {
-	LeftLease      roachpb.Lease
-	GCThreshold    *hlc.Timestamp
-	GCHint         *roachpb.GCHint
-	ReplicaVersion roachpb.Version
+	LeftLease            roachpb.Lease
+	GCThreshold          *hlc.Timestamp
+	GCHint               *roachpb.GCHint
+	ReplicaVersion       roachpb.Version
+	LHSAbortSpanEntries  []abortspan.Entry
 }
 
 // MergeTriggerHelperInput contains metadata required by the mergeTrigger.
@@ -1483,10 +1494,10 @@ func splitTriggerHelper(
 		return enginepb.MVCCStats{}, result.Result{}, err
 	}
 
-	// Initialize the RHS range's AbortSpan by copying the LHS's.
-	if err := rec.AbortSpan().CopyTo(
-		ctx, batch, batch, h.AbsPostSplitRight(), ts, split.RightDesc.RangeID,
-		gc.TxnCleanupThreshold.Get(&rec.ClusterSettings().SV),
+	// Initialize the RHS range's AbortSpan by writing the LHS's entries into
+	// the RHS.
+	if err := abortspan.WriteTo(
+		ctx, batch, h.AbsPostSplitRight(), split.RightDesc.RangeID, in.LHSAbortSpanEntries,
 	); err != nil {
 		return enginepb.MVCCStats{}, result.Result{}, err
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -951,12 +951,21 @@ func RunCommitTrigger(
 				ctx, errors.Wrap(err, "unable to collect LHS abort span entries"),
 			)
 		}
+		var consistencyCheckerLastRun hlc.Timestamp
+		if _, err := storage.MVCCGetProto(ctx, batch,
+			keys.QueueLastProcessedKey(ct.SplitTrigger.LeftDesc.StartKey, "consistencyChecker"),
+			hlc.Timestamp{}, &consistencyCheckerLastRun, storage.MVCCGetOptions{}); err != nil {
+			return result.Result{}, maybeWrapReplicaCorruptionError(
+				ctx, errors.Wrap(err, "unable to load consistency checker last run"),
+			)
+		}
 		in := SplitTriggerHelperInput{
-			LeftLease:           lhsLease,
-			GCThreshold:        gcThreshold,
-			GCHint:             gcHint,
-			ReplicaVersion:     replicaVersion,
-			LHSAbortSpanEntries: lhsAbortSpanEntries,
+			LeftLease:                 lhsLease,
+			GCThreshold:              gcThreshold,
+			GCHint:                   gcHint,
+			ReplicaVersion:           replicaVersion,
+			LHSAbortSpanEntries:      lhsAbortSpanEntries,
+			ConsistencyCheckerLastRun: consistencyCheckerLastRun,
 		}
 
 		newMS, res, err := splitTrigger(
@@ -1378,11 +1387,12 @@ func makeScanStatsFn(
 // SplitTriggerHelperInput contains metadata needed by the RHS when running the
 // splitTriggerHelper.
 type SplitTriggerHelperInput struct {
-	LeftLease            roachpb.Lease
-	GCThreshold          *hlc.Timestamp
-	GCHint               *roachpb.GCHint
-	ReplicaVersion       roachpb.Version
-	LHSAbortSpanEntries  []abortspan.Entry
+	LeftLease                  roachpb.Lease
+	GCThreshold                *hlc.Timestamp
+	GCHint                     *roachpb.GCHint
+	ReplicaVersion             roachpb.Version
+	LHSAbortSpanEntries        []abortspan.Entry
+	ConsistencyCheckerLastRun  hlc.Timestamp
 }
 
 // MergeTriggerHelperInput contains metadata required by the mergeTrigger.
@@ -1505,20 +1515,9 @@ func splitTriggerHelper(
 	// Copy the last consistency checker run timestamp from the LHS to the RHS.
 	// This avoids running the consistency checker on the RHS immediately after
 	// the split.
-	lastTS := hlc.Timestamp{}
-	// TODO(arul): instead of fetching the consistency checker timestamp here
-	// like this, we should instead pass it using the SplitTriggerHelperInput to
-	// make it easier to test.
-	if _, err := storage.MVCCGetProto(ctx, batch,
-		keys.QueueLastProcessedKey(split.LeftDesc.StartKey, "consistencyChecker"),
-		hlc.Timestamp{}, &lastTS, storage.MVCCGetOptions{}); err != nil {
-		return enginepb.MVCCStats{}, result.Result{}, errors.Wrap(err,
-			"unable to fetch the last consistency checker run for LHS")
-	}
-
 	if err := storage.MVCCPutProto(ctx, batch,
 		keys.QueueLastProcessedKey(split.RightDesc.StartKey, "consistencyChecker"),
-		hlc.Timestamp{}, &lastTS,
+		hlc.Timestamp{}, &in.ConsistencyCheckerLastRun,
 		storage.MVCCWriteOptions{Stats: h.AbsPostSplitRight(), Category: fs.BatchEvalReadCategory}); err != nil {
 		return enginepb.MVCCStats{}, result.Result{}, errors.Wrap(err,
 			"unable to copy the last consistency checker run to RHS")

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -959,6 +959,12 @@ func RunCommitTrigger(
 				ctx, errors.Wrap(err, "unable to load consistency checker last run"),
 			)
 		}
+		lastReplicaGCTS, err := rec.GetLastReplicaGCTimestamp(ctx)
+		if err != nil {
+			return result.Result{}, maybeWrapReplicaCorruptionError(
+				ctx, errors.Wrap(err, "unable to load last replica GC timestamp"),
+			)
+		}
 		in := SplitTriggerHelperInput{
 			LeftLease:                 lhsLease,
 			GCThreshold:              gcThreshold,
@@ -966,6 +972,7 @@ func RunCommitTrigger(
 			ReplicaVersion:           replicaVersion,
 			LHSAbortSpanEntries:      lhsAbortSpanEntries,
 			ConsistencyCheckerLastRun: consistencyCheckerLastRun,
+			LastReplicaGCTimestamp:    lastReplicaGCTS,
 		}
 
 		newMS, res, err := splitTrigger(
@@ -1393,6 +1400,7 @@ type SplitTriggerHelperInput struct {
 	ReplicaVersion             roachpb.Version
 	LHSAbortSpanEntries        []abortspan.Entry
 	ConsistencyCheckerLastRun  hlc.Timestamp
+	LastReplicaGCTimestamp      hlc.Timestamp
 }
 
 // MergeTriggerHelperInput contains metadata required by the mergeTrigger.
@@ -1427,16 +1435,11 @@ func splitTriggerHelper(
 
 	// Copy the last replica GC timestamp. This value is unreplicated,
 	// which is why the MVCC stats are set to nil on calls to
-	// MVCCBlindPutProto.
-	replicaGCTS, err := rec.GetLastReplicaGCTimestamp(ctx)
-	if err != nil {
-		return enginepb.MVCCStats{}, result.Result{}, errors.Wrap(err, "unable to fetch last replica GC timestamp")
-	}
-
-	if err := storage.MVCCBlindPutProto(
+	// MVCCPutProto.
+	if err := storage.MVCCPutProto(
 		ctx, spanset.DisableForbiddenSpanAssertions(batch),
 		keys.RangeLastReplicaGCTimestampKey(split.RightDesc.RangeID), hlc.Timestamp{},
-		&replicaGCTS, storage.MVCCWriteOptions{Category: fs.BatchEvalReadCategory}); err != nil {
+		&in.LastReplicaGCTimestamp, storage.MVCCWriteOptions{Category: fs.BatchEvalReadCategory}); err != nil {
 		return enginepb.MVCCStats{}, result.Result{}, errors.Wrap(err, "unable to copy last replica GC timestamp")
 	}
 
@@ -1480,6 +1483,7 @@ func splitTriggerHelper(
 
 	computeAccurateStats := (noPreComputedStats || manualSplit || emptyLeftOrRight || preComputedStatsDiff)
 	computeAccurateStats = computeAccurateStats && !shouldUseCrudeEstimates
+	var err error
 	if computeAccurateStats {
 		var reason redact.RedactableString
 		if noPreComputedStats {

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -977,10 +977,20 @@ func RunCommitTrigger(
 				ctx, errors.Wrap(err, "unable to load LHS prior read summary"),
 			)
 		}
+		rhsAbortSpanEntries, err := abortspan.New(mt.RightDesc.RangeID).Collect(
+			ctx, batch, txn.WriteTimestamp,
+			gc.TxnCleanupThreshold.Get(&rec.ClusterSettings().SV),
+		)
+		if err != nil {
+			return result.Result{}, maybeWrapReplicaCorruptionError(
+				ctx, errors.Wrap(err, "unable to collect RHS abort span entries"),
+			)
+		}
 		in := MergeTriggerHelperInput{
 			LHSGCHint:           lhsHint,
 			RHSGCHint:           rhsHint,
 			LHSPriorReadSummary: lhsPriorReadSummary,
+			RHSAbortSpanEntries: rhsAbortSpanEntries,
 		}
 		res, err := mergeTrigger(ctx, rec, batch, ms, mt, txn.WriteTimestamp, in)
 		if err != nil {
@@ -1366,9 +1376,10 @@ type SplitTriggerHelperInput struct {
 
 // MergeTriggerHelperInput contains metadata required by the mergeTrigger.
 type MergeTriggerHelperInput struct {
-	LHSGCHint          *roachpb.GCHint
-	RHSGCHint          *roachpb.GCHint
+	LHSGCHint           *roachpb.GCHint
+	RHSGCHint           *roachpb.GCHint
 	LHSPriorReadSummary *rspb.ReadSummary
+	RHSAbortSpanEntries []abortspan.Entry
 }
 
 // splitTriggerHelper continues the work begun by splitTrigger, but has a
@@ -1643,9 +1654,8 @@ func mergeTrigger(
 			desc.EndKey, merge.LeftDesc.EndKey)
 	}
 
-	if err := abortspan.New(merge.RightDesc.RangeID).CopyTo(
-		ctx, batch, batch, ms, ts, merge.LeftDesc.RangeID,
-		gc.TxnCleanupThreshold.Get(&rec.ClusterSettings().SV),
+	if err := abortspan.WriteTo(
+		ctx, batch, ms, merge.LeftDesc.RangeID, in.RHSAbortSpanEntries,
 	); err != nil {
 		return result.Result{}, err
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/lockspanset"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/readsummary"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/readsummary/rspb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -970,7 +971,17 @@ func RunCommitTrigger(
 				ctx, errors.Wrap(err, "unable to load RHS GCHint"),
 			)
 		}
-		in := MergeTriggerHelperInput{LHSGCHint: lhsHint, RHSGCHint: rhsHint}
+		lhsPriorReadSummary, err := readsummary.Load(ctx, batch, rec.GetRangeID())
+		if err != nil {
+			return result.Result{}, maybeWrapReplicaCorruptionError(
+				ctx, errors.Wrap(err, "unable to load LHS prior read summary"),
+			)
+		}
+		in := MergeTriggerHelperInput{
+			LHSGCHint:           lhsHint,
+			RHSGCHint:           rhsHint,
+			LHSPriorReadSummary: lhsPriorReadSummary,
+		}
 		res, err := mergeTrigger(ctx, rec, batch, ms, mt, txn.WriteTimestamp, in)
 		if err != nil {
 			return result.Result{}, maybeWrapReplicaCorruptionError(ctx, err)
@@ -1355,8 +1366,9 @@ type SplitTriggerHelperInput struct {
 
 // MergeTriggerHelperInput contains metadata required by the mergeTrigger.
 type MergeTriggerHelperInput struct {
-	LHSGCHint *roachpb.GCHint
-	RHSGCHint *roachpb.GCHint
+	LHSGCHint          *roachpb.GCHint
+	RHSGCHint          *roachpb.GCHint
+	LHSPriorReadSummary *rspb.ReadSummary
 }
 
 // splitTriggerHelper continues the work begun by splitTrigger, but has a
@@ -1659,10 +1671,8 @@ func mergeTrigger(
 	// not updated by the SubsumeRequest.
 	if merge.RightReadSummary != nil {
 		mergedSum := merge.RightReadSummary.Clone()
-		if priorSum, err := readsummary.Load(ctx, batch, rec.GetRangeID()); err != nil {
-			return result.Result{}, err
-		} else if priorSum != nil {
-			mergedSum.Merge(*priorSum)
+		if in.LHSPriorReadSummary != nil {
+			mergedSum.Merge(*in.LHSPriorReadSummary)
 		}
 		// Compress the persisted read summary, as it will likely never be needed.
 		mergedSum.Compress(0)

--- a/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
+++ b/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
@@ -418,6 +418,10 @@ func TestReplicaLifecycleDataDriven(t *testing.T) {
 				var ms enginepb.MVCCStats
 				_, err := batcheval.TestingMergeTrigger(
 					ctx, rec, batch, &ms, &merge, hlc.Timestamp{},
+					batcheval.MergeTriggerHelperInput{
+						LHSGCHint: &lhsRS.gcHint,
+						RHSGCHint: &rhsRS.gcHint,
+					},
 				)
 				require.NoError(t, err)
 

--- a/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
+++ b/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
@@ -420,12 +420,21 @@ func TestReplicaLifecycleDataDriven(t *testing.T) {
 				batch := tc.stateStorage.NewBatch()
 				rec := tc.makeEvalCtx(lhsRS, &lhsDesc)
 
+				// Collect the RHS abort span entries upfront, matching
+				// the pattern in RunCommitTrigger. Use a zero timestamp
+				// and duration so all entries are collected.
+				rhsAbortSpanEntries, err := rhsRS.abortspan.Collect(
+					ctx, tc.stateStorage, hlc.Timestamp{}, 0,
+				)
+				require.NoError(t, err)
+
 				var ms enginepb.MVCCStats
-				_, err := batcheval.TestingMergeTrigger(
+				_, err = batcheval.TestingMergeTrigger(
 					ctx, rec, batch, &ms, &merge, hlc.Timestamp{},
 					batcheval.MergeTriggerHelperInput{
-						LHSGCHint: &lhsRS.gcHint,
-						RHSGCHint: &rhsRS.gcHint,
+						LHSGCHint:           &lhsRS.gcHint,
+						RHSGCHint:           &rhsRS.gcHint,
+						RHSAbortSpanEntries: rhsAbortSpanEntries,
 					},
 				)
 				require.NoError(t, err)
@@ -718,12 +727,12 @@ func (tc *testCtx) makeEvalCtx(
 	rs *rangeState, desc *roachpb.RangeDescriptor,
 ) batcheval.EvalContext {
 	return (&batcheval.MockEvalCtx{
-		ClusterSettings:       tc.st,
-		Desc:                  desc,
-		Clock:                 tc.clock,
-		AbortSpan:             rs.abortspan,
+		ClusterSettings:        tc.st,
+		Desc:                   desc,
+		Clock:                  tc.clock,
+		AbortSpan:              rs.abortspan,
 		LastReplicaGCTimestamp: rs.lastGCTimestamp,
-		RangeLeaseDuration:    tc.rangeLeaseDuration,
+		RangeLeaseDuration:     tc.rangeLeaseDuration,
 	}).EvalContext()
 }
 

--- a/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
+++ b/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/uint128"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/errors"
@@ -103,6 +104,25 @@ import (
 //	context's state; if the replica doesn't exist, or a newer (higher ReplicaID)
 //	replica exists, it is considered destroyed.
 //
+// eval-merge lhs-range-id=<int> rhs-range-id=<int> [verbose]
+// ----
+//
+//	Evaluates a merge of the RHS range into the LHS range. The LHS and RHS
+//	ranges must be adjacent (LHS.EndKey == RHS.StartKey). This constructs a
+//	MergeTrigger, runs the merge trigger evaluation, and stashes the resulting
+//	batch representing the pending raft log command. The batch is NOT committed
+//	until the merge is applied. However, the in-memory range state is updated
+//	to reflect the merge -- the LHS widens to cover the RHS keyspace.
+//	Optionally, we print the evaluated batch if running with the verbose flag.
+//
+// apply-merge range-id=<int>
+// ----
+//
+//	Applies the pending merge for the specified (LHS) range using the stashed
+//	batch that was generated during merge evaluation. This also subsumes the
+//	RHS replica, removing its RangeID-local state from storage and installing
+//	a merge tombstone. The RHS range is removed from the test context.
+//
 // destroy-replica range-id=<int>
 // ----
 //
@@ -124,6 +144,13 @@ import (
 //	not nonsensical. If base-key is provided, it must lie within the range's
 //	boundaries and is used as the base key for generating range data; otherwise
 //	the range's start key is used.
+//
+// add-abortspan-entry range-id=<int> [num-entries=<int>]
+// ----
+//
+//	Adds one or more synthetic abortspan entries to the specified range.
+//	Each entry uses a unique deterministic txn ID. The number of entries
+//	defaults to 1.
 //
 // print-range-state [sort-keys=<bool>]
 // ----
@@ -274,14 +301,7 @@ func TestReplicaLifecycleDataDriven(t *testing.T) {
 				// raft log entry that will be applied as part of split
 				// application.
 				batch := tc.stateStorage.NewBatch()
-				rec := (&batcheval.MockEvalCtx{
-					ClusterSettings:        tc.st,
-					Desc:                   &desc,
-					Clock:                  tc.clock,
-					AbortSpan:              rs.abortspan,
-					LastReplicaGCTimestamp: rs.lastGCTimestamp,
-					RangeLeaseDuration:     tc.rangeLeaseDuration,
-				}).EvalContext()
+				rec := tc.makeEvalCtx(rs, &desc)
 
 				in := batcheval.SplitTriggerHelperInput{
 					LeftLease:      rs.lease,
@@ -365,6 +385,86 @@ func TestReplicaLifecycleDataDriven(t *testing.T) {
 						tc.updateReplicaStateFromStorage(t, ctx, rhsRangeState, stateBatch, raftBatch, false /* justCreated */)
 					}
 				})
+
+			case "eval-merge":
+				lhsRangeID := dd.ScanArg[roachpb.RangeID](t, d, "lhs-range-id")
+				rhsRangeID := dd.ScanArg[roachpb.RangeID](t, d, "rhs-range-id")
+				verbose := d.HasArg("verbose")
+				lhsRS := tc.mustGetRangeState(t, lhsRangeID)
+				rhsRS := tc.mustGetRangeState(t, rhsRangeID)
+				require.True(t,
+					lhsRS.desc.EndKey.Equal(rhsRS.desc.StartKey),
+					"ranges are not adjacent: lhs end key %s != rhs start key %s",
+					lhsRS.desc.EndKey, rhsRS.desc.StartKey,
+				)
+
+				lhsDesc := lhsRS.desc
+				mergedDesc := lhsDesc
+				mergedDesc.EndKey = rhsRS.desc.EndKey
+				// NB: LeftDesc in the MergeTrigger is the *post-merge*
+				// descriptor (with the widened EndKey), matching production
+				// behavior in AdminMerge. The EvalContext's Desc, on the other
+				// hand, is the original pre-merge LHS descriptor; mergeTrigger
+				// validates that the two are consistent (same StartKey,
+				// LeftDesc.EndKey > Desc.EndKey).
+				merge := roachpb.MergeTrigger{
+					LeftDesc:  mergedDesc,
+					RightDesc: rhsRS.desc,
+				}
+
+				batch := tc.stateStorage.NewBatch()
+				rec := tc.makeEvalCtx(lhsRS, &lhsDesc)
+
+				var ms enginepb.MVCCStats
+				_, err := batcheval.TestingMergeTrigger(
+					ctx, rec, batch, &ms, &merge, hlc.Timestamp{},
+				)
+				require.NoError(t, err)
+
+				batchRepr := batch.Repr()
+				tc.merges[lhsRangeID] = pendingMerge{
+					trigger:   merge,
+					batchRepr: batchRepr,
+				}
+				lhsRS.desc = mergedDesc
+				rhsRS.subsumed = true
+				batch.Close()
+
+				if verbose {
+					output, err := print.DecodeWriteBatch(batchRepr)
+					require.NoError(t, err)
+					return strings.ReplaceAll(output, "\n\n", "\n")
+				}
+				return fmt.Sprintf("merged: r%d [%s, %s) + r%d [%s, %s) -> r%d [%s, %s)",
+					lhsDesc.RangeID, lhsDesc.StartKey, lhsDesc.EndKey,
+					rhsRS.desc.RangeID, rhsRS.desc.StartKey, rhsRS.desc.EndKey,
+					mergedDesc.RangeID, mergedDesc.StartKey, mergedDesc.EndKey)
+
+			case "apply-merge":
+				rangeID := dd.ScanArg[roachpb.RangeID](t, d, "range-id")
+				pm, ok := tc.merges[rangeID]
+				require.True(t, ok, "pending merge not found for range-id %d", rangeID)
+				delete(tc.merges, rangeID)
+				merge := pm.trigger
+
+				rhsRS, ok := tc.ranges[merge.RightDesc.RangeID]
+				require.True(t, ok, "rhs range r%d not found", merge.RightDesc.RangeID)
+				require.True(t, rhsRS.subsumed, "rhs range r%d is not subsumed", merge.RightDesc.RangeID)
+				require.NotNil(t, rhsRS.replica, "rhs replica must exist for merge application")
+
+				output := tc.mutate(t, func(stateBatch, raftBatch storage.Batch) {
+					require.NoError(t, stateBatch.ApplyBatchRepr(pm.batchRepr, false /* sync */))
+					rw := kvstorage.ReadWriter{
+						State: kvstorage.WrapState(stateBatch),
+						Raft:  kvstorage.WrapRaft(raftBatch),
+					}
+					require.NoError(t, kvstorage.SubsumeReplica(ctx, rw, kvstorage.DestroyReplicaInfo{
+						FullReplicaID: rhsRS.replica.FullReplicaID,
+						Keys:          rhsRS.desc.RSpan(),
+					}))
+				})
+				delete(tc.ranges, merge.RightDesc.RangeID)
+				return output
 
 			case "destroy-replica":
 				rangeID := dd.ScanArg[roachpb.RangeID](t, d, "range-id")
@@ -460,6 +560,23 @@ func TestReplicaLifecycleDataDriven(t *testing.T) {
 					}
 				})
 
+			case "add-abortspan-entry":
+				rangeID := dd.ScanArg[roachpb.RangeID](t, d, "range-id")
+				numEntries := dd.ScanArgOr(t, d, "num-entries", 1)
+				rs := tc.mustGetRangeState(t, rangeID)
+				return tc.mutate(t, func(stateBatch, _ storage.Batch) {
+					for i := 0; i < numEntries; i++ {
+						txnID := uuid.FromUint128(uint128.FromInts(0, uint64(i+1)))
+						require.NoError(t, rs.abortspan.Put(ctx, stateBatch, nil, /* ms */
+							txnID, &roachpb.AbortSpanEntry{
+								Key:       rs.desc.StartKey.AsRawKey(),
+								Timestamp: hlc.Timestamp{WallTime: 10},
+								Priority:  100,
+							},
+						))
+					}
+				})
+
 			case "print-range-state":
 				var sb strings.Builder
 				if len(tc.ranges) == 0 {
@@ -504,6 +621,10 @@ type rangeState struct {
 	abortspan       *abortspan.AbortSpan
 	lastGCTimestamp hlc.Timestamp
 	replica         *replicaInfo // replica on n1/s1.
+	// subsumed is set to true when a merge has been evaluated but not yet
+	// applied. A subsumed range should not be operated on by any command
+	// other than apply-merge.
+	subsumed bool
 }
 
 // replicaInfo contains the basic info about a replica, used for managing its
@@ -527,6 +648,12 @@ type pendingSplit struct {
 	raftIndex kvpb.RaftIndex
 }
 
+// pendingMerge represents a merge that has been evaluated but not yet applied.
+type pendingMerge struct {
+	trigger   roachpb.MergeTrigger
+	batchRepr []byte
+}
+
 // testCtx is a single test's context. It tracks the state of all ranges and any
 // intermediate steps when performing replica lifecycle events.
 type testCtx struct {
@@ -537,6 +664,7 @@ type testCtx struct {
 	nextRangeID roachpb.RangeID // monotonically-increasing rangeID
 	ranges      map[roachpb.RangeID]*rangeState
 	splits      map[roachpb.RangeID]pendingSplit
+	merges      map[roachpb.RangeID]pendingMerge
 	// The storage engines correspond to a single store, (n1, s1). The engines
 	// are logically separated into two -- one for the state machine, and one
 	// for Raft.
@@ -559,9 +687,24 @@ func newTestCtx() *testCtx {
 		nextRangeID:  1,
 		ranges:       make(map[roachpb.RangeID]*rangeState),
 		splits:       make(map[roachpb.RangeID]pendingSplit),
+		merges:       make(map[roachpb.RangeID]pendingMerge),
 		stateStorage: storage.NewDefaultInMemForTesting(),
 		raftStorage:  storage.NewDefaultInMemForTesting(),
 	}
+}
+
+// makeEvalCtx constructs a batcheval.EvalContext for the given range.
+func (tc *testCtx) makeEvalCtx(
+	rs *rangeState, desc *roachpb.RangeDescriptor,
+) batcheval.EvalContext {
+	return (&batcheval.MockEvalCtx{
+		ClusterSettings:       tc.st,
+		Desc:                  desc,
+		Clock:                 tc.clock,
+		AbortSpan:             rs.abortspan,
+		LastReplicaGCTimestamp: rs.lastGCTimestamp,
+		RangeLeaseDuration:    tc.rangeLeaseDuration,
+	}).EvalContext()
 }
 
 // close closes the test context's storage engines.
@@ -704,10 +847,13 @@ func newRangeState(desc roachpb.RangeDescriptor) *rangeState {
 	}
 }
 
-// mustGetRangeState returns the range state for the given range ID.
+// mustGetRangeState returns the range state for the given range ID. It fails
+// the test if the range is subsumed — callers operating on a subsumed range
+// (e.g. apply-merge) should access tc.ranges directly.
 func (tc *testCtx) mustGetRangeState(t *testing.T, rangeID roachpb.RangeID) *rangeState {
 	rs, ok := tc.ranges[rangeID]
 	require.True(t, ok, "range-id %d not found", rangeID)
+	require.False(t, rs.subsumed, "range r%d is subsumed", rangeID)
 	return rs
 }
 

--- a/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
+++ b/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
@@ -152,6 +152,11 @@ import (
 //	Each entry uses a unique deterministic txn ID. The number of entries
 //	defaults to 1.
 //
+// set-gc-hint range-id=<int> [gc-timestamp=<int>] [gc-timestamp-next=<int>]
+// ----
+//
+//	Sets the in-memory GC hint for the specified range.
+//
 // print-range-state [sort-keys=<bool>]
 // ----
 //
@@ -580,6 +585,17 @@ func TestReplicaLifecycleDataDriven(t *testing.T) {
 						))
 					}
 				})
+
+			case "set-gc-hint":
+				rangeID := dd.ScanArg[roachpb.RangeID](t, d, "range-id")
+				rs := tc.mustGetRangeState(t, rangeID)
+				if ts, ok := dd.ScanArgOpt[int64](t, d, "gc-timestamp"); ok {
+					rs.gcHint.GCTimestamp = hlc.Timestamp{WallTime: ts}
+				}
+				if ts, ok := dd.ScanArgOpt[int64](t, d, "gc-timestamp-next"); ok {
+					rs.gcHint.GCTimestampNext = hlc.Timestamp{WallTime: ts}
+				}
+				return "ok"
 
 			case "print-range-state":
 				var sb strings.Builder

--- a/pkg/kv/kvserver/testdata/replica_lifecycle/merge.txt
+++ b/pkg/kv/kvserver/testdata/replica_lifecycle/merge.txt
@@ -1,0 +1,88 @@
+# Happy path: two adjacent initialized ranges merge into one.
+
+# Set up the LHS range.
+create-descriptor start=a end=m replicas=(1,2,3)
+----
+created descriptor: r1:{a-m} [(n1,s1):1, (n2,s2):2, (n3,s3):3, next=4, gen=0]
+
+create-replica range-id=1 initialized
+----
+created replica: (n1,s1):1
+state engine:
+Put: 0,0 /Local/RangeID/1/r/RangeLease (0x01698972726c6c2d00): <empty>
+Put: 0,0 /Local/RangeID/1/r/RangeGCThreshold (0x016989726c67632d00): 0,0
+Put: 0,0 /Local/RangeID/1/r/RangeGCHint (0x016989727267636800): latest_range_delete_timestamp:<> gc_timestamp:<> gc_timestamp_next:<> 
+Put: 0,0 /Local/RangeID/1/r/RangeVersion (0x016989727276657200): 10.8-upgrading-step-007
+Put: 0,0 /Local/RangeID/1/r/RangeAppliedState (0x016989727261736b00): raft_applied_index:10 lease_applied_index:10 range_stats:<sys_bytes:142 sys_count:4 > raft_closed_timestamp:<> raft_applied_index_term:5 
+Put: 0,0 /Local/RangeID/1/u/RaftReplicaID (0x016989757266747200): replica_id:1 
+log engine:
+Put: 0,0 /Local/RangeID/1/u/RaftHardState (0x016989757266746800): term:5 vote:0 commit:10 lead:0 lead_epoch:0 
+Put: 0,0 /Local/RangeID/1/u/RaftTruncatedState (0x016989757266747400): index:10 term:5 
+
+set-lease range-id=1 replica=1
+----
+ok
+
+# Set up the RHS range.
+create-descriptor start=m end=z replicas=(1,2,3)
+----
+created descriptor: r2:{m-z} [(n1,s1):1, (n2,s2):2, (n3,s3):3, next=4, gen=0]
+
+create-replica range-id=2 initialized
+----
+created replica: (n1,s1):1
+state engine:
+Put: 0,0 /Local/RangeID/2/r/RangeLease (0x01698a72726c6c2d00): <empty>
+Put: 0,0 /Local/RangeID/2/r/RangeGCThreshold (0x01698a726c67632d00): 0,0
+Put: 0,0 /Local/RangeID/2/r/RangeGCHint (0x01698a727267636800): latest_range_delete_timestamp:<> gc_timestamp:<> gc_timestamp_next:<> 
+Put: 0,0 /Local/RangeID/2/r/RangeVersion (0x01698a727276657200): 10.8-upgrading-step-007
+Put: 0,0 /Local/RangeID/2/r/RangeAppliedState (0x01698a727261736b00): raft_applied_index:10 lease_applied_index:10 range_stats:<sys_bytes:142 sys_count:4 > raft_closed_timestamp:<> raft_applied_index_term:5 
+Put: 0,0 /Local/RangeID/2/u/RaftReplicaID (0x01698a757266747200): replica_id:1 
+log engine:
+Put: 0,0 /Local/RangeID/2/u/RaftHardState (0x01698a757266746800): term:5 vote:0 commit:10 lead:0 lead_epoch:0 
+Put: 0,0 /Local/RangeID/2/u/RaftTruncatedState (0x01698a757266747400): index:10 term:5 
+
+set-lease range-id=2 replica=1
+----
+ok
+
+# Add some abortspan entries on the RHS. These should be copied to the LHS
+# during merge trigger evaluation.
+add-abortspan-entry range-id=2 num-entries=2
+----
+state engine:
+Put: 0,0 /Local/RangeID/2/r/AbortSpan/"00000000-0000-0000-0000-000000000001" (0x01698a726162632d1200ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff01000100): key:"m" timestamp:<wall_time:10 > priority:100 
+Put: 0,0 /Local/RangeID/2/r/AbortSpan/"00000000-0000-0000-0000-000000000002" (0x01698a726162632d1200ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff02000100): key:"m" timestamp:<wall_time:10 > priority:100 
+
+# Evaluate the merge of RHS into LHS.
+eval-merge lhs-range-id=1 rhs-range-id=2 verbose
+----
+Put: 0,0 /Local/RangeID/1/r/AbortSpan/"00000000-0000-0000-0000-000000000001" (0x016989726162632d1200ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff01000100): key:"m" timestamp:<wall_time:10 > priority:100 
+Put: 0,0 /Local/RangeID/1/r/AbortSpan/"00000000-0000-0000-0000-000000000002" (0x016989726162632d1200ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff02000100): key:"m" timestamp:<wall_time:10 > priority:100 
+
+# Apply the merge.
+apply-merge range-id=1
+----
+state engine:
+Put: 0,0 /Local/RangeID/1/r/AbortSpan/"00000000-0000-0000-0000-000000000001" (0x016989726162632d1200ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff01000100): key:"m" timestamp:<wall_time:10 > priority:100 
+Put: 0,0 /Local/RangeID/1/r/AbortSpan/"00000000-0000-0000-0000-000000000002" (0x016989726162632d1200ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff02000100): key:"m" timestamp:<wall_time:10 > priority:100 
+Delete (Sized at 71): 0,0 /Local/RangeID/2/r/AbortSpan/"00000000-0000-0000-0000-000000000001" (0x01698a726162632d1200ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff01000100): 
+Delete (Sized at 71): 0,0 /Local/RangeID/2/r/AbortSpan/"00000000-0000-0000-0000-000000000002" (0x01698a726162632d1200ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff02000100): 
+Delete (Sized at 28): 0,0 /Local/RangeID/2/r/RangeGCThreshold (0x01698a726c67632d00): 
+Delete (Sized at 43): 0,0 /Local/RangeID/2/r/RangeAppliedState (0x01698a727261736b00): 
+Delete (Sized at 34): 0,0 /Local/RangeID/2/r/RangeGCHint (0x01698a727267636800): 
+Delete (Sized at 44): 0,0 /Local/RangeID/2/r/RangeLease (0x01698a72726c6c2d00): 
+Delete (Sized at 36): 0,0 /Local/RangeID/2/r/RangeVersion (0x01698a727276657200): 
+Put: 0,0 /Local/RangeID/2/u/RangeTombstone (0x01698a757266746200): next_replica_id:2147483647 
+Delete: 0,0 /Local/RangeID/2/u/RaftReplicaID (0x01698a757266747200): 
+log engine:
+Delete (Sized at 38): 0,0 /Local/RangeID/2/u/RaftHardState (0x01698a757266746800): 
+Delete (Sized at 32): 0,0 /Local/RangeID/2/u/RaftTruncatedState (0x01698a757266747400): 
+
+# After the merge, only the LHS should remain, now spanning [a, z).
+# The RHS range should be gone from the test context.
+print-range-state
+----
+range desc: r1:{a-z} [(n1,s1):1, (n2,s2):2, (n3,s3):3, next=4, gen=0]
+		replica (n1/s1): id=1 HardState={Term:5,Vote:0,Commit:10} TruncatedState={Index:10,Term:5} LastIdx=10
+		lease: repl=(n1,s1):1 seq=0 start=0,0 type=LeaseLeader term=10 min-exp=0.000000100,0 pro=0,0 acq=Unspecified

--- a/pkg/kv/kvserver/testdata/replica_lifecycle/merge.txt
+++ b/pkg/kv/kvserver/testdata/replica_lifecycle/merge.txt
@@ -54,11 +54,19 @@ state engine:
 Put: 0,0 /Local/RangeID/2/r/AbortSpan/"00000000-0000-0000-0000-000000000001" (0x01698a726162632d1200ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff01000100): key:"m" timestamp:<wall_time:10 > priority:100 
 Put: 0,0 /Local/RangeID/2/r/AbortSpan/"00000000-0000-0000-0000-000000000002" (0x01698a726162632d1200ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff02000100): key:"m" timestamp:<wall_time:10 > priority:100 
 
+# Give the RHS a different GC hint so the merge produces a visible GCHint write.
+# The LHS has gc-timestamp=4 (default); with the RHS at gc-timestamp=8, the
+# merged hint should be gc-timestamp=4, gc-timestamp-next=8.
+set-gc-hint range-id=2 gc-timestamp=8
+----
+ok
+
 # Evaluate the merge of RHS into LHS.
 eval-merge lhs-range-id=1 rhs-range-id=2 verbose
 ----
 Put: 0,0 /Local/RangeID/1/r/AbortSpan/"00000000-0000-0000-0000-000000000001" (0x016989726162632d1200ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff01000100): key:"m" timestamp:<wall_time:10 > priority:100 
 Put: 0,0 /Local/RangeID/1/r/AbortSpan/"00000000-0000-0000-0000-000000000002" (0x016989726162632d1200ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff02000100): key:"m" timestamp:<wall_time:10 > priority:100 
+Put: 0,0 /Local/RangeID/1/r/RangeGCHint (0x016989727267636800): latest_range_delete_timestamp:<> gc_timestamp:<wall_time:4 > gc_timestamp_next:<wall_time:8 > 
 
 # Apply the merge.
 apply-merge range-id=1
@@ -66,6 +74,7 @@ apply-merge range-id=1
 state engine:
 Put: 0,0 /Local/RangeID/1/r/AbortSpan/"00000000-0000-0000-0000-000000000001" (0x016989726162632d1200ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff01000100): key:"m" timestamp:<wall_time:10 > priority:100 
 Put: 0,0 /Local/RangeID/1/r/AbortSpan/"00000000-0000-0000-0000-000000000002" (0x016989726162632d1200ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff02000100): key:"m" timestamp:<wall_time:10 > priority:100 
+Put: 0,0 /Local/RangeID/1/r/RangeGCHint (0x016989727267636800): latest_range_delete_timestamp:<> gc_timestamp:<wall_time:4 > gc_timestamp_next:<wall_time:8 > 
 Delete (Sized at 71): 0,0 /Local/RangeID/2/r/AbortSpan/"00000000-0000-0000-0000-000000000001" (0x01698a726162632d1200ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff01000100): 
 Delete (Sized at 71): 0,0 /Local/RangeID/2/r/AbortSpan/"00000000-0000-0000-0000-000000000002" (0x01698a726162632d1200ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff02000100): 
 Delete (Sized at 28): 0,0 /Local/RangeID/2/r/RangeGCThreshold (0x01698a726c67632d00): 


### PR DESCRIPTION
Builds on #164747 (split out from #163879 per review feedback).

Moves reads out of splitTrigger and mergeTrigger into RunCommitTrigger, passing the loaded values as explicit inputs. This makes the trigger helpers write-only, which is easier to test and reason about.

See individual commits for details.

Release note: None
Epic: none