### PR TITLE
server: unskip TestStatusVarsSizeLimit and fix to use system tenant

### DIFF
--- a/pkg/server/application_api/metrics_test.go
+++ b/pkg/server/application_api/metrics_test.go
@@ -31,8 +31,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// _status/vars outputted lines as of the creation of the TestStatusVarsSizeLimit test.
-var sizeLimit = 9650
+// _status/vars outputted lines as of the last update of the
+// TestStatusVarsSizeLimit test. When updating this value, please also
+// update the comment with the date of the change and a brief reason.
+//
+// 2026-03: 18252 lines observed (high-water mark; nondeterministic metric
+// init causes variance between ~11k and ~18k across runs). Cap set at 25% above
+// high-water mark.
+var sizeLimit = 22815
 
 // TestMetricsMetadata ensures that the server's recorder return metrics and
 // that each metric has a Name, Help, Unit, and DisplayUnit defined.
@@ -285,18 +291,19 @@ func TestStatusVarsSizeLimit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.WithIssue(t, 161937)
-
 	skip.UnderRace(t, "unrelated data race")
 	skip.UnderStress(t, "unnecessary to test this scenario")
-	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
+	})
 	defer s.Stopper().Stop(context.Background())
+
 	body, err := srvtestutils.GetText(s, s.AdminURL().WithPath(apiconstants.StatusPrefix+"vars").String())
 	if err != nil {
 		t.Fatal(err)
 	}
 	lines := strings.Split(string(body), "\n")
-	require.LessOrEqual(t, len(lines), int(float64(sizeLimit)*1.5))
+	require.LessOrEqual(t, len(lines), sizeLimit)
 }
 
 func TestSpanStatsResponse(t *testing.T) {


### PR DESCRIPTION
The test was skipped (#161937) after the line count exceeded its cap. Two issues contributed to the flake:

1. The test was running on the default (virtual cluster) tenant, which sees a subset of metrics and doesn't reflect what Prometheus actually scrapes from the system tenant.

2. Nondeterministic metric initialization causes the line count to vary between ~11k and ~18k across runs, making a tight cap flaky.

Fix the test to use the system tenant and set the cap at 25% above the observed high-water mark (18252 lines) to accommodate the variance. Also simplify the assertion by baking the margin into sizeLimit directly instead of using a floating-point multiplier.

Fixes: #161937
Release note: None