### PR TITLE
mmaprototype: plumb node CPU in MakeStoreLoadMsg

### DIFF
--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
@@ -903,7 +903,20 @@ func newStoreState() *storeState {
 type nodeState struct {
 	stores []roachpb.StoreID
 	NodeLoad
-	// NB: adjustedCPU can be negative.
+	// adjustedCPU starts at NodeCPULoad (physical node CPU) and is
+	// adjusted by pending change deltas, mirroring how storeState.adjusted.load
+	// tracks pending changes on top of reportedLoad. The deltas are in
+	// store-level modeled CPU units while NodeCPULoad is physical — a known
+	// imprecision accepted because the delta is small and transient.
+	// TODO(wenyihu6): fix this by introducing physical load modeling.
+	//
+	// Only CPU is tracked at the node level because CPU is a shared physical
+	// resource across all stores on a node: if any store saturates the CPU,
+	// the whole node is affected. Other dimensions (WriteBandwidth, ByteSize)
+	// are per-store (each store has its own disk) and only need store-level
+	// overload detection.
+	//
+	// NB: can be negative.
 	adjustedCPU LoadValue
 }
 
@@ -1368,11 +1381,21 @@ func (cs *clusterState) processStoreLoadMsg(
 	if ss == nil {
 		panic(fmt.Sprintf("store %d not found", storeMsg.StoreID))
 	}
-	ns.ReportedCPU += storeMsg.Load[CPURate] - ss.reportedLoad[CPURate]
-	ns.CapacityCPU += storeMsg.Capacity[CPURate] - ss.capacity[CPURate]
-	// Undo the adjustment for the store. We will apply the adjustment again
-	// below.
-	ns.adjustedCPU += storeMsg.Load[CPURate] - ss.adjusted.load[CPURate]
+	// Update adjustedCPU (= NodeCPULoad + sum of pending deltas across all
+	// stores on this node). NodeCPULoad is a node-level physical value carried
+	// in every store's message; each store generates its descriptor
+	// independently, so the values may differ slightly across stores on the
+	// same node. For simplicity, we overwrite with the latest one received.
+	//
+	// For a single-store node we could simply set adjustedCPU =
+	// storeMsg.NodeCPULoad and let the loop below re-apply pending deltas.
+	// With multiple stores we must preserve other stores' pending deltas,
+	// so we incrementally adjust for the baseline shift and strip only this
+	// store's pending delta.
+	storePendingDelta := ss.adjusted.load[CPURate] - ss.reportedLoad[CPURate]
+	ns.adjustedCPU += (storeMsg.NodeCPULoad - ns.NodeCPULoad) - storePendingDelta
+	ns.NodeCPULoad = storeMsg.NodeCPULoad
+	ns.NodeCPUCapacity = storeMsg.NodeCPUCapacity
 
 	// The store's load sequence number is incremented on each load change. The
 	// store's load is updated below.
@@ -2400,11 +2423,6 @@ func (cs *clusterState) canShedAndAddLoad(
 	// Add the delta.
 	deltaToAdd := loadVectorToAdd(delta)
 	targetSS.adjusted.load.add(deltaToAdd)
-	// TODO(tbg): why does NodeLoad have an adjustedCPU field but not fields for
-	// the other load dimensions? We just added deltaToAdd to targetSS.adjusted,
-	// shouldn't this be wholly reflected in targetNS as well, not just for CPU?
-	// Or maybe CPU is the only dimension that matters at the node level. It feels
-	// sloppy/confusing though.
 	targetNS.adjustedCPU += deltaToAdd[CPURate]
 	targetSLS := computeLoadSummary(ctx, targetSS, targetNS, &means.storeLoad, &means.nodeLoad)
 	postTransferHighDiskSpaceUtil := highDiskSpaceUtilization(targetSS.adjusted.load[ByteSize],
@@ -2643,7 +2661,15 @@ func computeLoadSummary(
 		}
 		dimSummary[i] = ls
 	}
-	nls := loadSummaryForDimension(ctx, storeIDForLogging, ns.NodeID, CPURate, ns.adjustedCPU, ns.CapacityCPU, mnl.loadCPU, mnl.utilCPU)
+	// Use adjustedCPU for node-level overload detection. It starts at
+	// NodeCPULoad (physical) and is adjusted by pending change deltas (in
+	// store-level modeled CPU units — a known imprecision accepted because the
+	// delta is small and transient).
+	//
+	// TODO(wenyihu6): the unit mismatch between physical NodeCPULoad and
+	// store-level pending deltas will be resolved with the introduction of
+	// physical load modeling.
+	nls := loadSummaryForDimension(ctx, storeIDForLogging, ns.NodeID, CPURate, ns.adjustedCPU, ns.NodeCPUCapacity, mnl.loadCPU, mnl.utilCPU)
 	return storeLoadSummary{
 		worstDim:                   worstDim,
 		sls:                        sls,

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_test.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_test.go
@@ -121,6 +121,7 @@ func parseStatusFromArgs(t *testing.T, d *datadriven.TestData, status *Status) {
 
 func parseStoreLoadMsg(t *testing.T, in string) StoreLoadMsg {
 	var msg StoreLoadMsg
+	hasNodeCPULoad, hasNodeCPUCapacity := false, false
 	for _, v := range strings.Fields(in) {
 		parts := strings.Split(v, "=")
 		require.Len(t, parts, 2)
@@ -144,9 +145,24 @@ func parseStoreLoadMsg(t *testing.T, in string) StoreLoadMsg {
 			msg.LoadTime = testingBaseTime.Add(duration)
 		case "secondary-load":
 			msg.SecondaryLoad = parseSecondaryLoadVector(t, parts[1])
+		case "node-cpu-load":
+			msg.NodeCPULoad = LoadValue(parseInt(t, parts[1]))
+			hasNodeCPULoad = true
+		case "node-cpu-capacity":
+			msg.NodeCPUCapacity = LoadValue(parseInt(t, parts[1]))
+			hasNodeCPUCapacity = true
 		default:
 			t.Fatalf("Unknown argument: %s", parts[0])
 		}
+	}
+	// Default node-level CPU to store-level CPU values. This is correct for
+	// single-store-per-node setups (the common case). Multi-store tests
+	// should specify these fields explicitly.
+	if !hasNodeCPULoad {
+		msg.NodeCPULoad = msg.Load[CPURate]
+	}
+	if !hasNodeCPUCapacity {
+		msg.NodeCPUCapacity = msg.Capacity[CPURate]
 	}
 	return msg
 }
@@ -491,7 +507,7 @@ func TestClusterState(t *testing.T) {
 						fmt.Fprintf(&buf,
 							"store-id=%v node-id=%v status=%s reported=%v adjusted=%v node-reported-cpu=%v node-adjusted-cpu=%v seq"+
 								"=%d\n",
-							ss.StoreID, ss.NodeID, ss.status, ss.reportedLoad, ss.adjusted.load, ns.ReportedCPU, ns.adjustedCPU,
+							ss.StoreID, ss.NodeID, ss.status, ss.reportedLoad, ss.adjusted.load, ns.NodeCPULoad, ns.adjustedCPU,
 							ss.loadSeqNum,
 						)
 						var localStores []roachpb.StoreID

--- a/pkg/kv/kvserver/allocator/mmaprototype/load.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/load.go
@@ -215,10 +215,14 @@ type storeLoad struct {
 // NodeLoad is the load information for a node.
 type NodeLoad struct {
 	NodeID roachpb.NodeID
-	// ReportedCPU and CapacityCPU are simply the sum of what we get for all
-	// stores on this node.
-	ReportedCPU LoadValue
-	CapacityCPU LoadValue
+	// NodeCPULoad and NodeCPUCapacity are the physical node-level CPU values
+	// (NodeCPURateUsage and NodeCPURateCapacity), set directly from
+	// StoreLoadMsg rather than derived from store sums. These are used for
+	// node-level overload detection because the capped multiplier model
+	// breaks the invariant sum(store loads)/sum(store capacities) = cpuUtil
+	// when background CPU exceeds the cap. See computeCPUCapacityWithCap.
+	NodeCPULoad     LoadValue
+	NodeCPUCapacity LoadValue
 }
 
 // The mean store load for a set of stores.
@@ -483,8 +487,8 @@ func computeMeansForStoreSet(
 
 	n = len(scratchNodes)
 	for _, nl := range scratchNodes {
-		means.nodeLoad.loadCPU += nl.ReportedCPU
-		means.nodeLoad.capacityCPU += nl.CapacityCPU
+		means.nodeLoad.loadCPU += nl.NodeCPULoad
+		means.nodeLoad.capacityCPU += nl.NodeCPUCapacity
 	}
 	// NB: capacityCPU can be 0 if all nodes report 0 store CPU capacity.
 	means.nodeLoad.utilCPU =
@@ -749,8 +753,8 @@ var _ = storeLoad{}.reportedLoad
 var _ = storeLoad{}.capacity
 var _ = storeLoad{}.reportedSecondaryLoad
 var _ = NodeLoad{}.NodeID
-var _ = NodeLoad{}.ReportedCPU
-var _ = NodeLoad{}.CapacityCPU
+var _ = NodeLoad{}.NodeCPULoad
+var _ = NodeLoad{}.NodeCPUCapacity
 var _ = CPURate
 var _ = WriteBandwidth
 var _ = ByteSize

--- a/pkg/kv/kvserver/allocator/mmaprototype/load_test.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/load_test.go
@@ -104,9 +104,9 @@ func TestMeansMemo(t *testing.T) {
 
 			case "node-load":
 				nLoad := &NodeLoad{
-					NodeID:      dd.ScanArg[roachpb.NodeID](t, d, "node-id"),
-					ReportedCPU: dd.ScanArg[LoadValue](t, d, "cpu-load"),
-					CapacityCPU: dd.ScanArg[LoadValue](t, d, "cpu-capacity"),
+					NodeID:          dd.ScanArg[roachpb.NodeID](t, d, "node-id"),
+					NodeCPULoad:     dd.ScanArg[LoadValue](t, d, "cpu-load"),
+					NodeCPUCapacity: dd.ScanArg[LoadValue](t, d, "cpu-capacity"),
 				}
 				loadProvider.nloads[nLoad.NodeID] = nLoad
 				return ""

--- a/pkg/kv/kvserver/allocator/mmaprototype/messages.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/messages.go
@@ -19,12 +19,20 @@ type StoreLoadMsg struct {
 	roachpb.StoreID
 
 	Load LoadVector
-	// Capacity[CPURate] is derived based on considering the aggregate usage
-	// across all stores, and using the utilization observed at the node, to
-	// derive a node level capacity, and then dividing that by the number of
-	// stores.
+	// Capacity[CPURate] is derived using a capped multiplier model that
+	// subtracts background CPU and divides by the multiplier and number of
+	// stores. See computeCPUCapacityWithCap for details.
 	Capacity      LoadVector
 	SecondaryLoad SecondaryLoadVector
+
+	// NodeCPULoad and NodeCPUCapacity carry the physical node-level CPU
+	// values (NodeCPURateUsage and NodeCPURateCapacity in ns/s). These are
+	// needed because the capped multiplier model breaks the invariant
+	// sum(store loads)/sum(store capacities) = NodeCPURateUsage/NodeCPURateCapacity
+	// when background CPU exceeds the cap. Node-level overload detection
+	// uses these values directly instead of summing store-level CPU.
+	NodeCPULoad     LoadValue
+	NodeCPUCapacity LoadValue
 
 	LoadTime time.Time
 }

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica_local_stores.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica_local_stores.txt
@@ -161,7 +161,7 @@ change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80ns/s, write-bandw
 
 # Store load msg from s2, showing its new load.
 store-load-msg
-  store-id=2 node-id=1 load=[80,80,80] capacity=[100,100,100] secondary-load=1 load-time=15s
+  store-id=2 node-id=1 load=[80,80,80] capacity=[100,100,100] secondary-load=1 load-time=15s node-cpu-load=160 node-cpu-capacity=200
 ----
 
 # The adjusted load on s2 reflects both the reported load and the addition of
@@ -176,7 +176,7 @@ store-id=2 node-id=1 status=ok accepting all reported=[cpu:80ns/s, write-bandwid
 # Store load msg from s2 at time 16s, which is 11s after the enactment of
 # change 1. So the change is no longer needed for load adjustment.
 store-load-msg
-  store-id=2 node-id=1 load=[80,80,80] capacity=[100,100,100] secondary-load=1 load-time=16s
+  store-id=2 node-id=1 load=[80,80,80] capacity=[100,100,100] secondary-load=1 load-time=16s node-cpu-load=160 node-cpu-capacity=200
 ----
 
 # We are no longer tracking change 1 for the sake of load.
@@ -239,7 +239,7 @@ store-id=2 node-id=1 status=ok accepting all reported=[cpu:80ns/s, write-bandwid
 
 # Store load msg from s2, showing its new load.
 store-load-msg
-  store-id=2 node-id=1 load=[85,85,85] capacity=[100,100,100] secondary-load=1 load-time=20s
+  store-id=2 node-id=1 load=[85,85,85] capacity=[100,100,100] secondary-load=1 load-time=20s node-cpu-load=165 node-cpu-capacity=200
 ----
 
 get-load-info
@@ -256,7 +256,7 @@ t=40s
 # longer needed for load adjustment since load-time is 20s after the enactment
 # time (and lagForChangeReflectedInLoad is 10s).
 store-load-msg
-  store-id=1 node-id=1 load=[5,5,5] capacity=[100,100,100] secondary-load=1 load-time=40s
+  store-id=1 node-id=1 load=[5,5,5] capacity=[100,100,100] secondary-load=1 load-time=40s node-cpu-load=90 node-cpu-capacity=200
 ----
 
 # No longer tracking change 2 for the sake of load.

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_lateral.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_lateral.txt
@@ -27,8 +27,8 @@ node-id=3 locality-tiers=node=3
 store-load-msg
   store-id=1 node-id=1 load=[100,20000000,0] capacity=[1000,100000000,1000] secondary-load=0 load-time=0s
   store-id=2 node-id=2 load=[100,20000000,0] capacity=[1000,100000000,1000] secondary-load=0 load-time=0s
-  store-id=3 node-id=3 load=[50,80000000,0] capacity=[1000,100000000,1000] secondary-load=0 load-time=0s
-  store-id=4 node-id=3 load=[50,10000000,0] capacity=[1000,100000000,1000] secondary-load=0 load-time=0s
+  store-id=3 node-id=3 load=[50,80000000,0] capacity=[1000,100000000,1000] secondary-load=0 load-time=0s node-cpu-load=100 node-cpu-capacity=2000
+  store-id=4 node-id=3 load=[50,10000000,0] capacity=[1000,100000000,1000] secondary-load=0 load-time=0s node-cpu-load=100 node-cpu-capacity=2000
 ----
 
 store-leaseholder-msg

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_nls_sls_mismatch.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_nls_sls_mismatch.txt
@@ -48,8 +48,8 @@ ok refusing=replicas
 # Node mean = (7B + 1B) / 2 = 4B
 # n1's 7B is 75% above mean => overloadSlow for node CPU
 store-load-msg
-  store-id=1 node-id=1 load=[1000000000,50000000,0] capacity=[8000000000,100000000,1000000000] secondary-load=0 load-time=0s
-  store-id=2 node-id=1 load=[6000000000,10000000,0] capacity=[8000000000,100000000,1000000000] secondary-load=0 load-time=0s
+  store-id=1 node-id=1 load=[1000000000,50000000,0] capacity=[8000000000,100000000,1000000000] secondary-load=0 load-time=0s node-cpu-load=7000000000 node-cpu-capacity=16000000000
+  store-id=2 node-id=1 load=[6000000000,10000000,0] capacity=[8000000000,100000000,1000000000] secondary-load=0 load-time=0s node-cpu-load=7000000000 node-cpu-capacity=16000000000
   store-id=3 node-id=2 load=[1000000000,50000000,0] capacity=[8000000000,100000000,1000000000] secondary-load=0 load-time=0s
 ----
 

--- a/pkg/kv/kvserver/mmaintegration/capacity_model.go
+++ b/pkg/kv/kvserver/mmaintegration/capacity_model.go
@@ -110,6 +110,33 @@ const cpuIndirectOverheadMultiplier = 3.0
 //  5. storeCapacity = mmaDirectCapacity / numStores
 //     Split evenly across stores on the node.
 //
+// Relationship to the naive model:
+//
+// The naive model (computeStoreCPURateCapacityNaive in legacy_model_test.go)
+// attributes all node CPU to MMA-tracked store work. It maintains an
+// invariant that lets node-level utilization be recovered from store values
+// alone:
+//
+//	sum(store loads) / sum(store capacities) = NodeCPURateUsage / NodeCPURateCapacity
+//
+// That model is the special case where cap = infinity (clamping never
+// activates). When clamping does activate (background > 0), this function
+// intentionally breaks the invariant. Example with one store
+// (storesCPURate=2, NodeCPURateUsage=10, NodeCPURateCapacity=16, cap=3):
+//
+//	Naive:  capacity = 2 / (10/16) = 3.2   load/cap = 2/3.2 = 0.625 = 10/16  (matches)
+//	Capped: capacity = (16 - 4) / 3 = 4    load/cap = 2/4   = 0.5   != 10/16 (breaks)
+//
+// The capped model reports lower store utilization because it no longer
+// charges stores for background CPU they do not control. The trade-off is
+// that node-level overload detection cannot sum store values to recover
+// physical utilization. MakeStoreLoadMsg addresses this by passing
+// physical node-level CPU (NodeCPURateUsage, NodeCPURateCapacity) through
+// StoreLoadMsg so that node-level overload detection can use them directly.
+//
+// When no clamping occurs (implicit mult in [1, cap]), backgroundLoad = 0
+// and this function is equivalent to the naive model.
+//
 // When storesCPURate is 0 (no replicas reporting CPU yet), we use the limiting
 // behavior: MMA attributes none of the node usage to itself (all is
 // background), and divides the idle capacity by the multiplier across stores.

--- a/pkg/kv/kvserver/mmaintegration/legacy_model_test.go
+++ b/pkg/kv/kvserver/mmaintegration/legacy_model_test.go
@@ -26,8 +26,8 @@ import (
 //  1. Normal: storesCPURate > 0, cpuUtil >= 0.01.
 //     We compute cpuUtil = nodeCPURateUsage / nodeCPURateCapacity, then
 //     derive a per-store capacity = (storesCPURate / cpuUtil) / numStores.
-//     See MakeStoreLoadMsg for why this construction preserves the
-//     node-level utilization as the mean store-level utilization.
+//     This construction preserves node-level utilization as the mean
+//     store-level utilization (see proof below).
 //
 //  2. Low utilization fallback: storesCPURate is zero or cpuUtil < 0.01.
 //     We assume 50% of the node capacity is attributable to stores and
@@ -71,10 +71,14 @@ import (
 //	            = StoresCPURate / StoresCPURateCapacity
 //	            = cpuUtil
 //
-// The above mathematical property is used to avoid having any explicit
-// communication of node load to MMA. The
-// NodeLoad.{ReportedCPU,CapacityCPU} is incrementally maintained as a sum
-// of the load and capacity reported by each store (at different times).
+// The above mathematical property was originally used to avoid explicit
+// communication of node load to MMA: NodeLoad.{ReportedCPU,CapacityCPU}
+// could be incrementally maintained as a sum of per-store load and capacity.
+// However, MakeStoreLoadMsg uses computeCPUCapacityWithCap which applies a
+// capped multiplier that subtracts background CPU, breaking this invariant
+// when background > 0. Node-level overload detection now uses explicit
+// physical node CPU values (NodeCPURateUsage, NodeCPURateCapacity) passed
+// through StoreLoadMsg.NodeCPULoad/NodeCPUCapacity instead.
 //
 // Additionally, when the meanCPUUtil indicates overload, at least one
 // store will be above that mean, so it is overloaded as well and will

--- a/pkg/kv/kvserver/mmaintegration/store_load_msg.go
+++ b/pkg/kv/kvserver/mmaintegration/store_load_msg.go
@@ -11,7 +11,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
-// MakeStoreLoadMsg makes a store load message.
+// MakeStoreLoadMsg constructs a StoreLoadMsg with per-store load/capacity and
+// physical node-level CPU values for node overload detection.
 func MakeStoreLoadMsg(
 	desc roachpb.StoreDescriptor, origTimestampNanos int64,
 ) mmaprototype.StoreLoadMsg {
@@ -55,11 +56,13 @@ func MakeStoreLoadMsg(
 	// 	panic("ouch")
 	// }
 	return mmaprototype.StoreLoadMsg{
-		NodeID:        desc.Node.NodeID,
-		StoreID:       desc.StoreID,
-		Load:          load,
-		Capacity:      capacity,
-		SecondaryLoad: secondaryLoad,
-		LoadTime:      timeutil.FromUnixNanos(origTimestampNanos),
+		NodeID:          desc.Node.NodeID,
+		StoreID:         desc.StoreID,
+		Load:            load,
+		Capacity:        capacity,
+		SecondaryLoad:   secondaryLoad,
+		NodeCPULoad:     mmaprototype.LoadValue(desc.NodeCapacity.NodeCPURateUsage),
+		NodeCPUCapacity: mmaprototype.LoadValue(desc.NodeCapacity.NodeCPURateCapacity),
+		LoadTime:        timeutil.FromUnixNanos(origTimestampNanos),
 	}
 }


### PR DESCRIPTION
The capped multiplier model (`computeCPUCapacityWithCap`) subtracts
background CPU when deriving per-store capacity. This intentionally
breaks the invariant maintained by the naive model:

```
sum(store loads) / sum(store capacities) = NodeCPURateUsage / NodeCPURateCapacity
```

When background CPU exceeds the cap, node-level overload detection can
no longer recover physical utilization by summing store-level values.

This change replaces the derived `NodeLoad` fields (`ReportedCPU`,
`CapacityCPU` — incremental sums of per-store values) which relied
on this invariance with explicit physical node-level CPU values
(`NodeCPULoad`, `NodeCPUCapacity`) carried through `StoreLoadMsg`
from `NodeCapacity` fields.

Note that each store generates its descriptor independently, so
`NodeCPULoad` values may differ slightly across stores on the same
node due to sampling time differences. This is acceptable since
they should be roughly the same.

Epic: CRDB-55052
Release note: none
