### PR TITLE
ci: pin google-github-actions to SHA

### DIFF
--- a/.github/workflows/code-cover-publish.yaml
+++ b/.github/workflows/code-cover-publish.yaml
@@ -44,12 +44,12 @@ jobs:
           unzip cover.zip -d cover
 
       - name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v1'
+        uses: 'google-github-actions/auth@3a3c4c57d294ef65efaaee4ff17b22fa88dd3c69' # v1
         with:
           credentials_json: '${{ secrets.CODECOVER_SERVICE_ACCOUNT_KEY }}'
 
       - name: 'Upload to GCS'
-        uses: 'google-github-actions/upload-cloud-storage@v1'
+        uses: 'google-github-actions/upload-cloud-storage@e95a15f226403ed658d3e65f40205649f342ba2c' # v1
         with:
           path: 'cover'
           glob: '**/cover-*.json'

--- a/.github/workflows/investigate.yml
+++ b/.github/workflows/investigate.yml
@@ -128,7 +128,7 @@ jobs:
       # ANTHROPIC_API_KEY secret is set (e.g. on a personal fork).
       - name: Authenticate to Google Cloud
         if: env.HAS_API_KEY != 'true'
-        uses: 'google-github-actions/auth@v3'
+        uses: 'google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093' # v3
         with:
           project_id: 'vertex-model-runners'
           service_account: 'ai-review@dev-inf-prod.iam.gserviceaccount.com'

--- a/.github/workflows/issue-autosolve.yml
+++ b/.github/workflows/issue-autosolve.yml
@@ -67,7 +67,7 @@ jobs:
           fetch-depth: 0
 
       - name: Authenticate to Google Cloud
-        uses: 'google-github-actions/auth@v3'
+        uses: 'google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093' # v3
         with:
           project_id: 'vertex-model-runners'
           service_account: 'ai-review@dev-inf-prod.iam.gserviceaccount.com'

--- a/.github/workflows/pr-analyzer-threestage.yml
+++ b/.github/workflows/pr-analyzer-threestage.yml
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 1
 
       - name: Authenticate to Google Cloud
-        uses: 'google-github-actions/auth@v3'
+        uses: 'google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093' # v3
         with:
           project_id: 'vertex-model-runners'
           service_account: 'ai-review@dev-inf-prod.iam.gserviceaccount.com'

--- a/.github/workflows/pr-autosolve-comments.yml
+++ b/.github/workflows/pr-autosolve-comments.yml
@@ -138,7 +138,7 @@ jobs:
           token: ${{ secrets.AUTOSOLVER_PAT }}
 
       - name: Authenticate to Google Cloud
-        uses: 'google-github-actions/auth@v3'
+        uses: 'google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093' # v3
         with:
           project_id: 'vertex-model-runners'
           service_account: 'ai-review@dev-inf-prod.iam.gserviceaccount.com'


### PR DESCRIPTION
Pin google-github-actions/auth (v1, v3) and google-github-actions/upload-cloud-storage (v1) to commit SHAs across 5 CI workflow files. Original version tags are preserved as trailing comments.

Fixes: SECENG-1217.

Release note: None