### PR TITLE
sql/row: reuse a single txn for external row data fetches

### DIFF
--- a/pkg/sql/row/kv_batch_fetcher.go
+++ b/pkg/sql/row/kv_batch_fetcher.go
@@ -307,53 +307,69 @@ func makeExternalSpanSendFunc(
 	batchRequestsIssued *int64,
 	kvCPUTime *int64,
 ) sendFunc {
-	return func(ctx context.Context, ba *kvpb.BatchRequest) (*kvpb.BatchResponse, error) {
+	// Use a background context for the txn lifetime since it outlives any
+	// single request context.
+	bgCtx := context.Background()
+
+	// Lazily create a single read-only transaction with a fixed timestamp for
+	// all batch requests. The txn is initialized on the first batch request so
+	// that we can use the priority from that batch's AdmissionHeader. A
+	// read-only txn at a fixed timestamp is safe to reuse. The txn does not need
+	// explicit cleanup via Commit or Rollback — read-only transactions hold no
+	// server-side resources (no transaction record, no intents), so they can
+	// simply be garbage collected.
+	var txn *kv.Txn
+
+	nodeID, _ := db.Context().NodeID.OptionalNodeID()
+
+	sf := func(ctx context.Context, ba *kvpb.BatchRequest) (*kvpb.BatchResponse, error) {
+		if txn == nil {
+			txn = kv.NewTxnWithAdmissionControl(
+				bgCtx, db, nodeID,
+				kvpb.AdmissionHeader_FROM_SQL,
+				admissionpb.WorkPriority(ba.AdmissionHeader.Priority),
+			)
+			if err := txn.SetFixedTimestamp(bgCtx, ext.AsOf); err != nil {
+				return nil, err
+			}
+		}
+
 		for _, req := range ba.Requests {
-			// We only allow external row data for a few known types of request.
 			switch r := req.GetInner().(type) {
 			case *kvpb.GetRequest:
 			case *kvpb.ScanRequest:
 			case *kvpb.ReverseScanRequest:
 			default:
-				return nil, errors.AssertionFailedf("request type %T unsupported for external row data", r)
+				return nil, errors.AssertionFailedf(
+					"request type %T unsupported for external row data", r,
+				)
 			}
 		}
-		log.VEventf(ctx, 2, "kv external fetcher: sending a batch with %d requests", len(ba.Requests))
 
-		// Open a new transaction with fixed timestamp set to the external
-		// timestamp. We must do this with txn.Send rather than using
-		// db.NonTransactionalSender to get the 1-to-1 request-response guarantee
-		// required by txnKVFetcher.
-		// TODO(michae2): Explore whether we should keep this transaction open for
-		// the duration of the surrounding transaction.
-		var res *kvpb.BatchResponse
-		err := db.TxnWithAdmissionControl(
-			ctx, ba.AdmissionHeader.Source, admissionpb.WorkPriority(ba.AdmissionHeader.Priority),
-			kv.SteppingDisabled,
-			func(ctx context.Context, txn *kv.Txn) error {
-				if err := txn.SetFixedTimestamp(ctx, ext.AsOf); err != nil {
-					return err
-				}
-				var err *kvpb.Error
-				res, err = txn.Send(ctx, ba)
-				if err != nil {
-					return err.GoError()
-				}
-				return nil
-			})
-		// Note that in some code paths there is no concurrency when using the
-		// sendFunc, but we choose to unconditionally use atomics here since its
-		// overhead should be negligible in the grand scheme of things anyway.
-		atomic.AddInt64(batchRequestsIssued, 1)
-		if err != nil {
-			return nil, err
+		if log.V(2) {
+			log.VEventf(
+				ctx, 2,
+				"kv external fetcher: sending a batch with %d requests",
+				len(ba.Requests),
+			)
 		}
 
+		res, pErr := txn.Send(ctx, ba)
+		// Note that in some code paths there is no concurrency when using
+		// the sendFunc, but we choose to unconditionally use atomics here
+		// since its overhead should be negligible in the grand scheme of
+		// things anyway.
+		atomic.AddInt64(batchRequestsIssued, 1)
+		if pErr != nil {
+			return nil, pErr.GoError()
+		}
 		if res.CPUTime > 0 {
 			atomic.AddInt64(kvCPUTime, res.CPUTime)
 		}
 		return res, nil
 	}
+
+	return sf
 }
 
 type newTxnKVFetcherArgs struct {


### PR DESCRIPTION
sql/row: reuse a single txn for external row data fetches
Previously, makeExternalSpanSendFunc created a new transaction via
db.TxnWithAdmissionControl for every batch request sent to fetch external row
data. This added unnecessary per batch overhead.

Now, a single read-only transaction with a fixed timestamp is created up front
and reused across all batch requests in a given read from standby query. This
is safe because read-only transactions at a fixed timestamp have no write
intents, no heartbeat loop (only starts on locking requests), and no timestamp
pushes. The transaction holds no server-side resources and does not need
explicit cleanup.

Epic: none

Release note: None

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>