### PR TITLE
kvserver: fix TestFlowControlRaftMembershipV2 flake

### DIFF
--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -1002,6 +1002,14 @@ func TestFlowControlRaftMembershipV2(t *testing.T) {
 		h.comment(`-- (Adding non-voting replica to n5.)`)
 		tc.AddNonVotersOrFatal(t, k, tc.Target(4))
 		h.waitForConnectedStreams(ctx, desc.RangeID, 4, 0 /* serverIdx */)
+		// Wait for all send queues to drain before issuing the next write. In
+		// MsgAppPull mode (apply_to_all), entries routed through a send queue
+		// are tracked at LowPri/elastic regardless of the original write
+		// priority. If the newly added non-voter still has a send queue (from
+		// catch-up entries) when the write arrives, its entry would be
+		// classified as entering the send queue and have its priority
+		// downgraded, causing regular token metrics to be 1 MiB short.
+		h.waitForSendQueueSize(ctx, desc.RangeID, 0 /* expSize */, 0 /* serverIdx */)
 
 		h.comment(`-- (Issuing 1x1MiB, 4x replicated write (w/ one non-voter) that's not admitted.`)
 		h.put(ctx, k, 1, testFlowModeToPri(mode))


### PR DESCRIPTION
Wait for send queues to drain after adding the non-voter before issuing the next write. In MsgAppPull mode, entries in a send queue are tracked at LowPri regardless of the original priority. A residual send queue on the newly added non-voter caused one 1 MiB deduction to land in elastic instead of regular, producing the observed 10 MiB vs 11 MiB mismatch.

Fixes: #164732
