### PR TITLE
sql: add SHOW STATISTICS WITH FORECAST_STATUS

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -914,6 +914,46 @@ s4               {b,c}
 s4               {c,d}
 s8               {a}
 
+# Test forecast_status option. We exclude latest_created and forecast_at from
+# the main assertion because timestamps are non-deterministic. Instead we check
+# that they are all non-NULL.
+query TFFFFFTT colnames
+SELECT column_names,
+       row_count_r2, null_count_r2, distinct_count_r2, avg_size_r2, histogram_r2,
+       forecast_error, histogram_error
+FROM [SHOW STATISTICS FOR TABLE data WITH FORECAST_STATUS]
+ORDER BY column_names::STRING
+----
+column_names  row_count_r2  null_count_r2  distinct_count_r2  avg_size_r2  histogram_r2  forecast_error                                  histogram_error
+{a,b,c,d}     1             1              1                  1            NULL          NULL                                            NULL
+{a,b,c}       1             1              1                  1            NULL          NULL                                            NULL
+{a,b}         1             1              1                  1            NULL          NULL                                            NULL
+{a}           1             1              1                  1            1             NULL                                            NULL
+{b,c}         NULL          NULL           NULL               NULL         NULL          not enough observations to forecast statistics  NULL
+{b}           1             1              1                  1            1             NULL                                            NULL
+{c,d}         NULL          NULL           NULL               NULL         NULL          not enough observations to forecast statistics  NULL
+{c}           1             1              1                  1            1             NULL                                            NULL
+{d}           1             1              1                  1            NULL          NULL                                            not enough observations to forecast histogram
+{e}           1             1              1                  1            NULL          NULL                                            not enough observations to forecast histogram
+
+query B
+SELECT bool_and(latest_created IS NOT NULL AND forecast_at IS NOT NULL)
+FROM [SHOW STATISTICS FOR TABLE data WITH FORECAST_STATUS]
+----
+true
+
+# Test that forecast_status is incompatible with USING JSON.
+statement error cannot use forecast_status with USING JSON
+SHOW STATISTICS USING JSON FOR TABLE data WITH FORECAST_STATUS
+
+# Test that forecast_status is incompatible with forecast.
+statement error cannot use forecast_status with forecast
+SHOW STATISTICS FOR TABLE data WITH FORECAST_STATUS, FORECAST
+
+# Test that forecast_status is incompatible with merge.
+statement error cannot use forecast_status with merge
+SHOW STATISTICS FOR TABLE data WITH FORECAST_STATUS, MERGE
+
 # Test deletion of old non-default stats.
 
 statement ok

--- a/pkg/sql/show_stats.go
+++ b/pkg/sql/show_stats.go
@@ -48,9 +48,25 @@ const showTableStatsOptForecast = "forecast"
 
 const showTableStatsOptMerge = "merge"
 
+const showTableStatsOptForecastStatus = "forecast_status"
+
 var showTableStatsOptValidate = map[string]exprutil.KVStringOptValidate{
-	showTableStatsOptForecast: exprutil.KVStringOptRequireNoValue,
-	showTableStatsOptMerge:    exprutil.KVStringOptRequireNoValue,
+	showTableStatsOptForecast:       exprutil.KVStringOptRequireNoValue,
+	showTableStatsOptMerge:          exprutil.KVStringOptRequireNoValue,
+	showTableStatsOptForecastStatus: exprutil.KVStringOptRequireNoValue,
+}
+
+var showTableStatsForecastStatusColumns = colinfo.ResultColumns{
+	{Name: "column_names", Typ: types.StringArray},
+	{Name: "latest_created", Typ: types.TimestampTZ},
+	{Name: "forecast_at", Typ: types.TimestampTZ},
+	{Name: "row_count_r2", Typ: types.Float},
+	{Name: "null_count_r2", Typ: types.Float},
+	{Name: "distinct_count_r2", Typ: types.Float},
+	{Name: "avg_size_r2", Typ: types.Float},
+	{Name: "histogram_r2", Typ: types.Float},
+	{Name: "forecast_error", Typ: types.String},
+	{Name: "histogram_error", Typ: types.String},
 }
 
 func containsDroppedColumn(colIDs tree.Datums, desc catalog.TableDescriptor) bool {
@@ -82,9 +98,25 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 	if err := p.CheckAnyPrivilege(ctx, desc); err != nil {
 		return nil, err
 	}
+	_, withForecastStatus := opts[showTableStatsOptForecastStatus]
+	if withForecastStatus {
+		if n.UsingJSON {
+			return nil, errors.New("cannot use forecast_status with USING JSON")
+		}
+		if _, ok := opts[showTableStatsOptForecast]; ok {
+			return nil, errors.New("cannot use forecast_status with forecast")
+		}
+		if _, ok := opts[showTableStatsOptMerge]; ok {
+			return nil, errors.New("cannot use forecast_status with merge")
+		}
+	}
+
 	columns := showTableStatsColumns
 	if n.UsingJSON {
 		columns = showTableStatsJSONColumns
+	}
+	if withForecastStatus {
+		columns = showTableStatsForecastStatusColumns
 	}
 
 	return &delayedNode{
@@ -137,6 +169,102 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 
 			// Guard against crashes in the code below (e.g. #56356).
 			defer errorutil.MaybeCatchPanic(&retErr, nil /* errCallback */)
+
+			if withForecastStatus {
+				statsList := make([]*stats.TableStatistic, 0, len(rows))
+				for _, row := range rows {
+					colIDs := row[columnIDsIdx].(*tree.DArray).Array
+					if containsDroppedColumn(colIDs, desc) {
+						continue
+					}
+					stat, err := stats.NewTableStatisticProto(row)
+					if err != nil {
+						return nil, err
+					}
+					obs := &stats.TableStatistic{TableStatisticProto: *stat}
+					if obs.HistogramData != nil && !obs.HistogramData.ColumnType.UserDefined() {
+						if err := stats.DecodeHistogramBuckets(ctx, obs); err != nil {
+							return nil, err
+						}
+					}
+					statsList = append(statsList, obs)
+				}
+
+				// Reverse to sort by CreatedAt descending.
+				for i := 0; i < len(statsList)/2; i++ {
+					j := len(statsList) - i - 1
+					statsList[i], statsList[j] = statsList[j], statsList[i]
+				}
+
+				statuses := stats.ForecastTableStatisticsStatus(
+					ctx, p.ExtendedEvalContext().Settings, statsList,
+				)
+				v := p.newContainerValuesNode(columns, len(statuses))
+				for _, s := range statuses {
+					colNames := make(tree.Datums, len(s.ColumnIDs))
+					for i, colID := range s.ColumnIDs {
+						colDesc := catalog.FindColumnByID(desc, colID)
+						if colDesc == nil {
+							colNames[i] = tree.NewDString("<unknown>")
+						} else {
+							colNames[i] = tree.NewDString(colDesc.GetName())
+						}
+					}
+
+					var latestCreated tree.Datum = tree.DNull
+					if !s.LatestCreated.IsZero() {
+						d, err := tree.MakeDTimestampTZ(s.LatestCreated, time.Microsecond)
+						if err != nil {
+							v.Close(ctx)
+							return nil, err
+						}
+						latestCreated = d
+					}
+					var forecastAtDatum tree.Datum = tree.DNull
+					if !s.ForecastAt.IsZero() {
+						d, err := tree.MakeDTimestampTZ(s.ForecastAt, time.Microsecond)
+						if err != nil {
+							v.Close(ctx)
+							return nil, err
+						}
+						forecastAtDatum = d
+					}
+
+					f64OrNull := func(p *float64) tree.Datum {
+						if p == nil {
+							return tree.DNull
+						}
+						return tree.NewDFloat(tree.DFloat(*p))
+					}
+
+					forecastErr := tree.DNull
+					if s.ForecastError != nil {
+						forecastErr = tree.NewDString(s.ForecastError.Error())
+					}
+					histErr := tree.DNull
+					if s.HistogramError != nil {
+						histErr = tree.NewDString(s.HistogramError.Error())
+					}
+
+					res := tree.Datums{
+						tree.NewDArrayFromDatums(types.String, colNames),
+						latestCreated,
+						forecastAtDatum,
+						f64OrNull(s.RowCountR2),
+						f64OrNull(s.NullCountR2),
+						f64OrNull(s.DistinctCountR2),
+						f64OrNull(s.AvgSizeR2),
+						f64OrNull(s.HistogramR2),
+						forecastErr,
+						histErr,
+					}
+					if _, err := v.rows.AddRow(ctx, res); err != nil {
+						v.Close(ctx)
+						return nil, err
+					}
+				}
+				return v, nil
+			}
 
 			_, withMerge := opts[showTableStatsOptMerge]
 			_, withForecast := opts[showTableStatsOptForecast]

--- a/pkg/sql/stats/forecast.go
+++ b/pkg/sql/stats/forecast.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -77,6 +78,122 @@ var maxDecrease = settings.RegisterFloatSetting(
 )
 
 // TODO(michae2): Consider whether we need a corresponding maxIncrease.
+
+// ForecastStatus holds diagnostic information about why a forecast was or was
+// not produced for a particular column set.
+type ForecastStatus struct {
+	ColumnIDs       []descpb.ColumnID
+	LatestCreated   time.Time
+	ForecastAt      time.Time
+	RowCountR2      *float64
+	NullCountR2     *float64
+	DistinctCountR2 *float64
+	AvgSizeR2       *float64
+	HistogramR2     *float64
+	ForecastError   error
+	HistogramError  error
+}
+
+// ForecastTableStatisticsStatus returns per-column-set diagnostic information
+// about forecast generation. For each column set in the observed statistics, it
+// reports whether the forecast succeeded or failed, and if the histogram
+// prediction failed separately from the overall forecast.
+func ForecastTableStatisticsStatus(
+	ctx context.Context, st *cluster.Settings, observed []*TableStatistic,
+) []ForecastStatus {
+	// Group observed statistics by column set, tracking which ones are skipped.
+	type colGroup struct {
+		columnIDs  []descpb.ColumnID
+		stats      []*TableStatistic
+		skipReason error
+	}
+	var groups []colGroup
+	groupIndex := make(map[string]int)
+
+	for _, stat := range observed {
+		colKey := MakeSortedColStatKey(stat.ColumnIDs)
+		idx, ok := groupIndex[colKey]
+		if !ok {
+			idx = len(groups)
+			groupIndex[colKey] = idx
+			groups = append(groups, colGroup{columnIDs: stat.ColumnIDs})
+		}
+		g := &groups[idx]
+		if stat.IsPartial() {
+			if g.skipReason == nil {
+				g.skipReason = errors.New("partial statistics skipped")
+			}
+			continue
+		}
+		if stat.HistogramData != nil && stat.HistogramData.ColumnType != nil &&
+			stat.HistogramData.ColumnType.Family() == types.BytesFamily {
+			if g.skipReason == nil {
+				g.skipReason = errors.New("inverted/BYTES histogram skipped")
+			}
+			continue
+		}
+		g.stats = append(g.stats, stat)
+	}
+
+	if len(groups) == 0 {
+		return nil
+	}
+	avgRefresh := avgFullRefreshTime(observed)
+
+	results := make([]ForecastStatus, 0, len(groups))
+	for _, g := range groups {
+		status := ForecastStatus{ColumnIDs: g.columnIDs}
+
+		if g.skipReason != nil && len(g.stats) == 0 {
+			status.ForecastError = g.skipReason
+			results = append(results, status)
+			continue
+		}
+		if len(g.stats) == 0 {
+			status.ForecastError = errors.New("no suitable observations")
+			results = append(results, status)
+			continue
+		}
+
+		latest := g.stats[0].CreatedAt
+		at := latest.Add(avgRefresh)
+		status.LatestCreated = latest
+		status.ForecastAt = at
+
+		var histErr error
+		// Initialize R² values to NaN to distinguish "not computed" from a
+		// computed value of 0.
+		r2 := [5]float64{
+			math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(),
+		}
+		_, err := forecastColumnStatisticsWithHistErr(
+			ctx, st, g.stats, at, minGoodnessOfFit.Get(&st.SV), &histErr, &r2,
+		)
+		if err != nil {
+			status.ForecastError = err
+		} else if histErr != nil {
+			status.HistogramError = histErr
+		}
+
+		// Populate R² values. Each R² is non-nil when the corresponding
+		// regression was computed (i.e. there were enough observations and,
+		// for distinct/avg_size, non-empty observations).
+		for i, ptr := range []*(*float64){
+			&status.RowCountR2,
+			&status.NullCountR2,
+			&status.DistinctCountR2,
+			&status.AvgSizeR2,
+			&status.HistogramR2,
+		} {
+			if !math.IsNaN(r2[i]) {
+				v := r2[i]
+				*ptr = &v
+			}
+		}
+		results = append(results, status)
+	}
+	return results
+}
 
 // ForecastTableStatistics produces zero or more statistics forecasts based on
 // the given observed statistics. The observed statistics must be ordered by
@@ -180,6 +297,23 @@ func forecastColumnStatistics(
 	observed []*TableStatistic,
 	at time.Time,
 	minRequiredFit float64,
+	r2Out *[5]float64,
+) (forecast *TableStatistic, err error) {
+	return forecastColumnStatisticsWithHistErr(
+		ctx, st, observed, at, minRequiredFit, nil, r2Out,
+	)
+}
+
+// forecastColumnStatisticsWithHistErr is like forecastColumnStatistics but
+// optionally captures the histogram prediction error in histErr rather than
+// silently falling back to the latest observed histogram.
+func forecastColumnStatisticsWithHistErr(
+	ctx context.Context,
+	st *cluster.Settings,
+	observed []*TableStatistic,
+	at time.Time,
+	minRequiredFit float64,
+	histErr *error,
 	r2Out *[5]float64,
 ) (forecast *TableStatistic, err error) {
 	if len(observed) < int(minObservationsForForecast.Get(&st.SV)) {
@@ -364,6 +498,9 @@ func forecastColumnStatistics(
 				ctx, 3, "forecast for table %v columns %v: could not predict histogram due to: %v",
 				tableID, columnIDs, err,
 			)
+			if histErr != nil {
+				*histErr = err
+			}
 			hist.buckets = append([]cat.HistogramBucket{}, observed[0].nonNullHistogram().buckets...)
 		}
 

--- a/pkg/sql/stats/forecast.go
+++ b/pkg/sql/stats/forecast.go
@@ -142,6 +142,7 @@ func ForecastTableStatistics(
 
 		forecast, err := forecastColumnStatistics(
 			ctx, st, observedByCols[colKey], at, minGoodnessOfFit.Get(&st.SV),
+			nil, /* r2Out */
 		)
 		if err != nil {
 			log.VEventf(
@@ -179,6 +180,7 @@ func forecastColumnStatistics(
 	observed []*TableStatistic,
 	at time.Time,
 	minRequiredFit float64,
+	r2Out *[5]float64,
 ) (forecast *TableStatistic, err error) {
 	if len(observed) < int(minObservationsForForecast.Get(&st.SV)) {
 		return nil, errors.New("not enough observations to forecast statistics")
@@ -215,15 +217,20 @@ func forecastColumnStatistics(
 		}
 	}
 
-	// predict tries to predict the value of the given statistic at forecast time.
-	predict := func(name redact.SafeString, y, createdAts []float64) (float64, error) {
+	// predict tries to predict the value of the given statistic at forecast
+	// time. It returns the predicted value, the R² goodness-of-fit, and an error
+	// if the R² is below the minimum required fit. It always returns the R² even
+	// when the fit is bad.
+	predict := func(
+		name redact.SafeString, y, createdAts []float64,
+	) (float64, float64, error) {
 		yₙ, r2 := float64SimpleLinearRegression(createdAts, y, forecastAt)
 		log.VEventf(
 			ctx, 3, "forecast for table %v columns %v predicted %s %v R² %v",
 			tableID, columnIDs, name, yₙ, r2,
 		)
 		if r2 < minRequiredFit {
-			return yₙ, errors.Newf(
+			return yₙ, r2, errors.Newf(
 				"predicted %v R² %v below min required R² %v", name, r2, minRequiredFit,
 			)
 		}
@@ -235,32 +242,67 @@ func forecastColumnStatistics(
 		lowerBound := math.Round(slices.Min(y) * maxDecrease.Get(&st.SV))
 		lowerBound = math.Max(0, lowerBound)
 		if yₙ < lowerBound {
-			return lowerBound, nil
+			return lowerBound, r2, nil
 		}
 		if yₙ > math.MaxInt64 {
-			return math.MaxInt64, nil
+			return math.MaxInt64, r2, nil
 		}
-		return math.Round(yₙ), nil
+		return math.Round(yₙ), r2, nil
 	}
 
-	rowCount, err := predict("RowCount", rowCounts, createdAts)
-	if err != nil {
-		return nil, err
-	}
-	nullCount, err := predict("NullCount", nullCounts, createdAts)
-	if err != nil {
-		return nil, err
-	}
+	// Predict all four stat values, collecting R² and errors for each. We
+	// always compute all four R² values (when possible) before checking for
+	// errors, so that callers requesting R² diagnostics get a complete picture.
+	rowCount, rowR2, rowErr := predict("RowCount", rowCounts, createdAts)
+	nullCount, nullR2, nullErr := predict("NullCount", nullCounts, createdAts)
 	var distinctCount, avgSize float64
+	var distR2, avgR2 float64
+	var distErr, avgErr error
 	if len(nonEmptyCreatedAts) > 0 {
-		distinctCount, err = predict("DistinctCount", distinctCounts, nonEmptyCreatedAts)
-		if err != nil {
-			return nil, err
+		distinctCount, distR2, distErr = predict(
+			"DistinctCount", distinctCounts, nonEmptyCreatedAts,
+		)
+		avgSize, avgR2, avgErr = predict("AvgSize", avgSizes, nonEmptyCreatedAts)
+	}
+
+	if r2Out != nil {
+		r2Out[0] = rowR2
+		r2Out[1] = nullR2
+		r2Out[2] = distR2
+		r2Out[3] = avgR2
+	}
+
+	// Find the first stat prediction error, if any.
+	var statErr error
+	for _, e := range []error{rowErr, nullErr, distErr, avgErr} {
+		if e != nil {
+			statErr = e
+			break
 		}
-		avgSize, err = predict("AvgSize", avgSizes, nonEmptyCreatedAts)
-		if err != nil {
-			return nil, err
+	}
+
+	if statErr != nil {
+		// When r2Out is non-nil, still attempt histogram prediction for
+		// diagnostics even though the stat-level forecast failed.
+		if r2Out != nil &&
+			observed[0].HistogramData != nil && observed[0].HistogramData.ColumnType != nil {
+			nonNullRowCount := float64(observed[0].RowCount - observed[0].NullCount)
+			if rowErr == nil && nullErr == nil {
+				nonNullRowCount = rowCount - nullCount
+				if nonNullRowCount < 0 {
+					nonNullRowCount = 0
+				}
+			}
+			if nonNullRowCount >= 1 {
+				// We only care about the R² written to r2Out[4], not the
+				// histogram or error.
+				_, _ = predictHistogram(
+					ctx, st, observed, forecastAt, minRequiredFit, nonNullRowCount,
+					&r2Out[4],
+				)
+			}
 		}
+		return nil, statErr
 	}
 
 	// Adjust predicted statistics for consistency.
@@ -308,7 +350,13 @@ func forecastColumnStatistics(
 	// histogram. NOTE: If any of the observed histograms were for inverted
 	// indexes this will produce an incorrect histogram.
 	if observed[0].HistogramData != nil && observed[0].HistogramData.ColumnType != nil {
-		hist, err := predictHistogram(ctx, st, observed, forecastAt, minRequiredFit, nonNullRowCount)
+		var histR2Out *float64
+		if r2Out != nil {
+			histR2Out = &r2Out[4]
+		}
+		hist, err := predictHistogram(
+			ctx, st, observed, forecastAt, minRequiredFit, nonNullRowCount, histR2Out,
+		)
 		if err != nil {
 			// If we did not successfully predict a histogram then copy the latest
 			// histogram so we can adjust it.
@@ -362,6 +410,7 @@ func predictHistogram(
 	forecastAt float64,
 	minRequiredFit float64,
 	nonNullRowCount float64,
+	r2Out *float64,
 ) (histogram, error) {
 	if observed[0].HistogramData == nil || observed[0].HistogramData.ColumnType == nil {
 		return histogram{}, errors.New("latest observed stat missing histogram")
@@ -410,6 +459,9 @@ func predictHistogram(
 	// Construct a linear regression model of quantile functions over time, and
 	// use it to predict a quantile function at the given time.
 	yₙ, r2 := quantileSimpleLinearRegression(createdAts, quantiles, forecastAt)
+	if r2Out != nil {
+		*r2Out = r2
+	}
 	if yₙ.isInvalid() {
 		return histogram{}, errors.Newf("predicted histogram contains overflow values")
 	}

--- a/pkg/sql/stats/forecast_test.go
+++ b/pkg/sql/stats/forecast_test.go
@@ -636,6 +636,159 @@ func TestForecastColumnStatistics(t *testing.T) {
 	}
 }
 
+// TestForecastTableStatisticsStatus verifies that ForecastTableStatisticsStatus
+// returns appropriate error diagnostics for various scenarios.
+func TestForecastTableStatisticsStatus(t *testing.T) {
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+
+	makeStats := func(
+		columnIDs descpb.ColumnIDs, stats ...*testStat,
+	) []*TableStatistic {
+		result := make([]*TableStatistic, len(stats))
+		for i, ts := range stats {
+			// Store in CreatedAt descending order.
+			result[len(result)-i-1] = ts.toTableStatistic(
+				ctx, "test", 1, columnIDs, 0, 0, st,
+			)
+		}
+		return result
+	}
+
+	t.Run("not enough observations", func(t *testing.T) {
+		observed := makeStats(
+			descpb.ColumnIDs{1},
+			&testStat{at: 1, row: 1, dist: 1, null: 0, size: 1},
+			&testStat{at: 2, row: 2, dist: 2, null: 0, size: 1},
+		)
+		statuses := ForecastTableStatisticsStatus(ctx, st, observed)
+		if len(statuses) != 1 {
+			t.Fatalf("expected 1 status, got %d", len(statuses))
+		}
+		if statuses[0].ForecastError == nil {
+			t.Error("expected forecast error for too few observations")
+		}
+		if statuses[0].HistogramError != nil {
+			t.Errorf("unexpected histogram error: %v", statuses[0].HistogramError)
+		}
+	})
+
+	t.Run("successful forecast", func(t *testing.T) {
+		observed := makeStats(
+			descpb.ColumnIDs{1},
+			&testStat{at: 1, row: 10, dist: 5, null: 0, size: 1},
+			&testStat{at: 2, row: 20, dist: 10, null: 0, size: 1},
+			&testStat{at: 3, row: 30, dist: 15, null: 0, size: 1},
+		)
+		statuses := ForecastTableStatisticsStatus(ctx, st, observed)
+		if len(statuses) != 1 {
+			t.Fatalf("expected 1 status, got %d", len(statuses))
+		}
+		if statuses[0].ForecastError != nil {
+			t.Errorf("unexpected forecast error: %v", statuses[0].ForecastError)
+		}
+		if statuses[0].HistogramError != nil {
+			t.Errorf("unexpected histogram error: %v", statuses[0].HistogramError)
+		}
+	})
+
+	t.Run("bad fit", func(t *testing.T) {
+		observed := makeStats(
+			descpb.ColumnIDs{1},
+			&testStat{at: 1, row: 7, dist: 1, null: 1, size: 1},
+			&testStat{at: 2, row: 9, dist: 2, null: 2, size: 2},
+			&testStat{at: 3, row: 5, dist: 3, null: 3, size: 3},
+		)
+		statuses := ForecastTableStatisticsStatus(ctx, st, observed)
+		if len(statuses) != 1 {
+			t.Fatalf("expected 1 status, got %d", len(statuses))
+		}
+		if statuses[0].ForecastError == nil {
+			t.Error("expected forecast error for bad fit")
+		}
+	})
+
+	t.Run("partial statistics skipped", func(t *testing.T) {
+		observed := makeStats(
+			descpb.ColumnIDs{1},
+			&testStat{at: 1, row: 10, dist: 5, null: 0, size: 1},
+			&testStat{at: 2, row: 20, dist: 10, null: 0, size: 1},
+			&testStat{at: 3, row: 30, dist: 15, null: 0, size: 1},
+		)
+		// Make all stats partial.
+		for _, s := range observed {
+			s.PartialPredicate = "x > 0"
+		}
+		statuses := ForecastTableStatisticsStatus(ctx, st, observed)
+		if len(statuses) != 1 {
+			t.Fatalf("expected 1 status, got %d", len(statuses))
+		}
+		if statuses[0].ForecastError == nil {
+			t.Error("expected forecast error for partial statistics")
+		}
+	})
+
+	t.Run("histogram bad fit", func(t *testing.T) {
+		// Set minGoodnessOfFit to 1.0 so histogram prediction fails for
+		// imperfect fits.
+		minGoodnessOfFit.Override(ctx, &st.SV, 1.0)
+		defer minGoodnessOfFit.Override(ctx, &st.SV, 0.95)
+		observed := makeStats(
+			descpb.ColumnIDs{1},
+			&testStat{
+				at: 1, row: 10, dist: 2, null: 0, size: 1,
+				hist: testHistogram{{5, 0, 0, 50}, {5, 0, 0, 100}},
+			},
+			&testStat{
+				at: 2, row: 20, dist: 2, null: 0, size: 1,
+				hist: testHistogram{{10, 0, 0, 50}, {10, 0, 0, 200}},
+			},
+			&testStat{
+				at: 3, row: 30, dist: 2, null: 0, size: 1,
+				hist: testHistogram{{15, 0, 0, 50}, {15, 0, 0, 301}},
+			},
+		)
+		statuses := ForecastTableStatisticsStatus(ctx, st, observed)
+		if len(statuses) != 1 {
+			t.Fatalf("expected 1 status, got %d", len(statuses))
+		}
+		if statuses[0].ForecastError != nil {
+			t.Errorf("unexpected forecast error: %v", statuses[0].ForecastError)
+		}
+		if statuses[0].HistogramError == nil {
+			t.Error("expected histogram error for bad fit histogram")
+		}
+	})
+
+	t.Run("multiple column sets", func(t *testing.T) {
+		col1Stats := makeStats(
+			descpb.ColumnIDs{1},
+			&testStat{at: 1, row: 10, dist: 5, null: 0, size: 1},
+			&testStat{at: 2, row: 20, dist: 10, null: 0, size: 1},
+			&testStat{at: 3, row: 30, dist: 15, null: 0, size: 1},
+		)
+		col2Stats := makeStats(
+			descpb.ColumnIDs{2},
+			&testStat{at: 1, row: 7, dist: 1, null: 1, size: 1},
+			&testStat{at: 2, row: 9, dist: 2, null: 2, size: 2},
+			&testStat{at: 3, row: 5, dist: 3, null: 3, size: 3},
+		)
+		observed := append(col1Stats, col2Stats...)
+		statuses := ForecastTableStatisticsStatus(ctx, st, observed)
+		if len(statuses) != 2 {
+			t.Fatalf("expected 2 statuses, got %d", len(statuses))
+		}
+		// Column 1 should succeed.
+		if statuses[0].ForecastError != nil {
+			t.Errorf("unexpected forecast error for col 1: %v", statuses[0].ForecastError)
+		}
+		// Column 2 should fail (bad fit).
+		if statuses[1].ForecastError == nil {
+			t.Error("expected forecast error for col 2 (bad fit)")
+		}
+	})
+}
+
 type testStat struct {
 	at, row, dist, null, size uint64
 	hist                      testHistogram

--- a/pkg/sql/stats/forecast_test.go
+++ b/pkg/sql/stats/forecast_test.go
@@ -618,7 +618,7 @@ func TestForecastColumnStatistics(t *testing.T) {
 			)
 			at := testStatTime(tc.at)
 
-			forecast, err := forecastColumnStatistics(ctx, st, observed, at, 1)
+			forecast, err := forecastColumnStatistics(ctx, st, observed, at, 1, nil)
 			if err != nil {
 				if !tc.err {
 					t.Errorf("test case %d unexpected forecastColumnStatistics err: %v", i, err)


### PR DESCRIPTION
### sql/stats: refactor predict and predictHistogram to expose R² values

Refactor the `predict` closure in `forecastColumnStatistics` to return
the R² goodness-of-fit value alongside the predicted value and error.
Add an `r2Out *[5]float64` parameter to `forecastColumnStatistics` that,
when non-nil, receives R² values for row_count, null_count,
distinct_count, avg_size, and histogram. All four stat R² values are now
computed before checking for errors, so callers requesting diagnostics
get a complete picture. When a stat-level forecast fails and r2Out is
non-nil, the histogram R² is still computed for diagnostics.

Similarly, add an `r2Out *float64` parameter to `predictHistogram` that
receives the histogram regression R² before the fit check.

This is a pure refactor: existing callers pass nil for r2Out, preserving
the same functional behavior.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

---

### sql/stats: add ForecastTableStatisticsStatus for forecast diagnostics

Add a ForecastStatus struct and ForecastTableStatisticsStatus function
that returns per-column-set diagnostic information about forecast
generation. For each column set in the observed statistics, it reports
whether the overall forecast succeeded or failed, and whether the
histogram prediction failed separately.

Previously, forecast errors were silently logged at VEventf levels 2-3
and skipped, giving users no visibility into why a forecast wasn't
produced for a particular column set (e.g., poor R² fit, not enough
observations) or whether the histogram prediction failed.

To capture histogram errors separately, forecastColumnStatistics is
refactored to delegate to forecastColumnStatisticsWithHistErr, which
accepts an optional *error parameter for the histogram prediction error.
The existing caller passes nil so behavior is unchanged.

Epic: none
Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

---

### sql: add SHOW STATISTICS WITH FORECAST_STATUS option

Wire up a new forecast_status option for SHOW STATISTICS that returns
per-column-set forecast diagnostics instead of the normal statistics
output.

Syntax: SHOW STATISTICS FOR TABLE t WITH FORECAST_STATUS

Result columns:
- column_names (STRING[]): the column set
- forecast_error (STRING): error from overall forecasting, NULL if ok
- histogram_error (STRING): error from histogram prediction, NULL if
ok or if the forecast failed first

This option is incompatible with USING JSON, forecast, and merge.

Epic: none
Release note (sql change): Added SHOW STATISTICS FOR TABLE t WITH
FORECAST_STATUS, which returns per-column-set diagnostic information
about why a forecast was or was not produced. This surfaces errors that
were previously only visible in debug logs, such as poor R² fit, not
enough observations, or histogram prediction failures.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>