### PR TITLE
sql: enforce primary/secondary super region invariant on ALTER PRIMARY REGION

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/secondary_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/secondary_region
@@ -741,3 +741,83 @@ statement ok
 SELECT crdb_internal.validate_multi_region_zone_configs()
 
 subtest end
+
+# Verify ALTER PRIMARY REGION is blocked when it would break the
+# primary/secondary super region invariant.
+subtest alter_primary_region_super_region_secondary
+
+statement ok
+CREATE DATABASE pr_sr_test PRIMARY REGION "us-east-1"
+    REGIONS "us-west-1", "us-central-1", "ca-central-1", "ap-southeast-2"
+
+statement ok
+SET enable_super_regions = 'on'
+
+statement ok
+ALTER DATABASE pr_sr_test ADD SUPER REGION "usa"
+    VALUES "us-east-1", "us-west-1", "us-central-1"
+
+statement ok
+ALTER DATABASE pr_sr_test ADD SUPER REGION "other"
+    VALUES "ca-central-1", "ap-southeast-2"
+
+statement ok
+ALTER DATABASE pr_sr_test SET SECONDARY REGION "us-west-1"
+
+statement ok
+SET alter_primary_region_super_region_override = 'on'
+
+# Case 1: Cross-SR move (usa -> other) should fail.
+statement error pq: cannot change primary region to ca-central-1: the primary and secondary regions must be in the same super region
+ALTER DATABASE pr_sr_test SET PRIMARY REGION "ca-central-1"
+
+# Case 2: Within-SR move (us-east-1 -> us-central-1, both in "usa") should succeed.
+statement ok
+ALTER DATABASE pr_sr_test SET PRIMARY REGION "us-central-1"
+
+# Case 3: Escape hatch — drop secondary, move cross-SR, re-establish.
+statement ok
+ALTER DATABASE pr_sr_test DROP SECONDARY REGION
+
+statement ok
+ALTER DATABASE pr_sr_test SET PRIMARY REGION "ca-central-1"
+
+statement ok
+ALTER DATABASE pr_sr_test SET SECONDARY REGION "ap-southeast-2"
+
+# Case 4: Cross-SR move back (other -> usa) should fail.
+statement error pq: cannot change primary region to us-east-1: the primary and secondary regions must be in the same super region
+ALTER DATABASE pr_sr_test SET PRIMARY REGION "us-east-1"
+
+# Case 5: Fix by dropping secondary first, then move.
+statement ok
+ALTER DATABASE pr_sr_test DROP SECONDARY REGION
+
+statement ok
+ALTER DATABASE pr_sr_test SET PRIMARY REGION "us-east-1"
+
+statement ok
+ALTER DATABASE pr_sr_test SET SECONDARY REGION "us-west-1"
+
+# State: P=us-east-1, S=us-west-1, SR "usa"={us-east-1, us-west-1, us-central-1}.
+
+# Case 6: ALTER SUPER REGION dropping the secondary region should fail.
+statement error pq: the secondary region must be in the same super region as the current primary region
+ALTER DATABASE pr_sr_test ALTER SUPER REGION "usa" VALUES "us-east-1", "us-central-1"
+
+# Case 7: ALTER SUPER REGION dropping the primary region should fail.
+statement error pq: the secondary region must be in the same super region as the current primary region
+ALTER DATABASE pr_sr_test ALTER SUPER REGION "usa" VALUES "us-west-1", "us-central-1"
+
+# Case 8: ALTER SUPER REGION dropping both primary and secondary should succeed.
+statement ok
+ALTER DATABASE pr_sr_test ALTER SUPER REGION "usa" VALUES "us-central-1"
+
+# Case 9: ALTER SUPER REGION adding back both primary and secondary should succeed.
+statement ok
+ALTER DATABASE pr_sr_test ALTER SUPER REGION "usa" VALUES "us-east-1", "us-west-1", "us-central-1"
+
+statement ok
+DROP DATABASE pr_sr_test
+
+subtest end

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -1033,6 +1033,28 @@ func (n *alterDatabasePrimaryRegionNode) switchPrimaryRegion(params runParams) e
 		}
 	}
 
+	// Enforce invariant: if a secondary region is set, the primary and
+	// secondary must be in the same super region (or both outside all
+	// super regions).
+	if updatedRegionConfig.HasSecondaryRegion() {
+		secondaryRegion := updatedRegionConfig.SecondaryRegion()
+		_, secondarySR := multiregion.IsMemberOfSuperRegion(
+			secondaryRegion, updatedRegionConfig)
+
+		if superRegionOfNewPrimaryRegion != secondarySR {
+			return errors.WithHintf(
+				pgerror.Newf(pgcode.InvalidDatabaseDefinition,
+					"cannot change primary region to %s: the primary and "+
+						"secondary regions must be in the same super region",
+					n.n.PrimaryRegion,
+				),
+				"drop the secondary region first using "+
+					"ALTER DATABASE %s DROP SECONDARY REGION",
+				n.n.Name.String(),
+			)
+		}
+	}
+
 	if isNewPrimaryRegionMemberOfASuperRegion {
 		params.p.BufferClientNotice(params.ctx, pgnotice.Newf("all REGIONAL BY TABLE tables without a region explicitly set are now part of the super region %s", superRegionOfNewPrimaryRegion))
 	}


### PR DESCRIPTION
When a database has both a secondary region and super regions, the primary and secondary regions must be in the same super region (or both outside all super regions). This invariant was already enforced on SET SECONDARY REGION, ADD SUPER REGION, and ALTER SUPER REGION (via #84999), but ALTER DATABASE SET PRIMARY REGION could silently move the primary into a different super region, breaking the invariant.

This change adds the missing check in `switchPrimaryRegion()`. When the primary region change would place the primary and secondary in different super regions, the operation is now rejected with a clear error and a hint to drop the secondary region first as an escape hatch.

This could impact existing deployments that already have primary and secondary in different super regions due to the prior gap. Those customers will encounter the new error on their next ALTER PRIMARY REGION and can resolve it by dropping the secondary region first. Because of this potential impact on existing deployments, no descriptor validation was added.

Closes #163497
Epic: CRDB-58694

Release note (bug fix): Fixes a bug that had previously allowed the primary and secondary to be in separate super regions.