### PR TITLE
schemafeed: reduce overhead of schema_locked

### DIFF
--- a/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
@@ -64,6 +64,7 @@ type leaseAcquirer interface {
 	AcquireFreshestFromStore(ctx context.Context, id descpb.ID) error
 	// TODO(yang): Investigate whether the codec can be stored in the schema feed itself.
 	Codec() keys.SQLCodec
+	RegisterLeaseObserver(observer lease.Observer) (unregisterFn func())
 }
 
 // SchemaFeed is a stream of events corresponding the relevant set of
@@ -110,6 +111,12 @@ func New(
 	}
 	m.mu.previousTableVersion = make(map[descpb.ID]catalog.TableDescriptor)
 	m.mu.typeDeps = typeDependencyTracker{deps: make(map[descpb.ID][]descpb.ID)}
+	m.mu.heldLeases = make(map[descpb.ID]*heldLeaseInfo)
+	_ = m.targets.EachTableID(func(id descpb.ID) error {
+		m.mu.heldLeases[id] = &heldLeaseInfo{}
+		return nil
+	})
+	m.mu.staleLeases = true
 	return m
 }
 
@@ -167,7 +174,18 @@ type schemaFeed struct {
 		// Polling can be paused if all tables are locked from schema changes because
 		// we know no table events will occur.
 		pollingPaused bool
+
+		// heldLeases tracks leases currently held by the schemafeed.
+		heldLeases map[descpb.ID]*heldLeaseInfo
+
+		// staleLeases indicates if a new version of a table was detected since the last time we checked.
+		staleLeases bool
 	}
+}
+
+type heldLeaseInfo struct {
+	leasedDescriptor lease.LeasedDescriptor
+	latestVersion    descpb.DescriptorVersion
 }
 
 type typeDependencyTracker struct {
@@ -263,6 +281,24 @@ func (tf *schemaFeed) Run(ctx context.Context) error {
 	if err := tf.init(); err != nil {
 		return err
 	}
+
+	unregisterFn := tf.leaseMgr.RegisterLeaseObserver(tf)
+	// Make sure the observer unregisters before trying to release leases.
+	defer func() {
+		tf.mu.Lock()
+		defer tf.mu.Unlock()
+		for _, ld := range tf.mu.heldLeases {
+			if ld.leasedDescriptor == nil {
+				continue
+			}
+			ld.leasedDescriptor.Release(ctx)
+			ld.leasedDescriptor = nil
+		}
+		// Reset the stale leases  so we don't try to get fresh ones.
+		tf.mu.heldLeases = nil
+		tf.mu.staleLeases = false
+	}()
+	defer unregisterFn()
 
 	// Fetch the table descs as of the initial frontier and prime the table
 	// history with them. This addresses #41694 where we'd skip the rest of a
@@ -508,60 +544,72 @@ func (tf *schemaFeed) pauseOrResumePolling(ctx context.Context, atOrBefore hlc.T
 		advanceTo = now
 	}
 
-	// Always assume we need to resume polling until we've proven otherwise.
-	tf.mu.pollingPaused = false
-
-	if canPausePolling, err := tf.targets.EachTableIDWithBool(func(id descpb.ID) (bool, error) {
-		// Check if target table is schema-locked at the current frontier.
-		ld1, err := tf.leaseMgr.Acquire(ctx, lease.TimestampToReadTimestamp(frontier), id)
-		if err != nil {
-			return false, err
-		}
-		defer ld1.Release(ctx)
-		desc1 := ld1.Underlying().(catalog.TableDescriptor)
-		if !desc1.IsSchemaLocked() {
-			if log.V(2) {
-				log.Changefeed.Infof(ctx, "desc %d not schema-locked at frontier %s", desc1.GetID(), frontier)
+	// Only recompute the state if something has changed.
+	if tf.mu.staleLeases {
+		// Always assume we need to resume polling until we've proven otherwise.
+		tf.mu.pollingPaused = false
+		heldProcessed := 0
+		canPausePolling := true
+		// Iterate through all IDs, since we are acquiring leases, even if polling
+		// is paused, we still have to cover everything.
+		if err := tf.targets.EachTableID(func(id descpb.ID) error {
+			// Check if a lease is already held, if it is then we know the descriptor
+			// version could not have changed.
+			heldLease := tf.mu.heldLeases[id]
+			if heldLease.leasedDescriptor == nil {
+				// Otherwise, a new version was detected, so acquire it at advanceTo.
+				newLease, err := tf.leaseMgr.Acquire(ctx, lease.TimestampToReadTimestamp(advanceTo), id)
+				if err != nil {
+					return err
+				}
+				// Store the new lease if this is the latest version or newer.
+				if newLease.Underlying().GetVersion() >= heldLease.latestVersion {
+					heldLease.latestVersion = newLease.Underlying().GetVersion()
+					tf.mu.heldLeases[id].leasedDescriptor = newLease
+				} else {
+					// The latest observed version was not picked up yet.
+					newLease.Release(ctx)
+				}
+				// This new version could be schema_locked, but we don't know if multiple versions
+				// could show up after, since the lease was released OnNewVersion, so we will poll until
+				// the next timestamp advance.
+				canPausePolling = false
+				return nil
 			}
-			return false, nil
-		}
-
-		if advanceTo.LessEq(frontier) {
-			return true, nil
-		}
-
-		// Check if target table remains at the same version at atOrBefore.
-		ld2, err := tf.leaseMgr.Acquire(ctx, lease.TimestampToReadTimestamp(advanceTo), id)
-		if err != nil {
-			return false, err
-		}
-		defer ld2.Release(ctx)
-		desc2 := ld2.Underlying().(catalog.TableDescriptor)
-		if desc1.GetVersion() != desc2.GetVersion() {
+			// Since we hold the lease already (OnNewVersion hasn't been called
+			// since we last checked), so we know the descriptor version could not
+			// have changed.
+			heldProcessed++
+			// We can only pause polling if the schema feed has actually ingested
+			// the same version that the lease manager is holding. If the lease
+			// manager is ahead, then we need to wait for the background polling
+			// loop to catch up and generate TableEvents for any intermediate
+			// descriptor versions.
+			prevDesc := tf.mu.previousTableVersion[id]
+			canPausePolling = canPausePolling && prevDesc != nil && heldLease.leasedDescriptor.Underlying().GetVersion() == prevDesc.GetVersion() && heldLease.leasedDescriptor.Underlying().(catalog.TableDescriptor).IsSchemaLocked()
+			return nil
+		}); !canPausePolling || err != nil {
+			if errors.Is(err, catalog.ErrDescriptorDropped) {
+				// If a table is dropped and causes Acquire to fail, we mark it as a
+				// terminal error, so that we don't retry, and let the changefeed job
+				// handle this error.
+				return changefeedbase.WithTerminalError(err)
+			}
+			// We swallow any non-terminal errors so that the slow path can be tried
+			// after we resume polling.
 			if log.V(1) {
-				log.Changefeed.Infof(ctx,
-					"desc %d version changed from version %d to %d between frontier %s and atOrBefore %s",
-					desc1.GetID(), desc1.GetVersion(), desc2.GetVersion(), frontier, advanceTo)
+				log.Changefeed.Infof(ctx, "got a non-terminal error while checking if polling can be paused: %s", err)
 			}
-			return false, nil
+			return nil
 		}
-		return true, nil
-	}); !canPausePolling || err != nil {
-		if errors.Is(err, catalog.ErrDescriptorDropped) {
-			// If a table is dropped and causes Acquire to fail, we mark it as a
-			// terminal error, so that we don't retry, and let the changefeed job
-			// handle this error.
-			return changefeedbase.WithTerminalError(err)
-		}
-		// We swallow any non-terminal errors so that the slow path can be tried
-		// after we resume polling.
-		if log.V(1) {
-			log.Changefeed.Infof(ctx, "got a non-terminal error while checking if polling can be paused: %s", err)
-		}
+		// All the descriptor versions are up to date if polling can be paused.
+		tf.mu.staleLeases = heldProcessed != tf.targets.NumUniqueTables()
+		tf.mu.pollingPaused = true
+	} else if !tf.mu.pollingPaused {
+		// The state has not changed, no need to rescan descriptors.
 		return nil
 	}
 
-	tf.mu.pollingPaused = true
 	if !frontier.Less(advanceTo) {
 		return nil
 	}
@@ -943,6 +991,36 @@ func (tf *schemaFeed) fetchDescriptorVersions(
 	}
 
 	return descriptors, nil
+}
+
+// OnNewVersion implements lease.Observer, and will enable polling
+// when a new version is detected.
+func (tf *schemaFeed) OnNewVersion(
+	ctx context.Context, id descpb.ID, version descpb.DescriptorVersion, _ hlc.Timestamp,
+) {
+	tf.mu.Lock()
+	defer tf.mu.Unlock()
+	// Observer are buffered and can fire after unregister.
+	if tf.mu.heldLeases == nil {
+		return
+	}
+	ld, ok := tf.mu.heldLeases[id]
+	if !ok {
+		return
+	}
+	// Check if the new version is greater than the latest version we know
+	// about.
+	if ld.latestVersion >= version {
+		return
+	}
+	ld.latestVersion = version
+	tf.mu.staleLeases = true
+	tf.mu.pollingPaused = false
+	// Release the old leased descriptor if it was acquired.
+	if ld.leasedDescriptor != nil {
+		ld.leasedDescriptor.Release(ctx)
+		ld.leasedDescriptor = nil
+	}
 }
 
 type doNothingSchemaFeed struct{}

--- a/pkg/ccl/changefeedccl/schemafeed/schema_feed_test.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schema_feed_test.go
@@ -36,6 +36,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// testingInitSchemaFeed sets up the heldLeases map and staleLeases boolean.
+func (tf *schemaFeed) testingInitSchemaFeed() {
+	tf.mu.heldLeases = make(map[descpb.ID]*heldLeaseInfo)
+	_ = tf.targets.EachTableID(func(id descpb.ID) error {
+		tf.mu.heldLeases[id] = &heldLeaseInfo{}
+		return nil
+	})
+	tf.mu.staleLeases = true
+}
+
 func TestTableHistoryIngestionTracking(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
@@ -57,6 +67,7 @@ func TestTableHistoryIngestionTracking(t *testing.T) {
 	}
 
 	m := schemaFeed{}
+	m.testingInitSchemaFeed()
 	frontier := func() hlc.Timestamp {
 		m.mu.Lock()
 		defer m.mu.Unlock()
@@ -328,8 +339,10 @@ func TestSchemaFeedHandlesCascadeDatabaseDrop(t *testing.T) {
 // It contains an ordered time map of descriptors for a single ID.
 // TODO(yang): Extend this for multiple IDs.
 type testLeaseAcquirer struct {
-	id    descpb.ID
-	descs []*testLeasedDescriptor
+	id             descpb.ID
+	descs          []*testLeasedDescriptor
+	eventsExecuted []bool
+	observers      []lease.Observer
 }
 
 func (t *testLeaseAcquirer) Acquire(
@@ -360,6 +373,49 @@ func (t *testLeaseAcquirer) AcquireFreshestFromStore(ctx context.Context, id des
 
 func (t *testLeaseAcquirer) Codec() keys.SQLCodec {
 	panic("should not be called")
+}
+
+func (t *testLeaseAcquirer) RegisterLeaseObserver(observer lease.Observer) (unregisterFn func()) {
+	t.observers = append(t.observers, observer)
+	return func() {
+		t.unregisterLeaseObserver(observer)
+	}
+}
+
+func (t *testLeaseAcquirer) unregisterLeaseObserver(observer lease.Observer) {
+	for i, o := range t.observers {
+		if o == observer {
+			t.observers = append(t.observers[:i], t.observers[i+1:]...)
+			return
+		}
+	}
+}
+
+// advanceTimestamp advances the timestamp forward, and emits any events.
+func (t *testLeaseAcquirer) advanceTimestamp(timestamp hlc.Timestamp) {
+	if t.eventsExecuted == nil {
+		t.eventsExecuted = make([]bool, len(t.descs))
+	}
+	// Determine if a new event should fire.
+	i, _ := slices.BinarySearchFunc(t.descs, timestamp, func(desc *testLeasedDescriptor, timestamp hlc.Timestamp) int {
+		return desc.timestamp.Compare(timestamp)
+	})
+	// If timestmap is greater then our entire array,
+	// return the last value.
+	if i > len(t.descs)-1 {
+		i = len(t.descs) - 1
+	}
+	// Timestamp is already visible
+	if t.eventsExecuted[i] {
+		return
+	}
+	// Otherwise, check if the event would fire.
+	if t.descs[i].timestamp.LessEq(timestamp) {
+		t.eventsExecuted[i] = true
+		for _, observer := range t.observers {
+			observer.OnNewVersion(context.Background(), t.descs[i].Underlying().GetID(), t.descs[i].Underlying().GetVersion(), t.descs[i].timestamp)
+		}
+	}
 }
 
 type testLeasedDescriptor struct {
@@ -432,14 +488,18 @@ func TestPauseOrResumePolling(t *testing.T) {
 	// Use a clock set to time 0, before any test timestamps.
 	clock := hlc.NewClockForTesting(timeutil.NewManualTime(timeutil.Unix(0, 0)))
 
-	sf := schemaFeed{
-		clock: clock,
-		leaseMgr: &testLeaseAcquirer{
-			id:    tableID,
-			descs: tableDescs,
-		},
-		targets: CreateChangefeedTargets(tableID),
+	lm := &testLeaseAcquirer{
+		id:    tableID,
+		descs: tableDescs,
 	}
+	sf := schemaFeed{
+		clock:    clock,
+		leaseMgr: lm,
+		targets:  CreateChangefeedTargets(tableID),
+	}
+	sf.testingInitSchemaFeed()
+	unregisterFn := lm.RegisterLeaseObserver(&sf)
+	defer unregisterFn()
 
 	getFrontier := func() hlc.Timestamp {
 		sf.mu.Lock()
@@ -447,6 +507,16 @@ func TestPauseOrResumePolling(t *testing.T) {
 		return sf.mu.ts.frontier
 	}
 	setFrontier := func(ts hlc.Timestamp) error {
+		lm.advanceTimestamp(ts)
+		leasedDesc, err := lm.Acquire(ctx, lease.TimestampToReadTimestamp(ts), tableID)
+		if err == nil {
+			sf.mu.Lock()
+			if sf.mu.previousTableVersion == nil {
+				sf.mu.previousTableVersion = make(map[descpb.ID]catalog.TableDescriptor)
+			}
+			sf.mu.previousTableVersion[tableID] = leasedDesc.Underlying().(catalog.TableDescriptor)
+			sf.mu.Unlock()
+		}
 		sf.mu.Lock()
 		defer sf.mu.Unlock()
 		return sf.mu.ts.advanceFrontier(ts)
@@ -486,10 +556,13 @@ func TestPauseOrResumePolling(t *testing.T) {
 	require.Equal(t, hlc.Timestamp{WallTime: 40}, getFrontier())
 
 	// We expect polling to be paused for time 40 now that the highwater has
-	// caught up to the schema-locked version.
+	// caught up to the schema-locked version. However, polling will be enabled
+	// until the next advance after.
 	require.NoError(t, sf.pauseOrResumePolling(ctx, hlc.Timestamp{WallTime: 40}))
+	require.False(t, sf.pollingPaused())
+	require.NoError(t, sf.pauseOrResumePolling(ctx, hlc.Timestamp{WallTime: 41}))
 	require.True(t, sf.pollingPaused())
-	require.Equal(t, hlc.Timestamp{WallTime: 40}, getFrontier())
+	require.Equal(t, hlc.Timestamp{WallTime: 41}, getFrontier())
 
 	// We expect polling continue to be paused for time 50 and to see the
 	// highwater bumped up.
@@ -505,6 +578,7 @@ func TestPauseOrResumePolling(t *testing.T) {
 
 	// We expect polling to be resumed for time 60 and to not see the highwater
 	// bumped up.
+	lm.advanceTimestamp(hlc.Timestamp{WallTime: 60})
 	require.NoError(t, sf.pauseOrResumePolling(ctx, hlc.Timestamp{WallTime: 60}))
 	require.False(t, sf.pollingPaused())
 	require.Equal(t, hlc.Timestamp{WallTime: 50}, getFrontier())
@@ -528,14 +602,18 @@ func TestPauseOrResumePollingAdvancesToNow(t *testing.T) {
 	manualClock := timeutil.NewManualTime(timeutil.Unix(0, 100))
 	clock := hlc.NewClockForTesting(manualClock)
 
-	sf := schemaFeed{
-		clock: clock,
-		leaseMgr: &testLeaseAcquirer{
-			id:    tableID,
-			descs: tableDescs,
-		},
-		targets: CreateChangefeedTargets(tableID),
+	lm := &testLeaseAcquirer{
+		id:    tableID,
+		descs: tableDescs,
 	}
+	sf := schemaFeed{
+		clock:    clock,
+		leaseMgr: lm,
+		targets:  CreateChangefeedTargets(tableID),
+	}
+	sf.testingInitSchemaFeed()
+	unregisterFn := lm.RegisterLeaseObserver(&sf)
+	defer unregisterFn()
 
 	getFrontier := func() hlc.Timestamp {
 		sf.mu.Lock()
@@ -543,6 +621,16 @@ func TestPauseOrResumePollingAdvancesToNow(t *testing.T) {
 		return sf.mu.ts.frontier
 	}
 	setFrontier := func(ts hlc.Timestamp) error {
+		lm.advanceTimestamp(ts)
+		leasedDesc, err := lm.Acquire(ctx, lease.TimestampToReadTimestamp(ts), tableID)
+		if err == nil {
+			sf.mu.Lock()
+			if sf.mu.previousTableVersion == nil {
+				sf.mu.previousTableVersion = make(map[descpb.ID]catalog.TableDescriptor)
+			}
+			sf.mu.previousTableVersion[tableID] = leasedDesc.Underlying().(catalog.TableDescriptor)
+			sf.mu.Unlock()
+		}
 		sf.mu.Lock()
 		defer sf.mu.Unlock()
 		return sf.mu.ts.advanceFrontier(ts)
@@ -552,8 +640,11 @@ func TestPauseOrResumePollingAdvancesToNow(t *testing.T) {
 	require.NoError(t, setFrontier(hlc.Timestamp{WallTime: 10}))
 
 	// Call with a timestamp in the past (20). Since the clock is at 100,
-	// the frontier should advance to 100.
+	// the frontier should advance to 100.However, polling will be enabled
+	// until the next advance after.
 	require.NoError(t, sf.pauseOrResumePolling(ctx, hlc.Timestamp{WallTime: 20}))
+	require.False(t, sf.pollingPaused())
+	require.NoError(t, sf.pauseOrResumePolling(ctx, hlc.Timestamp{WallTime: 21}))
 	require.True(t, sf.pollingPaused())
 	require.Equal(t, int64(100), getFrontier().WallTime)
 
@@ -576,18 +667,33 @@ func BenchmarkPauseOrResumePolling(b *testing.B) {
 	const tableID = 123
 	// Use a clock set to time 0, matching test timestamps.
 	manualClock := timeutil.NewManualTime(timeutil.Unix(0, 0))
-	sf := schemaFeed{
-		clock: hlc.NewClockForTesting(manualClock),
-		leaseMgr: &testLeaseAcquirer{
-			id: tableID,
-			descs: []*testLeasedDescriptor{
-				newTestLeasedDescriptor(tableID, 1, false, hlc.Timestamp{WallTime: 30}),
-				newTestLeasedDescriptor(tableID, 2, true, hlc.Timestamp{WallTime: 40}),
-			},
+	lm := &testLeaseAcquirer{
+		id: tableID,
+		descs: []*testLeasedDescriptor{
+			newTestLeasedDescriptor(tableID, 1, false, hlc.Timestamp{WallTime: 30}),
+			newTestLeasedDescriptor(tableID, 2, true, hlc.Timestamp{WallTime: 40}),
 		},
-		targets: CreateChangefeedTargets(tableID),
 	}
+	sf := schemaFeed{
+		clock:    hlc.NewClockForTesting(manualClock),
+		leaseMgr: lm,
+		targets:  CreateChangefeedTargets(tableID),
+	}
+	sf.testingInitSchemaFeed()
+	unregisterFn := lm.RegisterLeaseObserver(&sf)
+	defer unregisterFn()
+
 	setFrontier := func(ts hlc.Timestamp) error {
+		lm.advanceTimestamp(ts)
+		leasedDesc, err := lm.Acquire(ctx, lease.TimestampToReadTimestamp(ts), tableID)
+		if err == nil {
+			sf.mu.Lock()
+			if sf.mu.previousTableVersion == nil {
+				sf.mu.previousTableVersion = make(map[descpb.ID]catalog.TableDescriptor)
+			}
+			sf.mu.previousTableVersion[tableID] = leasedDesc.Underlying().(catalog.TableDescriptor)
+			sf.mu.Unlock()
+		}
 		sf.mu.Lock()
 		defer sf.mu.Unlock()
 		return sf.mu.ts.advanceFrontier(ts)
@@ -610,6 +716,8 @@ func BenchmarkPauseOrResumePolling(b *testing.B) {
 	b.Run("not schema locked", func(b *testing.B) {
 		// We bump the highwater up to reflect a descriptor being read at time 30.
 		require.NoError(b, setFrontier(hlc.Timestamp{WallTime: 30}))
+		// Prime the leasedDescriptor.
+		require.NoError(b, sf.pauseOrResumePolling(ctx, hlc.Timestamp{WallTime: 30}))
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			// We do not expect polling to be paused for time 30 since the descriptor
@@ -621,9 +729,14 @@ func BenchmarkPauseOrResumePolling(b *testing.B) {
 	b.Run("schema locked", func(b *testing.B) {
 		// We bump the highwater up to reflect a descriptor being read at time 50.
 		require.NoError(b, setFrontier(hlc.Timestamp{WallTime: 50}))
+		// We expect polling to be paused for time 50 now that the highwater on a
+		// schema-locked version. It takes two iterations to pause: one to
+		// acquire the descriptor and one to confirm it's still current and locked.
+		for !sf.pollingPaused() {
+			require.NoError(b, sf.pauseOrResumePolling(ctx, hlc.Timestamp{WallTime: 50}))
+		}
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			// We expect polling to be paused for time 50 now that the highwater on a
-			// schema-locked version.
 			require.NoError(b, sf.pauseOrResumePolling(ctx, hlc.Timestamp{WallTime: 50}))
 		}
 		require.True(b, sf.pollingPaused())

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1692,7 +1692,7 @@ func (s *SQLServer) preStart(
 	// run.
 
 	s.leaseMgr.StartRefreshLeasesTask(ctx, stopper, s.execCfg.DB)
-	s.leaseMgr.RunBackgroundLeasingTask(ctx)
+	s.leaseMgr.RunBackgroundLeasingTasks(ctx)
 
 	if err := s.jobRegistry.Start(ctx, stopper); err != nil {
 		return err

--- a/pkg/sql/catalog/lease/BUILD.bazel
+++ b/pkg/sql/catalog/lease/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "lease_test_utils.go",
         "lease_timestamp.go",
         "name_cache.go",
+        "observer.go",
         "storage.go",
         "testutils.go",
     ],
@@ -86,6 +87,7 @@ go_test(
         "lease_internal_test.go",
         "lease_test.go",
         "main_test.go",
+        "observer_test.go",
     ],
     embed = [":lease"],
     exec_properties = {

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -1622,7 +1622,9 @@ func (m *Manager) acquireNodeLease(
 					return false, err
 				}
 			}
-
+			// If the version of the lease we are acquiring has changed,
+			// then notify any observers.
+			m.maybeAddObserverEvent(id, currentVersion, false /* dropped */)
 			return true, nil
 		})
 	if m.testingKnobs.LeaseStoreTestingKnobs.LeaseAcquireResultBlockEvent != nil {
@@ -1713,12 +1715,18 @@ func (m *Manager) purgeOldVersions(
 	}
 
 	removeInactives := func(dropped bool) {
+		wasOffline := false
 		leases, leaseToExpire := func() (leasesToRemove []*storedLease, leasesToExpire *descriptorVersionState) {
 			t.mu.Lock()
 			defer t.mu.Unlock()
+			wasOffline = t.mu.takenOffline
 			t.setTakenOfflineLocked(dropped)
 			return t.removeInactiveVersions(ctx), t.mu.active.findPreviousToExpire(dropped)
 		}()
+		// Fire a notification for dropped descriptors.
+		if dropped && !wasOffline {
+			m.maybeAddObserverEvent(id, minVersion, true /* dropped */)
+		}
 		for _, l := range leases {
 			releaseLease(ctx, l, m)
 		}
@@ -2019,6 +2027,12 @@ type Manager struct {
 		// activeCloseTimestamps contains the most recent timestamp handles currently
 		// in use by transactions.
 		activeCloseTimestamps []*closeTimeStampHandle
+
+		// observers is list of lease manager observers.
+		observers atomic.Pointer[[]Observer]
+
+		// pendingObserverEvents is a list of observer events.
+		pendingObserverEvents []observerEvent
 	}
 
 	// closeTimeStamp is the most recent closeTimeStamp handle, for
@@ -2043,6 +2057,8 @@ type Manager struct {
 	descDelCh chan descpb.ID
 	// rangeFeedCheckpointCh receives rangefeed checkpoints from the rangefeed.
 	rangeFeedCheckpointCh chan *kvpb.RangeFeedCheckpoint
+	// observerEvent receives an event for the observer.
+	observerEvent chan struct{}
 	// rangefeedErrCh receives any terminal errors from the rangefeed.
 	rangefeedErrCh chan error
 	// leaseGeneration increments any time a new or existing descriptor is
@@ -2176,6 +2192,7 @@ func NewLeaseManager(
 		ambientCtx:       ambientCtx,
 		stopper:          stopper,
 		sem:              quotapool.NewIntPool("lease manager", leaseConcurrencyLimit),
+		observerEvent:    make(chan struct{}, 1),
 	}
 	lm.leaseGeneration.Swap(1) // Start off with 1 as the initial value.
 	lm.storage.regionPrefix = &atomic.Value{}
@@ -2257,6 +2274,40 @@ func (m *Manager) findNewest(id descpb.ID) (state *descriptorVersionState, offli
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	return t.mu.active.findNewest(), t.mu.takenOffline
+}
+
+// maybeAddObserverEvent appends a new observer event if the version has changed.
+func (m *Manager) maybeAddObserverEvent(
+	id descpb.ID, currentVersion descpb.DescriptorVersion, dropped bool,
+) {
+	newest, _ := m.findNewest(id)
+	// If the version hasn't changed, then nothing needs to be emitted.
+	if (newest != nil && newest.GetVersion() == currentVersion) || (newest == nil && !dropped) {
+		return
+	}
+	// Append the new observer event.
+	func() {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		var ts hlc.Timestamp
+		newVersion := currentVersion
+		if dropped {
+			ts = m.storage.clock.Now()
+		} else {
+			ts = newest.GetModificationTime()
+			newVersion = newest.GetVersion()
+		}
+		m.mu.pendingObserverEvents = append(m.mu.pendingObserverEvents, observerEvent{id: id,
+			version:          newVersion,
+			modificationTime: ts,
+		})
+	}()
+	// Signal there is an event waiting, unless the channel is already
+	// posted.
+	select {
+	case m.observerEvent <- struct{}{}:
+	default:
+	}
 }
 
 // SetRegionPrefix sets the prefix this Manager uses to write leases. If val
@@ -3198,11 +3249,11 @@ func (m *Manager) checkRangeFeedStatus(ctx context.Context) (forceRefresh bool) 
 	return forceRefresh
 }
 
-// RunBackgroundLeasingTask runs background leasing tasks which are
+// RunBackgroundLeasingTasks runs background leasing tasks which are
 // responsible for expiring old descriptor versions, monitoring
 // range feed progress / recovery, and supporting legacy expiry
 // based leases.
-func (m *Manager) RunBackgroundLeasingTask(ctx context.Context) {
+func (m *Manager) RunBackgroundLeasingTasks(ctx context.Context) {
 	ctx = multitenant.WithTenantCostControlExemption(ctx)
 	// The refresh loop is used to clean up leases that have expired (because of
 	// a new version), and track range feed availability. This will run based on
@@ -3264,6 +3315,28 @@ func (m *Manager) RunBackgroundLeasingTask(ctx context.Context) {
 					log.Dev.Warningf(ctx, "error cleaning up update keys: %v", err)
 				}
 				descriptorUpdateCleanupTimer.Reset(descriptorUpdateCleanupTimerDuration)
+			}
+		}
+	})
+	// Background thread for lease observers.
+	_ = m.stopper.RunAsyncTask(ctx, "lease-observers", func(ctx context.Context) {
+		for {
+			select {
+			case <-m.stopper.ShouldQuiesce():
+				return
+			case <-m.observerEvent:
+				// Extract all the opending events.
+				events := func() []observerEvent {
+					m.mu.Lock()
+					defer m.mu.Unlock()
+					events := m.mu.pendingObserverEvents
+					m.mu.pendingObserverEvents = nil
+					return events
+				}()
+				// Notify all observers.
+				for _, event := range events {
+					m.notifyObservers(ctx, event.id, event.version, event.modificationTime)
+				}
 			}
 		}
 	})

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -293,7 +293,7 @@ func (t *leaseTest) node(nodeID uint32) *lease.Manager {
 			cfgCpy.RootMemoryMonitor,
 		)
 		ctx := logtags.AddTag(context.Background(), "leasemgr", nodeID)
-		mgr.RunBackgroundLeasingTask(ctx)
+		mgr.RunBackgroundLeasingTasks(ctx)
 		mgr.TestingMarkInit()
 		t.nodes[nodeID] = mgr
 	}
@@ -4460,7 +4460,7 @@ func TestLeaseManagerMemoryCloser(t *testing.T) {
 		app.ExecutorConfig().(sql.ExecutorConfig).RangeFeedFactory,
 		monitor,
 	)
-	lm.RunBackgroundLeasingTask(ctx)
+	lm.RunBackgroundLeasingTasks(ctx)
 	lm.TestingMarkInit()
 
 	// Create a table to lease.

--- a/pkg/sql/catalog/lease/observer.go
+++ b/pkg/sql/catalog/lease/observer.go
@@ -1,0 +1,87 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package lease
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+)
+
+// Observer is an interface that allows observers to be notified of new
+// versions of descriptors.
+type Observer interface {
+	// OnNewVersion Invoked when a new version of a descriptor becomes available.
+	OnNewVersion(ctx context.Context, descID descpb.ID, newVersion descpb.DescriptorVersion, modificationTime hlc.Timestamp)
+}
+
+// RegisterLeaseObserver registers an observer. An unregisterFn is returned
+// to remove this observer. Note: Observers are buffered, pending events may
+// still fire after unregistering.
+func (m *Manager) RegisterLeaseObserver(observer Observer) (unregisterFn func()) {
+	// Writers will need mutual exclusion to avoid clobbering.
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// We will always allocate a new array, so readers can keep
+	// using existing pointers.
+	oldObservers := m.mu.observers.Load()
+	var newObservers []Observer
+	if oldObservers != nil {
+		newObservers = make([]Observer, len(*oldObservers), len(*oldObservers)+1)
+		copy(newObservers, *oldObservers)
+	}
+	newObservers = append(newObservers, observer)
+	m.mu.observers.Store(&newObservers)
+	return func() {
+		m.unregisterLeaseObserver(observer)
+	}
+}
+
+// UnregisterLeaseObserver unregisters an observer.
+func (m *Manager) unregisterLeaseObserver(observer Observer) {
+	// Writers will need mutual exclusion to avoid clobbering.
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// We will always allocate a new array, so readers can keep
+	// using existing pointers.
+	oldObservers := m.mu.observers.Load()
+	if oldObservers == nil {
+		panic("observers is nil")
+	}
+	newObservers := make([]Observer, 0, len(*oldObservers)-1)
+	for _, o := range *oldObservers {
+		if o != observer {
+			newObservers = append(newObservers, o)
+		}
+	}
+	m.mu.observers.Store(&newObservers)
+}
+
+// notifyObservers notifies all registered observers of a new descriptor version.
+func (m *Manager) notifyObservers(
+	ctx context.Context,
+	id descpb.ID,
+	version descpb.DescriptorVersion,
+	modificationTime hlc.Timestamp,
+) {
+	// Writers will always allocate a new slice, so we can
+	// safely just use an atomic to load the list.
+	observers := m.mu.observers.Load()
+	if observers == nil {
+		return
+	}
+	for _, observer := range *observers {
+		observer.OnNewVersion(ctx, id, version, modificationTime)
+	}
+}
+
+// observerEvent used internally to emit events via the observerEvent channel.
+type observerEvent struct {
+	id               descpb.ID
+	version          descpb.DescriptorVersion
+	modificationTime hlc.Timestamp
+}

--- a/pkg/sql/catalog/lease/observer_test.go
+++ b/pkg/sql/catalog/lease/observer_test.go
@@ -1,0 +1,133 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package lease_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+type testObserver struct {
+	notified  chan descpb.DescriptorVersion
+	targetID  descpb.ID
+	numEvents atomic.Int64
+}
+
+func (o *testObserver) OnNewVersion(
+	ctx context.Context, id descpb.ID, version descpb.DescriptorVersion, timestamp hlc.Timestamp,
+) {
+	o.numEvents.Add(1)
+	if id != o.targetID {
+		return
+	}
+	o.notified <- version
+}
+
+// TestLeaseObserver sanity checks the lease observer implementation,
+// by ensuring observers can concurrently acqure and release versions.
+// Additionally, they observe all versions.
+func TestLeaseObserver(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	server, db, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	defer server.Stopper().Stop(context.Background())
+
+	sqlRunner := sqlutils.MakeSQLRunner(db)
+	sqlRunner.Exec(t, "CREATE TABLE t (k INT PRIMARY KEY)")
+	var tableID descpb.ID
+	sqlRunner.QueryRow(t, "SELECT 't'::regclass::int").Scan(&tableID)
+	obs := &testObserver{
+		notified: make(chan descpb.DescriptorVersion, 100),
+		targetID: tableID,
+	}
+	lm := server.LeaseManager().(*lease.Manager)
+	unregisterFn := lm.RegisterLeaseObserver(obs)
+
+	// Trigger initial acquisition on node 0.
+	sqlRunner.Exec(t, "SELECT * FROM t")
+
+	grp := ctxgroup.WithContext(context.Background())
+	schemaChangeComplete := make(chan struct{})
+	schemaChangeCompleteClosed := false
+	maybeCloseSchemaChangeComplete := func() {
+		if schemaChangeCompleteClosed {
+			return
+		}
+		close(schemaChangeComplete)
+		schemaChangeCompleteClosed = true
+	}
+	defer maybeCloseSchemaChangeComplete()
+	var maxVersion atomic.Int64
+	maxVersion.Store(1)
+	// Ensure the first version is locked before we start the schema change.
+	firstVersionLocked := make(chan struct{})
+	grp.GoCtx(func(ctx context.Context) error {
+		firstVersionLockedClosed := false
+		maybeCloseFirstVersionLocked := func() {
+			if firstVersionLockedClosed {
+				return
+			}
+			close(firstVersionLocked)
+			firstVersionLockedClosed = true
+		}
+		defer maybeCloseFirstVersionLocked()
+		// Get a leaase on the current version.
+		ld, err := lm.Acquire(ctx, lease.TimestampToReadTimestamp(kvDB.Clock().Now()), tableID)
+		if err != nil {
+			return err
+		}
+		maybeCloseFirstVersionLocked()
+		defer func() {
+			ld.Release(ctx)
+		}()
+		for {
+			select {
+			case v := <-obs.notified:
+				if ld.Underlying().GetVersion()+1 != v {
+					return errors.AssertionFailedf("expected version %d, got %d", ld.Underlying().GetVersion()+1, v)
+				}
+				require.Equal(t, ld.Underlying().GetVersion()+1, v)
+				maxVersion.Store(int64(v))
+				newLease, err := lm.Acquire(ctx, lease.TimestampToReadTimestamp(kvDB.Clock().Now()), tableID)
+				if err != nil {
+					return err
+				}
+				ld.Release(ctx)
+				ld = newLease
+				if ld.Underlying().GetVersion() != descpb.DescriptorVersion(maxVersion.Load()) {
+					return errors.AssertionFailedf("expected version %d, got %d", maxVersion.Load(), ld.Underlying().GetVersion())
+				}
+			case <-schemaChangeComplete:
+				return nil
+			}
+		}
+	})
+	<-firstVersionLocked
+	// Add the first column and validate all versions are observed.
+	sqlRunner.Exec(t, "ALTER TABLE t ADD COLUMN v INT")
+	// Validate the schema change was observed.
+	require.Greaterf(t, maxVersion.Load(), int64(1), "new versions were not detected")
+	// Confirm the observer stops firing after unregistering.
+	unregisterFn()
+	maybeCloseSchemaChangeComplete()
+	numEvents := obs.numEvents.Load()
+	sqlRunner.Exec(t, "ALTER TABLE t ADD COLUMN v2 INT")
+	// No new events should be see.
+	require.Equal(t, numEvents, obs.numEvents.Load())
+	require.NoError(t, grp.Wait())
+}


### PR DESCRIPTION
Previously, there was no easy way of know if leased descriptors were modified without querying the lease manager. To support more optimal detection of changes descriptors, this patch adds the ability to register an Observer with the lease manager, which will be notified when a new version to lease is available. This observer is now used to implement tracking the schema_locked state in the schema feed. So, descriptors are only check when schema_locked is modified.

Fixes: #163761
Release note: None