### PR TITLE
release-25.2: schemachangerccl: deflake TestBackupRollbacksMixedVersion

### DIFF
--- a/pkg/sql/schemachanger/sctest/backup.go
+++ b/pkg/sql/schemachanger/sctest/backup.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -241,7 +242,12 @@ func backupRollbacks(t *testing.T, factory TestServerFactory, cs CumulativeTestC
 	}
 	maybeRandomlySkip(t)
 	ctx := context.Background()
-	var urls atomic.Value
+	var mu struct {
+		syncutil.Mutex
+		urls        []string
+		urlsSamples map[string]struct{}
+	}
+	mu.urlsSamples = make(map[string]struct{})
 	var dbForBackup atomic.Pointer[gosql.DB]
 	pe := MakePlanExplainer()
 	knobs := &scexec.TestingKnobs{
@@ -259,13 +265,27 @@ func backupRollbacks(t *testing.T, factory TestServerFactory, cs CumulativeTestC
 				return nil
 			}
 			if p.InRollback {
+				// Discard the first backup, which is going to be the backup taken
+				// right at the very beginning of the rollback. Due to various quirks,
+				// the declarative schema changer state in that backup is going to be
+				// exactly the same as the state pre-rollback.
+				//
+				// This doesn't matter in production, as whichever error triggered the
+				// rollback in the first place will simply manifest itself again during
+				// the post-RESTORE schema change and roll it back.
+				if stageIdx == 0 {
+					return nil
+				}
 				url := fmt.Sprintf("userfile://backups.public.userfiles_$user/data_%s_%d_%d",
 					cs.Phase, cs.StageOrdinal, stageIdx)
-				if v := urls.Load(); v == nil {
-					urls.Store([]string{url})
-				} else {
-					urls.Store(append(v.([]string), url))
+				mu.Lock()
+				defer mu.Unlock()
+				// De-duplicated URLs that occur due to retries.
+				if _, ok := mu.urlsSamples[url]; ok {
+					return nil
 				}
+				mu.urlsSamples[url] = struct{}{}
+				mu.urls = append(mu.urls, url)
 				backupStmt := fmt.Sprintf("BACKUP DATABASE %s INTO '%s'", cs.DatabaseName, url)
 				_, err := dbForBackup.Load().Exec(backupStmt)
 				return err
@@ -304,29 +324,18 @@ func backupRollbacks(t *testing.T, factory TestServerFactory, cs CumulativeTestC
 
 		// Restore the backups of the database taken mid-rolled-back-schema-change
 		// in various ways, check that they end up in the same state as present.
-		for i, url := range urls.Load().([]string) {
+		urls := func() []string {
+			mu.Lock()
+			defer mu.Unlock()
+			return append([]string{}, mu.urls...)
+		}()
+		for i, url := range urls {
 			b := backupRestoreOutcome{
 				url:                url,
 				mayRollback:        true,
 				expectedOnRollback: postRollback,
 			}
-			var name string
-			switch i {
-			case 0:
-				// Discard the first backup, which is going to be the backup taken
-				// right at the very beginning of the rollback. Due to various quirks,
-				// the declarative schema changer state in that backup is going to be
-				// exactly the same as the state pre-rollback.
-				//
-				// This doesn't matter in production, as whichever error triggered the
-				// rollback in the first place will simply manifest itself again during
-				// the post-RESTORE schema change and roll it back.
-				continue
-			case 1:
-				name = "post_1_rollback_stage_exec"
-			default:
-				name = fmt.Sprintf("post_%d_rollback_stages_exec", i)
-			}
+			name := fmt.Sprintf("post_%d_rollback_stages_exec", i+1)
 			t.Run(name, func(t *testing.T) {
 				exerciseBackupRestore(t, tdb, cs, b, pe)
 			})


### PR DESCRIPTION
Backport 1/1 commits from #164696 on behalf of @fqazi.

----

Previously, the backup / restore rollback tests could flake due to retryable errors on the first stage. The test hooks are designed to execute before each stage, so when a back up is taken at the first stage the rollback is effectively not active. This patch modifies the test hook so that only one backup is taken per stage.

Fixes: #164196
Fixes: #164775

Release note: None

----

Release justification: test only change, the file is in the sctest package