### PR TITLE
release-26.1: colexecjoin: add missing cancellation checking to hash joiner

### DIFF
--- a/pkg/sql/colexec/colexechash/hashtable.go
+++ b/pkg/sql/colexec/colexechash/hashtable.go
@@ -268,7 +268,7 @@ type HashTable struct {
 	allowNullEquality bool
 
 	datumAlloc    tree.DatumAlloc
-	cancelChecker colexecutils.CancelChecker
+	CancelChecker colexecutils.CancelChecker
 
 	BuildMode HashTableBuildMode
 	probeMode HashTableProbeMode
@@ -372,7 +372,7 @@ func NewHashTable(
 		ht.BuildScratch.Next = []keyID{0}
 	}
 
-	ht.cancelChecker.Init(ctx)
+	ht.CancelChecker.Init(ctx)
 	return ht
 }
 
@@ -772,7 +772,7 @@ func (ht *HashTable) ComputeBuckets(buckets []uint32, keys []*coldata.Vec, nKeys
 	}
 
 	for i := range ht.keyCols {
-		rehash(buckets, keys[i], nKeys, sel, ht.cancelChecker, &ht.datumAlloc)
+		rehash(buckets, keys[i], nKeys, sel, ht.CancelChecker, &ht.datumAlloc)
 	}
 
 	finalizeHash(buckets, nKeys, ht.numBuckets)
@@ -805,7 +805,7 @@ func (ht *HashTable) buildNextChains(first, next []keyID, offset, batchSize uint
 			next[firstKeyID] = id
 		}
 	}
-	ht.cancelChecker.CheckEveryCall()
+	ht.CancelChecker.CheckEveryCall()
 }
 
 // SetupLimitedSlices ensures that HeadID, differs, foundNull, ToCheckID, and

--- a/pkg/sql/colexec/colexecjoin/hashjoiner.go
+++ b/pkg/sql/colexec/colexecjoin/hashjoiner.go
@@ -289,6 +289,7 @@ func (hj *hashJoiner) Init(ctx context.Context) {
 
 func (hj *hashJoiner) Next() coldata.Batch {
 	for {
+		hj.ht.CancelChecker.CheckEveryCall()
 		switch hj.state {
 		case hjBuilding:
 			hj.build()


### PR DESCRIPTION
Backport 1/1 commits from #164879 on behalf of @yuzefovich.

----

This commit adds the missing cancellation checking to the hash joiner: namely, previously it was possible to build the hash table (i.e. consume the right input) and then fully build the cross product of the batch from the left input before the cancellation was observed. If the right input was large, say 100k rows, then we'd have materialized about 100M rows before we'd observe the cancellation. This commit adds the cancel checking before every batch emitted by the hash joiner.

Fixes: #163263.

Release note (bug fix): Previously, CockroachDB might not have promptly responded to the statement timeout when performing a hash join with ON filter that is mostly `false`. This is now fixed.

----

Release justification: stability fix - without it, a query might not be cancelable (without CRDB process restart) for a while.