### PR TITLE
dev: add --repository_cache doctor check

### DIFF
--- a/pkg/cmd/dev/doctor.go
+++ b/pkg/cmd/dev/doctor.go
@@ -539,6 +539,43 @@ slightly slower and introduce a noticeable delay in first-time build setup.`
 		nonRemoteOnly:            true,
 	},
 	{
+		name: "repository_cache",
+		check: func(d *dev, ctx context.Context, cfg doctorConfig) string {
+			lines, err := getRepositoryCacheBazelrcLines()
+			if err != nil {
+				return err.Error()
+			}
+			for _, line := range lines {
+				if !d.checkLinePresenceInBazelRcUser(cfg.workspace, line) {
+					return fmt.Sprintf("Please add the string `%s` to your .bazelrc.user", line)
+				}
+			}
+			return ""
+		},
+		autofix: func(d *dev, ctx context.Context, cfg doctorConfig) error {
+			dir, err := repositoryCacheDir()
+			if err != nil {
+				return err
+			}
+			if err := d.os.MkdirAll(dir); err != nil {
+				return err
+			}
+			lines, err := getRepositoryCacheBazelrcLines()
+			if err != nil {
+				return err
+			}
+			for _, line := range lines {
+				if !d.checkLinePresenceInBazelRcUser(cfg.workspace, line) {
+					if err := d.addLineToBazelRcUser(cfg.workspace, line); err != nil {
+						return err
+					}
+				}
+			}
+			return nil
+		},
+		nonRemoteOnly: true,
+	},
+	{
 		name: "cache_remote",
 		check: func(d *dev, ctx context.Context, cfg doctorConfig) string {
 			if d.checkLinePresenceInBazelRcUser(cfg.workspace, "build --remote_cache=") {
@@ -939,6 +976,25 @@ func (d *dev) removeAllPrefixesInFile(filename, prefixToRemove string) error {
 	outStr := out.String()
 	outStr = strings.TrimSpace(outStr) + "\n"
 	return d.os.WriteFile(filename, outStr)
+}
+
+func repositoryCacheDir() (string, error) {
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(cacheDir, "go-build", "dev-bazel-repository-cache"), nil
+}
+
+func getRepositoryCacheBazelrcLines() ([]string, error) {
+	dir, err := repositoryCacheDir()
+	if err != nil {
+		return nil, err
+	}
+	return []string{
+		fmt.Sprintf("build --repository_cache=%s", dir),
+		"build --experimental_repository_cache_hardlinks",
+	}, nil
 }
 
 // checkFileExistsUnderHomedir checks whether the given file or path is present


### PR DESCRIPTION
Add a `repository_cache` doctor check that configures Bazel's `--repository_cache` and `--experimental_repository_cache_hardlinks` flags in `.bazelrc.user`. This shares downloaded external dependency archives across all Bazel output bases/worktrees, avoiding redundant downloads. The autofix creates the cache directory and manages the lines in both `~/.bazelrc` and `.bazelrc.user`.

Epic: none.
Release note: none.