### PR TITLE
release-26.1: roachtest: skip flaky hibernate SchemaUpdateTest

### DIFF
--- a/pkg/cmd/roachtest/tests/hibernate_blocklist.go
+++ b/pkg/cmd/roachtest/tests/hibernate_blocklist.go
@@ -24,6 +24,7 @@ var hibernateIgnoreList = blocklist{
 	"org.hibernate.orm.test.hql.BulkManipulationTest.testInsertWithManyToOne":                            "https://hibernate.atlassian.net/browse/HHH-19332",
 	`org.hibernate.orm.test.jpa.txn.JtaTransactionJoiningTest.control()`:                                 "flaky",
 	`org.hibernate.orm.test.jpa.txn.JtaTransactionJoiningTest.testImplicitJoining()`:                     "flaky",
+	"org.hibernate.orm.test.schemaupdate.SchemaUpdateTest.testSchemaUpdateAndValidation[0]":              "flaky",
 	"org.hibernate.serialization.SessionFactorySerializationTest.testUnNamedSessionFactorySerialization": "flaky",
 	"org.hibernate.serialization.SessionFactorySerializationTest.testNamedSessionFactorySerialization":   "flaky",
 	"org.hibernate.test.batch.BatchTest.testBatchInsertUpdate":                                           "flaky",


### PR DESCRIPTION
Backport 1/1 commits from #164518 on behalf of @bghal.

----

## Summary
- Add `SchemaUpdateTest.testSchemaUpdateAndValidation[0]` to the hibernate ignore list as it is flaky.

Resolves: #164249

Release note: None

----

Release justification: