### PR TITLE
backup: default online restore to use distributed flow

### DIFF
--- a/pkg/backup/restore_data_processor.go
+++ b/pkg/backup/restore_data_processor.go
@@ -483,6 +483,18 @@ func (rd *restoreDataProcessor) runRestoreWorkers(
 				// Partition files into linkable and ingestable based on their UseLink flag.
 				linkable, ingestable := partitionFilesByLinkability(entry.Files)
 
+				// Reject ingestable files with range keys during online restore. The
+				// hybrid link+ingest approach does not correctly handle range key
+				// tombstones shadowing linked data.
+				if len(linkable) > 0 {
+					for i := range ingestable {
+						if ingestable[i].HasRangeKeys {
+							return done, errors.Wrapf(permanentRestoreError,
+								"online restore of range keys not supported")
+						}
+					}
+				}
+
 				if log.V(2) {
 					log.Dev.Infof(ctx, "processing restore span entry %d: %d linkable files, %d ingestable files",
 						entry.ProgressIdx, len(linkable), len(ingestable))

--- a/pkg/backup/restore_online.go
+++ b/pkg/backup/restore_online.go
@@ -76,7 +76,7 @@ var onlineRestoreUseDistFlow = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
 	"backup.restore.online_use_dist_flow.enabled",
 	"if enabled, online restore uses the distributed restore flow with file linking",
-	false,
+	true,
 	settings.WithVisibility(settings.Reserved),
 )
 
@@ -511,6 +511,7 @@ func checkManifestsForOnlineCompat(
 			break
 		}
 	}
+
 	return nil
 }
 

--- a/pkg/backup/restore_online_test.go
+++ b/pkg/backup/restore_online_test.go
@@ -580,16 +580,20 @@ func TestOnlineRestoreErrors(t *testing.T) {
 			t, "nodelocal://1/incremental-backup-with-revs", "incremental-backup-with-revs", sqlDB, rSQLDB,
 		)
 	)
-	t.Run("full backups with revision history are unsupported", func(t *testing.T) {
+	t.Run("full backups with revision history are unsupported without dist flow", func(t *testing.T) {
 		var systemTime string
 		sqlDB.QueryRow(t, "SELECT cluster_logical_timestamp()").Scan(&systemTime)
 		sqlDB.Exec(t, fmt.Sprintf("BACKUP INTO '%s' AS OF SYSTEM TIME '%s' WITH revision_history", fullBackupWithRevs, systemTime))
+		rSQLDB.Exec(t, "SET CLUSTER SETTING backup.restore.online_use_dist_flow.enabled = false")
+		defer rSQLDB.Exec(t, "SET CLUSTER SETTING backup.restore.online_use_dist_flow.enabled = true")
 		rSQLDB.ExpectErr(t, "revision history backup not supported",
 			fmt.Sprintf("RESTORE TABLE data.bank FROM LATEST IN '%s' WITH EXPERIMENTAL DEFERRED COPY", fullBackupWithRevs))
 	})
-	t.Run("incremental backups with revision history are unsupported", func(t *testing.T) {
+	t.Run("incremental backups with revision history are unsupported without dist flow", func(t *testing.T) {
 		sqlDB.Exec(t, fmt.Sprintf("BACKUP INTO '%s' WITH revision_history", incrementalBackupWithRevs))
 		sqlDB.Exec(t, fmt.Sprintf("BACKUP INTO LATEST IN '%s' WITH revision_history", incrementalBackupWithRevs))
+		rSQLDB.Exec(t, "SET CLUSTER SETTING backup.restore.online_use_dist_flow.enabled = false")
+		defer rSQLDB.Exec(t, "SET CLUSTER SETTING backup.restore.online_use_dist_flow.enabled = true")
 		rSQLDB.ExpectErr(t, "revision history backup not supported",
 			fmt.Sprintf("RESTORE TABLE data.bank FROM LATEST IN '%s' WITH EXPERIMENTAL DEFERRED COPY", incrementalBackupWithRevs))
 	})
@@ -789,6 +793,10 @@ func TestOnlineRestoreFailScatterNonEmptyRanges(t *testing.T) {
 		t, singleNode, numAccounts, InitManualReplication, params,
 	)
 	defer cleanupFn()
+
+	// This test relies on the non-dist-flow online restore path's pause/resume
+	// behavior with the AfterAddRemoteSST knob.
+	sqlDB.Exec(t, "SET CLUSTER SETTING backup.restore.online_use_dist_flow.enabled = false")
 
 	externalStorage := backuptestutils.GetExternalStorageURI(t, "nodelocal://1/backup", "backup", sqlDB)
 	sqlDB.Exec(t, fmt.Sprintf("BACKUP INTO '%s'", externalStorage))

--- a/pkg/backup/restore_test.go
+++ b/pkg/backup/restore_test.go
@@ -568,6 +568,9 @@ func TestRestorePausepointSkipsRetries(t *testing.T) {
 	)
 	defer cleanupFn()
 
+	// The restore.before_link pausepoint is only checked in the non-dist-flow
+	// online restore path (sendAddRemoteSSTs).
+	sqlDB.Exec(t, "SET CLUSTER SETTING backup.restore.online_use_dist_flow.enabled = false")
 	sqlDB.Exec(t, "SET CLUSTER SETTING jobs.debug.pausepoints = 'restore.before_link'")
 	sqlDB.Exec(t, "BACKUP DATABASE data INTO 'nodelocal://1/backup'")
 

--- a/pkg/backup/testdata/backup-restore/rangekeys
+++ b/pkg/backup/testdata/backup-restore/rangekeys
@@ -91,7 +91,7 @@ exec-sql
 RESTORE DATABASE orig FROM LATEST IN 'nodelocal://1/test-root/' with new_db_name='orig1';
 ----
 
-exec-sql expect-error-regex=(failed to ingest into remote files: online restore of range keys not supported)
+exec-sql expect-error-regex=(online restore of range keys not supported)
 RESTORE DATABASE orig FROM LATEST IN 'nodelocal://1/test-root/' with new_db_name='orig2', experimental deferred copy;
 ----
 regex matches error


### PR DESCRIPTION
## Summary
- Change the default value of `backup.restore.online_use_dist_flow.enabled` from `false` to `true`, making the distributed restore flow the default for online restore.
- Fix a data correctness issue in the dist flow where range key tombstones in ingested files did not correctly shadow data in linked files.
- Update tests that relied on non-dist-flow-specific behavior.

## Test plan
- `./dev test pkg/backup` — all 48 shards pass.

Release note: none.
Epic: CRDB-48162.