### PR TITLE
roachtest: disable strict GC TTL enforcement in single-node index backfill test

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_single_node_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_single_node_index_backfill.go
@@ -229,6 +229,17 @@ func runSingleNodeIndexBackfill(
 		t.Fatal(err)
 	}
 
+	// Work around https://github.com/cockroachdb/cockroach/issues/98311.
+	// TPC-E tables use a 300s GC TTL. When admission control delays
+	// AddSSTable requests beyond this TTL, the GC threshold advances past
+	// the batch timestamp and the request fails. Disabling strict
+	// enforcement avoids this.
+	if _, err := db.ExecContext(
+		ctx, "SET CLUSTER SETTING kv.gc_ttl.strict_enforcement.enabled = false;",
+	); err != nil {
+		t.Fatal(err)
+	}
+
 	// Run TPC-E workload, KV0 workload, and index backfill concurrently.
 	workloadDuration := 120 * time.Minute
 	m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())


### PR DESCRIPTION
## Summary
- The `admission-control/single-node-index-backfill/provisioned-bandwidth=true` test failed because TPC-E tables use a 300s GC TTL. When admission control delays AddSSTable requests beyond this TTL, the GC threshold advances past the batch timestamp and the request is rejected (#98311). The repeated failures and retries caused the index backfill to take over 2 hours, exceeding the 90-minute upper bound.
- The multi-node index backfill test already sets `kv.gc_ttl.strict_enforcement.enabled=false` for this reason. This PR applies the same workaround to the single-node variant.

Fixes #164592
Epic: CRDB-47073
Release note: None