### PR TITLE
sql/regions: respect num_replicas zone config ext. for super region

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_config_extensions
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_config_extensions
@@ -76,7 +76,7 @@ TABLE tbl  ALTER TABLE tbl CONFIGURE ZONE USING
              gc.ttlseconds = 14400,
              num_replicas = 9,
              num_voters = 5,
-             constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',
+             constraints = '{+region=ap-southeast-2: 3, +region=ca-central-1: 3, +region=us-east-1: 3}',
              voter_constraints = '{+region=ca-central-1: 2}',
              lease_preferences = '[[+region=ca-central-1]]'
 
@@ -113,7 +113,7 @@ TABLE tbl  ALTER TABLE tbl CONFIGURE ZONE USING
              gc.ttlseconds = 14400,
              num_replicas = 9,
              num_voters = 5,
-             constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',
+             constraints = '{+region=ap-southeast-2: 3, +region=ca-central-1: 3, +region=us-east-1: 3}',
              voter_constraints = '{+region=ca-central-1: 2}',
              lease_preferences = '[[+region=ca-central-1], [+region=ap-southeast-2]]'
 
@@ -135,7 +135,7 @@ TABLE tbl  ALTER TABLE tbl CONFIGURE ZONE USING
              gc.ttlseconds = 14400,
              num_replicas = 9,
              num_voters = 5,
-             constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',
+             constraints = '{+region=ap-southeast-2: 3, +region=ca-central-1: 3, +region=us-east-1: 3}',
              voter_constraints = '{+region=ca-central-1: 2}',
              lease_preferences = '[[+region=ca-central-1], [+region=ap-southeast-2]]'
 
@@ -157,7 +157,7 @@ TABLE tbl  ALTER TABLE tbl CONFIGURE ZONE USING
              gc.ttlseconds = 14400,
              num_replicas = 9,
              num_voters = 5,
-             constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',
+             constraints = '{+region=ap-southeast-2: 3, +region=ca-central-1: 3, +region=us-east-1: 3}',
              voter_constraints = '{+region=ap-southeast-2: 2}',
              lease_preferences = '[[+region=ap-southeast-2], [+region=us-east-1]]'
 
@@ -179,7 +179,7 @@ TABLE tbl  ALTER TABLE tbl CONFIGURE ZONE USING
              gc.ttlseconds = 14400,
              num_replicas = 9,
              num_voters = 5,
-             constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 2}',
+             constraints = '{+region=ap-southeast-2: 3, +region=ca-central-1: 3, +region=us-east-1: 3}',
              voter_constraints = '{+region=us-east-1: 2}',
              lease_preferences = '[[+region=us-east-1]]'
 

--- a/pkg/ccl/multiregionccl/multiregion_test.go
+++ b/pkg/ccl/multiregionccl/multiregion_test.go
@@ -519,7 +519,6 @@ func TestSuperRegionConstraintConformanceZoneSurvival(t *testing.T) {
 
 	skip.UnderShort(t)
 	skip.UnderDuress(t)
-
 	// The topology uses 4 regions across 8 nodes (2 per region):
 	//
 	//   - Super region "americas": {us-east-1, us-central-1, us-west-1}
@@ -559,7 +558,6 @@ func TestSuperRegionConstraintConformanceZoneSurvival(t *testing.T) {
 	// Setup MR database with zone survival.
 	tdb.Exec(t, `CREATE DATABASE testdb PRIMARY REGION "ap-southeast-1"
 		REGIONS "us-east-1", "us-central-1", "us-west-1"`)
-	tdb.Exec(t, `SET enable_super_regions = 'on'`)
 	tdb.Exec(t, `ALTER DATABASE testdb ADD SUPER REGION "americas"
 		VALUES "us-east-1", "us-central-1", "us-west-1"`)
 	tdb.Exec(t, `ALTER DATABASE testdb SURVIVE ZONE FAILURE`)
@@ -704,4 +702,70 @@ func TestSuperRegionConstraintConformanceZoneSurvival(t *testing.T) {
 		}
 		return nil
 	})
+}
+
+// TestSuperRegionWithNumReplicasExtension verifies that creating an RBR table
+// with super regions succeeds when the user has set num_replicas via a zone
+// config extension to a value lower than the default.
+func TestSuperRegionWithNumReplicasExtension(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	skip.UnderShort(t)
+	skip.UnderDuress(t)
+
+	regionNames := []string{
+		"us-east-1", "us-east-2", "eu-west-1",
+	}
+	_, sqlDB, cleanup :=
+		multiregionccltestutils.TestingCreateMultiRegionClusterWithRegionList(
+			t,
+			regionNames,
+			3, /* serversPerRegion */
+			base.TestingKnobs{},
+		)
+	defer cleanup()
+
+	tdb := sqlutils.MakeSQLRunner(sqlDB)
+
+	// Create a 3-region database with zone survival (default).
+	tdb.Exec(t, `CREATE DATABASE testdb PRIMARY REGION "us-east-1"
+		REGIONS "us-east-2", "eu-west-1"`)
+
+	// Set num_replicas = 3 via Regional zone config extension.
+	tdb.Exec(t, `ALTER DATABASE testdb ALTER LOCALITY REGIONAL
+		CONFIGURE ZONE USING num_replicas = 3`)
+
+	// Create super regions.
+	tdb.Exec(t, `ALTER DATABASE testdb ADD SUPER REGION "us"
+		VALUES "us-east-1", "us-east-2"`)
+	tdb.Exec(t, `ALTER DATABASE testdb ADD SUPER REGION "eu"
+		VALUES "eu-west-1"`)
+
+	// Create an RBR table — this previously failed with:
+	// "the number of replicas specified in constraints (4) cannot be greater
+	// than the number of replicas configured for the zone (3)"
+	tdb.Exec(t, `CREATE TABLE testdb.rbr(k INT PRIMARY KEY, v INT)
+		LOCALITY REGIONAL BY ROW`)
+
+	// Insert rows into each region and verify they work.
+	tdb.Exec(t, `INSERT INTO testdb.rbr(crdb_region, k, v) VALUES
+		('us-east-1', 1, 10), ('us-east-2', 2, 20), ('eu-west-1', 3, 30)`)
+
+	var count int
+	tdb.QueryRow(t, `SELECT count(*) FROM testdb.rbr`).Scan(&count)
+	require.Equal(t, 3, count)
+
+	// Verify zone configs show correct constraints — constraints total
+	// should not exceed num_replicas.
+	for _, region := range []string{"us-east-1", "us-east-2"} {
+		var target, rawSQL string
+		tdb.QueryRow(t, fmt.Sprintf(
+			`SHOW ZONE CONFIGURATION FOR PARTITION "%s" OF TABLE testdb.rbr`,
+			region)).Scan(&target, &rawSQL)
+		require.Contains(t, rawSQL, "num_replicas = 3",
+			"partition %s should have num_replicas = 3", region)
+		require.Contains(t, rawSQL, region,
+			"partition %s should reference its home region in constraints", region)
+	}
 }

--- a/pkg/sql/region_util_test.go
+++ b/pkg/sql/region_util_test.go
@@ -2771,6 +2771,135 @@ func TestZoneConfigForMultiRegionPartition(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc:   "2-region super region, zone survival, Regional extension num_replicas=3",
+			region: "region_a",
+			regionConfig: multiregion.MakeRegionConfig(
+				catpb.RegionNames{"region_a", "region_b", "region_c"},
+				"region_a",
+				descpb.SurvivalGoal_ZONE_FAILURE,
+				descpb.InvalidID,
+				descpb.DataPlacement_DEFAULT,
+				[]descpb.SuperRegion{{
+					SuperRegionName: "sr1",
+					Regions:         []catpb.RegionName{"region_a", "region_b"},
+				}},
+				descpb.ZoneConfigExtensions{
+					Regional: &zonepb.ZoneConfig{
+						NumReplicas:               proto.Int32(3),
+						InheritedConstraints:      true,
+						InheritedLeasePreferences: true,
+					},
+				},
+			),
+			expected: zonepb.ZoneConfig{
+				NumReplicas: proto.Int32(3),
+				NumVoters:   proto.Int32(3),
+				Constraints: []zonepb.ConstraintsConjunction{
+					{NumReplicas: 3, Constraints: []zonepb.Constraint{
+						{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_a"},
+					}},
+				},
+				NullVoterConstraintsIsEmpty: true,
+				VoterConstraints: []zonepb.ConstraintsConjunction{
+					{Constraints: []zonepb.Constraint{
+						{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_a"},
+					}},
+				},
+				LeasePreferences: []zonepb.LeasePreference{
+					{Constraints: []zonepb.Constraint{
+						{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_a"},
+					}},
+				},
+			},
+		},
+		{
+			desc:   "3-region super region, zone survival, Regional extension num_replicas=3",
+			region: "region_a",
+			regionConfig: multiregion.MakeRegionConfig(
+				catpb.RegionNames{"region_a", "region_b", "region_c"},
+				"region_a",
+				descpb.SurvivalGoal_ZONE_FAILURE,
+				descpb.InvalidID,
+				descpb.DataPlacement_DEFAULT,
+				[]descpb.SuperRegion{{
+					SuperRegionName: "sr1",
+					Regions:         []catpb.RegionName{"region_a", "region_b", "region_c"},
+				}},
+				descpb.ZoneConfigExtensions{
+					Regional: &zonepb.ZoneConfig{
+						NumReplicas:               proto.Int32(3),
+						InheritedConstraints:      true,
+						InheritedLeasePreferences: true,
+					},
+				},
+			),
+			expected: zonepb.ZoneConfig{
+				NumReplicas: proto.Int32(3),
+				NumVoters:   proto.Int32(3),
+				Constraints: []zonepb.ConstraintsConjunction{
+					{NumReplicas: 3, Constraints: []zonepb.Constraint{
+						{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_a"},
+					}},
+				},
+				NullVoterConstraintsIsEmpty: true,
+				VoterConstraints: []zonepb.ConstraintsConjunction{
+					{Constraints: []zonepb.Constraint{
+						{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_a"},
+					}},
+				},
+				LeasePreferences: []zonepb.LeasePreference{
+					{Constraints: []zonepb.Constraint{
+						{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_a"},
+					}},
+				},
+			},
+		},
+		{
+			desc:   "2-region super region, zone survival, Regional extension num_replicas=4 (matches default)",
+			region: "region_a",
+			regionConfig: multiregion.MakeRegionConfig(
+				catpb.RegionNames{"region_a", "region_b", "region_c"},
+				"region_a",
+				descpb.SurvivalGoal_ZONE_FAILURE,
+				descpb.InvalidID,
+				descpb.DataPlacement_DEFAULT,
+				[]descpb.SuperRegion{{
+					SuperRegionName: "sr1",
+					Regions:         []catpb.RegionName{"region_a", "region_b"},
+				}},
+				descpb.ZoneConfigExtensions{
+					Regional: &zonepb.ZoneConfig{
+						NumReplicas:               proto.Int32(4),
+						InheritedConstraints:      true,
+						InheritedLeasePreferences: true,
+					},
+				},
+			),
+			expected: zonepb.ZoneConfig{
+				NumReplicas: proto.Int32(4),
+				NumVoters:   proto.Int32(3),
+				Constraints: []zonepb.ConstraintsConjunction{
+					{NumReplicas: 3, Constraints: []zonepb.Constraint{
+						{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_a"},
+					}},
+					{NumReplicas: 1, Constraints: []zonepb.Constraint{
+						{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_b"},
+					}},
+				},
+				NullVoterConstraintsIsEmpty: true,
+				VoterConstraints: []zonepb.ConstraintsConjunction{
+					{Constraints: []zonepb.Constraint{
+						{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_a"},
+					}},
+				},
+				LeasePreferences: []zonepb.LeasePreference{
+					{Constraints: []zonepb.Constraint{
+						{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_a"},
+					}},
+				},
+			},
+		},
 	}
 	testCases = append(testCases, superRegionTestCases...)
 

--- a/pkg/sql/regions/region_util.go
+++ b/pkg/sql/regions/region_util.go
@@ -852,6 +852,22 @@ func AddConstraintsForSuperRegion(
 	srConfig := regionConfig.WithRegions(regions)
 	numVoters, numReplicas := GetNumVotersAndNumReplicas(srConfig)
 
+	// If a zone config extension will override num_replicas, use the
+	// effective value for constraint generation so constraints are
+	// consistent with the final num_replicas after extensions are applied
+	// by ExtendZoneConfigWithRegionalIn.
+	exts := regionConfig.ZoneConfigExtensions()
+	if ext := exts.Regional; ext != nil && ext.NumReplicas != nil && *ext.NumReplicas > 0 {
+		if *ext.NumReplicas >= numVoters {
+			numReplicas = *ext.NumReplicas
+		}
+	}
+	if ext, ok := exts.RegionalIn[affinityRegion]; ok && ext.NumReplicas != nil && *ext.NumReplicas > 0 {
+		if *ext.NumReplicas >= numVoters {
+			numReplicas = *ext.NumReplicas
+		}
+	}
+
 	zc.NumReplicas = &numReplicas
 
 	var minAffinity int32


### PR DESCRIPTION
Previously, `AddConstraintsForSuperRegion` computed `numReplicas` independently (e.g. 4 for a 2-region super region with zone survival) and generated constraints totaling that value. When a zone config extension subsequently overrode `num_replicas` to a lower value (e.g. 3), `ExtendZoneConfigWithRegionalIn` inherited the constraints from the first step (still totaling 4) but set `num_replicas` to 3. Zone config validation then rejected the config because constraints (4) exceeded num_replicas (3).

This commit fixes `AddConstraintsForSuperRegion` to check the Regional and RegionalIn zone config extensions for a `num_replicas` override before generating constraints. If the override is at least `numVoters`, it is used as the effective `numReplicas` for constraint distribution, ensuring the generated constraints are consistent with the final `num_replicas` after extensions are applied.

Closes: #165851
Epic: CRDB-58694
Release note: None