### PR TITLE
ci: skip issue autosolver when labeler is the issue author

### DIFF
--- a/.github/workflows/issue-autosolve.yml
+++ b/.github/workflows/issue-autosolve.yml
@@ -26,6 +26,20 @@ jobs:
       id-token: write
 
     steps:
+      - name: Check that labeler is not the issue author
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LABELER: ${{ github.actor }}
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
+        run: |
+          if [ "$LABELER" = "$ISSUE_AUTHOR" ]; then
+            echo "::notice::Skipping auto-solver: labeler ($LABELER) is the issue author"
+            gh issue comment ${{ github.event.issue.number }} --body \
+              "Auto-solver skipped: the \`c-autosolve\` label should be applied by someone other than the issue author."
+            gh issue edit ${{ github.event.issue.number }} --remove-label "c-autosolve" || true
+            exit 1
+          fi
+
       - name: Validate required secrets and configuration
         env:
           AUTOSOLVER_PAT: ${{ secrets.AUTOSOLVER_PAT }}


### PR DESCRIPTION
## Summary

- Prevents the issue autosolver from running when the person who applied the
  `c-autosolve` label is the same person who opened the issue.
- Posts a comment explaining why the autosolver was skipped and removes the label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>