### PR TITLE
server/dbconsole: add schedules BFF endpoints

### DIFF
--- a/pkg/server/api_v2.go
+++ b/pkg/server/api_v2.go
@@ -222,6 +222,8 @@ func registerRoutes(
 
 		// DB Console BFF endpoints.
 		{"dbconsole/nodes/", dbconsoleAPI.GetNodes, true, authserver.ViewClusterMetadataRole, true},
+		{"dbconsole/schedules/", dbconsoleAPI.GetSchedules, true, authserver.ViewClusterMetadataRole, true},
+		{"dbconsole/schedules/{schedule_id:[0-9]+}/", dbconsoleAPI.GetSchedule, true, authserver.ViewClusterMetadataRole, true},
 	}
 
 	// For all routes requiring authentication, have the outer mux (a.mux)

--- a/pkg/server/dbconsole/BUILD.bazel
+++ b/pkg/server/dbconsole/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "dbconsole",
-    srcs = ["dbconsole.go"],
+    srcs = [
+        "dbconsole.go",
+        "schedules.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/server/dbconsole",
     visibility = ["//visibility:public"],
     deps = [
@@ -12,20 +15,31 @@ go_library(
         "//pkg/server/serverpb",
         "//pkg/server/srverrors",
         "//pkg/sql/isql",
+        "//pkg/sql/sem/tree",
+        "//pkg/sql/sessiondata",
+        "//pkg/util/safesql",
+        "@com_github_cockroachdb_errors//:errors",
+        "@com_github_gorilla_mux//:mux",
     ],
 )
 
 go_test(
     name = "dbconsole_test",
-    srcs = ["dbconsole_test.go"],
+    srcs = [
+        "dbconsole_test.go",
+        "schedules_test.go",
+    ],
     embed = [":dbconsole"],
     deps = [
         "//pkg/build",
         "//pkg/kv/kvserver/liveness/livenesspb",
         "//pkg/roachpb",
         "//pkg/server/serverpb",
+        "//pkg/sql/sem/tree",
         "//pkg/util",
+        "//pkg/util/json",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_gorilla_mux//:mux",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/server/dbconsole/schedules.go
+++ b/pkg/server/dbconsole/schedules.go
@@ -1,0 +1,242 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package dbconsole
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/server/apiutil"
+	"github.com/cockroachdb/cockroach/pkg/server/authserver"
+	"github.com/cockroachdb/cockroach/pkg/server/srverrors"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/util/safesql"
+	"github.com/cockroachdb/errors"
+	"github.com/gorilla/mux"
+)
+
+// ScheduleInfo contains summarized schedule information for the UI.
+type ScheduleInfo struct {
+	// ID is the unique identifier for the schedule. Serialized as a string to
+	// avoid JavaScript integer precision loss for values exceeding 2^53.
+	ID int64 `json:"id,string"`
+	// Label is the name of the schedule.
+	Label string `json:"label"`
+	// Status is the schedule status (ACTIVE or PAUSED).
+	Status string `json:"status"`
+	// NextRun is the next scheduled run time in ISO 8601 format, empty if paused.
+	NextRun string `json:"next_run"`
+	// State is the schedule state from the schedule_state protobuf.
+	State string `json:"state"`
+	// Recurrence is the cron expression or NEVER.
+	Recurrence string `json:"recurrence"`
+	// JobsRunning is the number of currently running jobs for this schedule.
+	JobsRunning int64 `json:"jobs_running"`
+	// Owner is the user who owns this schedule.
+	Owner string `json:"owner"`
+	// Created is the schedule creation time in ISO 8601 format.
+	Created string `json:"created"`
+	// Command is the JSON representation of the schedule's execution arguments.
+	Command string `json:"command"`
+}
+
+// SchedulesListResponse contains schedules for the schedules list page.
+type SchedulesListResponse struct {
+	// Schedules contains information for all matching schedules.
+	Schedules []ScheduleInfo `json:"schedules"`
+}
+
+// GetSchedules returns schedule information for the schedules list page.
+// @Summary List schedules
+// @Description Returns schedule information, optionally filtered by status.
+// @Tags Schedules
+// @Produce json
+// @Param status query string false "Filter by status (ACTIVE or PAUSED)"
+// @Param limit query int false "Maximum number of schedules to return"
+// @Success 200 {object} SchedulesListResponse "Schedule list"
+// @Failure 400 {object} ErrorResponse "Invalid limit"
+// @Failure 500 {object} ErrorResponse "Internal error"
+// @Security ApiKeyAuth
+// @Router /schedules [get]
+func (api *ApiV2DBConsole) GetSchedules(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	limit, err := apiutil.GetIntQueryStringVal(r.URL.Query(), "limit")
+	if err != nil {
+		apiutil.WriteJSONResponse(ctx, w, http.StatusBadRequest, ErrorResponse{
+			Error: "invalid limit parameter",
+		})
+		return
+	}
+
+	userName := authserver.UserFromHTTPAuthInfoContext(ctx)
+
+	query := safesql.NewQuery()
+	query.Append(
+		`WITH s AS (SHOW SCHEDULES)
+SELECT id, label, schedule_status, next_run, state,
+       recurrence, jobsrunning, owner, created, command
+FROM s`,
+	)
+
+	statusFilter := strings.ToUpper(r.URL.Query().Get("status"))
+	if statusFilter != "" {
+		if statusFilter != "ACTIVE" && statusFilter != "PAUSED" {
+			apiutil.WriteJSONResponse(ctx, w, http.StatusBadRequest, ErrorResponse{
+				Error: "invalid status parameter, must be ACTIVE or PAUSED",
+			})
+			return
+		}
+		query.Append(` WHERE schedule_status = $`, statusFilter)
+	}
+
+	query.Append(` ORDER BY created DESC`)
+
+	if limit > 0 {
+		query.Append(` LIMIT $`, limit)
+	}
+
+	if queryErrs := query.Errors(); len(queryErrs) > 0 {
+		srverrors.APIV2InternalError(ctx, queryErrs[0], w)
+		return
+	}
+
+	rows, err := api.InternalDB.Executor().QueryBufferedEx(
+		ctx, "dbconsole-schedules", nil, /* txn */
+		sessiondata.InternalExecutorOverride{User: userName},
+		query.String(), query.QueryArguments()...,
+	)
+	if err != nil {
+		srverrors.APIV2InternalError(ctx, err, w)
+		return
+	}
+
+	schedules := make([]ScheduleInfo, 0, len(rows))
+	for _, row := range rows {
+		info, err := scanScheduleRow(row)
+		if err != nil {
+			srverrors.APIV2InternalError(ctx, err, w)
+			return
+		}
+		schedules = append(schedules, info)
+	}
+
+	apiutil.WriteJSONResponse(ctx, w, http.StatusOK, SchedulesListResponse{
+		Schedules: schedules,
+	})
+}
+
+// GetSchedule returns information for a single schedule.
+// @Summary Get schedule
+// @Description Returns information for a single schedule by ID.
+// @Tags Schedules
+// @Produce json
+// @Param schedule_id path int true "Schedule ID"
+// @Success 200 {object} ScheduleInfo "Schedule info"
+// @Failure 400 {object} ErrorResponse "Invalid schedule ID"
+// @Failure 404 {object} ErrorResponse "Schedule not found"
+// @Failure 500 {object} ErrorResponse "Internal error"
+// @Security ApiKeyAuth
+// @Router /schedules/{schedule_id} [get]
+func (api *ApiV2DBConsole) GetSchedule(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	scheduleIDStr := mux.Vars(r)["schedule_id"]
+	scheduleID, err := strconv.ParseInt(scheduleIDStr, 10, 64)
+	if err != nil {
+		apiutil.WriteJSONResponse(ctx, w, http.StatusBadRequest, ErrorResponse{
+			Error: "invalid schedule_id",
+		})
+		return
+	}
+
+	userName := authserver.UserFromHTTPAuthInfoContext(ctx)
+
+	rows, err := api.InternalDB.Executor().QueryBufferedEx(
+		ctx, "dbconsole-schedule", nil, /* txn */
+		sessiondata.InternalExecutorOverride{User: userName},
+		`WITH s AS (SHOW SCHEDULES)
+SELECT id, label, schedule_status, next_run, state,
+       recurrence, jobsrunning, owner, created, command
+FROM s
+WHERE id = $1`,
+		scheduleID,
+	)
+	if err != nil {
+		srverrors.APIV2InternalError(ctx, err, w)
+		return
+	}
+
+	if len(rows) == 0 {
+		apiutil.WriteJSONResponse(ctx, w, http.StatusNotFound, ErrorResponse{
+			Error: "schedule not found",
+		})
+		return
+	}
+
+	info, err := scanScheduleRow(rows[0])
+	if err != nil {
+		srverrors.APIV2InternalError(ctx, err, w)
+		return
+	}
+
+	apiutil.WriteJSONResponse(ctx, w, http.StatusOK, info)
+}
+
+// scanScheduleRow converts a tree.Datums row from the schedules query into a
+// ScheduleInfo struct.
+func scanScheduleRow(row tree.Datums) (ScheduleInfo, error) {
+	if len(row) != 10 {
+		return ScheduleInfo{}, errors.Newf("expected 10 columns, got %d", len(row))
+	}
+
+	info := ScheduleInfo{
+		ID:          int64(tree.MustBeDInt(row[0])),
+		Label:       string(tree.MustBeDString(row[1])),
+		Status:      string(tree.MustBeDString(row[2])),
+		Recurrence:  string(tree.MustBeDString(row[5])),
+		JobsRunning: int64(tree.MustBeDInt(row[6])),
+		Owner:       string(tree.MustBeDString(row[7])),
+	}
+
+	// next_run: nullable timestamp.
+	if row[3] != tree.DNull {
+		ts, ok := row[3].(*tree.DTimestampTZ)
+		if !ok {
+			return ScheduleInfo{}, errors.Newf(
+				"expected DTimestampTZ for next_run, got %T", row[3])
+		}
+		info.NextRun = ts.Time.Format(time.RFC3339)
+	}
+
+	// state: nullable text field (extracted via ->> which returns DString).
+	if row[4] != tree.DNull {
+		info.State = tree.AsStringWithFlags(row[4], tree.FmtBareStrings)
+	}
+
+	// created: non-nullable timestamp.
+	createdTS, ok := row[8].(*tree.DTimestampTZ)
+	if !ok {
+		return ScheduleInfo{}, errors.Newf(
+			"expected DTimestampTZ for created, got %T", row[8])
+	}
+	info.Created = createdTS.Time.Format(time.RFC3339)
+
+	// command: nullable JSONB field (the delegate strips @type from execution args).
+	if row[9] != tree.DNull {
+		cmdJSON, ok := row[9].(*tree.DJSON)
+		if !ok {
+			return ScheduleInfo{}, errors.Newf(
+				"expected DJSON for command, got %T", row[9])
+		}
+		info.Command = cmdJSON.JSON.String()
+	}
+
+	return info, nil
+}

--- a/pkg/server/dbconsole/schedules_test.go
+++ b/pkg/server/dbconsole/schedules_test.go
@@ -1,0 +1,152 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package dbconsole
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	crjson "github.com/cockroachdb/cockroach/pkg/util/json"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScanScheduleRow(t *testing.T) {
+	now := time.Date(2024, 6, 15, 10, 30, 0, 0, time.UTC)
+
+	t.Run("all fields populated", func(t *testing.T) {
+		commandJSON, err := crjson.ParseJSON(`{"backup_statement": "BACKUP INTO 'nodelocal://1/backup'"}`)
+		require.NoError(t, err)
+
+		row := tree.Datums{
+			tree.NewDInt(tree.DInt(123)),                                        // id
+			tree.NewDString("daily-backup"),                                     // label
+			tree.NewDString("ACTIVE"),                                           // schedule_status
+			tree.MustMakeDTimestampTZ(now, time.Microsecond),                    // next_run
+			tree.NewDString("WAITING"),                                          // state
+			tree.NewDString("@daily"),                                           // recurrence
+			tree.NewDInt(tree.DInt(2)),                                          // jobsRunning
+			tree.NewDString("root"),                                             // owner
+			tree.MustMakeDTimestampTZ(now.Add(-24*time.Hour), time.Microsecond), // created
+			tree.NewDJSON(commandJSON),                                          // command (JSONB)
+		}
+
+		info, err := scanScheduleRow(row)
+		require.NoError(t, err)
+		require.Equal(t, int64(123), info.ID)
+		require.Equal(t, "daily-backup", info.Label)
+		require.Equal(t, "ACTIVE", info.Status)
+		require.Equal(t, "2024-06-15T10:30:00Z", info.NextRun)
+		require.Equal(t, "WAITING", info.State)
+		require.Equal(t, "@daily", info.Recurrence)
+		require.Equal(t, int64(2), info.JobsRunning)
+		require.Equal(t, "root", info.Owner)
+		require.Equal(t, "2024-06-14T10:30:00Z", info.Created)
+		require.Contains(t, info.Command, "backup_statement")
+	})
+
+	t.Run("nullable fields null", func(t *testing.T) {
+		now := time.Date(2024, 6, 15, 10, 30, 0, 0, time.UTC)
+		row := tree.Datums{
+			tree.NewDInt(tree.DInt(456)),                     // schedule_id
+			tree.NewDString("paused-backup"),                 // schedule_name
+			tree.NewDString("PAUSED"),                        // schedule_status
+			tree.DNull,                                       // next_run (null when paused)
+			tree.DNull,                                       // state (null)
+			tree.NewDString("NEVER"),                         // recurrence
+			tree.NewDInt(tree.DInt(0)),                       // jobs_running
+			tree.NewDString("admin"),                         // owner
+			tree.MustMakeDTimestampTZ(now, time.Microsecond), // created
+			tree.DNull,                                       // command (null)
+		}
+
+		info, err := scanScheduleRow(row)
+		require.NoError(t, err)
+		require.Equal(t, int64(456), info.ID)
+		require.Equal(t, "paused-backup", info.Label)
+		require.Equal(t, "PAUSED", info.Status)
+		require.Empty(t, info.NextRun)
+		require.Empty(t, info.State)
+		require.Equal(t, "NEVER", info.Recurrence)
+		require.Equal(t, int64(0), info.JobsRunning)
+		require.Equal(t, "admin", info.Owner)
+		require.Equal(t, "2024-06-15T10:30:00Z", info.Created)
+		require.Empty(t, info.Command)
+	})
+
+	t.Run("wrong column count", func(t *testing.T) {
+		row := tree.Datums{
+			tree.NewDInt(tree.DInt(1)),
+			tree.NewDString("test"),
+		}
+		_, err := scanScheduleRow(row)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "expected 10 columns")
+	})
+}
+
+func TestGetScheduleInvalidID(t *testing.T) {
+	api := &ApiV2DBConsole{}
+
+	router := mux.NewRouter()
+	router.HandleFunc(
+		"/api/v2/dbconsole/schedules/{schedule_id}", api.GetSchedule,
+	).Methods("GET")
+
+	req := httptest.NewRequest("GET", "/api/v2/dbconsole/schedules/not-a-number", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+
+	var errResp ErrorResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &errResp))
+	require.Equal(t, "invalid schedule_id", errResp.Error)
+}
+
+func TestGetSchedulesInvalidLimit(t *testing.T) {
+	api := &ApiV2DBConsole{}
+
+	req := httptest.NewRequest("GET", "/api/v2/dbconsole/schedules/?limit=abc", nil)
+	w := httptest.NewRecorder()
+	api.GetSchedules(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+
+	var errResp ErrorResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &errResp))
+	require.Equal(t, "invalid limit parameter", errResp.Error)
+}
+
+func TestScheduleInfoJSON(t *testing.T) {
+	info := ScheduleInfo{
+		ID:          1234567890123456789,
+		Label:       "test-schedule",
+		Status:      "ACTIVE",
+		NextRun:     "2024-06-15T10:30:00Z",
+		State:       "WAITING",
+		Recurrence:  "@daily",
+		JobsRunning: 1,
+		Owner:       "root",
+		Created:     "2024-06-14T10:30:00Z",
+		Command:     `{"backup_statement": "BACKUP"}`,
+	}
+
+	data, err := json.Marshal(info)
+	require.NoError(t, err)
+
+	// Verify int64 ID is serialized as a quoted string.
+	require.Contains(t, string(data), `"id":"1234567890123456789"`)
+
+	// Verify round-trip.
+	var decoded ScheduleInfo
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.Equal(t, info.ID, decoded.ID)
+}

--- a/pkg/ui/workspaces/cluster-ui/src/api/schedulesApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/schedulesApi.ts
@@ -6,27 +6,25 @@
 import Long from "long";
 import moment from "moment-timezone";
 
-import { RequestError } from "../util";
+import { fetchDataJSON } from "./fetchData";
 
-import {
-  executeInternalSql,
-  LARGE_RESULT_SIZE,
-  SqlExecutionRequest,
-  sqlResultsAreEmpty,
-} from "./sqlApi";
-
-type ScheduleColumns = {
+// BFF response types (private, match the Go BFF handler structs).
+interface BffScheduleInfo {
   id: string;
   label: string;
-  schedule_status: string;
+  status: string;
   next_run: string;
   state: string;
   recurrence: string;
-  jobsrunning: number;
+  jobs_running: number;
   owner: string;
   created: string;
   command: string;
-};
+}
+
+interface BffSchedulesListResponse {
+  schedules: BffScheduleInfo[];
+}
 
 export type Schedule = {
   id: Long;
@@ -43,106 +41,54 @@ export type Schedule = {
 
 export type Schedules = Schedule[];
 
+function prettyJson(s: string): string {
+  try {
+    return JSON.stringify(JSON.parse(s), null, 2);
+  } catch {
+    return s;
+  }
+}
+
+function bffScheduleToSchedule(bff: BffScheduleInfo): Schedule {
+  return {
+    id: Long.fromString(bff.id),
+    label: bff.label,
+    status: bff.status,
+    nextRun: bff.next_run ? moment.utc(bff.next_run) : null,
+    state: bff.state,
+    recurrence: bff.recurrence,
+    jobsRunning: bff.jobs_running,
+    owner: bff.owner,
+    created: moment.utc(bff.created),
+    command: bff.command ? prettyJson(bff.command) : "",
+  };
+}
+
 export function getSchedules(req: {
   status: string;
   limit: number;
 }): Promise<Schedules> {
-  // Cast int64 to string, since otherwise it gets truncated.
-  // Likewise, prettify `command` on the server since contained int64s
-  // may also be truncated.
-  let stmt = `
-    WITH schedules AS (SHOW SCHEDULES)
-    SELECT id::string, label, schedule_status, next_run,
-           state, recurrence, jobsrunning, owner,
-           created, jsonb_pretty(command) as command
-    FROM schedules
-  `;
-  const args = [];
+  const params = new URLSearchParams();
   if (req.status) {
-    stmt += " WHERE schedule_status = $" + (args.length + 1);
-    args.push(req.status);
+    params.set("status", req.status);
   }
-  stmt += " ORDER BY created DESC";
   if (req.limit) {
-    stmt += " LIMIT $" + (args.length + 1);
-    args.push(req.limit.toString());
+    params.set("limit", req.limit.toString());
   }
-  const request: SqlExecutionRequest = {
-    statements: [
-      {
-        sql: stmt,
-        arguments: args,
-      },
-    ],
-    max_result_size: LARGE_RESULT_SIZE,
-    execute: true,
-  };
-  return executeInternalSql<ScheduleColumns>(request).then(result => {
-    const txnResults = result.execution.txn_results;
-    if (sqlResultsAreEmpty(result)) {
-      // No data.
+  const queryStr = params.toString();
+  const path = queryStr
+    ? `api/v2/dbconsole/schedules/?${queryStr}`
+    : "api/v2/dbconsole/schedules/";
+  return fetchDataJSON<BffSchedulesListResponse, void>(path).then(resp => {
+    if (!resp.schedules || resp.schedules.length === 0) {
       return [];
     }
-
-    return txnResults[0].rows.map(row => {
-      return {
-        id: Long.fromString(row.id),
-        label: row.label,
-        status: row.schedule_status,
-        nextRun: row.next_run ? moment.utc(row.next_run) : null,
-        state: row.state,
-        recurrence: row.recurrence,
-        jobsRunning: row.jobsrunning,
-        owner: row.owner,
-        created: moment.utc(row.created),
-        command: JSON.parse(row.command),
-      };
-    });
+    return resp.schedules.map(bffScheduleToSchedule);
   });
 }
 
 export function getSchedule(id: Long): Promise<Schedule> {
-  const request: SqlExecutionRequest = {
-    statements: [
-      {
-        // Cast int64 to string, since otherwise it gets truncated.
-        // Likewise, prettify `command` on the server since contained int64s
-        // may also be truncated.
-        sql: `
-          WITH schedules AS (SHOW SCHEDULES)
-          SELECT id::string, label, schedule_status, next_run,
-                 state, recurrence, jobsrunning, owner,
-                 created, jsonb_pretty(command) as command
-          FROM schedules
-          WHERE ID = $1::int64
-        `,
-        arguments: [id.toString()],
-      },
-    ],
-    execute: true,
-  };
-  return executeInternalSql<ScheduleColumns>(request).then(result => {
-    const txnResults = result.execution.txn_results;
-    if (txnResults.length === 0 || !txnResults[0].rows) {
-      // No data.
-      throw new RequestError(400, "No schedule found with this ID.");
-    }
-
-    if (txnResults[0].rows.length > 1) {
-      throw new RequestError(500, "Multiple schedules found for ID.");
-    }
-    const row = txnResults[0].rows[0];
-    return {
-      id: Long.fromString(row.id),
-      label: row.label,
-      status: row.schedule_status,
-      nextRun: row.next_run ? moment.utc(row.next_run) : null,
-      state: row.state,
-      recurrence: row.recurrence,
-      jobsRunning: row.jobsrunning,
-      owner: row.owner,
-      created: moment.utc(row.created),
-      command: row.command,
-    };
-  });
+  return fetchDataJSON<BffScheduleInfo, void>(
+    `api/v2/dbconsole/schedules/${id.toString()}/`,
+  ).then(bffScheduleToSchedule);
 }

--- a/pkg/ui/workspaces/db-console/src/api/api-types.ts
+++ b/pkg/ui/workspaces/db-console/src/api/api-types.ts
@@ -52,6 +52,137 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/schedules": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List schedules
+         * @description Returns schedule information, optionally filtered by status.
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description Filter by status (ACTIVE or PAUSED) */
+                    status?: string;
+                    /** @description Maximum number of schedules to return */
+                    limit?: number;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Schedule list */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["dbconsole.SchedulesListResponse"];
+                    };
+                };
+                /** @description Invalid limit */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["dbconsole.ErrorResponse"];
+                    };
+                };
+                /** @description Internal error */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["dbconsole.ErrorResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/schedules/{schedule_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get schedule
+         * @description Returns information for a single schedule by ID.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Schedule ID */
+                    schedule_id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Schedule info */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["dbconsole.ScheduleInfo"];
+                    };
+                };
+                /** @description Invalid schedule ID */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["dbconsole.ErrorResponse"];
+                    };
+                };
+                /** @description Schedule not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["dbconsole.ErrorResponse"];
+                    };
+                };
+                /** @description Internal error */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["dbconsole.ErrorResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -102,6 +233,36 @@ export interface components {
         "dbconsole.NodesResponse": {
             /** @description Nodes contains status information for all nodes in the cluster. */
             nodes?: components["schemas"]["dbconsole.NodeInfo"][];
+        };
+        "dbconsole.ScheduleInfo": {
+            /** @description Command is the JSON representation of the schedule's execution arguments. */
+            command?: string;
+            /** @description Created is the schedule creation time in ISO 8601 format. */
+            created?: string;
+            /**
+             * @description ID is the unique identifier for the schedule. Serialized as a string to
+             *     avoid JavaScript integer precision loss for values exceeding 2^53.
+             * @example 0
+             */
+            id?: string;
+            /** @description JobsRunning is the number of currently running jobs for this schedule. */
+            jobs_running?: number;
+            /** @description Label is the name of the schedule. */
+            label?: string;
+            /** @description NextRun is the next scheduled run time in ISO 8601 format, empty if paused. */
+            next_run?: string;
+            /** @description Owner is the user who owns this schedule. */
+            owner?: string;
+            /** @description Recurrence is the cron expression or NEVER. */
+            recurrence?: string;
+            /** @description State is the schedule state from the schedule_state protobuf. */
+            state?: string;
+            /** @description Status is the schedule status (ACTIVE or PAUSED). */
+            status?: string;
+        };
+        "dbconsole.SchedulesListResponse": {
+            /** @description Schedules contains information for all matching schedules. */
+            schedules?: components["schemas"]["dbconsole.ScheduleInfo"][];
         };
     };
     responses: never;

--- a/pkg/ui/workspaces/db-console/src/api/openapi.json
+++ b/pkg/ui/workspaces/db-console/src/api/openapi.json
@@ -42,6 +42,137 @@
                     }
                 }
             }
+        },
+        "/schedules": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Returns schedule information, optionally filtered by status.",
+                "tags": [
+                    "Schedules"
+                ],
+                "summary": "List schedules",
+                "parameters": [
+                    {
+                        "description": "Filter by status (ACTIVE or PAUSED)",
+                        "name": "status",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Maximum number of schedules to return",
+                        "name": "limit",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Schedule list",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/dbconsole.SchedulesListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid limit",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/dbconsole.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/dbconsole.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/schedules/{schedule_id}": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Returns information for a single schedule by ID.",
+                "tags": [
+                    "Schedules"
+                ],
+                "summary": "Get schedule",
+                "parameters": [
+                    {
+                        "description": "Schedule ID",
+                        "name": "schedule_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Schedule info",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/dbconsole.ScheduleInfo"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid schedule ID",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/dbconsole.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Schedule not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/dbconsole.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/dbconsole.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "servers": [
@@ -128,6 +259,64 @@
                         "type": "array",
                         "items": {
                             "$ref": "#/components/schemas/dbconsole.NodeInfo"
+                        }
+                    }
+                }
+            },
+            "dbconsole.ScheduleInfo": {
+                "type": "object",
+                "properties": {
+                    "command": {
+                        "description": "Command is the JSON representation of the schedule's execution arguments.",
+                        "type": "string"
+                    },
+                    "created": {
+                        "description": "Created is the schedule creation time in ISO 8601 format.",
+                        "type": "string"
+                    },
+                    "id": {
+                        "description": "ID is the unique identifier for the schedule. Serialized as a string to\navoid JavaScript integer precision loss for values exceeding 2^53.",
+                        "type": "string",
+                        "example": "0"
+                    },
+                    "jobs_running": {
+                        "description": "JobsRunning is the number of currently running jobs for this schedule.",
+                        "type": "integer"
+                    },
+                    "label": {
+                        "description": "Label is the name of the schedule.",
+                        "type": "string"
+                    },
+                    "next_run": {
+                        "description": "NextRun is the next scheduled run time in ISO 8601 format, empty if paused.",
+                        "type": "string"
+                    },
+                    "owner": {
+                        "description": "Owner is the user who owns this schedule.",
+                        "type": "string"
+                    },
+                    "recurrence": {
+                        "description": "Recurrence is the cron expression or NEVER.",
+                        "type": "string"
+                    },
+                    "state": {
+                        "description": "State is the schedule state from the schedule_state protobuf.",
+                        "type": "string"
+                    },
+                    "status": {
+                        "description": "Status is the schedule status (ACTIVE or PAUSED).",
+                        "type": "string"
+                    }
+                }
+            },
+            "dbconsole.SchedulesListResponse": {
+                "type": "object",
+                "properties": {
+                    "schedules": {
+                        "description": "Schedules contains information for all matching schedules.",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/dbconsole.ScheduleInfo"
                         }
                     }
                 }

--- a/pkg/ui/workspaces/db-console/src/api/swagger.json
+++ b/pkg/ui/workspaces/db-console/src/api/swagger.json
@@ -39,6 +39,109 @@
                     }
                 }
             }
+        },
+        "/schedules": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Returns schedule information, optionally filtered by status.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Schedules"
+                ],
+                "summary": "List schedules",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Filter by status (ACTIVE or PAUSED)",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum number of schedules to return",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Schedule list",
+                        "schema": {
+                            "$ref": "#/definitions/dbconsole.SchedulesListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid limit",
+                        "schema": {
+                            "$ref": "#/definitions/dbconsole.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "$ref": "#/definitions/dbconsole.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/schedules/{schedule_id}": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Returns information for a single schedule by ID.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Schedules"
+                ],
+                "summary": "Get schedule",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Schedule ID",
+                        "name": "schedule_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Schedule info",
+                        "schema": {
+                            "$ref": "#/definitions/dbconsole.ScheduleInfo"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid schedule ID",
+                        "schema": {
+                            "$ref": "#/definitions/dbconsole.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Schedule not found",
+                        "schema": {
+                            "$ref": "#/definitions/dbconsole.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "$ref": "#/definitions/dbconsole.ErrorResponse"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -112,6 +215,64 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/dbconsole.NodeInfo"
+                    }
+                }
+            }
+        },
+        "dbconsole.ScheduleInfo": {
+            "type": "object",
+            "properties": {
+                "command": {
+                    "description": "Command is the JSON representation of the schedule's execution arguments.",
+                    "type": "string"
+                },
+                "created": {
+                    "description": "Created is the schedule creation time in ISO 8601 format.",
+                    "type": "string"
+                },
+                "id": {
+                    "description": "ID is the unique identifier for the schedule. Serialized as a string to\navoid JavaScript integer precision loss for values exceeding 2^53.",
+                    "type": "string",
+                    "example": "0"
+                },
+                "jobs_running": {
+                    "description": "JobsRunning is the number of currently running jobs for this schedule.",
+                    "type": "integer"
+                },
+                "label": {
+                    "description": "Label is the name of the schedule.",
+                    "type": "string"
+                },
+                "next_run": {
+                    "description": "NextRun is the next scheduled run time in ISO 8601 format, empty if paused.",
+                    "type": "string"
+                },
+                "owner": {
+                    "description": "Owner is the user who owns this schedule.",
+                    "type": "string"
+                },
+                "recurrence": {
+                    "description": "Recurrence is the cron expression or NEVER.",
+                    "type": "string"
+                },
+                "state": {
+                    "description": "State is the schedule state from the schedule_state protobuf.",
+                    "type": "string"
+                },
+                "status": {
+                    "description": "Status is the schedule status (ACTIVE or PAUSED).",
+                    "type": "string"
+                }
+            }
+        },
+        "dbconsole.SchedulesListResponse": {
+            "type": "object",
+            "properties": {
+                "schedules": {
+                    "description": "Schedules contains information for all matching schedules.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/dbconsole.ScheduleInfo"
                     }
                 }
             }


### PR DESCRIPTION
Add /api/v2/dbconsole/schedules/ and /api/v2/dbconsole/schedules/{id}
endpoints that wrap SHOW SCHEDULES in a CTE via the internal executor,
returning page-ready JSON for the DB Console schedules page.

Each schedule row includes status (derived from next_run nullability),
the running-jobs count (subquery on system.jobs), the cron recurrence,
and the execution-args command as embedded JSON. The list endpoint
supports optional status and limit query parameters. Dynamic WHERE and
LIMIT clauses are built using safesql.NewQuery to manage parameter
numbering automatically.

Int64 IDs are serialized as JSON strings (json:",string") to prevent
JavaScript precision loss for values exceeding 2^53.

-----

Replace the inline SQL-over-HTTP calls in schedulesApi.ts with
fetch calls to the new /api/v2/dbconsole/schedules/ BFF endpoints.

Epic: CRDB-58145
Release note: None