### PR TITLE
tree: prevent double type annotation for FuncExpr in AnnotateTypeExpr

### DIFF
--- a/pkg/ccl/changefeedccl/cdceval/validation_test.go
+++ b/pkg/ccl/changefeedccl/cdceval/validation_test.go
@@ -206,6 +206,29 @@ func TestNormalizeAndValidate(t *testing.T) {
 			stmt:      "SELECT *, cdc_prev() FROM foo AS bar",
 			expectErr: `unknown function: cdc_prev()`,
 		},
+		{ // Regression for #147573: type-annotated CDC timestamp functions should
+			// not produce double type annotations after normalization.
+			name:       "statement_timestamp type annotation",
+			desc:       fooDesc,
+			stmt:       "SELECT *, statement_timestamp():::TIMESTAMP FROM foo",
+			expectStmt: "SELECT *, statement_timestamp():::TIMESTAMP FROM foo",
+		},
+		{ // Regression for #147573: event_op has no ambiguous return type, but
+			// the shared cdcFnProps pointer was mutated by cdcTimestampBuiltin
+			// functions (which have preferred overloads), causing event_op to
+			// incorrectly get AmbiguousReturnType and a spurious :::STRING
+			// annotation.
+			name:       "event_op no spurious type annotation",
+			desc:       fooDesc,
+			stmt:       "SELECT *, event_op() FROM foo",
+			expectStmt: "SELECT *, event_op() FROM foo",
+		},
+		{ // Regression for #147573: same as above but with TIMESTAMPTZ.
+			name:       "statement_timestamp timestamptz annotation",
+			desc:       fooDesc,
+			stmt:       "SELECT *, statement_timestamp():::TIMESTAMPTZ FROM foo",
+			expectStmt: "SELECT *, statement_timestamp():::TIMESTAMPTZ FROM foo",
+		},
 		{ // Regression for #115245
 			name:      "changefeed_creation_timestamp",
 			desc:      fooDesc,
@@ -248,8 +271,21 @@ func TestNormalizeAndValidate(t *testing.T) {
 			require.Equal(t, tc.expectStmt, serialized)
 
 			// Make sure we can deserialize back.
-			_, err = ParseChangefeedExpression(serialized)
+			sc2, err := ParseChangefeedExpression(serialized)
 			require.NoError(t, err)
+
+			// Verify that re-normalizing the deserialized expression produces
+			// the same result (idempotent round-trip). This catches bugs where
+			// normalization adds spurious type annotations that accumulate on
+			// each round-trip.
+			norm2, _, _, err := normalizeAndPlan(
+				ctx, &execCfg, username.RootUserName(), defaultDBSessionData,
+				tc.desc, schemaTS, target, sc2, tc.splitColFams,
+			)
+			require.NoError(t, err)
+			serialized2 := AsStringUnredacted(norm2)
+			require.Equal(t, serialized, serialized2,
+				"expression is not stable across round-trips")
 		})
 	}
 }

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -1646,6 +1646,15 @@ func (node *AnnotateTypeExpr) Format(ctx *FmtCtx) {
 				return
 			}
 		}
+		// Similarly, FuncExpr.Format adds its own :::TYPE annotation when
+		// FmtParsable is set and the function has AmbiguousReturnType. Skip
+		// the AnnotateTypeExpr annotation to prevent double type annotation,
+		// which can cause type-check errors on re-parse.
+		if funcExpr, ok := node.Expr.(*FuncExpr); ok {
+			if ctx.HasFlags(FmtParsable) && funcExpr.typ != nil && funcExpr.fnProps != nil && funcExpr.fnProps.AmbiguousReturnType {
+				return
+			}
+		}
 		ctx.WriteString(":::")
 		ctx.FormatTypeReference(node.Type)
 

--- a/pkg/sql/sem/tree/function_definition.go
+++ b/pkg/sql/sem/tree/function_definition.go
@@ -174,22 +174,24 @@ func NewFunctionDefinition(
 ) *FunctionDefinition {
 	overloads := make([]*Overload, len(def))
 
+	// Copy props to avoid mutating the caller's pointer.
+	propsCopy := *props
 	for i := range def {
 		if def[i].OverloadPreference == OverloadPreferencePreferred {
 			// Builtins with a preferred overload are always ambiguous.
-			props.AmbiguousReturnType = true
+			propsCopy.AmbiguousReturnType = true
 			break
 		}
 	}
 
 	for i := range def {
-		def[i].FunctionProperties = *props
+		def[i].FunctionProperties = propsCopy
 		overloads[i] = &def[i]
 	}
 	return &FunctionDefinition{
 		Name:               name,
 		Definition:         overloads,
-		FunctionProperties: *props,
+		FunctionProperties: propsCopy,
 	}
 }
 


### PR DESCRIPTION
When a FuncExpr with AmbiguousReturnType (e.g., statement_timestamp with preferred overloads) is wrapped in an AnnotateTypeExpr (:::TYPE) and has been type-checked, both FuncExpr.Format and AnnotateTypeExpr.Format add :::TYPE annotations under FmtParsable, producing a double annotation like `statement_timestamp():::TIMESTAMP:::TIMESTAMP`. This grows on each serialize/deserialize round-trip and can cause type-check errors when types don't match.

Fix AnnotateTypeExpr.Format to skip its annotation when the inner FuncExpr already provides one, following the same pattern already used for Array expressions. Also fix NewFunctionDefinition to copy the input FunctionProperties before mutating AmbiguousReturnType, preventing mutation of shared pointers like cdcFnProps.

Fixes: #147573