### PR TITLE
asim: fix TestDataDriven

### DIFF
--- a/pkg/kv/kvserver/asim/tests/testdata/non_rand/sma/fulldisk.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/non_rand/sma/fulldisk.txt
@@ -29,29 +29,29 @@ set_capacity store=5 capacity=107374182400
 eval duration=20m seed=42 metrics=(replicas,disk_fraction_used) cfgs=(sma-count,mma-only,mma-count)
 ----
 sma-count:
-disk_fraction_used#1: first: [s1=0.20, s2=0.20, s3=0.20, s4=0.20, s5=1.05] (stddev=0.34, mean=0.37, sum=2)
+disk_fraction_used#1: first: [s1=0.20, s2=0.20, s3=0.20, s4=0.20, s5=1.00] (stddev=0.32, mean=0.36, sum=2)
 disk_fraction_used#1: last:  [s1=0.27, s2=0.27, s3=0.27, s4=0.27, s5=0.94] (stddev=0.27, mean=0.40, sum=2)
-disk_fraction_used#1: thrash_pct: [s1=19%, s2=20%, s3=20%, s4=22%, s5=67%]  (sum=149%)
+disk_fraction_used#1: thrash_pct: [s1=20%, s2=22%, s3=21%, s4=23%, s5=68%]  (sum=155%)
 replicas#1: first: [s1=300, s2=300, s3=300, s4=300, s5=300] (stddev=0.00, mean=300.00, sum=1500)
 replicas#1: last:  [s1=319, s2=317, s3=324, s4=323, s5=217] (stddev=41.58, mean=300.00, sum=1500)
 replicas#1: thrash_pct: [s1=185%, s2=197%, s3=197%, s4=213%, s5=43%]  (sum=835%)
-hash: 8473bd9f50baf595
+hash: c3f26592a16d40d7
 ==========================
 mma-only:
-disk_fraction_used#1: first: [s1=0.20, s2=0.20, s3=0.20, s4=0.20, s5=1.05] (stddev=0.34, mean=0.37, sum=2)
+disk_fraction_used#1: first: [s1=0.20, s2=0.20, s3=0.20, s4=0.20, s5=1.00] (stddev=0.32, mean=0.36, sum=2)
 disk_fraction_used#1: last:  [s1=0.28, s2=0.28, s3=0.28, s4=0.26, s5=0.90] (stddev=0.25, mean=0.40, sum=2)
 disk_fraction_used#1: thrash_pct: [s1=1%, s2=0%, s3=1%, s4=0%, s5=47%]  (sum=48%)
 replicas#1: first: [s1=300, s2=300, s3=300, s4=300, s5=300] (stddev=0.00, mean=300.00, sum=1500)
 replicas#1: last:  [s1=329, s2=330, s3=329, s4=305, s5=207] (stddev=47.45, mean=300.00, sum=1500)
 replicas#1: thrash_pct: [s1=4%, s2=0%, s3=6%, s4=0%, s5=0%]  (sum=11%)
-hash: 491e5ffd11727f20
+hash: 7b3a6b16bb384000
 ==========================
 mma-count:
-disk_fraction_used#1: first: [s1=0.20, s2=0.20, s3=0.20, s4=0.20, s5=1.05] (stddev=0.34, mean=0.37, sum=2)
+disk_fraction_used#1: first: [s1=0.20, s2=0.20, s3=0.20, s4=0.20, s5=1.00] (stddev=0.32, mean=0.36, sum=2)
 disk_fraction_used#1: last:  [s1=0.28, s2=0.28, s3=0.27, s4=0.27, s5=0.83] (stddev=0.22, mean=0.39, sum=2)
-disk_fraction_used#1: thrash_pct: [s1=23%, s2=21%, s3=23%, s4=27%, s5=46%]  (sum=141%)
+disk_fraction_used#1: thrash_pct: [s1=24%, s2=22%, s3=25%, s4=29%, s5=46%]  (sum=147%)
 replicas#1: first: [s1=300, s2=300, s3=300, s4=300, s5=300] (stddev=0.00, mean=300.00, sum=1500)
 replicas#1: last:  [s1=329, s2=329, s3=325, s4=324, s5=193] (stddev=53.54, mean=300.00, sum=1500)
 replicas#1: thrash_pct: [s1=179%, s2=166%, s3=183%, s4=215%, s5=0%]  (sum=743%)
-hash: 1f619c1de43e855f
+hash: d5529a0f915662df
 ==========================


### PR DESCRIPTION
Resolves: https://github.com/cockroachdb/cockroach/issues/164790 
Release note: none 

Bisected it to https://github.com/cockroachdb/cockroach/commit/2eb8a244912e876988f4c51f2efd2f0ec94d2631 due to the clamping https://github.com/cockroachdb/cockroach/blob/2eb8a244912e876988f4c51f2efd2f0ec94d2631/pkg/kv/kvserver/asim/state/impl.go#L307-L309. Before this commit, we allowed negative `Available`, so the fraction was > 1.0. 