### PR TITLE
roachtest: handle first run scenario in test selector

### DIFF
--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -373,18 +373,34 @@ func testsToRun(
 
 // updateSpecForSelectiveTests is responsible for updating the test spec skip and skip details
 // based on the test categorization criteria.
+//
+// Normal Operation (with Snowflake history):
 // The following steps are performed in this function:
 //  1. Queries Snowflake for the test run data.
 //  2. The snowflake data sets "selected=true" based on the following criteria:
-//     a. the test that has failed at least once in last 30 days
+//     a. The test that has failed at least once in the last 30 days
 //     b. the test is newer than 20 days
-//     c. the test has not been run for more than 7 days
-//  2. The rest of the tests returned by snowflake are the successful tests marked as "selected=false".
-//  3. Now, an intersection of the tests that are selected by the build (specs) and tests returned by snowflake
-//     as successful is taken. This is done to select tests on the next criteria of selecting the 35% of
-//     the successful tests.
-//  4. The tests that meet the 35% criteria, are marked as "selected=true"
-//  5. All tests that are marked "selected=true" are considered for the test run.
+//     c. The test has not been run for more than 7 days
+//     d. Tests that have never run (first_run IS NULL)
+//  3. The rest of the tests returned by snowflake are the successful tests marked as "selected=false".
+//  4. Now, an intersection of the tests that are selected by the build (specs) and tests returned by snowflake
+//     as successful is taken. This is done to select tests on the next criteria of selecting
+//     --successful-test-select-pct percentage of the successful tests.
+//  5. The tests that meet the --successful-test-select-pct criteria are marked as "selected=true"
+//  6. All tests that are marked "selected=true" are considered for the test run.
+//
+// First Run Scenario (new release branch or no Snowflake history):
+// When Snowflake returns no test history for a branch (e.g., new release branch):
+//  1. Falls back to querying master branch test execution data.
+//  2. Uses master branch's test selection results to determine which tests to run.
+//  3. Skipped tests are recorded in Snowflake as "IGNORED" with first_run=NULL.
+//  4. On Day 2+, these tests get auto-selected by criterion 2d above.
+//
+// Safety Valve (applies to all scenarios):
+// A safety valve caps never-run test selection at 50% of total tests to prevent CI overload.
+// This is most impactful on Day 2 of new branches when many "IGNORED" tests from Day 1
+// are auto-selected. If >50% of tests have first_run=NULL and are selected, the safety
+// valve randomly deselects half of them, allowing gradual coverage over 2-3 days.
 func updateSpecForSelectiveTests(
 	ctx context.Context, specs []registry.TestSpec, logFunc func(format string, args ...interface{}),
 ) {

--- a/pkg/cmd/roachtest/main_test.go
+++ b/pkg/cmd/roachtest/main_test.go
@@ -169,6 +169,12 @@ func Test_updateSpecForSelectiveTests(t *testing.T) {
 			} else if strings.Contains(s.Name, "skipped") {
 				require.Equal(t, "test spec skip", s.Skip, s.Name)
 				require.Equal(t, "test spec skip test", s.SkipDetails, s.Name)
+			} else if strings.Contains(s.Name, "new_test") {
+				// Tests without Snowflake history may be skipped based on random selection
+				if s.Skip != "" {
+					require.Equal(t, "test selector", s.Skip, s.Name)
+					require.Equal(t, "test skipped because it is stable and selective-tests is set.", s.SkipDetails, s.Name)
+				}
 			} else {
 				require.Empty(t, s.Skip, s.Name)
 			}
@@ -180,7 +186,7 @@ func Test_updateSpecForSelectiveTests(t *testing.T) {
 		}
 	})
 	// We run the randomized tests 100 times for 100 randomly generated tests
-	t.Run("run with randomised data", func(t *testing.T) {
+	t.Run("run with randomized data", func(t *testing.T) {
 		iteration := 0
 		totalIterations := 100
 
@@ -211,7 +217,7 @@ func Test_updateSpecForSelectiveTests(t *testing.T) {
 				defer wg.Done()
 				dbs, mocks, err := sqlmock.New()
 				require.Nil(t, err)
-				specs, data, rows, toBeSelectedTestsMap := getRandomisedTests(t, totalTestCount)
+				specs, data, rows, toBeSelectedTestsMap := getRandomizedTests(t, totalTestCount)
 				mocks.ExpectPrepare(regexp.QuoteMeta(testselector.PreparedQuery))
 				mocks.ExpectQuery(regexp.QuoteMeta(testselector.PreparedQuery)).WillReturnRows(rows)
 				specsLengthBefore := len(specs)
@@ -280,7 +286,7 @@ func getSkippedMessage(testName string) string {
 	return fmt.Sprintf("%s skipped", testName)
 }
 
-// getRandomisedTests returns "totalTests" number of randomised tests.
+// getRandomizedTests returns "totalTests" number of randomized tests.
 // Out of the totalTests,
 // > 0-90% of the tests are added as tests in specs
 // > 10-100% of the tests are added as snowflake returned tests
@@ -291,7 +297,7 @@ func getSkippedMessage(testName string) string {
 // > The rows to be returned by the snowflake as [][]string
 // > The rows as *sqlmock.Rows
 // > The map of tests that will be selected based on the percent criteria
-func getRandomisedTests(
+func getRandomizedTests(
 	t *testing.T, totalTests int,
 ) ([]registry.TestSpec, [][]string, *sqlmock.Rows, map[string]struct{}) {
 	r, _ := randutil.NewTestRand()
@@ -311,13 +317,13 @@ func getRandomisedTests(
 	// marked as "selected=true"
 	commonSuccessTestMap := make(map[string]struct{})
 	for _, tn := range testNames[sfStart:specEnd] {
-		// all the common tests are added first. The tests marked as "selected=true" will be removed later.
+		// All the common tests are added first. The tests marked as "selected=true" will be removed later.
 		commonSuccessTestMap[tn] = struct{}{}
 	}
 	rows := sqlmock.NewRows(testselector.AllRows)
 	// data is created and returned for easier assertions
 	data := make([][]string, len(testForSF))
-	// testSelected is a randomised value which is the number of tests that are marked as "selected=true"
+	// testSelected is a randomized value which is the number of tests that are marked as "selected=true"
 	testSelected := randutil.RandIntInRange(r, 0, int(0.6*float32(len(testForSF))))
 	for i, sfn := range testForSF {
 		selected := "no"
@@ -335,8 +341,8 @@ func getRandomisedTests(
 		}
 		// generate a random duration value
 		duration := randutil.RandIntInRange(r, 0, 10000000)
-		// populate the data
-		data[i] = []string{sfn, selected, strconv.Itoa(duration + 1), lastFailureIsPreempt}
+		// populate the data with first_run timestamp (all tests in mock data have run before)
+		data[i] = []string{sfn, selected, strconv.Itoa(duration + 1), lastFailureIsPreempt, "2024-01-01"}
 		// add the same to the rows
 		rows.FromCSVString(strings.Join(data[i], ","))
 	}
@@ -425,30 +431,30 @@ func getTestSelectionMockData() ([]registry.TestSpec, *sqlmock.Rows) {
 		s.Suites = registry.Suites(registry.Nightly, registry.Weekly)
 	}
 	// data are the rows returned by snowflake. This is a 2-dimensional list of strings represent the rows
-	// and columns that are returned. Each column has values for 4 rows in sequence:
-	// "name", "selected", "avg_duration", "last_failure_is_preempt"
+	// and columns that are returned. Each column has values for 5 rows in sequence:
+	// "name", "selected", "avg_duration", "last_failure_is_preempt", "first_run"
 	data := [][]string{
-		{"t1_selected", "yes", "1", "no"},
-		{"t2_selected_preempted", "yes", "2", "yes"},
-		{"t_skipped_selected", "yes", "3", "no"},
+		{"t1_selected", "yes", "1", "no", "2024-01-01"},
+		{"t2_selected_preempted", "yes", "2", "yes", "2024-01-01"},
+		{"t_skipped_selected", "yes", "3", "no", "2024-01-01"},
 		// tests from here are selected under percent criteria
-		{"t1_success", "no", "4", "no"},
-		{"t2_success", "no", "6", "no"},
-		{"t3_success", "no", "7", "no"},
+		{"t1_success", "no", "4", "no", "2024-01-01"},
+		{"t2_success", "no", "6", "no", "2024-01-01"},
+		{"t3_success", "no", "7", "no", "2024-01-01"},
 		// test is opted out from test selection
-		{"t_opt_out", "no", "8", "no"},
-		{"t4_missing", "no", "9", "no"},
+		{"t_opt_out", "no", "8", "no", "2024-01-01"},
+		{"t4_missing", "no", "9", "no", "2024-01-01"},
 		// tests from here are skipped as these are beyond the percentage criteria
-		{"t5_success_skip_selector", "no", "10", "no"},
-		{"t6_success_skip_selector", "no", "11", "no"},
+		{"t5_success_skip_selector", "no", "10", "no", "2024-01-01"},
+		{"t6_success_skip_selector", "no", "11", "no", "2024-01-01"},
 		// the test is skipped by test selector, but is already skipped in spec
-		{"t_skipped_not_selected", "no", "12", "no"},
-		{"t7_missing", "no", "13", "no"},
-		{"t8_success_skip_selector", "no", "14", "no"},
-		{"t9_missing", "no", "15", "no"},
-		{"t10_success_skip_selector", "no", "16", "no"},
+		{"t_skipped_not_selected", "no", "12", "no", "2024-01-01"},
+		{"t7_missing", "no", "13", "no", "2024-01-01"},
+		{"t8_success_skip_selector", "no", "14", "no", "2024-01-01"},
+		{"t9_missing", "no", "15", "no", "2024-01-01"},
+		{"t10_success_skip_selector", "no", "16", "no", "2024-01-01"},
 		// test is Randomized=true, so, will always be selected even being at the last in the list
-		{"t_randomized", "no", "5", "no"},
+		{"t_randomized", "no", "5", "no", "2024-01-01"},
 	}
 	// rows are the rows that are returned by snowflake. The list of string represents the columns of each row
 	rows := sqlmock.NewRows(testselector.AllRows)

--- a/pkg/cmd/roachtest/roachtestflags/flags.go
+++ b/pkg/cmd/roachtest/roachtestflags/flags.go
@@ -92,8 +92,10 @@ var (
 
 	SuccessfulTestsSelectPct = 0.35
 	_                        = registerRunFlag(&SuccessfulTestsSelectPct, FlagInfo{
-		Name:  "successful-test-select-pct",
-		Usage: `The percent of test that should be selected from the tests that have been running successfully as per test selection. Default is 0.35`,
+		Name: "successful-test-select-pct",
+		Usage: `Percentage (0.0-1.0) of stable, successful tests to select from those marked as
+		selected=false by Snowflake. Default is 0.35 (35%).
+		See pkg/cmd/roachtest/testselector/README.md for details.`,
 	})
 
 	Username string = os.Getenv("ROACHPROD_USER")

--- a/pkg/cmd/roachtest/testselector/README.md
+++ b/pkg/cmd/roachtest/testselector/README.md
@@ -1,0 +1,197 @@
+# Test Selector
+
+The test selector reduces CI runtime by intelligently selecting which tests to run in nightly builds, while ensuring all tests eventually get coverage.
+
+## Overview
+
+The test selector queries Snowflake for historical test execution data and selects tests based on:
+1. Recent failures
+2. Recently added tests
+3. Tests that haven't run recently
+4. A percentage of stable, successful tests
+
+## Selection Criteria
+
+### Tests Always Selected (by Snowflake SQL query)
+
+The following tests are automatically marked as `selected=true` by the Snowflake query:
+
+1. **Failed recently**: Tests that failed at least once in the last 30 days
+2. **New tests**: Tests first run within the last 20 days (on master branch only)
+3. **Not run recently**: Tests that haven't run in the last 7 days
+4. **Never run**: Tests with `first_run IS NULL` (no Snowflake history)
+
+### Tests Selected Based on Percentage (by roachtest)
+
+After Snowflake returns results, roachtest applies additional selection:
+
+1. **Successful tests**: Of the tests marked `selected=false` by Snowflake (stable, successful tests), select `--successful-test-select-pct` percentage (default 35%)
+2. Tests are selected in the order returned by Snowflake (sorted by last run time)
+
+### Tests Never Skipped
+
+The following tests bypass test selection and always run:
+
+1. **Randomized tests**: Tests with `Randomized=true`
+2. **Opt-out tests**: Tests with `TestSelectionOptOutSuites` matching the current suite
+
+## Command-Line Flags
+
+### `--selective-tests` (default: true)
+Enable or disable test selection entirely.
+- `--selective-tests=true`: Apply test selection logic
+- `--selective-tests=false`: Run all tests
+
+### `--successful-test-select-pct` (default: 0.35)
+Controls what percentage of successful tests to run. Applies to tests marked `selected=false` by Snowflake.
+
+Valid range: 0.0 to 1.0
+
+## First Run Scenario
+
+When a new release branch is created, Snowflake has no execution history for that branch. The test selector handles this gracefully by falling back to master branch data.
+
+### Day 1: Master Branch Fallback
+1. Snowflake query for `release-24.3` returns zero results
+2. Test selector automatically queries master branch data
+3. Uses master's test selection results to determine which tests to run
+4. Example: If master selects 480/1000 tests based on its criteria, the same 480 tests run on the new release branch
+
+### Day 2+: Auto-Selection + Safety Valve
+1. Tests that ran on Day 1 now have Snowflake history on the release branch
+2. Tests that were skipped on Day 1 still have `first_run IS NULL` on the release branch
+3. Snowflake auto-selects these never-run tests
+4. **Safety valve**: If never-run selections exceed 50% of total tests, randomly deselect half of them
+   - Prevents CI overload from too many auto-selected tests
+   - Example: 520 never-run tests (52%) > 50% threshold → deselect 260 tests → 260 selected
+
+### Day 3+: Gradual Coverage
+1. Remaining never-run tests continue to cycle through selection
+2. Within 2-3 days, all tests achieve coverage on the new branch
+3. Normal selection criteria take over
+
+### Safety Valve Details
+
+The `maxNeverRunSelectedPct` constant (50%) prevents CI overload:
+- Only applies to tests with `first_run IS NULL`
+- Triggers when never-run selected tests exceed 50% of total tests
+- Randomly deselects half of the never-run tests
+- Hardcoded because:
+  - Only relevant for first few days of new branches
+  - Users can use `--selective-tests=false` to run all tests
+  - Users can increase `--successful-test-select-pct` for more coverage
+
+## Branch-Specific Behavior
+
+### Master Branch
+- `firstRunOn` = 20 days: Tests newer than 20 days are auto-selected
+- Normal test selection criteria apply
+
+### Release Branches
+- `firstRunOn` = 0 days: Disables "new test" criterion
+- Prevents marking all tests as "new" when branch is created
+- Falls back to master branch data if no Snowflake history exists
+
+The branch is detected via `TC_BUILD_BRANCH` environment variable, defaulting to "master".
+
+## Example Scenarios
+
+### Scenario 1: Normal Nightly Run (Master Branch)
+- Total tests: 1000
+- Snowflake auto-selects: 200 (failures + new + not run recently)
+- Successful tests: 800 (marked `selected=false`)
+- Additional selection: 800 × 35% = 280 successful tests
+- **Total selected: 480 tests** (200 + 280)
+
+### Scenario 2: New Release Branch Day 1
+- Total tests: 1000
+- Snowflake results for `release-24.3`: 0 (no history)
+- Falls back to master branch data
+- Uses master's selection: 480 tests (same as master)
+- **Total selected: 480 tests**
+
+### Scenario 3: New Release Branch Day 2
+- Total tests: 1000
+- Tests with history (ran Day 1 on release branch): 480
+- Tests never run on release branch (Day 1 skipped): 520
+- Snowflake auto-selects: 520 never-run tests (52%)
+- Safety valve triggers: 52% > 50%
+- Deselect: 520 / 2 = 260 tests
+- **Total selected: 260 never-run + normal selection from tests with history**
+
+### Scenario 4: Test Opted Out of Nightly
+```go
+registry.TestSpec{
+    Name: "acceptance/version-upgrade",
+    TestSelectionOptOutSuites: registry.Suites(registry.Nightly),
+    // ... other fields
+}
+```
+This test always runs in Nightly suite, bypassing selection logic.
+
+## Implementation Details
+
+### Code Structure
+
+**pkg/cmd/roachtest/testselector/selector.go**:
+- `CategoriseTests()`: Queries Snowflake; falls back to master if no results
+- `querySnowflake()`: Helper to query Snowflake with given parameters
+- `applySafetyValve()`: Caps never-run test selection at 50%
+
+**pkg/cmd/roachtest/main.go**:
+- `updateSpecForSelectiveTests()`: Applies percentage selection to successful tests
+- `testShouldBeSkipped()`: Determines if a test should be skipped
+
+### Snowflake Query
+
+The query is defined in `snowflake_query.sql`. It returns:
+- `name`: Test name
+- `selected`: 'yes' or 'no' based on auto-selection criteria
+- `avg_duration`: Average test duration in milliseconds
+- `last_failure_is_preempt`: Whether last failure was infrastructure-related
+- `first_run`: First execution timestamp (NULL if never run)
+
+### Test Spec Fields
+
+**Set by test selector**:
+- `Skip`: Set to "test selector" for skipped tests
+- `SkipDetails`: Explanation of why test was skipped
+- `Stats`: Average duration and preemption status
+
+**Read by test selector**:
+- `Randomized`: If true, test always runs
+- `TestSelectionOptOutSuites`: Suites where test always runs
+
+## Debugging
+
+### Verbose Logging
+
+Run with verbose mode to see selection details:
+```bash
+roachtest run --selective-tests --successful-test-select-pct=0.5 -v
+```
+
+Logs will show:
+- `X selected out of Y successful tests` (percentage selection)
+- `X out of Y tests selected for the run` (final count)
+
+### Common Issues
+
+**All tests skipped**:
+- Check `--selective-tests=false` to disable selection
+- Verify Snowflake credentials are set (`SNOWFLAKE_USER`, `SNOWFLAKE_PVT_KEY`)
+
+**Too many tests running**:
+- Lower `--successful-test-select-pct` (e.g., 0.2 for 20%)
+- On new branches, behavior matches master for first day
+
+**Specific test always skipped**:
+- Check if test is randomized or opted out
+- Verify test appears in Snowflake results
+- Test may be very stable and not selected in master branch data
+
+## References
+
+- Main implementation: `pkg/cmd/roachtest/testselector/selector.go`
+- Integration: `pkg/cmd/roachtest/main.go:updateSpecForSelectiveTests`
+- Tests: `pkg/cmd/roachtest/main_test.go:Test_updateSpecForSelectiveTests`

--- a/pkg/cmd/roachtest/testselector/selector.go
+++ b/pkg/cmd/roachtest/testselector/selector.go
@@ -13,6 +13,7 @@ import (
 	_ "embed"
 	"encoding/pem"
 	"fmt"
+	"math/rand"
 	"os"
 	"strconv"
 
@@ -39,10 +40,15 @@ const (
 	DataSelectedIndex = 1
 	DataDurationIndex = 2
 	DataLastPreempted = 3
+	DataFirstRunIndex = 4
+
+	// maxNeverRunSelectedPct is the maximum percentage of tests that can be auto-selected
+	// due to first_run being null (never run). This safety valve prevents CI overload.
+	maxNeverRunSelectedPct = 0.5
 )
 
 // AllRows are all the rows returned by snowflake. This is used for testing
-var AllRows = []string{"name", "selected", "avg_duration", "last_failure_is_preempt"}
+var AllRows = []string{"name", "selected", "avg_duration", "last_failure_is_preempt", "first_run"}
 
 //go:embed snowflake_query.sql
 var PreparedQuery string
@@ -57,41 +63,110 @@ var suites = map[string]string{
 
 // TestDetails has the details of the test as fetched from snowflake
 type TestDetails struct {
-	Name                 string // test name
-	Selected             bool   // whether a test is Selected or not
-	AvgDurationInMillis  int64  // average duration of the test
-	LastFailureIsPreempt bool   // last failure is due to a VM preemption
+	Name                 string  // test name
+	Selected             bool    // whether a test is Selected or not
+	AvgDurationInMillis  int64   // average duration of the test
+	LastFailureIsPreempt bool    // last failure is due to a VM preemption
+	FirstRun             *string // first run timestamp (nil if never run)
 }
 
 // SelectTestsReq is the request for CategoriseTests
 type SelectTestsReq struct {
-	ForPastDays int // number of days data to consider for test selection
-	FirstRunOn  int // number of days to consider for the first time the test is run
-	LastRunOn   int // number of days to consider for the last time the test is run
+	currentBranch string // the current branch for which the selection is being done
 
-	Cloud spec.Cloud // the cloud where the tests were run
-	Suite string     // the test suite for which the selection is done
+	forPastDays int // number of days data to consider for test selection
+	firstRunOn  int // number of days to consider for the first time the test is run
+	lastRunOn   int // number of days to consider for the last time the test is run
+
+	cloud spec.Cloud // the cloud where the tests were run
+	suite string     // the test suite for which the selection is done
 }
 
 // NewDefaultSelectTestsReq returns a new SelectTestsReq with default values populated
 func NewDefaultSelectTestsReq(cloud spec.Cloud, suite string) *SelectTestsReq {
+	currentBranch := os.Getenv("TC_BUILD_BRANCH")
+	// Default to master if no TC branch env var is set.
+	if currentBranch == "" {
+		currentBranch = "master"
+	}
+
+	// On non-master branches (e.g., release branches), disable the FirstRunOn
+	// criterion by setting it to 0. This prevents marking all tests as "new"
+	// when a release branch is first created, since they won't have execution
+	// history on that branch yet.
+	firstRunOn := defaultFirstRunOn
+	if currentBranch != "master" {
+		firstRunOn = 0
+	}
+
 	return &SelectTestsReq{
-		ForPastDays: defaultForPastDays,
-		FirstRunOn:  defaultFirstRunOn,
-		LastRunOn:   defaultLastRunOn,
-		Cloud:       cloud,
-		Suite:       suite,
+		currentBranch: currentBranch,
+		forPastDays:   defaultForPastDays,
+		firstRunOn:    firstRunOn,
+		lastRunOn:     defaultLastRunOn,
+		cloud:         cloud,
+		suite:         suite,
 	}
 }
 
-// CategoriseTests returns the tests categorised based on the snowflake query
+// CategoriseTests returns the tests categorised based on the snowflake query.
 // The tests are Selected by selector.go based on certain criteria:
-// 1. the number of time a test has been successfully running
-// 2. the test is new
-// 3. the test has not been run for a while
-// It returns all the tests. The selected tests have the value TestDetails.Selected as true
-// The tests are sorted by the last run and is used for further test selection criteria. So, the order should not be modified.
+// 1. Tests that have failed recently
+// 2. Tests that are new (within firstRunOn days)
+// 3. Tests that have not been run for a while (lastRunOn days)
+// 4. Tests that have never run (first_run IS NULL in Snowflake)
+//
+// It returns all the tests with TestDetails.Selected as true for selected tests.
+// The tests are sorted by the last run and is used for further test selection criteria,
+// so the order should not be modified.
+//
+// For first run scenarios (e.g., new release branch with no Snowflake history),
+// falls back to querying master branch data to determine test selection.
+//
+// A safety valve is applied in all scenarios to prevent too many never-run tests
+// from being selected at once. See applySafetyValve for details.
 func CategoriseTests(ctx context.Context, req *SelectTestsReq) ([]*TestDetails, error) {
+	allTestDetails, err := querySnowflake(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Handle first run scenario: if Snowflake returned no test history for the current branch
+	// (e.g., new release branch), fall back to querying master branch data.
+	//
+	// How this achieves full coverage over multiple days:
+	// Day 1: Uses master's test selection (e.g., 480/1000 tests). The 480 selected tests run
+	//        and get recorded in Snowflake. The 520 skipped tests are also recorded in Snowflake
+	//        as "IGNORED" entries with first_run=NULL (never actually executed).
+	// Day 2+: Snowflake now has 1000 entries for this branch. The SQL query auto-selects the 520
+	//         tests with first_run=NULL. Safety valve caps this to prevent overload, and tests
+	//         gradually cycle through until all achieve coverage within 2-3 days.
+	if len(allTestDetails) == 0 && req.currentBranch != "master" {
+		masterReq := &SelectTestsReq{
+			currentBranch: "master",
+			forPastDays:   req.forPastDays,
+			firstRunOn:    defaultFirstRunOn, // use master's firstRunOn setting
+			lastRunOn:     req.lastRunOn,
+			cloud:         req.cloud,
+			suite:         req.suite,
+		}
+		allTestDetails, err = querySnowflake(ctx, masterReq)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Apply safety valve to prevent too many never-run tests from being selected.
+	// This applies to all scenarios (normal operation, first-run, etc.) but is most
+	// impactful on Day 2 of new branches when many skipped tests from Day 1 are
+	// auto-selected due to first_run IS NULL.
+	applySafetyValve(allTestDetails, maxNeverRunSelectedPct)
+
+	return allTestDetails, nil
+}
+
+// querySnowflake queries Snowflake for test execution history and returns test details.
+func querySnowflake(ctx context.Context, req *SelectTestsReq) ([]*TestDetails, error) {
 	db, err := getConnect(ctx)
 	if err != nil {
 		return nil, err
@@ -102,15 +177,10 @@ func CategoriseTests(ctx context.Context, req *SelectTestsReq) ([]*TestDetails, 
 		return nil, err
 	}
 	defer func() { _ = statement.Close() }()
-	// get the current branch from the teamcity environment
-	currentBranch := os.Getenv("TC_BUILD_BRANCH")
-	if currentBranch == "" {
-		currentBranch = "master"
-	}
 	// add the parameters in sequence
-	rows, err := statement.QueryContext(ctx, req.ForPastDays*-1, currentBranch,
-		fmt.Sprintf("%%%s - %s%%", suites[req.Suite], req.Cloud),
-		req.FirstRunOn*-1, req.LastRunOn*-1)
+	rows, err := statement.QueryContext(ctx, req.forPastDays*-1, req.currentBranch,
+		fmt.Sprintf("%%%s - %s%%", suites[req.suite], req.cloud),
+		req.firstRunOn*-1, req.lastRunOn*-1)
 	if err != nil {
 		return nil, err
 	}
@@ -140,15 +210,77 @@ func CategoriseTests(ctx context.Context, req *SelectTestsReq) ([]*TestDetails, 
 		// 1. whether a test is Selected or not
 		// 2. average duration of the test
 		// 3. last failure is due to an infra flake
+		// 4. first run timestamp (empty string if never run)
+		var firstRun *string
+		if testInfos[DataFirstRunIndex] != "" {
+			firstRun = &testInfos[DataFirstRunIndex]
+		}
 		testDetails := &TestDetails{
 			Name:                 testInfos[DataTestNameIndex],
 			Selected:             testInfos[DataSelectedIndex] != "no",
 			AvgDurationInMillis:  getDuration(testInfos[DataDurationIndex]),
 			LastFailureIsPreempt: testInfos[DataLastPreempted] == "yes",
+			FirstRun:             firstRun,
 		}
 		allTestDetails = append(allTestDetails, testDetails)
 	}
+
 	return allTestDetails, nil
+}
+
+// applySafetyValve ensures that no more than maxPct of tests are auto-selected
+// due to first_run being null (never run). If exceeded, it randomly deselects
+// half of the never-run tests to prevent CI overload.
+//
+// Example scenario with 100 tests and maxPct=0.5 on a new release branch:
+//
+// Day 1 (new branch, uses master branch fallback):
+//   - Master selects 48 tests → 48 tests run on new branch, 52 skipped
+//   - All 100 tests recorded in Snowflake: 48 with first_run set, 52 as "IGNORED" with first_run=NULL
+//
+// Day 2 (Snowflake has entries from Day 1):
+//   - 48 tests that ran: have first_run set → go through normal selection criteria
+//   - 52 tests that were skipped: first_run IS NULL in Snowflake → auto-selected by SQL
+//   - Safety valve triggers: 52/100 = 52% > 50% threshold
+//   - Randomly deselects half of never-run tests: 52/2 = 26 tests deselected
+//   - Result: 26 never-run tests selected + existing selections = controlled load
+//
+// Day 3:
+//   - Remaining ~26 tests with first_run=NULL are auto-selected
+//   - 26/100 = 26% < 50% threshold → safety valve does not trigger
+//   - All tests achieve coverage by Day 3 while respecting the 50% safety limit
+//
+// Note: Skipped tests are recorded in Snowflake as "IGNORED" entries, which is why
+// they appear in Day 2+ queries and can be auto-selected based on first_run IS NULL.
+func applySafetyValve(allTestDetails []*TestDetails, maxPct float64) {
+	totalTests := len(allTestDetails)
+	if totalTests == 0 {
+		return
+	}
+
+	// Find tests that were auto-selected due to first_run being null
+	var neverRunSelected []*TestDetails
+	for _, td := range allTestDetails {
+		if td.Selected && td.FirstRun == nil {
+			neverRunSelected = append(neverRunSelected, td)
+		}
+	}
+
+	// Check if they exceed the threshold
+	selectedPct := float64(len(neverRunSelected)) / float64(totalTests)
+	if selectedPct <= maxPct {
+		return // within limits
+	}
+
+	// Exceeds threshold: randomly deselect half of them
+	numToDeselect := len(neverRunSelected) / 2
+	rand.Shuffle(len(neverRunSelected), func(i, j int) {
+		neverRunSelected[i], neverRunSelected[j] = neverRunSelected[j], neverRunSelected[i]
+	})
+
+	for i := 0; i < numToDeselect; i++ {
+		neverRunSelected[i].Selected = false
+	}
 }
 
 // getDuration extracts the duration from the snowflake query duration field

--- a/pkg/cmd/roachtest/testselector/selector_test.go
+++ b/pkg/cmd/roachtest/testselector/selector_test.go
@@ -68,11 +68,11 @@ func TestCategoriseTests(t *testing.T) {
 		mock.ExpectPrepare(regexp.QuoteMeta(PreparedQuery))
 		mock.ExpectQuery(regexp.QuoteMeta(PreparedQuery)).WillReturnError(fmt.Errorf("failed to execute query"))
 		tds, err := CategoriseTests(context.Background(), &SelectTestsReq{
-			ForPastDays: 1,
-			FirstRunOn:  2,
-			LastRunOn:   3,
-			Cloud:       spec.AWS,
-			Suite:       "unit test",
+			forPastDays: 1,
+			firstRunOn:  2,
+			lastRunOn:   3,
+			cloud:       spec.AWS,
+			suite:       "unit test",
 		})
 		require.Nil(t, tds)
 		require.NotNil(t, err)
@@ -83,26 +83,26 @@ func TestCategoriseTests(t *testing.T) {
 		mock.ExpectPrepare(regexp.QuoteMeta(PreparedQuery))
 		rows := sqlmock.NewRows(AllRows)
 		data := [][]string{
-			{"t1", "no", "12345", "no"},
-			{"t2", "no", "12345", "no"},
-			{"t3", "no", "12345", "yes"},
-			{"t4", "no", "12345", "no"},
-			{"t5", "yes", "12345", "no"},
-			{"t6", "yes", "12345", "no"},
-			{"t7", "yes", "12345", "no"},
-			{"t8", "yes", "12345", "no"},
-			{"t9", "yes", "12345", "no"},
+			{"t1", "no", "12345", "no", "2026-01-01"},
+			{"t2", "no", "12345", "no", "2026-01-02"},
+			{"t3", "no", "12345", "yes", "2026-01-03"},
+			{"t4", "no", "12345", "no", ""},
+			{"t5", "yes", "12345", "no", "2026-01-05"},
+			{"t6", "yes", "12345", "no", "2026-01-06"},
+			{"t7", "yes", "12345", "no", "2026-01-07"},
+			{"t8", "yes", "12345", "no", "2026-01-08"},
+			{"t9", "yes", "12345", "no", "2026-01-09"},
 		}
 		for _, ds := range data {
 			rows.FromCSVString(strings.Join(ds, ","))
 		}
 		mock.ExpectQuery(regexp.QuoteMeta(PreparedQuery)).WillReturnRows(rows)
 		tds, err := CategoriseTests(context.Background(), &SelectTestsReq{
-			ForPastDays: 1,
-			FirstRunOn:  2,
-			LastRunOn:   3,
-			Cloud:       spec.AWS,
-			Suite:       "unit test",
+			forPastDays: 1,
+			firstRunOn:  2,
+			lastRunOn:   3,
+			cloud:       spec.AWS,
+			suite:       "unit test",
 		})
 		require.NotNil(t, tds)
 		require.Nil(t, err)
@@ -114,7 +114,140 @@ func TestCategoriseTests(t *testing.T) {
 			require.Equal(t, d[DataSelectedIndex] != "no", td.Selected)
 			require.Equal(t, getDuration(d[DataDurationIndex]), td.AvgDurationInMillis)
 			require.Equal(t, d[DataLastPreempted] == "yes", td.LastFailureIsPreempt)
+			if d[DataFirstRunIndex] != "" {
+				require.NotNil(t, td.FirstRun)
+				require.Equal(t, d[DataFirstRunIndex], *td.FirstRun)
+			} else {
+				require.Nil(t, td.FirstRun)
+			}
 		}
+	})
+	t.Run("first run with no snowflake history falls back to master", func(t *testing.T) {
+		// Track how many connections are made
+		connectionCount := 0
+		var currentMock sqlmock.Sqlmock
+		var currentDb *gosql.DB
+
+		// Override connector to track connections
+		SqlConnectorFunc = func(driverName, dataSourceName string) (*gosql.DB, error) {
+			connectionCount++
+			if connectionCount == 1 {
+				// First connection for release branch query
+				currentDb, currentMock, err = sqlmock.New()
+				require.Nil(t, err)
+				currentMock.ExpectPrepare(regexp.QuoteMeta(PreparedQuery))
+				emptyRows := sqlmock.NewRows(AllRows)
+				currentMock.ExpectQuery(regexp.QuoteMeta(PreparedQuery)).WillReturnRows(emptyRows)
+			} else if connectionCount == 2 {
+				// Second connection for master branch fallback
+				currentDb, currentMock, err = sqlmock.New()
+				require.Nil(t, err)
+				currentMock.ExpectPrepare(regexp.QuoteMeta(PreparedQuery))
+				masterRows := sqlmock.NewRows(AllRows)
+				masterData := [][]string{
+					{"acceptance", "yes", "12345", "no", "2026-01-01"},
+					{"backup", "no", "12345", "no", "2026-01-02"},
+					{"import", "yes", "12345", "no", "2026-01-03"},
+					{"kv", "no", "12345", "no", "2026-01-04"},
+					{"schemachange", "yes", "12345", "no", "2026-01-05"},
+				}
+				for _, ds := range masterData {
+					masterRows.FromCSVString(strings.Join(ds, ","))
+				}
+				currentMock.ExpectQuery(regexp.QuoteMeta(PreparedQuery)).WillReturnRows(masterRows)
+			}
+			return currentDb, nil
+		}
+
+		tds, err := CategoriseTests(context.Background(), &SelectTestsReq{
+			currentBranch: "release-24.3", // not master
+			forPastDays:   1,
+			firstRunOn:    0, // disabled for non-master
+			lastRunOn:     3,
+			cloud:         spec.AWS,
+			suite:         "unit test",
+		})
+		require.Nil(t, err)
+		require.NotNil(t, tds)
+		require.Equal(t, 2, connectionCount, "Should make two connections: one for release branch, one for master")
+
+		// Should have 5 tests from master branch
+		require.Equal(t, 5, len(tds))
+
+		// Verify test names and selection match master data
+		require.Equal(t, "acceptance", tds[0].Name)
+		require.True(t, tds[0].Selected)
+		require.Equal(t, "backup", tds[1].Name)
+		require.False(t, tds[1].Selected)
+		require.Equal(t, "import", tds[2].Name)
+		require.True(t, tds[2].Selected)
+		require.Equal(t, "kv", tds[3].Name)
+		require.False(t, tds[3].Selected)
+		require.Equal(t, "schemachange", tds[4].Name)
+		require.True(t, tds[4].Selected)
+
+		// Restore original connector
+		SqlConnectorFunc = func(driverName, dataSourceName string) (*gosql.DB, error) {
+			dsn, err := getDSN()
+			require.Equal(t, "snowflake", driverName)
+			require.Equal(t, dsn, dataSourceName)
+			return db, err
+		}
+	})
+	t.Run("safety valve triggers when too many never-run tests selected", func(t *testing.T) {
+		db, mock, err = sqlmock.New()
+		require.Nil(t, err)
+		mock.ExpectPrepare(regexp.QuoteMeta(PreparedQuery))
+		rows := sqlmock.NewRows(AllRows)
+		// Create scenario where 8 out of 10 tests have first_run=null and are selected (80%)
+		// This exceeds the 50% threshold, so safety valve should trigger
+		data := [][]string{
+			{"t1", "yes", "0", "no", ""},                // never run, selected
+			{"t2", "yes", "0", "no", ""},                // never run, selected
+			{"t3", "yes", "0", "no", ""},                // never run, selected
+			{"t4", "yes", "0", "no", ""},                // never run, selected
+			{"t5", "yes", "0", "no", ""},                // never run, selected
+			{"t6", "yes", "0", "no", ""},                // never run, selected
+			{"t7", "yes", "0", "no", ""},                // never run, selected
+			{"t8", "yes", "0", "no", ""},                // never run, selected
+			{"t9", "no", "12345", "no", "2026-01-01"},   // has run, not selected
+			{"t10", "yes", "12345", "no", "2026-01-02"}, // has run, selected
+		}
+		for _, ds := range data {
+			rows.FromCSVString(strings.Join(ds, ","))
+		}
+		mock.ExpectQuery(regexp.QuoteMeta(PreparedQuery)).WillReturnRows(rows)
+		tds, err := CategoriseTests(context.Background(), &SelectTestsReq{
+			forPastDays: 1,
+			firstRunOn:  2,
+			lastRunOn:   3,
+			cloud:       spec.AWS,
+			suite:       "unit test",
+		})
+		require.Nil(t, err)
+		require.NotNil(t, tds)
+		require.Equal(t, len(data), len(tds))
+
+		// Count never-run tests that are still selected after safety valve
+		neverRunSelected := 0
+		for _, td := range tds {
+			if td.Selected && td.FirstRun == nil {
+				neverRunSelected++
+			}
+		}
+
+		// Safety valve should have deselected half of the 8 never-run tests (4 deselected)
+		// So we should have 4 never-run selected tests remaining
+		// Total selected = 4 (never-run) + 1 (t10 has run) = 5
+		require.Equal(t, 4, neverRunSelected, "Safety valve should deselect half of never-run tests")
+
+		totalSelected := 0
+		for _, td := range tds {
+			if td.Selected {
+				totalSelected++
+			}
+		}
+		require.Equal(t, 5, totalSelected, "Total selected should be 5 after safety valve")
 	})
 	t.Run("expect failure due to invalid private key", func(t *testing.T) {
 		SqlConnectorFunc = nil
@@ -128,12 +261,30 @@ func TestCategoriseTests(t *testing.T) {
 }
 
 func TestNewDefaultSelectTestsReq(t *testing.T) {
-	req := NewDefaultSelectTestsReq(spec.Azure, "ut suite")
-	require.Equal(t, spec.Azure, req.Cloud)
-	require.Equal(t, "ut suite", req.Suite)
-	require.Equal(t, defaultForPastDays, req.ForPastDays)
-	require.Equal(t, defaultFirstRunOn, req.FirstRunOn)
-	require.Equal(t, defaultLastRunOn, req.LastRunOn)
+	t.Run("defaults to master branch behavior", func(t *testing.T) {
+		// No TC_BUILD_BRANCH env var set
+		_ = os.Unsetenv("TC_BUILD_BRANCH")
+
+		req := NewDefaultSelectTestsReq(spec.Azure, "ut suite")
+		require.Equal(t, spec.Azure, req.cloud)
+		require.Equal(t, "ut suite", req.suite)
+		require.Equal(t, defaultForPastDays, req.forPastDays)
+		require.Equal(t, defaultFirstRunOn, req.firstRunOn, "master branch should use defaultFirstRunOn")
+		require.Equal(t, defaultLastRunOn, req.lastRunOn)
+		require.Equal(t, "master", req.currentBranch)
+	})
+
+	t.Run("non-master branch disables firstRunOn", func(t *testing.T) {
+		// Set to a release branch
+		_ = os.Setenv("TC_BUILD_BRANCH", "release-24.3")
+		defer func() { _ = os.Unsetenv("TC_BUILD_BRANCH") }()
+
+		req := NewDefaultSelectTestsReq(spec.GCE, "nightly")
+		require.Equal(t, spec.GCE, req.cloud)
+		require.Equal(t, "nightly", req.suite)
+		require.Equal(t, 0, req.firstRunOn, "non-master branch should disable firstRunOn")
+		require.Equal(t, "release-24.3", req.currentBranch)
+	})
 }
 
 func Test_getSFCreds(t *testing.T) {

--- a/pkg/cmd/roachtest/testselector/snowflake_query.sql
+++ b/pkg/cmd/roachtest/testselector/snowflake_query.sql
@@ -55,11 +55,14 @@ select
            -- test is never run - we always select
            -- test is not run by test selector in the last run
             -- The test should not be selected by default in this case and should be selected based on the sorted unselected list
-         (last_status='UNKNOWN' and recent_ignore_details!='test selector')
+         (last_status='UNKNOWN' and recent_ignore_details!='test selector') or
+          -- test has never run at all - auto-select to ensure coverage within 2 days
+         first_run is null
          then 'yes' else 'no' end as selected,
   -- average duration - this is set to 0 if the test is never run (total_successful_runs=0)
   case when total_successful_runs > 0 then total_duration/total_successful_runs else 0 end as avg_duration,
   -- indicates the last failure was due to infra flake
   case when recent_details like '%VMs preempted during the test run%' then 'yes' else 'no' end as last_failure_is_preeempt,
+  first_run,
 from test_stats, ts
 order by selected desc, last_run -- selected="yes" appears first. Rest of the tests are sorted by the last run.


### PR DESCRIPTION
Previously, when a new release branch was cut or when tests had no Snowflake execution history, all tests would be marked as "selected" and run. This defeated the purpose of test selection and caused all tests to run for approximately 20 consecutive nightly runs until sufficient history was built up.

This change adds logic to handle tests without Snowflake history by falling back to master branch data. When Snowflake returns no execution history for a branch (e.g., new release branch), the test selector automatically queries master branch test data and uses those selection results. This ensures consistent test selection behavior from day one of a new branch.

Additionally, the SQL query now auto-selects tests that have never run (first_run IS NULL) to ensure full coverage within 2-3 days. A safety valve prevents CI overload by capping never-run test selection at 50% of total tests, randomly deselecting half if the threshold is exceeded.

Changes:
- Removed AllTestNames and SelectPct fields from SelectTestsReq
- Made all SelectTestsReq fields private to enforce construction via NewDefaultSelectTestsReq and prevent direct field mutation
- Added currentBranch as a private field to avoid request mutation
- Moved branch detection and FirstRunOn logic from CategoriseTests to NewDefaultSelectTestsReq constructor for better encapsulation
- Improved branch detection logic: added explicit comment and blank line for better code separation, inverted conditional for clarity
- Modified CategoriseTests to fall back to master branch query when no results are found for the current branch
- Extracted query logic into querySnowflake helper function
- Updated updateSpecForSelectiveTests to remove parameters no longer needed (allTestNames, selectPct)
- Added first_run IS NULL condition to SQL query to auto-select tests that have never run, ensuring 2-3 day coverage
- Added FirstRun field to TestDetails to track test execution history
- Implemented applySafetyValve function with 50% threshold to prevent CI overload when too many never-run tests are auto-selected
- Enhanced TestNewDefaultSelectTestsReq with two test cases covering both master and non-master branch behavior
- Added comprehensive tests including master branch fallback validation
- Updated README.md with detailed explanation of first-run scenario
- Updated flag documentation to clarify --successful-test-select-pct

This ensures that on first run or for new branches, test selection
uses master branch data rather than random selection, providing
consistent and predictable test coverage. Full test coverage is
achieved within 2-3 days with the safety valve preventing overload.

Resolves: #155343
Epic: CRDB-55391

Release note: None