### PR TITLE
release-25.4: opt: apply min_row_count to anti-joins

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -4559,6 +4559,10 @@ func (m *sessionDataMutator) SetDistSQLPreventPartitioningSoftLimitedScans(val b
 	m.data.DistSQLPreventPartitioningSoftLimitedScans = val
 }
 
+func (m *sessionDataMutator) SetOptimizerUseMinRowCountAntiJoinFix(val bool) {
+	m.data.OptimizerUseMinRowCountAntiJoinFix = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4221,6 +4221,7 @@ optimizer_use_lock_elision_multiple_families                     off
 optimizer_use_lock_op_for_serializable                           off
 optimizer_use_max_frequency_selectivity                          on
 optimizer_use_merged_partial_statistics                          on
+optimizer_use_min_row_count_anti_join_fix                        off
 optimizer_use_multicol_stats                                     on
 optimizer_use_not_visible_indexes                                off
 optimizer_use_polymorphic_parameter_fix                          on

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3123,6 +3123,7 @@ optimizer_use_lock_elision_multiple_families                     off            
 optimizer_use_lock_op_for_serializable                           off                 NULL      NULL        NULL        string
 optimizer_use_max_frequency_selectivity                          on                  NULL      NULL        NULL        string
 optimizer_use_merged_partial_statistics                          on                  NULL      NULL        NULL        string
+optimizer_use_min_row_count_anti_join_fix                        off                 NULL      NULL        NULL        string
 optimizer_use_multicol_stats                                     on                  NULL      NULL        NULL        string
 optimizer_use_not_visible_indexes                                off                 NULL      NULL        NULL        string
 optimizer_use_polymorphic_parameter_fix                          on                  NULL      NULL        NULL        string
@@ -3374,6 +3375,7 @@ optimizer_use_lock_elision_multiple_families                     off            
 optimizer_use_lock_op_for_serializable                           off                 NULL  user     NULL      off                 off
 optimizer_use_max_frequency_selectivity                          on                  NULL  user     NULL      on                  on
 optimizer_use_merged_partial_statistics                          on                  NULL  user     NULL      on                  on
+optimizer_use_min_row_count_anti_join_fix                        off                 NULL  user     NULL      off                 off
 optimizer_use_multicol_stats                                     on                  NULL  user     NULL      on                  on
 optimizer_use_not_visible_indexes                                off                 NULL  user     NULL      off                 off
 optimizer_use_polymorphic_parameter_fix                          on                  NULL  user     NULL      on                  on
@@ -3616,6 +3618,7 @@ optimizer_use_lock_elision_multiple_families                     NULL    NULL   
 optimizer_use_lock_op_for_serializable                           NULL    NULL     NULL     NULL        NULL
 optimizer_use_max_frequency_selectivity                          NULL    NULL     NULL     NULL        NULL
 optimizer_use_merged_partial_statistics                          NULL    NULL     NULL     NULL        NULL
+optimizer_use_min_row_count_anti_join_fix                        NULL    NULL     NULL     NULL        NULL
 optimizer_use_multicol_stats                                     NULL    NULL     NULL     NULL        NULL
 optimizer_use_not_visible_indexes                                NULL    NULL     NULL     NULL        NULL
 optimizer_use_polymorphic_parameter_fix                          NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -187,6 +187,7 @@ optimizer_use_lock_elision_multiple_families                     off
 optimizer_use_lock_op_for_serializable                           off
 optimizer_use_max_frequency_selectivity                          on
 optimizer_use_merged_partial_statistics                          on
+optimizer_use_min_row_count_anti_join_fix                        off
 optimizer_use_multicol_stats                                     on
 optimizer_use_not_visible_indexes                                off
 optimizer_use_polymorphic_parameter_fix                          on

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -216,6 +216,7 @@ type Memo struct {
 	useMaxFrequencySelectivity                 bool
 	preventUpdateSetColumnDrop                 bool
 	useImprovedRoutineDepsTriggersComputedCols bool
+	useMinRowCountAntiJoinFix                  bool
 
 	// txnIsoLevel is the isolation level under which the plan was created. This
 	// affects the planning of some locking operations, so it must be included in
@@ -332,6 +333,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		useMaxFrequencySelectivity:                 evalCtx.SessionData().OptimizerUseMaxFrequencySelectivity,
 		preventUpdateSetColumnDrop:                 evalCtx.SessionData().PreventUpdateSetColumnDrop,
 		useImprovedRoutineDepsTriggersComputedCols: evalCtx.SessionData().UseImprovedRoutineDepsTriggersAndComputedCols,
+		useMinRowCountAntiJoinFix:                  evalCtx.SessionData().OptimizerUseMinRowCountAntiJoinFix,
 		txnIsoLevel:                                evalCtx.TxnIsoLevel,
 	}
 	m.metadata.Init()
@@ -512,6 +514,7 @@ func (m *Memo) IsStale(
 		m.useMaxFrequencySelectivity != evalCtx.SessionData().OptimizerUseMaxFrequencySelectivity ||
 		m.preventUpdateSetColumnDrop != evalCtx.SessionData().PreventUpdateSetColumnDrop ||
 		m.useImprovedRoutineDepsTriggersComputedCols != evalCtx.SessionData().UseImprovedRoutineDepsTriggersAndComputedCols ||
+		m.useMinRowCountAntiJoinFix != evalCtx.SessionData().OptimizerUseMinRowCountAntiJoinFix ||
 		m.txnIsoLevel != evalCtx.TxnIsoLevel {
 		return true, nil
 	}

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -623,6 +623,12 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().UseImprovedRoutineDepsTriggersAndComputedCols = false
 	notStale()
 
+	// Stale optimizer_use_min_row_count_anti_join_fix.
+	evalCtx.SessionData().OptimizerUseMinRowCountAntiJoinFix = true
+	stale()
+	evalCtx.SessionData().OptimizerUseMinRowCountAntiJoinFix = false
+	notStale()
+
 	// User no longer has access to view.
 	catalog.View(tree.NewTableNameWithSchema("t", catconstants.PublicSchemaName, "abcview")).Revoked = true
 	_, err = o.Memo().IsStale(ctx, &evalCtx, catalog)

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -1556,8 +1556,17 @@ func (sb *statisticsBuilder) buildJoin(
 	// Fix the stats for anti join.
 	switch h.joinType {
 	case opt.AntiJoinOp, opt.AntiJoinApplyOp:
-		s.RowCount = max(leftStats.RowCount-s.RowCount, epsilon)
-		s.Selectivity = props.MakeSelectivity(1 - s.Selectivity.AsFloat())
+		if sb.evalCtx.SessionData().OptimizerUseMinRowCountAntiJoinFix {
+			// Make sure to use ApplySelectivity instead of setting the selectivity and
+			// row count directly so that min_row_count is respected.
+			originalSel := s.Selectivity
+			s.RowCount = leftStats.RowCount
+			s.Selectivity = props.OneSelectivity
+			s.ApplySelectivity(props.MakeSelectivity(1 - originalSel.AsFloat()))
+		} else {
+			s.RowCount = max(leftStats.RowCount-s.RowCount, epsilon)
+			s.Selectivity = props.MakeSelectivity(1 - s.Selectivity.AsFloat())
+		}
 
 		// Converting column stats is error-prone. If any column stats are needed,
 		// colStatJoin will use the selectivity calculated above to estimate the

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -765,6 +765,9 @@ message LocalOnlySessionData {
   // physical planner from partitioning scans with soft limits into multiple
   // TableReaders. When true, this matches the behavior for hard limits.
   bool distsql_prevent_partitioning_soft_limited_scans = 197 [(gogoproto.customname) = "DistSQLPreventPartitioningSoftLimitedScans"];
+  // OptimizerUseMinRowCountAntiJoinFix, when true, causes the
+  // optimizer_min_row_count setting to be applied correctly to anti-joins.
+  bool optimizer_use_min_row_count_anti_join_fix = 203;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -4506,6 +4506,23 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalFalse,
 	},
+
+	// CockroachDB extension.
+	`optimizer_use_min_row_count_anti_join_fix`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`optimizer_use_min_row_count_anti_join_fix`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("optimizer_use_min_row_count_anti_join_fix", s)
+			if err != nil {
+				return err
+			}
+			m.SetOptimizerUseMinRowCountAntiJoinFix(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().OptimizerUseMinRowCountAntiJoinFix), nil
+		},
+		GlobalDefault: globalFalse,
+	},
 }
 
 func ReplicationModeFromString(s string) (sessiondatapb.ReplicationMode, error) {


### PR DESCRIPTION
Backport 1/4 commits from #163244.

/cc @cockroachdb/release

---

#### opt: apply min_row_count to anti-joins

Previously, the `optimizer_min_row_count` setting did not apply to the
final selectivity calculated for AntiJoin expressions. This meant that
the setting was applied asymmetrically, which could cause the optimizer
to choose bad plans. This commit fixes the issue, gated behind a session
setting `optimizer_use_min_row_count_anti_join_fix`.

Fixes #162258

Release note (bug fix): Fixed a bug that prevented the optimizer_min_row_count
setting from applying to anti-join expressions, which could lead to bad query
plans. The fix is gated behind `optimizer_use_min_row_count_anti_join_fix`, and
will be on by default on 26.2+, and off by default in prior versions.

---

Release justification: critical fix for optimizer regression in 25.4