### PR TITLE
clisqlshell: fix index out of range panic in statement-diag download

### DIFF
--- a/pkg/cli/clisqlshell/statement_diag.go
+++ b/pkg/cli/clisqlshell/statement_diag.go
@@ -40,7 +40,7 @@ func (c *cliState) handleStatementDiag(
 		}
 		id, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
-			return c.cliError(errState, errors.Wrapf(err, "%q is not a valid bundle ID", args[1]))
+			return c.cliError(errState, errors.Wrapf(err, "%q is not a valid bundle ID", args[0]))
 		}
 		var filename string
 		if len(args) > 1 {


### PR DESCRIPTION
Use args[0] instead of args[1] in the error message for invalid bundle IDs, since args may have only one element.

Fixes: #164209
Release note: None