### PR TITLE
admission: rate-limit stale disk stat logging at all thresholds

### DIFF
--- a/pkg/util/admission/granter.go
+++ b/pkg/util/admission/granter.go
@@ -590,15 +590,10 @@ func (t *staleStatTracker) recordChange() {
 }
 
 func (t *staleStatTracker) shouldLog() bool {
-	for _, thresh := range t.thresholds {
-		if t.consecutiveCount == thresh {
-			// Always log if we've just exceeded a threshold
-			return true
-		} else if t.consecutiveCount > thresh {
-			return t.logLimiter.ShouldLog()
-		}
+	if len(t.thresholds) == 0 || t.consecutiveCount < t.thresholds[0] {
+		return false
 	}
-	return false
+	return t.logLimiter.ShouldLog()
 }
 
 // adjustDiskTokenErrorLocked is used to account for extra reads and writes that


### PR DESCRIPTION
## Summary

- Fix excessive log spam from `staleStatTracker.shouldLog()` in the admission control disk token error adjustment path.
- The `consecutiveCount == threshold` case bypassed the rate limiter entirely, causing ~50 log lines/second when the kernel updates disk stats every ~20ms (the count repeatedly hits exactly 20, resets, and hits 20 again).
- Apply `logLimiter` (once per minute) unconditionally once the minimum threshold is reached.
- Add a defensive `len(t.thresholds) > 0` check in `shouldLog()` to avoid a panic on an empty thresholds slice.

Informs: #163347

Release note: None