### PR TITLE
wagpb: simplify WAG Node datamodel

### DIFF
--- a/pkg/kv/kvserver/kvstorage/wag/BUILD.bazel
+++ b/pkg/kv/kvserver/kvstorage/wag/BUILD.bazel
@@ -10,10 +10,8 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/keys",
-        "//pkg/kv/kvserver/kvstorage",
         "//pkg/kv/kvserver/kvstorage/wag/wagpb",
         "//pkg/storage",
-        "@com_github_cockroachdb_errors//:errors",
     ],
 )
 

--- a/pkg/kv/kvserver/kvstorage/wag/store_test.go
+++ b/pkg/kv/kvserver/kvstorage/wag/store_test.go
@@ -45,9 +45,10 @@ func TestWrite(t *testing.T) {
 	}
 
 	id := roachpb.FullReplicaID{RangeID: 123, ReplicaID: 4}
+	rhsID := roachpb.FullReplicaID{RangeID: 567, ReplicaID: 1}
 	write("create", func(w storage.Writer) error { return createReplica(&s, w, id) })
 	write("init", func(w storage.Writer) error { return initReplica(&s, w, id, 10) })
-	write("split", func(w storage.Writer) error { return splitReplica(&s, w, id, 200) })
+	write("split", func(w storage.Writer) error { return splitReplica(&s, w, id, rhsID, 200) })
 
 	// TODO(pav-kv): the trailing \n in DecodeWriteBatch is duplicated with
 	// recursion. Remove it, and let the caller handle new lines.
@@ -61,7 +62,9 @@ func TestWrite(t *testing.T) {
 		count++
 	}
 	require.NoError(t, iter.Error())
-	require.Equal(t, 4, count)
+	// 3 WAG nodes: create, init, split. The split is a single node with two
+	// events (Split + Init) rather than two separate nodes (dep + event).
+	require.Equal(t, 3, count)
 }
 
 type store struct {
@@ -76,23 +79,27 @@ func createReplica(s *store, w storage.Writer, id roachpb.FullReplicaID) error {
 		return err
 	}
 	return Write(w, s.seq.Next(1), wagpb.Node{
-		Addr:     wagpb.MakeAddr(id, 0),
-		Type:     wagpb.NodeType_NodeCreate,
+		Events: []wagpb.Event{
+			{Addr: wagpb.MakeAddr(id, 0), Type: wagpb.EventCreate},
+		},
 		Mutation: wagpb.Mutation{Batch: b.Repr()},
 	})
 }
 
 func initReplica(s *store, w storage.Writer, id roachpb.FullReplicaID, index uint64) error {
 	return Write(w, s.seq.Next(1), wagpb.Node{
-		Addr: wagpb.MakeAddr(id, kvpb.RaftIndex(index)),
-		Type: wagpb.NodeType_NodeSnap,
+		Events: []wagpb.Event{
+			{Addr: wagpb.MakeAddr(id, kvpb.RaftIndex(index)), Type: wagpb.EventInit},
+		},
 		Mutation: wagpb.Mutation{Ingestion: &wagpb.Ingestion{
 			SSTs: []string{"tmp/1.sst", "tmp/2.sst"},
 		}},
 	})
 }
 
-func splitReplica(s *store, w storage.Writer, id roachpb.FullReplicaID, index uint64) error {
+func splitReplica(
+	s *store, w storage.Writer, lhsID, rhsID roachpb.FullReplicaID, index uint64,
+) error {
 	b := s.eng.NewWriteBatch()
 	defer b.Close()
 	if err := writeStateMachine(b, "lhs-key", "lhs-state"); err != nil {
@@ -100,19 +107,12 @@ func splitReplica(s *store, w storage.Writer, id roachpb.FullReplicaID, index ui
 	} else if err := writeStateMachine(b, "rhs-key", "rhs-state"); err != nil {
 		return err
 	}
-
-	seq := s.seq.Next(2)
-	if err := Write(w, seq, wagpb.Node{
-		Addr: wagpb.MakeAddr(id, kvpb.RaftIndex(index-1)),
-		Type: wagpb.NodeType_NodeApply,
-	}); err != nil {
-		return err
-	}
-	return Write(w, seq+1, wagpb.Node{
-		Addr:     wagpb.MakeAddr(id, kvpb.RaftIndex(index)),
-		Type:     wagpb.NodeType_NodeSplit,
+	return Write(w, s.seq.Next(1), wagpb.Node{
+		Events: []wagpb.Event{
+			{Addr: wagpb.MakeAddr(rhsID, 10), Type: wagpb.EventInit},
+			{Addr: wagpb.MakeAddr(lhsID, kvpb.RaftIndex(index)), Type: wagpb.EventSplit},
+		},
 		Mutation: wagpb.Mutation{Batch: b.Repr()},
-		Create:   567, // the RHS range ID
 	})
 }
 

--- a/pkg/kv/kvserver/kvstorage/wag/testdata/TestWrite.txt
+++ b/pkg/kv/kvserver/kvstorage/wag/testdata/TestWrite.txt
@@ -1,13 +1,12 @@
 echo
 ----
 >> create
-Put: 0,0 /Local/Store/wag/1 (0x01737761676e000000000000000100): NodeCreate r123/4:0
+Put: 0,0 /Local/Store/wag/1 (0x01737761676e000000000000000100): (r123/4:0,EventCreate)
 > Put: 0,0 "state-machine-key" (0x73746174652d6d616368696e652d6b657900): "state"
 >> init
-Put: 0,0 /Local/Store/wag/2 (0x01737761676e000000000000000200): NodeSnap r123/4:10
+Put: 0,0 /Local/Store/wag/2 (0x01737761676e000000000000000200): (r123/4:10,EventInit)
 ingestion: SSTs:"tmp/1.sst" SSTs:"tmp/2.sst" 
 >> split
-Put: 0,0 /Local/Store/wag/3 (0x01737761676e000000000000000300): NodeApply r123/4:199
-Put: 0,0 /Local/Store/wag/4 (0x01737761676e000000000000000400): NodeSplit r123/4:200 create:567
+Put: 0,0 /Local/Store/wag/3 (0x01737761676e000000000000000300): (r567/1:10,EventInit) (r123/4:200,EventSplit)
 > Put: 0,0 "lhs-key" (0x6c68732d6b657900): "lhs-state"
 > Put: 0,0 "rhs-key" (0x7268732d6b657900): "rhs-state"

--- a/pkg/kv/kvserver/kvstorage/wag/wagpb/wag.go
+++ b/pkg/kv/kvserver/kvstorage/wag/wagpb/wag.go
@@ -29,3 +29,18 @@ func (a Addr) String() string {
 func (a Addr) SafeFormat(w redact.SafePrinter, _ rune) {
 	w.Printf("r%d/%d:%d", a.RangeID, a.ReplicaID, a.Index)
 }
+
+// SafeValue implements the redact.SafeValue interface.
+func (EventType) SafeValue() {}
+
+var _ redact.SafeValue = EventType(0)
+
+// String implements the fmt.Stringer interface.
+func (e Event) String() string {
+	return redact.StringWithoutMarkers(e)
+}
+
+// SafeFormat implements the redact.SafeFormatter interface.
+func (e Event) SafeFormat(w redact.SafePrinter, _ rune) {
+	w.Printf("(%s,%s)", e.Addr, e.Type)
+}

--- a/pkg/kv/kvserver/kvstorage/wag/wagpb/wag.proto
+++ b/pkg/kv/kvserver/kvstorage/wag/wagpb/wag.proto
@@ -41,6 +41,8 @@ enum NodeType {
 
 // EventType identifies the type of a replica lifecycle event within a WAG node.
 enum EventType {
+  option (gogoproto.goproto_enum_prefix) = false;
+
   // EventUnknown is the zero value. It should not be used.
   EventUnknown = 0;
   // EventCreate corresponds to the creation of an uninitialized replica. All
@@ -78,6 +80,8 @@ enum EventType {
 
 // Event describes a single replica lifecycle event within a WAG node.
 message Event {
+  option (gogoproto.goproto_stringer) = false;
+
   // Addr identifies the range, replica and raft index this event pertains to.
   // The interpretation of the Raft Index depends on the EventType.
   Addr addr = 1 [(gogoproto.nullable) = false];

--- a/pkg/kv/kvserver/kvstorage/wag/wagpb/wag.proto
+++ b/pkg/kv/kvserver/kvstorage/wag/wagpb/wag.proto
@@ -12,6 +12,8 @@ import "kv/kvserver/kvserverpb/raft.proto";
 
 // NodeType defines the type of the WAG node. It corresponds to a replica
 // lifecycle event, and specifies how the node is addressed and interpreted.
+//
+// TODO(arul): there should no longer be used; remove in a subsequent commit.
 enum NodeType {
   // NodeEmpty is the "empty" type. Can be used as a nil/no-op indicator. We
   // just have it so that all "real" types are specified explicitly.
@@ -37,43 +39,96 @@ enum NodeType {
   NodeDestroy = 6;
 }
 
-// Addr describes the full address of a WAG node, consisting of RangeID,
+// EventType identifies the type of a replica lifecycle event within a WAG node.
+enum EventType {
+  // EventUnknown is the zero value. It should not be used.
+  EventUnknown = 0;
+  // EventCreate corresponds to the creation of an uninitialized replica. All
+  // replicas on a Store go through this transition. The Addr index must be 0,
+  // as there is no log to speak of.
+  EventCreate = 1;
+  // EventInit corresponds to initializing a replica's state machine at a
+  // specific raft index. This happens when an uninitialized replica receives a
+  // snapshot, or when a split creates the RHS. The Addr index is the index at
+  // which the replica is initialized.
+  EventInit = 2;
+  // EventApply corresponds to applying a replica's raft log up to a specific
+  // committed index. The Addr index identifies the log prefix that has been
+  // applied.
+  EventApply = 3;
+  // EventSplit corresponds to applying a split command on a replica. The Addr
+  // index is the raft log index of the split command. Implies a dependency on
+  // the replica being caught up to index-1 before the split.
+  EventSplit = 4;
+  // EventMerge corresponds to the LHS applying a merge command. The Addr index
+  // is the raft log index of the merge command. Implies a dependency on the LHS
+  // being caught up to index-1 before the merge.
+  EventMerge = 5;
+  // EventSubsume corresponds to a replica being subsumed as part of a merge.
+  // The Addr index is the replica's last applied index before subsumption.
+  // Implies a dependency on the replica being caught up to that index. The
+  // post-subsumption state of the replica is "destroyed".
+  EventSubsume = 6;
+  // EventDestroy corresponds to a destruction of a replica. The Addr index is
+  // the replica's last applied index before destruction, and it implies a
+  // dependency on the replica being caught up to that index. The
+  // post-destruction state of the replica is "destroyed".
+  EventDestroy = 7;
+}
+
+// Event describes a single replica lifecycle event within a WAG node.
+message Event {
+  // Addr identifies the range, replica and raft index this event pertains to.
+  // The interpretation of the Raft Index depends on the EventType.
+  Addr addr = 1 [(gogoproto.nullable) = false];
+  // Type identifies the kind of lifecycle event.
+  EventType type = 2;
+}
+
+// Addr describes the full address of a WAG event, consisting of RangeID,
 // ReplicaID, and index into the raft log.
 //
-// It establishes "happens before" relationships between WAG nodes of a RangeID.
-// For example, when applying a node with Addr.ReplicaID, we know that all nodes
-// with lower ReplicaIDs (including their destruction), or same ReplicaID and
-// lower Index have been applied.
+// It establishes "happens before" relationships between WAG events of a
+// RangeID. For example, when applying an event with Addr.ReplicaID, we know
+// that all events with lower ReplicaIDs (including their destruction), or same
+// ReplicaID and lower Index have been applied.
 message Addr {
   option (gogoproto.goproto_stringer) = false;
 
-  // RangeID is the ID of the range that the WAG node pertains to.
+  // RangeID is the ID of the range that the event pertains to.
   int64 range_id = 1 [
     (gogoproto.customname) = "RangeID",
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.RangeID"];
-  // ReplicaID is the ID of the RangeID replica that the WAG node pertains to.
+  // ReplicaID is the ID of the RangeID replica that the event pertains to.
   int32 replica_id = 2 [
     (gogoproto.customname) = "ReplicaID",
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.ReplicaID"];
-  // Index identifies the raft log entry associated with this WAG node.
-  //  - For NodeCreate, it is 0 and signifies an uninitialized replica.
-  //  - For NodeSnap, it is the index of the snapshot, and the index at which
-  //  the raft log is initialized.
-  //  - For NodeApply, it is the log index identifying a prefix of the raft log.
-  //  - For NodeSplit and NodeMerge, it identifies the raft log command
-  //  containing the corresponding split/merge trigger.
-  //  - For NodeDestroy, it is MaxUint64.
+  // Index identifies the raft log entry associated with this event. Its
+  // interpretation depends on the EventType:
+  //  - EventCreate: 0, signifying an uninitialized replica.
+  //  - EventInit: the index at which the replica is initialized.
+  //  - EventApply: the log index identifying a prefix of the raft log.
+  //  - EventSplit, EventMerge: the raft log index of the split/merge command.
+  //  - EventSubsume, EventDestroy: the replica's last applied index before
+  //    removal.
   uint64 index = 4 [
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/kv/kvpb.RaftIndex"];
 }
 
-// Node describes a node of the WAG.
+// Node describes a node of the WAG. A node represents an atomic state machine
+// mutation along with one or more replica lifecycle events it encompasses. For
+// example, a split node contains an Init event for the newly created RHS and
+// a Split event that both initializes the RHS and narrows the LHS.
 message Node {
   // Addr is the full address of the node, consisting of RangeID, ReplicaID, and
   // index into the raft log.
+  //
+  // Deprecated: use events instead.
   Addr addr = 1 [(gogoproto.nullable) = false];
   // Type identifies the type of the replica lifecycle event that this node
   // represents, such as replica creation, destruction, split or merge.
+  //
+  // TODO(arul): get rid of this field.
   NodeType type = 2;
   // Mutation contains the mutation that will be applied to the state machine
   // engine when applying this WAG node.
@@ -82,14 +137,27 @@ message Node {
   // Create is the RangeID that this node brings into existence in the state
   // machine, or 0 if the node does not create new ranges. It is non-zero for
   // NodeCreate and NodeSplit.
+  //
+  // TODO(arul): get rid of this field.
   int64 create = 4 [
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.RangeID"];
   // Destroy contains the RangeIDs that this node removes from the state
   // machine, because they are known to have been merged.
   // - For NodeMerge, it contains the ID of the RHS range being merged.
   // - For NodeSnap, it contains the list of subsumed ranges.
+  //
+  // TODO(arul): get rid of this field
   repeated int64 destroy = 5 [
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.RangeID"];
+
+  // Events contains the replica lifecycle events that this node encompasses.
+  // Each event affects a single replica, identified by its Addr. A given
+  // RangeID must appear at most once in this list.
+  //
+  // Each EventType implicitly carries dependency semantics. For example, a
+  // Split event at raft index I implies the replica must be caught up to I-1
+  // before the split can be replayed.
+  repeated Event events = 6 [(gogoproto.nullable) = false];
 }
 
 // Mutation contains a mutation that can be applied to the state machine engine.

--- a/pkg/kv/kvserver/kvstorage/wag/wagpb/wag.proto
+++ b/pkg/kv/kvserver/kvstorage/wag/wagpb/wag.proto
@@ -10,35 +10,6 @@ option go_package = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/
 import "gogoproto/gogo.proto";
 import "kv/kvserver/kvserverpb/raft.proto";
 
-// NodeType defines the type of the WAG node. It corresponds to a replica
-// lifecycle event, and specifies how the node is addressed and interpreted.
-//
-// TODO(arul): there should no longer be used; remove in a subsequent commit.
-enum NodeType {
-  // NodeEmpty is the "empty" type. Can be used as a nil/no-op indicator. We
-  // just have it so that all "real" types are specified explicitly.
-  NodeEmpty = 0;
-  // NodeCreate corresponds to a creation of an uninitialized replica. All
-  // replicas on a Store go through this transition.
-  NodeCreate = 1;
-  // NodeSnap corresponds to initializing/resetting a replica state machine with
-  // a snapshot. Happens when an uninitialized replica is initialized, or when
-  // an initialized replica is caught up on a later applied state. A NodeSnap
-  // also subsumes replicas (if any) that overlap with this replica in keyspace.
-  NodeSnap = 2;
-  // NodeApply corresponds to applying a replica's raft log up to a specific
-  // committed index.
-  NodeApply = 3;
-  // NodeSplit corresponds to applying a split command on a replica, and
-  // creating the replica of the post-split RHS range.
-  NodeSplit = 4;
-  // NodeMerge corresponds to applying a merge command on this replica and its
-  // immediate RHS neighbour in the keyspace.
-  NodeMerge = 5;
-  // NodeDestroy correspond to destroying the replica and its state machine.
-  NodeDestroy = 6;
-}
-
 // EventType identifies the type of a replica lifecycle event within a WAG node.
 enum EventType {
   option (gogoproto.goproto_enum_prefix) = false;
@@ -124,36 +95,6 @@ message Addr {
 // example, a split node contains an Init event for the newly created RHS and
 // a Split event that both initializes the RHS and narrows the LHS.
 message Node {
-  // Addr is the full address of the node, consisting of RangeID, ReplicaID, and
-  // index into the raft log.
-  //
-  // Deprecated: use events instead.
-  Addr addr = 1 [(gogoproto.nullable) = false];
-  // Type identifies the type of the replica lifecycle event that this node
-  // represents, such as replica creation, destruction, split or merge.
-  //
-  // TODO(arul): get rid of this field.
-  NodeType type = 2;
-  // Mutation contains the mutation that will be applied to the state machine
-  // engine when applying this WAG node.
-  Mutation mutation = 3 [(gogoproto.nullable) = false];
-
-  // Create is the RangeID that this node brings into existence in the state
-  // machine, or 0 if the node does not create new ranges. It is non-zero for
-  // NodeCreate and NodeSplit.
-  //
-  // TODO(arul): get rid of this field.
-  int64 create = 4 [
-    (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.RangeID"];
-  // Destroy contains the RangeIDs that this node removes from the state
-  // machine, because they are known to have been merged.
-  // - For NodeMerge, it contains the ID of the RHS range being merged.
-  // - For NodeSnap, it contains the list of subsumed ranges.
-  //
-  // TODO(arul): get rid of this field
-  repeated int64 destroy = 5 [
-    (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.RangeID"];
-
   // Events contains the replica lifecycle events that this node encompasses.
   // Each event affects a single replica, identified by its Addr. A given
   // RangeID must appear at most once in this list.
@@ -161,7 +102,11 @@ message Node {
   // Each EventType implicitly carries dependency semantics. For example, a
   // Split event at raft index I implies the replica must be caught up to I-1
   // before the split can be replayed.
-  repeated Event events = 6 [(gogoproto.nullable) = false];
+  repeated Event events = 1 [(gogoproto.nullable) = false];
+
+  // Mutation contains the mutation that will be applied to the state machine
+  // engine when applying this WAG node.
+  Mutation mutation = 2 [(gogoproto.nullable) = false];
 }
 
 // Mutation contains a mutation that can be applied to the state machine engine.

--- a/pkg/kv/kvserver/kvstorage/wag/writer.go
+++ b/pkg/kv/kvserver/kvstorage/wag/writer.go
@@ -6,15 +6,14 @@
 package wag
 
 import (
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag/wagpb"
-	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 )
 
-// Writer prepares WAG nodes encoding a single state machine mutation. Replica
-// lifecycle events (splits, merges, destroys, etc.) use it to add dependencies
-// as they run, stage their event, and flush WAG nodes to the RaftBatch before
-// committing it towards the end of application.
+// Writer prepares a WAG node encoding a single state machine mutation and the
+// replica lifecycle events it encompasses. Callers add events via AddEvent as
+// they run, then call Flush to write the node to the raft engine when the time
+// comes.
 //
 // The zero value is a valid, disabled Writer. Use MakeWriter to create an
 // enabled Writer.
@@ -22,22 +21,10 @@ type Writer struct {
 	// seq allocates WAG sequence numbers using a store-level singleton. A nil
 	// seq indicates that the Writer is disabled.
 	seq *Seq
-	// deps tracks all dependency nodes. These carry a "happens before"
-	// relationship to the event node, but don't carry a mutation themselves.
-	// They are added via AddDep.
-	//
-	// For instance, a split at Raft index I needs a NodeApply at I-1 to
-	// indicate that the state machine must be caught up to that point before
-	// the split can be replayed.
-	deps []wagpb.Node
-	// event is the primary lifecycle event node. Its Mutation.Batch gets
-	// filled in at Flush time, once the State engine's batch has been fully
-	// prepared.
-	//
-	// There's exactly one of these per Writer, and can be set at any point
-	// before Flush is called. A zero-value (Type == NodeEmpty) means
-	// nothing's been staged yet, and is used to uphold this invariant.
-	event wagpb.Node
+	// events accumulates the lifecycle events for this node. Each event
+	// identifies a replica and the type of lifecycle transition it undergoes.
+	// A given RangeID must appear at most once.
+	events []wagpb.Event
 }
 
 // MakeWriter creates a new, enabled Writer.
@@ -51,69 +38,30 @@ func (w *Writer) disabled() bool {
 	return w.seq == nil
 }
 
-// Empty returns true if no WAG nodes have been staged on this Writer.
+// Empty returns true if no events have been staged on this Writer.
 func (w *Writer) Empty() bool {
-	return w.disabled() || w.event.Type == wagpb.NodeType_NodeEmpty
+	return w.disabled() || len(w.events) == 0
 }
 
-// AddDep stages a dependency node that must be satisfied before the event
-// can be replayed. These are written before the event node and don't carry
-// a mutation themselves.
-//
-// TODO(arul): as the code evolves, see if we add any dependencies other than
-// application up until a specific index. If we don't, this method can be
-// specialized to accept a wagpb.Addr instead.
-func (w *Writer) AddDep(node wagpb.Node) {
+// AddEvent stages a lifecycle event. Each event identifies a replica and the
+// type of lifecycle transition (create, split, destroy, etc.). A given RangeID
+// must appear at most once across all events in a Writer.
+func (w *Writer) AddEvent(addr wagpb.Addr, eventType wagpb.EventType) {
 	if w.disabled() {
 		return
 	}
-	w.deps = append(w.deps, node)
+	w.events = append(w.events, wagpb.Event{Addr: addr, Type: eventType})
 }
 
-// SetEvent stages the primary lifecycle event node. May not be called more
-// than once per Writer.
-func (w *Writer) SetEvent(node wagpb.Node) {
-	if w.disabled() {
-		return
-	}
-	if w.event.Type != wagpb.NodeType_NodeEmpty {
-		panic(errors.AssertionFailedf(
-			"WagWriter.SetEvent called twice: existing %s, new %s",
-			w.event.Addr, node.Addr,
-		))
-	}
-	w.event = node
-}
-
-// Flush writes all staged WAG nodes to the raft engine. The event node's
-// Mutation.Batch is populated with stateBatchRepr, which should be the
-// Repr() of the fully prepared State engine batch. No-ops if no event was
-// staged.
-func (w *Writer) Flush(raftBatch kvstorage.RaftWO, stateBatchRepr []byte) error {
-	if w.disabled() {
+// Flush writes the staged WAG node to the raft engine. The node's
+// Mutation.Batch is populated with stateBatchRepr, which should be the Repr()
+// of the fully prepared state engine batch. No-ops if no events were staged.
+func (w *Writer) Flush(raftBatch storage.Writer, stateBatchRepr []byte) error {
+	if w.disabled() || len(w.events) == 0 {
 		return nil
 	}
-	if w.event.Type == wagpb.NodeType_NodeEmpty {
-		if len(w.deps) != 0 {
-			return errors.AssertionFailedf(
-				"WAG dependency nodes staged without an event node",
-			)
-		}
-		return nil
-	}
-	seq := w.seq.Next(uint64(len(w.deps)) + 1)
-
-	for _, dep := range w.deps {
-		if err := Write(raftBatch, seq, dep); err != nil {
-			return errors.Wrap(err, "writing WAG dependency node")
-		}
-		seq++
-	}
-
-	w.event.Mutation.Batch = stateBatchRepr
-	if err := Write(raftBatch, seq, w.event); err != nil {
-		return errors.Wrap(err, "writing WAG event node")
-	}
-
-	return nil
+	return Write(raftBatch, w.seq.Next(1), wagpb.Node{
+		Events:   w.events,
+		Mutation: wagpb.Mutation{Batch: stateBatchRepr},
+	})
 }

--- a/pkg/kv/kvserver/print/debug_print.go
+++ b/pkg/kv/kvserver/print/debug_print.go
@@ -479,13 +479,24 @@ func tryWAGKey(kv storage.MVCCKeyValue) (string, error) {
 		return "", err
 	}
 
-	str := fmt.Appendf(nil, "%v %s", node.Type, node.Addr)
-	if c, d := node.Create, node.Destroy; c != 0 || len(d) != 0 {
-		if c != 0 {
-			str = fmt.Appendf(str, " create:%d", c)
+	var str []byte
+	if len(node.Events) > 0 {
+		for i, e := range node.Events {
+			if i > 0 {
+				str = append(str, ' ')
+			}
+			str = fmt.Appendf(str, "%s", e)
 		}
-		if len(d) != 0 {
-			str = fmt.Appendf(str, " destroy:%v", d)
+	} else {
+		// TODO(arul): this can go away shortly.
+		str = fmt.Appendf(nil, "%v %s", node.Type, node.Addr)
+		if c, d := node.Create, node.Destroy; c != 0 || len(d) != 0 {
+			if c != 0 {
+				str = fmt.Appendf(str, " create:%d", c)
+			}
+			if len(d) != 0 {
+				str = fmt.Appendf(str, " destroy:%v", d)
+			}
 		}
 	}
 

--- a/pkg/kv/kvserver/print/debug_print.go
+++ b/pkg/kv/kvserver/print/debug_print.go
@@ -480,24 +480,11 @@ func tryWAGKey(kv storage.MVCCKeyValue) (string, error) {
 	}
 
 	var str []byte
-	if len(node.Events) > 0 {
-		for i, e := range node.Events {
-			if i > 0 {
-				str = append(str, ' ')
-			}
-			str = fmt.Appendf(str, "%s", e)
+	for i, e := range node.Events {
+		if i > 0 {
+			str = append(str, ' ')
 		}
-	} else {
-		// TODO(arul): this can go away shortly.
-		str = fmt.Appendf(nil, "%v %s", node.Type, node.Addr)
-		if c, d := node.Create, node.Destroy; c != 0 || len(d) != 0 {
-			if c != 0 {
-				str = fmt.Appendf(str, " create:%d", c)
-			}
-			if len(d) != 0 {
-				str = fmt.Appendf(str, " destroy:%v", d)
-			}
-		}
+		str = fmt.Appendf(str, "%s", e)
 	}
 
 	if b := node.Mutation.Batch; len(b) > 0 {

--- a/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
+++ b/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
@@ -783,7 +783,7 @@ func assertWAGMutationBatch(t *testing.T, raftRepr, stateRepr []byte) bool {
 			"expected exactly one WAG node with a mutation batch, found multiple")
 		found = true
 		require.Equal(t, stateRepr, node.Mutation.Batch,
-			"WAG mutation batch for %s should match state engine batch", node.Addr)
+			"WAG mutation batch should match state engine batch")
 	}
 	return found
 }

--- a/pkg/kv/kvserver/store_split.go
+++ b/pkg/kv/kvserver/store_split.go
@@ -179,24 +179,14 @@ func splitPreApply(
 		log.KvExec.Fatalf(ctx, "cannot clear RaftTruncatedState: %v", err)
 	}
 
-	// Stage WAG nodes for the split. The LHS state machine must be caught up to
-	// the entry before the split before it can be replayed.
-	//
-	// NB: raftIndex > 1 is verified by validateAndPrepareSplit, so the
-	// subtraction below is safe.
+	// Stage WAG events for the split. The Split event on the LHS implicitly
+	// carries a dependency on the LHS being caught up to raftIndex-1.
 	//
 	// NB: we don't record an explicit dependency on the RHS's
 	// CreateUninitializedReplica WAG node here. That node is written by
 	// getOrCreateReplica (called upstream via maybeAcquireSplitMergeLock) and
 	// will always precede this split node in the WAG sequence.
-	wagWriter.AddDep(wagpb.Node{
-		Addr: wagpb.MakeAddr(in.lhsID, in.raftIndex-1),
-		Type: wagpb.NodeType_NodeApply,
-	})
-	wagWriter.SetEvent(wagpb.Node{
-		Addr: wagpb.MakeAddr(in.lhsID, in.raftIndex),
-		Type: wagpb.NodeType_NodeSplit,
-	})
+	wagWriter.AddEvent(wagpb.MakeAddr(in.lhsID, in.raftIndex), wagpb.EventSplit)
 
 	if in.rhsDestroyed {
 		// The RHS replica has already been removed from the store. To apply the

--- a/pkg/kv/kvserver/testdata/replica_lifecycle/split_pre_apply.txt
+++ b/pkg/kv/kvserver/testdata/replica_lifecycle/split_pre_apply.txt
@@ -58,8 +58,7 @@ apply-split range-id=1
 state engine:
 (matches WAG node)
 log engine:
-Put: 0,0 /Local/Store/wag/1 (0x01737761676e000000000000000100): NodeApply r1/1:10
-Put: 0,0 /Local/Store/wag/2 (0x01737761676e000000000000000200): NodeSplit r1/1:11
+Put: 0,0 /Local/Store/wag/1 (0x01737761676e000000000000000100): (r1/1:11,EventSplit)
 > Put: 0,0 /Local/RangeID/2/u/RangeLastReplicaGCTimestamp (0x01698a75726c727400): 0,0
 > Put: 0,0 /Local/Range"m"/QueueLastProcessed/"consistencyChecker" (0x016b126d0001716c7074636f6e73697374656e6379436865636b657200): meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0
 > Put: 0,0 /Local/RangeID/2/r/RangeLease (0x01698a72726c6c2d00): repl=(n1,s1):1 seq=0 start=0,0 type=LeaseExpiration exp=0.000000109,0 pro=0,0 acq=Unspecified
@@ -112,8 +111,7 @@ apply-split range-id=1
 state engine:
 (matches WAG node)
 log engine:
-Put: 0,0 /Local/Store/wag/3 (0x01737761676e000000000000000300): NodeApply r1/1:11
-Put: 0,0 /Local/Store/wag/4 (0x01737761676e000000000000000400): NodeSplit r1/1:12
+Put: 0,0 /Local/Store/wag/2 (0x01737761676e000000000000000200): (r1/1:12,EventSplit)
 > Put: 0,0 /Local/RangeID/3/u/RangeLastReplicaGCTimestamp (0x01698b75726c727400): 0,0
 > Put: 0,0 /Local/Range"f"/QueueLastProcessed/"consistencyChecker" (0x016b12660001716c7074636f6e73697374656e6379436865636b657200): meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0
 > Put: 0,0 /Local/RangeID/3/r/RangeLease (0x01698b72726c6c2d00): repl=(n1,s1):1 seq=0 start=0,0 type=LeaseExpiration exp=0.000000109,1 pro=0,0 acq=Unspecified
@@ -157,8 +155,7 @@ state engine:
 log engine:
 Put: 0,0 /Local/RangeID/4/u/RaftHardState (0x01698c757266746800): term:5 vote:0 commit:10 lead:0 lead_epoch:0 
 Put: 0,0 /Local/RangeID/4/u/RaftTruncatedState (0x01698c757266747400): index:10 term:5 
-Put: 0,0 /Local/Store/wag/5 (0x01737761676e000000000000000500): NodeApply r1/1:12
-Put: 0,0 /Local/Store/wag/6 (0x01737761676e000000000000000600): NodeSplit r1/1:13
+Put: 0,0 /Local/Store/wag/3 (0x01737761676e000000000000000300): (r1/1:13,EventSplit)
 > Put: 0,0 /Local/RangeID/4/u/RangeLastReplicaGCTimestamp (0x01698c75726c727400): 0,0
 > Put: 0,0 /Local/Range"c"/QueueLastProcessed/"consistencyChecker" (0x016b12630001716c7074636f6e73697374656e6379436865636b657200): meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0
 > Put: 0,0 /Local/RangeID/4/r/RangeLease (0x01698c72726c6c2d00): repl=(n1,s1):1 seq=0 start=0,0 type=LeaseExpiration exp=0.000000109,2 pro=0,0 acq=Unspecified

--- a/pkg/kv/kvserver/testdata/replica_lifecycle/split_trigger.txt
+++ b/pkg/kv/kvserver/testdata/replica_lifecycle/split_trigger.txt
@@ -51,8 +51,7 @@ state engine:
 log engine:
 Put: 0,0 /Local/RangeID/2/u/RaftHardState (0x01698a757266746800): term:5 vote:0 commit:10 lead:0 lead_epoch:0 
 Put: 0,0 /Local/RangeID/2/u/RaftTruncatedState (0x01698a757266747400): index:10 term:5 
-Put: 0,0 /Local/Store/wag/1 (0x01737761676e000000000000000100): NodeApply r1/1:10
-Put: 0,0 /Local/Store/wag/2 (0x01737761676e000000000000000200): NodeSplit r1/1:11
+Put: 0,0 /Local/Store/wag/1 (0x01737761676e000000000000000100): (r1/1:11,EventSplit)
 > Put: 0,0 /Local/RangeID/2/u/RangeLastReplicaGCTimestamp (0x01698a75726c727400): 0,0
 > Put: 0,0 /Local/Range"m"/QueueLastProcessed/"consistencyChecker" (0x016b126d0001716c7074636f6e73697374656e6379436865636b657200): meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0
 > Put: 0,0 /Local/RangeID/2/r/RangeLease (0x01698a72726c6c2d00): repl=(n2,s2):2 seq=0 start=0,0 type=LeaseExpiration exp=0.000000109,0 pro=0,0 acq=Unspecified
@@ -103,8 +102,7 @@ state engine:
 log engine:
 Put: 0,0 /Local/RangeID/3/u/RaftHardState (0x01698b757266746800): term:5 vote:0 commit:10 lead:0 lead_epoch:0 
 Put: 0,0 /Local/RangeID/3/u/RaftTruncatedState (0x01698b757266747400): index:10 term:5 
-Put: 0,0 /Local/Store/wag/3 (0x01737761676e000000000000000300): NodeApply r1/1:11
-Put: 0,0 /Local/Store/wag/4 (0x01737761676e000000000000000400): NodeSplit r1/1:12
+Put: 0,0 /Local/Store/wag/2 (0x01737761676e000000000000000200): (r1/1:12,EventSplit)
 > Put: 0,0 /Local/RangeID/3/u/RangeLastReplicaGCTimestamp (0x01698b75726c727400): 0,0
 > Put: 0,0 /Local/Range"f"/QueueLastProcessed/"consistencyChecker" (0x016b12660001716c7074636f6e73697374656e6379436865636b657200): meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0
 > Put: 0,0 /Local/RangeID/3/r/RangeLease (0x01698b72726c6c2d00): repl=(n1,s1):1 seq=0 start=0,0 type=LeaseEpoch epo=20 min-exp=0,0 pro=0,0 acq=Unspecified
@@ -141,8 +139,7 @@ state engine:
 log engine:
 Put: 0,0 /Local/RangeID/4/u/RaftHardState (0x01698c757266746800): term:5 vote:0 commit:10 lead:0 lead_epoch:0 
 Put: 0,0 /Local/RangeID/4/u/RaftTruncatedState (0x01698c757266747400): index:10 term:5 
-Put: 0,0 /Local/Store/wag/5 (0x01737761676e000000000000000500): NodeApply r2/1:10
-Put: 0,0 /Local/Store/wag/6 (0x01737761676e000000000000000600): NodeSplit r2/1:11
+Put: 0,0 /Local/Store/wag/3 (0x01737761676e000000000000000300): (r2/1:11,EventSplit)
 > Put: 0,0 /Local/RangeID/4/u/RangeLastReplicaGCTimestamp (0x01698c75726c727400): 0,0
 > Put: 0,0 /Local/Range"v"/QueueLastProcessed/"consistencyChecker" (0x016b12760001716c7074636f6e73697374656e6379436865636b657200): meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0
 > Put: 0,0 /Local/RangeID/4/r/RangeLease (0x01698c72726c6c2d00): repl=(n3,s3):3 seq=0 start=0,0 type=LeaseExpiration exp=0.000000300,0 pro=0,0 acq=Unspecified

--- a/pkg/testutils/lint/passes/redactcheck/redactcheck.go
+++ b/pkg/testutils/lint/passes/redactcheck/redactcheck.go
@@ -129,6 +129,9 @@ func runAnalyzer(pass *analysis.Pass) (interface{}, error) {
 					"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb": {
 						"SnapshotRequest_Type": {},
 					},
+					"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag/wagpb": {
+						"EventType": {},
+					},
 					"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb": {
 						"MembershipStatus": {},
 					},


### PR DESCRIPTION
Based on discussions with @pav-kv, we've realized that the WAG Node datamodel can be simplified. This PR has a series of commits that do exactly that.

---

**Commit-by-commit summary:**

1. **wagpb: introduce EventType enum and Event message** — adds the new EventType enum, Event message, and a repeated events field on Node.
2. **wag: teach pretty printer about the new Event-based WAG node format** — updates the pretty printer and tests to render/exercise the new format.
3. **wag: replace AddDep/SetEvent with unified AddEvent API** — collapses the Writer API from AddDep/SetEvent into a single AddEvent, writing one WAG node instead of N+1.
4. **wagpb: remove legacy NodeType enum and Node fields** — burns down the old fields now that everything uses Events.

Release note: None
Epic: none