### PR TITLE
release-26.1: changefeedccl: lower default max_retry_backoff from 10m to 30s

### DIFF
--- a/pkg/ccl/changefeedccl/changefeedbase/settings.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/settings.go
@@ -364,7 +364,7 @@ var MaxRetryBackoff = settings.RegisterDurationSettingWithExplicitUnit(
 	settings.ApplicationLevel,
 	"changefeed.max_retry_backoff",
 	"the maximum time a changefeed will backoff when retrying after a restart and how long between retries before backoff resets",
-	10*time.Minute, /* defaultValue */
+	30*time.Second, /* defaultValue */
 	settings.DurationInRange(1*time.Second, 1*time.Hour),
 )
 


### PR DESCRIPTION
Backport 1/1 commits from #164874 on behalf of @aerfrei.

----

The 10-minute default causes changefeed lag to accumulate during rolling restarts when the backoff exceeds the restart interval. With frontier checkpointing (introduced in 25.4), changefeeds preserve per-span progress across restarts, making aggressive retries safe. A 30-second max backoff gives changefeeds enough headroom to recover between restarts while still allowing time for transient issues like sink unavailability to resolve.

Fixes: #164872
Release note (bug fix): The default value of the
changefeed.max_retry_backoff cluster setting has been lowered from 10m to 30s to reduce changefeed lag during rolling restarts.

----

Release justification: This is a setting change that should be safe and most importantly, will help with changefeed lag for rolling restart which is an important production issue. This is already a cluster setting, so can always be changed manually. 