### PR TITLE
clustermetrics: update stopwatch to record nanoseconds elapsed

### DIFF
--- a/pkg/obs/clustermetrics/cmmetrics/metric.go
+++ b/pkg/obs/clustermetrics/cmmetrics/metric.go
@@ -201,7 +201,7 @@ func (g *Gauge) IsDeleted() bool {
 	return g.deleted.Load()
 }
 
-// WriteStopwatch wraps a metric.Gauge to record the unix-second
+// WriteStopwatch wraps a metric.Gauge to record the unix-nanosecond
 // timestamp at which Start() was called. The stored value is the
 // timestamp itself, not elapsed time. Dirty tracking ensures that
 // only updated stopwatches are flushed to storage.
@@ -236,11 +236,11 @@ func (s *WriteStopwatch) SetStartTime() {
 	if s.deleted.Load() {
 		return
 	}
-	s.Gauge.Update(s.timeSource.Now().Unix())
+	s.Gauge.Update(s.timeSource.Now().UnixNano())
 	s.dirty.Store(true)
 }
 
-// Value returns the stored unix timestamp (seconds), or 0 if not started.
+// Value returns the stored unix timestamp (nanoseconds), or 0 if not started.
 func (s *WriteStopwatch) Value() int64 {
 	return s.Gauge.Value()
 }

--- a/pkg/obs/clustermetrics/cmmetrics/vector.go
+++ b/pkg/obs/clustermetrics/cmmetrics/vector.go
@@ -189,7 +189,7 @@ func (v *CounterVec) CollectDeleted() []WritableMetric {
 }
 
 // WriteStopwatchVec wraps metric.GaugeVec for labeled stopwatch
-// metrics. Each child records a unix-second timestamp set via
+// metrics. Each child records a unix-nanosecond timestamp set via
 // SetStartTime. All children present at flush time are written;
 // Reset clears all children so only values set since the last
 // flush are emitted.
@@ -219,7 +219,7 @@ func NewWriteStopwatchVec(
 // SetStartTime records the current time as the start time for the
 // given label set.
 func (v *WriteStopwatchVec) SetStartTime(labels map[string]string) {
-	v.GaugeVec.Update(labels, v.timeSource.Now().Unix())
+	v.GaugeVec.Update(labels, v.timeSource.Now().UnixNano())
 }
 
 // Each calls f for every child stopwatch.


### PR DESCRIPTION
on the read side, the cluster metric expects unix-nanosecond timestamps for stopwatches. This commit updates the write side to be aligned with the read side

Epic: None
Release note: None