### PR TITLE
ci-stress: backport integration test filtering and query syntax fixes

### DIFF
--- a/pkg/cmd/ci-stress/main.go
+++ b/pkg/cmd/ci-stress/main.go
@@ -117,24 +117,75 @@ func getPkgToTests(diff string) map[string][]string {
 	return ret
 }
 
-func runTests(ctx context.Context, pkgToTests map[string][]string, extraBazelArgs []string) error {
-	var testPackages []string
+// selectAppropriateTests constructs bazel test targets from pkgToTests,
+// then uses `bazel query` to exclude any targets tagged with
+// "integration". Returns the surviving test targets and a sorted,
+// deduplicated list of test names to stress.
+func selectAppropriateTests(
+	ctx context.Context, pkgToTests map[string][]string,
+) (testTargets []string, tests []string, err error) {
+	var candidates []string
 	for pkg := range pkgToTests {
-		testPackages = append(testPackages, fmt.Sprintf("//%s:%s_test", pkg, filepath.Base(pkg)))
+		targetName := strings.ReplaceAll(filepath.Base(pkg), ".", "_")
+		candidates = append(candidates, fmt.Sprintf("//%s:%s_test", pkg, targetName))
+	}
+	if len(candidates) == 0 {
+		return nil, nil, nil
+	}
+	targetSet := strings.Join(candidates, " ")
+	query := fmt.Sprintf(
+		"set(%s) except attr(\"tags\", \"[\\[ ]integration[,\\]]\", set(%s))",
+		targetSet, targetSet,
+	)
+	cmd := exec.CommandContext(ctx, "bazel", "query", query)
+	outputBytes, err := cmd.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
+			return nil, nil, fmt.Errorf("unable to filter integration tests: bazel query: %w\nstderr: %s", err, exitErr.Stderr)
+		}
+		return nil, nil, fmt.Errorf("unable to filter integration tests: bazel query: %w", err)
+	}
+	output := strings.TrimSpace(string(outputBytes))
+	if output == "" {
+		return nil, nil, nil
+	}
+	testTargets = strings.Split(output, "\n")
+
+	// Collect tests only from packages that survived filtering.
+	survivingPkgs := make(map[string]bool, len(testTargets))
+	for _, target := range testTargets {
+		pkg := strings.TrimPrefix(target[:strings.IndexByte(target, ':')], "//")
+		survivingPkgs[pkg] = true
 	}
 	allTests := make(map[string]struct{})
-	for _, tests := range pkgToTests {
-		for _, test := range tests {
+	for pkg, pkgTests := range pkgToTests {
+		if !survivingPkgs[pkg] {
+			continue
+		}
+		for _, test := range pkgTests {
 			allTests[test] = struct{}{}
 		}
 	}
-	allTestsSlice := make([]string, 0, len(allTests))
+	tests = make([]string, 0, len(allTests))
 	for test := range allTests {
-		allTestsSlice = append(allTestsSlice, test)
+		tests = append(tests, test)
 	}
-	slices.Sort(allTestsSlice)
-	testFilter := strings.Join(allTestsSlice, "|")
-	testFilter = "^(" + testFilter + ")$"
+	slices.Sort(tests)
+	return testTargets, tests, nil
+}
+
+func runTests(ctx context.Context, pkgToTests map[string][]string, extraBazelArgs []string) error {
+	testTargets, tests, err := selectAppropriateTests(ctx, pkgToTests)
+	if err != nil {
+		return err
+	}
+	if len(testTargets) == 0 {
+		fmt.Println("no non-integration test targets to stress, exiting")
+		return nil
+	}
+
+	testFilter := "^(" + strings.Join(tests, "|") + ")$"
 	runsPerTest := 25
 	// Run each test multiple times. Calculate the number of times based on
 	// whether this is --race or not.
@@ -145,7 +196,7 @@ func runTests(ctx context.Context, pkgToTests map[string][]string, extraBazelArg
 		}
 	}
 	bazelArgs := []string{"test", "--test_filter", testFilter, "--runs_per_test", strconv.Itoa(runsPerTest)}
-	bazelArgs = append(bazelArgs, testPackages...)
+	bazelArgs = append(bazelArgs, testTargets...)
 	bazelArgs = append(bazelArgs, extraBazelArgs...)
 	fmt.Printf("running `bazel` with args %+v\n", bazelArgs)
 	cmd := exec.CommandContext(ctx, "bazel", bazelArgs...)


### PR DESCRIPTION
Backport of #164367 and #164532 to release-24.3.

- Prevent stressing `integration` tests like `lint_test` (#164367)
- Fix bazel query syntax for multi-package targets (#164532)

Release justification: Non-production code changes
Release note: none
Epic: none