### PR TITLE
sql: add AST stubs for SHOW USERS provisioning clauses

### DIFF
--- a/pkg/sql/sem/tree/BUILD.bazel
+++ b/pkg/sql/sem/tree/BUILD.bazel
@@ -232,6 +232,7 @@ go_test(
         "pretty_test.go",
         "replace_scalars_test.go",
         "schema_helpers_test.go",
+        "show_users_test.go",
         "table_name_test.go",
         "time_test.go",
         "txn_test.go",

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -1008,13 +1008,76 @@ func (node *ShowSavepointStatus) Format(ctx *FmtCtx) {
 	ctx.WriteString("SHOW SAVEPOINT STATUS")
 }
 
+// ShowUsersOptions describes options for the SHOW USERS statement.
+type ShowUsersOptions struct {
+	Source              Expr // SOURCE = 'ldap:...'
+	LastAccessOlderThan Expr // LAST ACCESS TIME OLDER THAN <timestamp>
+}
+
+// Format implements the NodeFormatter interface.
+func (s *ShowUsersOptions) Format(ctx *FmtCtx) {
+	var addSep bool
+	maybeAddSep := func() {
+		if addSep {
+			ctx.WriteString(", ")
+		}
+		addSep = true
+	}
+
+	if s.Source != nil {
+		maybeAddSep()
+		ctx.WriteString("SOURCE = ")
+		ctx.FormatNode(s.Source)
+	}
+	if s.LastAccessOlderThan != nil {
+		maybeAddSep()
+		ctx.WriteString("LAST ACCESS TIME OLDER THAN ")
+		ctx.FormatNode(s.LastAccessOlderThan)
+	}
+}
+
+// CombineWith merges other ShowUsersOptions into this struct.
+// An error is returned if the same option is specified multiple times.
+func (s *ShowUsersOptions) CombineWith(other *ShowUsersOptions) error {
+	var err error
+	s.Source, err = combineExpr(s.Source, other.Source, "SOURCE")
+	if err != nil {
+		return err
+	}
+	s.LastAccessOlderThan, err = combineExpr(
+		s.LastAccessOlderThan, other.LastAccessOlderThan,
+		"LAST ACCESS TIME OLDER THAN",
+	)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// IsDefault returns true if this options struct has the default (zero) value.
+func (s ShowUsersOptions) IsDefault() bool {
+	return s.Source == nil && s.LastAccessOlderThan == nil
+}
+
+var _ NodeFormatter = &ShowUsersOptions{}
+
 // ShowUsers represents a SHOW USERS statement.
 type ShowUsers struct {
+	Options *ShowUsersOptions
+	Limit   *Limit
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowUsers) Format(ctx *FmtCtx) {
 	ctx.WriteString("SHOW USERS")
+	if node.Options != nil && !node.Options.IsDefault() {
+		ctx.WriteString(" WITH ")
+		ctx.FormatNode(node.Options)
+	}
+	if node.Limit != nil {
+		ctx.WriteByte(' ')
+		ctx.FormatNode(node.Limit)
+	}
 }
 
 // ShowDefaultSessionVariablesForRole represents a SHOW DEFAULT SESSION VARIABLES FOR ROLE <name> statement.

--- a/pkg/sql/sem/tree/show_users_test.go
+++ b/pkg/sql/sem/tree/show_users_test.go
@@ -1,0 +1,151 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package tree_test
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShowUsersFormat(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testCases := []struct {
+		name     string
+		node     *tree.ShowUsers
+		expected string
+	}{
+		{
+			name:     "no options",
+			node:     &tree.ShowUsers{},
+			expected: "SHOW USERS",
+		},
+		{
+			name: "source only",
+			node: &tree.ShowUsers{
+				Options: &tree.ShowUsersOptions{
+					Source: tree.NewStrVal("ldap:ldap.example.com"),
+				},
+			},
+			expected: "SHOW USERS WITH SOURCE = 'ldap:ldap.example.com'",
+		},
+		{
+			name: "last access older than only",
+			node: &tree.ShowUsers{
+				Options: &tree.ShowUsersOptions{
+					LastAccessOlderThan: tree.NewStrVal("2024-01-01"),
+				},
+			},
+			expected: "SHOW USERS WITH LAST ACCESS TIME OLDER THAN '2024-01-01'",
+		},
+		{
+			name: "both options",
+			node: &tree.ShowUsers{
+				Options: &tree.ShowUsersOptions{
+					Source:              tree.NewStrVal("ldap:ldap.example.com"),
+					LastAccessOlderThan: tree.NewStrVal("2024-01-01"),
+				},
+			},
+			expected: "SHOW USERS WITH SOURCE = 'ldap:ldap.example.com', LAST ACCESS TIME OLDER THAN '2024-01-01'",
+		},
+		{
+			name: "source with limit",
+			node: &tree.ShowUsers{
+				Options: &tree.ShowUsersOptions{
+					Source: tree.NewStrVal("ldap:ldap.example.com"),
+				},
+				Limit: &tree.Limit{Count: tree.NewDInt(10)},
+			},
+			expected: "SHOW USERS WITH SOURCE = 'ldap:ldap.example.com' LIMIT 10",
+		},
+		{
+			name: "limit only",
+			node: &tree.ShowUsers{
+				Limit: &tree.Limit{Count: tree.NewDInt(5)},
+			},
+			expected: "SHOW USERS LIMIT 5",
+		},
+		{
+			name: "all options with limit",
+			node: &tree.ShowUsers{
+				Options: &tree.ShowUsersOptions{
+					Source:              tree.NewStrVal("ldap:ldap.example.com"),
+					LastAccessOlderThan: tree.NewStrVal("2024-01-01"),
+				},
+				Limit: &tree.Limit{Count: tree.NewDInt(10)},
+			},
+			expected: "SHOW USERS WITH SOURCE = 'ldap:ldap.example.com', LAST ACCESS TIME OLDER THAN '2024-01-01' LIMIT 10",
+		},
+		{
+			name: "nil options pointer",
+			node: &tree.ShowUsers{
+				Options: nil,
+			},
+			expected: "SHOW USERS",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tree.AsString(tc.node)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestShowUsersOptionsCombineWith(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	t.Run("merge disjoint options", func(t *testing.T) {
+		a := &tree.ShowUsersOptions{Source: tree.NewStrVal("ldap:x")}
+		b := &tree.ShowUsersOptions{
+			LastAccessOlderThan: tree.NewStrVal("2024-01-01"),
+		}
+		err := a.CombineWith(b)
+		require.NoError(t, err)
+		require.NotNil(t, a.Source)
+		require.NotNil(t, a.LastAccessOlderThan)
+	})
+
+	t.Run("duplicate source", func(t *testing.T) {
+		a := &tree.ShowUsersOptions{Source: tree.NewStrVal("ldap:x")}
+		b := &tree.ShowUsersOptions{Source: tree.NewStrVal("ldap:y")}
+		err := a.CombineWith(b)
+		require.ErrorContains(t, err, "SOURCE")
+		require.ErrorContains(t, err, "specified multiple times")
+	})
+
+	t.Run("duplicate last access older than", func(t *testing.T) {
+		a := &tree.ShowUsersOptions{
+			LastAccessOlderThan: tree.NewStrVal("2024-01-01"),
+		}
+		b := &tree.ShowUsersOptions{
+			LastAccessOlderThan: tree.NewStrVal("2025-01-01"),
+		}
+		err := a.CombineWith(b)
+		require.ErrorContains(t, err, "LAST ACCESS TIME OLDER THAN")
+		require.ErrorContains(t, err, "specified multiple times")
+	})
+}
+
+func TestShowUsersOptionsIsDefault(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	require.True(t, tree.ShowUsersOptions{}.IsDefault())
+	require.False(t,
+		tree.ShowUsersOptions{Source: tree.NewStrVal("x")}.IsDefault())
+	require.False(t,
+		tree.ShowUsersOptions{
+			LastAccessOlderThan: tree.NewStrVal("2024-01-01"),
+		}.IsDefault())
+}


### PR DESCRIPTION
Previously, the SHOW USERS statement accepted no options or filters. To support user provisioning workflows—such as identifying and deprovisioning dormant LDAP-provisioned users—we need filtering clauses on SHOW USERS.

This commit adds the AST types required for the new syntax:

  SHOW USERS WITH SOURCE = 'ldap:...', LAST ACCESS TIME OLDER THAN <ts> LIMIT n

Specifically, it introduces ShowUsersOptions (with Source and LastAccessOlderThan fields), along with Format, CombineWith, and IsDefault methods following existing patterns (e.g. ShowFingerprintOptions). The ShowUsers struct is extended with Options and Limit fields.

The grammar and delegation layers are not yet wired up; this is the first of three parts for the full feature.

Epic: CRDB-52460
Resolves: #150604

Release note: None