### PR TITLE
server: improve TestNodesV2 debuggability and skip under race

### DIFF
--- a/pkg/server/api_v2_ranges_test.go
+++ b/pkg/server/api_v2_ranges_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"testing"
 
@@ -122,7 +123,7 @@ func TestNodeRangesV2(t *testing.T) {
 func TestNodesV2(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.WithIssue(t, 164126)
+	skip.UnderRace(t, "flaky under race, see #164126")
 
 	testCluster := serverutils.StartCluster(t, 3, base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
@@ -148,7 +149,11 @@ func TestNodesV2(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 
-	require.Equal(t, 200, resp.StatusCode)
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		t.Fatalf("expected status 200 but got %d; response body: %s", resp.StatusCode, body)
+	}
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&nodesResp))
 	require.NoError(t, resp.Body.Close())
 

--- a/pkg/server/srverrors/errors.go
+++ b/pkg/server/srverrors/errors.go
@@ -68,6 +68,6 @@ func APIInternalError(ctx context.Context, err error) error {
 // of the error to the server log, and sends the standard internal error string
 // over the http.ResponseWriter.
 func APIV2InternalError(ctx context.Context, err error, w http.ResponseWriter) {
-	log.Dev.ErrorfDepth(ctx, 1, "%s", err)
+	log.Dev.ErrorfDepth(ctx, 1, "%+v", err)
 	http.Error(w, ErrAPIInternalErrorString, http.StatusInternalServerError)
 }


### PR DESCRIPTION
The test was fully skipped due to a ~40% flake rate on testrace/ARM64. This change narrows the skip to only race builds (the test has no race-specific coverage) and adds two debugging improvements:

1. APIV2InternalError now logs with %+v (stack traces) instead of %s, matching what ServerError already does for gRPC endpoints.
2. The test reads and logs the response body on non-200 status codes so future failures are diagnosable from CI output.

Fixes #164126