### PR TITLE
kvstorage: make Batch WAG-writing aware

### DIFF
--- a/pkg/kv/kvserver/kvstorage/BUILD.bazel
+++ b/pkg/kv/kvserver/kvstorage/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/keys",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver/kvserverpb",
+        "//pkg/kv/kvserver/kvstorage/wag",
         "//pkg/kv/kvserver/logstore",
         "//pkg/kv/kvserver/rditer",
         "//pkg/kv/kvserver/spanset",

--- a/pkg/kv/kvserver/kvstorage/storage.go
+++ b/pkg/kv/kvserver/kvstorage/storage.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -245,10 +246,10 @@ func (e *Engines) SetStoreID(ctx context.Context, id roachpb.StoreID) error {
 	return nil
 }
 
-// NewWriteBatch creates a new write batch to storage. When engines are
+// newWriteBatch creates a new write batch to storage. When engines are
 // separated, the raft engine batch is lazily initialized on first access via
-// Raft().
-func (e *Engines) NewWriteBatch() Batch[storage.WriteBatch] {
+// Raft(). Callers outside this package should use BatchFactory.
+func (e *Engines) newWriteBatch() Batch[storage.WriteBatch] {
 	if e.Separated() {
 		return Batch[storage.WriteBatch]{
 			state:     e.StateEngine().NewWriteBatch(),
@@ -270,9 +271,10 @@ func (e *Engines) NewWriteBatch() Batch[storage.WriteBatch] {
 	}
 }
 
-// NewBatch is like NewWriteBatch, but the StateEngine batch is a read-write
-// storage.Batch rather than a write-only storage.WriteBatch.
-func (e *Engines) NewBatch() Batch[storage.Batch] {
+// newBatch is like newWriteBatch, but the StateEngine batch is a read-write
+// storage.Batch rather than a write-only storage.WriteBatch. Callers outside
+// this package should use BatchFactory.
+func (e *Engines) newBatch() Batch[storage.Batch] {
 	if e.Separated() {
 		return Batch[storage.Batch]{
 			state:     e.StateEngine().NewBatch(),
@@ -294,6 +296,32 @@ func (e *Engines) NewBatch() Batch[storage.Batch] {
 	}
 }
 
+// BatchFactory is used to create engine separation aware and WAG aware batches.
+type BatchFactory struct {
+	eng *Engines
+	seq *wag.Seq
+}
+
+// MakeBatchFactory creates a BatchFactory for the given engines and WAG
+// sequencer.
+func MakeBatchFactory(eng *Engines, seq *wag.Seq) BatchFactory {
+	return BatchFactory{eng: eng, seq: seq}
+}
+
+// NewWriteBatch creates a new write-only batch with WAG writing enabled.
+func (f *BatchFactory) NewWriteBatch() Batch[storage.WriteBatch] {
+	b := f.eng.newWriteBatch()
+	b.seq = f.seq
+	return b
+}
+
+// NewBatch creates a new read-write batch with WAG writing enabled.
+func (f *BatchFactory) NewBatch() Batch[storage.Batch] {
+	b := f.eng.newBatch()
+	b.seq = f.seq
+	return b
+}
+
 // Batch is a write batch to storage which is aware whether the log and state
 // machine engines are separated. It supports any wrapper around
 // storage.WriteBatch, in particular a read-write storage.Batch.
@@ -305,11 +333,17 @@ type Batch[B storage.WriteBatch] struct {
 	state B
 	// raft is the LogEngine batch. When engines are not separated, it points to
 	// the same underlying batch as state. When separated, it is lazily
-	// initialized on the first call to Raft().
+	// initialized on the first call to Raft() or AddEvent().
 	raft storage.WriteBatch
 	// logEngine is a reference to the LogEngine, used for lazy raft batch
 	// creation. Only set when engines are separated.
 	logEngine storage.Engine
+	// w is the WAG writer for staging lifecycle events. Lazily initialized
+	// alongside the raft batch when engines are separated and seq is non-nil.
+	w wag.Writer
+	// seq is the WAG sequence number allocator. Non-nil only when engines are
+	// separated and the caller opted into WAG writing.
+	seq       *wag.Seq
 	separated bool
 }
 
@@ -319,20 +353,33 @@ func (b *Batch[B]) State() B {
 }
 
 // Raft returns the LogEngine writer. When engines are separated, the raft
-// batch is lazily created on first access.
+// batch and WAG writer are lazily created on first access.
 func (b *Batch[B]) Raft() RaftWO {
-	if b.separated && b.raft == nil {
-		b.raft = b.logEngine.NewWriteBatch()
-	}
+	b.maybeInitRaft()
 	return b.raft
 }
 
+// maybeInitRaft lazily initializes the raft batch and WAG writer when engines
+// are separated.
+func (b *Batch[B]) maybeInitRaft() {
+	if b.separated && b.raft == nil {
+		b.raft = b.logEngine.NewWriteBatch()
+		if b.seq != nil {
+			b.w = wag.MakeWriter(b.seq)
+		}
+	}
+}
+
 // CommitAndSync commits and syncs the batch to storage. When engines are
-// separated, only the LogEngine batch is synced, and the StateEngine part is
-// expected to be replayable from the LogEngine batch.
+// separated, the WAG node is flushed to the raft batch first, then only the
+// LogEngine batch is synced. The StateEngine part is expected to be
+// replayable from the LogEngine batch.
 func (b *Batch[B]) CommitAndSync() error {
 	if !b.separated {
 		return b.state.Commit(true /* sync */)
+	}
+	if err := b.w.Flush(b.Raft(), b.state.Repr()); err != nil {
+		return err
 	}
 	if b.raft != nil {
 		if err := b.raft.Commit(true /* sync */); err != nil {

--- a/pkg/kv/kvserver/kvstorage/storage.go
+++ b/pkg/kv/kvserver/kvstorage/storage.go
@@ -252,9 +252,10 @@ func (e *Engines) SetStoreID(ctx context.Context, id roachpb.StoreID) error {
 func (e *Engines) newWriteBatch() Batch[storage.WriteBatch] {
 	if e.Separated() {
 		return Batch[storage.WriteBatch]{
-			state:     e.StateEngine().NewWriteBatch(),
-			logEngine: e.LogEngine(),
-			separated: true,
+			state:        e.StateEngine().NewWriteBatch(),
+			logEngine:    e.LogEngine(),
+			newRaftBatch: func(eng storage.Engine) storage.WriteBatch { return eng.NewWriteBatch() },
+			separated:    true,
 		}
 	}
 	// With a single engine, create one batch, and reference it by both pointers.
@@ -271,15 +272,16 @@ func (e *Engines) newWriteBatch() Batch[storage.WriteBatch] {
 	}
 }
 
-// newBatch is like newWriteBatch, but the StateEngine batch is a read-write
-// storage.Batch rather than a write-only storage.WriteBatch. Callers outside
-// this package should use BatchFactory.
+// newBatch is like newWriteBatch, but the batches are read-write
+// storage.Batches rather than write-only storage.WriteBatches. Callers
+// outside this package should use BatchFactory.
 func (e *Engines) newBatch() Batch[storage.Batch] {
 	if e.Separated() {
 		return Batch[storage.Batch]{
-			state:     e.StateEngine().NewBatch(),
-			logEngine: e.LogEngine(),
-			separated: true,
+			state:        e.StateEngine().NewBatch(),
+			logEngine:    e.LogEngine(),
+			newRaftBatch: func(eng storage.Engine) storage.Batch { return eng.NewBatch() },
+			separated:    true,
 		}
 	}
 	// With a single engine, create one batch, and reference it by both pointers.
@@ -292,7 +294,7 @@ func (e *Engines) newBatch() Batch[storage.Batch] {
 	// are always wrapped, so we don't use conditional type assertions.
 	return Batch[storage.Batch]{
 		state: e.StateEngine().(batchWrapper).WrapBatch(b),
-		raft:  e.LogEngine().(batchWrapper).WrapWriteBatch(b),
+		raft:  e.LogEngine().(batchWrapper).WrapBatch(b),
 	}
 }
 
@@ -323,18 +325,27 @@ func (f *BatchFactory) NewBatch() Batch[storage.Batch] {
 }
 
 // Batch is a write batch to storage which is aware whether the log and state
-// machine engines are separated. It supports any wrapper around
-// storage.WriteBatch, in particular a read-write storage.Batch.
+// machine engines are separated. The generic parameter B constrains both the
+// state and raft batch types — both use the same type, either write-only
+// (storage.WriteBatch) or read-write (storage.Batch).
 //
 // When engines are separated, the raft engine batch is lazily initialized on
 // the first call to Raft(). This avoids creating a raft batch for operations
 // that only touch the state engine.
+//
+// In principle, we could use separate generic parameters for the state and raft
+// batches. For now, we use a single parameter to keep things simple and avoid
+// the combinatorial explosion.
 type Batch[B storage.WriteBatch] struct {
 	state B
 	// raft is the LogEngine batch. When engines are not separated, it points to
 	// the same underlying batch as state. When separated, it is lazily
 	// initialized on the first call to Raft() or WagWriter().
-	raft storage.WriteBatch
+	raft B
+	// newRaftBatch creates a new raft batch from the LogEngine. Stored as a
+	// function because the concrete batch type (storage.Batch vs
+	// storage.WriteBatch) depends on the generic parameter B.
+	newRaftBatch func(storage.Engine) B
 	// logEngine is a reference to the LogEngine, used for lazy raft batch
 	// creation. Only set when engines are separated.
 	logEngine storage.Engine
@@ -345,6 +356,11 @@ type Batch[B storage.WriteBatch] struct {
 	// separated and the caller opted into WAG writing.
 	seq       *wag.Seq
 	separated bool
+	// raftInitialized tracks whether the raft batch has been created. Only
+	// meaningful when engines are separated.
+	//
+	// NB: This is needed because generic types cannot be compared to nil.
+	raftInitialized bool
 }
 
 // State returns the StateEngine batch.
@@ -352,9 +368,9 @@ func (b *Batch[B]) State() B {
 	return b.state
 }
 
-// Raft returns the LogEngine writer. When engines are separated, the raft
+// Raft returns the LogEngine batch. When engines are separated, the raft
 // batch and WAG writer are lazily created on first access.
-func (b *Batch[B]) Raft() RaftWO {
+func (b *Batch[B]) Raft() B {
 	b.maybeInitRaft()
 	return b.raft
 }
@@ -376,8 +392,9 @@ func (b *Batch[B]) WagWriter() *wag.Writer {
 // maybeInitRaft lazily initializes the raft batch and WAG writer when engines
 // are separated.
 func (b *Batch[B]) maybeInitRaft() {
-	if b.separated && b.raft == nil {
-		b.raft = b.logEngine.NewWriteBatch()
+	if b.separated && !b.raftInitialized {
+		b.raft = b.newRaftBatch(b.logEngine)
+		b.raftInitialized = true
 		if b.seq != nil {
 			b.w = wag.MakeWriter(b.seq)
 		}
@@ -403,7 +420,7 @@ func (b *Batch[B]) Commit(syncStateEngine bool) error {
 			return err
 		}
 	}
-	if b.raft != nil {
+	if b.raftInitialized {
 		if err := b.raft.Commit(true /* sync */); err != nil {
 			return err
 		}
@@ -414,7 +431,7 @@ func (b *Batch[B]) Commit(syncStateEngine bool) error {
 // Close closes the batch.
 func (b *Batch[B]) Close() {
 	b.state.Close()
-	if b.separated && b.raft != nil {
+	if b.separated && b.raftInitialized {
 		b.raft.Close()
 	}
 }

--- a/pkg/kv/kvserver/kvstorage/storage.go
+++ b/pkg/kv/kvserver/kvstorage/storage.go
@@ -333,7 +333,7 @@ type Batch[B storage.WriteBatch] struct {
 	state B
 	// raft is the LogEngine batch. When engines are not separated, it points to
 	// the same underlying batch as state. When separated, it is lazily
-	// initialized on the first call to Raft() or AddEvent().
+	// initialized on the first call to Raft() or WagWriter().
 	raft storage.WriteBatch
 	// logEngine is a reference to the LogEngine, used for lazy raft batch
 	// creation. Only set when engines are separated.
@@ -359,6 +359,20 @@ func (b *Batch[B]) Raft() RaftWO {
 	return b.raft
 }
 
+// WagWriter returns a pointer to the batch's WAG writer. Returns nil when
+// engines are not separated, since WAG is only used with separated engines.
+// The nil *Writer is safe to use — all methods on it are no-ops.
+//
+// When engines are separated, lazily initializes the raft batch and WAG
+// writer if they haven't been created yet.
+func (b *Batch[B]) WagWriter() *wag.Writer {
+	if !b.separated {
+		return nil
+	}
+	b.maybeInitRaft()
+	return &b.w
+}
+
 // maybeInitRaft lazily initializes the raft batch and WAG writer when engines
 // are separated.
 func (b *Batch[B]) maybeInitRaft() {
@@ -370,23 +384,31 @@ func (b *Batch[B]) maybeInitRaft() {
 	}
 }
 
-// CommitAndSync commits and syncs the batch to storage. When engines are
-// separated, the WAG node is flushed to the raft batch first, then only the
-// LogEngine batch is synced. The StateEngine part is expected to be
-// replayable from the LogEngine batch.
-func (b *Batch[B]) CommitAndSync() error {
+// Commit commits the batch to storage. syncStateEngine controls whether the
+// state engine batch is synced or not. When engines are not separated, this
+// controls the sync behavior of the singular batch commit. If they are, it
+// applies only to the state engine batch; the raft engine's batch is always
+// synced.
+//
+// When engines are separated, any staged WAG events are flushed to the raft
+// batch before committing.
+func (b *Batch[B]) Commit(syncStateEngine bool) error {
 	if !b.separated {
-		return b.state.Commit(true /* sync */)
+		return b.state.Commit(syncStateEngine)
 	}
-	if err := b.w.Flush(b.Raft(), b.state.Repr()); err != nil {
-		return err
+	// Avoid eagerly creating a raft batch and computing Repr() when no WAG
+	// events were staged.
+	if !b.w.Empty() {
+		if err := b.w.Flush(b.Raft(), b.state.Repr()); err != nil {
+			return err
+		}
 	}
 	if b.raft != nil {
 		if err := b.raft.Commit(true /* sync */); err != nil {
 			return err
 		}
 	}
-	return b.state.Commit(false /* sync */)
+	return b.state.Commit(syncStateEngine)
 }
 
 // Close closes the batch.

--- a/pkg/kv/kvserver/kvstorage/storage.go
+++ b/pkg/kv/kvserver/kvstorage/storage.go
@@ -245,14 +245,14 @@ func (e *Engines) SetStoreID(ctx context.Context, id roachpb.StoreID) error {
 	return nil
 }
 
-// NewWriteBatch creates a new write batch to storage. If engines are separated,
-// it consists of two batches, one per engine.
-// TODO(sep-raft-log): generalize this so that the LogEngine batch is lazy.
+// NewWriteBatch creates a new write batch to storage. When engines are
+// separated, the raft engine batch is lazily initialized on first access via
+// Raft().
 func (e *Engines) NewWriteBatch() Batch[storage.WriteBatch] {
 	if e.Separated() {
 		return Batch[storage.WriteBatch]{
 			state:     e.StateEngine().NewWriteBatch(),
-			raft:      e.LogEngine().NewWriteBatch(),
+			logEngine: e.LogEngine(),
 			separated: true,
 		}
 	}
@@ -276,7 +276,7 @@ func (e *Engines) NewBatch() Batch[storage.Batch] {
 	if e.Separated() {
 		return Batch[storage.Batch]{
 			state:     e.StateEngine().NewBatch(),
-			raft:      e.LogEngine().NewWriteBatch(),
+			logEngine: e.LogEngine(),
 			separated: true,
 		}
 	}
@@ -297,9 +297,19 @@ func (e *Engines) NewBatch() Batch[storage.Batch] {
 // Batch is a write batch to storage which is aware whether the log and state
 // machine engines are separated. It supports any wrapper around
 // storage.WriteBatch, in particular a read-write storage.Batch.
+//
+// When engines are separated, the raft engine batch is lazily initialized on
+// the first call to Raft(). This avoids creating a raft batch for operations
+// that only touch the state engine.
 type Batch[B storage.WriteBatch] struct {
-	state     B
-	raft      storage.WriteBatch
+	state B
+	// raft is the LogEngine batch. When engines are not separated, it points to
+	// the same underlying batch as state. When separated, it is lazily
+	// initialized on the first call to Raft().
+	raft storage.WriteBatch
+	// logEngine is a reference to the LogEngine, used for lazy raft batch
+	// creation. Only set when engines are separated.
+	logEngine storage.Engine
 	separated bool
 }
 
@@ -308,8 +318,12 @@ func (b *Batch[B]) State() B {
 	return b.state
 }
 
-// Raft returns the LogEngine writer.
+// Raft returns the LogEngine writer. When engines are separated, the raft
+// batch is lazily created on first access.
 func (b *Batch[B]) Raft() RaftWO {
+	if b.separated && b.raft == nil {
+		b.raft = b.logEngine.NewWriteBatch()
+	}
 	return b.raft
 }
 
@@ -320,16 +334,18 @@ func (b *Batch[B]) CommitAndSync() error {
 	if !b.separated {
 		return b.state.Commit(true /* sync */)
 	}
-	if err := b.raft.Commit(true /* sync */); err != nil {
-		return err
+	if b.raft != nil {
+		if err := b.raft.Commit(true /* sync */); err != nil {
+			return err
+		}
 	}
-	return b.state.Commit(false /* false */)
+	return b.state.Commit(false /* sync */)
 }
 
 // Close closes the batch.
 func (b *Batch[B]) Close() {
 	b.state.Close()
-	if b.separated {
+	if b.separated && b.raft != nil {
 		b.raft.Close()
 	}
 }

--- a/pkg/kv/kvserver/kvstorage/storage.go
+++ b/pkg/kv/kvserver/kvstorage/storage.go
@@ -361,6 +361,7 @@ type Batch[B storage.WriteBatch] struct {
 	//
 	// NB: This is needed because generic types cannot be compared to nil.
 	raftInitialized bool
+	closed          bool
 }
 
 // State returns the StateEngine batch.
@@ -428,8 +429,12 @@ func (b *Batch[B]) Commit(syncStateEngine bool) error {
 	return b.state.Commit(syncStateEngine)
 }
 
-// Close closes the batch.
+// Close closes the batch. It is idempotent.
 func (b *Batch[B]) Close() {
+	if b.closed {
+		return
+	}
+	b.closed = true
 	b.state.Close()
 	if b.separated && b.raftInitialized {
 		b.raft.Close()

--- a/pkg/kv/kvserver/kvstorage/wag/BUILD.bazel
+++ b/pkg/kv/kvserver/kvstorage/wag/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/keys",
-        "//pkg/kv/kvserver/kvstorage",
         "//pkg/kv/kvserver/kvstorage/wag/wagpb",
         "//pkg/storage",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/kv/kvserver/kvstorage/wag/store_test.go
+++ b/pkg/kv/kvserver/kvstorage/wag/store_test.go
@@ -45,9 +45,10 @@ func TestWrite(t *testing.T) {
 	}
 
 	id := roachpb.FullReplicaID{RangeID: 123, ReplicaID: 4}
+	rhsID := roachpb.FullReplicaID{RangeID: 567, ReplicaID: 1}
 	write("create", func(w storage.Writer) error { return createReplica(&s, w, id) })
 	write("init", func(w storage.Writer) error { return initReplica(&s, w, id, 10) })
-	write("split", func(w storage.Writer) error { return splitReplica(&s, w, id, 200) })
+	write("split", func(w storage.Writer) error { return splitReplica(&s, w, id, rhsID, 200) })
 
 	// TODO(pav-kv): the trailing \n in DecodeWriteBatch is duplicated with
 	// recursion. Remove it, and let the caller handle new lines.
@@ -61,7 +62,9 @@ func TestWrite(t *testing.T) {
 		count++
 	}
 	require.NoError(t, iter.Error())
-	require.Equal(t, 4, count)
+	// 3 WAG nodes: create, init, split. The split is a single node with two
+	// events (Split + Init) rather than two separate nodes (dep + event).
+	require.Equal(t, 3, count)
 }
 
 type store struct {
@@ -70,49 +73,46 @@ type store struct {
 }
 
 func createReplica(s *store, w storage.Writer, id roachpb.FullReplicaID) error {
-	b := s.eng.NewWriteBatch()
-	defer b.Close()
-	if err := writeStateMachine(b, "state-machine-key", "state"); err != nil {
+	stateBatch := s.eng.NewWriteBatch()
+	defer stateBatch.Close()
+	if err := writeStateMachine(stateBatch, "state-machine-key", "state"); err != nil {
 		return err
 	}
 	return Write(w, s.seq.Next(1), wagpb.Node{
-		Addr:     wagpb.MakeAddr(id, 0),
-		Type:     wagpb.NodeType_NodeCreate,
-		Mutation: wagpb.Mutation{Batch: b.Repr()},
+		Events: []wagpb.Event{
+			{Addr: wagpb.MakeAddr(id, 0), Type: wagpb.EventType_EventCreate},
+		},
+		Mutation: wagpb.Mutation{Batch: stateBatch.Repr()},
 	})
 }
 
 func initReplica(s *store, w storage.Writer, id roachpb.FullReplicaID, index uint64) error {
 	return Write(w, s.seq.Next(1), wagpb.Node{
-		Addr: wagpb.MakeAddr(id, kvpb.RaftIndex(index)),
-		Type: wagpb.NodeType_NodeSnap,
+		Events: []wagpb.Event{
+			{Addr: wagpb.MakeAddr(id, kvpb.RaftIndex(index)), Type: wagpb.EventType_EventInit},
+		},
 		Mutation: wagpb.Mutation{Ingestion: &wagpb.Ingestion{
 			SSTs: []string{"tmp/1.sst", "tmp/2.sst"},
 		}},
 	})
 }
 
-func splitReplica(s *store, w storage.Writer, id roachpb.FullReplicaID, index uint64) error {
-	b := s.eng.NewWriteBatch()
-	defer b.Close()
-	if err := writeStateMachine(b, "lhs-key", "lhs-state"); err != nil {
+func splitReplica(
+	s *store, w storage.Writer, lhsID, rhsID roachpb.FullReplicaID, index uint64,
+) error {
+	stateBatch := s.eng.NewWriteBatch()
+	defer stateBatch.Close()
+	if err := writeStateMachine(stateBatch, "lhs-key", "lhs-state"); err != nil {
 		return err
-	} else if err := writeStateMachine(b, "rhs-key", "rhs-state"); err != nil {
-		return err
-	}
-
-	seq := s.seq.Next(2)
-	if err := Write(w, seq, wagpb.Node{
-		Addr: wagpb.MakeAddr(id, kvpb.RaftIndex(index-1)),
-		Type: wagpb.NodeType_NodeApply,
-	}); err != nil {
+	} else if err := writeStateMachine(stateBatch, "rhs-key", "rhs-state"); err != nil {
 		return err
 	}
-	return Write(w, seq+1, wagpb.Node{
-		Addr:     wagpb.MakeAddr(id, kvpb.RaftIndex(index)),
-		Type:     wagpb.NodeType_NodeSplit,
-		Mutation: wagpb.Mutation{Batch: b.Repr()},
-		Create:   567, // the RHS range ID
+	return Write(w, s.seq.Next(1), wagpb.Node{
+		Events: []wagpb.Event{
+			{Addr: wagpb.MakeAddr(rhsID, kvpb.RaftIndex(index)), Type: wagpb.EventType_EventInit},
+			{Addr: wagpb.MakeAddr(lhsID, kvpb.RaftIndex(index)), Type: wagpb.EventType_EventSplit},
+		},
+		Mutation: wagpb.Mutation{Batch: stateBatch.Repr()},
 	})
 }
 

--- a/pkg/kv/kvserver/kvstorage/wag/testdata/TestWrite.txt
+++ b/pkg/kv/kvserver/kvstorage/wag/testdata/TestWrite.txt
@@ -1,13 +1,12 @@
 echo
 ----
 >> create
-Put: 0,0 /Local/Store/wag/1 (0x01737761676e000000000000000100): NodeCreate r123/4:0
+Put: 0,0 /Local/Store/wag/1 (0x01737761676e000000000000000100): (r123/4:0,EventCreate)
 > Put: 0,0 "state-machine-key" (0x73746174652d6d616368696e652d6b657900): "state"
 >> init
-Put: 0,0 /Local/Store/wag/2 (0x01737761676e000000000000000200): NodeSnap r123/4:10
+Put: 0,0 /Local/Store/wag/2 (0x01737761676e000000000000000200): (r123/4:10,EventInit)
 ingestion: SSTs:"tmp/1.sst" SSTs:"tmp/2.sst" 
 >> split
-Put: 0,0 /Local/Store/wag/3 (0x01737761676e000000000000000300): NodeApply r123/4:199
-Put: 0,0 /Local/Store/wag/4 (0x01737761676e000000000000000400): NodeSplit r123/4:200 create:567
+Put: 0,0 /Local/Store/wag/3 (0x01737761676e000000000000000300): (r567/1:200,EventInit) (r123/4:200,EventSplit)
 > Put: 0,0 "lhs-key" (0x6c68732d6b657900): "lhs-state"
 > Put: 0,0 "rhs-key" (0x7268732d6b657900): "rhs-state"

--- a/pkg/kv/kvserver/kvstorage/wag/wagpb/wag.go
+++ b/pkg/kv/kvserver/kvstorage/wag/wagpb/wag.go
@@ -29,3 +29,18 @@ func (a Addr) String() string {
 func (a Addr) SafeFormat(w redact.SafePrinter, _ rune) {
 	w.Printf("r%d/%d:%d", a.RangeID, a.ReplicaID, a.Index)
 }
+
+// SafeValue implements the redact.SafeValue interface.
+func (EventType) SafeValue() {}
+
+var _ redact.SafeValue = EventType(0)
+
+// String implements the fmt.Stringer interface.
+func (e Event) String() string {
+	return redact.StringWithoutMarkers(e)
+}
+
+// SafeFormat implements the redact.SafeFormatter interface.
+func (e Event) SafeFormat(w redact.SafePrinter, _ rune) {
+	w.Printf("(%s,%s)", e.Addr, e.Type)
+}

--- a/pkg/kv/kvserver/kvstorage/wag/wagpb/wag.proto
+++ b/pkg/kv/kvserver/kvstorage/wag/wagpb/wag.proto
@@ -78,6 +78,8 @@ enum EventType {
 
 // Event describes a single replica lifecycle event within a WAG node.
 message Event {
+  option (gogoproto.goproto_stringer) = false;
+
   // Addr identifies the range, replica and raft index this event pertains to.
   // The interpretation of the Raft Index depends on the EventType.
   Addr addr = 1 [(gogoproto.nullable) = false];

--- a/pkg/kv/kvserver/kvstorage/wag/wagpb/wag.proto
+++ b/pkg/kv/kvserver/kvstorage/wag/wagpb/wag.proto
@@ -12,6 +12,8 @@ import "kv/kvserver/kvserverpb/raft.proto";
 
 // NodeType defines the type of the WAG node. It corresponds to a replica
 // lifecycle event, and specifies how the node is addressed and interpreted.
+//
+// TODO(arul): there should no longer be used; remove in a subsequent commit.
 enum NodeType {
   // NodeEmpty is the "empty" type. Can be used as a nil/no-op indicator. We
   // just have it so that all "real" types are specified explicitly.
@@ -37,43 +39,96 @@ enum NodeType {
   NodeDestroy = 6;
 }
 
-// Addr describes the full address of a WAG node, consisting of RangeID,
+// EventType identifies the type of a replica lifecycle event within a WAG node.
+enum EventType {
+  // EventUnknown is the zero value. It should not be used.
+  EventUnknown = 0;
+  // EventCreate corresponds to the creation of an uninitialized replica. All
+  // replicas on a Store go through this transition. The Addr index must be 0,
+  // as there is no log to speak of.
+  EventCreate = 1;
+  // EventInit corresponds to initializing a replica's state machine at a
+  // specific raft index. This happens when an uninitialized replica receives a
+  // snapshot, or when a split creates the RHS. The Addr index is the index at
+  // which the replica is initialized.
+  EventInit = 2;
+  // EventApply corresponds to applying a replica's raft log up to a specific
+  // committed index. The Addr index identifies the log prefix that has been
+  // applied.
+  EventApply = 3;
+  // EventSplit corresponds to applying a split command on a replica. The Addr
+  // index is the raft log index of the split command. Implies a dependency on
+  // the replica being caught up to index-1 before the split.
+  EventSplit = 4;
+  // EventMerge corresponds to the LHS applying a merge command. The Addr index
+  // is the raft log index of the merge command. Implies a dependency on the LHS
+  // being caught up to index-1 before the merge.
+  EventMerge = 5;
+  // EventSubsume corresponds to a replica being subsumed as part of a merge.
+  // The Addr index is the RHS replica's last applied index before subsumption.
+  // Implies a dependency on the replica being caught up to that index. The
+  // post-subsumption state of the replica is "destroyed".
+  EventSubsume = 6;
+  // EventDestroy corresponds to a destruction of a replica The Addr index is
+  // the replica's last applied index before destruction, and it implies a
+  // dependency on the replica being caught up to that index. The
+  // post-destruction state of the replica is "destroyed".
+  EventDestroy = 7;
+}
+
+// Event describes a single replica lifecycle event within a WAG node.
+message Event {
+  // Addr identifies the range, replica and raft index this event pertains to.
+  // The interpretation of the Raft Index depends on the EventType.
+  Addr addr = 1 [(gogoproto.nullable) = false];
+  // Type identifies the kind of lifecycle event.
+  EventType type = 2;
+}
+
+// Addr describes the full address of a WAG event, consisting of RangeID,
 // ReplicaID, and index into the raft log.
 //
-// It establishes "happens before" relationships between WAG nodes of a RangeID.
-// For example, when applying a node with Addr.ReplicaID, we know that all nodes
-// with lower ReplicaIDs (including their destruction), or same ReplicaID and
-// lower Index have been applied.
+// It establishes "happens before" relationships between WAG events of a
+// RangeID. For example, when applying an event with Addr.ReplicaID, we know
+// that all events with lower ReplicaIDs (including their destruction), or same
+// ReplicaID and lower Index have been applied.
 message Addr {
   option (gogoproto.goproto_stringer) = false;
 
-  // RangeID is the ID of the range that the WAG node pertains to.
+  // RangeID is the ID of the range that the event pertains to.
   int64 range_id = 1 [
     (gogoproto.customname) = "RangeID",
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.RangeID"];
-  // ReplicaID is the ID of the RangeID replica that the WAG node pertains to.
+  // ReplicaID is the ID of the RangeID replica that the event pertains to.
   int32 replica_id = 2 [
     (gogoproto.customname) = "ReplicaID",
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.ReplicaID"];
-  // Index identifies the raft log entry associated with this WAG node.
-  //  - For NodeCreate, it is 0 and signifies an uninitialized replica.
-  //  - For NodeSnap, it is the index of the snapshot, and the index at which
-  //  the raft log is initialized.
-  //  - For NodeApply, it is the log index identifying a prefix of the raft log.
-  //  - For NodeSplit and NodeMerge, it identifies the raft log command
-  //  containing the corresponding split/merge trigger.
-  //  - For NodeDestroy, it is MaxUint64.
+  // Index identifies the raft log entry associated with this event. Its
+  // interpretation depends on the EventType:
+  //  - EventCreate: 0, signifying an uninitialized replica.
+  //  - EventInit: the index at which the replica is initialized.
+  //  - EventApply: the log index identifying a prefix of the raft log.
+  //  - EventSplit, EventMerge: the raft log index of the split/merge command.
+  //  - EventSubsume, EventDestroy: the replica's last applied index before
+  //    removal. The post-removal effective address is infinity.
   uint64 index = 4 [
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/kv/kvpb.RaftIndex"];
 }
 
-// Node describes a node of the WAG.
+// Node describes a node of the WAG. A node represents an atomic state machine
+// mutation along with one or more replica lifecycle events it encompasses. For
+// example, a split node contains a an Init event for the newly created RHS and
+// a Split event that both initializes the RHS and narrows the LHS.
 message Node {
   // Addr is the full address of the node, consisting of RangeID, ReplicaID, and
   // index into the raft log.
+  //
+  // Deprecated: use events instead.
   Addr addr = 1 [(gogoproto.nullable) = false];
   // Type identifies the type of the replica lifecycle event that this node
   // represents, such as replica creation, destruction, split or merge.
+  //
+  // TODO(arul): get rid of this field.
   NodeType type = 2;
   // Mutation contains the mutation that will be applied to the state machine
   // engine when applying this WAG node.
@@ -82,14 +137,27 @@ message Node {
   // Create is the RangeID that this node brings into existence in the state
   // machine, or 0 if the node does not create new ranges. It is non-zero for
   // NodeCreate and NodeSplit.
+  //
+  // TODO(arul): get rid of this field.
   int64 create = 4 [
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.RangeID"];
   // Destroy contains the RangeIDs that this node removes from the state
   // machine, because they are known to have been merged.
   // - For NodeMerge, it contains the ID of the RHS range being merged.
   // - For NodeSnap, it contains the list of subsumed ranges.
+  //
+  // TODO(arul): get rid of this field
   repeated int64 destroy = 5 [
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.RangeID"];
+
+  // Events contains the replica lifecycle events that this node encompasses.
+  // Each event affects a single replica, identified by its Addr. A given
+  // RangeID must appear at most once in this list.
+  //
+  // Each EventType implicitly carries dependency semantics. For example, a
+  // Split event at raft index I implies the replica must be caught up to I-1
+  // before the split can be replayed.
+  repeated Event events = 6 [(gogoproto.nullable) = false];
 }
 
 // Mutation contains a mutation that can be applied to the state machine engine.

--- a/pkg/kv/kvserver/kvstorage/wag/wagpb/wag.proto
+++ b/pkg/kv/kvserver/kvstorage/wag/wagpb/wag.proto
@@ -10,35 +10,6 @@ option go_package = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/
 import "gogoproto/gogo.proto";
 import "kv/kvserver/kvserverpb/raft.proto";
 
-// NodeType defines the type of the WAG node. It corresponds to a replica
-// lifecycle event, and specifies how the node is addressed and interpreted.
-//
-// TODO(arul): there should no longer be used; remove in a subsequent commit.
-enum NodeType {
-  // NodeEmpty is the "empty" type. Can be used as a nil/no-op indicator. We
-  // just have it so that all "real" types are specified explicitly.
-  NodeEmpty = 0;
-  // NodeCreate corresponds to a creation of an uninitialized replica. All
-  // replicas on a Store go through this transition.
-  NodeCreate = 1;
-  // NodeSnap corresponds to initializing/resetting a replica state machine with
-  // a snapshot. Happens when an uninitialized replica is initialized, or when
-  // an initialized replica is caught up on a later applied state. A NodeSnap
-  // also subsumes replicas (if any) that overlap with this replica in keyspace.
-  NodeSnap = 2;
-  // NodeApply corresponds to applying a replica's raft log up to a specific
-  // committed index.
-  NodeApply = 3;
-  // NodeSplit corresponds to applying a split command on a replica, and
-  // creating the replica of the post-split RHS range.
-  NodeSplit = 4;
-  // NodeMerge corresponds to applying a merge command on this replica and its
-  // immediate RHS neighbour in the keyspace.
-  NodeMerge = 5;
-  // NodeDestroy correspond to destroying the replica and its state machine.
-  NodeDestroy = 6;
-}
-
 // EventType identifies the type of a replica lifecycle event within a WAG node.
 enum EventType {
   // EventUnknown is the zero value. It should not be used.
@@ -122,35 +93,12 @@ message Addr {
 // example, a split node contains a an Init event for the newly created RHS and
 // a Split event that both initializes the RHS and narrows the LHS.
 message Node {
-  // Addr is the full address of the node, consisting of RangeID, ReplicaID, and
-  // index into the raft log.
-  //
-  // Deprecated: use events instead.
-  Addr addr = 1 [(gogoproto.nullable) = false];
-  // Type identifies the type of the replica lifecycle event that this node
-  // represents, such as replica creation, destruction, split or merge.
-  //
-  // TODO(arul): get rid of this field.
-  NodeType type = 2;
+  // Fields 1, 2, 4, 5 were removed.
+  reserved 1, 2, 4, 5;
+
   // Mutation contains the mutation that will be applied to the state machine
   // engine when applying this WAG node.
   Mutation mutation = 3 [(gogoproto.nullable) = false];
-
-  // Create is the RangeID that this node brings into existence in the state
-  // machine, or 0 if the node does not create new ranges. It is non-zero for
-  // NodeCreate and NodeSplit.
-  //
-  // TODO(arul): get rid of this field.
-  int64 create = 4 [
-    (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.RangeID"];
-  // Destroy contains the RangeIDs that this node removes from the state
-  // machine, because they are known to have been merged.
-  // - For NodeMerge, it contains the ID of the RHS range being merged.
-  // - For NodeSnap, it contains the list of subsumed ranges.
-  //
-  // TODO(arul): get rid of this field
-  repeated int64 destroy = 5 [
-    (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.RangeID"];
 
   // Events contains the replica lifecycle events that this node encompasses.
   // Each event affects a single replica, identified by its Addr. A given

--- a/pkg/kv/kvserver/kvstorage/wag/writer.go
+++ b/pkg/kv/kvserver/kvstorage/wag/writer.go
@@ -6,15 +6,15 @@
 package wag
 
 import (
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag/wagpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/errors"
 )
 
-// Writer prepares WAG nodes encoding a single state machine mutation. Replica
-// lifecycle events (splits, merges, destroys, etc.) use it to add dependencies
-// as they run, stage their event, and flush WAG nodes to the RaftBatch before
-// committing it towards the end of application.
+// Writer prepares a WAG node encoding a single state machine mutation and the
+// replica lifecycle events it encompasses. Callers add events via AddEvent as
+// they run, then call Flush to write the node to the raft engine when the time
+// comes.
 //
 // The zero value is a valid, disabled Writer. Use MakeWriter to create an
 // enabled Writer.
@@ -22,22 +22,10 @@ type Writer struct {
 	// seq allocates WAG sequence numbers using a store-level singleton. A nil
 	// seq indicates that the Writer is disabled.
 	seq *Seq
-	// deps tracks all dependency nodes. These carry a "happens before"
-	// relationship to the event node, but don't carry a mutation themselves.
-	// They are added via AddDep.
-	//
-	// For instance, a split at Raft index I needs a NodeApply at I-1 to
-	// indicate that the state machine must be caught up to that point before
-	// the split can be replayed.
-	deps []wagpb.Node
-	// event is the primary lifecycle event node. Its Mutation.Batch gets
-	// filled in at Flush time, once the State engine's batch has been fully
-	// prepared.
-	//
-	// There's exactly one of these per Writer, and can be set at any point
-	// before Flush is called. A zero-value (Type == NodeEmpty) means
-	// nothing's been staged yet, and is used to uphold this invariant.
-	event wagpb.Node
+	// events accumulates the lifecycle events for this node. Each event
+	// identifies a replica and the type of lifecycle transition it undergoes.
+	// A given RangeID must appear at most once.
+	events []wagpb.Event
 }
 
 // MakeWriter creates a new, enabled Writer.
@@ -51,69 +39,35 @@ func (w *Writer) disabled() bool {
 	return w.seq == nil
 }
 
-// Empty returns true if no WAG nodes have been staged on this Writer.
+// Empty returns true if no events have been staged on this Writer.
 func (w *Writer) Empty() bool {
-	return w.disabled() || w.event.Type == wagpb.NodeType_NodeEmpty
+	return w.disabled() || len(w.events) == 0
 }
 
-// AddDep stages a dependency node that must be satisfied before the event
-// can be replayed. These are written before the event node and don't carry
-// a mutation themselves.
-//
-// TODO(arul): as the code evolves, see if we add any dependencies other than
-// application up until a specific index. If we don't, this method can be
-// specialized to accept a wagpb.Addr instead.
-func (w *Writer) AddDep(node wagpb.Node) {
+// AddEvent stages a lifecycle event. Each event identifies a replica and the
+// type of lifecycle transition (create, split, destroy, etc.). A given RangeID
+// must appear at most once across all events in a Writer.
+func (w *Writer) AddEvent(addr wagpb.Addr, eventType wagpb.EventType) {
 	if w.disabled() {
 		return
 	}
-	w.deps = append(w.deps, node)
+	w.events = append(w.events, wagpb.Event{Addr: addr, Type: eventType})
 }
 
-// SetEvent stages the primary lifecycle event node. May not be called more
-// than once per Writer.
-func (w *Writer) SetEvent(node wagpb.Node) {
-	if w.disabled() {
-		return
-	}
-	if w.event.Type != wagpb.NodeType_NodeEmpty {
-		panic(errors.AssertionFailedf(
-			"WagWriter.SetEvent called twice: existing %s, new %s",
-			w.event.Addr, node.Addr,
-		))
-	}
-	w.event = node
-}
-
-// Flush writes all staged WAG nodes to the raft engine. The event node's
-// Mutation.Batch is populated with stateBatchRepr, which should be the
-// Repr() of the fully prepared State engine batch. No-ops if no event was
-// staged.
-func (w *Writer) Flush(raftBatch kvstorage.RaftWO, stateBatchRepr []byte) error {
-	if w.disabled() {
+// Flush writes the staged WAG node to the raft engine. The node's
+// Mutation.Batch is populated with stateBatchRepr, which should be the Repr()
+// of the fully prepared state engine batch. No-ops if no events were staged.
+func (w *Writer) Flush(raftBatch storage.Writer, stateBatchRepr []byte) error {
+	if w.disabled() || len(w.events) == 0 {
 		return nil
 	}
-	if w.event.Type == wagpb.NodeType_NodeEmpty {
-		if len(w.deps) != 0 {
-			return errors.AssertionFailedf(
-				"WAG dependency nodes staged without an event node",
-			)
-		}
-		return nil
+	node := wagpb.Node{
+		Events:   w.events,
+		Mutation: wagpb.Mutation{Batch: stateBatchRepr},
 	}
-	seq := w.seq.Next(uint64(len(w.deps)) + 1)
-
-	for _, dep := range w.deps {
-		if err := Write(raftBatch, seq, dep); err != nil {
-			return errors.Wrap(err, "writing WAG dependency node")
-		}
-		seq++
+	seq := w.seq.Next(1)
+	if err := Write(raftBatch, seq, node); err != nil {
+		return errors.Wrap(err, "writing WAG node")
 	}
-
-	w.event.Mutation.Batch = stateBatchRepr
-	if err := Write(raftBatch, seq, w.event); err != nil {
-		return errors.Wrap(err, "writing WAG event node")
-	}
-
 	return nil
 }

--- a/pkg/kv/kvserver/kvstorage/wag/writer.go
+++ b/pkg/kv/kvserver/kvstorage/wag/writer.go
@@ -34,9 +34,10 @@ func MakeWriter(seq *Seq) Writer {
 }
 
 // disabled returns true if the Writer is disabled and no WAG nodes should be
-// written.
+// written. A nil Writer is considered disabled, making it safe to call methods
+// on a nil *Writer.
 func (w *Writer) disabled() bool {
-	return w.seq == nil
+	return w == nil || w.seq == nil
 }
 
 // Empty returns true if no events have been staged on this Writer.

--- a/pkg/kv/kvserver/print/debug_print.go
+++ b/pkg/kv/kvserver/print/debug_print.go
@@ -479,13 +479,24 @@ func tryWAGKey(kv storage.MVCCKeyValue) (string, error) {
 		return "", err
 	}
 
-	str := fmt.Appendf(nil, "%v %s", node.Type, node.Addr)
-	if c, d := node.Create, node.Destroy; c != 0 || len(d) != 0 {
-		if c != 0 {
-			str = fmt.Appendf(str, " create:%d", c)
+	var str []byte
+	if len(node.Events) > 0 {
+		for i, e := range node.Events {
+			if i > 0 {
+				str = append(str, ' ')
+			}
+			str = fmt.Appendf(str, "%s", e)
 		}
-		if len(d) != 0 {
-			str = fmt.Appendf(str, " destroy:%v", d)
+	} else {
+		// TODO(arul): this can go away shortly.
+		str = fmt.Appendf(nil, "%v %s", node.Type, node.Addr)
+		if c, d := node.Create, node.Destroy; c != 0 || len(d) != 0 {
+			if c != 0 {
+				str = fmt.Appendf(str, " create:%d", c)
+			}
+			if len(d) != 0 {
+				str = fmt.Appendf(str, " destroy:%v", d)
+			}
 		}
 	}
 

--- a/pkg/kv/kvserver/print/debug_print.go
+++ b/pkg/kv/kvserver/print/debug_print.go
@@ -480,24 +480,11 @@ func tryWAGKey(kv storage.MVCCKeyValue) (string, error) {
 	}
 
 	var str []byte
-	if len(node.Events) > 0 {
-		for i, e := range node.Events {
-			if i > 0 {
-				str = append(str, ' ')
-			}
-			str = fmt.Appendf(str, "%s", e)
+	for i, e := range node.Events {
+		if i > 0 {
+			str = append(str, ' ')
 		}
-	} else {
-		// TODO(arul): this can go away shortly.
-		str = fmt.Appendf(nil, "%v %s", node.Type, node.Addr)
-		if c, d := node.Create, node.Destroy; c != 0 || len(d) != 0 {
-			if c != 0 {
-				str = fmt.Appendf(str, " create:%d", c)
-			}
-			if len(d) != 0 {
-				str = fmt.Appendf(str, " destroy:%v", d)
-			}
-		}
+		str = fmt.Appendf(str, "%s", e)
 	}
 
 	if b := node.Mutation.Batch; len(b) > 0 {

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -43,15 +42,9 @@ type replicaAppBatch struct {
 	r          *Replica
 	applyStats *applyCommittedEntriesStats
 
-	// batch accumulates writes implied by the raft entries in this batch. If
-	// engines are separated, only contains the StateEngine writes.
-	batch storage.Batch
-	// raftBatch accumulates writes to the raft log engine. It is lazily
-	// initialized when RaftBatch() is called.
-	//
-	// NB: This is currently only non-nil in tests, as that's the only scenario
-	// where we run with separated engines.
-	raftBatch storage.Batch
+	// batch accumulates writes implied by the raft entries in this batch, across
+	// both the state and raft engines. It is engine separation aware.
+	batch kvstorage.Batch[storage.Batch]
 	// state is this batch's view of the replica's state. It is copied from
 	// under the Replica.mu when the batch is initialized and is updated in
 	// stageTrivialReplicatedEvalResult.
@@ -80,11 +73,6 @@ type replicaAppBatch struct {
 
 	start                   time.Time // time at NewBatch()
 	followerStoreWriteBytes kvadmission.FollowerStoreWriteBytes
-
-	// wagWriter stages WAG nodes for this batch. Lifecycle triggers (splits,
-	// merges, etc.) populate it during command processing, and it's flushed to
-	// the raft engine before the command is applied to the state machine.
-	wagWriter wag.Writer
 
 	// Reused by addAppliedStateKeyToBatch to avoid heap allocations.
 	asAlloc kvserverpb.RangeAppliedState
@@ -155,7 +143,7 @@ func (b *replicaAppBatch) Stage(
 	}
 
 	// Stage the command's write batch in the application batch.
-	if err := b.ab.addWriteBatch(ctx, b.batch, cmd); err != nil {
+	if err := b.ab.addWriteBatch(ctx, b.batch.State(), cmd); err != nil {
 		return nil, err
 	}
 
@@ -197,8 +185,8 @@ func (b *replicaAppBatch) Stage(
 
 func (b *replicaAppBatch) ReadWriter() kvstorage.ReadWriter {
 	return kvstorage.ReadWriter{
-		State: kvstorage.WrapState(b.batch),
-		Raft:  kvstorage.WrapRaft(b.RaftBatch()),
+		State: kvstorage.WrapState(b.batch.State()),
+		Raft:  kvstorage.WrapRaft(b.batch.Raft()),
 	}
 }
 
@@ -226,7 +214,7 @@ func (b *replicaAppBatch) runPreAddTriggersReplicaOnly(
 		// application there are no listening rangefeeds. So we do this only
 		// in Replica application.
 		if p, filter := b.r.getRangefeedProcessorAndFilter(); p != nil {
-			if err := populatePrevValsInLogicalOpLog(ctx, filter, ops, b.batch); err != nil {
+			if err := populatePrevValsInLogicalOpLog(ctx, filter, ops, b.batch.State()); err != nil {
 				b.r.disconnectRangefeedWithErr(p, kvpb.NewError(err))
 			}
 		}
@@ -351,7 +339,10 @@ func (b *replicaAppBatch) runPostAddTriggersReplicaOnly(
 			log.KvExec.Fatalf(ctx, "unable to validate split: %s", err)
 		}
 
-		splitPreApply(ctx, kvstorage.StateRW(b.batch), kvstorage.WrapRaft(b.RaftBatch()), &b.wagWriter, in)
+		// TODO(arul): consider passing in a kvstorage.Batch to splitPreApply
+		// instead. That way, we don't need to get the WagWriter out of the batch
+		// here, and can instead just have an AddEvent method on the type instead.
+		splitPreApply(ctx, kvstorage.StateRW(b.batch.State()), kvstorage.WrapRaft(b.batch.Raft()), b.batch.WagWriter(), in)
 
 		// The rangefeed processor will no longer be provided logical ops for
 		// its entire range, so it needs to be shut down and all registrations
@@ -495,7 +486,7 @@ func (b *replicaAppBatch) runPostAddTriggersReplicaOnly(
 	// shutdown of the rangefeed in that situation, so we don't pass anything to
 	// the rangefeed. If no rangefeed is running at all, this call will be a noop.
 	if ops := cmd.Cmd.LogicalOpLog; cmd.Cmd.WriteBatch != nil {
-		b.r.handleLogicalOpLogRaftMuLocked(ctx, ops, b.batch)
+		b.r.handleLogicalOpLogRaftMuLocked(ctx, ops, b.batch.State())
 	} else if ops != nil {
 		log.KvExec.Fatalf(ctx, "non-nil logical op log with nil write batch: %v", cmd.Cmd)
 	}
@@ -540,7 +531,7 @@ func (b *replicaAppBatch) stageTruncation(
 	// for now only to enable experimental testing.
 	if err := handleTruncatedStateBelowRaftPreApply(
 		ctx, b.truncState, *truncatedState,
-		b.r.raftMu.stateLoader.StateLoader, b.RaftBatch(),
+		b.r.raftMu.stateLoader.StateLoader, b.batch.Raft(),
 	); err != nil {
 		return errors.Wrap(err, "unable to handle truncated state")
 	}
@@ -611,7 +602,7 @@ func (b *replicaAppBatch) stageTrivialReplicatedEvalResult(
 		// are all safe.
 		b.state.ForceFlushIndex = roachpb.ForceFlushIndex{Index: cmd.Entry.Index}
 		if err := b.r.raftMu.stateLoader.SetForceFlushIndex(
-			ctx, b.batch, b.state.Stats, &b.state.ForceFlushIndex); err != nil {
+			ctx, b.batch.State(), b.state.Stats, &b.state.ForceFlushIndex); err != nil {
 			return err
 		}
 	}
@@ -636,31 +627,14 @@ func (b *replicaAppBatch) ApplyToStateMachine(ctx context.Context) error {
 		}
 	}
 
-	// Flush any staged WAG nodes to the raft batch. This must happen after the
-	// state batch is fully prepared (so Repr() captures everything) but before
-	// the raft batch is committed. The Empty() guard avoids eagerly creating a
-	// raft batch and computing Repr() when no WAG nodes were staged.
-	if !b.wagWriter.Empty() {
-		if err := b.wagWriter.Flush(b.RaftBatch(), b.batch.Repr()); err != nil {
-			return err
-		}
-	}
-
-	// Commit the Raft batch to Pebble, if it exists. Note that unlike batches
-	// to the State engine, we always sync writes to the Raft engine.
-	if b.raftBatch != nil {
-		if err := b.raftBatch.Commit(true /* sync */); err != nil {
-			return errors.Wrapf(err, "unable to commit Raft entry batch to raft engine")
-		}
-		b.raftBatch.Close()
-		b.raftBatch = nil
-	}
-
-	// Apply the write batch to Pebble. Entry application is done without syncing
-	// to disk. The atomicity guarantees of the batch, and the fact that the
-	// applied state is stored in this batch, ensure that if the batch ends up not
-	// being durably committed then the entries in this batch will be applied
-	// again upon startup. However, there are a couple of exceptions.
+	// Commit the batch to Pebble. When engines are separated, this also flushes
+	// any staged WAG nodes and commits the raft batch.
+	//
+	// Entry application is done without syncing the state engine to disk. The
+	// atomicity guarantees of the batch, and the fact that the applied state is
+	// stored in this batch, ensure that if the batch ends up not being durably
+	// committed then the entries in this batch will be applied again upon
+	// startup. However, there are a couple of exceptions.
 	//
 	// If we're removing the replica's data then we sync this batch as it is not
 	// safe to call postDestroyRaftMuLocked before ensuring that the replica's
@@ -682,12 +656,11 @@ func (b *replicaAppBatch) ApplyToStateMachine(ctx context.Context) error {
 	// asynchronously when sure that the state machine engine has synced the
 	// application of this command. I.e. the loosely coupled truncation migration
 	// mentioned above likely needs to be done first.
-	sync := b.changeRemovesReplica || b.changeTruncatesSideloadedFiles
-	if err := b.batch.Commit(sync); err != nil {
+	syncStateEngine := b.changeRemovesReplica || b.changeTruncatesSideloadedFiles
+	if err := b.batch.Commit(syncStateEngine); err != nil {
 		return errors.Wrapf(err, "unable to commit Raft entry batch")
 	}
 	b.batch.Close()
-	b.batch = nil
 
 	// Update the replica's applied indexes, mvcc stats and closed timestamp.
 	r := b.r
@@ -769,7 +742,7 @@ func (b *replicaAppBatch) addAppliedStateKeyToBatch(ctx context.Context) error {
 	// Set the range applied state, which includes the last applied raft and lease
 	// index along with the MVCC stats, all in one key.
 	b.asAlloc = b.state.ToRangeAppliedState()
-	return b.r.raftMu.stateLoader.SetRangeAppliedState(ctx, b.batch, &b.asAlloc)
+	return b.r.raftMu.stateLoader.SetRangeAppliedState(ctx, b.batch.State(), &b.asAlloc)
 }
 
 func (b *replicaAppBatch) recordStatsOnCommit() {
@@ -856,26 +829,8 @@ func (b *replicaAppBatch) verifySysBytes(ctx context.Context) error {
 
 // Close implements the apply.Batch interface.
 func (b *replicaAppBatch) Close() {
-	if b.batch != nil {
-		b.batch.Close()
-	}
-	if b.raftBatch != nil {
-		b.raftBatch.Close()
-	}
+	b.batch.Close()
 	*b = replicaAppBatch{}
-}
-
-// RaftBatch returns a batch from the Raft engine.
-func (b *replicaAppBatch) RaftBatch() storage.Batch {
-	if !b.r.store.internalEngines.Separated() {
-		// We're not running with separated engines; simply return the batch
-		// that was created for the one and only engine.
-		return b.batch
-	}
-	if b.raftBatch == nil {
-		b.raftBatch = b.r.store.LogEngine().NewBatch()
-	}
-	return b.raftBatch
 }
 
 // Assert that the current command is not writing under the closed timestamp.

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvadmission"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag"
 	"github.com/cockroachdb/cockroach/pkg/raft"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
@@ -150,14 +149,7 @@ func (sm *replicaStateMachine) NewBatch() apply.Batch {
 	// TODO(#144627): most commands do not need to read. Use NewWriteBatch because
 	// it is more efficient. If there are exceptions, sparingly use NewReader or
 	// NewBatch (if it needs to read its own writes, which is unlikely).
-	//
-	// TODO(sep-raft-log): wrap this to something like kvstorage.Batch, with
-	// appropriate engine access assertions.
-	if s := r.store; s.internalEngines.Separated() {
-		b.batch = s.internalEngines.StateEngine().NewBatch()
-	} else {
-		b.batch = s.internalEngines.Engine().NewBatch()
-	}
+	b.batch = r.store.batchFactory.NewBatch()
 
 	r.mu.RLock()
 	b.state = r.shMu.state
@@ -166,9 +158,6 @@ func (sm *replicaStateMachine) NewBatch() apply.Batch {
 	*b.state.Stats = *r.shMu.state.Stats
 	b.closedTimestampSetter = r.mu.closedTimestampSetter
 	r.mu.RUnlock()
-	if r.store.EnginesSeparated() {
-		b.wagWriter = wag.MakeWriter(&r.store.wagSeq)
-	}
 	b.start = timeutil.Now()
 	return b
 }

--- a/pkg/kv/kvserver/replica_destroy.go
+++ b/pkg/kv/kvserver/replica_destroy.go
@@ -86,7 +86,7 @@ func (r *Replica) destroyRaftMuLocked(ctx context.Context, nextReplicaID roachpb
 	startTime := timeutil.Now()
 
 	ms := r.GetMVCCStats()
-	batch := r.store.internalEngines.NewWriteBatch()
+	batch := r.store.batchFactory.NewWriteBatch()
 	defer batch.Close()
 
 	stateWO, raftWO := kvstorage.StateWO(batch.State()), batch.Raft()

--- a/pkg/kv/kvserver/replica_destroy.go
+++ b/pkg/kv/kvserver/replica_destroy.go
@@ -106,7 +106,7 @@ func (r *Replica) destroyRaftMuLocked(ctx context.Context, nextReplicaID roachpb
 	// a synchronous batch first and then delete the data alternatively, but
 	// then need to handle the case in which there is both the tombstone and
 	// leftover replica data.
-	if err := batch.CommitAndSync(); err != nil {
+	if err := batch.Commit(true /* syncStateEngine */); err != nil {
 		return err
 	}
 	commitTime := timeutil.Now()

--- a/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
+++ b/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
@@ -783,7 +783,7 @@ func assertWAGMutationBatch(t *testing.T, raftRepr, stateRepr []byte) bool {
 			"expected exactly one WAG node with a mutation batch, found multiple")
 		found = true
 		require.Equal(t, stateRepr, node.Mutation.Batch,
-			"WAG mutation batch for %s should match state engine batch", node.Addr)
+			"WAG mutation batch should match state engine batch")
 	}
 	return found
 }

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -881,6 +881,7 @@ type Store struct {
 	cfg                  StoreConfig
 	internalEngines      kvstorage.Engines
 	wagSeq               wag.Seq
+	batchFactory         kvstorage.BatchFactory
 	db                   *kv.DB
 	tsCache              tscache.Cache           // Most recent timestamps for keys / key ranges
 	allocator            allocatorimpl.Allocator // Makes allocation decisions
@@ -1497,6 +1498,9 @@ func NewStore(
 		ioThresholds:                      &iot,
 		rangeFeedSlowClosedTimestampNudge: singleflight.NewGroup("rangfeed-ct-nudge", "range"),
 	}
+	s.batchFactory = kvstorage.MakeBatchFactory(
+		&s.internalEngines, &s.wagSeq,
+	)
 	s.ioThreshold.t = &admissionpb.IOThreshold{}
 	// Track the maxScore over the last 5 minutes, in one minute windows.
 	now := cfg.Clock.Now().GoTime()

--- a/pkg/kv/kvserver/store_init.go
+++ b/pkg/kv/kvserver/store_init.go
@@ -156,8 +156,13 @@ func WriteInitialClusterData(
 		// TODO(#97616): the ranges are written one by one, so it is possible to end
 		// up with a partially initialized store if there is a crash in the middle.
 		// Write through a single batch, or find another way to make this atomic.
+
+		// No WAG nodes are going to be written here, so passing in a nil wag.Seq is
+		// fine.
+		factory := kvstorage.MakeBatchFactory(&eng, nil /* seq */)
+
 		err := func() error {
-			batch := eng.NewBatch()
+			batch := factory.NewBatch()
 			defer batch.Close()
 
 			now := hlc.Timestamp{

--- a/pkg/kv/kvserver/store_init.go
+++ b/pkg/kv/kvserver/store_init.go
@@ -272,7 +272,7 @@ func WriteInitialClusterData(
 				return err
 			}
 
-			return batch.CommitAndSync()
+			return batch.Commit(true /* syncStateEngine */)
 		}()
 		if err != nil {
 			return err

--- a/pkg/kv/kvserver/store_split.go
+++ b/pkg/kv/kvserver/store_split.go
@@ -179,24 +179,16 @@ func splitPreApply(
 		log.KvExec.Fatalf(ctx, "cannot clear RaftTruncatedState: %v", err)
 	}
 
-	// Stage WAG nodes for the split. The LHS state machine must be caught up to
-	// the entry before the split before it can be replayed.
-	//
-	// NB: raftIndex > 1 is verified by validateAndPrepareSplit, so the
-	// subtraction below is safe.
+	// Stage WAG events for the split. The Split event on the LHS implicitly
+	// carries a dependency on the LHS being caught up to raftIndex-1.
 	//
 	// NB: we don't record an explicit dependency on the RHS's
 	// CreateUninitializedReplica WAG node here. That node is written by
 	// getOrCreateReplica (called upstream via maybeAcquireSplitMergeLock) and
 	// will always precede this split node in the WAG sequence.
-	wagWriter.AddDep(wagpb.Node{
-		Addr: wagpb.MakeAddr(in.lhsID, in.raftIndex-1),
-		Type: wagpb.NodeType_NodeApply,
-	})
-	wagWriter.SetEvent(wagpb.Node{
-		Addr: wagpb.MakeAddr(in.lhsID, in.raftIndex),
-		Type: wagpb.NodeType_NodeSplit,
-	})
+	wagWriter.AddEvent(
+		wagpb.MakeAddr(in.lhsID, in.raftIndex), wagpb.EventType_EventSplit,
+	)
 
 	if in.rhsDestroyed {
 		// The RHS replica has already been removed from the store. To apply the

--- a/pkg/kv/kvserver/testdata/replica_lifecycle/split_pre_apply.txt
+++ b/pkg/kv/kvserver/testdata/replica_lifecycle/split_pre_apply.txt
@@ -58,8 +58,7 @@ apply-split range-id=1
 state engine:
 (matches WAG node)
 log engine:
-Put: 0,0 /Local/Store/wag/1 (0x01737761676e000000000000000100): NodeApply r1/1:10
-Put: 0,0 /Local/Store/wag/2 (0x01737761676e000000000000000200): NodeSplit r1/1:11
+Put: 0,0 /Local/Store/wag/1 (0x01737761676e000000000000000100): (r1/1:11,EventSplit)
 > Put: 0,0 /Local/RangeID/2/u/RangeLastReplicaGCTimestamp (0x01698a75726c727400): 0,0
 > Put: 0,0 /Local/Range"m"/QueueLastProcessed/"consistencyChecker" (0x016b126d0001716c7074636f6e73697374656e6379436865636b657200): meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0
 > Put: 0,0 /Local/RangeID/2/r/RangeLease (0x01698a72726c6c2d00): repl=(n1,s1):1 seq=0 start=0,0 type=LeaseExpiration exp=0.000000109,0 pro=0,0 acq=Unspecified
@@ -112,8 +111,7 @@ apply-split range-id=1
 state engine:
 (matches WAG node)
 log engine:
-Put: 0,0 /Local/Store/wag/3 (0x01737761676e000000000000000300): NodeApply r1/1:11
-Put: 0,0 /Local/Store/wag/4 (0x01737761676e000000000000000400): NodeSplit r1/1:12
+Put: 0,0 /Local/Store/wag/2 (0x01737761676e000000000000000200): (r1/1:12,EventSplit)
 > Put: 0,0 /Local/RangeID/3/u/RangeLastReplicaGCTimestamp (0x01698b75726c727400): 0,0
 > Put: 0,0 /Local/Range"f"/QueueLastProcessed/"consistencyChecker" (0x016b12660001716c7074636f6e73697374656e6379436865636b657200): meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0
 > Put: 0,0 /Local/RangeID/3/r/RangeLease (0x01698b72726c6c2d00): repl=(n1,s1):1 seq=0 start=0,0 type=LeaseExpiration exp=0.000000109,1 pro=0,0 acq=Unspecified
@@ -157,8 +155,7 @@ state engine:
 log engine:
 Put: 0,0 /Local/RangeID/4/u/RaftHardState (0x01698c757266746800): term:5 vote:0 commit:10 lead:0 lead_epoch:0 
 Put: 0,0 /Local/RangeID/4/u/RaftTruncatedState (0x01698c757266747400): index:10 term:5 
-Put: 0,0 /Local/Store/wag/5 (0x01737761676e000000000000000500): NodeApply r1/1:12
-Put: 0,0 /Local/Store/wag/6 (0x01737761676e000000000000000600): NodeSplit r1/1:13
+Put: 0,0 /Local/Store/wag/3 (0x01737761676e000000000000000300): (r1/1:13,EventSplit)
 > Put: 0,0 /Local/RangeID/4/u/RangeLastReplicaGCTimestamp (0x01698c75726c727400): 0,0
 > Put: 0,0 /Local/Range"c"/QueueLastProcessed/"consistencyChecker" (0x016b12630001716c7074636f6e73697374656e6379436865636b657200): meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0
 > Put: 0,0 /Local/RangeID/4/r/RangeLease (0x01698c72726c6c2d00): repl=(n1,s1):1 seq=0 start=0,0 type=LeaseExpiration exp=0.000000109,2 pro=0,0 acq=Unspecified

--- a/pkg/kv/kvserver/testdata/replica_lifecycle/split_trigger.txt
+++ b/pkg/kv/kvserver/testdata/replica_lifecycle/split_trigger.txt
@@ -51,8 +51,7 @@ state engine:
 log engine:
 Put: 0,0 /Local/RangeID/2/u/RaftHardState (0x01698a757266746800): term:5 vote:0 commit:10 lead:0 lead_epoch:0 
 Put: 0,0 /Local/RangeID/2/u/RaftTruncatedState (0x01698a757266747400): index:10 term:5 
-Put: 0,0 /Local/Store/wag/1 (0x01737761676e000000000000000100): NodeApply r1/1:10
-Put: 0,0 /Local/Store/wag/2 (0x01737761676e000000000000000200): NodeSplit r1/1:11
+Put: 0,0 /Local/Store/wag/1 (0x01737761676e000000000000000100): (r1/1:11,EventSplit)
 > Put: 0,0 /Local/RangeID/2/u/RangeLastReplicaGCTimestamp (0x01698a75726c727400): 0,0
 > Put: 0,0 /Local/Range"m"/QueueLastProcessed/"consistencyChecker" (0x016b126d0001716c7074636f6e73697374656e6379436865636b657200): meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0
 > Put: 0,0 /Local/RangeID/2/r/RangeLease (0x01698a72726c6c2d00): repl=(n2,s2):2 seq=0 start=0,0 type=LeaseExpiration exp=0.000000109,0 pro=0,0 acq=Unspecified
@@ -103,8 +102,7 @@ state engine:
 log engine:
 Put: 0,0 /Local/RangeID/3/u/RaftHardState (0x01698b757266746800): term:5 vote:0 commit:10 lead:0 lead_epoch:0 
 Put: 0,0 /Local/RangeID/3/u/RaftTruncatedState (0x01698b757266747400): index:10 term:5 
-Put: 0,0 /Local/Store/wag/3 (0x01737761676e000000000000000300): NodeApply r1/1:11
-Put: 0,0 /Local/Store/wag/4 (0x01737761676e000000000000000400): NodeSplit r1/1:12
+Put: 0,0 /Local/Store/wag/2 (0x01737761676e000000000000000200): (r1/1:12,EventSplit)
 > Put: 0,0 /Local/RangeID/3/u/RangeLastReplicaGCTimestamp (0x01698b75726c727400): 0,0
 > Put: 0,0 /Local/Range"f"/QueueLastProcessed/"consistencyChecker" (0x016b12660001716c7074636f6e73697374656e6379436865636b657200): meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0
 > Put: 0,0 /Local/RangeID/3/r/RangeLease (0x01698b72726c6c2d00): repl=(n1,s1):1 seq=0 start=0,0 type=LeaseEpoch epo=20 min-exp=0,0 pro=0,0 acq=Unspecified
@@ -141,8 +139,7 @@ state engine:
 log engine:
 Put: 0,0 /Local/RangeID/4/u/RaftHardState (0x01698c757266746800): term:5 vote:0 commit:10 lead:0 lead_epoch:0 
 Put: 0,0 /Local/RangeID/4/u/RaftTruncatedState (0x01698c757266747400): index:10 term:5 
-Put: 0,0 /Local/Store/wag/5 (0x01737761676e000000000000000500): NodeApply r2/1:10
-Put: 0,0 /Local/Store/wag/6 (0x01737761676e000000000000000600): NodeSplit r2/1:11
+Put: 0,0 /Local/Store/wag/3 (0x01737761676e000000000000000300): (r2/1:11,EventSplit)
 > Put: 0,0 /Local/RangeID/4/u/RangeLastReplicaGCTimestamp (0x01698c75726c727400): 0,0
 > Put: 0,0 /Local/Range"v"/QueueLastProcessed/"consistencyChecker" (0x016b12760001716c7074636f6e73697374656e6379436865636b657200): meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0
 > Put: 0,0 /Local/RangeID/4/r/RangeLease (0x01698c72726c6c2d00): repl=(n3,s3):3 seq=0 start=0,0 type=LeaseExpiration exp=0.000000300,0 pro=0,0 acq=Unspecified

--- a/pkg/testutils/lint/passes/redactcheck/redactcheck.go
+++ b/pkg/testutils/lint/passes/redactcheck/redactcheck.go
@@ -117,6 +117,9 @@ func runAnalyzer(pass *analysis.Pass) (interface{}, error) {
 					"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/ctpb": {
 						"SeqNum": {},
 					},
+					"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag/wagpb": {
+						"EventType": {},
+					},
 					"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation": {
 						"Level": {},
 					},


### PR DESCRIPTION
The first four commits are from #164965 — reviewers can focus on the
new ones starting with `kvstorage: introduce BatchFactory`.

The goal here is to make `kvstorage.Batch` WAG-writing aware so it can
serve as a single abstraction for the raft application stack. A bunch of
prep commits build up the `Batch` type -- lazy raft batch initialization,
a `BatchFactory` for centralized construction, a `WagWriter()` accessor,
a `Commit` method that handles WAG flushing and engine ordering, and
idempotent `Close`. The final commit wires it all up, replacing the three
separate fields on `replicaAppBatch` (`batch`, `raftBatch`, `wagWriter`)
with a single `kvstorage.Batch[storage.Batch]`. The apply stack no
longer needs to know about engine separation or WAG writing.

Epic: none
Release note: None