### PR TITLE
sql/inspect: skip non-physical tables in inspect job speccing

### DIFF
--- a/pkg/sql/inspect/inspect_job_entry.go
+++ b/pkg/sql/inspect/inspect_job_entry.go
@@ -113,8 +113,8 @@ func ChecksForTable(
 ) ([]*jobspb.InspectDetails_Check, error) {
 	checks := []*jobspb.InspectDetails_Check{}
 
-	// Skip virtual tables since they don't have physical storage to inspect.
-	if table.IsVirtualTable() {
+	// Skip non-physical tables that don't have physical storage to inspect.
+	if !table.IsPhysicalTable() {
 		return checks, nil
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/inspect
+++ b/pkg/sql/logictest/testdata/logic_test/inspect
@@ -20,6 +20,9 @@ WHERE job_type = 'INSPECT'
 ORDER BY id DESC
 LIMIT 1
 
+statement error pq: "last_inspect_job" is not a table
+INSPECT TABLE last_inspect_job;
+
 # Make job adoption faster. This is needed to speed up DETACHED jobs.
 statement ok
 SET CLUSTER SETTING jobs.registry.interval.adopt = '500ms';


### PR DESCRIPTION
The previous filter allowed non-physical tables such as virtual tables
to be evaluated for checks. This change restricts the candidates to only
physical tables so the qualifiers such as the those for the uniqueness
check in #164449 can make assumptions.

Epic: CRDB-58692

Part of: #154551
Part of: #155472

**Part of a stack.**

Release note: None