### PR TITLE
roachtest: remove 2TB import backup test

### DIFF
--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -381,8 +381,8 @@ func runBackup(ctx context.Context, t test.Test, c cluster.Cluster, abandon bool
 		}
 		baseKey := numTxns + txnIndex*perTransactionRowCount
 		statement = fmt.Sprintf(`
-          INSERT INTO foo (k, v) 
-          SELECT %d + gs, gs %% %d 
+          INSERT INTO foo (k, v)
+          SELECT %d + gs, gs %% %d
           FROM generate_series(0, %d) AS gs`,
 			baseKey, perTransactionRowCount, perTransactionRowCount-1)
 		_, err = tx.ExecContext(ctx, statement)
@@ -469,75 +469,6 @@ func initBulkJobPerfArtifacts(
 }
 
 func registerBackup(r registry.Registry) {
-	backup2TBSpec := r.MakeClusterSpec(10)
-	r.Add(registry.TestSpec{
-		Name:      fmt.Sprintf("backup/2TB/%s", backup2TBSpec),
-		Owner:     registry.OwnerDisasterRecovery,
-		Benchmark: true,
-		Cluster:   backup2TBSpec,
-		// The default storage on Azure Standard_D4ds_v5 is only 150 GiB compared
-		// to 400 on GCE, which is not enough for this test. We could request a
-		// larger volume size and set spec.LocalSSDDisable if we wanted to run
-		// this on Azure.
-		CompatibleClouds:          registry.OnlyGCE,
-		Suites:                    registry.Suites(registry.Nightly),
-		TestSelectionOptOutSuites: registry.Suites(registry.Nightly),
-		EncryptionSupport:         registry.EncryptionAlwaysDisabled,
-		PostProcessPerfMetrics: func(test string, histogram *roachtestutil.HistogramMetric) (roachtestutil.AggregatedPerfMetrics, error) {
-
-			metricName := fmt.Sprintf("%s_elapsed", test)
-			totalElapsed := histogram.Elapsed
-
-			numNodes := int64(10)
-			tb := int64(1 << 40)
-			mb := int64(1 << 20)
-			dataSizeInMB := (2 * tb) / mb
-			backupDuration := int64(totalElapsed / 1000)
-			avgRatePerNode := roachtestutil.MetricPoint(float64(dataSizeInMB) / float64(numNodes*backupDuration))
-
-			return roachtestutil.AggregatedPerfMetrics{
-				{
-					Name:           metricName,
-					Value:          avgRatePerNode,
-					Unit:           "MB/s/node",
-					IsHigherBetter: false,
-				},
-			}, nil
-		},
-		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			rows := rows2TiB
-			if c.IsLocal() {
-				rows = 100
-			}
-			dest := importBankData(ctx, rows, t, c)
-			exporter := roachtestutil.CreateWorkloadHistogramExporter(t, c)
-			tick, perfBuf := initBulkJobPerfArtifacts(2*time.Hour, t, exporter)
-			defer roachtestutil.CloseExporter(ctx, exporter, t, c, perfBuf, c.Node(1), "")
-
-			m := c.NewDeprecatedMonitor(ctx)
-			m.Go(func(ctx context.Context) error {
-				t.Status(`running backup`)
-				// Tick once before starting the backup, and once after to capture the
-				// total elapsed time. This is used by roachperf to compute and display
-				// the average MB/sec per node.
-				tick()
-				conn := c.Conn(ctx, t.L(), 1)
-				defer conn.Close()
-				var jobID jobspb.JobID
-				uri := `gs://` + backupTestingBucket + `/` + dest + `?AUTH=implicit`
-				if err := conn.QueryRowContext(ctx, fmt.Sprintf("BACKUP bank.bank INTO '%s' WITH detached", uri)).Scan(&jobID); err != nil {
-					return err
-				}
-				if err := AssertReasonableFractionCompleted(ctx, t.L(), c, jobID, 2); err != nil {
-					return err
-				}
-				tick()
-				return nil
-			})
-			m.Wait()
-		},
-	})
-
 	// Skip running on aws because the roachtest env does not have the proper
 	// credentials. See 127062
 	for _, cloudProvider := range []spec.Cloud{spec.GCE} {


### PR DESCRIPTION
With our 30k TPCC backup fixtures roachtest already in place, the 2TB import backup roachtest is largely redundant. This removes the test from our test suite.

Epic: None

Release note: None