### PR TITLE
sql: disable buffered writes for implicit txns by default

### DIFF
--- a/docs/generated/sql/session_vars.md
+++ b/docs/generated/sql/session_vars.md
@@ -34,6 +34,7 @@ SHOW application_name;
 <tr><td><code>avoid_buffering</code></td><td>Indicates that the returned data should not be buffered by conn executor. This is currently used by replication primitives to ensure the data is flushed to the consumer immediately.</td><td><code>off</code></td><td>No</td><td>-</td></tr>
 <tr><td><code>avoid_full_table_scans_in_mutations</code></td><td>Controls whether mutation queries that plan full table scans should be avoided.</td><td><code>on</code></td><td>No</td><td>-</td></tr>
 <tr><td><code>backslash_quote</code></td><td>Controls whether backslash can be used as a quote escape character (compatibility setting).</td><td><code>safe_encoding</code></td><td>No</td><td>-</td></tr>
+<tr><td><code>buffered_writes_implicit_txns_enabled</code></td><td>Controls whether buffered writes are enabled for implicit transactions.</td><td><code>off</code></td><td>No</td><td>-</td></tr>
 <tr><td><code>buffered_writes_use_locking_on_non_unique_indexes</code></td><td>Controls whether buffered writes use locking on non-unique indexes.</td><td><code>off</code></td><td>No</td><td>-</td></tr>
 <tr><td><code>bypass_pcr_reader_catalog_aost</code></td><td>Disables the AOST used by all user queries on the PCR reader catalog.</td><td><code>off</code></td><td>No</td><td>-</td></tr>
 <tr><td><code>bytea_output</code></td><td>Controls how to encode byte arrays when converting to string.</td><td><code>hex</code></td><td>No</td><td>-</td></tr>

--- a/pkg/ccl/logictestccl/testdata/logic_test/buffered_writes_lock_loss
+++ b/pkg/ccl/logictestccl/testdata/logic_test/buffered_writes_lock_loss
@@ -25,6 +25,9 @@ statement ok
 SET kv_transaction_buffered_writes_enabled=true
 
 statement ok
+SET buffered_writes_implicit_txns_enabled=true
+
+statement ok
 BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED
 
 statement ok

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -3878,11 +3878,11 @@ func (ex *connExecutor) omitInRangefeeds() bool {
 	return ex.sessionData().DisableChangefeedReplication
 }
 
-func (ex *connExecutor) bufferedWritesEnabled(ctx context.Context) bool {
+func (ex *connExecutor) bufferedWritesEnabled(typ txnType) bool {
 	if ex.sessionData() == nil {
 		return false
 	}
-	return ex.sessionData().BufferedWritesEnabled
+	return ex.sessionData().BufferedWritesEnabled && (typ == explicitTxn || ex.sessionData().BufferedWritesImplicitTxnsEnabled)
 }
 
 func (ex *connExecutor) bufferedWritesIsAllowedForIsolationLevel(
@@ -4173,8 +4173,18 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 			if err != nil {
 				return advanceInfo{}, err
 			}
-			if advInfo.txnEvent.eventType == txnUpgradeToExplicit {
-				ex.extraTxnState.txnFinishClosure.implicit = false
+		}
+		if advInfo.txnEvent.eventType == txnUpgradeToExplicit {
+			ex.extraTxnState.txnFinishClosure.implicit = false
+			// Update whether the buffered writes are enabled on the txn since
+			// it was upgraded to the explicit one.
+			if !ex.state.mu.txn.Active() {
+				// In an edge case, when multiple statements are sent via a
+				// single SimpleQuery pgwire message, the txn might have already
+				// issued some BatchRequests. We don't allow enabling buffered
+				// writes on such txn, so we'll keep the buffered writes
+				// enablement unchanged.
+				ex.state.mu.txn.SetBufferedWritesEnabled(ex.bufferedWritesEnabled(explicitTxn))
 			}
 		}
 	case txnStart:
@@ -4316,7 +4326,7 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 				ex.QualityOfService(),
 				chainModes.isoLevel,
 				ex.omitInRangefeeds(),
-				ex.bufferedWritesEnabled(ex.Ctx()),
+				ex.bufferedWritesEnabled(explicitTxn),
 				ex.rng.internal,
 			)
 			chainEvent := eventTxnStart{ImplicitTxn: fsm.False}

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -3845,7 +3845,7 @@ func (ex *connExecutor) execStmtInNoTxnState(
 				ex.QualityOfService(),
 				ex.txnIsolationLevelToKV(ctx, s.Modes.Isolation),
 				ex.omitInRangefeeds(),
-				ex.bufferedWritesEnabled(ctx),
+				ex.bufferedWritesEnabled(explicitTxn),
 				ex.rng.internal,
 			)
 	case *tree.ShowCommitTimestamp:
@@ -3880,7 +3880,7 @@ func (ex *connExecutor) execStmtInNoTxnState(
 				ex.QualityOfService(),
 				ex.txnIsolationLevelToKV(ctx, tree.UnspecifiedIsolation),
 				ex.omitInRangefeeds(),
-				ex.bufferedWritesEnabled(ctx),
+				ex.bufferedWritesEnabled(implicitTxn),
 				ex.rng.internal,
 			)
 	}
@@ -3915,7 +3915,7 @@ func (ex *connExecutor) beginImplicitTxn(
 			qos,
 			ex.txnIsolationLevelToKV(ctx, tree.UnspecifiedIsolation),
 			ex.omitInRangefeeds(),
-			ex.bufferedWritesEnabled(ctx),
+			ex.bufferedWritesEnabled(implicitTxn),
 			ex.rng.internal,
 		)
 }

--- a/pkg/sql/explain_test.go
+++ b/pkg/sql/explain_test.go
@@ -686,7 +686,10 @@ func TestExplainAnalyzeBufferedWrites(t *testing.T) {
 			infoPrinted: false,
 		},
 		{ // enabled
-			setup:       []string{`SET kv_transaction_buffered_writes_enabled = true;`},
+			setup: []string{
+				`SET kv_transaction_buffered_writes_enabled = true;`,
+				`SET buffered_writes_implicit_txns_enabled = true;`,
+			},
 			query:       `INSERT INTO t VALUES (1), (2)`,
 			infoPrinted: true,
 		},
@@ -699,6 +702,7 @@ func TestExplainAnalyzeBufferedWrites(t *testing.T) {
 		{
 			setup: []string{
 				`SET kv_transaction_buffered_writes_enabled = true;`,
+				`SET buffered_writes_implicit_txns_enabled = true;`,
 				`SET CLUSTER SETTING kv.transaction.write_buffering.max_buffer_size = '1B';`,
 			},
 			cleanup:     `RESET CLUSTER SETTING kv.transaction.write_buffering.max_buffer_size;`,
@@ -706,7 +710,10 @@ func TestExplainAnalyzeBufferedWrites(t *testing.T) {
 			infoPrinted: true,
 		},
 		{ // read-only implicit
-			setup:       []string{`SET kv_transaction_buffered_writes_enabled = true;`},
+			setup: []string{
+				`SET kv_transaction_buffered_writes_enabled = true;`,
+				`SET buffered_writes_implicit_txns_enabled = true;`,
+			},
 			query:       `SELECT * FROM t`,
 			infoPrinted: false,
 		},

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -3773,7 +3773,8 @@ WHERE
       'default_transaction_isolation',
       'transaction_isolation',
       'kv_transaction_buffered_writes_enabled',
-      'create_table_with_schema_locked'
+      'create_table_with_schema_locked',
+      'buffered_writes_implicit_txns_enabled'
     )
 ORDER BY variable
 ----

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3001,7 +3001,8 @@ WHERE
     'copy_fast_path_enabled',
     'direct_columnar_scans_enabled',
     'multiple_active_portals_enabled',
-    'kv_transaction_buffered_writes_enabled'
+    'kv_transaction_buffered_writes_enabled',
+    'buffered_writes_implicit_txns_enabled'
   )
 ORDER BY name
 ----
@@ -3257,7 +3258,8 @@ WHERE
     'copy_fast_path_enabled',
     'direct_columnar_scans_enabled',
     'multiple_active_portals_enabled',
-    'kv_transaction_buffered_writes_enabled'
+    'kv_transaction_buffered_writes_enabled',
+    'buffered_writes_implicit_txns_enabled'
   )
 ORDER BY name
 ----
@@ -3513,6 +3515,7 @@ autocommit_before_ddl                                            NULL    NULL   
 avoid_buffering                                                  NULL    NULL     NULL     NULL        NULL
 avoid_full_table_scans_in_mutations                              NULL    NULL     NULL     NULL        NULL
 backslash_quote                                                  NULL    NULL     NULL     NULL        NULL
+buffered_writes_implicit_txns_enabled                            NULL    NULL     NULL     NULL        NULL
 buffered_writes_use_locking_on_non_unique_indexes                NULL    NULL     NULL     NULL        NULL
 bypass_pcr_reader_catalog_aost                                   NULL    NULL     NULL     NULL        NULL
 bytea_output                                                     NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -32,7 +32,8 @@ WHERE
     'copy_fast_path_enabled',
     'direct_columnar_scans_enabled',
     'multiple_active_portals_enabled',
-    'kv_transaction_buffered_writes_enabled'
+    'kv_transaction_buffered_writes_enabled',
+    'buffered_writes_implicit_txns_enabled'
   )
 ORDER BY variable
 ----

--- a/pkg/sql/opt/exec/execbuilder/testdata/autocommit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/autocommit
@@ -10,6 +10,9 @@
 statement ok
 SET kv_transaction_buffered_writes_enabled = true
 
+statement ok
+SET buffered_writes_implicit_txns_enabled = true
+
 # The buffer size can be changed metamoprhically, and if it happens to be too
 # small (around 500B), then some of the txns below might flush the buffer,
 # resulting in different KV requests. To ensure deterministic traces we always

--- a/pkg/sql/session_var_descriptions.go
+++ b/pkg/sql/session_var_descriptions.go
@@ -20,6 +20,7 @@ var sessionVarDescriptions = map[string]string{
 	"avoid_buffering":                                                 "Indicates that the returned data should not be buffered by conn executor. This is currently used by replication primitives to ensure the data is flushed to the consumer immediately.",
 	"avoid_full_table_scans_in_mutations":                             "Controls whether mutation queries that plan full table scans should be avoided.",
 	"backslash_quote":                                                 "Controls whether backslash can be used as a quote escape character (compatibility setting).",
+	"buffered_writes_implicit_txns_enabled":                           "Controls whether buffered writes are enabled for implicit transactions.",
 	"buffered_writes_use_locking_on_non_unique_indexes":               "Controls whether buffered writes use locking on non-unique indexes.",
 	"bypass_pcr_reader_catalog_aost":                                  "Disables the AOST used by all user queries on the PCR reader catalog.",
 	"bytea_output":                                                    "Controls how to encode byte arrays when converting to string.",

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -804,6 +804,9 @@ message LocalOnlySessionData {
   // in the stable stats cache, a trace message would be logged, and
   // still the whole stable stats cache will be used for planning.
   util.hlc.Timestamp stats_as_of = 204 [(gogoproto.nullable) = false];
+  // BufferedWritesImplicitTxnsEnabled, if set, will make it so that the
+  // buffered writes feature is used for implicit txns.
+  bool buffered_writes_implicit_txns_enabled = 205;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/sessionmutator/mutator.go
+++ b/pkg/sql/sessionmutator/mutator.go
@@ -1194,3 +1194,7 @@ func (m *SessionDataMutator) SetOptimizerUseMinRowCountAntiJoinFix(val bool) {
 func (m *SessionDataMutator) SetStatsAsOf(val hlc.Timestamp) {
 	m.Data.StatsAsOf = val
 }
+
+func (m *SessionDataMutator) SetBufferedWritesImplicitTxnsEnabled(val bool) {
+	m.Data.BufferedWritesImplicitTxnsEnabled = val
+}

--- a/pkg/sql/txn_restart_test.go
+++ b/pkg/sql/txn_restart_test.go
@@ -669,6 +669,8 @@ func TestAbortedTxnOnlyRetriedOnce(t *testing.T) {
 	defer srv.Stopper().Stop(context.Background())
 	s := srv.ApplicationLayer()
 	kvcoord.BufferedWritesMaxBufferSize.Override(ctx, &s.ClusterSettings().SV, 2<<10 /* 2KiB */)
+	conn, err := sqlDB.Conn(ctx)
+	require.NoError(t, err)
 
 	{
 		pgURL, cleanup := s.PGUrl(t,
@@ -686,14 +688,15 @@ func TestAbortedTxnOnlyRetriedOnce(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := sqlDB.Exec(`
+	if _, err := conn.ExecContext(ctx, `
 CREATE DATABASE t;
 CREATE TABLE t.test (k INT PRIMARY KEY, v TEXT);
+SET buffered_writes_implicit_txns_enabled = true;
 `); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := sqlDB.Exec(insertStmt); err != nil {
+	if _, err := conn.ExecContext(ctx, insertStmt); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -4999,6 +4999,26 @@ var varGen = map[string]sessionVar{
 			return ""
 		},
 	},
+
+	// CockroachDB extension.
+	`buffered_writes_implicit_txns_enabled`: {
+		Description:  sessionVarDescriptions["buffered_writes_implicit_txns_enabled"],
+		GetStringVal: makePostgresBoolGetStringValFn(`buffered_writes_implicit_txns_enabled`),
+		Set: func(_ context.Context, m sessionmutator.SessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("buffered_writes_implicit_txns_enabled", s)
+			if err != nil {
+				return err
+			}
+			m.SetBufferedWritesImplicitTxnsEnabled(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().BufferedWritesImplicitTxnsEnabled), nil
+		},
+		GlobalDefault: func(sv *settings.Values) string {
+			return formatBoolAsPostgresSetting(bufferedWritesImplicitTxnsEnabledDefault)
+		},
+	},
 }
 
 func ReplicationModeFromString(s string) (sessiondatapb.ReplicationMode, error) {
@@ -5019,7 +5039,9 @@ func ReplicationModeFromString(s string) (sessiondatapb.ReplicationMode, error) 
 }
 
 // We want test coverage for this on and off so make it metamorphic.
-var copyFastPathDefault bool = metamorphic.ConstantWithTestBool("copy-fast-path-enabled-default", true)
+var copyFastPathDefault = metamorphic.ConstantWithTestBool("copy-fast-path-enabled-default", true)
+
+var bufferedWritesImplicitTxnsEnabledDefault = metamorphic.ConstantWithTestBool("buffered_writes_implicit_txns_enabled", false)
 
 const compatErrMsg = "this parameter is currently recognized only for compatibility and has no effect in CockroachDB."
 


### PR DESCRIPTION
We expect that vast majority of implicit serializable txns don't benefit from the buffered writes feature while we've seen some regressions around blind writes, so this commit disables the buffered writes for all implicit txns. As an escape hatch, a new session variable `buffered_writes_implicit_txns_enabled` is introduced which can be set to `true` to get the previous behavior (to increase test coverage the default value for the session variable is metamorphically randomized in test builds).

One notable case is worth calling out. In the PG wire protocol, entering the extended protocol starts an implicit transaction which is then upgraded to explicit if BEGIN is executed as a prepared statement. See 9fdb39b49e95320561ea58b8cac087afec62014d for more context.

Fixes: #154553.
Release note: None