### PR TITLE
importer: use two-stage distributed merge for import

### DIFF
--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -802,6 +802,12 @@ message ImportProgress {
   repeated string sst_storage_prefixes = 8 [(gogoproto.customname) = "SSTStoragePrefixes"];
 
   reserved 9;
+
+  // DistributedMergePhase tracks import progress through the distributed merge
+  // pipeline. Values: 0 = map complete (or no merge iterations done yet),
+  // N (N >= 1) = merge iteration N completed. Used on resume to skip completed
+  // iterations.
+  int32 distributed_merge_phase = 10;
 }
 
 // TypeSchemaChangeDetails is the job detail information for a type schema change job.

--- a/pkg/sql/bulksst/manifest_conversion.go
+++ b/pkg/sql/bulksst/manifest_conversion.go
@@ -7,7 +7,9 @@ package bulksst
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
 
@@ -49,6 +51,31 @@ func SSTFilesToManifests(files *SSTFiles, writeTS *hlc.Timestamp) []jobspb.BulkS
 	manifests := make([]jobspb.BulkSSTManifest, 0, len(files.SST))
 	for _, f := range files.SST {
 		manifests = append(manifests, SSTFileToManifest(f, writeTS))
+	}
+	return manifests
+}
+
+// MergeOutputToManifests converts BulkMergeSpec_SST output from a merge
+// iteration into BulkSSTManifest records suitable for checkpointing.
+// RowSample is populated with StartKey plus a family 0 suffix so that
+// CombineFileInfo can use it for span splitting on resume.
+func MergeOutputToManifests(merged []execinfrapb.BulkMergeSpec_SST) []jobspb.BulkSSTManifest {
+	manifests := make([]jobspb.BulkSSTManifest, 0, len(merged))
+	for _, sst := range merged {
+		span := roachpb.Span{
+			Key:    append(roachpb.Key(nil), sst.StartKey...),
+			EndKey: append(roachpb.Key(nil), sst.EndKey...),
+		}
+		manifests = append(manifests, jobspb.BulkSSTManifest{
+			URI:      sst.URI,
+			Span:     &span,
+			KeyCount: sst.KeyCount,
+			// StartKey is a row prefix (family suffix stripped by
+			// SSTWriter.Flush), but CombineFileInfo passes samples through
+			// keys.EnsureSafeSplitKey which expects a full key including the
+			// column family suffix. Re-appending family 0 makes the key valid.
+			RowSample: keys.MakeFamilyKey(append(roachpb.Key(nil), sst.StartKey...), 0),
+		})
 	}
 	return manifests
 }

--- a/pkg/sql/importer/import_processor_planning.go
+++ b/pkg/sql/importer/import_processor_planning.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"sync"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -32,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
@@ -188,12 +190,35 @@ func distImport(
 	}
 
 	lastSummary := getLastImportSummary(job)
-	priorRunSummary := lastSummary.DeepCopy()
 	checkpoint := newImportCheckpointTracker(
 		len(from), lastSummary, nil, /* manifestBuf */
 	)
 
 	var res kvpb.BulkOpSummary
+
+	// Check if we're resuming from a completed merge iteration. If so, skip
+	// the map phase entirely — runImportMergeIterations reads its own
+	// checkpointed manifests and determines the start iteration from the job
+	// progress.
+	importProgress := job.Progress().Details.(*jobspb.Progress_Import).Import
+	mergePhase := 0
+	if importProgress != nil {
+		mergePhase = int(importProgress.DistributedMergePhase)
+	}
+	if useDistributedMerge && mergePhase >= 1 {
+		execCfg := execCtx.ExecCfg()
+		schemaSpans := tabledesc.NewBuilder(table.Desc).BuildImmutableTable().AllIndexSpans(execCfg.Codec)
+		if err := runImportMergeIterations(
+			ctx, execCtx, job, checkpoint, nil, schemaSpans, walltime, addStoragePrefix,
+		); err != nil {
+			return kvpb.BulkOpSummary{}, err
+		}
+		// Return an empty summary — the current run ingested no new rows
+		// (the map phase ran in a previous attempt). Row counts for
+		// validation are read from the checkpointed job progress, not
+		// from this summary.
+		return res, nil
+	}
 
 	// Restore SST metadata checkpointed from prior attempts. On the first
 	// attempt these are empty. On retries, they contain manifests from files
@@ -201,28 +226,15 @@ func distImport(
 	processorOutput := make([]bulksst.SSTFiles, 0)
 	var resumeManifests []jobspb.BulkSSTManifest
 	if useDistributedMerge {
-		if err := execCtx.ExecCfg().InternalDB.Txn(ctx, func(
-			ctx context.Context, txn isql.Txn,
-		) error {
-			data, err := jobs.ReadChunkedFileToJobInfo(
-				ctx, importSSTManifestsInfoKey, txn, job.ID(),
-			)
-			if err != nil {
-				return err
-			}
-			if len(data) > 0 {
-				var stored jobspb.BulkSSTManifests
-				if err := protoutil.Unmarshal(data, &stored); err != nil {
-					return errors.Wrap(err, "unmarshaling SST manifests from job info")
-				}
-				resumeManifests = stored.Manifests
-				processorOutput = append(
-					processorOutput, bulksst.ManifestsToSSTFiles(resumeManifests),
-				)
-			}
-			return nil
-		}); err != nil {
+		var err error
+		resumeManifests, err = readImportMergeManifests(ctx, execCtx, job)
+		if err != nil {
 			return kvpb.BulkOpSummary{}, err
+		}
+		if len(resumeManifests) > 0 {
+			processorOutput = append(
+				processorOutput, bulksst.ManifestsToSSTFiles(resumeManifests),
+			)
 		}
 		checkpoint.manifestBuf = backfill.NewSSTManifestBuffer(resumeManifests)
 	}
@@ -288,16 +300,27 @@ func distImport(
 	)
 	defer recv.Release()
 
-	replanChecker, cancelReplanner := sql.PhysicalPlanChangeChecker(
+	replanChecker, cancelReplannerRaw := sql.PhysicalPlanChangeChecker(
 		ctx, p, makePlan, execCtx,
 		sql.ReplanOnChangedFraction(func() float64 { return replanThreshold.Get(&execCtx.ExecCfg().Settings.SV) }),
 		func() time.Duration { return replanFrequency.Get(&execCtx.ExecCfg().Settings.SV) },
 	)
+	// Wrap cancelReplanner in a Once since it closes an internal channel
+	// that panics on double-close. We call it both before entering the
+	// merge phase and via defer.
+	var cancelReplannerOnce sync.Once
+	cancelReplanner := func() { cancelReplannerOnce.Do(cancelReplannerRaw) }
 
 	stopProgress := make(chan struct{})
+	var stopProgressOnce sync.Once
+	// progressDone is closed when the progress ticker goroutine exits.
+	// The DSP goroutine waits on this after closing stopProgress to
+	// ensure no concurrent Persist calls overlap with the merge phase.
+	progressDone := make(chan struct{})
 
 	g := ctxgroup.WithContext(ctx)
 	g.GoCtx(func(ctx context.Context) error {
+		defer close(progressDone)
 		tick := time.NewTicker(time.Second * 10)
 		defer tick.Stop()
 		done := ctx.Done()
@@ -318,7 +341,7 @@ func distImport(
 
 	g.GoCtx(func(ctx context.Context) error {
 		defer cancelReplanner()
-		defer close(stopProgress)
+		defer stopProgressOnce.Do(func() { close(stopProgress) })
 
 		if testingKnobs.beforeRunDSP != nil {
 			if err := testingKnobs.beforeRunDSP(); err != nil {
@@ -339,6 +362,23 @@ func distImport(
 			return nil
 		}
 
+		// Stop the map-phase checkpoint ticker and replanner before entering
+		// the merge phase. The ticker writes map-phase manifests to the same
+		// job info key that merge iteration checkpoints use; letting it
+		// continue would risk overwriting merge output manifests with stale
+		// map-phase data, causing data loss on resume.
+		stopProgressOnce.Do(func() { close(stopProgress) })
+		// Wait for the ticker goroutine to fully exit so there is no
+		// concurrent Persist call in flight when we flush below.
+		<-progressDone
+		cancelReplanner()
+
+		// Flush any remaining map-phase progress so manifests accumulated
+		// since the last tick are persisted before we overwrite the key.
+		if err := checkpoint.Persist(ctx, job); err != nil {
+			return err
+		}
+
 		// TODO(jeffswenson): this isn't complete. We don't actually want to
 		// generate splits for each index. What we want to do is generate splits
 		// for each span config produced by the table that does not coalesce. For
@@ -349,53 +389,9 @@ func distImport(
 		// that has data for multiple ranges. At the very least that will handle
 		// the case where KV decides to run splits we were not expecting.
 		schemaSpans := tabledesc.NewBuilder(table.Desc).BuildImmutableTable().AllIndexSpans(execCfg.Codec)
-		inputSSTs, spans, err := bulksst.CombineFileInfo(processorOutput, schemaSpans)
-		if err != nil {
-			return err
-		}
-
-		writeTS := &hlc.Timestamp{WallTime: walltime}
-		mergeResult, err := bulkmerge.Merge(ctx, execCtx, inputSSTs, spans, func(instanceID base.SQLInstanceID) (string, error) {
-			// Record the storage prefix before any SSTs are written
-			prefix := fmt.Sprintf("nodelocal://%d/", instanceID)
-			if err := addStoragePrefix(ctx, prefix); err != nil {
-				return "", err
-			}
-			return prefix + bulkutil.NewDistMergePaths(job.ID()).MergePath(1), nil
-		}, bulkmerge.MergeOptions{
-			Iteration:         1,
-			MaxIterations:     1,
-			WriteTimestamp:    writeTS,
-			EnforceUniqueness: true,
-			MemoryMonitor:     execinfrapb.BulkMergeSpec_BULK_MONITOR,
-		})
-		if err != nil {
-			return err
-		}
-
-		// Correct res to exclude identical duplicates skipped during
-		// the merge. The map-phase res counts all rows produced in
-		// this run, including duplicates from checkpoint-and-resume
-		// overlap. The merge ingest summary counts all unique rows
-		// actually written to KV (from both old and new SSTs). To
-		// get the current run's contribution, subtract the rows
-		// already counted in prior runs (from the checkpointed
-		// progress summary).
-		if len(mergeResult.IngestSummary.EntryCounts) > 0 {
-			if res.EntryCounts == nil {
-				res.EntryCounts = make(map[uint64]int64)
-			}
-			for id, ingestCount := range mergeResult.IngestSummary.EntryCounts {
-				priorCount := priorRunSummary.EntryCounts[id]
-				res.EntryCounts[id] = ingestCount - priorCount
-			}
-			// Update the checkpoint's entry counts to reflect the
-			// actual KV-ingested totals so the final Persist writes
-			// the correct row count to the job progress.
-			checkpoint.CorrectEntryCounts(mergeResult.IngestSummary.EntryCounts)
-		}
-
-		return nil
+		return runImportMergeIterations(
+			ctx, execCtx, job, checkpoint, processorOutput, schemaSpans, walltime, addStoragePrefix,
+		)
 	})
 
 	g.GoCtx(replanChecker)
@@ -413,6 +409,203 @@ func distImport(
 	}
 
 	return res, nil
+}
+
+// runImportMergeIterations runs the distributed merge loop for import. It reads
+// DistributedMergePhase from the job progress to determine which iteration to
+// start from. When resuming from a completed iteration (phase >= 1), it reads
+// the checkpointed manifests from the job info key instead of using
+// processorOutput.
+//
+// The merge runs 2 iterations: a local merge (iteration 1) has each node merge
+// its local SSTs first, reducing network traffic. The final merge (iteration 2)
+// merges cross-node and writes directly to KV.
+//
+// After non-final iterations, the output manifests are checkpointed to the job
+// info key along with the completed phase number. This allows the job to resume
+// from a completed iteration without re-running the map phase or earlier
+// iterations.
+func runImportMergeIterations(
+	ctx context.Context,
+	execCtx sql.JobExecContext,
+	job *jobs.Job,
+	checkpoint *importCheckpointTracker,
+	processorOutput []bulksst.SSTFiles,
+	schemaSpans []roachpb.Span,
+	walltime int64,
+	addStoragePrefix func(ctx context.Context, prefix string) error,
+) error {
+	progress := job.Progress()
+	importProg := progress.GetImport()
+	mergePhase := 0
+	if importProg != nil {
+		mergePhase = int(importProg.DistributedMergePhase)
+	}
+	const maxIterations = 2
+	startIteration := mergePhase + 1
+
+	// All merge iterations already completed in a previous run. This
+	// happens when the final iteration finished and its checkpoint was
+	// persisted (clearing manifests) but the job failed before being
+	// marked successful. Nothing left to do.
+	if startIteration > maxIterations {
+		return nil
+	}
+
+	// On resume from a completed merge iteration, read the checkpointed
+	// manifests from the job info key instead of using processor output.
+	sstFiles := processorOutput
+	if mergePhase >= 1 {
+		manifests, err := readImportMergeManifests(ctx, execCtx, job)
+		if err != nil {
+			return err
+		}
+		if len(manifests) == 0 {
+			return errors.AssertionFailedf(
+				"distributed merge phase %d but no checkpointed manifests", mergePhase)
+		}
+		sstFiles = []bulksst.SSTFiles{bulksst.ManifestsToSSTFiles(manifests)}
+	}
+
+	inputSSTs, spans, err := bulksst.CombineFileInfo(sstFiles, schemaSpans)
+	if err != nil {
+		return err
+	}
+
+	// Run 2 merge iterations: a local merge (iteration 1) followed by a final
+	// cross-node merge (iteration 2). The local merge reduces network traffic by
+	// having each node merge its local SSTs first.
+	currentSSTs := inputSSTs
+	for iteration := startIteration; iteration <= maxIterations; iteration++ {
+		// Clean up leftover SSTs from a previous interrupted attempt of this
+		// non-final iteration, preventing orphaned files from wasting storage.
+		progress := job.Progress()
+		prog := progress.GetImport()
+		var storagePrefixes []string
+		if prog != nil {
+			storagePrefixes = prog.SSTStoragePrefixes
+		}
+		cleanupImportRedoIterationSSTs(ctx, execCtx, job.ID(), iteration, maxIterations, storagePrefixes)
+
+		var writeTS *hlc.Timestamp
+		if iteration == maxIterations {
+			writeTS = &hlc.Timestamp{WallTime: walltime}
+		}
+
+		merged, err := bulkmerge.Merge(
+			ctx, execCtx, currentSSTs, spans,
+			func(instanceID base.SQLInstanceID) (string, error) {
+				// Record the storage prefix before any SSTs are written.
+				prefix := fmt.Sprintf("nodelocal://%d/", instanceID)
+				if err := addStoragePrefix(ctx, prefix); err != nil {
+					return "", err
+				}
+				return prefix + bulkutil.NewDistMergePaths(job.ID()).MergePath(iteration), nil
+			},
+			bulkmerge.MergeOptions{
+				Iteration:         iteration,
+				MaxIterations:     maxIterations,
+				WriteTimestamp:    writeTS,
+				EnforceUniqueness: true,
+				MemoryMonitor:     execinfrapb.BulkMergeSpec_BULK_MONITOR,
+			},
+		)
+		if err != nil {
+			return err
+		}
+
+		// Checkpoint via the tracker so manifest serialization uses the
+		// same codepath as map-phase checkpoints.
+		if iteration < maxIterations {
+			manifests := bulksst.MergeOutputToManifests(merged.SSTs)
+			checkpoint.SetMergeIterationResult(manifests, int32(iteration))
+		} else {
+			// Final iteration: correct the entry counts to reflect actual
+			// KV-ingested totals. The map-phase counts include duplicates
+			// from checkpoint-and-resume overlap; the merge's ingest
+			// summary has the true count after skipping identical dupes.
+			if len(merged.IngestSummary.EntryCounts) > 0 {
+				checkpoint.CorrectEntryCounts(merged.IngestSummary.EntryCounts)
+			}
+			checkpoint.SetMergeComplete(int32(iteration))
+		}
+		if err := checkpoint.Persist(ctx, job); err != nil {
+			return err
+		}
+
+		// Pausepoint after checkpointing a non-final iteration so tests
+		// can verify resume from a completed merge iteration.
+		if iteration < maxIterations {
+			if err := execCtx.ExecCfg().JobRegistry.CheckPausepoint(
+				"import.after_merge_iteration",
+			); err != nil {
+				return err
+			}
+		}
+
+		currentSSTs = merged.SSTs
+	}
+
+	return nil
+}
+
+// readImportMergeManifests reads SST manifests from the job info key. Returns
+// nil if no manifests are stored.
+func readImportMergeManifests(
+	ctx context.Context, execCtx sql.JobExecContext, job *jobs.Job,
+) ([]jobspb.BulkSSTManifest, error) {
+	var manifests []jobspb.BulkSSTManifest
+	if err := execCtx.ExecCfg().InternalDB.Txn(ctx, func(
+		ctx context.Context, txn isql.Txn,
+	) error {
+		data, err := jobs.ReadChunkedFileToJobInfo(
+			ctx, importSSTManifestsInfoKey, txn, job.ID(),
+		)
+		if err != nil {
+			return err
+		}
+		if len(data) > 0 {
+			var stored jobspb.BulkSSTManifests
+			if err := protoutil.Unmarshal(data, &stored); err != nil {
+				return errors.Wrap(err, "unmarshaling SST manifests from job info")
+			}
+			manifests = stored.Manifests
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return manifests, nil
+}
+
+// cleanupImportRedoIterationSSTs removes leftover output SSTs from a previous
+// attempt of a non-final merge iteration. Best-effort: errors are logged as
+// warnings rather than failing the job.
+func cleanupImportRedoIterationSSTs(
+	ctx context.Context,
+	execCtx sql.JobExecContext,
+	jobID jobspb.JobID,
+	iteration int,
+	maxIterations int,
+	storagePrefixes []string,
+) {
+	if iteration >= maxIterations || len(storagePrefixes) == 0 {
+		return
+	}
+	outputSubdir := bulkutil.NewDistMergePaths(jobID).MergeSubdir(iteration)
+	cleaner := bulkutil.NewBulkJobCleaner(
+		execCtx.ExecCfg().DistSQLSrv.ExternalStorageFromURI, username.NodeUserName(),
+	)
+	defer func() {
+		if err := cleaner.Close(); err != nil {
+			log.Dev.Warningf(ctx, "error closing cleaner after SST cleanup: %v", err)
+		}
+	}()
+	if err := cleaner.CleanupJobSubdirectory(
+		ctx, jobID, storagePrefixes, outputSubdir,
+	); err != nil {
+		log.Dev.Warningf(ctx, "failed to clean up SSTs in %s before redo: %v", outputSubdir, err)
+	}
 }
 
 func getLastImportSummary(job *jobs.Job) kvpb.BulkOpSummary {

--- a/pkg/sql/importer/import_progress_tracker.go
+++ b/pkg/sql/importer/import_progress_tracker.go
@@ -45,6 +45,14 @@ type importCheckpointTracker struct {
 	// numFiles is the total number of input files, used to compute the
 	// overall fraction completed.
 	numFiles int
+
+	// mergePhase is the completed distributed merge iteration to record.
+	// When non-zero, Persist writes DistributedMergePhase to the job
+	// progress. Set by SetMergeIterationResult or SetMergeComplete.
+	mergePhase int32
+	// clearManifests signals that the manifest job info key should be
+	// cleared (written as nil). Set after the final merge iteration.
+	clearManifests bool
 }
 
 func newImportCheckpointTracker(
@@ -92,6 +100,29 @@ func (t *importCheckpointTracker) RecordProcessorUpdate(
 	t.bulkSummary.Add(progress.BulkSummary)
 }
 
+// SetMergeIterationResult replaces the manifest buffer with the output of
+// a completed non-final merge iteration and records the phase number.
+// The next call to Persist writes both atomically.
+func (t *importCheckpointTracker) SetMergeIterationResult(
+	manifests []jobspb.BulkSSTManifest, phase int32,
+) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.manifestBuf = backfill.NewSSTManifestBuffer(manifests)
+	t.manifestBuf.MarkDirty()
+	t.mergePhase = phase
+	t.clearManifests = false
+}
+
+// SetMergeComplete records the final merge iteration phase and signals
+// that the manifest job info key should be cleared on the next Persist.
+func (t *importCheckpointTracker) SetMergeComplete(phase int32) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.mergePhase = phase
+	t.clearManifests = true
+}
+
 // checkpointSnapshot is the data captured under the mutex for a single
 // checkpoint attempt.
 type checkpointSnapshot struct {
@@ -100,6 +131,8 @@ type checkpointSnapshot struct {
 	bulkSummary       kvpb.BulkOpSummary
 	manifestData      []byte
 	hasDirtyManifests bool
+	mergePhase        int32
+	clearManifests    bool
 }
 
 // snapshot captures the current progress state under the mutex and returns
@@ -113,6 +146,9 @@ func (t *importCheckpointTracker) snapshot() (checkpointSnapshot, error) {
 		fractionProgress: append([]float32(nil), t.fractionProgress...),
 		bulkSummary:      t.bulkSummary.DeepCopy(),
 	}
+
+	snap.mergePhase = t.mergePhase
+	snap.clearManifests = t.clearManifests
 
 	snap.hasDirtyManifests = t.manifestBuf != nil && t.manifestBuf.Dirty()
 	if snap.hasDirtyManifests {
@@ -166,12 +202,22 @@ func (t *importCheckpointTracker) Persist(ctx context.Context, job *jobs.Job) er
 		}
 		prog.Summary = snap.bulkSummary
 
-		if len(snap.manifestData) > 0 {
+		if snap.clearManifests {
+			if err := jobs.WriteChunkedFileToJobInfo(
+				ctx, importSSTManifestsInfoKey, nil, txn, job.ID(),
+			); err != nil {
+				return errors.Wrap(err, "clearing SST manifests from job info")
+			}
+		} else if len(snap.manifestData) > 0 {
 			if err := jobs.WriteChunkedFileToJobInfo(
 				ctx, importSSTManifestsInfoKey, snap.manifestData, txn, job.ID(),
 			); err != nil {
 				return errors.Wrap(err, "writing SST manifests to job info")
 			}
+		}
+
+		if snap.mergePhase > 0 {
+			prog.DistributedMergePhase = snap.mergePhase
 		}
 
 		fractionCompleted := overall / float32(numFiles)

--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -138,12 +138,9 @@ func TestImportDistributedMerge(t *testing.T) {
 // TestImportDistributedMergeDuplicateDetection verifies that IMPORT with
 // distributed merge detects duplicate keys at each phase of the pipeline.
 // These tests cover the fixes for cases 4-6 described in #161447.
-//
-// Case 4 (cross-SST duplicates during intermediate merge) does not apply to
-// IMPORT because it uses MaxIterations=1. That case is tested at the merge
-// level by TestCrossSSTDuplicateHandling in pkg/sql/bulkmerge.
-// TODO(mw5h): When IMPORT switches to multi-stage merge (MaxIterations>1),
-// add a test case for intermediate merge duplicate detection (case 4).
+// Case 4 (cross-SST duplicates during intermediate merge) is covered by the
+// "intermediate merge injected duplicate" test case below, now that IMPORT
+// uses MaxIterations=2.
 func TestImportDistributedMergeDuplicateDetection(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -155,6 +152,9 @@ func TestImportDistributedMergeDuplicateDetection(t *testing.T) {
 		// injectMergeDuplicate uses the InjectDuplicateKey testing knob to
 		// simulate a duplicate during the merge phase.
 		injectMergeDuplicate bool
+		// injectOnIteration restricts duplicate injection to a specific merge
+		// iteration. 0 means inject on the first call regardless of iteration.
+		injectOnIteration int32
 		// smallBatchSize forces each key into its own SST so that non-adjacent
 		// duplicate PKs land in separate SSTs, testing cross-SST detection.
 		smallBatchSize bool
@@ -188,6 +188,18 @@ func TestImportDistributedMergeDuplicateDetection(t *testing.T) {
 			injectMergeDuplicate: true,
 			errRegex:             "duplicate key",
 		},
+		{
+			// Case 4: cross-SST duplicate during the intermediate (non-final)
+			// merge iteration. With MaxIterations=2, iteration 1 is a local
+			// merge that writes to external storage rather than KV. This test
+			// verifies that duplicate detection works during intermediate
+			// iterations, not just the final one.
+			name:                 "intermediate merge injected duplicate",
+			csvData:              "1,a\n2,b\n3,c\n4,d\n5,e",
+			injectMergeDuplicate: true,
+			injectOnIteration:    1,
+			errRegex:             "duplicate key",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -201,10 +213,14 @@ func TestImportDistributedMergeDuplicateDetection(t *testing.T) {
 
 			var injected atomic.Bool
 			if tc.injectMergeDuplicate {
+				targetIteration := tc.injectOnIteration
 				serverArgs.Knobs = base.TestingKnobs{
 					DistSQL: &execinfra.TestingKnobs{
 						BulkMergeTestingKnobs: &bulkmerge.TestingKnobs{
 							InjectDuplicateKey: func(iteration, maxIteration int32) []byte {
+								if targetIteration != 0 && iteration != targetIteration {
+									return nil
+								}
 								if !injected.Swap(true) {
 									return []byte("injected-duplicate-value")
 								}
@@ -308,6 +324,92 @@ type importDataTest struct {
 	err      string
 	rejected string
 	query    map[string][][]string
+}
+
+// TestImportDistributedMergeResume verifies that an import using the 2-stage
+// distributed merge can resume correctly after being paused between merge
+// iterations. It pauses the job after merge iteration 1 checkpoints, then
+// resumes and verifies the data is correct.
+func TestImportDistributedMergeResume(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	dirname := t.TempDir()
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		ExternalIODir:     dirname,
+		DefaultTestTenant: base.TestNeedsTightIntegrationBetweenAPIsAndTestingKnobs,
+	})
+	ctx := context.Background()
+	defer s.Stopper().Stop(ctx)
+	sqlDB := sqlutils.MakeSQLRunner(db)
+
+	sqlDB.Exec(t, `SET CLUSTER SETTING bulkio.import.distributed_merge.enabled = true`)
+
+	// Write test data with enough rows to produce multiple SSTs.
+	var csvData strings.Builder
+	const numRows = 100
+	for i := 0; i < numRows; i++ {
+		fmt.Fprintf(&csvData, "%d,value-%d\n", i, i)
+	}
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dirname, "data.csv"),
+		[]byte(csvData.String()),
+		os.FileMode(0644),
+	))
+
+	sqlDB.Exec(t, `CREATE TABLE t (id INT PRIMARY KEY, name STRING)`)
+
+	// Set pausepoint to pause after the first merge iteration checkpoints.
+	sqlDB.Exec(t, `SET CLUSTER SETTING jobs.debug.pausepoints = 'import.after_merge_iteration'`)
+
+	// Run import — it will pause after merge iteration 1.
+	_, err := db.Exec(`IMPORT INTO t (id, name) CSV DATA ($1)`, "nodelocal://1/data.csv")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "pause point")
+
+	// Wait for the job to reach paused state.
+	var jobID int64
+	testutils.SucceedsSoon(t, func() error {
+		return db.QueryRow(
+			`SELECT job_id FROM [SHOW JOBS] WHERE job_type = 'IMPORT' AND status = 'paused'`,
+		).Scan(&jobID)
+	})
+
+	// Verify the checkpoint recorded merge phase 1.
+	var mergePhase int
+	sqlDB.QueryRow(t,
+		`SELECT COALESCE((crdb_internal.pb_to_json('cockroach.sql.jobs.jobspb.Progress', progress)->'import'->>'distributedMergePhase')::INT, 0) FROM crdb_internal.system_jobs WHERE id = $1`,
+		jobID,
+	).Scan(&mergePhase)
+	require.Equal(t, 1, mergePhase, "expected merge phase 1 to be checkpointed")
+
+	// Clear pausepoint and resume.
+	sqlDB.Exec(t, `SET CLUSTER SETTING jobs.debug.pausepoints = ''`)
+	sqlDB.Exec(t, fmt.Sprintf(`RESUME JOB %d`, jobID))
+
+	// Wait for success.
+	testutils.SucceedsSoon(t, func() error {
+		var status, errStr string
+		if err := db.QueryRow(
+			fmt.Sprintf(`SELECT status, COALESCE(error, '') FROM [SHOW JOB %d]`, jobID),
+		).Scan(&status, &errStr); err != nil {
+			return err
+		}
+		if status == string(jobs.StateFailed) {
+			return errors.Newf("import job %d failed: %s", jobID, errStr)
+		}
+		if status != string(jobs.StateSucceeded) {
+			return errors.Newf("job %d status: %s", jobID, status)
+		}
+		return nil
+	})
+
+	// Verify all rows were imported correctly.
+	sqlDB.CheckQueryResults(t, `SELECT count(*) FROM t`, [][]string{{fmt.Sprintf("%d", numRows)}})
+	sqlDB.CheckQueryResults(t,
+		`SELECT id, name FROM t ORDER BY id LIMIT 3`,
+		[][]string{{"0", "value-0"}, {"1", "value-1"}, {"2", "value-2"}},
+	)
 }
 
 var validImportDataTypes = map[string]struct{}{

--- a/pkg/sql/index_backfiller.go
+++ b/pkg/sql/index_backfiller.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -588,26 +587,7 @@ func (ib *IndexBackfillPlanner) runDistributedMerge(
 		// Convert merged SSTs to manifests for checkpointing. On resume, these
 		// manifests will be used as input to complete the merge in a single
 		// iteration directly to KV.
-		newManifests := make([]jobspb.BulkSSTManifest, 0, len(merged))
-		for _, sst := range merged {
-			span := roachpb.Span{
-				Key:    append([]byte(nil), sst.StartKey...),
-				EndKey: append([]byte(nil), sst.EndKey...),
-			}
-			newManifests = append(newManifests, jobspb.BulkSSTManifest{
-				URI:      sst.URI,
-				Span:     &span,
-				KeyCount: sst.KeyCount,
-				// Populate RowSample so CombineFileInfo can split schema spans on
-				// resume. StartKey is already a row prefix (family suffix stripped
-				// by SSTWriter.Flush), but CombineFileInfo passes samples through
-				// keys.EnsureSafeSplitKey which expects a full key including the
-				// column family suffix. Re-appending family 0 makes the key valid
-				// for that function.
-				RowSample: keys.MakeFamilyKey(append(roachpb.Key(nil), sst.StartKey...), 0),
-			})
-		}
-		progress.SSTManifests = newManifests
+		progress.SSTManifests = bulksst.MergeOutputToManifests(merged)
 		// Update the merge phase to track which iteration we completed.
 		// This allows resume logic to know we're in the middle of merge iterations.
 		// Clear task tracking fields so progress calculation doesn't incorrectly


### PR DESCRIPTION
## Summary

- Changed import to always use 2 merge stages (matching the index backfill
  pattern). The local merge (iteration 1) has each node consolidate its SSTs
  before the final cross-node merge (iteration 2) writes to KV, reducing
  network traffic.
- Added checkpoint/resume support between merge iterations via a new
  `distributed_merge_phase` field in `ImportProgress`. On resume after
  iteration 1, the map phase and first merge are skipped entirely.
- Added best-effort cleanup of leftover SSTs from interrupted non-final
  iterations.

Informs: #163396