### PR TITLE
importer: store SST manifests in job info keys instead of progress

### DIFF
--- a/pkg/cli/testdata/table_dump_column_parsing
+++ b/pkg/cli/testdata/table_dump_column_parsing
@@ -14,7 +14,7 @@ progress  \x10effdc3929b9f8a030d0000803fa8019984a0c1e09cd9e3486a0d1204000000002a
 ----
 {"Progress":null,"modified_micros":1733902763383997,"Details":{"table_metadata_cache":{}},"trace_id":0}
 {"Progress":null,"modified_micros":1733902768876277,"Details":{"AutoSpanConfigReconciliation":{"checkpoint":{"wall_time":1733902763154984000}}},"trace_id":0}
-{"Progress":{"fraction_completed":1},"modified_micros":1733902763884271,"Details":{"import":{"read_progress":[0],"span_progress":null,"resume_pos":[0],"sequence_details":[{}],"summary":{},"completed_map_work":null}},"trace_id":5244271230238327321}
+{"Progress":{"fraction_completed":1},"modified_micros":1733902763884271,"Details":{"import":{"read_progress":[0],"span_progress":null,"resume_pos":[0],"sequence_details":[{}],"summary":{}}},"trace_id":5244271230238327321}
 
 
 system.tenants.txt

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -794,10 +794,7 @@ message ImportProgress {
   // up job-scoped files on completion or cancellation.
   repeated string sst_storage_prefixes = 8 [(gogoproto.customname) = "SSTStoragePrefixes"];
 
-  // CompletedMapWork stores SST file metadata from processors that have
-  // finished during the map phase of distributed merge so that the files
-  // are not lost on retry.
-  repeated BulkSSTManifest completed_map_work = 9 [(gogoproto.nullable) = false];
+  reserved 9;
 }
 
 // TypeSchemaChangeDetails is the job detail information for a type schema change job.
@@ -917,6 +914,12 @@ message BackfillProgress {
   // MergeIterationCompletedTasks contains the task IDs that have been
   // completed in the current merge iteration.
   repeated int64 merge_iteration_completed_tasks = 10;
+}
+
+// BulkSSTManifests is a wrapper around a list of BulkSSTManifest messages,
+// used for serialization when storing manifests in job info keys.
+message BulkSSTManifests {
+  repeated BulkSSTManifest manifests = 1 [(gogoproto.nullable) = false];
 }
 
 // BulkSSTManifest describes an SST produced by bulk operations (backfill, import).

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -1057,6 +1057,16 @@ func (r *importResumer) cleanupTempStorage(ctx context.Context, execCfg *sql.Exe
 	if !details.UseDistributedMerge {
 		return
 	}
+
+	// Clean up SST manifest job info keys.
+	besteffort.Warning(ctx, "import-manifest-cleanup", func(ctx context.Context) error {
+		return execCfg.InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+			return jobs.InfoStorageForJob(txn, r.job.ID()).DeleteRange(
+				ctx, importSSTManifestsInfoKey, importSSTManifestsInfoKey+"~", 0,
+			)
+		})
+	})
+
 	progress := r.job.Progress()
 	importProgress := progress.GetImport()
 	if importProgress == nil {

--- a/pkg/sql/importer/import_processor_planning.go
+++ b/pkg/sql/importer/import_processor_planning.go
@@ -61,6 +61,10 @@ var replanFrequency = settings.RegisterDurationSetting(
 // import job progress.
 const importProgressDebugName = `import_progress`
 
+// importSSTManifestsInfoKey is the job info key used to store SST manifests
+// produced during the map phase of distributed merge import.
+const importSSTManifestsInfoKey = "~import/sst-manifests.binpb"
+
 // distImport is used by IMPORT to run a DistSQL flow to ingest data by starting
 // reader processes on many nodes that each read and ingest their assigned files
 // and then send back a summary of what they ingested. The combined summary is
@@ -207,11 +211,16 @@ func distImport(
 	var manifestBuf *backfill.SSTManifestBuffer
 
 	updateJobProgress := func() error {
-		return job.DebugNameNoTxn(importProgressDebugName).FractionProgressed(ctx, func(
-			ctx context.Context, details jobspb.ProgressDetails,
-		) float32 {
+		return job.DebugNameNoTxn(importProgressDebugName).Update(ctx, func(
+			txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater,
+		) error {
+			if err := md.CheckRunningOrReverting(); err != nil {
+				return err
+			}
+
+			prog := md.Progress.GetImport()
+
 			var overall float32
-			prog := details.(*jobspb.Progress_Import).Import
 			for i := range rowProgress {
 				prog.ResumePos[i] = atomic.LoadInt64(&rowProgress[i])
 			}
@@ -225,21 +234,34 @@ func distImport(
 			prog.Summary = accumulatedBulkSummary.BulkOpSummary.DeepCopy()
 			accumulatedBulkSummary.Unlock()
 
-			// Persist complete SST manifest snapshot for distributed merge, following
-			// the index backfiller pattern. This replaces the entire list rather than
-			// appending deltas, ensuring job state is always complete and eliminating
-			// the timing window for orphaned SSTs.
-			if useDistributedMerge && manifestBuf != nil {
-				if manifestBuf.Dirty() {
-					prog.CompletedMapWork = manifestBuf.SnapshotAndMarkClean()
-				} else {
-					prog.CompletedMapWork = manifestBuf.Snapshot()
+			// Persist SST manifests to job info keys for distributed merge.
+			// Only write when the buffer has new data to avoid unnecessary I/O.
+			if useDistributedMerge && manifestBuf != nil && manifestBuf.Dirty() {
+				manifests := manifestBuf.SnapshotAndMarkClean()
+				data, err := protoutil.Marshal(&jobspb.BulkSSTManifests{Manifests: manifests})
+				if err != nil {
+					return errors.Wrap(err, "marshaling SST manifests")
+				}
+				if err := jobs.WriteChunkedFileToJobInfo(
+					ctx, importSSTManifestsInfoKey, data, txn, job.ID(),
+				); err != nil {
+					return errors.Wrap(err, "writing SST manifests to job info")
 				}
 			}
 
-			return overall / float32(len(from))
-		},
-		)
+			fractionCompleted := overall / float32(len(from))
+			// Clamp to [0.0, 1.0].
+			if fractionCompleted > 1.0 {
+				fractionCompleted = 1.0
+			} else if fractionCompleted < 0.0 {
+				fractionCompleted = 0
+			}
+			md.Progress.Progress = &jobspb.Progress_FractionCompleted{
+				FractionCompleted: fractionCompleted,
+			}
+			ju.UpdateProgress(md.Progress)
+			return nil
+		})
 	}
 
 	var res kvpb.BulkOpSummary
@@ -249,11 +271,30 @@ func distImport(
 	// written in previous attempts, ensuring already-written SSTs are not lost.
 	processorOutput := make([]bulksst.SSTFiles, 0)
 	var resumeManifests []jobspb.BulkSSTManifest
-	if importProgress := job.Progress().Details.(*jobspb.Progress_Import).Import; importProgress != nil && len(importProgress.CompletedMapWork) > 0 {
-		resumeManifests = importProgress.CompletedMapWork
-		processorOutput = append(processorOutput, bulksst.ManifestsToSSTFiles(importProgress.CompletedMapWork))
-	}
 	if useDistributedMerge {
+		if err := execCtx.ExecCfg().InternalDB.Txn(ctx, func(
+			ctx context.Context, txn isql.Txn,
+		) error {
+			data, err := jobs.ReadChunkedFileToJobInfo(
+				ctx, importSSTManifestsInfoKey, txn, job.ID(),
+			)
+			if err != nil {
+				return err
+			}
+			if len(data) > 0 {
+				var stored jobspb.BulkSSTManifests
+				if err := protoutil.Unmarshal(data, &stored); err != nil {
+					return errors.Wrap(err, "unmarshaling SST manifests from job info")
+				}
+				resumeManifests = stored.Manifests
+				processorOutput = append(
+					processorOutput, bulksst.ManifestsToSSTFiles(resumeManifests),
+				)
+			}
+			return nil
+		}); err != nil {
+			return kvpb.BulkOpSummary{}, err
+		}
 		manifestBuf = backfill.NewSSTManifestBuffer(resumeManifests)
 	}
 


### PR DESCRIPTION
Previously, distributed merge IMPORT stored SST manifest metadata
inline in the `ImportProgress.CompletedMapWork` proto field. For large
imports with many SSTs, this can grow the job progress record
substantially and cause availability problems.

Move manifest storage to job info keys using `WriteChunkedFileToJobInfo`,
which breaks the data into compressed 1 MiB chunks. The manifests are
written atomically with the progress update in the same transaction,
preserving the checkpoint consistency guarantee. On resume, manifests
are read back via `ReadChunkedFileToJobInfo`. Manifests are cleaned up
from job info on both success and failure paths.

Since `CompletedMapWork` was added in the current v26.2 development cycle
and has never been released, no version gate is needed.

Resolves: #164675
Epic: CRDB-48845

Release note: None