### PR TITLE
mmaintegration: add SQL-aware decomposition to physical CPU model

### DIFF
--- a/pkg/kv/kvserver/mmaintegration/BUILD.bazel
+++ b/pkg/kv/kvserver/mmaintegration/BUILD.bazel
@@ -23,10 +23,13 @@ go_library(
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/roachpb",
         "//pkg/settings/cluster",
+        "//pkg/util/buildutil",
+        "//pkg/util/grunning",
         "//pkg/util/log",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 

--- a/pkg/kv/kvserver/mmaintegration/physical_model.go
+++ b/pkg/kv/kvserver/mmaintegration/physical_model.go
@@ -58,13 +58,13 @@ type physicalDimension struct {
 //     moved to this store carry their load as computed by the source store's
 //     amplification factor.
 //
-//  2. Estimate background CPU: node CPU usage not attributable to MMA-tracked
+//  2. Estimate immovable CPU: node CPU usage not attributable to MMA-tracked
 //     work (e.g. SQL gateway, GC, background jobs). This is
 //     max(0, nodeUsage - storesCPU*ampFactor).
 //
 //  3. Compute per-store load and capacity.
 //     Load uses this store's direct replica CPU (CPUPerSecond) amplified by
-//     the factor, plus an even share of background. This lets stores with more
+//     the factor, plus an even share of immovable CPU. This lets stores with more
 //     KV work report higher load while still accounting for node-level overhead.
 //     Falls back to storesCPU/numStores when CPUPerSecond is unavailable.
 //     Capacity is nodeCap/numStores — a real-world quantity (the store's share
@@ -73,19 +73,19 @@ type physicalDimension struct {
 // Design decisions for the CPU physical model. For simplicity, the examples
 // below assume single-store nodes unless stated otherwise.
 //
-// # Background in load, not capacity
+// # Immovable CPU in load, not capacity
 //
-// Background CPU (max(0, nodeUsage - storesCPU*ampFactor)) is added to each
+// Immovable CPU (max(0, nodeUsage - storesCPU*ampFactor)) is added to each
 // store's load rather than subtracted from capacity. Capacity stays a
 // real-world number (nodeCap/numStores) and nodes running hot from any cause
 // become shed candidates.
 //
-// The alternative — subtracting background from capacity — hides pressure in
-// the denominator:
+// The alternative — subtracting immovable CPU from capacity — hides pressure
+// in the denominator:
 //
 //	Two nodes, 10-core each:
-//	  X: 80% total CPU (60% background + 20% KV).  bg = 6, KV = 2.
-//	  Y: 60% total CPU (all KV).                   bg = 0, KV = 6.
+//	  X: 80% total CPU (60% immovable + 20% KV).  immov = 6, KV = 2.
+//	  Y: 60% total CPU (all KV).                  immov = 0, KV = 6.
 //
 //	  Subtract from capacity:  X = 2/(10-6)  = 50%,  Y = 6/10 = 60%.
 //	  Add to load (chosen):    X = 8/10      = 80%,  Y = 6/10 = 60%.
@@ -111,16 +111,16 @@ type physicalDimension struct {
 // imbalance. Even split preserves differentiation; the node-level overload
 // check (canShedAndAddLoad) prevents over-accepting.
 //
-// Trade-off: a background-heavy node with little KV work still appears loaded
-// and MMA may try to shed from it. We accept this because: with this model,
+// Trade-off: a node with heavy immovable CPU and little KV work still appears
+// loaded and MMA may try to shed from it. We accept this because:
 //
 //  1. Operators see balanced total CPU across nodes — they don't need to
 //     distinguish KV from non-KV usage to understand the cluster state.
 //  2. If the node has no ranges at all, the shed attempt is a harmless no-op.
 //  3. The inflated store load raises the topK threshold (minLoadFraction *
 //     adjustedLoad), filtering out tiny ranges that wouldn't meaningfully
-//     reduce load — naturally limiting churn on background-heavy nodes.
-//  4. The alternative (subtracting background from capacity) makes the numbers
+//     reduce load — naturally limiting churn on immovable-heavy nodes.
+//  4. The alternative (subtracting immovable CPU from capacity) makes the numbers
 //     harder to reason about and, as shown above, can cause MMA to send work
 //     toward already-hot nodes.
 func computePhysicalCPU(desc roachpb.StoreDescriptor) (res physicalDimension) {
@@ -138,9 +138,9 @@ func computePhysicalCPU(desc roachpb.StoreDescriptor) (res physicalDimension) {
 		ampFactor = max(1, min(nodeUsage/storesCPU, maxCPUAmplification))
 	}
 
-	// Step 2: Attribute CPU to MMA-tracked work vs background.
+	// Step 2: Attribute CPU to MMA-tracked work vs immovable.
 	mmaLoad := storesCPU * ampFactor
-	background := max(0, nodeUsage-mmaLoad)
+	immovable := max(0, nodeUsage-mmaLoad)
 
 	// Step 3: Compute per-store load and capacity.
 	storeCPU := desc.Capacity.CPUPerSecond
@@ -155,7 +155,7 @@ func computePhysicalCPU(desc roachpb.StoreDescriptor) (res physicalDimension) {
 	//
 	//	sum(load_i) = sum(storeCPU_i * ampFactor + background / N)
 	//	            = ampFactor * sum(storeCPU_i) + background
-	//	            = ampFactor * storesCPU + max(0, nodeUsage - storesCPU * ampFactor)
+	//	            = ampFactor * storesCPU + max(0, nodeUsage - storesCPU*ampFactor)
 	//
 	// When ampFactor = nodeUsage/storesCPU (unclamped interior):
 	//
@@ -168,7 +168,7 @@ func computePhysicalCPU(desc roachpb.StoreDescriptor) (res physicalDimension) {
 	//
 	// The overshoot (storesCPU - nodeUsage) is transient and conservative: stores
 	// appear slightly more loaded than reality until the measurement lag resolves.
-	load := mmaprototype.LoadValue(max(0, storeCPU*ampFactor+background/numStores))
+	load := mmaprototype.LoadValue(max(0, storeCPU*ampFactor+immovable/numStores))
 	capacity := mmaprototype.LoadValue(max(0, nodeCap/numStores))
 	if nodeCap <= 0 {
 		capacity = load * 2

--- a/pkg/kv/kvserver/mmaintegration/physical_model.go
+++ b/pkg/kv/kvserver/mmaintegration/physical_model.go
@@ -50,30 +50,22 @@ type physicalDimension struct {
 // computePhysicalCPU computes per-store physical CPU load, capacity, and
 // amplification factor from the store descriptor.
 //
-// The computation has three steps:
+// The computation has two steps:
 //
-//  1. Estimate the amplification factor: the ratio of total node CPU caused by
-//     store work to the directly-tracked store CPU (CPUPerSecond). This is
-//     clamped to [1, maxCPUAmplification]. When storesCPURate is 0, the factor
-//     defaults to the cap. For store-level load, this is inconsequential (it
-//     multiplies zero). The factor is also returned as this store's
-//     amplification factor (via ComputeAmplificationFactors) and applied to
-//     per-range loads on this store, but since storesCPURate is the sum of
-//     replica CPU, individual ranges also have ~0 CPU in this case. Ranges
-//     moved to this store carry their load as computed by the source store's
-//     amplification factor.
+//  1. Estimate the amplification factor and immovable CPU. When SQL CPU
+//     metrics are available, node CPU is decomposed into moveable work
+//     (KV + distSQL, scaled by k1) and immovable work (gateway SQL, scaled
+//     by k2). When SQL metrics are unavailable, falls back to a single-ratio
+//     model. See "SQL-aware decomposition" below.
 //
-//  2. Estimate immovable CPU: node CPU usage not attributable to MMA-tracked
-//     work (e.g. SQL gateway, GC, background jobs). This is
-//     max(0, nodeUsage - storesCPU*ampFactor).
-//
-//  3. Compute per-store load and capacity.
+//  2. Compute per-store load and capacity.
 //     Load uses this store's direct replica CPU (CPUPerSecond) amplified by
-//     the factor, plus an even share of immovable CPU. This lets stores with more
-//     KV work report higher load while still accounting for node-level overhead.
-//     Falls back to storesCPU/numStores when CPUPerSecond is unavailable.
-//     Capacity is nodeCap/numStores — a real-world quantity (the store's share
-//     of the node's CPU cores) that remains directly interpretable.
+//     the factor, plus an even share of immovable CPU. This lets stores with
+//     more KV work report higher load while still accounting for node-level
+//     overhead. Falls back to storesCPU/numStores when CPUPerSecond is
+//     unavailable. Capacity is nodeCap/numStores — a real-world quantity (the
+//     store's share of the node's CPU cores) that remains directly
+//     interpretable.
 //
 // Design decisions for the CPU physical model. For simplicity, the examples
 // below assume single-store nodes unless stated otherwise.
@@ -128,6 +120,59 @@ type physicalDimension struct {
 //  4. The alternative (subtracting immovable CPU from capacity) makes the numbers
 //     harder to reason about and, as shown above, can cause MMA to send work
 //     toward already-hot nodes.
+//
+// # SQL-aware decomposition
+//
+// In general, node CPU splits into moveable work (anything that scales with
+// KV ranges) and immovable work (everything else):
+//
+//	nodeUsage = moveable + immovable
+//	moveable  = k1 * (storesCPU + sqlDistCPU)
+//	immovable = k2 * sqlGatewayCPU
+//
+// k1 and k2 are overhead multipliers that scale the tracked CPU sources to
+// account for untracked work (backups, elastic work, GC, CDC, OS overhead,
+// etc.) that could belong to either bucket. With one equation
+// (nodeUsage = k1*trackedMoveable + k2*sqlGatewayCPU) and two unknowns, we
+// cannot solve for k1 and k2 independently — we'd need a second measurement
+// that separates moveable from immovable overhead, which we don't have.
+// Instead, we assume k1 = k2 = k and solve:
+//
+//	k = nodeUsage / totalTracked
+//
+// where totalTracked = storesCPU + sqlDistCPU + sqlGatewayCPU. This is more
+// accurate than the fallback's nodeUsage/storesCPU, which lumps all non-KV
+// CPU into the overhead.
+//
+// Distributed SQL scales proportionally with KV, so it is folded into the
+// amplification factor rather than treated as immovable:
+//
+// trackedMoveable = storesCPU + sqlDistCPU
+//
+//	= storesCPU * (1 + sqlDistCPU/storesCPU)
+//
+// physicalMoveable = trackedMoveable * k
+//
+//	= storesCPU * (1 + sqlDistCPU/storesCPU) * k
+//
+// By definition, physical = storesCPU * ampFactor, so ampFactor = (1 +
+// sqlDistCPU/storesCPU) * k.
+//
+//	ampFactor = (1 + sqlDistCPU/storesCPU) * k
+//	immovable = max(0, nodeUsage - trackedMoveable * k)
+//
+// where trackedMoveable = storesCPU + sqlDistCPU. The cap
+// (maxCPUAmplification) is applied to k — the per-source overhead
+// multiplier — so that the model doesn't attribute more than 3x overhead to
+// any tracked source. ampFactor = (1 + distRatio) * k may exceed the cap
+// when distSQL is significant; that's expected since it reflects real
+// measured distSQL work, not estimation error. When k is clamped, the
+// excess overhead spills into the immovable term. When k is unclamped,
+// immovable = sqlGatewayCPU * k.
+//
+// Fallback: when SQL metrics are zero, the model uses a single ratio
+// (ampFactor = clamp(nodeUsage/storesCPU, 1, cap)) and attributes the
+// residual as immovable, matching the pre-SQL behavior.
 func computePhysicalCPU(desc roachpb.StoreDescriptor) (res physicalDimension) {
 	assertCPUInputs(desc)
 	defer func() { res.capacity = max(minCapacity, res.capacity) }()
@@ -136,18 +181,31 @@ func computePhysicalCPU(desc roachpb.StoreDescriptor) (res physicalDimension) {
 	nodeUsage := max(0, float64(nc.NodeCPURateUsage))
 	nodeCap := max(0, float64(nc.NodeCPURateCapacity))
 	storesCPU := max(0, float64(nc.StoresCPURate))
+	sqlGatewayCPU := max(0, float64(nc.SQLGatewayCPUNanoPerSec))
+	sqlDistCPU := max(0, float64(nc.SQLDistCPUNanoPerSec))
 
-	// Step 1: Estimate the amplification factor.
-	ampFactor := maxCPUAmplification
-	if storesCPU > 0 {
+	// Step 1: Estimate the amplification factor and immovable CPU.
+	//
+	// See "SQL-aware decomposition" above. When SQL metrics are available, k is
+	// derived from the full tracked denominator and capped at
+	// maxCPUAmplification. Gateway SQL and any excess become immovable.
+	var ampFactor, immovable float64
+	hasSQLMetrics := (sqlGatewayCPU + sqlDistCPU) > 0
+	if storesCPU <= 0 {
+		ampFactor = maxCPUAmplification
+		immovable = max(0, nodeUsage)
+	} else if hasSQLMetrics {
+		trackedMoveable := storesCPU + sqlDistCPU
+		totalTracked := trackedMoveable + sqlGatewayCPU
+		k := max(1, min(nodeUsage/totalTracked, maxCPUAmplification))
+		ampFactor = (1 + sqlDistCPU/storesCPU) * k
+		immovable = max(0, nodeUsage-trackedMoveable*k)
+	} else {
 		ampFactor = max(1, min(nodeUsage/storesCPU, maxCPUAmplification))
+		immovable = max(0, nodeUsage-storesCPU*ampFactor)
 	}
 
-	// Step 2: Attribute CPU to MMA-tracked work vs immovable.
-	mmaLoad := storesCPU * ampFactor
-	immovable := max(0, nodeUsage-mmaLoad)
-
-	// Step 3: Compute per-store load and capacity.
+	// Step 2: Compute per-store load and capacity.
 	storeCPU := desc.Capacity.CPUPerSecond
 	if storeCPU <= 0 {
 		// Either because grunning is unsupported on the node's architecture, in
@@ -155,24 +213,6 @@ func computePhysicalCPU(desc roachpb.StoreDescriptor) (res physicalDimension) {
 		// have reported CPU usage, in which case CPUPerSecond is 0.
 		storeCPU = storesCPU / numStores
 	}
-
-	// Summing per-store loads across all stores on a node:
-	//
-	//	sum(load_i) = sum(storeCPU_i * ampFactor + background / N)
-	//	            = ampFactor * sum(storeCPU_i) + background
-	//	            = ampFactor * storesCPU + max(0, nodeUsage - storesCPU*ampFactor)
-	//
-	// When ampFactor = nodeUsage/storesCPU (unclamped interior):
-	//
-	//	= nodeUsage + max(0, nodeUsage - nodeUsage) = nodeUsage.  ✓
-	//
-	// When ampFactor is clamped to 1 (storesCPU > nodeUsage):
-	//
-	//	= storesCPU + max(0, nodeUsage - storesCPU)
-	//	= storesCPU + 0 = storesCPU > nodeUsage.
-	//
-	// The overshoot (storesCPU - nodeUsage) is transient and conservative: stores
-	// appear slightly more loaded than reality until the measurement lag resolves.
 	load := mmaprototype.LoadValue(storeCPU*ampFactor + immovable/numStores)
 	capacity := mmaprototype.LoadValue(nodeCap / numStores)
 	if nodeCap <= 0 {

--- a/pkg/kv/kvserver/mmaintegration/physical_model.go
+++ b/pkg/kv/kvserver/mmaintegration/physical_model.go
@@ -7,12 +7,15 @@ package mmaintegration
 
 import (
 	"context"
+	"fmt"
+	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/mmaprototype"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/grunning"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/redact"
 )
 
 // physicalStore holds the physical load, capacity, and amplification
@@ -170,9 +173,10 @@ type physicalDimension struct {
 // excess overhead spills into the immovable term. When k is unclamped,
 // immovable = sqlGatewayCPU * k.
 //
-// Fallback: when SQL metrics are zero, the model uses a single ratio
-// (ampFactor = clamp(nodeUsage/storesCPU, 1, cap)) and attributes the
-// residual as immovable, matching the pre-SQL behavior.
+// When SQL metrics are zero, the formula degenerates to the single-ratio
+// model: sqlDistCPU/storesCPU vanishes so (1+distRatio)*k = k, and
+// totalTracked collapses to storesCPU so k = clamp(nodeUsage/storesCPU,
+// 1, cap). No special case is needed.
 func computePhysicalCPU(desc roachpb.StoreDescriptor) (res physicalDimension) {
 	assertCPUInputs(desc)
 	defer func() { res.capacity = max(minCapacity, res.capacity) }()
@@ -186,24 +190,29 @@ func computePhysicalCPU(desc roachpb.StoreDescriptor) (res physicalDimension) {
 
 	// Step 1: Estimate the amplification factor and immovable CPU.
 	//
-	// See "SQL-aware decomposition" above. When SQL metrics are available, k is
-	// derived from the full tracked denominator and capped at
-	// maxCPUAmplification. Gateway SQL and any excess become immovable.
+	// See "SQL-aware decomposition" above. k is derived from the full tracked
+	// denominator and capped at maxCPUAmplification. Gateway SQL and any
+	// excess become immovable. The clamps provide graceful degradation when
+	// SQL metrics are inaccurate: k is floored at 1 (so ampFactor ≥ 1 even
+	// if SQL metrics hugely overcount), capped at maxCPUAmplification (so k
+	// doesn't blow up if they undercount), and immovable is floored at 0
+	// (absorbing any overcount). As SQL signal weakens toward zero, the
+	// formula continuously approaches the single-ratio model — no explicit
+	// fallback is needed.
 	var ampFactor, immovable float64
-	hasSQLMetrics := (sqlGatewayCPU + sqlDistCPU) > 0
 	if storesCPU <= 0 {
 		ampFactor = maxCPUAmplification
 		immovable = max(0, nodeUsage)
-	} else if hasSQLMetrics {
+	} else {
 		trackedMoveable := storesCPU + sqlDistCPU
 		totalTracked := trackedMoveable + sqlGatewayCPU
 		k := max(1, min(nodeUsage/totalTracked, maxCPUAmplification))
 		ampFactor = (1 + sqlDistCPU/storesCPU) * k
 		immovable = max(0, nodeUsage-trackedMoveable*k)
-	} else {
-		ampFactor = max(1, min(nodeUsage/storesCPU, maxCPUAmplification))
-		immovable = max(0, nodeUsage-storesCPU*ampFactor)
 	}
+
+	// Verify formula consistency (see assertCPULoadInvariant).
+	assertCPULoadInvariant(storesCPU, ampFactor, immovable, nodeUsage, sqlDistCPU, sqlGatewayCPU)
 
 	// Step 2: Compute per-store load and capacity.
 	storeCPU := desc.Capacity.CPUPerSecond
@@ -364,6 +373,69 @@ func MakePhysicalRangeLoad(
 	rl.Load[mmaprototype.WriteBandwidth] = mmaprototype.LoadValue(writeBytesPerSec * float64(amp[mmaprototype.WriteBandwidth]))
 	rl.Load[mmaprototype.ByteSize] = mmaprototype.LoadValue(float64(logicalBytes) * float64(amp[mmaprototype.ByteSize]))
 	return rl
+}
+
+// assertCPULoadInvariant verifies (in test builds only) that the formulas
+// in computePhysicalCPU are internally consistent. This is a mathematical
+// identity check, not a detection of runtime anomalies.
+//
+// Since immovable = max(0, nodeUsage - trackedMoveable*k), summing per-store
+// loads (sumLoad = storesCPU*ampFactor + immovable) yields:
+//
+//   - sumLoad = nodeUsage when trackedMoveable*k ≤ nodeUsage (the common case:
+//     the residual flows into immovable and the two terms add to nodeUsage).
+//   - sumLoad = trackedMoveable*k > nodeUsage when trackedMoveable*k > nodeUsage
+//     (k is floored at 1, immovable is 0, load conservatively overshoots).
+//
+// Both outcomes follow directly from the max(0, ...) clamp. The check guards
+// against future formula changes breaking this identity.
+func assertCPULoadInvariant(
+	storesCPU, ampFactor, immovable, nodeUsage, sqlDistCPU, sqlGatewayCPU float64,
+) {
+	if !buildutil.CrdbTestBuild {
+		return
+	}
+
+	// Relative epsilon comparison. A pure absolute epsilon (math.Abs(a-b) <=
+	// eps) would be too tight for CPU values in ns/s (1e8–1e10), where float64
+	// rounding errors are ~magnitude*2.2e-16 ≈ 1e-6. Scaling by max(1, |a|,
+	// |b|) makes the tolerance relative to the values being compared; the
+	// floor of 1 avoids demanding exact equality near zero.
+	const floatEps = 1e-9
+	approxEq := func(a, b float64) bool {
+		return math.Abs(a-b) <= floatEps*max(1, math.Abs(a), math.Abs(b))
+	}
+	moveable := storesCPU * ampFactor
+	sumLoad := moveable + immovable
+	ctx := context.Background()
+	state := redact.Safe(fmt.Sprintf(
+		"moveable=%.4f immovable=%.4f sumLoad=%.4f nodeUsage=%.4f "+
+			"storesCPU=%.4f ampFactor=%.4f sqlDistCPU=%.4f sqlGatewayCPU=%.4f",
+		moveable, immovable, sumLoad, nodeUsage,
+		storesCPU, ampFactor, sqlDistCPU, sqlGatewayCPU))
+
+	// immovable must be non-negative (it's clamped with max(0,...) at the call
+	// site, but double-check here).
+	if immovable < 0 {
+		log.Dev.Fatalf(ctx, "CPU load invariant: immovable < 0 (%v)", state)
+	}
+
+	// Overshoot case: trackedMoveable > nodeUsage, so immovable was clamped
+	// to 0 and sumLoad > nodeUsage by construction.
+	//
+	// Skip when storesCPU = 0: the main code ignores SQL metrics in that
+	// branch and sets immovable = nodeUsage directly.
+	if storesCPU > 0 && (storesCPU+sqlDistCPU) > nodeUsage {
+		if !approxEq(immovable, 0) {
+			log.Dev.Fatalf(ctx, "CPU load invariant: overshoot but immovable != 0 (%v)", state)
+		}
+		return
+	}
+
+	// Common case: sumLoad must equal nodeUsage.
+	if !approxEq(sumLoad, nodeUsage) {
+		log.Dev.Fatalf(ctx, "CPU load invariant: sumLoad != nodeUsage (%v)", state)
+	}
 }
 
 // assertCPUInputs verifies (in test builds only) that the raw NodeCapacity

--- a/pkg/kv/kvserver/mmaintegration/physical_model.go
+++ b/pkg/kv/kvserver/mmaintegration/physical_model.go
@@ -6,8 +6,13 @@
 package mmaintegration
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/mmaprototype"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
+	"github.com/cockroachdb/cockroach/pkg/util/grunning"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 // physicalStore holds the physical load, capacity, and amplification
@@ -124,13 +129,13 @@ type physicalDimension struct {
 //     harder to reason about and, as shown above, can cause MMA to send work
 //     toward already-hot nodes.
 func computePhysicalCPU(desc roachpb.StoreDescriptor) (res physicalDimension) {
+	assertCPUInputs(desc)
 	defer func() { res.capacity = max(minCapacity, res.capacity) }()
-
 	nc := desc.NodeCapacity
 	numStores := max(1, float64(nc.NumStores))
-	nodeUsage := float64(nc.NodeCPURateUsage)
-	nodeCap := float64(nc.NodeCPURateCapacity)
-	storesCPU := float64(nc.StoresCPURate)
+	nodeUsage := max(0, float64(nc.NodeCPURateUsage))
+	nodeCap := max(0, float64(nc.NodeCPURateCapacity))
+	storesCPU := max(0, float64(nc.StoresCPURate))
 
 	// Step 1: Estimate the amplification factor.
 	ampFactor := maxCPUAmplification
@@ -168,8 +173,8 @@ func computePhysicalCPU(desc roachpb.StoreDescriptor) (res physicalDimension) {
 	//
 	// The overshoot (storesCPU - nodeUsage) is transient and conservative: stores
 	// appear slightly more loaded than reality until the measurement lag resolves.
-	load := mmaprototype.LoadValue(max(0, storeCPU*ampFactor+immovable/numStores))
-	capacity := mmaprototype.LoadValue(max(0, nodeCap/numStores))
+	load := mmaprototype.LoadValue(storeCPU*ampFactor + immovable/numStores)
+	capacity := mmaprototype.LoadValue(nodeCap / numStores)
 	if nodeCap <= 0 {
 		capacity = load * 2
 	}
@@ -319,4 +324,35 @@ func MakePhysicalRangeLoad(
 	rl.Load[mmaprototype.WriteBandwidth] = mmaprototype.LoadValue(writeBytesPerSec * float64(amp[mmaprototype.WriteBandwidth]))
 	rl.Load[mmaprototype.ByteSize] = mmaprototype.LoadValue(float64(logicalBytes) * float64(amp[mmaprototype.ByteSize]))
 	return rl
+}
+
+// assertCPUInputs verifies (in test builds only) that the raw NodeCapacity
+// fields used by computePhysicalCPU are non-negative. All fields are int64 in
+// the protobuf, so they can technically be negative but shouldn't be
+// semantically. The caller clamps them with max(0, ...) after this check.
+func assertCPUInputs(desc roachpb.StoreDescriptor) {
+	if !buildutil.CrdbTestBuild {
+		return
+	}
+	nc := desc.NodeCapacity
+	// When !grunning.Supported (only in non-Bazel builds, i.e. plain
+	// `go test`; all production binaries use Bazel), each store sets
+	// CPUPerSecond to -1 and StoresCPURate (the sum across stores) is
+	// -numStores. Skip those checks since the physical model handles
+	// storesCPU <= 0 gracefully.
+	storesCPURateNegative := nc.StoresCPURate < 0 && grunning.Supported
+	storeCPURateNegative := desc.Capacity.CPUPerSecond < 0 && grunning.Supported
+	if nc.NumStores < 0 || storesCPURateNegative || storeCPURateNegative ||
+		nc.NodeCPURateUsage < 0 || nc.NodeCPURateCapacity < 0 ||
+		nc.SQLGatewayCPUNanoPerSec < 0 || nc.SQLDistCPUNanoPerSec < 0 {
+		log.Dev.Fatalf(context.Background(),
+			"computePhysicalCPU: negative NodeCapacity fields "+
+				"(NumStores=%d StoresCPURate=%d NodeCPURateUsage=%d "+
+				"NodeCPURateCapacity=%d SQLGatewayCPU=%d SQLDistCPU=%d "+
+				"grunning.Supported=%t)",
+			nc.NumStores, nc.StoresCPURate, nc.NodeCPURateUsage,
+			nc.NodeCPURateCapacity, nc.SQLGatewayCPUNanoPerSec, nc.SQLDistCPUNanoPerSec,
+			grunning.Supported,
+		)
+	}
 }

--- a/pkg/kv/kvserver/mmaintegration/physical_model_test.go
+++ b/pkg/kv/kvserver/mmaintegration/physical_model_test.go
@@ -46,15 +46,25 @@ func TestComputePhysicalStore(t *testing.T) {
 					d.ScanArgs(t, "store-cpu-per-second", &storeCPUCores)
 				}
 
+				var sqlGatewayCPUCores, sqlDistCPUCores float64
+				if d.HasArg("sql-gateway-cpu") {
+					d.ScanArgs(t, "sql-gateway-cpu", &sqlGatewayCPUCores)
+				}
+				if d.HasArg("sql-dist-cpu") {
+					d.ScanArgs(t, "sql-dist-cpu", &sqlDistCPUCores)
+				}
+
 				const nsPerCore = 1e9
 				const gib = 1 << 30
 
 				desc := roachpb.StoreDescriptor{
 					NodeCapacity: roachpb.NodeCapacity{
-						NumStores:           int32(numStores),
-						StoresCPURate:       int64(storesCPUCores * nsPerCore),
-						NodeCPURateUsage:    int64(nodeUsageCores * nsPerCore),
-						NodeCPURateCapacity: int64(nodeCapCores * nsPerCore),
+						NumStores:               int32(numStores),
+						StoresCPURate:           int64(storesCPUCores * nsPerCore),
+						NodeCPURateUsage:        int64(nodeUsageCores * nsPerCore),
+						NodeCPURateCapacity:     int64(nodeCapCores * nsPerCore),
+						SQLGatewayCPUNanoPerSec: int64(sqlGatewayCPUCores * nsPerCore),
+						SQLDistCPUNanoPerSec:    int64(sqlDistCPUCores * nsPerCore),
 					},
 					Capacity: roachpb.StoreCapacity{
 						CPUPerSecond:        storeCPUCores * nsPerCore,

--- a/pkg/kv/kvserver/mmaintegration/testdata/TestComputePhysicalStore
+++ b/pkg/kv/kvserver/mmaintegration/testdata/TestComputePhysicalStore
@@ -9,7 +9,7 @@
 # -------------------------------------------------------------------
 # Zero-value descriptor: all inputs are zero.
 # CPU: NumStores=0 treated as 1. storesCPU=0 so ampFactor defaults to
-# cap (3). No MMA load, all nodeUsage (0) is background. load=0, cap=0
+# cap (3). No MMA load, all nodeUsage (0) is immovable. load=0, cap=0
 # (floored to minCapacity by the defer).
 # Disk: LogicalBytes=0 and Used=0, so amp defaults to 1.
 # WriteBandwidth: always amp=1, capacity=unknown.
@@ -48,7 +48,7 @@ amplification-factors: [cpu=3.0000, disk=2.0000, write-bw=1.0000]
 # -------------------------------------------------------------------
 # Single store, stores CPU exceeds node CPU (measurement lag).
 # implicitMult = 4/8 = 0.5, clamped to floor of 1.
-# mmaLoad = 8*1 = 8 > nodeUsage=4, so background=0.
+# mmaLoad = 8*1 = 8 > nodeUsage=4, so immovable=0.
 # load = 8*1 = 8 (overshoots nodeUsage; see ampFactor=1 comment in code).
 # -------------------------------------------------------------------
 compute num-stores=1 stores-cpu=8 node-cpu-usage=4 node-cpu-capacity=16 logical-gib=40 used-gib=80 available-gib=20 write-bytes-per-sec=10000000
@@ -61,7 +61,7 @@ amplification-factors: [cpu=1.0000, disk=2.0000, write-bw=1.0000]
 # -------------------------------------------------------------------
 # Single store, huge implicit multiplier (clamped to cap).
 # implicitMult = 10/1 = 10, clamped to maxCPUAmplification (3).
-# mmaLoad = 1*3 = 3, background = 10-3 = 7.
+# mmaLoad = 1*3 = 3, immovable = 10-3 = 7.
 # load = 1*3 + 7/1 = 10.
 # -------------------------------------------------------------------
 compute num-stores=1 stores-cpu=1 node-cpu-usage=10 node-cpu-capacity=16 logical-gib=40 used-gib=80 available-gib=20 write-bytes-per-sec=10000000
@@ -74,7 +74,7 @@ amplification-factors: [cpu=3.0000, disk=2.0000, write-bw=1.0000]
 # -------------------------------------------------------------------
 # Multi-store: 4 stores on the node.
 # implicitMult = 8/4 = 2 (unclamped). mmaLoad = 4*2 = 8 = nodeUsage,
-# so background=0. Each store gets storesCPU/4 * 2 = 2 cores load.
+# so immovable=0. Each store gets storesCPU/4 * 2 = 2 cores load.
 # -------------------------------------------------------------------
 compute num-stores=4 stores-cpu=4 node-cpu-usage=8 node-cpu-capacity=16 logical-gib=40 used-gib=80 available-gib=20 write-bytes-per-sec=10000000
 ----
@@ -119,7 +119,7 @@ amplification-factors: [cpu=2.0000, disk=2.0000, write-bw=1.0000]
 # -------------------------------------------------------------------
 # Per-store CPUPerSecond: store reports 3 cores of direct CPU on a node
 # with 4 stores totaling 8 cores of store CPU, 12 cores node usage, 16 cap.
-# ampFactor = 12/8 = 1.5. mmaLoad = 8*1.5 = 12 = nodeUsage, background=0.
+# ampFactor = 12/8 = 1.5. mmaLoad = 8*1.5 = 12 = nodeUsage, immovable=0.
 # This store's load = 3*1.5 = 4.5, capacity = 16/4 = 4.
 # -------------------------------------------------------------------
 compute num-stores=4 stores-cpu=8 node-cpu-usage=12 node-cpu-capacity=16 store-cpu-per-second=3 logical-gib=40 used-gib=80 available-gib=20 write-bytes-per-sec=10000000
@@ -130,9 +130,9 @@ write-bandwidth: load=9.54 MiB/s  capacity=unknown  amp=1.0000
 amplification-factors: [cpu=1.5000, disk=2.0000, write-bw=1.0000]
 
 # -------------------------------------------------------------------
-# Per-store CPUPerSecond with background: 4 stores, 4 cores total store
+# Per-store CPUPerSecond, ampFactor unclamped: 4 stores, 4 cores total store
 # CPU, 10 cores node usage, 16 cap. ampFactor = min(10/4, 3) = 2.5.
-# mmaLoad = 4*2.5 = 10 = nodeUsage, background=0.
+# mmaLoad = 4*2.5 = 10 = nodeUsage, immovable=0.
 # This hot store reports 3 of the 4 store cores.
 # load = 3*2.5 = 7.5, capacity = 16/4 = 4.
 # -------------------------------------------------------------------
@@ -144,9 +144,9 @@ write-bandwidth: load=9.54 MiB/s  capacity=unknown  amp=1.0000
 amplification-factors: [cpu=2.5000, disk=2.0000, write-bw=1.0000]
 
 # -------------------------------------------------------------------
-# Per-store CPUPerSecond with background exceeding cap: 1 store,
+# Per-store CPUPerSecond with immovable CPU exceeding cap: 1 store,
 # 1 core store CPU, 10 cores node usage, 16 cap.
-# ampFactor = min(10/1, 3) = 3. mmaLoad = 1*3 = 3, background = 7.
+# ampFactor = min(10/1, 3) = 3. mmaLoad = 1*3 = 3, immovable = 7.
 # store reports 1 core. load = 1*3 + 7/1 = 10, capacity = 16.
 # Same as the even-split case since numStores=1 and storeCPU=storesCPU.
 # -------------------------------------------------------------------

--- a/pkg/kv/kvserver/mmaintegration/testdata/TestComputePhysicalStore
+++ b/pkg/kv/kvserver/mmaintegration/testdata/TestComputePhysicalStore
@@ -156,3 +156,125 @@ cpu:             load=10.00 cores  capacity=16.00 cores  amp=3.0000
 disk:            load=80.00 GiB  capacity=100.00 GiB  amp=2.0000
 write-bandwidth: load=9.54 MiB/s  capacity=unknown  amp=1.0000
 amplification-factors: [cpu=3.0000, disk=2.0000, write-bw=1.0000]
+
+# ===================================================================
+# SQL-aware model tests.
+# When sql-gateway-cpu and/or sql-dist-cpu are provided, the model
+# computes a uniform overhead multiplier k over all tracked sources
+# (storesCPU + sqlDistCPU + sqlGatewayCPU), then folds distSQL into
+# ampFactor and treats gateway SQL as immovable.
+# ===================================================================
+
+# -------------------------------------------------------------------
+# SQL-aware basic: unclamped k.
+# 1 store, storesCPU=2, nodeUsage=6, nodeCap=16.
+# sqlGatewayCPU=1, sqlDistCPU=1. moveableCPU = 3, totalTracked = 4.
+# k = 6/4 = 1.5. ampFactor = (1 + 1/2) * 1.5 = 2.25.
+# immovable = max(0, 6 - 3*1.5) = 1.5.
+# load = 2*2.25 + 1.5/1 = 6, capacity = 16.
+# -------------------------------------------------------------------
+compute num-stores=1 stores-cpu=2 node-cpu-usage=6 node-cpu-capacity=16 sql-gateway-cpu=1 sql-dist-cpu=1 logical-gib=10 used-gib=20 available-gib=80 write-bytes-per-sec=10000000
+----
+cpu:             load=6.00 cores  capacity=16.00 cores  amp=2.2500
+disk:            load=20.00 GiB  capacity=100.00 GiB  amp=2.0000
+write-bandwidth: load=9.54 MiB/s  capacity=unknown  amp=1.0000
+amplification-factors: [cpu=2.2500, disk=2.0000, write-bw=1.0000]
+
+# -------------------------------------------------------------------
+# SQL-aware gateway-heavy: gateway dominates, k unclamped.
+# 1 store, storesCPU=2, nodeUsage=9, nodeCap=16.
+# sqlGatewayCPU=3, sqlDistCPU=1. moveableCPU = 3, totalTracked = 6.
+# k = 9/6 = 1.5. ampFactor = 1.5 * 1.5 = 2.25.
+# immovable = max(0, 9 - 3*1.5) = 4.5.
+# load = 2*2.25 + 4.5/1 = 9, capacity = 16.
+# -------------------------------------------------------------------
+compute num-stores=1 stores-cpu=2 node-cpu-usage=9 node-cpu-capacity=16 sql-gateway-cpu=3 sql-dist-cpu=1 logical-gib=10 used-gib=20 available-gib=80 write-bytes-per-sec=10000000
+----
+cpu:             load=9.00 cores  capacity=16.00 cores  amp=2.2500
+disk:            load=20.00 GiB  capacity=100.00 GiB  amp=2.0000
+write-bandwidth: load=9.54 MiB/s  capacity=unknown  amp=1.0000
+amplification-factors: [cpu=2.2500, disk=2.0000, write-bw=1.0000]
+
+# -------------------------------------------------------------------
+# SQL-aware high distSQL: distSQL is 1.5x KV, k unclamped.
+# 1 store, storesCPU=2, nodeUsage=12, nodeCap=16.
+# sqlGatewayCPU=1, sqlDistCPU=3. moveableCPU = 5, totalTracked = 6.
+# k = max(1, min(12/6, 3)) = 2. ampFactor = 2.5*2 = 5.
+# immovable = max(0, 12 - 5*2) = 2.
+# load = 2*5 + 2/1 = 12, capacity = 16.
+# -------------------------------------------------------------------
+compute num-stores=1 stores-cpu=2 node-cpu-usage=12 node-cpu-capacity=16 sql-gateway-cpu=1 sql-dist-cpu=3 logical-gib=10 used-gib=20 available-gib=80 write-bytes-per-sec=10000000
+----
+cpu:             load=12.00 cores  capacity=16.00 cores  amp=5.0000
+disk:            load=20.00 GiB  capacity=100.00 GiB  amp=2.0000
+write-bandwidth: load=9.54 MiB/s  capacity=unknown  amp=1.0000
+amplification-factors: [cpu=5.0000, disk=2.0000, write-bw=1.0000]
+
+# -------------------------------------------------------------------
+# SQL-aware k clamped at cap: extreme overhead.
+# 1 store, storesCPU=1, nodeUsage=15, nodeCap=16.
+# sqlGatewayCPU=1, sqlDistCPU=1. moveableCPU = 2, totalTracked = 3.
+# k = max(1, min(15/3, 3)) = 3. ampFactor = 2*3 = 6.
+# immovable = max(0, 15 - 2*3) = 9.
+# load = 1*6 + 9/1 = 15, capacity = 16.
+# -------------------------------------------------------------------
+compute num-stores=1 stores-cpu=1 node-cpu-usage=15 node-cpu-capacity=16 sql-gateway-cpu=1 sql-dist-cpu=1 logical-gib=10 used-gib=20 available-gib=80 write-bytes-per-sec=10000000
+----
+cpu:             load=15.00 cores  capacity=16.00 cores  amp=6.0000
+disk:            load=20.00 GiB  capacity=100.00 GiB  amp=2.0000
+write-bandwidth: load=9.54 MiB/s  capacity=unknown  amp=1.0000
+amplification-factors: [cpu=6.0000, disk=2.0000, write-bw=1.0000]
+
+# -------------------------------------------------------------------
+# SQL-aware multi-store: 4 stores, even split.
+# storesCPU=4, nodeUsage=10, nodeCap=16.
+# sqlGatewayCPU=2, sqlDistCPU=2. moveableCPU = 6, totalTracked = 8.
+# k = 10/8 = 1.25. ampFactor = (1 + 2/4) * 1.25 = 1.875.
+# immovable = max(0, 10 - 6*1.25) = 2.5.
+# storeCPU = 4/4 = 1. load = 1*1.875 + 2.5/4 = 2.5, capacity = 4.
+# -------------------------------------------------------------------
+compute num-stores=4 stores-cpu=4 node-cpu-usage=10 node-cpu-capacity=16 sql-gateway-cpu=2 sql-dist-cpu=2 logical-gib=10 used-gib=20 available-gib=80 write-bytes-per-sec=10000000
+----
+cpu:             load=2.50 cores  capacity=4.00 cores  amp=1.8750
+disk:            load=20.00 GiB  capacity=100.00 GiB  amp=2.0000
+write-bandwidth: load=9.54 MiB/s  capacity=unknown  amp=1.0000
+amplification-factors: [cpu=1.8750, disk=2.0000, write-bw=1.0000]
+
+# -------------------------------------------------------------------
+# SQL-aware with store-cpu-per-second: hot store on a 4-store node.
+# Same node as above, but this store reports 3 of the 4 KV cores.
+# load = 3*1.875 + 2.5/4 = 6.25, capacity = 4.
+# -------------------------------------------------------------------
+compute num-stores=4 stores-cpu=4 node-cpu-usage=10 node-cpu-capacity=16 store-cpu-per-second=3 sql-gateway-cpu=2 sql-dist-cpu=2 logical-gib=10 used-gib=20 available-gib=80 write-bytes-per-sec=10000000
+----
+cpu:             load=6.25 cores  capacity=4.00 cores  amp=1.8750
+disk:            load=20.00 GiB  capacity=100.00 GiB  amp=2.0000
+write-bandwidth: load=9.54 MiB/s  capacity=unknown  amp=1.0000
+amplification-factors: [cpu=1.8750, disk=2.0000, write-bw=1.0000]
+
+# -------------------------------------------------------------------
+# SQL-aware zero storesCPU: no KV work, all gateway SQL.
+# Falls to storesCPU<=0 branch: ampFactor=cap(3), immovable=nodeUsage.
+# storeCPU=0, load = 0*3 + 5/1 = 5, capacity = 16.
+# -------------------------------------------------------------------
+compute num-stores=1 stores-cpu=0 node-cpu-usage=5 node-cpu-capacity=16 sql-gateway-cpu=3 sql-dist-cpu=0 logical-gib=10 used-gib=20 available-gib=80 write-bytes-per-sec=10000000
+----
+cpu:             load=5.00 cores  capacity=16.00 cores  amp=3.0000
+disk:            load=20.00 GiB  capacity=100.00 GiB  amp=2.0000
+write-bandwidth: load=9.54 MiB/s  capacity=unknown  amp=1.0000
+amplification-factors: [cpu=3.0000, disk=2.0000, write-bw=1.0000]
+
+# -------------------------------------------------------------------
+# SQL-aware k clamped at 1 (measurement lag): tracked CPU > nodeUsage.
+# 1 store, storesCPU=4, nodeUsage=3, nodeCap=16.
+# sqlGatewayCPU=1, sqlDistCPU=1. moveableCPU = 5, totalTracked = 6.
+# k = max(1, min(3/6, 3)) = 1. ampFactor = 1.25*1 = 1.25.
+# immovable = max(0, 3 - 5*1) = 0.
+# load = 4*1.25 + 0 = 5 (overshoots nodeUsage; transient, conservative).
+# -------------------------------------------------------------------
+compute num-stores=1 stores-cpu=4 node-cpu-usage=3 node-cpu-capacity=16 sql-gateway-cpu=1 sql-dist-cpu=1 logical-gib=10 used-gib=20 available-gib=80 write-bytes-per-sec=10000000
+----
+cpu:             load=5.00 cores  capacity=16.00 cores  amp=1.2500
+disk:            load=20.00 GiB  capacity=100.00 GiB  amp=2.0000
+write-bandwidth: load=9.54 MiB/s  capacity=unknown  amp=1.0000
+amplification-factors: [cpu=1.2500, disk=2.0000, write-bw=1.0000]


### PR DESCRIPTION
## Summary

- Renames "background" to "immovable" in `computePhysicalCPU` to better reflect that the term captures all non-moveable CPU, not just background work.
- Renames `cpuIndirectOverheadMultiplier` to `maxCPUAmplification` for clarity.
- Adds `assertCPUInputs` to validate inputs to `computePhysicalCPU`.
- Adds SQL-aware decomposition to `computePhysicalCPU`: when `SQLGatewayCPUNanoPerSec` and `SQLDistCPUNanoPerSec` are available, the model decomposes node CPU into moveable (KV + distSQL) and immovable (gateway SQL) work, fitting a per-source overhead multiplier `k` and folding distSQL into the amplification factor. Falls back to single-ratio behavior when SQL metrics are zero.
- Adds `assertCPULoadInvariant` to validate that the computed load and capacity satisfy expected invariants.

Resolves: https://github.com/cockroachdb/cockroach/issues/159584
Epic: CRDB-55052 
Release note: none