### PR TITLE
teamcity-bazel-support: update cache dir

### DIFF
--- a/build/teamcity-bazel-support.sh
+++ b/build/teamcity-bazel-support.sh
@@ -40,7 +40,7 @@ run_bazel() {
     artifacts_dir=$root/artifacts
     mkdir -p "$artifacts_dir"
     vols="${vols} --volume ${artifacts_dir}:/artifacts"
-    cache=/home/agent/.bzlhome
+    cache=/home/agent/.bzlhome24
     mkdir -p $cache
     vols="${vols} --volume ${root}:/go/src/github.com/cockroachdb/cockroach"
     vols="${vols} --volume ${cache}:/home/roach"


### PR DESCRIPTION
I think if two builds of different Docker containers have the same cache it can introduce problems (see #164785, #164756). This should prevent it.

Closes #164785

Part of: DEVINF-1703
Release note: none
Epic: none