### PR TITLE
obs/ash: add app name tracking and remote resolution to ASH

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -2609,6 +2609,7 @@ ASHSample represents a single active session history sample.
 | work_event | [string](#cockroach.server.serverpb.ListActiveSessionHistoryResponse-string) |  | WorkEvent is a more specific identifier for the work (e.g., "DistSenderLocal"). | [reserved](#support-status) |
 | goroutine_id | [int64](#cockroach.server.serverpb.ListActiveSessionHistoryResponse-int64) |  | GoroutineID is the ID of the goroutine that was sampled. | [reserved](#support-status) |
 | tenant_id | [cockroach.roachpb.TenantID](#cockroach.server.serverpb.ListActiveSessionHistoryResponse-cockroach.roachpb.TenantID) |  | TenantID identifies which tenant this sample belongs to. | [reserved](#support-status) |
+| app_name | [string](#cockroach.server.serverpb.ListActiveSessionHistoryResponse-string) |  | AppName is the application name string. Set when the sample corresponds to SQL execution. | [reserved](#support-status) |
 
 
 
@@ -2689,6 +2690,7 @@ ASHSample represents a single active session history sample.
 | work_event | [string](#cockroach.server.serverpb.ListActiveSessionHistoryResponse-string) |  | WorkEvent is a more specific identifier for the work (e.g., "DistSenderLocal"). | [reserved](#support-status) |
 | goroutine_id | [int64](#cockroach.server.serverpb.ListActiveSessionHistoryResponse-int64) |  | GoroutineID is the ID of the goroutine that was sampled. | [reserved](#support-status) |
 | tenant_id | [cockroach.roachpb.TenantID](#cockroach.server.serverpb.ListActiveSessionHistoryResponse-cockroach.roachpb.TenantID) |  | TenantID identifies which tenant this sample belongs to. | [reserved](#support-status) |
+| app_name | [string](#cockroach.server.serverpb.ListActiveSessionHistoryResponse-string) |  | AppName is the application name string. Set when the sample corresponds to SQL execution. | [reserved](#support-status) |
 
 
 
@@ -2703,6 +2705,66 @@ An error wrapper for ListActiveSessionHistory fan-out.
 | ----- | ---- | ----- | ----------- | -------------- |
 | node_id | [int32](#cockroach.server.serverpb.ListActiveSessionHistoryResponse-int32) |  | ID of node that was being contacted when this error occurred. | [reserved](#support-status) |
 | message | [string](#cockroach.server.serverpb.ListActiveSessionHistoryResponse-string) |  | Error message. | [reserved](#support-status) |
+
+
+
+
+
+
+## AppNameMappings
+
+
+
+AppNameMappings retrieves app name ID to string mappings from
+this node's local cache for the requested IDs.
+
+Support status: [reserved](#support-status)
+
+#### Request Parameters
+
+
+
+
+Request object for retrieving app name ID to string mappings from
+a node's local cache.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| ids | [uint64](#cockroach.server.serverpb.AppNameMappingsRequest-uint64) | repeated | ids is the set of app name IDs to resolve. Only mappings for these IDs are returned in the response. | [reserved](#support-status) |
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+Response object for AppNameMappings.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| mappings | [AppNameMappingsResponse.MappingsEntry](#cockroach.server.serverpb.AppNameMappingsResponse-cockroach.server.serverpb.AppNameMappingsResponse.MappingsEntry) | repeated | mappings is a map from app name ID to the original app name string. | [reserved](#support-status) |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.AppNameMappingsResponse-cockroach.server.serverpb.AppNameMappingsResponse.MappingsEntry"></a>
+#### AppNameMappingsResponse.MappingsEntry
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [uint64](#cockroach.server.serverpb.AppNameMappingsResponse-uint64) |  |  |  |
+| value | [string](#cockroach.server.serverpb.AppNameMappingsResponse-string) |  |  |  |
 
 
 

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
@@ -4136,6 +4136,8 @@ func TestBatchHeaderFieldsAreAccountedForInBufferedWrites(t *testing.T) {
 		"IsReverse": fieldIsHandledByBatchSplitting,
 		// Observability label, doesn't affect batch processing.
 		"WorkloadID": iSwearFieldDoesNotNeedHandling,
+		// Observability label, doesn't affect batch processing.
+		"AppNameID": iSwearFieldDoesNotNeedHandling,
 	}
 
 	header := kvpb.Header{}

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -3023,12 +3023,19 @@ message Header {
   bool is_reverse = 38;
 
   // workload_id identifies the workload that triggered this batch (statement
-  // fingerprint ID, job ID, etc.). Used for ASH sampling and profiling.
+  // fingerprint ID, job ID, etc.). Used for ASH sampling.
   uint64 workload_id = 39 [(gogoproto.customname) = "WorkloadID"];
+
+  // app_name_id is the hash of the application name. Used for ASH sampling.
+  // Set when the workload is from SQL execution.
+  // Note(alyshan): This will eventually be replaced by a general
+  // enrichment_id field which will enable the ASH sampler to
+  // enrich samples with more workload context.
+  uint64 app_name_id = 40 [(gogoproto.customname) = "AppNameID"];
 
   reserved 7, 10, 12, 14, 20, 24;
 
-  // Next ID: 40
+  // Next ID: 41
 }
 
 message WriteOptions {

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -82,6 +82,14 @@ type Txn struct {
 	// It will be attached to all requests sent through this transaction.
 	gatewayNodeID roachpb.NodeID
 
+	// appNameID, if != 0, is the hash of the application name for
+	// ASH sampling. Propagated alongside workloadID to all BatchRequests.
+	// Set when the workload is from SQL execution.
+	// Note(alyshan): This will eventually be replaced by a general
+	// enrichment_id field which will enable the ASH sampler to
+	// enrich samples with more workload context.
+	appNameID uint64
+
 	// workloadID, if != 0, is the identifier for the workload that is using
 	// this transaction (e.g., statement fingerprint ID, job ID). It will be
 	// attached to all requests sent through this transaction.
@@ -451,10 +459,12 @@ func (txn *Txn) debugNameLocked() string {
 	return fmt.Sprintf("%s (id: %s)", txn.mu.debugName, txn.mu.ID)
 }
 
-// SetWorkloadID sets the workload ID for ASH sampling.
-// Automatically propagated to all BatchRequests sent through this transaction.
-func (txn *Txn) SetWorkloadID(workloadID uint64) {
+// SetWorkloadInfo sets the workload ID and app name ID for ASH
+// sampling. Both are automatically propagated to all BatchRequests
+// sent through this transaction.
+func (txn *Txn) SetWorkloadInfo(workloadID, appNameID uint64) {
 	txn.workloadID = workloadID
+	txn.appNameID = appNameID
 }
 
 // SetBufferedWritesEnabled toggles whether the writes are buffered on the
@@ -1371,6 +1381,10 @@ func (txn *Txn) Send(
 
 	if txn.workloadID != 0 && ba.Header.WorkloadID == 0 {
 		ba.Header.WorkloadID = txn.workloadID
+	}
+
+	if txn.appNameID != 0 && ba.Header.AppNameID == 0 {
+		ba.Header.AppNameID = txn.appNameID
 	}
 
 	// Requests with a bounded staleness header should use NegotiateAndSend.

--- a/pkg/obs/ash/BUILD.bazel
+++ b/pkg/obs/ash/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "ash",
     srcs = [
+        "app_name.go",
         "buffer.go",
         "doc.go",
         "metrics.go",
@@ -17,6 +18,7 @@ go_library(
         "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/settings/cluster",
+        "//pkg/util",
         "//pkg/util/buildutil",
         "//pkg/util/cache",
         "//pkg/util/encoding",

--- a/pkg/obs/ash/app_name.go
+++ b/pkg/obs/ash/app_name.go
@@ -1,0 +1,137 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package ash
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+// maxAppNameMapSize is the maximum number of entries allowed in the
+// app name map. When this limit is reached, new entries are dropped
+// and a warning is logged periodically.
+const maxAppNameMapSize = 10000
+
+// appNameMap stores the mapping from app name ID (uint64) to app name
+// string. This map is process-wide (not per-tenant) and is populated
+// when app names are first seen. In shared-process multi-tenant
+// deployments, all SQL servers write to the same map. There is an isolation
+// concern here, but since multi-tenancy with many in-process tenants is not
+// a production use case today, we choose to simplify the implementation. Also,
+// consider that the sampler is a process-wide singleton that needs to resolve
+// app names from any tenant. Having to dial the specific tenant's server to
+// resolve app names is tedious.
+// syncutil.Map is used because the access pattern is read-heavy
+// (sampler reads on every tick) with infrequent writes (only when a
+// new app name is first seen).
+var appNameMap syncutil.Map[uint64, string]
+
+// appNameMapSize tracks the number of entries in appNameMap. Used to
+// enforce maxAppNameMapSize without iterating the syncutil.Map.
+var appNameMapSize atomic.Int64
+
+// appNameMapFullLog rate-limits the warning logged when the map is at
+// capacity.
+var appNameMapFullLog = log.Every(time.Minute)
+
+// hashAppName computes a uint64 FNV hash of the app name string.
+func hashAppName(appName string) uint64 {
+	fnv := util.MakeFNV64()
+	for i := 0; i < len(appName); i++ {
+		fnv.Add(uint64(appName[i]))
+	}
+	return fnv.Sum()
+}
+
+// GetOrStoreAppNameID hashes the app name string to an ID and stores
+// the mapping in the node-local map if it doesn't already exist.
+// Returns the ID. This is the primary entry point for statement
+// execution paths that know the app name string.
+func GetOrStoreAppNameID(appName string) uint64 {
+	if appName == "" {
+		return 0
+	}
+	id := hashAppName(appName)
+	if _, ok := appNameMap.Load(id); ok {
+		return id
+	}
+	storeAppNameMapping(id, appName)
+	return id
+}
+
+// StoreAppNameMapping stores a single app name ID to string mapping.
+// This is used when the ID is already known (e.g., received in a
+// SetupFlowRequest from a remote node) and we only need to populate
+// the local map without re-hashing the app name.
+func StoreAppNameMapping(id uint64, name string) {
+	if id == 0 || name == "" {
+		return
+	}
+	if _, ok := appNameMap.Load(id); ok {
+		return
+	}
+	storeAppNameMapping(id, name)
+}
+
+// storeAppNameMapping is the slow path for storing a new app name
+// mapping. It is split out from the callers so that taking &name does
+// not cause the string parameter to escape to the heap on the fast
+// path (Load hit).
+//
+//go:noinline
+func storeAppNameMapping(id uint64, name string) {
+	if appNameMapSize.Load() >= maxAppNameMapSize {
+		logAppNameMapFull()
+		return
+	}
+	if _, loaded := appNameMap.LoadOrStore(id, &name); !loaded {
+		appNameMapSize.Add(1)
+	}
+}
+
+// logAppNameMapFull logs a rate-limited warning when the app name map
+// is at capacity.
+func logAppNameMapFull() {
+	if appNameMapFullLog.ShouldLog() {
+		log.Ops.Warningf(
+			context.Background(),
+			"ASH app name map is at capacity (%d entries); "+
+				"new app names will not be recorded",
+			maxAppNameMapSize,
+		)
+	}
+}
+
+// GetAppName looks up the app name string for the given ID in the
+// node-local map. Returns the name and true if found, or empty
+// string and false on cache miss.
+func GetAppName(id uint64) (string, bool) {
+	if id == 0 {
+		return "", false
+	}
+	val, ok := appNameMap.Load(id)
+	if !ok {
+		return "", false
+	}
+	return *val, true
+}
+
+// GetAppNameMappings returns the app name strings for the given IDs.
+// Only IDs present in the node-local map are included in the result.
+func GetAppNameMappings(ids []uint64) map[uint64]string {
+	result := make(map[uint64]string, len(ids))
+	for _, id := range ids {
+		if val, ok := appNameMap.Load(id); ok {
+			result[id] = *val
+		}
+	}
+	return result
+}

--- a/pkg/obs/ash/doc.go
+++ b/pkg/obs/ash/doc.go
@@ -30,7 +30,8 @@
 // register their current activity. SetWorkState returns a cleanup
 // function that must be deferred:
 //
-//	cleanup := ash.SetWorkState(tenantID, fingerprintID, ash.WorkLock, "LockWait")
+//	info := ash.WorkloadInfo{WorkloadID: fingerprintID, AppNameID: appNameID}
+//	cleanup := ash.SetWorkState(tenantID, info, ash.WorkLock, "LockWait")
 //	defer cleanup()
 //
 // Each call pushes a new WorkState onto a per-goroutine stack (stored
@@ -71,6 +72,27 @@
 // called during server startup after the node ID is known. In a
 // shared-process multi-tenant environment, multiple SQL servers share
 // the single sampler instance.
+//
+// # App Name Resolution
+//
+// To correlate samples with applications, the SQL layer hashes each
+// session's application name to a uint64 ID (via GetOrStoreAppNameID)
+// and stores the ID-to-string mapping in a process-wide cache. The ID
+// is propagated through BatchRequest headers and DistSQL
+// SetupFlowRequests, avoiding string copies on the hot path.
+//
+// During sampling, the sampler resolves app name IDs in two phases:
+//
+//  1. Local resolution: look up the ID in the process-wide cache.
+//     This succeeds for work originating from the local node and for
+//     DistSQL flows, which eagerly store their mapping on the remote
+//     node during flow setup.
+//  2. Remote resolution: for cache misses where the work state has a
+//     non-zero GatewayNodeID different from the local node, the
+//     sampler fetches mappings from the gateway via the
+//     AppNameMappings RPC. RPCs are batched and deduplicated by
+//     gateway node, with a 250ms timeout to avoid stalling the
+//     sampling loop.
 //
 // # Ring Buffer
 //
@@ -113,6 +135,33 @@
 // string allocations on the hot path. The sampler converts these IDs
 // to hex-encoded strings when writing samples, caching the conversion
 // to avoid repeated allocations.
+//
+// # Multi-Tenancy
+//
+// The sampler and app name cache are process-wide singletons, not
+// per-tenant. Tenant isolation is enforced at the read path: each
+// ASHSample records a TenantID, and the ListLocalActiveSessionHistory
+// RPC filters samples so secondary tenants only see their own data.
+//
+// Shared-process (in-process) tenants: multiple SQL servers in the
+// same process share the sampler and app name cache. The sampler
+// observes work states from all tenants and can resolve app names
+// for any of them, since all SQL servers populate the same cache.
+// When a SQL statement executes on a remote node via DistSQL, the
+// app name mapping is eagerly stored on the remote node during flow
+// setup, so the remote sampler can resolve it without an RPC.
+//
+// Separate-process (out-of-process) tenants: each SQL pod runs its
+// own process with its own sampler and app name cache. App names are
+// always resolved locally on the SQL pod because the SQL execution
+// path calls GetOrStoreAppNameID before any work states are
+// registered. On KV nodes, BatchRequests from SQL pods carry the
+// app name ID but have GatewayNodeID set to 0 (since the gateway is
+// not a KV node). The sampler skips remote resolution for
+// GatewayNodeID 0, so KV-side samples from SQL pod workloads will
+// not have app names. This is acceptable because out-of-process
+// tenants only observe samples from their own SQL pods, not from KV
+// nodes.
 //
 // # Performance
 //

--- a/pkg/obs/ash/sampler.go
+++ b/pkg/obs/ash/sampler.go
@@ -59,6 +59,13 @@ var BufferSize = settings.RegisterIntSetting(
 	settings.PositiveInt,
 )
 
+// AppNameResolverFn fetches app name ID-to-string mappings from a
+// remote node. The sampler calls this when local resolution fails and
+// the work state has a non-zero GatewayNodeID that differs from the
+// local node. Only the specified IDs are requested; the returned map
+// contains entries for the subset that the remote node could resolve.
+type AppNameResolverFn func(ctx context.Context, nodeID roachpb.NodeID, ids []uint64) (map[uint64]string, error)
+
 // globalSampler is the process-wide ASH sampler singleton. It is
 // initialized once by InitGlobalSampler and read by GetSamples.
 var globalSampler atomic.Pointer[Sampler]
@@ -74,8 +81,10 @@ var initSamplerOnce sync.Once
 const maxWorkloadIDCacheSize = 10000
 
 type pendingSample struct {
-	gid   int64
-	state WorkState
+	gid           int64
+	state         WorkState
+	workloadIDStr string
+	appName       string
 }
 
 // Sampler periodically samples the active work states and stores ASH data.
@@ -92,6 +101,9 @@ type Sampler struct {
 	// workloadIDCache caches the result of encodeStmtFingerprintIDToString
 	// to avoid repeated allocations for the same workload ID.
 	workloadIDCache *cache.UnorderedCache
+	// resolver, when set, fetches app name mappings from remote nodes
+	// for work states whose app name could not be resolved locally.
+	resolver atomic.Pointer[AppNameResolverFn]
 	// pendingSamples is a reusable slice for collecting work state snapshots
 	// during rangeWorkStates. Reused across samples to avoid per-sample
 	// slice allocation.
@@ -114,6 +126,22 @@ func newSampler(nodeID roachpb.NodeID, st *cluster.Settings, stopper *stop.Stopp
 			},
 		}),
 	}
+}
+
+// SetAppNameResolver sets the callback used to fetch app name
+// mappings from remote nodes when local resolution fails.
+func (s *Sampler) SetAppNameResolver(fn AppNameResolverFn) {
+	s.resolver.Store(&fn)
+}
+
+// SetGlobalAppNameResolver sets the resolver on the global sampler.
+// This is a no-op if the global sampler has not been initialized.
+func SetGlobalAppNameResolver(fn AppNameResolverFn) {
+	s := globalSampler.Load()
+	if s == nil {
+		return
+	}
+	s.SetAppNameResolver(fn)
 }
 
 // start begins the background sampling loop. It must be called at most once.
@@ -153,7 +181,7 @@ func (s *Sampler) run(ctx context.Context) {
 			timer.Read = true
 			timer.Reset(time.Duration(s.interval.Load()))
 			if Enabled.Get(&s.st.SV) {
-				s.takeSample()
+				s.takeSample(ctx)
 			}
 		case <-s.stopper.ShouldQuiesce():
 			return
@@ -164,7 +192,7 @@ func (s *Sampler) run(ctx context.Context) {
 }
 
 // takeSample captures a snapshot of all active work states.
-func (s *Sampler) takeSample() {
+func (s *Sampler) takeSample(ctx context.Context) {
 	start := timeutil.Now()
 	defer func() {
 		elapsed := timeutil.Since(start)
@@ -181,27 +209,49 @@ func (s *Sampler) takeSample() {
 		return true
 	})
 
-	// Process collected samples.
+	// First pass: resolve app names and workload IDs, tracking
+	// indices where local app name resolution fails.
+	var unresolvedIndices []int
 	for i := range s.pendingSamples {
 		ps := &s.pendingSamples[i]
 
 		// Encode the workloadID to a string for the ASHSample.
 		// Note(alyshan): Consider encoding at read time.
-		var workloadIDStr string
-		if ps.state.WorkloadID != 0 {
-			if cached, ok := s.workloadIDCache.Get(ps.state.WorkloadID); ok {
-				workloadIDStr = cached.(string)
+		if ps.state.WorkloadInfo.WorkloadID != 0 {
+			if cached, ok := s.workloadIDCache.Get(ps.state.WorkloadInfo.WorkloadID); ok {
+				ps.workloadIDStr = cached.(string)
 			} else {
-				workloadIDStr = encodeStmtFingerprintIDToString(ps.state.WorkloadID)
-				s.workloadIDCache.Add(ps.state.WorkloadID, workloadIDStr)
+				ps.workloadIDStr = encodeStmtFingerprintIDToString(ps.state.WorkloadInfo.WorkloadID)
+				s.workloadIDCache.Add(ps.state.WorkloadInfo.WorkloadID, ps.workloadIDStr)
 			}
 		}
 
+		// Resolve app name ID to string via the node-local cache.
+		if ps.state.WorkloadInfo.AppNameID != 0 {
+			if name, ok := GetAppName(ps.state.WorkloadInfo.AppNameID); ok {
+				ps.appName = name
+			} else {
+				unresolvedIndices = append(unresolvedIndices, i)
+			}
+		}
+	}
+
+	// If there are unresolved app names, try fetching from remote
+	// gateway nodes. Group by gateway node ID to make at most one
+	// RPC per remote node.
+	if len(unresolvedIndices) > 0 {
+		s.resolveRemoteAppNames(ctx, unresolvedIndices)
+	}
+
+	// Emit samples.
+	for i := range s.pendingSamples {
+		ps := &s.pendingSamples[i]
 		sample := ASHSample{
 			SampleTime:    sampleTime,
 			NodeID:        s.nodeID,
 			TenantID:      ps.state.TenantID,
-			WorkloadID:    workloadIDStr,
+			WorkloadID:    ps.workloadIDStr,
+			AppName:       ps.appName,
 			WorkEventType: ps.state.WorkEventType,
 			WorkEvent:     ps.state.WorkEvent,
 			GoroutineID:   ps.gid,
@@ -209,6 +259,80 @@ func (s *Sampler) takeSample() {
 		s.buffer.Add(sample)
 	}
 	s.metrics.SamplesCollected.Inc(int64(len(s.pendingSamples)))
+}
+
+// resolveRemoteAppNames fetches app name mappings from remote gateway
+// nodes for samples that could not be resolved from the local cache.
+// It deduplicates RPCs by gateway node ID, groups the needed app name
+// IDs per node, and skips the local node (whose cache was already
+// consulted).
+func (s *Sampler) resolveRemoteAppNames(ctx context.Context, unresolvedIndices []int) {
+	resolverPtr := s.resolver.Load()
+	if resolverPtr == nil {
+		return
+	}
+	resolver := *resolverPtr
+
+	// Group unresolved app name IDs by gateway node, skipping node
+	// ID 0 (unknown) and the sampler's own node. Use a map of maps
+	// to deduplicate IDs within each gateway node.
+	//
+	// For separate-process SQL pods, GatewayNodeID in the
+	// BatchRequest is 0 (see kvpb.Header.GatewayNodeID), so no
+	// remote resolution is attempted. This is intentional: KV nodes
+	// cannot dial SQL pods, and out-of-process tenants only see
+	// their own SQL-side samples where app names resolve locally.
+	type idSet = map[uint64]struct{}
+	gatewayIDs := make(map[roachpb.NodeID]idSet)
+	for _, idx := range unresolvedIndices {
+		ps := &s.pendingSamples[idx]
+		gw := ps.state.WorkloadInfo.GatewayNodeID
+		if gw == 0 || gw == s.nodeID {
+			continue
+		}
+		ids, ok := gatewayIDs[gw]
+		if !ok {
+			ids = make(idSet)
+			gatewayIDs[gw] = ids
+		}
+		ids[ps.state.WorkloadInfo.AppNameID] = struct{}{}
+	}
+
+	// Fetch mappings from each unique gateway node and store them
+	// in the local cache. Use a short per-node timeout so that a
+	// slow or unreachable node doesn't stall resolution of the
+	// remaining nodes.
+	for nodeID, ids := range gatewayIDs {
+		idSlice := make([]uint64, 0, len(ids))
+		for id := range ids {
+			idSlice = append(idSlice, id)
+		}
+		if err := timeutil.RunWithTimeout(
+			ctx, "ash-resolve-app-names", 250*time.Millisecond,
+			func(resolveCtx context.Context) error {
+				mappings, err := resolver(resolveCtx, nodeID, idSlice)
+				if err != nil {
+					return err
+				}
+				for id, name := range mappings {
+					StoreAppNameMapping(id, name)
+				}
+				return nil
+			},
+		); err != nil {
+			log.Ops.Warningf(
+				ctx, "ASH: failed to resolve app name mappings from n%d: %v",
+				nodeID, err,
+			)
+		}
+	}
+
+	// Re-resolve the previously-unresolved samples from the
+	// now-populated local cache.
+	for _, idx := range unresolvedIndices {
+		ps := &s.pendingSamples[idx]
+		ps.appName, _ = GetAppName(ps.state.WorkloadInfo.AppNameID)
+	}
 }
 
 // GetSamples returns all samples currently in the Sampler's buffer.
@@ -222,18 +346,23 @@ func (s *Sampler) GetSamples(result []ASHSample) []ASHSample {
 // the metrics and register them with sysRegistry. This should be called
 // during process-level server initialization (not per-tenant), after
 // the node ID is known.
+//
+// The returned bool is true when this call actually created the
+// sampler (first caller) and false for subsequent no-op calls.
 func InitGlobalSampler(
 	ctx context.Context, nodeID roachpb.NodeID, st *cluster.Settings, stopper *stop.Stopper,
-) error {
+) (bool, error) {
 	var initErr error
+	initialized := false
 	initSamplerOnce.Do(func() {
 		s := newSampler(nodeID, st, stopper)
 		initErr = s.start(ctx)
 		if initErr == nil {
 			globalSampler.Store(s)
+			initialized = true
 		}
 	})
-	return initErr
+	return initialized, initErr
 }
 
 // GlobalSamplerMetrics returns the Metrics for the process-wide ASH

--- a/pkg/obs/ash/sampler_test.go
+++ b/pkg/obs/ash/sampler_test.go
@@ -8,6 +8,7 @@ package ash
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -35,10 +36,10 @@ func TestSamplerTakeSample(t *testing.T) {
 	defer enabled.Store(false)
 
 	tenantID := roachpb.MustMakeTenantID(5)
-	cleanup := SetWorkState(tenantID, 42, WorkCPU, "Optimize")
+	cleanup := SetWorkState(tenantID, WorkloadInfo{WorkloadID: 42}, WorkCPU, "Optimize")
 	defer cleanup()
 
-	s.takeSample()
+	s.takeSample(context.Background())
 
 	samples := s.GetSamples(nil)
 	require.Len(t, samples, 1)
@@ -67,12 +68,12 @@ func TestSamplerWorkloadIDCache(t *testing.T) {
 	tenantID := roachpb.MustMakeTenantID(3)
 
 	// Take two samples with the same workload ID.
-	cleanup := SetWorkState(tenantID, 99, WorkIO, "BatchEval")
-	s.takeSample()
+	cleanup := SetWorkState(tenantID, WorkloadInfo{WorkloadID: 99}, WorkIO, "BatchEval")
+	s.takeSample(context.Background())
 	cleanup()
 
-	cleanup = SetWorkState(tenantID, 99, WorkIO, "BatchEval")
-	s.takeSample()
+	cleanup = SetWorkState(tenantID, WorkloadInfo{WorkloadID: 99}, WorkIO, "BatchEval")
+	s.takeSample(context.Background())
 	cleanup()
 
 	samples := s.GetSamples(nil)
@@ -109,7 +110,7 @@ func TestSamplerMultipleGoroutines(t *testing.T) {
 			defer wg.Done()
 			cleanup := SetWorkState(
 				tenantID,
-				uint64(idx+1),
+				WorkloadInfo{WorkloadID: uint64(idx + 1)},
 				WorkNetwork,
 				"DistSenderRemote",
 			)
@@ -124,7 +125,7 @@ func TestSamplerMultipleGoroutines(t *testing.T) {
 		<-ready
 	}
 
-	s.takeSample()
+	s.takeSample(context.Background())
 
 	// Signal all goroutines to clean up.
 	close(release)
@@ -157,7 +158,7 @@ func TestSamplerStartAndBackgroundSampling(t *testing.T) {
 	require.NoError(t, s.start(ctx))
 
 	tenantID := roachpb.MustMakeTenantID(7)
-	cleanup := SetWorkState(tenantID, 100, WorkCPU, "BackgroundTest")
+	cleanup := SetWorkState(tenantID, WorkloadInfo{WorkloadID: 100}, WorkCPU, "BackgroundTest")
 	defer cleanup()
 
 	testutils.SucceedsSoon(t, func() error {
@@ -203,7 +204,7 @@ func TestSamplerRuntimeSettingChanges(t *testing.T) {
 		require.NoError(t, s.start(ctx))
 
 		tenantID := roachpb.MustMakeTenantID(4)
-		cleanup := SetWorkState(tenantID, 50, WorkIO, "ToggleTest")
+		cleanup := SetWorkState(tenantID, WorkloadInfo{WorkloadID: 50}, WorkIO, "ToggleTest")
 		defer cleanup()
 
 		testutils.SucceedsSoon(t, func() error {
@@ -276,7 +277,7 @@ func TestSamplerMetrics(t *testing.T) {
 			defer wg.Done()
 			cleanup := SetWorkState(
 				tenantID,
-				uint64(idx+1),
+				WorkloadInfo{WorkloadID: uint64(idx + 1)},
 				WorkNetwork,
 				"MetricsTest",
 			)
@@ -295,7 +296,7 @@ func TestSamplerMetrics(t *testing.T) {
 	require.Equal(t, int64(numGoroutines), s.metrics.ActiveWorkStates.Value())
 
 	// Take a sample and verify latency and counter metrics.
-	s.takeSample()
+	s.takeSample(context.Background())
 	count, _ := s.metrics.TakeSampleLatency.CumulativeSnapshot().Total()
 	require.Equal(t, int64(1), count, "expected one latency sample after one takeSample call")
 	require.Equal(
@@ -310,9 +311,9 @@ func TestSamplerMetrics(t *testing.T) {
 
 	// Test nested (stacked) work states: a single goroutine calling
 	// SetWorkState twice should only count as 1 active work state.
-	cleanup1 := SetWorkState(tenantID, 1, WorkCPU, "Outer")
+	cleanup1 := SetWorkState(tenantID, WorkloadInfo{WorkloadID: 1}, WorkCPU, "Outer")
 	require.Equal(t, int64(1), s.metrics.ActiveWorkStates.Value())
-	cleanup2 := SetWorkState(tenantID, 2, WorkIO, "Inner")
+	cleanup2 := SetWorkState(tenantID, WorkloadInfo{WorkloadID: 2}, WorkIO, "Inner")
 	require.Equal(t, int64(1), s.metrics.ActiveWorkStates.Value(),
 		"nested SetWorkState should not increase the active count")
 	cleanup2()
@@ -335,16 +336,18 @@ func TestInitGlobalSampler(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	ctx := context.Background()
 
-	err := InitGlobalSampler(ctx, 42, st, stopper)
+	initialized, err := InitGlobalSampler(ctx, 42, st, stopper)
 	require.NoError(t, err)
+	require.True(t, initialized)
 	require.NotNil(t, globalSampler.Load())
 	metrics := GlobalSamplerMetrics()
 	require.NotNil(t, metrics, "first call should produce non-nil metrics")
 
 	// Second call is a no-op (sync.Once); GlobalSamplerMetrics still
 	// returns the same non-nil metrics.
-	err = InitGlobalSampler(ctx, 99, st, stopper)
+	initialized, err = InitGlobalSampler(ctx, 99, st, stopper)
 	require.NoError(t, err)
+	require.False(t, initialized)
 	metrics2 := GlobalSamplerMetrics()
 	require.NotNil(t, metrics2, "metrics should remain available after second init")
 	require.True(t, metrics == metrics2, "metrics pointer should be identical")
@@ -354,13 +357,210 @@ func TestInitGlobalSampler(t *testing.T) {
 	// Enable and take a sample via the global sampler.
 	Enabled.Override(ctx, &st.SV, true)
 	tenantID := roachpb.MustMakeTenantID(10)
-	cleanup := SetWorkState(tenantID, 200, WorkCPU, "GlobalTest")
+	cleanup := SetWorkState(tenantID, WorkloadInfo{WorkloadID: 200}, WorkCPU, "GlobalTest")
 	defer cleanup()
-	s.takeSample()
+	s.takeSample(context.Background())
 
 	// Package-level GetSamples should return the sample.
 	samples := GetSamples()
 	require.Len(t, samples, 1)
 	require.Equal(t, roachpb.NodeID(42), samples[0].NodeID)
 	require.Equal(t, tenantID, samples[0].TenantID)
+}
+
+func TestSamplerAppName(t *testing.T) {
+	// setup creates a Sampler with sampling enabled, cleaned up via
+	// t.Cleanup. All subtests share this common initialization.
+	setup := func(t *testing.T) *Sampler {
+		t.Helper()
+		s, stopper := newTestSampler()
+		t.Cleanup(func() { stopper.Stop(context.Background()) })
+		enabled.Store(true)
+		t.Cleanup(func() { enabled.Store(false) })
+		t.Cleanup(func() { s.resolver.Store(nil) })
+		return s
+	}
+
+	tenantID := roachpb.MustMakeTenantID(5)
+
+	t.Run("local cache hit", func(t *testing.T) {
+		s := setup(t)
+		appName := "myapp"
+		appID := GetOrStoreAppNameID(appName)
+
+		info := WorkloadInfo{WorkloadID: 42, AppNameID: appID}
+		cleanup := SetWorkState(tenantID, info, WorkCPU, "Optimize")
+		defer cleanup()
+
+		s.takeSample(context.Background())
+
+		samples := s.GetSamples(nil)
+		require.Len(t, samples, 1)
+		require.Equal(t, appName, samples[0].AppName)
+	})
+
+	t.Run("local cache miss", func(t *testing.T) {
+		s := setup(t)
+		// Use an app name ID without storing it in the cache.
+		info := WorkloadInfo{WorkloadID: 42, AppNameID: 12345}
+		cleanup := SetWorkState(tenantID, info, WorkCPU, "Optimize")
+		defer cleanup()
+
+		s.takeSample(context.Background())
+
+		samples := s.GetSamples(nil)
+		require.Len(t, samples, 1)
+		require.Equal(t, "", samples[0].AppName)
+	})
+
+	t.Run("remote resolution", func(t *testing.T) {
+		s := setup(t)
+		const unknownAppID uint64 = 99999
+		const remoteNodeID roachpb.NodeID = 10
+		info := WorkloadInfo{
+			WorkloadID:    42,
+			AppNameID:     unknownAppID,
+			GatewayNodeID: remoteNodeID,
+		}
+		cleanup := SetWorkState(tenantID, info, WorkCPU, "RemoteResolve")
+		defer cleanup()
+
+		s.SetAppNameResolver(func(
+			ctx context.Context, nodeID roachpb.NodeID, ids []uint64,
+		) (map[uint64]string, error) {
+			require.Equal(t, remoteNodeID, nodeID)
+			require.Contains(t, ids, unknownAppID)
+			return map[uint64]string{unknownAppID: "remote-app"}, nil
+		})
+
+		s.takeSample(context.Background())
+
+		samples := s.GetSamples(nil)
+		require.Len(t, samples, 1)
+		require.Equal(t, "remote-app", samples[0].AppName)
+	})
+
+	t.Run("skips local node", func(t *testing.T) {
+		s := setup(t)
+		// Gateway node ID matches the sampler's own node ID (1).
+		info := WorkloadInfo{
+			WorkloadID:    42,
+			AppNameID:     55555,
+			GatewayNodeID: 1,
+		}
+		cleanup := SetWorkState(tenantID, info, WorkCPU, "LocalSkip")
+		defer cleanup()
+
+		var called atomic.Bool
+		s.SetAppNameResolver(func(
+			ctx context.Context, nodeID roachpb.NodeID, ids []uint64,
+		) (map[uint64]string, error) {
+			called.Store(true)
+			return nil, nil
+		})
+
+		s.takeSample(context.Background())
+
+		require.False(t, called.Load())
+		samples := s.GetSamples(nil)
+		require.Len(t, samples, 1)
+		require.Equal(t, "", samples[0].AppName)
+	})
+
+	t.Run("resolver error", func(t *testing.T) {
+		s := setup(t)
+		info := WorkloadInfo{
+			WorkloadID:    42,
+			AppNameID:     66666,
+			GatewayNodeID: 20,
+		}
+		cleanup := SetWorkState(tenantID, info, WorkCPU, "ErrorCase")
+		defer cleanup()
+
+		s.SetAppNameResolver(func(
+			ctx context.Context, nodeID roachpb.NodeID, ids []uint64,
+		) (map[uint64]string, error) {
+			return nil, errors.New("connection refused")
+		})
+
+		s.takeSample(context.Background())
+
+		samples := s.GetSamples(nil)
+		require.Len(t, samples, 1)
+		require.Equal(t, "", samples[0].AppName)
+	})
+
+	t.Run("nil resolver", func(t *testing.T) {
+		s := setup(t)
+		// No resolver set — cache miss should leave app name empty.
+		info := WorkloadInfo{
+			WorkloadID:    42,
+			AppNameID:     44444,
+			GatewayNodeID: 30,
+		}
+		cleanup := SetWorkState(tenantID, info, WorkCPU, "NilResolver")
+		defer cleanup()
+
+		s.takeSample(context.Background())
+
+		samples := s.GetSamples(nil)
+		require.Len(t, samples, 1)
+		require.Equal(t, "", samples[0].AppName)
+	})
+
+	t.Run("deduplicates resolver calls", func(t *testing.T) {
+		s := setup(t)
+		const remoteNodeID roachpb.NodeID = 10
+
+		// Two work states with different unknown app name IDs but the
+		// same gateway node ID.
+		ready := make(chan struct{}, 2)
+		release := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+		for _, appID := range []uint64{77777, 88888} {
+			go func(id uint64) {
+				defer wg.Done()
+				info := WorkloadInfo{
+					WorkloadID:    1,
+					AppNameID:     id,
+					GatewayNodeID: remoteNodeID,
+				}
+				cl := SetWorkState(tenantID, info, WorkCPU, "Dedup")
+				ready <- struct{}{}
+				<-release
+				cl()
+			}(appID)
+		}
+		<-ready
+		<-ready
+
+		var callCount atomic.Int32
+		s.SetAppNameResolver(func(
+			ctx context.Context, nodeID roachpb.NodeID, ids []uint64,
+		) (map[uint64]string, error) {
+			callCount.Add(1)
+			return map[uint64]string{
+				77777: "app-a",
+				88888: "app-b",
+			}, nil
+		})
+
+		s.takeSample(context.Background())
+		close(release)
+		wg.Wait()
+
+		// The resolver should have been called exactly once for the
+		// single remote gateway node.
+		require.Equal(t, int32(1), callCount.Load())
+
+		samples := s.GetSamples(nil)
+		require.Len(t, samples, 2)
+		appNames := map[string]struct{}{}
+		for _, sample := range samples {
+			appNames[sample.AppName] = struct{}{}
+		}
+		require.Contains(t, appNames, "app-a")
+		require.Contains(t, appNames, "app-b")
+	})
 }

--- a/pkg/obs/ash/types.go
+++ b/pkg/obs/ash/types.go
@@ -44,6 +44,21 @@ func (w WorkEventType) String() string {
 	}
 }
 
+// WorkloadInfo groups the fields that identify the workload producing
+// a work state.
+type WorkloadInfo struct {
+	// WorkloadID identifies the workload (e.g., statement fingerprint ID).
+	WorkloadID uint64
+	// AppNameID is the hash of the application name. Set when the
+	// workload is from SQL execution.
+	// Note(alyshan): This will eventually be replaced by a general
+	// enrichment_id field which will enable the ASH sampler to
+	// enrich samples with more workload context.
+	AppNameID uint64
+	// GatewayNodeID is the node that initiated the workload.
+	GatewayNodeID roachpb.NodeID
+}
+
 // ASHSample represents a single Active Session History sample.
 type ASHSample struct {
 	// SampleTime is when this sample was taken.
@@ -58,6 +73,9 @@ type ASHSample struct {
 	TenantID roachpb.TenantID
 	// WorkloadID identifies the workload (e.g., statement fingerprint).
 	WorkloadID string
+	// AppName is the application name string. Set when the workload is from
+	// SQL execution.
+	AppName string
 	// WorkEventType categorizes the work by resource type (e.g., "CPU",
 	// "NETWORK", "LOCK").
 	WorkEventType WorkEventType

--- a/pkg/obs/ash/work_state.go
+++ b/pkg/obs/ash/work_state.go
@@ -22,8 +22,8 @@ import (
 type WorkState struct {
 	// TenantID identifies which tenant this work belongs to.
 	TenantID roachpb.TenantID
-	// WorkloadID identifies the workload (e.g., statement fingerprint).
-	WorkloadID uint64
+	// WorkloadInfo groups workload identity fields.
+	WorkloadInfo WorkloadInfo
 	// WorkEventType categorizes the type of work.
 	WorkEventType WorkEventType
 	// WorkEvent is a more specific identifier for the work event.
@@ -72,11 +72,12 @@ var retiredWorkStates struct {
 //
 // Example usage:
 //
-//	cleanup := ash.SetWorkState(tenantID, stmtFingerprintID, ash.WorkLock, "LockWait")
+//	info := ash.WorkloadInfo{WorkloadID: stmtFingerprintID, AppNameID: appNameID}
+//	cleanup := ash.SetWorkState(tenantID, info, ash.WorkLock, "LockWait")
 //	defer cleanup()
 //	// ... perform work ...
 func SetWorkState(
-	tenantID roachpb.TenantID, workloadID uint64, eventType WorkEventType, event string,
+	tenantID roachpb.TenantID, info WorkloadInfo, eventType WorkEventType, event string,
 ) func() {
 	if !enabled.Load() {
 		return noop
@@ -84,7 +85,7 @@ func SetWorkState(
 	gid := goid.Get()
 	state := workStatePool.Get().(*WorkState)
 	state.TenantID = tenantID
-	state.WorkloadID = workloadID
+	state.WorkloadInfo = info
 	state.WorkEventType = eventType
 	state.WorkEvent = event
 	prev, ok := getWorkState(gid)

--- a/pkg/obs/ash/work_state_test.go
+++ b/pkg/obs/ash/work_state_test.go
@@ -22,47 +22,47 @@ func TestWorkStateStack(t *testing.T) {
 	tenantID := roachpb.MustMakeTenantID(5)
 
 	// Push first work state.
-	clear1 := SetWorkState(tenantID, 100, WorkCPU, "query-1")
+	clear1 := SetWorkState(tenantID, WorkloadInfo{WorkloadID: 100}, WorkCPU, "query-1")
 
 	state, ok := getWorkState(gid)
 	require.True(t, ok, "first work state not found")
 	require.Equal(t, tenantID, state.TenantID)
-	require.Equal(t, uint64(100), state.WorkloadID)
+	require.Equal(t, uint64(100), state.WorkloadInfo.WorkloadID)
 	require.Equal(t, WorkCPU, state.WorkEventType)
 	require.Equal(t, "query-1", state.WorkEvent)
 	require.Nil(t, state.prev)
 
 	// Push second work state (nested).
-	clear2 := SetWorkState(tenantID, 200, WorkIO, "kv-read")
+	clear2 := SetWorkState(tenantID, WorkloadInfo{WorkloadID: 200}, WorkIO, "kv-read")
 
 	state, ok = getWorkState(gid)
 	require.True(t, ok, "second work state not found")
 	require.Equal(t, tenantID, state.TenantID)
-	require.Equal(t, uint64(200), state.WorkloadID)
+	require.Equal(t, uint64(200), state.WorkloadInfo.WorkloadID)
 	require.Equal(t, WorkIO, state.WorkEventType)
 	require.Equal(t, "kv-read", state.WorkEvent)
 	require.NotNil(t, state.prev)
-	require.Equal(t, uint64(100), state.prev.WorkloadID)
+	require.Equal(t, uint64(100), state.prev.WorkloadInfo.WorkloadID)
 
 	// Push third work state (deeply nested).
-	clear3 := SetWorkState(tenantID, 300, WorkNetwork, "rpc-call")
+	clear3 := SetWorkState(tenantID, WorkloadInfo{WorkloadID: 300}, WorkNetwork, "rpc-call")
 
 	state, ok = getWorkState(gid)
 	require.True(t, ok, "third work state not found")
-	require.Equal(t, uint64(300), state.WorkloadID)
+	require.Equal(t, uint64(300), state.WorkloadInfo.WorkloadID)
 	require.Equal(t, WorkNetwork, state.WorkEventType)
 	require.Equal(t, "rpc-call", state.WorkEvent)
 	require.NotNil(t, state.prev)
-	require.Equal(t, uint64(200), state.prev.WorkloadID)
+	require.Equal(t, uint64(200), state.prev.WorkloadInfo.WorkloadID)
 	require.NotNil(t, state.prev.prev)
-	require.Equal(t, uint64(100), state.prev.prev.WorkloadID)
+	require.Equal(t, uint64(100), state.prev.prev.WorkloadInfo.WorkloadID)
 
 	// Pop third work state; second should be restored.
 	clear3()
 
 	state, ok = getWorkState(gid)
 	require.True(t, ok, "second work state not restored after popping third")
-	require.Equal(t, uint64(200), state.WorkloadID)
+	require.Equal(t, uint64(200), state.WorkloadInfo.WorkloadID)
 	require.Equal(t, WorkIO, state.WorkEventType)
 
 	// Pop second work state; first should be restored.
@@ -70,7 +70,7 @@ func TestWorkStateStack(t *testing.T) {
 
 	state, ok = getWorkState(gid)
 	require.True(t, ok, "first work state not restored after popping second")
-	require.Equal(t, uint64(100), state.WorkloadID)
+	require.Equal(t, uint64(100), state.WorkloadInfo.WorkloadID)
 	require.Equal(t, WorkCPU, state.WorkEventType)
 
 	// Pop first work state; goroutine should have no state.
@@ -84,7 +84,7 @@ func TestWorkStateRetiredList(t *testing.T) {
 	enabled.Store(true)
 	defer enabled.Store(false)
 	// Push and pop a work state.
-	clear := SetWorkState(roachpb.SystemTenantID, 42, WorkCPU, "test")
+	clear := SetWorkState(roachpb.SystemTenantID, WorkloadInfo{WorkloadID: 42}, WorkCPU, "test")
 	clear()
 
 	// The work state should no longer be visible.
@@ -103,19 +103,19 @@ func TestWorkStateInterleavedNestedPushPopWithReclaim(t *testing.T) {
 	tenantID := roachpb.MustMakeTenantID(7)
 
 	// Push first state.
-	clear1 := SetWorkState(tenantID, 10, WorkCPU, "query")
+	clear1 := SetWorkState(tenantID, WorkloadInfo{WorkloadID: 10}, WorkCPU, "query")
 
 	// Sample active states (as the sampler would).
 	var count int
 	rangeWorkStates(func(gid int64, state WorkState) bool {
 		count++
-		require.Equal(t, uint64(10), state.WorkloadID)
+		require.Equal(t, uint64(10), state.WorkloadInfo.WorkloadID)
 		return true
 	})
 	require.Equal(t, 1, count)
 
 	// Push nested state.
-	clear2 := SetWorkState(tenantID, 20, WorkIO, "batch-eval")
+	clear2 := SetWorkState(tenantID, WorkloadInfo{WorkloadID: 20}, WorkIO, "batch-eval")
 
 	// Pop the nested state while the outer one is still active.
 	clear2()
@@ -125,17 +125,17 @@ func TestWorkStateInterleavedNestedPushPopWithReclaim(t *testing.T) {
 	gid := goid.Get()
 	state, ok := getWorkState(gid)
 	require.True(t, ok, "outer state should still be active")
-	require.Equal(t, uint64(10), state.WorkloadID)
+	require.Equal(t, uint64(10), state.WorkloadInfo.WorkloadID)
 	require.Nil(t, state.prev, "prev pointer should have been nilled before retire")
 
 	// Push another nested state.
-	clear3 := SetWorkState(tenantID, 30, WorkLock, "lock-wait")
+	clear3 := SetWorkState(tenantID, WorkloadInfo{WorkloadID: 30}, WorkLock, "lock-wait")
 
 	// Sample again.
 	count = 0
 	rangeWorkStates(func(gid int64, state WorkState) bool {
 		count++
-		require.Equal(t, uint64(30), state.WorkloadID)
+		require.Equal(t, uint64(30), state.WorkloadInfo.WorkloadID)
 		return true
 	})
 	require.Equal(t, 1, count)
@@ -146,7 +146,7 @@ func TestWorkStateInterleavedNestedPushPopWithReclaim(t *testing.T) {
 
 	state, ok = getWorkState(gid)
 	require.True(t, ok, "outer state should be restored")
-	require.Equal(t, uint64(10), state.WorkloadID)
+	require.Equal(t, uint64(10), state.WorkloadInfo.WorkloadID)
 
 	clear1()
 	reclaimRetiredWorkStates()
@@ -158,7 +158,9 @@ func TestWorkStateInterleavedNestedPushPopWithReclaim(t *testing.T) {
 func TestWorkStateDisabled(t *testing.T) {
 	enabled.Store(false)
 
-	clear := SetWorkState(roachpb.SystemTenantID, 999, WorkCPU, "should-not-appear")
+	clear := SetWorkState(
+		roachpb.SystemTenantID, WorkloadInfo{WorkloadID: 999}, WorkCPU, "should-not-appear",
+	)
 	defer clear()
 
 	var found bool
@@ -181,7 +183,7 @@ func TestRetiredWorkStatesCapOverflow(t *testing.T) {
 	// Fill the retired list to the cap by setting and clearing
 	// work states without calling rangeWorkStates (which drains).
 	for range maxRetiredWorkStates {
-		clear := SetWorkState(tenantID, 1, WorkCPU, "fill")
+		clear := SetWorkState(tenantID, WorkloadInfo{WorkloadID: 1}, WorkCPU, "fill")
 		clear()
 	}
 
@@ -190,7 +192,7 @@ func TestRetiredWorkStatesCapOverflow(t *testing.T) {
 	retiredWorkStates.Unlock()
 
 	// One more retire should be silently dropped.
-	clear := SetWorkState(tenantID, 1, WorkCPU, "overflow")
+	clear := SetWorkState(tenantID, WorkloadInfo{WorkloadID: 1}, WorkCPU, "overflow")
 	clear()
 
 	retiredWorkStates.Lock()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1884,13 +1884,28 @@ func (s *topLevelServer) PreStart(ctx context.Context) error {
 
 	// Initialize the process-global ASH sampler now that the node ID is
 	// known. The sampler is a process-wide singleton tied to the
-	// process-level stopper.
-	if err := ash.InitGlobalSampler(ctx, state.nodeID, s.st, s.stopper); err != nil {
+	// process-level stopper. This path handles KV+SQL nodes (the system
+	// tenant). Standalone SQL pods (out-of-process tenants) are handled by
+	// SQLServerWrapper.PreStart in tenant.go.
+	if _, err := ash.InitGlobalSampler(ctx, state.nodeID, s.st, s.stopper); err != nil {
 		return err
 	}
 	if m := ash.GlobalSamplerMetrics(); m != nil {
 		s.sysRegistry.AddMetricStruct(m)
 	}
+	ash.SetGlobalAppNameResolver(func(
+		ctx context.Context, nodeID roachpb.NodeID, ids []uint64,
+	) (map[uint64]string, error) {
+		client, err := s.status.dialNode(ctx, nodeID)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := client.AppNameMappings(ctx, &serverpb.AppNameMappingsRequest{Ids: ids})
+		if err != nil {
+			return nil, err
+		}
+		return resp.Mappings, nil
+	})
 
 	// TODO(irfansharif): Now that we have our node ID, we should run another
 	// check here to make sure we've not been decommissioned away (if we're here

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -1203,6 +1203,9 @@ message ASHSample {
   // TenantID identifies which tenant this sample belongs to.
   roachpb.TenantID tenant_id = 7
       [(gogoproto.nullable) = false, (gogoproto.customname) = "TenantID"];
+  // AppName is the application name string. Set when the sample corresponds
+  // to SQL execution.
+  string app_name = 8;
 }
 
 // An error wrapper for ListActiveSessionHistory fan-out.
@@ -1225,6 +1228,20 @@ message ListActiveSessionHistoryResponse {
   // Any errors that occurred during fan-out calls to other nodes.
   repeated ListActiveSessionHistoryError errors = 2
       [ (gogoproto.nullable) = false ];
+}
+
+// Request object for retrieving app name ID to string mappings from
+// a node's local cache.
+message AppNameMappingsRequest {
+  // ids is the set of app name IDs to resolve. Only mappings for
+  // these IDs are returned in the response.
+  repeated uint64 ids = 1;
+}
+
+// Response object for AppNameMappings.
+message AppNameMappingsResponse {
+  // mappings is a map from app name ID to the original app name string.
+  map<uint64, string> mappings = 1;
 }
 
 // Request object for issuing a query cancel request.
@@ -2481,6 +2498,11 @@ service Status {
   // ListLocalActiveSessionHistory retrieves ASH samples on this node.
   rpc ListLocalActiveSessionHistory(ListActiveSessionHistoryRequest)
       returns (ListActiveSessionHistoryResponse) {}
+
+  // AppNameMappings retrieves app name ID to string mappings from
+  // this node's local cache for the requested IDs.
+  rpc AppNameMappings(AppNameMappingsRequest)
+      returns (AppNameMappingsResponse) {}
 
   // CancelQuery cancels a SQL query given its ID.
   rpc CancelQuery(CancelQueryRequest) returns (CancelQueryResponse) {

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -3381,6 +3381,7 @@ func (s *statusServer) ListLocalActiveSessionHistory(
 			NodeID:        sample.NodeID,
 			TenantID:      sample.TenantID,
 			WorkloadID:    sample.WorkloadID,
+			AppName:       sample.AppName,
 			WorkEventType: serverpb.WorkEventType(sample.WorkEventType),
 			WorkEvent:     sample.WorkEvent,
 			GoroutineID:   sample.GoroutineID,
@@ -3394,6 +3395,25 @@ func (s *statusServer) ListLocalActiveSessionHistory(
 
 	return &serverpb.ListActiveSessionHistoryResponse{
 		Samples: protoSamples,
+	}, nil
+}
+
+// AppNameMappings returns app name ID to string mappings from this
+// node's local cache for the requested IDs. This is used by ASH so
+// that nodes can resolve an app_name_id when they perform work for
+// queries that they have not recieved as a gateway node (i.e. they
+// do not have the app name mapping locally).
+func (s *statusServer) AppNameMappings(
+	ctx context.Context, req *serverpb.AppNameMappingsRequest,
+) (*serverpb.AppNameMappingsResponse, error) {
+	ctx = s.AnnotateCtx(ctx)
+
+	if err := s.privilegeChecker.RequireViewActivityOrViewActivityRedactedPermission(ctx); err != nil {
+		return nil, err
+	}
+
+	return &serverpb.AppNameMappingsResponse{
+		Mappings: ash.GetAppNameMappings(req.Ids),
 	}, nil
 }
 

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -861,19 +861,40 @@ func (s *SQLServerWrapper) PreStart(ctx context.Context) error {
 		return err
 	}
 
-	// Initialize the process-global ASH sampler. This is a no-op if
-	// already initialized by a topLevelServer; for standalone SQL pods
-	// this is the first initialization point.
-	if err := ash.InitGlobalSampler(
+	// Initialize the process-global ASH sampler. For standalone SQL pods
+	// this is the first (and only) initialization point. For
+	// shared-process secondary tenants, the sampler was already
+	// initialized by topLevelServer.PreStart in server.go, so
+	// InitGlobalSampler is a no-op. We only set the resolver when we
+	// actually created the sampler (standalone SQL pod), since the
+	// app name cache is process-global and the system tenant's resolver
+	// (set in server.go) is sufficient for shared-process tenants.
+	initialized, err := ash.InitGlobalSampler(
 		ctx,
 		roachpb.NodeID(s.sqlServer.SQLInstanceID()),
 		s.ClusterSettings(),
 		s.stopper,
-	); err != nil {
+	)
+	if err != nil {
 		return err
 	}
 	if m := ash.GlobalSamplerMetrics(); m != nil {
 		s.sysRegistry.AddMetricStruct(m)
+	}
+	if initialized {
+		ash.SetGlobalAppNameResolver(func(
+			ctx context.Context, nodeID roachpb.NodeID, ids []uint64,
+		) (map[uint64]string, error) {
+			client, err := s.tenantStatus.dialNode(ctx, nodeID)
+			if err != nil {
+				return nil, err
+			}
+			resp, err := client.AppNameMappings(ctx, &serverpb.AppNameMappingsRequest{Ids: ids})
+			if err != nil {
+				return nil, err
+			}
+			return resp.Mappings, nil
+		})
 	}
 
 	var apiInternalServer http.Handler

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/multitenantcpu"
+	"github.com/cockroachdb/cockroach/pkg/obs/ash"
 	"github.com/cockroachdb/cockroach/pkg/obs/workloadid"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
@@ -656,11 +657,13 @@ func (ex *connExecutor) execStmtInOpenState(
 	ctx = ih.Setup(ctx, ex, p, &stmt, os.ImplicitTxn.Get(),
 		ex.state.mu.priority, ex.state.mu.autoRetryCounter)
 
-	// Set workload ID for ASH sampling. ih.Setup already computed the
-	// statement fingerprint ID, so reuse it here.
+	// Set workload ID and app name ID for ASH sampling. ih.Setup
+	// already computed the statement fingerprint ID, so reuse it here.
 	p.extendedEvalCtx.WorkloadID = uint64(ih.fingerprintId)
+	appNameID := ash.GetOrStoreAppNameID(p.SessionData().ApplicationName)
+	p.extendedEvalCtx.AppNameID = appNameID
 	if p.txn != nil {
-		p.txn.SetWorkloadID(uint64(ih.fingerprintId))
+		p.txn.SetWorkloadInfo(uint64(ih.fingerprintId), appNameID)
 	}
 
 	// Note that here we always unconditionally defer a function that takes care
@@ -1736,11 +1739,13 @@ func (ex *connExecutor) execStmtInOpenStateWithPausablePortal(
 	p.semaCtx.Placeholders.Assign(pinfo, vars.stmt.NumPlaceholders)
 	p.extendedEvalCtx.Placeholders = &p.semaCtx.Placeholders
 
-	// Set workload ID for ASH sampling. ih.Setup already computed the
-	// statement fingerprint ID, so reuse it here.
+	// Set workload ID and app name ID for ASH sampling. ih.Setup
+	// already computed the statement fingerprint ID, so reuse it here.
 	p.extendedEvalCtx.WorkloadID = uint64(ih.fingerprintId)
+	appNameID2 := ash.GetOrStoreAppNameID(p.SessionData().ApplicationName)
+	p.extendedEvalCtx.AppNameID = appNameID2
 	if p.txn != nil {
-		p.txn.SetWorkloadID(uint64(ih.fingerprintId))
+		p.txn.SetWorkloadInfo(uint64(ih.fingerprintId), appNameID2)
 	}
 
 	if buildutil.CrdbTestBuild {

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -9842,6 +9842,7 @@ CREATE TABLE crdb_internal.node_active_session_history (
   node_id          INT NOT NULL,
   tenant_id        INT NOT NULL,
   workload_id      STRING,
+  app_name         STRING,
   work_event_type  STRING NOT NULL,
   work_event       STRING NOT NULL,
   goroutine_id     INT NOT NULL
@@ -9870,6 +9871,7 @@ CREATE TABLE crdb_internal.node_active_session_history (
 				tree.NewDInt(tree.DInt(sample.NodeID)),
 				tree.NewDInt(tree.DInt(sample.TenantID.ToUint64())),
 				tree.NewDString(sample.WorkloadID),
+				tree.NewDString(sample.AppName),
 				tree.NewDString(ash.WorkEventType(sample.WorkEventType).String()),
 				tree.NewDString(sample.WorkEvent),
 				tree.NewDInt(tree.DInt(sample.GoroutineID)),
@@ -9894,6 +9896,7 @@ CREATE TABLE crdb_internal.cluster_active_session_history (
   node_id          INT NOT NULL,
   tenant_id        INT NOT NULL,
   workload_id      STRING,
+  app_name         STRING,
   work_event_type  STRING NOT NULL,
   work_event       STRING NOT NULL,
   goroutine_id     INT NOT NULL
@@ -9922,6 +9925,7 @@ CREATE TABLE crdb_internal.cluster_active_session_history (
 				tree.NewDInt(tree.DInt(sample.NodeID)),
 				tree.NewDInt(tree.DInt(sample.TenantID.ToUint64())),
 				tree.NewDString(sample.WorkloadID),
+				tree.NewDString(sample.AppName),
 				tree.NewDString(ash.WorkEventType(sample.WorkEventType).String()),
 				tree.NewDString(sample.WorkEvent),
 				tree.NewDInt(tree.DInt(sample.GoroutineID)),

--- a/pkg/sql/distsql/BUILD.bazel
+++ b/pkg/sql/distsql/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//pkg/base",
         "//pkg/gossip",
         "//pkg/kv",
+        "//pkg/obs/ash",
         "//pkg/roachpb",
         "//pkg/server/telemetry",
         "//pkg/sql/catalog/catsessiondata",

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/obs/ash"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catsessiondata"
@@ -282,7 +283,7 @@ func (ds *ServerImpl) setupFlow(
 		// Txn to heartbeat the transaction.
 		nodeID := roachpb.NodeID(req.Flow.Gateway)
 		leafTxn := kv.NewLeafTxn(ctx, ds.DB.KV(), nodeID, tis, &req.LeafTxnAdmissionHeader)
-		leafTxn.SetWorkloadID(req.EvalContext.WorkloadID)
+		leafTxn.SetWorkloadInfo(req.EvalContext.WorkloadID, req.EvalContext.AppNameID)
 		return leafTxn, nil
 	}
 
@@ -388,6 +389,16 @@ func (ds *ServerImpl) setupFlow(
 		evalCtx.SetTxnTimestamp(timeutil.Unix(0 /* sec */, req.EvalContext.TxnTimestampNanos))
 		evalCtx.TestingKnobs.ForceProductionValues = req.EvalContext.TestingKnobsForceProductionValues
 		evalCtx.WorkloadID = req.EvalContext.WorkloadID
+		evalCtx.AppNameID = req.EvalContext.AppNameID
+
+		// In DistSQL flows, we eagerly store the app name on remote nodes to reduce
+		// cache misses when the local ASH sampler resolves the app name ID.
+		if req.EvalContext.AppNameID != 0 {
+			ash.StoreAppNameMapping(
+				req.EvalContext.AppNameID,
+				req.EvalContext.SessionData.ApplicationName,
+			)
+		}
 
 		if ds.SQLCPUProvider != nil {
 			var cpuHandle *admission.SQLCPUHandle

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -396,6 +396,7 @@ func serializeEvalContext(evalCtx *eval.Context) execinfrapb.EvalContext {
 		TxnTimestampNanos:                 evalCtx.TxnTimestamp.UnixNano(),
 		TestingKnobsForceProductionValues: evalCtx.TestingKnobs.ForceProductionValues,
 		WorkloadID:                        evalCtx.WorkloadID,
+		AppNameID:                         evalCtx.AppNameID,
 	}
 }
 
@@ -475,10 +476,11 @@ func (dsp *DistSQLPlanner) setupFlows(
 		StatementSQL:      statementSQL,
 	}
 	if localState.IsLocal {
-		// VectorizeMode, and workloadID are the only fields that the setup code expects to be set
-		// in the local flows.
+		// VectorizeMode, workloadID, and appNameID are the only fields
+		// that the setup code expects to be set in the local flows.
 		setupReq.EvalContext.SessionData.VectorizeMode = evalCtx.SessionData().VectorizeMode
 		setupReq.EvalContext.WorkloadID = evalCtx.WorkloadID
+		setupReq.EvalContext.AppNameID = evalCtx.AppNameID
 	} else {
 		// In distributed plans populate some extra state.
 		setupReq.EvalContext = serializeEvalContext(evalCtx)

--- a/pkg/sql/execinfrapb/api.proto
+++ b/pkg/sql/execinfrapb/api.proto
@@ -90,6 +90,12 @@ message EvalContext {
   // WorkloadID for ASH sampling.
   optional uint64 workload_id = 17 [(gogoproto.nullable) = false,
     (gogoproto.customname) = "WorkloadID"];
+  // AppNameID is the hash of the application name, for ASH sampling.
+  // Note(alyshan): This will eventually be replaced by a general
+  // enrichment_id field which will enable the ASH sampler to
+  // enrich samples with more workload context.
+  optional uint64 app_name_id = 18 [(gogoproto.nullable) = false,
+    (gogoproto.customname) = "AppNameID"];
 }
 
 message SimpleResponse {

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -363,6 +363,13 @@ type Context struct {
 
 	// WorkloadID for ASH sampling.
 	WorkloadID uint64
+
+	// AppNameID is the hash of the application name, for ASH
+	// sampling. Set alongside WorkloadID in the connExecutor.
+	// Note(alyshan): This will eventually be replaced by a general
+	// enrichment_id field which will enable the ASH sampler to
+	// enrich samples with more workload context.
+	AppNameID uint64
 }
 
 // RoutineStatementCounters encapsulates metrics for tracking the execution

--- a/pkg/sql/workload_id_test.go
+++ b/pkg/sql/workload_id_test.go
@@ -159,7 +159,7 @@ func TestWorkloadIDPropagation(t *testing.T) {
 			hexFPs, capturedIDsString(captured))
 	}
 
-	// Verify that txn.SetWorkloadID propagates to KV BatchRequest headers.
+	// Verify that txn.SetWorkloadInfo propagates to KV BatchRequest headers.
 	// All fetcher/streamer variants share this same txn-level path, so a
 	// single SELECT suffices.
 	t.Run("batch_request", func(t *testing.T) {


### PR DESCRIPTION
Previously, ASH samples only carried a workload ID (statement
fingerprint). This commit adds application name tracking to the ASH
infrastructure so samples can be correlated with the originating
application.

- WorkloadInfo struct: groups workload ID, app name ID, and gateway
  node ID into a single struct propagated through SetWorkState.
- App name map: a node-local sync.Map caches app name ID to string
  mappings, populated when app names are first seen during SQL
  execution.
- KV propagation: app name ID is propagated alongside workload ID in
  BatchRequest headers and KV transactions. Note that GatewayNodeID is
  already present in the BatchRequest header.
- DistSQL propagation: app name ID is serialized in the EvalContext
  proto and eagerly stored on remote nodes during flow setup.
- Remote resolution: when the ASH sampler encounters an unresolved app
  name ID, it fetches mappings from the gateway node via the new
  AppNameMappings RPC. RPCs are deduplicated by gateway node ID, and
  the local node is skipped. A 250ms timeout prevents unreachable nodes
  from stalling the sampling loop.
- Authorization: the AppNameMappings RPC requires
  VIEWACTIVITY or VIEWACTIVITYREDACTED, matching
  ListLocalActiveSessionHistory.
- Virtual tables: crdb_internal.node_active_session_history and
  cluster_active_session_history now include an app_name column.

Resolves: https://github.com/cockroachdb/cockroach/issues/164682

Release note: None