### PR TITLE
catalog/lease: deflake TestLeaseManagerLockedTimestampCluster

### DIFF
--- a/pkg/sql/catalog/lease/lease_internal_test.go
+++ b/pkg/sql/catalog/lease/lease_internal_test.go
@@ -1855,6 +1855,14 @@ func TestLeaseManagerLockedTimestampCluster(t *testing.T) {
 
 	var blockUpdates atomic.Bool
 	updateCh := make(chan struct{})
+	updateChClosed := false
+	closeUpdateCh := func() {
+		if updateChClosed {
+			return
+		}
+		updateChClosed = true
+		close(updateCh)
+	}
 
 	st := cluster.MakeTestingClusterSettings()
 	ctx := context.Background()
@@ -1870,11 +1878,12 @@ func TestLeaseManagerLockedTimestampCluster(t *testing.T) {
 			ServerArgsPerNode: map[int]base.TestServerArgs{2: {
 				Knobs: base.TestingKnobs{
 					SQLLeaseManager: &ManagerTestingKnobs{
-						TestingDescriptorRefreshedEvent: func(descriptor *descpb.Descriptor) {
+						TestingDescriptorUpdateEvent: func(descriptor *descpb.Descriptor) error {
 							if !blockUpdates.Load() {
-								return
+								return nil
 							}
 							<-updateCh
+							return nil
 						},
 					},
 				},
@@ -1882,12 +1891,14 @@ func TestLeaseManagerLockedTimestampCluster(t *testing.T) {
 			},
 		})
 	defer tc.Stopper().Stop(context.Background())
+	defer closeUpdateCh()
 
 	node1Conn := tc.ServerConn(0)
 	r := sqlutils.MakeSQLRunner(node1Conn)
 	node2Conn := tc.ServerConn(2)
 	execConn := sqlutils.MakeSQLRunner(node2Conn)
-
+	// Disable automatic stats collection, since it can interfere with this test.
+	r.Exec(t, "SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false")
 	r.Exec(t, "CREATE DATABASE d1")
 	r.Exec(t, "CREATE TABLE d1.public.t1(n int)")
 	var id int
@@ -1904,22 +1915,45 @@ func TestLeaseManagerLockedTimestampCluster(t *testing.T) {
 	assertDescriptorsCount := func(expectedCount int) {
 		state := lm.findDescriptorState(descpb.ID(id), false)
 		require.NotNilf(t, state, "the descriptor was not leased yet")
-		state.mu.Lock()
-		defer state.mu.Unlock()
-		require.Equal(t, expectedCount, len(state.mu.active.data),
-			"unexpected number of descriptors in active state: %s",
-			state.mu.active)
+		// Since the testing knob being used for moving to the next version
+		// is invoked before a descriptor is fully processed. Its possible that
+		// we may temporarily see extra old versions, until they are purged.
+		require.NoError(t, testutils.SucceedsSoonError(func() error {
+			state.mu.Lock()
+			defer state.mu.Unlock()
+			if len(state.mu.active.data) == expectedCount {
+				return nil
+			}
+			return errors.AssertionFailedf("expected %d descriptors, got %d (state: %s)", expectedCount, len(state.mu.active.data), state.mu.active.String())
+		}))
+	}
+	// Allows the next version of the descriptor to be processed
+	// and then confirms a newer version is available to lease.
+	moveToNextDescriptorVersion := func() {
+		newest, _ := lm.findNewest(descpb.ID(id))
+		require.NotNil(t, newest)
+		lastVersion := newest.GetVersion()
+		updateCh <- struct{}{}
+		require.NoError(t, testutils.SucceedsSoonError(func() error {
+			// Ensure a new version is available
+			newest, _ = lm.findNewest(descpb.ID(id))
+			require.NotNil(t, newest)
+			if newest.GetVersion() > lastVersion {
+				return nil
+			}
+			return errors.AssertionFailedf("new version was not leased yet")
+		}))
 	}
 	// Initial state we only expect a single version.
 	assertDescriptorsCount(1)
-	updateCh <- struct{}{}
+	moveToNextDescriptorVersion()
 	execConn.Exec(t, "SELECT * FROM d1.public.t1")
-	updateCh <- struct{}{}
+	moveToNextDescriptorVersion()
 	txn := execConn.Begin(t)
 	_, err := txn.Exec("SELECT * FROM d1.public.t1")
 	require.NoError(t, err)
 	assertDescriptorsCount(1)
-	updateCh <- struct{}{}
+	moveToNextDescriptorVersion()
 	_, err = txn.Exec("SELECT * FROM d1.public.t1")
 	require.NoError(t, err)
 	_, err = txn.Exec("SELECT * FROM d1.public.t1")
@@ -1931,8 +1965,8 @@ func TestLeaseManagerLockedTimestampCluster(t *testing.T) {
 	require.NoError(t, err)
 	assertDescriptorsCount(2)
 	require.NoError(t, txn.Commit())
-	updateCh <- struct{}{}
-	close(updateCh)
+	moveToNextDescriptorVersion()
+	closeUpdateCh()
 	assertDescriptorsCount(1)
 	require.NoError(t, grp.Wait())
 }


### PR DESCRIPTION
Previously, this test could flake because the testing knob was executed after a new version was acquired. This meant that whenever a new version was acquired, a small race condition existed where the following version could also be fetched via the range feed.

To address this, the test has been modified so the testing knob blocks the new version before acquisition, then waits for the new version via polling. Additionally, the old testing knob did not guarantee that the new version would be acquired when clock skew occurred (i.e., it would wait for the modification time in an async task).

Fixes: #164705

Release note: None