### PR TITLE
txnlock: support foreign key lock synthesis

### DIFF
--- a/pkg/crosscluster/logical/txnlock/column_set.go
+++ b/pkg/crosscluster/logical/txnlock/column_set.go
@@ -17,13 +17,13 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-func uniqueIndexMixin(tableID descpb.ID, ucID descpb.ConstraintID) (uint64, error) {
+func constraintMixin(tableID descpb.ID, ucID descpb.ConstraintID) (uint64, error) {
 	h := fnv.New64a()
 	var buf [8]byte
 	binary.BigEndian.PutUint32(buf[:4], uint32(tableID))
 	binary.BigEndian.PutUint32(buf[4:], uint32(ucID))
 	if _, err := h.Write(buf[:]); err != nil {
-		return 0, errors.Wrap(err, "hashing unique index mixin")
+		return 0, errors.Wrap(err, "hashing constraint mixin")
 	}
 	return h.Sum64(), nil
 }
@@ -31,6 +31,7 @@ func uniqueIndexMixin(tableID descpb.ID, ucID descpb.ConstraintID) (uint64, erro
 // A columnSet is a collection of columns that are relevant for an individual
 // constraint.
 type columnSet struct {
+	tableID descpb.ID
 	columns []int32
 	// mixin is an integer that is combined with the hash. It is used to ensure
 	// different tables or unique constraints produce different hashes.
@@ -80,17 +81,35 @@ func (c *columnSet) null(row tree.Datums) bool {
 }
 
 // equal returns true if the columns are equal. equal(rowA, rowB) implies
-// hash(rowA) == hash(rowB).
+// hash(rowA) == hash(rowB). Convenience wrapper around columnSetEqual for
+// comparing columns from the same column set.
 func (c *columnSet) equal(
 	ctx context.Context, evalCtx *eval.Context, rowA, rowB tree.Datums,
 ) (bool, error) {
-	if c.null(rowA) || c.null(rowB) {
+	return columnSetEqual(ctx, evalCtx, c, c, rowA, rowB)
+}
+
+// equal returns true if the columns are equal. equal(rowA, rowB) implies
+// hash(rowA) == hash(rowB). Supports comparing columns from different column
+// sets, in the case of foreign key constraints.
+func columnSetEqual(
+	ctx context.Context, evalCtx *eval.Context, colA, colB *columnSet, rowA, rowB tree.Datums,
+) (bool, error) {
+	if len(colA.columns) != len(colB.columns) {
+		return false, errors.AssertionFailedf(
+			"mismatched column count in equal: table %d has %d columns, table %d has %d columns",
+			colA.tableID, len(colA.columns), colB.tableID, len(colB.columns),
+		)
+	}
+	if colA.null(rowA) || colB.null(rowB) {
 		return false, nil
 	}
-	for _, idx := range c.columns {
-		cmp, err := rowA[idx].Compare(ctx, evalCtx, rowB[idx])
+	for i := range colA.columns {
+		cmp, err := rowA[colA.columns[i]].Compare(ctx, evalCtx, rowB[colB.columns[i]])
 		if err != nil {
-			return false, errors.Wrap(err, "comparing datums for lock derivation")
+			return false, errors.NewAssertionErrorWithWrappedErrf(err,
+				"comparing datums for lock derivation: table %d column %d vs table %d column %d",
+				colA.tableID, colA.columns[i], colB.tableID, colB.columns[i])
 		}
 		if cmp != 0 {
 			return false, nil

--- a/pkg/crosscluster/logical/txnlock/lock_synthesis.go
+++ b/pkg/crosscluster/logical/txnlock/lock_synthesis.go
@@ -21,8 +21,6 @@ type LockHash uint64
 
 type Lock struct {
 	Hash LockHash
-	// TODO(jeffswenson): Read will be set to true for foreign key locks that
-	// only require a shared/read lock rather than an exclusive/write lock.
 	Read bool
 }
 
@@ -143,12 +141,22 @@ func (ls *LockSynthesizer) deriveLocks(
 func (ls *LockSynthesizer) dependsOn(
 	ctx context.Context, a, b ldrdecoder.DecodedRow,
 ) (bool, error) {
-	if a.TableID != b.TableID {
-		return false, nil
-	}
-	tc, ok := ls.tableConstraints[a.TableID]
+	tcA, ok := ls.tableConstraints[a.TableID]
 	if !ok {
 		return false, nil
 	}
-	return tc.DependsOn(ctx, a, b)
+
+	if a.TableID == b.TableID {
+		dep, err := tcA.DependsOn(ctx, a, b)
+		if err != nil || dep {
+			return dep, err
+		}
+	}
+
+	tcB, ok := ls.tableConstraints[b.TableID]
+	if !ok {
+		return false, nil
+	}
+
+	return tcA.fkDependsOn(ctx, tcB, a, b)
 }

--- a/pkg/crosscluster/logical/txnlock/lock_synthesis_bench_test.go
+++ b/pkg/crosscluster/logical/txnlock/lock_synthesis_bench_test.go
@@ -16,14 +16,26 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
-// makeBenchRows builds a batch of n rows modeling the schema:
+type benchSpec struct {
+	name                string
+	makeRows            func(n int) []ldrdecoder.DecodedRow
+	makeLockSynthesizer func(b *testing.B) *LockSynthesizer
+}
+
+var benchSpecs = []benchSpec{
+	{name: "basic", makeRows: makeBasicBenchRows, makeLockSynthesizer: makeBasicLockSynthesizer},
+	{name: "fk", makeRows: makeFKBenchRows, makeLockSynthesizer: makeFKLockSynthesizer},
+}
+
+// makeBasicBenchRows builds a batch of n rows modeling the schema:
 //
 //	CREATE TABLE t (id INT PRIMARY KEY, val INT UNIQUE)
 //
 // Each row is an update that forms a dependency chain via the unique constraint
 // on val: row i's new val equals row (i-1)'s old val. This produces n-1
 // dependency edges that the topological sort must resolve.
-func makeBenchRows(tableID descpb.ID, n int) []ldrdecoder.DecodedRow {
+func makeBasicBenchRows(n int) []ldrdecoder.DecodedRow {
+	tableID := descpb.ID(100)
 	rows := make([]ldrdecoder.DecodedRow, n)
 	for i := range rows {
 		id := tree.NewDInt(tree.DInt(i + 1))
@@ -43,19 +55,18 @@ func makeBenchRows(tableID descpb.ID, n int) []ldrdecoder.DecodedRow {
 	return rows
 }
 
-func BenchmarkDeriveLocks(b *testing.B) {
+func makeBasicLockSynthesizer(b *testing.B) *LockSynthesizer {
 	tableID := descpb.ID(100)
-
-	pkMixin, err := uniqueIndexMixin(tableID, 1)
+	pkMixin, err := constraintMixin(tableID, 1)
 	if err != nil {
 		b.Fatal(err)
 	}
-	ucMixin, err := uniqueIndexMixin(tableID, 2)
+	ucMixin, err := constraintMixin(tableID, 2)
 	if err != nil {
 		b.Fatal(err)
 	}
 
-	ls := &LockSynthesizer{
+	return &LockSynthesizer{
 		tableConstraints: map[descpb.ID]*tableConstraints{
 			tableID: {
 				evalCtx: &eval.Context{},
@@ -70,16 +81,98 @@ func BenchmarkDeriveLocks(b *testing.B) {
 			},
 		},
 	}
+}
 
-	for _, n := range []int{2, 10, 50} {
-		rows := makeBenchRows(tableID, n)
-		ctx := context.Background()
-		b.Run(fmt.Sprintf("rows=%d", n), func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				if _, err := ls.DeriveLocks(ctx, rows); err != nil {
-					b.Fatal(err)
-				}
-			}
+// makeFKBenchRows builds n/2 parent + n/2 child update rows modeling:
+//
+//	CREATE TABLE parent (id INT PRIMARY KEY, val INT)
+//	CREATE TABLE child (
+//	  id INT PRIMARY KEY, parent_id INT REFERENCES parent(id), data INT
+//	)
+//
+// Each parent update changes val, producing inbound FK write locks. Each child
+// update changes parent_id, producing outbound FK read locks on both old and
+// new values. The child's new parent_id references the corresponding parent's
+// new id, creating FK dependency edges for the topological sort.
+func makeFKBenchRows(n int) []ldrdecoder.DecodedRow {
+	parentTableID := descpb.ID(100)
+	childTableID := descpb.ID(200)
+	rows := make([]ldrdecoder.DecodedRow, 0, n)
+	for i := range n / 2 {
+		oldFK := tree.NewDInt(tree.DInt(i + 100))
+		newFK := tree.NewDInt(tree.DInt(i + 200))
+		rows = append(rows, ldrdecoder.DecodedRow{
+			TableID: parentTableID,
+			Row:     tree.Datums{tree.NewDInt(tree.DInt(i + 1)), newFK},
+			PrevRow: tree.Datums{tree.NewDInt(tree.DInt(i + 1)), oldFK},
+		}, ldrdecoder.DecodedRow{
+			TableID: childTableID,
+			Row:     tree.Datums{tree.NewDInt(tree.DInt(n/2 + i + 1)), newFK, tree.NewDInt(0)},
+			PrevRow: tree.Datums{tree.NewDInt(tree.DInt(n/2 + i + 1)), oldFK, tree.NewDInt(0)},
 		})
+	}
+	return rows
+}
+
+func makeFKLockSynthesizer(b *testing.B) *LockSynthesizer {
+	parentTableID := descpb.ID(100)
+	childTableID := descpb.ID(200)
+
+	parentPKMixin, err := constraintMixin(parentTableID, 1)
+	if err != nil {
+		b.Fatal(err)
+	}
+	childPKMixin, err := constraintMixin(childTableID, 1)
+	if err != nil {
+		b.Fatal(err)
+	}
+	// Use the child table ID as origin for the FK mixin so both sides match.
+	fkMixin, err := constraintMixin(childTableID, 2)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	return &LockSynthesizer{
+		tableConstraints: map[descpb.ID]*tableConstraints{
+			parentTableID: {
+				evalCtx: &eval.Context{},
+				PrimaryKeyConstraint: columnSet{
+					columns: []int32{0},
+					mixin:   parentPKMixin,
+				},
+				OutboundForeignKeyConstraints: map[uint64]columnSet{},
+				InboundForeignKeyConstraints: map[uint64]columnSet{
+					fkMixin: {columns: []int32{0}, mixin: fkMixin},
+				},
+			},
+			childTableID: {
+				evalCtx: &eval.Context{},
+				PrimaryKeyConstraint: columnSet{
+					columns: []int32{0},
+					mixin:   childPKMixin,
+				},
+				OutboundForeignKeyConstraints: map[uint64]columnSet{
+					fkMixin: {columns: []int32{1}, mixin: fkMixin},
+				},
+				InboundForeignKeyConstraints: map[uint64]columnSet{},
+			},
+		},
+	}
+}
+
+func BenchmarkDeriveLocks(b *testing.B) {
+	for _, spec := range benchSpecs {
+		ls := spec.makeLockSynthesizer(b)
+		for _, n := range []int{2, 10, 50} {
+			rows := spec.makeRows(n)
+			ctx := context.Background()
+			b.Run(fmt.Sprintf("rows=%d/%s", n, spec.name), func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					if _, err := ls.DeriveLocks(ctx, rows); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
 	}
 }

--- a/pkg/crosscluster/logical/txnlock/lock_synthesis_test.go
+++ b/pkg/crosscluster/logical/txnlock/lock_synthesis_test.go
@@ -24,19 +24,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// overlappingLocks counts lock hashes shared between two LockSets.
-func overlappingLocks(a, b LockSet) int {
-	set := make(map[LockHash]struct{}, len(a.Locks))
+// overlappingLocks counts lock hashes shared between two LockSets,
+// separated by whether the overlap involves a write lock (at least one
+// side is write) or is read-only (both sides are read).
+func overlappingLocks(a, b LockSet) (writeOverlaps, readOverlaps int) {
+	set := make(map[LockHash]bool, len(a.Locks))
 	for _, l := range a.Locks {
-		set[l.Hash] = struct{}{}
+		set[l.Hash] = l.Read
 	}
-	count := 0
 	for _, l := range b.Locks {
-		if _, ok := set[l.Hash]; ok {
-			count++
+		aRead, ok := set[l.Hash]
+		if !ok {
+			continue
+		}
+		if aRead && l.Read {
+			readOverlaps++
+		} else {
+			writeOverlaps++
 		}
 	}
-	return count
+	return writeOverlaps, readOverlaps
 }
 
 // requireSortOrder verifies that sorted rows match the expected permutation
@@ -73,16 +80,18 @@ func requireSortOrder(
 // txnCase holds a batch of events and the expected DeriveLocks outcome.
 // A zero-value txnCase (nil events) means "no transaction".
 type txnCase struct {
-	events    []streampb.StreamEvent_KV
-	lockCount int
-	order     []int // expected permutation of input row indices
-	err       error // nil means success
+	events         []streampb.StreamEvent_KV
+	writeLockCount int
+	readLockCount  int
+	order          []int // expected permutation of input row indices
+	err            error // nil means success
 }
 
 type lockSynthesisTestCase struct {
-	name         string
-	txn1, txn2   txnCase
-	overlapCount int
+	name              string
+	txn1, txn2        txnCase
+	writeOverlapCount int
+	readOverlapCount  int
 }
 
 // plainRow builds datums for schema (id INT PRIMARY KEY, data STRING).
@@ -127,6 +136,91 @@ func compositeRow(pk1, pk2, a, b int) tree.Datums {
 	}
 }
 
+// fkParentRow builds datums for schema
+// (id INT PRIMARY KEY, ref_col INT UNIQUE, val INT).
+func fkParentRow(id, refCol, val int) tree.Datums {
+	return tree.Datums{
+		tree.NewDInt(tree.DInt(id)),
+		tree.NewDInt(tree.DInt(refCol)),
+		tree.NewDInt(tree.DInt(val)),
+	}
+}
+
+// fkChildRow builds datums for schema
+//
+//	(id INT PRIMARY KEY,
+//	 parent_id INT REFERENCES fk_parent(id),
+//	 parent_ref INT REFERENCES fk_parent(ref_col),
+//	 data INT)
+//
+// Negative values for parent_id or parent_ref map to DNull.
+func fkChildRow(id, parentID, parentRef, data int) tree.Datums {
+	var pidDatum, refDatum tree.Datum
+	if parentID < 0 {
+		pidDatum = tree.DNull
+	} else {
+		pidDatum = tree.NewDInt(tree.DInt(parentID))
+	}
+	if parentRef < 0 {
+		refDatum = tree.DNull
+	} else {
+		refDatum = tree.NewDInt(tree.DInt(parentRef))
+	}
+	return tree.Datums{
+		tree.NewDInt(tree.DInt(id)),
+		pidDatum,
+		refDatum,
+		tree.NewDInt(tree.DInt(data)),
+	}
+}
+
+// selfRefRow builds datums for schema
+// (id INT PRIMARY KEY, parent_id INT REFERENCES self_ref(id), data INT).
+// A negative parent_id maps to DNull.
+func selfRefRow(id, parentID, data int) tree.Datums {
+	var pidDatum tree.Datum
+	if parentID < 0 {
+		pidDatum = tree.DNull
+	} else {
+		pidDatum = tree.NewDInt(tree.DInt(parentID))
+	}
+	return tree.Datums{
+		tree.NewDInt(tree.DInt(id)),
+		pidDatum,
+		tree.NewDInt(tree.DInt(data)),
+	}
+}
+
+// compositeFKParentRow builds datums for schema
+// (a INT, b INT, c INT, d INT, val INT, PRIMARY KEY (a, b), UNIQUE (c, d)).
+func compositeFKParentRow(a, b, c, d, val int) tree.Datums {
+	return tree.Datums{
+		tree.NewDInt(tree.DInt(a)),
+		tree.NewDInt(tree.DInt(b)),
+		tree.NewDInt(tree.DInt(c)),
+		tree.NewDInt(tree.DInt(d)),
+		tree.NewDInt(tree.DInt(val)),
+	}
+}
+
+// compositeFKChildRow builds datums for schema
+//
+//	(id INT PRIMARY KEY, b_pk_ref INT, a_pk_ref INT, d_uc_ref INT, c_uc_ref INT,
+//	 FOREIGN KEY (a_pk_ref, b_pk_ref) REFERENCES composite_fk_parent(a, b),
+//	 FOREIGN KEY (c_uc_ref, d_uc_ref) REFERENCES composite_fk_parent(c, d))
+//
+// Note the column order in the table is inverted relative to the FK
+// column order for both constraints.
+func compositeFKChildRow(id, bPKRef, aPKRef, dUCRef, cUCRef int) tree.Datums {
+	return tree.Datums{
+		tree.NewDInt(tree.DInt(id)),
+		tree.NewDInt(tree.DInt(bPKRef)),
+		tree.NewDInt(tree.DInt(aPKRef)),
+		tree.NewDInt(tree.DInt(dUCRef)),
+		tree.NewDInt(tree.DInt(cUCRef)),
+	}
+}
+
 func TestDeriveLocks(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -141,7 +235,32 @@ func TestDeriveLocks(t *testing.T) {
 	runner.Exec(t, `CREATE TABLE uc_table (id INT PRIMARY KEY, email STRING UNIQUE)`)
 	// TODO(164507): make one of these columns a stored computed column.
 	runner.Exec(t, `CREATE TABLE composite_table (pk1 INT, pk2 INT, a INT, b INT, PRIMARY KEY (pk1, pk2), UNIQUE (a, b))`)
-
+	runner.Exec(t, `CREATE TABLE fk_parent (id INT PRIMARY KEY, ref_col INT UNIQUE, val INT)`)
+	runner.Exec(t, `
+		CREATE TABLE fk_child (
+			id INT PRIMARY KEY,
+			parent_id INT REFERENCES fk_parent(id),
+			parent_ref INT REFERENCES fk_parent(ref_col),
+			data INT
+		)`)
+	runner.Exec(t, `
+		CREATE TABLE fk_self_ref (
+			id INT PRIMARY KEY,
+			parent_id INT REFERENCES fk_self_ref(id),
+			data INT
+		)`)
+	runner.Exec(t, `
+		CREATE TABLE composite_fk_parent (
+			a INT, b INT, c INT, d INT, val INT,
+			PRIMARY KEY (a, b),
+			UNIQUE (c, d)
+		)`)
+	runner.Exec(t, `
+		CREATE TABLE composite_fk_child (
+			id INT PRIMARY KEY, b_pk_ref INT, a_pk_ref INT, d_uc_ref INT, c_uc_ref INT,
+			FOREIGN KEY (a_pk_ref, b_pk_ref) REFERENCES composite_fk_parent(a, b),
+			FOREIGN KEY (c_uc_ref, d_uc_ref) REFERENCES composite_fk_parent(c, d)
+		)`)
 	plainDesc := cdctest.GetHydratedTableDescriptor(
 		t, s.ExecutorConfig(), "plain_table",
 	)
@@ -151,10 +270,30 @@ func TestDeriveLocks(t *testing.T) {
 	compositeDesc := cdctest.GetHydratedTableDescriptor(
 		t, s.ExecutorConfig(), "composite_table",
 	)
+	parentDesc := cdctest.GetHydratedTableDescriptor(
+		t, s.ExecutorConfig(), "fk_parent",
+	)
+	childDesc := cdctest.GetHydratedTableDescriptor(
+		t, s.ExecutorConfig(), "fk_child",
+	)
+	selfRefDesc := cdctest.GetHydratedTableDescriptor(
+		t, s.ExecutorConfig(), "fk_self_ref",
+	)
+	compositeFKParentDesc := cdctest.GetHydratedTableDescriptor(
+		t, s.ExecutorConfig(), "composite_fk_parent",
+	)
+	compositeChildDesc := cdctest.GetHydratedTableDescriptor(
+		t, s.ExecutorConfig(), "composite_fk_child",
+	)
 
 	plainEB := ldrdecoder.NewTestEventBuilder(t, plainDesc.TableDesc())
 	ucEB := ldrdecoder.NewTestEventBuilder(t, ucDesc.TableDesc())
 	compositeEB := ldrdecoder.NewTestEventBuilder(t, compositeDesc.TableDesc())
+	parentEB := ldrdecoder.NewTestEventBuilder(t, parentDesc.TableDesc())
+	childEB := ldrdecoder.NewTestEventBuilder(t, childDesc.TableDesc())
+	selfRefEB := ldrdecoder.NewTestEventBuilder(t, selfRefDesc.TableDesc())
+	compositeFKParentEB := ldrdecoder.NewTestEventBuilder(t, compositeFKParentDesc.TableDesc())
+	compositeChildEB := ldrdecoder.NewTestEventBuilder(t, compositeChildDesc.TableDesc())
 	txnTime := s.Clock().Now()
 
 	decoder, err := ldrdecoder.NewTxnDecoder(
@@ -163,6 +302,11 @@ func TestDeriveLocks(t *testing.T) {
 			{SourceDescriptor: plainDesc, DestID: plainDesc.GetID()},
 			{SourceDescriptor: ucDesc, DestID: ucDesc.GetID()},
 			{SourceDescriptor: compositeDesc, DestID: compositeDesc.GetID()},
+			{SourceDescriptor: parentDesc, DestID: parentDesc.GetID()},
+			{SourceDescriptor: childDesc, DestID: childDesc.GetID()},
+			{SourceDescriptor: selfRefDesc, DestID: selfRefDesc.GetID()},
+			{SourceDescriptor: compositeFKParentDesc, DestID: compositeFKParentDesc.GetID()},
+			{SourceDescriptor: compositeChildDesc, DestID: compositeChildDesc.GetID()},
 		},
 	)
 	require.NoError(t, err)
@@ -176,6 +320,11 @@ func TestDeriveLocks(t *testing.T) {
 			{DestID: plainDesc.GetID()},
 			{DestID: ucDesc.GetID()},
 			{DestID: compositeDesc.GetID()},
+			{DestID: parentDesc.GetID()},
+			{DestID: childDesc.GetID()},
+			{DestID: selfRefDesc.GetID()},
+			{DestID: compositeFKParentDesc.GetID()},
+			{DestID: compositeChildDesc.GetID()},
 		},
 	)
 	require.NoError(t, err)
@@ -183,62 +332,62 @@ func TestDeriveLocks(t *testing.T) {
 	testCases := []lockSynthesisTestCase{
 		{
 			// Two txns insert into a plain table with disjoint PKs. Each row
-			// produces one PK lock. No overlap.
+			// produces one PK write lock. No overlap.
 			name: "pk_only_no_overlap",
 			txn1: txnCase{
 				events: []streampb.StreamEvent_KV{
 					plainEB.InsertEvent(txnTime, plainRow(1, "a")),
 					plainEB.InsertEvent(txnTime, plainRow(2, "b")),
 				},
-				lockCount: 2,
-				order:     []int{0, 1},
+				writeLockCount: 2,
+				order:          []int{0, 1},
 			},
 			txn2: txnCase{
 				events: []streampb.StreamEvent_KV{
 					plainEB.InsertEvent(txnTime, plainRow(3, "c")),
 					plainEB.InsertEvent(txnTime, plainRow(4, "d")),
 				},
-				lockCount: 2,
-				order:     []int{0, 1},
+				writeLockCount: 2,
+				order:          []int{0, 1},
 			},
 		},
 		{
-			// Both txns touch the same PK. Each gets 1 lock, with 1 overlap.
+			// Both txns touch the same PK. Each gets 1 write lock, with
+			// 1 overlap.
 			name: "pk_only_with_overlap",
 			txn1: txnCase{
 				events: []streampb.StreamEvent_KV{
 					plainEB.InsertEvent(txnTime, plainRow(1, "a")),
 				},
-				lockCount: 1,
-				order:     []int{0},
+				writeLockCount: 1,
+				order:          []int{0},
 			},
 			txn2: txnCase{
 				events: []streampb.StreamEvent_KV{
 					plainEB.InsertEvent(txnTime, plainRow(1, "x")),
 				},
-				lockCount: 1,
-				order:     []int{0},
+				writeLockCount: 1,
+				order:          []int{0},
 			},
-			overlapCount: 1,
+			writeOverlapCount: 1, // PK
 		},
 		{
 			// Inserts with different unique values produce PK + UC locks each.
 			// No overlap because emails differ.
 			name: "unique_no_overlap",
 			txn1: txnCase{
-				// Insert (nil PrevRow): PK + UC = 2 locks.
 				events: []streampb.StreamEvent_KV{
 					ucEB.InsertEvent(txnTime, ucRow(1, "a@test.com")),
 				},
-				lockCount: 2,
-				order:     []int{0},
+				writeLockCount: 2, // PK + UC(new)
+				order:          []int{0},
 			},
 			txn2: txnCase{
 				events: []streampb.StreamEvent_KV{
 					ucEB.InsertEvent(txnTime, ucRow(2, "b@test.com")),
 				},
-				lockCount: 2,
-				order:     []int{0},
+				writeLockCount: 2, // PK + UC(new)
+				order:          []int{0},
 			},
 		},
 		{
@@ -249,17 +398,17 @@ func TestDeriveLocks(t *testing.T) {
 				events: []streampb.StreamEvent_KV{
 					ucEB.InsertEvent(txnTime, ucRow(1, "shared@test.com")),
 				},
-				lockCount: 2,
-				order:     []int{0},
+				writeLockCount: 2, // PK + UC(new)
+				order:          []int{0},
 			},
 			txn2: txnCase{
 				events: []streampb.StreamEvent_KV{
 					ucEB.InsertEvent(txnTime, ucRow(2, "shared@test.com")),
 				},
-				lockCount: 2,
-				order:     []int{0},
+				writeLockCount: 2, // PK + UC(new)
+				order:          []int{0},
 			},
-			overlapCount: 1,
+			writeOverlapCount: 1, // UC(shared@test.com)
 		},
 		{
 			// Insert with email "x" is given before delete whose PrevRow has
@@ -275,15 +424,15 @@ func TestDeriveLocks(t *testing.T) {
 				},
 				// Insert: PK + UC(new) = 2; delete: PK + UC(prev) = 2.
 				// UC("user@example.com") shared, so deduplicated: 3 total.
-				lockCount: 3,
-				order:     []int{1, 0}, // delete before insert
+				writeLockCount: 3,
+				order:          []int{1, 0},
 			},
 			txn2: txnCase{
 				events: []streampb.StreamEvent_KV{
 					ucEB.InsertEvent(txnTime, ucRow(3, "other@example.com")),
 				},
-				lockCount: 2,
-				order:     []int{0},
+				writeLockCount: 2, // PK + UC(new)
+				order:          []int{0},
 			},
 		},
 		{
@@ -310,15 +459,15 @@ func TestDeriveLocks(t *testing.T) {
 					ucEB.InsertEvent(txnTime, ucRow(1, "")),
 					ucEB.InsertEvent(txnTime, ucRow(2, "")),
 				},
-				lockCount: 2, // PK-only
-				order:     []int{0, 1},
+				writeLockCount: 2, // PK-only
+				order:          []int{0, 1},
 			},
 			txn2: txnCase{
 				events: []streampb.StreamEvent_KV{
 					ucEB.InsertEvent(txnTime, ucRow(3, "")),
 				},
-				lockCount: 1, // PK-only
-				order:     []int{0},
+				writeLockCount: 1, // PK-only
+				order:          []int{0},
 			},
 		},
 		{
@@ -330,21 +479,22 @@ func TestDeriveLocks(t *testing.T) {
 				events: []streampb.StreamEvent_KV{
 					plainEB.InsertEvent(txnTime, plainRow(1, "same")),
 				},
-				lockCount: 1, // PK only
-				order:     []int{0},
+				writeLockCount: 1, // PK only
+				order:          []int{0},
 			},
 			txn2: txnCase{
 				events: []streampb.StreamEvent_KV{
 					ucEB.InsertEvent(txnTime, ucRow(1, "same")),
 				},
-				lockCount: 2, // PK + UC
-				order:     []int{0},
+				writeLockCount: 2, // PK + UC(new)
+				order:          []int{0},
 			},
 		},
 		{
 			// Three-row dependency chain via unique values that must be
 			// reordered. Row 0 takes the value freed by row 1, and row 1
 			// takes the value freed by row 2, so the sort order is {2, 1, 0}.
+			// Shared UC hashes (val-b, val-c) are upgraded to write.
 			name: "dependency_chain",
 			txn1: txnCase{
 				events: []streampb.StreamEvent_KV{
@@ -358,16 +508,16 @@ func TestDeriveLocks(t *testing.T) {
 						ucRow(3, "val-d"),
 						ucRow(3, "val-c")),
 				},
-				// 3 PKs + 4 UCs (val-a, val-b, val-c, val-d) = 7.
-				lockCount: 7,
-				order:     []int{2, 1, 0},
+				// 3 PK + UC(val-a,val-b,val-c,val-d) = 7 write.
+				writeLockCount: 7,
+				order:          []int{2, 1, 0},
 			},
 			txn2: txnCase{
 				events: []streampb.StreamEvent_KV{
 					ucEB.InsertEvent(txnTime, ucRow(10, "unrelated")),
 				},
-				lockCount: 2,
-				order:     []int{0},
+				writeLockCount: 2, // PK + UC(new)
+				order:          []int{0},
 			},
 		},
 		{
@@ -379,9 +529,8 @@ func TestDeriveLocks(t *testing.T) {
 					compositeEB.InsertEvent(txnTime,
 						compositeRow(1, 2, 10, 20)),
 				},
-				// PK + UC(10,20) = 2.
-				lockCount: 2,
-				order:     []int{0},
+				writeLockCount: 2, // PK + UC(new: 10,20)
+				order:          []int{0},
 			},
 			txn2: txnCase{
 				events: []streampb.StreamEvent_KV{
@@ -389,15 +538,14 @@ func TestDeriveLocks(t *testing.T) {
 						compositeRow(1, 2, 10, 20),
 						compositeRow(1, 2, 10, 20)),
 				},
-				// PK only, UC unchanged.
-				lockCount: 1,
-				order:     []int{0},
+				writeLockCount: 1, // PK only, UC unchanged
+				order:          []int{0},
 			},
-			overlapCount: 1, // shared PK(1,2)
+			writeOverlapCount: 1, // PK(1,2)
 		},
 		{
-			// One txn updates a row's unique columns, the other deletes
-			// the same composite PK. PK locks overlap.
+			// One txn updates a row's unique columns, the other deletes the
+			// same composite PK. PK and UC(30,40) locks overlap.
 			name: "composite_pk_update_and_delete",
 			txn1: txnCase{
 				events: []streampb.StreamEvent_KV{
@@ -405,25 +553,25 @@ func TestDeriveLocks(t *testing.T) {
 						compositeRow(1, 2, 30, 40),
 						compositeRow(1, 2, 10, 20)),
 				},
-				// PK + UC(new: 30,40) + UC(old: 10,20) = 3.
-				lockCount: 3,
-				order:     []int{0},
+				// PK + UC(old: 10,20) + UC(new: 30,40) = 3 write.
+				writeLockCount: 3,
+				order:          []int{0},
 			},
 			txn2: txnCase{
 				events: []streampb.StreamEvent_KV{
 					compositeEB.DeleteEvent(txnTime,
 						compositeRow(1, 2, 30, 40)),
 				},
-				// PK + UC(prev: 30,40) = 2.
-				lockCount: 2,
-				order:     []int{0},
+				writeLockCount: 2, // PK + UC(prev: 30,40)
+				order:          []int{0},
 			},
-			overlapCount: 2, // shared PK(1,2), UC(30, 40)
+			writeOverlapCount: 2, // PK(1,2) + UC(30,40)
 		},
 		{
-			// Unique key transfer on composite table: row 0 takes the
-			// unique value (10,20) freed by row 1's update away from it.
-			// The sort must place row 1 before row 0.
+			// Unique key transfer on composite table: row 0 takes the unique
+			// value (10,20) freed by row 1's update. The sort must place
+			// row 1 before row 0. UC(10,20) is deduplicated across rows:
+			// read(row0) && write(row1) → write.
 			name: "composite_unique_key_transfer",
 			txn1: txnCase{
 				events: []streampb.StreamEvent_KV{
@@ -434,10 +582,563 @@ func TestDeriveLocks(t *testing.T) {
 						compositeRow(2, 2, 30, 40),
 						compositeRow(2, 2, 10, 20)),
 				},
-				// PK(1, 1) + UC(10, 20) + PK(2, 2) + UC(30, 40) = 4
-				lockCount: 4,
-				order:     []int{1, 0}, // row 1 frees (10,20), row 0 takes it
+				// 2 PK + UC(10,20) + UC(30,40) = 4 write.
+				writeLockCount: 4,
+				order:          []int{1, 0},
 			},
+		},
+		{
+			// Inserting children that reference different parents should
+			// not conflict, since they don't compete for the same FK slot.
+			name: "fk_insert_children_different_parents",
+			txn1: txnCase{
+				events: []streampb.StreamEvent_KV{
+					childEB.InsertEvent(txnTime, fkChildRow(1, 10, 100, 0)),
+				},
+				// PK + FK(read,parent_id=10) + FK(read,parent_ref=100).
+				writeLockCount: 1,
+				readLockCount:  2,
+				order:          []int{0},
+			},
+			txn2: txnCase{
+				events: []streampb.StreamEvent_KV{
+					childEB.InsertEvent(txnTime, fkChildRow(2, 20, 200, 0)),
+				},
+				writeLockCount: 1,
+				readLockCount:  2,
+				order:          []int{0},
+			},
+		},
+		{
+			// Inserting two children that reference the same parent should
+			// conflict, since both depend on that parent row existing.
+			name: "fk_insert_children_same_parent",
+			txn1: txnCase{
+				events: []streampb.StreamEvent_KV{
+					childEB.InsertEvent(txnTime, fkChildRow(1, 10, 100, 0)),
+				},
+				writeLockCount: 1,
+				readLockCount:  2,
+				order:          []int{0},
+			},
+			txn2: txnCase{
+				events: []streampb.StreamEvent_KV{
+					childEB.InsertEvent(txnTime, fkChildRow(2, 20, 100, 0)),
+				},
+				writeLockCount: 1,
+				readLockCount:  2,
+				order:          []int{0},
+			},
+			readOverlapCount: 1, // FK(parent_ref=100)
+		},
+		{
+			// A child insert that references a parent's unique column must
+			// conflict with a concurrent parent update that changes that
+			// column away from the referenced value.
+			name: "fk_insert_child_while_parent_changes_ref",
+			txn1: txnCase{
+				events: []streampb.StreamEvent_KV{
+					childEB.InsertEvent(txnTime, fkChildRow(1, 10, 10, 0)),
+				},
+				// PK + FK(read,parent_id=10) + FK(read,parent_ref=10).
+				writeLockCount: 1,
+				readLockCount:  2,
+				order:          []int{0},
+			},
+			txn2: txnCase{
+				events: []streampb.StreamEvent_KV{
+					parentEB.UpdateEvent(txnTime,
+						fkParentRow(2, 20, 0),
+						fkParentRow(2, 10, 0)),
+				},
+				// PK + UC(write,10) + UC(write,20) + FK(write,10,ref) + FK(write,20,ref)
+				writeLockCount: 5,
+				order:          []int{0},
+			},
+			// Overlap on FK(parent_ref=10)
+			writeOverlapCount: 1,
+		},
+		{
+			// Deleting a child that references a parent must conflict with
+			// deleting that parent, since the child delete must be applied
+			// first to avoid violating the FK constraint.
+			name: "fk_delete_child_and_parent",
+			txn1: txnCase{
+				events: []streampb.StreamEvent_KV{
+					childEB.DeleteEvent(txnTime, fkChildRow(1, 10, 100, 0)),
+				},
+				writeLockCount: 1,
+				readLockCount:  2,
+				order:          []int{0},
+			},
+			txn2: txnCase{
+				events: []streampb.StreamEvent_KV{
+					parentEB.DeleteEvent(txnTime, fkParentRow(10, 50, 0)),
+				},
+				writeLockCount: 4,
+				order:          []int{0},
+			},
+			writeOverlapCount: 1,
+		},
+		{
+			// Updating a child row without changing any FK columns should
+			// not produce FK locks, since the parent relationship is unchanged.
+			name: "fk_update_child_unchanged_fk_cols",
+			txn1: txnCase{
+				events: []streampb.StreamEvent_KV{
+					childEB.UpdateEvent(txnTime,
+						fkChildRow(1, 10, 100, 1),
+						fkChildRow(1, 10, 100, 0)),
+				},
+				writeLockCount: 1, // PK only
+				order:          []int{0},
+			},
+		},
+		{
+			// Updating a child's FK column to reference a different parent
+			// should produce locks on both the old and new parent values.
+			name: "fk_update_child_changed_fk_col",
+			txn1: txnCase{
+				events: []streampb.StreamEvent_KV{
+					childEB.UpdateEvent(txnTime,
+						fkChildRow(1, 10, 200, 0),
+						fkChildRow(1, 10, 100, 0)),
+				},
+				// PK + FK(read,100) + FK(read,200). parent_id=10 unchanged.
+				writeLockCount: 1,
+				readLockCount:  2,
+				order:          []int{0},
+			},
+		},
+		{
+			// Inserting a child with NULL FK columns does not reference any
+			// parent, so no FK locks should be produced.
+			name: "fk_insert_child_null_fk_cols",
+			txn1: txnCase{
+				events: []streampb.StreamEvent_KV{
+					childEB.InsertEvent(txnTime, fkChildRow(1, -1, -1, 0)),
+				},
+				writeLockCount: 1, // PK only
+				order:          []int{0},
+			},
+		},
+		{
+			// Updating a parent's referenced column (ref_col) must produce
+			// FK locks, since children may depend on both the old and new
+			// values.
+			name: "fk_update_parent_referenced_col",
+			txn1: txnCase{
+				events: []streampb.StreamEvent_KV{
+					parentEB.UpdateEvent(txnTime,
+						fkParentRow(1, 20, 0),
+						fkParentRow(1, 10, 0)),
+				},
+				// PK + UC(write,10) + UC(write,20) + FK(write,10,ref_col) +
+				// FK(write,20,ref_col) = 5 write.
+				// Inbound FK on id=1: unchanged → skipped.
+				writeLockCount: 5,
+				order:          []int{0},
+			},
+		},
+		{
+			// Updating a parent column that no child references should not
+			// produce any FK or UC locks.
+			name: "fk_update_parent_unreferenced_col",
+			txn1: txnCase{
+				events: []streampb.StreamEvent_KV{
+					parentEB.UpdateEvent(txnTime,
+						fkParentRow(1, 10, 1),
+						fkParentRow(1, 10, 0)),
+				},
+				writeLockCount: 1, // PK only
+				order:          []int{0},
+			},
+		},
+		{
+			name: "fk_child_starts_referencing_value_parent_is_changing",
+			txn1: txnCase{
+				events: []streampb.StreamEvent_KV{
+					// Child starts referencing ref_col=10.
+					childEB.UpdateEvent(txnTime,
+						fkChildRow(1, 10, 10, 0),
+						fkChildRow(1, 10, 20, 0)),
+					// Parent changes ref_col from 5 to 10.
+					parentEB.UpdateEvent(txnTime,
+						fkParentRow(2, 10, 0),
+						fkParentRow(2, 5, 0)),
+				},
+				writeLockCount: 6,
+				readLockCount:  1,
+				order:          []int{1, 0},
+			},
+		},
+		{
+			// Child and parent updates that touch completely disjoint FK
+			// values should not require reordering, since neither depends
+			// on a value the other is changing.
+			name: "fk_child_and_parent_disjoint_values",
+			txn1: txnCase{
+				events: []streampb.StreamEvent_KV{
+					childEB.UpdateEvent(txnTime,
+						fkChildRow(1, 10, 20, 0),
+						fkChildRow(1, 10, 10, 0)),
+					parentEB.UpdateEvent(txnTime,
+						fkParentRow(2, 40, 0),
+						fkParentRow(2, 30, 0)),
+				},
+				writeLockCount: 6,
+				readLockCount:  2,
+				order:          []int{0, 1},
+			},
+		},
+		{
+			// Inserting a child that references a parent's ref_col while
+			// the parent is updating that ref_col to a new value in the
+			// same txn. The parent update must be applied first so the
+			// referenced value still exists when the child is inserted.
+			name: "fk_insert_child_while_parent_updates_ref",
+			txn1: txnCase{
+				events: []streampb.StreamEvent_KV{
+					childEB.InsertEvent(txnTime, fkChildRow(1, 5, 20, 0)),
+					parentEB.UpdateEvent(txnTime,
+						fkParentRow(2, 20, 0),
+						fkParentRow(2, 10, 0)),
+				},
+				writeLockCount: 6,
+				readLockCount:  1,
+				order:          []int{1, 0},
+			},
+		},
+		{
+			// Deleting a child and its parent in the same txn. The child
+			// must be deleted before the parent to avoid violating the FK
+			// constraint.
+			name: "fk_delete_child_then_parent_same_txn",
+			txn1: txnCase{
+				events: []streampb.StreamEvent_KV{
+					parentEB.DeleteEvent(txnTime, fkParentRow(10, 50, 0)),
+					childEB.DeleteEvent(txnTime, fkChildRow(1, 10, 50, 0)),
+				},
+				writeLockCount: 5,
+				readLockCount:  0,
+				order:          []int{1, 0},
+			},
+		},
+		{
+			// Inserting a new parent and a child that references it in the
+			// same txn. The parent must be inserted before the child so the
+			// FK reference is valid.
+			name: "fk_insert_parent_then_child_same_txn",
+			txn1: txnCase{
+				events: []streampb.StreamEvent_KV{
+					childEB.InsertEvent(txnTime, fkChildRow(1, 10, 50, 0)),
+					parentEB.InsertEvent(txnTime, fkParentRow(10, 50, 0)),
+				},
+				writeLockCount: 5,
+				order:          []int{1, 0},
+			},
+		},
+		{
+			// Self-referential: inserting a parent row and a child row
+			// that references it in the same txn. The parent must be
+			// inserted first.
+			name: "fk_self_ref_insert_parent_then_child",
+			txn1: txnCase{
+				events: []streampb.StreamEvent_KV{
+					selfRefEB.InsertEvent(txnTime, selfRefRow(2, 1, 0)),
+					selfRefEB.InsertEvent(txnTime, selfRefRow(1, -1, 0)),
+				},
+				writeLockCount: 4,
+				readLockCount:  0,
+				order:          []int{1, 0},
+			},
+		},
+		{
+			// Self-referential: deleting a child row and the parent row it
+			// references in the same txn. The child must be deleted first.
+			name: "fk_self_ref_delete_child_then_parent",
+			txn1: txnCase{
+				events: []streampb.StreamEvent_KV{
+					selfRefEB.DeleteEvent(txnTime, selfRefRow(1, -1, 0)),
+					selfRefEB.DeleteEvent(txnTime, selfRefRow(2, 1, 0)),
+				},
+				writeLockCount: 4,
+				readLockCount:  0,
+				order:          []int{1, 0},
+			},
+		},
+		{
+			// Self-referential FK: updating a row's parent_id should only
+			// produce outbound FK locks (on the referenced parent rows),
+			// not inbound locks on the row's own PK since it is unchanged.
+			name: "fk_self_ref_update_parent_id",
+			txn1: txnCase{
+				events: []streampb.StreamEvent_KV{
+					selfRefEB.UpdateEvent(txnTime,
+						selfRefRow(1, 10, 0),
+						selfRefRow(1, 5, 0)),
+				},
+				// PK = 1 write; FK(read,5) + FK(read,10) = 2 read.
+				writeLockCount: 1,
+				readLockCount:  2,
+				order:          []int{0},
+			},
+		},
+		{
+			// We should delete the id=10 row only after we've updated the id=1 row that references it.
+			name: "fk_self_ref_delete_parent_id",
+			txn1: txnCase{
+				events: []streampb.StreamEvent_KV{
+					selfRefEB.DeleteEvent(txnTime, selfRefRow(10, -1, 0)),
+					selfRefEB.UpdateEvent(txnTime,
+						selfRefRow(1, 5, 0),
+						selfRefRow(1, 10, 0)),
+				},
+				// 3 write locks = 2 PK + FK(10); 1 read lock = FK(5).
+				writeLockCount: 3,
+				readLockCount:  1,
+				order:          []int{1, 0},
+			},
+		},
+		{
+			name: "fk_update_null_to_non_null_insert",
+			txn1: txnCase{
+				events: []streampb.StreamEvent_KV{
+					childEB.UpdateEvent(txnTime,
+						fkChildRow(1, 1, 1, 1),
+						fkChildRow(1, -1, -1, 0)),
+					parentEB.InsertEvent(txnTime,
+						fkParentRow(1, 1, 1)),
+				},
+				// 2 PKs + UC(1) + 2 FKs that are changing
+				writeLockCount: 5,
+				order:          []int{1, 0},
+			},
+		},
+		{
+			name: "fk_update_non_null_to_null_delete",
+			txn1: txnCase{
+				events: []streampb.StreamEvent_KV{
+					parentEB.DeleteEvent(txnTime,
+						fkParentRow(1, 1, 1)),
+					childEB.UpdateEvent(txnTime,
+						fkChildRow(1, -1, -1, 0),
+						fkChildRow(1, 1, 1, 1)),
+				},
+				// 2 PKs + 2 FKs that are changing + 1 UC delete
+				writeLockCount: 5,
+				order:          []int{1, 0},
+			},
+		},
+		{
+			name: "fk_swap_parents",
+			txn1: txnCase{
+				events: []streampb.StreamEvent_KV{
+					parentEB.DeleteEvent(txnTime, fkParentRow(10, 100, 0)),
+					childEB.UpdateEvent(txnTime,
+						fkChildRow(1, 20, -1, 0),
+						fkChildRow(1, 10, -1, 0)),
+					parentEB.InsertEvent(txnTime, fkParentRow(20, 200, 0)),
+				},
+
+				// Delete: PK + UC delete + 2 FK parent = 4
+				// Update: PK = 1 (FK reads upgraded to write via collision)
+				// Insert: PK + UC insert + 2 FK parent = 4
+				writeLockCount: 9,
+				order:          []int{2, 1, 0},
+			},
+		},
+
+		{
+			// Ensure we don't have spurious dependencies when deleting two unrelated
+			// rows with fk dependencies.
+			name: "fk_delete_null_fk_child_and_parent_same_txn",
+			txn1: txnCase{
+				events: []streampb.StreamEvent_KV{
+					parentEB.DeleteEvent(txnTime, fkParentRow(10, 50, 0)),
+					childEB.DeleteEvent(txnTime, fkChildRow(1, -1, -1, 0)),
+				},
+				// parent delete: PK + UC(50) + FK(id=10) + FK(ref_col=50) = 4
+				// child delete: PK
+				writeLockCount: 5,
+				order:          []int{0, 1},
+			},
+		},
+		{
+			name: "fk_insert_parent_update_child_to_new_parent",
+			txn1: txnCase{
+				events: []streampb.StreamEvent_KV{
+					childEB.UpdateEvent(txnTime,
+						fkChildRow(1, 10, -1, 0),
+						fkChildRow(1, 5, -1, 0)),
+					parentEB.InsertEvent(txnTime, fkParentRow(10, 50, 0)),
+				},
+				// child: PK
+				// parent: PK + UC(50) + FK(id=10) + FK(ref_col=50) = 4
+				writeLockCount: 5,
+				// child: FK(parent_id=5)
+				readLockCount: 1,
+				order:         []int{1, 0},
+			},
+		},
+		{
+			// Cross-txn: Txn1 inserts a parent, Txn2 inserts a child
+			// referencing that parent. The child's FK read lock on
+			// parent_id overlaps with the parent's PK write lock.
+			name: "fk_cross_txn_parent_insert_child_insert",
+			txn1: txnCase{
+				events: []streampb.StreamEvent_KV{
+					parentEB.InsertEvent(txnTime, fkParentRow(10, 50, 0)),
+				},
+				// PK + UC(50) + FK(id=10) + FK(ref_col=50) = 4
+				writeLockCount: 4,
+				order:          []int{0},
+			},
+			txn2: txnCase{
+				events: []streampb.StreamEvent_KV{
+					childEB.InsertEvent(txnTime, fkChildRow(1, 10, -1, 0)),
+				},
+				// PK
+				writeLockCount: 1,
+				// FK(parent_id=10)
+				readLockCount: 1,
+				order:         []int{0},
+			},
+			// child FK read lock on parent_id=10 overlaps with
+			// parent's inbound FK write lock on id=10.
+			writeOverlapCount: 1,
+		},
+		{
+			// Txn1 deletes a parent, Txn2 inserts a child
+			// referencing that parent. The child's FK read lock
+			// overlaps with the parent delete's write lock.
+			name: "fk_cross_txn_parent_delete_child_insert",
+			txn1: txnCase{
+				events: []streampb.StreamEvent_KV{
+					parentEB.DeleteEvent(txnTime, fkParentRow(10, 50, 0)),
+				},
+				// PK + UC + 2 FK
+				writeLockCount: 4,
+				order:          []int{0},
+			},
+			txn2: txnCase{
+				events: []streampb.StreamEvent_KV{
+					childEB.InsertEvent(txnTime, fkChildRow(1, 10, -1, 0)),
+				},
+				// PK = 1 write
+				writeLockCount: 1,
+				// FK(parent_id=10)
+				readLockCount: 1,
+				order:         []int{0},
+			},
+			// child FK read lock on parent_id=10 overlaps with
+			// parent's inbound FK write lock on id=10.
+			writeOverlapCount: 1,
+		},
+		{
+			// We always emit pk locks, but we don't need to do the same for fk locks on
+			// pk, i.e why we use separate FK locks instead of letting them overlap with
+			// the UC locks. Test we don't have spurious dependencies in this case.
+			name: "fk_cross_txn_no_overlap",
+			txn1: txnCase{
+				events: []streampb.StreamEvent_KV{
+					parentEB.UpdateEvent(txnTime,
+						fkParentRow(10, 50, 1),
+						fkParentRow(10, 50, 0)),
+				},
+				writeLockCount: 1,
+				order:          []int{0},
+			},
+			txn2: txnCase{
+				events: []streampb.StreamEvent_KV{
+					childEB.DeleteEvent(txnTime, fkChildRow(1, 10, 50, 0)),
+				},
+				writeLockCount: 1,
+				readLockCount:  2,
+				order:          []int{0},
+			},
+		},
+		{
+			// Composite FK child with column order inverted relative to the
+			// parent. Child insert must overlap with parent delete
+			// on both the PK and UC FK locks.
+			name: "composite_fk_insert_child_and_parent",
+			txn1: txnCase{
+				events: []streampb.StreamEvent_KV{
+					compositeChildEB.InsertEvent(txnTime, compositeFKChildRow(0, 2, 1, 4, 3)),
+				},
+				writeLockCount: 1,
+				readLockCount:  2,
+				order:          []int{0},
+			},
+			txn2: txnCase{
+				events: []streampb.StreamEvent_KV{
+					compositeFKParentEB.DeleteEvent(txnTime, compositeFKParentRow(1, 2, 3, 4, 0)),
+				},
+				// PK + UC + 2 inbound FK = 4.
+				writeLockCount: 4,
+				order:          []int{0},
+			},
+			writeOverlapCount: 2,
+		},
+		{
+			// Insert parent and child in same txn. Parent must come first.
+			name: "composite_fk_insert_parent_then_child_same_txn",
+			txn1: txnCase{
+				events: []streampb.StreamEvent_KV{
+					compositeChildEB.InsertEvent(txnTime, compositeFKChildRow(1, 2, 1, 4, 3)),
+					compositeFKParentEB.InsertEvent(txnTime, compositeFKParentRow(1, 2, 3, 4, 0)),
+				},
+				// 2 PKs + UC + 2 FK (read→write via collision) = 5.
+				writeLockCount: 5,
+				order:          []int{1, 0},
+			},
+		},
+		{
+			// Disjoint FK values should not overlap.
+			name: "composite_fk_no_overlap_disjoint_values",
+			txn1: txnCase{
+				events: []streampb.StreamEvent_KV{
+					compositeChildEB.InsertEvent(txnTime, compositeFKChildRow(2, 20, 10, 40, 30)),
+				},
+				writeLockCount: 1,
+				readLockCount:  2,
+				order:          []int{0},
+			},
+			txn2: txnCase{
+				events: []streampb.StreamEvent_KV{
+					compositeFKParentEB.DeleteEvent(txnTime, compositeFKParentRow(1, 2, 3, 4, 0)),
+				},
+				writeLockCount: 4,
+				order:          []int{0},
+			},
+		},
+		{
+			// Updating child FK columns produces locks on both old and new
+			// values. Old values overlap with parent delete.
+			name: "composite_fk_update_child_fk_cols",
+			txn1: txnCase{
+				events: []streampb.StreamEvent_KV{
+					compositeChildEB.UpdateEvent(txnTime,
+						compositeFKChildRow(1, 20, 10, 40, 30),
+						compositeFKChildRow(1, 2, 1, 4, 3)),
+				},
+				// PK + 2 old FK + 2 new FK = 1 write, 4 read.
+				writeLockCount: 1,
+				readLockCount:  4,
+				order:          []int{0},
+			},
+			txn2: txnCase{
+				events: []streampb.StreamEvent_KV{
+					// Parent that the child is moving away from.
+					compositeFKParentEB.DeleteEvent(txnTime, compositeFKParentRow(1, 2, 3, 4, 0)),
+				},
+				writeLockCount: 4,
+				order:          []int{0},
+			},
+			// Child's old FK read locks on (a=1,b=2) and (c=3,d=4) overlap
+			// with parent's inbound FK write locks.
+			writeOverlapCount: 2,
 		},
 	}
 
@@ -461,7 +1162,17 @@ func TestDeriveLocks(t *testing.T) {
 			return LockSet{}
 		}
 		require.NoError(t, err)
-		require.Len(t, result.Locks, tc.lockCount, "%s lock count", label)
+
+		var readCount, writeCount int
+		for _, l := range result.Locks {
+			if l.Read {
+				readCount++
+			} else {
+				writeCount++
+			}
+		}
+		require.Equal(t, tc.writeLockCount, writeCount, "%s write lock count", label)
+		require.Equal(t, tc.readLockCount, readCount, "%s read lock count", label)
 		requireSortOrder(t, rows, result.SortedRows, tc.order, label)
 		return result
 	}
@@ -476,8 +1187,9 @@ func TestDeriveLocks(t *testing.T) {
 			ls2 := checkTxn(t, tc.txn2, "txn2")
 
 			if tc.txn1.err == nil && tc.txn2.err == nil {
-				require.Equal(t, tc.overlapCount,
-					overlappingLocks(ls1, ls2), "overlap count")
+				writeOverlaps, readOverlaps := overlappingLocks(ls1, ls2)
+				require.Equal(t, tc.writeOverlapCount, writeOverlaps, "write overlap count")
+				require.Equal(t, tc.readOverlapCount, readOverlaps, "read overlap count")
 			}
 		})
 	}

--- a/pkg/crosscluster/logical/txnlock/schema.go
+++ b/pkg/crosscluster/logical/txnlock/schema.go
@@ -26,7 +26,21 @@ type tableConstraints struct {
 	// changing.
 	PrimaryKeyConstraint columnSet
 	UniqueConstraints    []columnSet
-	// TODO(jeffswenson): add support for foreign key ordering
+	// OutboundForeignKeyConstraints are the column sets for the foreign key constraints
+	// where this is the origin table, i.e. the child. It maps the constraint mixin
+	// to the column set for the constraint.
+	OutboundForeignKeyConstraints map[uint64]columnSet
+	// InboundForeignKeyConstraints are the column sets for the foreign key constraints
+	// where this is the referenced table, i.e. the parent.
+	//
+	// Note that for every inbound FK constraint, there must be a corresponding PK/UC constraint
+	// that we've created either in this table or another. However, we opt for separate column sets
+	// for locking since:
+	// 1. We always emit a write lock for the primary key constraint, but want to make the same
+	// optimization as unique constraints where we only acquire a write lock if the value is changing.
+	// 2. We need to be able to cross-reference which outbound FK constraint corresponds to which inbound
+	// FK constraint to easily determine equality of rows.
+	InboundForeignKeyConstraints map[uint64]columnSet
 }
 
 func newTableConstraints(
@@ -38,7 +52,11 @@ func newTableConstraints(
 		colIDToIndex[col.Column.GetID()] = int32(i)
 	}
 
-	tc := &tableConstraints{evalCtx: evalCtx}
+	tc := &tableConstraints{
+		evalCtx:                       evalCtx,
+		OutboundForeignKeyConstraints: make(map[uint64]columnSet),
+		InboundForeignKeyConstraints:  make(map[uint64]columnSet),
+	}
 
 	makeUniqueConstraint := func(uc catalog.UniqueConstraint) (columnSet, error) {
 		colIDs := uc.CollectKeyColumnIDs().Ordered()
@@ -46,7 +64,7 @@ func newTableConstraints(
 		for i, colID := range colIDs {
 			cols[i] = colIDToIndex[colID]
 		}
-		ucMixin, err := uniqueIndexMixin(
+		ucMixin, err := constraintMixin(
 			table.GetID(),
 			uc.GetConstraintID(),
 		)
@@ -54,6 +72,7 @@ func newTableConstraints(
 			return columnSet{}, err
 		}
 		return columnSet{
+			tableID: table.GetID(),
 			columns: cols,
 			mixin:   ucMixin,
 		}, nil
@@ -77,6 +96,46 @@ func newTableConstraints(
 			return nil, err
 		}
 		tc.UniqueConstraints = append(tc.UniqueConstraints, constraint)
+	}
+
+	for _, fk := range table.EnforcedOutboundForeignKeys() {
+		// Use the origin column ID ordering here in the case of composite FKs where the ordering
+		// of the outbound and inbound columns may differ, but we still need the hash to collide.
+		numCols := fk.NumOriginColumns()
+		cols := make([]int32, numCols)
+		for i := range numCols {
+			cols[i] = colIDToIndex[fk.GetOriginColumnID(i)]
+		}
+		// N.B. we use the origin table ID and constraint ID for the mixin for both sides
+		// so they collide. We use the origin side for uniqueness since there can be one
+		// to many referenced to origin relationships but not the other way around.
+		fkMixin, err := constraintMixin(fk.GetOriginTableID(), fk.GetConstraintID())
+		if err != nil {
+			return nil, err
+		}
+		tc.OutboundForeignKeyConstraints[fkMixin] = columnSet{
+			tableID: table.GetID(),
+			columns: cols,
+			mixin:   fkMixin,
+		}
+	}
+
+	for _, fk := range table.InboundForeignKeys() {
+		numCols := fk.NumReferencedColumns()
+		cols := make([]int32, numCols)
+		for i := range numCols {
+			cols[i] = colIDToIndex[fk.GetReferencedColumnID(i)]
+		}
+		// Use the origin table ID so both sides of the FK produce the same mixin.
+		fkMixin, err := constraintMixin(fk.GetOriginTableID(), fk.GetConstraintID())
+		if err != nil {
+			return nil, err
+		}
+		tc.InboundForeignKeyConstraints[fkMixin] = columnSet{
+			tableID: table.GetID(),
+			columns: cols,
+			mixin:   fkMixin,
+		}
 	}
 
 	if len(tc.PrimaryKeyConstraint.columns) == 0 {
@@ -104,6 +163,26 @@ func (t *tableConstraints) deriveLocks(
 ) ([]Lock, error) {
 	locks := make([]Lock, 0, len(t.UniqueConstraints)*2+1)
 
+	var err error
+	locks, err = t.derivePKLocks(ctx, row, locks)
+	if err != nil {
+		return nil, err
+	}
+	locks, err = t.deriveUniqueLocks(ctx, row, locks)
+	if err != nil {
+		return nil, err
+	}
+	locks, err = t.deriveFKLocks(ctx, row, locks)
+	if err != nil {
+		return nil, err
+	}
+
+	return locks, nil
+}
+
+func (t *tableConstraints) derivePKLocks(
+	ctx context.Context, row ldrdecoder.DecodedRow, locks []Lock,
+) ([]Lock, error) {
 	pkRow := row.Row
 	if row.IsDeleteRow() {
 		pkRow = row.PrevRow
@@ -116,7 +195,12 @@ func (t *tableConstraints) deriveLocks(
 		Hash: lock,
 		Read: false,
 	})
+	return locks, nil
+}
 
+func (t *tableConstraints) deriveUniqueLocks(
+	ctx context.Context, row ldrdecoder.DecodedRow, locks []Lock,
+) ([]Lock, error) {
 	for _, uc := range t.UniqueConstraints {
 		if uc.null(row.Row) && uc.null(row.PrevRow) {
 			continue
@@ -135,7 +219,7 @@ func (t *tableConstraints) deriveLocks(
 			}
 			locks = addLock(locks, Lock{
 				Hash: h,
-				Read: true,
+				Read: false,
 			})
 		}
 		if !uc.null(row.PrevRow) {
@@ -152,7 +236,56 @@ func (t *tableConstraints) deriveLocks(
 	return locks, nil
 }
 
-// DependsOn returns true if b must be applied before a can be applied.
+func (t *tableConstraints) deriveFKLocks(
+	ctx context.Context, row ldrdecoder.DecodedRow, locks []Lock,
+) ([]Lock, error) {
+	addFKLocks := func(constraints map[uint64]columnSet, read bool) error {
+		for _, fk := range constraints {
+			// Skip emitting locks if the FK columns did not change.
+			if row.IsUpdateRow() {
+				eq, err := fk.equal(ctx, t.evalCtx, row.Row, row.PrevRow)
+				if err != nil {
+					return err
+				}
+				if eq {
+					continue
+				}
+			}
+			if !fk.null(row.Row) {
+				h, err := fk.hash(ctx, row.Row)
+				if err != nil {
+					return err
+				}
+				locks = addLock(locks, Lock{
+					Hash: h,
+					Read: read,
+				})
+			}
+			if !fk.null(row.PrevRow) {
+				h, err := fk.hash(ctx, row.PrevRow)
+				if err != nil {
+					return err
+				}
+				locks = addLock(locks, Lock{
+					Hash: h,
+					Read: read,
+				})
+			}
+		}
+		return nil
+	}
+	if err := addFKLocks(t.OutboundForeignKeyConstraints, true); err != nil {
+		return nil, err
+	}
+	if err := addFKLocks(t.InboundForeignKeyConstraints, false); err != nil {
+		return nil, err
+	}
+
+	return locks, nil
+}
+
+// DependsOn returns true if b must be applied before a can be applied. Only
+// unique constraint conflicts are checked here. FK ordering is handled by fkDependsOn.
 func (t *tableConstraints) DependsOn(
 	ctx context.Context, a, b ldrdecoder.DecodedRow,
 ) (bool, error) {
@@ -167,5 +300,46 @@ func (t *tableConstraints) DependsOn(
 			return true, nil
 		}
 	}
+	return false, nil
+}
+
+// fkDependsOn returns true if b must be applied before a can be applied.
+// t is a's tableConstraints, otherTC is b's tableConstraints.
+func (t *tableConstraints) fkDependsOn(
+	ctx context.Context, otherTC *tableConstraints, a, b ldrdecoder.DecodedRow,
+) (bool, error) {
+	// a is the child, b is the parent. a depends on b if b is inserting a
+	// parent value that a's new row needs to reference.
+	for _, outbound := range t.OutboundForeignKeyConstraints {
+		inbound, ok := otherTC.InboundForeignKeyConstraints[outbound.mixin]
+		if !ok {
+			continue
+		}
+		eq, err := columnSetEqual(ctx, t.evalCtx, &outbound, &inbound, a.Row, b.Row)
+		if err != nil {
+			return false, err
+		}
+		if eq {
+			return true, nil
+		}
+	}
+
+	// a is the parent, b is the child. a depends on b if b is removing a
+	// child reference that currently prevents a's parent row from being
+	// deleted.
+	for _, inbound := range t.InboundForeignKeyConstraints {
+		outbound, ok := otherTC.OutboundForeignKeyConstraints[inbound.mixin]
+		if !ok {
+			continue
+		}
+		eq, err := columnSetEqual(ctx, t.evalCtx, &inbound, &outbound, a.PrevRow, b.PrevRow)
+		if err != nil {
+			return false, err
+		}
+		if eq {
+			return true, nil
+		}
+	}
+
 	return false, nil
 }


### PR DESCRIPTION
This change introduces foreign key lock synthesis for ldr's transaction mode. Transactions with FK constraints are now sorted within the transaction.

Epic: https://cockroachlabs.atlassian.net/browse/CRDB-57649
Release note: none