### PR TITLE
kvserver: defer ForceFlushIndex write to batch commit

### DIFF
--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -86,7 +86,7 @@ type replicaAppBatch struct {
 	// the raft engine before the command is applied to the state machine.
 	wagWriter wag.Writer
 
-	// Reused by addAppliedStateKeyToBatch to avoid heap allocations.
+	// Reused by addAppliedStateToBatch to avoid heap allocations.
 	asAlloc kvserverpb.RangeAppliedState
 }
 
@@ -606,7 +606,7 @@ func (b *replicaAppBatch) stageTrivialReplicatedEvalResult(
 
 	if res.DoTimelyApplicationToAllReplicas {
 		// Update the pending ForceFlushIndex of this batch. Writing is deferred to
-		// addAppliedStateKeyToBatch, following the same pattern as AppliedState
+		// addAppliedStateToBatch, following the same pattern as AppliedState
 		// fields (RaftAppliedIndex, LeaseAppliedIndex). This allows multiple
 		// commands in the same batch to update ForceFlushIndex, with only the final
 		// value being written.
@@ -628,7 +628,7 @@ func (b *replicaAppBatch) ApplyToStateMachine(ctx context.Context) error {
 	// Add the replica applied state key to the write batch if this change
 	// doesn't remove us.
 	if !b.changeRemovesReplica {
-		if err := b.addAppliedStateKeyToBatch(ctx); err != nil {
+		if err := b.addAppliedStateToBatch(ctx); err != nil {
 			return err
 		}
 	}
@@ -759,10 +759,10 @@ func (b *replicaAppBatch) ApplyToStateMachine(ctx context.Context) error {
 	return nil
 }
 
-// addAppliedStateKeyToBatch adds the applied state key to the application
-// batch's Pebble batch. This records the highest raft and lease index that have
-// been applied as of this batch. It also records the Range's MVCC stats.
-func (b *replicaAppBatch) addAppliedStateKeyToBatch(ctx context.Context) error {
+// addAppliedStateToBatch adds the applied state to the application batch's
+// Pebble batch. This records the highest raft and lease index that have been
+// applied as of this batch. It also records the Range's MVCC stats.
+func (b *replicaAppBatch) addAppliedStateToBatch(ctx context.Context) error {
 	// Write the ForceFlushIndex if it was staged during this batch. This index is
 	// stored in a separate RangeForceFlushKey but follows the same deferred-write
 	// pattern as RangeAppliedState.

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -604,16 +604,13 @@ func (b *replicaAppBatch) stageTrivialReplicatedEvalResult(
 	deltaStats := res.Delta.ToStats()
 	b.state.Stats.Add(deltaStats)
 
-	if res.DoTimelyApplicationToAllReplicas && !b.changeRemovesReplica {
-		// Update in-memory and persistent state. A later command accumulated in
-		// this batch may update these again. Also, a later command may set
-		// changeRemovesReplica to true and wipe out the state in the batch. These
-		// are all safe.
+	if res.DoTimelyApplicationToAllReplicas {
+		// Update the pending ForceFlushIndex of this batch. Writing is deferred to
+		// addAppliedStateKeyToBatch, following the same pattern as AppliedState
+		// fields (RaftAppliedIndex, LeaseAppliedIndex). This allows multiple
+		// commands in the same batch to update ForceFlushIndex, with only the final
+		// value being written.
 		b.state.ForceFlushIndex = roachpb.ForceFlushIndex{Index: cmd.Entry.Index}
-		if err := b.r.raftMu.stateLoader.SetForceFlushIndex(
-			ctx, b.batch, b.state.Stats, &b.state.ForceFlushIndex); err != nil {
-			return err
-		}
 	}
 	return nil
 }
@@ -766,6 +763,16 @@ func (b *replicaAppBatch) ApplyToStateMachine(ctx context.Context) error {
 // batch's Pebble batch. This records the highest raft and lease index that have
 // been applied as of this batch. It also records the Range's MVCC stats.
 func (b *replicaAppBatch) addAppliedStateKeyToBatch(ctx context.Context) error {
+	// Write the ForceFlushIndex if it was staged during this batch. This index is
+	// stored in a separate RangeForceFlushKey but follows the same deferred-write
+	// pattern as RangeAppliedState.
+	if b.state.ForceFlushIndex != b.r.shMu.state.ForceFlushIndex {
+		// NB: this branch goes first, so that MVCC stats are accurate below.
+		if err := b.r.raftMu.stateLoader.SetForceFlushIndex(
+			ctx, b.batch, b.state.Stats, &b.state.ForceFlushIndex); err != nil {
+			return err
+		}
+	}
 	// Set the range applied state, which includes the last applied raft and lease
 	// index along with the MVCC stats, all in one key.
 	b.asAlloc = b.state.ToRangeAppliedState()


### PR DESCRIPTION
Move the `ForceFlushIndex` write from the staging phase to `addAppliedStateKeyToBatch`, following the same deferred-write pattern as `RaftAppliedIndex` and `LeaseAppliedIndex`. This reduces redundant writes when multiple commands in a batch have `DoTimelyApplicationToAllReplicas` set, writing only the final value instead of once per command.

This also removes one potential use of "read our own writes" from the command application stack.

Epic: none
Release note: none