### PR TITLE
mmaprototype: populate lease_grace overloaded store metrics

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -15682,7 +15682,7 @@ layers:
     - name: mma.overloaded_store.lease_grace.failure
       exported_name: mma_overloaded_store_lease_grace_failure
       labeled_name: 'mma.overloaded_store{type: lease_grace, result: failure}'
-      description: Number of overloaded stores in the lease shedding grace period (first 2 min of overload) where all shedding attempts failed during this store's MMA rebalancing pass. During this grace period, MMA holds off on replica moves to give the overloaded store time to shed its own leases.
+      description: Number of overloaded stores in the lease shedding grace period (first 2 min of overload) where the local store failed to shed any leases or replicas during this store's MMA rebalancing pass. During this grace period, remote stores wait for the overloaded store to shed its own leases before intervening. A non-zero value indicates the overloaded store is struggling to self-shed.
       y_axis_label: Stores
       type: GAUGE
       unit: COUNT
@@ -15691,7 +15691,7 @@ layers:
     - name: mma.overloaded_store.lease_grace.success
       exported_name: mma_overloaded_store_lease_grace_success
       labeled_name: 'mma.overloaded_store{type: lease_grace, result: success}'
-      description: Number of overloaded stores in the lease shedding grace period (first 2 min of overload) where at least one lease or replica was successfully moved away during this store's MMA rebalancing pass. During this grace period, MMA holds off on replica moves to give the overloaded store time to shed its own leases. This metric should normally be 0 since MMA skips shedding during the grace period.
+      description: Number of overloaded stores in the lease shedding grace period (first 2 min of overload) where at least one lease or replica was successfully moved away during this store's MMA rebalancing pass. During this grace period, remote stores wait for the overloaded store to shed its own leases before intervening with replica moves. This metric tracks whether the local store's self-shedding is effective.
       y_axis_label: Stores
       type: GAUGE
       unit: COUNT

--- a/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
@@ -124,9 +124,9 @@ type metricsEtc struct {
 
 // These constants are semi-arbitrary.
 
-// Don't start moving ranges from a cpu overloaded remote store, to give it
-// some time to shed its leases.
-const remoteStoreLeaseSheddingGraceDuration = 2 * time.Minute
+// Grace period before remote stores intervene with replica moves on an
+// overloaded store, giving it time to shed its own leases.
+const leaseSheddingGraceDuration = 2 * time.Minute
 const overloadGracePeriod = time.Minute
 
 func (a *allocatorState) InitMetricsForLocalStore(

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
@@ -383,17 +383,18 @@ func (re *rebalanceEnv) rebalanceStore(
 	} else if overloadDur > ignoreLoadThresholdAndHigherGraceDuration {
 		iLevel = ignoreLoadThresholdAndHigher
 	}
-	// Will only become true for remote stores.
-	withinLeaseSheddingGracePeriod := false
-	if store.StoreID != localStoreID && store.dimSummary[CPURate] >= overloadSlow &&
-		re.now.Sub(ss.overloadStartTime) < remoteStoreLeaseSheddingGraceDuration {
-		withinLeaseSheddingGracePeriod = true
-	}
+	// withinLeaseSheddingGracePeriod is true when the store is overloaded but
+	// still within the initial grace period where the overloaded store is
+	// expected to shed its own leases. For remote stores, MMA skips shedding
+	// during this period. For the local store, MMA proceeds with shedding and
+	// the lease_grace metrics track whether that self-shedding succeeds.
+	withinLeaseSheddingGracePeriod := store.dimSummary[CPURate] >= overloadSlow &&
+		overloadDur < remoteStoreLeaseSheddingGraceDuration
 	re.passObs.storeOverloaded(ss.StoreID, withinLeaseSheddingGracePeriod, iLevel)
 	defer func() {
 		re.passObs.finishStore()
 	}()
-	if withinLeaseSheddingGracePeriod {
+	if withinLeaseSheddingGracePeriod && store.StoreID != localStoreID {
 		log.KvDistribution.VEventf(ctx, 2, "skipping remote store s%d: in lease shedding grace period", store.StoreID)
 		return
 	}

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
@@ -389,7 +389,7 @@ func (re *rebalanceEnv) rebalanceStore(
 	// during this period. For the local store, MMA proceeds with shedding and
 	// the lease_grace metrics track whether that self-shedding succeeds.
 	withinLeaseSheddingGracePeriod := store.dimSummary[CPURate] >= overloadSlow &&
-		overloadDur < remoteStoreLeaseSheddingGraceDuration
+		overloadDur < leaseSheddingGraceDuration
 	re.passObs.storeOverloaded(ss.StoreID, withinLeaseSheddingGracePeriod, iLevel)
 	defer func() {
 		re.passObs.finishStore()
@@ -447,7 +447,7 @@ func (re *rebalanceEnv) rebalanceReplicas(
 	ignoreLevel ignoreLevel,
 ) {
 	if store.StoreID != localStoreID && store.dimSummary[CPURate] >= overloadSlow &&
-		re.now.Sub(ss.overloadStartTime) < remoteStoreLeaseSheddingGraceDuration {
+		re.now.Sub(ss.overloadStartTime) < leaseSheddingGraceDuration {
 		log.KvDistribution.VEventf(ctx, 2, "skipping remote store s%d: in lease shedding grace period", store.StoreID)
 		return
 	}

--- a/pkg/kv/kvserver/allocator/mmaprototype/mma_metrics.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/mma_metrics.go
@@ -345,8 +345,11 @@ func makeLoadAndCapacityMetrics() *loadAndCapacityMetrics {
 type overloadKind uint8
 
 const (
-	// overloadedWaitingForLeaseShedding represents when the remote store is
-	// still in the grace period for shedding its own leases.
+	// overloadedWaitingForLeaseShedding represents when the store is still in
+	// the grace period for shedding its own leases. NB: this applies to both
+	// local and remote stores. For remote stores, MMA skips shedding during
+	// this period. For the local store, MMA proceeds with shedding and the
+	// lease_grace metrics track whether that self-shedding succeeds.
 	overloadedWaitingForLeaseShedding overloadKind = iota
 	// overloadedShortDuration corresponds to ignoreLoadNoChangeAndHigher.
 	overloadedShortDuration
@@ -491,16 +494,13 @@ type reasonCount struct {
 }
 
 var (
-	// NB: mma.overloaded_store.lease_grace.success should always be 0, but we
-	// declare the metric to avoid making assumptions about rebalancing
-	// behavior.
 	metaOverloadedStoreLeaseGraceSuccess = metric.Metadata{
 		Name: "mma.overloaded_store.lease_grace.success",
 		Help: "Number of overloaded stores in the lease shedding grace period (first 2 min of " +
 			"overload) where at least one lease or replica was successfully moved away during " +
-			"this store's MMA rebalancing pass. During this grace period, MMA holds off on " +
-			"replica moves to give the overloaded store time to shed its own leases. This " +
-			"metric should normally be 0 since MMA skips shedding during the grace period.",
+			"this store's MMA rebalancing pass. During this grace period, remote stores wait " +
+			"for the overloaded store to shed its own leases before intervening with replica " +
+			"moves. This metric tracks whether the local store's self-shedding is effective.",
 		Measurement: "Stores",
 		Unit:        metric.Unit_COUNT,
 		LabeledName: "mma.overloaded_store",
@@ -510,9 +510,10 @@ var (
 	metaOverloadedStoreLeaseGraceFailure = metric.Metadata{
 		Name: "mma.overloaded_store.lease_grace.failure",
 		Help: "Number of overloaded stores in the lease shedding grace period (first 2 min of " +
-			"overload) where all shedding attempts failed during this store's MMA rebalancing " +
-			"pass. During this grace period, MMA holds off on replica moves to give the " +
-			"overloaded store time to shed its own leases.",
+			"overload) where the local store failed to shed any leases or replicas during " +
+			"this store's MMA rebalancing pass. During this grace period, remote stores wait " +
+			"for the overloaded store to shed its own leases before intervening. A non-zero " +
+			"value indicates the overloaded store is struggling to self-shed.",
 		Measurement: "Stores",
 		Unit:        metric.Unit_COUNT,
 		LabeledName: "mma.overloaded_store",

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_capacity_mismatch.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_capacity_mismatch.txt
@@ -354,8 +354,7 @@ rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-t
 [mmaid=1] skipping remote store s3: in lease shedding grace period
 [mmaid=1] rebalancing pass summary [local=s1]:
 	overloaded:
-		lease-grace: [s2, s3]
-		short: [s1]
+		lease-grace: [s1, s2, s3]
 	failure: [{s1, total: 6, no-cand-to-accept-load:5, not-overloaded:1}]
 	no-ranges-evaluated: [s2, s3]
 pending(0)

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_frac_threshold.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_frac_threshold.txt
@@ -90,7 +90,7 @@ rebalance-stores store-id=1 fraction-pending-decrease-threshold=0.4
 [mmaid=1] skipping replica transfers for s1 to try more leases next time
 [mmaid=1] rebalancing pass summary [local=s1]:
 	overloaded:
-		short: [s1]
+		lease-grace: [s1]
 	success: [s1]
 pending(4)
 change-id=1 store-id=1 node-id=1 range-id=4 load-delta=[cpu:-230ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=1m0s

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_refusing_target.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_refusing_target.txt
@@ -88,6 +88,6 @@ rebalance-stores store-id=1
 [mmaid=1] no top-K[CPURate] ranges found for s3 with lease on local s1
 [mmaid=1] rebalancing pass summary [local=s1]:
 	overloaded:
-		short: [s1]
+		lease-grace: [s1]
 	failure: [{s1, total: 2, not-overloaded:1, no-cand:1}]
 pending(0)

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_replica_refusing.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_replica_refusing.txt
@@ -105,7 +105,7 @@ rebalance-stores store-id=1
 [mmaid=1] skipping replica transfers for s1 to try more leases next time
 [mmaid=1] rebalancing pass summary [local=s1]:
 	overloaded:
-		short: [s1]
+		lease-grace: [s1]
 	success: [s1]
 pending(2)
 change-id=1 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-90ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=1m0s

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_transfer_count.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_transfer_count.txt
@@ -90,7 +90,7 @@ rebalance-stores store-id=1 fraction-pending-decrease-threshold=1.0 max-lease-tr
 [mmaid=1] skipping replica transfers for s1 to try more leases next time
 [mmaid=1] rebalancing pass summary [local=s1]:
 	overloaded:
-		short: [s1]
+		lease-grace: [s1]
 	success: [s1]
 pending(4)
 change-id=1 store-id=1 node-id=1 range-id=4 load-delta=[cpu:-230ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=1m0s

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_transfer_unbounded.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_transfer_unbounded.txt
@@ -133,7 +133,7 @@ rebalance-stores store-id=1 fraction-pending-decrease-threshold=10.0 max-lease-t
 [mmaid=1] skipping replica transfers for s1 to try more leases next time
 [mmaid=1] rebalancing pass summary [local=s1]:
 	overloaded:
-		short: [s1]
+		lease-grace: [s1]
 	success: [s1]
 pending(4)
 change-id=1 store-id=1 node-id=1 range-id=4 load-delta=[cpu:-230ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=1m0s

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_lateral.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_lateral.txt
@@ -128,8 +128,8 @@ rebalance-stores store-id=1
 [mmaid=1] cannot add load from n3s3 to n3s4 for r1 due to target_summary(overloadSlow)>=loadNoChange,target-node(overloadSlow)>target-store(loadNormal): delta([cpu:10ns/s, write-bandwidth:10 MB/s, byte-size:0 B]) targetSLS[(store=loadNormal worst=ByteSize cpu=loadLow writes=loadLow bytes=loadNormal node=overloadSlow frac_pending=0.00,0.00(true))] srcSLS[(store=overloadSlow worst=WriteBandwidth cpu=loadLow writes=overloadSlow bytes=loadNormal node=loadNormal frac_pending=0.00,0.00(true))]
 [mmaid=1] rebalancing pass summary [local=s1]:
 	overloaded:
-		lease-grace: [s2]
-		short: [s1, s3]
+		lease-grace: [s1, s2]
+		short: [s3]
 	failure: [{s1, total: 2, no-cand:1, no-cand-load:1}, {s3, total: 1, no-cand-to-accept-load:1}]
 	no-ranges-evaluated: [s2]
 pending(0)

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_refusing_target.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_refusing_target.txt
@@ -104,8 +104,7 @@ rebalance-stores store-id=1
 [mmaid=1] skipping remote store s3: in lease shedding grace period
 [mmaid=1] rebalancing pass summary [local=s1]:
 	overloaded:
-		lease-grace: [s2, s3]
-		short: [s1]
+		lease-grace: [s1, s2, s3]
 	failure: [{s1, total: 2, not-overloaded:2}]
 	no-ranges-evaluated: [s2, s3]
 pending(0)

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/skip_range_invalid_config.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/skip_range_invalid_config.txt
@@ -77,6 +77,6 @@ rebalance-stores store-id=1
 [mmaid=1] skipping r1: no constraints analyzed (conf=<nil> replicas=[s1:replica-id=1 type=VOTER_FULL leaseholder=true lease disposition:ok])
 [mmaid=1] rebalancing pass summary [local=s1]:
 	overloaded:
-		short: [s1]
+		lease-grace: [s1]
 	failure: [{s1, total: 2, constraint-error:2}]
 pending(0)

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/store_status_exclusion.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/store_status_exclusion.txt
@@ -204,7 +204,7 @@ rebalance-stores store-id=1
 [mmaid=1] skipping replica transfers for s1 to try more leases next time
 [mmaid=1] rebalancing pass summary [local=s1]:
 	overloaded:
-		short: [s1]
+		lease-grace: [s1]
 	success: [s1]
 pending(2)
 change-id=1 store-id=1 node-id=1 range-id=1 load-delta=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=1m0s


### PR DESCRIPTION
Rebased on top of https://github.com/cockroachdb/cockroach/pull/163305.
Epic: CRDB-55052 
Release note: none

---
**mmaprototype: populate lease_grace overloaded store metrics**

The `mma.overloaded_store.lease_grace.{success,failure}` metrics were
not incremented. The `withinLeaseSheddingGracePeriod` flag was only
set for remote stores, and when set, the function returned early before
any `leaseShed()` or `replicaShed()` calls. The resulting
`storePassState` had all-zero `shedCounts`, causing `summarize()` to
produce zero successes and zero failures, which hit the "else ignore"
branch in `finishRebalancingPass`.

This change extends `withinLeaseSheddingGracePeriod` to also cover the
local store when it is overloaded and within the first 2 minutes of
overload. The early return that skips shedding is now gated on
`store.StoreID != localStoreID`, so the local store still proceeds with
its own lease and replica shedding. The shedding results are tagged with
`overloadedWaitingForLeaseShedding`, which routes them into the
`lease_grace` gauge metrics.

Note that the behavioral change is limited to metric reporting. The
local store was already shedding during this window — its results were
simply categorized under the duration-based overload kinds instead of
`lease_grace`.

Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

---
**mmaprototype: rename remoteStoreLeaseSheddingGraceDuration**

Rename `remoteStoreLeaseSheddingGraceDuration` to
`leaseSheddingGraceDuration`. The constant is now used for both local
and remote stores, so the `remote` prefix is misleading.

Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

