### PR TITLE
dbconsole: add InternalDB field for SQL execution

### DIFF
--- a/pkg/server/api_v2.go
+++ b/pkg/server/api_v2.go
@@ -132,7 +132,9 @@ func newAPIV2Server(ctx context.Context, opts *apiV2ServerOpts) http.Handler {
 			systemStatus: systemStatus,
 		}
 		dbconsoleAPI := &dbconsole.ApiV2DBConsole{
-			Status: systemStatus.statusServer,
+			Status:     systemStatus.statusServer,
+			Admin:      systemAdmin.adminServer,
+			InternalDB: opts.sqlServer.internalDB,
 		}
 		registerRoutes(innerMux, authMux, inner, a, dbconsoleAPI)
 		return a
@@ -147,7 +149,8 @@ func newAPIV2Server(ctx context.Context, opts *apiV2ServerOpts) http.Handler {
 			db:               opts.db,
 		}
 		dbconsoleAPI := &dbconsole.ApiV2DBConsole{
-			Status: a.status,
+			Status:     a.status,
+			InternalDB: opts.sqlServer.internalDB,
 		}
 		registerRoutes(innerMux, authMux, a, a, dbconsoleAPI)
 		return a

--- a/pkg/server/dbconsole/BUILD.bazel
+++ b/pkg/server/dbconsole/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//pkg/server/authserver",
         "//pkg/server/serverpb",
         "//pkg/server/srverrors",
+        "//pkg/sql/isql",
     ],
 )
 

--- a/pkg/server/dbconsole/dbconsole.go
+++ b/pkg/server/dbconsole/dbconsole.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/authserver"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/srverrors"
+	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 )
 
 // StatusAPI defines the status methods used by dbconsole.
@@ -33,9 +34,14 @@ type StatusAPI interface {
 	NodesUI(ctx context.Context, req *serverpb.NodesRequest) (*serverpb.NodesResponseExternal, error)
 }
 
+// AdminAPI defines admin methods used by dbconsole
+type AdminAPI interface{}
+
 // ApiV2DBConsole implements the DB Console BFF API endpoints.
 type ApiV2DBConsole struct {
-	Status StatusAPI
+	Status     StatusAPI
+	Admin      AdminAPI
+	InternalDB isql.DB
 }
 
 // NodeInfo contains summarized node information for the UI.


### PR DESCRIPTION
Add an isql.DB field to ApiV2DBConsole to enable upcoming BFF endpoints to execute SQL queries server-side. Wire the field through both initialization paths in api_v2.go.

This is pure plumbing — no new endpoints or behavioral changes.

Epic: CRDB-58145
Release note: None