### PR TITLE
rangescanstats: copy frontier before scanning

### DIFF
--- a/pkg/util/rangescanstats/poller.go
+++ b/pkg/util/rangescanstats/poller.go
@@ -91,6 +91,10 @@ func computeRangeStats(
 	ranges rangedesc.IteratorFactory,
 	laggingSpanThreshold time.Duration,
 ) (rangescanstatspb.RangeStats, error) {
+	// Copy the frontier so we don't hold its lock during the range iteration.
+	frontierCopy := frontier.Copy()
+	defer frontierCopy.Release()
+
 	var stats rangescanstatspb.RangeStats
 	for _, initialSpan := range spans {
 		lazyIterator, err := ranges.NewLazyIterator(ctx, initialSpan, 100)
@@ -104,7 +108,7 @@ func computeRangeStats(
 				EndKey: lazyIterator.CurRangeDescriptor().EndKey.AsRawKey(),
 			}
 			stats.RangeCount += 1
-			for _, timestamp := range frontier.SpanEntries(rangeSpan) {
+			for _, timestamp := range frontierCopy.SpanEntries(rangeSpan) {
 				if timestamp.IsEmpty() {
 					stats.ScanningRangeCount += 1
 					break

--- a/pkg/util/span/frontier.go
+++ b/pkg/util/span/frontier.go
@@ -81,6 +81,9 @@ type ReadOnlyFrontier interface {
 	// Updates to the frontier are restricted until iteration is stopped.
 	SpanEntries(span roachpb.Span) iter.Seq2[roachpb.Span, hlc.Timestamp]
 
+	// Copy returns a copy of all frontier entries as a new Frontier.
+	Copy() Frontier
+
 	// Len returns the number of spans tracked by the frontier.
 	Len() int
 
@@ -609,6 +612,16 @@ func (f *btreeFrontier) String() string {
 	return buf.String()
 }
 
+// Copy implements Frontier.
+func (f *btreeFrontier) Copy() Frontier {
+	copy := newFrontier()
+	it := f.tree.MakeIter()
+	for it.First(); it.Valid(); it.Next() {
+		_ = copy.AddSpansAt(it.Cur().ts, it.Cur().span())
+	}
+	return copy
+}
+
 // Len implements Frontier.
 func (f *btreeFrontier) Len() int {
 	return f.tree.Len()
@@ -866,6 +879,13 @@ func (f *concurrentFrontier) SpanEntries(span roachpb.Span) iter.Seq2[roachpb.Sp
 			}
 		}
 	}
+}
+
+// Copy implements Frontier.
+func (f *concurrentFrontier) Copy() Frontier {
+	f.Lock()
+	defer f.Unlock()
+	return f.f.Copy()
 }
 
 // Len implements Frontier.

--- a/pkg/util/span/multi_frontier.go
+++ b/pkg/util/span/multi_frontier.go
@@ -214,6 +214,20 @@ func (f *MultiFrontier[P]) SpanEntries(span roachpb.Span) iter.Seq2[roachpb.Span
 	}
 }
 
+// Copy implements Frontier.
+func (f *MultiFrontier[P]) Copy() Frontier {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	copy := newFrontier()
+	for _, frontier := range f.mu.frontiers.all() {
+		for sp, ts := range frontier.Entries() {
+			_ = copy.AddSpansAt(ts, sp)
+		}
+	}
+	return copy
+}
+
 // Len implements Frontier.
 func (f *MultiFrontier[P]) Len() int {
 	f.mu.Lock()


### PR DESCRIPTION
For large enough frontiers, we found that the stats poller, which acquires one lock per span, was contending with changefeeds checkpointing, and potentially causing the changefeed to lag.

This change snapshots the frontier before scanning to reduce lock contention.

Informs: https://github.com/cockroachdb/cockroach/issues/164417
Informs:  #161039
Epic: none
Release note: none