### PR TITLE
concurrency: fix data race in lockTableGuardImpl toResolve mutation

### DIFF
--- a/pkg/kv/kvserver/concurrency/concurrency_control.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_control.go
@@ -904,6 +904,10 @@ type lockTableGuard interface {
 	// virtually during evaluation rather than physically before re-scanning.
 	VirtuallyResolvesIntents() bool
 
+	// AddReplicatedToResolveAndSignal adds a lock update for a replicated lock
+	// to the guard's resolve list and signals the guard to rescan.
+	AddReplicatedToResolveAndSignal(roachpb.LockUpdate)
+
 	// PrepareForLockConflictRetry is called when handling a LockConflictError
 	// after evaluation. It condenses point resolve entries into range entries
 	// that persist across re-sequencing.

--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -1002,7 +1002,13 @@ func (g *lockTableGuardImpl) doneActivelyWaitingAtLock() {
 
 // AddReplicatedToResolveAndSignal implements the lockTableGuard interface.
 func (g *lockTableGuardImpl) AddReplicatedToResolveAndSignal(up roachpb.LockUpdate) {
+	g.lt.removeReaderFromKey(g, up.Span.Key)
 	g.toResolve.add(up)
+	// removeReaderFromKey notifies the guard when it successfully removes
+	// us from the waiting readers list. If we weren't found (e.g. because
+	// another goroutine already removed us), that goroutine would have
+	// already notified us. We notify defensively here to ensure the guard
+	// always makes progress, even if the above reasoning is violated.
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	g.doneActivelyWaitingAtLock()
@@ -5063,6 +5069,29 @@ func stepToNextSpan(g *lockTableGuardImpl) *roachpb.Span {
 // have been pushed above the reader's timestamp.
 func (t *lockTableImpl) batchPushedLockResolution() bool {
 	return BatchPushedLockResolution.Get(&t.settings.SV)
+}
+
+// removeReaderFromKey removes the guard from the waitingReaders list of the
+// keyLocks at the given key, if the guard is present. This is called after a
+// successful push with virtual intent resolution so the guard does not remain
+// as a stale entry in the lock's waiter list.
+func (t *lockTableImpl) removeReaderFromKey(g *lockTableGuardImpl, key roachpb.Key) {
+	t.locks.mu.RLock()
+	defer t.locks.mu.RUnlock()
+	iter := t.locks.MakeIter()
+	iter.FirstOverlap(&keyLocks{key: key})
+	if !iter.Valid() {
+		return
+	}
+	kl := iter.Cur()
+	kl.mu.Lock()
+	defer kl.mu.Unlock()
+	for e := kl.waitingReaders.Front(); e != nil; e = e.Next() {
+		if e.Value == g {
+			kl.removeReader(e)
+			return
+		}
+	}
 }
 
 // PushedTransactionUpdated implements the lockTable interface.

--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -1000,6 +1000,14 @@ func (g *lockTableGuardImpl) doneActivelyWaitingAtLock() {
 	g.notify()
 }
 
+// AddReplicatedToResolveAndSignal implements the lockTableGuard interface.
+func (g *lockTableGuardImpl) AddReplicatedToResolveAndSignal(up roachpb.LockUpdate) {
+	g.toResolve.add(up)
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.doneActivelyWaitingAtLock()
+}
+
 func (g *lockTableGuardImpl) txnMeta() *enginepb.TxnMeta {
 	if g.txn == nil {
 		return nil
@@ -1092,11 +1100,16 @@ func (g *lockTableGuardImpl) isSameTxn(txn *enginepb.TxnMeta) bool {
 // conflictWithHeld locks return true if the given lock conflicts with the
 // request for this guard.
 //
-// The resolveMustBeVirtual indicates whether locks which can be resolved based
-// on the txn status cache should only be considered when the request is
-// configured for a virtual resolution.
+// When readOnly is true, the method only checks for conflicts without appending
+// to the guard's toResolve lists. This is used by recomputeWaitQueues, which
+// runs on guards owned by OTHER goroutines, to avoid the data race of mutating
+// toResolve/toResolveUnreplicated concurrently with the guard's own goroutine.
+//
+// When readOnly is false (the normal scan path), locks that can be resolved
+// based on the txn status cache are appended to toResolve and the lock is
+// treated as non-conflicting.
 func (g *lockTableGuardImpl) conflictsWithHeldLock(
-	tl *txnLock, key roachpb.Key, resolveMustBeVirtual bool,
+	tl *txnLock, key roachpb.Key, readOnly bool,
 ) bool {
 	lockHolderTxn := tl.getLockHolderTxn()
 	if g.isSameTxn(lockHolderTxn) {
@@ -1113,12 +1126,10 @@ func (g *lockTableGuardImpl) conflictsWithHeldLock(
 		return false // No conflict for a lock we are going to resolve.
 	}
 
-	if canResolve, up := g.canResolveKeyForHoldingTransaction(lockHolderTxn, g.curStrength(), key); canResolve {
-		// We share this code with a couple of contexts. For now, we want to avoid waking up
-		// readers who are not going to virtually resolve their intents.
-		//
-		// TODO(ssd): Should we just wake up everyone?
-		if (resolveMustBeVirtual && g.virtuallyResolveIntents) || !resolveMustBeVirtual {
+	if !readOnly {
+		if canResolve, up := g.canResolveKeyForHoldingTransaction(
+			lockHolderTxn, g.curStrength(), key,
+		); canResolve {
 			if !tl.isHeldReplicated() {
 				// Only held unreplicated. Accumulate it as an unreplicated lock to
 				// resolve, in case any other waiting readers can benefit from the
@@ -3021,7 +3032,7 @@ func (kl *keyLocks) conflictsWithLockHolders(g *lockTableGuardImpl) bool {
 	}
 
 	for e := kl.holders.Front(); e != nil; e = e.Next() {
-		if g.conflictsWithHeldLock(e.Value, kl.key, false) {
+		if g.conflictsWithHeldLock(e.Value, kl.key, false /* readOnly */) {
 			return true
 		}
 	}
@@ -3843,7 +3854,7 @@ func (kl *keyLocks) recomputeWaitQueues(st *cluster.Settings) {
 		reader := e.Value
 		curr := e
 		e = e.Next()
-		if !reader.conflictsWithHeldLock(txnLock, kl.key, true /* only allow virtual resolve */) {
+		if !reader.conflictsWithHeldLock(txnLock, kl.key, true /* readOnly */) {
 			kl.removeReader(curr)
 		}
 	}
@@ -5061,34 +5072,6 @@ func (t *lockTableImpl) PushedTransactionUpdated(
 	txn *roachpb.Transaction, clockObs roachpb.ObservedTimestamp,
 ) {
 	t.txnStatusCache.add(txn, clockObs)
-	t.maybeWakeReadersForPushedTxn(txn, clockObs)
-}
-
-// maybeWakeReadersForPushedTxn iterates over all locks in the lock table and
-// wakes waiting readers that can virtually resolve replicated locks held by the
-// pushed transaction. For each eligible reader, a LockUpdate is added to its
-// toResolve slice and the reader is removed from the lock's wait queue.
-//
-// TODO(ssd): Currently this is scanning the entire lock table and recomputing
-// the queue for any lock held by the pushed txn. We may want to only wake the
-// queue for the specific key that led to us pushing in the first place.
-func (t *lockTableImpl) maybeWakeReadersForPushedTxn(
-	txn *roachpb.Transaction, clockObs roachpb.ObservedTimestamp,
-) {
-	t.locks.mu.RLock()
-	defer t.locks.mu.RUnlock()
-	iter := t.locks.MakeIter()
-	for iter.First(); iter.Valid(); iter.Next() {
-		kl := iter.Cur()
-		kl.mu.Lock()
-
-		if !kl.isLockedBy(txn.ID) {
-			kl.mu.Unlock()
-			continue
-		}
-		kl.recomputeWaitQueues(t.settings)
-		kl.mu.Unlock()
-	}
 }
 
 // Enable implements the lockTable interface.

--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -1097,19 +1097,17 @@ func (g *lockTableGuardImpl) isSameTxn(txn *enginepb.TxnMeta) bool {
 	return g.txn != nil && g.txn.ID == txn.ID
 }
 
-// conflictWithHeld locks return true if the given lock conflicts with the
+// conflictsWithHeldLock returns true if the given lock conflicts with the
 // request for this guard.
 //
-// When readOnly is true, the method only checks for conflicts without appending
-// to the guard's toResolve lists. This is used by recomputeWaitQueues, which
-// runs on guards owned by OTHER goroutines, to avoid the data race of mutating
-// toResolve/toResolveUnreplicated concurrently with the guard's own goroutine.
-//
-// When readOnly is false (the normal scan path), locks that can be resolved
-// based on the txn status cache are appended to toResolve and the lock is
-// treated as non-conflicting.
+// callerOwned indicates whether the caller's goroutine owns this guard. When
+// false (e.g. when called from recomputeWaitQueues on another request's guard),
+// the method avoids accessing unsynchronized guard state such as toResolve and
+// toResolveUnreplicated to prevent data races. When true (the normal scan
+// path), locks that can be resolved based on the txn status cache or existing
+// resolve entries are treated as non-conflicting.
 func (g *lockTableGuardImpl) conflictsWithHeldLock(
-	tl *txnLock, key roachpb.Key, readOnly bool,
+	tl *txnLock, key roachpb.Key, callerOwned bool,
 ) bool {
 	lockHolderTxn := tl.getLockHolderTxn()
 	if g.isSameTxn(lockHolderTxn) {
@@ -1122,11 +1120,11 @@ func (g *lockTableGuardImpl) conflictsWithHeldLock(
 		return false // no conflict with a lock held by our own transaction
 	}
 
-	if g.toResolve.contains(lockHolderTxn.ID, key) {
-		return false // No conflict for a lock we are going to resolve.
-	}
+	if callerOwned {
+		if g.toResolve.contains(lockHolderTxn.ID, key) {
+			return false // No conflict for a lock we are going to resolve.
+		}
 
-	if !readOnly {
 		if canResolve, up := g.canResolveKeyForHoldingTransaction(
 			lockHolderTxn, g.curStrength(), key,
 		); canResolve {
@@ -3032,7 +3030,7 @@ func (kl *keyLocks) conflictsWithLockHolders(g *lockTableGuardImpl) bool {
 	}
 
 	for e := kl.holders.Front(); e != nil; e = e.Next() {
-		if g.conflictsWithHeldLock(e.Value, kl.key, false /* readOnly */) {
+		if g.conflictsWithHeldLock(e.Value, kl.key, true /* callerOwned */) {
 			return true
 		}
 	}
@@ -3854,7 +3852,7 @@ func (kl *keyLocks) recomputeWaitQueues(st *cluster.Settings) {
 		reader := e.Value
 		curr := e
 		e = e.Next()
-		if !reader.conflictsWithHeldLock(txnLock, kl.key, true /* readOnly */) {
+		if !reader.conflictsWithHeldLock(txnLock, kl.key, false /* callerOwned */) {
 			kl.removeReader(curr)
 		}
 	}

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter.go
@@ -602,10 +602,11 @@ func (w *lockTableWaiterImpl) pushLockTxn(
 		// after the reader's read timestamp surpasses its global uncertainty limit.
 		resolve.ClockWhilePending = beforePushObs
 	}
-	// If the guard resolves intents virtually, skip the physical resolution.
-	// The intent is already queued in the guard's toResolve list and will be
-	// resolved virtually during evaluation.
+	// If the guard resolves intents virtually, add the lock update to the
+	// guard's toResolve list and signal it to rescan. The guard will skip the
+	// lock on rescan and carry the resolution through to evaluation.
 	if guard.VirtuallyResolvesIntents() {
+		guard.AddReplicatedToResolveAndSignal(resolve)
 		return nil
 	}
 	logResolveIntent(ctx, resolve)

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
@@ -78,13 +78,27 @@ func (g *mockLockTableGuard) CurState() (waitingState, error) {
 	return s, nil
 }
 func (g *mockLockTableGuard) ResolveBeforeScanning() []roachpb.LockUpdate {
+	if g.virtuallyResolveIntents {
+		return nil
+	}
 	return g.toResolve
 }
 func (g *mockLockTableGuard) IntentsToResolveVirtually() []roachpb.LockUpdate {
-	return g.toResolve
+	if g.virtuallyResolveIntents {
+		return g.toResolve
+	}
+	return nil
 }
 func (g *mockLockTableGuard) VirtuallyResolvesIntents() bool {
 	return g.virtuallyResolveIntents
+}
+func (g *mockLockTableGuard) AddReplicatedToResolveAndSignal(up roachpb.LockUpdate) {
+	g.toResolve = append(g.toResolve, up)
+	// Use non-blocking send, matching the real lockTableGuardImpl.notify().
+	select {
+	case g.signal <- struct{}{}:
+	default:
+	}
 }
 func (g *mockLockTableGuard) CheckOptimisticNoConflicts(*lockspanset.LockSpanSet) (ok bool) {
 	return true
@@ -421,10 +435,10 @@ func TestLockTableWaiterSkipsResolveWithVIR(t *testing.T) {
 	) (*roachpb.Transaction, bool, *Error) {
 		resp := &roachpb.Transaction{TxnMeta: *pusheeArg, Status: roachpb.ABORTED}
 		w.lt.(*mockLockTable).txnFinalizedFn = func(txn *roachpb.Transaction) {}
-		// With VIR, the physical resolve should be skipped. Transition
-		// directly to doneWaiting.
+		// With VIR, AddReplicatedToResolveAndSignal will be called after
+		// pushTxn returns, which handles signaling the guard. Transition
+		// to doneWaiting so the next CurState returns doneWaiting.
 		g.state = waitingState{kind: doneWaiting}
-		g.notify()
 		return resp, false, nil
 	}
 	ir.resolveIntent = func(context.Context, roachpb.LockUpdate, intentresolver.ResolveOptions) *Error {

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/pushed_txn_with_virtual_resolve
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/pushed_txn_with_virtual_resolve
@@ -1,5 +1,11 @@
+# Tests for the interaction between pushed transactions (PushedTransactionUpdated)
+# and virtual intent resolution. PushedTransactionUpdated populates the
+# txnStatusCache but does not directly wake waiting readers. VIR-enabled readers
+# pick up the pushed txn from the cache on their next scan and proceed to
+# resolve intents virtually during evaluation.
+
 # ---------------------------------------------------------------------------
-# Test 1: Basic wake — pending pushed txn wakes reader on replicated lock.
+# Test 1: Basic — pending pushed txn. VIR reader picks up cache on rescan.
 # ---------------------------------------------------------------------------
 
 new-lock-table maxlocks=10000
@@ -31,11 +37,10 @@ num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
 
-# Enable virtual intent resolution.
 set-virtual-intent-resolution ok=true
 ----
 
-# Reader waits on the replicated lock.
+# VIR reader waits on the replicated lock.
 new-request r=req2 txn=txn1 ts=10,1 spans=none@a
 ----
 
@@ -47,11 +52,20 @@ guard-state r=req2
 ----
 new: state=waitFor txn=txn2 key="a" held=true guard-strength=None
 
-# Push txn2 above the reader's timestamp.
+# Push txn2 above the reader's timestamp. This only populates the cache.
 pushed-txn-updated txn=txn2 status=pending ts=11,1
 ----
 
-# Reader should be woken with the intent to resolve.
+# Reader stays waiting; pushed-txn-updated does not wake it.
+guard-state r=req2
+----
+old: state=waitFor txn=txn2 key="a" held=true guard-strength=None
+
+# On rescan, the reader picks up the pushed txn from the cache and proceeds.
+scan r=req2
+----
+start-waiting: false
+
 guard-state r=req2
 ----
 new: state=doneWaiting
@@ -65,7 +79,7 @@ num=1
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
 
 # ---------------------------------------------------------------------------
-# Test 2: Finalized txn (committed) wakes reader.
+# Test 2: Committed txn — VIR reader picks up finalized status on rescan.
 # ---------------------------------------------------------------------------
 
 new-lock-table maxlocks=10000
@@ -115,6 +129,14 @@ pushed-txn-updated txn=txn2 status=committed
 
 guard-state r=req2
 ----
+old: state=waitFor txn=txn2 key="a" held=true guard-strength=None
+
+scan r=req2
+----
+start-waiting: false
+
+guard-state r=req2
+----
 new: state=doneWaiting
 Intents to resolve:
  key="a" txn=00000000-0000-0000-0000-000000000002 epoch=0 ts=10.000000000,1 status=COMMITTED
@@ -126,7 +148,7 @@ num=1
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent] [holder finalized: committed]
 
 # ---------------------------------------------------------------------------
-# Test 3: Finalized txn (aborted) wakes reader.
+# Test 3: Aborted txn — VIR reader picks up finalized status on rescan.
 # ---------------------------------------------------------------------------
 
 new-lock-table maxlocks=10000
@@ -176,6 +198,14 @@ pushed-txn-updated txn=txn2 status=aborted
 
 guard-state r=req2
 ----
+old: state=waitFor txn=txn2 key="a" held=true guard-strength=None
+
+scan r=req2
+----
+start-waiting: false
+
+guard-state r=req2
+----
 new: state=doneWaiting
 Intents to resolve:
  key="a" txn=00000000-0000-0000-0000-000000000002 epoch=0 ts=10.000000000,1 status=ABORTED
@@ -187,8 +217,9 @@ num=1
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent] [holder finalized: aborted]
 
 # ---------------------------------------------------------------------------
-# Test 4: Reader timestamp too high — NOT woken.
-# Reader at ts=12, txn2 pushed to ts=11.
+# Test 4: Push insufficient — txn2 pushed to ts=11, but VIR reader is at
+# ts=12. The pushed timestamp is still below the reader's, so the cache
+# doesn't help and the reader stays waiting even on rescan.
 # ---------------------------------------------------------------------------
 
 new-lock-table maxlocks=10000
@@ -237,18 +268,13 @@ new: state=waitFor txn=txn2 key="a" held=true guard-strength=None
 pushed-txn-updated txn=txn2 status=pending ts=11,1
 ----
 
-# Reader should NOT be woken.
 guard-state r=req2
 ----
 old: state=waitFor txn=txn2 key="a" held=true guard-strength=None
 
-print
-----
-num=1
- lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
-   waiting readers:
-    req: 2, txn: 00000000-0000-0000-0000-000000000001
+# The reader stays waiting. In the real system, eventually the reader's own
+# push timer fires and pushLockTxn discovers the push is insufficient. It
+# would NOT rescan via ScanAndEnqueue while still actively waiting.
 
 dequeue r=req2
 ----
@@ -257,293 +283,10 @@ num=1
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
 
 # ---------------------------------------------------------------------------
-# Test 5: Reader without virtuallyResolveIntents — NOT woken.
-# ---------------------------------------------------------------------------
-
-new-lock-table maxlocks=10000
-----
-
-new-txn txn=txn1 ts=10,1 epoch=0
-----
-
-new-txn txn=txn2 ts=10,1 epoch=0
-----
-
-new-request r=req1 txn=txn1 ts=10,1 spans=none@a
-----
-
-scan r=req1
-----
-start-waiting: false
-
-add-discovered r=req1 k=a txn=txn2
-----
-num=1
- lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
-
-dequeue r=req1
-----
-num=1
- lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
-
-# Explicitly disable virtual intent resolution.
-set-virtual-intent-resolution ok=false
-----
-
-new-request r=req2 txn=txn1 ts=10,1 spans=none@a
-----
-
-scan r=req2
-----
-start-waiting: true
-
-guard-state r=req2
-----
-new: state=waitFor txn=txn2 key="a" held=true guard-strength=None
-
-pushed-txn-updated txn=txn2 status=pending ts=11,1
-----
-
-# Reader should NOT be woken.
-guard-state r=req2
-----
-old: state=waitFor txn=txn2 key="a" held=true guard-strength=None
-
-print
-----
-num=1
- lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
-   waiting readers:
-    req: 2, txn: 00000000-0000-0000-0000-000000000001
-
-dequeue r=req2
-----
-num=1
- lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
-
-# ---------------------------------------------------------------------------
-# Test 6: Multiple readers on same lock — mix of eligible/ineligible.
-# One with virtuallyResolveIntents=true, one without. Only the eligible
-# one is woken.
-# ---------------------------------------------------------------------------
-
-new-lock-table maxlocks=10000
-----
-
-new-txn txn=txn1 ts=10,1 epoch=0
-----
-
-new-txn txn=txn2 ts=10,1 epoch=0
-----
-
-new-txn txn=txn3 ts=10,1 epoch=0
-----
-
-new-request r=req1 txn=txn1 ts=10,1 spans=none@a
-----
-
-scan r=req1
-----
-start-waiting: false
-
-add-discovered r=req1 k=a txn=txn2
-----
-num=1
- lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
-
-dequeue r=req1
-----
-num=1
- lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
-
-# req2 created WITHOUT virtual intent resolution.
-set-virtual-intent-resolution ok=false
-----
-
-new-request r=req2 txn=txn1 ts=10,1 spans=none@a
-----
-
-scan r=req2
-----
-start-waiting: true
-
-# req3 created WITH virtual intent resolution.
-set-virtual-intent-resolution ok=true
-----
-
-new-request r=req3 txn=txn3 ts=10,1 spans=none@a
-----
-
-scan r=req3
-----
-start-waiting: true
-
-print
-----
-num=1
- lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
-   waiting readers:
-    req: 3, txn: 00000000-0000-0000-0000-000000000003
-    req: 2, txn: 00000000-0000-0000-0000-000000000001
-
-pushed-txn-updated txn=txn2 status=pending ts=11,1
-----
-
-# req2 should remain waiting; req3 should be woken.
-guard-state r=req2
-----
-new: state=waitFor txn=txn2 key="a" held=true guard-strength=None
-
-guard-state r=req3
-----
-new: state=doneWaiting
-Intents to resolve:
- key="a" txn=00000000-0000-0000-0000-000000000002 epoch=0 ts=11.000000000,1 status=PENDING
-
-print
-----
-num=1
- lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
-   waiting readers:
-    req: 2, txn: 00000000-0000-0000-0000-000000000001
-
-dequeue r=req2
-----
-num=1
- lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
-
-dequeue r=req3
-----
-num=1
- lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
-
-# ---------------------------------------------------------------------------
-# Test 7: Multiple locks held by same txn — readers on different keys.
-# Replicated locks on "a" and "b" both held by txn2.
-# ---------------------------------------------------------------------------
-
-new-lock-table maxlocks=10000
-----
-
-new-txn txn=txn1 ts=10,1 epoch=0
-----
-
-new-txn txn=txn2 ts=10,1 epoch=0
-----
-
-new-txn txn=txn3 ts=10,1 epoch=0
-----
-
-new-request r=req1 txn=txn1 ts=10,1 spans=none@a,c
-----
-
-scan r=req1
-----
-start-waiting: false
-
-add-discovered r=req1 k=a txn=txn2
-----
-num=1
- lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
-
-add-discovered r=req1 k=b txn=txn2
-----
-num=2
- lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
- lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
-
-dequeue r=req1
-----
-num=2
- lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
- lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
-
-set-virtual-intent-resolution ok=true
-----
-
-new-request r=req2 txn=txn1 ts=10,1 spans=none@a
-----
-
-scan r=req2
-----
-start-waiting: true
-
-new-request r=req3 txn=txn3 ts=10,1 spans=none@b
-----
-
-scan r=req3
-----
-start-waiting: true
-
-print
-----
-num=2
- lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
-   waiting readers:
-    req: 2, txn: 00000000-0000-0000-0000-000000000001
- lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
-   waiting readers:
-    req: 3, txn: 00000000-0000-0000-0000-000000000003
-
-pushed-txn-updated txn=txn2 status=pending ts=11,1
-----
-
-guard-state r=req2
-----
-new: state=doneWaiting
-Intents to resolve:
- key="a" txn=00000000-0000-0000-0000-000000000002 epoch=0 ts=11.000000000,1 status=PENDING
-
-guard-state r=req3
-----
-new: state=doneWaiting
-Intents to resolve:
- key="b" txn=00000000-0000-0000-0000-000000000002 epoch=0 ts=11.000000000,1 status=PENDING
-
-print
-----
-num=2
- lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
- lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
-
-dequeue r=req2
-----
-num=2
- lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
- lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
-
-dequeue r=req3
-----
-num=2
- lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
- lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
-
-# ---------------------------------------------------------------------------
-# Test 8: Locking requests unaffected.
-# A locking request (exclusive) waits on a lock. Push should not disturb it.
+# Test 5: Locking request unaffected by push.
+# A locking request (Intent strength) waits on a lock. The cache-based
+# resolution only applies to non-locking readers (strength=None), so
+# the locking request stays waiting.
 # ---------------------------------------------------------------------------
 
 new-lock-table maxlocks=10000
@@ -592,7 +335,7 @@ new: state=waitFor txn=txn2 key="a" held=true guard-strength=Intent
 pushed-txn-updated txn=txn2 status=pending ts=11,1
 ----
 
-# Locking request should NOT be affected.
+# Locking request is not affected by the push.
 guard-state r=req2
 ----
 old: state=waitFor txn=txn2 key="a" held=true guard-strength=Intent
@@ -612,8 +355,8 @@ num=1
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
 
 # ---------------------------------------------------------------------------
-# Test 9: Mixed replicated+unreplicated lock — reader IS woken.
-# Lock held both replicated (intent) and unreplicated (exclusive).
+# Test 6: Mixed replicated+unreplicated lock — VIR reader proceeds on
+# rescan via cache (replicated component present).
 # ---------------------------------------------------------------------------
 
 new-lock-table maxlocks=10000
@@ -682,18 +425,30 @@ new: state=waitFor txn=txn2 key="a" held=true guard-strength=None
 pushed-txn-updated txn=txn2 status=pending ts=11,1
 ----
 
-# Reader IS woken (replicated component present).
+guard-state r=req3
+----
+old: state=waitFor txn=txn2 key="a" held=true guard-strength=None
+
+# On rescan, cache hit — reader proceeds.
+scan r=req3
+----
+start-waiting: false
+
 guard-state r=req3
 ----
 new: state=doneWaiting
 Intents to resolve:
  key="a" txn=00000000-0000-0000-0000-000000000002 epoch=0 ts=11.000000000,1 status=PENDING
 
+# The guard is still tracked in waitingReaders from the first scan;
+# ScanAndEnqueue does not remove it. Dequeue cleans it up.
 print
 ----
 num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent], unrepl [(str: Exclusive seq: 0)]
+   waiting readers:
+    req: 3, txn: 00000000-0000-0000-0000-000000000001
 
 dequeue r=req3
 ----
@@ -702,10 +457,9 @@ num=1
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent], unrepl [(str: Exclusive seq: 0)]
 
 # ---------------------------------------------------------------------------
-# Test 10: After wake, scan encounters second lock by same txn.
+# Test 7: Multi-lock span — VIR reader picks up all locks from same txn.
 # Two replicated locks by txn2 on "a" and "b". Reader spans both.
-# After push, reader is woken at "a". On rescan, it encounters "b" and
-# the txnStatusCache handles it, adding it to toResolve as well.
+# After push populates cache, reader rescans and picks up BOTH locks.
 # ---------------------------------------------------------------------------
 
 new-lock-table maxlocks=10000
@@ -764,7 +518,15 @@ new: state=waitFor txn=txn2 key="a" held=true guard-strength=None
 pushed-txn-updated txn=txn2 status=pending ts=11,1
 ----
 
-# Reader should be doneWaiting with BOTH intents in toResolve.
+guard-state r=req2
+----
+old: state=waitFor txn=txn2 key="a" held=true guard-strength=None
+
+# On rescan, reader picks up BOTH intents from the cache.
+scan r=req2
+----
+start-waiting: false
+
 guard-state r=req2
 ----
 new: state=doneWaiting


### PR DESCRIPTION
maybeWakeReadersForPushedTxn (introduced in 177e7c96) calls recomputeWaitQueues → conflictsWithHeldLock on guards owned by other requests, mutating their toResolve/toResolveUnreplicated fields without synchronization. The guard's own request may concurrently be in takeToResolveUnreplicated, writing nil to the same field.

Here, we fix this by removing maybeWakeReadersForPushedTxn entirely and instead having each guard handle its own pushed-txn resolution in pushLockTxn. After a successful push, if the guard uses virtual intent resolution, pushLockTxn calls AddReplicatedToResolveAndSignal to append the lock update and signal the guard to rescan. On rescan the guard finds the pushed txn in its resolvableTxns map and proceeds without waiting.

The conflictsWithHeldLock parameter is renamed from resolveMustBeVirtual to readOnly. When readOnly=true (called from recomputeWaitQueues), the cache-based resolution path is skipped entirely, preventing any cross-goroutine mutation.

Fixes: #164261

Release note: None