### PR TITLE
docs: import style guide and build/pr instructions from wiki

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,40 +1,60 @@
-## CockroachDB Projects
+# Contributing to CockroachDB
 
-Suitable for | Project |  Resources
--------------|---------|------------
-For new developers | [Create a to-do app using CockroachDB and a language/ORM of your choice](https://github.com/cockroachdb/cockroachdb-todo-apps) | [How to contribute to the to-do apps repository](https://github.com/cockroachdb/cockroachdb-todo-apps#how-to-contribute-to-this-repository)
-For Go developers | Work on CockroachDB code: [List of good first issues](https://github.com/cockroachdb/cockroach/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) | [Your first CockroachDB PR](https://wiki.crdb.io/wiki/spaces/CRDB/pages/181633464/Your+first+CockroachDB+PR)
-For Kubernetes enthusiasts | Work on the Kubernetes Operator: [List of good first issues](https://github.com/cockroachdb/cockroach-operator/labels/good%20first%20issue) | [Your first CockroachDB PR](https://wiki.crdb.io/wiki/spaces/CRDB/pages/181633464/Your+first+CockroachDB+PR)
-For tech writers and docs enthusiasts | Help improve CockroachDB docs: [List of good first issues](https://github.com/cockroachdb/docs/issues?q=is%3Aopen+is%3Aissue+label%3Agood-first-issue) | [Docs contribution guide](https://github.com/cockroachdb/docs/wiki#using-github-desktop)
+## Getting Started
 
-## Contributor Guidelines
+1. Find something to work on: [good first issues](https://github.com/cockroachdb/cockroach/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
+2. [Build from source](docs/building.md)
+3. Read the [style guide](docs/style.md)
 
-Our contributor guidelines are available on [the public wiki at **wiki.crdb.io**](https://wiki.crdb.io/wiki/spaces/CRDB/pages/73204033/Contributing+to+CockroachDB).
+**Trivial changes:** We typically do not accept trivial spelling/wording
+changes to comments or error messages unless they are part of a larger
+change, as they can cause merge conflicts in ongoing development.
 
-At this location, we share our team guidelines and knowledge base
-regarding:
+## Submitting a PR
 
-- repository layout
-- how to build from source
-- how to organize your code change
-- commenting guidelines
-- commit message guidelines
-- code style guidelines
-- how to write and run tests
-- how to write release notes
-- how to submit a change for review
-- how to use continuous integration (CI)
-- how to troubleshoot certain issues
+1. Sign the [Contributor License Agreement](https://cla.crdb.dev/cockroachdb/cockroach).
+2. Create a feature branch and make your changes.
+3. Write tests. CockroachDB uses several test frameworks:
+   - **Go unit tests** (`TestXXX` in the same package) — most common.
+   - **Data-driven tests** via [`datadriven.RunTest`](https://github.com/cockroachdb/datadriven), with files in `testdata/`.
+   - **SQL logic tests** via `logictest.RunLogicTest` — for SQL behavior changes.
+   - **Roachtests** in `pkg/cmd/roachtest` — for tests needing `cockroach start` or long runtimes.
+4. Format with `crlfmt -w -tab 2 <file>.go`.
+5. Run `./dev generate && ./dev lint --short && ./dev test pkg/your/package`.
+6. Follow the [commit message guidelines](docs/commits-and-prs.md):
+   commit message is the primary record, not the PR description.
+   Include release note annotations.
+7. Push and [create a PR](https://help.github.com/articles/creating-a-pull-request).
+8. Merge via `bors r+` (not the green button).
 
-as well as many other practical topics.
+## Code Review
 
-## Don’t Forget to Join our Community
-Join our [Community Slack](https://go.crdb.dev/p/slack) (there's a dedicated #contributors channel!) to ask questions, discuss your ideas, or connect with other contributors.
+As a reviewer:
+- Respond within a few business hours for small PRs, 24 hours for larger ones.
+- Discuss design before details. If you foresee multiple passes, say so upfront.
+- Check [release notes](docs/commits-and-prs.md): user-facing changes
+  must be mentioned, backward-incompatible changes highlighted.
+- Prefix minor style suggestions with "nit:".
 
-Please follow the guidelines outlined in our [Code of Conduct](https://docs.google.com/document/d/1_BB3IrsAVglDNPy37Z6KQlii_c3fYETFlWMMBUpbY1M/edit#) to help us make the CockroachDB community a welcoming and helpful place for everyone.
+As an author:
+- Expect comments on test coverage, [Go idioms](docs/style.md), and nits.
+- Read the style guide before your first PR.
+
+## Other Resources
+
+- [Building from source](docs/building.md)
+- [Go style guide](docs/style.md)
+- [Commit and PR guidelines](docs/commits-and-prs.md)
+- [Backporting](docs/backporting.md)
+- [Configuration UX guidelines for cluster settings, flags and knobs](docs/configuration.md)
+- [Architecture overview](https://www.cockroachlabs.com/docs/stable/architecture/overview.html)
+
+## Community
+
+Join our [Community Slack](https://go.crdb.dev/p/slack) (#contributors channel)
+to ask questions or connect with other contributors.
 
 ## Code of Conduct
 
-As a contributor, you can help us keep our community open and
-inclusive. Please read and follow our [Code of
-Conduct](https://github.com/cockroachdb/code-of-conduct).
+Please read and follow our
+[Code of Conduct](https://github.com/cockroachdb/code-of-conduct).

--- a/docs/backporting.md
+++ b/docs/backporting.md
@@ -1,0 +1,73 @@
+# Backporting a change to a release branch
+
+All development starts on the `master` branch.
+
+In most cases, to add a commit to a patch release (or a beta/rc after a release branch has been created), you should submit a PR to `master` first and get it reviewed and merged there.
+
+PRs should be eligible for backport+Policy?search_id=c8caa49f-8458-41b8-8eec-607ce6cba6fc) if you would like to backport them.
+
+Tag your PR with one or more of the `backport` labels (like `backport-21.1.x`, for the 21.1 release) to indicate that it should be backported once merged on master.
+
+## “Must check” for reviewers of backport PRs
+
+* Double check the PR is eligible for backport as per the backport policy+Policy?search_id=c8caa49f-8458-41b8-8eec-607ce6cba6fc).
+* Verify that the backport PR **does not add a cluster version nor a version gate**.  
+  (i.e. it does not make changes to `pkg/clusterversion/cockroach_versions.go` nor does it contain checks that compare the current version to one of the newer versions.)  
+  Ask on #engineering if you need details about why backports must never add cluster versions or version gates.
+* Check the release notes in the commit messages, to ensure they are applicable to the branch (if a release note refers to another change / PR that is not being backported, or that may be backported later, suggest a rephrasing.)
+
+## Blathers
+
+Blathers is a bot deployed to cockroachdb/cockroach and is used to facilitate the backport process. Before using Blathers to create backports one must authenticate with Blathers to allow it to access your cockroachdb/cockroach fork.
+
+1. Clone <https://github.com/cockroachlabs/blathers-bot> locally on your laptop.
+2. Run `` `go run ./serv/main.go --auth` `` to initiate the authentication flow and follow the instructions. They will ask you to go to `https://github.com/login/device` and enter the device code printed out on the command line. Enter the code and verify the script returns with `` `Successfully saved authentication token ``. If it fails or hangs, retry, if it still does not work ask #dev-inf for help.
+3. Leave the following comment`` `blathers auth-check` `` to verify authentication worked. Blathers will respond as you in another comment to say `` `You shall pass` ``. If it responds as itself with `` `You shall not pass` ``try step 2 above again or ask #dev-inf for help.
+4. Navigate to <https://github.com/apps/blathers-crl/installations/select_target> and add your fork to the list of repositories Blathers can access. This URL will start with an account picker, please make sure to select your username to find you fork.
+
+Now you are ready to use Blathers for backports. There are two ways to do this via labels or comments.
+
+### Labels
+
+Upon merge, [Blathers](https://github.com/cockroachlabs/blathers-bot) will automatically attempt to create backport PRs for each branch that was indicated via a `backport` label on your PR, i.e. `backport-25.1`. Optionally you can use `backport-all`label to have Blathers automatically backport to all supported release branches.
+
+If any of the backport PRs fail, Blathers will post a comment on the original PR with details and add a `backport-failed` label to the original PR.
+
+Automatic backport can fail for a few reasons, such as:
+
+* backport branch already exists for a PR
+* backport has merge conflicts
+* backport branch contains merge commits, which are not allowed in backports
+
+If this happens, you must use the manual method (the `backport` command-line tool) described below.
+
+### Comments
+
+You can ask Blathers to create a backport PR without using the tagging system and waiting for merge by commenting on a PR, with the following syntax:
+
+`blathers backport <branch1> <branch2> …`
+
+For example, to backport a PR to 21.1 and 20.2, you would add a comment on the PR that says:
+
+`blathers backport 21.1 20.2`
+
+Blathers will then immediately carry out the backports just as it would when it detects a merged PR with backport tags.
+
+Blathers additionally supports `blathers backport all` command to backport to all supported branches.
+
+## Manual Method with the backport CLI tool
+
+If Blathers was unable to automatically create a backport PR, follow these steps after the main PR is merged to cherry-pick it into the release branch.
+
+1. Make sure the `backport` tool is installed: `go install github.com/cockroachdb/backport@latest`
+
+   1. For first time setup, you will need to set the `cockroach.remote` git config option. Run `git config cockroach.remote <myfork>` where `<myfork>` is the remote in which your fork of cockroach is, e.g. `origin`. You might also need to add `$GOPATH/bin` to your `$PATH`.
+2. Run `backport -r VV.V xxxxx`, where `VV.V` is replaced by the version number of the release branch and `xxxxx` is replaced by the GitHub PR number of the PR you are trying to backport, or a space-separated list of PR numbers.  
+   This will automatically create a backport branch and upload it to your repository against the release branch to GitHub.   
+   Then, it will try to open your browser to create a new PR with that branch, or provide instruction on how to do this manually if it cannot open your browser.
+
+   1. If there were merge conflicts, `backport` will halt and ask you to fix them. Once they're fixed, run `backport --continue` to continue the procedure.
+   2. If there were any non-trivial merge conflicts, be sure to call those out in the PR message so reviewers can pay closer attention to the diff.
+   3. If something goes wrong, you can use `backport --abort` to give up on the current manual backport.
+
+Note: **You do not need to use bors** to merge a backport PR; just hit the big green button once the CI is green and the backport is approved by the reviewer (usually the main reviewer of the original PR to `master` branch). But note that if the backport has been open and unmerged for many days, CI results could be stale, and might not reflect the current state of the release branch. If the backport has been open and unmerged for many days, be sure to **rebase the backport PR on the tip of the release branch before merging** to get an up-to-date CI run.

--- a/docs/building.md
+++ b/docs/building.md
@@ -1,0 +1,113 @@
+# Building and developing CockroachDB
+
+At least 4GB of RAM is required to build from source and run tests.
+
+## Prerequisites
+
+**macOS:** Install XCode (full installation, not just command-line tools), then:
+
+```bash
+brew install autoconf cmake bazelisk make gpatch
+```
+
+**Linux (Debian/Ubuntu):**
+
+```bash
+sudo apt install build-essential cmake autoconf bison patch libncurses-dev
+```
+
+Install [Bazelisk](https://github.com/bazelbuild/bazelisk) separately on Linux.
+
+Install Go matching the version in `go.mod` (not strictly required for Bazel builds, but needed for IDE development).
+
+**Docker note:** CRL employees must not use Docker Desktop (restricted software). Use [Rancher Desktop](https://rancherdesktop.io/) or [Podman](https://podman.io/) instead.
+
+## First steps
+
+Run `./dev doctor` before attempting any build -- it checks your environment and tells you how to fix problems.
+
+## The `dev` tool
+
+`dev` is a light wrapper around Bazel whose source lives in `pkg/cmd/dev`. The top-level `./dev` script builds and runs the version matching your checked-out commit. It supplements `bazel` by providing aliases for common targets and copying binaries out of Bazel's output tree into your workspace. You can always pass extra flags to the underlying `bazel` invocation after `--`.
+
+## Building
+
+| Command | What it does |
+|---------|-------------|
+| `./dev build short` | Build cockroach without DB Console (faster) |
+| `./dev build` | Build full cockroach binary (includes JS/UI) |
+| `./dev build crlfmt` | Build crlfmt formatter |
+| `./dev build roachprod` | Build roachprod |
+| `./dev build pkg/util/log` | Compile a package (useful as a check) |
+| `./dev build pkg/util/log:log_test` | Compile tests for a package |
+
+The built `cockroach` binary is staged at `./cockroach` in the repo root.
+
+## Testing
+
+| Command | What it does |
+|---------|-------------|
+| `./dev test pkg/sql` | Run all tests in a package |
+| `./dev test pkg/sql -f=TestParse -v` | Run matching tests with verbose output |
+| `./dev test pkg/sql --count=5` | Run tests multiple times |
+| `./dev test pkg/sql --stress` | Run tests under stress |
+| `./dev test pkg/sql --race` | Run with race detector |
+| `./dev testlogic --files=F --subtests=S --config=C` | Run logic tests |
+
+**Tips:**
+- Always use `-v` with `-f` so you see `testing: warning: no tests to run` if your filter matches nothing.
+- Add `-v -- --test_output streamed` to print results as tests run (reduces parallelism).
+- To debug a hung test: append `-- -c dbg` to disable symbol stripping for `dlv`.
+
+## Code generation
+
+| Command | When to use |
+|---------|-------------|
+| `./dev generate bazel` | After adding/removing files or changing imports. Use `--mirror` when vendoring new deps. |
+| `./dev generate protobuf` | After editing `.proto` files (relatively fast) |
+| `./dev generate go` | Regenerate all Go code (protobuf, cgo stubs, etc.) |
+| `./dev generate` | Regenerate everything (slow) |
+
+Set `ALWAYS_RUN_GAZELLE=1` in your shell to auto-run gazelle before every `dev test` or `dev build` (adds a small delay).
+
+## Cross-compilation
+
+```bash
+./dev build --cross          # default: linux
+./dev build --cross=windows  # also: macos, linuxarm, macosarm
+```
+
+Requires a Docker-compatible runtime (Rancher Desktop, Podman, etc.). Outputs go to the `artifacts` directory.
+
+## IDE / non-Bazel development (escape hatch)
+
+Generated code is not checked into the repo, so IDEs need it produced locally. Run `./dev gen go` to generate all `.go` files (protobuf, cgo stubs, etc.) into the worktree. If your IDE still complains, try the slower `./dev gen` to regenerate everything. This escape hatch is explicitly supported -- file a bug if tests pass under Bazel but fail under `go test` after generating.
+
+## Local dependency overrides
+
+To iterate on a dependency without updating commits in `DEPS.bzl`, use `--override_repository` in `.bazelrc.user`:
+
+```bash
+echo 'build --override_repository=com_github_google_btree=/path/to/local/btree' >> .bazelrc.user
+```
+
+The repo name (e.g. `com_github_google_btree`) matches the `name` field in the `go_repository` rule in `DEPS.bzl`. The local clone needs a `WORKSPACE` file (can be empty) and `BUILD.bazel` files (generate with `gazelle -go_prefix=<import-path> -repo_root=.`). Remove the override line when done.
+
+For a simpler approach (no local clone), you can edit the `go_repository` in `DEPS.bzl` directly to point to a custom `remote` and `commit`. See the comment at the top of `DEPS.bzl`.
+
+## Bazel troubleshooting
+
+**Missing proto dependencies:** Gazelle cannot detect dependencies introduced by `gogoproto.customtype` annotations in `.proto` files. You must manually add them to the `go_proto_library` in `BUILD.bazel` with a `# keep` comment so Gazelle does not remove them:
+
+```python
+go_proto_library(
+    name = "execinfrapb_go_proto",
+    deps = [
+        "//pkg/ccl/streamingccl",  # keep
+    ],
+)
+```
+
+**`go:generate` directives:** New `go:generate` calls are not run inside the Bazel sandbox. If you add one, ensure equivalent generation logic exists in the Bazel build.
+
+**`broken_in_bazel` tag:** If a test cannot practically support Bazel sandboxing in the same PR, tag it `broken_in_bazel` and follow up with the dev-infra team.

--- a/docs/commits-and-prs.md
+++ b/docs/commits-and-prs.md
@@ -1,0 +1,81 @@
+# Commits and PRs
+
+## Commit title
+
+Prefix with the affected package/area, lowercase after the colon, imperative
+mood, no trailing period. Keep under ~70 characters.
+
+```
+server: use net.Pipe instead of TCP for HTTP/gRPC connections
+```
+
+Use `*:` or `all:` for changes spanning many packages with no clear primary.
+
+## Commit body
+
+Explain *what* changed (before/after) and *why*, not *how*. Wrap at 100
+characters. For general commit-message philosophy, see
+[Chris Beams's guide](https://chris.beams.io/posts/git-commit/).
+
+## Issue and epic references
+
+Place references after the explanation, before the release note.
+
+```
+Fixes #123
+See also: #456, #789
+Epic: CRDB-357
+
+Release note (bug fix): ...
+```
+
+`Fixes` / `Resolves` auto-closes the issue on merge. `See also` creates
+cross-references. `Epic` links to the Jira epic.
+
+## Release note
+
+Every PR must have at least one release note annotation. Use `Release note: None`
+for non-user-facing changes.
+
+Categories: `bug fix`, `general change`, `sql change`,
+`performance improvement`, `backward-incompatible change`, `security update`,
+`build change`.
+
+A release note can span multiple paragraphs; it must appear last in the commit
+message so that subsequent paragraphs are not mistaken for part of it.
+
+```
+Release note (sql change): Added support for the `SHOW RANGES FOR
+INDEX` statement, which displays the range boundaries for a given
+index. Previously, users had to query `crdb_internal.ranges` directly
+to obtain this information.
+```
+
+## PR organization
+
+One commit per logical change. Each commit must build and pass tests
+independently (enables `git bisect`). Consider splitting a PR when it exceeds
+3-5 commits or ~200 changed lines of non-mechanical edits.
+
+When moving code to a new file or package, use one commit for the move (no
+logical changes) and a second commit for the modifications. This keeps logical
+changes visible to reviewers.
+
+Avoid gratuitous aesthetic changes (spelling fixes, reformatting) that pollute
+`git blame` without meaningful improvement.
+
+## Review iteration
+
+Use `git commit --fixup <sha>` for changes requested during review. Before
+merging, squash fixups with `git rebase -i --autosquash origin/master` and
+polish each resulting commit message.
+
+## Incomplete work
+
+Merging incomplete implementations is acceptable when unimplemented paths are
+loud -- use `unimplemented.New(...)` or similar. Track remaining work with a
+TODO referencing a GitHub issue:
+
+```go
+// TODO(username): support multi-column indexes. See #12345.
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,150 @@
+# Configuration UX Guidelines
+
+Note: these are a work in progress; check with #technical-leads-council for questions/clarification.
+
+# Cluster settings
+
+## Appropriateness
+
+**Guideline:** Consider appropriateness of a cluster setting versus some other configuration mechanism.
+
+* A behavior specific to a node, such as compaction rates or threads or memory limits is not well suited to a cluster setting.
+
+  + A CLI flag, env var, or some other form of persisted configuration may be a better fit.
+* A behavior where developers or operators may require it to differ by table, application or user is not well suited to a cluster setting.
+
+  + A session variable, role option, table storage parameter, span config or other persisted attribute may be a better fit.
+* A behavior that needs to be configurable by developers working on a single application, who are not cluster administrators, is generally not a good fit for a cluster setting.
+
+## Organization and naming for cluster settings
+
+**Guideline:** A name is composed of three main parts, the middle of which could have sub-parts, joined by dots:
+
+* 1) a broad, high level area prefix such as `sql.` or `kv.`
+* 2) a component, feature or behavior name within that area (possibly with multiple sub-parts), and then
+* 3) a suffix identifying the aspect of that behavior being configured.
+
+Example: `sql.catalog.descriptor_lease_renewal.cross_validation.enabled`
+
+* Identifies the `descriptor_lease_renewal.cross_validation` behavior within the `catalog` component in the `sql` area, and configures the `enabled` aspect of it.
+
+**Guideline:** Always use a separate suffix to identify the aspect of a behavior being configured, even when it is the only aspect being configured.
+
+* Thus a boolean should nearly always have the suffix `.enabled` as it is configuring the enabled aspect of some behavior.
+* This leaves room for other aspects, such as frequency or strictness, to be added alongside it in the future.
+
+**Guideline:** Use only ASCII lower-case letters and numbers, avoiding any special characters or punctuation other than dot to separate parts of the name and underscore to separate words within a part.
+
+This ensures that settings names can appear as "bare" unquoted identifiers in our SQL grammar, e.g `SET … a.b_c.d = x`
+
+## Default values
+
+**Guideline:** Review and adjust defaults to be appropriate out of the box.
+
+The more settings each cluster sets, the harder it is to support them, as their behaviors become increasingly unique and dependent on who set them up, what doc or guide they followed, on what version, etc which can complicate subsequent operation or support. If you see docs or customers or field teams setting a particular setting often, stop and ask why, then see if its default can be adjusted, or the behavior reworked with additional smarts/adaptiveness, to avoid the need to be setting it manually.
+
+A setting set via automation should smell like a bug most of the time (except in CC, where we’re OK with custom defaults).
+
+A setting can use a sentinel such as zero or ““ for its default then document that this value causes the some special case or dynamic behavior instead, for example “0 = GOPAXPROCs” or “0 = no limit”. However the definition of the default itself should use a constant, not derived from an env var, flag or runtime/compiler value that could differ between nodes (though making the constant metamorphic for testing is allowed and encouraged).
+
+## Visibility
+
+**Guideline:** Do not make a setting “public” unless:
+
+* a) it *needs* to be adjusted self-service by operators AND
+* b) you have put in place appropriate guardrails to minimize risk of causing performance or reliability problems AND
+* c) documentation around its correct use has been written.
+
+It is okay to add a setting without doing the above so long as it remains non-public
+
+* Misadjusting non-public settings may risk availability and reliability
+* Non-public settings should only be adjusted with the guidance of engineering
+
+  + Such guidance could be either in the form of live ad-hoc guidance or engineer reviewed internal docs or runbooks
+
+**Guideline:** Tread carefully around unsafe configuration. Use “unsafe” in the name AND description / help texts.
+
+This applies to settings that are known to have potential for lead to data loss or corruption.
+
+* Potentially avoid a cluster setting in favor of an environment variable if used only for testing/debugging
+
+  + Needing to start the cluster in a specific configuration makes it more clear it is for the express purpose of a test.
+* If a cluster setting is the answer, its name should include `unsafe`, `experimental` or some similar descriptive word in its name. This may be revisited it in future.
+
+  + Such a setting generally should not be made public until guardrails to eliminate those risks are in place.
+  + "Unsafe" or similar scary name should be kept *even if non-public* when potential for data loss is known.
+
+# CLI configuration for server commands
+
+In server commands (`cockroach start`), we use a combination of CLI flags and environment variables for knobs that either:
+
+* can be different on different nodes (e.g. max memory available)
+* needs to apply before a cluster starts up (e.g. join flags, logging config, security parameters)
+
+There are two general categories described in the following sub-sections.
+
+## User-visible CLI configuration
+
+We generally prefer CLI command-line flags for user-visible configuration.
+
+User-visible CLI configuration always applies according to a common schema:
+
+* in any case, the user can override using a CLI flag on the command-line (`--my-arg` or `--my-arg=value`)
+* for very few flags, if the user has not passed a value explicitly, we also provide an env var that can also be used to provide a custom value (lower priority than the explicit CLI flag), for example `COCKROACH_SOCKET_DIR` for `--socket-dir`.
+* if no value was provided by the user, a default is applied in code.
+
+**Guideline:** Ensure any addition or change to user-visible CLI configuration is documented in release notes and has a documentation follow-up project.
+
+**Guideline**: Use descriptive names for CLI flags that **pertain to the mechanism, not the use case**. For example, we use the flag name `--clock-device` to make CockroachDB work with VMWare PTP clocks, not `--vmware-ptp-device`, because the mechanism is more generic than the use case.
+
+**Guideline:** Don’t define CLI flags such that the user must pass PII or secrets as value: CLI flags can be inspected from other unprivileged processes on the same machine. In those use cases that require it, make the CLI flag point to a file path and load the PII/secret from there.
+
+**Guideline**: Use env var aliases for user-visible CLI *server* flags extremely sparingly. Currently only 4 CLI flags have env var aliases, mostly for historical purposes. We should shy away from using env vars for CLI *server* configuration.
+
+**Guideline**: Tread carefully about CockroachDB version upgrades.
+
+A user may have built automation that embeds specific CLI flags and env vars. During an upgrade, they will use the same automation to run both previous and new version nodes. Therefore:
+
+* any change OR removal of a CLI flag must follow a deprecation cycle that announces the deprecation/removal at least one version in advance.
+* any change to an env var must also follow a deprecation cycle (but removals are OK - the env var will simply be ignored).
+
+**Guideline:** Tread carefully around unsafe configuration. Use “unsafe” in the name AND description / help texts.
+
+* Possibly mark the flag as “Hidden”.
+* Consider not using a CLI flag at all for unsafe configuration. See the next section instead
+
+**Guideline:** If the same aspect of a behavior must be controllable by both a cluster setting and a per-node flag/env var, the flag/env var should override the cluster setting.
+
+* Having both is confusing and should be avoided if possible, however in cases where both exist…
+* Flags and env vars as per-node, which means they are more specific and should thus override cluster-wide settings.
+
+  + Example: a cluster setting might set the `storage.max_sync_duration` to 5s on a cluster where that is based on the most common disk configuration, while some nodes in that cluster might have different disks and/or other applications specific to those nodes sharing those specific disks and thus need to specify a different value.
+
+## Ad-hoc back-end configuration overrides
+
+We use environment variables for server configuration that is ad-hoc to specific deployments, that is, where the specificity is such that relatively very few users will ever need to change it. This includes:
+
+* changes to internal node behavior that should ever be changed under instruction by a CRL employee (e.g. `COCKROACH_RAFT_ENTRY_CACHE_SIZE`);
+* one-off configurations to use in emergency situations (e.g. `COCKROACH_AUTO_BALLAST`)
+
+Like other CLI config for server commands, env vars are only used for behavior that can be different on different nodes, or need to apply before a cluster is fully initialized.
+
+**Guideline**: Ensure that the definition of env vars in code has detailed documentation next to it that explains its impact.
+
+**Guideline:** Don’t define env vars such that the user must pass PII or secrets as value: env vars can be inspected from other unprivileged processes on the same machine. In those use cases that require it, make the env var point to a file path and load the PII/secret from there.
+
+# CLI configuration for client commands
+
+In client commands (e.g. `cockroach node`, `cockroach sql`) we primarily use CLI flags for all configuration: both documented, user-visible and internal, ad-hoc configuration.
+
+* The guidelines from the section above about CLI flags for server commands apply here, with regards to documentation and release notes, naming, PII/secrets, version upgrades and unsafe configuration.
+* Additional guidelines include:
+
+  + Experimental or internal configuration can be marked as “hidden” so they don’t show up in docs and help texts (e.g. `--experimental-dns-srv`).
+  + We can also hide configuration flags that provide redundant configurability for convenience (for example `--port` is hidden because the port number can be included in `--host` or `--url`).
+
+As a main difference from server commands, we do **provide slightly more env var aliases for CLI client configurations** that are expected to be configured the same across many invocations of client commands, and across multiple client commands. For example: `COCKROACH_HOST`, `COCKROACH_PORT`, `COCKROACH_URL`.
+
+# Review
+
+TBD

--- a/docs/first-pr.md
+++ b/docs/first-pr.md
@@ -1,4 +1,0 @@
-# Submitting your first PR
-
-This guide has been migrated to:
-https://wiki.crdb.io/wiki/spaces/CRDB/pages/181633464/Your+first+CockroachDB+PR

--- a/docs/style.md
+++ b/docs/style.md
@@ -1,4 +1,482 @@
-# CockroachDB Style guide
+# Go Coding Guidelines
 
-The CockroachDB Go style guide can be found here:
-https://wiki.crdb.io/wiki/spaces/CRDB/pages/181371303/Go+style+guide
+Our style is derived from the
+[Uber Go Style Guide](https://github.com/uber-go/guide/blob/master/style.md).
+This document covers CockroachDB-specific conventions only; readers are expected
+to know standard Go and the Uber guide. Use `crlfmt -w -tab 2 <file>.go` (not
+`gofmt`) to format code: 100-column code lines, 80-column comments, tab width 2.
+
+## Wrapping Function Signatures
+
+We use `crlfmt`'s rules for wrapping long function signatures.
+
+While it is fairly perscriptive, it does not add or remove repeated identical
+argument types, e.g. `start int, end int` vs `start, end int`; the latter form
+with the omitted specifier should only be used on a single line no argument
+should appear by itself on a line with no type (confusing and brittle to edits).
+
+## Go Conventions
+
+- **Enums**: start at `iota + 1` unless the zero value is meaningful.
+- **Error flow**: reduce nesting — handle errors early and return, keeping the
+  happy path at the lowest indentation level. Reduce variable scope by using
+  `if err := f(); err != nil` where possible.
+- **Mutexes**: embed `sync.Mutex` directly in private types; use a named `mu`
+  field for exported types.
+- **Channels**: size should be one or unbuffered (zero). Any other size requires
+  high scrutiny and justification.
+- **Slice/map ownership**: document whether a function captures or copies its
+  slice/map arguments.
+- **Empty slices**: prefer `var` declaration (not `[]int{}`). `nil` is a valid
+  empty slice. Check emptiness with `len(s) == 0`, not `s == nil`.
+- **Defer**: always use `defer` for releasing locks, closing files, and similar
+  cleanup.
+- **Struct initialization**: always specify field names. Use `&T{}` instead of
+  `new(T)`.
+- **String performance**: prefer `strconv` over `fmt` for primitive conversions.
+  Avoid repeated `[]byte("...")` conversions in loops.
+- **Type assertions**: always use the "comma ok" idiom.
+- **Functional options**: use the `Option` interface pattern at API boundaries;
+  use option structs for internal functions.
+
+---
+
+## Code Comments
+
+- **Data structure comments** belong at the declaration. Explain purpose,
+  lifecycle, field interactions, and what code initializes/accesses each field.
+- **Function declaration comments** focus on inputs, outputs, and contract --
+  not implementation.
+- **Algorithmic comments** belong inside function bodies. Separate processing
+  phases and explain *why*, not *what*.
+- In struct, API, and protobuf definitions, there should be more comments than
+  code.
+- Do not narrate code ("this increments x", "now we iterate over strings").
+- **Block comments** (standalone line) use full sentences with capitalization
+  and punctuation. **Inline comments** (end of code line) are lowercase
+  without terminal punctuation.
+- **Overview and design comments** must be understandable with zero knowledge
+  of the code. Minimize new terminology; define new terms immediately.
+- Factually incorrect comments are bugs -- fix immediately or file an issue.
+- In reviews, prefix grammar suggestions with "nit:".
+
+### Naked bool and other simple literal parameters
+
+For `bool` literals passed to functions, and in some cases other simple literals
+like `nil`, `0`, or `1`, it can be helpful to add a C-style comment with the
+parameter name, e.g. `printInfo(ctx, txn, 1 /* depth */, false /* verbose */)`.
+When doing so the comment always uses the parameter name verbatim -- do not
+negate it and do not substitute a different word. Another good option in such
+cases is to define a named const, e.g. `const verbose, notVerbose = true, false`
+to pass, or even have the function take a typed arg e.g. `type Verbosity bool`.
+
+### Example: protobuf enum with architectural context
+
+From `roachpb/metadata.proto` -- the enum-level comment provides a birds-eye
+view of joint configs; each value explains its role in replication changes.
+
+```proto
+// ReplicaType identifies which raft activities a replica participates in. In
+// normal operation, VOTER_FULL and LEARNER are the only used states. However,
+// atomic replication changes require a transition through a "joint config"; in
+// this joint config, the VOTER_DEMOTING and VOTER_INCOMING types are used as
+// well to denote voters which are being downgraded to learners and newly added
+// by the change, respectively.
+//
+// All voter types indicate a replica that participates in all raft activities,
+// including voting for leadership and committing entries. In a joint config, two
+// separate majorities are required: one from the set of replicas that have
+// either type VOTER or VOTER_OUTGOING or VOTER_DEMOTING, as well as that of the
+// set of types VOTER and VOTER_INCOMING.
+enum ReplicaType {
+  VOTER_FULL = 0;
+  VOTER_INCOMING = 2;
+  VOTER_OUTGOING = 3;
+}
+```
+
+### Example: function body phase comments with domain depth
+
+From `replica_command.go` -- comments explain lease semantics and range-merge
+edge cases, not just control flow.
+
+```go
+func (r *Replica) executeAdminCommandWithDescriptor(
+  ctx context.Context, updateDesc func(*roachpb.RangeDescriptor) error,
+) *roachpb.Error {
+  // Retry forever as long as we see errors we know will resolve.
+  retryOpts := base.DefaultRetryOptions()
+  // Randomize quite a lot just in case someone else also interferes with us
+  // in a retry loop. Note that this is speculative; there wasn't an incident
+  // that suggested this.
+  retryOpts.RandomizationFactor = 0.5
+  var lastErr error
+  for retryable := retry.StartWithCtx(ctx, retryOpts); retryable.Next(); {
+    // The replica may have been destroyed since the start of the retry loop.
+    // We need to explicitly check this condition. Having a valid lease, as we
+    // verify below, does not imply that the range still exists: even after a
+    // range has been merged into its left-hand neighbor, its final lease
+    // (i.e., the lease we have in r.mu.state.Lease) can remain valid
+    // indefinitely.
+    if _, err := r.IsDestroyed(); err != nil {
+      return roachpb.NewError(err)
+    }
+
+    // Admin commands always require the range lease to begin (see
+    // executeAdminBatch), but we may have lost it while in this retry loop.
+    // Without the lease, a replica's local descriptor can be arbitrarily
+    // stale, which will result in a ConditionFailedError. To avoid this, we
+    // make sure that we still have the lease before each attempt.
+    if _, pErr := r.redirectOnOrAcquireLease(ctx); pErr != nil {
+      return pErr
+    }
+```
+
+---
+
+## Code Organization
+
+### Function ordering
+
+Order by receiver, then rough call order; constructors after type definition.
+
+### Package naming
+
+- **Names must be unique across the entire project**, because otherwise
+  `goimports` may auto-import the wrong package.
+- Use the parent name plus a suffix to achieve uniqueness: `server/serverpb`,
+  `kv/kvserver`, `util/contextutil`, `util/testutil`.
+- Protobuf definitions go in a `xxxxpb` sub-directory of the parent package
+  (e.g. `pkg/server/serverpb`, `pkg/sql/sessiondatapb`).
+
+### Breaking cyclical dependencies
+
+**Interface extraction:** Extract an interface into a leaf sub-package that
+both sides can import.
+
+```go
+// Package bapi defines the interface.
+package bapi
+type B interface { Bar() }
+
+// Package a imports only the interface.
+package a
+import "b/bapi"
+func Foo(b bapi.B) { b.Bar() }
+
+// Package b imports a and implements the interface.
+package b
+import "a"
+type bImpl struct{}
+func (x bImpl) Bar() { a.Foo(x) }
+```
+
+Ensure package `a` has a mock implementation for its own unit tests.
+
+**Dependency injection:** Use when the interface approach is impractical.
+
+1. In package `a`: `var BarFn = func() { /* placeholder */ }`
+2. In package `b`: `func init() { a.BarFn = Bar }`
+
+The package exposing the injection slot must pass its unit tests independently,
+with valid default behavior when the slot is not populated.
+
+**`X_test` package trick:** Test files in package `X` can declare
+`package X_test`, which is allowed to import packages that transitively depend
+on `X`. For example, `testserver` depends on `pkg/server` which depends on
+`pkg/sql`, so tests needing a test server use `package sql_test` or
+`package server_test`.
+
+---
+
+## Data-Driven Tests and Scope of Tested Behavior
+
+We use the [datadriven](https://github.com/cockroachdb/datadriven) package as an
+alternative to table-driven tests. One of the most used implementations is
+"logic tests" which execute SQL and compare results to golden files.
+
+A well-written test should observe and assert *only* behavior directly relevant
+to the functionality under test. Overly broad assertions (e.g. selecting all
+system tables instead of only tables the test created) make tests brittle and
+train engineers to blindly update them, defeating their purpose. A logic test
+should choose its `SELECT` and `WHERE` clause so that the output is fully
+determined by the test's own constructed conditions -- not by unrelated factors
+like total system table count, OS version, table IDs, or range IDs.
+
+This is particularly important to consider intentionally when working with tests
+that have a `--rewrite` option as this can easily capture more output in what is
+being tested than intended.
+
+---
+
+## Error Handling
+
+We use [cockroachdb/errors](https://github.com/cockroachdb/errors), a superset
+of Go's standard `errors` package that integrates with `cockroachdb/redact`.
+
+### Creating and wrapping errors
+
+```go
+errors.New("connection failed")                      // static string
+errors.Newf("invalid value: %d", val)                // formatted
+errors.AssertionFailedf("expected non-nil pointer")  // assertion failure
+errors.Wrap(err, "opening file")                     // add context
+errors.Wrapf(err, "connecting to %s", addr)          // formatted context
+```
+
+Keep context succinct; avoid "failed to" which piles up:
+```go
+// Bad: "failed to x: failed to y: failed to create store: the error"
+return errors.Newf("failed to create new store: %s", err)
+
+// Good: "x: y: new store: the error"
+return errors.Wrap(err, "new store")
+```
+
+### User-facing information
+
+```go
+errors.WithHint(err, "check your network connection")
+errors.WithDetail(err, "request payload was 2.5MB")
+errors.WithSafeDetails(err, "node_id=%d", nodeID)   // safe for Sentry reports
+```
+
+### Detecting errors
+
+```go
+if errors.Is(err, ErrNotFound) { /* ... */ }    // sentinel errors
+var nfErr *NotFoundError
+if errors.As(err, &nfErr) { /* ... */ }         // typed errors
+```
+
+### Error propagation
+
+| Scenario | Approach |
+|----------|----------|
+| No additional context needed | Return original error |
+| Adding context | `errors.Wrap` or `errors.Wrapf` |
+| Passing through goroutine channel | `errors.WithStack` on both ends |
+| Callers don't need to detect this error | `errors.Newf` |
+| Hide original cause | `errors.Handled` or `errors.Opaque` |
+
+### `%v` for potentially-nil errors
+
+Prefer `%v` over `%s` when formatting errors that might be nil. A nil error
+formatted with `%s` renders as `%!s(<nil>)`, while `%v` renders as `<nil>`.
+
+### Error stability
+
+How errors should affect process and session lifecycle:
+
+- **User input / query errors** (e.g. `SELECT invalid`, `SELECT 1/0`):
+  Return a regular error with an appropriate SQLSTATE code. Do not kill
+  the session or the process.
+
+- **Unexpected condition scoped to one query** (unreachable code,
+  precondition failure): Return `errors.AssertionFailedf(...)`. Crash
+  reports are sent automatically. Do not kill the session or the process.
+
+- **Candidate future feature** (unsupported parameter combination, unexpected
+  but valid input hitting a `default`/`else` clause): Use
+  `pgerror.UnimplementedWithIssue(...)` or `pgerror.Unimplemented(...)`.
+  See "Unimplemented features" below.
+
+- **Invalid session-scoped state** (unreachable code operating on session
+  state): Propagate an assertion error to the client. Kill or make the
+  session read-only. Do not kill the process.
+
+- **Invalid state on a read-only or non-persisting path** (unexpected disk
+  data, bad subsystem return): Propagate an assertion error, also call
+  `log.Errorf`. Ensure no data is persisted. Do not kill the process.
+
+- **Invalid state on a data-persisting path** (post-condition failure during
+  write, corruption in KV storage): Call `log.Fatalf`. This kills the
+  process and sends a crash report automatically.
+
+### SQLSTATE codes
+
+SQLSTATE is the stable, documented error API -- not message text. Use the
+same code PostgreSQL would use in an equivalent situation. Only invent new
+codes when PostgreSQL has no equivalent; respect the two-character category
+prefix. Verify codes with SQL logic tests.
+
+CockroachDB-specific codes:
+- **XX000** -- internal error; auto-derived for assertion failures, triggers
+  a crash report when the error flows back to the client.
+- **XXUUU** -- auto-chosen when no SQLSTATE is set. Reduce these over time.
+- **XXA00** -- txn committed but a schema change op failed; manual
+  intervention likely needed.
+- **40001** -- serialization error. Txn did **not** commit; **can** be retried.
+- **40003** -- statement completion unknown. Txn **may or may not** have
+  committed; manual intervention likely needed.
+
+See `pkg/sql/pgwire/pgcode/codes.go` for the full list.
+
+### Errors as API
+
+- **Messages, hints, and details** can be changed freely without release notes.
+- **SQLSTATE values** are the stable contract. New codes or splitting one code
+  into multiple alternatives requires a release note.
+
+### Message formatting
+
+- **Message**: lowercase start, no trailing period, no newlines. Keep it
+  short and descriptive.
+- **Hint / Detail**: full sentences (capital start, period at end). May be
+  multi-line. Hints tell the user what to *do*; details elaborate on what
+  *happened*.
+
+### Large strings
+
+Do not include arbitrarily large strings in error payloads -- they cause
+excessive memory use and truncated crash reports. When in doubt, truncate
+to a prefix and append a unicode ellipsis (`…`).
+
+### Unimplemented features
+
+Mark unsupported-but-plausible functionality with
+`pgerror.UnimplementedWithIssue(issueNum, ...)` or
+`pgerror.Unimplemented(...)`. Label the tracking issue with `docs-todo`,
+`known-limitation`, and `X-anchored-telemetry`. Unimplemented errors get
+their own non-crash telemetry automatically.
+
+### Incomplete implementations
+
+Merging incomplete implementations is acceptable as long as every
+unimplemented code path uses `unimplemented.New(...)` (or the variants
+above). Track each gap with a GitHub issue and a `// TODO(#NNNNN)`
+comment at the call site.
+
+---
+
+## Log and Error Redactability
+
+Data in logs and errors is **unsafe (PII-laden) by default** and will be
+redacted before being sent to Cockroach Labs. Mark information as safe to
+preserve observability. Always use `cockroachdb/errors` (not `fmt.Errorf`) so
+that error messages are automatically redactable.
+
+### What is automatically safe
+
+- Format string literals in `errors.New`/`Newf`/`Wrap`/`log.Infof`/etc.
+- Booleans, integers, floats, `time.Time`, `time.Duration`.
+- The redactable contents of existing `error` values when wrapped.
+- Everything else is unsafe by default.
+
+### Implementing redactability on your types
+
+| Scenario | Approach |
+|----------|----------|
+| Type contains only IDs, counts, or other non-PII (e.g. `NodeID`) | Implement `SafeValue` and update the allowlist in `pkg/testutils/lint/passes/redactcheck/redactcheck.go`. |
+| Type has a mix of safe and unsafe fields | Implement `SafeFormatter` (preferred). |
+
+**Prefer `SafeFormatter` over `SafeValue`** -- it is more precise, does not
+require linter allowlist changes, and is resistant to someone later adding
+unsafe fields to the type.
+
+#### Example: migrating `String()` to `SafeFormat()`
+
+```go
+// Before: entire output is considered unsafe.
+func (m MetricSnap) String() string {
+        suffix := ""
+        if m.ConnsRefused > 0 {
+                suffix = fmt.Sprintf(", refused %d conns", m.ConnsRefused)
+        }
+        return fmt.Sprintf("infos %d/%d sent/received, bytes %dB/%dB sent/received%s",
+                m.InfosSent, m.InfosReceived,
+                m.BytesSent, m.BytesReceived,
+                suffix)
+}
+
+// After: output is safe (all fields are integers, format strings are literals).
+func (m MetricSnap) SafeFormat(w redact.SafePrinter, _ rune) {
+        w.Printf("infos %d/%d sent/received, bytes %dB/%dB sent/received",
+                m.InfosSent, m.InfosReceived,
+                m.BytesSent, m.BytesReceived)
+        if m.ConnsRefused > 0 {
+                w.Printf(", refused %d conns", m.ConnsRefused)
+        }
+}
+
+func (m MetricSnap) String() string { return redact.StringWithoutMarkers(m) }
+```
+
+### Composing redactable strings
+
+- `redact.Sprint()` / `redact.Sprintf()` -- create a `RedactableString` from
+  mixed safe/unsafe values.
+- `redact.StringBuilder` -- build a `RedactableString` programmatically.
+- Store `redact.RedactableString` in struct fields that will appear in logs,
+  instead of plain `string`.
+
+### Don'ts
+
+- **Don't** use `redact.Safe()` / `errors.Safe()` / `log.Safe()` -- these are
+  fragile promises that break when someone changes the argument's type.
+- **Don't** cast a `string` to `RedactableString` manually -- use
+  `redact.Sprintf` instead.
+- **Don't** use `SafeValue` on complex types -- someone may later add an unsafe
+  field without noticing.
+
+### Testing redactability
+
+Use `echotest` to lock down `SafeFormat` output:
+
+```go
+func TestMyType_SafeFormat(t *testing.T) {
+    v := MyType{ID: 1, Name: "sensitive"}
+    redacted := string(redact.Sprint(v))
+    echotest.Require(t, redacted, datapathutils.TestDataPath(t, t.Name()))
+}
+```
+
+Run with `-rewrite` to generate the initial testdata file, then verify markers
+appear around unsafe fields.
+
+---
+
+## Working with Protobufs
+
+CockroachDB uses a [gogoproto fork](https://github.com/cockroachdb/gogoproto).
+Proto definitions live in `.proto` files; generated `.pb.go` files are
+regenerated by `./dev gen protobuf` or `./dev build short`.
+
+* Don't use `required` -- it breaks backward/forward compatibility between
+  nodes running different binaries.
+* Use `gogoproto.nullable` so the compiled field type is the value itself
+  (not a pointer). Absence is represented as the zero value. Exceptions:
+  when you need to distinguish zero from absent, or when the message type
+  is very large and pointer copying is cheaper.
+* Don't use `optional` -- use `gogoproto.nullable` instead if you need
+  presence semantics.
+* Avoid `types.Any` and `json` types -- they are very hard to decode when
+  inspecting debug zips.
+
+**Gotcha:** Empty proto fields can have non-zero marshalling overhead on
+hot paths. Use the
+[omitEmpty field](https://github.com/cockroachdb/gogoproto/pull/2) to
+ensure truly empty encoding.
+
+---
+
+## SQL Column Labels
+
+When defining result column labels for statements or virtual tables:
+
+* Use consistent casing; use underscores to separate words (consistent with
+  `information_schema`), e.g. `start_key` not `startkey`.
+* The same concept across different statements should use the same label, e.g.
+  `variable` and `value` match between `SHOW ALL CLUSTER SETTINGS` and
+  `SHOW SESSION ALL`.
+* Labels must be usable without quoting. Avoid SQL keywords: `table_name` not
+  `"table"`, `index_name` not `"index"`. Never name a column `"user"` -- use
+  `user_name`.
+* Avoid abbreviations unless universally used in spoken English (`id` is fine,
+  `loc` is not).
+* For "primary key" columns, disambiguate overloaded words: `zone_id`, `job_id`,
+  `table_id` instead of just `id`.
+* For objects with multiple handle types (ID, name), disambiguate in the label:
+  `table_name` not `table`, so `table_id` can be added later.
+* Reuse labels from `information_schema` or existing `SHOW` statements when they
+  match the principles above.


### PR DESCRIPTION
Previously CRDB's repo linked to an external, public wiki that had pages which were publicly accessible (to humans and bots alike) documenting how to build CRDB code and the style conventions to follow when writing and committing it.

This moves this information about how to build and write CRDB code in the CRDB repo closer to that code, by moving it to docs in the repo along-side said code. This is intended both to make it easier to find and consult during development (for both humans but even more so bots), reduce the amount we need to duplicate this content in bot-specific files like .claude/rules, and also ensure this info remains easily accessible, including to tools, now that that wiki is no longer publicly accessible.

Release note: none.
Epic: none.