### PR TITLE
sql,stats: minor cleanup around logging scan misestimates

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -3659,7 +3659,7 @@ func (ex *connExecutor) execWithDistSQLEngine(
 	}
 
 	if err == nil && res.Err() == nil {
-		recv.maybeLogMisestimates(ctx, planner)
+		recv.handleMisestimates(ctx, planner)
 	}
 	return recv.stats, err
 }

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -222,7 +222,7 @@ func (n *createStatsNode) runJob(ctx context.Context) error {
 	if err := n.p.ExecCfg().InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) (err error) {
 		if n.isAuto() {
 			if details.UseLocksTable {
-				if err := n.checkConcurrencyLimit(ctx, txn, details.Table.ID, jobID); err != nil {
+				if err := n.checkConcurrencyLimit(ctx, txn, details, jobID); err != nil {
 					return err
 				}
 			} else if !jobCheckBefore {
@@ -271,15 +271,18 @@ func (n *createStatsNode) runJob(ctx context.Context) error {
 	return err
 }
 
-func getAutoStatsKind(name string) int {
-	switch name {
+func getAutoStatsKind(details jobspb.CreateStatsDetails) int {
+	switch details.Name {
 	case jobspb.AutoStatsName:
 		return 1
 	case jobspb.AutoPartialStatsName:
-		return 2
+		if details.UsingExtremes {
+			return 2
+		}
+		fallthrough
 	default:
 		if buildutil.CrdbTestBuild {
-			panic(errors.AssertionFailedf("getAutoStatsKind shouldn't have been called for %s stats job", name))
+			panic(errors.AssertionFailedf("getAutoStatsKind shouldn't have been called for %s stats job", details.Name))
 		}
 		return 0
 	}
@@ -318,12 +321,13 @@ var checkGlobalStatsJobsQuery = fmt.Sprintf(checkStatsJobsQuery, " = $2")
 // system.table_statistics_locks have been acquired and the caller / the new
 // stats job is responsible for releasing them when job reaches terminal state).
 func (n *createStatsNode) checkConcurrencyLimit(
-	ctx context.Context, txn isql.Txn, tableID descpb.ID, jobID jobspb.JobID,
+	ctx context.Context, txn isql.Txn, details jobspb.CreateStatsDetails, jobID jobspb.JobID,
 ) error {
 	if !n.isAuto() {
 		// We don't apply any concurrency limits to manual stats jobs.
 		return nil
 	}
+	tableID := details.Table.ID
 	var tableLimitQuery string
 	var globalLimit int
 	switch n.Name {
@@ -334,7 +338,7 @@ func (n *createStatsNode) checkConcurrencyLimit(
 		tableLimitQuery = checkExtremesStatsJobsQuery
 		globalLimit = int(automaticExtremesStatsConcurrencyLimit.Get(n.p.ExecCfg().SV()))
 	}
-	kind := getAutoStatsKind(string(n.Name))
+	kind := getAutoStatsKind(details)
 
 	// First, limit the concurrency on the target table to at most one.
 	row, err := txn.QueryRowEx(
@@ -388,16 +392,16 @@ func (n *createStatsNode) checkConcurrencyLimit(
 // release the locks that were acquired for the given JobID. The method assumes
 // that it's called on behalf of an auto stats job.
 func releaseAutoStatsConcurrencyLocks(
-	ctx context.Context, txn isql.Txn, tableID descpb.ID, jobID jobspb.JobID, statsJobName string,
+	ctx context.Context, txn isql.Txn, details jobspb.CreateStatsDetails, jobID jobspb.JobID,
 ) error {
-	kind := getAutoStatsKind(statsJobName)
+	kind := getAutoStatsKind(details)
 
 	// Simply overwrite the table-specific row to have empty job_ids since we
 	// allow at most one auto stats job on any table.
 	_, err := txn.ExecEx(
 		ctx, "create-stats-release-table-lock", txn.KV(), sessiondata.InternalExecutorOverride{},
 		"UPSERT INTO system.table_statistics_locks (table_id, kind, job_ids) VALUES ($1, $2, '{}')",
-		tableID, kind,
+		details.Table.ID, kind,
 	)
 	if err != nil {
 		return err
@@ -969,8 +973,7 @@ func createStatsDefaultColumns(
 // createStatsResumer implements the jobs.Resumer interface for CreateStats
 // jobs. A new instance is created for each job.
 type createStatsResumer struct {
-	job     *jobs.Job
-	tableID descpb.ID
+	job *jobs.Job
 }
 
 var _ jobs.Resumer = &createStatsResumer{}
@@ -991,7 +994,7 @@ func (r *createStatsResumer) Resume(ctx context.Context, execCtx interface{}) (r
 		defer func() {
 			if retErr == nil {
 				retErr = jobsPlanner.ExecCfg().InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-					return releaseAutoStatsConcurrencyLocks(ctx, txn, r.tableID, r.job.ID(), details.Name)
+					return releaseAutoStatsConcurrencyLocks(ctx, txn, details, r.job.ID())
 				})
 				if retErr != nil {
 					log.Dev.Warningf(ctx, "failed to release auto stats concurrency locks: %v", retErr)
@@ -1015,8 +1018,6 @@ func (r *createStatsResumer) Resume(ctx context.Context, execCtx interface{}) (r
 			return err
 		}
 	}
-
-	r.tableID = details.Table.ID
 
 	if err := jobsPlanner.ExecCfg().InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 		// We create a third "inner planner" associated with this txn in order to
@@ -1257,7 +1258,7 @@ func (r *createStatsResumer) OnFailOrCancel(
 		return nil
 	}
 	return execCtx.(JobExecContext).ExecCfg().InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-		return releaseAutoStatsConcurrencyLocks(ctx, txn, r.tableID, r.job.ID(), details.Name)
+		return releaseAutoStatsConcurrencyLocks(ctx, txn, details, r.job.ID())
 	})
 }
 

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -28,7 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/colflow"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
@@ -1167,6 +1167,7 @@ type DistSQLReceiver struct {
 	// scanStageEstimateMap maps stage IDs for logical scans to their
 	// corresponding scanStageEstimate.
 	scanStageEstimateMap map[int32]scanStageEstimate
+	logMisestimates      bool
 
 	// isTenantExplainAnalyze is used to indicate that network egress should be
 	// collected in order to estimate RU consumption for a tenant that is running
@@ -1191,6 +1192,8 @@ type DistSQLReceiver struct {
 }
 
 var _ metadataForwarder = &DistSQLReceiver{}
+var _ execinfra.RowReceiver = &DistSQLReceiver{}
+var _ execinfra.BatchReceiver = &DistSQLReceiver{}
 
 // rowResultWriter is a subset of CommandResult to be used with the
 // DistSQLReceiver. It's implemented by RowResultWriter.
@@ -1405,7 +1408,7 @@ func (c *CallbackResultWriter) Err() error {
 type scanStageEstimate struct {
 	estimatedRowCount uint64
 	statsCreatedAt    time.Time
-	tableID           descpb.ID
+	tableDesc         catalog.TableDescriptor
 	indexName         string
 
 	rowsRead uint64
@@ -1414,7 +1417,9 @@ type scanStageEstimate struct {
 var misestimateLogLimiter = log.Every(10 * time.Second)
 
 func (s *scanStageEstimate) logMisestimate(ctx context.Context, planner *planner) {
-	tn, err := planner.GetQualifiedTableNameByID(ctx, int64(s.tableID), tree.ResolveAnyTableKind)
+	// TODO(yuzefovich): we have the table descriptor, so we can probably
+	// simplify this.
+	tn, err := planner.GetQualifiedTableNameByID(ctx, int64(s.tableDesc.GetID()), tree.ResolveAnyTableKind)
 	if err != nil {
 		return
 	}
@@ -1432,16 +1437,13 @@ func (s *scanStageEstimate) logMisestimate(ctx context.Context, planner *planner
 		event.NanosSinceStatsCollected = nanosSinceStats
 
 		if estimatedStaleness, err :=
-			planner.ExecCfg().StatsRefresher.EstimateStaleness(ctx, s.tableID); err == nil {
+			planner.ExecCfg().StatsRefresher.EstimateStaleness(ctx, s.tableDesc); err == nil {
 			event.EstimatedStaleness = estimatedStaleness
 		}
 	}
 
 	log.StructuredEvent(ctx, severity.WARNING, event)
 }
-
-var _ execinfra.RowReceiver = &DistSQLReceiver{}
-var _ execinfra.BatchReceiver = &DistSQLReceiver{}
 
 var receiverSyncPool = sync.Pool{
 	New: func() interface{} {
@@ -1930,32 +1932,68 @@ func (r *DistSQLReceiver) ProducerDone() {
 	r.closed = true
 }
 
-func (r *DistSQLReceiver) makeScanEstimates(physPlan *PhysicalPlan, st *cluster.Settings) {
-	if !execinfra.LogScanRowCountMisestimate.Get(&st.SV) {
+// logScanRowCountMisestimate controls whether we log a warning when the
+// actual row count observed by a scan differs significantly from the optimizer
+// estimate.
+var logScanRowCountMisestimate = settings.RegisterBoolSetting(
+	settings.ApplicationLevel,
+	"sql.log.scan_row_count_misestimate.enabled",
+	"when set to true, log a warning when a scan's actual row count differs "+
+		"significantly from the optimizer's estimate",
+	false,
+	settings.WithPublic,
+)
+
+func (r *DistSQLReceiver) makeScanEstimates(
+	ctx context.Context, planner *planner, physPlan *PhysicalPlan, st *cluster.Settings,
+) {
+	if planner.SessionData().Internal {
+		// Internal queries should only touch the system tables which we exempt
+		// from the scan estimates.
+		return
+	}
+	r.logMisestimates = logScanRowCountMisestimate.Get(&st.SV)
+	if !r.logMisestimates {
 		return
 	}
 
 	for _, p := range physPlan.Processors {
-		if p.Spec.Core.TableReader == nil {
+		core := p.Spec.Core.TableReader
+		if core == nil {
 			continue
 		}
 		stageID := p.Spec.StageID
-		if _, exists := r.scanStageEstimateMap[stageID]; !exists {
-			r.scanStageEstimateMap[stageID] = scanStageEstimate{
-				estimatedRowCount: p.Spec.EstimatedRowCount,
-				statsCreatedAt:    p.Spec.StatsCreatedAt,
-				tableID:           p.Spec.Core.TableReader.FetchSpec.TableID,
-				indexName:         p.Spec.Core.TableReader.FetchSpec.IndexName,
-			}
+		if _, exists := r.scanStageEstimateMap[stageID]; exists {
+			continue
+		}
+		tableID := core.FetchSpec.TableID
+		tableDesc, err := planner.LookupTableByID(ctx, tableID)
+		if err != nil {
+			continue
+		}
+		// Exempt the following:
+		// - system tables since we hope to have the internal queries touching
+		//   them to be resilient / agnostic to table stats and the users
+		//   shouldn't be touching the system tables.
+		// - virtual tables and views since we cannot collect stats on them.
+		if catalog.IsSystemDescriptor(tableDesc) || tableDesc.IsVirtualTable() || tableDesc.IsView() {
+			continue
+		}
+		r.scanStageEstimateMap[stageID] = scanStageEstimate{
+			estimatedRowCount: p.Spec.EstimatedRowCount,
+			statsCreatedAt:    p.Spec.StatsCreatedAt,
+			tableDesc:         tableDesc,
+			indexName:         core.FetchSpec.IndexName,
 		}
 	}
 }
 
-func (r *DistSQLReceiver) maybeLogMisestimates(ctx context.Context, planner *planner) {
-	if !execinfra.LogScanRowCountMisestimate.Get(&planner.ExecCfg().Settings.SV) {
+// TODO(yuzefovich): consider whether we want to handle misestimates for
+// postqueries too.
+func (r *DistSQLReceiver) handleMisestimates(ctx context.Context, planner *planner) {
+	if !r.logMisestimates {
 		return
 	}
-
 	checkedLimiter := false
 	for _, s := range r.scanStageEstimateMap {
 		actualRowCount := s.rowsRead
@@ -1972,18 +2010,17 @@ func (r *DistSQLReceiver) maybeLogMisestimates(ctx context.Context, planner *pla
 		if !inaccurateEstimate {
 			continue
 		}
-		if isSystemTable, err := planner.IsSystemTable(ctx, int64(s.tableID)); err != nil || isSystemTable {
-			continue
-		}
 
-		// Log all or none of the misestimated scans in the query.
-		if !checkedLimiter {
-			if !misestimateLogLimiter.ShouldLog() {
-				return
+		if r.logMisestimates {
+			if !checkedLimiter {
+				// Log all or none of the misestimated scans in the query.
+				if !misestimateLogLimiter.ShouldLog() {
+					return
+				}
+				checkedLimiter = true
 			}
-			checkedLimiter = true
+			s.logMisestimate(ctx, planner)
 		}
-		s.logMisestimate(ctx, planner)
 	}
 }
 
@@ -2179,7 +2216,7 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 	// receiver, and use it and serialize the results of the subquery. The type
 	// of the results stored in the container depends on the type of the subquery.
 	subqueryRecv := recv.clone()
-	subqueryRecv.makeScanEstimates(subqueryPhysPlan, dsp.st)
+	subqueryRecv.makeScanEstimates(ctx, planner, subqueryPhysPlan, dsp.st)
 	defer subqueryRecv.Release()
 	defer recv.stats.add(&subqueryRecv.stats)
 	var typs []*types.T
@@ -2305,7 +2342,7 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 		// with many duplicate elements.
 		subqueryResultMemAcc.Shrink(ctx, alreadyAccountedFor-actualSize)
 	}
-	subqueryRecv.maybeLogMisestimates(ctx, planner)
+	subqueryRecv.handleMisestimates(ctx, planner)
 	return nil
 }
 
@@ -2353,7 +2390,7 @@ func (dsp *DistSQLPlanner) PlanAndRun(
 	} else {
 		finalizePlanWithRowCount(ctx, planCtx, physPlan, planCtx.planner.curPlan.mainRowCount)
 		recv.expectedRowsRead = int64(physPlan.TotalEstimatedScannedRows)
-		recv.makeScanEstimates(physPlan, dsp.st)
+		recv.makeScanEstimates(ctx, planCtx.planner, physPlan, dsp.st)
 		dsp.Run(ctx, planCtx, txn, physPlan, recv, &extEvalCtx.Context, finishedSetupFn)
 	}
 	if planCtx.isLocal {
@@ -2426,7 +2463,7 @@ func (dsp *DistSQLPlanner) PlanAndRun(
 		}
 		finalizePlanWithRowCount(ctx, localPlanCtx, localPhysPlan, localPlanCtx.planner.curPlan.mainRowCount)
 		recv.expectedRowsRead = int64(localPhysPlan.TotalEstimatedScannedRows)
-		recv.makeScanEstimates(localPhysPlan, dsp.st)
+		recv.makeScanEstimates(ctx, localPlanCtx.planner, localPhysPlan, dsp.st)
 		// We already called finishedSetupFn in the previous call to Run, since we
 		// only got here if we got a distributed error, not an error during setup.
 		dsp.Run(ctx, localPlanCtx, txn, localPhysPlan, recv, &extEvalCtx.Context, nil /* finishedSetupFn */)

--- a/pkg/sql/execinfra/utils.go
+++ b/pkg/sql/execinfra/utils.go
@@ -60,15 +60,3 @@ var IncludeRUEstimateInExplainAnalyze = settings.RegisterBoolSetting(
 	true,
 	settings.WithName("sql.explain_analyze.include_ru_estimation.enabled"),
 )
-
-// LogScanRowCountMisestimate controls whether we log a warning when the
-// actual row count observed by a scan differs significantly from the optimizer
-// estimate.
-var LogScanRowCountMisestimate = settings.RegisterBoolSetting(
-	settings.ApplicationLevel,
-	"sql.log.scan_row_count_misestimate.enabled",
-	"when set to true, log a warning when a scan's actual row count differs "+
-		"significantly from the optimizer's estimate",
-	false,
-	settings.WithPublic,
-)

--- a/pkg/sql/stats/automatic_stats.go
+++ b/pkg/sql/stats/automatic_stats.go
@@ -345,10 +345,6 @@ type TableStatsTestingKnobs struct {
 	// DisableInitialTableCollection, if set, indicates that the "initial table
 	// collection" performed by the Refresher should be skipped.
 	DisableInitialTableCollection bool
-	// DisableFullStatsRefresh, if set, indicates that the Refresher should not
-	// perform full statistics refreshes. Useful for testing the partial stats
-	// refresh logic.
-	DisableFullStatsRefresh bool
 	// StubTimeNow allows tests to override the current time, used by
 	// EstimateStaleness to get the latest stats' age.
 	StubTimeNow func() time.Time
@@ -554,6 +550,13 @@ func (r *Refresher) Start(
 		return nil
 	}
 
+	// We always sleep for r.asOfTime at the beginning of each refresh, so
+	// subtract it from the refreshInterval.
+	refreshInterval -= r.asOfTime
+	if refreshInterval < 0 {
+		refreshInterval = 0
+	}
+
 	// The refresher has the same lifetime as the server, so the cancellation
 	// function can be ignored and it'll be called by the stopper.
 	stoppingCtx, _ := stopper.WithCancelOnQuiesce(context.Background()) // nolint:quiesce
@@ -561,13 +564,6 @@ func (r *Refresher) Start(
 	r.startedTasksWG.Add(1)
 	if err := stopper.RunAsyncTask(bgCtx, "refresher", func(ctx context.Context) {
 		defer r.startedTasksWG.Done()
-
-		// We always sleep for r.asOfTime at the beginning of each refresh, so
-		// subtract it from the refreshInterval.
-		refreshInterval -= r.asOfTime
-		if refreshInterval < 0 {
-			refreshInterval = 0
-		}
 
 		timer := time.NewTimer(refreshInterval)
 		defer timer.Stop()
@@ -685,7 +681,6 @@ func (r *Refresher) Start(
 							case <-ctx.Done():
 								return
 							case <-r.drainAutoStats:
-								// Ditto.
 								return
 							default:
 							}
@@ -904,12 +899,10 @@ func (r *Refresher) NotifyMutation(
 // EstimateStaleness returns an estimate fraction of stale rows in the given
 // table based on how long it has been since the last full statistics refresh,
 // and the average time between refreshes.
-func (r *Refresher) EstimateStaleness(ctx context.Context, tableID descpb.ID) (float64, error) {
-	desc := r.getTableDescriptor(ctx, tableID)
-	if desc == nil {
-		return 0, errors.New("could not access the table descriptor")
-	}
-	if !r.cache.autostatsCollectionAllowed(desc) {
+func (r *Refresher) EstimateStaleness(
+	ctx context.Context, tableDesc catalog.TableDescriptor,
+) (float64, error) {
+	if !r.cache.autostatsCollectionAllowed(tableDesc) {
 		return 0, errors.New("automatic stats collection is not allowed for this table")
 	}
 
@@ -917,7 +910,7 @@ func (r *Refresher) EstimateStaleness(ctx context.Context, tableID descpb.ID) (f
 	// NB: we pass nil boolean as 'forecast' argument in order to not invalidate
 	// the stats cache entry since we don't care whether there is a forecast or
 	// not in the stats.
-	tableStats, err := r.cache.getTableStatsFromCache(ctx, tableID, forecast, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
+	tableStats, err := r.cache.getTableStatsFromCache(ctx, tableDesc.GetID(), forecast, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
 	if err != nil {
 		return 0, err
 	}
@@ -935,7 +928,7 @@ func (r *Refresher) EstimateStaleness(ctx context.Context, tableID descpb.ID) (f
 	}
 
 	var explicitSettings *catpb.AutoStatsSettings
-	if s, ok := r.settingOverrides[tableID]; ok {
+	if s, ok := r.settingOverrides[tableDesc.GetID()]; ok {
 		explicitSettings = &s
 	}
 	staleTargetFraction := r.autoStatsFractionStaleRows(explicitSettings)
@@ -1009,23 +1002,22 @@ func (r *Refresher) maybeRefreshStats(
 		mustRefresh = true
 	}
 
-	// We will always do a full stats refresh if we must or if the maximum
-	// rowsAffected value was specified.
-	doFullRefresh := mustRefresh || rowsAffected >= math.MaxInt32
-	if !doFullRefresh {
-		// Perform the "dice roll".
-		statsFractionStaleRows := r.autoStatsFractionStaleRows(explicitSettings)
-		statsMinStaleRows := r.autoStatsMinStaleRows(explicitSettings)
-		targetRows := int64(rowCount*statsFractionStaleRows) + statsMinStaleRows
-		randomTargetRows := int64(0)
-		if targetRows > 0 {
-			randomTargetRows = r.rng.Int63n(targetRows)
+	var doFullRefresh bool
+	if fullStatsEnabled {
+		// We will always do a full stats refresh if we must or if the maximum
+		// rowsAffected value was specified.
+		doFullRefresh = mustRefresh || rowsAffected >= math.MaxInt32
+		if !doFullRefresh {
+			// Perform the "dice roll".
+			statsFractionStaleRows := r.autoStatsFractionStaleRows(explicitSettings)
+			statsMinStaleRows := r.autoStatsMinStaleRows(explicitSettings)
+			targetRows := int64(rowCount*statsFractionStaleRows) + statsMinStaleRows
+			randomTargetRows := int64(0)
+			if targetRows > 0 {
+				randomTargetRows = r.rng.Int63n(targetRows)
+			}
+			doFullRefresh = randomTargetRows < rowsAffected
 		}
-		doFullRefresh = randomTargetRows < rowsAffected
-	}
-	if (r.knobs != nil && r.knobs.DisableFullStatsRefresh) || !fullStatsEnabled {
-		// We cannot do the full stats refresh.
-		doFullRefresh = false
 	}
 
 	if !doFullRefresh {

--- a/pkg/sql/stats/automatic_stats_test.go
+++ b/pkg/sql/stats/automatic_stats_test.go
@@ -1093,8 +1093,7 @@ func TestEstimateStaleness(t *testing.T) {
 
 	checkEstimatedStaleness := func(expected float64) error {
 		return testutils.SucceedsSoonError(func() error {
-			actual, err := refresher.EstimateStaleness(ctx,
-				table.GetID())
+			actual, err := refresher.EstimateStaleness(ctx, table)
 			if err != nil {
 				return err
 			}
@@ -1165,7 +1164,7 @@ func TestEstimateStaleness(t *testing.T) {
 	}
 
 	// Ensure that we return an error if estimating staleness without any stats.
-	_, err := refresher.EstimateStaleness(ctx, table.GetID())
+	_, err := refresher.EstimateStaleness(ctx, table)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "no full statistics available")
 
@@ -1173,7 +1172,7 @@ func TestEstimateStaleness(t *testing.T) {
 	// doesn't allow auto stats.
 	descTableStats := desctestutils.TestingGetPublicTableDescriptor(s.DB(),
 		codec, "system", "table_statistics")
-	_, err = refresher.EstimateStaleness(ctx, descTableStats.GetID())
+	_, err = refresher.EstimateStaleness(ctx, descTableStats)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "automatic stats collection is not allowed for this table")
 
@@ -1188,7 +1187,7 @@ func TestEstimateStaleness(t *testing.T) {
 	}
 
 	err = testutils.SucceedsSoonError(func() error {
-		_, err := refresher.EstimateStaleness(ctx, table.GetID())
+		_, err := refresher.EstimateStaleness(ctx, table)
 		if err == nil {
 			return fmt.Errorf("expected error but got nil")
 		}


### PR DESCRIPTION
This commit moves and renames a few things around. The only functional changes are:
- not creating scan estimates for internal queries (which previously was redundant since we don't handle misestimates for system tables, and internal queries - presumably - only touch those).
- exempting virtual tables and views from scan estimates - these are unactionable by the user (we can't collect stats on them), so there is no point in logging misestimates on them.
- being stricter in `getAutoStatsKind` around types of auto stats we expect.

Epic: CRDB-55121
Release note: None