### PR TITLE
importer: enforce unique constraints during distributed merge

### DIFF
--- a/pkg/sql/importer/BUILD.bazel
+++ b/pkg/sql/importer/BUILD.bazel
@@ -191,6 +191,7 @@ go_test(
         "//pkg/server",
         "//pkg/settings/cluster",
         "//pkg/sql",
+        "//pkg/sql/bulkmerge",
         "//pkg/sql/bulksst",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/bootstrap",

--- a/pkg/sql/importer/import_processor.go
+++ b/pkg/sql/importer/import_processor.go
@@ -383,7 +383,7 @@ func ingestKvs(
 			prefix,
 			writeTS,
 			processorID,
-			false, /*checkDuplicates */
+			true, /*checkDuplicates */
 		)
 		if err != nil {
 			return nil, err

--- a/pkg/sql/importer/import_processor_planning.go
+++ b/pkg/sql/importer/import_processor_planning.go
@@ -400,11 +400,10 @@ func distImport(
 			}
 			return prefix + bulkutil.NewDistMergePaths(job.ID()).MergePath(1), nil
 		}, bulkmerge.MergeOptions{
-			Iteration:      1,
-			MaxIterations:  1,
-			WriteTimestamp: writeTS,
-			// TODO(161447): uniqueness is currently not enforced
-			EnforceUniqueness: false,
+			Iteration:         1,
+			MaxIterations:     1,
+			WriteTimestamp:    writeTS,
+			EnforceUniqueness: true,
 			MemoryMonitor:     execinfrapb.BulkMergeSpec_BULK_MONITOR,
 		})
 

--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -40,6 +41,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/bulkmerge"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsql"
@@ -131,6 +133,111 @@ func TestImportDistributedMerge(t *testing.T) {
 	sqlDB.Exec(t, `IMPORT INTO customers (id, name, email) CSV DATA ($1)`, "nodelocal://1/data.csv")
 
 	require.Equal(t, [][]string{{"1", "jeff"}}, sqlDB.QueryStr(t, `SELECT id, name FROM customers`))
+}
+
+// TestImportDistributedMergeDuplicateDetection verifies that IMPORT with
+// distributed merge detects duplicate keys at each phase of the pipeline.
+// These tests cover the fixes for cases 4-6 described in #161447.
+//
+// Case 4 (cross-SST duplicates during intermediate merge) does not apply to
+// IMPORT because it uses MaxIterations=1. That case is tested at the merge
+// level by TestCrossSSTDuplicateHandling in pkg/sql/bulkmerge.
+// TODO(mw5h): When IMPORT switches to multi-stage merge (MaxIterations>1),
+// add a test case for intermediate merge duplicate detection (case 4).
+func TestImportDistributedMergeDuplicateDetection(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testCases := []struct {
+		name string
+		// csvData is the import data.
+		csvData string
+		// injectMergeDuplicate uses the InjectDuplicateKey testing knob to
+		// simulate a duplicate during the merge phase.
+		injectMergeDuplicate bool
+		// smallBatchSize forces each key into its own SST so that non-adjacent
+		// duplicate PKs land in separate SSTs, testing cross-SST detection.
+		smallBatchSize bool
+		errRegex       string
+	}{
+		{
+			// Within-batch: adjacent duplicates land in the same map-phase SST
+			// batch. The SSTSink's checkDuplicates catches them after sorting.
+			name:     "within-batch duplicate PK",
+			csvData:  "1,a\n1,b",
+			errRegex: "duplicate key",
+		},
+		{
+			// Cross-SST: small batch size forces each key into its own SST file.
+			// Non-adjacent duplicate PKs land in different SSTs. Without
+			// EnforceUniqueness, Pebble's external iterator shadows one copy of
+			// the duplicate key, causing silent data loss. EnforceUniqueness
+			// enables suffixed iterators that expose both copies for detection
+			// by extractKeyAndCheckDuplicate.
+			name:           "cross-SST duplicate PK",
+			csvData:        "1,aaaa\n2,bbbb\n3,cccc\n4,dddd\n1,eeee",
+			smallBatchSize: true,
+			errRegex:       "duplicate key",
+		},
+		{
+			// Injected merge duplicate: InjectDuplicateKey causes the merge
+			// processor to write the same key twice consecutively, exercising
+			// extractKeyAndCheckDuplicate in the merge processing loop.
+			name:                 "merge phase injected duplicate",
+			csvData:              "1,a\n2,b\n3,c\n4,d\n5,e",
+			injectMergeDuplicate: true,
+			errRegex:             "duplicate key",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dirname := t.TempDir()
+
+			serverArgs := base.TestServerArgs{
+				ExternalIODir:     dirname,
+				DefaultTestTenant: base.TestNeedsTightIntegrationBetweenAPIsAndTestingKnobs,
+			}
+
+			var injected atomic.Bool
+			if tc.injectMergeDuplicate {
+				serverArgs.Knobs = base.TestingKnobs{
+					DistSQL: &execinfra.TestingKnobs{
+						BulkMergeTestingKnobs: &bulkmerge.TestingKnobs{
+							InjectDuplicateKey: func(iteration, maxIteration int32) bool {
+								return !injected.Swap(true)
+							},
+						},
+					},
+				}
+			}
+
+			s, db, _ := serverutils.StartServer(t, serverArgs)
+			ctx := context.Background()
+			defer s.Stopper().Stop(ctx)
+			sqlDB := sqlutils.MakeSQLRunner(db)
+
+			sqlDB.Exec(t, `SET CLUSTER SETTING bulkio.import.distributed_merge.enabled = true`)
+			if tc.smallBatchSize {
+				sqlDB.Exec(t, `SET CLUSTER SETTING bulkio.sst_writer.batch_size = '1B'`)
+			}
+
+			require.NoError(t, os.WriteFile(
+				filepath.Join(dirname, "data.csv"),
+				[]byte(tc.csvData),
+				os.FileMode(0644),
+			))
+
+			sqlDB.Exec(t, `CREATE TABLE t (id INT PRIMARY KEY, name STRING)`)
+			sqlDB.ExpectErr(t, tc.errRegex,
+				`IMPORT INTO t (id, name) CSV DATA ($1)`, "nodelocal://1/data.csv")
+
+			if tc.injectMergeDuplicate {
+				require.True(t, injected.Load(),
+					"InjectDuplicateKey was not called during merge")
+			}
+		})
+	}
 }
 
 func TestImportData(t *testing.T) {


### PR DESCRIPTION
IMPORT's distributed merge silently dropped duplicate keys in several
scenarios (cases 4-6 in #161447): cross-SST duplicates during merge
iterations were shadowed by ExternalSSTReader, and same-batch duplicates
could escape SSTBatcher's check which resets on flush.

Enable `checkDuplicates` on the SSTSink during the map phase to catch
within-batch duplicates, and set `EnforceUniqueness: true` in the merge
spec to activate cross-SST detection via suffixed iterators and
pre-existing KV conflict detection via `disallowShadowingBelow`. Since
IMPORT has no post-validation step (unlike CREATE INDEX which uses
ValidateForwardIndexes), duplicate detection must happen during the
merge.

Add TestImportDistributedMergeDuplicateDetection with subtests covering
map-phase within-batch duplicates, merge-phase consecutive duplicates
(case 5 via InjectDuplicateKey knob), and cross-SST merge duplicates
(case 6 via small batch sizes forcing separate SSTs).

Resolves: #161447
Epic: CRDB-48845