### PR TITLE
release-26.1: catalog/lease: deflake TestLeaseManagerLockedTimestampConcurrent

### DIFF
--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -3831,7 +3831,11 @@ func TestLeaseManagerLockedTimestampConcurrent(t *testing.T) {
 		nextObjectToRead := make(chan string)
 		nextObjectToModify := make(chan string)
 		var objectModified atomic.Bool
-
+		// Detect cancellation from either the client or server.
+		isCancellationError := func(err error) bool {
+			return errors.Is(err, context.Canceled) ||
+				sqltestutils.IsClientSideQueryCanceledErr(err)
+		}
 		// Creates tables in the background.
 		createThreads := func(ctx context.Context) (err error) {
 			defer close(nextObjectToRead)
@@ -3840,7 +3844,7 @@ func TestLeaseManagerLockedTimestampConcurrent(t *testing.T) {
 				objectName := fmt.Sprintf("t%d", i)
 				sql := fmt.Sprintf("CREATE TABLE %s(n int PRIMARY KEY)\n", objectName)
 				if _, err := conn.ExecContext(ctx, sql); err != nil {
-					if errors.Is(err, context.Canceled) {
+					if isCancellationError(err) {
 						return nil
 					}
 					panic(err)
@@ -3877,7 +3881,7 @@ func TestLeaseManagerLockedTimestampConcurrent(t *testing.T) {
 					// Repeat usage of the descriptor.
 					sql := fmt.Sprintf("SELECT * FROM %s", objectName)
 					if _, err := conn.ExecContext(ctx, sql); err != nil {
-						if errors.Is(err, context.Canceled) {
+						if isCancellationError(err) {
 							return nil
 						}
 						panic(err)
@@ -3894,7 +3898,7 @@ func TestLeaseManagerLockedTimestampConcurrent(t *testing.T) {
 			for objectName := range nextObjectToModify {
 				sql := fmt.Sprintf("ALTER TABLE %s ADD COLUMN n2 int", objectName)
 				if _, err := conn.ExecContext(ctx, sql); err != nil {
-					if errors.Is(err, context.Canceled) {
+					if isCancellationError(err) {
 						return nil
 					}
 					panic(err)


### PR DESCRIPTION
Backport 1/1 commits from #164878 on behalf of @fqazi.

----

Previously, this test could flake since it didn't detect context cancellation effectively when executing queries. This patch updates the logic to include the QueryCanceled pgcode.

Fixes: #164527

Release note: None

----

Release justification: