### PR TITLE
rpc: add DRPC interceptors to Partitioner for network partition tests

### DIFF
--- a/pkg/kv/kvclient/kvcoord/partial_partition_test.go
+++ b/pkg/kv/kvclient/kvcoord/partial_partition_test.go
@@ -89,9 +89,6 @@ func testPartialPartition(t *testing.T, useProxy bool, numServers int) {
 			require.NoError(t, p.AddPartition(roachpb.NodeID(1), roachpb.NodeID(2)))
 			require.NoError(t, p.AddPartition(roachpb.NodeID(2), roachpb.NodeID(1)))
 			tc := testcluster.StartTestCluster(t, numServers, base.TestClusterArgs{
-				ServerArgs: base.TestServerArgs{
-					DefaultDRPCOption: base.TestDRPCDisabled,
-				},
 				ServerArgsPerNode: func() map[int]base.TestServerArgs {
 					perNode := make(map[int]base.TestServerArgs)
 					for i := 0; i < numServers; i++ {

--- a/pkg/rpc/context_testutils.go
+++ b/pkg/rpc/context_testutils.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"google.golang.org/grpc"
+	"storj.io/drpc"
 	"storj.io/drpc/drpcclient"
 )
 
@@ -132,8 +133,30 @@ func (d disablingClientStream) RecvMsg(m interface{}) error {
 	return d.ClientStream.RecvMsg(m)
 }
 
+// Embed the partitionCheck function into the stream and check it when we are
+// sending or receiving a message. It is same as disablingClientStream but for
+// DRPC.
+type disablingDRPCStream struct {
+	drpc.Stream
+	partitionCheck func() error
+}
+
+func (d *disablingDRPCStream) MsgSend(msg drpc.Message, enc drpc.Encoding) error {
+	if err := d.partitionCheck(); err != nil {
+		return err
+	}
+	return d.Stream.MsgSend(msg, enc)
+}
+
+func (d *disablingDRPCStream) MsgRecv(msg drpc.Message, enc drpc.Encoding) error {
+	if err := d.partitionCheck(); err != nil {
+		return err
+	}
+	return d.Stream.MsgRecv(msg, enc)
+}
+
 // Partitioner is used to create partial partitions between nodes at the GRPC
-// layer. It uses StreamInterceptors to fail requests to nodes that are not
+// and DRPC layer. It uses interceptors to fail requests to nodes that are not
 // connected. Node addresses need to be registered before enabling the
 // partition, but partitions can be added and removed at any point (before or
 // after starting the cluster or enabling the partition).
@@ -270,6 +293,28 @@ func (p *Partitioner) RegisterTestingKnobs(id roachpb.NodeID, knobs *ContextTest
 				}
 				return &disablingClientStream{
 					ClientStream:   cs,
+					partitionCheck: func() error { return isPartitioned(target) },
+				}, nil
+			}
+		}
+	knobs.UnaryClientInterceptorDRPC =
+		func(target string, class rpcbase.ConnectionClass) drpcclient.UnaryClientInterceptor {
+			return func(ctx context.Context, rpc string, enc drpc.Encoding, in, out drpc.Message, cc *drpcclient.ClientConn, next drpcclient.UnaryInvoker) error {
+				if err := isPartitioned(target); err != nil {
+					return err
+				}
+				return next(ctx, rpc, enc, in, out, cc)
+			}
+		}
+	knobs.StreamClientInterceptorDRPC =
+		func(target string, class rpcbase.ConnectionClass) drpcclient.StreamClientInterceptor {
+			return func(ctx context.Context, rpc string, enc drpc.Encoding, cc *drpcclient.ClientConn, streamer drpcclient.Streamer) (drpc.Stream, error) {
+				stream, err := streamer(ctx, rpc, enc, cc)
+				if err != nil {
+					return nil, err
+				}
+				return &disablingDRPCStream{
+					Stream:         stream,
 					partitionCheck: func() error { return isPartitioned(target) },
 				}, nil
 			}


### PR DESCRIPTION
The Partitioner test utility simulates network partitions between nodes by injecting gRPC interceptors that reject requests to partitioned peers. However, it only set the gRPC interceptors (UnaryClientInterceptor, StreamClientInterceptor) and not the DRPC equivalents. When DRPC is enabled, connections bypass the partition entirely because the DRPC dial path checks separate knob fields (UnaryClientInterceptorDRPC, StreamClientInterceptorDRPC) which were never populated.

This caused TestPartialPartitionDirectFiveFail to fail under DRPC: the test expects a Put from a partitioned node to the leaseholder to fail, but with DRPC the request succeeded.

Fixed the issue by also setting the DRPC interceptor knobs in Partitioner.RegisterTestingKnobs(), using the same isPartitioned() check.

Fixes: #161565
Epic: CRDB-55382
Release note: None