### PR TITLE
sql/inspect: gate complex key support for inspect uniqueness validation

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/inspect
+++ b/pkg/ccl/logictestccl/testdata/logic_test/inspect
@@ -29,10 +29,38 @@ INSPECT TABLE uniqueness_check WITH OPTIONS INDEX (uniqueness_check_pkey);
 statement ok
 DROP TABLE uniqueness_check;
 
+subtest complex_keys
+
+# Build the table
+
 statement ok
-USE system
+CREATE TABLE uniqueness_check_complex (
+  filler TEXT,
+  id INT64 DEFAULT unordered_unique_rowid(),
+  data TEXT,
+  PRIMARY KEY (filler, id)
+) LOCALITY REGIONAL BY ROW;
+
+statement ok
+INSERT INTO uniqueness_check_complex (crdb_region, filler, id, data) VALUES ('us-east-1', 'filler1', 100, 'foo');
+INSERT INTO uniqueness_check_complex (crdb_region, filler, id, data) VALUES ('ca-central-1', 'filler1', 200, 'bar');
+INSERT INTO uniqueness_check_complex (crdb_region, filler, id, data) VALUES ('ap-southeast-2', 'filler1', 300, 'tata');
+
+statement ok
+SET CLUSTER SETTING sql.inspect.uniqueness_check.complex_keys.enabled = true;
+
+statement ok
+INSPECT TABLE uniqueness_check_complex;
+
+statement ok
+DROP TABLE uniqueness_check_complex;
 
 subtest end
+
+subtest end
+
+statement ok
+USE system
 
 statement ok
 DROP DATABASE mr_db CASCADE;

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -408,12 +408,12 @@ func (r *importResumer) Resume(ctx context.Context, execCtx interface{}) error {
 			if creationVersion := r.job.Payload().CreationClusterVersion; !details.Table.WasEmpty && creationVersion.Less(clusterversion.V26_2.Version()) {
 				log.Eventf(ctx, "skipping row count on table %q: the table was not empty and the job was started in an unsupported version", tableName)
 
-				checks, err = inspect.ChecksForTable(ctx, p.ExecCfg(), nil /* p */, tblDesc, nil /* expectedRowCount */)
+				checks, err = inspect.ChecksForTable(ctx, p.ExecCfg(), tblDesc, nil /* expectedRowCount */)
 				return err
 			}
 
 			expectedRowCount := uint64(r.res.Rows + previouslyImportedRows + int64(table.InitialRowCount) + r.testingKnobs.expectedRowCountOffset)
-			checks, err = inspect.ChecksForTable(ctx, p.ExecCfg(), nil /* p */, tblDesc, &expectedRowCount)
+			checks, err = inspect.ChecksForTable(ctx, p.ExecCfg(), tblDesc, &expectedRowCount)
 			return err
 		}); err != nil {
 			return err

--- a/pkg/sql/inspect/check_helpers.go
+++ b/pkg/sql/inspect/check_helpers.go
@@ -365,9 +365,11 @@ func errorToInternalInspectIssue(
 	}
 }
 
-// findUniqueColIdxs returns the indexes of the unique columns in the index.
-func findUniqueColIdxs(tableDesc catalog.TableDescriptor, index catalog.Index) ([]int, error) {
-	var uniqueColIdxs []int
+// findUniqueRowIDColPositions returns the indices of the unique row ID columns in the index.
+func findUniqueRowIDColPositions(
+	tableDesc catalog.TableDescriptor, index catalog.Index,
+) ([]int, error) {
+	var indices []int
 	for i := 0; i < index.NumKeyColumns(); i++ {
 		colID := index.GetKeyColumnID(i)
 		col, err := catalog.MustFindColumnByID(tableDesc, colID)
@@ -377,12 +379,12 @@ func findUniqueColIdxs(tableDesc catalog.TableDescriptor, index catalog.Index) (
 		if col.HasDefault() {
 			switch col.GetDefaultExpr() {
 			case "unique_rowid()", "unordered_unique_rowid()":
-				uniqueColIdxs = append(uniqueColIdxs, i)
+				indices = append(indices, i)
 			}
 		}
 
 	}
-	return uniqueColIdxs, nil
+	return indices, nil
 }
 
 // getRegionsForTable retrieves the list of regions from an RBR table.

--- a/pkg/sql/inspect/inspect_job_entry.go
+++ b/pkg/sql/inspect/inspect_job_entry.go
@@ -7,6 +7,7 @@ package inspect
 
 import (
 	"context"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
@@ -18,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/idxtype"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -95,7 +95,7 @@ func checksForDatabase(
 	checks := []*jobspb.InspectDetails_Check{}
 
 	if err := tables.ForEachDescriptor(func(desc catalog.Descriptor) error {
-		tableChecks, err := ChecksForTable(ctx, p.ExecCfg(), p, desc.(catalog.TableDescriptor), nil /* rowCount */)
+		tableChecks, err := ChecksForTable(ctx, p.ExecCfg(), desc.(catalog.TableDescriptor), nil /* rowCount */)
 		if err != nil {
 			return err
 		}
@@ -112,7 +112,6 @@ func checksForDatabase(
 func ChecksForTable(
 	ctx context.Context,
 	execCfg *sql.ExecutorConfig,
-	p sql.PlanHookState,
 	table catalog.TableDescriptor,
 	expectedRowCount *uint64,
 ) ([]*jobspb.InspectDetails_Check, error) {
@@ -123,36 +122,12 @@ func ChecksForTable(
 		return checks, nil
 	}
 
-	priIndex := table.GetPrimaryIndex()
-
-	if execCfg.Settings.Version.IsActive(ctx, clusterversion.V26_2) {
-		if uniqueColIdxs, err := findUniqueColIdxs(table, priIndex); err != nil {
+	for _, idx := range table.ActiveIndexes() {
+		checksOnIndex, err := checksForIndex(ctx, execCfg, index{TableDescriptor: table, Index: idx}, false /* errorOnNoSupport */)
+		if err != nil {
 			return nil, err
-		} else if isRegionalByRow(table) && len(uniqueColIdxs) == 1 {
-			checks = append(checks, &jobspb.InspectDetails_Check{
-				Type:         jobspb.InspectCheckUniqueness,
-				TableID:      table.GetID(),
-				IndexID:      priIndex.GetID(),
-				TableVersion: table.GetVersion(),
-			})
 		}
-	}
-
-	for _, index := range table.PublicNonPrimaryIndexes() {
-		if reason := isSupportedIndexForIndexConsistencyCheck(index, table); reason != "" {
-			if p != nil {
-				p.BufferClientNotice(ctx, pgnotice.Newf(
-					"skipping index %q on table %q: not supported for index consistency checking", index.GetName(), table.GetName()))
-			}
-			continue
-		}
-		check := jobspb.InspectDetails_Check{
-			Type:         jobspb.InspectCheckIndexConsistency,
-			TableID:      table.GetID(),
-			IndexID:      index.GetID(),
-			TableVersion: table.GetVersion(),
-		}
-		checks = append(checks, &check)
+		checks = append(checks, checksOnIndex...)
 	}
 
 	if expectedRowCount != nil {
@@ -180,10 +155,6 @@ func checksByIndexNames(
 		descpb.ID
 		descpb.IndexID
 	}
-	type index struct {
-		catalog.TableDescriptor
-		catalog.Index
-	}
 
 	var indexes []index
 	var seenIndexes = make(map[indexKey]struct{})
@@ -201,42 +172,84 @@ func checksByIndexNames(
 	}
 
 	for _, idx := range indexes {
-		index := idx.Index
-		table := idx.TableDescriptor
-
-		var isIndexSupportedForChecks bool
-		if reason := isSupportedIndexForIndexConsistencyCheck(index, table); reason == "" {
-			isIndexSupportedForChecks = true
-			checks = append(checks,
-				&jobspb.InspectDetails_Check{
-					Type:         jobspb.InspectCheckIndexConsistency,
-					TableID:      table.GetID(),
-					IndexID:      index.GetID(),
-					TableVersion: table.GetVersion(),
-				})
-		}
-		if execCfg.Settings.Version.IsActive(ctx, clusterversion.V26_2) {
-			if index.Primary() {
-				if uniqueColIdxs, err := findUniqueColIdxs(table, index); err != nil {
-					return nil, err
-				} else if isRegionalByRow(table) && len(uniqueColIdxs) == 1 {
-					isIndexSupportedForChecks = true
-					checks = append(checks, &jobspb.InspectDetails_Check{
-						Type:         jobspb.InspectCheckUniqueness,
-						TableID:      table.GetID(),
-						IndexID:      index.GetID(),
-						TableVersion: table.GetVersion(),
-					})
-				}
-			}
-		}
-
-		if !isIndexSupportedForChecks {
-			return nil, pgerror.Newf(pgcode.InvalidParameterValue, "index %q on table %q is not supported by INSPECT checks", index.GetName(), table.GetName())
+		if checksForIndex, err := checksForIndex(ctx, execCfg, idx, true /* errorOnNoSupport */); err != nil {
+			return nil, err
+		} else {
+			checks = append(checks, checksForIndex...)
 		}
 	}
 
 	return checks, nil
+}
+
+type index struct {
+	catalog.TableDescriptor
+	catalog.Index
+}
+
+// checkFromIndexFunc defines a function that returns a check for a given index, a
+// string reason for why the index is unsupported, or an error.
+type checkFromIndexFunc func(ctx context.Context, execCfg *sql.ExecutorConfig, idx index) (*jobspb.InspectDetails_Check, string, error)
+
+var checkSpecFactories = []checkFromIndexFunc{
+	func(ctx context.Context, execCfg *sql.ExecutorConfig, idx index) (*jobspb.InspectDetails_Check, string, error) {
+		if reason := isSupportedIndexForIndexConsistencyCheck(idx.Index, idx.TableDescriptor); reason != "" {
+			return nil, reason, nil
+		}
+
+		return &jobspb.InspectDetails_Check{
+			Type:         jobspb.InspectCheckIndexConsistency,
+			TableID:      idx.TableDescriptor.GetID(),
+			IndexID:      idx.Index.GetID(),
+			TableVersion: idx.TableDescriptor.GetVersion(),
+		}, "", nil
+	},
+	func(ctx context.Context, execCfg *sql.ExecutorConfig, idx index) (*jobspb.InspectDetails_Check, string, error) {
+		if reason, _, err := isSupportedIndexForUniquenessCheck(
+			ctx,
+			idx.Index,
+			idx.TableDescriptor,
+			execCfg.Settings.Version.IsActive(ctx, clusterversion.V26_2),
+			uniquenessCheckComplexKeysEnabled.Get(execCfg.SV()),
+		); err != nil {
+			return nil, "", err
+		} else if reason != "" {
+			return nil, reason, nil
+		}
+
+		return &jobspb.InspectDetails_Check{
+			Type:         jobspb.InspectCheckUniqueness,
+			TableID:      idx.TableDescriptor.GetID(),
+			IndexID:      idx.Index.GetID(),
+			TableVersion: idx.TableDescriptor.GetVersion(),
+		}, "", nil
+	},
+}
+
+func checksForIndex(
+	ctx context.Context, execCfg *sql.ExecutorConfig, idx index, errorOnNoSupport bool,
+) ([]*jobspb.InspectDetails_Check, error) {
+	var checksForIndex []*jobspb.InspectDetails_Check
+	var reasons []string
+	for _, specFactory := range checkSpecFactories {
+		check, reason, err := specFactory(ctx, execCfg, idx)
+		if err != nil {
+			return nil, err
+		}
+		if reason != "" {
+			reasons = append(reasons, reason)
+		} else if check != nil {
+			checksForIndex = append(checksForIndex, check)
+		}
+	}
+
+	if len(checksForIndex) == 0 && errorOnNoSupport {
+		return nil, pgerror.Newf(pgcode.InvalidParameterValue,
+			"no supported checks for index %q on table %q (%s)",
+			idx.Index.GetName(), idx.TableDescriptor.GetName(), strings.Join(reasons, "; "))
+	}
+
+	return checksForIndex, nil
 }
 
 // isSupportedIndexForIndexConsistencyCheck returns an empty string if a given
@@ -263,6 +276,13 @@ func isSupportedIndexForIndexConsistencyCheck(
 	if index.IsSharded() {
 		return "hash-sharded index"
 	}
+
+	switch t := index.GetType(); t {
+	// TODO(154860): support inverted indexes
+	case idxtype.INVERTED, idxtype.VECTOR:
+		return t.String()
+	}
+
 	// TODO(154772): support expression indexes
 	if table.IsExpressionIndex(index) {
 		return "expression index"
@@ -278,11 +298,41 @@ func isSupportedIndexForIndexConsistencyCheck(
 		}
 	}
 
-	switch t := index.GetType(); t {
-	// TODO(154860): support inverted indexes
-	case idxtype.INVERTED, idxtype.VECTOR:
-		return t.String()
+	return ""
+}
+
+func isSupportedIndexForUniquenessCheck(
+	ctx context.Context,
+	index catalog.Index,
+	table catalog.TableDescriptor,
+	isActiveV26_2, isComplexKeysEnabled bool,
+) (reason string, uniquePos int, err error) {
+	if !isActiveV26_2 {
+		return "uniqueness: check requires v26.2", 0, nil
 	}
 
-	return ""
+	if !index.Primary() {
+		return "uniqueness: check only valid on primary index", 0, nil
+	}
+
+	if !isRegionalByRow(table) {
+		return "uniqueness: check only supported on REGIONAL BY ROW tables", 0, nil
+	}
+
+	uniquePositions, err := findUniqueRowIDColPositions(table, index)
+	if err != nil {
+		return "", 0, err
+	}
+
+	if len(uniquePositions) == 0 {
+		return "uniqueness: check only supported on tables with a unique column", 0, nil
+	} else if len(uniquePositions) > 1 {
+		return "uniqueness: check only supported on tables with a single unique column", 0, nil
+	}
+
+	if uniquePositions[0] == 1 || isComplexKeysEnabled {
+		return "", uniquePositions[0], nil
+	} else {
+		return "uniqueness: complex key layout requires the cluster setting to opt in to (expensive) validation", 0, nil
+	}
 }

--- a/pkg/sql/inspect/inspect_plan.go
+++ b/pkg/sql/inspect/inspect_plan.go
@@ -109,7 +109,7 @@ func newInspectRun(
 		// No INDEX options or INDEX ALL specified - inspect all indexes.
 		switch stmt.Typ {
 		case tree.InspectTable:
-			checks, err := ChecksForTable(ctx, p.ExecCfg(), p, run.table, nil /* rowCount */)
+			checks, err := ChecksForTable(ctx, p.ExecCfg(), run.table, nil /* rowCount */)
 			if err != nil {
 				return inspectRun{}, err
 			}

--- a/pkg/sql/inspect/row_count_check_test.go
+++ b/pkg/sql/inspect/row_count_check_test.go
@@ -140,7 +140,7 @@ func TestRowCountCheck(t *testing.T) {
 
 			for _, tc := range matchCases {
 				t.Run(tc.name, func(t *testing.T) {
-					checks, err := ChecksForTable(ctx, &execCfg, nil /* PlanHookState */, tableDesc, &tc.expectedRowCount)
+					checks, err := ChecksForTable(ctx, &execCfg, tableDesc, &tc.expectedRowCount)
 					require.NoError(t, err)
 					require.Len(t, checks, expectedCheckCount)
 

--- a/pkg/sql/inspect/uniqueness_check.go
+++ b/pkg/sql/inspect/uniqueness_check.go
@@ -11,9 +11,11 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -24,6 +26,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
+)
+
+var uniquenessCheckComplexKeysEnabled = settings.RegisterBoolSetting(
+	settings.ApplicationLevel,
+	"sql.inspect.uniqueness_check.complex_keys.enabled",
+	"if true, the uniqueness check is enabled for INSPECT jobs on indexes where the unique column does not immediately follow the region column",
+	false,
 )
 
 type uniquenessCheck struct {
@@ -402,36 +411,28 @@ func (c *uniquenessCheck) loadCatalogInfo(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	if !isRegionalByRow(tableDesc) {
-		return errors.AssertionFailedf("uniqueness check is only supported for tables with REGIONAL BY ROW locality")
+
+	index, err := findIndexByID(tableDesc, c.indexID)
+	if err != nil {
+		return err
 	}
+
+	reason, uniquePos, err := isSupportedIndexForUniquenessCheck(
+		ctx,
+		index,
+		tableDesc,
+		c.execCfg.Settings.Version.IsActive(ctx, clusterversion.V26_2),
+		true, /* isComplexKeysEnabled */ // The cluster setting gates when the job is specced.
+	)
+	if err != nil {
+		return err
+	} else if reason != "" {
+		return errors.AssertionFailedf("%s", reason)
+	}
+
 	c.tableDesc = tableDesc
-
-	index, err := findIndexByID(c.tableDesc, c.indexID)
-	if err != nil {
-		return err
-	}
-
-	if !index.Primary() {
-		return errors.AssertionFailedf("uniqueness check is only supported for primary indexes")
-	}
-
-	if !index.IsUnique() {
-		return errors.AssertionFailedf("non-unique index shouldn't be unique checked")
-	}
-
-	uniqueColIdxs, err := findUniqueColIdxs(c.tableDesc, index)
-	if err != nil {
-		return err
-	}
-	if len(uniqueColIdxs) == 0 {
-		return errors.AssertionFailedf("index has no `unique_rowid()` or `unordered_unique_rowid()` column to be unique checked")
-	} else if len(uniqueColIdxs) > 1 {
-		return errors.AssertionFailedf("uniqueness check for indexes with multiple `unique_rowid()` or `unordered_unique_rowid()` columns is not supported")
-	}
-
 	c.index = index
-	c.uniqueColIdx = uniqueColIdxs[0]
+	c.uniqueColIdx = uniquePos
 
 	return nil
 }

--- a/pkg/sql/inspect/uniqueness_check_test.go
+++ b/pkg/sql/inspect/uniqueness_check_test.go
@@ -156,7 +156,7 @@ func TestUniquenessCheck(t *testing.T) {
 				data TEXT,
 				PRIMARY KEY (crdb_region)
 				)`,
-			expectError: "index has no `unique_rowid()` or `unordered_unique_rowid()` column",
+			expectError: "uniqueness: check only supported on tables with a unique column",
 		},
 		{
 			name: "multiple_unique_rowid",
@@ -167,7 +167,7 @@ func TestUniquenessCheck(t *testing.T) {
 				data TEXT,
 				PRIMARY KEY (crdb_region, id_a, id_b)
 				)`,
-			expectError: "uniqueness check for indexes with multiple `unique_rowid()`",
+			expectError: "uniqueness: check only supported on tables with a single unique column",
 		},
 		{
 			name: "single_region_no_duplicates",

--- a/pkg/sql/logictest/testdata/logic_test/inspect
+++ b/pkg/sql/logictest/testdata/logic_test/inspect
@@ -20,6 +20,30 @@ WHERE job_type = 'INSPECT'
 ORDER BY id DESC
 LIMIT 1
 
+# Helper view equivalent to `SHOW INSPECT ERRORS WITH DETAILS` but omitting
+# the non-deterministic aost and job_id columns.
+statement ok
+CREATE VIEW last_inspect_errors AS
+SELECT
+  ie.error_type,
+  COALESCE(t.database_name, '<unknown>') AS database_name,
+  COALESCE(t.schema_name, '<unknown>') AS schema_name,
+  COALESCE(t.object_name, '<unknown>') AS table_name,
+  ie.primary_key,
+  jsonb_pretty(ie.details) AS details
+FROM crdb_internal.cluster_inspect_errors ie
+LEFT JOIN crdb_internal.fully_qualified_names t ON ie.id = t.object_id
+WHERE ie.job_id = (
+  SELECT id
+  FROM crdb_internal.system_jobs
+  WHERE job_type = 'INSPECT'
+  AND status IN ('failed', 'succeeded', 'canceled', 'revert-failed')
+  ORDER BY id DESC
+  LIMIT 1
+)
+ORDER BY ie.error_type, database_name, schema_name, table_name, ie.primary_key
+LIMIT 10000
+
 statement error pq: "last_inspect_job" is not a table
 INSPECT TABLE last_inspect_job;
 
@@ -264,25 +288,32 @@ SELECT * FROM last_inspect_job;
 ----
 succeeded  2
 
-statement error pq: index "t2_pkey" on table "t2" is not supported by INSPECT checks
+skipif config local-mixed-25.4 local-mixed-26.1
+statement error pq: no supported checks for index "t2_pkey" on table "t2" \(cannot check primary index consistency against itself; uniqueness: check only supported on REGIONAL BY ROW tables\)
 INSPECT TABLE t2 WITH OPTIONS INDEX (t2@t2_pkey);
 
-statement error pq: index "hash_idx" on table "t2" is not supported by INSPECT checks
+skipif config local-mixed-25.4 local-mixed-26.1
+statement error pq: no supported checks for index "hash_idx" on table "t2" \(hash-sharded index; uniqueness: check only valid on primary index\)
 INSPECT TABLE t2 WITH OPTIONS INDEX (hash_idx);
 
-statement error pq: index "expr_idx" on table "t2" is not supported by INSPECT checks
+skipif config local-mixed-25.4 local-mixed-26.1
+statement error pq: no supported checks for index "expr_idx" on table "t2" \(expression index; uniqueness: check only valid on primary index\)
 INSPECT TABLE t2 WITH OPTIONS INDEX (expr_idx);
 
-statement error pq: index "vector_idx" on table "t2" is not supported by INSPECT checks
+skipif config local-mixed-25.4 local-mixed-26.1
+statement error pq: no supported checks for index "vector_idx" on table "t2" \(VECTOR; uniqueness: check only valid on primary index\)
 INSPECT TABLE t2 WITH OPTIONS INDEX (vector_idx);
 
-statement error pq: index "partial_idx" on table "t2" is not supported by INSPECT checks
+skipif config local-mixed-25.4 local-mixed-26.1
+statement error pq: no supported checks for index "partial_idx" on table "t2" \(partial index; uniqueness: check only valid on primary index\)
 INSPECT TABLE t2 WITH OPTIONS INDEX (partial_idx);
 
-statement error pq: index "inverted_idx" on table "t2" is not supported by INSPECT checks
+skipif config local-mixed-25.4 local-mixed-26.1
+statement error pq: no supported checks for index "inverted_idx" on table "t2" \(INVERTED; uniqueness: check only valid on primary index\)
 INSPECT TABLE t2 WITH OPTIONS INDEX (inverted_idx);
 
 # Confirm no jobs were run.
+skipif config local-mixed-25.4 local-mixed-26.1
 query TI
 SELECT * FROM last_inspect_job;
 ----
@@ -321,7 +352,8 @@ SELECT * FROM last_inspect_job;
 succeeded  1
 
 # Explicitly specifying the virtual column index should fail.
-statement error pq: index "idx_c2" on table "t_virtual" is not supported by INSPECT checks
+skipif config local-mixed-25.4 local-mixed-26.1
+statement error pq: no supported checks for index "idx_c2" on table "t_virtual" \(index on virtual column; uniqueness: check only valid on primary index\)
 INSPECT TABLE t_virtual WITH OPTIONS INDEX (idx_c2);
 
 # Explicitly specifying the regular index should succeed.
@@ -357,7 +389,8 @@ SELECT * FROM last_inspect_job;
 succeeded  1
 
 # Explicitly specifying the index with virtual columns should fail.
-statement error pq: index "idx_virtual_combo" on table "t_multi_virtual" is not supported by INSPECT checks
+skipif config local-mixed-25.4 local-mixed-26.1
+statement error pq: no supported checks for index "idx_virtual_combo" on table "t_multi_virtual" \(index on virtual column; uniqueness: check only valid on primary index\)
 INSPECT TABLE t_multi_virtual WITH OPTIONS INDEX (idx_virtual_combo);
 
 statement ok
@@ -750,5 +783,133 @@ query TI retry
 SELECT * FROM last_inspect_job
 ----
 failed  1
+
+statement ok
+DROP TABLE uniqueness_check;
+
+subtest complex_keys
+
+# Build the table
+
+statement ok
+CREATE TABLE uniqueness_check_complex (
+  crdb_region test.region_enum NOT NULL,
+  filler TEXT,
+  id INT64 DEFAULT unordered_unique_rowid(),
+  data TEXT,
+  PRIMARY KEY (crdb_region, filler, id)
+);
+
+statement ok
+INSERT INTO uniqueness_check_complex (crdb_region, filler, id, data) VALUES ('us-east1', 'filler1', 100, 'foo');
+INSERT INTO uniqueness_check_complex (crdb_region, filler, id, data) VALUES ('us-west1', 'filler1', 100, 'biz');
+INSERT INTO uniqueness_check_complex (crdb_region, filler, id, data) VALUES ('us-west4', 'filler1', 100, 'toto');
+
+statement ok
+INSERT INTO uniqueness_check_complex (crdb_region, filler, id, data) VALUES ('us-east1', 'filler1', 200, 'bar');
+INSERT INTO uniqueness_check_complex (crdb_region, filler, id, data) VALUES ('us-west1', 'filler1', 200, 'baz');
+
+statement ok
+INSERT INTO uniqueness_check_complex (crdb_region, filler, id, data) VALUES ('us-west1', 'filler1', 300, 'titi');
+INSERT INTO uniqueness_check_complex (crdb_region, filler, id, data) VALUES ('us-west4', 'filler1', 300, 'tata');
+
+# Run INSPECT which will not use the uniqueness check because it's a complex key.
+
+statement ok
+INSPECT TABLE uniqueness_check_complex;
+
+skipif config local-mixed-25.4 local-mixed-26.1
+statement error pq: no supported checks for index "uniqueness_check_complex_pkey" on table "uniqueness_check_complex" \(cannot check primary index consistency against itself; uniqueness: complex key layout requires the cluster setting to opt in to \(expensive\) validation\)
+INSPECT TABLE uniqueness_check_complex WITH OPTIONS INDEX (uniqueness_check_complex_pkey);
+
+# Enable and run again to see the unique validations.
+
+statement ok
+SET CLUSTER SETTING sql.inspect.uniqueness_check.complex_keys.enabled = true;
+
+skipif config local-mixed-25.4 local-mixed-26.1
+statement error pq: INSPECT found inconsistencies
+INSPECT TABLE uniqueness_check_complex;
+
+skipif config local-mixed-25.4 local-mixed-26.1
+query TI retry
+SELECT * FROM last_inspect_job
+----
+failed  1
+
+skipif config local-mixed-25.4 local-mixed-26.1
+query TTTTTT nosort
+SELECT * FROM last_inspect_errors
+----
+duplicate_unique_value  test  public  uniqueness_check_complex  e'(\'us-east1\', \'filler1\', 100)'  {
+                                                                                                         "index_name": "uniqueness_check_complex_pkey",
+                                                                                                         "remote_regions": [
+                                                                                                             "us-west1",
+                                                                                                             "us-west4"
+                                                                                                         ]
+                                                                                                     }
+duplicate_unique_value  test  public  uniqueness_check_complex  e'(\'us-east1\', \'filler1\', 200)'  {
+                                                                                                         "index_name": "uniqueness_check_complex_pkey",
+                                                                                                         "remote_regions": [
+                                                                                                             "us-west1"
+                                                                                                         ]
+                                                                                                     }
+duplicate_unique_value  test  public  uniqueness_check_complex  e'(\'us-west1\', \'filler1\', 100)'  {
+                                                                                                         "index_name": "uniqueness_check_complex_pkey",
+                                                                                                         "remote_regions": [
+                                                                                                             "us-west4"
+                                                                                                         ]
+                                                                                                     }
+duplicate_unique_value  test  public  uniqueness_check_complex  e'(\'us-west1\', \'filler1\', 300)'  {
+                                                                                                         "index_name": "uniqueness_check_complex_pkey",
+                                                                                                         "remote_regions": [
+                                                                                                             "us-west4"
+                                                                                                         ]
+                                                                                                     }
+
+skipif config local-mixed-25.4 local-mixed-26.1
+statement error pq: INSPECT found inconsistencies
+INSPECT TABLE uniqueness_check_complex WITH OPTIONS INDEX (uniqueness_check_complex_pkey);
+
+skipif config local-mixed-25.4 local-mixed-26.1
+query TI retry
+SELECT * FROM last_inspect_job
+----
+failed  1
+
+skipif config local-mixed-25.4 local-mixed-26.1
+query TTTTTT nosort
+SELECT * FROM last_inspect_errors
+----
+duplicate_unique_value  test  public  uniqueness_check_complex  e'(\'us-east1\', \'filler1\', 100)'  {
+                                                                                                         "index_name": "uniqueness_check_complex_pkey",
+                                                                                                         "remote_regions": [
+                                                                                                             "us-west1",
+                                                                                                             "us-west4"
+                                                                                                         ]
+                                                                                                     }
+duplicate_unique_value  test  public  uniqueness_check_complex  e'(\'us-east1\', \'filler1\', 200)'  {
+                                                                                                         "index_name": "uniqueness_check_complex_pkey",
+                                                                                                         "remote_regions": [
+                                                                                                             "us-west1"
+                                                                                                         ]
+                                                                                                     }
+duplicate_unique_value  test  public  uniqueness_check_complex  e'(\'us-west1\', \'filler1\', 100)'  {
+                                                                                                         "index_name": "uniqueness_check_complex_pkey",
+                                                                                                         "remote_regions": [
+                                                                                                             "us-west4"
+                                                                                                         ]
+                                                                                                     }
+duplicate_unique_value  test  public  uniqueness_check_complex  e'(\'us-west1\', \'filler1\', 300)'  {
+                                                                                                         "index_name": "uniqueness_check_complex_pkey",
+                                                                                                         "remote_regions": [
+                                                                                                             "us-west4"
+                                                                                                         ]
+                                                                                                     }
+
+statement ok
+DROP TABLE uniqueness_check_complex;
+
+subtest end
 
 subtest end


### PR DESCRIPTION
Validating unique columns in tables with a
"complex" primary key (e.g. `(crdb_region, ...,
unique_rowid, ...)`) is significantly more
expensive than the less read-intensive case where
the unique column immediately follows the region
column. This change introduces a cluster setting
that gates that more expensive validation when
speccing checks for an inspect job.

Epic: CRDB-58692

Part of: #154551

Release note: None