### PR TITLE
spanconfig: cleanup unused spans introduced in e5a3e0029cf

### DIFF
--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -11258,7 +11258,7 @@ func TestStrictLocalityAwareBackup(t *testing.T) {
 	// Wait for span config to be applied correctly.
 	checkSpanConfig := func() error {
 		kvSubscriber := srv.SpanConfigKVSubscriber().(spanconfig.KVSubscriber)
-		conf, _, err := kvSubscriber.GetSpanConfigForKey(ctx, roachpb.RKey(tableDesc.PrimaryIndexSpan(codec).Key))
+		conf, err := kvSubscriber.GetSpanConfigForKey(ctx, roachpb.RKey(tableDesc.PrimaryIndexSpan(codec).Key))
 		if err != nil {
 			return err
 		}
@@ -11451,7 +11451,7 @@ func TestStrictPartitionedBackup(t *testing.T) {
 		kvSubscriber := srv.SpanConfigKVSubscriber().(spanconfig.KVSubscriber)
 
 		for _, part := range partitions {
-			conf, _, err := kvSubscriber.GetSpanConfigForKey(ctx, roachpb.RKey(part.startKey))
+			conf, err := kvSubscriber.GetSpanConfigForKey(ctx, roachpb.RKey(part.startKey))
 			if err != nil {
 				return errors.Wrapf(err, "partition %s", part.name)
 			}

--- a/pkg/config/system.go
+++ b/pkg/config/system.go
@@ -328,15 +328,15 @@ func (s *SystemConfig) getZoneConfigForKey(
 	return id, s.DefaultZoneConfig, nil
 }
 
-// GetSpanConfigForKey looks of the span config for the given key and the bounds
-// that span the configuration applies to. It's part of spanconfig.StoreReader
-// interface. Note that it is only usable for the system tenant config.
+// GetSpanConfigForKey looks up the span config for the given key. It's part of
+// the spanconfig.StoreReader interface. Note that it is only usable for the
+// system tenant config.
 func (s *SystemConfig) GetSpanConfigForKey(
 	ctx context.Context, key roachpb.RKey,
-) (roachpb.SpanConfig, roachpb.Span, error) {
+) (roachpb.SpanConfig, error) {
 	id, zone, err := s.getZoneConfigForKey(keys.SystemSQLCodec, key)
 	if err != nil {
-		return roachpb.SpanConfig{}, roachpb.Span{}, err
+		return roachpb.SpanConfig{}, err
 	}
 	spanConfig := zone.AsSpanConfig()
 	if id <= keys.MaxReservedDescID {
@@ -349,8 +349,7 @@ func (s *SystemConfig) GetSpanConfigForKey(
 		// applicable to user tables.
 		spanConfig.GCPolicy.IgnoreStrictEnforcement = true
 	}
-	prefix := keys.SystemSQLCodec.TablePrefix(uint32(id))
-	return spanConfig, roachpb.Span{Key: prefix, EndKey: prefix.PrefixEnd()}, nil
+	return spanConfig, nil
 }
 
 // DecodeKeyIntoZoneIDAndSuffix figures out the zone that the key belongs to.

--- a/pkg/config/system_test.go
+++ b/pkg/config/system_test.go
@@ -612,7 +612,7 @@ func TestGetZoneConfigForKey(t *testing.T) {
 			objectID = id
 			return cfg.DefaultZoneConfig, nil, false, nil
 		}
-		_, _, err := cfg.GetSpanConfigForKey(ctx, tc.key)
+		_, err := cfg.GetSpanConfigForKey(ctx, tc.key)
 		if err != nil {
 			t.Errorf("#%d: GetSpanConfigForKey(%v) got error: %v", tcNum, tc.key, err)
 		}

--- a/pkg/kv/kvnemesis/kvnemesis_test.go
+++ b/pkg/kv/kvnemesis/kvnemesis_test.go
@@ -933,7 +933,7 @@ func setAndVerifyZoneConfigs(
 					desc := replica.Desc()
 					confReader, err := store.GetConfReader(ctx)
 					require.NoError(t, err)
-					spanConfig, _, err := confReader.GetSpanConfigForKey(ctx, desc.StartKey)
+					spanConfig, err := confReader.GetSpanConfigForKey(ctx, desc.StartKey)
 					require.NoError(t, err)
 					if len(spanConfig.Constraints) == 0 {
 						return errors.Errorf("range %d has no constraints in span config yet", desc.RangeID)

--- a/pkg/kv/kvserver/asim/state/impl.go
+++ b/pkg/kv/kvserver/asim/state/impl.go
@@ -1391,15 +1391,12 @@ func (s *state) ForEachOverlappingSpanConfig(
 // SpanConfigConformanceReport.
 func (s *state) GetSpanConfigForKey(
 	ctx context.Context, key roachpb.RKey,
-) (roachpb.SpanConfig, roachpb.Span, error) {
+) (roachpb.SpanConfig, error) {
 	rng := s.rangeFor(ToKey(key.AsRawKey()))
 	if rng == nil {
 		panic(fmt.Sprintf("programming error: range for key %s doesn't exist", key))
 	}
-	return *rng.config, roachpb.Span{
-		Key:    rng.startKey.ToRKey().AsRawKey(),
-		EndKey: rng.endKey.ToRKey().AsRawKey(),
-	}, nil
+	return *rng.config, nil
 }
 
 // Scan is added for the rangedesc.Scanner interface, required for

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -4450,14 +4450,6 @@ func TestMergeQueue(t *testing.T) {
 	lhsStartKey := roachpb.RKey(tc.ScratchRange(t))
 	rhsStartKey := lhsStartKey.Next().Next()
 	rhsEndKey := rhsStartKey.Next().Next()
-	lhsSp := roachpb.Span{
-		Key:    lhsStartKey.AsRawKey(),
-		EndKey: rhsStartKey.AsRawKey(),
-	}
-	rhsSp := roachpb.Span{
-		Key:    rhsStartKey.AsRawKey(),
-		EndKey: rhsEndKey.AsRawKey(),
-	}
 
 	for _, k := range []roachpb.RKey{lhsStartKey, rhsStartKey, rhsEndKey} {
 		split(t, k.AsRawKey(), hlc.Timestamp{} /* expirationTime */)
@@ -4472,12 +4464,12 @@ func TestMergeQueue(t *testing.T) {
 		if l := lhs(); l == nil {
 			t.Fatal("left-hand side range not found")
 		} else {
-			l.SetSpanConfig(conf, lhsSp)
+			l.SetSpanConfig(conf)
 		}
 		if r := rhs(); r == nil {
 			t.Fatal("right-hand side range not found")
 		} else {
-			r.SetSpanConfig(conf, rhsSp)
+			r.SetSpanConfig(conf)
 		}
 	}
 
@@ -4520,7 +4512,7 @@ func TestMergeQueue(t *testing.T) {
 		reset(t)
 		conf := conf
 		conf.RangeMinBytes *= 2
-		lhs().SetSpanConfig(conf, lhsSp)
+		lhs().SetSpanConfig(conf)
 		verifyMergedSoon(t, store, lhsStartKey, rhsStartKey)
 	})
 

--- a/pkg/kv/kvserver/client_spanconfigs_test.go
+++ b/pkg/kv/kvserver/client_spanconfigs_test.go
@@ -175,7 +175,7 @@ func (m *mockSpanConfigSubscriber) ComputeSplitKey(
 
 func (m *mockSpanConfigSubscriber) GetSpanConfigForKey(
 	ctx context.Context, key roachpb.RKey,
-) (roachpb.SpanConfig, roachpb.Span, error) {
+) (roachpb.SpanConfig, error) {
 	return m.Store.GetSpanConfigForKey(ctx, key)
 }
 

--- a/pkg/kv/kvserver/lease_queue.go
+++ b/pkg/kv/kvserver/lease_queue.go
@@ -104,7 +104,7 @@ func newLeaseQueue(store *Store, allocator allocatorimpl.Allocator) *leaseQueue 
 func (lq *leaseQueue) shouldQueue(
 	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, confReader spanconfig.StoreReader,
 ) (shouldQueue bool, priority float64) {
-	conf, _, err := confReader.GetSpanConfigForKey(ctx, repl.startKey)
+	conf, err := confReader.GetSpanConfigForKey(ctx, repl.startKey)
 	if err != nil {
 		return false, 0
 	}
@@ -131,7 +131,7 @@ func (lq *leaseQueue) process(
 	}
 	defer repl.allocatorToken.Release(ctx)
 
-	conf, _, err := confReader.GetSpanConfigForKey(ctx, repl.startKey)
+	conf, err := confReader.GetSpanConfigForKey(ctx, repl.startKey)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/kv/kvserver/merge_queue_test.go
+++ b/pkg/kv/kvserver/merge_queue_test.go
@@ -151,7 +151,7 @@ func TestMergeQueueShouldQueue(t *testing.T) {
 			repl.shMu.state.Stats = &enginepb.MVCCStats{KeyBytes: tc.bytes}
 			zoneConfig := zonepb.DefaultZoneConfigRef()
 			zoneConfig.RangeMinBytes = proto.Int64(tc.minBytes)
-			repl.SetSpanConfig(zoneConfig.AsSpanConfig(), roachpb.Span{Key: tc.startKey, EndKey: tc.endKey})
+			repl.SetSpanConfig(zoneConfig.AsSpanConfig())
 			shouldQ, priority := mq.shouldQueue(ctx, hlc.ClockTimestamp{}, repl, config.NewSystemConfig(zoneConfig))
 			if tc.expShouldQ != shouldQ {
 				t.Errorf("incorrect shouldQ: expected %v but got %v", tc.expShouldQ, shouldQ)

--- a/pkg/kv/kvserver/mvcc_gc_queue_test.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue_test.go
@@ -1516,11 +1516,7 @@ func TestMVCCGCQueueGroupsRangeDeletions(t *testing.T) {
 	require.NoError(t, store.AddReplica(r2))
 	r2.RaftStatus()
 	r2.handleGCHintResult(ctx, &roachpb.GCHint{LatestRangeDeleteTimestamp: hlc.Timestamp{WallTime: 1}})
-	r2.SetSpanConfig(roachpb.SpanConfig{GCPolicy: roachpb.GCPolicy{TTLSeconds: 100}},
-		roachpb.Span{
-			Key:    key("b").AsRawKey(),
-			EndKey: key("c").AsRawKey(),
-		})
+	r2.SetSpanConfig(roachpb.SpanConfig{GCPolicy: roachpb.GCPolicy{TTLSeconds: 100}})
 
 	gcQueue := newMVCCGCQueue(store)
 

--- a/pkg/kv/kvserver/mvcc_gc_queue_test.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue_test.go
@@ -870,7 +870,7 @@ func testMVCCGCQueueProcessImpl(t *testing.T, snapshotBounds bool) {
 		}
 		defer snap.Close()
 
-		conf, _, err := cfg.GetSpanConfigForKey(ctx, desc.StartKey)
+		conf, err := cfg.GetSpanConfigForKey(ctx, desc.StartKey)
 		if err != nil {
 			t.Fatalf("could not find zone config for range %s: %+v", tc.repl, err)
 		}
@@ -1462,7 +1462,7 @@ func TestMVCCGCQueueChunkRequests(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	conf, _, err := confReader.GetSpanConfigForKey(ctx, roachpb.RKey("key"))
+	conf, err := confReader.GetSpanConfigForKey(ctx, roachpb.RKey("key"))
 	if err != nil {
 		t.Fatalf("could not find span config for range %s", err)
 	}

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -698,16 +698,9 @@ type Replica struct {
 		//
 		// NB: Span configuration is applied asyncronously. After a span
 		// configuration change but before the replica has been split
-		// based on the new span configuration, the span stored here may
+		// based on the new span configuration, the config stored here may
 		// not represent the span configuration for the entire replica.
-		//
-		// Use of this span configuration that may affect correct
-		// responses should be guarded by a check to confSpan below.
 		conf roachpb.SpanConfig
-		// The bounds of the span configuration. This may not match the
-		// replica's bounds in the case where a span configuration was
-		// recently updated.
-		confSpan roachpb.Span
 		// spanConfigExplicitlySet tracks whether a span config was explicitly set
 		// on this replica (as opposed to it having initialized with the default
 		// span config).
@@ -1160,7 +1153,7 @@ func (r *Replica) GetMaxBytes(_ context.Context) int64 {
 // to the span config was "significant". For significant changes, the caller
 // should queue up the span to all the relevant queues since they may not decide
 // to process this replica.
-func (r *Replica) SetSpanConfig(conf roachpb.SpanConfig, sp roachpb.Span) bool {
+func (r *Replica) SetSpanConfig(conf roachpb.SpanConfig) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	oldConf := r.mu.conf
@@ -1190,7 +1183,6 @@ func (r *Replica) SetSpanConfig(conf roachpb.SpanConfig, sp roachpb.Span) bool {
 	}
 	r.mu.conf = conf
 	r.mu.spanConfigExplicitlySet = true
-	r.mu.confSpan = sp
 	r.store.policyRefresher.EnqueueReplicaForRefresh(r)
 	// Inform mma when the span config changes.
 	(*mmaReplica)(r).markSpanConfigNeedsUpdateLocked()
@@ -1509,7 +1501,7 @@ func excludeReplicaFromBackup(
 // replica's cached config does not have ExcludeDataFromBackup, we can
 // skip the iteration entirely. When span config coalescing is enabled,
 // a single range may cover multiple span config entries, so we must
-// check all of them rather than relying on a single cached confSpan.
+// check all of them rather than relying on the replica's cached config.
 func entireSpanExcludedFromBackup(
 	ctx context.Context,
 	sp roachpb.Span,

--- a/pkg/kv/kvserver/replica_closedts_test.go
+++ b/pkg/kv/kvserver/replica_closedts_test.go
@@ -976,7 +976,7 @@ func TestClosedTimestampPolicyRefreshOnSetSpanConfig(t *testing.T) {
 	spanConfig.GlobalReads = true
 	require.NoError(t, err)
 	require.NotNil(t, spanConfig)
-	repl.SetSpanConfig(*spanConfig, roachpb.Span{Key: scratchKey})
+	repl.SetSpanConfig(*spanConfig)
 
 	// Trigger policy refresh.
 	testutils.SucceedsSoon(t, func() error {
@@ -1012,7 +1012,7 @@ func TestClosedTimestampPolicyRefreshIntervalOnLivenessRanges(t *testing.T) {
 	spanConfig.GlobalReads = true
 	require.NoError(t, err)
 	require.NotNil(t, spanConfig)
-	livenessRepl.SetSpanConfig(*spanConfig, roachpb.Span{Key: keys.NodeLivenessPrefix})
+	livenessRepl.SetSpanConfig(*spanConfig)
 
 	require.Never(t, func() bool {
 		expectedState := livenessRepl.GetRangeInfo(ctx).ClosedTimestampPolicy == roachpb.LAG_BY_CLUSTER_SETTING
@@ -1103,7 +1103,7 @@ func TestClosedTimestampPolicyRefreshIntervalOnLeaseTransfers(t *testing.T) {
 	spanConfig.GlobalReads = true
 	require.NoError(t, err)
 	require.NotNil(t, spanConfig)
-	repl2.SetSpanConfig(*spanConfig, roachpb.Span{Key: scratchKey})
+	repl2.SetSpanConfig(*spanConfig)
 	testutils.SucceedsSoon(t, func() error {
 		if repl2.GetRangeInfo(ctx).ClosedTimestampPolicy != roachpb.LEAD_FOR_GLOBAL_READS {
 			return errors.New("expected LEAD_FOR_GLOBAL_READS")
@@ -1147,7 +1147,7 @@ func TestRefreshPolicyWithVariousLatencies(t *testing.T) {
 	store := tc.GetFirstStoreFromServer(t, 1)
 	repl := store.LookupReplica(roachpb.RKey(scratchKey))
 	require.NotNil(t, repl)
-	repl.SetSpanConfig(roachpb.SpanConfig{GlobalReads: true}, roachpb.Span{Key: scratchKey})
+	repl.SetSpanConfig(roachpb.SpanConfig{GlobalReads: true})
 
 	// Verify that the range is properly configured to use global reads.
 	testutils.SucceedsSoon(t, func() error {

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -3774,7 +3774,7 @@ func (roo *replicaRelocateOneOptions) LoadSpanConfig(
 	if err != nil {
 		return nil, errors.Wrap(err, "can't relocate range")
 	}
-	conf, _, err := confReader.GetSpanConfigForKey(ctx, startKey)
+	conf, err := confReader.GetSpanConfigForKey(ctx, startKey)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -405,7 +405,7 @@ func (r *Replica) updateRangeInfo(ctx context.Context, desc *roachpb.RangeDescri
 	}
 
 	// Find span config for this range.
-	conf, _, err := confReader.GetSpanConfigForKey(ctx, desc.StartKey)
+	conf, err := confReader.GetSpanConfigForKey(ctx, desc.StartKey)
 	if err != nil {
 		return errors.Wrapf(err, "%s: failed to lookup span config", r)
 	}

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -405,12 +405,12 @@ func (r *Replica) updateRangeInfo(ctx context.Context, desc *roachpb.RangeDescri
 	}
 
 	// Find span config for this range.
-	conf, sp, err := confReader.GetSpanConfigForKey(ctx, desc.StartKey)
+	conf, _, err := confReader.GetSpanConfigForKey(ctx, desc.StartKey)
 	if err != nil {
 		return errors.Wrapf(err, "%s: failed to lookup span config", r)
 	}
 
-	changed := r.SetSpanConfig(conf, sp)
+	changed := r.SetSpanConfig(conf)
 	if changed {
 		r.MaybeQueue(ctx, r.store.cfg.Clock.NowAsClockTimestamp())
 	}

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -15362,7 +15362,7 @@ func (r *backupExclusionStoreReader) ComputeSplitKey(
 
 func (r *backupExclusionStoreReader) GetSpanConfigForKey(
 	context.Context, roachpb.RKey,
-) (roachpb.SpanConfig, roachpb.Span, error) {
+) (roachpb.SpanConfig, error) {
 	panic("unimplemented")
 }
 

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -687,7 +687,7 @@ func (rq *replicateQueue) shouldQueue(
 ) (shouldQueue bool, priority float64) {
 	// TODO(baptist): Change to Replica.SpanConfig() once the refactor is done to
 	// have that use the confReader.
-	conf, _, err := confReader.GetSpanConfigForKey(ctx, repl.startKey)
+	conf, err := confReader.GetSpanConfigForKey(ctx, repl.startKey)
 	if err != nil {
 		return false, 0
 	}
@@ -720,7 +720,7 @@ func (rq *replicateQueue) process(
 	}
 	// TODO(baptist): Change to Replica.SpanConfig() once the refactor is done to
 	// have that use the confReader.
-	conf, _, err := confReader.GetSpanConfigForKey(ctx, repl.startKey)
+	conf, err := confReader.GetSpanConfigForKey(ctx, repl.startKey)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -2268,11 +2268,11 @@ WHERE range_id IN (SELECT range_id FROM [SHOW RANGES FROM TABLE t] LIMIT 1);`
 			// be contained in the start key's span config. If this is not the
 			// case, it can explain why the replication changes are not being made.
 			iterateOverAllStores(t, tc, func(s *kvserver.Store) error {
-				cfg, sp, err := s.GetStoreConfig().SpanConfigSubscriber.GetSpanConfigForKey(ctx, desc.StartKey)
+				cfg, err := s.GetStoreConfig().SpanConfigSubscriber.GetSpanConfigForKey(ctx, desc.StartKey)
 				if err != nil {
 					return err
 				}
-				t.Logf("s%d: r%d %s -> span config %s %s", s.StoreID(), desc.RangeID, desc.RSpan(), sp, &cfg)
+				t.Logf("s%d: r%d %s -> span config %s", s.StoreID(), desc.RangeID, desc.RSpan(), &cfg)
 				return nil
 			})
 		}

--- a/pkg/kv/kvserver/split_queue_test.go
+++ b/pkg/kv/kvserver/split_queue_test.go
@@ -118,11 +118,7 @@ func TestSplitQueueShouldQueue(t *testing.T) {
 		repl.mu.Unlock()
 		conf := roachpb.TestingDefaultSpanConfig()
 		conf.RangeMaxBytes = test.maxBytes
-		sp := roachpb.Span{
-			Key:    cpy.StartKey.AsRawKey().Clone(),
-			EndKey: cpy.EndKey.AsRawKey().Clone(),
-		}
-		repl.SetSpanConfig(conf, sp)
+		repl.SetSpanConfig(conf)
 
 		// Testing using shouldSplitRange instead of shouldQueue to avoid using the splitFinder
 		// This tests the merge queue behavior too as a result. For splitFinder tests,

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2725,12 +2725,12 @@ func (s *Store) onSpanConfigUpdate(ctx context.Context, updated roachpb.Span) {
 				// adjacent table. This results in a single update, corresponding to the
 				// new table's span, which forms the right-hand side post split.
 
-				conf, sp, err := s.cfg.SpanConfigSubscriber.GetSpanConfigForKey(replCtx, startKey)
+				conf, _, err := s.cfg.SpanConfigSubscriber.GetSpanConfigForKey(replCtx, startKey)
 				if err != nil {
 					log.KvDistribution.Errorf(replCtx, "skipped applying update, unexpected error reading from subscriber: %v", err)
 					return err
 				}
-				changed = repl.SetSpanConfig(conf, sp)
+				changed = repl.SetSpanConfig(conf)
 			}
 			if changed {
 				repl.MaybeQueue(ctx, now)
@@ -2750,13 +2750,13 @@ func (s *Store) applyAllFromSpanConfigStore(ctx context.Context) {
 	newStoreReplicaVisitor(s).Visit(func(repl *Replica) bool {
 		replCtx := repl.AnnotateCtx(ctx)
 		key := repl.Desc().StartKey
-		conf, confSpan, err := s.cfg.SpanConfigSubscriber.GetSpanConfigForKey(replCtx, key)
+		conf, _, err := s.cfg.SpanConfigSubscriber.GetSpanConfigForKey(replCtx, key)
 		if err != nil {
 			log.KvDistribution.Errorf(ctx, "skipped applying config update, unexpected error reading from subscriber: %v", err)
 			return true // more
 		}
 
-		changed := repl.SetSpanConfig(conf, confSpan)
+		changed := repl.SetSpanConfig(conf)
 		if changed {
 			repl.MaybeQueue(replCtx, now)
 		}

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2725,7 +2725,7 @@ func (s *Store) onSpanConfigUpdate(ctx context.Context, updated roachpb.Span) {
 				// adjacent table. This results in a single update, corresponding to the
 				// new table's span, which forms the right-hand side post split.
 
-				conf, _, err := s.cfg.SpanConfigSubscriber.GetSpanConfigForKey(replCtx, startKey)
+				conf, err := s.cfg.SpanConfigSubscriber.GetSpanConfigForKey(replCtx, startKey)
 				if err != nil {
 					log.KvDistribution.Errorf(replCtx, "skipped applying update, unexpected error reading from subscriber: %v", err)
 					return err
@@ -2750,7 +2750,7 @@ func (s *Store) applyAllFromSpanConfigStore(ctx context.Context) {
 	newStoreReplicaVisitor(s).Visit(func(repl *Replica) bool {
 		replCtx := repl.AnnotateCtx(ctx)
 		key := repl.Desc().StartKey
-		conf, _, err := s.cfg.SpanConfigSubscriber.GetSpanConfigForKey(replCtx, key)
+		conf, err := s.cfg.SpanConfigSubscriber.GetSpanConfigForKey(replCtx, key)
 		if err != nil {
 			log.KvDistribution.Errorf(ctx, "skipped applying config update, unexpected error reading from subscriber: %v", err)
 			return true // more
@@ -3968,7 +3968,7 @@ func (s *Store) AllocatorCheckRange(
 		return allocatorimpl.AllocatorNoop, roachpb.ReplicationTarget{}, sp.FinishAndGetConfiguredRecording(), err
 	}
 
-	conf, _, err := confReader.GetSpanConfigForKey(ctx, desc.StartKey)
+	conf, err := confReader.GetSpanConfigForKey(ctx, desc.StartKey)
 	if err != nil {
 		log.Eventf(ctx, "error retrieving span config for range %s: %s", desc, err)
 		return allocatorimpl.AllocatorNoop, roachpb.ReplicationTarget{}, sp.FinishAndGetConfiguredRecording(), err

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -3732,9 +3732,9 @@ func (m *mockSpanConfigReader) ComputeSplitKey(
 
 func (m *mockSpanConfigReader) GetSpanConfigForKey(
 	ctx context.Context, key roachpb.RKey,
-) (roachpb.SpanConfig, roachpb.Span, error) {
+) (roachpb.SpanConfig, error) {
 	if e, ok := m.overrides[string(key)]; ok {
-		return e.conf, roachpb.Span{}, nil
+		return e.conf, nil
 	}
 	return m.GetSpanConfigForKey(ctx, key)
 }

--- a/pkg/server/storage_api/decommission_test.go
+++ b/pkg/server/storage_api/decommission_test.go
@@ -319,7 +319,7 @@ func waitForSpanConfig(
 			if err != nil {
 				return errors.Wrapf(err, "missing store on server %d", i)
 			}
-			conf, _, err := store.GetStoreConfig().SpanConfigSubscriber.GetSpanConfigForKey(context.Background(), key)
+			conf, err := store.GetStoreConfig().SpanConfigSubscriber.GetSpanConfigForKey(context.Background(), key)
 			if err != nil {
 				return errors.Wrapf(err, "missing span config for %s on server %d", key, i)
 			}

--- a/pkg/spanconfig/spanconfig.go
+++ b/pkg/spanconfig/spanconfig.go
@@ -267,11 +267,8 @@ type StoreWriter interface {
 type StoreReader interface {
 	NeedsSplit(ctx context.Context, start, end roachpb.RKey) (bool, error)
 	ComputeSplitKey(ctx context.Context, start, end roachpb.RKey) (roachpb.RKey, error)
-	// GetSpanConfigForKey returns the span configuration for the
-	// given key and the span that the retruened configuration
-	// applies to. Callers can use the returned span to check if a
-	// request is completely contained by the returned config.
-	GetSpanConfigForKey(ctx context.Context, key roachpb.RKey) (roachpb.SpanConfig, roachpb.Span, error)
+	// GetSpanConfigForKey returns the span config for the given key.
+	GetSpanConfigForKey(ctx context.Context, key roachpb.RKey) (roachpb.SpanConfig, error)
 	// ForEachOverlappingSpanConfig invokes the supplied callback on each span
 	// config that overlaps with the supplied span. The config is combined with
 	// all the system span configs that also apply to this span. In addition to

--- a/pkg/spanconfig/spanconfigkvsubscriber/datadriven_test.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/datadriven_test.go
@@ -274,7 +274,7 @@ func TestDataDriven(t *testing.T) {
 				case "key":
 					var keyStr string
 					d.ScanArgs(t, cmdArg.Key, &keyStr)
-					config, _, err := kvSubscriber.GetSpanConfigForKey(ctx, roachpb.RKey(keyStr))
+					config, err := kvSubscriber.GetSpanConfigForKey(ctx, roachpb.RKey(keyStr))
 					require.NoError(t, err)
 					return fmt.Sprintf("conf=%s", spanconfigtestutils.PrintSpanConfig(config))
 

--- a/pkg/spanconfig/spanconfigkvsubscriber/dummy.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/dummy.go
@@ -52,8 +52,8 @@ func (n *noopKVSubscriber) ComputeSplitKey(
 // GetSpanConfigForKey is part of the spanconfig.KVSubscriber interface.
 func (n *noopKVSubscriber) GetSpanConfigForKey(
 	context.Context, roachpb.RKey,
-) (roachpb.SpanConfig, roachpb.Span, error) {
-	return roachpb.SpanConfig{}, roachpb.Span{}, nil
+) (roachpb.SpanConfig, error) {
+	return roachpb.SpanConfig{}, nil
 }
 
 // ForEachOverlappingSpanConfig is part of the spanconfig.KVSubscriber

--- a/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber.go
@@ -366,7 +366,7 @@ func (s *KVSubscriber) ComputeSplitKey(
 // GetSpanConfigForKey is part of the spanconfig.KVSubscriber interface.
 func (s *KVSubscriber) GetSpanConfigForKey(
 	ctx context.Context, key roachpb.RKey,
-) (roachpb.SpanConfig, roachpb.Span, error) {
+) (roachpb.SpanConfig, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 

--- a/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber_test.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber_test.go
@@ -213,7 +213,7 @@ func (m *manualStore) ComputeSplitKey(
 // GetSpanConfigForKey implements the spanconfig.Store interface.
 func (m *manualStore) GetSpanConfigForKey(
 	context.Context, roachpb.RKey,
-) (roachpb.SpanConfig, roachpb.Span, error) {
+) (roachpb.SpanConfig, error) {
 	panic("unimplemented")
 }
 

--- a/pkg/spanconfig/spanconfigptsreader/adapter_test.go
+++ b/pkg/spanconfig/spanconfigptsreader/adapter_test.go
@@ -97,7 +97,7 @@ func (m *manualSubscriber) ComputeSplitKey(
 
 func (m *manualSubscriber) GetSpanConfigForKey(
 	context.Context, roachpb.RKey,
-) (roachpb.SpanConfig, roachpb.Span, error) {
+) (roachpb.SpanConfig, error) {
 	panic("unimplemented")
 }
 

--- a/pkg/spanconfig/spanconfigreporter/datadriven_test.go
+++ b/pkg/spanconfig/spanconfigreporter/datadriven_test.go
@@ -276,7 +276,7 @@ func (s *mockCluster) ComputeSplitKey(
 // GetSpanConfigForKey implements spanconfig.StoreReader.
 func (s *mockCluster) GetSpanConfigForKey(
 	ctx context.Context, key roachpb.RKey,
-) (roachpb.SpanConfig, roachpb.Span, error) {
+) (roachpb.SpanConfig, error) {
 	return s.store.GetSpanConfigForKey(ctx, key)
 }
 

--- a/pkg/spanconfig/spanconfigreporter/reporter.go
+++ b/pkg/spanconfig/spanconfigreporter/reporter.go
@@ -140,7 +140,7 @@ func (r *Reporter) SpanConfigConformance(
 			span,
 			func(descriptors ...roachpb.RangeDescriptor) error {
 				for _, desc := range descriptors {
-					conf, _, err := r.dep.StoreReader.GetSpanConfigForKey(ctx, desc.StartKey)
+					conf, err := r.dep.StoreReader.GetSpanConfigForKey(ctx, desc.StartKey)
 					if err != nil {
 						return err
 					}

--- a/pkg/spanconfig/spanconfigstore/store.go
+++ b/pkg/spanconfig/spanconfigstore/store.go
@@ -118,7 +118,7 @@ func (s *Store) ComputeSplitKey(
 // GetSpanConfigForKey is part of the spanconfig.StoreReader interface.
 func (s *Store) GetSpanConfigForKey(
 	ctx context.Context, key roachpb.RKey,
-) (roachpb.SpanConfig, roachpb.Span, error) {
+) (roachpb.SpanConfig, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.getSpanConfigForKeyRLocked(ctx, key)
@@ -128,34 +128,34 @@ func (s *Store) GetSpanConfigForKey(
 // caller to hold the Store read lock.
 func (s *Store) getSpanConfigForKeyRLocked(
 	ctx context.Context, key roachpb.RKey,
-) (roachpb.SpanConfig, roachpb.Span, error) {
-	conf, confSpan, found := s.mu.spanConfigStore.getSpanConfigForKey(ctx, key)
+) (roachpb.SpanConfig, error) {
+	conf, _, found := s.mu.spanConfigStore.getSpanConfigForKey(ctx, key)
 	if !found {
 		conf = s.getFallbackConfig()
 	}
 	var err error
 	conf, err = s.mu.systemSpanConfigStore.combine(key, conf)
 	if err != nil {
-		return roachpb.SpanConfig{}, roachpb.Span{}, err
+		return roachpb.SpanConfig{}, err
 	}
 
 	// No need to perform clamping if SpanConfigBounds are not enabled.
 	if !boundsEnabled.Get(&s.settings.SV) {
-		return conf, confSpan, nil
+		return conf, nil
 	}
 
 	_, tenID, err := keys.DecodeTenantPrefix(roachpb.Key(key))
 	if err != nil {
-		return roachpb.SpanConfig{}, roachpb.Span{}, err
+		return roachpb.SpanConfig{}, err
 	}
 	if tenID.IsSystem() {
 		// SpanConfig bounds do not apply to the system tenant.
-		return conf, confSpan, nil
+		return conf, nil
 	}
 
 	bounds, found := s.boundsReader.Bounds(tenID)
 	if !found {
-		return conf, confSpan, nil
+		return conf, nil
 	}
 
 	clamped := bounds.Clamp(&conf)
@@ -163,7 +163,7 @@ func (s *Store) getSpanConfigForKeyRLocked(
 	if clamped {
 		log.Dev.VInfof(ctx, 3, "span config for tenant clamped to %v", conf)
 	}
-	return conf, confSpan, nil
+	return conf, nil
 }
 
 func (s *Store) getFallbackConfig() roachpb.SpanConfig {
@@ -206,7 +206,7 @@ func (s *Store) ForEachOverlappingSpanConfig(
 	var foundOverlapping bool
 	err := s.mu.spanConfigStore.forEachOverlapping(span, func(sp roachpb.Span, conf roachpb.SpanConfig) error {
 		foundOverlapping = true
-		config, _, err := s.getSpanConfigForKeyRLocked(ctx, roachpb.RKey(sp.Key))
+		config, err := s.getSpanConfigForKeyRLocked(ctx, roachpb.RKey(sp.Key))
 		if err != nil {
 			return err
 		}
@@ -227,7 +227,7 @@ func (s *Store) ForEachOverlappingSpanConfig(
 	// applicable to the replica with the empty table span.
 	if !foundOverlapping {
 		log.Dev.VInfof(ctx, 3, "no overlapping span config found for span %s", span)
-		config, _, err := s.getSpanConfigForKeyRLocked(ctx, roachpb.RKey(span.Key))
+		config, err := s.getSpanConfigForKeyRLocked(ctx, roachpb.RKey(span.Key))
 		if err != nil {
 			return err
 		}

--- a/pkg/spanconfig/spanconfigstore/store_test.go
+++ b/pkg/spanconfig/spanconfigstore/store_test.go
@@ -170,7 +170,7 @@ func TestDataDriven(t *testing.T) {
 			case "get":
 				d.ScanArgs(t, "key", &keyStr)
 				key, _ := spanconfigtestutils.ParseKey(t, keyStr)
-				config, _, err := store.GetSpanConfigForKey(ctx, roachpb.RKey(key))
+				config, err := store.GetSpanConfigForKey(ctx, roachpb.RKey(key))
 				require.NoError(t, err)
 				return fmt.Sprintf("conf=%s", spanconfigtestutils.PrintSpanConfig(config))
 

--- a/pkg/spanconfig/spanconfigtestutils/utils.go
+++ b/pkg/spanconfig/spanconfigtestutils/utils.go
@@ -808,14 +808,14 @@ func (w *WrappedKVSubscriber) ComputeSplitKey(
 // GetSpanConfigForKey implements spanconfig.StoreReader.
 func (w *WrappedKVSubscriber) GetSpanConfigForKey(
 	ctx context.Context, key roachpb.RKey,
-) (roachpb.SpanConfig, roachpb.Span, error) {
-	spanConfig, span, err := w.wrapped.GetSpanConfigForKey(ctx, key)
+) (roachpb.SpanConfig, error) {
+	spanConfig, err := w.wrapped.GetSpanConfigForKey(ctx, key)
 	for _, o := range w.overrides {
 		if key.Equal(o.key) {
-			return o.config, span, nil
+			return o.config, nil
 		}
 	}
-	return spanConfig, span, err
+	return spanConfig, err
 }
 
 // NeedsSplit implements spanconfig.StoreReader.


### PR DESCRIPTION
The first two commits are from https://github.com/cockroachdb/cockroach/pull/164841.

----

**spanconfig: remove span return value from GetSpanConfigForKey**

Now that `entireSpanExcludedFromBackup` uses `ForEachOverlappingSpanConfig` instead of manually iterating with `GetSpanConfigForKey`, no caller uses the span returned by `GetSpanConfigForKey`. Every call site either discarded it with `_` or used it only for debug logging.

Remove the `roachpb.Span` from the return signature of `StoreReader.GetSpanConfigForKey`, simplifying the interface and all implementations/callers. The internal `spanConfigStore.getSpanConfigForKey` retains the span return since `maybeLogUpdate` uses it to log span boundary changes.

The span return was originally introduced as `GetSpanConfigForKeyWithBounds` in e5a3e0029cf and merged into `GetSpanConfigForKey` in dd75019add6.

Informs: https://github.com/cockroachdb/cockroach/issues/131993
Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

----

**kvserver: remove unused confSpan field from Replica**

Now that `entireSpanExcludedFromBackup` uses `ForEachOverlappingSpanConfig` to iterate over span configs instead of reading the cached `confSpan`, the field is dead code — it is written but never read.

Remove `confSpan` from the Replica struct and drop the `sp roachpb.Span` parameter from `SetSpanConfig`, simplifying all call sites. Both were introduced in e5a3e0029cf.

Informs: https://github.com/cockroachdb/cockroach/issues/131993
Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>