### PR TITLE
import: support computed columns with UDF references

### DIFF
--- a/pkg/backup/testdata/backup-restore/user-defined-functions-in-computed
+++ b/pkg/backup/testdata/backup-restore/user-defined-functions-in-computed
@@ -11,11 +11,9 @@ USE computed_col_db;
 ----
 
 exec-sql
-CREATE FUNCTION public.add_tax(price DECIMAL) RETURNS DECIMAL IMMUTABLE AS $$
-BEGIN
-  RETURN price * 1.1;
-END;
-$$ LANGUAGE PLpgSQL;
+CREATE FUNCTION public.add_tax(price DECIMAL) RETURNS DECIMAL IMMUTABLE LANGUAGE SQL AS $$
+  SELECT price * 1.1
+$$;
 ----
 
 # Test if computed columns with UDFs are supported.
@@ -199,11 +197,9 @@ USE stored_computed_test;
 ----
 
 exec-sql
-CREATE FUNCTION public.format_display(id INT, data TEXT) RETURNS TEXT IMMUTABLE AS $$
-BEGIN
-  RETURN 'ID: ' || id || ', Data: ' || data;
-END;
-$$ LANGUAGE PLpgSQL;
+CREATE FUNCTION public.format_display(id INT, data TEXT) RETURNS TEXT IMMUTABLE LANGUAGE SQL AS $$
+  SELECT 'ID: ' || id || ', Data: ' || data
+$$;
 ----
 
 exec-sql
@@ -275,11 +271,9 @@ USE virtual_computed_test;
 ----
 
 exec-sql
-CREATE FUNCTION public.format_display(id INT, data TEXT) RETURNS TEXT IMMUTABLE AS $$
-BEGIN
-  RETURN 'ID: ' || id || ', Data: ' || data;
-END;
-$$ LANGUAGE PLpgSQL;
+CREATE FUNCTION public.format_display(id INT, data TEXT) RETURNS TEXT IMMUTABLE LANGUAGE SQL AS $$
+  SELECT 'ID: ' || id || ', Data: ' || data
+$$;
 ----
 
 exec-sql
@@ -374,11 +368,9 @@ $$ LANGUAGE PLpgSQL;
 ----
 
 exec-sql
-CREATE FUNCTION public.calculate_total(base DECIMAL, tax_rate DECIMAL) RETURNS DECIMAL IMMUTABLE AS $$
-BEGIN
-  RETURN base * (1 + tax_rate);
-END;
-$$ LANGUAGE PLpgSQL;
+CREATE FUNCTION public.calculate_total(base DECIMAL, tax_rate DECIMAL) RETURNS DECIMAL IMMUTABLE LANGUAGE SQL AS $$
+  SELECT base * (1 + tax_rate)
+$$;
 ----
 
 exec-sql

--- a/pkg/sql/catalog/descs/dist_sql_function_resolver.go
+++ b/pkg/sql/catalog/descs/dist_sql_function_resolver.go
@@ -34,6 +34,14 @@ func NewDistSQLFunctionResolver(descs *Collection, txn *kv.Txn) *DistSQLFunction
 	}
 }
 
+// NewDistSQLFunctionResolverFromGetter returns a new DistSQLFunctionResolver
+// using the provided ByIDGetter directly. This is useful when the caller
+// needs to control how descriptors are looked up, for example using
+// ByIDWithoutLeased on a bare-bones collection that lacks a lease manager.
+func NewDistSQLFunctionResolverFromGetter(g ByIDGetter) *DistSQLFunctionResolver {
+	return &DistSQLFunctionResolver{g: g}
+}
+
 // ResolveFunction implements tree.FunctionReferenceResolver interface.
 // It only resolves builtin functions.
 // TODO(chengxiong): extract resolution logics in schema_resolver.go into

--- a/pkg/sql/catalog/schemaexpr/computed_column.go
+++ b/pkg/sql/catalog/schemaexpr/computed_column.go
@@ -323,8 +323,8 @@ func MakeComputedExprs(
 			continue
 		}
 
-		// Collect all column IDs that are referenced in the partial index
-		// predicate expression.
+		// Collect all column IDs that are referenced in the computed
+		// column expression.
 		colIDs, err := ExtractColumnIDs(tableDesc, exprs[compExprIdx])
 		if err != nil {
 			return nil, refColIDs, err
@@ -337,6 +337,19 @@ func MakeComputedExprs(
 		}
 
 		typedExpr, err := tree.TypeCheck(ctx, expr, semaCtx, col.GetType())
+		if err != nil {
+			return nil, catalog.TableColSet{}, err
+		}
+
+		// Inline any UDF calls so that the expression can be evaluated
+		// by eval.Expr. Contexts that bypass the optimizer (IMPORT,
+		// backfill) cannot evaluate functions with SQL bodies directly.
+		// This must happen before the assignment cast so the cast
+		// operates on the resolved expression, not a FuncExpr wrapper.
+		typedExpr, err = inlineUDFCalls(
+			ctx, typedExpr, semaCtx,
+			tree.ComputedColumnExprContext(col.IsVirtual()),
+		)
 		if err != nil {
 			return nil, catalog.TableColSet{}, err
 		}
@@ -356,4 +369,211 @@ func MakeComputedExprs(
 		nr.addColumn(col)
 	}
 	return computedExprs, refColIDs, nil
+}
+
+// inlineUDFCalls walks a TypedExpr tree and replaces FuncExpr nodes that
+// reference user-defined functions (those with SQL bodies) with the inlined
+// body expression. This is necessary because eval.Expr cannot evaluate
+// functions with SQL bodies — that capability is only available through
+// the optimizer. Contexts that evaluate computed column expressions without
+// the optimizer (IMPORT, schema change backfill) rely on this inlining.
+//
+// Only single-statement SQL-language UDFs can be inlined. Multi-statement
+// or PL/pgSQL functions will produce an error.
+func inlineUDFCalls(
+	ctx context.Context,
+	expr tree.TypedExpr,
+	semaCtx *tree.SemaContext,
+	schemaCtx tree.SchemaExprContext,
+) (tree.TypedExpr, error) {
+	newExpr, err := tree.SimpleVisit(expr, func(e tree.Expr) (recurse bool, newExpr tree.Expr, err error) {
+		funcExpr, ok := e.(*tree.FuncExpr)
+		if !ok {
+			return true, e, nil
+		}
+		fn := funcExpr.ResolvedOverload()
+		if fn == nil || fn.Body == "" {
+			return true, e, nil
+		}
+		if fn.Language != tree.RoutineLangSQL {
+			return false, nil, unimplemented.Newf(
+				"computed_column_plpgsql_udf",
+				"PL/pgSQL user-defined functions in computed columns "+
+					"cannot be evaluated in this context",
+			)
+		}
+
+		// Parse the function body.
+		stmts, err := parserutils.Parse(fn.Body)
+		if err != nil {
+			return false, nil, errors.Wrap(err, "parsing UDF body for inlining")
+		}
+		if len(stmts) != 1 {
+			return false, nil, unimplemented.Newf(
+				"computed_column_multi_stmt_udf",
+				"multi-statement user-defined functions in computed columns "+
+					"cannot be evaluated in this context",
+			)
+		}
+
+		// Extract the result expression from the SELECT statement.
+		sel, ok := stmts[0].AST.(*tree.Select)
+		if !ok {
+			return false, nil, errors.Newf(
+				"expected SELECT in UDF body, got %T", stmts[0].AST,
+			)
+		}
+		if sel.With != nil {
+			return false, nil, unimplemented.Newf(
+				"computed_column_cte_udf",
+				"user-defined functions with CTEs in computed columns "+
+					"cannot be evaluated in this context",
+			)
+		}
+		selClause, ok := sel.Select.(*tree.SelectClause)
+		if !ok || len(selClause.Exprs) != 1 {
+			return false, nil, errors.Newf(
+				"expected single-expression SELECT in UDF body",
+			)
+		}
+		if len(selClause.From.Tables) > 0 {
+			return false, nil, unimplemented.Newf(
+				"computed_column_from_udf",
+				"user-defined functions with FROM clauses in computed columns "+
+					"cannot be evaluated in this context",
+			)
+		}
+		bodyExpr := selClause.Exprs[0].Expr
+
+		// Build a mapping from named parameters to the actual argument
+		// expressions from the call site. Unnamed parameters (those
+		// with empty names) are only referenceable via ordinal $1/$2
+		// placeholders, so they are excluded from this map.
+		paramMap := make(map[string]tree.Expr, len(fn.RoutineParams))
+		for i, p := range fn.RoutineParams {
+			if tree.IsOutParamClass(p.Class) {
+				return false, nil, unimplemented.Newf(
+					"computed_column_out_param_udf",
+					"user-defined functions with OUT or INOUT parameters "+
+						"in computed columns cannot be evaluated in this context",
+				)
+			}
+			if p.Name != "" && i < len(funcExpr.Exprs) {
+				paramMap[string(p.Name)] = funcExpr.Exprs[i]
+			}
+		}
+
+		// Substitute parameter references in the body. Named
+		// parameters appear as UnresolvedName or ColumnItem nodes;
+		// unnamed parameters use ordinal placeholders ($1, $2, etc.).
+		inlined, err := tree.SimpleVisit(
+			bodyExpr,
+			func(inner tree.Expr) (bool, tree.Expr, error) {
+				// Named param in parsed-but-unresolved body (e.g. "x" in SELECT x + 1).
+				if name, ok := inner.(*tree.UnresolvedName); ok &&
+					name.NumParts == 1 {
+					if arg, exists := paramMap[name.Parts[0]]; exists {
+						return false, arg, nil
+					}
+				}
+				// Named param after name resolution has converted it to a ColumnItem.
+				if ci, ok := inner.(*tree.ColumnItem); ok {
+					if arg, exists := paramMap[string(ci.ColumnName)]; exists {
+						return false, arg, nil
+					}
+				}
+				// Ordinal placeholder for unnamed params (e.g. $1, $2).
+				if ph, ok := inner.(*tree.Placeholder); ok {
+					idx := int(ph.Idx)
+					if idx < len(funcExpr.Exprs) {
+						return false, funcExpr.Exprs[idx], nil
+					}
+				}
+				return true, inner, nil
+			},
+		)
+		if err != nil {
+			return false, nil, err
+		}
+
+		// Verify the inlined body contains no constructs that cannot
+		// be evaluated outside the optimizer.
+		if _, err := tree.SimpleVisit(inlined, func(inner tree.Expr) (bool, tree.Expr, error) {
+			if _, ok := inner.(*tree.Subquery); ok {
+				return false, inner, unimplemented.Newf(
+					"computed_column_subquery_udf",
+					"user-defined functions with subqueries in computed columns "+
+						"cannot be evaluated in this context",
+				)
+			}
+			// Check for unreplaced parameter references. These
+			// indicate a parameter substitution bug or an
+			// unsupported reference pattern.
+			if ph, ok := inner.(*tree.Placeholder); ok {
+				return false, inner, errors.Newf(
+					"unresolved parameter reference $%d in inlined UDF body", ph.Idx+1,
+				)
+			}
+			return true, inner, nil
+		}); err != nil {
+			return false, nil, err
+		}
+
+		// For strict functions (RETURNS NULL ON NULL INPUT), wrap the
+		// inlined body to return NULL when any argument is NULL,
+		// preserving the function's null-handling semantics.
+		if !fn.CalledOnNullInput && len(funcExpr.Exprs) > 0 {
+			var nullCheck tree.TypedExpr
+			for i, arg := range funcExpr.Exprs {
+				isNull := &tree.IsNullExpr{Expr: arg}
+				if i == 0 {
+					nullCheck = isNull
+				} else {
+					nullCheck = tree.NewTypedOrExpr(nullCheck, isNull)
+				}
+			}
+			inlined = &tree.CaseExpr{
+				Whens: []*tree.When{{
+					Cond: nullCheck,
+					Val:  tree.DNull,
+				}},
+				Else: inlined,
+			}
+		}
+
+		// Type-check the inlined expression against the function's
+		// return type, rejecting generators, aggregates, window
+		// functions, and procedures via sanitizeExpr.
+		typedInlined, err := sanitizeExpr(
+			ctx, inlined, funcExpr.ResolvedType(), schemaCtx, semaCtx,
+			volatility.Volatile, false, /* allowAssignmentCast */
+		)
+		if err != nil {
+			return false, nil, errors.Wrap(err, "type-checking inlined UDF body")
+		}
+
+		// After type-checking, check for nested UDF calls. The
+		// inliner does not recursively inline, so any remaining
+		// UDF calls in the body will fail during backfill.
+		if _, err := tree.SimpleVisit(typedInlined, func(inner tree.Expr) (bool, tree.Expr, error) {
+			if nestedFunc, ok := inner.(*tree.FuncExpr); ok {
+				if nestedFn := nestedFunc.ResolvedOverload(); nestedFn != nil && nestedFn.Body != "" {
+					return false, inner, unimplemented.Newf(
+						"computed_column_nested_udf",
+						"nested user-defined function calls in computed columns "+
+							"cannot be evaluated in this context",
+					)
+				}
+			}
+			return true, inner, nil
+		}); err != nil {
+			return false, nil, err
+		}
+
+		return false, typedInlined, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return newExpr.(tree.TypedExpr), nil
 }

--- a/pkg/sql/catalog/schemaexpr/expr.go
+++ b/pkg/sql/catalog/schemaexpr/expr.go
@@ -83,6 +83,15 @@ func DequalifyAndValidateExprImpl(
 		return "", nil, colIDs, err
 	}
 
+	// For computed columns, verify that any UDF calls can be inlined for
+	// backfill. A table with a computed column that can't be backfilled
+	// can't have schema changes performed on it, so we reject upfront.
+	if context == tree.StoredComputedColumnExpr || context == tree.VirtualComputedColumnExpr {
+		if _, err := inlineUDFCalls(ctx, typedExpr, semaCtx, context); err != nil {
+			return "", nil, colIDs, err
+		}
+	}
+
 	// We need to do the rewrite here before the expression is serialized because
 	// the serialization would drop the prefixes to functions.
 	//
@@ -465,6 +474,24 @@ func SanitizeVarFreeExpr(
 			"variable sub-expressions are not allowed in %s", context)
 	}
 
+	return sanitizeExpr(ctx, expr, expectedType, context, semaCtx, maxVolatility, allowAssignmentCast)
+}
+
+// sanitizeExpr type-checks an expression, rejects special functions
+// (generators, aggregates, window functions, procedures) and optionally
+// restricts volatility. It is the shared core of SanitizeVarFreeExpr
+// (which additionally rejects variable sub-expressions) and is also used
+// by inlineUDFCalls to validate inlined UDF bodies that legitimately
+// contain column references.
+func sanitizeExpr(
+	ctx context.Context,
+	expr tree.Expr,
+	expectedType *types.T,
+	context tree.SchemaExprContext,
+	semaCtx *tree.SemaContext,
+	maxVolatility volatility.V,
+	allowAssignmentCast bool,
+) (tree.TypedExpr, error) {
 	// We need to save and restore the previous value of the field in
 	// semaCtx in case we are recursively called from another context
 	// which uses the properties field.

--- a/pkg/sql/importer/import_processor_test.go
+++ b/pkg/sql/importer/import_processor_test.go
@@ -93,8 +93,9 @@ func TestConverterFlushesBatches(t *testing.T) {
 	evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 
 	params := base.TestServerArgs{}
-	s, _, db := serverutils.StartServer(t, params)
+	s := serverutils.StartServerOnly(t, params)
 	defer s.Stopper().Stop(ctx)
+	kvDB := s.ApplicationLayer().DB()
 
 	tests := []testSpec{
 		newTestSpec(ctx, t, csvFormat(), "testdata/csv/data-0"),
@@ -121,7 +122,7 @@ func TestConverterFlushesBatches(t *testing.T) {
 				kvCh := make(chan row.KVBatch, batchSize)
 				semaCtx := tree.MakeSemaContext(nil /* resolver */)
 				conv, err := makeInputConverter(ctx, &semaCtx, converterSpec, &evalCtx, kvCh,
-					nil /* seqChunkProvider */, db)
+					nil /* seqChunkProvider */, kvDB)
 				if err != nil {
 					t.Fatalf("makeInputConverter() error = %v", err)
 				}

--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -1252,6 +1252,41 @@ END
 	}
 }
 
+// TestImportIntoComputedColumnWithUDF verifies that IMPORT INTO works when
+// the destination table has computed columns defined using user-defined
+// functions. Regression test for #157195.
+func TestImportIntoComputedColumnWithUDF(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	baseDir, cleanup := testutils.TempDir(t)
+	defer cleanup()
+	tc := serverutils.StartCluster(
+		t, 1, base.TestClusterArgs{ServerArgs: base.TestServerArgs{ExternalIODir: baseDir}})
+	defer tc.Stopper().Stop(ctx)
+	conn := tc.ServerConn(0)
+	sqlDB := sqlutils.MakeSQLRunner(conn)
+
+	// Helper that writes CSV data and runs IMPORT INTO.
+	importCSV := func(t *testing.T, table, intoCols, csvData string) {
+		t.Helper()
+		f, err := os.CreateTemp(baseDir, "data")
+		require.NoError(t, err)
+		_, err = f.Write([]byte(csvData))
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+		sqlDB.Exec(t, fmt.Sprintf(
+			`IMPORT INTO %s (%s) CSV DATA ($1)`, table, intoCols,
+		), fmt.Sprintf("nodelocal://1/%s", filepath.Base(f.Name())))
+	}
+
+	sqlDB.Exec(t, `CREATE FUNCTION double_val(x INT) RETURNS INT IMMUTABLE LANGUAGE SQL AS $$ SELECT x * 2 $$`)
+	sqlDB.Exec(t, `CREATE TABLE t (a INT, b INT AS (double_val(a)) STORED)`)
+	importCSV(t, "t", "a", "1\n2\n3\n")
+	sqlDB.CheckQueryResults(t, `SELECT a, b FROM t ORDER BY a`,
+		[][]string{{"1", "2"}, {"2", "4"}, {"3", "6"}})
+}
+
 func TestImportRowLimit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/sql/importer/read_import_base.go
+++ b/pkg/sql/importer/read_import_base.go
@@ -123,11 +123,12 @@ func runImport(
 	// at the end is one row containing an encoded BulkOpSummary.
 	var summary *kvpb.BulkOpSummary
 	group.GoCtx(func(ctx context.Context) error {
-		summary, err = ingestKvs(ctx, flowCtx, spec, processorID, table.Desc.Name, progCh, kvCh)
-		return err
+		var ingestErr error
+		summary, ingestErr = ingestKvs(ctx, flowCtx, spec, processorID, table.Desc.Name, progCh, kvCh)
+		return ingestErr
 	})
 
-	if err = group.Wait(); err != nil {
+	if err := group.Wait(); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -1531,3 +1531,275 @@ statement ok
 DROP TABLE test_virtual
 
 subtest end
+
+
+subtest udf_computed_column
+
+# Test that computed columns can reference user-defined functions.
+# UDF calls are inlined during expression evaluation for contexts
+# that bypass the optimizer (backfill, IMPORT). The inlining handles
+# single-expression SQL UDFs containing the same scalar expression
+# constructs allowed in non-UDF computed columns: arithmetic, string
+# operations, type casts, CASE/COALESCE, immutable builtin calls,
+# and array constructors. See the udf_unsupported test file for
+# patterns that are not yet supported.
+
+statement ok
+CREATE FUNCTION cc_udf_const() RETURNS INT IMMUTABLE LANGUAGE SQL AS $$ SELECT 1 $$;
+
+statement ok
+CREATE TABLE cc_udf_t (a INT PRIMARY KEY, b INT);
+
+statement ok
+INSERT INTO cc_udf_t VALUES (1, 10), (2, 20), (3, 30);
+
+# Adding a computed column with a UDF triggers a backfill.
+statement ok
+ALTER TABLE cc_udf_t ADD COLUMN c INT AS (cc_udf_const()) STORED;
+
+query III rowsort
+SELECT * FROM cc_udf_t
+----
+1  10  1
+2  20  1
+3  30  1
+
+# UDFs with parameters.
+statement ok
+CREATE FUNCTION cc_udf_double(x INT) RETURNS INT IMMUTABLE LANGUAGE SQL AS $$ SELECT x * 2 $$;
+
+statement ok
+CREATE TABLE cc_udf_param_t (a INT PRIMARY KEY);
+
+statement ok
+INSERT INTO cc_udf_param_t VALUES (1), (2), (3), (4), (5);
+
+statement ok
+ALTER TABLE cc_udf_param_t ADD COLUMN b INT AS (cc_udf_double(a)) STORED;
+
+query II rowsort
+SELECT * FROM cc_udf_param_t
+----
+1  2
+2  4
+3  6
+4  8
+5  10
+
+# Strict UDFs (RETURNS NULL ON NULL INPUT) on a nullable column.
+# Rows with NULL input should produce NULL output.
+statement ok
+CREATE FUNCTION cc_udf_strict(x INT) RETURNS INT IMMUTABLE RETURNS NULL ON NULL INPUT LANGUAGE SQL AS $$ SELECT CASE WHEN x IS NULL THEN -1 ELSE x + 100 END $$;
+
+statement ok
+CREATE TABLE cc_udf_strict_t (a INT PRIMARY KEY, b INT);
+
+statement ok
+INSERT INTO cc_udf_strict_t VALUES (1, 10), (2, NULL), (3, 30), (4, NULL);
+
+statement ok
+ALTER TABLE cc_udf_strict_t ADD COLUMN c INT AS (cc_udf_strict(b)) STORED;
+
+query III rowsort
+SELECT * FROM cc_udf_strict_t
+----
+1  10    110
+2  NULL  NULL
+3  30    130
+4  NULL  NULL
+
+# UDFs in expression indexes are supported via expression inlining.
+statement ok
+CREATE INDEX cc_udf_idx ON cc_udf_t (cc_udf_const());
+
+# UDFs with ordinal parameter references ($1, $2).
+statement ok
+CREATE FUNCTION cc_udf_ordinal(INT) RETURNS INT IMMUTABLE LANGUAGE SQL AS $$ SELECT $1 * 3 $$;
+
+statement ok
+CREATE TABLE cc_udf_ordinal_t (a INT PRIMARY KEY);
+
+statement ok
+INSERT INTO cc_udf_ordinal_t VALUES (1), (2), (3);
+
+statement ok
+ALTER TABLE cc_udf_ordinal_t ADD COLUMN b INT AS (cc_udf_ordinal(a)) STORED;
+
+query II rowsort
+SELECT * FROM cc_udf_ordinal_t
+----
+1  3
+2  6
+3  9
+
+# UDFs with multiple unnamed parameters (all referenced via $N).
+statement ok
+CREATE FUNCTION cc_udf_multi_unnamed(INT, INT) RETURNS INT IMMUTABLE LANGUAGE SQL AS $$
+  SELECT $1 + $2
+$$;
+
+statement ok
+CREATE TABLE cc_udf_multi_unnamed_t (a INT PRIMARY KEY, b INT);
+
+statement ok
+INSERT INTO cc_udf_multi_unnamed_t VALUES (1, 10), (2, 20);
+
+statement ok
+ALTER TABLE cc_udf_multi_unnamed_t ADD COLUMN c INT AS (cc_udf_multi_unnamed(a, b)) STORED;
+
+query III rowsort
+SELECT * FROM cc_udf_multi_unnamed_t
+----
+1  10  11
+2  20  22
+
+# UDFs with mixed named and ordinal references. CockroachDB stores
+# the body as written, so named params use names and unnamed use $N.
+statement ok
+CREATE FUNCTION cc_udf_mixed(x INT, INT) RETURNS INT IMMUTABLE LANGUAGE SQL AS $$ SELECT x + $2 $$;
+
+statement ok
+CREATE TABLE cc_udf_mixed_t (a INT PRIMARY KEY, b INT);
+
+statement ok
+INSERT INTO cc_udf_mixed_t VALUES (1, 10), (2, 20);
+
+statement ok
+ALTER TABLE cc_udf_mixed_t ADD COLUMN c INT AS (cc_udf_mixed(a, b)) STORED;
+
+query III rowsort
+SELECT * FROM cc_udf_mixed_t
+----
+1  10  11
+2  20  22
+
+# UDFs with CASE expressions and multiple branches.
+statement ok
+CREATE FUNCTION cc_udf_case(x INT) RETURNS INT IMMUTABLE LANGUAGE SQL AS $$
+  SELECT CASE WHEN x > 0 THEN x * 2 WHEN x < 0 THEN x * -1 ELSE 0 END
+$$;
+
+statement ok
+CREATE TABLE cc_udf_case_t (a INT PRIMARY KEY);
+
+statement ok
+INSERT INTO cc_udf_case_t VALUES (-5), (0), (10);
+
+statement ok
+ALTER TABLE cc_udf_case_t ADD COLUMN b INT AS (cc_udf_case(a)) STORED;
+
+query II rowsort
+SELECT * FROM cc_udf_case_t
+----
+-5  5
+0   0
+10  20
+
+# UDFs calling immutable builtins.
+statement ok
+CREATE FUNCTION cc_udf_builtins(x INT) RETURNS INT IMMUTABLE LANGUAGE SQL AS $$
+  SELECT abs(x) + length('hello')
+$$;
+
+statement ok
+CREATE TABLE cc_udf_builtins_t (a INT PRIMARY KEY);
+
+statement ok
+INSERT INTO cc_udf_builtins_t VALUES (-3);
+
+statement ok
+ALTER TABLE cc_udf_builtins_t ADD COLUMN b INT AS (cc_udf_builtins(a)) STORED;
+
+query II
+SELECT * FROM cc_udf_builtins_t
+----
+-3  8
+
+# UDFs with type casts and string concatenation.
+statement ok
+CREATE FUNCTION cc_udf_casts(x INT) RETURNS TEXT IMMUTABLE LANGUAGE SQL AS $$
+  SELECT x::TEXT || '_suffix'
+$$;
+
+statement ok
+CREATE TABLE cc_udf_casts_t (a INT PRIMARY KEY);
+
+statement ok
+INSERT INTO cc_udf_casts_t VALUES (42);
+
+statement ok
+ALTER TABLE cc_udf_casts_t ADD COLUMN b TEXT AS (cc_udf_casts(a)) STORED;
+
+query IT
+SELECT * FROM cc_udf_casts_t
+----
+42  42_suffix
+
+# UDFs with COALESCE and NULLIF.
+statement ok
+CREATE FUNCTION cc_udf_coalesce(x INT) RETURNS INT IMMUTABLE LANGUAGE SQL AS $$
+  SELECT coalesce(nullif(x, 0), -1)
+$$;
+
+statement ok
+CREATE TABLE cc_udf_coalesce_t (a INT PRIMARY KEY);
+
+statement ok
+INSERT INTO cc_udf_coalesce_t VALUES (0), (5);
+
+statement ok
+ALTER TABLE cc_udf_coalesce_t ADD COLUMN b INT AS (cc_udf_coalesce(a)) STORED;
+
+query II rowsort
+SELECT * FROM cc_udf_coalesce_t
+----
+0   -1
+5   5
+
+# UDFs with multiple parameters.
+statement ok
+CREATE FUNCTION cc_udf_multi(a INT, b INT, c TEXT) RETURNS TEXT IMMUTABLE LANGUAGE SQL AS $$
+  SELECT CASE
+    WHEN a > b THEN c || '_a_wins'
+    WHEN b > a THEN c || '_b_wins'
+    ELSE c || '_tie'
+  END
+$$;
+
+statement ok
+CREATE TABLE cc_udf_multi_t (x INT PRIMARY KEY, y INT, label TEXT);
+
+statement ok
+INSERT INTO cc_udf_multi_t VALUES (1, 2, 'game1'), (5, 3, 'game2'), (4, 4, 'game3');
+
+statement ok
+ALTER TABLE cc_udf_multi_t ADD COLUMN result TEXT AS (cc_udf_multi(x, y, label)) STORED;
+
+query IITT rowsort
+SELECT * FROM cc_udf_multi_t
+----
+1  2  game1  game1_b_wins
+4  4  game3  game3_tie
+5  3  game2  game2_a_wins
+
+# UDFs with array constructors.
+statement ok
+CREATE FUNCTION cc_udf_array(x INT) RETURNS INT[] IMMUTABLE LANGUAGE SQL AS $$
+  SELECT ARRAY[x, x+1, x+2]
+$$;
+
+statement ok
+CREATE TABLE cc_udf_array_t (a INT PRIMARY KEY);
+
+statement ok
+INSERT INTO cc_udf_array_t VALUES (1);
+
+statement ok
+ALTER TABLE cc_udf_array_t ADD COLUMN b INT[] AS (cc_udf_array(a)) STORED;
+
+query IT
+SELECT * FROM cc_udf_array_t
+----
+1  {1,2,3}
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/udf_unsupported
+++ b/pkg/sql/logictest/testdata/logic_test/udf_unsupported
@@ -1,26 +1,94 @@
-subtest disallow_udf_in_table
+subtest udf_computed_column_limitations
+
+# The following tests verify that UDF patterns which cannot be inlined
+# for schema change backfill are rejected at DDL time (CREATE TABLE,
+# ALTER TABLE ADD COLUMN). While the optimizer can evaluate these
+# patterns directly, rejecting them upfront prevents creating tables
+# that cannot have schema changes performed on them.
+
+# UDFs with OUT parameters cannot be inlined.
+statement ok
+CREATE FUNCTION cc_udf_out(x INT, OUT result INT) RETURNS INT IMMUTABLE LANGUAGE SQL AS $$ SELECT x + 1 $$;
+
+statement error pgcode 0A000 unimplemented: user-defined functions with OUT or INOUT parameters in computed columns cannot be evaluated in this context
+CREATE TABLE cc_udf_out_t (a INT PRIMARY KEY, b INT AS (cc_udf_out(a)) STORED);
+
+# Multi-statement UDFs cannot be inlined.
+statement ok
+CREATE FUNCTION cc_udf_multi_stmt(x INT) RETURNS INT IMMUTABLE LANGUAGE SQL AS $$
+  SELECT x + 1;
+  SELECT x + 2
+$$;
+
+statement error pgcode 0A000 unimplemented: multi-statement user-defined functions in computed columns cannot be evaluated in this context
+CREATE TABLE cc_udf_multi_stmt_t (a INT PRIMARY KEY, b INT AS (cc_udf_multi_stmt(a)) STORED);
+
+# ALTER TABLE ADD COLUMN is also rejected.
+statement ok
+CREATE TABLE cc_udf_multi_stmt_alter_t (a INT PRIMARY KEY);
+
+statement error pgcode 0A000 unimplemented: multi-statement user-defined functions in computed columns cannot be evaluated in this context
+ALTER TABLE cc_udf_multi_stmt_alter_t ADD COLUMN b INT AS (cc_udf_multi_stmt(a)) STORED;
+
+# PL/pgSQL UDFs cannot be inlined.
+statement ok
+CREATE FUNCTION cc_udf_plpgsql(x INT) RETURNS INT IMMUTABLE LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RETURN x + 1;
+  END
+$$;
+
+statement error pgcode 0A000 unimplemented: PL/pgSQL user-defined functions in computed columns cannot be evaluated in this context
+CREATE TABLE cc_udf_plpgsql_t (a INT PRIMARY KEY, b INT AS (cc_udf_plpgsql(a)) STORED);
+
+# Scalar subqueries in UDF body cannot be inlined.
+statement ok
+CREATE FUNCTION cc_udf_subquery(x INT) RETURNS INT IMMUTABLE LANGUAGE SQL AS $$
+  SELECT x + (SELECT 100)
+$$;
+
+statement error pgcode 0A000 unimplemented: user-defined functions with subqueries in computed columns cannot be evaluated in this context
+CREATE TABLE cc_udf_subquery_t (a INT PRIMARY KEY, b INT AS (cc_udf_subquery(a)) STORED);
+
+# CTEs in UDF body cannot be inlined.
+statement ok
+CREATE FUNCTION cc_udf_cte(x INT) RETURNS INT IMMUTABLE LANGUAGE SQL AS $$
+  WITH t AS (SELECT x + 10 AS v) SELECT v FROM t
+$$;
+
+statement error pgcode 0A000 unimplemented: user-defined functions with CTEs in computed columns cannot be evaluated in this context
+CREATE TABLE cc_udf_cte_t (a INT PRIMARY KEY, b INT AS (cc_udf_cte(a)) STORED);
+
+# Generator (set-returning) functions inside a UDF body are rejected.
+# The function itself is not SETOF, but its body contains
+# generate_series which is a generator.
+statement ok
+CREATE FUNCTION cc_udf_gen_body(x INT) RETURNS INT IMMUTABLE LANGUAGE SQL AS $$
+  SELECT generate_series(1, x)
+$$;
+
+statement error set-returning functions are not allowed in STORED COMPUTED COLUMN
+CREATE TABLE cc_udf_gen_body_t (a INT PRIMARY KEY, b INT AS (cc_udf_gen_body(a)) STORED);
+
+# Nested UDF calls cannot be inlined (the inliner does not recurse).
+statement ok
+CREATE FUNCTION cc_udf_inner(x INT) RETURNS INT IMMUTABLE LANGUAGE SQL AS $$ SELECT x * 10 $$;
 
 statement ok
-CREATE FUNCTION test_tbl_f() RETURNS INT IMMUTABLE LANGUAGE SQL AS $$ SELECT 1 $$;
+CREATE FUNCTION cc_udf_outer(x INT) RETURNS INT IMMUTABLE LANGUAGE SQL AS $$ SELECT cc_udf_inner(x) + 1 $$;
 
+statement error pgcode 0A000 unimplemented: nested user-defined function calls in computed columns cannot be evaluated in this context
+CREATE TABLE cc_udf_nested_t (a INT PRIMARY KEY, b INT AS (cc_udf_outer(a)) STORED);
+
+# RECORD-returning UDFs are rejected because the return type (tuple)
+# does not match any valid column type.
 statement ok
-CREATE TABLE test_tbl_t (a INT PRIMARY KEY, b INT);
+CREATE FUNCTION cc_udf_record(x INT) RETURNS RECORD IMMUTABLE LANGUAGE SQL AS $$
+  SELECT x, x+1
+$$;
 
-# Insert a row to verify that backfills that use UDFs are blocked without internal errors.
-statement ok
-INSERT INTO test_tbl_t VALUES (1, 1);
-
-statement error pgcode 0A000 unimplemented: cannot evaluate function in this context
-ALTER TABLE test_tbl_t ADD COLUMN c int AS (test_tbl_f()) stored;
-
-statement error pgcode 0A000 unimplemented: cannot evaluate function in this context
-ALTER TABLE test_tbl_t ADD COLUMN c int DEFAULT (test_tbl_f());
-
-statement error pgcode 0A000 unimplemented: cannot evaluate function in this context
-CREATE INDEX t_idx_partial ON test_tbl_t(b) WHERE test_tbl_f() > 0;
-
-statement error pgcode 0A000 unimplemented: cannot evaluate function in this context
-CREATE INDEX idx_b ON test_tbl_t (test_tbl_f());
+statement error expected STORED COMPUTED COLUMN expression to have type int, but .* has type tuple
+CREATE TABLE cc_udf_record_t (a INT PRIMARY KEY, b INT AS (cc_udf_record(a)) STORED);
 
 subtest end
 

--- a/pkg/sql/row/row_converter.go
+++ b/pkg/sql/row/row_converter.go
@@ -484,20 +484,65 @@ func NewDatumRowConverter(
 		// MakeComputedExprs to map that of Datums.
 		colsOrdered[ri.InsertColIDtoRowIndex.GetDefault(col.GetID())] = col
 	}
-	// Here, computeExprs will be nil if there's no computed column, or
-	// the list of computed expressions (including nil, for those columns
-	// that are not computed) otherwise, according to colsOrdered.
-	c.computedExprs, _, err = schemaexpr.MakeComputedExprs(
-		ctx,
-		colsOrdered,
-		c.tableDesc.PublicColumns(),
-		c.tableDesc,
-		tree.NewUnqualifiedTableName(tree.Name(c.tableDesc.GetName())),
-		c.EvalCtx,
-		c.SemaCtx,
-	)
-	if err != nil {
-		return nil, errors.Wrapf(err, "error type checking and building computed expression for IMPORT INTO")
+
+	// If any computed columns reference UDFs, we need a FunctionResolver
+	// to resolve them by OID during type-checking. Set up a per-instance
+	// resolver using a bare-bones descs.Collection inside a short-lived
+	// txn, and call MakeComputedExprs within the txn so the resolver
+	// remains valid. Each DatumRowConverter instance gets its own
+	// resolver to avoid races when multiple import workers run in
+	// parallel. This mirrors the sequence resolution pattern above.
+	hasComputedCols := false
+	for _, col := range colsOrdered {
+		if col != nil && col.IsComputed() {
+			hasComputedCols = true
+			break
+		}
+	}
+	if hasComputedCols && c.SemaCtx.FunctionResolver == nil && c.db != nil {
+		cf := descs.NewBareBonesCollectionFactory(evalCtx.Settings, evalCtx.Codec)
+		dsdp := catsessiondata.NewDescriptorSessionDataStackProvider(evalCtx.SessionDataStack)
+		descsCol := cf.NewCollection(ctx, descs.WithDescriptorSessionDataProvider(dsdp))
+		defer descsCol.ReleaseAll(ctx)
+		err = c.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+			if err := txn.SetFixedTimestamp(ctx, hlc.Timestamp{WallTime: evalCtx.TxnTimestamp.UnixNano()}); err != nil {
+				return err
+			}
+			// Use ByIDWithoutLeased because the bare-bones collection
+			// does not have a lease manager.
+			c.SemaCtx.FunctionResolver = descs.NewDistSQLFunctionResolverFromGetter(
+				descsCol.ByIDWithoutLeased(txn).Get(),
+			)
+			c.computedExprs, _, err = schemaexpr.MakeComputedExprs(
+				ctx,
+				colsOrdered,
+				c.tableDesc.PublicColumns(),
+				c.tableDesc,
+				tree.NewUnqualifiedTableName(tree.Name(c.tableDesc.GetName())),
+				c.EvalCtx,
+				c.SemaCtx,
+			)
+			return err
+		})
+		if err != nil {
+			return nil, errors.Wrapf(err, "error type checking and building computed expression for IMPORT INTO")
+		}
+	} else {
+		// Here, computeExprs will be nil if there's no computed column, or
+		// the list of computed expressions (including nil, for those columns
+		// that are not computed) otherwise, according to colsOrdered.
+		c.computedExprs, _, err = schemaexpr.MakeComputedExprs(
+			ctx,
+			colsOrdered,
+			c.tableDesc.PublicColumns(),
+			c.tableDesc,
+			tree.NewUnqualifiedTableName(tree.Name(c.tableDesc.GetName())),
+			c.EvalCtx,
+			c.SemaCtx,
+		)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error type checking and building computed expression for IMPORT INTO")
+		}
 	}
 
 	// Here, partialIndexExprs will be nil if there are no partial indexes, or a


### PR DESCRIPTION
## Summary

IMPORT INTO fails when the destination table has computed columns that
reference user-defined functions, with error `function <oid> not found`.

This PR fixes the issue in two commits:

1. **importer: set up FunctionResolver for computed column type-checking** —
   Sets up a `DistSQLFunctionResolver` on the `SemaContext` during import so
   that UDF references (stored as OIDs) in computed column expressions can be
   resolved. Follows the existing pattern from `ColumnBackfiller.InitForDistributedUse`.

2. **schemaexpr: inline UDF calls in computed column expressions** —
   Adds UDF inlining in `MakeComputedExprs` (the shared entry point for both
   IMPORT and backfill) so that `eval.Expr` can evaluate the resulting
   expressions without requiring the full optimizer/execbuilder infrastructure.
   Only single-statement immutable SQL UDFs are supported, which is the only
   kind allowed in computed columns.

Fixes: #157195
Informs: #147472

## Test plan

- Added `TestImportIntoComputedColumnWithUDF` regression test
- Verified existing `TestImportIntoUserDefinedTypes` still passes
- Verified `schemaexpr` unit tests still pass