### PR TITLE
rpc: enable DRPC for TestProxyTracing test

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -4343,9 +4343,6 @@ func TestProxyTracing(t *testing.T) {
 		require.NoError(t, p.AddPartition(roachpb.NodeID(1), roachpb.NodeID(3)))
 		require.NoError(t, p.AddPartition(roachpb.NodeID(3), roachpb.NodeID(1)))
 		tc := testcluster.StartTestCluster(t, numServers, base.TestClusterArgs{
-			ServerArgs: base.TestServerArgs{
-				DefaultDRPCOption: base.TestDRPCDisabled,
-			},
 			ServerArgsPerNode: func() map[int]base.TestServerArgs {
 				perNode := make(map[int]base.TestServerArgs)
 				for i := 0; i < numServers; i++ {

--- a/pkg/rpc/client.go
+++ b/pkg/rpc/client.go
@@ -130,6 +130,7 @@ func NewClientContext(ctx context.Context, cfg ClientConnConfig) (*Context, *sto
 		Knobs:                          cfg.TestingKnobs,
 		AdvertiseAddrH:                 &base.AdvertiseAddrH{},
 		SQLAdvertiseAddrH:              &base.SQLAdvertiseAddrH{},
+		UseDRPC:                        cfg.UseDRPC,
 	}
 
 	if cfg.Clock == nil {

--- a/pkg/rpc/context_testutils.go
+++ b/pkg/rpc/context_testutils.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"google.golang.org/grpc"
+	"storj.io/drpc"
 	"storj.io/drpc/drpcclient"
 )
 
@@ -132,8 +133,30 @@ func (d disablingClientStream) RecvMsg(m interface{}) error {
 	return d.ClientStream.RecvMsg(m)
 }
 
+// Embed the partitionCheck function into the stream and check it when we are
+// sending or receiving a message. It is same as disablingClientStream but for
+// DRPC.
+type disablingDRPCStream struct {
+	drpc.Stream
+	partitionCheck func() error
+}
+
+func (d *disablingDRPCStream) MsgSend(msg drpc.Message, enc drpc.Encoding) error {
+	if err := d.partitionCheck(); err != nil {
+		return err
+	}
+	return d.Stream.MsgSend(msg, enc)
+}
+
+func (d *disablingDRPCStream) MsgRecv(msg drpc.Message, enc drpc.Encoding) error {
+	if err := d.partitionCheck(); err != nil {
+		return err
+	}
+	return d.Stream.MsgRecv(msg, enc)
+}
+
 // Partitioner is used to create partial partitions between nodes at the GRPC
-// layer. It uses StreamInterceptors to fail requests to nodes that are not
+// and DRPC layer. It uses interceptors to fail requests to nodes that are not
 // connected. Node addresses need to be registered before enabling the
 // partition, but partitions can be added and removed at any point (before or
 // after starting the cluster or enabling the partition).
@@ -270,6 +293,28 @@ func (p *Partitioner) RegisterTestingKnobs(id roachpb.NodeID, knobs *ContextTest
 				}
 				return &disablingClientStream{
 					ClientStream:   cs,
+					partitionCheck: func() error { return isPartitioned(target) },
+				}, nil
+			}
+		}
+	knobs.UnaryClientInterceptorDRPC =
+		func(target string, class rpcbase.ConnectionClass) drpcclient.UnaryClientInterceptor {
+			return func(ctx context.Context, rpc string, enc drpc.Encoding, in, out drpc.Message, cc *drpcclient.ClientConn, next drpcclient.UnaryInvoker) error {
+				if err := isPartitioned(target); err != nil {
+					return err
+				}
+				return next(ctx, rpc, enc, in, out, cc)
+			}
+		}
+	knobs.StreamClientInterceptorDRPC =
+		func(target string, class rpcbase.ConnectionClass) drpcclient.StreamClientInterceptor {
+			return func(ctx context.Context, rpc string, enc drpc.Encoding, cc *drpcclient.ClientConn, streamer drpcclient.Streamer) (drpc.Stream, error) {
+				stream, err := streamer(ctx, rpc, enc, cc)
+				if err != nil {
+					return nil, err
+				}
+				return &disablingDRPCStream{
+					Stream:         stream,
 					partitionCheck: func() error { return isPartitioned(target) },
 				}, nil
 			}


### PR DESCRIPTION
TestProxyTracing was disabled for DRPC because the Partitioner test utility did not block DRPC traffic when a partition is active.

Partitioner.RegisterTestingKnobs was missing DRPC interceptors. Adding a UnaryClientInterceptorDRPC was sufficient for unary RPCs, but the stream interceptor needed extra care since the DRPCBatchStreamPool reuses streams across requests, so checking the partition only at stream creation time is not enough. A stream created before the partition is enabled gets pooled and reused for subsequent Batch RPCs, bypassing the check.

The fix adds disablingDRPCStream, the DRPC counterpart of the existing disablingClientStream for gRPC, which checks the partition on every MsgSend and MsgRecv. DRPCStreamClientInterceptor wraps each stream with this type so the partition is enforced for the lifetime of the stream.

Also fix NewClientContext to propagate UseDRPC from ClientConnConfig to ContextOptions.

Epic: CRDB-55382
Fixes: #161564
Release note: None