### PR TITLE
server/status: recover from gopsutil panics in getSummedNetStats

### DIFF
--- a/pkg/server/status/runtime.go
+++ b/pkg/server/status/runtime.go
@@ -1351,7 +1351,20 @@ type netCounters struct {
 
 var mockableMaybeReadProcStatFile = maybeReadProcStatFile
 
-func getSummedNetStats(ctx context.Context) (netCounters, error) {
+func getSummedNetStats(ctx context.Context) (result netCounters, err error) {
+	// Recover from panics in gopsutil. The library has known bugs where it
+	// accesses slice indices without bounds checks when parsing OS command
+	// output (e.g. netstat on darwin). Since this is a metrics sampling path,
+	// returning zero counters is acceptable.
+	// See: https://github.com/cockroachdb/cockroach/issues/164074
+	defer func() {
+		if r := recover(); r != nil {
+			err = errors.Newf("panic in gopsutil: %v", r)
+			log.Ops.Warningf(ctx, "recovered from %s", err)
+			result = netCounters{}
+		}
+	}()
+
 	c, err := net.IOCountersWithContext(ctx, true /* per NIC */)
 	if err != nil {
 		log.Dev.VWarningf(ctx, 1, "error reading network IO counters: %v", err)


### PR DESCRIPTION
The gopsutil library accesses slice indices without bounds checks when parsing OS command output. On darwin, parseNetstatLine has been observed to panic occasionally with "index out of range [2] with length 1" when netstat produces lines with fewer than 3 fields. This has been a recurring issue (#34447, #50189, #50191) with no upstream fix. The output of netstat does not document this possibility so it may be triggered by some transient interruption.

Add a defer/recover in getSummedNetStats so that a gopsutil panic returns zero counters and a warning log instead of crashing the process. This is acceptable because the function is only called from the periodic environment sampler.

Resolves: #164074

Release note: None