### PR TITLE
admission: promote key admission control metrics to Essential

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -10466,7 +10466,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.cpu.bulk-normal-pri
       exported_name: admission_wait_durations_cpu_bulk_normal_pri
       description: Wait time durations for requests that waited
@@ -10476,7 +10475,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.cpu.high-pri
       exported_name: admission_wait_durations_cpu_high_pri
       description: Wait time durations for requests that waited
@@ -10486,7 +10484,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.cpu.locking-normal-pri
       exported_name: admission_wait_durations_cpu_locking_normal_pri
       description: Wait time durations for requests that waited
@@ -10496,7 +10493,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.cpu.locking-pri
       exported_name: admission_wait_durations_cpu_locking_pri
       description: Wait time durations for requests that waited
@@ -10506,7 +10502,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.cpu.low-pri
       exported_name: admission_wait_durations_cpu_low_pri
       description: Wait time durations for requests that waited
@@ -10516,7 +10511,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.cpu.normal-pri
       exported_name: admission_wait_durations_cpu_normal_pri
       description: Wait time durations for requests that waited
@@ -10526,7 +10520,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.cpu.user-high-pri
       exported_name: admission_wait_durations_cpu_user_high_pri
       description: Wait time durations for requests that waited
@@ -10536,7 +10529,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.cpu.user-low-pri
       exported_name: admission_wait_durations_cpu_user_low_pri
       description: Wait time durations for requests that waited
@@ -10546,7 +10538,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.elastic-cpu
       exported_name: admission_wait_durations_elastic_cpu
       description: Wait time durations for requests that waited
@@ -10566,7 +10557,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.elastic-cpu.bulk-normal-pri
       exported_name: admission_wait_durations_elastic_cpu_bulk_normal_pri
       description: Wait time durations for requests that waited
@@ -10576,7 +10566,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.elastic-cpu.high-pri
       exported_name: admission_wait_durations_elastic_cpu_high_pri
       description: Wait time durations for requests that waited
@@ -10586,7 +10575,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.elastic-cpu.locking-normal-pri
       exported_name: admission_wait_durations_elastic_cpu_locking_normal_pri
       description: Wait time durations for requests that waited
@@ -10596,7 +10584,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.elastic-cpu.locking-pri
       exported_name: admission_wait_durations_elastic_cpu_locking_pri
       description: Wait time durations for requests that waited
@@ -10606,7 +10593,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.elastic-cpu.low-pri
       exported_name: admission_wait_durations_elastic_cpu_low_pri
       description: Wait time durations for requests that waited
@@ -10616,7 +10602,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.elastic-cpu.normal-pri
       exported_name: admission_wait_durations_elastic_cpu_normal_pri
       description: Wait time durations for requests that waited
@@ -10626,7 +10611,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.elastic-cpu.user-high-pri
       exported_name: admission_wait_durations_elastic_cpu_user_high_pri
       description: Wait time durations for requests that waited
@@ -10636,7 +10620,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.elastic-cpu.user-low-pri
       exported_name: admission_wait_durations_elastic_cpu_user_low_pri
       description: Wait time durations for requests that waited
@@ -10646,7 +10629,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.elastic-stores
       exported_name: admission_wait_durations_elastic_stores
       description: Wait time durations for requests that waited
@@ -10666,7 +10648,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.elastic-stores.bulk-normal-pri
       exported_name: admission_wait_durations_elastic_stores_bulk_normal_pri
       description: Wait time durations for requests that waited
@@ -10676,7 +10657,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.elastic-stores.high-pri
       exported_name: admission_wait_durations_elastic_stores_high_pri
       description: Wait time durations for requests that waited
@@ -10686,7 +10666,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.elastic-stores.locking-normal-pri
       exported_name: admission_wait_durations_elastic_stores_locking_normal_pri
       description: Wait time durations for requests that waited
@@ -10696,7 +10675,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.elastic-stores.locking-pri
       exported_name: admission_wait_durations_elastic_stores_locking_pri
       description: Wait time durations for requests that waited
@@ -10706,7 +10684,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.elastic-stores.low-pri
       exported_name: admission_wait_durations_elastic_stores_low_pri
       description: Wait time durations for requests that waited
@@ -10716,7 +10693,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.elastic-stores.normal-pri
       exported_name: admission_wait_durations_elastic_stores_normal_pri
       description: Wait time durations for requests that waited
@@ -10726,7 +10702,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.elastic-stores.user-high-pri
       exported_name: admission_wait_durations_elastic_stores_user_high_pri
       description: Wait time durations for requests that waited
@@ -10736,7 +10711,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.elastic-stores.user-low-pri
       exported_name: admission_wait_durations_elastic_stores_user_low_pri
       description: Wait time durations for requests that waited
@@ -10746,7 +10720,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.kv
       exported_name: admission_wait_durations_kv
       description: Wait time durations for requests that waited
@@ -10776,7 +10749,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.kv-stores.bulk-normal-pri
       exported_name: admission_wait_durations_kv_stores_bulk_normal_pri
       description: Wait time durations for requests that waited
@@ -10786,7 +10758,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.kv-stores.high-pri
       exported_name: admission_wait_durations_kv_stores_high_pri
       description: Wait time durations for requests that waited
@@ -10796,7 +10767,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.kv-stores.locking-normal-pri
       exported_name: admission_wait_durations_kv_stores_locking_normal_pri
       description: Wait time durations for requests that waited
@@ -10806,7 +10776,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.kv-stores.locking-pri
       exported_name: admission_wait_durations_kv_stores_locking_pri
       description: Wait time durations for requests that waited
@@ -10816,7 +10785,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.kv-stores.low-pri
       exported_name: admission_wait_durations_kv_stores_low_pri
       description: Wait time durations for requests that waited
@@ -10826,7 +10794,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.kv-stores.normal-pri
       exported_name: admission_wait_durations_kv_stores_normal_pri
       description: Wait time durations for requests that waited
@@ -10836,7 +10803,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.kv-stores.user-high-pri
       exported_name: admission_wait_durations_kv_stores_user_high_pri
       description: Wait time durations for requests that waited
@@ -10846,7 +10812,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.kv-stores.user-low-pri
       exported_name: admission_wait_durations_kv_stores_user_low_pri
       description: Wait time durations for requests that waited
@@ -10856,7 +10821,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.kv.bulk-low-pri
       exported_name: admission_wait_durations_kv_bulk_low_pri
       description: Wait time durations for requests that waited
@@ -10866,7 +10830,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.kv.bulk-normal-pri
       exported_name: admission_wait_durations_kv_bulk_normal_pri
       description: Wait time durations for requests that waited
@@ -10876,7 +10839,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.kv.high-pri
       exported_name: admission_wait_durations_kv_high_pri
       description: Wait time durations for requests that waited
@@ -10886,7 +10848,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.kv.locking-normal-pri
       exported_name: admission_wait_durations_kv_locking_normal_pri
       description: Wait time durations for requests that waited
@@ -10896,7 +10857,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.kv.locking-pri
       exported_name: admission_wait_durations_kv_locking_pri
       description: Wait time durations for requests that waited
@@ -10906,7 +10866,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.kv.low-pri
       exported_name: admission_wait_durations_kv_low_pri
       description: Wait time durations for requests that waited
@@ -10916,7 +10875,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.kv.normal-pri
       exported_name: admission_wait_durations_kv_normal_pri
       description: Wait time durations for requests that waited
@@ -10926,7 +10884,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.kv.user-high-pri
       exported_name: admission_wait_durations_kv_user_high_pri
       description: Wait time durations for requests that waited
@@ -10936,7 +10893,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.kv.user-low-pri
       exported_name: admission_wait_durations_kv_user_low_pri
       description: Wait time durations for requests that waited
@@ -10946,7 +10902,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.sql-kv-response
       exported_name: admission_wait_durations_sql_kv_response
       description: Wait time durations for requests that waited
@@ -10966,7 +10921,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.sql-kv-response.bulk-normal-pri
       exported_name: admission_wait_durations_sql_kv_response_bulk_normal_pri
       description: Wait time durations for requests that waited
@@ -10976,7 +10930,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.sql-kv-response.high-pri
       exported_name: admission_wait_durations_sql_kv_response_high_pri
       description: Wait time durations for requests that waited
@@ -10986,7 +10939,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.sql-kv-response.locking-normal-pri
       exported_name: admission_wait_durations_sql_kv_response_locking_normal_pri
       description: Wait time durations for requests that waited
@@ -10996,7 +10948,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.sql-kv-response.locking-pri
       exported_name: admission_wait_durations_sql_kv_response_locking_pri
       description: Wait time durations for requests that waited
@@ -11006,7 +10957,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.sql-kv-response.low-pri
       exported_name: admission_wait_durations_sql_kv_response_low_pri
       description: Wait time durations for requests that waited
@@ -11016,7 +10966,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.sql-kv-response.normal-pri
       exported_name: admission_wait_durations_sql_kv_response_normal_pri
       description: Wait time durations for requests that waited
@@ -11026,7 +10975,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.sql-kv-response.user-high-pri
       exported_name: admission_wait_durations_sql_kv_response_user_high_pri
       description: Wait time durations for requests that waited
@@ -11036,7 +10984,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.sql-kv-response.user-low-pri
       exported_name: admission_wait_durations_sql_kv_response_user_low_pri
       description: Wait time durations for requests that waited
@@ -11046,7 +10993,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.sql-sql-response
       exported_name: admission_wait_durations_sql_sql_response
       description: Wait time durations for requests that waited
@@ -11066,7 +11012,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.sql-sql-response.bulk-normal-pri
       exported_name: admission_wait_durations_sql_sql_response_bulk_normal_pri
       description: Wait time durations for requests that waited
@@ -11076,7 +11021,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.sql-sql-response.high-pri
       exported_name: admission_wait_durations_sql_sql_response_high_pri
       description: Wait time durations for requests that waited
@@ -11086,7 +11030,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.sql-sql-response.locking-normal-pri
       exported_name: admission_wait_durations_sql_sql_response_locking_normal_pri
       description: Wait time durations for requests that waited
@@ -11096,7 +11039,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.sql-sql-response.locking-pri
       exported_name: admission_wait_durations_sql_sql_response_locking_pri
       description: Wait time durations for requests that waited
@@ -11106,7 +11048,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.sql-sql-response.low-pri
       exported_name: admission_wait_durations_sql_sql_response_low_pri
       description: Wait time durations for requests that waited
@@ -11116,7 +11057,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.sql-sql-response.normal-pri
       exported_name: admission_wait_durations_sql_sql_response_normal_pri
       description: Wait time durations for requests that waited
@@ -11126,7 +11066,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.sql-sql-response.user-high-pri
       exported_name: admission_wait_durations_sql_sql_response_user_high_pri
       description: Wait time durations for requests that waited
@@ -11136,7 +11075,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: admission.wait_durations.sql-sql-response.user-low-pri
       exported_name: admission_wait_durations_sql_sql_response_user_low_pri
       description: Wait time durations for requests that waited
@@ -11146,7 +11084,6 @@ layers:
       aggregation: AVG
       derivative: NONE
       how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
-      visibility: ESSENTIAL
     - name: kvflowcontrol.eval_wait.elastic.duration
       exported_name: kvflowcontrol_eval_wait_elastic_duration
       description: Latency histogram for time elastic requests spent waiting for flow tokens to evaluate

--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -10407,6 +10407,346 @@ layers:
   categories:
   - name: OVERLOAD
     metrics:
+    - name: admission.elastic_cpu.nanos_exhausted_duration
+      exported_name: admission_elastic_cpu_nanos_exhausted_duration
+      description: Total duration when elastic CPU tokens (tokens measured in nanoseconds) were exhausted, as observed by the token granter (not waiters). This is reported in nanoseconds from 26.1 onwards, and was microseconds before that.
+      y_axis_label: Nanoseconds
+      type: COUNTER
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+      how_to_use: This metric indicates when elastic CPU tokens are exhausted. Extended periods of elastic CPU token exhaustion may indicate high CPU utilization affecting elastic workloads.
+      visibility: ESSENTIAL
+    - name: admission.granter.elastic_io_tokens_exhausted_duration.kv
+      exported_name: admission_granter_elastic_io_tokens_exhausted_duration_kv
+      description: Total duration when Elastic IO tokens were exhausted, as observed by the token granter (not waiters). This is reported in nanoseconds from 26.1 onwards, and was microseconds before that.
+      y_axis_label: Nanoseconds
+      type: COUNTER
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+      how_to_use: This metric indicates when elastic I/O tokens are exhausted. Extended periods of elastic token exhaustion may indicate I/O bandwidth saturation affecting elastic workloads.
+      visibility: ESSENTIAL
+    - name: admission.granter.io_tokens_exhausted_duration.kv
+      exported_name: admission_granter_io_tokens_exhausted_duration_kv
+      description: Total duration when IO tokens were exhausted, as observed by the token granter (not waiters). This is reported in nanoseconds from 26.1 onwards, and was microseconds before that.
+      y_axis_label: Nanoseconds
+      type: COUNTER
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+      how_to_use: This metric indicates when I/O tokens are exhausted. Extended periods of token exhaustion may indicate I/O bandwidth saturation or high disk utilization requiring attention.
+      visibility: ESSENTIAL
+    - name: admission.granter.slots_exhausted_duration.kv
+      exported_name: admission_granter_slots_exhausted_duration_kv
+      description: Total duration when KV slots were exhausted, as observed by the slot granter (not waiters). This is reported in nanoseconds from 26.1 onwards, and was microseconds before that.
+      y_axis_label: Nanoseconds
+      type: COUNTER
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+      how_to_use: This metric indicates when KV slots are exhausted. Extended periods of slot exhaustion may indicate insufficient slot allocation or high request concurrency requiring attention.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.cpu
+      exported_name: admission_wait_durations_cpu
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.cpu.bulk-low-pri
+      exported_name: admission_wait_durations_cpu_bulk_low_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.cpu.bulk-normal-pri
+      exported_name: admission_wait_durations_cpu_bulk_normal_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.cpu.high-pri
+      exported_name: admission_wait_durations_cpu_high_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.cpu.locking-normal-pri
+      exported_name: admission_wait_durations_cpu_locking_normal_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.cpu.locking-pri
+      exported_name: admission_wait_durations_cpu_locking_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.cpu.low-pri
+      exported_name: admission_wait_durations_cpu_low_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.cpu.normal-pri
+      exported_name: admission_wait_durations_cpu_normal_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.cpu.user-high-pri
+      exported_name: admission_wait_durations_cpu_user_high_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.cpu.user-low-pri
+      exported_name: admission_wait_durations_cpu_user_low_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.elastic-cpu
+      exported_name: admission_wait_durations_elastic_cpu
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.elastic-cpu.bulk-low-pri
+      exported_name: admission_wait_durations_elastic_cpu_bulk_low_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.elastic-cpu.bulk-normal-pri
+      exported_name: admission_wait_durations_elastic_cpu_bulk_normal_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.elastic-cpu.high-pri
+      exported_name: admission_wait_durations_elastic_cpu_high_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.elastic-cpu.locking-normal-pri
+      exported_name: admission_wait_durations_elastic_cpu_locking_normal_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.elastic-cpu.locking-pri
+      exported_name: admission_wait_durations_elastic_cpu_locking_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.elastic-cpu.low-pri
+      exported_name: admission_wait_durations_elastic_cpu_low_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.elastic-cpu.normal-pri
+      exported_name: admission_wait_durations_elastic_cpu_normal_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.elastic-cpu.user-high-pri
+      exported_name: admission_wait_durations_elastic_cpu_user_high_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.elastic-cpu.user-low-pri
+      exported_name: admission_wait_durations_elastic_cpu_user_low_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.elastic-stores
+      exported_name: admission_wait_durations_elastic_stores
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.elastic-stores.bulk-low-pri
+      exported_name: admission_wait_durations_elastic_stores_bulk_low_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.elastic-stores.bulk-normal-pri
+      exported_name: admission_wait_durations_elastic_stores_bulk_normal_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.elastic-stores.high-pri
+      exported_name: admission_wait_durations_elastic_stores_high_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.elastic-stores.locking-normal-pri
+      exported_name: admission_wait_durations_elastic_stores_locking_normal_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.elastic-stores.locking-pri
+      exported_name: admission_wait_durations_elastic_stores_locking_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.elastic-stores.low-pri
+      exported_name: admission_wait_durations_elastic_stores_low_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.elastic-stores.normal-pri
+      exported_name: admission_wait_durations_elastic_stores_normal_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.elastic-stores.user-high-pri
+      exported_name: admission_wait_durations_elastic_stores_user_high_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.elastic-stores.user-low-pri
+      exported_name: admission_wait_durations_elastic_stores_user_low_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
     - name: admission.wait_durations.kv
       exported_name: admission_wait_durations_kv
       description: Wait time durations for requests that waited
@@ -10415,7 +10755,7 @@ layers:
       unit: NANOSECONDS
       aggregation: AVG
       derivative: NONE
-      how_to_use: This metric shows if CPU utilization-based admission control feature is working effectively or potentially overaggressive. This is a latency histogram of how much delay was added to the workload due to throttling. If observing over 100ms waits for over 5 seconds while there was excess capacity available, then the admission control is overly aggressive.
+      how_to_use: This is a latency histogram of wait time in the CPU utilization-based admission control queue. Non-zero wait times are expected when CPU is saturated.
       visibility: ESSENTIAL
     - name: admission.wait_durations.kv-stores
       exported_name: admission_wait_durations_kv_stores
@@ -10425,7 +10765,417 @@ layers:
       unit: NANOSECONDS
       aggregation: AVG
       derivative: NONE
-      how_to_use: This metric shows if I/O utilization-based admission control feature is working effectively or potentially overaggressive. This is a latency histogram of how much delay was added to the workload due to throttling. If observing over 100ms waits for over 5 seconds while there was excess capacity available, then the admission control is overly aggressive.
+      how_to_use: This is a latency histogram of wait time in the I/O utilization-based admission control queue. Non-zero wait times are expected when I/O is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.kv-stores.bulk-low-pri
+      exported_name: admission_wait_durations_kv_stores_bulk_low_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.kv-stores.bulk-normal-pri
+      exported_name: admission_wait_durations_kv_stores_bulk_normal_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.kv-stores.high-pri
+      exported_name: admission_wait_durations_kv_stores_high_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.kv-stores.locking-normal-pri
+      exported_name: admission_wait_durations_kv_stores_locking_normal_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.kv-stores.locking-pri
+      exported_name: admission_wait_durations_kv_stores_locking_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.kv-stores.low-pri
+      exported_name: admission_wait_durations_kv_stores_low_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.kv-stores.normal-pri
+      exported_name: admission_wait_durations_kv_stores_normal_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.kv-stores.user-high-pri
+      exported_name: admission_wait_durations_kv_stores_user_high_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.kv-stores.user-low-pri
+      exported_name: admission_wait_durations_kv_stores_user_low_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.kv.bulk-low-pri
+      exported_name: admission_wait_durations_kv_bulk_low_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.kv.bulk-normal-pri
+      exported_name: admission_wait_durations_kv_bulk_normal_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.kv.high-pri
+      exported_name: admission_wait_durations_kv_high_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.kv.locking-normal-pri
+      exported_name: admission_wait_durations_kv_locking_normal_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.kv.locking-pri
+      exported_name: admission_wait_durations_kv_locking_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.kv.low-pri
+      exported_name: admission_wait_durations_kv_low_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.kv.normal-pri
+      exported_name: admission_wait_durations_kv_normal_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.kv.user-high-pri
+      exported_name: admission_wait_durations_kv_user_high_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.kv.user-low-pri
+      exported_name: admission_wait_durations_kv_user_low_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.sql-kv-response
+      exported_name: admission_wait_durations_sql_kv_response
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.sql-kv-response.bulk-low-pri
+      exported_name: admission_wait_durations_sql_kv_response_bulk_low_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.sql-kv-response.bulk-normal-pri
+      exported_name: admission_wait_durations_sql_kv_response_bulk_normal_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.sql-kv-response.high-pri
+      exported_name: admission_wait_durations_sql_kv_response_high_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.sql-kv-response.locking-normal-pri
+      exported_name: admission_wait_durations_sql_kv_response_locking_normal_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.sql-kv-response.locking-pri
+      exported_name: admission_wait_durations_sql_kv_response_locking_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.sql-kv-response.low-pri
+      exported_name: admission_wait_durations_sql_kv_response_low_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.sql-kv-response.normal-pri
+      exported_name: admission_wait_durations_sql_kv_response_normal_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.sql-kv-response.user-high-pri
+      exported_name: admission_wait_durations_sql_kv_response_user_high_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.sql-kv-response.user-low-pri
+      exported_name: admission_wait_durations_sql_kv_response_user_low_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.sql-sql-response
+      exported_name: admission_wait_durations_sql_sql_response
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.sql-sql-response.bulk-low-pri
+      exported_name: admission_wait_durations_sql_sql_response_bulk_low_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.sql-sql-response.bulk-normal-pri
+      exported_name: admission_wait_durations_sql_sql_response_bulk_normal_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.sql-sql-response.high-pri
+      exported_name: admission_wait_durations_sql_sql_response_high_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.sql-sql-response.locking-normal-pri
+      exported_name: admission_wait_durations_sql_sql_response_locking_normal_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.sql-sql-response.locking-pri
+      exported_name: admission_wait_durations_sql_sql_response_locking_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.sql-sql-response.low-pri
+      exported_name: admission_wait_durations_sql_sql_response_low_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.sql-sql-response.normal-pri
+      exported_name: admission_wait_durations_sql_sql_response_normal_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.sql-sql-response.user-high-pri
+      exported_name: admission_wait_durations_sql_sql_response_user_high_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: admission.wait_durations.sql-sql-response.user-low-pri
+      exported_name: admission_wait_durations_sql_sql_response_user_low_pri
+      description: Wait time durations for requests that waited
+      y_axis_label: Wait time Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.
+      visibility: ESSENTIAL
+    - name: kvflowcontrol.eval_wait.elastic.duration
+      exported_name: kvflowcontrol_eval_wait_elastic_duration
+      description: Latency histogram for time elastic requests spent waiting for flow tokens to evaluate
+      y_axis_label: Nanoseconds
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This metric shows how long requests are waiting for flow tokens before evaluation. Extended wait times may indicate flow control token exhaustion or replication lag.
+      visibility: ESSENTIAL
+    - name: kvflowcontrol.eval_wait.regular.duration
+      exported_name: kvflowcontrol_eval_wait_regular_duration
+      description: Latency histogram for time regular requests spent waiting for flow tokens to evaluate
+      y_axis_label: Nanoseconds
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This metric shows how long requests are waiting for flow tokens before evaluation. Extended wait times may indicate flow control token exhaustion or replication lag.
+      visibility: ESSENTIAL
+    - name: kvflowcontrol.send_queue.bytes
+      exported_name: kvflowcontrol_send_queue_bytes
+      description: Byte size of all raft entries queued for sending to followers, waiting on available elastic send tokens
+      y_axis_label: Bytes
+      type: GAUGE
+      unit: BYTES
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This metric indicates the size of queued raft entries waiting for elastic send tokens. Large or growing queue sizes may indicate replication backlog or follower lag.
       visibility: ESSENTIAL
   - name: REPLICATION
     metrics:
@@ -11361,14 +12111,6 @@ layers:
       unit: NANOSECONDS
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
-    - name: admission.elastic_cpu.nanos_exhausted_duration
-      exported_name: admission_elastic_cpu_nanos_exhausted_duration
-      description: Total duration when elastic CPU tokens (tokens measured in nanoseconds) were exhausted, as observed by the token granter (not waiters). This is reported in nanoseconds from 26.1 onwards, and was microseconds before that.
-      y_axis_label: Nanoseconds
-      type: COUNTER
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
     - name: admission.elastic_cpu.over_limit_durations
       exported_name: admission_elastic_cpu_over_limit_durations
       description: Measurement of how much over the prescribed limit elastic requests ran (not recorded if requests don't run over)
@@ -12017,14 +12759,6 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NONE
-    - name: admission.granter.elastic_io_tokens_exhausted_duration.kv
-      exported_name: admission_granter_elastic_io_tokens_exhausted_duration_kv
-      description: Total duration when Elastic IO tokens were exhausted, as observed by the token granter (not waiters). This is reported in nanoseconds from 26.1 onwards, and was microseconds before that.
-      y_axis_label: Nanoseconds
-      type: COUNTER
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
     - name: admission.granter.io_tokens_available.kv
       exported_name: admission_granter_io_tokens_available_kv
       description: Number of tokens available
@@ -12039,14 +12773,6 @@ layers:
       y_axis_label: Tokens
       type: COUNTER
       unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: admission.granter.io_tokens_exhausted_duration.kv
-      exported_name: admission_granter_io_tokens_exhausted_duration_kv
-      description: Total duration when IO tokens were exhausted, as observed by the token granter (not waiters). This is reported in nanoseconds from 26.1 onwards, and was microseconds before that.
-      y_axis_label: Nanoseconds
-      type: COUNTER
-      unit: NANOSECONDS
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
     - name: admission.granter.io_tokens_returned.kv
@@ -12079,14 +12805,6 @@ layers:
       y_axis_label: Slots
       type: COUNTER
       unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: admission.granter.slots_exhausted_duration.kv
-      exported_name: admission_granter_slots_exhausted_duration_kv
-      description: Total duration when KV slots were exhausted, as observed by the slot granter (not waiters). This is reported in nanoseconds from 26.1 onwards, and was microseconds before that.
-      y_axis_label: Nanoseconds
-      type: COUNTER
-      unit: NANOSECONDS
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
     - name: admission.granter.total_slots.kv
@@ -12713,553 +13431,9 @@ layers:
       unit: NANOSECONDS
       aggregation: AVG
       derivative: NONE
-    - name: admission.wait_durations.cpu
-      exported_name: admission_wait_durations_cpu
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.cpu.bulk-low-pri
-      exported_name: admission_wait_durations_cpu_bulk_low_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.cpu.bulk-normal-pri
-      exported_name: admission_wait_durations_cpu_bulk_normal_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.cpu.high-pri
-      exported_name: admission_wait_durations_cpu_high_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.cpu.locking-normal-pri
-      exported_name: admission_wait_durations_cpu_locking_normal_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.cpu.locking-pri
-      exported_name: admission_wait_durations_cpu_locking_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.cpu.low-pri
-      exported_name: admission_wait_durations_cpu_low_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.cpu.normal-pri
-      exported_name: admission_wait_durations_cpu_normal_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.cpu.user-high-pri
-      exported_name: admission_wait_durations_cpu_user_high_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.cpu.user-low-pri
-      exported_name: admission_wait_durations_cpu_user_low_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.elastic-cpu
-      exported_name: admission_wait_durations_elastic_cpu
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.elastic-cpu.bulk-low-pri
-      exported_name: admission_wait_durations_elastic_cpu_bulk_low_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.elastic-cpu.bulk-normal-pri
-      exported_name: admission_wait_durations_elastic_cpu_bulk_normal_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.elastic-cpu.high-pri
-      exported_name: admission_wait_durations_elastic_cpu_high_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.elastic-cpu.locking-normal-pri
-      exported_name: admission_wait_durations_elastic_cpu_locking_normal_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.elastic-cpu.locking-pri
-      exported_name: admission_wait_durations_elastic_cpu_locking_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.elastic-cpu.low-pri
-      exported_name: admission_wait_durations_elastic_cpu_low_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.elastic-cpu.normal-pri
-      exported_name: admission_wait_durations_elastic_cpu_normal_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.elastic-cpu.user-high-pri
-      exported_name: admission_wait_durations_elastic_cpu_user_high_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.elastic-cpu.user-low-pri
-      exported_name: admission_wait_durations_elastic_cpu_user_low_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.elastic-stores
-      exported_name: admission_wait_durations_elastic_stores
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.elastic-stores.bulk-low-pri
-      exported_name: admission_wait_durations_elastic_stores_bulk_low_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.elastic-stores.bulk-normal-pri
-      exported_name: admission_wait_durations_elastic_stores_bulk_normal_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.elastic-stores.high-pri
-      exported_name: admission_wait_durations_elastic_stores_high_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.elastic-stores.locking-normal-pri
-      exported_name: admission_wait_durations_elastic_stores_locking_normal_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.elastic-stores.locking-pri
-      exported_name: admission_wait_durations_elastic_stores_locking_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.elastic-stores.low-pri
-      exported_name: admission_wait_durations_elastic_stores_low_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.elastic-stores.normal-pri
-      exported_name: admission_wait_durations_elastic_stores_normal_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.elastic-stores.user-high-pri
-      exported_name: admission_wait_durations_elastic_stores_user_high_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.elastic-stores.user-low-pri
-      exported_name: admission_wait_durations_elastic_stores_user_low_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.kv-stores.bulk-low-pri
-      exported_name: admission_wait_durations_kv_stores_bulk_low_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.kv-stores.bulk-normal-pri
-      exported_name: admission_wait_durations_kv_stores_bulk_normal_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.kv-stores.high-pri
-      exported_name: admission_wait_durations_kv_stores_high_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.kv-stores.locking-normal-pri
-      exported_name: admission_wait_durations_kv_stores_locking_normal_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.kv-stores.locking-pri
-      exported_name: admission_wait_durations_kv_stores_locking_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.kv-stores.low-pri
-      exported_name: admission_wait_durations_kv_stores_low_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.kv-stores.normal-pri
-      exported_name: admission_wait_durations_kv_stores_normal_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.kv-stores.user-high-pri
-      exported_name: admission_wait_durations_kv_stores_user_high_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.kv-stores.user-low-pri
-      exported_name: admission_wait_durations_kv_stores_user_low_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.kv.bulk-low-pri
-      exported_name: admission_wait_durations_kv_bulk_low_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.kv.bulk-normal-pri
-      exported_name: admission_wait_durations_kv_bulk_normal_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.kv.high-pri
-      exported_name: admission_wait_durations_kv_high_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.kv.locking-normal-pri
-      exported_name: admission_wait_durations_kv_locking_normal_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.kv.locking-pri
-      exported_name: admission_wait_durations_kv_locking_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.kv.low-pri
-      exported_name: admission_wait_durations_kv_low_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.kv.normal-pri
-      exported_name: admission_wait_durations_kv_normal_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.kv.user-high-pri
-      exported_name: admission_wait_durations_kv_user_high_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.kv.user-low-pri
-      exported_name: admission_wait_durations_kv_user_low_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
     - name: admission.wait_durations.snapshot_ingest
       exported_name: admission_wait_durations_snapshot_ingest
       description: Wait time for snapshot ingest requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.sql-kv-response
-      exported_name: admission_wait_durations_sql_kv_response
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.sql-kv-response.bulk-low-pri
-      exported_name: admission_wait_durations_sql_kv_response_bulk_low_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.sql-kv-response.bulk-normal-pri
-      exported_name: admission_wait_durations_sql_kv_response_bulk_normal_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.sql-kv-response.high-pri
-      exported_name: admission_wait_durations_sql_kv_response_high_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.sql-kv-response.locking-normal-pri
-      exported_name: admission_wait_durations_sql_kv_response_locking_normal_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.sql-kv-response.locking-pri
-      exported_name: admission_wait_durations_sql_kv_response_locking_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.sql-kv-response.low-pri
-      exported_name: admission_wait_durations_sql_kv_response_low_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.sql-kv-response.normal-pri
-      exported_name: admission_wait_durations_sql_kv_response_normal_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.sql-kv-response.user-high-pri
-      exported_name: admission_wait_durations_sql_kv_response_user_high_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.sql-kv-response.user-low-pri
-      exported_name: admission_wait_durations_sql_kv_response_user_low_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.sql-sql-response
-      exported_name: admission_wait_durations_sql_sql_response
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.sql-sql-response.bulk-low-pri
-      exported_name: admission_wait_durations_sql_sql_response_bulk_low_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.sql-sql-response.bulk-normal-pri
-      exported_name: admission_wait_durations_sql_sql_response_bulk_normal_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.sql-sql-response.high-pri
-      exported_name: admission_wait_durations_sql_sql_response_high_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.sql-sql-response.locking-normal-pri
-      exported_name: admission_wait_durations_sql_sql_response_locking_normal_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.sql-sql-response.locking-pri
-      exported_name: admission_wait_durations_sql_sql_response_locking_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.sql-sql-response.low-pri
-      exported_name: admission_wait_durations_sql_sql_response_low_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.sql-sql-response.normal-pri
-      exported_name: admission_wait_durations_sql_sql_response_normal_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.sql-sql-response.user-high-pri
-      exported_name: admission_wait_durations_sql_sql_response_user_high_pri
-      description: Wait time durations for requests that waited
-      y_axis_label: Wait time Duration
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: admission.wait_durations.sql-sql-response.user-low-pri
-      exported_name: admission_wait_durations_sql_sql_response_user_low_pri
-      description: Wait time durations for requests that waited
       y_axis_label: Wait time Duration
       type: HISTOGRAM
       unit: NANOSECONDS
@@ -14881,14 +15055,6 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
-    - name: kvflowcontrol.eval_wait.elastic.duration
-      exported_name: kvflowcontrol_eval_wait_elastic_duration
-      description: Latency histogram for time elastic requests spent waiting for flow tokens to evaluate
-      y_axis_label: Nanoseconds
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
     - name: kvflowcontrol.eval_wait.elastic.requests.admitted
       exported_name: kvflowcontrol_eval_wait_elastic_requests_admitted
       description: Number of elastic requests admitted by the flow controller
@@ -14919,14 +15085,6 @@ layers:
       y_axis_label: Requests
       type: GAUGE
       unit: COUNT
-      aggregation: AVG
-      derivative: NONE
-    - name: kvflowcontrol.eval_wait.regular.duration
-      exported_name: kvflowcontrol_eval_wait_regular_duration
-      description: Latency histogram for time regular requests spent waiting for flow tokens to evaluate
-      y_axis_label: Nanoseconds
-      type: HISTOGRAM
-      unit: NANOSECONDS
       aggregation: AVG
       derivative: NONE
     - name: kvflowcontrol.eval_wait.regular.requests.admitted
@@ -14967,14 +15125,6 @@ layers:
       y_axis_label: Count
       type: GAUGE
       unit: COUNT
-      aggregation: AVG
-      derivative: NONE
-    - name: kvflowcontrol.send_queue.bytes
-      exported_name: kvflowcontrol_send_queue_bytes
-      description: Byte size of all raft entries queued for sending to followers, waiting on available elastic send tokens
-      y_axis_label: Bytes
-      type: GAUGE
-      unit: BYTES
       aggregation: AVG
       derivative: NONE
     - name: kvflowcontrol.send_queue.count

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/metrics.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/metrics.go
@@ -110,6 +110,9 @@ var (
 		Help:        "Latency histogram for time %s requests spent waiting for flow tokens to evaluate",
 		Measurement: "Nanoseconds",
 		Unit:        metric.Unit_NANOSECONDS,
+		Visibility:  metric.Metadata_ESSENTIAL,
+		Category:    metric.Metadata_OVERLOAD,
+		HowToUse:    "This metric shows how long requests are waiting for flow tokens before evaluation. Extended wait times may indicate flow control token exhaustion or replication lag.",
 	}
 
 	// RangeController metrics.
@@ -126,6 +129,9 @@ var (
 		Help:        "Byte size of all raft entries queued for sending to followers, waiting on available elastic send tokens",
 		Measurement: "Bytes",
 		Unit:        metric.Unit_BYTES,
+		Visibility:  metric.Metadata_ESSENTIAL,
+		Category:    metric.Metadata_OVERLOAD,
+		HowToUse:    "This metric indicates the size of queued raft entries waiting for elastic send tokens. Large or growing queue sizes may indicate replication backlog or follower lag.",
 	}
 	sendQueueCount = metric.Metadata{
 		Name:        "kvflowcontrol.send_queue.count",

--- a/pkg/util/admission/elastic_cpu_granter.go
+++ b/pkg/util/admission/elastic_cpu_granter.go
@@ -320,6 +320,9 @@ var ( // granter-side metrics (some of these have parallels on the requester sid
 			"nanoseconds from 26.1 onwards, and was microseconds before that.",
 		Measurement: "Nanoseconds",
 		Unit:        metric.Unit_NANOSECONDS,
+		Visibility:  metric.Metadata_ESSENTIAL,
+		Category:    metric.Metadata_OVERLOAD,
+		HowToUse:    "This metric indicates when elastic CPU tokens are exhausted. Extended periods of elastic CPU token exhaustion may indicate high CPU utilization affecting elastic workloads.",
 	}
 
 	elasticCPUOverLimitDurations = metric.Metadata{

--- a/pkg/util/admission/granter.go
+++ b/pkg/util/admission/granter.go
@@ -1052,6 +1052,9 @@ var (
 			"and was microseconds before that.",
 		Measurement: "Nanoseconds",
 		Unit:        metric.Unit_NANOSECONDS,
+		Visibility:  metric.Metadata_ESSENTIAL,
+		Category:    metric.Metadata_OVERLOAD,
+		HowToUse:    "This metric indicates when KV slots are exhausted. Extended periods of slot exhaustion may indicate insufficient slot allocation or high request concurrency requiring attention.",
 	}
 	// We have a metric for both short and long period. These metrics use the
 	// period provided in CPULoad and not wall time. So if the sum of the rate
@@ -1090,6 +1093,9 @@ var (
 			"microseconds before that.",
 		Measurement: "Nanoseconds",
 		Unit:        metric.Unit_NANOSECONDS,
+		Visibility:  metric.Metadata_ESSENTIAL,
+		Category:    metric.Metadata_OVERLOAD,
+		HowToUse:    "This metric indicates when I/O tokens are exhausted. Extended periods of token exhaustion may indicate I/O bandwidth saturation or high disk utilization requiring attention.",
 	}
 	kvElasticIOTokensExhaustedDuration = metric.Metadata{
 		Name: "admission.granter.elastic_io_tokens_exhausted_duration.kv",
@@ -1098,6 +1104,9 @@ var (
 			"microseconds before that.",
 		Measurement: "Nanoseconds",
 		Unit:        metric.Unit_NANOSECONDS,
+		Visibility:  metric.Metadata_ESSENTIAL,
+		Category:    metric.Metadata_OVERLOAD,
+		HowToUse:    "This metric indicates when elastic I/O tokens are exhausted. Extended periods of elastic token exhaustion may indicate I/O bandwidth saturation affecting elastic workloads.",
 	}
 	kvIOTokensTaken = metric.Metadata{
 		Name:        "admission.granter.io_tokens_taken.kv",

--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -2001,6 +2001,9 @@ var (
 		Help:        "Wait time durations for requests that waited",
 		Measurement: "Wait time Duration",
 		Unit:        metric.Unit_NANOSECONDS,
+		Visibility:  metric.Metadata_ESSENTIAL,
+		Category:    metric.Metadata_OVERLOAD,
+		HowToUse:    "This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.",
 	}
 	kvWaitDurationsMeta = metric.Metadata{
 		Name:        "admission.wait_durations.",
@@ -2009,7 +2012,7 @@ var (
 		Unit:        metric.Unit_NANOSECONDS,
 		Visibility:  metric.Metadata_ESSENTIAL,
 		Category:    metric.Metadata_OVERLOAD,
-		HowToUse:    "This metric shows if CPU utilization-based admission control feature is working effectively or potentially overaggressive. This is a latency histogram of how much delay was added to the workload due to throttling. If observing over 100ms waits for over 5 seconds while there was excess capacity available, then the admission control is overly aggressive.",
+		HowToUse:    "This is a latency histogram of wait time in the CPU utilization-based admission control queue. Non-zero wait times are expected when CPU is saturated.",
 	}
 	kvStoresWaitDurationsMeta = metric.Metadata{
 		Name:        "admission.wait_durations.",
@@ -2018,7 +2021,7 @@ var (
 		Unit:        metric.Unit_NANOSECONDS,
 		Visibility:  metric.Metadata_ESSENTIAL,
 		Category:    metric.Metadata_OVERLOAD,
-		HowToUse:    "This metric shows if I/O utilization-based admission control feature is working effectively or potentially overaggressive. This is a latency histogram of how much delay was added to the workload due to throttling. If observing over 100ms waits for over 5 seconds while there was excess capacity available, then the admission control is overly aggressive.",
+		HowToUse:    "This is a latency histogram of wait time in the I/O utilization-based admission control queue. Non-zero wait times are expected when I/O is saturated.",
 	}
 	waitQueueLengthMeta = metric.Metadata{
 		Name:        "admission.wait_queue_length.",

--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -2001,7 +2001,6 @@ var (
 		Help:        "Wait time durations for requests that waited",
 		Measurement: "Wait time Duration",
 		Unit:        metric.Unit_NANOSECONDS,
-		Visibility:  metric.Metadata_ESSENTIAL,
 		Category:    metric.Metadata_OVERLOAD,
 		HowToUse:    "This is a latency histogram of wait time in the admission control queue. Non-zero wait times are expected when the corresponding resource is saturated.",
 	}
@@ -2010,7 +2009,6 @@ var (
 		Help:        "Wait time durations for requests that waited",
 		Measurement: "Wait time Duration",
 		Unit:        metric.Unit_NANOSECONDS,
-		Visibility:  metric.Metadata_ESSENTIAL,
 		Category:    metric.Metadata_OVERLOAD,
 		HowToUse:    "This is a latency histogram of wait time in the CPU utilization-based admission control queue. Non-zero wait times are expected when CPU is saturated.",
 	}
@@ -2019,7 +2017,6 @@ var (
 		Help:        "Wait time durations for requests that waited",
 		Measurement: "Wait time Duration",
 		Unit:        metric.Unit_NANOSECONDS,
-		Visibility:  metric.Metadata_ESSENTIAL,
 		Category:    metric.Metadata_OVERLOAD,
 		HowToUse:    "This is a latency histogram of wait time in the I/O utilization-based admission control queue. Non-zero wait times are expected when I/O is saturated.",
 	}
@@ -2062,7 +2059,7 @@ func (m *WorkQueueMetrics) getOrCreate(priority admissionpb.WorkPriority) *workQ
 		// It is not called the first Load so that we don't have to unnecessarily
 		// create the metrics.
 		statPrefix := fmt.Sprintf("%v.%v", m.name, priority.String())
-		val, ok = m.byPriority.LoadOrStore(priority, makeWorkQueueMetricsSingle(statPrefix))
+		val, ok = m.byPriority.LoadOrStore(priority, makeWorkQueueMetricsSingle(statPrefix, false /* essential */))
 		if !ok {
 			m.registry.AddMetricStruct(val)
 		}
@@ -2131,7 +2128,7 @@ func (m *WorkQueueMetrics) recordFastPathAdmission(priority admissionpb.WorkPrio
 func (*WorkQueueMetrics) MetricStruct() {}
 
 func makeWorkQueueMetrics(name string, registry *metric.Registry) *WorkQueueMetrics {
-	totalMetric := makeWorkQueueMetricsSingle(name)
+	totalMetric := makeWorkQueueMetricsSingle(name, true /* essential */)
 	registry.AddMetricStruct(totalMetric)
 	wqm := &WorkQueueMetrics{
 		name:     name,
@@ -2145,12 +2142,15 @@ func makeWorkQueueMetrics(name string, registry *metric.Registry) *WorkQueueMetr
 	return wqm
 }
 
-func makeWorkQueueMetricsSingle(name string) *workQueueMetricsSingle {
+func makeWorkQueueMetricsSingle(name string, essential bool) *workQueueMetricsSingle {
 	wdm := waitDurationsMeta
 	if name == KVWork.String() {
 		wdm = kvWaitDurationsMeta
 	} else if name == fmt.Sprintf("%s-stores", KVWork.String()) {
 		wdm = kvStoresWaitDurationsMeta
+	}
+	if essential {
+		wdm.Visibility = metric.Metadata_ESSENTIAL
 	}
 
 	return &workQueueMetricsSingle{


### PR DESCRIPTION
Resolves: #162508
Epic: CRDB-35697

---
**admission: promote key admission control metrics to Essential**

Previously, several critical admission control metrics lacked
Essential status, making them harder to discover for monitoring
and troubleshooting cluster health issues.

This commit promotes 9 admission control metrics to Essential:
- admission.wait_durations.* (sql-kv-response, sql-sql-response,
  elastic-stores, elastic-cpu) - latency histograms showing
  throttling delays
- admission.granter.*_exhausted_duration.kv (slots, io_tokens,
  elastic_io_tokens) - duration metrics indicating resource
  exhaustion
- admission.elastic_cpu.nanos_exhausted_duration - elastic CPU
  token exhaustion tracking
- kvflowcontrol.eval_wait.*.duration - flow token wait times
- kvflowcontrol.send_queue.bytes - queued raft entry size

Each metric now includes:
- Visibility: ESSENTIAL for dashboard/monitoring inclusion
- Category: OVERLOAD for resource exhaustion tracking
- HowToUse: guidance on interpreting values and troubleshooting

Release note (ops change): Promoted 9 admission control metrics
to Essential status, making them more discoverable in monitoring
dashboards and troubleshooting workflows. These metrics track
admission control wait times, resource exhaustion (slots, I/O
tokens, CPU tokens), and replication flow control, providing
critical visibility into cluster health and performance throttling.

---
**admission: make metrics with priority non-essential**

The per-priority variants of the wait duration metrics are created
dynamically for each `WorkPriority` observed at runtime. These share
`Metadata` definitions with the aggregate metrics, which were promoted
to Essential in the previous commit.

This commit removes `Visibility: ESSENTIAL` from per-priority
admission control metrics.

