### PR TITLE
changefeedccl: reset retry backoff on highwater advance

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -229,6 +229,7 @@ go_test(
         "nemeses_test.go",
         "parquet_test.go",
         "protected_timestamps_test.go",
+        "retry_test.go",
         "scheduled_changefeed_test.go",
         "schema_registry_test.go",
         "show_changefeed_jobs_test.go",

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -1944,9 +1944,9 @@ func (cf *changeFrontier) checkpointJobProgress(
 	defer sp.Finish()
 	defer cf.sliMetrics.Timers.CheckpointJobProgress.Start().End()
 
-	if cf.knobs.RaiseRetryableError != nil {
-		if err := cf.knobs.RaiseRetryableError(); err != nil {
-			return changefeedbase.MarkRetryableError(errors.New("cf.knobs.RaiseRetryableError"))
+	if cf.knobs.BeforeCheckpoint != nil {
+		if err := cf.knobs.BeforeCheckpoint(); err != nil {
+			return changefeedbase.MarkRetryableError(err)
 		}
 	}
 

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -1803,6 +1803,14 @@ func (b *changefeedResumer) resumeWithRetries(
 	var lastRunStatusUpdate time.Time
 
 	for r := getRetry(ctx, maxBackoff, backoffReset); r.Next(); {
+		// Capture the current highwater before running the flow so we can
+		// detect if the changefeed made forward progress. If it did, the
+		// retry backoff is reset regardless of how long the flow ran.
+		var preFlowHighWater hlc.Timestamp
+		if hw := progress.GetHighWater(); hw != nil {
+			preFlowHighWater = *hw
+		}
+
 		flowErr := maybeUpgradePreProductionReadyExpression(ctx, jobID, details, jobExec)
 
 		if flowErr == nil {
@@ -1971,6 +1979,18 @@ func (b *changefeedResumer) resumeWithRetries(
 			// claim information, and will restart this job somewhere else (though,
 			// it's possible that the job gets restarted on this node).
 			return jobs.MarkAsRetryJobError(err)
+		}
+
+		// Reset retry backoff if the highwater advanced, indicating the
+		// changefeed made meaningful forward progress before the error.
+		if hw := progress.GetHighWater(); hw != nil && preFlowHighWater.Less(*hw) {
+			log.Changefeed.Infof(ctx,
+				"changefeed %d highwater advanced (%s -> %s); resetting retry backoff",
+				jobID, preFlowHighWater, *hw)
+			r.Reset()
+			if knobs != nil && knobs.OnRetryBackoffReset != nil {
+				knobs.OnRetryBackoffReset()
+			}
 		}
 
 		if errors.Is(flowErr, changefeedbase.ErrNodeDraining) {

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -11731,7 +11731,7 @@ func TestHighwaterDoesNotRegressOnRetry(t *testing.T) {
 
 		// A flag we toggle on to put the changefeed in a retrying state.
 		var changefeedIsRetrying atomic.Bool
-		knobs.RaiseRetryableError = func() error {
+		knobs.BeforeCheckpoint = func() error {
 			if changefeedIsRetrying.Load() {
 				return errors.New("test retryable error")
 			}
@@ -11814,7 +11814,7 @@ func TestHighwaterDoesNotRegressOnRetry(t *testing.T) {
 		// Check that the following happens soon.
 		//
 		// Step 2: Since `changefeedIsRetrying` is true, the changefeed will now attempt retries in
-		//         via `knobs.RaiseRetryableError`.
+		//         via `knobs.BeforeCheckpoint`.
 		// Step 3: `knobs.LoadJobErr` will result an in error when reading the job record a couple of times, causing
 		//          more retries.
 		// Step 4: Eventually, a dist changefeed is started at a certain highwater timestamp.
@@ -12273,7 +12273,7 @@ func TestChangefeedRetryBackoffLogging(t *testing.T) {
 
 		var errorCount atomic.Int32
 		knobs := s.TestingKnobs.DistSQL.(*execinfra.TestingKnobs).Changefeed.(*TestingKnobs)
-		knobs.RaiseRetryableError = func() error {
+		knobs.BeforeCheckpoint = func() error {
 			if errorCount.Add(1) == 1 {
 				return errors.New("test transient error")
 			}

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -12319,6 +12319,58 @@ func TestChangefeedRetryBackoffLogging(t *testing.T) {
 	cdcTest(t, testFn, feedTestEnterpriseSinks)
 }
 
+// TestChangefeedRetryBackoffResetOnHighwaterAdvance verifies that the retry
+// backoff is reset when a changefeed advances its highwater mark before
+// encountering a retryable error. This ensures that transient errors after
+// meaningful forward progress don't leave the backoff unnecessarily elevated.
+func TestChangefeedRetryBackoffResetOnHighwaterAdvance(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
+
+		knobs := s.TestingKnobs.DistSQL.(*execinfra.TestingKnobs).Changefeed.(*TestingKnobs)
+
+		// Let the first few checkpoints succeed so the highwater gets
+		// persisted to the job record, then fire a retryable error. The
+		// retry loop should detect that the highwater advanced past its
+		// initial value and reset the backoff.
+		var checkpointCount atomic.Int32
+		knobs.BeforeCheckpoint = func() error {
+			if checkpointCount.Add(1) == 3 {
+				return errors.New("test transient error")
+			}
+			return nil
+		}
+
+		backoffResetCh := make(chan struct{}, 1)
+		knobs.OnRetryBackoffReset = func() {
+			select {
+			case backoffResetCh <- struct{}{}:
+			default:
+			}
+		}
+
+		feed := feed(t, f, `CREATE CHANGEFEED FOR foo WITH initial_scan='no'`)
+		defer closeFeed(t, feed)
+
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (1)`)
+		assertPayloads(t, feed, []string{
+			`foo: [1]->{"after": {"a": 1}}`,
+		})
+
+		select {
+		case <-backoffResetCh:
+		case <-time.After(testutils.DefaultSucceedsSoonDuration):
+			t.Fatal("timed out waiting for retry backoff reset after highwater advance")
+		}
+	}
+
+	cdcTest(t, testFn, feedTestEnterpriseSinks)
+}
+
 // TestPubsubAttributes tests that the "attributes" field in the
 // `pubsub_sink_config` behaves as expected.
 func TestPubsubAttributes(t *testing.T) {

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -936,8 +936,7 @@ func requireNoFeedsFail(t *testing.T) (fn updateKnobsFn) {
 		`was truncated`,
 		`connection refused`,
 		`connection reset by peer`,
-		`knobs.RaiseRetryableError`,
-		`test error`,
+		`test .*error`,
 		`context canceled`,
 	}
 	shouldIgnoreErr := func(err error) bool {

--- a/pkg/ccl/changefeedccl/retry_test.go
+++ b/pkg/ccl/changefeedccl/retry_test.go
@@ -1,0 +1,43 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package changefeedccl
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRetryResetOnProgress verifies that calling Reset()
+// on the changefeed Retry wrapper resets the backoff to
+// its initial value.
+func TestRetryResetOnProgress(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	r := getRetry(ctx, 10*time.Minute, 10*time.Minute)
+
+	require.True(t, r.Next())
+	require.Equal(t, 0, r.CurrentAttempt())
+	initialBackoff := r.NextBackoff()
+
+	for i := 0; i < 5; i++ {
+		require.True(t, r.Next())
+	}
+	require.Equal(t, 5, r.CurrentAttempt())
+	elevatedBackoff := r.NextBackoff()
+	require.Greater(t, elevatedBackoff, initialBackoff,
+		"backoff should increase after multiple attempts")
+
+	r.Reset()
+	require.Equal(t, 0, r.CurrentAttempt(),
+		"attempt counter should be zero after reset")
+	require.Equal(t, initialBackoff, r.NextBackoff(),
+		"backoff should return to initial value after reset")
+}

--- a/pkg/ccl/changefeedccl/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/testing_knobs.go
@@ -52,8 +52,10 @@ type TestingKnobs struct {
 	NullSinkIsExternalIOAccounted bool
 	// OnDistflowSpec is called when specs for distflow planning have been created
 	OnDistflowSpec func(aggregatorSpecs []*execinfrapb.ChangeAggregatorSpec, frontierSpec *execinfrapb.ChangeFrontierSpec)
-	// RaiseRetryableError is a knob used to possibly return an error.
-	RaiseRetryableError func() error
+	// BeforeCheckpoint, if set, is called at the start of
+	// checkpointJobProgress. Returning a non-nil error causes a retryable
+	// failure before the checkpoint is persisted.
+	BeforeCheckpoint func() error
 	// StartDistChangefeedInitialHighwater is called when starting the dist changefeed with the initial highwater
 	// of the changefeed. Note that this will be called when the changefeed starts and subsequently when the changefeed
 	// is retried.

--- a/pkg/ccl/changefeedccl/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/testing_knobs.go
@@ -56,6 +56,9 @@ type TestingKnobs struct {
 	// checkpointJobProgress. Returning a non-nil error causes a retryable
 	// failure before the checkpoint is persisted.
 	BeforeCheckpoint func() error
+	// OnRetryBackoffReset, if set, is called when the changefeed retry loop
+	// resets its backoff due to changefeed progress.
+	OnRetryBackoffReset func()
 	// StartDistChangefeedInitialHighwater is called when starting the dist changefeed with the initial highwater
 	// of the changefeed. Note that this will be called when the changefeed starts and subsequently when the changefeed
 	// is retried.


### PR DESCRIPTION
Previously, the changefeed retry backoff only reset after running
error-free for a configurable duration (default 10 minutes via
`changefeed.retry_backoff_reset`).

Now the retry backoff also resets whenever the changefeed's highwater
mark (resolved timestamp) advances between retries. This directly
measures forward progress, so transient errors during rolling restarts
no longer leave the backoff unnecessarily elevated when the changefeed
is otherwise healthy.

The time-based reset remains as a fallback.

Fixes: https://github.com/cockroachdb/cockroach/issues/164695
Release note (bug fix): Changefeed retry backoff now resets when
the changefeed's resolved timestamp (highwater mark) advances between
retries, in addition to the existing time-based reset
(changefeed.retry_backoff_reset). This prevents transient rolling
restarts from causing changefeeds to fall behind because of
excessive backoff.