### PR TITLE
asim: add low write bandwidth quantization thrashing test

### DIFF
--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/low_cpu_integer_granularity.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/low_cpu_integer_granularity.txt
@@ -1,0 +1,246 @@
+# This test demonstrates how integer granularity at low CPU values causes MMA
+# to classify a store as overloaded when it's only 1 unit above the mean.
+#
+# With stores at CPU load 6 and 7, the integer mean is 6. A store at load 7
+# is 16.7% above mean, exceeding the 10% overloadSlow threshold. But the
+# smallest possible move (raft-cpu=1) shifts the full step size: moving 1
+# unit from s3 (7) to any target (6) pushes the target to 7, making it
+# equally overloaded. MMA correctly identifies the overload but rejects all
+# candidate moves because they would just swap the problem.
+#
+# Note: CPURate has a 5% utilization floor (load.go:607) — if fractionUsed
+# < 5%, overload is capped at loadNormal. We use capacity=100 so that
+# CPU=7 gives fractionUsed=7%, above the floor.
+#
+# See: https://github.com/cockroachdb/cockroach/issues/164539
+
+# Set up 5 stores.
+set-store
+  store-id=1 node-id=1
+  store-id=2 node-id=2
+  store-id=3 node-id=3
+  store-id=4 node-id=4
+  store-id=5 node-id=5
+----
+node-id=1 locality-tiers=node=1
+  store-id=1 attrs=
+node-id=2 locality-tiers=node=2
+  store-id=2 attrs=
+node-id=3 locality-tiers=node=3
+  store-id=3 attrs=
+node-id=4 locality-tiers=node=4
+  store-id=4 attrs=
+node-id=5 locality-tiers=node=5
+  store-id=5 attrs=
+
+# s3 CPU = 7 -> fractionAbove = 7/6 - 1 = 16.7% -> overloadSlow
+# s1, s2, s4, s5 CPU = 6 -> loadNormal
+# Mean CPU = floor(31/5) = 6
+# CPU capacity = 100 -> fractionUsed = 7% (above the 5% floor)
+# WB is uniform at 1000 B/s -> quantized to 0, not a factor.
+store-load-msg
+  store-id=1 node-id=1 load=[6,1000,0] capacity=[100,-1,1000000] secondary-load=[83,250] load-time=0s
+  store-id=2 node-id=2 load=[6,1000,0] capacity=[100,-1,1000000] secondary-load=[83,250] load-time=0s
+  store-id=3 node-id=3 load=[7,1000,0] capacity=[100,-1,1000000] secondary-load=[83,250] load-time=0s
+  store-id=4 node-id=4 load=[6,1000,0] capacity=[100,-1,1000000] secondary-load=[83,250] load-time=0s
+  store-id=5 node-id=5 load=[6,1000,0] capacity=[100,-1,1000000] secondary-load=[83,250] load-time=0s
+----
+
+# Three ranges with leases on s1 (the local store) and replicas on s3 (the
+# overloaded store). Each range has raft-cpu=1, which is the minimum possible
+# move size — and also the full integer step from load 6 to load 7.
+store-leaseholder-msg
+store-id=1
+  range-id=1 load=[1,0,0] raft-cpu=1
+    store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
+    store-id=2 replica-id=2 type=VOTER_FULL
+    store-id=3 replica-id=3 type=VOTER_FULL
+    config=num_replicas=3 constraints={} voter_constraints={}
+  range-id=2 load=[1,0,0] raft-cpu=1
+    store-id=1 replica-id=4 type=VOTER_FULL leaseholder=true
+    store-id=3 replica-id=5 type=VOTER_FULL
+    store-id=4 replica-id=6 type=VOTER_FULL
+    config=num_replicas=3 constraints={} voter_constraints={}
+  range-id=3 load=[1,0,0] raft-cpu=1
+    store-id=1 replica-id=7 type=VOTER_FULL leaseholder=true
+    store-id=3 replica-id=8 type=VOTER_FULL
+    store-id=5 replica-id=9 type=VOTER_FULL
+    config=num_replicas=3 constraints={} voter_constraints={}
+----
+
+get-load-info
+----
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:6ns/s, write-bandwidth:1.0 kB/s, byte-size:0 B] adjusted=[cpu:6ns/s, write-bandwidth:1.0 kB/s, byte-size:0 B] node-reported-cpu=6 node-adjusted-cpu=6 seq=1
+  top-k-ranges (local-store-id=1) dim=CPURate: r3 r2 r1
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:6ns/s, write-bandwidth:1.0 kB/s, byte-size:0 B] adjusted=[cpu:6ns/s, write-bandwidth:1.0 kB/s, byte-size:0 B] node-reported-cpu=6 node-adjusted-cpu=6 seq=1
+store-id=3 node-id=3 status=ok accepting all reported=[cpu:7ns/s, write-bandwidth:1.0 kB/s, byte-size:0 B] adjusted=[cpu:7ns/s, write-bandwidth:1.0 kB/s, byte-size:0 B] node-reported-cpu=7 node-adjusted-cpu=7 seq=1
+  top-k-ranges (local-store-id=1) dim=CPURate: r3 r2 r1
+store-id=4 node-id=4 status=ok accepting all reported=[cpu:6ns/s, write-bandwidth:1.0 kB/s, byte-size:0 B] adjusted=[cpu:6ns/s, write-bandwidth:1.0 kB/s, byte-size:0 B] node-reported-cpu=6 node-adjusted-cpu=6 seq=1
+store-id=5 node-id=5 status=ok accepting all reported=[cpu:6ns/s, write-bandwidth:1.0 kB/s, byte-size:0 B] adjusted=[cpu:6ns/s, write-bandwidth:1.0 kB/s, byte-size:0 B] node-reported-cpu=6 node-adjusted-cpu=6 seq=1
+
+# Advance past the overload grace period (1 min).
+tick seconds=300
+----
+t=5m0s
+
+# First rebalance pass: triggers overload-start for s3. MMA detects the CPU
+# overload but can't act yet because of the remote store lease shedding grace
+# period (2 min from overload-start). This grace period gives s3's own
+# leaseholder a chance to shed leases first (cheaper than moving replicas).
+rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-threshold=0.01
+----
+[mmaid=1] rebalanceStores begins
+[mmaid=1] cluster means: (stores-load [cpu:6ns/s, write-bandwidth:1.0 kB/s, byte-size:0 B]) (stores-capacity [cpu:100ns/s, write-bandwidth:unknown/s, byte-size:1.0 MB]) (nodes-cpu-load 6) (nodes-cpu-capacity 100)
+[mmaid=1] load summary for dim=CPURate (s1): loadNormal, reason: load is within 5% of mean [load=6 meanLoad=6 fractionUsed=6.00% meanUtil=6.20% capacity=100]
+[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
+[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000000]
+[mmaid=1] load summary for dim=CPURate (n1): loadNormal, reason: load is within 5% of mean [load=6 meanLoad=6 fractionUsed=6.00% meanUtil=6.20% capacity=100]
+[mmaid=1] evaluating s1: node load loadNormal, store load loadNormal, worst dim CPURate
+[mmaid=1] load summary for dim=CPURate (s2): loadNormal, reason: load is within 5% of mean [load=6 meanLoad=6 fractionUsed=6.00% meanUtil=6.20% capacity=100]
+[mmaid=1] load summary for dim=WriteBandwidth (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
+[mmaid=1] load summary for dim=ByteSize (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000000]
+[mmaid=1] load summary for dim=CPURate (n2): loadNormal, reason: load is within 5% of mean [load=6 meanLoad=6 fractionUsed=6.00% meanUtil=6.20% capacity=100]
+[mmaid=1] evaluating s2: node load loadNormal, store load loadNormal, worst dim CPURate
+[mmaid=1] load summary for dim=CPURate (s3): overloadSlow, reason: fractionUsed < 75% [load=7 meanLoad=6 fractionUsed=7.00% meanUtil=6.20% capacity=100]
+[mmaid=1] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
+[mmaid=1] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000000]
+[mmaid=1] load summary for dim=CPURate (n3): overloadSlow, reason: fractionUsed < 75% [load=7 meanLoad=6 fractionUsed=7.00% meanUtil=6.20% capacity=100]
+[mmaid=1] evaluating s3: node load overloadSlow, store load overloadSlow, worst dim CPURate
+[mmaid=1] overload-start s3 ((store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow frac_pending=0.00,0.00(true))) - grace period expired
+[mmaid=1] store s3 was added to shedding store list
+[mmaid=1] load summary for dim=CPURate (s4): loadNormal, reason: load is within 5% of mean [load=6 meanLoad=6 fractionUsed=6.00% meanUtil=6.20% capacity=100]
+[mmaid=1] load summary for dim=WriteBandwidth (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
+[mmaid=1] load summary for dim=ByteSize (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000000]
+[mmaid=1] load summary for dim=CPURate (n4): loadNormal, reason: load is within 5% of mean [load=6 meanLoad=6 fractionUsed=6.00% meanUtil=6.20% capacity=100]
+[mmaid=1] evaluating s4: node load loadNormal, store load loadNormal, worst dim CPURate
+[mmaid=1] load summary for dim=CPURate (s5): loadNormal, reason: load is within 5% of mean [load=6 meanLoad=6 fractionUsed=6.00% meanUtil=6.20% capacity=100]
+[mmaid=1] load summary for dim=WriteBandwidth (s5): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
+[mmaid=1] load summary for dim=ByteSize (s5): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000000]
+[mmaid=1] load summary for dim=CPURate (n5): loadNormal, reason: load is within 5% of mean [load=6 meanLoad=6 fractionUsed=6.00% meanUtil=6.20% capacity=100]
+[mmaid=1] evaluating s5: node load loadNormal, store load loadNormal, worst dim CPURate
+[mmaid=1] start processing shedding store s3: cpu node load overloadSlow, store load overloadSlow, worst dim CPURate
+[mmaid=1] top-K[CPURate] ranges for s3 with lease on local s1: r3:[cpu:1ns/s, write-bandwidth:0 B/s, byte-size:0 B] r2:[cpu:1ns/s, write-bandwidth:0 B/s, byte-size:0 B] r1:[cpu:1ns/s, write-bandwidth:0 B/s, byte-size:0 B]
+[mmaid=1] skipping remote store s3: in lease shedding grace period
+[mmaid=1] rebalancing pass summary [local=s1]:
+	overloaded:
+		lease-grace: [s3]
+	no-ranges-evaluated: [s3]
+pending(0)
+
+# Advance past the lease shedding grace period (2 min from overload-start).
+tick seconds=121
+----
+t=7m1s
+
+# Second rebalance pass: lease shedding grace expired. MMA now tries to shed
+# replicas from s3. The trace shows:
+# - s3 CPURate: load=7, meanLoad=6 -> overloadSlow (16.7% above mean)
+# - For each candidate range, moving raft-cpu=1 to the target pushes it from
+#   6 to 7, making the target overloadSlow too
+# - All moves rejected: the target would become as overloaded as the source
+rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-threshold=0.01
+----
+[mmaid=2] rebalanceStores begins
+[mmaid=2] cluster means: (stores-load [cpu:6ns/s, write-bandwidth:1.0 kB/s, byte-size:0 B]) (stores-capacity [cpu:100ns/s, write-bandwidth:unknown/s, byte-size:1.0 MB]) (nodes-cpu-load 6) (nodes-cpu-capacity 100)
+[mmaid=2] evaluating s1: node load loadNormal, store load loadNormal, worst dim CPURate
+[mmaid=2] evaluating s2: node load loadNormal, store load loadNormal, worst dim CPURate
+[mmaid=2] evaluating s3: node load overloadSlow, store load overloadSlow, worst dim CPURate
+[mmaid=2] store s3 was added to shedding store list
+[mmaid=2] evaluating s4: node load loadNormal, store load loadNormal, worst dim CPURate
+[mmaid=2] evaluating s5: node load loadNormal, store load loadNormal, worst dim CPURate
+[mmaid=2] start processing shedding store s3: cpu node load overloadSlow, store load overloadSlow, worst dim CPURate
+[mmaid=2] top-K[CPURate] ranges for s3 with lease on local s1: r3:[cpu:1ns/s, write-bandwidth:0 B/s, byte-size:0 B] r2:[cpu:1ns/s, write-bandwidth:0 B/s, byte-size:0 B] r1:[cpu:1ns/s, write-bandwidth:0 B/s, byte-size:0 B]
+[mmaid=2] attempting to shed replicas next
+[mmaid=2] load summary for dim=CPURate (s3): overloadSlow, reason: fractionUsed < 75% [load=7 meanLoad=6 fractionUsed=7.00% meanUtil=6.20% capacity=100]
+[mmaid=2] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
+[mmaid=2] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000000]
+[mmaid=2] load summary for dim=CPURate (n3): overloadSlow, reason: fractionUsed < 75% [load=7 meanLoad=6 fractionUsed=7.00% meanUtil=6.20% capacity=100]
+[mmaid=2] load summary for dim=CPURate (s2): loadNormal, reason: load is within 5% of mean [load=6 meanLoad=6 fractionUsed=6.00% meanUtil=6.20% capacity=100]
+[mmaid=2] load summary for dim=WriteBandwidth (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
+[mmaid=2] load summary for dim=ByteSize (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000000]
+[mmaid=2] load summary for dim=CPURate (n2): loadNormal, reason: load is within 5% of mean [load=6 meanLoad=6 fractionUsed=6.00% meanUtil=6.20% capacity=100]
+[mmaid=2] load summary for dim=CPURate (s4): loadNormal, reason: load is within 5% of mean [load=6 meanLoad=6 fractionUsed=6.00% meanUtil=6.20% capacity=100]
+[mmaid=2] load summary for dim=WriteBandwidth (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
+[mmaid=2] load summary for dim=ByteSize (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000000]
+[mmaid=2] load summary for dim=CPURate (n4): loadNormal, reason: load is within 5% of mean [load=6 meanLoad=6 fractionUsed=6.00% meanUtil=6.20% capacity=100]
+[mmaid=2] considering replica-transfer r3 from s3: store load [cpu:7ns/s, write-bandwidth:1.0 kB/s, byte-size:0 B]
+[mmaid=2] candidates for r3:
+	s2: (store=loadNormal worst=CPURate cpu=loadNormal writes=loadNormal bytes=loadNormal node=loadNormal frac_pending=0.00,0.00(true))
+	s4: (store=loadNormal worst=CPURate cpu=loadNormal writes=loadNormal bytes=loadNormal node=loadNormal frac_pending=0.00,0.00(true))
+[mmaid=2] sortTargetCandidateSetAndPick: candidates: s2(SLS:loadNormal, overloadedDimLoadSummary:loadNormal) s4(SLS:loadNormal, overloadedDimLoadSummary:loadNormal), overloadedDim:CPURate, picked s2
+[mmaid=2] load summary for dim=CPURate (s2): overloadSlow, reason: fractionUsed < 75% [load=7 meanLoad=6 fractionUsed=7.00% meanUtil=6.20% capacity=100]
+[mmaid=2] load summary for dim=WriteBandwidth (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
+[mmaid=2] load summary for dim=ByteSize (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000000]
+[mmaid=2] load summary for dim=CPURate (n2): overloadSlow, reason: fractionUsed < 75% [load=7 meanLoad=6 fractionUsed=7.00% meanUtil=6.20% capacity=100]
+[mmaid=2] load summary for dim=CPURate (s3): loadNormal, reason: load is within 5% of mean [load=6 meanLoad=6 fractionUsed=6.00% meanUtil=6.20% capacity=100]
+[mmaid=2] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
+[mmaid=2] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000000]
+[mmaid=2] load summary for dim=CPURate (n3): loadNormal, reason: load is within 5% of mean [load=6 meanLoad=6 fractionUsed=6.00% meanUtil=6.20% capacity=100]
+[mmaid=2] cannot add load from n3s3 to n2s2 for r3 due to !overloadedDimPermitsChange,target_summary(overloadSlow)>=loadNoChange,target-store(overloadSlow)>src-store(loadNormal): delta([cpu:1ns/s, write-bandwidth:0 B/s, byte-size:0 B]) targetSLS[(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow frac_pending=0.00,0.00(true))] srcSLS[(store=loadNormal worst=CPURate cpu=loadNormal writes=loadNormal bytes=loadNormal node=loadNormal frac_pending=0.00,0.00(true))]
+[mmaid=2] load summary for dim=CPURate (s3): overloadSlow, reason: fractionUsed < 75% [load=7 meanLoad=6 fractionUsed=7.00% meanUtil=6.20% capacity=100]
+[mmaid=2] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
+[mmaid=2] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000000]
+[mmaid=2] load summary for dim=CPURate (n3): overloadSlow, reason: fractionUsed < 75% [load=7 meanLoad=6 fractionUsed=7.00% meanUtil=6.20% capacity=100]
+[mmaid=2] load summary for dim=CPURate (s2): loadNormal, reason: load is within 5% of mean [load=6 meanLoad=6 fractionUsed=6.00% meanUtil=6.20% capacity=100]
+[mmaid=2] load summary for dim=WriteBandwidth (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
+[mmaid=2] load summary for dim=ByteSize (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000000]
+[mmaid=2] load summary for dim=CPURate (n2): loadNormal, reason: load is within 5% of mean [load=6 meanLoad=6 fractionUsed=6.00% meanUtil=6.20% capacity=100]
+[mmaid=2] load summary for dim=CPURate (s5): loadNormal, reason: load is within 5% of mean [load=6 meanLoad=6 fractionUsed=6.00% meanUtil=6.20% capacity=100]
+[mmaid=2] load summary for dim=WriteBandwidth (s5): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
+[mmaid=2] load summary for dim=ByteSize (s5): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000000]
+[mmaid=2] load summary for dim=CPURate (n5): loadNormal, reason: load is within 5% of mean [load=6 meanLoad=6 fractionUsed=6.00% meanUtil=6.20% capacity=100]
+[mmaid=2] considering replica-transfer r2 from s3: store load [cpu:7ns/s, write-bandwidth:1.0 kB/s, byte-size:0 B]
+[mmaid=2] candidates for r2:
+	s2: (store=loadNormal worst=CPURate cpu=loadNormal writes=loadNormal bytes=loadNormal node=loadNormal frac_pending=0.00,0.00(true))
+	s5: (store=loadNormal worst=CPURate cpu=loadNormal writes=loadNormal bytes=loadNormal node=loadNormal frac_pending=0.00,0.00(true))
+[mmaid=2] sortTargetCandidateSetAndPick: candidates: s2(SLS:loadNormal, overloadedDimLoadSummary:loadNormal) s5(SLS:loadNormal, overloadedDimLoadSummary:loadNormal), overloadedDim:CPURate, picked s2
+[mmaid=2] load summary for dim=CPURate (s2): overloadSlow, reason: fractionUsed < 75% [load=7 meanLoad=6 fractionUsed=7.00% meanUtil=6.20% capacity=100]
+[mmaid=2] load summary for dim=WriteBandwidth (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
+[mmaid=2] load summary for dim=ByteSize (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000000]
+[mmaid=2] load summary for dim=CPURate (n2): overloadSlow, reason: fractionUsed < 75% [load=7 meanLoad=6 fractionUsed=7.00% meanUtil=6.20% capacity=100]
+[mmaid=2] load summary for dim=CPURate (s3): loadNormal, reason: load is within 5% of mean [load=6 meanLoad=6 fractionUsed=6.00% meanUtil=6.20% capacity=100]
+[mmaid=2] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
+[mmaid=2] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000000]
+[mmaid=2] load summary for dim=CPURate (n3): loadNormal, reason: load is within 5% of mean [load=6 meanLoad=6 fractionUsed=6.00% meanUtil=6.20% capacity=100]
+[mmaid=2] cannot add load from n3s3 to n2s2 for r2 due to !overloadedDimPermitsChange,target_summary(overloadSlow)>=loadNoChange,target-store(overloadSlow)>src-store(loadNormal): delta([cpu:1ns/s, write-bandwidth:0 B/s, byte-size:0 B]) targetSLS[(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow frac_pending=0.00,0.00(true))] srcSLS[(store=loadNormal worst=CPURate cpu=loadNormal writes=loadNormal bytes=loadNormal node=loadNormal frac_pending=0.00,0.00(true))]
+[mmaid=2] load summary for dim=CPURate (s3): overloadSlow, reason: fractionUsed < 75% [load=7 meanLoad=6 fractionUsed=7.00% meanUtil=6.20% capacity=100]
+[mmaid=2] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
+[mmaid=2] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000000]
+[mmaid=2] load summary for dim=CPURate (n3): overloadSlow, reason: fractionUsed < 75% [load=7 meanLoad=6 fractionUsed=7.00% meanUtil=6.20% capacity=100]
+[mmaid=2] load summary for dim=CPURate (s4): loadNormal, reason: load is within 5% of mean [load=6 meanLoad=6 fractionUsed=6.00% meanUtil=6.20% capacity=100]
+[mmaid=2] load summary for dim=WriteBandwidth (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
+[mmaid=2] load summary for dim=ByteSize (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000000]
+[mmaid=2] load summary for dim=CPURate (n4): loadNormal, reason: load is within 5% of mean [load=6 meanLoad=6 fractionUsed=6.00% meanUtil=6.20% capacity=100]
+[mmaid=2] load summary for dim=CPURate (s5): loadNormal, reason: load is within 5% of mean [load=6 meanLoad=6 fractionUsed=6.00% meanUtil=6.20% capacity=100]
+[mmaid=2] load summary for dim=WriteBandwidth (s5): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
+[mmaid=2] load summary for dim=ByteSize (s5): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000000]
+[mmaid=2] load summary for dim=CPURate (n5): loadNormal, reason: load is within 5% of mean [load=6 meanLoad=6 fractionUsed=6.00% meanUtil=6.20% capacity=100]
+[mmaid=2] considering replica-transfer r1 from s3: store load [cpu:7ns/s, write-bandwidth:1.0 kB/s, byte-size:0 B]
+[mmaid=2] candidates for r1:
+	s4: (store=loadNormal worst=CPURate cpu=loadNormal writes=loadNormal bytes=loadNormal node=loadNormal frac_pending=0.00,0.00(true))
+	s5: (store=loadNormal worst=CPURate cpu=loadNormal writes=loadNormal bytes=loadNormal node=loadNormal frac_pending=0.00,0.00(true))
+[mmaid=2] sortTargetCandidateSetAndPick: candidates: s4(SLS:loadNormal, overloadedDimLoadSummary:loadNormal) s5(SLS:loadNormal, overloadedDimLoadSummary:loadNormal), overloadedDim:CPURate, picked s5
+[mmaid=2] load summary for dim=CPURate (s5): overloadSlow, reason: fractionUsed < 75% [load=7 meanLoad=6 fractionUsed=7.00% meanUtil=6.20% capacity=100]
+[mmaid=2] load summary for dim=WriteBandwidth (s5): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
+[mmaid=2] load summary for dim=ByteSize (s5): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000000]
+[mmaid=2] load summary for dim=CPURate (n5): overloadSlow, reason: fractionUsed < 75% [load=7 meanLoad=6 fractionUsed=7.00% meanUtil=6.20% capacity=100]
+[mmaid=2] load summary for dim=CPURate (s3): loadNormal, reason: load is within 5% of mean [load=6 meanLoad=6 fractionUsed=6.00% meanUtil=6.20% capacity=100]
+[mmaid=2] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
+[mmaid=2] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000000]
+[mmaid=2] load summary for dim=CPURate (n3): loadNormal, reason: load is within 5% of mean [load=6 meanLoad=6 fractionUsed=6.00% meanUtil=6.20% capacity=100]
+[mmaid=2] cannot add load from n3s3 to n5s5 for r1 due to !overloadedDimPermitsChange,target_summary(overloadSlow)>=loadNoChange,target-store(overloadSlow)>src-store(loadNormal): delta([cpu:1ns/s, write-bandwidth:0 B/s, byte-size:0 B]) targetSLS[(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow frac_pending=0.00,0.00(true))] srcSLS[(store=loadNormal worst=CPURate cpu=loadNormal writes=loadNormal bytes=loadNormal node=loadNormal frac_pending=0.00,0.00(true))]
+[mmaid=2] rebalancing pass summary [local=s1]:
+	overloaded:
+		short: [s3]
+	failure: [{s3, total: 3, no-cand-to-accept-load:3}]
+pending(0)
+
+get-load-info
+----
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:6ns/s, write-bandwidth:1.0 kB/s, byte-size:0 B] adjusted=[cpu:6ns/s, write-bandwidth:1.0 kB/s, byte-size:0 B] node-reported-cpu=6 node-adjusted-cpu=6 seq=1
+  top-k-ranges (local-store-id=1) dim=CPURate: r3 r2 r1
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:6ns/s, write-bandwidth:1.0 kB/s, byte-size:0 B] adjusted=[cpu:6ns/s, write-bandwidth:1.0 kB/s, byte-size:0 B] node-reported-cpu=6 node-adjusted-cpu=6 seq=1
+store-id=3 node-id=3 status=ok accepting all reported=[cpu:7ns/s, write-bandwidth:1.0 kB/s, byte-size:0 B] adjusted=[cpu:7ns/s, write-bandwidth:1.0 kB/s, byte-size:0 B] node-reported-cpu=7 node-adjusted-cpu=7 seq=1
+  top-k-ranges (local-store-id=1) dim=CPURate: r3 r2 r1
+store-id=4 node-id=4 status=ok accepting all reported=[cpu:6ns/s, write-bandwidth:1.0 kB/s, byte-size:0 B] adjusted=[cpu:6ns/s, write-bandwidth:1.0 kB/s, byte-size:0 B] node-reported-cpu=6 node-adjusted-cpu=6 seq=1
+store-id=5 node-id=5 status=ok accepting all reported=[cpu:6ns/s, write-bandwidth:1.0 kB/s, byte-size:0 B] adjusted=[cpu:6ns/s, write-bandwidth:1.0 kB/s, byte-size:0 B] node-reported-cpu=6 node-adjusted-cpu=6 seq=1

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/low_write_integer_granularity_transfer_6_to_7.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/low_write_integer_granularity_transfer_6_to_7.txt
@@ -1,0 +1,208 @@
+# This test demonstrates that MMA permits a WB-driven replica transfer that
+# pushes a target store from WriteBandwidth load=6 (loadNormal) to load=7
+# (overloadSlow). The transfer is approved because the source also remains at
+# load=7 post-transfer, and canShedAndAddLoad permits
+# targetSLS.dimSummary[WB] <= srcSLS.dimSummary[WB] (overloadSlow <= overloadSlow).
+#
+# Setup:
+#   - s1: WB=900,000 (load=6, loadNormal), leaseholder for r1
+#   - s2: WB=930,000 (load=7, overloadSlow)
+#   - s3: WB=960,000 (load=7, overloadSlow), has r1 replica — source
+#   - s4: WB=900,000 (load=6, loadNormal) — target
+#   - s5: WB=786,432 (load=6, loadNormal), has r1 replica
+#   - Mean WB = 895,286 -> meanLoad = floor(895,286/131,072) = 6
+#   - Per-range WB = 20,000 B/s (0.15 quantization steps)
+#
+# After the transfer of r1 from s3 to s4:
+#   - Source s3: 960,000 - 20,000 = 940,000 -> load=7 (still overloadSlow)
+#   - Target s4: 900,000 + 20,000 = 920,000 -> load=7 (now overloadSlow!)
+#
+# The move is approved but it created a new overloaded store (s4) without
+# relieving the source (s3). This is part of the write bandwidth quantization
+# problem described in https://github.com/cockroachdb/cockroach/issues/164539.
+
+set-store
+  store-id=1 node-id=1
+  store-id=2 node-id=2
+  store-id=3 node-id=3
+  store-id=4 node-id=4
+  store-id=5 node-id=5
+----
+node-id=1 locality-tiers=node=1
+  store-id=1 attrs=
+node-id=2 locality-tiers=node=2
+  store-id=2 attrs=
+node-id=3 locality-tiers=node=3
+  store-id=3 attrs=
+node-id=4 locality-tiers=node=4
+  store-id=4 attrs=
+node-id=5 locality-tiers=node=5
+  store-id=5 attrs=
+
+# Store loads: CPU uniform at 100 (high enough that raft-cpu=1 stays in
+# loadNormal), WB varies to create load=6 vs load=7 split.
+# Mean WB = (900000+930000+960000+900000+786432)/5 = 895286 -> meanLoad=6
+store-load-msg
+  store-id=1 node-id=1 load=[100,900000,0] capacity=[2000,-1,1000000] secondary-load=0 load-time=0s
+  store-id=2 node-id=2 load=[100,930000,0] capacity=[2000,-1,1000000] secondary-load=0 load-time=0s
+  store-id=3 node-id=3 load=[100,960000,0] capacity=[2000,-1,1000000] secondary-load=0 load-time=0s
+  store-id=4 node-id=4 load=[100,900000,0] capacity=[2000,-1,1000000] secondary-load=0 load-time=0s
+  store-id=5 node-id=5 load=[100,786432,0] capacity=[2000,-1,1000000] secondary-load=0 load-time=0s
+----
+
+# Range r1: leaseholder on s1, replicas on s1, s3, s5.
+# s4 does NOT have r1 and is the only store at load=6 without a replica.
+# Per-range WB = 20,000 B/s — small relative to the 131,072 quantization step.
+store-leaseholder-msg
+store-id=1
+  range-id=1 load=[1,20000,0] raft-cpu=1
+    store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
+    store-id=3 replica-id=2 type=VOTER_FULL
+    store-id=5 replica-id=3 type=VOTER_FULL
+    config=num_replicas=3 constraints={} voter_constraints={}
+----
+
+get-load-info
+----
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:100ns/s, write-bandwidth:900 kB/s, byte-size:0 B] adjusted=[cpu:100ns/s, write-bandwidth:900 kB/s, byte-size:0 B] node-reported-cpu=100 node-adjusted-cpu=100 seq=1
+  top-k-ranges (local-store-id=1) dim=CPURate: r1
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:100ns/s, write-bandwidth:930 kB/s, byte-size:0 B] adjusted=[cpu:100ns/s, write-bandwidth:930 kB/s, byte-size:0 B] node-reported-cpu=100 node-adjusted-cpu=100 seq=1
+store-id=3 node-id=3 status=ok accepting all reported=[cpu:100ns/s, write-bandwidth:960 kB/s, byte-size:0 B] adjusted=[cpu:100ns/s, write-bandwidth:960 kB/s, byte-size:0 B] node-reported-cpu=100 node-adjusted-cpu=100 seq=1
+  top-k-ranges (local-store-id=1) dim=WriteBandwidth: r1
+store-id=4 node-id=4 status=ok accepting all reported=[cpu:100ns/s, write-bandwidth:900 kB/s, byte-size:0 B] adjusted=[cpu:100ns/s, write-bandwidth:900 kB/s, byte-size:0 B] node-reported-cpu=100 node-adjusted-cpu=100 seq=1
+store-id=5 node-id=5 status=ok accepting all reported=[cpu:100ns/s, write-bandwidth:786 kB/s, byte-size:0 B] adjusted=[cpu:100ns/s, write-bandwidth:786 kB/s, byte-size:0 B] node-reported-cpu=100 node-adjusted-cpu=100 seq=1
+  top-k-ranges (local-store-id=1) dim=WriteBandwidth: r1
+
+# Rebalance: s3 is overloaded in WB (load=7). It tries to shed r1. The only
+# candidate that passes sortTargetCandidateSetAndPick is s4 (load=6, loadNormal
+# in WB). s2 is discarded because dimSummary[WB]=overloadSlow >= loadNoChange.
+#
+# canShedAndAddLoad then checks the post-transfer state:
+#   source s3: 960K-20K = 940K -> load=7 -> overloadSlow
+#   target s4: 900K+20K = 920K -> load=7 -> overloadSlow
+#   overloadedDimPermitsChange: overloadSlow <= overloadSlow -> TRUE
+#
+# Result: transfer approved. s4 goes from loadNormal to overloadSlow.
+rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-threshold=10.0
+----
+[mmaid=1] rebalanceStores begins
+[mmaid=1] cluster means: (stores-load [cpu:100ns/s, write-bandwidth:895 kB/s, byte-size:0 B]) (stores-capacity [cpu:2µs/s, write-bandwidth:unknown/s, byte-size:1.0 MB]) (nodes-cpu-load 100) (nodes-cpu-capacity 2000)
+[mmaid=1] load summary for dim=CPURate (s1): loadNormal, reason: load is within 5% of mean [load=100 meanLoad=100 fractionUsed=5.00% meanUtil=5.00% capacity=2000]
+[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=6 meanLoad=6]
+[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000000]
+[mmaid=1] load summary for dim=CPURate (n1): loadNormal, reason: load is within 5% of mean [load=100 meanLoad=100 fractionUsed=5.00% meanUtil=5.00% capacity=2000]
+[mmaid=1] evaluating s1: node load loadNormal, store load loadNormal, worst dim CPURate
+[mmaid=1] load summary for dim=CPURate (s2): loadNormal, reason: load is within 5% of mean [load=100 meanLoad=100 fractionUsed=5.00% meanUtil=5.00% capacity=2000]
+[mmaid=1] load summary for dim=WriteBandwidth (s2): overloadSlow, reason: load is >10% above mean [load=7 meanLoad=6]
+[mmaid=1] load summary for dim=ByteSize (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000000]
+[mmaid=1] load summary for dim=CPURate (n2): loadNormal, reason: load is within 5% of mean [load=100 meanLoad=100 fractionUsed=5.00% meanUtil=5.00% capacity=2000]
+[mmaid=1] evaluating s2: node load loadNormal, store load overloadSlow, worst dim WriteBandwidth
+[mmaid=1] overload-continued s2 ((store=overloadSlow worst=WriteBandwidth cpu=loadNormal writes=overloadSlow bytes=loadNormal node=loadNormal frac_pending=0.00,0.00(true))) - within grace period
+[mmaid=1] store s2 was added to shedding store list
+[mmaid=1] load summary for dim=CPURate (s3): loadNormal, reason: load is within 5% of mean [load=100 meanLoad=100 fractionUsed=5.00% meanUtil=5.00% capacity=2000]
+[mmaid=1] load summary for dim=WriteBandwidth (s3): overloadSlow, reason: load is >10% above mean [load=7 meanLoad=6]
+[mmaid=1] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000000]
+[mmaid=1] load summary for dim=CPURate (n3): loadNormal, reason: load is within 5% of mean [load=100 meanLoad=100 fractionUsed=5.00% meanUtil=5.00% capacity=2000]
+[mmaid=1] evaluating s3: node load loadNormal, store load overloadSlow, worst dim WriteBandwidth
+[mmaid=1] overload-continued s3 ((store=overloadSlow worst=WriteBandwidth cpu=loadNormal writes=overloadSlow bytes=loadNormal node=loadNormal frac_pending=0.00,0.00(true))) - within grace period
+[mmaid=1] store s3 was added to shedding store list
+[mmaid=1] load summary for dim=CPURate (s4): loadNormal, reason: load is within 5% of mean [load=100 meanLoad=100 fractionUsed=5.00% meanUtil=5.00% capacity=2000]
+[mmaid=1] load summary for dim=WriteBandwidth (s4): loadNormal, reason: load is within 5% of mean [load=6 meanLoad=6]
+[mmaid=1] load summary for dim=ByteSize (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000000]
+[mmaid=1] load summary for dim=CPURate (n4): loadNormal, reason: load is within 5% of mean [load=100 meanLoad=100 fractionUsed=5.00% meanUtil=5.00% capacity=2000]
+[mmaid=1] evaluating s4: node load loadNormal, store load loadNormal, worst dim CPURate
+[mmaid=1] load summary for dim=CPURate (s5): loadNormal, reason: load is within 5% of mean [load=100 meanLoad=100 fractionUsed=5.00% meanUtil=5.00% capacity=2000]
+[mmaid=1] load summary for dim=WriteBandwidth (s5): loadNormal, reason: load is within 5% of mean [load=6 meanLoad=6]
+[mmaid=1] load summary for dim=ByteSize (s5): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000000]
+[mmaid=1] load summary for dim=CPURate (n5): loadNormal, reason: load is within 5% of mean [load=100 meanLoad=100 fractionUsed=5.00% meanUtil=5.00% capacity=2000]
+[mmaid=1] evaluating s5: node load loadNormal, store load loadNormal, worst dim CPURate
+[mmaid=1] start processing shedding store s2: cpu node load loadNormal, store load overloadSlow, worst dim WriteBandwidth
+[mmaid=1] no top-K[WriteBandwidth] ranges found for s2 with lease on local s1
+[mmaid=1] start processing shedding store s3: cpu node load loadNormal, store load overloadSlow, worst dim WriteBandwidth
+[mmaid=1] top-K[WriteBandwidth] ranges for s3 with lease on local s1: r1:[cpu:1ns/s, write-bandwidth:20 kB/s, byte-size:0 B]
+[mmaid=1] attempting to shed replicas next
+[mmaid=1] load summary for dim=CPURate (s3): loadNormal, reason: load is within 5% of mean [load=100 meanLoad=100 fractionUsed=5.00% meanUtil=5.00% capacity=2000]
+[mmaid=1] load summary for dim=WriteBandwidth (s3): overloadSlow, reason: load is >10% above mean [load=7 meanLoad=6]
+[mmaid=1] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000000]
+[mmaid=1] load summary for dim=CPURate (n3): loadNormal, reason: load is within 5% of mean [load=100 meanLoad=100 fractionUsed=5.00% meanUtil=5.00% capacity=2000]
+[mmaid=1] load summary for dim=CPURate (s2): loadNormal, reason: load is within 5% of mean [load=100 meanLoad=100 fractionUsed=5.00% meanUtil=5.00% capacity=2000]
+[mmaid=1] load summary for dim=WriteBandwidth (s2): overloadSlow, reason: load is >10% above mean [load=7 meanLoad=6]
+[mmaid=1] load summary for dim=ByteSize (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000000]
+[mmaid=1] load summary for dim=CPURate (n2): loadNormal, reason: load is within 5% of mean [load=100 meanLoad=100 fractionUsed=5.00% meanUtil=5.00% capacity=2000]
+[mmaid=1] load summary for dim=CPURate (s4): loadNormal, reason: load is within 5% of mean [load=100 meanLoad=100 fractionUsed=5.00% meanUtil=5.00% capacity=2000]
+[mmaid=1] load summary for dim=WriteBandwidth (s4): loadNormal, reason: load is within 5% of mean [load=6 meanLoad=6]
+[mmaid=1] load summary for dim=ByteSize (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000000]
+[mmaid=1] load summary for dim=CPURate (n4): loadNormal, reason: load is within 5% of mean [load=100 meanLoad=100 fractionUsed=5.00% meanUtil=5.00% capacity=2000]
+[mmaid=1] considering replica-transfer r1 from s3: store load [cpu:100ns/s, write-bandwidth:960 kB/s, byte-size:0 B]
+[mmaid=1] candidates for r1:
+	s2: (store=overloadSlow worst=WriteBandwidth cpu=loadNormal writes=overloadSlow bytes=loadNormal node=loadNormal frac_pending=0.00,0.00(true))
+	s4: (store=loadNormal worst=CPURate cpu=loadNormal writes=loadNormal bytes=loadNormal node=loadNormal frac_pending=0.00,0.00(true))
+[mmaid=1] discarding candidates with higher load than lowestLoadSet(loadNormal):  s2(SLS:overloadSlow, overloadedDimLoadSummary:overloadSlow), overloadedDim:WriteBandwidth
+[mmaid=1] sortTargetCandidateSetAndPick: candidates: s4(SLS:loadNormal, overloadedDimLoadSummary:loadNormal), overloadedDim:WriteBandwidth, picked s4
+[mmaid=1] load summary for dim=CPURate (s4): loadNormal, reason: load is within 5% of mean [load=101 meanLoad=100 fractionUsed=5.05% meanUtil=5.00% capacity=2000]
+[mmaid=1] load summary for dim=WriteBandwidth (s4): overloadSlow, reason: load is >10% above mean [load=7 meanLoad=6]
+[mmaid=1] load summary for dim=ByteSize (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000000]
+[mmaid=1] load summary for dim=CPURate (n4): loadNormal, reason: load is within 5% of mean [load=101 meanLoad=100 fractionUsed=5.05% meanUtil=5.00% capacity=2000]
+[mmaid=1] load summary for dim=CPURate (s3): loadNormal, reason: load is within 5% of mean [load=99 meanLoad=100 fractionUsed=4.95% meanUtil=5.00% capacity=2000]
+[mmaid=1] load summary for dim=WriteBandwidth (s3): overloadSlow, reason: load is >10% above mean [load=7 meanLoad=6]
+[mmaid=1] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000000]
+[mmaid=1] load summary for dim=CPURate (n3): loadNormal, reason: load is within 5% of mean [load=99 meanLoad=100 fractionUsed=4.95% meanUtil=5.00% capacity=2000]
+[mmaid=1] can add load to n4s4: true targetSLS[(store=overloadSlow worst=WriteBandwidth cpu=loadNormal writes=overloadSlow bytes=loadNormal node=loadNormal frac_pending=0.00,0.00(true))] srcSLS[(store=overloadSlow worst=WriteBandwidth cpu=loadNormal writes=overloadSlow bytes=loadNormal node=loadNormal frac_pending=0.00,0.00(true))]
+[mmaid=1] applying replica change r1 type: AddReplica target store n4,s4 (replica-id=none type=VOTER_FULL)->(replica-id=unknown type=VOTER_FULL) to range 1 on store 4
+[mmaid=1] addPendingRangeChange: change_id=1, range_id=1, change=r1 type: AddReplica target store n4,s4 (replica-id=none type=VOTER_FULL)->(replica-id=unknown type=VOTER_FULL)
+[mmaid=1] applying replica change r1 type: RemoveReplica target store n3,s3 (replica-id=2 type=VOTER_FULL)->(replica-id=none type=VOTER_FULL) to range 1 on store 3
+[mmaid=1] addPendingRangeChange: change_id=2, range_id=1, change=r1 type: RemoveReplica target store n3,s3 (replica-id=2 type=VOTER_FULL)->(replica-id=none type=VOTER_FULL)
+[mmaid=1] result(success): rebalancing r1 from s3 to s4 [change: r1=[change_replicas=[{ADD_VOTER n4,s4} {REMOVE_VOTER n3,s3}] cids=1,2]] with resulting loads source: [cpu:99ns/s, write-bandwidth:940 kB/s, byte-size:0 B] target: [cpu:101ns/s, write-bandwidth:922 kB/s, byte-size:0 B]
+[mmaid=1] rebalancing pass summary [local=s1]:
+	overloaded:
+		short: [s3]
+	success: [s3]
+pending(2)
+change-id=1 store-id=4 node-id=4 range-id=1 load-delta=[cpu:1ns/s, write-bandwidth:22 kB/s, byte-size:0 B] start=0s gc=5m0s
+  prev=(replica-id=none type=VOTER_FULL)
+  next=(replica-id=unknown type=VOTER_FULL)
+change-id=2 store-id=3 node-id=3 range-id=1 load-delta=[cpu:-1ns/s, write-bandwidth:-20 kB/s, byte-size:0 B] start=0s gc=5m0s
+  prev=(replica-id=2 type=VOTER_FULL)
+  next=(replica-id=none type=VOTER_FULL)
+
+# Verify s4 is now overloadSlow in WriteBandwidth after the transfer.
+# A second rebalance pass prints load summaries for each store, confirming
+# s4 is now classified overloadSlow (adjusted WB=922 kB/s -> load=7).
+rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-threshold=10.0
+----
+[mmaid=2] rebalanceStores begins
+[mmaid=2] cluster means: (stores-load [cpu:100ns/s, write-bandwidth:895 kB/s, byte-size:0 B]) (stores-capacity [cpu:2µs/s, write-bandwidth:unknown/s, byte-size:1.0 MB]) (nodes-cpu-load 100) (nodes-cpu-capacity 2000)
+[mmaid=2] evaluating s1: node load loadNormal, store load loadNormal, worst dim CPURate
+[mmaid=2] evaluating s2: node load loadNormal, store load overloadSlow, worst dim WriteBandwidth
+[mmaid=2] store s2 was added to shedding store list
+[mmaid=2] load summary for dim=CPURate (s3): loadNormal, reason: load is within 5% of mean [load=99 meanLoad=100 fractionUsed=4.95% meanUtil=5.00% capacity=2000]
+[mmaid=2] load summary for dim=WriteBandwidth (s3): overloadSlow, reason: load is >10% above mean [load=7 meanLoad=6]
+[mmaid=2] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000000]
+[mmaid=2] load summary for dim=CPURate (n3): loadNormal, reason: load is within 5% of mean [load=99 meanLoad=100 fractionUsed=4.95% meanUtil=5.00% capacity=2000]
+[mmaid=2] evaluating s3: node load loadNormal, store load overloadSlow, worst dim WriteBandwidth
+[mmaid=2] store s3 was added to shedding store list
+[mmaid=2] load summary for dim=CPURate (s4): loadNormal, reason: load is within 5% of mean [load=101 meanLoad=100 fractionUsed=5.05% meanUtil=5.00% capacity=2000]
+[mmaid=2] load summary for dim=WriteBandwidth (s4): overloadSlow, reason: load is >10% above mean [load=7 meanLoad=6]
+[mmaid=2] load summary for dim=ByteSize (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000000]
+[mmaid=2] load summary for dim=CPURate (n4): loadNormal, reason: load is within 5% of mean [load=101 meanLoad=100 fractionUsed=5.05% meanUtil=5.00% capacity=2000]
+[mmaid=2] evaluating s4: node load loadNormal, store load overloadSlow, worst dim WriteBandwidth
+[mmaid=2] overload-continued s4 ((store=overloadSlow worst=WriteBandwidth cpu=loadNormal writes=overloadSlow bytes=loadNormal node=loadNormal frac_pending=0.02,0.00(false))) - within grace period
+[mmaid=2] skipping overloaded store s4 (worst dim: WriteBandwidth): pending decrease 0.00 >= threshold 10.00 or pending increase 0.02 >= epsilon
+[mmaid=2] evaluating s5: node load loadNormal, store load loadNormal, worst dim CPURate
+[mmaid=2] start processing shedding store s2: cpu node load loadNormal, store load overloadSlow, worst dim WriteBandwidth
+[mmaid=2] no top-K[WriteBandwidth] ranges found for s2 with lease on local s1
+[mmaid=2] start processing shedding store s3: cpu node load loadNormal, store load overloadSlow, worst dim WriteBandwidth
+[mmaid=2] top-K[WriteBandwidth] ranges for s3 with lease on local s1: r1:[cpu:1ns/s, write-bandwidth:20 kB/s, byte-size:0 B]
+[mmaid=2] attempting to shed replicas next
+[mmaid=2] skipping r1: has pending changes
+[mmaid=2] rebalancing pass summary [local=s1]:
+	overloaded:
+		short: [s3]
+	failure: [{s3, total: 1, range-transient:1}]
+pending(2)
+change-id=1 store-id=4 node-id=4 range-id=1 load-delta=[cpu:1ns/s, write-bandwidth:22 kB/s, byte-size:0 B] start=0s gc=5m0s
+  prev=(replica-id=none type=VOTER_FULL)
+  next=(replica-id=unknown type=VOTER_FULL)
+change-id=2 store-id=3 node-id=3 range-id=1 load-delta=[cpu:-1ns/s, write-bandwidth:-20 kB/s, byte-size:0 B] start=0s gc=5m0s
+  prev=(replica-id=2 type=VOTER_FULL)
+  next=(replica-id=none type=VOTER_FULL)

--- a/pkg/kv/kvserver/asim/tests/testdata/non_rand/mma/low_write_quantization.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/non_rand/mma/low_write_quantization.txt
@@ -1,0 +1,62 @@
+# This test demonstrates WriteBandwidth quantization thrashing at low write
+# throughput. MMA normalizes WriteBandwidth by dividing raw bytes/s by 128 KiB
+# (131,072 bytes) and truncating to an integer. At balanced write throughput of
+# ~917 KB/s per store, the normalized load is either 6 or 7. The 10%
+# mean-fraction threshold classifies load=7 as overloadSlow (16.7% above
+# mean=6), while load=6 is loadNormal. This means a difference of just ~17.5
+# KB/s in raw write throughput -- crossing the 917,504 B/s boundary -- causes a
+# store to jump from "normal" to "overloaded."
+#
+# Per-range WB contributions (~3.7 KB/s) are far too small to change a store's
+# normalized load level in a single move, so MMA must execute many successive
+# moves to cross the boundary. A single extra replica pushes a store over the
+# boundary, MMA sheds it, and the receiving store crosses in turn.
+#
+# In mma-only mode, we see 23% replica thrashing and 144% WB thrashing. In
+# mma-count mode, replica count balancing continuously shuffles ranges to
+# equalize counts, and each move shifts ~3.7 KB/s of WB, pushing stores back
+# and forth across the boundary. This results in 574% replica thrashing and
+# 1134% WB thrashing.
+#
+# See: https://github.com/cockroachdb/cockroach/issues/164539
+#
+# Setup:
+#   - 6 nodes, 500 ranges with skewed initial placement
+#   - Write-only uniform workload, so after convergence all stores cluster near
+#     the balanced WB = 917,500 B/s — just 4 B/s below the load 7 boundary
+#   - Per-range WB = 3,670 B/s; one extra replica crosses the boundary
+gen_cluster nodes=6 node_cpu_cores=8
+----
+
+gen_ranges ranges=500 placement_type=skewed
+----
+
+gen_load rate=1835 rw_ratio=0 min_block=1000 max_block=1000 raft_cpu_per_write=1
+----
+0.00 raft-vcpus, 1.7 MiB/s goodput
+
+setting split_queue_enabled=false
+----
+
+eval duration=25m cfgs=(mma-only,mma-count) metrics=(write_bytes_per_second,replicas,cpu)
+----
+mma-only:
+cpu#1: last:  [s1=911, s2=916, s3=916, s4=916, s5=916, s6=917] (stddev=1.97, mean=915.33, sum=5492)
+cpu#1: thrash_pct: [s1=30%, s2=19%, s3=39%, s4=22%, s5=22%, s6=18%]  (sum=150%)
+replicas#1: first: [s1=500, s2=433, s3=243, s4=148, s5=100, s6=76] (stddev=162.90, mean=250.00, sum=1500)
+replicas#1: last:  [s1=249, s2=251, s3=250, s4=250, s5=250, s6=250] (stddev=0.58, mean=250.00, sum=1500)
+replicas#1: thrash_pct: [s1=10%, s2=1%, s3=7%, s4=5%, s5=0%, s6=0%]  (sum=23%)
+write_bytes_per_second#1: last:  [s1=911159, s2=916879, s3=916922, s4=916244, s5=916628, s6=917269] (stddev=2120.83, mean=915850.17, sum=5495101)
+write_bytes_per_second#1: thrash_pct: [s1=25%, s2=20%, s3=37%, s4=23%, s5=20%, s6=18%]  (sum=144%)
+hash: c2eb401e9f1d35a
+==========================
+mma-count:
+cpu#1: last:  [s1=917, s2=914, s3=913, s4=916, s5=901, s6=910] (stddev=5.34, mean=911.83, sum=5471)
+cpu#1: thrash_pct: [s1=194%, s2=216%, s3=185%, s4=182%, s5=193%, s6=162%]  (sum=1131%)
+replicas#1: first: [s1=500, s2=433, s3=243, s4=148, s5=100, s6=76] (stddev=162.90, mean=250.00, sum=1500)
+replicas#1: last:  [s1=251, s2=251, s3=250, s4=251, s5=247, s6=250] (stddev=1.41, mean=250.00, sum=1500)
+replicas#1: thrash_pct: [s1=93%, s2=115%, s3=87%, s4=96%, s5=110%, s6=73%]  (sum=574%)
+write_bytes_per_second#1: last:  [s1=917257, s2=914588, s3=913066, s4=916677, s5=901997, s6=910389] (stddev=5153.48, mean=912329.00, sum=5473974)
+write_bytes_per_second#1: thrash_pct: [s1=197%, s2=216%, s3=182%, s4=186%, s5=191%, s6=163%]  (sum=1134%)
+hash: dca54d6a01bf5141
+==========================


### PR DESCRIPTION
**asim: add low write bandwidth quantization thrashing test**

This adds an asim test that demonstrates WriteBandwidth quantization
thrashing at low write throughput. MMA normalizes WB by dividing raw
bytes/s by 128 KiB and truncating, so at ~917 KB/s per store the
normalized load is either 6 or 7. The 10% mean-fraction threshold
flags load=7 as overloaded (16.7% above mean=6), but per-range WB
contributions (~3.7 KB/s) are too small to meaningfully shift a
store's normalized load in a single move.

The test runs both mma-only and mma-count configurations. mma-count
exacerbates the problem — replica count balancing continuously
shuffles ranges to equalize counts, and each move shifts ~3.7 KB/s
of WB, pushing stores back and forth across the boundary. In mma-only
mode we see 23% replica thrashing, and 144% WB thrashing. In mma-count,
we see 574% replica thrashing and 1134% WB thrashing.

Informs: https://github.com/cockroachdb/cockroach/issues/164539
Epic: [CRDB-55052](https://cockroachlabs.atlassian.net/browse/CRDB-55052)
Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

<img width="1255" height="446" alt="Screenshot 2026-03-05 at 11 08 50 AM" src="https://github.com/user-attachments/assets/d9c721ed-3d07-414c-bb09-f9b686b19193" />


---

**mmaprototype: add TestClusterState test for low CPU integer granularity**

This adds a datadriven test that demonstrates how integer granularity at
low CPU values causes MMA to classify a store as overloaded when it's
only 1 unit above the mean. With stores at CPU load 6 and 7, the integer
mean is 6. A store at load 7 is 16.7% above mean, exceeding the 10%
overloadSlow threshold. The smallest possible move (raft-cpu=1) shifts
the full step size — moving 1 unit from s3 (7) to any target (6) pushes
the target to 7, making it equally overloaded. MMA correctly identifies
the overload but rejects all candidate moves because they would just
swap the problem.

The test also exercises the 5% CPU utilization floor: we use
capacity=100 so that CPU=7 gives fractionUsed=7%, above the floor that
would otherwise cap overload at loadNormal.

Informs: https://github.com/cockroachdb/cockroach/issues/164539
Epic: [CRDB-55052](https://cockroachlabs.atlassian.net/browse/CRDB-55052)
Release note: None