### PR TITLE
obs/ash: write ASH reports with goroutine dumps and CPU profiles

### DIFF
--- a/pkg/obs/ash/BUILD.bazel
+++ b/pkg/obs/ash/BUILD.bazel
@@ -3,10 +3,12 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "ash",
     srcs = [
+        "aggregate.go",
         "app_name.go",
         "buffer.go",
         "doc.go",
         "metrics.go",
+        "report.go",
         "sampler.go",
         "types.go",
         "work_state.go",
@@ -38,7 +40,9 @@ go_library(
 go_test(
     name = "ash_test",
     srcs = [
+        "aggregate_test.go",
         "buffer_test.go",
+        "report_test.go",
         "sampler_test.go",
         "work_state_test.go",
     ],

--- a/pkg/obs/ash/BUILD.bazel
+++ b/pkg/obs/ash/BUILD.bazel
@@ -46,6 +46,7 @@ go_test(
         "sampler_test.go",
         "work_state_test.go",
     ],
+    data = glob(["testdata/**"]),
     embed = [":ash"],
     deps = [
         "//pkg/roachpb",
@@ -56,6 +57,7 @@ go_test(
         "//pkg/util/log/logtestutils",
         "//pkg/util/stop",
         "//pkg/util/timeutil",
+        "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_petermattis_goid//:goid",
         "@com_github_stretchr_testify//require",

--- a/pkg/obs/ash/aggregate.go
+++ b/pkg/obs/ash/aggregate.go
@@ -1,0 +1,78 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package ash
+
+import (
+	"sort"
+	"time"
+)
+
+// AggregatedASH represents a group of ASH samples that share the same
+// (WorkEventType, WorkEvent, WorkloadID) key. Count is the number of
+// samples observed in the aggregation window.
+type AggregatedASH struct {
+	WorkEventType WorkEventType
+	WorkEvent     string
+	WorkloadID    string
+	Count         int64
+}
+
+// AggregateSamples filters samples to [now-lookback, now] and groups
+// them by (WorkEventType, WorkEvent, WorkloadID). The result is sorted
+// by Count descending. samples must be ordered oldest-to-newest (as
+// returned by RingBuffer.GetAll).
+//
+// The grouping key is workloadKey, the same type used by the periodic
+// log summary in the sampler.
+func AggregateSamples(samples []ASHSample, now time.Time, lookback time.Duration) []AggregatedASH {
+	cutoff := now.Add(-lookback)
+
+	// Binary search for the first sample at or after the cutoff. Since
+	// samples are sorted oldest-to-newest, everything from startIdx
+	// onward is within the window.
+	startIdx := sort.Search(len(samples), func(i int) bool {
+		return !samples[i].SampleTime.Before(cutoff)
+	})
+
+	if startIdx >= len(samples) {
+		return nil
+	}
+
+	// Aggregate using a map keyed by workloadKey.
+	counts := make(map[workloadKey]int64)
+	for i := startIdx; i < len(samples); i++ {
+		s := &samples[i]
+		if s.SampleTime.After(now) {
+			continue
+		}
+		k := workloadKey{
+			WorkEventType: s.WorkEventType,
+			WorkEvent:     s.WorkEvent,
+			WorkloadID:    s.WorkloadID,
+		}
+		counts[k]++
+	}
+
+	if len(counts) == 0 {
+		return nil
+	}
+
+	result := make([]AggregatedASH, 0, len(counts))
+	for k, c := range counts {
+		result = append(result, AggregatedASH{
+			WorkEventType: k.WorkEventType,
+			WorkEvent:     k.WorkEvent,
+			WorkloadID:    k.WorkloadID,
+			Count:         c,
+		})
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Count > result[j].Count
+	})
+
+	return result
+}

--- a/pkg/obs/ash/aggregate_test.go
+++ b/pkg/obs/ash/aggregate_test.go
@@ -1,0 +1,113 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package ash
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAggregateSamples(t *testing.T) {
+	now := time.Date(2026, 3, 5, 12, 0, 0, 0, time.UTC)
+	lookback := 60 * time.Second
+
+	t.Run("empty input", func(t *testing.T) {
+		result := AggregateSamples(nil, now, lookback)
+		require.Nil(t, result)
+	})
+
+	t.Run("all outside window", func(t *testing.T) {
+		samples := []ASHSample{
+			{SampleTime: now.Add(-2 * time.Minute), WorkEventType: WorkCPU, WorkEvent: "A"},
+			{SampleTime: now.Add(-90 * time.Second), WorkEventType: WorkIO, WorkEvent: "B"},
+		}
+		result := AggregateSamples(samples, now, lookback)
+		require.Nil(t, result)
+	})
+
+	t.Run("boundary inclusion", func(t *testing.T) {
+		// Sample exactly at the cutoff (now - lookback) should be included.
+		samples := []ASHSample{
+			{SampleTime: now.Add(-lookback), WorkEventType: WorkCPU, WorkEvent: "exact"},
+		}
+		result := AggregateSamples(samples, now, lookback)
+		require.Len(t, result, 1)
+		require.Equal(t, int64(1), result[0].Count)
+		require.Equal(t, "exact", result[0].WorkEvent)
+	})
+
+	t.Run("samples after now are excluded", func(t *testing.T) {
+		samples := []ASHSample{
+			{SampleTime: now.Add(-10 * time.Second), WorkEventType: WorkCPU, WorkEvent: "in"},
+			{SampleTime: now.Add(1 * time.Second), WorkEventType: WorkCPU, WorkEvent: "future"},
+		}
+		result := AggregateSamples(samples, now, lookback)
+		require.Len(t, result, 1)
+		require.Equal(t, "in", result[0].WorkEvent)
+	})
+
+	t.Run("multiple groups sorted by count", func(t *testing.T) {
+		samples := []ASHSample{
+			// 3 CPU samples.
+			{SampleTime: now.Add(-30 * time.Second), WorkEventType: WorkCPU, WorkEvent: "ReplicaSend", WorkloadID: "aaa"},
+			{SampleTime: now.Add(-20 * time.Second), WorkEventType: WorkCPU, WorkEvent: "ReplicaSend", WorkloadID: "aaa"},
+			{SampleTime: now.Add(-10 * time.Second), WorkEventType: WorkCPU, WorkEvent: "ReplicaSend", WorkloadID: "aaa"},
+			// 1 IO sample.
+			{SampleTime: now.Add(-25 * time.Second), WorkEventType: WorkIO, WorkEvent: "StorageEval", WorkloadID: "bbb"},
+			// 2 Lock samples.
+			{SampleTime: now.Add(-15 * time.Second), WorkEventType: WorkLock, WorkEvent: "LockWait", WorkloadID: "ccc"},
+			{SampleTime: now.Add(-5 * time.Second), WorkEventType: WorkLock, WorkEvent: "LockWait", WorkloadID: "ccc"},
+		}
+		result := AggregateSamples(samples, now, lookback)
+		require.Len(t, result, 3)
+
+		// Sorted by count descending.
+		require.Equal(t, int64(3), result[0].Count)
+		require.Equal(t, WorkCPU, result[0].WorkEventType)
+		require.Equal(t, "ReplicaSend", result[0].WorkEvent)
+		require.Equal(t, "aaa", result[0].WorkloadID)
+
+		require.Equal(t, int64(2), result[1].Count)
+		require.Equal(t, WorkLock, result[1].WorkEventType)
+		require.Equal(t, "LockWait", result[1].WorkEvent)
+
+		require.Equal(t, int64(1), result[2].Count)
+		require.Equal(t, WorkIO, result[2].WorkEventType)
+		require.Equal(t, "StorageEval", result[2].WorkEvent)
+	})
+
+	t.Run("same event type different workload IDs", func(t *testing.T) {
+		samples := []ASHSample{
+			{SampleTime: now.Add(-10 * time.Second), WorkEventType: WorkCPU, WorkEvent: "X", WorkloadID: "w1"},
+			{SampleTime: now.Add(-9 * time.Second), WorkEventType: WorkCPU, WorkEvent: "X", WorkloadID: "w2"},
+		}
+		result := AggregateSamples(samples, now, lookback)
+		require.Len(t, result, 2)
+		// Both should have count 1.
+		require.Equal(t, int64(1), result[0].Count)
+		require.Equal(t, int64(1), result[1].Count)
+	})
+
+	t.Run("mixed in-window and out-of-window", func(t *testing.T) {
+		samples := []ASHSample{
+			// Out of window.
+			{SampleTime: now.Add(-2 * time.Minute), WorkEventType: WorkCPU, WorkEvent: "old", WorkloadID: "x"},
+			{SampleTime: now.Add(-90 * time.Second), WorkEventType: WorkCPU, WorkEvent: "old", WorkloadID: "x"},
+			// In window.
+			{SampleTime: now.Add(-50 * time.Second), WorkEventType: WorkCPU, WorkEvent: "new", WorkloadID: "y"},
+			{SampleTime: now.Add(-40 * time.Second), WorkEventType: WorkCPU, WorkEvent: "new", WorkloadID: "y"},
+			{SampleTime: now.Add(-30 * time.Second), WorkEventType: WorkIO, WorkEvent: "io", WorkloadID: "z"},
+		}
+		result := AggregateSamples(samples, now, lookback)
+		require.Len(t, result, 2)
+		require.Equal(t, int64(2), result[0].Count)
+		require.Equal(t, "new", result[0].WorkEvent)
+		require.Equal(t, int64(1), result[1].Count)
+		require.Equal(t, "io", result[1].WorkEvent)
+	})
+}

--- a/pkg/obs/ash/report.go
+++ b/pkg/obs/ash/report.go
@@ -1,0 +1,109 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package ash
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+)
+
+// totalSampleCount returns the sum of counts across all entries.
+func totalSampleCount(entries []AggregatedASH) int64 {
+	var total int64
+	for i := range entries {
+		total += entries[i].Count
+	}
+	return total
+}
+
+// WriteTextReport writes a human-readable aggregated ASH report to w.
+// The report is designed for debug zip inspection.
+func WriteTextReport(
+	w io.Writer, entries []AggregatedASH, generated time.Time, lookback time.Duration,
+) error {
+	totalSamples := totalSampleCount(entries)
+
+	if _, err := io.WriteString(w, "ASH Aggregated Report\n"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "Generated: %s\n", generated.UTC().Format(time.RFC3339Nano)); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "Lookback:  %s\n", lookback); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "Samples:   %d\n\n", totalSamples); err != nil {
+		return err
+	}
+
+	if len(entries) == 0 {
+		_, err := io.WriteString(w, "No samples in window.\n")
+		return err
+	}
+
+	// Print header.
+	if _, err := fmt.Fprintf(w, "%8s  %-16s  %-22s  %s\n",
+		"COUNT", "WORK_EVENT_TYPE", "WORK_EVENT", "WORKLOAD_ID"); err != nil {
+		return err
+	}
+
+	// Print rows.
+	for i := range entries {
+		e := &entries[i]
+		if _, err := fmt.Fprintf(w, "%8d  %-16s  %-22s  %s\n",
+			e.Count, e.WorkEventType, e.WorkEvent, e.WorkloadID); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// jsonReport is the serialization format for a JSON ASH report.
+type jsonReport struct {
+	Generated    string      `json:"generated"`
+	LookbackSecs float64     `json:"lookback_seconds"`
+	TotalSamples int64       `json:"total_samples"`
+	Groups       []jsonGroup `json:"groups"`
+}
+
+// jsonGroup is a single entry in the JSON report.
+type jsonGroup struct {
+	WorkEventType string `json:"work_event_type"`
+	WorkEvent     string `json:"work_event"`
+	WorkloadID    string `json:"workload_id"`
+	Count         int64  `json:"count"`
+}
+
+// WriteJSONReport writes a machine-readable JSON aggregated ASH report to w.
+func WriteJSONReport(
+	w io.Writer, entries []AggregatedASH, generated time.Time, lookback time.Duration,
+) error {
+	totalSamples := totalSampleCount(entries)
+
+	groups := make([]jsonGroup, len(entries))
+	for i := range entries {
+		groups[i] = jsonGroup{
+			WorkEventType: entries[i].WorkEventType.String(),
+			WorkEvent:     entries[i].WorkEvent,
+			WorkloadID:    entries[i].WorkloadID,
+			Count:         entries[i].Count,
+		}
+	}
+
+	report := jsonReport{
+		Generated:    generated.UTC().Format(time.RFC3339Nano),
+		LookbackSecs: lookback.Seconds(),
+		TotalSamples: totalSamples,
+		Groups:       groups,
+	}
+
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(report)
+}

--- a/pkg/obs/ash/report_test.go
+++ b/pkg/obs/ash/report_test.go
@@ -1,0 +1,107 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package ash
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteTextReport(t *testing.T) {
+	generated := time.Date(2026, 3, 5, 12, 34, 56, 789000000, time.UTC)
+	lookback := 60 * time.Second
+
+	t.Run("with entries", func(t *testing.T) {
+		entries := []AggregatedASH{
+			{WorkEventType: WorkCPU, WorkEvent: "ReplicaSend", WorkloadID: "00000000000002a", Count: 523},
+			{WorkEventType: WorkLock, WorkEvent: "LockWait", WorkloadID: "000000000000001a", Count: 312},
+			{WorkEventType: WorkIO, WorkEvent: "StorageEval", WorkloadID: "0000000000000003", Count: 201},
+		}
+
+		var buf bytes.Buffer
+		err := WriteTextReport(&buf, entries, generated, lookback)
+		require.NoError(t, err)
+
+		output := buf.String()
+		require.Contains(t, output, "ASH Aggregated Report")
+		require.Contains(t, output, "Generated: 2026-03-05T12:34:56.789Z")
+		require.Contains(t, output, "Lookback:  1m0s")
+		require.Contains(t, output, "Samples:   1036")
+		require.Contains(t, output, "COUNT")
+		require.Contains(t, output, "WORK_EVENT_TYPE")
+		require.Contains(t, output, "523")
+		require.Contains(t, output, "ReplicaSend")
+		require.Contains(t, output, "312")
+		require.Contains(t, output, "LockWait")
+		require.Contains(t, output, "201")
+		require.Contains(t, output, "StorageEval")
+	})
+
+	t.Run("empty entries", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := WriteTextReport(&buf, nil, generated, lookback)
+		require.NoError(t, err)
+
+		output := buf.String()
+		require.Contains(t, output, "ASH Aggregated Report")
+		require.Contains(t, output, "Samples:   0")
+		require.Contains(t, output, "No samples in window.")
+	})
+}
+
+func TestWriteJSONReport(t *testing.T) {
+	generated := time.Date(2026, 3, 5, 12, 34, 56, 789000000, time.UTC)
+	lookback := 60 * time.Second
+
+	t.Run("with entries", func(t *testing.T) {
+		entries := []AggregatedASH{
+			{WorkEventType: WorkCPU, WorkEvent: "ReplicaSend", WorkloadID: "aaa", Count: 100},
+			{WorkEventType: WorkIO, WorkEvent: "StorageEval", WorkloadID: "bbb", Count: 50},
+		}
+
+		var buf bytes.Buffer
+		err := WriteJSONReport(&buf, entries, generated, lookback)
+		require.NoError(t, err)
+
+		// Verify it's valid JSON.
+		var report jsonReport
+		err = json.NewDecoder(strings.NewReader(buf.String())).Decode(&report)
+		require.NoError(t, err)
+
+		require.Equal(t, "2026-03-05T12:34:56.789Z", report.Generated)
+		require.Equal(t, float64(60), report.LookbackSecs)
+		require.Equal(t, int64(150), report.TotalSamples)
+		require.Len(t, report.Groups, 2)
+
+		require.Equal(t, "CPU", report.Groups[0].WorkEventType)
+		require.Equal(t, "ReplicaSend", report.Groups[0].WorkEvent)
+		require.Equal(t, "aaa", report.Groups[0].WorkloadID)
+		require.Equal(t, int64(100), report.Groups[0].Count)
+
+		require.Equal(t, "IO", report.Groups[1].WorkEventType)
+		require.Equal(t, "StorageEval", report.Groups[1].WorkEvent)
+		require.Equal(t, "bbb", report.Groups[1].WorkloadID)
+		require.Equal(t, int64(50), report.Groups[1].Count)
+	})
+
+	t.Run("empty entries", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := WriteJSONReport(&buf, nil, generated, lookback)
+		require.NoError(t, err)
+
+		var report jsonReport
+		err = json.NewDecoder(strings.NewReader(buf.String())).Decode(&report)
+		require.NoError(t, err)
+
+		require.Equal(t, int64(0), report.TotalSamples)
+		require.Empty(t, report.Groups)
+	})
+}

--- a/pkg/obs/ash/report_test.go
+++ b/pkg/obs/ash/report_test.go
@@ -7,101 +7,117 @@ package ash
 
 import (
 	"bytes"
-	"encoding/json"
+	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
+	"github.com/cockroachdb/datadriven"
 )
 
-func TestWriteTextReport(t *testing.T) {
-	generated := time.Date(2026, 3, 5, 12, 34, 56, 789000000, time.UTC)
-	lookback := 60 * time.Second
+func TestReport(t *testing.T) {
+	datadriven.RunTest(t, "testdata/report", func(t *testing.T, d *datadriven.TestData) string {
+		generated, lookback := parseReportArgs(t, d)
+		entries := parseEntries(t, d.Input)
 
-	t.Run("with entries", func(t *testing.T) {
-		entries := []AggregatedASH{
-			{WorkEventType: WorkCPU, WorkEvent: "ReplicaSend", WorkloadID: "00000000000002a", Count: 523},
-			{WorkEventType: WorkLock, WorkEvent: "LockWait", WorkloadID: "000000000000001a", Count: 312},
-			{WorkEventType: WorkIO, WorkEvent: "StorageEval", WorkloadID: "0000000000000003", Count: 201},
+		var buf bytes.Buffer
+		var err error
+		switch d.Cmd {
+		case "text-report":
+			err = WriteTextReport(&buf, entries, generated, lookback)
+		case "json-report":
+			err = WriteJSONReport(&buf, entries, generated, lookback)
+		default:
+			return fmt.Sprintf("unknown command: %s", d.Cmd)
 		}
 
-		var buf bytes.Buffer
-		err := WriteTextReport(&buf, entries, generated, lookback)
-		require.NoError(t, err)
+		if err != nil {
+			return fmt.Sprintf("error: %v", err)
+		}
 
-		output := buf.String()
-		require.Contains(t, output, "ASH Aggregated Report")
-		require.Contains(t, output, "Generated: 2026-03-05T12:34:56.789Z")
-		require.Contains(t, output, "Lookback:  1m0s")
-		require.Contains(t, output, "Samples:   1036")
-		require.Contains(t, output, "COUNT")
-		require.Contains(t, output, "WORK_EVENT_TYPE")
-		require.Contains(t, output, "523")
-		require.Contains(t, output, "ReplicaSend")
-		require.Contains(t, output, "312")
-		require.Contains(t, output, "LockWait")
-		require.Contains(t, output, "201")
-		require.Contains(t, output, "StorageEval")
-	})
-
-	t.Run("empty entries", func(t *testing.T) {
-		var buf bytes.Buffer
-		err := WriteTextReport(&buf, nil, generated, lookback)
-		require.NoError(t, err)
-
-		output := buf.String()
-		require.Contains(t, output, "ASH Aggregated Report")
-		require.Contains(t, output, "Samples:   0")
-		require.Contains(t, output, "No samples in window.")
+		// Replace blank lines with "." for datadriven compatibility.
+		lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+		for i, line := range lines {
+			if line == "" {
+				lines[i] = "."
+			}
+		}
+		return strings.Join(lines, "\n")
 	})
 }
 
-func TestWriteJSONReport(t *testing.T) {
-	generated := time.Date(2026, 3, 5, 12, 34, 56, 789000000, time.UTC)
-	lookback := 60 * time.Second
-
-	t.Run("with entries", func(t *testing.T) {
-		entries := []AggregatedASH{
-			{WorkEventType: WorkCPU, WorkEvent: "ReplicaSend", WorkloadID: "aaa", Count: 100},
-			{WorkEventType: WorkIO, WorkEvent: "StorageEval", WorkloadID: "bbb", Count: 50},
+func parseReportArgs(t *testing.T, d *datadriven.TestData) (time.Time, time.Duration) {
+	t.Helper()
+	var generated time.Time
+	var lookback time.Duration
+	for _, arg := range d.CmdArgs {
+		switch arg.Key {
+		case "generated":
+			var err error
+			generated, err = time.Parse(time.RFC3339Nano, arg.Vals[0])
+			if err != nil {
+				t.Fatalf("parsing generated: %v", err)
+			}
+		case "lookback":
+			var err error
+			lookback, err = time.ParseDuration(arg.Vals[0])
+			if err != nil {
+				t.Fatalf("parsing lookback: %v", err)
+			}
 		}
+	}
+	return generated, lookback
+}
 
-		var buf bytes.Buffer
-		err := WriteJSONReport(&buf, entries, generated, lookback)
-		require.NoError(t, err)
+func parseEntries(t *testing.T, input string) []AggregatedASH {
+	t.Helper()
+	if strings.TrimSpace(input) == "" {
+		return nil
+	}
+	var entries []AggregatedASH
+	for _, line := range strings.Split(input, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) != 4 {
+			t.Fatalf("expected 4 fields (TYPE EVENT WORKLOAD_ID COUNT), got %d: %q", len(fields), line)
+		}
+		count, err := strconv.ParseInt(fields[3], 10, 64)
+		if err != nil {
+			t.Fatalf("parsing count %q: %v", fields[3], err)
+		}
+		entries = append(entries, AggregatedASH{
+			WorkEventType: parseWorkEventType(t, fields[0]),
+			WorkEvent:     fields[1],
+			WorkloadID:    fields[2],
+			Count:         count,
+		})
+	}
+	return entries
+}
 
-		// Verify it's valid JSON.
-		var report jsonReport
-		err = json.NewDecoder(strings.NewReader(buf.String())).Decode(&report)
-		require.NoError(t, err)
-
-		require.Equal(t, "2026-03-05T12:34:56.789Z", report.Generated)
-		require.Equal(t, float64(60), report.LookbackSecs)
-		require.Equal(t, int64(150), report.TotalSamples)
-		require.Len(t, report.Groups, 2)
-
-		require.Equal(t, "CPU", report.Groups[0].WorkEventType)
-		require.Equal(t, "ReplicaSend", report.Groups[0].WorkEvent)
-		require.Equal(t, "aaa", report.Groups[0].WorkloadID)
-		require.Equal(t, int64(100), report.Groups[0].Count)
-
-		require.Equal(t, "IO", report.Groups[1].WorkEventType)
-		require.Equal(t, "StorageEval", report.Groups[1].WorkEvent)
-		require.Equal(t, "bbb", report.Groups[1].WorkloadID)
-		require.Equal(t, int64(50), report.Groups[1].Count)
-	})
-
-	t.Run("empty entries", func(t *testing.T) {
-		var buf bytes.Buffer
-		err := WriteJSONReport(&buf, nil, generated, lookback)
-		require.NoError(t, err)
-
-		var report jsonReport
-		err = json.NewDecoder(strings.NewReader(buf.String())).Decode(&report)
-		require.NoError(t, err)
-
-		require.Equal(t, int64(0), report.TotalSamples)
-		require.Empty(t, report.Groups)
-	})
+func parseWorkEventType(t *testing.T, s string) WorkEventType {
+	t.Helper()
+	switch s {
+	case "CPU":
+		return WorkCPU
+	case "ADMISSION":
+		return WorkAdmission
+	case "IO":
+		return WorkIO
+	case "NETWORK":
+		return WorkNetwork
+	case "LOCK":
+		return WorkLock
+	case "OTHER":
+		return WorkOther
+	case "UNKNOWN":
+		return WorkUnknown
+	default:
+		t.Fatalf("unknown WorkEventType: %s", s)
+		return WorkUnknown
+	}
 }

--- a/pkg/obs/ash/sampler.go
+++ b/pkg/obs/ash/sampler.go
@@ -66,10 +66,16 @@ var BufferSize = settings.RegisterIntSetting(
 // logged to the OPS channel. Each summary reports the most
 // frequently sampled (WorkEventType, WorkEvent, WorkloadID)
 // combinations in the ring buffer since the last report.
+//
+// This value is also used as the lookback window by the ASH report
+// profiler when writing reports alongside CPU profiles or goroutine
+// dumps triggered by the env sampler.
 var LogInterval = settings.RegisterDurationSetting(
 	settings.SystemVisible,
 	"obs.ash.log_interval",
-	"interval between periodic ASH top-N workload summary logs",
+	"interval between periodic ASH top-N workload summary logs; "+
+		"also used as the lookback window for ASH reports written "+
+		"by the env sampler profiler",
 	10*time.Minute,
 	settings.PositiveDuration,
 )

--- a/pkg/obs/ash/sampler.go
+++ b/pkg/obs/ash/sampler.go
@@ -498,6 +498,13 @@ func encodeStmtFingerprintIDToString(id uint64) string {
 	return hex.EncodeToString(encodeUint64ToBytes(id))
 }
 
+// GetGlobalSampler returns the process-wide ASH sampler, or nil if it
+// has not been initialized. Use this when you need to call
+// Sampler.GetSamples with a reusable buffer to avoid allocations.
+func GetGlobalSampler() *Sampler {
+	return globalSampler.Load()
+}
+
 // GetSamples returns all samples from the global ASH sampler. Returns
 // nil if the global sampler has not been initialized.
 func GetSamples() []ASHSample {

--- a/pkg/obs/ash/testdata/report
+++ b/pkg/obs/ash/testdata/report
@@ -1,0 +1,60 @@
+# Text report with entries.
+text-report generated=2026-03-05T12:34:56.789Z lookback=60s
+CPU ReplicaSend 00000000000002a 523
+LOCK LockWait 000000000000001a 312
+IO StorageEval 0000000000000003 201
+----
+ASH Aggregated Report
+Generated: 2026-03-05T12:34:56.789Z
+Lookback:  1m0s
+Samples:   1036
+.
+   COUNT  WORK_EVENT_TYPE   WORK_EVENT              WORKLOAD_ID
+     523  CPU               ReplicaSend             00000000000002a
+     312  LOCK              LockWait                000000000000001a
+     201  IO                StorageEval             0000000000000003
+
+# Text report with no entries.
+text-report generated=2026-03-05T12:34:56.789Z lookback=60s
+----
+ASH Aggregated Report
+Generated: 2026-03-05T12:34:56.789Z
+Lookback:  1m0s
+Samples:   0
+.
+No samples in window.
+
+# JSON report with entries.
+json-report generated=2026-03-05T12:34:56.789Z lookback=60s
+CPU ReplicaSend aaa 100
+IO StorageEval bbb 50
+----
+{
+  "generated": "2026-03-05T12:34:56.789Z",
+  "lookback_seconds": 60,
+  "total_samples": 150,
+  "groups": [
+    {
+      "work_event_type": "CPU",
+      "work_event": "ReplicaSend",
+      "workload_id": "aaa",
+      "count": 100
+    },
+    {
+      "work_event_type": "IO",
+      "work_event": "StorageEval",
+      "workload_id": "bbb",
+      "count": 50
+    }
+  ]
+}
+
+# JSON report with no entries.
+json-report generated=2026-03-05T12:34:56.789Z lookback=60s
+----
+{
+  "generated": "2026-03-05T12:34:56.789Z",
+  "lookback_seconds": 60,
+  "total_samples": 0,
+  "groups": []
+}

--- a/pkg/server/env_sampler.go
+++ b/pkg/server/env_sampler.go
@@ -92,6 +92,7 @@ func startSampleEnvironment(
 	var statsProfiler *profiler.StatsProfiler
 	var queryProfiler *profiler.ActiveQueryProfiler
 	var cpuProfiler *profiler.CPUProfiler
+	var ashReportProfiler *profiler.ASHReportProfiler
 	if cfg.heapProfileDirName != "" {
 		hasValidDumpDir := true
 		if err := os.MkdirAll(cfg.heapProfileDirName, 0755); err != nil {
@@ -130,6 +131,10 @@ func startSampleEnvironment(
 			if err != nil {
 				log.Dev.Warningf(ctx, "failed to start cpu profiler worker: %v", err)
 			}
+			ashReportProfiler, err = profiler.NewASHReportProfiler(ctx, cfg.heapProfileDirName, cfg.st)
+			if err != nil {
+				log.Dev.Warningf(ctx, "failed to start ASH report profiler: %v", err)
+			}
 		}
 	}
 
@@ -166,7 +171,11 @@ func startSampleEnvironment(
 					}
 
 					if goroutineDumper != nil {
-						goroutineDumper.MaybeDump(ctx, cfg.st, cfg.runtime.Goroutines.Value())
+						if goroutineDumper.MaybeDump(ctx, cfg.st, cfg.runtime.Goroutines.Value()) {
+							if ashReportProfiler != nil {
+								ashReportProfiler.WriteReport(ctx, profiler.TriggerGoroutineDump)
+							}
+						}
 					}
 					if heapProfiler != nil {
 						heapProfiler.MaybeTakeProfile(ctx, cfg.runtime.GoAllocBytes.Value())
@@ -178,7 +187,11 @@ func startSampleEnvironment(
 						queryProfiler.MaybeDumpQueries(ctx, cfg.sessionRegistry, cfg.st)
 					}
 					if cpuProfiler != nil {
-						cpuProfiler.MaybeTakeProfile(ctx, int64(cfg.runtime.CPUCombinedPercentNorm.Value()*100))
+						if cpuProfiler.MaybeTakeProfile(ctx, int64(cfg.runtime.CPUCombinedPercentNorm.Value()*100)) {
+							if ashReportProfiler != nil {
+								ashReportProfiler.WriteReport(ctx, profiler.TriggerCPUProfile)
+							}
+						}
 					}
 				}
 			}

--- a/pkg/server/goroutinedumper/goroutinedumper.go
+++ b/pkg/server/goroutinedumper/goroutinedumper.go
@@ -92,9 +92,11 @@ type GoroutineDumper struct {
 }
 
 // MaybeDump takes a goroutine dump only when at least one heuristic in
-// GoroutineDumper is true.
+// GoroutineDumper is true. Returns true if a dump was successfully taken.
 // At most one dump is taken in a call of this function.
-func (gd *GoroutineDumper) MaybeDump(ctx context.Context, st *cluster.Settings, goroutines int64) {
+func (gd *GoroutineDumper) MaybeDump(
+	ctx context.Context, st *cluster.Settings, goroutines int64,
+) bool {
 	gd.goroutines = goroutines
 	if gd.goroutinesThreshold != numGoroutinesThreshold.Get(&st.SV) {
 		gd.goroutinesThreshold = numGoroutinesThreshold.Get(&st.SV)
@@ -110,9 +112,10 @@ func (gd *GoroutineDumper) MaybeDump(ctx context.Context, st *cluster.Settings, 
 			}
 			gd.maxGoroutinesDumped = goroutines
 			gd.gcDumps(ctx, now)
-			break
+			return true
 		}
 	}
+	return false
 }
 
 // DumpNow requests a goroutine dump on demand.

--- a/pkg/server/profiler/BUILD.bazel
+++ b/pkg/server/profiler/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "profiler",
     srcs = [
         "activequeryprofiler.go",
+        "ashreportprofiler.go",
         "cgoprofiler.go",
         "cluster_settings.go",
         "cpuprofiler.go",
@@ -18,6 +19,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/build",
+        "//pkg/obs/ash",
         "//pkg/server/debug",
         "//pkg/server/dumpstore",
         "//pkg/server/status",
@@ -43,6 +45,7 @@ go_test(
     size = "small",
     srcs = [
         "activequeryprofiler_test.go",
+        "ashreportprofiler_test.go",
         "cpuprofile_test.go",
         "memory_monitoring_profiler_test.go",
         "profiler_common_test.go",
@@ -55,6 +58,7 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/mon",
         "//pkg/util/timeutil",
+        "@com_github_cockroachdb_errors//oserror",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/pkg/server/profiler/ashreportprofiler.go
+++ b/pkg/server/profiler/ashreportprofiler.go
@@ -1,0 +1,165 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package profiler
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/obs/ash"
+	"github.com/cockroachdb/cockroach/pkg/server/dumpstore"
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
+)
+
+const ashReportPrefix = "ash_report"
+
+// ASH report trigger names embedded in filenames.
+const (
+	TriggerGoroutineDump = "goroutine_dump"
+	TriggerCPUProfile    = "cpu_profile"
+)
+
+var ashReportTotalDumpSizeLimit = settings.RegisterByteSizeSetting(
+	settings.ApplicationLevel,
+	"obs.ash.report.total_dump_size_limit",
+	"maximum combined disk size of preserved ASH report files",
+	32<<20, // 32MiB
+)
+
+// ASHReportProfiler writes aggregated ASH reports to disk when triggered
+// by external events (goroutine dumps, CPU profiles). It is not
+// threshold-based like the other profilers; instead, it is called
+// explicitly after a dump or profile is taken.
+//
+// It is not safe for concurrent use and must only be called from the
+// env sampler goroutine.
+type ASHReportProfiler struct {
+	store *dumpstore.DumpStore
+	st    *cluster.Settings
+	// samplesBuf is reused across calls to avoid repeated large
+	// allocations when retrieving ASH samples from the ring buffer.
+	samplesBuf []ash.ASHSample
+	now        func() time.Time
+}
+
+// NewASHReportProfiler creates a new ASHReportProfiler. dir is the
+// directory in which ASH reports are stored.
+func NewASHReportProfiler(
+	ctx context.Context, dir string, st *cluster.Settings,
+) (*ASHReportProfiler, error) {
+	if dir == "" {
+		return nil, errors.New("directory to store ASH reports could not be determined")
+	}
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return nil, err
+	}
+
+	log.Dev.Infof(ctx, "writing ASH reports to %s", log.SafeManaged(dir))
+	return &ASHReportProfiler{
+		store: dumpstore.NewStore(dir, ashReportTotalDumpSizeLimit, st),
+		st:    st,
+		now:   timeutil.Now,
+	}, nil
+}
+
+// WriteReport writes an aggregated ASH report. trigger is included in
+// the filename (e.g. "goroutine_dump", "cpu_profile"). Returns true
+// if at least one report file was written.
+func (p *ASHReportProfiler) WriteReport(ctx context.Context, trigger string) bool {
+	now := p.now()
+
+	sampler := ash.GetGlobalSampler()
+	if sampler == nil {
+		return false
+	}
+
+	lookback := ash.LogInterval.Get(&p.st.SV)
+	p.samplesBuf = sampler.GetSamples(p.samplesBuf)
+	entries := ash.AggregateSamples(p.samplesBuf, now, lookback)
+
+	// Write both text and JSON reports.
+	txtOk := p.writeFile(ctx, now, trigger, ".txt", func(f *os.File) error {
+		return ash.WriteTextReport(f, entries, now, lookback)
+	})
+	jsonOk := p.writeFile(ctx, now, trigger, ".json", func(f *os.File) error {
+		return ash.WriteJSONReport(f, entries, now, lookback)
+	})
+
+	if txtOk || jsonOk {
+		p.store.GC(ctx, now, p)
+		return true
+	}
+	return false
+}
+
+func (p *ASHReportProfiler) writeFile(
+	ctx context.Context, now time.Time, trigger string, suffix string, writeFn func(f *os.File) error,
+) bool {
+	fileName := fmt.Sprintf(
+		"%s.%s.%s%s",
+		ashReportPrefix, now.Format(timestampFormat), trigger, suffix,
+	)
+	path := p.store.GetFullPath(fileName)
+	f, err := os.Create(path)
+	if err != nil {
+		log.Dev.Warningf(ctx, "error creating ASH report %s: %v", path, err)
+		return false
+	}
+
+	if err := writeFn(f); err != nil {
+		log.Dev.Warningf(ctx, "error writing ASH report %s: %v", path, err)
+		_ = f.Close()
+		_ = os.Remove(path)
+		return false
+	}
+	if err := f.Close(); err != nil {
+		log.Dev.Warningf(ctx, "error closing ASH report %s: %v", path, err)
+		_ = os.Remove(path)
+		return false
+	}
+	return true
+}
+
+// PreFilter is part of the dumpstore.Dumper interface. It preserves the
+// most recent .txt file and the most recent .json file, which are
+// typically (but not necessarily) from the same trigger event.
+func (p *ASHReportProfiler) PreFilter(
+	ctx context.Context, files []os.DirEntry, cleanupFn func(fileName string) error,
+) (preserved map[int]bool, _ error) {
+	preserved = make(map[int]bool)
+	// Preserve the latest .txt and .json files.
+	foundTxt, foundJSON := false, false
+	for i := len(files) - 1; i >= 0; i-- {
+		if !p.CheckOwnsFile(ctx, files[i]) {
+			continue
+		}
+		name := files[i].Name()
+		if !foundTxt && strings.HasSuffix(name, ".txt") {
+			preserved[i] = true
+			foundTxt = true
+		}
+		if !foundJSON && strings.HasSuffix(name, ".json") {
+			preserved[i] = true
+			foundJSON = true
+		}
+		if foundTxt && foundJSON {
+			break
+		}
+	}
+	return preserved, nil
+}
+
+// CheckOwnsFile is part of the dumpstore.Dumper interface.
+func (p *ASHReportProfiler) CheckOwnsFile(_ context.Context, fi os.DirEntry) bool {
+	return strings.HasPrefix(fi.Name(), ashReportPrefix+".")
+}

--- a/pkg/server/profiler/ashreportprofiler_test.go
+++ b/pkg/server/profiler/ashreportprofiler_test.go
@@ -1,0 +1,132 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package profiler
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/errors/oserror"
+	"github.com/stretchr/testify/require"
+)
+
+func TestASHReportProfiler(t *testing.T) {
+	ctx := context.Background()
+	st := cluster.MakeClusterSettings()
+	dir := t.TempDir()
+
+	p, err := NewASHReportProfiler(ctx, dir, st)
+	require.NoError(t, err)
+
+	now := time.Date(2026, 3, 5, 12, 0, 0, 0, time.UTC)
+
+	t.Run("writeFile/success", func(t *testing.T) {
+		ok := p.writeFile(ctx, now, "test_trigger", ".txt", func(f *os.File) error {
+			_, err := f.WriteString("hello")
+			return err
+		})
+		require.True(t, ok)
+
+		path := filepath.Join(dir, "ash_report.2026-03-05T12_00_00.000.test_trigger.txt")
+		data, err := os.ReadFile(path)
+		require.NoError(t, err)
+		require.Equal(t, "hello", string(data))
+	})
+
+	t.Run("writeFile/error cleans up partial file", func(t *testing.T) {
+		ok := p.writeFile(ctx, now, "fail_trigger", ".txt", func(f *os.File) error {
+			return os.ErrPermission
+		})
+		require.False(t, ok)
+
+		path := filepath.Join(dir, "ash_report.2026-03-05T12_00_00.000.fail_trigger.txt")
+		_, err := os.Stat(path)
+		require.True(t, oserror.IsNotExist(err), "partial file should be cleaned up")
+	})
+
+	t.Run("CheckOwnsFile", func(t *testing.T) {
+		cases := []struct {
+			name string
+			owns bool
+		}{
+			{"ash_report.2026-03-05T12_00_00.000.goroutine_dump.txt", true},
+			{"ash_report.2026-03-05T12_00_00.000.cpu_profile.json", true},
+			{"memprof.2026-03-05T12_00_00.000.1234", false},
+			{"ash_report_something_else", false},
+		}
+		subDir := t.TempDir()
+		for _, c := range cases {
+			t.Run(c.name, func(t *testing.T) {
+				path := filepath.Join(subDir, c.name)
+				require.NoError(t, os.WriteFile(path, nil, 0644))
+				defer func() { _ = os.Remove(path) }()
+
+				entries, err := os.ReadDir(subDir)
+				require.NoError(t, err)
+				var entry os.DirEntry
+				for _, e := range entries {
+					if e.Name() == c.name {
+						entry = e
+						break
+					}
+				}
+				require.NotNil(t, entry)
+				require.Equal(t, c.owns, p.CheckOwnsFile(ctx, entry))
+			})
+		}
+	})
+
+	t.Run("PreFilter", func(t *testing.T) {
+		subDir := t.TempDir()
+		fileNames := []string{
+			"ash_report.2026-03-05T10_00_00.000.goroutine_dump.json",
+			"ash_report.2026-03-05T10_00_00.000.goroutine_dump.txt",
+			"ash_report.2026-03-05T11_00_00.000.cpu_profile.json",
+			"ash_report.2026-03-05T11_00_00.000.cpu_profile.txt",
+			"memprof.2026-03-05T12_00_00.000.1234", // not owned
+		}
+		for _, name := range fileNames {
+			require.NoError(t, os.WriteFile(filepath.Join(subDir, name), nil, 0644))
+		}
+
+		entries, err := os.ReadDir(subDir)
+		require.NoError(t, err)
+
+		preserved, err := p.PreFilter(ctx, entries, func(fileName string) error {
+			return nil
+		})
+		require.NoError(t, err)
+
+		// The newest .txt (index 3) and newest .json (index 2) should be
+		// preserved. The non-owned file (index 4) should not be in the map.
+		require.True(t, preserved[3], "newest .txt should be preserved")
+		require.True(t, preserved[2], "newest .json should be preserved")
+		require.False(t, preserved[0], "older .json should not be preserved")
+		require.False(t, preserved[1], "older .txt should not be preserved")
+		require.False(t, preserved[4], "non-owned file should not be preserved")
+	})
+
+	t.Run("WriteReport/no global sampler", func(t *testing.T) {
+		ok := p.WriteReport(ctx, "test")
+		require.False(t, ok)
+
+		entries, err := os.ReadDir(dir)
+		require.NoError(t, err)
+		ashFiles := 0
+		for _, e := range entries {
+			if strings.HasPrefix(e.Name(), ashReportPrefix) {
+				ashFiles++
+			}
+		}
+		// Only the file from the writeFile/success subtest should exist.
+		require.Equal(t, 1, ashFiles)
+	})
+}

--- a/pkg/server/profiler/cpuprofiler.go
+++ b/pkg/server/profiler/cpuprofiler.go
@@ -98,13 +98,14 @@ func NewCPUProfiler(ctx context.Context, dir string, st *cluster.Settings) (*CPU
 }
 
 // MaybeTakeProfile takes a cpu profile if cpu usage is high enough.
-func (cp *CPUProfiler) MaybeTakeProfile(ctx context.Context, currentCpuUsage int64) {
+// Returns true if a profile was successfully taken.
+func (cp *CPUProfiler) MaybeTakeProfile(ctx context.Context, currentCpuUsage int64) bool {
 	defer func() {
 		if p := recover(); p != nil {
 			logcrash.ReportPanic(ctx, &cp.st.SV, p, 1)
 		}
 	}()
-	cp.profiler.maybeTakeProfile(ctx, currentCpuUsage, cp.takeCPUProfile)
+	return cp.profiler.maybeTakeProfile(ctx, currentCpuUsage, cp.takeCPUProfile)
 }
 
 func (cp *CPUProfiler) takeCPUProfile(

--- a/pkg/server/profiler/profiler_common.go
+++ b/pkg/server/profiler/profiler_common.go
@@ -81,16 +81,18 @@ func (o *profiler) now() time.Time {
 	return timeutil.Now()
 }
 
-// args is optional and will be passed as is into takeProfileFn.
+// maybeTakeProfile takes a profile if the threshold exceeds the high water
+// mark. Returns true if a profile was successfully taken. args is optional
+// and will be passed as is into takeProfileFn.
 func (o *profiler) maybeTakeProfile(
 	ctx context.Context,
 	thresholdValue int64,
 	takeProfileFn func(ctx context.Context, path string, args ...interface{}) bool,
 	args ...interface{},
-) {
+) bool {
 	if o.resetInterval() == 0 {
 		// Instruction to disable.
-		return
+		return false
 	}
 
 	now := o.now()
@@ -106,14 +108,14 @@ func (o *profiler) maybeTakeProfile(
 		hook(takeProfile)
 	}
 	if !takeProfile {
-		return
+		return false
 	}
 
 	o.highWaterMark = thresholdValue
 	o.lastProfileTime = now
 
 	if o.knobs.dontWriteProfiles {
-		return
+		return false
 	}
 	success := takeProfileFn(ctx, o.store.makeNewFileName(now, thresholdValue), args...)
 	if success {
@@ -122,4 +124,5 @@ func (o *profiler) maybeTakeProfile(
 		// from a previous crash.
 		o.store.gcProfiles(ctx, now)
 	}
+	return success
 }


### PR DESCRIPTION
When the environment sampler triggers a goroutine dump or CPU profile, also write an aggregated ASH (Active Session History) report alongside it. This provides immediate context about what workloads were active at the time of interest, aiding diagnosis of performance issues.

Two output formats are produced per trigger:
- `.txt` — human-readable table for debug zip inspection
- `.json` — machine-readable for tooling/log aggregation

To support this, `GoroutineDumper.MaybeDump()` and `CPUProfiler.MaybeTakeProfile()` now return `bool` indicating whether a dump/profile was successfully taken. The env sampler checks these return values to decide when to trigger an ASH report.

New cluster settings:
- `obs.ash.report.lookback_window` (default 60s): aggregation window
- `obs.ash.report.total_dump_size_limit` (default 32MiB): GC size limit

Resolves: #164383

Release note: None