### PR TITLE
txnapply: deflake TestTxnApplierIndependent under deadlock

### DIFF
--- a/pkg/crosscluster/logical/txnapply/txn_applier_test.go
+++ b/pkg/crosscluster/logical/txnapply/txn_applier_test.go
@@ -36,7 +36,7 @@ type testWriter struct {
 func (w *testWriter) ApplyBatch(
 	ctx context.Context, txns []ldrdecoder.Transaction,
 ) ([]txnwriter.ApplyResult, error) {
-	delay := time.Duration(w.rng.Int63n(int64(10 * time.Microsecond)))
+	delay := time.Duration(w.rng.Int63n(int64(100 * time.Microsecond)))
 	select {
 	case <-time.After(delay):
 	case <-ctx.Done():


### PR DESCRIPTION
For some reason, when TestTxnApplierIndependent is run under deadlock, the 10us of random jitter is not enough to get the applies to run in different orders. This may be caused by deadlock adding enough overhead that the two tasks are scheduled more than 10us apart in runtime which causes the execution to be mostly deterministic.

Release note: none
Fixes: #164914