### PR TITLE
backup: add test for online restore pre-splitting with slow external IO

### DIFF
--- a/pkg/backup/BUILD.bazel
+++ b/pkg/backup/BUILD.bazel
@@ -198,6 +198,7 @@ go_test(
         "partitioned_backup_test.go",
         "restore_data_processor_test.go",
         "restore_multiregion_rbr_test.go",
+        "restore_online_distflow_test.go",
         "restore_online_test.go",
         "restore_planning_test.go",
         "restore_progress_test.go",

--- a/pkg/backup/backup_processor.go
+++ b/pkg/backup/backup_processor.go
@@ -652,16 +652,23 @@ func runBackupProcessor(
 						for i, file := range resp.Files {
 							entryCounts := countRows(file.Exported, spec.PKIDs)
 
+							fileMeta := backuppb.BackupManifest_File{
+								Span:                    file.Span,
+								EntryCounts:             entryCounts,
+								LocalityKV:              destLocalityKV,
+								ApproximatePhysicalSize: uint64(len(file.SST)),
+							}
+							if backupKnobs, ok := flowCtx.TestingKnobs().BackupRestoreTestingKnobs.(*sql.BackupRestoreTestingKnobs); ok {
+								if backupKnobs.BackupProcessFileOverride != nil {
+									fileMeta = backupKnobs.BackupProcessFileOverride(fileMeta)
+								}
+							}
+
 							ret := backupsink.ExportedSpan{
 								// BackupManifest_File just happens to contain the exact fields
 								// to store the metadata we need, but there's no actual File
 								// on-disk anywhere yet.
-								Metadata: backuppb.BackupManifest_File{
-									Span:                    file.Span,
-									EntryCounts:             entryCounts,
-									LocalityKV:              destLocalityKV,
-									ApproximatePhysicalSize: uint64(len(file.SST)),
-								},
+								Metadata: fileMeta,
 								DataSST:  file.SST,
 								RevStart: resp.StartTime,
 							}

--- a/pkg/backup/generative_split_and_scatter_processor.go
+++ b/pkg/backup/generative_split_and_scatter_processor.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 )
@@ -159,6 +160,7 @@ func (s dbSplitAndScatterer) split(
 		newSplitKey = splitAt
 	}
 	log.VEventf(ctx, 1, "presplitting new key %+v", newSplitKey)
+	splitStart := timeutil.Now()
 	retryOpts := retry.Options{
 		InitialBackoff: 100 * time.Millisecond,
 		MaxBackoff:     5 * time.Second,
@@ -171,6 +173,9 @@ func (s dbSplitAndScatterer) split(
 				ctx, 1, "attempt %d failed to split at key %s: %v", r.CurrentAttempt(), newSplitKey, err,
 			)
 			continue
+		}
+		if elapsed := timeutil.Since(splitStart); elapsed > 5*time.Second {
+			log.Dev.Infof(ctx, "slow split at key %s took %s (%d attempts)", newSplitKey, elapsed, r.CurrentAttempt())
 		}
 		return nil
 	}
@@ -469,8 +474,12 @@ func runGenerativeSplitAndScatter(
 
 	// This goroutine generates import spans one at a time and sends them to
 	// restoreSpanEntriesCh.
+	genStart := timeutil.Now()
 	g.GoCtx(func(ctx context.Context) error {
-		defer close(restoreSpanEntriesCh)
+		defer func() {
+			log.Dev.Infof(ctx, "span generation complete in %s", timeutil.Since(genStart))
+			close(restoreSpanEntriesCh)
+		}()
 
 		backups, layerToFileIterFactory, err := makeBackupMetadata(ctx,
 			flowCtx, spec)
@@ -549,6 +558,7 @@ func runGenerativeSplitAndScatter(
 			chunk.entries = append(chunk.entries, entry)
 		}
 
+		log.Dev.Infof(ctx, "chunked %d import span entries into chunks of size %d", idx, spec.ChunkSize)
 		if len(chunk.entries) > 0 {
 			select {
 			case <-ctx.Done():

--- a/pkg/backup/restore_data_processor.go
+++ b/pkg/backup/restore_data_processor.go
@@ -655,8 +655,12 @@ func (rd *restoreDataProcessor) linkFiles(
 			MVCCStats:               fileStats,
 		}
 
+		linkStart := timeutil.Now()
 		if err := kvDB.LinkExternalSSTable(ctx, restoringSubspan, loc, batchTimestamp); err != nil {
 			return summary, errors.Wrap(err, "linking external SSTable")
+		}
+		if elapsed := timeutil.Since(linkStart); elapsed > 5*time.Second {
+			log.Dev.Infof(ctx, "slow link of file %s span %s took %s", file.Path, restoringSubspan, elapsed)
 		}
 
 		// Call testing knob after each file link, matching the old online restore path.

--- a/pkg/backup/restore_online_distflow_test.go
+++ b/pkg/backup/restore_online_distflow_test.go
@@ -1,0 +1,186 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package backup
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/backup/backuppb"
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/cloud/nodelocal"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+// TestOnlineRestoreDistFlowSplitScatter verifies that online restore correctly
+// pre-splits spans so linked external files are distributed across ranges.
+//
+// The test strategy:
+// 1. Block all reads of backup data SSTs at the storage layer
+// 2. Inflate backup file stats by 100,000x (making ~3KB files appear as ~300MB)
+// 3. Force-enqueue ranges into the split queue after each LinkExternalSSTable
+// 4. Create a deep backup (9 incremental layers) with files across multiple ranges
+//
+// If restore fails to pre-split properly:
+// - All files accumulate on one range
+// - Inflated stats trigger write backpressure (blocking further links)
+// - The range must split, but split-key finding requires reading blocked SSTs
+// - Result: deadlock/timeout
+//
+// If restore correctly pre-splits:
+// - Files distribute across ranges
+// - No backpressure triggers
+// - Blocked reads are never hit
+func TestOnlineRestoreDistFlowSplitScatter(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Block reads of backup data SSTs to simulate high S3 latency.
+	blockCh := make(chan struct{})
+	defer nodelocal.ReplaceNodeLocalForTestingWithInterceptor(
+		t.TempDir(),
+		func(ctx context.Context, basename string) {
+			if strings.HasPrefix(basename, "data/") && strings.HasSuffix(basename, ".sst") {
+				select {
+				case <-ctx.Done():
+				case <-blockCh:
+				}
+			}
+		},
+	)()
+
+	ctx := context.Background()
+	const statsMultiplier = 100000 // Inflate file sizes to trigger backpressure
+
+	var storePtr atomic.Pointer[kvserver.Store]
+
+	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
+		Knobs: base.TestingKnobs{
+			Store: &kvserver.StoreTestingKnobs{
+				// Disable queues that read external SSTs unrelated to split finding.
+				DisableMergeQueue:       true,
+				DisableConsistencyQueue: true,
+				// After each link, enqueue the range into the split queue.
+				// This triggers backpressure checks on subsequent links.
+				TestingResponseFilter: func(
+					ctx context.Context, ba *kvpb.BatchRequest, _ *kvpb.BatchResponse,
+				) *kvpb.Error {
+					st := storePtr.Load()
+					if st == nil {
+						return nil
+					}
+					for _, req := range ba.Requests {
+						if _, ok := req.GetInner().(*kvpb.LinkExternalSSTableRequest); ok {
+							if repl, err := st.GetReplica(ba.Header.RangeID); err == nil {
+								_, _ = st.Enqueue(ctx, "split", repl, true /* skipShouldQueue */, true /* async */)
+							}
+							return nil
+						}
+					}
+					return nil
+				},
+			},
+			// Inflate file stats in both execution paths.
+			BackupRestore: &sql.BackupRestoreTestingKnobs{
+				BackupProcessFileOverride: func(f backuppb.BackupManifest_File) backuppb.BackupManifest_File {
+					f.EntryCounts.DataSize *= statsMultiplier
+					f.ApproximatePhysicalSize *= statsMultiplier
+					return f
+				},
+			},
+			DistSQL: &execinfra.TestingKnobs{
+				BackupRestoreTestingKnobs: &sql.BackupRestoreTestingKnobs{
+					BackupProcessFileOverride: func(f backuppb.BackupManifest_File) backuppb.BackupManifest_File {
+						f.EntryCounts.DataSize *= statsMultiplier
+						f.ApproximatePhysicalSize *= statsMultiplier
+						return f
+					},
+				},
+			},
+		},
+	})
+
+	store, err := s.GetStores().(*kvserver.Stores).GetStore(s.GetFirstStoreID())
+	if err != nil {
+		t.Fatal(err)
+	}
+	storePtr.Store(store)
+
+	// Close blockCh before server shutdown to avoid deadlock with Pebble's
+	// table stats collector, which reads external SSTs asynchronously.
+	defer s.Stopper().Stop(ctx)
+	defer close(blockCh)
+
+	runner := sqlutils.MakeSQLRunner(sqlDB)
+
+	// Increase backpressure tolerance so inflated stats reliably trigger it.
+	runner.Exec(t, "SET CLUSTER SETTING kv.range.backpressure_byte_tolerance = '10 GiB'")
+
+	// Create test data across multiple ranges.
+	runner.Exec(t, "CREATE DATABASE data")
+	runner.Exec(t, "CREATE TABLE data.bank (id INT PRIMARY KEY, balance INT, payload STRING)")
+	for i := 0; i < 100; i++ {
+		runner.Exec(t, "INSERT INTO data.bank VALUES ($1, $2, $3)",
+			i, i*100, strings.Repeat("x", 100))
+	}
+	runner.Exec(t, "ALTER TABLE data.bank SPLIT AT VALUES (20), (40), (60), (80)")
+
+	// Create backup with 10 total layers (1 full + 9 incremental).
+	const backupURI = "nodelocal://1/backup"
+	runner.Exec(t, fmt.Sprintf("BACKUP TABLE data.bank INTO '%s'", backupURI))
+
+	// Each incremental updates a sliding window of rows for varied SST boundaries.
+	for i := 0; i < 9; i++ {
+		start := (i * 13) % 100
+		end := start + 35
+		if end > 100 {
+			end = 100
+		}
+		runner.Exec(t, "UPDATE data.bank SET balance = balance + 1 WHERE id >= $1 AND id < $2",
+			start, end)
+		runner.Exec(t, fmt.Sprintf("BACKUP TABLE data.bank INTO LATEST IN '%s'", backupURI))
+	}
+
+	// Pause at download phase - if link phase completes, test passes.
+	runner.Exec(t, "SET CLUSTER SETTING jobs.debug.pausepoints = 'restore.before_download'")
+
+	// Helper to run restore and verify link phase completes without deadlock.
+	restoreAndCancel := func(t *testing.T) {
+		runner.Exec(t, "DROP TABLE IF EXISTS data.bank")
+		runner.Exec(t, fmt.Sprintf(
+			"RESTORE TABLE data.bank FROM LATEST IN '%s' WITH EXPERIMENTAL DEFERRED COPY",
+			backupURI))
+
+		// Cancel the paused download job for cleanup.
+		var downloadJobID jobspb.JobID
+		runner.QueryRow(t, latestDownloadJobIDQuery).Scan(&downloadJobID)
+		runner.Exec(t, "SET CLUSTER SETTING jobs.debug.pausepoints = ''")
+		runner.Exec(t, fmt.Sprintf("CANCEL JOB %d", downloadJobID))
+		runner.Exec(t, "SET CLUSTER SETTING jobs.debug.pausepoints = 'restore.before_download'")
+	}
+
+	t.Run("goroutine-path", func(t *testing.T) {
+		runner.Exec(t, "SET CLUSTER SETTING backup.restore.online_use_dist_flow.enabled = false")
+		restoreAndCancel(t)
+	})
+
+	t.Run("distflow-path", func(t *testing.T) {
+		runner.Exec(t, "SET CLUSTER SETTING backup.restore.online_use_dist_flow.enabled = true")
+		restoreAndCancel(t)
+	})
+}

--- a/pkg/cloud/nodelocal/test_nodelocal_storage.go
+++ b/pkg/cloud/nodelocal/test_nodelocal_storage.go
@@ -7,6 +7,7 @@ package nodelocal
 
 import (
 	"context"
+	"io"
 	"net/url"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -15,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cloud/cloudpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
+	"github.com/cockroachdb/cockroach/pkg/util/ioctx"
 )
 
 // ReplaceNodeLocalForTesting replaces the implementation of of
@@ -65,4 +67,79 @@ func TestingMakeNodelocalStorage(
 		settings:   settings,
 		uri:        es.URI,
 	}
+}
+
+// ReplaceNodeLocalForTestingWithInterceptor is like ReplaceNodeLocalForTesting
+// but calls interceptRead before each ReadFile call. The interceptor receives
+// the basename of the file being read. This can be used to inject blocking or
+// delays for specific files, e.g. to block reads of data SSTs during online
+// restore testing. Size calls are not intercepted so that Pebble can still
+// query external file sizes for disk usage accounting.
+func ReplaceNodeLocalForTestingWithInterceptor(
+	root string, interceptRead func(context.Context, string),
+) func() {
+	makeFn := func(ctx context.Context, conf cloud.EarlyBootExternalStorageContext, es cloudpb.ExternalStorage) (cloud.ExternalStorage, error) {
+		inner := TestingMakeNodelocalStorage(root, conf.Settings, es)
+		return &interceptingStorage{inner: inner, interceptRead: interceptRead}, nil
+	}
+	parserFn := func(uri *url.URL) (cloudpb.ExternalStorage, error) {
+		if !buildutil.CrdbTestBuild {
+			panic("nodelocal test implementation in non-test build")
+		}
+		return cloudpb.ExternalStorage{
+			Provider: cloudpb.ExternalStorageProvider_nodelocal,
+			LocalFileConfig: cloudpb.ExternalStorage_LocalFileConfig{
+				Path: uri.Path,
+			},
+			URI: uri.String(),
+		}, nil
+	}
+	return cloud.ReplaceProviderForTesting(cloudpb.ExternalStorageProvider_nodelocal, cloud.RegisteredProvider{
+		EarlyBootConstructFn: makeFn,
+		EarlyBootParseFn:     parserFn,
+		Schemes:              []string{scheme},
+	})
+}
+
+// interceptingStorage wraps a cloud.ExternalStorage and calls an interceptor
+// before ReadFile operations.
+type interceptingStorage struct {
+	inner         cloud.ExternalStorage
+	interceptRead func(context.Context, string)
+}
+
+var _ cloud.ExternalStorage = &interceptingStorage{}
+
+func (s *interceptingStorage) Close() error { return s.inner.Close() }
+func (s *interceptingStorage) Conf() cloudpb.ExternalStorage {
+	return s.inner.Conf()
+}
+func (s *interceptingStorage) ExternalIOConf() base.ExternalIODirConfig {
+	return s.inner.ExternalIOConf()
+}
+func (s *interceptingStorage) RequiresExternalIOAccounting() bool {
+	return s.inner.RequiresExternalIOAccounting()
+}
+func (s *interceptingStorage) Settings() *cluster.Settings {
+	return s.inner.Settings()
+}
+func (s *interceptingStorage) Writer(ctx context.Context, basename string) (io.WriteCloser, error) {
+	return s.inner.Writer(ctx, basename)
+}
+func (s *interceptingStorage) List(
+	ctx context.Context, prefix string, opts cloud.ListOptions, fn cloud.ListingFn,
+) error {
+	return s.inner.List(ctx, prefix, opts, fn)
+}
+func (s *interceptingStorage) Delete(ctx context.Context, basename string) error {
+	return s.inner.Delete(ctx, basename)
+}
+func (s *interceptingStorage) ReadFile(
+	ctx context.Context, basename string, opts cloud.ReadOptions,
+) (ioctx.ReadCloserCtx, int64, error) {
+	s.interceptRead(ctx, basename)
+	return s.inner.ReadFile(ctx, basename, opts)
+}
+func (s *interceptingStorage) Size(ctx context.Context, basename string) (int64, error) {
+	return s.inner.Size(ctx, basename)
 }

--- a/pkg/cloud/nodelocal/test_nodelocal_storage.go
+++ b/pkg/cloud/nodelocal/test_nodelocal_storage.go
@@ -7,7 +7,6 @@ package nodelocal
 
 import (
 	"context"
-	"io"
 	"net/url"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -80,7 +79,7 @@ func ReplaceNodeLocalForTestingWithInterceptor(
 ) func() {
 	makeFn := func(ctx context.Context, conf cloud.EarlyBootExternalStorageContext, es cloudpb.ExternalStorage) (cloud.ExternalStorage, error) {
 		inner := TestingMakeNodelocalStorage(root, conf.Settings, es)
-		return &interceptingStorage{inner: inner, interceptRead: interceptRead}, nil
+		return &interceptingStorage{ExternalStorage: inner, interceptRead: interceptRead}, nil
 	}
 	parserFn := func(uri *url.URL) (cloudpb.ExternalStorage, error) {
 		if !buildutil.CrdbTestBuild {
@@ -104,42 +103,13 @@ func ReplaceNodeLocalForTestingWithInterceptor(
 // interceptingStorage wraps a cloud.ExternalStorage and calls an interceptor
 // before ReadFile operations.
 type interceptingStorage struct {
-	inner         cloud.ExternalStorage
+	cloud.ExternalStorage
 	interceptRead func(context.Context, string)
 }
 
-var _ cloud.ExternalStorage = &interceptingStorage{}
-
-func (s *interceptingStorage) Close() error { return s.inner.Close() }
-func (s *interceptingStorage) Conf() cloudpb.ExternalStorage {
-	return s.inner.Conf()
-}
-func (s *interceptingStorage) ExternalIOConf() base.ExternalIODirConfig {
-	return s.inner.ExternalIOConf()
-}
-func (s *interceptingStorage) RequiresExternalIOAccounting() bool {
-	return s.inner.RequiresExternalIOAccounting()
-}
-func (s *interceptingStorage) Settings() *cluster.Settings {
-	return s.inner.Settings()
-}
-func (s *interceptingStorage) Writer(ctx context.Context, basename string) (io.WriteCloser, error) {
-	return s.inner.Writer(ctx, basename)
-}
-func (s *interceptingStorage) List(
-	ctx context.Context, prefix string, opts cloud.ListOptions, fn cloud.ListingFn,
-) error {
-	return s.inner.List(ctx, prefix, opts, fn)
-}
-func (s *interceptingStorage) Delete(ctx context.Context, basename string) error {
-	return s.inner.Delete(ctx, basename)
-}
 func (s *interceptingStorage) ReadFile(
 	ctx context.Context, basename string, opts cloud.ReadOptions,
 ) (ioctx.ReadCloserCtx, int64, error) {
 	s.interceptRead(ctx, basename)
-	return s.inner.ReadFile(ctx, basename, opts)
-}
-func (s *interceptingStorage) Size(ctx context.Context, basename string) (int64, error) {
-	return s.inner.Size(ctx, basename)
+	return s.ExternalStorage.ReadFile(ctx, basename, opts)
 }

--- a/pkg/sql/exec_util_backup.go
+++ b/pkg/sql/exec_util_backup.go
@@ -102,6 +102,12 @@ type BackupRestoreTestingKnobs struct {
 	RestoreSpanConfigConformanceRetryPolicy *retry.Options
 
 	OnCompactionFileAccess *func(processorLocality roachpb.Locality, fileLocality string) error
+
+	// BackupProcessFileOverride, if set, is called for each file entry
+	// produced during backup. It can modify and return the entry, e.g. to
+	// inflate file sizes for testing restore behavior under conditions that
+	// would normally require a very large backup fixture.
+	BackupProcessFileOverride func(backuppb.BackupManifest_File) backuppb.BackupManifest_File
 }
 
 var _ base.ModuleTestingKnobs = &BackupRestoreTestingKnobs{}


### PR DESCRIPTION
Add TestOnlineRestoreDistFlowSplitScatter which verifies that online
restore's dist flow path uses a fine-grained span target size (384MB)
rather than the goroutine path's coarse target (16GB). With the coarse
target, all files merge into one span, producing an oversized range.
When external IO is slow, the split queue cannot find a split key in
time, and write backpressure blocks further linking — a deadlock.

The test inflates backup file stats by 100,000x via a new
BackupProcessFileOverride testing knob and blocks all reads of data
SSTs at the storage layer. After each LinkExternalSSTable, a
TestingResponseFilter enqueues the range into the split queue so that
backpressure's MaybeAddCallback finds it. With proper pre-splitting,
each range stays small and backpressure never triggers. Without it,
the test deadlocks.

Epic: none
Release note: None