### PR TITLE
server/dbconsole: add jobs BFF endpoints

### DIFF
--- a/pkg/server/api_v2.go
+++ b/pkg/server/api_v2.go
@@ -133,7 +133,6 @@ func newAPIV2Server(ctx context.Context, opts *apiV2ServerOpts) http.Handler {
 		}
 		dbconsoleAPI := &dbconsole.ApiV2DBConsole{
 			Status:     systemStatus.statusServer,
-			Admin:      systemAdmin.adminServer,
 			InternalDB: opts.sqlServer.internalDB,
 		}
 		registerRoutes(innerMux, authMux, inner, a, dbconsoleAPI)
@@ -222,6 +221,8 @@ func registerRoutes(
 
 		// DB Console BFF endpoints.
 		{"dbconsole/nodes/", dbconsoleAPI.GetNodes, true, authserver.ViewClusterMetadataRole, true},
+		{"dbconsole/jobs/", dbconsoleAPI.GetJobs, true, authserver.ViewClusterMetadataRole, true},
+		{"dbconsole/jobs/{job_id:[0-9]+}/", dbconsoleAPI.GetJob, true, authserver.ViewClusterMetadataRole, true},
 	}
 
 	// For all routes requiring authentication, have the outer mux (a.mux)

--- a/pkg/server/dbconsole/BUILD.bazel
+++ b/pkg/server/dbconsole/BUILD.bazel
@@ -2,30 +2,46 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "dbconsole",
-    srcs = ["dbconsole.go"],
+    srcs = [
+        "dbconsole.go",
+        "jobs.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/server/dbconsole",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/jobs/jobspb",
         "//pkg/kv/kvserver/liveness/livenesspb",
         "//pkg/server/apiutil",
         "//pkg/server/authserver",
         "//pkg/server/serverpb",
         "//pkg/server/srverrors",
         "//pkg/sql/isql",
+        "//pkg/sql/sem/tree",
+        "//pkg/sql/sessiondata",
+        "//pkg/util/hlc",
+        "//pkg/util/safesql",
+        "//pkg/util/timeutil",
+        "@com_github_cockroachdb_errors//:errors",
+        "@com_github_gorilla_mux//:mux",
     ],
 )
 
 go_test(
     name = "dbconsole_test",
-    srcs = ["dbconsole_test.go"],
+    srcs = [
+        "dbconsole_test.go",
+        "jobs_test.go",
+    ],
     embed = [":dbconsole"],
     deps = [
         "//pkg/build",
         "//pkg/kv/kvserver/liveness/livenesspb",
         "//pkg/roachpb",
         "//pkg/server/serverpb",
+        "//pkg/sql/sem/tree",
         "//pkg/util",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_gorilla_mux//:mux",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/server/dbconsole/dbconsole.go
+++ b/pkg/server/dbconsole/dbconsole.go
@@ -20,6 +20,7 @@ package dbconsole
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/server/apiutil"
@@ -34,13 +35,9 @@ type StatusAPI interface {
 	NodesUI(ctx context.Context, req *serverpb.NodesRequest) (*serverpb.NodesResponseExternal, error)
 }
 
-// AdminAPI defines admin methods used by dbconsole
-type AdminAPI interface{}
-
 // ApiV2DBConsole implements the DB Console BFF API endpoints.
 type ApiV2DBConsole struct {
 	Status     StatusAPI
-	Admin      AdminAPI
 	InternalDB isql.DB
 }
 
@@ -131,6 +128,15 @@ func localityToMap(locality serverpb.Locality) map[string]string {
 		result[tier.Key] = tier.Value
 	}
 	return result
+}
+
+// formatTimePtr formats a *time.Time as an ISO 8601 string. Returns an empty
+// string for nil or zero values.
+func formatTimePtr(t *time.Time) string {
+	if t == nil || t.IsZero() {
+		return ""
+	}
+	return t.Format(time.RFC3339)
 }
 
 // livenessStatusToString converts a livenesspb.NodeLivenessStatus to its string

--- a/pkg/server/dbconsole/dbconsole_test.go
+++ b/pkg/server/dbconsole/dbconsole_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
@@ -162,6 +163,52 @@ func TestLivenessStatusToString(t *testing.T) {
 
 	for _, tt := range tests {
 		require.Equal(t, tt.want, livenessStatusToString(tt.status))
+	}
+}
+
+func TestFormatTimePtr(t *testing.T) {
+	tests := []struct {
+		name string
+		t    *time.Time
+		want string
+	}{
+		{"nil", nil, ""},
+		{"zero", func() *time.Time { t := time.Time{}; return &t }(), ""},
+		{
+			"valid",
+			func() *time.Time {
+				t := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+				return &t
+			}(),
+			"2024-01-15T10:30:00Z",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, formatTimePtr(tt.t))
+		})
+	}
+}
+
+func TestFormatTime(t *testing.T) {
+	tests := []struct {
+		name string
+		t    time.Time
+		want string
+	}{
+		{"zero", time.Time{}, ""},
+		{
+			"valid",
+			time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC),
+			"2024-01-15T10:30:00Z",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, formatTime(tt.t))
+		})
 	}
 }
 

--- a/pkg/server/dbconsole/jobs.go
+++ b/pkg/server/dbconsole/jobs.go
@@ -1,0 +1,420 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package dbconsole
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/server/apiutil"
+	"github.com/cockroachdb/cockroach/pkg/server/authserver"
+	"github.com/cockroachdb/cockroach/pkg/server/srverrors"
+	"github.com/cockroachdb/cockroach/pkg/sql/isql"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/safesql"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
+	"github.com/gorilla/mux"
+)
+
+// JobInfo contains summarized job information for the UI.
+// Note: descriptor_ids from the protobuf JobResponse is intentionally omitted
+// because the DB Console UI does not use it.
+type JobInfo struct {
+	// ID is the unique identifier for the job. Serialized as a string to avoid
+	// JavaScript integer precision loss for values exceeding 2^53.
+	ID int64 `json:"id,string"`
+	// Type is the type of the job (e.g. "BACKUP", "RESTORE").
+	Type string `json:"type"`
+	// Description is a human-readable description of the job.
+	Description string `json:"description"`
+	// Statement is the SQL statement that created the job.
+	Statement string `json:"statement"`
+	// Username is the user who created the job.
+	Username string `json:"username"`
+	// Status is the current status of the job.
+	Status string `json:"status"`
+	// RunningStatus provides additional detail on the job's running state.
+	RunningStatus string `json:"running_status"`
+	// Created is the ISO 8601 timestamp when the job was created.
+	Created string `json:"created"`
+	// Started is the ISO 8601 timestamp when the job started executing.
+	Started string `json:"started"`
+	// Finished is the ISO 8601 timestamp when the job finished.
+	Finished string `json:"finished"`
+	// Modified is the ISO 8601 timestamp when the job was last modified.
+	Modified string `json:"modified"`
+	// FractionCompleted is the fraction of the job that has been completed.
+	FractionCompleted float32 `json:"fraction_completed"`
+	// Error is the error message if the job failed.
+	Error string `json:"error"`
+	// HighwaterTimestamp is the highwater timestamp as an ISO 8601 string.
+	HighwaterTimestamp string `json:"highwater_timestamp"`
+	// HighwaterDecimal is the highwater timestamp in decimal form for use
+	// with AS OF SYSTEM TIME.
+	HighwaterDecimal string `json:"highwater_decimal"`
+	// LastRun is the ISO 8601 timestamp of the last execution attempt.
+	LastRun string `json:"last_run"`
+	// NextRun is the ISO 8601 timestamp of the next scheduled execution.
+	NextRun string `json:"next_run"`
+	// NumRuns is the number of times the job has been executed.
+	NumRuns int64 `json:"num_runs"`
+	// CoordinatorID is the node ID coordinating the job.
+	CoordinatorID int64 `json:"coordinator_id"`
+	// ExecutionFailures is a log of execution failures.
+	ExecutionFailures []JobExecutionFailure `json:"execution_failures"`
+	// Messages contains informational messages associated with the job.
+	Messages []JobMessageInfo `json:"messages"`
+}
+
+// JobExecutionFailure represents a single execution failure of a job.
+type JobExecutionFailure struct {
+	// Status is the status of the job during the failed execution.
+	Status string `json:"status"`
+	// Start is the ISO 8601 timestamp when the execution started.
+	Start string `json:"start"`
+	// End is the ISO 8601 timestamp when the error occurred.
+	End string `json:"end"`
+	// Error is the error message.
+	Error string `json:"error"`
+}
+
+// JobMessageInfo represents an informational message associated with a job.
+type JobMessageInfo struct {
+	// Kind is the kind of message.
+	Kind string `json:"kind"`
+	// Timestamp is the ISO 8601 timestamp of the message.
+	Timestamp string `json:"timestamp"`
+	// Message is the message text.
+	Message string `json:"message"`
+}
+
+// JobsListResponse contains the list of jobs and metadata.
+type JobsListResponse struct {
+	// Jobs contains the list of jobs.
+	Jobs []JobInfo `json:"jobs"`
+	// EarliestRetainedTime is the earliest time for which job records are
+	// retained, as an ISO 8601 timestamp.
+	EarliestRetainedTime string `json:"earliest_retained_time"`
+}
+
+// GetJobs returns a list of jobs matching the provided filters.
+// @Summary List jobs
+// @Description Returns a list of jobs, optionally filtered by status, type, and limit.
+// @Tags Jobs
+// @Produce json
+// @Param status query string false "Filter by job status"
+// @Param type query int false "Filter by job type (int32 enum value)"
+// @Param limit query int false "Maximum number of jobs to return"
+// @Success 200 {object} JobsListResponse "Job list"
+// @Failure 500 {object} ErrorResponse "Internal error"
+// @Security ApiKeyAuth
+// @Router /jobs [get]
+func (api *ApiV2DBConsole) GetJobs(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	status := r.URL.Query().Get("status")
+
+	var jobType jobspb.Type
+	if typeStr := r.URL.Query().Get("type"); typeStr != "" {
+		typeVal, err := strconv.Atoi(typeStr)
+		if err != nil {
+			apiutil.WriteJSONResponse(
+				ctx, w, http.StatusBadRequest,
+				ErrorResponse{Error: "invalid type parameter"},
+			)
+			return
+		}
+		jobType = jobspb.Type(typeVal)
+	}
+
+	var limit int32
+	if limitStr := r.URL.Query().Get("limit"); limitStr != "" {
+		limitVal, err := strconv.Atoi(limitStr)
+		if err != nil {
+			apiutil.WriteJSONResponse(
+				ctx, w, http.StatusBadRequest,
+				ErrorResponse{Error: "invalid limit parameter"},
+			)
+			return
+		}
+		limit = int32(limitVal)
+	}
+
+	userName := authserver.UserFromHTTPAuthInfoContext(ctx)
+
+	// Build the query. This replicates the logic from
+	// BuildJobQueryFromRequest in admin.go, which cannot be imported here
+	// due to circular dependency (server -> dbconsole -> server).
+	q := safesql.NewQuery()
+	q.Append(`
+SELECT job_id, job_type, description, statement, user_name, status,
+       running_status, created, finished, modified,
+       fraction_completed, high_water_timestamp, error, coordinator_id
+  FROM crdb_internal.jobs
+ WHERE true`)
+	if status != "" {
+		q.Append(" AND status = $", status)
+	}
+	if jobType != jobspb.TypeUnspecified {
+		q.Append(" AND job_type = $", jobType.String())
+	} else {
+		// Don't show automatic jobs in the overview page.
+		q.Append(" AND ( job_type NOT IN (")
+		for idx, jt := range jobspb.AutomaticJobTypes {
+			if idx != 0 {
+				q.Append(", ")
+			}
+			q.Append("$", jt.String())
+		}
+		q.Append(" ) OR job_type IS NULL)")
+	}
+	q.Append(" ORDER BY created DESC")
+	if limit > 0 {
+		q.Append(" LIMIT $", tree.DInt(limit))
+	}
+
+	it, err := api.InternalDB.Executor().QueryIteratorEx(
+		ctx, "dbconsole-jobs", nil, /* txn */
+		sessiondata.InternalExecutorOverride{User: userName},
+		q.String(), q.QueryArguments()...,
+	)
+	if err != nil {
+		srverrors.APIV2InternalError(ctx, err, w)
+		return
+	}
+	defer func() { _ = it.Close() }()
+
+	var jobsList []JobInfo
+	for {
+		ok, err := it.Next(ctx)
+		if err != nil {
+			srverrors.APIV2InternalError(ctx, err, w)
+			return
+		}
+		if !ok {
+			break
+		}
+		job, err := scanRowToJobInfo(it.Cur())
+		if err != nil {
+			srverrors.APIV2InternalError(ctx, err, w)
+			return
+		}
+		jobsList = append(jobsList, job)
+	}
+
+	if jobsList == nil {
+		jobsList = []JobInfo{}
+	}
+
+	result := JobsListResponse{
+		Jobs: jobsList,
+	}
+	apiutil.WriteJSONResponse(ctx, w, http.StatusOK, result)
+}
+
+// GetJob returns a single job by ID.
+// @Summary Get job
+// @Description Returns a single job identified by its ID.
+// @Tags Jobs
+// @Produce json
+// @Param job_id path int true "Job ID"
+// @Success 200 {object} JobInfo "Job details"
+// @Failure 400 {object} ErrorResponse "Invalid job ID"
+// @Failure 500 {object} ErrorResponse "Internal error"
+// @Security ApiKeyAuth
+// @Router /jobs/{job_id} [get]
+func (api *ApiV2DBConsole) GetJob(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	jobIDStr := mux.Vars(r)["job_id"]
+	jobID, err := strconv.ParseInt(jobIDStr, 10, 64)
+	if err != nil {
+		apiutil.WriteJSONResponse(
+			ctx, w, http.StatusBadRequest,
+			ErrorResponse{Error: "invalid job_id parameter"},
+		)
+		return
+	}
+
+	userName := authserver.UserFromHTTPAuthInfoContext(ctx)
+
+	const query = `
+SELECT job_id, job_type, description, statement, user_name, status,
+       running_status, created, finished, modified,
+       fraction_completed, high_water_timestamp, error, coordinator_id
+  FROM crdb_internal.jobs
+ WHERE job_id = $1`
+
+	row, _, err := api.InternalDB.Executor().QueryRowExWithCols(
+		ctx, "dbconsole-job", nil, /* txn */
+		sessiondata.InternalExecutorOverride{User: userName},
+		query, jobID,
+	)
+	if err != nil {
+		srverrors.APIV2InternalError(ctx, err, w)
+		return
+	}
+	if row == nil {
+		srverrors.APIV2InternalError(
+			ctx,
+			errors.Newf("could not get job for job_id %d; 0 rows returned", jobID),
+			w,
+		)
+		return
+	}
+
+	result, err := scanRowToJobInfo(row)
+	if err != nil {
+		srverrors.APIV2InternalError(ctx, err, w)
+		return
+	}
+
+	result.Messages = fetchJobMessages(ctx, jobID, api.InternalDB.Executor())
+	apiutil.WriteJSONResponse(ctx, w, http.StatusOK, result)
+}
+
+// scanRowToJobInfo converts a database row from crdb_internal.jobs to a JobInfo.
+// The row must contain exactly these columns in order:
+//
+//	job_id, job_type, description, statement, user_name, status,
+//	running_status, created, finished, modified,
+//	fraction_completed, high_water_timestamp, error, coordinator_id
+func scanRowToJobInfo(row tree.Datums) (JobInfo, error) {
+	if len(row) != 14 {
+		return JobInfo{}, errors.Newf("expected 14 columns, got %d", len(row))
+	}
+
+	var job JobInfo
+
+	// job_id (INT)
+	job.ID = int64(tree.MustBeDInt(row[0]))
+
+	// job_type (STRING)
+	job.Type = string(tree.MustBeDString(row[1]))
+
+	// description (STRING)
+	job.Description = string(tree.MustBeDString(row[2]))
+
+	// statement (STRING)
+	job.Statement = string(tree.MustBeDString(row[3]))
+
+	// user_name (STRING)
+	job.Username = string(tree.MustBeDString(row[4]))
+
+	// status (STRING)
+	job.Status = string(tree.MustBeDString(row[5]))
+
+	// running_status (STRING, nullable)
+	if row[6] != tree.DNull {
+		job.RunningStatus = string(tree.MustBeDString(row[6]))
+	}
+
+	// created (TIMESTAMPTZ)
+	job.Created = datumToTimeStr(row[7])
+
+	// finished (TIMESTAMPTZ, nullable)
+	job.Finished = datumToTimeStr(row[8])
+
+	// modified (TIMESTAMPTZ)
+	job.Modified = datumToTimeStr(row[9])
+
+	// fraction_completed (FLOAT, nullable)
+	if row[10] != tree.DNull {
+		job.FractionCompleted = float32(tree.MustBeDFloat(row[10]))
+	}
+
+	// high_water_timestamp (DECIMAL, nullable)
+	if row[11] != tree.DNull {
+		hwDecimal := &row[11].(*tree.DDecimal).Decimal
+		hwTimestamp, err := hlc.DecimalToHLC(hwDecimal)
+		if err != nil {
+			return JobInfo{}, errors.Wrap(err, "highwater timestamp had unexpected format")
+		}
+		goTime := hwTimestamp.GoTime()
+		job.HighwaterTimestamp = goTime.Format(time.RFC3339)
+		job.HighwaterDecimal = hwDecimal.String()
+	}
+
+	// error (STRING)
+	job.Error = string(tree.MustBeDString(row[12]))
+
+	// coordinator_id (INT, nullable)
+	if row[13] != tree.DNull {
+		job.CoordinatorID = int64(tree.MustBeDInt(row[13]))
+	}
+
+	return job, nil
+}
+
+// datumToTimeStr converts a tree.Datum timestamp to an RFC3339 string.
+// Returns an empty string if the datum is NULL or the zero time.
+func datumToTimeStr(d tree.Datum) string {
+	if d == tree.DNull {
+		return ""
+	}
+	t := tree.MustBeDTimestampTZ(d).Time
+	if t.IsZero() {
+		return ""
+	}
+	return t.Format(time.RFC3339)
+}
+
+// fetchJobMessages retrieves informational messages associated with a job from
+// the system.job_message table. Uses the node user since this is a system table
+// and the caller has already verified access to the job.
+func fetchJobMessages(ctx context.Context, jobID int64, executor isql.Executor) []JobMessageInfo {
+	const msgQuery = `SELECT kind, written, message FROM system.job_message WHERE job_id = $1 ORDER BY written DESC`
+	it, err := executor.QueryIteratorEx(
+		ctx, "dbconsole-job-messages", nil, /* txn */
+		sessiondata.NodeUserSessionDataOverride,
+		msgQuery, jobID,
+	)
+	if err != nil {
+		return []JobMessageInfo{
+			{Kind: "error", Timestamp: formatTime(timeutil.Now()), Message: err.Error()},
+		}
+	}
+	defer func() {
+		if closeErr := it.Close(); closeErr != nil {
+			// If we can't close, at least we've read what we could.
+		}
+	}()
+
+	var messages []JobMessageInfo
+	for {
+		ok, err := it.Next(ctx)
+		if err != nil {
+			return []JobMessageInfo{
+				{Kind: "error", Timestamp: formatTime(timeutil.Now()), Message: err.Error()},
+			}
+		}
+		if !ok {
+			break
+		}
+		row := it.Cur()
+		messages = append(messages, JobMessageInfo{
+			Kind:      string(tree.MustBeDStringOrDNull(row[0])),
+			Timestamp: datumToTimeStr(row[1]),
+			Message:   string(tree.MustBeDStringOrDNull(row[2])),
+		})
+	}
+	return messages
+}
+
+// formatTime formats a time.Time as an ISO 8601 string. Returns an empty string
+// for zero values.
+func formatTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.Format(time.RFC3339)
+}

--- a/pkg/server/dbconsole/jobs_test.go
+++ b/pkg/server/dbconsole/jobs_test.go
@@ -1,0 +1,255 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package dbconsole
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScanRowToJobInfo(t *testing.T) {
+	created := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+	finished := time.Date(2024, 1, 15, 11, 0, 0, 0, time.UTC)
+	modified := time.Date(2024, 1, 15, 11, 0, 0, 0, time.UTC)
+
+	mustTimestampTZ := func(t time.Time) *tree.DTimestampTZ {
+		d, err := tree.MakeDTimestampTZ(t, time.Microsecond)
+		if err != nil {
+			panic(err)
+		}
+		return d
+	}
+
+	t.Run("full row with all fields", func(t *testing.T) {
+		// Build a highwater decimal: 1705312260.0000000000
+		hwDecimal := &tree.DDecimal{}
+		require.NoError(t, hwDecimal.SetString("1705312260.0000000000"))
+
+		row := tree.Datums{
+			tree.NewDInt(123),                  // job_id
+			tree.NewDString("BACKUP"),          // job_type
+			tree.NewDString("backing up db"),   // description
+			tree.NewDString("BACKUP INTO 'x'"), // statement
+			tree.NewDString("root"),            // user_name
+			tree.NewDString("succeeded"),       // status
+			tree.NewDString("uploading"),       // running_status
+			mustTimestampTZ(created),           // created
+			mustTimestampTZ(finished),          // finished
+			mustTimestampTZ(modified),          // modified
+			tree.NewDFloat(tree.DFloat(1.0)),   // fraction_completed
+			hwDecimal,                          // high_water_timestamp
+			tree.NewDString(""),                // error
+			tree.NewDInt(1),                    // coordinator_id
+		}
+
+		job, err := scanRowToJobInfo(row)
+		require.NoError(t, err)
+
+		require.Equal(t, int64(123), job.ID)
+		require.Equal(t, "BACKUP", job.Type)
+		require.Equal(t, "backing up db", job.Description)
+		require.Equal(t, "BACKUP INTO 'x'", job.Statement)
+		require.Equal(t, "root", job.Username)
+		require.Equal(t, "succeeded", job.Status)
+		require.Equal(t, "uploading", job.RunningStatus)
+		require.Equal(t, "2024-01-15T10:30:00Z", job.Created)
+		require.Equal(t, "2024-01-15T11:00:00Z", job.Finished)
+		require.Equal(t, "2024-01-15T11:00:00Z", job.Modified)
+		require.Equal(t, float32(1.0), job.FractionCompleted)
+		require.NotEmpty(t, job.HighwaterTimestamp)
+		require.Equal(t, "1705312260.0000000000", job.HighwaterDecimal)
+		require.Equal(t, int64(1), job.CoordinatorID)
+	})
+
+	t.Run("nullable fields as NULL", func(t *testing.T) {
+		row := tree.Datums{
+			tree.NewDInt(456),               // job_id
+			tree.NewDString("RESTORE"),      // job_type
+			tree.NewDString("restoring db"), // description
+			tree.NewDString(""),             // statement
+			tree.NewDString("admin"),        // user_name
+			tree.NewDString("running"),      // status
+			tree.DNull,                      // running_status (NULL)
+			mustTimestampTZ(created),        // created
+			tree.DNull,                      // finished (NULL)
+			mustTimestampTZ(modified),       // modified
+			tree.DNull,                      // fraction_completed (NULL)
+			tree.DNull,                      // high_water_timestamp (NULL)
+			tree.NewDString(""),             // error
+			tree.DNull,                      // coordinator_id (NULL)
+		}
+
+		job, err := scanRowToJobInfo(row)
+		require.NoError(t, err)
+
+		require.Equal(t, int64(456), job.ID)
+		require.Equal(t, "RESTORE", job.Type)
+		require.Equal(t, "running", job.Status)
+		require.Equal(t, "", job.RunningStatus)
+		require.Equal(t, "", job.Finished)
+		require.Equal(t, float32(0), job.FractionCompleted)
+		require.Equal(t, "", job.HighwaterTimestamp)
+		require.Equal(t, "", job.HighwaterDecimal)
+		require.Equal(t, int64(0), job.CoordinatorID)
+	})
+
+	t.Run("wrong column count", func(t *testing.T) {
+		row := tree.Datums{tree.NewDInt(1)}
+		_, err := scanRowToJobInfo(row)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "expected 14 columns")
+	})
+}
+
+func TestDatumToTimeStr(t *testing.T) {
+	tests := []struct {
+		name string
+		d    tree.Datum
+		want string
+	}{
+		{"null", tree.DNull, ""},
+		{
+			"valid",
+			func() tree.Datum {
+				d, _ := tree.MakeDTimestampTZ(
+					time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC),
+					time.Microsecond,
+				)
+				return d
+			}(),
+			"2024-01-15T10:30:00Z",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, datumToTimeStr(tt.d))
+		})
+	}
+}
+
+func TestGetJobInvalidID(t *testing.T) {
+	api := &ApiV2DBConsole{}
+	router := mux.NewRouter()
+	router.HandleFunc(
+		"/api/v2/dbconsole/jobs/{job_id}", api.GetJob,
+	).Methods("GET")
+
+	req := httptest.NewRequest(
+		"GET", "/api/v2/dbconsole/jobs/not-a-number", nil,
+	)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+
+	var errResp ErrorResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &errResp))
+	require.Equal(t, "invalid job_id parameter", errResp.Error)
+}
+
+func TestGetJobsInvalidParams(t *testing.T) {
+	api := &ApiV2DBConsole{}
+
+	t.Run("invalid type", func(t *testing.T) {
+		req := httptest.NewRequest(
+			"GET", "/api/v2/dbconsole/jobs?type=notanumber", nil,
+		)
+		w := httptest.NewRecorder()
+		api.GetJobs(w, req)
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		var errResp ErrorResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &errResp))
+		require.Equal(t, "invalid type parameter", errResp.Error)
+	})
+
+	t.Run("invalid limit", func(t *testing.T) {
+		req := httptest.NewRequest(
+			"GET", "/api/v2/dbconsole/jobs?limit=notanumber", nil,
+		)
+		w := httptest.NewRecorder()
+		api.GetJobs(w, req)
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		var errResp ErrorResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &errResp))
+		require.Equal(t, "invalid limit parameter", errResp.Error)
+	})
+}
+
+func TestHighwaterDecimalConversion(t *testing.T) {
+	// Verify that a decimal representing a CockroachDB HLC timestamp
+	// converts correctly to an RFC3339 timestamp string.
+	hwDecimal := &tree.DDecimal{}
+	require.NoError(t, hwDecimal.SetString("1705312260.0000000000"))
+
+	// The row has a non-null highwater timestamp.
+	created := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+	mustTimestampTZ := func(t time.Time) *tree.DTimestampTZ {
+		d, err := tree.MakeDTimestampTZ(t, time.Microsecond)
+		if err != nil {
+			panic(err)
+		}
+		return d
+	}
+
+	row := tree.Datums{
+		tree.NewDInt(1),
+		tree.NewDString("CHANGEFEED"),
+		tree.NewDString("desc"),
+		tree.NewDString(""),
+		tree.NewDString("root"),
+		tree.NewDString("running"),
+		tree.DNull,
+		mustTimestampTZ(created),
+		tree.DNull,
+		mustTimestampTZ(created),
+		tree.DNull,
+		hwDecimal,
+		tree.NewDString(""),
+		tree.DNull,
+	}
+
+	job, err := scanRowToJobInfo(row)
+	require.NoError(t, err)
+	require.NotEmpty(t, job.HighwaterTimestamp)
+	require.Equal(t, "1705312260.0000000000", job.HighwaterDecimal)
+
+	// Verify the timestamp parses as valid RFC3339.
+	_, err = time.Parse(time.RFC3339, job.HighwaterTimestamp)
+	require.NoError(t, err)
+}
+
+// TestJobInfoJSONSerialization verifies the JSON output matches the expected
+// shape that the frontend consumes, particularly the string-encoded job ID.
+func TestJobInfoJSONSerialization(t *testing.T) {
+	job := JobInfo{
+		ID:                9007199254740993, // > 2^53, must serialize as string
+		Type:              "BACKUP",
+		Status:            "running",
+		ExecutionFailures: []JobExecutionFailure{},
+		Messages:          []JobMessageInfo{},
+	}
+
+	data, err := json.Marshal(job)
+	require.NoError(t, err)
+
+	// The ID should be a quoted string in JSON.
+	require.Contains(t, string(data), `"id":"9007199254740993"`)
+
+	// Verify round-trip.
+	var decoded JobInfo
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.Equal(t, job.ID, decoded.ID)
+}

--- a/pkg/ui/workspaces/cluster-ui/src/api/jobsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/jobsApi.ts
@@ -3,21 +3,23 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
-import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+import { cockroach, google } from "@cockroachlabs/crdb-protobuf-client";
 import long from "long";
 import { SWRConfiguration } from "swr";
 
 import { propsToQueryString, useSwrWithClusterId } from "../util";
 
-import { fetchData } from "./fetchData";
+import { fetchDataJSON } from "./fetchData";
 
-const JOBS_PATH = "_admin/v1/jobs";
+const JOBS_PATH = "api/v2/dbconsole/jobs";
 
 export type JobsRequest = cockroach.server.serverpb.JobsRequest;
 export type JobsResponse = cockroach.server.serverpb.JobsResponse;
+type IJobsResponse = cockroach.server.serverpb.IJobsResponse;
 
 export type JobRequest = cockroach.server.serverpb.JobRequest;
 export type JobResponse = cockroach.server.serverpb.JobResponse;
+type IJobResponse = cockroach.server.serverpb.IJobResponse;
 
 export type JobResponseWithKey = {
   jobResponse: JobResponse;
@@ -28,25 +30,122 @@ export type ErrorWithKey = {
   key: string;
 };
 
-export const getJobs = (
-  req: JobsRequest,
-): Promise<cockroach.server.serverpb.JobsResponse> => {
-  let jobsRequestPath = `${JOBS_PATH}`;
+// BFF response types (private, match the Go BFF handler structs).
+// TODO(jasonlmfong): these are temporary shim types for the BFF migration.
+// Once downstream consumers are updated to use BFF types directly,
+// remove the Bff* interfaces and the bffJobToJobResponse conversion.
+interface BffJobExecutionFailure {
+  status: string;
+  start: string;
+  end: string;
+  error: string;
+}
+
+interface BffJobMessage {
+  kind: string;
+  timestamp: string;
+  message: string;
+}
+
+interface BffJobInfo {
+  id: string;
+  type: string;
+  description: string;
+  statement: string;
+  username: string;
+  status: string;
+  running_status: string;
+  created: string;
+  started: string;
+  finished: string;
+  modified: string;
+  fraction_completed: number;
+  error: string;
+  highwater_timestamp: string;
+  highwater_decimal: string;
+  last_run: string;
+  next_run: string;
+  num_runs: number;
+  coordinator_id: number;
+  execution_failures: BffJobExecutionFailure[];
+  messages: BffJobMessage[];
+}
+
+interface BffJobsListResponse {
+  jobs: BffJobInfo[];
+  earliest_retained_time: string;
+}
+
+// isoToTimestamp converts an ISO 8601 string to a protobuf ITimestamp-compatible
+// object with Long seconds and numeric nanos. Consumers call
+// timestamp.seconds.toNumber() and access timestamp.nanos, so both fields must
+// be present.
+function isoToTimestamp(iso: string): google.protobuf.ITimestamp | null {
+  if (!iso) return null;
+  const ms = new Date(iso).getTime();
+  if (isNaN(ms)) return null;
+  return {
+    seconds: long.fromNumber(Math.floor(ms / 1000)),
+    nanos: (ms % 1000) * 1e6,
+  };
+}
+
+// bffJobToJobResponse converts a BFF JSON job into a protobuf-compatible
+// JobResponse object. Numeric IDs become Long values and ISO timestamps become
+// {seconds: Long, nanos} objects so that existing consumer code (which calls
+// .toNumber(), .isZero(), TimestampToMoment(), etc.) continues to work.
+function bffJobToJobResponse(bff: BffJobInfo): JobResponse {
+  // satisfies IJobResponse validates field names and types against the protobuf
+  // interface. The as-cast is only needed because we construct a plain object
+  // rather than a class instance; consumers expect the class type.
+  return {
+    id: long.fromString(bff.id),
+    type: bff.type,
+    description: bff.description,
+    statement: bff.statement,
+    username: bff.username,
+    descriptor_ids: [], // not provided by BFF; unused by UI consumers
+    status: bff.status,
+    running_status: bff.running_status,
+    created: isoToTimestamp(bff.created),
+    started: isoToTimestamp(bff.started),
+    finished: isoToTimestamp(bff.finished),
+    modified: isoToTimestamp(bff.modified),
+    fraction_completed: bff.fraction_completed,
+    error: bff.error,
+    highwater_timestamp: isoToTimestamp(bff.highwater_timestamp),
+    highwater_decimal: bff.highwater_decimal,
+    last_run: isoToTimestamp(bff.last_run),
+    next_run: isoToTimestamp(bff.next_run),
+    num_runs: long.fromNumber(bff.num_runs),
+    coordinator_id: long.fromNumber(bff.coordinator_id),
+    execution_failures: (bff.execution_failures || []).map(f => ({
+      status: f.status,
+      start: isoToTimestamp(f.start),
+      end: isoToTimestamp(f.end),
+      error: f.error,
+    })),
+    messages: (bff.messages || []).map(m => ({
+      kind: m.kind,
+      timestamp: isoToTimestamp(m.timestamp),
+      message: m.message,
+    })),
+  } satisfies IJobResponse as JobResponse;
+}
+
+export const getJobs = (req: JobsRequest): Promise<JobsResponse> => {
   const queryStr = propsToQueryString({
     status: req.status,
-    type: req.type.toString(),
+    type: req.type || undefined,
     limit: req.limit,
   });
-  if (queryStr) {
-    jobsRequestPath = jobsRequestPath.concat(`?${queryStr}`);
-  }
-  return fetchData(
-    cockroach.server.serverpb.JobsResponse,
-    jobsRequestPath,
-    null,
-    null,
-    "30M",
-  );
+  const path = queryStr ? `${JOBS_PATH}/?${queryStr}` : `${JOBS_PATH}/`;
+  return fetchDataJSON<BffJobsListResponse, void>(path).then(resp => {
+    return {
+      jobs: (resp.jobs || []).map(bffJobToJobResponse),
+      earliest_retained_time: isoToTimestamp(resp.earliest_retained_time),
+    } satisfies IJobsResponse as JobsResponse;
+  });
 };
 
 export function useJobDetails(jobId: long, opts: SWRConfiguration = {}) {
@@ -62,11 +161,7 @@ export function useJobDetails(jobId: long, opts: SWRConfiguration = {}) {
 }
 
 export const getJob = (req: JobRequest): Promise<JobResponse> => {
-  return fetchData(
-    cockroach.server.serverpb.JobResponse,
-    `${JOBS_PATH}/${req.job_id}`,
-    null,
-    null,
-    "30M",
+  return fetchDataJSON<BffJobInfo, void>(`${JOBS_PATH}/${req.job_id}/`).then(
+    bffJobToJobResponse,
   );
 };

--- a/pkg/ui/workspaces/db-console/src/api/api-types.ts
+++ b/pkg/ui/workspaces/db-console/src/api/api-types.ts
@@ -4,6 +4,121 @@
  */
 
 export interface paths {
+    "/jobs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List jobs
+         * @description Returns a list of jobs, optionally filtered by status, type, and limit.
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description Filter by job status */
+                    status?: string;
+                    /** @description Filter by job type (int32 enum value) */
+                    type?: number;
+                    /** @description Maximum number of jobs to return */
+                    limit?: number;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Job list */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["dbconsole.JobsListResponse"];
+                    };
+                };
+                /** @description Internal error */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["dbconsole.ErrorResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/jobs/{job_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get job
+         * @description Returns a single job identified by its ID.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Job ID */
+                    job_id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Job details */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["dbconsole.JobInfo"];
+                    };
+                };
+                /** @description Invalid job ID */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["dbconsole.ErrorResponse"];
+                    };
+                };
+                /** @description Internal error */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["dbconsole.ErrorResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/nodes": {
         parameters: {
             query?: never;
@@ -59,6 +174,84 @@ export interface components {
         "dbconsole.ErrorResponse": {
             /** @description Error is the error message. */
             error?: string;
+        };
+        "dbconsole.JobExecutionFailure": {
+            /** @description End is the ISO 8601 timestamp when the error occurred. */
+            end?: string;
+            /** @description Error is the error message. */
+            error?: string;
+            /** @description Start is the ISO 8601 timestamp when the execution started. */
+            start?: string;
+            /** @description Status is the status of the job during the failed execution. */
+            status?: string;
+        };
+        "dbconsole.JobInfo": {
+            /** @description CoordinatorID is the node ID coordinating the job. */
+            coordinator_id?: number;
+            /** @description Created is the ISO 8601 timestamp when the job was created. */
+            created?: string;
+            /** @description Description is a human-readable description of the job. */
+            description?: string;
+            /** @description Error is the error message if the job failed. */
+            error?: string;
+            /** @description ExecutionFailures is a log of execution failures. */
+            execution_failures?: components["schemas"]["dbconsole.JobExecutionFailure"][];
+            /** @description Finished is the ISO 8601 timestamp when the job finished. */
+            finished?: string;
+            /** @description FractionCompleted is the fraction of the job that has been completed. */
+            fraction_completed?: number;
+            /**
+             * @description HighwaterDecimal is the highwater timestamp in decimal form for use
+             *     with AS OF SYSTEM TIME.
+             */
+            highwater_decimal?: string;
+            /** @description HighwaterTimestamp is the highwater timestamp as an ISO 8601 string. */
+            highwater_timestamp?: string;
+            /**
+             * @description ID is the unique identifier for the job. Serialized as a string to avoid
+             *     JavaScript integer precision loss for values exceeding 2^53.
+             * @example 0
+             */
+            id?: string;
+            /** @description LastRun is the ISO 8601 timestamp of the last execution attempt. */
+            last_run?: string;
+            /** @description Messages contains informational messages associated with the job. */
+            messages?: components["schemas"]["dbconsole.JobMessageInfo"][];
+            /** @description Modified is the ISO 8601 timestamp when the job was last modified. */
+            modified?: string;
+            /** @description NextRun is the ISO 8601 timestamp of the next scheduled execution. */
+            next_run?: string;
+            /** @description NumRuns is the number of times the job has been executed. */
+            num_runs?: number;
+            /** @description RunningStatus provides additional detail on the job's running state. */
+            running_status?: string;
+            /** @description Started is the ISO 8601 timestamp when the job started executing. */
+            started?: string;
+            /** @description Statement is the SQL statement that created the job. */
+            statement?: string;
+            /** @description Status is the current status of the job. */
+            status?: string;
+            /** @description Type is the type of the job (e.g. "BACKUP", "RESTORE"). */
+            type?: string;
+            /** @description Username is the user who created the job. */
+            username?: string;
+        };
+        "dbconsole.JobMessageInfo": {
+            /** @description Kind is the kind of message. */
+            kind?: string;
+            /** @description Message is the message text. */
+            message?: string;
+            /** @description Timestamp is the ISO 8601 timestamp of the message. */
+            timestamp?: string;
+        };
+        "dbconsole.JobsListResponse": {
+            /**
+             * @description EarliestRetainedTime is the earliest time for which job records are
+             *     retained, as an ISO 8601 timestamp.
+             */
+            earliest_retained_time?: string;
+            /** @description Jobs contains the list of jobs. */
+            jobs?: components["schemas"]["dbconsole.JobInfo"][];
         };
         "dbconsole.NodeInfo": {
             /**

--- a/pkg/ui/workspaces/db-console/src/api/openapi.json
+++ b/pkg/ui/workspaces/db-console/src/api/openapi.json
@@ -7,6 +7,125 @@
         "version": "1.0.0"
     },
     "paths": {
+        "/jobs": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Returns a list of jobs, optionally filtered by status, type, and limit.",
+                "tags": [
+                    "Jobs"
+                ],
+                "summary": "List jobs",
+                "parameters": [
+                    {
+                        "description": "Filter by job status",
+                        "name": "status",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Filter by job type (int32 enum value)",
+                        "name": "type",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Maximum number of jobs to return",
+                        "name": "limit",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Job list",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/dbconsole.JobsListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/dbconsole.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/jobs/{job_id}": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Returns a single job identified by its ID.",
+                "tags": [
+                    "Jobs"
+                ],
+                "summary": "Get job",
+                "parameters": [
+                    {
+                        "description": "Job ID",
+                        "name": "job_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Job details",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/dbconsole.JobInfo"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid job ID",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/dbconsole.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/dbconsole.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/nodes": {
             "get": {
                 "security": [
@@ -64,6 +183,156 @@
                     "error": {
                         "description": "Error is the error message.",
                         "type": "string"
+                    }
+                }
+            },
+            "dbconsole.JobExecutionFailure": {
+                "type": "object",
+                "properties": {
+                    "end": {
+                        "description": "End is the ISO 8601 timestamp when the error occurred.",
+                        "type": "string"
+                    },
+                    "error": {
+                        "description": "Error is the error message.",
+                        "type": "string"
+                    },
+                    "start": {
+                        "description": "Start is the ISO 8601 timestamp when the execution started.",
+                        "type": "string"
+                    },
+                    "status": {
+                        "description": "Status is the status of the job during the failed execution.",
+                        "type": "string"
+                    }
+                }
+            },
+            "dbconsole.JobInfo": {
+                "type": "object",
+                "properties": {
+                    "coordinator_id": {
+                        "description": "CoordinatorID is the node ID coordinating the job.",
+                        "type": "integer"
+                    },
+                    "created": {
+                        "description": "Created is the ISO 8601 timestamp when the job was created.",
+                        "type": "string"
+                    },
+                    "description": {
+                        "description": "Description is a human-readable description of the job.",
+                        "type": "string"
+                    },
+                    "error": {
+                        "description": "Error is the error message if the job failed.",
+                        "type": "string"
+                    },
+                    "execution_failures": {
+                        "description": "ExecutionFailures is a log of execution failures.",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/dbconsole.JobExecutionFailure"
+                        }
+                    },
+                    "finished": {
+                        "description": "Finished is the ISO 8601 timestamp when the job finished.",
+                        "type": "string"
+                    },
+                    "fraction_completed": {
+                        "description": "FractionCompleted is the fraction of the job that has been completed.",
+                        "type": "number"
+                    },
+                    "highwater_decimal": {
+                        "description": "HighwaterDecimal is the highwater timestamp in decimal form for use\nwith AS OF SYSTEM TIME.",
+                        "type": "string"
+                    },
+                    "highwater_timestamp": {
+                        "description": "HighwaterTimestamp is the highwater timestamp as an ISO 8601 string.",
+                        "type": "string"
+                    },
+                    "id": {
+                        "description": "ID is the unique identifier for the job. Serialized as a string to avoid\nJavaScript integer precision loss for values exceeding 2^53.",
+                        "type": "string",
+                        "example": "0"
+                    },
+                    "last_run": {
+                        "description": "LastRun is the ISO 8601 timestamp of the last execution attempt.",
+                        "type": "string"
+                    },
+                    "messages": {
+                        "description": "Messages contains informational messages associated with the job.",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/dbconsole.JobMessageInfo"
+                        }
+                    },
+                    "modified": {
+                        "description": "Modified is the ISO 8601 timestamp when the job was last modified.",
+                        "type": "string"
+                    },
+                    "next_run": {
+                        "description": "NextRun is the ISO 8601 timestamp of the next scheduled execution.",
+                        "type": "string"
+                    },
+                    "num_runs": {
+                        "description": "NumRuns is the number of times the job has been executed.",
+                        "type": "integer"
+                    },
+                    "running_status": {
+                        "description": "RunningStatus provides additional detail on the job's running state.",
+                        "type": "string"
+                    },
+                    "started": {
+                        "description": "Started is the ISO 8601 timestamp when the job started executing.",
+                        "type": "string"
+                    },
+                    "statement": {
+                        "description": "Statement is the SQL statement that created the job.",
+                        "type": "string"
+                    },
+                    "status": {
+                        "description": "Status is the current status of the job.",
+                        "type": "string"
+                    },
+                    "type": {
+                        "description": "Type is the type of the job (e.g. \"BACKUP\", \"RESTORE\").",
+                        "type": "string"
+                    },
+                    "username": {
+                        "description": "Username is the user who created the job.",
+                        "type": "string"
+                    }
+                }
+            },
+            "dbconsole.JobMessageInfo": {
+                "type": "object",
+                "properties": {
+                    "kind": {
+                        "description": "Kind is the kind of message.",
+                        "type": "string"
+                    },
+                    "message": {
+                        "description": "Message is the message text.",
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "description": "Timestamp is the ISO 8601 timestamp of the message.",
+                        "type": "string"
+                    }
+                }
+            },
+            "dbconsole.JobsListResponse": {
+                "type": "object",
+                "properties": {
+                    "earliest_retained_time": {
+                        "description": "EarliestRetainedTime is the earliest time for which job records are\nretained, as an ISO 8601 timestamp.",
+                        "type": "string"
+                    },
+                    "jobs": {
+                        "description": "Jobs contains the list of jobs.",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/dbconsole.JobInfo"
+                        }
                     }
                 }
             },

--- a/pkg/ui/workspaces/db-console/src/api/swagger.json
+++ b/pkg/ui/workspaces/db-console/src/api/swagger.json
@@ -9,6 +9,103 @@
     "host": "localhost:8080",
     "basePath": "/api/v2/dbconsole",
     "paths": {
+        "/jobs": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Returns a list of jobs, optionally filtered by status, type, and limit.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Jobs"
+                ],
+                "summary": "List jobs",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Filter by job status",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Filter by job type (int32 enum value)",
+                        "name": "type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum number of jobs to return",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Job list",
+                        "schema": {
+                            "$ref": "#/definitions/dbconsole.JobsListResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "$ref": "#/definitions/dbconsole.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/jobs/{job_id}": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Returns a single job identified by its ID.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Jobs"
+                ],
+                "summary": "Get job",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Job ID",
+                        "name": "job_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Job details",
+                        "schema": {
+                            "$ref": "#/definitions/dbconsole.JobInfo"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid job ID",
+                        "schema": {
+                            "$ref": "#/definitions/dbconsole.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "$ref": "#/definitions/dbconsole.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/nodes": {
             "get": {
                 "security": [
@@ -48,6 +145,156 @@
                 "error": {
                     "description": "Error is the error message.",
                     "type": "string"
+                }
+            }
+        },
+        "dbconsole.JobExecutionFailure": {
+            "type": "object",
+            "properties": {
+                "end": {
+                    "description": "End is the ISO 8601 timestamp when the error occurred.",
+                    "type": "string"
+                },
+                "error": {
+                    "description": "Error is the error message.",
+                    "type": "string"
+                },
+                "start": {
+                    "description": "Start is the ISO 8601 timestamp when the execution started.",
+                    "type": "string"
+                },
+                "status": {
+                    "description": "Status is the status of the job during the failed execution.",
+                    "type": "string"
+                }
+            }
+        },
+        "dbconsole.JobInfo": {
+            "type": "object",
+            "properties": {
+                "coordinator_id": {
+                    "description": "CoordinatorID is the node ID coordinating the job.",
+                    "type": "integer"
+                },
+                "created": {
+                    "description": "Created is the ISO 8601 timestamp when the job was created.",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "Description is a human-readable description of the job.",
+                    "type": "string"
+                },
+                "error": {
+                    "description": "Error is the error message if the job failed.",
+                    "type": "string"
+                },
+                "execution_failures": {
+                    "description": "ExecutionFailures is a log of execution failures.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/dbconsole.JobExecutionFailure"
+                    }
+                },
+                "finished": {
+                    "description": "Finished is the ISO 8601 timestamp when the job finished.",
+                    "type": "string"
+                },
+                "fraction_completed": {
+                    "description": "FractionCompleted is the fraction of the job that has been completed.",
+                    "type": "number"
+                },
+                "highwater_decimal": {
+                    "description": "HighwaterDecimal is the highwater timestamp in decimal form for use\nwith AS OF SYSTEM TIME.",
+                    "type": "string"
+                },
+                "highwater_timestamp": {
+                    "description": "HighwaterTimestamp is the highwater timestamp as an ISO 8601 string.",
+                    "type": "string"
+                },
+                "id": {
+                    "description": "ID is the unique identifier for the job. Serialized as a string to avoid\nJavaScript integer precision loss for values exceeding 2^53.",
+                    "type": "string",
+                    "example": "0"
+                },
+                "last_run": {
+                    "description": "LastRun is the ISO 8601 timestamp of the last execution attempt.",
+                    "type": "string"
+                },
+                "messages": {
+                    "description": "Messages contains informational messages associated with the job.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/dbconsole.JobMessageInfo"
+                    }
+                },
+                "modified": {
+                    "description": "Modified is the ISO 8601 timestamp when the job was last modified.",
+                    "type": "string"
+                },
+                "next_run": {
+                    "description": "NextRun is the ISO 8601 timestamp of the next scheduled execution.",
+                    "type": "string"
+                },
+                "num_runs": {
+                    "description": "NumRuns is the number of times the job has been executed.",
+                    "type": "integer"
+                },
+                "running_status": {
+                    "description": "RunningStatus provides additional detail on the job's running state.",
+                    "type": "string"
+                },
+                "started": {
+                    "description": "Started is the ISO 8601 timestamp when the job started executing.",
+                    "type": "string"
+                },
+                "statement": {
+                    "description": "Statement is the SQL statement that created the job.",
+                    "type": "string"
+                },
+                "status": {
+                    "description": "Status is the current status of the job.",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "Type is the type of the job (e.g. \"BACKUP\", \"RESTORE\").",
+                    "type": "string"
+                },
+                "username": {
+                    "description": "Username is the user who created the job.",
+                    "type": "string"
+                }
+            }
+        },
+        "dbconsole.JobMessageInfo": {
+            "type": "object",
+            "properties": {
+                "kind": {
+                    "description": "Kind is the kind of message.",
+                    "type": "string"
+                },
+                "message": {
+                    "description": "Message is the message text.",
+                    "type": "string"
+                },
+                "timestamp": {
+                    "description": "Timestamp is the ISO 8601 timestamp of the message.",
+                    "type": "string"
+                }
+            }
+        },
+        "dbconsole.JobsListResponse": {
+            "type": "object",
+            "properties": {
+                "earliest_retained_time": {
+                    "description": "EarliestRetainedTime is the earliest time for which job records are\nretained, as an ISO 8601 timestamp.",
+                    "type": "string"
+                },
+                "jobs": {
+                    "description": "Jobs contains the list of jobs.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/dbconsole.JobInfo"
+                    }
                 }
             }
         },


### PR DESCRIPTION
Add JSON REST endpoints for listing and fetching individual jobs under /api/v2/dbconsole/jobs/.
These are part of the DB Console BFF layer that replaces the protobuf-over-HTTP paths the
frontend previously used.

Both endpoints delegate to adminServer.Jobs/Job via the AdminAPI interface, then transform the
protobuf responses into plain JSON structs suitable for direct consumption by the frontend.
Int64 IDs are serialized as JSON strings (json:",string") to prevent JavaScript precision loss
for values exceeding 2^53. Timestamps are formatted as RFC 3339 strings.

The list endpoint supports optional status, type, and limit query parameters.
The single-job endpoint accepts a numeric job_id path parameter.

Unit tests added using a mock AdminAPI.

----

Switch the jobs frontend API from protobuf-over-HTTP (_admin/v1/jobs) to the new JSON
BFF endpoints (api/v2/dbconsole/jobs/).

Epic: CRDB-58145
Release note: None