### PR TITLE
changefeedccl: fix min_checkpoint_frequency=0 regression

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -2562,7 +2562,7 @@ func newSaveRateLimiter(
 // canSave returns whether enough time has passed to save progress again.
 func (l *saveRateLimiter) canSave(ctx context.Context) bool {
 	interval := l.config.interval()
-	if interval <= 0 {
+	if interval < 0 {
 		return false
 	}
 	if l.config.jitter != nil {

--- a/pkg/ccl/changefeedccl/changefeed_processors_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors_test.go
@@ -65,12 +65,22 @@ func TestSaveRateLimiter(t *testing.T) {
 				}, clock)
 				require.NoError(t, err)
 
-				// A non-positive interval indicates that saving is disabled so we only
+				// A negative interval indicates that saving is disabled so we only
 				// need to test that we can't save at all.
-				if interval <= 0 {
+				if interval < 0 {
 					require.False(t, l.canSave(ctx))
 					clock.Advance(24 * time.Hour)
 					require.False(t, l.canSave(ctx))
+					return
+				}
+
+				// A zero interval means save as often as possible.
+				if interval == 0 {
+					require.True(t, l.canSave(ctx))
+					l.doneSave(0 /* saveDuration */)
+					// With zero interval, we can always save again immediately.
+					require.True(t, l.canSave(ctx))
+					l.doneSave(0 /* saveDuration */)
 					return
 				}
 

--- a/pkg/ccl/changefeedccl/changefeed_progress_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_progress_test.go
@@ -317,6 +317,61 @@ WITH no_initial_scan, min_checkpoint_frequency='1s', resolved, metrics_label='%s
 	})
 }
 
+// TestChangefeedProgressUpdatesWithZeroMinCheckpointFrequency verifies that
+// resolved timestamps are still sent when we set min_checkpoint_frequency='0'.
+// This is a regression test for #164866.
+func TestChangefeedProgressUpdatesWithZeroMinCheckpointFrequency(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (1), (2), (3)`)
+
+		foo := feed(t, f, `CREATE CHANGEFEED FOR foo WITH resolved='10ms', min_checkpoint_frequency='0'`)
+		defer closeFeed(t, foo)
+
+		// Drain the initial rows.
+		assertPayloads(t, foo, []string{
+			`foo: [1]->{"after": {"a": 1}}`,
+			`foo: [2]->{"after": {"a": 2}}`,
+			`foo: [3]->{"after": {"a": 3}}`,
+		})
+
+		// Collect a resolved timestamp and verify it's non-empty.
+		var first hlc.Timestamp
+		testutils.SucceedsSoon(t, func() error {
+			ts, _ := expectResolvedTimestamp(t, foo)
+			if ts.IsEmpty() {
+				return errors.New("waiting for non-empty resolved timestamp")
+			}
+			first = ts
+			return nil
+		})
+
+		// Insert more data to push the frontier forward.
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (4), (5)`)
+
+		// Drain the new rows.
+		assertPayloads(t, foo, []string{
+			`foo: [4]->{"after": {"a": 4}}`,
+			`foo: [5]->{"after": {"a": 5}}`,
+		})
+
+		// Wait for a resolved timestamp that is strictly greater than the first.
+		testutils.SucceedsSoon(t, func() error {
+			ts, _ := expectResolvedTimestamp(t, foo)
+			if !first.Less(ts) {
+				return errors.Newf("waiting for resolved timestamp to advance beyond %s", first)
+			}
+			return nil
+		})
+	}
+
+	cdcTest(t, testFn)
+}
+
 // TestCoreChangefeedProgress verifies that core (sinkless) changefeeds
 // save and restore their full span frontier across retries. It creates
 // a changefeed over two tables with one table's resolved timestamps


### PR DESCRIPTION
In adfa8890a81c5cbc5d34a95c222137ee5f41948d, we advertently made it
so that setting `min_checkpoint_frequency` to 0 would cause the changefeed's
highwater to not advance/not send resolved timestamps. This patch fixes that.

Fixes #164866

Release note (bug fix): In a recent change that was included in 25.4+,
we inadvertently made it so that setting `min_checkpoint_frequency` to
0 would cause the changefeed's highwater to not advance/not send
resolved timestamps. This bug has been fixed. Note however that setting
`min_checkpoint_frequency` to lower than `500ms` is not recommended as
it may cause degraded changefeed performance.