### PR TITLE
backuptestutils: add fast restore metamorphic helpers

### DIFF
--- a/pkg/backup/backup_tenant_test.go
+++ b/pkg/backup/backup_tenant_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/backup/backuptestutils"
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/multiregionccl/multiregionccltestutils"
 	_ "github.com/cockroachdb/cockroach/pkg/cloud/impl" // register cloud storage providers
@@ -34,6 +35,9 @@ import (
 func TestBackupTenantImportingTable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	// TODO(at): enable once LinkExternalSSTable is permitted for secondary tenants.
+	backuptestutils.DisableFastRestoreForTest(t)
 
 	ctx := context.Background()
 	tc := testcluster.StartTestCluster(t, 1,
@@ -134,6 +138,9 @@ func TestTenantBackupMultiRegionDatabases(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	skip.UnderRace(t, "test is too heavy to run under stress")
+
+	// TODO(at): enable once LinkExternalSSTable is permitted for secondary tenants.
+	backuptestutils.DisableFastRestoreForTest(t)
 
 	tc, db, cleanup := multiregionccltestutils.TestingCreateMultiRegionCluster(
 		t, 3 /*numServers*/, base.TestingKnobs{},

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -119,6 +119,10 @@ import (
 
 func init() {
 	cloud.RegisterKMSFromURIFactory(MakeTestKMS, "testkms")
+
+	// Wire the OR metamorphic into the restore planner. When OnlineRestore is
+	// enabled, all RESTORE statements exercise the online restore code path.
+	testFastRestore = func() bool { return backuptestutils.FastRestore }
 }
 
 func makeTableSpan(codec keys.SQLCodec, tableID uint32) roachpb.Span {
@@ -164,6 +168,9 @@ func TestBackupRestoreStatementResult(t *testing.T) {
 func TestBackupRestoreSingleUserfile(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	// OR does not support userfile URIs.
+	backuptestutils.DisableFastRestoreForTest(t)
 
 	const numAccounts = 1000
 	ctx := context.Background()
@@ -450,6 +457,9 @@ func TestBackupRestoreExecLocality(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	// TODO(at): restructure test to work with OR metamorphic.
+	backuptestutils.DisableFastRestoreForTest(t)
+
 	skip.UnderRace(t, "too slow")
 
 	const numAccounts = 1000
@@ -699,6 +709,9 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	skip.UnderRace(t, "this test is heavyweight and is not expected to reveal any direct bugs under stress race")
+
+	// TODO(at): restructure test to work with OR metamorphic.
+	backuptestutils.DisableFastRestoreForTest(t)
 
 	const numAccounts = 2
 	_, sqlDB, tmpDir, cleanupFn := backupRestoreTestSetup(t, multiNode, numAccounts, InitManualReplication)
@@ -985,12 +998,27 @@ func verifyRestoreData(
 
 	var unused string
 	var restoredRows int64
-	sqlDB.QueryRow(t, restoreQuery, restoreURIArgs...).Scan(
-		&unused, &unused, &unused, &restoredRows,
-	)
+	if backuptestutils.FastRestore {
+		sqlDB.QueryRow(t, restoreQuery, restoreURIArgs...).Scan(
+			&unused, &unused, &restoredRows, &unused, &unused,
+		)
 
-	if expected := int64(numAccounts); restoredRows != expected {
-		t.Fatalf("expected %d rows for %d accounts, got %d", expected, numAccounts, restoredRows)
+		// OR returns a flawed approximation of row count, so failing on this check is not very useful.
+		//
+		// TODO(at): revisit this when we have a better approximation
+		if expected := int64(numAccounts); restoredRows != expected {
+			log.Dev.Warningf(ctx,
+				"expected %d rows for %d accounts, got %d (fast-restore)",
+				expected, numAccounts, restoredRows,
+			)
+		}
+	} else {
+		sqlDB.QueryRow(t, restoreQuery, restoreURIArgs...).Scan(
+			&unused, &unused, &unused, &restoredRows,
+		)
+		if expected := int64(numAccounts); restoredRows != expected {
+			t.Fatalf("expected %d rows for %d accounts, got %d", expected, numAccounts, restoredRows)
+		}
 	}
 
 	var rowCount int64
@@ -1004,8 +1032,10 @@ func verifyRestoreData(
 		t.Fatalf("expected %d rows but found %d", numAccounts, rowCount)
 	}
 
-	// Verify there's no /Table/51 - /Table/51/1 empty span.
-	{
+	if !backuptestutils.FastRestore {
+		// TODO(at): investigate why this check fails with OR.
+		//
+		// Verify there's no /Table/51 - /Table/51/1 empty span.
 		var count int
 		// We're querying the crdb_internal.ranges view which only exists in the
 		// system tenant. As a result, we must use the storageSQLDB.
@@ -1094,6 +1124,9 @@ func TestBackupRestoreSystemJobs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	// TODO(at): restructure test to work with OR metamorphic.
+	backuptestutils.DisableFastRestoreForTest(t)
+
 	const numAccounts = 0
 	_, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, multiNode, numAccounts, InitManualReplication)
 	conn := sqlDB.DB.(*gosql.DB)
@@ -1169,6 +1202,9 @@ func redactTestKMSURI(path string) (string, error) {
 func TestEncryptedBackupRestoreSystemJobs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	// TODO(at): enable once OR supports encrypted backups.
+	backuptestutils.DisableFastRestoreForTest(t)
 
 	regionEnvVariable := "AWS_KMS_REGION_A"
 	keyIDEnvVariable := "AWS_KMS_KEY_ARN_A"
@@ -1277,6 +1313,9 @@ func TestRestoreCheckpointing(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	defer jobs.TestingSetProgressThresholds()()
+
+	// TODO(at): OR does not use RunAfterProcessingRestoreSpanEntry; adapt test for OR.
+	backuptestutils.DisableFastRestoreForTest(t)
 
 	// totalEntries represents the number of entries to appear in the persisted frontier.
 	const totalEntries = 7
@@ -2849,6 +2888,9 @@ func TestBackupRestoreCrossTableReferences(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	// TODO(at): restructure test to work with OR metamorphic.
+	backuptestutils.DisableFastRestoreForTest(t)
+
 	const numAccounts = 30
 	const createStore = "CREATE DATABASE store"
 	const createStoreStats = "CREATE DATABASE storestats"
@@ -3869,6 +3911,9 @@ func TestEmptyBackupsInChain(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	// TODO(at): enable once we allow `LinkExternalSSTable` for more tenant types.
+	backuptestutils.DisableFastRestoreForTest(t)
+
 	const numAccounts = 10
 	_, sqlDB, _, cleanupFn := backupRestoreTestSetupWithParams(t, singleNode, numAccounts,
 		InitManualReplication, base.TestClusterArgs{
@@ -4015,6 +4060,11 @@ func TestBackupRestoreChecksum(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	// TODO(at): OR links external SSTs without reading them; the corrupt-data
+	// checksum error surfaces during download, not during the RESTORE statement.
+	// Explore whether this test can be adapted to validate OR's error path.
+	backuptestutils.DisableFastRestoreForTest(t)
+
 	// Test Server too slow under deadlock.
 	skip.UnderDeadlock(t)
 	// Flaky under race.
@@ -4076,6 +4126,9 @@ func TestBackupRestoreChecksum(t *testing.T) {
 func TestNonLinearChain(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	// TODO(at): enable once LinkExternalSSTable is permitted for secondary tenants.
+	backuptestutils.DisableFastRestoreForTest(t)
 
 	dir, cleanup := testutils.TempDir(t)
 	defer cleanup()
@@ -4323,6 +4376,9 @@ func TestEncryptedBackup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	// TODO(at): enable once OR supports encrypted backups.
+	backuptestutils.DisableFastRestoreForTest(t)
+
 	regionEnvVariable := "AWS_KMS_REGION_A"
 	keyIDEnvVariable := "AWS_KMS_KEY_ARN_A"
 
@@ -4435,6 +4491,9 @@ func concatMultiRegionKMSURIs(uris []string) string {
 func TestRegionalKMSEncryptedBackup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	// TODO(at): enable once OR supports encrypted backups.
+	backuptestutils.DisableFastRestoreForTest(t)
 
 	regionEnvVariables := []string{"AWS_KMS_REGION_A", "AWS_KMS_REGION_B"}
 	keyIDEnvVariables := []string{"AWS_KMS_KEY_ARN_A", "AWS_KMS_KEY_ARN_B"}
@@ -4573,6 +4632,9 @@ func TestValidateKMSURIsAgainstFullBackup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	// TODO(at): enable once OR supports encrypted backups.
+	backuptestutils.DisableFastRestoreForTest(t)
+
 	for _, tc := range []struct {
 		name                  string
 		fullBackupURIs        []string
@@ -4648,6 +4710,9 @@ func TestGetEncryptedDataKeyByKMSMasterKeyID(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	// TODO(at): enable once OR supports encrypted backups.
+	backuptestutils.DisableFastRestoreForTest(t)
+
 	ctx := context.Background()
 	plaintextDataKey := []byte("supersecret")
 	for _, tc := range []struct {
@@ -4698,6 +4763,9 @@ func TestGetEncryptedDataKeyByKMSMasterKeyID(t *testing.T) {
 func TestRestoredPrivileges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	// TODO(at): restructure test to work with OR metamorphic.
+	backuptestutils.DisableFastRestoreForTest(t)
 
 	const numAccounts = 2
 	_, sqlDB, dir, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
@@ -4775,6 +4843,9 @@ func TestRestoreInto(t *testing.T) {
 func TestRestoreDatabaseVersusTable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	// TODO(at): restructure test to work with OR metamorphic.
+	backuptestutils.DisableFastRestoreForTest(t)
 
 	const numAccounts = 2
 	tc, origDB, _, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
@@ -5254,6 +5325,10 @@ func TestDetachedRestore(t *testing.T) {
 func TestBackupRestoreSequence(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	// TODO(at): restructure test to work with OR metamorphic.
+	backuptestutils.DisableFastRestoreForTest(t)
+
 	const numAccounts = 2
 	_, origDB, dir, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
 	defer cleanupFn()
@@ -5469,6 +5544,9 @@ func TestBackupRestoreSequencesInViews(t *testing.T) {
 func TestBackupRestoreSequenceOwnership(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	// TODO(at): restructure test to work with OR metamorphic.
+	backuptestutils.DisableFastRestoreForTest(t)
 
 	const numAccounts = 2
 	_, origDB, dir, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
@@ -5727,6 +5805,9 @@ func TestBackupRestoreSequenceOwnership(t *testing.T) {
 func TestBackupRestoreShowJob(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	// TODO(at): restructure test to work with OR metamorphic.
+	backuptestutils.DisableFastRestoreForTest(t)
 
 	const numAccounts = 2
 	_, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
@@ -5990,6 +6071,9 @@ func TestBatchedInsertStats(t *testing.T) {
 func TestBackupRestoreCorruptedStatsIgnored(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	// OR does not support userfile:// backup URIs.
+	backuptestutils.DisableFastRestoreForTest(t)
 
 	const dest = "userfile:///basefoo"
 	const numAccounts = 2
@@ -6419,6 +6503,9 @@ func TestRestoreErrorPropagates(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	// TODO(at): restructure test to work with OR metamorphic.
+	backuptestutils.DisableFastRestoreForTest(t)
+
 	skip.UnderRace(t, "multinode cluster setup times out under race, likely due to resource starvation.")
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -6666,6 +6753,9 @@ func TestBackupRestoreInsideTenant(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	// TODO(at): enable once LinkExternalSSTable is permitted for secondary tenants.
+	backuptestutils.DisableFastRestoreForTest(t)
+
 	skip.UnderRace(t, "runs slow under race, ~10+ mins")
 
 	const numAccounts = 2
@@ -6826,6 +6916,9 @@ func TestBackupRestoreInsideMultiPodTenant(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	skip.UnderRace(t, "may time out due to multiple servers")
+
+	// TODO(at): enable once LinkExternalSSTable is permitted for secondary tenants.
+	backuptestutils.DisableFastRestoreForTest(t)
 
 	const numAccounts = 2
 	const npods = 2
@@ -7436,6 +7529,11 @@ func TestClientDisconnect(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.jobType, func(t *testing.T) {
+			if testCase.jobType == "RESTORE" {
+				// TODO(at): OR does not use RunAfterProcessingRestoreSpanEntry; adapt test for OR.
+				backuptestutils.DisableFastRestoreForTest(t)
+			}
+
 			// When completing an export request, signal the a request has been sent and
 			// then wait to be signaled.
 			allowResponse := make(chan struct{})
@@ -8652,6 +8750,9 @@ func TestRestoreJobEventLogging(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.ScopeWithoutShowLogs(t).Close(t)
 
+	// TODO(at): restructure test to work with OR metamorphic.
+	backuptestutils.DisableFastRestoreForTest(t)
+
 	defer jobs.TestingSetProgressThresholds()()
 
 	baseDir := "testdata"
@@ -9131,6 +9232,7 @@ DROP INDEX idx_3;
 func TestDroppedDescriptorRevisionAndSystemDBIDClash(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
 	_, sqlDB, tempDir, cleanupFn := backupRestoreTestSetup(t, singleNode, 2, InitManualReplication)
 	defer cleanupFn()
 
@@ -9642,6 +9744,9 @@ func TestExcludeDataFromBackupDoesNotHoldupGC(t *testing.T) {
 func TestProtectRestoreTargets(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	// TODO(at): enable once LinkExternalSSTable is permitted for secondary tenants.
+	backuptestutils.DisableFastRestoreForTest(t)
 
 	skip.UnderRace(t, "slow test") // takes >1mn under race
 
@@ -10176,6 +10281,9 @@ func TestBackupRestoreTelemetryEvents(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.ScopeWithoutShowLogs(t).Close(t)
 
+	// TODO(at): restructure test to work with OR metamorphic.
+	backuptestutils.DisableFastRestoreForTest(t)
+
 	defer jobs.TestingSetProgressThresholds()()
 
 	defer besteffort.TestForbidSkip("log-backup-telemetry")()
@@ -10571,6 +10679,9 @@ $$;
 func TestBackupRestoreClusterWithUDFs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	// TODO(at): enable once LinkExternalSSTable is permitted for secondary tenants.
+	backuptestutils.DisableFastRestoreForTest(t)
 
 	tempDir, tempDirCleanupFn := testutils.TempDir(t)
 	defer tempDirCleanupFn()

--- a/pkg/backup/backuptestutils/BUILD.bazel
+++ b/pkg/backup/backuptestutils/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     deps = [
         "//pkg/backup/backupbase",
         "//pkg/base",
+        "//pkg/cloud/nodelocal",
         "//pkg/clusterversion",
         "//pkg/jobs",
         "//pkg/keyvisualizer",

--- a/pkg/backup/backuptestutils/testutils.go
+++ b/pkg/backup/backuptestutils/testutils.go
@@ -15,6 +15,7 @@ import (
 
 	_ "github.com/cockroachdb/cockroach/pkg/backup/backupbase" // imported for cluster settings.
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/cloud/nodelocal"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/keyvisualizer"
@@ -49,6 +50,29 @@ const (
 // bugs in time-bound iterators. We disable this in race builds, which can
 // be too slow.
 var smallEngineBlocks = !util.RaceEnabled && metamorphic.ConstantWithTestBool("small-engine-blocks", false)
+
+var FastRestore = metamorphic.ConstantWithTestBool("fast-restore", false)
+
+func DisableFastRestoreForTest(t testing.TB) {
+	t.Helper()
+	prev := FastRestore
+	FastRestore = false
+	t.Cleanup(func() { FastRestore = prev })
+}
+
+// EnableFastRestoreForTest marks the test as exercising Online Restore,
+// causing StartBackupRestoreTestCluster to set up the necessary nodelocal
+// storage and system-tenant configuration on the caller's behalf.
+//
+// Note that if we want to use this in a test that uses t.Parallel, we should restructure
+// how we turn on and off this metamorphic.
+func EnableFastRestoreForTest(t testing.TB) {
+	t.Helper()
+	prev := FastRestore
+	FastRestore = true
+	t.Cleanup(func() { FastRestore = prev })
+}
+
 var externalConnection = metamorphic.ConstantWithTestBool("external-connection", false)
 
 // GetExternalStorageURI metamorphically chooses between baseURI,
@@ -140,6 +164,11 @@ func StartBackupRestoreTestCluster(
 		opts.dataDir, dirCleanupFunc = testutils.TempDir(t)
 	}
 
+	nodelocalCleanupFunc := func() {}
+	if FastRestore {
+		nodelocalCleanupFunc = nodelocal.ReplaceNodeLocalForTesting(opts.dataDir)
+	}
+
 	if opts.initFunc == nil {
 		// TODO(ssd): Is anything actually using a custom init
 		// func?
@@ -196,6 +225,7 @@ func StartBackupRestoreTestCluster(
 			CheckForInvalidDescriptors(t, tc.Conns[0])
 		}
 		tc.Stopper().Stop(ctx) // cleans up in memory storage's auxiliary dirs
+		nodelocalCleanupFunc()
 		dirCleanupFunc()
 	}
 }
@@ -224,6 +254,14 @@ func setTestClusterDefaults(params *base.TestClusterArgs, dataDir string, useDat
 		params.ServerArgs.Knobs.Store.(*kvserver.StoreTestingKnobs).SmallEngineBlocks = true
 	}
 
+	// TODO(at): remove once LinkExternalSSTable is enabled for secondary tenants.
+	if FastRestore {
+		var tenantzero base.DefaultTestTenantOptions
+		if params.ServerArgs.DefaultTestTenant == tenantzero {
+			params.ServerArgs.DefaultTestTenant = base.TestIsSpecificToStorageLayerAndNeedsASystemTenant
+		}
+	}
+
 	if params.ServerArgs.Knobs.JobsTestingKnobs == nil {
 		params.ServerArgs.Knobs.JobsTestingKnobs = jobs.NewTestingKnobsWithShortIntervals()
 	}
@@ -243,11 +281,15 @@ func setTestClusterDefaults(params *base.TestClusterArgs, dataDir string, useDat
 }
 
 // VerifyBackupRestoreStatementResult conducts a Backup or Restore and verifies
-// it was properly written to the jobs table. Note, does not verify online restores
+// it was properly written to the jobs table. Note, does not verify online restores.
 func VerifyBackupRestoreStatementResult(
 	t *testing.T, sqlDB *sqlutils.SQLRunner, query string, args ...interface{},
 ) error {
 	t.Helper()
+	if FastRestore {
+		sqlDB.Exec(t, query, args...)
+		return nil
+	}
 	rows := sqlDB.Query(t, query, args...)
 
 	columns, err := rows.Columns()

--- a/pkg/backup/compaction_test.go
+++ b/pkg/backup/compaction_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/backup/backuppb"
+	"github.com/cockroachdb/cockroach/pkg/backup/backuptestutils"
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/cloud/cloudpb"
@@ -249,6 +250,9 @@ func TestBackupCompaction(t *testing.T) {
 	})
 
 	t.Run("encrypted backups", func(t *testing.T) {
+		// TODO(at): enable once OR supports encrypted backups.
+		backuptestutils.DisableFastRestoreForTest(t)
+
 		bucketNum++
 		collectionURI := []string{fmt.Sprintf("nodelocal://1/backup/%d", bucketNum)}
 		encryptOpts := "WITH encryption_passphrase = 'correct-horse-battery-staple'"
@@ -665,6 +669,9 @@ func TestBlockConcurrentScheduledCompactions(t *testing.T) {
 func TestBackupCompactionExecLocality(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	// TODO(at): restructure test to work with OR metamorphic.
+	backuptestutils.DisableFastRestoreForTest(t)
 
 	skip.UnderRace(t, "too slow")
 
@@ -1414,14 +1421,17 @@ func TestToggleCompactionForRestore(t *testing.T) {
 	waitForSuccessfulJob(t, tc, compactionID)
 
 	var compRestoreID, classicRestoreID jobspb.JobID
-	var unused any
-	db.QueryRow(
-		t, restoreQuery(t, "DATABASE data", collectionURI, noAOST, "WITH new_db_name = 'data1'"),
-	).Scan(&compRestoreID, &unused, &unused, &unused)
+	scanRestore := func(id *jobspb.JobID, q string) {
+		var unused any
+		if backuptestutils.FastRestore {
+			db.QueryRow(t, q).Scan(id, &unused, &unused, &unused, &unused)
+		} else {
+			db.QueryRow(t, q).Scan(id, &unused, &unused, &unused)
+		}
+	}
+	scanRestore(&compRestoreID, restoreQuery(t, "DATABASE data", collectionURI, noAOST, "WITH new_db_name = 'data1'"))
 	db.Exec(t, "SET CLUSTER SETTING restore.compacted_backups.enabled = false")
-	db.QueryRow(
-		t, restoreQuery(t, "DATABASE data", collectionURI, noAOST, "WITH new_db_name = 'data2'"),
-	).Scan(&classicRestoreID, &unused, &unused, &unused)
+	scanRestore(&classicRestoreID, restoreQuery(t, "DATABASE data", collectionURI, noAOST, "WITH new_db_name = 'data2'"))
 
 	require.Equal(t, 2, getNumBackupsInRestore(t, db, compRestoreID))
 	require.Equal(t, 3, getNumBackupsInRestore(t, db, classicRestoreID))
@@ -1642,7 +1652,11 @@ func validateCompactedBackupForTables(
 	row := db.QueryRow(t, restoreQuery(t, "TABLE "+tablesList, collectionURI, noAOST, restoreOpts))
 	var restoreJobID jobspb.JobID
 	var discard *any
-	row.Scan(&restoreJobID, &discard, &discard, &discard)
+	if backuptestutils.FastRestore {
+		row.Scan(&restoreJobID, &discard, &discard, &discard, &discard)
+	} else {
+		row.Scan(&restoreJobID, &discard, &discard, &discard)
+	}
 	for table, originalRows := range rows {
 		restoredRows := db.QueryStr(t, "SELECT * FROM "+table+" ORDER BY PRIMARY KEY "+table)
 		require.Equal(t, originalRows, restoredRows, "table %s", table)

--- a/pkg/backup/datadriven_test.go
+++ b/pkg/backup/datadriven_test.go
@@ -488,6 +488,10 @@ func (d *datadrivenTestState) getSQLDBForVC(
 //
 //lint:ignore U1000 unused
 func runTestDataDriven(t *testing.T, testFilePathFromWorkspace string) {
+	// TODO(at): data driven tests will need some tweaks to work with OR metamorphic, which will
+	// likely be simplified after fixing some of the other test infra issues.
+	backuptestutils.DisableFastRestoreForTest(t)
+
 	// This test uses this mock HTTP server to pass the backup files between tenants.
 	httpAddr, httpServerCleanup := makeInsecureHTTPServer(t)
 	defer httpServerCleanup()

--- a/pkg/backup/flaky_storage_test.go
+++ b/pkg/backup/flaky_storage_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/backup/backuptestutils"
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
@@ -33,6 +34,9 @@ func TestBackupRestore_FlakyStorage(t *testing.T) {
 	// Allow besteffort operations to fail without panicking since fault
 	// injection may cause cleanup/telemetry operations to fail.
 	defer besteffort.TestAllowAllFailures()()
+
+	// TODO(at): restructure test to work with OR metamorphic.
+	backuptestutils.DisableFastRestoreForTest(t)
 
 	// Set up a slim test server with flaky storage enabled
 	params := base.TestClusterArgs{

--- a/pkg/backup/full_cluster_backup_restore_test.go
+++ b/pkg/backup/full_cluster_backup_restore_test.go
@@ -53,6 +53,9 @@ func TestFullClusterBackup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	// TODO(at): enable once LinkExternalSSTable is permitted for secondary tenants.
+	backuptestutils.DisableFastRestoreForTest(t)
+
 	// It is easier to assert state in this test if both the backing up and
 	// restoring cluster are run with the same tenant option. We already have
 	// targeted tests for combinations of backing up and restoring between a

--- a/pkg/backup/restore_multiregion_rbr_test.go
+++ b/pkg/backup/restore_multiregion_rbr_test.go
@@ -30,6 +30,9 @@ func TestMultiRegionRegionlessRestoreNoLicense(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	// TODO(at): enable once LinkExternalSSTable is permitted for secondary tenants.
+	backuptestutils.DisableFastRestoreForTest(t)
+
 	skip.UnderRace(t, "test is too heavy to run under stress")
 
 	ctx := context.Background()

--- a/pkg/backup/restore_online_test.go
+++ b/pkg/backup/restore_online_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/backup/backuptestutils"
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/cloud/nodelocal"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
@@ -41,13 +40,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var orParams = base.TestClusterArgs{
-	// Online restore is not supported in a secondary tenant yet.
-	ServerArgs: base.TestServerArgs{
-		DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
-	},
-}
-
 var latestDownloadJobIDQuery = `SELECT id FROM system.jobs WHERE description LIKE '%Background Data Download%' ORDER BY created DESC LIMIT 1`
 
 func onlineImpl(rng *rand.Rand) string {
@@ -62,16 +54,16 @@ func TestOnlineRestoreBasic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer nodelocal.ReplaceNodeLocalForTesting(t.TempDir())()
+	backuptestutils.EnableFastRestoreForTest(t)
 
 	ctx := context.Background()
 
 	const numAccounts = 1000
 
-	tc, sqlDB, dir, cleanupFn := backupRestoreTestSetupWithParams(t, singleNode, numAccounts, InitManualReplication, orParams)
+	tc, sqlDB, dir, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
 	defer cleanupFn()
 
-	rtc, rSQLDB, cleanupFnRestored := backupRestoreTestSetupEmpty(t, 1, dir, InitManualReplication, orParams)
+	rtc, rSQLDB, cleanupFnRestored := backupRestoreTestSetupEmpty(t, 1, dir, InitManualReplication, base.TestClusterArgs{})
 	defer cleanupFnRestored()
 
 	externalStorage := backuptestutils.GetExternalStorageURI(t, "nodelocal://1/backup", "backup", sqlDB, rSQLDB)
@@ -119,13 +111,11 @@ func TestOnlineRestoreRecovery(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	tmpDir := t.TempDir()
-
-	defer nodelocal.ReplaceNodeLocalForTesting(tmpDir)()
+	backuptestutils.EnableFastRestoreForTest(t)
 
 	const numAccounts = 1000
 
-	_, sqlDB, _, cleanupFn := backupRestoreTestSetupWithParams(t, singleNode, numAccounts, InitManualReplication, orParams)
+	_, sqlDB, tmpDir, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
 	defer cleanupFn()
 
 	trueExternalStorage := "nodelocal://1/backup"
@@ -216,13 +206,11 @@ func TestFullClusterOnlineRestoreRecovery(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	tmpDir := t.TempDir()
-
-	defer nodelocal.ReplaceNodeLocalForTesting(tmpDir)()
+	backuptestutils.EnableFastRestoreForTest(t)
 
 	const numAccounts = 1000
 
-	_, sqlDB, _, cleanupFn := backupRestoreTestSetupWithParams(t, singleNode, numAccounts, InitManualReplication, orParams)
+	_, sqlDB, tmpDir, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
 	defer cleanupFn()
 
 	trueExternalStorage := "nodelocal://1/backup"
@@ -285,14 +273,10 @@ func corruptBackup(t *testing.T, sqlDB *sqlutils.SQLRunner, ioDir string, uri st
 func TestOnlineRestorePartitioned(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	defer nodelocal.ReplaceNodeLocalForTesting(t.TempDir())()
 
-	srv, sqlDB, _, cleanupFn := backupRestoreTestSetupWithParams(t, 3, 100,
-		InitManualReplication,
-		base.TestClusterArgs{
-			ServerArgs: base.TestServerArgs{DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant},
-		},
-	)
+	backuptestutils.EnableFastRestoreForTest(t)
+
+	srv, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, 3, 100, InitManualReplication)
 	defer cleanupFn()
 
 	a := backuptestutils.GetExternalStorageURI(t, "nodelocal://1/a", "conn-a", sqlDB) + "?COCKROACH_LOCALITY=default"
@@ -315,18 +299,13 @@ func TestOnlineRestorePartitioned(t *testing.T) {
 func TestOnlineRestoreLinkCheckpoint(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	defer nodelocal.ReplaceNodeLocalForTesting(t.TempDir())()
+
+	backuptestutils.EnableFastRestoreForTest(t)
 
 	rng, _ := randutil.NewTestRand()
 
 	const numAccounts = 10
-	_, sqlDB, _, cleanupFn := backupRestoreTestSetupWithParams(
-		t,
-		singleNode,
-		numAccounts,
-		InitManualReplication,
-		orParams,
-	)
+	_, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
 	defer cleanupFn()
 
 	externalStorage := backuptestutils.GetExternalStorageURI(t, "nodelocal://1/backup", "backup", sqlDB)
@@ -348,20 +327,11 @@ func TestOnlineRestoreLinkCheckpoint(t *testing.T) {
 func TestOnlineRestoreStatementResult(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	defer nodelocal.ReplaceNodeLocalForTesting(t.TempDir())()
+
+	backuptestutils.EnableFastRestoreForTest(t)
 
 	const numAccounts = 2
-	_, sqlDB, _, cleanupFn := backupRestoreTestSetupWithParams(
-		t,
-		singleNode,
-		numAccounts,
-		InitManualReplication,
-		base.TestClusterArgs{
-			ServerArgs: base.TestServerArgs{
-				DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
-			},
-		},
-	)
+	_, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
 	defer cleanupFn()
 
 	externalStorage := backuptestutils.GetExternalStorageURI(t, "nodelocal://1/backup", "backup", sqlDB)
@@ -421,15 +391,11 @@ func TestOnlineRestoreStatementResult(t *testing.T) {
 func TestOnlineRestoreWaitForDownload(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	defer nodelocal.ReplaceNodeLocalForTesting(t.TempDir())()
+
+	backuptestutils.EnableFastRestoreForTest(t)
 
 	const numAccounts = 1000
-	_, sqlDB, _, cleanupFn := backupRestoreTestSetupWithParams(t, singleNode, numAccounts, InitManualReplication, base.TestClusterArgs{
-		// Online restore is not supported in a secondary tenant yet.
-		ServerArgs: base.TestServerArgs{
-			DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
-		},
-	})
+	_, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
 	defer cleanupFn()
 	externalStorage := backuptestutils.GetExternalStorageURI(t, "nodelocal://1/backup", "backup", sqlDB)
 
@@ -455,7 +421,7 @@ func TestOnlineRestoreTenant(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer nodelocal.ReplaceNodeLocalForTesting(t.TempDir())()
+	backuptestutils.EnableFastRestoreForTest(t)
 
 	params := base.TestClusterArgs{ServerArgs: base.TestServerArgs{
 		Knobs: base.TestingKnobs{
@@ -556,17 +522,11 @@ func TestOnlineRestoreErrors(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer nodelocal.ReplaceNodeLocalForTesting(t.TempDir())()
+	backuptestutils.EnableFastRestoreForTest(t)
 
 	_, sqlDB, dir, cleanupFn := backupRestoreTestSetup(t, singleNode, 2, InitManualReplication)
 	defer cleanupFn()
-	params := base.TestClusterArgs{
-		// Online restore is not supported in a secondary tenant yet.
-		ServerArgs: base.TestServerArgs{
-			DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
-		},
-	}
-	_, rSQLDB, cleanupFnRestored := backupRestoreTestSetupEmpty(t, 1, dir, InitManualReplication, params)
+	_, rSQLDB, cleanupFnRestored := backupRestoreTestSetupEmpty(t, 1, dir, InitManualReplication, base.TestClusterArgs{})
 	defer cleanupFnRestored()
 	rSQLDB.Exec(t, "CREATE DATABASE data")
 	var (
@@ -614,7 +574,7 @@ func TestOnlineRestoreRetryingDownloadRequests(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer nodelocal.ReplaceNodeLocalForTesting(t.TempDir())()
+	backuptestutils.EnableFastRestoreForTest(t)
 
 	rng, seed := randutil.NewPseudoRand()
 	t.Logf("random seed: %d", seed)
@@ -626,7 +586,6 @@ func TestOnlineRestoreRetryingDownloadRequests(t *testing.T) {
 
 	clusterArgs := base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
-			DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
 			Knobs: base.TestingKnobs{
 				BackupRestore: &sql.BackupRestoreTestingKnobs{
 					RunBeforeSendingDownloadSpan: func() error {
@@ -673,12 +632,11 @@ func TestOnlineRestoreDownloadRetryReset(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer nodelocal.ReplaceNodeLocalForTesting(t.TempDir())()
+	backuptestutils.EnableFastRestoreForTest(t)
 
 	var attemptCount int
 	clusterArgs := base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
-			DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
 			Knobs: base.TestingKnobs{
 				BackupRestore: &sql.BackupRestoreTestingKnobs{
 					// We want the retry loop to fail until its final attempt, and then
@@ -728,7 +686,8 @@ func TestOnlineRestoreDownloadRetryReset(t *testing.T) {
 func TestOnlineRestoreFailScatterNonEmptyRanges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	defer nodelocal.ReplaceNodeLocalForTesting(t.TempDir())()
+
+	backuptestutils.EnableFastRestoreForTest(t)
 
 	// This test first runs online restore and waits for an external SST to be
 	// added to ensure at least one range has ingested an external SST. It then
@@ -748,8 +707,7 @@ func TestOnlineRestoreFailScatterNonEmptyRanges(t *testing.T) {
 	var postPauseScatterRequests atomic.Int32
 	var postPauseSuccessfulScatters atomic.Int32
 
-	params := orParams
-	params.ServerArgs.Knobs = base.TestingKnobs{
+	params := base.TestClusterArgs{ServerArgs: base.TestServerArgs{Knobs: base.TestingKnobs{
 		BackupRestore: &sql.BackupRestoreTestingKnobs{
 			AfterAddRemoteSST: func() error {
 				if resumed.Load() {
@@ -786,7 +744,7 @@ func TestOnlineRestoreFailScatterNonEmptyRanges(t *testing.T) {
 				return nil
 			},
 		},
-	}
+	}}}
 
 	const numAccounts = 100
 	_, sqlDB, _, cleanupFn := backupRestoreTestSetupWithParams(
@@ -893,17 +851,17 @@ func TestOnlineRestoreRevisionHistoryLayers(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer nodelocal.ReplaceNodeLocalForTesting(t.TempDir())()
+	backuptestutils.EnableFastRestoreForTest(t)
 
 	ctx := context.Background()
 
 	// Use enough accounts to create multiple ranges.
 	const numAccounts = 500
 
-	srcTC, sqlDB, dir, cleanupFn := backupRestoreTestSetupWithParams(t, singleNode, numAccounts, InitManualReplication, orParams)
+	srcTC, sqlDB, dir, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
 	defer cleanupFn()
 
-	dstTC, rSQLDB, cleanupFnRestored := backupRestoreTestSetupEmpty(t, 1, dir, InitManualReplication, orParams)
+	dstTC, rSQLDB, cleanupFnRestored := backupRestoreTestSetupEmpty(t, 1, dir, InitManualReplication, base.TestClusterArgs{})
 	defer cleanupFnRestored()
 
 	externalStorage := backuptestutils.GetExternalStorageURI(t, "nodelocal://1/backup-rev-history", "backup-rev-history", sqlDB, rSQLDB)
@@ -1223,12 +1181,11 @@ func TestOnlineRestoreLinkingNonexistentFiles(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	tmpDir := t.TempDir()
-	defer nodelocal.ReplaceNodeLocalForTesting(tmpDir)()
+	backuptestutils.EnableFastRestoreForTest(t)
 
 	const numAccounts = 1000
 
-	_, sqlDB, _, cleanupFn := backupRestoreTestSetupWithParams(t, singleNode, numAccounts, InitManualReplication, orParams)
+	_, sqlDB, dir, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
 	defer cleanupFn()
 
 	// Force each backup layer into a single wide SST by setting a large file
@@ -1264,7 +1221,7 @@ func TestOnlineRestoreLinkingNonexistentFiles(t *testing.T) {
 	// (filelist.sst, descriptorslist.sst) are preserved so restore can read
 	// the manifest. When Pebble's overlap checker tries to open a previously-
 	// linked backing file during the link phase, the I/O will fail.
-	backupDir := filepath.Join(tmpDir, "backup")
+	backupDir := filepath.Join(dir, "backup")
 	var deleted int
 	require.NoError(t, filepath.WalkDir(backupDir, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
@@ -1294,16 +1251,16 @@ func TestOnlineRestoreWithDistFlow(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer nodelocal.ReplaceNodeLocalForTesting(t.TempDir())()
+	backuptestutils.EnableFastRestoreForTest(t)
 
 	ctx := context.Background()
 
 	const numAccounts = 100
 
-	tc, sqlDB, dir, cleanupFn := backupRestoreTestSetupWithParams(t, singleNode, numAccounts, InitManualReplication, orParams)
+	tc, sqlDB, dir, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
 	defer cleanupFn()
 
-	rtc, rSQLDB, cleanupFnRestored := backupRestoreTestSetupEmpty(t, 1, dir, InitManualReplication, orParams)
+	rtc, rSQLDB, cleanupFnRestored := backupRestoreTestSetupEmpty(t, 1, dir, InitManualReplication, base.TestClusterArgs{})
 	defer cleanupFnRestored()
 
 	testutils.RunTrueAndFalse(t, "incremental", func(t *testing.T, incremental bool) {

--- a/pkg/backup/restore_planning.go
+++ b/pkg/backup/restore_planning.go
@@ -78,6 +78,11 @@ const (
 	restoreOptForceTenantID             = "virtual_cluster"
 )
 
+// testFastRestore is a hook set by backup_test.go to enable OR for all
+// restores in test builds, without importing testonly packages into production
+// code. It returns false in production.
+var testFastRestore = func() bool { return false }
+
 // featureRestoreEnabled is used to enable and disable the RESTORE feature.
 var featureRestoreEnabled = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
@@ -1318,6 +1323,9 @@ func restoreTypeCheck(
 	if !ok {
 		return false, nil, nil
 	}
+	if testFastRestore() && !restoreStmt.Options.ExperimentalCopy && !restoreStmt.Options.ExperimentalOnline {
+		restoreStmt.Options.ExperimentalCopy = true
+	}
 	if err := exprutil.TypeCheck(
 		ctx, "RESTORE", p.SemaCtx(),
 		exprutil.StringArrays{
@@ -1361,6 +1369,9 @@ func restorePlanHook(
 	restoreStmt, ok := stmt.(*tree.Restore)
 	if !ok {
 		return nil, nil, false, nil
+	}
+	if testFastRestore() && !restoreStmt.Options.ExperimentalCopy && !restoreStmt.Options.ExperimentalOnline {
+		restoreStmt.Options.ExperimentalCopy = true
 	}
 
 	if err := featureflag.CheckEnabled(

--- a/pkg/backup/restore_test.go
+++ b/pkg/backup/restore_test.go
@@ -377,6 +377,10 @@ func TestRestoreRevisionHistoryWithCompactions(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	// TODO(at): refactor test to work with FastRestore
+	// currently uses newTestHelper which bypasses our special test setup.
+	backuptestutils.DisableFastRestoreForTest(t)
+
 	th, cleanup := newTestHelper(t)
 	defer cleanup()
 

--- a/pkg/backup/statement_hints_restore_test.go
+++ b/pkg/backup/statement_hints_restore_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/backup/backuptestutils"
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
@@ -31,6 +32,9 @@ import (
 func TestStatementHintsRestoreFromOldBackup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	// TODO(at): restructure test to work with OR metamorphic.
+	backuptestutils.DisableFastRestoreForTest(t)
 
 	ctx := context.Background()
 

--- a/pkg/backup/tenant_backup_nemesis_test.go
+++ b/pkg/backup/tenant_backup_nemesis_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/backup/backuptestutils"
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -54,6 +55,9 @@ import (
 func TestTenantBackupWithCanceledImport(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	// TODO(at): enable once LinkExternalSSTable is permitted for secondary tenants.
+	backuptestutils.DisableFastRestoreForTest(t)
 
 	ctx := context.Background()
 	tempDir, tempDirCleanupFn := testutils.TempDir(t)
@@ -120,6 +124,9 @@ func TestTenantBackupNemesis(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	skip.UnderRace(t, "slow test") // take >1mn under race
+
+	// TODO(at): enable once LinkExternalSSTable is permitted for secondary tenants.
+	backuptestutils.DisableFastRestoreForTest(t)
 
 	ctx := context.Background()
 	tempDir, tempDirCleanupFn := testutils.TempDir(t)


### PR DESCRIPTION
This patch adds a metamorphic for running fast restore in our test suite, along with some helpers for using it.

Informs: #163236

Release note: None