### PR TITLE
importer: fix output type mismatch for distributed merge import processor

### DIFF
--- a/pkg/sql/importer/import_processor.go
+++ b/pkg/sql/importer/import_processor.go
@@ -43,13 +43,7 @@ import (
 	gogotypes "github.com/gogo/protobuf/types"
 )
 
-var csvOutputTypes = []*types.T{
-	types.Bytes,
-	types.Bytes,
-}
-
-var distributedMergeOutputTypes = []*types.T{
-	types.Bytes,
+var importProcessorOutputTypes = []*types.T{
 	types.Bytes,
 	types.Bytes,
 }
@@ -143,11 +137,7 @@ func newReadImportDataProcessor(
 		processorID: processorID,
 		progCh:      make(chan execinfrapb.RemoteProducerMetadata_BulkProcessorProgress),
 	}
-	outputTypes := csvOutputTypes
-	if spec.UseDistributedMerge {
-		outputTypes = distributedMergeOutputTypes
-	}
-	if err := idp.Init(ctx, idp, post, outputTypes, flowCtx, processorID, nil, /* memMonitor */
+	if err := idp.Init(ctx, idp, post, importProcessorOutputTypes, flowCtx, processorID, nil, /* memMonitor */
 		execinfra.ProcStateOpts{
 			// This processor doesn't have any inputs to drain.
 			InputsToDrain: nil,


### PR DESCRIPTION
## Summary

When distributed merge was refactored to send SST metadata via the
progress channel instead of the processor's row output (520e1ccb1bc),
`distributedMergeOutputTypes` was not updated. It still declared 3
output columns, but the processor now always emits 2-column rows.
This caused `StreamEncoder.AddRow` to fail with "inconsistent row
length: expected 3, got 2" when a remote node's Outbox tried to send
the final summary row back to the gateway.

- Remove the stale `distributedMergeOutputTypes` (3 columns)
- Unify on a single `importProcessorOutputTypes` (2 columns) for all import modes

Fixes: #164908
Epic: CRDB-48845

Release note: None