### PR TITLE
roachtest: fix roachperf metric emission for AC benchmark tests

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
@@ -39,8 +39,7 @@ func registerDiskBandwidthOverload(r registry.Registry) {
 		// Disabled on IBM only because the Azure test suite was used as a base
 		// for IBM tests, and this test was disabled on Azure as of 05/2025.
 		CompatibleClouds: registry.AllExceptAzure,
-		// TODO(aaditya): change to weekly once the test stabilizes.
-		Suites: registry.Suites(registry.Nightly),
+		Suites:           registry.Suites(registry.Nightly),
 		// TODO(darryl): Enable FIPS once we can upgrade to Ubuntu 22 and use cgroups v2 for disk stalls.
 		Cluster: r.MakeClusterSpec(
 			2,
@@ -104,20 +103,17 @@ func registerDiskBandwidthOverload(r registry.Registry) {
 
 			// Run foreground kv workload, QoS="regular".
 			duration := 45 * time.Minute
+			var monitoringStart, monitoringEnd time.Time
+			var totalBWValues []float64
 			m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 			m.Go(func(ctx context.Context) error {
 				t.Status(fmt.Sprintf("starting foreground kv workload thread (<%s)", time.Minute))
 				dur := " --duration=" + duration.String()
-				labels := map[string]string{
-					"concurrency":  "2",
-					"splits":       "1000",
-					"read-percent": "50",
-				}
 				url := fmt.Sprintf(" {pgurl%s}", c.CRDBNodes())
-				cmd := fmt.Sprintf("./cockroach workload run kv %s --concurrency=2 "+
+				cmd := fmt.Sprintf("./cockroach workload run kv --concurrency=2 "+
 					"--splits=1000 --read-percent=50 --min-block-bytes=256 --max-block-bytes=256 "+
 					"--txn-qos='regular' --tolerate-errors %s %s %s",
-					roachtestutil.GetWorkloadHistogramArgs(t, c, labels), foregroundDB, dur, url)
+					foregroundDB, dur, url)
 				c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmd)
 				return nil
 			})
@@ -127,13 +123,10 @@ func registerDiskBandwidthOverload(r registry.Registry) {
 				t.Status(fmt.Sprintf("starting background kv workload thread (<%s)", time.Minute))
 				dur := " --duration=" + duration.String()
 				url := fmt.Sprintf(" {pgurl%s}", c.CRDBNodes())
-				labels := map[string]string{
-					"concurrency":  "1024",
-					"read-percent": "0",
-				}
-				cmd := fmt.Sprintf("./cockroach workload run kv %s --concurrency=1024 "+
+				cmd := fmt.Sprintf("./cockroach workload run kv --concurrency=1024 "+
 					"--read-percent=0 --min-block-bytes=4096 --max-block-bytes=4096 "+
-					"--txn-qos='background' --tolerate-errors %s %s %s", roachtestutil.GetWorkloadHistogramArgs(t, c, labels), backgroundDB, dur, url)
+					"--txn-qos='background' --tolerate-errors %s %s %s",
+					backgroundDB, dur, url)
 				c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmd)
 				return nil
 			})
@@ -164,6 +157,8 @@ func registerDiskBandwidthOverload(r registry.Registry) {
 			time.Sleep(5 * time.Minute)
 
 			m.Go(func(ctx context.Context) error {
+				monitoringStart = timeutil.Now()
+				defer func() { monitoringEnd = timeutil.Now() }()
 				t.Status(fmt.Sprintf("starting monitoring thread (<%s)", time.Minute))
 				writeBWMetric := divQuery("rate(sys_host_disk_write_bytes[1m])", 1<<20 /* 1MiB */)
 				readBWMetric := divQuery("rate(sys_host_disk_read_bytes[1m])", 1<<20 /* 1MiB */)
@@ -198,7 +193,6 @@ func registerDiskBandwidthOverload(r registry.Registry) {
 				// Loop for ~20 minutes.
 				const numIterations = int(20 / (collectionIntervalSeconds / 60))
 				var writeBWValues []float64
-				var totalBWValues []float64
 				numErrors := 0
 				numSuccesses := 0
 				for i := 0; i < numIterations; i++ {
@@ -248,18 +242,34 @@ func registerDiskBandwidthOverload(r registry.Registry) {
 				if numErrors > numSuccesses {
 					t.Fatalf("too many errors retrieving metrics")
 				}
-				// Export mean total bandwidth to roachperf.
-				if len(totalBWValues) > 0 {
-					finalMeanTotalBW := roachtestutil.GetMeanOverLastN(len(totalBWValues), totalBWValues)
-					c.Run(ctx, option.WithNodes(c.CRDBNodes()), "mkdir", "-p", t.PerfArtifactsDir())
-					perfResult := fmt.Sprintf(`{"mean_total_bandwidth_mbs": %.1f}`, finalMeanTotalBW)
-					c.Run(ctx, option.WithNodes(c.CRDBNodes()),
-						fmt.Sprintf(`echo '%s' > %s/stats.json`, perfResult, t.PerfArtifactsDir()))
-				}
 				return nil
 			})
 
 			m.Wait()
+
+			// Export mean total bandwidth as a scalar metric for roachperf,
+			// derived from the values collected during monitoring.
+			if !monitoringStart.IsZero() && !monitoringEnd.IsZero() {
+				_, err := statCollector.Exporter().Export(
+					ctx, c, t, false, /* dryRun */
+					monitoringStart, monitoringEnd,
+					[]clusterstats.AggQuery{},
+					func(stats map[string]clusterstats.StatSummary) *roachtestutil.AggregatedMetric {
+						if len(totalBWValues) == 0 {
+							return nil
+						}
+						return &roachtestutil.AggregatedMetric{
+							Name:           "mean_total_bandwidth",
+							Value:          roachtestutil.MetricPoint(roachtestutil.GetMeanOverLastN(len(totalBWValues), totalBWValues)),
+							Unit:           "MiB/s",
+							IsHigherBetter: true,
+						}
+					},
+				)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
 		},
 	})
 }

--- a/pkg/cmd/roachtest/tests/admission_control_single_node_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_single_node_index_backfill.go
@@ -69,7 +69,7 @@ func registerSingleNodeIndexBackfill(r registry.Registry) {
 			Timeout:          12 * time.Hour,
 			Benchmark:        true,
 			CompatibleClouds: registry.OnlyGCE,
-			Suites:           registry.Suites(registry.Weekly),
+			Suites:           registry.Suites(registry.Nightly),
 			Cluster: r.MakeClusterSpec(
 				2, // 1 CRDB node + 1 workload node
 				// 16vCPUs so that CPU is not the bottleneck.
@@ -234,6 +234,7 @@ func runSingleNodeIndexBackfill(
 	m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 	var backfillDuration time.Duration
 	var totalBWSamples []float64
+	var metricsStart, metricsEnd time.Time
 
 	// Goroutine 1: Run TPC-E workload.
 	m.Go(func(ctx context.Context) error {
@@ -303,6 +304,8 @@ func runSingleNodeIndexBackfill(
 		metricsDone := make(chan struct{})
 		t.Go(func(context.Context, *logger.Logger) error {
 			defer close(metricsDone)
+			metricsStart = timeutil.Now()
+			defer func() { metricsEnd = timeutil.Now() }()
 			writeBWQuery := divQuery("rate(sys_host_disk_write_bytes[1m])", 1<<20)
 			readBWQuery := divQuery("rate(sys_host_disk_read_bytes[1m])", 1<<20)
 
@@ -368,12 +371,52 @@ func runSingleNodeIndexBackfill(
 
 	m.Wait()
 
-	// Export index backfill duration to roachperf.
-	c.Run(ctx, option.WithNodes(c.CRDBNodes()), "mkdir", "-p", t.PerfArtifactsDir())
-	perfResult := fmt.Sprintf(`{"index_backfill_duration_secs": %.1f}`, backfillDuration.Seconds())
-	c.Run(ctx, option.WithNodes(c.CRDBNodes()),
-		fmt.Sprintf(`echo '%s' > %s/stats.json`, perfResult, t.PerfArtifactsDir()))
-	t.L().Printf("roachperf stats: %s", perfResult)
+	t.L().Printf("index backfill duration: %s", backfillDuration)
+
+	// Compute mean total bandwidth from the samples collected during
+	// index backfill.
+	var avgTotalBW float64
+	if len(totalBWSamples) > 0 {
+		var sum float64
+		for _, s := range totalBWSamples {
+			sum += s
+		}
+		avgTotalBW = sum / float64(len(totalBWSamples))
+		t.L().Printf("average total disk bandwidth during backfill: %.2f MiB/s (%d samples)",
+			avgTotalBW, len(totalBWSamples))
+	}
+
+	// Export backfill duration and mean total bandwidth as scalar metrics
+	// for roachperf.
+	if !metricsStart.IsZero() && !metricsEnd.IsZero() {
+		_, err := statCollector.Exporter().Export(
+			ctx, c, t, false, /* dryRun */
+			metricsStart, metricsEnd,
+			[]clusterstats.AggQuery{},
+			func(stats map[string]clusterstats.StatSummary) *roachtestutil.AggregatedMetric {
+				return &roachtestutil.AggregatedMetric{
+					Name:           "index_backfill_duration",
+					Value:          roachtestutil.MetricPoint(backfillDuration.Seconds()),
+					Unit:           "s",
+					IsHigherBetter: false,
+				}
+			},
+			func(stats map[string]clusterstats.StatSummary) *roachtestutil.AggregatedMetric {
+				if avgTotalBW == 0 {
+					return nil
+				}
+				return &roachtestutil.AggregatedMetric{
+					Name:           "mean_total_bandwidth",
+					Value:          roachtestutil.MetricPoint(avgTotalBW),
+					Unit:           "MiB/s",
+					IsHigherBetter: true,
+				}
+			},
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
 
 	// Validate pass/fail criteria. Thresholds are intentionally loose to
 	// tolerate run-to-run variance while catching severe regressions (e.g.,
@@ -386,18 +429,9 @@ func runSingleNodeIndexBackfill(
 		t.Fatalf("index backfill took %s, exceeding maximum of %s",
 			backfillDuration, maxBackfillDuration)
 	}
-	if len(totalBWSamples) > 0 {
-		var sum float64
-		for _, s := range totalBWSamples {
-			sum += s
-		}
-		avgTotalBW := sum / float64(len(totalBWSamples))
-		t.L().Printf("average total disk bandwidth during backfill: %.2f MiB/s (%d samples)",
-			avgTotalBW, len(totalBWSamples))
-		if avgTotalBW < minAvgTotalBW {
-			t.Fatalf("average total disk bandwidth %.2f MiB/s is below minimum of %.0f MiB/s",
-				avgTotalBW, minAvgTotalBW)
-		}
+	if avgTotalBW > 0 && avgTotalBW < minAvgTotalBW {
+		t.Fatalf("average total disk bandwidth %.2f MiB/s is below minimum of %.0f MiB/s",
+			avgTotalBW, minAvgTotalBW)
 	}
 
 	t.Status("test completed successfully")


### PR DESCRIPTION
Previously, the disk-bandwidth-limiter and single-node-index-backfill tests emitted their metrics by writing raw JSON directly to `stats.json` via shell `echo`. This format is not recognized by roachperf, so the metrics were never surfaced.

Now, both tests encode their values through the histogram exporter and decode them via `PostProcessPerfMetrics` callbacks. This matches the pattern used by other AC benchmark tests (e.g. the inspect test) and ensures roachperf can actually pick up and display the metrics.

Epic: CRDB-47073
Fixes: #162219
Release note: None