### PR TITLE
sql/inspect: handle empty spans in row count check

### DIFF
--- a/pkg/sql/inspect/row_count_check.go
+++ b/pkg/sql/inspect/row_count_check.go
@@ -153,6 +153,12 @@ func (c *rowCountCheck) CheckSpan(
 		return err
 	}
 
+	// An empty predicate means the span has no rows so no further counting is
+	// necessary.
+	if predicate == "" {
+		return nil
+	}
+
 	rowCount, err := c.computeRowCount(ctx, predicate, queryArgs)
 	if err != nil {
 		return err

--- a/pkg/sql/inspect/row_count_check_test.go
+++ b/pkg/sql/inspect/row_count_check_test.go
@@ -40,6 +40,7 @@ func TestRowCountCheck(t *testing.T) {
 		name               string
 		createTableStmts   []string // statements to create and populate the table
 		skipTablePopulate  bool     // if true, do not populate the table with data
+		actualRowCount     uint64   // the actual row count in the table after if skipTablePopulate is applied
 		expectedCheckCount int      // expected number of checks from ChecksForTable
 	}{
 		{
@@ -80,6 +81,17 @@ func TestRowCountCheck(t *testing.T) {
 				`ALTER TABLE test.t SPLIT AT VALUES (33), (36)`},
 			expectedCheckCount: 1,
 		},
+		{
+			name: "multiple_spans_with_empty",
+			createTableStmts: []string{
+				`CREATE TABLE test.t (id INT PRIMARY KEY)`,
+				`ALTER TABLE test.t SPLIT AT VALUES (33), (36)`,
+				`INSERT INTO test.t SELECT * FROM generate_series(1, 30)`,
+				`INSERT INTO test.t SELECT * FROM generate_series(41, 110)`},
+			skipTablePopulate:  true,
+			actualRowCount:     100,
+			expectedCheckCount: 1,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -92,7 +104,7 @@ func TestRowCountCheck(t *testing.T) {
 			if !tc.skipTablePopulate {
 				stmts = append(stmts, `INSERT INTO test.t SELECT * FROM generate_series(1, 100)`)
 			} else {
-				actualRowCount = 0
+				actualRowCount = tc.actualRowCount
 			}
 
 			r.ExecMultiple(t,


### PR DESCRIPTION
The changes in #164447 exposed an issue were a row count check on a span
with no rows would do a full scan and count the full table. This change
adds a check for an empty predicate and, when appropriate, ends the
check early with a zero count on the span.

Epic: CRDB-58692

Part of: #154551

Release note: None

**Part of a stack.**
