### PR TITLE
admission: fix staleStatTracker.shouldLog() rate-limiter bypass

### DIFF
--- a/pkg/util/admission/granter.go
+++ b/pkg/util/admission/granter.go
@@ -6,11 +6,14 @@
 package admission
 
 import (
+	"context"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble"
@@ -46,13 +49,8 @@ type slotGranter struct {
 var _ granterWithLockedCalls = &slotGranter{}
 var _ granter = &slotGranter{}
 
-// grantKind implements granter.
-func (sg *slotGranter) grantKind() grantKind {
-	return slot
-}
-
 // tryGet implements granter.
-func (sg *slotGranter) tryGet(count int64) bool {
+func (sg *slotGranter) tryGet(_ burstQualification, count int64) bool {
 	return sg.coord.tryGet(sg.workKind, count, 0 /*arbitrary*/)
 }
 
@@ -87,8 +85,8 @@ func (sg *slotGranter) returnGrantLocked(count int64, _ int8) {
 	}
 	if sg.usedSlots == sg.totalSlots {
 		now := timeutil.Now()
-		exhaustedMicros := now.Sub(sg.exhaustedStart).Microseconds()
-		sg.slotsExhaustedDurationMetric.Inc(exhaustedMicros)
+		exhaustedDuration := now.Sub(sg.exhaustedStart)
+		sg.slotsExhaustedDurationMetric.Inc(exhaustedDuration.Nanoseconds())
 	}
 	sg.usedSlots--
 	if sg.usedSlots < 0 {
@@ -121,7 +119,8 @@ func (sg *slotGranter) continueGrantChain(grantChainID grantChainID) {
 
 // requesterHasWaitingRequests implements granterWithLockedCalls.
 func (sg *slotGranter) requesterHasWaitingRequests() bool {
-	return sg.requester.hasWaitingRequests()
+	hasWaiting, _ := sg.requester.hasWaitingRequests()
+	return hasWaiting
 }
 
 // tryGrantLocked implements granterWithLockedCalls.
@@ -153,8 +152,8 @@ func (sg *slotGranter) setTotalSlotsLockedInternal(totalSlots int) {
 	if totalSlots > sg.totalSlots {
 		if sg.totalSlots <= sg.usedSlots && totalSlots > sg.usedSlots {
 			now := timeutil.Now()
-			exhaustedMicros := now.Sub(sg.exhaustedStart).Microseconds()
-			sg.slotsExhaustedDurationMetric.Inc(exhaustedMicros)
+			exhaustedDuration := now.Sub(sg.exhaustedStart)
+			sg.slotsExhaustedDurationMetric.Inc(exhaustedDuration.Nanoseconds())
 		}
 	} else if totalSlots < sg.totalSlots {
 		if sg.totalSlots > sg.usedSlots && totalSlots <= sg.usedSlots {
@@ -186,13 +185,8 @@ func (tg *tokenGranter) refillBurstTokens(skipTokenEnforcement bool) {
 	tg.skipTokenEnforcement = skipTokenEnforcement
 }
 
-// grantKind implements granter.
-func (tg *tokenGranter) grantKind() grantKind {
-	return token
-}
-
 // tryGet implements granter.
-func (tg *tokenGranter) tryGet(count int64) bool {
+func (tg *tokenGranter) tryGet(_ burstQualification, count int64) bool {
 	return tg.coord.tryGet(tg.workKind, count, 0 /*arbitrary*/)
 }
 
@@ -238,7 +232,8 @@ func (tg *tokenGranter) continueGrantChain(grantChainID grantChainID) {
 
 // requesterHasWaitingRequests implements granterWithLockedCalls.
 func (tg *tokenGranter) requesterHasWaitingRequests() bool {
-	return tg.requester.hasWaitingRequests()
+	hasWaiting, _ := tg.requester.hasWaitingRequests()
+	return hasWaiting
 }
 
 // tryGrantLocked implements granterWithLockedCalls.
@@ -257,15 +252,15 @@ func (tg *tokenGranter) tryGrantLocked(grantChainID grantChainID) grantResult {
 	return res
 }
 
-// kvStoreTokenGranter implements granterWithLockedCalls. It is used for
-// grants to KVWork to a store, that is limited by IO tokens. It encapsulates
-// two granter-requester pairs, for the two workClasses. The granter in these
-// pairs is implemented by kvStoreTokenChildGranter, and the requester by
-// WorkQueue. We have separate WorkQueues for these work classes so that we
-// don't have a situation where tenant1's elastic work is queued ahead of
-// tenant2's regular work (due to inter-tenant fairness) and blocks the latter
-// from getting tokens, because elastic tokens are exhausted (and tokens for
-// regular work are not exhausted).
+// kvStoreTokenGranter is used for grants to KVWork to a store, that is
+// limited by IO tokens. It encapsulates three granter-requester pairs, for
+// the two workClasses and for incoming snapshots. The granter in these pairs
+// is implemented by kvStoreTokenChildGranter, and the requester either by
+// WorkQueue or SnapshotQueue. We have separate WorkQueues for the work
+// classes so that we don't have a situation where tenant1's elastic work is
+// queued ahead of tenant2's regular work (due to inter-tenant fairness) and
+// blocks the latter from getting tokens, because elastic tokens are exhausted
+// (and tokens for regular work are not exhausted).
 //
 // The kvStoreTokenChildGranters delegate the actual interaction to
 // their "parent", kvStoreTokenGranter. For elasticWorkClass, multiple kinds
@@ -274,12 +269,13 @@ func (tg *tokenGranter) tryGrantLocked(grantChainID grantChainID) grantResult {
 // tokens, which are based on disk bandwidth as a constrained resource, and
 // apply to all the elastic incoming bytes into the LSM.
 type kvStoreTokenGranter struct {
-	coord             *GrantCoordinator
+	knobs             *TestingKnobs
 	regularRequester  requester
 	elasticRequester  requester
 	snapshotRequester requester
 
-	coordMu struct { // holds fields protected by coord.mu.Lock
+	mu struct {
+		syncutil.Mutex
 		// There is no rate limiting in granting these tokens. That is, they are
 		// all burst tokens.
 
@@ -290,35 +286,86 @@ type kvStoreTokenGranter struct {
 		availableIOTokens            [admissionpb.NumWorkClasses]int64
 		elasticIOTokensUsedByElastic int64
 		// TODO(aaditya): add support for read/IOPS tokens.
-		// Disk bandwidth tokens.
+		//
+		// Disk tokens available represents the current size of the token bucket.
+		// The diskTokens.readByteTokens is currently unused, since estimated
+		// future reads are added to the diskReadTokensAlreadyDeducted directly
+		// and then compared with observed reads. That is, we are pretending as if
+		// we observed token deductions from (the non-existent) read token bucket,
+		// corresponding to reads observed in the last adjustment interval. We
+		// need to do this since read code is not instrumented to interface with
+		// admission control.
 		diskTokensAvailable diskTokens
-		diskTokensError     struct {
+		// The capacity of the token bucket for disk write bytes.
+		diskWriteByteTokensCapacity int64
+		diskTokensError             struct {
+			initialized bool
 			// prevObserved{Writes,Reads} is the observed disk metrics in the last
 			// call to adjustDiskTokenErrorLocked. These are used to compute the
 			// delta.
-			prevObservedWrites             uint64
-			prevObservedReads              uint64
-			diskWriteTokensAlreadyDeducted int64
-			diskReadTokensAlreadyDeducted  int64
+			prevObservedWrites uint64
+			prevObservedReads  uint64
+			// staleStats tracks consecutive intervals where disk stats don't change.
+			staleStats staleStatTracker
+			// alreadyDeductedTokens is the number of tokens deducted that can be
+			// used to partially explain the observed writes and reads. The write
+			// tokens here correspond to deductions from
+			// diskTokensAvailable.writeByteTokens. These are reset on each error
+			// correction tick (every 1ms when loaded).
+			alreadyDeductedTokens diskTokens
+			// Error details for the latest adjustmentInterval, across the various
+			// adjustDiskTokenErrorLocked calls (which happen every 1ms when loaded).
+			// We don't track beyond an adjustmentInterval since the last interval's
+			// observations of disk reads/writes are already used in the modeling (of
+			// write amplification and the alreadyDeductedTokens.readByteTokens).
+			//
+			// - cumError is the error summed across the various
+			//   adjustDiskTokenErrorLocked calls. Since errors can be positive and
+			//   negative, they can cancel out.
+			//
+			// - absError is the sum of absolute values of error across these calls,
+			//   so they don't cancel out. This is only used for observability since
+			//   large positive and negative errors become observable here, and helps
+			//   with understanding the system behavior.
+			//
+			// On each tick, the full interval error (observed - deducted) is
+			// immediately applied to the available disk write tokens. Since error
+			// correction now happens at 1ms granularity (matching the token
+			// allocation tick rate), the per-tick error magnitude is small, avoiding
+			// the large oscillations that were problematic when error correction
+			// happened at coarser intervals. See #160964 for context on earlier
+			// approaches that used partial error accounting with dampening.
+			cumError diskTokens
+			absError diskTokens
 		}
 		diskTokensUsed [admissionpb.NumStoreWorkTypes]diskTokens
+		// prevIntervalDiskWriteTokensRemaining is the value of
+		// diskTokensAvailable.writeByteTokens at the end of the previous
+		// adjustment interval. A negative value indicates overadmission.
+		prevIntervalDiskWriteTokensRemaining int64
+		// exhaustedStart is the time when the corresponding availableIOTokens
+		// became <= 0. Ignored when the corresponding availableIOTokens is > 0.
+		exhaustedStart [admissionpb.NumWorkClasses]time.Time
+		// startingIOTokens is the number of tokens set by addAvailableTokens for
+		// regular work. It is used to compute the tokens used, by computing
+		// startingIOTokens-availableIOTokens[RegularWorkClass].
+		startingIOTokens int64
+		// diskWriteByteTokensExhaustedStart is the time when
+		// diskTokensAvailable.writeByteTokens became <= 0. Ignored when
+		// diskTokensAvailable.writeByteTokens is > 0.
+		diskWriteByteTokensExhaustedStart time.Time
+
+		// Estimation models.
+		l0WriteLM, l0IngestLM, ingestLM, writeAmpLM tokensLinearModel
 	}
 
-	ioTokensExhaustedDurationMetric [admissionpb.NumWorkClasses]*metric.Counter
-	availableTokensMetric           [admissionpb.NumWorkClasses]*metric.Gauge
-	exhaustedStart                  [admissionpb.NumWorkClasses]time.Time
-	// startingIOTokens is the number of tokens set by
-	// setAvailableTokens. It is used to compute the tokens used, by
-	// computing startingIOTokens-availableIOTokens.
-	startingIOTokens     int64
-	tokensReturnedMetric *metric.Counter
-	tokensTakenMetric    *metric.Counter
-
-	// Estimation models.
-	l0WriteLM, l0IngestLM, ingestLM, writeAmpLM tokensLinearModel
+	ioTokensExhaustedDurationMetric            [admissionpb.NumWorkClasses]*metric.Counter
+	availableTokensMetric                      [admissionpb.NumWorkClasses]*metric.Gauge
+	tokensReturnedMetric                       *metric.Counter
+	tokensTakenMetric                          *metric.Counter
+	diskWriteByteTokensExhaustedDurationMetric *metric.Counter
 }
 
-var _ granterWithLockedCalls = &kvStoreTokenGranter{}
 var _ granterWithIOTokens = &kvStoreTokenGranter{}
 
 // kvStoreTokenChildGranter handles a particular workClass. Its methods
@@ -331,13 +378,8 @@ type kvStoreTokenChildGranter struct {
 var _ granterWithStoreReplicatedWorkAdmitted = &kvStoreTokenChildGranter{}
 var _ granter = &kvStoreTokenChildGranter{}
 
-// grantKind implements granter.
-func (cg *kvStoreTokenChildGranter) grantKind() grantKind {
-	return token
-}
-
 // tryGet implements granter.
-func (cg *kvStoreTokenChildGranter) tryGet(count int64) bool {
+func (cg *kvStoreTokenChildGranter) tryGet(_ burstQualification, count int64) bool {
 	return cg.parent.tryGet(cg.workType, count)
 }
 
@@ -360,14 +402,12 @@ func (cg *kvStoreTokenChildGranter) continueGrantChain(grantChainID grantChainID
 func (cg *kvStoreTokenChildGranter) storeWriteDone(
 	originalTokens int64, doneInfo StoreWorkDoneInfo,
 ) (additionalTokens int64) {
-	cg.parent.coord.mu.Lock()
-	defer cg.parent.coord.mu.Unlock()
 	// NB: the token/metric adjustments we want to make here are the same as we
 	// want to make through the storeReplicatedWorkAdmittedLocked, so we (ab)use
 	// it. The one difference is that post token adjustments, if we observe the
 	// granter was previously exhausted but is no longer so, we're allowed to
 	// admit other waiting requests.
-	return cg.parent.storeReplicatedWorkAdmittedLocked(
+	return cg.parent.storeReplicatedWorkAdmitted(
 		cg.workType, originalTokens, storeReplicatedWorkAdmittedInfo(doneInfo), true /* canGrantAnother */)
 }
 
@@ -379,12 +419,14 @@ func (cg *kvStoreTokenChildGranter) storeReplicatedWorkAdmittedLocked(
 }
 
 func (sg *kvStoreTokenGranter) tryGet(workType admissionpb.StoreWorkType, count int64) bool {
-	return sg.coord.tryGet(KVWork, count, int8(workType))
+	sg.mu.Lock()
+	defer sg.mu.Unlock()
+	return sg.tryGetLocked(count, workType)
 }
 
-// tryGetLocked implements granterWithLockedCalls.
-func (sg *kvStoreTokenGranter) tryGetLocked(count int64, demuxHandle int8) grantResult {
-	wt := admissionpb.StoreWorkType(demuxHandle)
+// tryGetLocked is the real implementation of tryGet from the granter
+// interface.
+func (sg *kvStoreTokenGranter) tryGetLocked(count int64, wt admissionpb.StoreWorkType) bool {
 	// NB: ideally if regularRequester.hasWaitingRequests() returns true and
 	// wc==elasticWorkClass we should reject this request, since it means that
 	// more important regular work is waiting. However, we rely on the
@@ -415,48 +457,49 @@ func (sg *kvStoreTokenGranter) tryGetLocked(count int64, demuxHandle int8) grant
 	if wt != admissionpb.SnapshotIngestStoreWorkType {
 		// Snapshot ingests do not incur the write amplification described above, so
 		// we skip applying the model for those writes.
-		diskWriteTokens = sg.writeAmpLM.applyLinearModel(count)
+		diskWriteTokens = sg.mu.writeAmpLM.applyLinearModel(count)
 	}
 	switch wt {
 	case admissionpb.RegularStoreWorkType:
-		if sg.coordMu.availableIOTokens[admissionpb.RegularWorkClass] > 0 {
+		if sg.mu.availableIOTokens[admissionpb.RegularWorkClass] > 0 {
 			sg.subtractIOTokensLocked(count, count, false)
-			sg.coordMu.diskTokensAvailable.writeByteTokens -= diskWriteTokens
-			sg.coordMu.diskTokensError.diskWriteTokensAlreadyDeducted += diskWriteTokens
-			sg.coordMu.diskTokensUsed[wt].writeByteTokens += diskWriteTokens
-			return grantSuccess
+			sg.subtractDiskWriteTokensLocked(diskWriteTokens, false)
+			sg.mu.diskTokensUsed[wt].writeByteTokens += diskWriteTokens
+			return true
 		}
 	case admissionpb.ElasticStoreWorkType:
-		if sg.coordMu.diskTokensAvailable.writeByteTokens > 0 &&
-			sg.coordMu.availableIOTokens[admissionpb.RegularWorkClass] > 0 &&
-			sg.coordMu.availableIOTokens[admissionpb.ElasticWorkClass] > 0 {
+		if sg.mu.diskTokensAvailable.writeByteTokens > 0 &&
+			sg.mu.availableIOTokens[admissionpb.RegularWorkClass] > 0 &&
+			sg.mu.availableIOTokens[admissionpb.ElasticWorkClass] > 0 {
 			sg.subtractIOTokensLocked(count, count, false)
-			sg.coordMu.elasticIOTokensUsedByElastic += count
-			sg.coordMu.diskTokensAvailable.writeByteTokens -= diskWriteTokens
-			sg.coordMu.diskTokensError.diskWriteTokensAlreadyDeducted += diskWriteTokens
-			sg.coordMu.diskTokensUsed[wt].writeByteTokens += diskWriteTokens
-			return grantSuccess
+			sg.mu.elasticIOTokensUsedByElastic += count
+			sg.subtractDiskWriteTokensLocked(diskWriteTokens, false)
+			sg.mu.diskTokensUsed[wt].writeByteTokens += diskWriteTokens
+			return true
 		}
 	case admissionpb.SnapshotIngestStoreWorkType:
 		// Snapshot ingests do not go into L0, so we only subject them to
 		// writeByteTokens.
-		if sg.coordMu.diskTokensAvailable.writeByteTokens > 0 {
-			sg.coordMu.diskTokensAvailable.writeByteTokens -= diskWriteTokens
-			sg.coordMu.diskTokensError.diskWriteTokensAlreadyDeducted += diskWriteTokens
-			sg.coordMu.diskTokensUsed[wt].writeByteTokens += diskWriteTokens
-			return grantSuccess
+		if sg.mu.diskTokensAvailable.writeByteTokens > 0 {
+			sg.subtractDiskWriteTokensLocked(diskWriteTokens, false)
+			sg.mu.diskTokensUsed[wt].writeByteTokens += diskWriteTokens
+			return true
 		}
 	}
-	return grantFailLocal
+	return false
 }
 
 func (sg *kvStoreTokenGranter) returnGrant(workType admissionpb.StoreWorkType, count int64) {
-	sg.coord.returnGrant(KVWork, count, int8(workType))
+	sg.mu.Lock()
+	defer sg.mu.Unlock()
+	sg.returnGrantLocked(count, workType)
+	// Try granting, since tokens have been returned.
+	sg.tryGrantLocked()
 }
 
-// returnGrantLocked implements granterWithLockedCalls.
-func (sg *kvStoreTokenGranter) returnGrantLocked(count int64, demuxHandle int8) {
-	wt := admissionpb.StoreWorkType(demuxHandle)
+// returnGrantLocked is the real implementation of returnGrant from the
+// granter interface.
+func (sg *kvStoreTokenGranter) returnGrantLocked(count int64, wt admissionpb.StoreWorkType) {
 	// Return store tokens.
 	sg.subtractTokensForStoreWorkTypeLocked(wt, -count)
 }
@@ -472,78 +515,178 @@ func (sg *kvStoreTokenGranter) subtractTokensForStoreWorkTypeLocked(
 		sg.subtractIOTokensLocked(count, count, false)
 	}
 	if wt == admissionpb.ElasticStoreWorkType {
-		sg.coordMu.elasticIOTokensUsedByElastic += count
+		sg.mu.elasticIOTokensUsedByElastic += count
 	}
 	// Adjust tokens for disk bandwidth bucket.
 	switch wt {
 	case admissionpb.RegularStoreWorkType, admissionpb.ElasticStoreWorkType:
-		diskTokenCount := sg.writeAmpLM.applyLinearModel(count)
-		sg.coordMu.diskTokensAvailable.writeByteTokens -= diskTokenCount
-		sg.coordMu.diskTokensError.diskWriteTokensAlreadyDeducted += diskTokenCount
-		sg.coordMu.diskTokensUsed[wt].writeByteTokens += diskTokenCount
+		diskTokenCount := sg.mu.writeAmpLM.applyLinearModel(count)
+		sg.subtractDiskWriteTokensLocked(diskTokenCount, false)
+		sg.mu.diskTokensUsed[wt].writeByteTokens += diskTokenCount
 	case admissionpb.SnapshotIngestStoreWorkType:
 		// Do not apply the writeAmpLM since these writes do not incur additional
 		// write-amp.
-		sg.coordMu.diskTokensAvailable.writeByteTokens -= count
-		sg.coordMu.diskTokensError.diskWriteTokensAlreadyDeducted += count
-		sg.coordMu.diskTokensUsed[wt].writeByteTokens += count
+		sg.subtractDiskWriteTokensLocked(count, false)
+		sg.mu.diskTokensUsed[wt].writeByteTokens += count
 	}
+}
+
+func (sg *kvStoreTokenGranter) adjustDiskTokenError(stats DiskStats) {
+	sg.mu.Lock()
+	defer sg.mu.Unlock()
+	sg.adjustDiskTokenErrorLocked(stats.BytesRead, stats.BytesWritten)
+}
+
+// staleStatTracker tracks consecutive intervals where disk stats don't change,
+// and rate-limits logging at configurable thresholds. This helps assess whether
+// the 1ms error correction tick rate is effective given the kernel's disk stat
+// update frequency.
+type staleStatTracker struct {
+	// consecutiveCount is the current number of consecutive ticks where disk
+	// stats have not changed.
+	consecutiveCount int
+	// thresholds defines the consecutive count values at which we log warnings.
+	thresholds []int // e.g., [20, 50, 100]
+	// cumExceededCounts tracks how many times consecutiveCount exceeded each
+	// threshold before stats changed. Index i corresponds to thresholds[i].
+	cumExceededCounts []uint64
+	logLimiter        log.EveryN
+}
+
+func newStaleStatTracker() staleStatTracker {
+	return staleStatTracker{
+		thresholds:        []int{20, 50, 100},
+		cumExceededCounts: make([]uint64, 3),
+		logLimiter:        log.Every(time.Minute),
+	}
+}
+
+// recordNoChange increments consecutiveCount and logs if a threshold is exceeded.
+func (t *staleStatTracker) recordNoChange(ctx context.Context) {
+	t.consecutiveCount++
+	if t.shouldLog() {
+		log.Dev.Infof(ctx,
+			"disk token error adjustment: no stat change for %d consecutive intervals "+
+				"(cumulative runs exceeding 20/50/100: %d/%d/%d)",
+			t.consecutiveCount, t.cumExceededCounts[0], t.cumExceededCounts[1], t.cumExceededCounts[2])
+	}
+}
+
+// recordChange records the completed run in the appropriate threshold bucket
+// and resets consecutiveCount.
+func (t *staleStatTracker) recordChange() {
+	if t.consecutiveCount == 0 {
+		return
+	}
+
+	// Record in highest matching threshold bucket.
+	for i := len(t.thresholds) - 1; i >= 0; i-- {
+		if t.consecutiveCount >= t.thresholds[i] {
+			t.cumExceededCounts[i]++
+			break
+		}
+	}
+	t.consecutiveCount = 0
+}
+
+// shouldLog returns true if the current consecutiveCount warrants a log line.
+// All threshold checks go through the rate limiter to prevent log spam.
+func (t *staleStatTracker) shouldLog() bool {
+	for _, thresh := range t.thresholds {
+		if t.consecutiveCount >= thresh {
+			return t.logLimiter.ShouldLog()
+		}
+	}
+	return false
 }
 
 // adjustDiskTokenErrorLocked is used to account for extra reads and writes that
 // are in excess of tokens already deducted.
 //
 // (1) For writes, we deduct tokens at admission for each request. If the actual
-// writes seen on disk for a given interval is higher than the tokens already
+// writes seen on disk for a given tick is higher than the tokens already
 // deducted, the delta is the write error. This value is then subtracted from
 // available disk tokens.
 //
 // (2) For reads, we do not deduct any tokens at admission. However, we deduct
 // tokens in advance during token estimation in the diskBandwidthLimiter for the
 // next adjustment interval. These pre-deducted tokens are then allocated at the
-// same interval as write tokens. Any additional reads in the interval are
+// same interval as write tokens. Any additional reads in the tick interval are
 // considered error and are subtracted from the available disk write tokens.
 //
-// For both reads, and writes, we reset the
-// disk{read,write}TokensAlreadyDeducted to 0 for the next adjustment interval.
-// For writes, we do this so that we are accounting for errors only in the given
-// interval, and not across them. For reads, this is so that we don't grow
-// arbitrarily large "burst" tokens, since they are not capped to an allocation
-// period.
+// For both reads and writes, we reset the alreadyDeductedTokens to 0 for the
+// next error tick interval, since we will use those to compare with the
+// observed disk reads and writes for the next error tick interval.
+//
+// readBytes and writeBytes are the cumulative values retrieved from the disk stats.
 func (sg *kvStoreTokenGranter) adjustDiskTokenErrorLocked(readBytes uint64, writeBytes uint64) {
-	intWrites := int64(writeBytes - sg.coordMu.diskTokensError.prevObservedWrites)
-	intReads := int64(readBytes - sg.coordMu.diskTokensError.prevObservedReads)
+	// On the first call, we only record the baseline cumulative values. We can't
+	// compute error yet because we need a valid previous observation to compute
+	// the delta (otherwise we'd treat total bytes since boot as "error").
+	if !sg.mu.diskTokensError.initialized {
+		sg.mu.diskTokensError.prevObservedWrites = writeBytes
+		sg.mu.diskTokensError.prevObservedReads = readBytes
+		sg.mu.diskTokensError.initialized = true
+		return
+	}
+
+	intWrites := int64(writeBytes - sg.mu.diskTokensError.prevObservedWrites)
+	intReads := int64(readBytes - sg.mu.diskTokensError.prevObservedReads)
+
+	if intWrites == 0 && intReads == 0 {
+		sg.mu.diskTokensError.staleStats.recordNoChange(context.Background())
+	} else {
+		sg.mu.diskTokensError.staleStats.recordChange()
+	}
+
+	errorAdjFunc := func(
+		intObserved int64, intTokensDeducted int64, cumError *int64, absError *int64) {
+		intError := intObserved - intTokensDeducted
+
+		if intError == 0 {
+			return
+		}
+
+		*cumError += intError
+		absIntError := intError
+		if absIntError < 0 {
+			absIntError = -absIntError
+		}
+		*absError += absIntError
+
+		// NB: the following also updates alreadyDeductedTokens.writeByteTokens,
+		// which is harmless, since we reset it to 0 later in this function.
+		sg.subtractDiskWriteTokensLocked(intError, false)
+	}
 
 	// Compensate for error due to writes.
-	writeError := intWrites - sg.coordMu.diskTokensError.diskWriteTokensAlreadyDeducted
-	if writeError > 0 {
-		sg.coordMu.diskTokensAvailable.writeByteTokens -= writeError
-	}
+	errorAdjFunc(intWrites, sg.mu.diskTokensError.alreadyDeductedTokens.writeByteTokens,
+		&sg.mu.diskTokensError.cumError.writeByteTokens, &sg.mu.diskTokensError.absError.writeByteTokens)
 
 	// Compensate for error due to reads.
-	readError := intReads - sg.coordMu.diskTokensError.diskReadTokensAlreadyDeducted
-	if readError > 0 {
-		sg.coordMu.diskTokensAvailable.writeByteTokens -= readError
-	}
+	errorAdjFunc(intReads, sg.mu.diskTokensError.alreadyDeductedTokens.readByteTokens,
+		&sg.mu.diskTokensError.cumError.readByteTokens, &sg.mu.diskTokensError.absError.readByteTokens)
 
-	// We have compensated for error, if any, in this interval, so we reset the
-	// deducted count for the next compensation interval.
-	sg.coordMu.diskTokensError.diskWriteTokensAlreadyDeducted = 0
-	sg.coordMu.diskTokensError.diskReadTokensAlreadyDeducted = 0
+	// Reset the deducted count for the next compensation interval.
+	sg.mu.diskTokensError.alreadyDeductedTokens = diskTokens{}
 
-	sg.coordMu.diskTokensError.prevObservedWrites = writeBytes
-	sg.coordMu.diskTokensError.prevObservedReads = readBytes
+	sg.mu.diskTokensError.prevObservedWrites = writeBytes
+	sg.mu.diskTokensError.prevObservedReads = readBytes
 }
 
 func (sg *kvStoreTokenGranter) tookWithoutPermission(
 	workType admissionpb.StoreWorkType, count int64,
 ) {
-	sg.coord.tookWithoutPermission(KVWork, count, int8(workType))
+	sg.mu.Lock()
+	defer sg.mu.Unlock()
+	sg.tookWithoutPermissionLocked(count, workType)
 }
 
-// tookWithoutPermissionLocked implements granterWithLockedCalls.
-func (sg *kvStoreTokenGranter) tookWithoutPermissionLocked(count int64, demuxHandle int8) {
-	wt := admissionpb.StoreWorkType(demuxHandle)
+// tookWithoutPermissionLocked is the real implementation of
+// tookWithoutPermission from the granter interface.
+func (sg *kvStoreTokenGranter) tookWithoutPermissionLocked(
+	count int64, wt admissionpb.StoreWorkType,
+) {
 	// Deduct store tokens.
 	sg.subtractTokensForStoreWorkTypeLocked(wt, count)
 }
@@ -567,63 +710,100 @@ func (sg *kvStoreTokenGranter) subtractIOTokensLocked(
 func (sg *kvStoreTokenGranter) subtractTokensLockedForWorkClass(
 	wc admissionpb.WorkClass, count int64, settingAvailableTokens bool,
 ) {
-	avail := sg.coordMu.availableIOTokens[wc]
-	sg.coordMu.availableIOTokens[wc] -= count
-	sg.availableTokensMetric[wc].Update(sg.coordMu.availableIOTokens[wc])
-	if count > 0 && avail > 0 && sg.coordMu.availableIOTokens[wc] <= 0 {
+	avail := sg.mu.availableIOTokens[wc]
+	sg.mu.availableIOTokens[wc] -= count
+	sg.availableTokensMetric[wc].Update(sg.mu.availableIOTokens[wc])
+	if count > 0 && avail > 0 && sg.mu.availableIOTokens[wc] <= 0 {
 		// Transition from > 0 to <= 0.
-		sg.exhaustedStart[wc] = timeutil.Now()
-	} else if count < 0 && avail <= 0 && (sg.coordMu.availableIOTokens[wc] > 0 || settingAvailableTokens) {
+		sg.mu.exhaustedStart[wc] = timeutil.Now()
+	} else if count < 0 && avail <= 0 && (sg.mu.availableIOTokens[wc] > 0 || settingAvailableTokens) {
 		// Transition from <= 0 to > 0, or if we're newly setting available
 		// tokens. The latter ensures that if the available tokens stay <= 0, we
 		// don't show a sudden change in the metric after minutes of exhaustion
 		// (we had observed such behavior prior to this change).
 		now := timeutil.Now()
-		exhaustedMicros := now.Sub(sg.exhaustedStart[wc]).Microseconds()
-		sg.ioTokensExhaustedDurationMetric[wc].Inc(exhaustedMicros)
-		if sg.coordMu.availableIOTokens[wc] <= 0 {
-			sg.exhaustedStart[wc] = now
+		exhaustedDuration := now.Sub(sg.mu.exhaustedStart[wc])
+		sg.ioTokensExhaustedDurationMetric[wc].Inc(exhaustedDuration.Nanoseconds())
+		if sg.mu.availableIOTokens[wc] <= 0 {
+			sg.mu.exhaustedStart[wc] = now
 		}
 	}
 }
 
-// requesterHasWaitingRequests implements granterWithLockedCalls.
-func (sg *kvStoreTokenGranter) requesterHasWaitingRequests() bool {
-	return sg.regularRequester.hasWaitingRequests() ||
-		sg.elasticRequester.hasWaitingRequests() ||
-		sg.snapshotRequester.hasWaitingRequests()
+func (sg *kvStoreTokenGranter) subtractDiskWriteTokensLocked(
+	count int64, settingAvailableTokens bool,
+) {
+	avail := sg.mu.diskTokensAvailable.writeByteTokens
+	sg.mu.diskTokensAvailable.writeByteTokens -= count
+	if settingAvailableTokens && sg.mu.diskTokensAvailable.writeByteTokens > sg.mu.diskWriteByteTokensCapacity {
+		sg.mu.diskTokensAvailable.writeByteTokens = sg.mu.diskWriteByteTokensCapacity
+	}
+	if !settingAvailableTokens {
+		sg.mu.diskTokensError.alreadyDeductedTokens.writeByteTokens += count
+	}
+	if count > 0 && avail > 0 && sg.mu.diskTokensAvailable.writeByteTokens <= 0 {
+		// Transition from > 0 to <= 0.
+		sg.mu.diskWriteByteTokensExhaustedStart = timeutil.Now()
+	} else if count < 0 && avail <= 0 &&
+		(sg.mu.diskTokensAvailable.writeByteTokens > 0 || settingAvailableTokens) {
+		// Transition from <= 0 to > 0, or if we're setting available tokens. The
+		// latter ensures that if the available tokens stay <= 0, we don't show a
+		// sudden change in the metric after minutes of exhaustion.
+		now := timeutil.Now()
+		exhaustedDur := now.Sub(sg.mu.diskWriteByteTokensExhaustedStart)
+		sg.diskWriteByteTokensExhaustedDurationMetric.Inc(exhaustedDur.Nanoseconds())
+		if sg.mu.diskTokensAvailable.writeByteTokens <= 0 {
+			sg.mu.diskWriteByteTokensExhaustedStart = now
+		}
+	}
 }
 
-// tryGrantLocked implements granterWithLockedCalls.
-func (sg *kvStoreTokenGranter) tryGrantLocked(grantChainID grantChainID) grantResult {
+func (sg *kvStoreTokenGranter) tryGrant() {
+	sg.mu.Lock()
+	defer sg.mu.Unlock()
+	sg.tryGrantLocked()
+}
+
+// tryGrantLocked attempts to grant to as many requests as possible.
+func (sg *kvStoreTokenGranter) tryGrantLocked() {
+	for sg.tryGrantLockedOne() {
+	}
+}
+
+// tryGrantLocked is used to attempt to grant to waiting requests. Used by
+// storeGrantCoordinator. It successfully grants to at most one waiting
+// request. If there are no waiting requests, or all waiters reject the grant,
+// it returns false.
+func (sg *kvStoreTokenGranter) tryGrantLockedOne() bool {
 	// NB: We grant work in the following priority order: regular, snapshot
 	// ingest, elastic work. Snapshot ingests are a special type of elastic work.
 	// They queue separately in the SnapshotQueue and get priority over other
 	// elastic work since they are used for node re-balancing and up-replication,
 	// which are typically higher priority than other background writes.
-	for wt := 0; wt < admissionpb.NumStoreWorkTypes; wt++ {
+	for wt := admissionpb.StoreWorkType(0); wt < admissionpb.NumStoreWorkTypes; wt++ {
 		req := sg.regularRequester
-		if admissionpb.StoreWorkType(wt) == admissionpb.ElasticStoreWorkType {
+		if wt == admissionpb.ElasticStoreWorkType {
 			req = sg.elasticRequester
-		} else if admissionpb.StoreWorkType(wt) == admissionpb.SnapshotIngestStoreWorkType {
+		} else if wt == admissionpb.SnapshotIngestStoreWorkType {
 			req = sg.snapshotRequester
 		}
-		if req.hasWaitingRequests() {
-			res := sg.tryGetLocked(1, int8(wt))
-			if res == grantSuccess {
-				tookTokenCount := req.granted(grantChainID)
+		hasWaiting, _ := req.hasWaitingRequests()
+		if hasWaiting {
+			res := sg.tryGetLocked(1, wt)
+			if res {
+				tookTokenCount := req.granted(noGrantChain)
 				if tookTokenCount == 0 {
 					// Did not accept grant.
-					sg.returnGrantLocked(1, int8(wt))
+					sg.returnGrantLocked(1, wt)
 					// Continue with the loop since this requester does not have waiting
 					// requests. If the loop terminates we will correctly return
 					// grantFailLocal.
 				} else {
 					// May have taken more.
 					if tookTokenCount > 1 {
-						sg.tookWithoutPermissionLocked(tookTokenCount-1, int8(wt))
+						sg.tookWithoutPermissionLocked(tookTokenCount-1, wt)
 					}
-					return grantSuccess
+					return true
 				}
 			} else {
 				// Was not able to get token. Do not continue with looping to grant to
@@ -633,11 +813,11 @@ func (sg *kvStoreTokenGranter) tryGrantLocked(grantChainID grantChainID) grantRe
 			}
 		}
 	}
-	return grantFailLocal
+	return false
 }
 
-// setAvailableTokens implements granterWithIOTokens.
-func (sg *kvStoreTokenGranter) setAvailableTokens(
+// addAvailableTokens implements granterWithIOTokens.
+func (sg *kvStoreTokenGranter) addAvailableTokens(
 	ioTokens int64,
 	elasticIOTokens int64,
 	diskWriteTokens int64,
@@ -647,22 +827,22 @@ func (sg *kvStoreTokenGranter) setAvailableTokens(
 	diskWriteTokensCapacity int64,
 	lastTick bool,
 ) (ioTokensUsed int64, ioTokensUsedByElasticWork int64) {
-	sg.coord.mu.Lock()
-	defer sg.coord.mu.Unlock()
-	ioTokensUsed = sg.startingIOTokens - sg.coordMu.availableIOTokens[admissionpb.RegularWorkClass]
-	ioTokensUsedByElasticWork = sg.coordMu.elasticIOTokensUsedByElastic
-	sg.coordMu.elasticIOTokensUsedByElastic = 0
+	sg.mu.Lock()
+	defer sg.mu.Unlock()
+	ioTokensUsed = sg.mu.startingIOTokens - sg.mu.availableIOTokens[admissionpb.RegularWorkClass]
+	ioTokensUsedByElasticWork = sg.mu.elasticIOTokensUsedByElastic
+	sg.mu.elasticIOTokensUsedByElastic = 0
 
 	// It is possible for availableIOTokens to be negative because of
 	// tookWithoutPermission or because tryGet will satisfy requests until
 	// availableIOTokens become <= 0. We want to remember this previous
 	// over-allocation.
 	sg.subtractIOTokensLocked(-ioTokens, -elasticIOTokens, true)
-	if sg.coordMu.availableIOTokens[admissionpb.RegularWorkClass] > ioTokenCapacity {
-		sg.coordMu.availableIOTokens[admissionpb.RegularWorkClass] = ioTokenCapacity
+	if sg.mu.availableIOTokens[admissionpb.RegularWorkClass] > ioTokenCapacity {
+		sg.mu.availableIOTokens[admissionpb.RegularWorkClass] = ioTokenCapacity
 	}
-	if sg.coordMu.availableIOTokens[admissionpb.ElasticWorkClass] > elasticIOTokenCapacity {
-		sg.coordMu.availableIOTokens[admissionpb.ElasticWorkClass] = elasticIOTokenCapacity
+	if sg.mu.availableIOTokens[admissionpb.ElasticWorkClass] > elasticIOTokenCapacity {
+		sg.mu.availableIOTokens[admissionpb.ElasticWorkClass] = elasticIOTokenCapacity
 	}
 	// availableIOTokens[ElasticWorkClass] can become very negative since it can
 	// be fewer than the tokens for regular work, and regular work deducts from it
@@ -671,46 +851,75 @@ func (sg *kvStoreTokenGranter) setAvailableTokens(
 	// provides a good enough frequency for resetting the deficit. That is, we are
 	// resetting every 15s.
 	if lastTick {
-		sg.coordMu.availableIOTokens[admissionpb.ElasticWorkClass] =
-			max(sg.coordMu.availableIOTokens[admissionpb.ElasticWorkClass], 0)
+		sg.mu.availableIOTokens[admissionpb.ElasticWorkClass] =
+			max(sg.mu.availableIOTokens[admissionpb.ElasticWorkClass], 0)
 		// It is possible that availableIOTokens[RegularWorkClass] is negative, in
 		// which case we want availableIOTokens[ElasticWorkClass] to not exceed it.
-		sg.coordMu.availableIOTokens[admissionpb.ElasticWorkClass] =
-			min(sg.coordMu.availableIOTokens[admissionpb.ElasticWorkClass], sg.coordMu.availableIOTokens[admissionpb.RegularWorkClass])
+		sg.mu.availableIOTokens[admissionpb.ElasticWorkClass] =
+			min(sg.mu.availableIOTokens[admissionpb.ElasticWorkClass], sg.mu.availableIOTokens[admissionpb.RegularWorkClass])
+
+		// Stash the balance before resetting, so getDiskTokensUsedAndReset can
+		// return it to the ioLoadListener for logging.
+		sg.mu.prevIntervalDiskWriteTokensRemaining = sg.mu.diskTokensAvailable.writeByteTokens
 		// We also want to avoid very negative disk write tokens, so we reset them.
-		sg.coordMu.diskTokensAvailable.writeByteTokens = max(sg.coordMu.diskTokensAvailable.writeByteTokens, 0)
+		sg.mu.diskTokensAvailable.writeByteTokens = max(sg.mu.diskTokensAvailable.writeByteTokens, 0)
 	}
 	var w admissionpb.WorkClass
 	for w = 0; w < admissionpb.NumWorkClasses; w++ {
-		sg.availableTokensMetric[w].Update(sg.coordMu.availableIOTokens[w])
+		sg.availableTokensMetric[w].Update(sg.mu.availableIOTokens[w])
 	}
-	sg.startingIOTokens = sg.coordMu.availableIOTokens[admissionpb.RegularWorkClass]
+	sg.mu.startingIOTokens = sg.mu.availableIOTokens[admissionpb.RegularWorkClass]
 
 	// Allocate disk write and read tokens.
-	sg.coordMu.diskTokensAvailable.writeByteTokens += diskWriteTokens
-	if sg.coordMu.diskTokensAvailable.writeByteTokens > diskWriteTokensCapacity {
-		sg.coordMu.diskTokensAvailable.writeByteTokens = diskWriteTokensCapacity
-	}
-	// NB: We don't cap the disk read tokens as they are only deducted during the
-	// error accounting loop. So essentially, we give reads the "burst" capacity
-	// of the error accounting interval. See `adjustDiskTokenErrorLocked` for the
-	// error accounting logic, and where we reset this bucket to 0.
-	sg.coordMu.diskTokensError.diskReadTokensAlreadyDeducted += diskReadTokens
+	sg.mu.diskWriteByteTokensCapacity = diskWriteTokensCapacity
+	sg.subtractDiskWriteTokensLocked(-diskWriteTokens, true)
+	// The read tokens are not added to a token bucket, and instead are
+	// considered "already deducted" since they were pre-deducted when computing
+	// the write tokens in the diskBandwidthLimiter. The actual observed reads
+	// in the error accounting loop will be compared against these pre-deducted
+	// tokens to compute read error.
+	//
+	// NB: We don't cap the disk read tokens as they are only compared during
+	// the error accounting loop. So essentially, we give reads the "burst"
+	// capacity of the error accounting interval. See
+	// `adjustDiskTokenErrorLocked` for the error accounting logic, and where we
+	// reset this bucket to 0.
+	sg.mu.diskTokensError.alreadyDeductedTokens.readByteTokens += diskReadTokens
 
 	return ioTokensUsed, ioTokensUsedByElasticWork
 }
 
-// getDiskTokensUsedAndResetLocked implements granterWithIOTokens.
+// diskErrorStats holds various error stats for disk token accounting. See the
+// corresponding fields in kvStoreTokenGranter.mu.diskTokensError for the
+// explanation.
+type diskErrorStats struct {
+	cumError diskTokens
+	absError diskTokens
+}
+
+// getDiskTokensUsedAndResetLocked implements granterWithIOTokens. It is
+// called at the start of each adjustment interval to get various stats useful
+// for calculating the next interval's token allocation.
 func (sg *kvStoreTokenGranter) getDiskTokensUsedAndReset() (
 	usedTokens [admissionpb.NumStoreWorkTypes]diskTokens,
+	errStats diskErrorStats,
+	remainingDiskWriteTokens int64,
 ) {
-	sg.coord.mu.Lock()
-	defer sg.coord.mu.Unlock()
+	sg.mu.Lock()
+	defer sg.mu.Unlock()
 	for i := 0; i < admissionpb.NumStoreWorkTypes; i++ {
-		usedTokens[i] = sg.coordMu.diskTokensUsed[i]
-		sg.coordMu.diskTokensUsed[i] = diskTokens{}
+		usedTokens[i] = sg.mu.diskTokensUsed[i]
+		sg.mu.diskTokensUsed[i] = diskTokens{}
 	}
-	return usedTokens
+	diskErrStats := diskErrorStats{
+		cumError: sg.mu.diskTokensError.cumError,
+		absError: sg.mu.diskTokensError.absError,
+	}
+	sg.mu.diskTokensError.cumError = diskTokens{}
+	sg.mu.diskTokensError.absError = diskTokens{}
+	remainingDiskWriteTokens = sg.mu.prevIntervalDiskWriteTokensRemaining
+	sg.mu.prevIntervalDiskWriteTokensRemaining = 0
+	return usedTokens, diskErrStats, remainingDiskWriteTokens
 }
 
 // setAdmittedModelsLocked implements granterWithIOTokens.
@@ -720,12 +929,23 @@ func (sg *kvStoreTokenGranter) setLinearModels(
 	ingestLM tokensLinearModel,
 	writeAmpLM tokensLinearModel,
 ) {
-	sg.coord.mu.Lock()
-	defer sg.coord.mu.Unlock()
-	sg.l0WriteLM = l0WriteLM
-	sg.l0IngestLM = l0IngestLM
-	sg.ingestLM = ingestLM
-	sg.writeAmpLM = writeAmpLM
+	sg.mu.Lock()
+	defer sg.mu.Unlock()
+	sg.mu.l0WriteLM = l0WriteLM
+	sg.mu.l0IngestLM = l0IngestLM
+	sg.mu.ingestLM = ingestLM
+	sg.mu.writeAmpLM = writeAmpLM
+}
+
+func (sg *kvStoreTokenGranter) storeReplicatedWorkAdmitted(
+	wt admissionpb.StoreWorkType,
+	originalTokens int64,
+	admittedInfo storeReplicatedWorkAdmittedInfo,
+	canGrantAnother bool,
+) (additionalTokens int64) {
+	sg.mu.Lock()
+	defer sg.mu.Unlock()
+	return sg.storeReplicatedWorkAdmittedLocked(wt, originalTokens, admittedInfo, canGrantAnother)
 }
 
 func (sg *kvStoreTokenGranter) storeReplicatedWorkAdmittedLocked(
@@ -737,33 +957,38 @@ func (sg *kvStoreTokenGranter) storeReplicatedWorkAdmittedLocked(
 	// Reminder: coord.mu protects the state in the kvStoreTokenGranter.
 	wc := admissionpb.WorkClassFromStoreWorkType(wt)
 	exhaustedFunc := func() bool {
-		return sg.coordMu.availableIOTokens[admissionpb.RegularWorkClass] <= 0 ||
-			(wc == admissionpb.ElasticWorkClass && (sg.coordMu.diskTokensAvailable.writeByteTokens <= 0 ||
-				sg.coordMu.availableIOTokens[admissionpb.ElasticWorkClass] <= 0))
+		return sg.mu.availableIOTokens[admissionpb.RegularWorkClass] <= 0 ||
+			(wc == admissionpb.ElasticWorkClass && (sg.mu.diskTokensAvailable.writeByteTokens <= 0 ||
+				sg.mu.availableIOTokens[admissionpb.ElasticWorkClass] <= 0))
 	}
 	wasExhausted := exhaustedFunc()
-	actualL0WriteTokens := sg.l0WriteLM.applyLinearModel(admittedInfo.WriteBytes)
-	actualL0IngestTokens := sg.l0IngestLM.applyLinearModel(admittedInfo.IngestedBytes)
+	actualL0WriteTokens := sg.mu.l0WriteLM.applyLinearModel(admittedInfo.WriteBytes)
+	actualL0IngestTokens := sg.mu.l0IngestLM.applyLinearModel(admittedInfo.IngestedBytes)
 	actualL0Tokens := actualL0WriteTokens + actualL0IngestTokens
 	additionalL0TokensNeeded := actualL0Tokens - originalTokens
 	sg.subtractIOTokensLocked(additionalL0TokensNeeded, additionalL0TokensNeeded, false)
 	if wt == admissionpb.ElasticStoreWorkType {
-		sg.coordMu.elasticIOTokensUsedByElastic += additionalL0TokensNeeded
+		sg.mu.elasticIOTokensUsedByElastic += additionalL0TokensNeeded
 	}
 
 	// Adjust disk write tokens.
-	ingestIntoLSM := sg.ingestLM.applyLinearModel(admittedInfo.IngestedBytes)
+	ingestIntoLSM := sg.mu.ingestLM.applyLinearModel(admittedInfo.IngestedBytes)
 	totalBytesIntoLSM := actualL0WriteTokens + ingestIntoLSM
-	actualDiskWriteTokens := sg.writeAmpLM.applyLinearModel(totalBytesIntoLSM)
-	originalDiskTokens := sg.writeAmpLM.applyLinearModel(originalTokens)
+	actualDiskWriteTokens := sg.mu.writeAmpLM.applyLinearModel(totalBytesIntoLSM)
+	// NB: there is a small inconsistency here in that the linear model applied
+	// to the originalTokens may have been different, since the linear model
+	// changes every 15s. So we may have previously deducted something different
+	// from originalDiskTokens. We accept that inconsistency in token accounting
+	// for simplicity.
+	originalDiskTokens := sg.mu.writeAmpLM.applyLinearModel(originalTokens)
 	additionalDiskWriteTokens := actualDiskWriteTokens - originalDiskTokens
-	sg.coordMu.diskTokensAvailable.writeByteTokens -= additionalDiskWriteTokens
-	sg.coordMu.diskTokensUsed[wt].writeByteTokens += additionalDiskWriteTokens
+	sg.subtractDiskWriteTokensLocked(additionalDiskWriteTokens, false)
+	sg.mu.diskTokensUsed[wt].writeByteTokens += additionalDiskWriteTokens
 
 	if canGrantAnother && (additionalL0TokensNeeded < 0) {
 		isExhausted := exhaustedFunc()
-		if (wasExhausted && !isExhausted) || sg.coord.knobs.AlwaysTryGrantWhenAdmitted {
-			sg.coord.tryGrantLocked()
+		if (wasExhausted && !isExhausted) || sg.knobs.AlwaysTryGrantWhenAdmitted {
+			sg.tryGrantLocked()
 		}
 	}
 	// For multi-tenant fairness accounting, we choose to ignore disk bandwidth
@@ -773,20 +998,8 @@ func (sg *kvStoreTokenGranter) storeReplicatedWorkAdmittedLocked(
 	return additionalL0TokensNeeded
 }
 
-// PebbleMetricsProvider provides the pebble.Metrics for all stores.
-type PebbleMetricsProvider interface {
-	GetPebbleMetrics() []StoreMetrics
-	Close()
-}
-
-// MetricsRegistryProvider provides the store metric.Registry for a given store.
-type MetricsRegistryProvider interface {
-	GetMetricsRegistry(roachpb.StoreID) *metric.Registry
-}
-
-// IOThresholdConsumer is informed about updated IOThresholds.
-type IOThresholdConsumer interface {
-	UpdateIOThreshold(roachpb.StoreID, *admissionpb.IOThreshold)
+func (sg *kvStoreTokenGranter) hasExhaustedDiskTokens() bool {
+	return sg.diskWriteByteTokensExhaustedDurationMetric.Count() > 0
 }
 
 // StoreMetrics are the metrics and some config information for a store.
@@ -794,6 +1007,8 @@ type StoreMetrics struct {
 	StoreID roachpb.StoreID
 	*pebble.Metrics
 	WriteStallCount int64
+	// DiskUnhealthy corresponds to Engine.GetDiskUnhealthy.
+	DiskUnhealthy bool
 	// Optional.
 	DiskStats DiskStats
 	// Config.
@@ -835,26 +1050,30 @@ var (
 	// NB: this metric is independent of whether slots enforcement is happening
 	// or not.
 	kvSlotsExhaustedDuration = metric.Metadata{
-		Name:        "admission.granter.slots_exhausted_duration.kv",
-		Help:        "Total duration when KV slots were exhausted, in micros",
-		Measurement: "Microseconds",
-		Unit:        metric.Unit_COUNT,
+		Name: "admission.granter.slots_exhausted_duration.kv",
+		Help: "Total duration when KV slots were exhausted, as observed by the slot " +
+			"granter (not waiters). This is reported in nanoseconds from 26.1 onwards, " +
+			"and was microseconds before that.",
+		Measurement: "Nanoseconds",
+		Unit:        metric.Unit_NANOSECONDS,
 	}
 	// We have a metric for both short and long period. These metrics use the
 	// period provided in CPULoad and not wall time. So if the sum of the rate
 	// of these two is < 1sec/sec, the CPULoad ticks are not happening at the
 	// expected frequency (this could happen due to CPU overload).
 	kvCPULoadShortPeriodDuration = metric.Metadata{
-		Name:        "admission.granter.cpu_load_short_period_duration.kv",
-		Help:        "Total duration when CPULoad was being called with a short period, in micros",
-		Measurement: "Microseconds",
-		Unit:        metric.Unit_COUNT,
+		Name: "admission.granter.cpu_load_short_period_duration.kv",
+		Help: "Total duration when CPULoad was being called with a short period. This is " +
+			"reported in nanoseconds from 26.1 onwards, and was microseconds before that.",
+		Measurement: "Nanoseconds",
+		Unit:        metric.Unit_NANOSECONDS,
 	}
 	kvCPULoadLongPeriodDuration = metric.Metadata{
-		Name:        "admission.granter.cpu_load_long_period_duration.kv",
-		Help:        "Total duration when CPULoad was being called with a long period, in micros",
-		Measurement: "Microseconds",
-		Unit:        metric.Unit_COUNT,
+		Name: "admission.granter.cpu_load_long_period_duration.kv",
+		Help: "Total duration when CPULoad was being called with a long period. This is " +
+			"reported in nanoseconds from 26.1 onwards, and was microseconds before that.",
+		Measurement: "Nanoseconds",
+		Unit:        metric.Unit_NANOSECONDS,
 	}
 	kvSlotAdjusterIncrements = metric.Metadata{
 		Name:        "admission.granter.slot_adjuster_increments.kv",
@@ -869,16 +1088,20 @@ var (
 		Unit:        metric.Unit_COUNT,
 	}
 	kvIOTokensExhaustedDuration = metric.Metadata{
-		Name:        "admission.granter.io_tokens_exhausted_duration.kv",
-		Help:        "Total duration when IO tokens were exhausted, in micros",
-		Measurement: "Microseconds",
-		Unit:        metric.Unit_COUNT,
+		Name: "admission.granter.io_tokens_exhausted_duration.kv",
+		Help: "Total duration when IO tokens were exhausted, as observed by the token granter " +
+			"(not waiters). This is reported in nanoseconds from 26.1 onwards, and was " +
+			"microseconds before that.",
+		Measurement: "Nanoseconds",
+		Unit:        metric.Unit_NANOSECONDS,
 	}
 	kvElasticIOTokensExhaustedDuration = metric.Metadata{
-		Name:        "admission.granter.elastic_io_tokens_exhausted_duration.kv",
-		Help:        "Total duration when Elastic IO tokens were exhausted, in micros",
-		Measurement: "Microseconds",
-		Unit:        metric.Unit_COUNT,
+		Name: "admission.granter.elastic_io_tokens_exhausted_duration.kv",
+		Help: "Total duration when Elastic IO tokens were exhausted, as observed by the token " +
+			"granter (not waiters). This is reported in nanoseconds from 26.1 onwards, and was " +
+			"microseconds before that.",
+		Measurement: "Nanoseconds",
+		Unit:        metric.Unit_NANOSECONDS,
 	}
 	kvIOTokensTaken = metric.Metadata{
 		Name:        "admission.granter.io_tokens_taken.kv",
@@ -909,6 +1132,13 @@ var (
 		Help:        "Number of tokens available",
 		Measurement: "Tokens",
 		Unit:        metric.Unit_COUNT,
+	}
+	kvDiskWriteByteTokensExhaustedDuration = metric.Metadata{
+		Name: "admission.granter.disk_write_byte_tokens_exhausted_duration.kv",
+		Help: "Total duration (in nanos) when disk write byte tokens were exhausted, as observed by " +
+			"the token granter (not waiters)",
+		Measurement: "Nanoseconds",
+		Unit:        metric.Unit_NANOSECONDS,
 	}
 	l0CompactedBytes = metric.Metadata{
 		Name:        "admission.l0_compacted_bytes.kv",


### PR DESCRIPTION
Fixes the log spam reported by @yuzefovich in #163347.

## Problem

`staleStatTracker.shouldLog()` had a special case where
`consecutiveCount == thresh` returned `true` unconditionally, bypassing
the `log.Every(time.Minute)` rate limiter:

```go
// BEFORE (buggy)
func (t *staleStatTracker) shouldLog() bool {
    for _, thresh := range t.thresholds {
        if t.consecutiveCount == thresh {
            return true  // no rate limiting!
        } else if t.consecutiveCount > thresh {
            return t.logLimiter.ShouldLog()
        }
    }
    return false
}
```

On Linux, disk stats update roughly every 4ms but the error-correction
tick fires every 1ms. So `consecutiveCount` oscillates: it resets to 0
on any stat change and climbs back to exactly 20 roughly every 20ms,
triggering the exact-match branch on every cycle — producing dozens of
log lines per second as seen in the linked comment.

## Fix

Collapse the two branches into a single `>= thresh` check that always
goes through the rate limiter:

```go
// AFTER (fixed)
func (t *staleStatTracker) shouldLog() bool {
    for _, thresh := range t.thresholds {
        if t.consecutiveCount >= thresh {
            return t.logLimiter.ShouldLog()
        }
    }
    return false
}
```

This ensures at most one log line per minute regardless of which branch
is taken on threshold crossing.

Epic: none
Release note: None