### PR TITLE
dev: add support for `AUTOMATION` environment variable

### DIFF
--- a/pkg/cmd/dev/dev.go
+++ b/pkg/cmd/dev/dev.go
@@ -158,7 +158,9 @@ Typical usage:
 			"cache",
 		}
 		skipCacheCheckCommands = append(skipCacheCheckCommands, skipDoctorCheckCommands...)
-		skipCacheCheck := buildutil.CrdbTestBuild || ret.os.Getenv("DEV_NO_REMOTE_CACHE") != ""
+		skipCacheCheck := buildutil.CrdbTestBuild ||
+			ret.os.Getenv("AUTOMATION") != "" ||
+			ret.os.Getenv("DEV_NO_REMOTE_CACHE") != ""
 		for _, skipCacheCheckCommand := range skipCacheCheckCommands {
 			skipCacheCheck = skipCacheCheck || cmd.Name() == skipCacheCheckCommand
 		}

--- a/pkg/cmd/dev/doctor.go
+++ b/pkg/cmd/dev/doctor.go
@@ -650,6 +650,10 @@ func (d *dev) checkDoctorStatus(ctx context.Context) error {
 	if buildutil.CrdbTestBuild {
 		return nil
 	}
+	// In automation mode, assume the environment is correctly configured.
+	if d.os.Getenv("AUTOMATION") != "" {
+		return nil
+	}
 
 	status, err := d.getDoctorStatus(ctx)
 	if err != nil {


### PR DESCRIPTION
In this context, `dev` will not perform `doctor` checks or loopback cache setup, and will instead assume the environment is appropriately set up for builds. This is intended for use in automation especially by agents.

Normal (non-agentic) workflows should not use `dev` and should continue to use `bazel` commands directly. Meanwhile, agents that are running "as" users on their corporate machines/GCEWorkers should not set the `AUTOMATION` variable, they should "pretend" they are the users and go through the normal `doctor` checks.

Part of: DEVINF-1656
Release note: none
Epic: DEVINF-1684