### PR TITLE
obs/ash: add sampler metrics for operational visibility

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -9989,6 +9989,30 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
   - name: UNSET
     metrics:
+    - name: ash.sampler.take_sample.latency
+      exported_name: ash_sampler_take_sample_latency
+      description: Latency of ASH sample collection ticks
+      y_axis_label: Latency
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+    - name: ash.samples.collected
+      exported_name: ash_samples_collected
+      description: Total number of ASH samples collected
+      y_axis_label: Samples
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: ash.work_states.active
+      exported_name: ash_work_states_active
+      description: Number of goroutines with an active ASH work state
+      y_axis_label: Goroutines
+      type: GAUGE
+      unit: COUNT
+      aggregation: AVG
+      derivative: NONE
     - name: build.timestamp
       exported_name: build_timestamp
       description: Build information

--- a/pkg/obs/ash/BUILD.bazel
+++ b/pkg/obs/ash/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "buffer.go",
         "doc.go",
+        "metrics.go",
         "sampler.go",
         "types.go",
         "work_state.go",
@@ -12,6 +13,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/obs/ash",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/base",
         "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/settings/cluster",
@@ -19,11 +21,13 @@ go_library(
         "//pkg/util/cache",
         "//pkg/util/encoding",
         "//pkg/util/log",
+        "//pkg/util/metric",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_petermattis_goid//:goid",
+        "@com_github_prometheus_client_model//go",
     ],
 )
 

--- a/pkg/obs/ash/metrics.go
+++ b/pkg/obs/ash/metrics.go
@@ -1,0 +1,64 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package ash
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	io_prometheus_client "github.com/prometheus/client_model/go"
+)
+
+var (
+	metaActiveWorkStates = metric.Metadata{
+		Name:        "ash.work_states.active",
+		Help:        "Number of goroutines with an active ASH work state",
+		Measurement: "Goroutines",
+		Unit:        metric.Unit_COUNT,
+		MetricType:  io_prometheus_client.MetricType_GAUGE,
+	}
+	metaTakeSampleLatency = metric.Metadata{
+		Name:        "ash.sampler.take_sample.latency",
+		Help:        "Latency of ASH sample collection ticks",
+		Measurement: "Latency",
+		Unit:        metric.Unit_NANOSECONDS,
+		MetricType:  io_prometheus_client.MetricType_HISTOGRAM,
+	}
+	metaSamplesCollected = metric.Metadata{
+		Name:        "ash.samples.collected",
+		Help:        "Total number of ASH samples collected",
+		Measurement: "Samples",
+		Unit:        metric.Unit_COUNT,
+		MetricType:  io_prometheus_client.MetricType_COUNTER,
+	}
+)
+
+// Metrics holds the metrics for the ASH sampler subsystem.
+type Metrics struct {
+	ActiveWorkStates  *metric.FunctionalGauge
+	TakeSampleLatency metric.IHistogram
+	SamplesCollected  *metric.Counter
+}
+
+// MetricStruct implements the metric.Struct interface.
+func (Metrics) MetricStruct() {}
+
+var _ metric.Struct = (*Metrics)(nil)
+
+func makeMetrics() Metrics {
+	return Metrics{
+		ActiveWorkStates: metric.NewFunctionalGauge(
+			metaActiveWorkStates,
+			func() int64 { return activeWorkStatesCount.Load() },
+		),
+		TakeSampleLatency: metric.NewHistogram(metric.HistogramOptions{
+			Mode:         metric.HistogramModePreferHdrLatency,
+			Metadata:     metaTakeSampleLatency,
+			Duration:     base.DefaultHistogramWindowInterval(),
+			BucketConfig: metric.IOLatencyBuckets,
+		}),
+		SamplesCollected: metric.NewCounter(metaSamplesCollected),
+	}
+}

--- a/pkg/obs/ash/sampler.go
+++ b/pkg/obs/ash/sampler.go
@@ -85,6 +85,7 @@ type Sampler struct {
 	buffer  *RingBuffer
 	stopper *stop.Stopper
 	started bool
+	metrics Metrics
 	// interval caches the sample interval so the timer loop can read it
 	// without locking, while the SetOnChange callback updates it.
 	interval atomic.Int64
@@ -105,6 +106,7 @@ func newSampler(nodeID roachpb.NodeID, st *cluster.Settings, stopper *stop.Stopp
 		st:      st,
 		buffer:  NewRingBuffer(bufSize),
 		stopper: stopper,
+		metrics: makeMetrics(),
 		workloadIDCache: cache.NewUnorderedCache(cache.Config{
 			Policy: cache.CacheLRU,
 			ShouldEvict: func(size int, key, value interface{}) bool {
@@ -163,7 +165,13 @@ func (s *Sampler) run(ctx context.Context) {
 
 // takeSample captures a snapshot of all active work states.
 func (s *Sampler) takeSample() {
-	sampleTime := timeutil.Now()
+	start := timeutil.Now()
+	defer func() {
+		elapsed := timeutil.Since(start)
+		s.metrics.TakeSampleLatency.RecordValue(elapsed.Nanoseconds())
+	}()
+
+	sampleTime := start
 
 	// Collect work states. rangeWorkStates reclaims retired states after
 	// iteration so pooled objects can be reused.
@@ -200,6 +208,7 @@ func (s *Sampler) takeSample() {
 		}
 		s.buffer.Add(sample)
 	}
+	s.metrics.SamplesCollected.Inc(int64(len(s.pendingSamples)))
 }
 
 // GetSamples returns all samples currently in the Sampler's buffer.
@@ -209,8 +218,10 @@ func (s *Sampler) GetSamples(result []ASHSample) []ASHSample {
 
 // InitGlobalSampler creates and starts the process-wide ASH sampler.
 // It is idempotent: only the first call creates the sampler; subsequent
-// calls are no-ops. This should be called during process-level server
-// initialization (not per-tenant), after the node ID is known.
+// calls are no-ops. Callers should use GlobalSamplerMetrics() to obtain
+// the metrics and register them with sysRegistry. This should be called
+// during process-level server initialization (not per-tenant), after
+// the node ID is known.
 func InitGlobalSampler(
 	ctx context.Context, nodeID roachpb.NodeID, st *cluster.Settings, stopper *stop.Stopper,
 ) error {
@@ -223,6 +234,15 @@ func InitGlobalSampler(
 		}
 	})
 	return initErr
+}
+
+// GlobalSamplerMetrics returns the Metrics for the process-wide ASH
+// sampler, or nil if the sampler has not been initialized yet.
+func GlobalSamplerMetrics() *Metrics {
+	if s := globalSampler.Load(); s != nil {
+		return &s.metrics
+	}
+	return nil
 }
 
 // encodeUint64ToBytes returns the []byte representation of a uint64 value.

--- a/pkg/obs/ash/sampler_test.go
+++ b/pkg/obs/ash/sampler_test.go
@@ -254,6 +254,75 @@ func TestSamplerRuntimeSettingChanges(t *testing.T) {
 	})
 }
 
+func TestSamplerMetrics(t *testing.T) {
+	s, stopper := newTestSampler()
+	defer stopper.Stop(context.Background())
+
+	enabled.Store(true)
+	defer enabled.Store(false)
+
+	tenantID := roachpb.MustMakeTenantID(2)
+	const numGoroutines = 5
+
+	// Each goroutine registers its work state, then waits for a signal
+	// to clean up.
+	ready := make(chan struct{}, numGoroutines)
+	release := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	for i := range numGoroutines {
+		go func(idx int) {
+			defer wg.Done()
+			cleanup := SetWorkState(
+				tenantID,
+				uint64(idx+1),
+				WorkNetwork,
+				"MetricsTest",
+			)
+			ready <- struct{}{}
+			<-release
+			cleanup()
+		}(i)
+	}
+
+	// Wait for all goroutines to have registered their state.
+	for range numGoroutines {
+		<-ready
+	}
+
+	// Verify the active work states gauge reflects the registered goroutines.
+	require.Equal(t, int64(numGoroutines), s.metrics.ActiveWorkStates.Value())
+
+	// Take a sample and verify latency and counter metrics.
+	s.takeSample()
+	count, _ := s.metrics.TakeSampleLatency.CumulativeSnapshot().Total()
+	require.Equal(t, int64(1), count, "expected one latency sample after one takeSample call")
+	require.Equal(
+		t, int64(numGoroutines), s.metrics.SamplesCollected.Count(),
+		"expected samples collected to equal number of active goroutines",
+	)
+
+	// Signal all goroutines to clean up and verify the gauge drops to zero.
+	close(release)
+	wg.Wait()
+	require.Equal(t, int64(0), s.metrics.ActiveWorkStates.Value())
+
+	// Test nested (stacked) work states: a single goroutine calling
+	// SetWorkState twice should only count as 1 active work state.
+	cleanup1 := SetWorkState(tenantID, 1, WorkCPU, "Outer")
+	require.Equal(t, int64(1), s.metrics.ActiveWorkStates.Value())
+	cleanup2 := SetWorkState(tenantID, 2, WorkIO, "Inner")
+	require.Equal(t, int64(1), s.metrics.ActiveWorkStates.Value(),
+		"nested SetWorkState should not increase the active count")
+	cleanup2()
+	require.Equal(t, int64(1), s.metrics.ActiveWorkStates.Value(),
+		"popping to outer state should keep the active count at 1")
+	cleanup1()
+	require.Equal(t, int64(0), s.metrics.ActiveWorkStates.Value(),
+		"clearing the last state should drop the active count to 0")
+}
+
 func TestInitGlobalSampler(t *testing.T) {
 	// Save and restore globalSampler. initSamplerOnce is consumed
 	// by this test; no other test in the package calls InitGlobalSampler.
@@ -266,11 +335,19 @@ func TestInitGlobalSampler(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	ctx := context.Background()
 
-	require.NoError(t, InitGlobalSampler(ctx, 42, st, stopper))
+	err := InitGlobalSampler(ctx, 42, st, stopper)
+	require.NoError(t, err)
 	require.NotNil(t, globalSampler.Load())
+	metrics := GlobalSamplerMetrics()
+	require.NotNil(t, metrics, "first call should produce non-nil metrics")
 
-	// Second call is a no-op (sync.Once).
-	require.NoError(t, InitGlobalSampler(ctx, 99, st, stopper))
+	// Second call is a no-op (sync.Once); GlobalSamplerMetrics still
+	// returns the same non-nil metrics.
+	err = InitGlobalSampler(ctx, 99, st, stopper)
+	require.NoError(t, err)
+	metrics2 := GlobalSamplerMetrics()
+	require.NotNil(t, metrics2, "metrics should remain available after second init")
+	require.True(t, metrics == metrics2, "metrics pointer should be identical")
 	s := globalSampler.Load()
 	require.Equal(t, roachpb.NodeID(42), s.nodeID)
 

--- a/pkg/obs/ash/work_state.go
+++ b/pkg/obs/ash/work_state.go
@@ -7,6 +7,7 @@ package ash
 
 import (
 	"sync"
+	"sync/atomic"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
@@ -39,6 +40,13 @@ var workStatePool = sync.Pool{
 // activeWorkStates maps goroutine IDs to their work state.
 // This is a global map that the sampler reads from periodically.
 var activeWorkStates syncutil.Map[int64, WorkState]
+
+// activeWorkStatesCount tracks the number of goroutines with an
+// active work state. It is incremented when a goroutine is first
+// registered in activeWorkStates and decremented when it is fully
+// removed. Nested (stacked) states do not change the count because
+// the map key already exists.
+var activeWorkStatesCount atomic.Int64
 
 // maxRetiredWorkStates caps the retired list to prevent unbounded growth
 // during bursts between sampler drain ticks. This value is based on an
@@ -84,6 +92,7 @@ func SetWorkState(
 		state.prev = prev
 	} else {
 		state.prev = nil
+		activeWorkStatesCount.Add(1)
 	}
 	activeWorkStates.Store(gid, state)
 
@@ -131,6 +140,7 @@ func _clearWorkState(gid int64) {
 		activeWorkStates.Store(gid, prev)
 	} else {
 		activeWorkStates.Delete(gid)
+		activeWorkStatesCount.Add(-1)
 	}
 	retireWorkState(state)
 }

--- a/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
+++ b/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
@@ -699,6 +699,12 @@ admission_wait_sum_kv_stores: admission.wait.sum.kv_stores
 admission_wait_sum_sql_kv_response: admission.wait.sum.sql_kv.response
 admission_wait_sum_sql_root_start: admission.wait.sum.sql.root.start
 admission_wait_sum_sql_sql_response: admission.wait.sum.sql_sql.response
+ash_sampler_take_sample_latency: ash.sampler.take_sample.latency
+ash_sampler_take_sample_latency_bucket: ash.sampler.take_sample.latency.bucket
+ash_sampler_take_sample_latency_count: ash.sampler.take_sample.latency.count
+ash_sampler_take_sample_latency_sum: ash.sampler.take_sample.latency.sum
+ash_samples_collected: ash.samples.collected
+ash_work_states_active: ash.work_states.active
 auth_cert_conn_latency: auth.cert.conn.latency
 auth_gss_conn_latency: auth.gss.conn.latency
 auth_jwt_conn_latency: auth.jwt.conn.latency

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1887,6 +1887,9 @@ func (s *topLevelServer) PreStart(ctx context.Context) error {
 	if err := ash.InitGlobalSampler(ctx, state.nodeID, s.st, s.stopper); err != nil {
 		return err
 	}
+	if m := ash.GlobalSamplerMetrics(); m != nil {
+		s.sysRegistry.AddMetricStruct(m)
+	}
 
 	// TODO(irfansharif): Now that we have our node ID, we should run another
 	// check here to make sure we've not been decommissioned away (if we're here

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -872,6 +872,9 @@ func (s *SQLServerWrapper) PreStart(ctx context.Context) error {
 	); err != nil {
 		return err
 	}
+	if m := ash.GlobalSamplerMetrics(); m != nil {
+		s.sysRegistry.AddMetricStruct(m)
+	}
 
 	var apiInternalServer http.Handler
 	var drpcEnabled = false


### PR DESCRIPTION
Add three metrics to the ASH (Active Session History) subsystem:

- ash.work_states.active: gauge of goroutines with an active work state
- ash.sampler.take_sample.latency: histogram of sample collection tick latency
- ash.samples.collected: counter of total ASH samples collected

Metrics are registered with sysRegistry (the process-level registry),
following the RuntimeStatSampler pattern. A new GlobalSamplerMetrics()
function provides access to the singleton's metrics, decoupling metric
retrieval from initialization. Both server.go and tenant.go call
InitGlobalSampler (idempotent via sync.Once) and then register via
GlobalSamplerMetrics(), so the metrics are always registered exactly
once regardless of deployment topology (shared-process or standalone
SQL pod).

Also sets HistogramModePreferHdrLatency on the latency histogram to
avoid a panic when HDR histograms are metamorphically enabled.

Resolves: https://github.com/cockroachdb/cockroach/issues/164681

Release note: None