### PR TITLE
ci: pin create-pull-request and cockroachdb/claude-code-action actions to commit SHAs

### DIFF
--- a/.github/workflows/issue-autosolve.yml
+++ b/.github/workflows/issue-autosolve.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Stage 1 - Assess Issue Feasibility
         id: assess
-        uses: cockroachdb/claude-code-action@v1
+        uses: cockroachdb/claude-code-action@426380f01bad0a17200865605a85cb28926dccbf # v1
         env:
           ANTHROPIC_VERTEX_PROJECT_ID: vertex-model-runners
           CLOUD_ML_REGION: us-east5

--- a/.github/workflows/update_releases.yaml
+++ b/.github/workflows/update_releases.yaml
@@ -48,7 +48,7 @@ jobs:
           $(bazel info bazel-bin)/pkg/cmd/release/release_/release update-releases-file
           git diff
       - name: Update pkg/testutils/release/cockroach_releases.yaml on ${{ matrix.branch }}
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5 # v5
         with:
           base: "${{ matrix.branch }}"
           branch: "crdb-releases-yaml-update-${{ matrix.branch }}"


### PR DESCRIPTION
Pin peter-evans/create-pull-request@v5 and cockroachdb/claude-code-action@v1 to their current commit SHAs to prevent supply chain attacks via mutable tags. Original tags preserved as trailing comments.

Release note: None

Epic: SECENG-1214