### PR TITLE
catalog/rewrite: drop FK mutations with missing referenced tables during restore

### DIFF
--- a/pkg/backup/testdata/backup-restore/skip-missing-fks
+++ b/pkg/backup/testdata/backup-restore/skip-missing-fks
@@ -1,0 +1,216 @@
+# Test that foreign key mutations with missing referenced tables are properly
+# dropped during restore when skip_missing_foreign_keys is used.
+#
+# Regression test: previously, outbound FKs in table.OutboundFKs were correctly
+# dropped when their referenced table was missing, but FK constraints still
+# in table.Mutations (from an in-progress schema change) were left with stale
+# ReferencedTableIDs, causing catalog corruption.
+
+subtest fk-mutation-with-missing-referenced-table
+
+new-cluster name=s1
+----
+
+exec-sql
+CREATE DATABASE d;
+USE d;
+CREATE TABLE parent (id INT PRIMARY KEY) WITH (schema_locked = false);
+CREATE TABLE child (id INT PRIMARY KEY, parent_id INT) WITH (schema_locked = false);
+INSERT INTO parent VALUES (1), (2), (3);
+INSERT INTO child VALUES (1, 1), (2, 2);
+----
+
+# Use the legacy schema changer so the FK addition goes through
+# table.Mutations rather than the declarative schema changer elements.
+exec-sql
+SET use_declarative_schema_changer = 'off';
+----
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = 'schemachanger.before.exec';
+----
+
+# Start adding a foreign key constraint. The pausepoint will keep it as
+# a pending mutation in the table descriptor.
+schema-change expect-pausepoint tag=sc
+ALTER TABLE d.child ADD CONSTRAINT fk_parent FOREIGN KEY (parent_id) REFERENCES d.parent(id);
+----
+job paused at pausepoint
+
+# Verify the child table descriptor has a FK mutation.
+let $child_id
+SELECT id FROM system.namespace WHERE name = 'child' AND "parentID" != 0 AND "parentSchemaID" != 0;
+----
+
+query-sql
+SELECT
+  json_array_length(
+    COALESCE(
+      crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', descriptor)->'table'->'mutations',
+      '[]'
+    )
+  )
+FROM system.descriptor
+WHERE id = $child_id;
+----
+1
+
+# Clear the pausepoint so backup can run.
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = '';
+----
+
+exec-sql
+BACKUP DATABASE d INTO 'nodelocal://1/test-backup';
+----
+
+# Restore only the child table (without parent) into a new database,
+# using skip_missing_foreign_keys. The existing outbound FK should be
+# dropped, and the in-progress FK mutation should also be dropped.
+exec-sql
+CREATE DATABASE d2;
+----
+
+exec-sql
+RESTORE TABLE d.child FROM LATEST IN 'nodelocal://1/test-backup' WITH into_db = 'd2', skip_missing_foreign_keys;
+----
+
+# Verify the restored child table has no FK mutations left. Without the
+# fix, the mutation would still reference the old (now nonexistent) parent
+# table ID, corrupting the catalog.
+let $restored_child_id
+SELECT id FROM system.namespace WHERE name = 'child' AND "parentID" = (SELECT id FROM system.namespace WHERE name = 'd2' AND "parentID" = 0);
+----
+
+query-sql
+SELECT
+  json_array_length(
+    COALESCE(
+      crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', descriptor)->'table'->'mutations',
+      '[]'
+    )
+  )
+FROM system.descriptor
+WHERE id = $restored_child_id;
+----
+0
+
+# Also verify no outbound FKs exist on the restored table.
+query-sql
+SELECT
+  json_array_length(
+    COALESCE(
+      crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', descriptor)->'table'->'outboundFks',
+      '[]'
+    )
+  )
+FROM system.descriptor
+WHERE id = $restored_child_id;
+----
+0
+
+# Verify the table is usable.
+query-sql
+SELECT * FROM d2.child ORDER BY id;
+----
+1 1
+2 2
+
+subtest end
+
+subtest fk-mutation-with-missing-referenced-table-dsc
+
+new-cluster name=s2
+----
+
+exec-sql
+CREATE DATABASE d;
+USE d;
+CREATE TABLE parent (id INT PRIMARY KEY);
+CREATE TABLE child (id INT PRIMARY KEY, parent_id INT);
+INSERT INTO parent VALUES (1), (2), (3);
+INSERT INTO child VALUES (1, 1), (2, 2);
+----
+
+# Use the declarative schema changer so the FK addition goes through
+# DeclarativeSchemaChangerState targets rather than table.Mutations.
+exec-sql
+SET use_declarative_schema_changer = 'on';
+----
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = 'newschemachanger.before.exec';
+----
+
+# Start adding a foreign key constraint. The pausepoint will keep it as
+# a pending target in the declarative schema changer state.
+new-schema-change expect-pausepoint
+ALTER TABLE d.child ADD CONSTRAINT fk_parent FOREIGN KEY (parent_id) REFERENCES d.parent(id);
+----
+job paused at pausepoint
+
+# Verify the child table descriptor has declarative schema changer state
+# with targets.
+let $child_id
+SELECT id FROM system.namespace WHERE name = 'child' AND "parentID" != 0 AND "parentSchemaID" != 0;
+----
+
+query-sql
+SELECT
+  json_array_length(
+    COALESCE(
+      crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', descriptor)->'table'->'declarativeSchemaChangerState'->'targets',
+      '[]'
+    )
+  ) > 0
+FROM system.descriptor
+WHERE id = $child_id;
+----
+true
+
+# Clear the pausepoint so backup can run.
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = '';
+----
+
+exec-sql
+BACKUP DATABASE d INTO 'nodelocal://1/test-backup-dsc';
+----
+
+# Restore only the child table (without parent) into a new database,
+# using skip_missing_foreign_keys. This should handle the FK target
+# in the declarative schema changer state.
+exec-sql
+CREATE DATABASE d2;
+----
+
+exec-sql
+RESTORE TABLE d.child FROM LATEST IN 'nodelocal://1/test-backup-dsc' WITH into_db = 'd2', skip_missing_foreign_keys;
+----
+
+# Also verify no outbound FKs exist on the restored table.
+let $restored_child_id
+SELECT id FROM system.namespace WHERE name = 'child' AND "parentID" = (SELECT id FROM system.namespace WHERE name = 'd2' AND "parentID" = 0);
+----
+
+query-sql
+SELECT
+  json_array_length(
+    COALESCE(
+      crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', descriptor)->'table'->'outboundFks',
+      '[]'
+    )
+  )
+FROM system.descriptor
+WHERE id = $restored_child_id;
+----
+0
+
+# Verify the table is usable.
+query-sql
+SELECT * FROM d2.child ORDER BY id;
+----
+1 1
+2 2
+
+subtest end

--- a/pkg/sql/catalog/rewrite/rewrite.go
+++ b/pkg/sql/catalog/rewrite/rewrite.go
@@ -187,13 +187,38 @@ func TableDescs(
 			// we update the FK to point to it?
 			table.OutboundFKs = append(table.OutboundFKs, *fk)
 		}
-		for idx := range table.Mutations {
-			if c := table.Mutations[idx].GetConstraint(); c != nil &&
+		origMutations := table.Mutations
+		table.Mutations = table.Mutations[:0]
+		for idx := range origMutations {
+			if c := origMutations[idx].GetConstraint(); c != nil &&
 				c.ConstraintType == descpb.ConstraintToUpdate_FOREIGN_KEY {
 				fk := &c.ForeignKey
 				if rewriteOfReferencedTable, ok := descriptorRewrites[fk.ReferencedTableID]; ok {
 					fk.ReferencedTableID = rewriteOfReferencedTable.ID
 					fk.OriginTableID = tableRewrite.ID
+				} else {
+					// The referenced table is not being restored. If the user
+					// specified skip_missing_foreign_keys, drop this mutation.
+					// Error checking for the case where the user did not specify
+					// the option has already been done in allocateDescriptorRewrites.
+					continue
+				}
+			}
+			table.Mutations = append(table.Mutations, origMutations[idx])
+		}
+		// Clean up MutationJobs entries for mutation IDs that no longer
+		// have any corresponding mutations (e.g. because we dropped FK
+		// mutations above).
+		if len(table.Mutations) < len(origMutations) {
+			remainingMutIDs := make(map[descpb.MutationID]struct{})
+			for i := range table.Mutations {
+				remainingMutIDs[table.Mutations[i].MutationID] = struct{}{}
+			}
+			origMutJobs := table.MutationJobs
+			table.MutationJobs = table.MutationJobs[:0]
+			for i := range origMutJobs {
+				if _, ok := remainingMutIDs[origMutJobs[i].MutationID]; ok {
+					table.MutationJobs = append(table.MutationJobs, origMutJobs[i])
 				}
 			}
 		}
@@ -1068,6 +1093,22 @@ func rewriteSchemaChangerState(
 				_, scExists := descriptorRewrites[el.SchemaID]
 				if !scExists && state.CurrentStatuses[i] == scpb.Status_ABSENT {
 					removeElementAtCurrentIdx()
+					continue
+				}
+			case *scpb.ForeignKeyConstraint:
+				// If the referenced table is missing, drop this FK constraint
+				// element. This mirrors the skip_missing_foreign_keys handling
+				// for legacy schema changer mutations in TableDescs.
+				if el.ReferencedTableID == missingID {
+					removeElementAtCurrentIdx()
+					droppedConstraints.Add(el.ConstraintID)
+					continue
+				}
+			case *scpb.ForeignKeyConstraintUnvalidated:
+				// Same handling as ForeignKeyConstraint for unvalidated FKs.
+				if el.ReferencedTableID == missingID {
+					removeElementAtCurrentIdx()
+					droppedConstraints.Add(el.ConstraintID)
 					continue
 				}
 			case *scpb.CheckConstraint:


### PR DESCRIPTION
Previously, when restoring with `skip_missing_foreign_keys`, outbound
foreign keys in `table.OutboundFKs` were correctly dropped if their
referenced table was missing. However, FK constraints still in-progress
via schema changes were not handled:

1. Legacy schema changer: FK constraints in `table.Mutations` were left
   with stale `ReferencedTableID` and `OriginTableID` values, causing
   descriptor validation errors.
2. Declarative schema changer: `ForeignKeyConstraint` elements in
   `DeclarativeSchemaChangerState` had no error handler case, causing
   the restore to fail with a "missing rewrite for id" error.

Now, both paths are handled:
- Legacy: FK constraint mutations whose referenced table is missing are
  dropped from `table.Mutations`, and corresponding `MutationJobs`
  entries are cleaned up.
- Declarative: `ForeignKeyConstraint` and
  `ForeignKeyConstraintUnvalidated` elements with missing referenced
  tables are removed, and their constraint IDs are recorded in
  `droppedConstraints` so sibling elements are also cleaned up.

Resolves: https://github.com/cockroachdb/cockroach/issues/164752

Release note (bug fix): Fixed a bug where `RESTORE` with
`skip_missing_foreign_keys` would fail with an internal error if the
table being restored had an in-progress schema change adding a foreign
key constraint whose referenced table was not included in the restore.