### PR TITLE
mmaintegration: add SQL-aware decomposition to computePhysicalCPU

### DIFF
--- a/pkg/kv/kvserver/mmaintegration/BUILD.bazel
+++ b/pkg/kv/kvserver/mmaintegration/BUILD.bazel
@@ -23,10 +23,13 @@ go_library(
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/roachpb",
         "//pkg/settings/cluster",
+        "//pkg/util/buildutil",
+        "//pkg/util/grunning",
         "//pkg/util/log",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 

--- a/pkg/kv/kvserver/mmaintegration/physical_model.go
+++ b/pkg/kv/kvserver/mmaintegration/physical_model.go
@@ -58,13 +58,13 @@ type physicalDimension struct {
 //     moved to this store carry their load as computed by the source store's
 //     amplification factor.
 //
-//  2. Estimate background CPU: node CPU usage not attributable to MMA-tracked
+//  2. Estimate immovable CPU: node CPU usage not attributable to MMA-tracked
 //     work (e.g. SQL gateway, GC, background jobs). This is
 //     max(0, nodeUsage - storesCPU*ampFactor).
 //
 //  3. Compute per-store load and capacity.
 //     Load uses this store's direct replica CPU (CPUPerSecond) amplified by
-//     the factor, plus an even share of background. This lets stores with more
+//     the factor, plus an even share of immovable CPU. This lets stores with more
 //     KV work report higher load while still accounting for node-level overhead.
 //     Falls back to storesCPU/numStores when CPUPerSecond is unavailable.
 //     Capacity is nodeCap/numStores — a real-world quantity (the store's share
@@ -73,19 +73,19 @@ type physicalDimension struct {
 // Design decisions for the CPU physical model. For simplicity, the examples
 // below assume single-store nodes unless stated otherwise.
 //
-// # Background in load, not capacity
+// # Immovable CPU in load, not capacity
 //
-// Background CPU (max(0, nodeUsage - storesCPU*ampFactor)) is added to each
+// Immovable CPU (max(0, nodeUsage - storesCPU*ampFactor)) is added to each
 // store's load rather than subtracted from capacity. Capacity stays a
 // real-world number (nodeCap/numStores) and nodes running hot from any cause
 // become shed candidates.
 //
-// The alternative — subtracting background from capacity — hides pressure in
-// the denominator:
+// The alternative — subtracting immovable CPU from capacity — hides pressure
+// in the denominator:
 //
 //	Two nodes, 10-core each:
-//	  X: 80% total CPU (60% background + 20% KV).  bg = 6, KV = 2.
-//	  Y: 60% total CPU (all KV).                   bg = 0, KV = 6.
+//	  X: 80% total CPU (60% immovable + 20% KV).  immov = 6, KV = 2.
+//	  Y: 60% total CPU (all KV).                  immov = 0, KV = 6.
 //
 //	  Subtract from capacity:  X = 2/(10-6)  = 50%,  Y = 6/10 = 60%.
 //	  Add to load (chosen):    X = 8/10      = 80%,  Y = 6/10 = 60%.
@@ -111,16 +111,16 @@ type physicalDimension struct {
 // imbalance. Even split preserves differentiation; the node-level overload
 // check (canShedAndAddLoad) prevents over-accepting.
 //
-// Trade-off: a background-heavy node with little KV work still appears loaded
-// and MMA may try to shed from it. We accept this because: with this model,
+// Trade-off: a node with heavy immovable CPU and little KV work still appears
+// loaded and MMA may try to shed from it. We accept this because:
 //
 //  1. Operators see balanced total CPU across nodes — they don't need to
 //     distinguish KV from non-KV usage to understand the cluster state.
 //  2. If the node has no ranges at all, the shed attempt is a harmless no-op.
 //  3. The inflated store load raises the topK threshold (minLoadFraction *
 //     adjustedLoad), filtering out tiny ranges that wouldn't meaningfully
-//     reduce load — naturally limiting churn on background-heavy nodes.
-//  4. The alternative (subtracting background from capacity) makes the numbers
+//     reduce load — naturally limiting churn on immovable-heavy nodes.
+//  4. The alternative (subtracting immovable CPU from capacity) makes the numbers
 //     harder to reason about and, as shown above, can cause MMA to send work
 //     toward already-hot nodes.
 func computePhysicalCPU(desc roachpb.StoreDescriptor) (res physicalDimension) {
@@ -138,9 +138,9 @@ func computePhysicalCPU(desc roachpb.StoreDescriptor) (res physicalDimension) {
 		ampFactor = max(1, min(nodeUsage/storesCPU, maxCPUAmplification))
 	}
 
-	// Step 2: Attribute CPU to MMA-tracked work vs background.
+	// Step 2: Attribute CPU to MMA-tracked work vs immovable.
 	mmaLoad := storesCPU * ampFactor
-	background := max(0, nodeUsage-mmaLoad)
+	immovable := max(0, nodeUsage-mmaLoad)
 
 	// Step 3: Compute per-store load and capacity.
 	storeCPU := desc.Capacity.CPUPerSecond
@@ -155,7 +155,7 @@ func computePhysicalCPU(desc roachpb.StoreDescriptor) (res physicalDimension) {
 	//
 	//	sum(load_i) = sum(storeCPU_i * ampFactor + background / N)
 	//	            = ampFactor * sum(storeCPU_i) + background
-	//	            = ampFactor * storesCPU + max(0, nodeUsage - storesCPU * ampFactor)
+	//	            = ampFactor * storesCPU + max(0, nodeUsage - storesCPU*ampFactor)
 	//
 	// When ampFactor = nodeUsage/storesCPU (unclamped interior):
 	//
@@ -168,7 +168,7 @@ func computePhysicalCPU(desc roachpb.StoreDescriptor) (res physicalDimension) {
 	//
 	// The overshoot (storesCPU - nodeUsage) is transient and conservative: stores
 	// appear slightly more loaded than reality until the measurement lag resolves.
-	load := mmaprototype.LoadValue(max(0, storeCPU*ampFactor+background/numStores))
+	load := mmaprototype.LoadValue(max(0, storeCPU*ampFactor+immovable/numStores))
 	capacity := mmaprototype.LoadValue(max(0, nodeCap/numStores))
 	if nodeCap <= 0 {
 		capacity = load * 2

--- a/pkg/kv/kvserver/mmaintegration/physical_model.go
+++ b/pkg/kv/kvserver/mmaintegration/physical_model.go
@@ -50,30 +50,22 @@ type physicalDimension struct {
 // computePhysicalCPU computes per-store physical CPU load, capacity, and
 // amplification factor from the store descriptor.
 //
-// The computation has three steps:
+// The computation has two steps:
 //
-//  1. Estimate the amplification factor: the ratio of total node CPU caused by
-//     store work to the directly-tracked store CPU (CPUPerSecond). This is
-//     clamped to [1, maxCPUAmplification]. When storesCPURate is 0, the factor
-//     defaults to the cap. For store-level load, this is inconsequential (it
-//     multiplies zero). The factor is also returned as this store's
-//     amplification factor (via ComputeAmplificationFactors) and applied to
-//     per-range loads on this store, but since storesCPURate is the sum of
-//     replica CPU, individual ranges also have ~0 CPU in this case. Ranges
-//     moved to this store carry their load as computed by the source store's
-//     amplification factor.
+//  1. Estimate the amplification factor and immovable CPU. When SQL CPU
+//     metrics are available, node CPU is decomposed into moveable work
+//     (KV + distSQL, scaled by k1) and immovable work (gateway SQL, scaled
+//     by k2). When SQL metrics are unavailable, falls back to a single-ratio
+//     model. See "SQL-aware decomposition" below.
 //
-//  2. Estimate immovable CPU: node CPU usage not attributable to MMA-tracked
-//     work (e.g. SQL gateway, GC, background jobs). This is
-//     max(0, nodeUsage - storesCPU*ampFactor).
-//
-//  3. Compute per-store load and capacity.
+//  2. Compute per-store load and capacity.
 //     Load uses this store's direct replica CPU (CPUPerSecond) amplified by
-//     the factor, plus an even share of immovable CPU. This lets stores with more
-//     KV work report higher load while still accounting for node-level overhead.
-//     Falls back to storesCPU/numStores when CPUPerSecond is unavailable.
-//     Capacity is nodeCap/numStores — a real-world quantity (the store's share
-//     of the node's CPU cores) that remains directly interpretable.
+//     the factor, plus an even share of immovable CPU. This lets stores with
+//     more KV work report higher load while still accounting for node-level
+//     overhead. Falls back to storesCPU/numStores when CPUPerSecond is
+//     unavailable. Capacity is nodeCap/numStores — a real-world quantity (the
+//     store's share of the node's CPU cores) that remains directly
+//     interpretable.
 //
 // Design decisions for the CPU physical model. For simplicity, the examples
 // below assume single-store nodes unless stated otherwise.
@@ -128,6 +120,59 @@ type physicalDimension struct {
 //  4. The alternative (subtracting immovable CPU from capacity) makes the numbers
 //     harder to reason about and, as shown above, can cause MMA to send work
 //     toward already-hot nodes.
+//
+// # SQL-aware decomposition
+//
+// In general, node CPU splits into moveable work (anything that scales with
+// KV ranges) and immovable work (everything else):
+//
+//	nodeUsage = moveable + immovable
+//	moveable  = k1 * (storesCPU + sqlDistCPU)
+//	immovable = k2 * sqlGatewayCPU
+//
+// k1 and k2 are overhead multipliers that scale the tracked CPU sources to
+// account for untracked work (backups, elastic work, GC, CDC, OS overhead,
+// etc.) that could belong to either bucket. With one equation
+// (nodeUsage = k1*trackedMoveable + k2*sqlGatewayCPU) and two unknowns, we
+// cannot solve for k1 and k2 independently — we'd need a second measurement
+// that separates moveable from immovable overhead, which we don't have.
+// Instead, we assume k1 = k2 = k and solve:
+//
+//	k = nodeUsage / totalTracked
+//
+// where totalTracked = storesCPU + sqlDistCPU + sqlGatewayCPU. This is more
+// accurate than the fallback's nodeUsage/storesCPU, which lumps all non-KV
+// CPU into the overhead.
+//
+// Distributed SQL scales proportionally with KV, so it is folded into the
+// amplification factor rather than treated as immovable:
+
+// trackedMoveable = storesCPU + sqlDistCPU
+//
+//	= storesCPU * (1 + sqlDistCPU/storesCPU)
+//
+// physical by trackedMoveable = trackedMoveable * k
+//
+//	= storesCPU * (1 + sqlDistCPU/storesCPU) * k
+//
+// By definition, physical = storesCPU * ampFactor, so ampsFactor = (1 +
+// sqlDistCPU/storesCPU) * k.
+//
+//	ampFactor = (1 + sqlDistCPU/storesCPU) * k
+//	immovable = max(0, nodeUsage - trackedMoveable * k)
+//
+// where trackedMoveable = storesCPU + sqlDistCPU. The cap
+// (maxCPUAmplification) is applied to k — the per-source overhead
+// multiplier — so that the model doesn't attribute more than 3x overhead to
+// any tracked source. ampFactor = (1 + distRatio) * k may exceed the cap
+// when distSQL is significant; that's expected since it reflects real
+// measured distSQL work, not estimation error. When k is clamped, the
+// excess overhead spills into the immovable term. When k is unclamped,
+// immovable = sqlGatewayCPU * k.
+//
+// Fallback: when SQL metrics are zero, the model uses a single ratio
+// (ampFactor = clamp(nodeUsage/storesCPU, 1, cap)) and attributes the
+// residual as immovable, matching the pre-SQL behavior.
 func computePhysicalCPU(desc roachpb.StoreDescriptor) (res physicalDimension) {
 	assertCPUInputs(desc)
 	defer func() { res.capacity = max(minCapacity, res.capacity) }()
@@ -136,18 +181,31 @@ func computePhysicalCPU(desc roachpb.StoreDescriptor) (res physicalDimension) {
 	nodeUsage := max(0, float64(nc.NodeCPURateUsage))
 	nodeCap := max(0, float64(nc.NodeCPURateCapacity))
 	storesCPU := max(0, float64(nc.StoresCPURate))
+	sqlGatewayCPU := max(0, float64(nc.SQLGatewayCPUNanoPerSec))
+	sqlDistCPU := max(0, float64(nc.SQLDistCPUNanoPerSec))
 
-	// Step 1: Estimate the amplification factor.
-	ampFactor := maxCPUAmplification
-	if storesCPU > 0 {
+	// Step 1: Estimate the amplification factor and immovable CPU.
+	//
+	// See "SQL-aware decomposition" above. When SQL metrics are available, k is
+	// derived from the full tracked denominator and capped at
+	// maxCPUAmplification. Gateway SQL and any excess become immovable.
+	var ampFactor, immovable float64
+	hasSQLMetrics := (sqlGatewayCPU + sqlDistCPU) > 0
+	if storesCPU <= 0 {
+		ampFactor = maxCPUAmplification
+		immovable = max(0, nodeUsage)
+	} else if hasSQLMetrics {
+		trackedMoveable := storesCPU + sqlDistCPU
+		totalTracked := trackedMoveable + sqlGatewayCPU
+		k := max(1, min(nodeUsage/totalTracked, maxCPUAmplification))
+		ampFactor = (1 + sqlDistCPU/storesCPU) * k
+		immovable = max(0, nodeUsage-trackedMoveable*k)
+	} else {
 		ampFactor = max(1, min(nodeUsage/storesCPU, maxCPUAmplification))
+		immovable = max(0, nodeUsage-storesCPU*ampFactor)
 	}
 
-	// Step 2: Attribute CPU to MMA-tracked work vs immovable.
-	mmaLoad := storesCPU * ampFactor
-	immovable := max(0, nodeUsage-mmaLoad)
-
-	// Step 3: Compute per-store load and capacity.
+	// Step 2: Compute per-store load and capacity.
 	storeCPU := desc.Capacity.CPUPerSecond
 	if storeCPU <= 0 {
 		// Either because grunning is unsupported on the node's architecture, in
@@ -155,24 +213,6 @@ func computePhysicalCPU(desc roachpb.StoreDescriptor) (res physicalDimension) {
 		// have reported CPU usage, in which case CPUPerSecond is 0.
 		storeCPU = storesCPU / numStores
 	}
-
-	// Summing per-store loads across all stores on a node:
-	//
-	//	sum(load_i) = sum(storeCPU_i * ampFactor + background / N)
-	//	            = ampFactor * sum(storeCPU_i) + background
-	//	            = ampFactor * storesCPU + max(0, nodeUsage - storesCPU*ampFactor)
-	//
-	// When ampFactor = nodeUsage/storesCPU (unclamped interior):
-	//
-	//	= nodeUsage + max(0, nodeUsage - nodeUsage) = nodeUsage.  ✓
-	//
-	// When ampFactor is clamped to 1 (storesCPU > nodeUsage):
-	//
-	//	= storesCPU + max(0, nodeUsage - storesCPU)
-	//	= storesCPU + 0 = storesCPU > nodeUsage.
-	//
-	// The overshoot (storesCPU - nodeUsage) is transient and conservative: stores
-	// appear slightly more loaded than reality until the measurement lag resolves.
 	load := mmaprototype.LoadValue(storeCPU*ampFactor + immovable/numStores)
 	capacity := mmaprototype.LoadValue(nodeCap / numStores)
 	if nodeCap <= 0 {

--- a/pkg/kv/kvserver/mmaintegration/physical_model.go
+++ b/pkg/kv/kvserver/mmaintegration/physical_model.go
@@ -6,8 +6,13 @@
 package mmaintegration
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/mmaprototype"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
+	"github.com/cockroachdb/cockroach/pkg/util/grunning"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 // physicalStore holds the physical load, capacity, and amplification
@@ -124,13 +129,13 @@ type physicalDimension struct {
 //     harder to reason about and, as shown above, can cause MMA to send work
 //     toward already-hot nodes.
 func computePhysicalCPU(desc roachpb.StoreDescriptor) (res physicalDimension) {
+	assertCPUInputs(desc)
 	defer func() { res.capacity = max(minCapacity, res.capacity) }()
-
 	nc := desc.NodeCapacity
 	numStores := max(1, float64(nc.NumStores))
-	nodeUsage := float64(nc.NodeCPURateUsage)
-	nodeCap := float64(nc.NodeCPURateCapacity)
-	storesCPU := float64(nc.StoresCPURate)
+	nodeUsage := max(0, float64(nc.NodeCPURateUsage))
+	nodeCap := max(0, float64(nc.NodeCPURateCapacity))
+	storesCPU := max(0, float64(nc.StoresCPURate))
 
 	// Step 1: Estimate the amplification factor.
 	ampFactor := maxCPUAmplification
@@ -168,8 +173,8 @@ func computePhysicalCPU(desc roachpb.StoreDescriptor) (res physicalDimension) {
 	//
 	// The overshoot (storesCPU - nodeUsage) is transient and conservative: stores
 	// appear slightly more loaded than reality until the measurement lag resolves.
-	load := mmaprototype.LoadValue(max(0, storeCPU*ampFactor+immovable/numStores))
-	capacity := mmaprototype.LoadValue(max(0, nodeCap/numStores))
+	load := mmaprototype.LoadValue(storeCPU*ampFactor + immovable/numStores)
+	capacity := mmaprototype.LoadValue(nodeCap / numStores)
 	if nodeCap <= 0 {
 		capacity = load * 2
 	}
@@ -319,4 +324,35 @@ func MakePhysicalRangeLoad(
 	rl.Load[mmaprototype.WriteBandwidth] = mmaprototype.LoadValue(writeBytesPerSec * float64(amp[mmaprototype.WriteBandwidth]))
 	rl.Load[mmaprototype.ByteSize] = mmaprototype.LoadValue(float64(logicalBytes) * float64(amp[mmaprototype.ByteSize]))
 	return rl
+}
+
+// assertCPUInputs verifies (in test builds only) that the raw NodeCapacity
+// fields used by computePhysicalCPU are non-negative. All fields are int64 in
+// the protobuf, so they can technically be negative but shouldn't be
+// semantically. The caller clamps them with max(0, ...) after this check.
+func assertCPUInputs(desc roachpb.StoreDescriptor) {
+	if !buildutil.CrdbTestBuild {
+		return
+	}
+	nc := desc.NodeCapacity
+	// When !grunning.Supported (only in non-Bazel builds, i.e. plain
+	// `go test`; all production binaries use Bazel), each store sets
+	// CPUPerSecond to -1 and StoresCPURate (the sum across stores) is
+	// -numStores. Skip those checks since the physical model handles
+	// storesCPU <= 0 gracefully.
+	storesCPURateNegative := nc.StoresCPURate < 0 && grunning.Supported
+	storeCPURateNegative := desc.Capacity.CPUPerSecond < 0 && grunning.Supported
+	if nc.NumStores < 0 || storesCPURateNegative || storeCPURateNegative ||
+		nc.NodeCPURateUsage < 0 || nc.NodeCPURateCapacity < 0 ||
+		nc.SQLGatewayCPUNanoPerSec < 0 || nc.SQLDistCPUNanoPerSec < 0 {
+		log.Dev.Fatalf(context.Background(),
+			"computePhysicalCPU: negative NodeCapacity fields "+
+				"(NumStores=%d StoresCPURate=%d NodeCPURateUsage=%d "+
+				"NodeCPURateCapacity=%d SQLGatewayCPU=%d SQLDistCPU=%d "+
+				"grunning.Supported=%t)",
+			nc.NumStores, nc.StoresCPURate, nc.NodeCPURateUsage,
+			nc.NodeCPURateCapacity, nc.SQLGatewayCPUNanoPerSec, nc.SQLDistCPUNanoPerSec,
+			grunning.Supported,
+		)
+	}
 }

--- a/pkg/kv/kvserver/mmaintegration/physical_model.go
+++ b/pkg/kv/kvserver/mmaintegration/physical_model.go
@@ -7,12 +7,15 @@ package mmaintegration
 
 import (
 	"context"
+	"fmt"
+	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/mmaprototype"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/grunning"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/redact"
 )
 
 // physicalStore holds the physical load, capacity, and amplification
@@ -205,6 +208,10 @@ func computePhysicalCPU(desc roachpb.StoreDescriptor) (res physicalDimension) {
 		immovable = max(0, nodeUsage-storesCPU*ampFactor)
 	}
 
+	// Invariant: sum of per-store loads equals nodeUsage, unless measurement lag
+	// causes a transient overshoot (see assertCPULoadInvariant).
+	assertCPULoadInvariant(storesCPU, ampFactor, immovable, nodeUsage, sqlDistCPU, sqlGatewayCPU)
+
 	// Step 2: Compute per-store load and capacity.
 	storeCPU := desc.Capacity.CPUPerSecond
 	if storeCPU <= 0 {
@@ -364,6 +371,84 @@ func MakePhysicalRangeLoad(
 	rl.Load[mmaprototype.WriteBandwidth] = mmaprototype.LoadValue(writeBytesPerSec * float64(amp[mmaprototype.WriteBandwidth]))
 	rl.Load[mmaprototype.ByteSize] = mmaprototype.LoadValue(float64(logicalBytes) * float64(amp[mmaprototype.ByteSize]))
 	return rl
+}
+
+// assertCPULoadInvariant verifies (in test builds only) that the sum of
+// per-store CPU loads is consistent with nodeUsage.
+//
+// Each store's load is storeCPU_i * ampFactor + immovable/numStores. Summing
+// across all stores (sum(storeCPU_i) = storesCPU):
+//
+//	sumLoad = storesCPU * ampFactor + immovable
+//
+// Substituting ampFactor = (1 + sqlDistCPU/storesCPU) * k:
+//
+//	storesCPU * ampFactor = (storesCPU + sqlDistCPU) * k
+//	                      = trackedMoveable * k
+//
+// So sumLoad = trackedMoveable * k + immovable. Since
+// immovable = max(0, nodeUsage - trackedMoveable*k):
+//
+//   - k unclamped (1 ≤ nodeUsage/totalTracked ≤ cap):
+//     k = nodeUsage / totalTracked.
+//     trackedMoveable * k ≤ nodeUsage (since trackedMoveable ≤ totalTracked).
+//     immovable = nodeUsage - trackedMoveable*k ≥ 0.
+//     sum = trackedMoveable*k + (nodeUsage - trackedMoveable*k) = nodeUsage.
+//
+//   - k clamped at cap (nodeUsage/totalTracked > cap):
+//     k = cap. trackedMoveable * cap ≤ totalTracked * cap < nodeUsage.
+//     immovable = nodeUsage - trackedMoveable*cap > 0.
+//     sum = trackedMoveable*cap + (nodeUsage - trackedMoveable*cap) = nodeUsage.
+//
+//   - k floored at 1 (nodeUsage/totalTracked < 1, measurement lag):
+//     k = 1.
+//     If trackedMoveable ≤ nodeUsage (gateway CPU accounts for the gap):
+//     immovable = nodeUsage - trackedMoveable ≥ 0.
+//     sum = trackedMoveable + (nodeUsage - trackedMoveable) = nodeUsage.
+//     If trackedMoveable > nodeUsage:
+//     immovable = max(0, nodeUsage - trackedMoveable) = 0.
+//     sum = trackedMoveable > nodeUsage.
+//     Transient overshoot — stores appear slightly more loaded than
+//     reality until measurements converge.
+func assertCPULoadInvariant(
+	storesCPU, ampFactor, immovable, nodeUsage, sqlDistCPU, sqlGatewayCPU float64,
+) {
+	if !buildutil.CrdbTestBuild {
+		return
+	}
+
+	const floatEps = 1e-6
+	approxEq := func(a, b float64) bool { return math.Abs(a-b) <= floatEps }
+	moveable := storesCPU * ampFactor
+	sumLoad := moveable + immovable
+	ctx := context.Background()
+	state := redact.Safe(fmt.Sprintf(
+		"moveable=%.4f immovable=%.4f sumLoad=%.4f nodeUsage=%.4f "+
+			"storesCPU=%.4f ampFactor=%.4f sqlDistCPU=%.4f sqlGatewayCPU=%.4f",
+		moveable, immovable, sumLoad, nodeUsage,
+		storesCPU, ampFactor, sqlDistCPU, sqlGatewayCPU))
+
+	// immovable must be non-negative (it's clamped with max(0,...) at the call
+	// site, but double-check here).
+	if immovable < 0 {
+		log.Dev.Fatalf(ctx, "CPU load invariant: immovable < 0 (%v)", state)
+	}
+
+	// Measurement lag: tracked moveable CPU (storesCPU + sqlDistCPU) exceeds
+	// measured nodeUsage, so k is floored at 1 and moveable > nodeUsage. In
+	// this case immovable = 0 and sumLoad = moveable > nodeUsage — a transient,
+	// conservative overshoot that resolves as measurements converge.
+	if (storesCPU + sqlDistCPU) > nodeUsage {
+		if !approxEq(immovable, 0) {
+			log.Dev.Fatalf(ctx, "CPU load invariant: measurement lag but immovable != 0 (%v)", state)
+		}
+		return
+	}
+
+	// Normal case: moveable + immovable must equal nodeUsage.
+	if !approxEq(sumLoad, nodeUsage) {
+		log.Dev.Fatalf(ctx, "CPU load invariant: sumLoad != nodeUsage (%v)", state)
+	}
 }
 
 // assertCPUInputs verifies (in test builds only) that the raw NodeCapacity

--- a/pkg/kv/kvserver/mmaintegration/physical_model_test.go
+++ b/pkg/kv/kvserver/mmaintegration/physical_model_test.go
@@ -46,15 +46,25 @@ func TestComputePhysicalStore(t *testing.T) {
 					d.ScanArgs(t, "store-cpu-per-second", &storeCPUCores)
 				}
 
+				var sqlGatewayCPUCores, sqlDistCPUCores float64
+				if d.HasArg("sql-gateway-cpu") {
+					d.ScanArgs(t, "sql-gateway-cpu", &sqlGatewayCPUCores)
+				}
+				if d.HasArg("sql-dist-cpu") {
+					d.ScanArgs(t, "sql-dist-cpu", &sqlDistCPUCores)
+				}
+
 				const nsPerCore = 1e9
 				const gib = 1 << 30
 
 				desc := roachpb.StoreDescriptor{
 					NodeCapacity: roachpb.NodeCapacity{
-						NumStores:           int32(numStores),
-						StoresCPURate:       int64(storesCPUCores * nsPerCore),
-						NodeCPURateUsage:    int64(nodeUsageCores * nsPerCore),
-						NodeCPURateCapacity: int64(nodeCapCores * nsPerCore),
+						NumStores:               int32(numStores),
+						StoresCPURate:           int64(storesCPUCores * nsPerCore),
+						NodeCPURateUsage:        int64(nodeUsageCores * nsPerCore),
+						NodeCPURateCapacity:     int64(nodeCapCores * nsPerCore),
+						SQLGatewayCPUNanoPerSec: int64(sqlGatewayCPUCores * nsPerCore),
+						SQLDistCPUNanoPerSec:    int64(sqlDistCPUCores * nsPerCore),
 					},
 					Capacity: roachpb.StoreCapacity{
 						CPUPerSecond:        storeCPUCores * nsPerCore,

--- a/pkg/kv/kvserver/mmaintegration/testdata/TestComputePhysicalStore
+++ b/pkg/kv/kvserver/mmaintegration/testdata/TestComputePhysicalStore
@@ -156,3 +156,125 @@ cpu:             load=10.00 cores  capacity=16.00 cores  amp=3.0000
 disk:            load=80.00 GiB  capacity=100.00 GiB  amp=2.0000
 write-bandwidth: load=9.54 MiB/s  capacity=unknown  amp=1.0000
 amplification-factors: [cpu=3.0000, disk=2.0000, write-bw=1.0000]
+
+# ===================================================================
+# SQL-aware model tests.
+# When sql-gateway-cpu and/or sql-dist-cpu are provided, the model
+# computes a uniform overhead multiplier k over all tracked sources
+# (storesCPU + sqlDistCPU + sqlGatewayCPU), then folds distSQL into
+# ampFactor and treats gateway SQL as background.
+# ===================================================================
+
+# -------------------------------------------------------------------
+# SQL-aware basic: unclamped k.
+# 1 store, storesCPU=2, nodeUsage=6, nodeCap=16.
+# sqlGatewayCPU=1, sqlDistCPU=1. moveableCPU = 3, totalTracked = 4.
+# k = 6/4 = 1.5. ampFactor = (1 + 1/2) * 1.5 = 2.25.
+# background = max(0, 6 - 3*1.5) = 1.5.
+# load = 2*2.25 + 1.5/1 = 6, capacity = 16.
+# -------------------------------------------------------------------
+compute num-stores=1 stores-cpu=2 node-cpu-usage=6 node-cpu-capacity=16 sql-gateway-cpu=1 sql-dist-cpu=1 logical-gib=10 used-gib=20 available-gib=80 write-bytes-per-sec=10000000
+----
+cpu:             load=6.00 cores  capacity=16.00 cores  amp=2.2500
+disk:            load=20.00 GiB  capacity=100.00 GiB  amp=2.0000
+write-bandwidth: load=9.54 MiB/s  capacity=unknown  amp=1.0000
+amplification-factors: [cpu=2.2500, disk=2.0000, write-bw=1.0000]
+
+# -------------------------------------------------------------------
+# SQL-aware gateway-heavy: gateway dominates, k unclamped.
+# 1 store, storesCPU=2, nodeUsage=9, nodeCap=16.
+# sqlGatewayCPU=3, sqlDistCPU=1. moveableCPU = 3, totalTracked = 6.
+# k = 9/6 = 1.5. ampFactor = 1.5 * 1.5 = 2.25.
+# background = max(0, 9 - 3*1.5) = 4.5.
+# load = 2*2.25 + 4.5/1 = 9, capacity = 16.
+# -------------------------------------------------------------------
+compute num-stores=1 stores-cpu=2 node-cpu-usage=9 node-cpu-capacity=16 sql-gateway-cpu=3 sql-dist-cpu=1 logical-gib=10 used-gib=20 available-gib=80 write-bytes-per-sec=10000000
+----
+cpu:             load=9.00 cores  capacity=16.00 cores  amp=2.2500
+disk:            load=20.00 GiB  capacity=100.00 GiB  amp=2.0000
+write-bandwidth: load=9.54 MiB/s  capacity=unknown  amp=1.0000
+amplification-factors: [cpu=2.2500, disk=2.0000, write-bw=1.0000]
+
+# -------------------------------------------------------------------
+# SQL-aware high distSQL: distSQL is 1.5x KV, k unclamped.
+# 1 store, storesCPU=2, nodeUsage=12, nodeCap=16.
+# sqlGatewayCPU=1, sqlDistCPU=3. moveableCPU = 5, totalTracked = 6.
+# k = max(1, min(12/6, 3)) = 2. ampFactor = 2.5*2 = 5.
+# background = max(0, 12 - 5*2) = 2.
+# load = 2*5 + 2/1 = 12, capacity = 16.
+# -------------------------------------------------------------------
+compute num-stores=1 stores-cpu=2 node-cpu-usage=12 node-cpu-capacity=16 sql-gateway-cpu=1 sql-dist-cpu=3 logical-gib=10 used-gib=20 available-gib=80 write-bytes-per-sec=10000000
+----
+cpu:             load=12.00 cores  capacity=16.00 cores  amp=5.0000
+disk:            load=20.00 GiB  capacity=100.00 GiB  amp=2.0000
+write-bandwidth: load=9.54 MiB/s  capacity=unknown  amp=1.0000
+amplification-factors: [cpu=5.0000, disk=2.0000, write-bw=1.0000]
+
+# -------------------------------------------------------------------
+# SQL-aware k clamped at cap: extreme overhead.
+# 1 store, storesCPU=1, nodeUsage=15, nodeCap=16.
+# sqlGatewayCPU=1, sqlDistCPU=1. moveableCPU = 2, totalTracked = 3.
+# k = max(1, min(15/3, 3)) = 3. ampFactor = 2*3 = 6.
+# background = max(0, 15 - 2*3) = 9.
+# load = 1*6 + 9/1 = 15, capacity = 16.
+# -------------------------------------------------------------------
+compute num-stores=1 stores-cpu=1 node-cpu-usage=15 node-cpu-capacity=16 sql-gateway-cpu=1 sql-dist-cpu=1 logical-gib=10 used-gib=20 available-gib=80 write-bytes-per-sec=10000000
+----
+cpu:             load=15.00 cores  capacity=16.00 cores  amp=6.0000
+disk:            load=20.00 GiB  capacity=100.00 GiB  amp=2.0000
+write-bandwidth: load=9.54 MiB/s  capacity=unknown  amp=1.0000
+amplification-factors: [cpu=6.0000, disk=2.0000, write-bw=1.0000]
+
+# -------------------------------------------------------------------
+# SQL-aware multi-store: 4 stores, even split.
+# storesCPU=4, nodeUsage=10, nodeCap=16.
+# sqlGatewayCPU=2, sqlDistCPU=2. moveableCPU = 6, totalTracked = 8.
+# k = 10/8 = 1.25. ampFactor = (1 + 2/4) * 1.25 = 1.875.
+# background = max(0, 10 - 6*1.25) = 2.5.
+# storeCPU = 4/4 = 1. load = 1*1.875 + 2.5/4 = 2.5, capacity = 4.
+# -------------------------------------------------------------------
+compute num-stores=4 stores-cpu=4 node-cpu-usage=10 node-cpu-capacity=16 sql-gateway-cpu=2 sql-dist-cpu=2 logical-gib=10 used-gib=20 available-gib=80 write-bytes-per-sec=10000000
+----
+cpu:             load=2.50 cores  capacity=4.00 cores  amp=1.8750
+disk:            load=20.00 GiB  capacity=100.00 GiB  amp=2.0000
+write-bandwidth: load=9.54 MiB/s  capacity=unknown  amp=1.0000
+amplification-factors: [cpu=1.8750, disk=2.0000, write-bw=1.0000]
+
+# -------------------------------------------------------------------
+# SQL-aware with store-cpu-per-second: hot store on a 4-store node.
+# Same node as above, but this store reports 3 of the 4 KV cores.
+# load = 3*1.875 + 2.5/4 = 6.25, capacity = 4.
+# -------------------------------------------------------------------
+compute num-stores=4 stores-cpu=4 node-cpu-usage=10 node-cpu-capacity=16 store-cpu-per-second=3 sql-gateway-cpu=2 sql-dist-cpu=2 logical-gib=10 used-gib=20 available-gib=80 write-bytes-per-sec=10000000
+----
+cpu:             load=6.25 cores  capacity=4.00 cores  amp=1.8750
+disk:            load=20.00 GiB  capacity=100.00 GiB  amp=2.0000
+write-bandwidth: load=9.54 MiB/s  capacity=unknown  amp=1.0000
+amplification-factors: [cpu=1.8750, disk=2.0000, write-bw=1.0000]
+
+# -------------------------------------------------------------------
+# SQL-aware zero storesCPU: no KV work, all gateway SQL.
+# Falls to storesCPU<=0 branch: ampFactor=cap(3), background=nodeUsage.
+# storeCPU=0, load = 0*3 + 5/1 = 5, capacity = 16.
+# -------------------------------------------------------------------
+compute num-stores=1 stores-cpu=0 node-cpu-usage=5 node-cpu-capacity=16 sql-gateway-cpu=3 sql-dist-cpu=0 logical-gib=10 used-gib=20 available-gib=80 write-bytes-per-sec=10000000
+----
+cpu:             load=5.00 cores  capacity=16.00 cores  amp=3.0000
+disk:            load=20.00 GiB  capacity=100.00 GiB  amp=2.0000
+write-bandwidth: load=9.54 MiB/s  capacity=unknown  amp=1.0000
+amplification-factors: [cpu=3.0000, disk=2.0000, write-bw=1.0000]
+
+# -------------------------------------------------------------------
+# SQL-aware k clamped at 1 (measurement lag): tracked CPU > nodeUsage.
+# 1 store, storesCPU=4, nodeUsage=3, nodeCap=16.
+# sqlGatewayCPU=1, sqlDistCPU=1. moveableCPU = 5, totalTracked = 6.
+# k = max(1, min(3/6, 3)) = 1. ampFactor = 1.25*1 = 1.25.
+# background = max(0, 3 - 5*1) = 0.
+# load = 4*1.25 + 0 = 5 (overshoots nodeUsage; transient, conservative).
+# -------------------------------------------------------------------
+compute num-stores=1 stores-cpu=4 node-cpu-usage=3 node-cpu-capacity=16 sql-gateway-cpu=1 sql-dist-cpu=1 logical-gib=10 used-gib=20 available-gib=80 write-bytes-per-sec=10000000
+----
+cpu:             load=5.00 cores  capacity=16.00 cores  amp=1.2500
+disk:            load=20.00 GiB  capacity=100.00 GiB  amp=2.0000
+write-bandwidth: load=9.54 MiB/s  capacity=unknown  amp=1.0000
+amplification-factors: [cpu=1.2500, disk=2.0000, write-bw=1.0000]


### PR DESCRIPTION
Epic: CRDB-55052 
Release note: none

---
**mmaintegration: rename background to immovable in `computePhysicalCPU`**


---
**mmaintegration: add `assertCPUInputs `**


---
**mmaintegration: add SQL-aware decomposition to `computePhysicalCPU`**

The existing CPU physical model computes the amplification factor as
`nodeUsage / storesCPU`, which attributes all non-KV CPU (gateway SQL,
distSQL, GC, CDC, backups) to overhead on KV work. On nodes with
significant SQL gateway or distSQL load, this inflates the
amplification factor and overstates the cost of moving a single range.

This change teaches `computePhysicalCPU` to decompose node CPU into
moveable work (KV + distSQL) and immovable work (gateway SQL) when
`SQLGatewayCPUNanoPerSec` and `SQLDistCPUNanoPerSec` are available in
`NodeCapacity`. The model fits a uniform overhead multiplier k:

    k = nodeUsage / (storesCPU + sqlDistCPU + sqlGatewayCPU)

Distributed SQL scales proportionally with KV work, so it is folded
into the amplification factor rather than treated as immovable:

    ampFactor = (1 + sqlDistCPU/storesCPU) * k
    immovable = max(0, nodeUsage - trackedMoveable * k)

The cap (`maxCPUAmplification`) is applied to k — the per-source
overhead multiplier — rather than to `ampFactor`. This ensures the
model does not attribute more than 3x untracked overhead to any
tracked source. `ampFactor` may exceed the cap when distSQL is
significant; that reflects real measured distSQL work, not estimation
error. When k is clamped, the excess overhead spills into the
immovable term.

When SQL metrics are zero, the model falls back to the single-ratio
behavior (`ampFactor = clamp(nodeUsage/storesCPU, 1, cap)`), matching
the pre-SQL behavior.

The test harness is extended with optional `sql-gateway-cpu` and
`sql-dist-cpu` parameters, and new datadriven test cases exercise the
SQL-aware branch across all k-clamping regimes (unclamped, capped,
floored at 1).

---
**mmaintegration: add `assertCPULoadInvariant`**


