### PR TITLE
sql/regions: fix unsatisfiable zone config for super regions with zone survival

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/super_regions
+++ b/pkg/ccl/logictestccl/testdata/logic_test/super_regions
@@ -21,7 +21,7 @@ TABLE oncreate.public.rbt  ALTER TABLE oncreate.public.rbt CONFIGURE ZONE USING
                              gc.ttlseconds = 14400,
                              num_replicas = 4,
                              num_voters = 3,
-                             constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
+                             constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 3}',
                              voter_constraints = '[+region=us-east-1]',
                              lease_preferences = '[[+region=us-east-1]]'
 
@@ -34,7 +34,7 @@ PARTITION "us-east-1" OF TABLE oncreate.public.rbr  ALTER PARTITION "us-east-1" 
                                                       gc.ttlseconds = 14400,
                                                       num_replicas = 4,
                                                       num_voters = 3,
-                                                      constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
+                                                      constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 3}',
                                                       voter_constraints = '[+region=us-east-1]',
                                                       lease_preferences = '[[+region=us-east-1]]'
 
@@ -158,7 +158,7 @@ TABLE mr2.public.t_rt_us_east_1  ALTER TABLE mr2.public.t_rt_us_east_1 CONFIGURE
                                    gc.ttlseconds = 14400,
                                    num_replicas = 4,
                                    num_voters = 3,
-                                   constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
+                                   constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 3}',
                                    voter_constraints = '[+region=us-east-1]',
                                    lease_preferences = '[[+region=us-east-1]]'
 
@@ -171,7 +171,7 @@ TABLE mr2.public.t_rt_primary_region  ALTER TABLE mr2.public.t_rt_primary_region
                                         gc.ttlseconds = 14400,
                                         num_replicas = 4,
                                         num_voters = 3,
-                                        constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
+                                        constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 3}',
                                         voter_constraints = '[+region=us-east-1]',
                                         lease_preferences = '[[+region=us-east-1]]'
 
@@ -184,7 +184,7 @@ TABLE mr2.public.t_rt  ALTER TABLE mr2.public.t_rt CONFIGURE ZONE USING
                          gc.ttlseconds = 14400,
                          num_replicas = 4,
                          num_voters = 3,
-                         constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
+                         constraints = '{+region=ap-southeast-2: 3, +region=us-east-1: 1}',
                          voter_constraints = '[+region=ap-southeast-2]',
                          lease_preferences = '[[+region=ap-southeast-2]]'
 
@@ -197,7 +197,7 @@ TABLE mr2.public.t_rt_with_idx  ALTER TABLE mr2.public.t_rt_with_idx CONFIGURE Z
                                   gc.ttlseconds = 14400,
                                   num_replicas = 4,
                                   num_voters = 3,
-                                  constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
+                                  constraints = '{+region=ap-southeast-2: 3, +region=us-east-1: 1}',
                                   voter_constraints = '[+region=ap-southeast-2]',
                                   lease_preferences = '[[+region=ap-southeast-2]]'
 
@@ -210,7 +210,7 @@ TABLE mr2.public.t_rt_with_idx  ALTER TABLE mr2.public.t_rt_with_idx CONFIGURE Z
                                   gc.ttlseconds = 14400,
                                   num_replicas = 4,
                                   num_voters = 3,
-                                  constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
+                                  constraints = '{+region=ap-southeast-2: 3, +region=us-east-1: 1}',
                                   voter_constraints = '[+region=ap-southeast-2]',
                                   lease_preferences = '[[+region=ap-southeast-2]]'
 
@@ -223,7 +223,7 @@ PARTITION "us-east-1" OF TABLE mr2.public.t_rbr  ALTER PARTITION "us-east-1" OF 
                                                    gc.ttlseconds = 14400,
                                                    num_replicas = 4,
                                                    num_voters = 3,
-                                                   constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
+                                                   constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 3}',
                                                    voter_constraints = '[+region=us-east-1]',
                                                    lease_preferences = '[[+region=us-east-1]]'
 
@@ -236,7 +236,7 @@ PARTITION "ap-southeast-2" OF TABLE mr2.public.t_rbr_with_idx  ALTER PARTITION "
                                                                  gc.ttlseconds = 14400,
                                                                  num_replicas = 4,
                                                                  num_voters = 3,
-                                                                 constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
+                                                                 constraints = '{+region=ap-southeast-2: 3, +region=us-east-1: 1}',
                                                                  voter_constraints = '[+region=ap-southeast-2]',
                                                                  lease_preferences = '[[+region=ap-southeast-2]]'
 
@@ -263,7 +263,7 @@ PARTITION "ap-southeast-2" OF INDEX mr2.public.t_rbr_with_idx@idx  ALTER PARTITI
                                                                      gc.ttlseconds = 14400,
                                                                      num_replicas = 4,
                                                                      num_voters = 3,
-                                                                     constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
+                                                                     constraints = '{+region=ap-southeast-2: 3, +region=us-east-1: 1}',
                                                                      voter_constraints = '[+region=ap-southeast-2]',
                                                                      lease_preferences = '[[+region=ap-southeast-2]]'
 
@@ -289,7 +289,7 @@ TABLE mr2.public.t_rt2  ALTER TABLE mr2.public.t_rt2 CONFIGURE ZONE USING
                           gc.ttlseconds = 14400,
                           num_replicas = 4,
                           num_voters = 3,
-                          constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
+                          constraints = '{+region=ap-southeast-2: 3, +region=us-east-1: 1}',
                           voter_constraints = '[+region=ap-southeast-2]',
                           lease_preferences = '[[+region=ap-southeast-2]]'
 
@@ -302,7 +302,7 @@ TABLE mr2.public.t_rt_with_idx2  ALTER TABLE mr2.public.t_rt_with_idx2 CONFIGURE
                                    gc.ttlseconds = 14400,
                                    num_replicas = 4,
                                    num_voters = 3,
-                                   constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
+                                   constraints = '{+region=ap-southeast-2: 3, +region=us-east-1: 1}',
                                    voter_constraints = '[+region=ap-southeast-2]',
                                    lease_preferences = '[[+region=ap-southeast-2]]'
 
@@ -315,7 +315,7 @@ TABLE mr2.public.t_rt_with_idx2  ALTER TABLE mr2.public.t_rt_with_idx2 CONFIGURE
                                    gc.ttlseconds = 14400,
                                    num_replicas = 4,
                                    num_voters = 3,
-                                   constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
+                                   constraints = '{+region=ap-southeast-2: 3, +region=us-east-1: 1}',
                                    voter_constraints = '[+region=ap-southeast-2]',
                                    lease_preferences = '[[+region=ap-southeast-2]]'
 
@@ -328,7 +328,7 @@ PARTITION "us-east-1" OF TABLE mr2.public.t_rbr2  ALTER PARTITION "us-east-1" OF
                                                     gc.ttlseconds = 14400,
                                                     num_replicas = 4,
                                                     num_voters = 3,
-                                                    constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
+                                                    constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 3}',
                                                     voter_constraints = '[+region=us-east-1]',
                                                     lease_preferences = '[[+region=us-east-1]]'
 
@@ -341,7 +341,7 @@ PARTITION "ap-southeast-2" OF TABLE mr2.public.t_rbr_with_idx2  ALTER PARTITION 
                                                                   gc.ttlseconds = 14400,
                                                                   num_replicas = 4,
                                                                   num_voters = 3,
-                                                                  constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
+                                                                  constraints = '{+region=ap-southeast-2: 3, +region=us-east-1: 1}',
                                                                   voter_constraints = '[+region=ap-southeast-2]',
                                                                   lease_preferences = '[[+region=ap-southeast-2]]'
 
@@ -355,7 +355,7 @@ PARTITION "ap-southeast-2" OF INDEX mr2.public.t_rbr_with_idx2@idx  ALTER PARTIT
                                                                       gc.ttlseconds = 14400,
                                                                       num_replicas = 4,
                                                                       num_voters = 3,
-                                                                      constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
+                                                                      constraints = '{+region=ap-southeast-2: 3, +region=us-east-1: 1}',
                                                                       voter_constraints = '[+region=ap-southeast-2]',
                                                                       lease_preferences = '[[+region=ap-southeast-2]]'
 
@@ -368,7 +368,7 @@ PARTITION "us-east-1" OF INDEX mr2.public.t_rbr_with_idx2@idx  ALTER PARTITION "
                                                                  gc.ttlseconds = 14400,
                                                                  num_replicas = 4,
                                                                  num_voters = 3,
-                                                                 constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
+                                                                 constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 3}',
                                                                  voter_constraints = '[+region=us-east-1]',
                                                                  lease_preferences = '[[+region=us-east-1]]'
 
@@ -446,7 +446,7 @@ PARTITION "us-east-1" OF TABLE mr3.public.rt  ALTER PARTITION "us-east-1" OF TAB
                                                 gc.ttlseconds = 14400,
                                                 num_replicas = 4,
                                                 num_voters = 3,
-                                                constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
+                                                constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 3}',
                                                 voter_constraints = '[+region=us-east-1]',
                                                 lease_preferences = '[[+region=us-east-1]]'
 
@@ -459,7 +459,7 @@ PARTITION "ap-southeast-2" OF TABLE mr3.public.rt  ALTER PARTITION "ap-southeast
                                                      gc.ttlseconds = 14400,
                                                      num_replicas = 4,
                                                      num_voters = 3,
-                                                     constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
+                                                     constraints = '{+region=ap-southeast-2: 3, +region=us-east-1: 1}',
                                                      voter_constraints = '[+region=ap-southeast-2]',
                                                      lease_preferences = '[[+region=ap-southeast-2]]'
 
@@ -472,7 +472,7 @@ PARTITION "ca-central-1" OF TABLE mr3.public.rt  ALTER PARTITION "ca-central-1" 
                                                    gc.ttlseconds = 14400,
                                                    num_replicas = 5,
                                                    num_voters = 3,
-                                                   constraints = '{+region=ca-central-1: 2, +region=us-central-1: 2, +region=us-west-1: 1}',
+                                                   constraints = '{+region=ca-central-1: 3, +region=us-central-1: 1, +region=us-west-1: 1}',
                                                    voter_constraints = '[+region=ca-central-1]',
                                                    lease_preferences = '[[+region=ca-central-1]]'
 
@@ -485,7 +485,7 @@ PARTITION "us-west-1" OF TABLE mr3.public.rt  ALTER PARTITION "us-west-1" OF TAB
                                                 gc.ttlseconds = 14400,
                                                 num_replicas = 5,
                                                 num_voters = 3,
-                                                constraints = '{+region=ca-central-1: 2, +region=us-central-1: 1, +region=us-west-1: 2}',
+                                                constraints = '{+region=ca-central-1: 1, +region=us-central-1: 1, +region=us-west-1: 3}',
                                                 voter_constraints = '[+region=us-west-1]',
                                                 lease_preferences = '[[+region=us-west-1]]'
 
@@ -498,7 +498,7 @@ PARTITION "us-central-1" OF TABLE mr3.public.rt  ALTER PARTITION "us-central-1" 
                                                    gc.ttlseconds = 14400,
                                                    num_replicas = 5,
                                                    num_voters = 3,
-                                                   constraints = '{+region=ca-central-1: 2, +region=us-central-1: 2, +region=us-west-1: 1}',
+                                                   constraints = '{+region=ca-central-1: 1, +region=us-central-1: 3, +region=us-west-1: 1}',
                                                    voter_constraints = '[+region=us-central-1]',
                                                    lease_preferences = '[[+region=us-central-1]]'
 
@@ -680,7 +680,7 @@ TABLE db3.public.t  ALTER TABLE db3.public.t CONFIGURE ZONE USING
                       gc.ttlseconds = 14400,
                       num_replicas = 4,
                       num_voters = 3,
-                      constraints = '{+region=ca-central-1: 2, +region=us-west-1: 2}',
+                      constraints = '{+region=ca-central-1: 3, +region=us-west-1: 1}',
                       voter_constraints = '[+region=ca-central-1]',
                       lease_preferences = '[[+region=ca-central-1]]'
 
@@ -734,7 +734,7 @@ TABLE db3.public.t  ALTER TABLE db3.public.t CONFIGURE ZONE USING
                       gc.ttlseconds = 14400,
                       num_replicas = 4,
                       num_voters = 3,
-                      constraints = '{+region=ca-central-1: 2, +region=us-west-1: 2}',
+                      constraints = '{+region=ca-central-1: 1, +region=us-west-1: 3}',
                       voter_constraints = '[+region=us-west-1]',
                       lease_preferences = '[[+region=us-west-1]]'
 
@@ -769,7 +769,7 @@ TABLE db3.public.t  ALTER TABLE db3.public.t CONFIGURE ZONE USING
                       gc.ttlseconds = 14400,
                       num_replicas = 5,
                       num_voters = 3,
-                      constraints = '{+region=ca-central-1: 2, +region=us-east-1: 1, +region=us-west-1: 2}',
+                      constraints = '{+region=ca-central-1: 1, +region=us-east-1: 1, +region=us-west-1: 3}',
                       voter_constraints = '[+region=us-west-1]',
                       lease_preferences = '[[+region=us-west-1]]'
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/super_regions_backup
+++ b/pkg/ccl/logictestccl/testdata/logic_test/super_regions_backup
@@ -65,7 +65,7 @@ PARTITION "us-east-1" OF TABLE mr1.public.t2  ALTER PARTITION "us-east-1" OF TAB
                                                 gc.ttlseconds = 14400,
                                                 num_replicas = 4,
                                                 num_voters = 3,
-                                                constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
+                                                constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 3}',
                                                 voter_constraints = '[+region=us-east-1]',
                                                 lease_preferences = '[[+region=us-east-1]]'
 
@@ -103,7 +103,7 @@ PARTITION "us-east-1" OF TABLE mr1.public.t2  ALTER PARTITION "us-east-1" OF TAB
                                                 gc.ttlseconds = 14400,
                                                 num_replicas = 4,
                                                 num_voters = 3,
-                                                constraints = '{+region=ap-southeast-2: 2, +region=us-east-1: 2}',
+                                                constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 3}',
                                                 voter_constraints = '[+region=us-east-1]',
                                                 lease_preferences = '[[+region=us-east-1]]'
 

--- a/pkg/ccl/multiregionccl/multiregion_test.go
+++ b/pkg/ccl/multiregionccl/multiregion_test.go
@@ -8,6 +8,7 @@ package multiregionccl_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -468,7 +469,7 @@ func TestSuperRegionConstraintConformance(t *testing.T) {
 		}
 		checkZone := func(zid int) error {
 			rows, err := sqlDB.Query(
-				`SELECT type, violating_ranges
+				`SELECT subzone_id, type, config, violating_ranges
 				   FROM system.replication_constraint_stats
 				  WHERE zone_id = $1 AND violating_ranges > 0`,
 				zid,
@@ -480,21 +481,220 @@ func TestSuperRegionConstraintConformance(t *testing.T) {
 
 			var violations []string
 			for rows.Next() {
-				var cType string
-				var count int
-				if err := rows.Scan(&cType, &count); err != nil {
+				var subzoneID, count int
+				var cType, config string
+				if err := rows.Scan(
+					&subzoneID, &cType, &config, &count,
+				); err != nil {
 					return err
 				}
-				violations = append(violations,
-					fmt.Sprintf("%s: %d violating ranges", cType, count))
+				violations = append(violations, fmt.Sprintf(
+					"subzone %d: %s %q: %d violating ranges",
+					subzoneID, cType, config, count))
 			}
 			if err := rows.Err(); err != nil {
 				return err
 			}
 			if len(violations) > 0 {
 				return fmt.Errorf(
-					"constraint violations still present for zone %d: %v",
-					zid, violations)
+					"constraint violations for zone %d:\n  %s",
+					zid, strings.Join(violations, "\n  "))
+			}
+			return nil
+		}
+		for _, zid := range zoneIDs {
+			if err := checkZone(zid); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// TestSuperRegionConstraintConformanceZoneSurvival verifies that REGIONAL BY
+// ROW and REGIONAL BY TABLE tables in a database with super regions and
+// SURVIVE ZONE FAILURE eventually reach full constraint conformance.
+func TestSuperRegionConstraintConformanceZoneSurvival(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	skip.UnderShort(t)
+	skip.UnderDuress(t)
+
+	// The topology uses 4 regions across 8 nodes (2 per region):
+	//
+	//   - Super region "americas": {us-east-1, us-central-1, us-west-1}
+	//   - Primary region: {ap-southeast-1} — outside any super region.
+	//
+	// With 3 regions per super region + SURVIVE ZONE FAILURE, each
+	// super-region-confined table/partition gets 3 voters (all in the home
+	// region) and 2 non-voters spread across the other two regions.
+	//
+	// Zone survival pins all 3 voters to the home region via
+	// voter_constraints, so we need at least 3 stores (nodes) per region to
+	// place them.
+	regionNames := []string{
+		"ap-southeast-1",
+		"us-east-1", "us-central-1", "us-west-1",
+	}
+	tc, sqlDB, cleanup :=
+		multiregionccltestutils.TestingCreateMultiRegionClusterWithRegionList(
+			t,
+			regionNames,
+			3, /* serversPerRegion */
+			base.TestingKnobs{},
+		)
+	defer cleanup()
+
+	tdb := sqlutils.MakeSQLRunner(sqlDB)
+
+	// Speed up replication reporting and closed timestamps.
+	tdb.Exec(t, "SET CLUSTER SETTING kv.replication_reports.interval = '1ms'")
+	tdb.Exec(t,
+		"SET CLUSTER SETTING kv.closed_timestamp.target_duration = '10ms'")
+	tdb.Exec(t,
+		"SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '10ms'")
+	tdb.Exec(t,
+		"SET CLUSTER SETTING kv.rangefeed.closed_timestamp_refresh_interval = '10ms'")
+
+	// Setup MR database with zone survival.
+	tdb.Exec(t, `CREATE DATABASE testdb PRIMARY REGION "ap-southeast-1"
+		REGIONS "us-east-1", "us-central-1", "us-west-1"`)
+	tdb.Exec(t, `SET enable_super_regions = 'on'`)
+	tdb.Exec(t, `ALTER DATABASE testdb ADD SUPER REGION "americas"
+		VALUES "us-east-1", "us-central-1", "us-west-1"`)
+	tdb.Exec(t, `ALTER DATABASE testdb SURVIVE ZONE FAILURE`)
+
+	// REGIONAL BY ROW table with rows in all 4 regions.
+	tdb.Exec(t,
+		`CREATE TABLE testdb.rbr(k INT PRIMARY KEY, v INT)
+		 LOCALITY REGIONAL BY ROW`)
+	tdb.Exec(t, `INSERT INTO testdb.rbr(crdb_region, k, v) VALUES
+		('us-east-1', 1, 10), ('us-central-1', 2, 20), ('us-west-1', 3, 30),
+		('ap-southeast-1', 4, 40)`)
+
+	// RBT in a super region (non-primary).
+	tdb.Exec(t,
+		`CREATE TABLE testdb.rbt_sr(k INT PRIMARY KEY, v INT)
+		 LOCALITY REGIONAL BY TABLE IN "us-east-1"`)
+	tdb.Exec(t, `INSERT INTO testdb.rbt_sr(k, v) VALUES (1, 10)`)
+
+	// Look up zone_ids for both tables.
+	var rbrZoneID, rbtSRZoneID int
+	tdb.QueryRow(t,
+		"SELECT zone_id FROM crdb_internal.zones WHERE table_name = 'rbr'",
+	).Scan(&rbrZoneID)
+	tdb.QueryRow(t,
+		"SELECT zone_id FROM crdb_internal.zones WHERE table_name = 'rbt_sr'",
+	).Scan(&rbtSRZoneID)
+	zoneIDs := []int{rbrZoneID, rbtSRZoneID}
+
+	// Verify zone configs have the expected structure.
+	verifyZoneConfig := func(query string, expectedFragments []string) {
+		t.Helper()
+		var target, rawSQL string
+		tdb.QueryRow(t, query).Scan(&target, &rawSQL)
+		for _, frag := range expectedFragments {
+			require.Contains(t, rawSQL, frag,
+				"zone config for %s missing expected fragment", target)
+		}
+	}
+	// RBT in super region: voters pinned to home, replicas confined to
+	// americas.
+	verifyZoneConfig(
+		`SHOW ZONE CONFIGURATION FOR TABLE testdb.rbt_sr`,
+		[]string{
+			"voter_constraints", "us-east-1",
+			"constraints", "us-east-1",
+		},
+	)
+	// RBR partitions inside the super region: voters pinned to partition
+	// region, replicas confined to americas.
+	for _, region := range []string{
+		"us-east-1", "us-central-1", "us-west-1",
+	} {
+		verifyZoneConfig(
+			fmt.Sprintf(
+				`SHOW ZONE CONFIGURATION FOR PARTITION "%s" OF TABLE testdb.rbr`,
+				region),
+			[]string{
+				"voter_constraints", region,
+				"constraints",
+			},
+		)
+	}
+
+	forceProcess := func() error {
+		for i := 0; i < tc.NumServers(); i++ {
+			if err := tc.Server(i).GetStores().(*kvserver.Stores).VisitStores(
+				func(s *kvserver.Store) error {
+					return s.ForceReplicationScanAndProcess()
+				},
+			); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	// Wait for constraint stats report to be generated for all zones.
+	testutils.SucceedsSoon(t, func() error {
+		if err := forceProcess(); err != nil {
+			return err
+		}
+		for _, zid := range zoneIDs {
+			var count int
+			if err := sqlDB.QueryRow(
+				`SELECT count(*) FROM system.replication_constraint_stats
+				  WHERE zone_id = $1`, zid,
+			).Scan(&count); err != nil {
+				return err
+			}
+			if count == 0 {
+				return fmt.Errorf(
+					"constraint stats report not yet generated for zone %d", zid)
+			}
+		}
+		return nil
+	})
+
+	// Verify that every reported constraint has zero violating ranges.
+	testutils.SucceedsSoon(t, func() error {
+		if err := forceProcess(); err != nil {
+			return err
+		}
+		checkZone := func(zid int) error {
+			rows, err := sqlDB.Query(
+				`SELECT subzone_id, type, config, violating_ranges
+				   FROM system.replication_constraint_stats
+				  WHERE zone_id = $1 AND violating_ranges > 0`,
+				zid,
+			)
+			if err != nil {
+				return err
+			}
+			defer rows.Close()
+
+			var violations []string
+			for rows.Next() {
+				var subzoneID, count int
+				var cType, config string
+				if err := rows.Scan(
+					&subzoneID, &cType, &config, &count,
+				); err != nil {
+					return err
+				}
+				violations = append(violations, fmt.Sprintf(
+					"subzone %d: %s %q: %d violating ranges",
+					subzoneID, cType, config, count))
+			}
+			if err := rows.Err(); err != nil {
+				return err
+			}
+			if len(violations) > 0 {
+				return fmt.Errorf(
+					"constraint violations for zone %d:\n  %s",
+					zid, strings.Join(violations, "\n  "))
 			}
 			return nil
 		}

--- a/pkg/sql/region_util_test.go
+++ b/pkg/sql/region_util_test.go
@@ -1925,10 +1925,10 @@ func TestZoneConfigForMultiRegionPartition(t *testing.T) {
 				NumReplicas: proto.Int32(5),
 				NumVoters:   proto.Int32(3),
 				Constraints: []zonepb.ConstraintsConjunction{
-					{NumReplicas: 2, Constraints: []zonepb.Constraint{
+					{NumReplicas: 3, Constraints: []zonepb.Constraint{
 						{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_a"},
 					}},
-					{NumReplicas: 2, Constraints: []zonepb.Constraint{
+					{NumReplicas: 1, Constraints: []zonepb.Constraint{
 						{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_b"},
 					}},
 					{NumReplicas: 1, Constraints: []zonepb.Constraint{
@@ -2012,10 +2012,10 @@ func TestZoneConfigForMultiRegionPartition(t *testing.T) {
 				NumReplicas: proto.Int32(5),
 				NumVoters:   proto.Int32(3),
 				Constraints: []zonepb.ConstraintsConjunction{
-					{NumReplicas: 2, Constraints: []zonepb.Constraint{
+					{NumReplicas: 3, Constraints: []zonepb.Constraint{
 						{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_a"},
 					}},
-					{NumReplicas: 2, Constraints: []zonepb.Constraint{
+					{NumReplicas: 1, Constraints: []zonepb.Constraint{
 						{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_b"},
 					}},
 					{NumReplicas: 1, Constraints: []zonepb.Constraint{
@@ -2054,14 +2054,8 @@ func TestZoneConfigForMultiRegionPartition(t *testing.T) {
 				NumReplicas: proto.Int32(3),
 				NumVoters:   proto.Int32(3),
 				Constraints: []zonepb.ConstraintsConjunction{
-					{NumReplicas: 1, Constraints: []zonepb.Constraint{
+					{NumReplicas: 3, Constraints: []zonepb.Constraint{
 						{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_a"},
-					}},
-					{NumReplicas: 1, Constraints: []zonepb.Constraint{
-						{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_b"},
-					}},
-					{NumReplicas: 1, Constraints: []zonepb.Constraint{
-						{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_c"},
 					}},
 				},
 				NullVoterConstraintsIsEmpty: true,
@@ -2097,10 +2091,10 @@ func TestZoneConfigForMultiRegionPartition(t *testing.T) {
 				NumReplicas: proto.Int32(5),
 				NumVoters:   proto.Int32(3),
 				Constraints: []zonepb.ConstraintsConjunction{
-					{NumReplicas: 2, Constraints: []zonepb.Constraint{
+					{NumReplicas: 3, Constraints: []zonepb.Constraint{
 						{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_a"},
 					}},
-					{NumReplicas: 2, Constraints: []zonepb.Constraint{
+					{NumReplicas: 1, Constraints: []zonepb.Constraint{
 						{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_b"},
 					}},
 					{NumReplicas: 1, Constraints: []zonepb.Constraint{

--- a/pkg/sql/regions/region_util.go
+++ b/pkg/sql/regions/region_util.go
@@ -730,8 +730,17 @@ func synthesizeLeasePreferencesForTable(
 // regions, ensuring all replicas are constrained within the region set. The
 // affinityRegion receives priority for any extra replicas beyond an even
 // distribution. The affinityRegion must be a member of the regions slice.
+//
+// When minAffinityReplicas > 0, at least that many replicas are reserved for
+// the affinity region (clamped to numReplicas). The remainder is distributed
+// evenly across the other regions. This is used for zone survival in super
+// regions, where voter_constraints pin all voters to the home region and
+// constraints must not demand more non-home replicas than non-voters available.
 func distributeReplicasAcrossRegions(
-	numReplicas int32, regions catpb.RegionNames, affinityRegion catpb.RegionName,
+	numReplicas int32,
+	regions catpb.RegionNames,
+	affinityRegion catpb.RegionName,
+	minAffinityReplicas int32,
 ) ([]zonepb.ConstraintsConjunction, error) {
 	numRegions := int32(len(regions))
 	if numRegions == 0 {
@@ -740,25 +749,64 @@ func distributeReplicasAcrossRegions(
 	if !regions.Contains(affinityRegion) {
 		return nil, errors.AssertionFailedf("affinity region %s must be a member of the region set %v", affinityRegion, regions)
 	}
-	base := numReplicas / numRegions
-	extra := numReplicas % numRegions
 
-	// Determine which regions get an extra replica. The affinity region gets
-	// first priority, then remaining extras go to other regions in their
-	// original order.
-	getsExtra := make(map[catpb.RegionName]bool)
-	remaining := extra
-	if remaining > 0 {
-		getsExtra[affinityRegion] = true
-		remaining--
+	// Clamp the affinity minimum to the total replica count.
+	if minAffinityReplicas > numReplicas {
+		minAffinityReplicas = numReplicas
 	}
-	for _, r := range regions {
-		if remaining == 0 {
-			break
+
+	// replicasPerRegion maps each region to its assigned replica count.
+	replicasPerRegion := make(map[catpb.RegionName]int32, numRegions)
+
+	if minAffinityReplicas > 0 {
+		// Reserve minAffinityReplicas for the affinity region and distribute
+		// the rest evenly across the remaining regions.
+		replicasPerRegion[affinityRegion] = minAffinityReplicas
+		remainder := numReplicas - minAffinityReplicas
+		otherRegions := numRegions - 1
+		if otherRegions > 0 && remainder > 0 {
+			base := remainder / otherRegions
+			extra := remainder % otherRegions
+			idx := int32(0)
+			for _, r := range regions {
+				if r == affinityRegion {
+					continue
+				}
+				n := base
+				if idx < extra {
+					n++
+				}
+				if n > 0 {
+					replicasPerRegion[r] = n
+				}
+				idx++
+			}
 		}
-		if r != affinityRegion {
-			getsExtra[r] = true
+	} else {
+		// Even distribution: affinity region gets first priority for extras.
+		base := numReplicas / numRegions
+		extra := numReplicas % numRegions
+		getsExtra := make(map[catpb.RegionName]bool)
+		remaining := extra
+		if remaining > 0 {
+			getsExtra[affinityRegion] = true
 			remaining--
+		}
+		for _, r := range regions {
+			if remaining == 0 {
+				break
+			}
+			if r != affinityRegion {
+				getsExtra[r] = true
+				remaining--
+			}
+		}
+		for _, r := range regions {
+			n := base
+			if getsExtra[r] {
+				n++
+			}
+			replicasPerRegion[r] = n
 		}
 	}
 
@@ -766,10 +814,7 @@ func distributeReplicasAcrossRegions(
 	// deterministic and predictable across runs.
 	var constraints []zonepb.ConstraintsConjunction
 	for _, region := range regions {
-		n := base
-		if getsExtra[region] {
-			n++
-		}
+		n := replicasPerRegion[region]
 		if n > 0 {
 			constraints = append(constraints, zonepb.ConstraintsConjunction{
 				NumReplicas: n,
@@ -782,9 +827,21 @@ func distributeReplicasAcrossRegions(
 
 // AddConstraintsForSuperRegion updates the ZoneConfig.Constraints field such
 // that every replica is guaranteed to be constrained to a region within the
-// super region. Replicas are distributed evenly across regions with the
-// affinity region receiving priority for any remainder. An error is returned
-// if the affinity region is not a member of a super region.
+// super region. An error is returned if the affinity region is not a member of
+// a super region.
+//
+// The distribution strategy depends on the survival goal:
+//
+//   - Zone survival: voter_constraints pin ALL voters to the affinity (home)
+//     region, so the only replicas available for non-home regions are
+//     non-voters. We pass numVoters as minAffinityReplicas so the home region
+//     gets at least that many, and the remaining replicas spread across
+//     other regions. For restricted placement (no non-voters), numReplicas
+//     equals numVoters so all replicas go to the home region.
+//
+//   - Region survival: replicas are distributed evenly across all super-region
+//     members (minAffinityReplicas == 0) with the affinity region receiving
+//     priority for any remainder.
 func AddConstraintsForSuperRegion(
 	zc *zonepb.ZoneConfig, regionConfig multiregion.RegionConfig, affinityRegion catpb.RegionName,
 ) error {
@@ -792,13 +849,22 @@ func AddConstraintsForSuperRegion(
 	if !ok {
 		return errors.AssertionFailedf("region %s is not part of a super region", affinityRegion)
 	}
-	_, numReplicas := GetNumVotersAndNumReplicas(regionConfig.WithRegions(regions))
+	srConfig := regionConfig.WithRegions(regions)
+	numVoters, numReplicas := GetNumVotersAndNumReplicas(srConfig)
 
 	zc.NumReplicas = &numReplicas
-	constraints, err := distributeReplicasAcrossRegions(numReplicas, regions, affinityRegion)
+
+	var minAffinity int32
+	if srConfig.SurvivalGoal() == descpb.SurvivalGoal_ZONE_FAILURE {
+		minAffinity = numVoters
+	}
+	constraints, err := distributeReplicasAcrossRegions(
+		numReplicas, regions, affinityRegion, minAffinity,
+	)
 	if err != nil {
 		return err
 	}
+
 	zc.Constraints = constraints
 	zc.InheritedConstraints = false
 	return nil

--- a/pkg/sql/regions/region_util_test.go
+++ b/pkg/sql/regions/region_util_test.go
@@ -22,12 +22,13 @@ func TestDistributeReplicasAcrossRegions(t *testing.T) {
 	}
 
 	tests := []struct {
-		name           string
-		numReplicas    int32
-		regions        catpb.RegionNames
-		affinityRegion catpb.RegionName
-		expected       []zonepb.ConstraintsConjunction
-		expectErr      string
+		name                string
+		numReplicas         int32
+		regions             catpb.RegionNames
+		affinityRegion      catpb.RegionName
+		minAffinityReplicas int32
+		expected            []zonepb.ConstraintsConjunction
+		expectErr           string
 	}{{
 		name:           "even distribution",
 		numReplicas:    6,
@@ -93,11 +94,54 @@ func TestDistributeReplicasAcrossRegions(t *testing.T) {
 		regions:        catpb.RegionNames{"us-east", "us-west"},
 		affinityRegion: "eu-west",
 		expectErr:      "affinity region eu-west must be a member of the region set",
+	}, {
+		name:                "minAffinity reserves replicas for home region",
+		numReplicas:         5,
+		regions:             catpb.RegionNames{"us-east", "us-west", "eu-west"},
+		affinityRegion:      "us-east",
+		minAffinityReplicas: 3,
+		expected: []zonepb.ConstraintsConjunction{
+			mkConstraint("us-east", 3),
+			mkConstraint("us-west", 1),
+			mkConstraint("eu-west", 1),
+		},
+	}, {
+		name:                "minAffinity equals numReplicas, all to home",
+		numReplicas:         3,
+		regions:             catpb.RegionNames{"us-east", "us-west", "eu-west"},
+		affinityRegion:      "us-east",
+		minAffinityReplicas: 3,
+		expected: []zonepb.ConstraintsConjunction{
+			mkConstraint("us-east", 3),
+		},
+	}, {
+		name:                "minAffinity exceeds numReplicas, clamped",
+		numReplicas:         3,
+		regions:             catpb.RegionNames{"us-east", "us-west", "eu-west"},
+		affinityRegion:      "us-east",
+		minAffinityReplicas: 5,
+		expected: []zonepb.ConstraintsConjunction{
+			mkConstraint("us-east", 3),
+		},
+	}, {
+		name:                "minAffinity with uneven remainder across other regions",
+		numReplicas:         7,
+		regions:             catpb.RegionNames{"us-east", "us-west", "eu-west", "ap-south"},
+		affinityRegion:      "us-east",
+		minAffinityReplicas: 3,
+		expected: []zonepb.ConstraintsConjunction{
+			mkConstraint("us-east", 3),
+			mkConstraint("us-west", 2),
+			mkConstraint("eu-west", 1),
+			mkConstraint("ap-south", 1),
+		},
 	}}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := distributeReplicasAcrossRegions(tt.numReplicas, tt.regions, tt.affinityRegion)
+			result, err := distributeReplicasAcrossRegions(
+				tt.numReplicas, tt.regions, tt.affinityRegion, tt.minAffinityReplicas,
+			)
 			if tt.expectErr != "" {
 				require.ErrorContains(t, err, tt.expectErr)
 				return


### PR DESCRIPTION
A recent commit (6328625c8ab) fixed a replica leak bug in super region constraint generation by replacing the old per-survival-goal switch with distributeReplicasAcrossRegions, which evenly distributes all replicas across regions. However, that change did not account for zone survival, where voter_constraints pin ALL voters to the home region. Even distribution (e.g. [a:2, b:2, c:1]) demands more replicas in non-home regions than there are non-voters available, making the zone config unsatisfiable.

Fix this by adding a minAffinityReplicas parameter to distributeReplicasAcrossRegions. For zone survival, we pass numVoters so the home region gets at least that many replicas, and only the remainder spreads to other regions (e.g. [a:3, b:1, c:1]). For region survival, we pass 0.

Fixes #165087

Epic: CRDB-58694
Release note: None