### PR TITLE
roachprod: enable histogram aggregation metrics in Datadog exporter

### DIFF
--- a/pkg/roachprod/agents/opentelemetry/files/opentelemetry-config.yaml.tmpl
+++ b/pkg/roachprod/agents/opentelemetry/files/opentelemetry-config.yaml.tmpl
@@ -6,7 +6,7 @@ receivers:
   prometheus/cockroachdb:
     config:
       global:
-        scrape_interval: 30s
+        scrape_interval: 10s
       scrape_configs:
       - job_name: cockroachdb
         honor_timestamps: false
@@ -85,6 +85,10 @@ exporters:
     api:
       key: ${env:DD_API_KEY}
       site: ${env:DD_SITE}
+    metrics:
+      histograms:
+        mode: distributions
+        send_aggregation_metrics: true
 
 service:
   pipelines:


### PR DESCRIPTION
Two fixes to the OpenTelemetry config template:

1. Enable histogram aggregation metrics. The Datadog exporter was not
   emitting `.sum` and `.count` metrics for histograms. Set
   `send_aggregation_metrics: true` so these values are exported as
   individual metrics to Datadog.

2. Reduce the Prometheus scrape interval from 30s to 10s to make it
   consistent across all metric sources (host metrics collection
   interval and the standalone Prometheus DefaultScrapeInterval are
   both 10s).

Epic: CC-35038
Release note: None