### PR TITLE
ci: pin pnpm/action-setup to SHA

### DIFF
--- a/.github/workflows/cluster-ui-release-next.yml
+++ b/.github/workflows/cluster-ui-release-next.yml
@@ -27,7 +27,7 @@ jobs:
         path: ~/.cache/bazel
         key: ${{ runner.os }}-bazel-cache
 
-    - uses: pnpm/action-setup@v2
+    - uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2
       with:
         version: "8.6.10"
 

--- a/.github/workflows/cluster-ui-release.yml
+++ b/.github/workflows/cluster-ui-release.yml
@@ -27,7 +27,7 @@ jobs:
         path: ~/.cache/bazel
         key: ${{ runner.os }}-bazel-cache
 
-    - uses: pnpm/action-setup@v2
+    - uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2
       with:
         version: "8.6.10"
 


### PR DESCRIPTION
Pin pnpm/action-setup@v2 to its commit SHA (eae0cfeb286e66ffb5155f1a79b90583a127a68b) in cluster-ui-release and cluster-ui-release-next workflows.

Fixes: SECENG-1214

Release note: None