### PR TITLE
roachtest: jepsen timeout - race in pkill

### DIFF
--- a/pkg/cmd/roachtest/tests/jepsen.go
+++ b/pkg/cmd/roachtest/tests/jepsen.go
@@ -389,7 +389,12 @@ func runJepsen(ctx context.Context, t test.Test, c cluster.Cluster, testName, ne
 		// extra debugging help.
 		run(c, ctx, controller, "pkill -QUIT java")
 		time.Sleep(10 * time.Second)
-		run(c, ctx, controller, "pkill java")
+		if err := runE(c, ctx, controller, "pkill java"); err != nil {
+			// pkill exits 1 when no matching process is found.
+			// This is expected if the JVM already exited after
+			// the SIGQUIT above.
+			t.L().Printf("pkill java: %s", err)
+		}
 		t.L().Printf("timed out")
 		testErr = fmt.Errorf("timed out")
 	}


### PR DESCRIPTION
In case of a timeout, an initial `SIGQUIT` signal is sent to the java process via `pkill -QUIT java`, followed 10 seconds later by a `SIGTERM` via `pkill java`.

This is problematic because if the process honors the SIGQUIT signal during the 10 second window of opporunity, the second `pkill` command will exit 1 because no processed was matched.

This patch treats `pkill java` as a best effort command and only logs an error instead of failing the test to avoid the described race condition.

Epic: none
Fixes: #164920
Release note: None