### PR TITLE
kvserver,server: sep engines on server startup

### DIFF
--- a/pkg/kv/kvserver/kvstorage/datadriven_test.go
+++ b/pkg/kv/kvserver/kvstorage/datadriven_test.go
@@ -162,7 +162,7 @@ func TestDataDriven(t *testing.T) {
 				e.handleRangeTombstone(t, ctx, rangeID, nextID)
 
 			case "load-and-reconcile":
-				replicas, err := LoadAndReconcileReplicas(ctx, e.eng.TODOEngine())
+				replicas, err := LoadAndReconcileReplicas(ctx, e.eng)
 				if err != nil {
 					fmt.Fprintln(&buf, err)
 					break

--- a/pkg/kv/kvserver/kvstorage/datadriven_test.go
+++ b/pkg/kv/kvserver/kvstorage/datadriven_test.go
@@ -34,28 +34,37 @@ type env struct {
 	tr  *tracing.Tracer
 }
 
-func newEnv(t *testing.T) *env {
-	ctx := context.Background()
-	eng := MakeEngines(storage.NewDefaultInMemForTesting())
+func newEnv() *env {
+	tr := tracing.NewTracer()
+	tr.SetRedactable(true)
+	return &env{tr: tr}
+}
+
+func (e *env) maybeInit(t *testing.T, separated bool) {
+	if e.eng.StateEngine() != nil { // initialized
+		return
+	}
+	eng := storage.NewDefaultInMemForTesting()
+	if separated {
+		e.eng = MakeSeparatedEnginesForTesting(eng, eng)
+	} else {
+		e.eng = MakeEngines(eng)
+	}
 	// TODO(tbg): ideally this would do full bootstrap, which requires
 	// moving a lot more code from kvserver. But then we could unit test
 	// all of it with the datadriven harness!
-	require.NoError(t, eng.SetMinVersion(clusterversion.TestingClusterVersion))
-	require.NoError(t, InitEngine(ctx, eng, roachpb.StoreIdent{
+	require.NoError(t, e.eng.SetMinVersion(clusterversion.TestingClusterVersion))
+	require.NoError(t, InitEngine(context.Background(), e.eng, roachpb.StoreIdent{
 		ClusterID: uuid.MakeV4(),
 		NodeID:    1,
 		StoreID:   1,
 	}))
-	tr := tracing.NewTracer()
-	tr.SetRedactable(true)
-	return &env{
-		eng: eng,
-		tr:  tr,
-	}
 }
 
 func (e *env) close() {
-	e.eng.Close()
+	if e.eng.StateEngine() != nil { // initialized
+		e.eng.Close()
+	}
 	e.tr.Close()
 }
 
@@ -112,7 +121,7 @@ func TestDataDriven(t *testing.T) {
 
 	dir := filepath.Join(datapathutils.TestDataPath(t), t.Name())
 	datadriven.Walk(t, dir, func(t *testing.T, path string) {
-		e := newEnv(t)
+		e := newEnv()
 		defer e.close()
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) (output string) {
 			ctx, finishAndGet := tracing.ContextWithRecordingSpan(context.Background(), e.tr, path)
@@ -142,7 +151,12 @@ func TestDataDriven(t *testing.T) {
 			}()
 
 			switch d.Cmd {
+			case "init":
+				separated := dd.ScanArgOr(t, d, "separated", false)
+				e.maybeInit(t, separated)
+
 			case "new-replica":
+				e.maybeInit(t, false /* separated */)
 				rangeID := dd.ScanArg[roachpb.RangeID](t, d, "range-id")
 				replicaID := dd.ScanArgOr[roachpb.ReplicaID](t, d, "replica-id", 0)
 				k := dd.ScanArgOr(t, d, "k", "")
@@ -157,11 +171,13 @@ func TestDataDriven(t *testing.T) {
 				}
 
 			case "range-tombstone":
+				e.maybeInit(t, false /* separated */)
 				rangeID := dd.ScanArg[roachpb.RangeID](t, d, "range-id")
 				nextID := dd.ScanArg[roachpb.ReplicaID](t, d, "next-replica-id")
 				e.handleRangeTombstone(t, ctx, rangeID, nextID)
 
 			case "load-and-reconcile":
+				e.maybeInit(t, false /* separated */)
 				replicas, err := LoadAndReconcileReplicas(ctx, e.eng)
 				if err != nil {
 					fmt.Fprintln(&buf, err)

--- a/pkg/kv/kvserver/kvstorage/init.go
+++ b/pkg/kv/kvserver/kvstorage/init.go
@@ -86,21 +86,30 @@ func checkCanInitializeEngine(ctx context.Context, eng Engines) error {
 	// keys that cannot be parsed as MVCCKeys (e.g. lock table keys) in the
 	// engine.
 	// TODO(pav-kv): verify this is actually true, attempt removing this quirk.
-	return CheckEngineKeys(ctx, eng.TODOEngine(), func(k storage.MVCCKey) error {
+	check := func(k storage.MVCCKey) error {
 		if _, err := keys.DecodeStoreCachedSettingsKey(k.Key); err != nil {
 			return errors.Errorf("engine cannot be bootstrapped, contains key:\n%s", k.String())
 		}
 		return nil
-	})
+	}
+	if eng.Separated() {
+		return CheckEngineKeys(ctx, eng.StateEngine(), check)
+	}
+	return CheckEngineKeys(ctx, eng.LogEngine(), check)
 }
 
 // CheckEngineKeys iterates the Engine that is expected to be mostly empty. Some
 // callers allow certain keys to be present in partially initialized engines, so
 // this information is given to the caller via a callback for validation.
 func CheckEngineKeys(
-	ctx context.Context, r storage.Reader, allowed func(key storage.MVCCKey) error,
+	ctx context.Context, eng storage.Engine, allowed func(key storage.MVCCKey) error,
 ) error {
-	iter, err := r.NewEngineIterator(ctx, storage.IterOptions{
+	// Disable engine access assertions since we are iterating the entirety of the
+	// engine without trying to target specific key subsets. The caller knows what
+	// they are doing.
+	eng = disableAccessAssertions(eng)
+
+	iter, err := eng.NewEngineIterator(ctx, storage.IterOptions{
 		KeyTypes:   storage.IterKeyTypePointsAndRanges,
 		UpperBound: roachpb.KeyMax,
 	})

--- a/pkg/kv/kvserver/kvstorage/init.go
+++ b/pkg/kv/kvserver/kvstorage/init.go
@@ -443,7 +443,7 @@ func (r Replica) ID() roachpb.FullReplicaID {
 
 // Load loads the state necessary to instantiate a replica in memory.
 func (r Replica) Load(
-	ctx context.Context, eng storage.Reader, storeID roachpb.StoreID,
+	ctx context.Context, stateRO StateRO, raftRO RaftRO, storeID roachpb.StoreID,
 ) (LoadedReplicaState, error) {
 	ls := LoadedReplicaState{
 		ReplicaID: r.ReplicaID,
@@ -451,13 +451,13 @@ func (r Replica) Load(
 	}
 	sl := MakeStateLoader(r.Desc.RangeID)
 	var err error
-	if ls.TruncState, err = sl.LoadRaftTruncatedState(ctx, eng); err != nil {
+	if ls.TruncState, err = sl.LoadRaftTruncatedState(ctx, raftRO); err != nil {
 		return LoadedReplicaState{}, err
 	}
-	if ls.LastEntryID, err = sl.LoadLastEntryID(ctx, eng, ls.TruncState); err != nil {
+	if ls.LastEntryID, err = sl.LoadLastEntryID(ctx, raftRO, ls.TruncState); err != nil {
 		return LoadedReplicaState{}, err
 	}
-	if ls.ReplState, err = sl.Load(ctx, eng, r.Desc); err != nil {
+	if ls.ReplState, err = sl.Load(ctx, stateRO, r.Desc); err != nil {
 		return LoadedReplicaState{}, err
 	}
 

--- a/pkg/kv/kvserver/kvstorage/init.go
+++ b/pkg/kv/kvserver/kvstorage/init.go
@@ -227,13 +227,12 @@ func iterateRangeIDKeys(
 	return iterErr
 }
 
-// ReadStoreIdent reads the StoreIdent from the store.
-// It returns *NotBootstrappedError if the ident is missing (meaning that the
-// store needs to be bootstrapped).
-func ReadStoreIdent(ctx context.Context, eng storage.Engine) (roachpb.StoreIdent, error) {
+// ReadStoreIdent reads the StoreIdent. Returns *NotBootstrappedError if the
+// ident is missing, meaning that the store still needs to be bootstrapped.
+func ReadStoreIdent(ctx context.Context, r storage.Reader) (roachpb.StoreIdent, error) {
 	var ident roachpb.StoreIdent
 	ok, err := storage.MVCCGetProto(
-		ctx, eng, keys.StoreIdentKey(), hlc.Timestamp{}, &ident, storage.MVCCGetOptions{})
+		ctx, r, keys.StoreIdentKey(), hlc.Timestamp{}, &ident, storage.MVCCGetOptions{})
 	if err != nil {
 		return roachpb.StoreIdent{}, err
 	} else if !ok {

--- a/pkg/kv/kvserver/kvstorage/init.go
+++ b/pkg/kv/kvserver/kvstorage/init.go
@@ -85,7 +85,21 @@ func checkCanInitializeEngine(ctx context.Context, eng storage.Engine) error {
 	// settings, but nothing else. Use EngineIterator to ensure that there are no
 	// keys that cannot be parsed as MVCCKeys (e.g. lock table keys) in the
 	// engine.
-	iter, err := eng.NewEngineIterator(ctx, storage.IterOptions{
+	return CheckEngineKeys(ctx, eng, func(k storage.MVCCKey) error {
+		if _, err := keys.DecodeStoreCachedSettingsKey(k.Key); err != nil {
+			return errors.Errorf("engine cannot be bootstrapped, contains key:\n%s", k.String())
+		}
+		return nil
+	})
+}
+
+// CheckEngineKeys iterates the Engine that is expected to be mostly empty. Some
+// callers allow certain keys to be present in partially initialized engines, so
+// this information is given to the caller via a callback for validation.
+func CheckEngineKeys(
+	ctx context.Context, r storage.Reader, allowed func(key storage.MVCCKey) error,
+) error {
+	iter, err := r.NewEngineIterator(ctx, storage.IterOptions{
 		KeyTypes:   storage.IterKeyTypePointsAndRanges,
 		UpperBound: roachpb.KeyMax,
 	})
@@ -98,6 +112,7 @@ func checkCanInitializeEngine(ctx context.Context, eng storage.Engine) error {
 		return err
 	}
 
+	// NB: only MVCC point keys are possibly allowed in an empty engine.
 	getMVCCKey := func() (storage.MVCCKey, error) {
 		if _, hasRange := iter.HasPointAndRange(); hasRange {
 			bounds, err := iter.EngineRangeBounds()
@@ -106,27 +121,21 @@ func checkCanInitializeEngine(ctx context.Context, eng storage.Engine) error {
 			}
 			return storage.MVCCKey{}, errors.Errorf("found mvcc range key: %s", bounds)
 		}
-		var k storage.EngineKey
-		k, err = iter.EngineKey()
+		k, err := iter.EngineKey()
 		if err != nil {
 			return storage.MVCCKey{}, err
-		}
-		if !k.IsMVCCKey() {
+		} else if !k.IsMVCCKey() {
 			return storage.MVCCKey{}, errors.Errorf("found non-mvcc key: %s", k)
 		}
 		return k.ToMVCCKey()
 	}
 
-	for valid {
-		var k storage.MVCCKey
-		if k, err = getMVCCKey(); err != nil {
+	for ; valid; valid, err = iter.NextEngineKey() {
+		if k, err := getMVCCKey(); err != nil {
+			return err
+		} else if err := allowed(k); err != nil {
 			return err
 		}
-		// Only allowed to find cached cluster settings on an uninitialized engine.
-		if _, err := keys.DecodeStoreCachedSettingsKey(k.Key); err != nil {
-			return errors.Errorf("engine cannot be bootstrapped, contains key:\n%s", k.String())
-		}
-		valid, err = iter.NextEngineKey()
 	}
 	return err
 }

--- a/pkg/kv/kvserver/kvstorage/init.go
+++ b/pkg/kv/kvserver/kvstorage/init.go
@@ -56,18 +56,10 @@ func InitEngine(ctx context.Context, eng Engines, ident roachpb.StoreIdent) erro
 	}
 
 	batch := eng.LogEngine().NewBatch()
-	if err := storage.MVCCPutProto(
-		ctx,
-		batch,
-		keys.StoreIdentKey(),
-		hlc.Timestamp{},
-		&ident,
-		storage.MVCCWriteOptions{},
-	); err != nil {
-		batch.Close()
-		return err
-	}
-	if err := batch.Commit(true /* sync */); err != nil {
+	defer batch.Close()
+	if err := WriteStoreIdent(ctx, batch, ident); err != nil {
+		return errors.Wrap(err, "writing StoreIdent")
+	} else if err := batch.Commit(true /* sync */); err != nil {
 		return errors.Wrap(err, "persisting engine initialization data")
 	}
 	// We will set the store ID during start, but we want to set it as quickly as
@@ -239,6 +231,14 @@ func ReadStoreIdent(ctx context.Context, r storage.Reader) (roachpb.StoreIdent, 
 		return roachpb.StoreIdent{}, &NotBootstrappedError{}
 	}
 	return ident, err
+}
+
+// WriteStoreIdent writes the StoreIdent to storage.
+func WriteStoreIdent(ctx context.Context, rw storage.ReadWriter, ident roachpb.StoreIdent) error {
+	return storage.MVCCPutProto(
+		ctx, rw, keys.StoreIdentKey(),
+		hlc.Timestamp{}, &ident, storage.MVCCWriteOptions{},
+	)
 }
 
 // IterateRangeDescriptorsFromDisk discovers the initialized replicas and calls

--- a/pkg/kv/kvserver/kvstorage/init.go
+++ b/pkg/kv/kvserver/kvstorage/init.go
@@ -501,7 +501,7 @@ func (m replicaMap) setDesc(rangeID roachpb.RangeID, desc roachpb.RangeDescripto
 	return nil
 }
 
-func loadReplicas(ctx context.Context, eng storage.Engine) ([]Replica, error) {
+func loadReplicas(ctx context.Context, eng Engines) ([]Replica, error) {
 	s := replicaMap{}
 
 	// INVARIANT: the latest visible committed version of the RangeDescriptor
@@ -512,7 +512,7 @@ func loadReplicas(ctx context.Context, eng storage.Engine) ([]Replica, error) {
 	{
 		var lastDesc roachpb.RangeDescriptor
 		if err := IterateRangeDescriptorsFromDisk(
-			ctx, eng, func(desc roachpb.RangeDescriptor) error {
+			ctx, eng.StateEngine(), func(desc roachpb.RangeDescriptor) error {
 				if lastDesc.RangeID != 0 && desc.StartKey.Less(lastDesc.EndKey) {
 					return errors.AssertionFailedf("overlapping descriptors %s and %s", lastDesc, desc)
 				}
@@ -540,7 +540,34 @@ func loadReplicas(ctx context.Context, eng storage.Engine) ([]Replica, error) {
 	// entire raft state (i.e. HardState, TruncatedState, Log).
 	logEvery := log.Every(10 * time.Second)
 	var i int
-	if err := iterateRangeIDKeys(ctx, eng, func(id roachpb.RangeID, get readKeyFn) error {
+
+	// If engines are separated, scan the LogEngine to learn the HardState of each
+	// replica. Otherwise, it will be loaded as part of the other loop below.
+	if eng.Separated() {
+		logEng := disableAccessAssertions(eng.LogEngine())
+		if err := iterateRangeIDKeys(ctx, logEng, func(id roachpb.RangeID, get readKeyFn) error {
+			if logEvery.ShouldLog() && i > 0 { // only log if slow
+				log.KvExec.Infof(ctx, "loaded raft state for %d/%d replicas", i, len(s))
+			}
+			i++
+			var hs raftpb.HardState
+			if ok, err := get(keys.RaftHardStateKey(id), &hs); err != nil {
+				return err
+			} else if ok {
+				s.setHardState(id, hs)
+			}
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+		log.KvExec.Infof(ctx, "loaded raft state for %d/%d replicas", len(s), len(s))
+		i = 0 // reset counter for the second scan
+	}
+
+	// Scan the StateEngine to learn RangeTombstone and RaftReplicaID keys. If
+	// engines are not separated, also read the HardState keys.
+	stateEng := disableAccessAssertions(eng.StateEngine())
+	if err := iterateRangeIDKeys(ctx, stateEng, func(id roachpb.RangeID, get readKeyFn) error {
 		if logEvery.ShouldLog() && i > 0 { // only log if slow
 			log.KvExec.Infof(ctx, "loaded state for %d/%d replicas", i, len(s))
 		}
@@ -554,11 +581,13 @@ func loadReplicas(ctx context.Context, eng storage.Engine) ([]Replica, error) {
 			ts = kvserverpb.RangeTombstone{} // just in case it was mutated
 		}
 		// NB: the keys must be requested in sorted order here.
-		var hs raftpb.HardState
-		if ok, err := get(buf.RaftHardStateKey(), &hs); err != nil {
-			return err
-		} else if ok {
-			s.setHardState(id, hs)
+		if !eng.Separated() {
+			var hs raftpb.HardState
+			if ok, err := get(buf.RaftHardStateKey(), &hs); err != nil {
+				return err
+			} else if ok {
+				s.setHardState(id, hs)
+			}
 		}
 		// NB: the keys must be requested in sorted order here.
 		var rID kvserverpb.RaftReplicaID
@@ -581,13 +610,14 @@ func loadReplicas(ctx context.Context, eng storage.Engine) ([]Replica, error) {
 	return sl, nil
 }
 
-// LoadAndReconcileReplicas loads the Replicas present on this
-// store. It reconciles inconsistent state and runs validation checks.
-// The returned slice is sorted by ReplicaID.
+// LoadAndReconcileReplicas loads the Replicas present on this store from the
+// engine(s). It reconciles inconsistent state and runs validation checks. The
+// returned slice is sorted by ReplicaID.
 //
 // TODO(sep-raft-log): consider a callback-visitor pattern here.
-func LoadAndReconcileReplicas(ctx context.Context, eng storage.Engine) ([]Replica, error) {
-	ident, err := ReadStoreIdent(ctx, eng)
+// TODO(sep-raft-log): implement WAG replay.
+func LoadAndReconcileReplicas(ctx context.Context, eng Engines) ([]Replica, error) {
+	ident, err := ReadStoreIdent(ctx, eng.LogEngine())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kv/kvserver/kvstorage/init.go
+++ b/pkg/kv/kvserver/kvstorage/init.go
@@ -51,7 +51,7 @@ func InitEngine(ctx context.Context, eng Engines, ident roachpb.StoreIdent) erro
 		return err
 	}
 
-	if err := checkCanInitializeEngine(ctx, eng.TODOEngine()); err != nil {
+	if err := checkCanInitializeEngine(ctx, eng); err != nil {
 		return errors.Wrap(err, "while trying to initialize engine")
 	}
 
@@ -73,9 +73,9 @@ func InitEngine(ctx context.Context, eng Engines, ident roachpb.StoreIdent) erro
 
 // checkCanInitializeEngine ensures that the engine is empty except possibly for
 // cluster version or cached cluster settings.
-func checkCanInitializeEngine(ctx context.Context, eng storage.Engine) error {
+func checkCanInitializeEngine(ctx context.Context, eng Engines) error {
 	// See if this is an already-bootstrapped store.
-	ident, err := ReadStoreIdent(ctx, eng)
+	ident, err := ReadStoreIdent(ctx, eng.LogEngine())
 	if err == nil {
 		return errors.Errorf("engine already initialized as %s", ident.String())
 	} else if !errors.HasType(err, (*NotBootstrappedError)(nil)) {
@@ -85,7 +85,8 @@ func checkCanInitializeEngine(ctx context.Context, eng storage.Engine) error {
 	// settings, but nothing else. Use EngineIterator to ensure that there are no
 	// keys that cannot be parsed as MVCCKeys (e.g. lock table keys) in the
 	// engine.
-	return CheckEngineKeys(ctx, eng, func(k storage.MVCCKey) error {
+	// TODO(pav-kv): verify this is actually true, attempt removing this quirk.
+	return CheckEngineKeys(ctx, eng.TODOEngine(), func(k storage.MVCCKey) error {
 		if _, err := keys.DecodeStoreCachedSettingsKey(k.Key); err != nil {
 			return errors.Errorf("engine cannot be bootstrapped, contains key:\n%s", k.String())
 		}

--- a/pkg/kv/kvserver/kvstorage/init_test.go
+++ b/pkg/kv/kvserver/kvstorage/init_test.go
@@ -20,8 +20,32 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/stretchr/testify/require"
 )
+
+// TestStoreIdent verifies that WriteStoreIdent and ReadStoreIdent work
+// correctly as a pair.
+func TestStoreIdent(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	eng := storage.NewDefaultInMemForTesting()
+	defer eng.Close()
+
+	// Reading from uninitialized storage should return NotBootstrappedError.
+	_, err := ReadStoreIdent(ctx, eng)
+	require.Error(t, err)
+	require.ErrorIs(t, err, &NotBootstrappedError{})
+
+	// Write a StoreIdent and verify we can read it back.
+	ident := roachpb.StoreIdent{ClusterID: uuid.MakeV4(), NodeID: 42, StoreID: 7}
+	require.NoError(t, WriteStoreIdent(ctx, eng, ident))
+	got, err := ReadStoreIdent(ctx, eng)
+	require.NoError(t, err)
+	require.Equal(t, ident, got)
+}
 
 // TestIterateRangeIDKeys lays down a number of RangeTombstone and ReplicaID
 // keys (at keys.RangeTombstoneKey and keys.RaftReplicaIDKey) interspersed with

--- a/pkg/kv/kvserver/kvstorage/storage.go
+++ b/pkg/kv/kvserver/kvstorage/storage.go
@@ -496,3 +496,11 @@ type batchWrapper interface {
 	WrapWriteBatch(storage.WriteBatch) storage.WriteBatch
 	WrapBatch(storage.Batch) storage.Batch
 }
+
+// disableAccessAssertions strips the engine from the access assertion wrapper.
+func disableAccessAssertions(eng storage.Engine) storage.Engine {
+	if !spanset.EnableAssertions {
+		return eng
+	}
+	return eng.(interface{ UnderlyingEngine() storage.Engine }).UnderlyingEngine()
+}

--- a/pkg/kv/kvserver/kvstorage/testdata/TestDataDriven/init_separated
+++ b/pkg/kv/kvserver/kvstorage/testdata/TestDataDriven/init_separated
@@ -1,0 +1,38 @@
+# This test is identical to "init", but uses separated engines.
+init separated=true
+----
+ok
+
+# Uninitialized replica. Expect this to stay around and be returned as such.
+new-replica range-id=6 replica-id=60
+----
+ok
+
+# Initialized replica with a replica ID.
+new-replica range-id=8 replica-id=80 k=c ek=f
+----
+r8:{c-f} [(n1,s1):80, next=81, gen=0]
+
+# Load the replicas.
+load-and-reconcile trace=true
+----
+r6/60: uninitialized
+r8/80: r8:{c-f} [(n1,s1):80, next=81, gen=0]
+beginning range descriptor iteration
+range descriptor iteration done: 1 range descriptors, 0 intents, 0 tombstones; stats: <redacted>
+loaded raft state for 2/2 replicas
+loaded state for 2/2 replicas
+loaded 2 replicas
+verified 2/2 replicas
+
+# Idempotency.
+load-and-reconcile trace=true
+----
+r6/60: uninitialized
+r8/80: r8:{c-f} [(n1,s1):80, next=81, gen=0]
+beginning range descriptor iteration
+range descriptor iteration done: 1 range descriptors, 0 intents, 0 tombstones; stats: <redacted>
+loaded raft state for 2/2 replicas
+loaded state for 2/2 replicas
+loaded 2 replicas
+verified 2/2 replicas

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -256,10 +256,6 @@ func (i *EngineIterator) Close() {
 
 // SeekEngineKeyGE is part of the storage.EngineIterator interface.
 func (i *EngineIterator) SeekEngineKeyGE(key storage.EngineKey) (valid bool, err error) {
-	valid, err = i.i.SeekEngineKeyGE(key)
-	if !valid {
-		return valid, err
-	}
 	if key.IsMVCCKey() && !i.spansOnly {
 		mvccKey, _ := key.ToMVCCKey()
 		if err := i.spans.CheckAllowedAt(SpanReadOnly, TrickySpan{Key: mvccKey.Key}, i.ts); err != nil {
@@ -268,15 +264,11 @@ func (i *EngineIterator) SeekEngineKeyGE(key storage.EngineKey) (valid bool, err
 	} else if err = i.spans.CheckAllowed(SpanReadOnly, TrickySpan{Key: key.Key}); err != nil {
 		return false, err
 	}
-	return valid, err
+	return i.i.SeekEngineKeyGE(key)
 }
 
 // SeekEngineKeyLT is part of the storage.EngineIterator interface.
 func (i *EngineIterator) SeekEngineKeyLT(key storage.EngineKey) (valid bool, err error) {
-	valid, err = i.i.SeekEngineKeyLT(key)
-	if !valid {
-		return valid, err
-	}
 	if key.IsMVCCKey() && !i.spansOnly {
 		mvccKey, _ := key.ToMVCCKey()
 		if err := i.spans.CheckAllowedAt(SpanReadOnly, TrickySpan{Key: mvccKey.Key}, i.ts); err != nil {
@@ -285,7 +277,7 @@ func (i *EngineIterator) SeekEngineKeyLT(key storage.EngineKey) (valid bool, err
 	} else if err = i.spans.CheckAllowed(SpanReadOnly, TrickySpan{EndKey: key.Key}); err != nil {
 		return false, err
 	}
-	return valid, err
+	return i.i.SeekEngineKeyLT(key)
 }
 
 // NextEngineKey is part of the storage.EngineIterator interface.

--- a/pkg/kv/kvserver/spanset/engine.go
+++ b/pkg/kv/kvserver/spanset/engine.go
@@ -48,6 +48,11 @@ func NewEngine(engine storage.Engine, forbiddenMatcher func(TrickySpan) error) s
 	}
 }
 
+// UnderlyingEngine returns the raw engine, with disabled assertions.
+func (s *spanSetEngine) UnderlyingEngine() storage.Engine {
+	return s.e
+}
+
 // NewBatch implements the storage.EngineWithoutRW interface.
 func (s *spanSetEngine) NewBatch() storage.Batch {
 	return NewBatch(s.e.NewBatch(), s.spans)

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2301,10 +2301,7 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 	// concurrently. Note that while we can perform this initialization
 	// concurrently, all initialization must be performed before we start
 	// listening for Raft messages and starting the process Raft loop.
-	//
-	// TODO(sep-raft-log): this will need to learn to stitch and reconcile data from
-	// both engines.
-	repls, err := kvstorage.LoadAndReconcileReplicas(ctx, s.TODOEngine())
+	repls, err := kvstorage.LoadAndReconcileReplicas(ctx, s.internalEngines)
 	if err != nil {
 		return err
 	}

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2318,7 +2318,7 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 			continue
 		}
 		// TODO(pavelkalinnikov): integrate into kvstorage.LoadAndReconcileReplicas.
-		state, err := repl.Load(ctx, s.TODOEngine(), s.StoreID())
+		state, err := repl.Load(ctx, s.StateEngine(), s.LogEngine(), s.StoreID())
 		if err != nil {
 			return err
 		}

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -530,12 +530,16 @@ func (s *initServer) initializeFirstStoreAfterJoin(
 func assertEnginesEmpty(engines []kvstorage.Engines) error {
 	// TODO(sumeer): plumb a context if necessary.
 	ctx := context.Background()
+	check := func(_ storage.MVCCKey) error {
+		return errors.New("engine is not empty")
+	}
 	for _, eng := range engines {
-		if err := kvstorage.CheckEngineKeys(ctx, eng.TODOEngine(),
-			func(_ storage.MVCCKey) error {
-				return errors.New("engine is not empty")
-			},
-		); err != nil {
+		if eng.Separated() {
+			if err := kvstorage.CheckEngineKeys(ctx, eng.StateEngine(), check); err != nil {
+				return err
+			}
+		}
+		if err := kvstorage.CheckEngineKeys(ctx, eng.LogEngine(), check); err != nil {
 			return err
 		}
 	}

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -530,26 +530,12 @@ func (s *initServer) initializeFirstStoreAfterJoin(
 func assertEnginesEmpty(engines []kvstorage.Engines) error {
 	// TODO(sumeer): plumb a context if necessary.
 	ctx := context.Background()
-
-	assertEmpty := func(eng kvstorage.Engines) error {
-		iter, err := eng.TODOEngine().NewEngineIterator(ctx, storage.IterOptions{
-			KeyTypes:   storage.IterKeyTypePointsAndRanges,
-			UpperBound: roachpb.KeyMax,
-		})
-		if err != nil {
-			return err
-		}
-		defer iter.Close()
-
-		valid, err := iter.SeekEngineKeyGE(storage.EngineKey{Key: roachpb.KeyMin})
-		if valid && err == nil {
-			return errors.New("engine is not empty")
-		}
-		return err
-	}
-
-	for _, engine := range engines {
-		if err := assertEmpty(engine); err != nil {
+	for _, eng := range engines {
+		if err := kvstorage.CheckEngineKeys(ctx, eng.TODOEngine(),
+			func(_ storage.MVCCKey) error {
+				return errors.New("engine is not empty")
+			},
+		); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This PR refactors replica loading code to support separated engines (`LogEngine` and `StateEngine`).

**Infrastructure Refactoring:**
- Factored out `StoreIdent` reading and writing into dedicated helper functions
- Extracted empty engine iteration logic into reusable `IterEmptyEngine` function
- Modified `StoreIdent` reading to support `LogEngine`
- Strengthened assertions in `spanset` to catch incorrect usage earlier

**Replica Loading:**
- Modified `LoadAndReconcileReplicas` to handle separated engines by reading `HardState` from `LogEngine` and other replica keys from `StateEngine`
- Updated `Replica.Load` to work with separated engines
- Added `TestDataDriven/init_separated` test covering separated engine loading

**Engine Verification:**
- Enhanced `assertEnginesEmpty` to verify emptiness of both engines when separated
- Added validation that both engines are properly initialized or empty

Part of #97627