### PR TITLE
kvserver: deflake TestStoreMetrics

### DIFF
--- a/pkg/kv/kvserver/client_metrics_test.go
+++ b/pkg/kv/kvserver/client_metrics_test.go
@@ -259,7 +259,7 @@ func TestStoreMetrics(t *testing.T) {
 			Size: storageconfig.BytesSize(512 << 20 /* 512 MiB */),
 		}
 		stickyServerArgs[i] = base.TestServerArgs{
-			CacheSize:  2 << 20, /* 2 MiB */
+			CacheSize:  4 << 20, /* 4 MiB */
 			StoreSpecs: []base.StoreSpec{spec},
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{


### PR DESCRIPTION
Since 74934ece2e40, TestStoreMetrics has been failing with:

    client_metrics_test.go:402: counter rocksdb.block.cache.hits = 0 < min 10

Our best theory is that since the bug fix results in pending proposals being re-submitted, that additional storage traffic occasionally ends up evicting entries from the block cache aggressively enough to result in no cache hits.

Here, we bump the cache to 4MB. Before this change, the test failed reliably on linux in < 200 runs. After the change, I was able to stress it for 1000 runs without failure.

Fixes: #164776

Release note: None