### PR TITLE
changefeedccl: modify persisted frontier during ALTER CHANGEFEED

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -263,7 +263,6 @@ go_test(
         "//pkg/ccl/changefeedccl/cdctest",
         "//pkg/ccl/changefeedccl/changefeedbase",
         "//pkg/ccl/changefeedccl/changefeedpb",
-        "//pkg/ccl/changefeedccl/checkpoint",
         "//pkg/ccl/changefeedccl/kcjsonschema",
         "//pkg/ccl/changefeedccl/kvevent",
         "//pkg/ccl/changefeedccl/mocks",

--- a/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
@@ -7,7 +7,6 @@ package changefeedccl
 
 import (
 	"context"
-	"maps"
 	"net/url"
 	"slices"
 
@@ -271,7 +270,7 @@ func alterDatabaseChangefeed(
 	}
 
 	return finalizeAlterChangefeed(
-		ctx, p, job, jobID, jobRecord, newDetails, &newProgress, targets, resultsCh,
+		ctx, p, job, jobID, jobRecord, newDetails, &newProgress, nil, targets, resultsCh,
 	)
 }
 
@@ -315,9 +314,15 @@ func alterTableChangefeed(
 		return err
 	}
 
+	prevResolvedSpans, _, err := jobfrontier.GetAllResolvedSpans(
+		ctx, p.InternalSQLTxn(), jobID)
+	if err != nil {
+		return err
+	}
+
 	// Compute the new progress based on the table ops.
-	newProgress, err := generateNewProgressForTableOps(
-		p, prevProgress, prevHighWater, resumeTS, primaryIndexIDs, tableOps,
+	newProgress, newSpanFrontier, err := generateNewProgressForTableOps(
+		p, prevProgress, prevHighWater, prevResolvedSpans, resumeTS, primaryIndexIDs, tableOps,
 	)
 	if err != nil {
 		return err
@@ -365,12 +370,13 @@ func alterTableChangefeed(
 	newDetails.Opts[changefeedbase.OptInitialScan] = ``
 
 	return finalizeAlterChangefeed(
-		ctx, p, job, jobID, jobRecord, newDetails, &newProgress, targets, resultsCh,
+		ctx, p, job, jobID, jobRecord, newDetails, &newProgress, newSpanFrontier, targets, resultsCh,
 	)
 }
 
 // finalizeAlterChangefeed persists the new job payload and progress,
-// emits telemetry, and sends the result to resultsCh.
+// emits telemetry, and sends the result to resultsCh. If newSpanFrontier is
+// non-nil, it is stored as the coordinator frontier and released after use.
 func finalizeAlterChangefeed(
 	ctx context.Context,
 	p sql.PlanHookState,
@@ -379,6 +385,7 @@ func finalizeAlterChangefeed(
 	jobRecord *jobs.Record,
 	newDetails jobspb.ChangefeedDetails,
 	newProgress *jobspb.Progress,
+	newSpanFrontier span.Frontier,
 	targets changefeedbase.Targets,
 	resultsCh chan<- tree.Datums,
 ) error {
@@ -403,6 +410,14 @@ func finalizeAlterChangefeed(
 		ju.UpdatePayload(&newPayload)
 		if newProgress != nil {
 			ju.UpdateProgress(newProgress)
+		}
+		if newSpanFrontier != nil {
+			defer newSpanFrontier.Release()
+			if err := jobfrontier.Store(
+				ctx, txn, jobID, coordinatorFrontierName, newSpanFrontier,
+			); err != nil {
+				return err
+			}
 		}
 		return nil
 	}); err != nil {
@@ -938,26 +953,47 @@ func validateNewTargetsAtResumeTime(
 
 // generateNewProgressForTableOps computes the new job progress for the
 // given table operations. It modifies the checkpoint to ensure that we
-// don't do any extra initial scans of any targets.
+// don't do any extra initial scans of any targets. The returned frontier
+// represents the new coordinator frontier that should be persisted; the
+// caller takes ownership and is responsible for calling Release.
+//
+// TODO(#163256): Once span-level checkpoints are fully deleted, add an
+// early return for empty tableOps. Currently we always rebuild
+// progress so that SLC data can be folded into the frontier.
 func generateNewProgressForTableOps(
 	p sql.PlanHookState,
 	prevProgress jobspb.Progress,
 	prevHighWater hlc.Timestamp,
+	prevResolvedSpans []jobspb.ResolvedSpan,
 	resumeTS hlc.Timestamp,
 	primaryIndexIDs map[descpb.ID]descpb.IndexID,
 	tableOps map[descpb.ID]targetOp,
-) (jobspb.Progress, error) {
-	if len(tableOps) == 0 {
-		return prevProgress, nil
-	}
-
+) (jobspb.Progress, span.Frontier, error) {
 	var ptsRecord uuid.UUID
-	var checkpoint *jobspb.TimestampSpansMap
-	if changefeedProgress := prevProgress.GetChangefeed(); changefeedProgress != nil {
+	changefeedProgress := prevProgress.GetChangefeed()
+	if changefeedProgress != nil {
 		// TODO(#142369): We should create a new PTS record instead of just
 		// keeping the old one.
 		ptsRecord = changefeedProgress.ProtectedTimestampRecord
-		checkpoint = changefeedProgress.SpanLevelCheckpoint
+	}
+
+	// Build a combined checkpoint from both the persisted frontier
+	// and the span-level checkpoint.
+	checkpointBuilder, err := newCheckpointBuilder()
+	if err != nil {
+		return jobspb.Progress{}, nil, err
+	}
+	for _, rs := range prevResolvedSpans {
+		if err := checkpointBuilder.addSpans([]roachpb.Span{rs.Span}, rs.Timestamp); err != nil {
+			return jobspb.Progress{}, nil, err
+		}
+	}
+	if changefeedProgress != nil {
+		for ts, spans := range changefeedProgress.SpanLevelCheckpoint.All() {
+			if err := checkpointBuilder.addSpans(spans, ts); err != nil {
+				return jobspb.Progress{}, nil, err
+			}
+		}
 	}
 
 	var alteredSpanIDs, addedWithoutScanSpanIDs, addedWithScanSpanIDs []spanID
@@ -979,21 +1015,25 @@ func generateNewProgressForTableOps(
 	addedWithoutScanSpans := fetchSpansForDescs(p, addedWithoutScanSpanIDs)
 
 	// Remove all altered spans from the checkpoint.
-	checkpoint = removeSpansFromCheckpoint(checkpoint, alteredSpans)
+	if err := checkpointBuilder.removeSpans(alteredSpans); err != nil {
+		return jobspb.Progress{}, nil, err
+	}
 
 	// If we're still in an initial scan, all we need to do is add any new
 	// targets that don't need to be scanned to the checkpoint.
 	if prevHighWater.IsEmpty() {
-		checkpoint = addSpansToCheckpoint(checkpoint, addedWithoutScanSpans, resumeTS)
+		if err := checkpointBuilder.addSpans(addedWithoutScanSpans, resumeTS); err != nil {
+			return jobspb.Progress{}, nil, err
+		}
 		return jobspb.Progress{
 			Progress: &jobspb.Progress_HighWater{},
 			Details: &jobspb.Progress_Changefeed{
 				Changefeed: &jobspb.ChangefeedProgress{
 					ProtectedTimestampRecord: ptsRecord,
-					SpanLevelCheckpoint:      checkpoint,
+					SpanLevelCheckpoint:      checkpointBuilder.spanLevelCheckpoint(hlc.Timestamp{}),
 				},
 			},
-		}, nil
+		}, checkpointBuilder.frontier(), nil
 	}
 
 	// If we're done the initial scan already and don't need to do an initial scan
@@ -1006,10 +1046,10 @@ func generateNewProgressForTableOps(
 			Details: &jobspb.Progress_Changefeed{
 				Changefeed: &jobspb.ChangefeedProgress{
 					ProtectedTimestampRecord: ptsRecord,
-					SpanLevelCheckpoint:      checkpoint,
+					SpanLevelCheckpoint:      checkpointBuilder.spanLevelCheckpoint(prevHighWater),
 				},
 			},
-		}, nil
+		}, checkpointBuilder.frontier(), nil
 	}
 
 	// Otherwise, we'll need to reset the highwater so that we do an initial scan
@@ -1026,17 +1066,21 @@ func generateNewProgressForTableOps(
 		}
 	}
 	unchangedSpans := fetchSpansForDescs(p, unchangedSpanIDs)
-	checkpoint = addSpansToCheckpoint(checkpoint, unchangedSpans, resumeTS)
-	checkpoint = addSpansToCheckpoint(checkpoint, addedWithoutScanSpans, resumeTS)
+	if err := checkpointBuilder.addSpans(unchangedSpans, resumeTS); err != nil {
+		return jobspb.Progress{}, nil, err
+	}
+	if err := checkpointBuilder.addSpans(addedWithoutScanSpans, resumeTS); err != nil {
+		return jobspb.Progress{}, nil, err
+	}
 	return jobspb.Progress{
 		Progress: &jobspb.Progress_HighWater{},
 		Details: &jobspb.Progress_Changefeed{
 			Changefeed: &jobspb.ChangefeedProgress{
 				ProtectedTimestampRecord: ptsRecord,
-				SpanLevelCheckpoint:      checkpoint,
+				SpanLevelCheckpoint:      checkpointBuilder.spanLevelCheckpoint(hlc.Timestamp{}),
 			},
 		},
-	}, nil
+	}, checkpointBuilder.frontier(), nil
 }
 
 // storeFilterChangeFrontierForDatabaseChangefeed uses the persistent job frontier to ensure that
@@ -1119,40 +1163,65 @@ func storeFilterChangeFrontierForDatabaseChangefeed(
 	return jobfrontier.Store(ctx, p.InternalSQLTxn(), jobID, `alter_changefeed`, frontier)
 }
 
-// addSpansToCheckpoint returns a new checkpoint with the given spans
-// merged in at the given timestamp.
-func addSpansToCheckpoint(
-	checkpoint *jobspb.TimestampSpansMap, spans []roachpb.Span, ts hlc.Timestamp,
-) *jobspb.TimestampSpansMap {
-	checkpointSpansMap := make(map[hlc.Timestamp]roachpb.Spans)
-	if checkpoint != nil {
-		checkpointSpansMap = maps.Collect(checkpoint.All())
-	}
-	var spanGroup roachpb.SpanGroup
-	spanGroup.Add(checkpointSpansMap[ts]...)
-	spanGroup.Add(spans...)
-	checkpointSpansMap[ts] = spanGroup.Slice()
-	return jobspb.NewTimestampSpansMap(checkpointSpansMap)
+type checkpointBuilder struct {
+	f span.Frontier
 }
 
-// removeSpansFromCheckpoint returns a new checkpoint with the given
-// spans removed from all timestamps.
-func removeSpansFromCheckpoint(
-	checkpoint *jobspb.TimestampSpansMap, spans []roachpb.Span,
-) *jobspb.TimestampSpansMap {
-	if checkpoint == nil || checkpoint.IsEmpty() {
-		return checkpoint
+func newCheckpointBuilder() (*checkpointBuilder, error) {
+	f, err := span.MakeFrontier()
+	if err != nil {
+		return nil, err
 	}
-	checkpointSpansMap := make(map[hlc.Timestamp]roachpb.Spans)
-	for ts, sp := range checkpoint.All() {
-		var spanGroup roachpb.SpanGroup
-		spanGroup.Add(sp...)
-		spanGroup.Sub(spans...)
-		if remaining := spanGroup.Slice(); len(remaining) > 0 {
-			checkpointSpansMap[ts] = remaining
+	return &checkpointBuilder{f: f}, nil
+}
+
+// addSpans adds the given spans to the frontier at the given timestamp.
+func (b *checkpointBuilder) addSpans(spans []roachpb.Span, ts hlc.Timestamp) error {
+	return b.f.AddSpansAt(ts, spans...)
+}
+
+// removeSpans removes the given spans from the frontier by rebuilding it
+// with only the remaining spans.
+func (b *checkpointBuilder) removeSpans(spans []roachpb.Span) error {
+	var remaining roachpb.SpanGroup
+	for sp := range b.f.Entries() {
+		remaining.Add(sp)
+	}
+	remaining.Sub(spans...)
+
+	oldFrontier := b.f
+	newFrontier, err := span.MakeFrontier(remaining.Slice()...)
+	if err != nil {
+		return err
+	}
+	for sp, ts := range oldFrontier.Entries() {
+		if _, err := newFrontier.Forward(sp, ts); err != nil {
+			newFrontier.Release()
+			return err
 		}
 	}
-	return jobspb.NewTimestampSpansMap(checkpointSpansMap)
+	oldFrontier.Release()
+	b.f = newFrontier
+	return nil
+}
+
+// spanLevelCheckpoint builds a span-level checkpoint from the frontier
+// entries. Only entries strictly above highWater are included, since the SLC
+// only tracks spans ahead of the highwater mark.
+func (b *checkpointBuilder) spanLevelCheckpoint(highWater hlc.Timestamp) *jobspb.TimestampSpansMap {
+	result := make(map[hlc.Timestamp]roachpb.Spans)
+	for sp, ts := range b.f.Entries() {
+		if highWater.Less(ts) {
+			result[ts] = append(result[ts], sp)
+		}
+	}
+	return jobspb.NewTimestampSpansMap(result)
+}
+
+// frontier returns the built frontier. The caller takes ownership and is
+// responsible for calling Release.
+func (b *checkpointBuilder) frontier() span.Frontier {
+	return b.f
 }
 
 type spanID struct {

--- a/pkg/ccl/changefeedccl/alter_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_test.go
@@ -2239,6 +2239,8 @@ WITH resolved = '1s', no_initial_scan, min_checkpoint_frequency='1ns'`,
 			context.Background(), &s.Server.ClusterSettings().SV, 1*time.Nanosecond)
 		changefeedbase.SpanCheckpointMaxBytes.Override(
 			context.Background(), &s.Server.ClusterSettings().SV, maxCheckpointSize)
+		changefeedbase.FrontierPersistenceInterval.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, 100*time.Millisecond)
 
 		// backfillTimestamp is used to track the timestamp of the backfill scan.
 		// We only emit checkpoints that are part of the boundary event or part of
@@ -2287,10 +2289,12 @@ WITH resolved = '1s', no_initial_scan, min_checkpoint_frequency='1ns'`,
 		require.NoError(t, jobFeed.Resume())
 		sqlDB.Exec(t, `ALTER TABLE foo ADD COLUMN b STRING DEFAULT 'd'`)
 
-		// Wait for a checkpoint to have been set
+		// Wait for a checkpoint, indicating partial backfill progress,
+		// before altering the changefeed to add a new target.
+		idb := s.Server.InternalDB().(isql.DB)
 		testutils.SucceedsSoon(t, func() error {
-			progress := loadProgress(t, jobFeed, jobRegistry)
-			if checkpoint := loadCheckpoint(t, progress); checkpoint == nil {
+			checkpointSpans := loadCheckpointSpans(t, jobFeed.JobID(), idb)
+			if len(checkpointSpans) == 0 {
 				return errors.Newf("waiting for checkpoint")
 			}
 			require.NoError(t, jobFeed.FetchTerminalJobErr())
@@ -2410,6 +2414,8 @@ func TestAlterChangefeedAddTargetsDuringBackfill(t *testing.T) {
 			context.Background(), &s.Server.ClusterSettings().SV, 1)
 		changefeedbase.SpanCheckpointMaxBytes.Override(
 			context.Background(), &s.Server.ClusterSettings().SV, maxCheckpointSize)
+		changefeedbase.FrontierPersistenceInterval.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, 100*time.Millisecond)
 
 		registry := s.Server.JobRegistry().(*jobs.Registry)
 		testFeed := feed(t, f, `CREATE CHANGEFEED FOR foo
@@ -2435,9 +2441,10 @@ WITH resolved = '100ms', min_checkpoint_frequency='1ns'`, optOutOfMetamorphicDBL
 		}()
 
 		jobFeed := testFeed.(cdctest.EnterpriseTestFeed)
+		idb := s.Server.InternalDB().(isql.DB)
 
 		// Wait for non-nil checkpoint.
-		waitForCheckpoint(t, jobFeed, registry)
+		waitForCheckpoint(t, jobFeed, idb)
 
 		// Pause the job and read and verify the latest checkpoint information.
 		require.NoError(t, jobFeed.Pause())
@@ -2447,7 +2454,8 @@ WITH resolved = '100ms', min_checkpoint_frequency='1ns'`, optOutOfMetamorphicDBL
 		noHighWater := h == nil || h.IsEmpty()
 		require.True(t, noHighWater)
 
-		checkpoint := makeSpanGroupFromCheckpoint(t, loadCheckpoint(t, progress))
+		checkpointSpans := loadCheckpointSpans(t, jobFeed.JobID(), idb)
+		checkpoint := makeSpanGroupFromFrontierSpans(t, checkpointSpans)
 		require.Greater(t, checkpoint.Len(), 0)
 
 		sqlDB.Exec(t, fmt.Sprintf(`ALTER CHANGEFEED %d ADD bar WITH initial_scan`, jobFeed.JobID()))
@@ -2468,10 +2476,6 @@ WITH resolved = '100ms', min_checkpoint_frequency='1ns'`, optOutOfMetamorphicDBL
 
 		// Wait for highwater to be set, which signifies that the initial scan is complete.
 		waitForHighwater(t, jobFeed, registry)
-
-		// At this point, highwater mark should be set, and previous checkpoint should be gone.
-		progress = loadProgress(t, jobFeed, registry)
-		require.Nil(t, loadCheckpoint(t, progress))
 
 		require.NoError(t, jobFeed.Pause())
 

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -2021,6 +2021,10 @@ func (cf *changeFrontier) checkpointJobProgress(
 	return nil
 }
 
+// coordinatorFrontierName is the name used for persisting the coordinator
+// frontier in the job_info table.
+const coordinatorFrontierName = "coordinator"
+
 func (cf *changeFrontier) maybePersistFrontier(ctx context.Context) error {
 	ctx, sp := tracing.ChildSpan(ctx, "changefeed.frontier.maybe_persist_frontier")
 	defer sp.Finish()
@@ -2035,11 +2039,15 @@ func (cf *changeFrontier) maybePersistFrontier(ctx context.Context) error {
 	} else {
 		timer := cf.sliMetrics.Timers.FrontierPersistence.Start()
 		if err := cf.FlowCtx.Cfg.DB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-			return jobfrontier.Store(ctx, txn, cf.spec.JobID, "coordinator", cf.frontier)
+			return jobfrontier.Store(ctx, txn, cf.spec.JobID, coordinatorFrontierName, cf.frontier)
 		}); err != nil {
 			return err
 		}
 		cf.frontierPersistenceLimiter.doneSave(timer.End())
+	}
+
+	if log.V(2) {
+		log.Changefeed.Infof(ctx, "change frontier persisted span frontier=%s", cf.frontier)
 	}
 
 	if cf.knobs.AfterPersistFrontier != nil {

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -39,7 +39,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdcprogresspb"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
-	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/checkpoint"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/kvevent"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/resolvedspan"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/schemafeed/schematestutils"
@@ -2983,6 +2982,8 @@ func TestChangefeedLaggingSpanCheckpointing(t *testing.T) {
 		context.Background(), &s.ClusterSettings().SV, 100<<20 /* 100 MiB */)
 	changefeedbase.SpanCheckpointLagThreshold.Override(
 		context.Background(), &s.ClusterSettings().SV, 10*time.Millisecond)
+	changefeedbase.FrontierPersistenceInterval.Override(
+		context.Background(), &s.ClusterSettings().SV, 100*time.Millisecond)
 
 	// We'll start the changefeed with the cursor set to the current time (not insert time).
 	// NB: The changefeed created in this test doesn't actually send any message events.
@@ -3035,11 +3036,15 @@ WITH resolved='50ms', min_checkpoint_frequency='50ms', no_initial_scan, cursor=$
 	}
 
 	// We should eventually checkpoint some spans that are ahead of the highwater.
-	// We'll wait until we have two unique timestamps.
+	// We'll wait until we have two unique timestamps above the minimum.
+	idb := s.InternalDB().(isql.DB)
 	testutils.SucceedsSoon(t, func() error {
-		progress := loadProgress()
-		cp := maps.Collect(loadCheckpoint(t, progress).All())
-		if len(cp) >= 2 {
+		checkpointSpans := loadCheckpointSpans(t, jobID, idb)
+		tsSet := make(map[hlc.Timestamp]struct{})
+		for _, rs := range checkpointSpans {
+			tsSet[rs.Timestamp] = struct{}{}
+		}
+		if len(tsSet) >= 2 {
 			return nil
 		}
 		return errors.New("waiting for checkpoint with two different timestamps")
@@ -3054,15 +3059,28 @@ WITH resolved='50ms', min_checkpoint_frequency='50ms', no_initial_scan, cursor=$
 	progress := loadProgress()
 	require.True(t, progress.GetHighWater().IsEmpty() || progress.GetHighWater().Equal(cursor),
 		"expected empty highwater or %s, found %s", cursor, progress.GetHighWater())
-	spanLevelCheckpoint := loadCheckpoint(t, progress)
-	require.NotNil(t, spanLevelCheckpoint)
-	require.True(t, cursor.LessEq(spanLevelCheckpoint.MinTimestamp()))
+	checkpointSpans := loadCheckpointSpans(t, jobID, idb)
+	require.NotEmpty(t, checkpointSpans)
+	// Verify all checkpoint timestamps are at least at the cursor.
+	for _, rs := range checkpointSpans {
+		require.True(t, cursor.LessEq(rs.Timestamp),
+			"expected checkpoint timestamp >= %s, found %s", cursor, rs.Timestamp)
+	}
 
-	// Construct a reverse index from spans to timestamps.
+	// Construct a reverse index from spans to timestamps for all checkpointed
+	// spans. Any spans not in this map are expected to resume at the cursor.
 	spanTimestamps := make(map[string]hlc.Timestamp)
-	for ts, spans := range spanLevelCheckpoint.All() {
-		for _, s := range spans {
-			spanTimestamps[s.String()] = ts
+	for _, rs := range checkpointSpans {
+		spanTimestamps[rs.Span.String()] = rs.Timestamp
+	}
+	// TODO(#164598): Delete this code.
+	if cfProgress := progress.GetChangefeed(); cfProgress != nil {
+		for ts, spans := range cfProgress.SpanLevelCheckpoint.All() {
+			for _, sp := range spans {
+				if existing, ok := spanTimestamps[sp.String()]; !ok || existing.Less(ts) {
+					spanTimestamps[sp.String()] = ts
+				}
+			}
 		}
 	}
 
@@ -3211,6 +3229,8 @@ WITH resolved='100ms', min_checkpoint_frequency='1ns', no_initial_scan`)
 			context.Background(), &s.Server.ClusterSettings().SV, 1)
 		changefeedbase.SpanCheckpointMaxBytes.Override(
 			context.Background(), &s.Server.ClusterSettings().SV, maxCheckpointSize)
+		changefeedbase.FrontierPersistenceInterval.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, 100*time.Millisecond)
 
 		var tableSpan roachpb.Span
 		refreshTableSpan := func() {
@@ -3222,6 +3242,7 @@ WITH resolved='100ms', min_checkpoint_frequency='1ns', no_initial_scan`)
 		// FilterSpanWithMutation should ensure that once the backfill begins, the following resolved events
 		// that are for that backfill (are of the timestamp right after the backfill timestamp) resolve some
 		// but not all of the time, which results in a checkpoint eventually being created
+		idb := s.Server.InternalDB().(isql.DB)
 		numGaps := 0
 		var backfillTimestamp hlc.Timestamp
 		var initialCheckpoint roachpb.SpanGroup
@@ -3246,16 +3267,19 @@ WITH resolved='100ms', min_checkpoint_frequency='1ns', no_initial_scan`)
 				return false, nil
 			}
 
-			// Check if we've set a checkpoint yet
-			progress := loadProgress()
-			if spanLevelCheckpoint := loadCheckpoint(t, progress); spanLevelCheckpoint != nil {
-				minCheckpointTS := spanLevelCheckpoint.MinTimestamp()
-				// Checkpoint timestamp should be the timestamp of the spans from the backfill
-				if !minCheckpointTS.Equal(backfillTimestamp.Next()) {
-					return false, changefeedbase.WithTerminalError(
-						errors.AssertionFailedf("expected checkpoint timestamp %s, found %s", backfillTimestamp, minCheckpointTS))
+			// Check if we've set a checkpoint yet (spans above the frontier minimum).
+			checkpointSpans := loadCheckpointSpans(t, jobFeed.JobID(), idb)
+			if len(checkpointSpans) > 0 {
+				// All checkpoint spans should be at the backfill timestamp
+				// (the filter below prevents any span from advancing beyond it).
+				for _, rs := range checkpointSpans {
+					if !rs.Timestamp.Equal(backfillTimestamp.Next()) {
+						return false, changefeedbase.WithTerminalError(
+							errors.AssertionFailedf("expected checkpoint timestamp %s, found %s",
+								backfillTimestamp.Next(), rs.Timestamp))
+					}
 				}
-				initialCheckpoint = makeSpanGroupFromCheckpoint(t, spanLevelCheckpoint)
+				initialCheckpoint = makeSpanGroupFromFrontierSpans(t, checkpointSpans)
 				atomic.StoreInt32(&foundCheckpoint, 1)
 			}
 
@@ -3314,9 +3338,9 @@ WITH resolved='100ms', min_checkpoint_frequency='1ns', no_initial_scan`)
 			}
 
 			// Once we've set a checkpoint that covers new spans, record it
-			progress := loadProgress()
-			if spanLevelCheckpoint := loadCheckpoint(t, progress); spanLevelCheckpoint != nil {
-				currentCheckpoint := makeSpanGroupFromCheckpoint(t, spanLevelCheckpoint)
+			checkpointSpans := loadCheckpointSpans(t, jobFeed.JobID(), idb)
+			if len(checkpointSpans) > 0 {
+				currentCheckpoint := makeSpanGroupFromFrontierSpans(t, checkpointSpans)
 				// Ensure that the second checkpoint both contains all spans in the first checkpoint as well as new spans
 				if currentCheckpoint.Encloses(initialCheckpoint.Slice()...) && !initialCheckpoint.Encloses(currentCheckpoint.Slice()...) {
 					secondCheckpoint = currentCheckpoint
@@ -3370,13 +3394,13 @@ WITH resolved='100ms', min_checkpoint_frequency='1ns', no_initial_scan`)
 		// Resume job.
 		require.NoError(t, jobFeed.Resume())
 
-		// checkpoint should eventually be gone once backfill completes.
+		// Wait for highwater to advance past the backfill, indicating backfill completion.
 		testutils.SucceedsSoon(t, func() error {
 			progress := loadProgress()
-			if loadCheckpoint(t, progress) != nil {
-				return errors.New("checkpoint still non-empty")
+			if hw := progress.GetHighWater(); hw != nil && backfillTimestamp.Less(*hw) {
+				return nil
 			}
-			return nil
+			return errors.New("waiting for highwater to advance past backfill")
 		})
 
 		// Pause job to avoid race on the resolved array
@@ -9504,6 +9528,8 @@ func TestChangefeedBackfillCheckpoint(t *testing.T) {
 			context.Background(), &s.Server.ClusterSettings().SV, 1)
 		changefeedbase.SpanCheckpointMaxBytes.Override(
 			context.Background(), &s.Server.ClusterSettings().SV, maxCheckpointSize)
+		changefeedbase.FrontierPersistenceInterval.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, 100*time.Millisecond)
 
 		registry := s.Server.JobRegistry().(*jobs.Registry)
 		foo := feed(t, f, `CREATE CHANGEFEED FOR foo
@@ -9535,6 +9561,7 @@ WITH resolved='100ms', min_checkpoint_frequency='1ns'`)
 		}()
 
 		jobFeed := foo.(cdctest.EnterpriseTestFeed)
+		idb := s.Server.InternalDB().(isql.DB)
 		loadProgress := func() jobspb.Progress {
 			jobID := jobFeed.JobID()
 			job, err := registry.LoadJob(context.Background(), jobID)
@@ -9544,8 +9571,8 @@ WITH resolved='100ms', min_checkpoint_frequency='1ns'`)
 
 		// Wait for non-nil checkpoint.
 		testutils.SucceedsSoon(t, func() error {
-			progress := loadProgress()
-			if loadCheckpoint(t, progress) != nil {
+			checkpointSpans := loadCheckpointSpans(t, jobFeed.JobID(), idb)
+			if len(checkpointSpans) > 0 {
 				return nil
 			}
 			return errors.New("waiting for checkpoint")
@@ -9559,9 +9586,9 @@ WITH resolved='100ms', min_checkpoint_frequency='1ns'`)
 		noHighWater := h == nil || h.IsEmpty()
 		require.True(t, noHighWater)
 
-		spanLevelCheckpoint := loadCheckpoint(t, progress)
-		require.NotNil(t, spanLevelCheckpoint)
-		checkpointSpanGroup := makeSpanGroupFromCheckpoint(t, spanLevelCheckpoint)
+		checkpointSpans := loadCheckpointSpans(t, jobFeed.JobID(), idb)
+		require.NotEmpty(t, checkpointSpans)
+		checkpointSpanGroup := makeSpanGroupFromFrontierSpans(t, checkpointSpans)
 
 		// Collect spans we attempt to resolve after when we resume.
 		var resolved []roachpb.Span
@@ -9572,17 +9599,8 @@ WITH resolved='100ms', min_checkpoint_frequency='1ns'`)
 			return false, nil
 		}
 
-		var actualFrontierStr atomic.Value
-		knobs.AfterCoordinatorFrontierRestore = func(frontier *resolvedspan.CoordinatorFrontier) {
-			require.NotNil(t, frontier)
-			actualFrontierStr.Store(frontier.String())
-		}
-
-		// Resume job.
-		require.NoError(t, jobFeed.Resume())
-
-		// Verify that the resumed job has restored the progress from the checkpoint
-		// to the change frontier.
+		// Build the expected frontier from saved changefeed progress.
+		allFrontierSpans := loadFrontierSpans(t, jobFeed.JobID(), idb)
 		expectedFrontier, err := resolvedspan.NewCoordinatorFrontier(
 			hlc.Timestamp{},
 			hlc.Timestamp{},
@@ -9593,8 +9611,29 @@ WITH resolved='100ms', min_checkpoint_frequency='1ns'`)
 		if err != nil {
 			t.Fatal(err)
 		}
-		assert.NoError(t, checkpoint.Restore(expectedFrontier, spanLevelCheckpoint))
+		for _, rs := range allFrontierSpans {
+			_, err := expectedFrontier.Forward(rs.Span, rs.Timestamp)
+			require.NoError(t, err)
+		}
+		// TODO(#164598): Delete this code.
+		if cfProgress := progress.GetChangefeed(); cfProgress != nil {
+			for ts, spans := range cfProgress.SpanLevelCheckpoint.All() {
+				for _, sp := range spans {
+					_, err := expectedFrontier.Forward(sp, ts)
+					require.NoError(t, err)
+				}
+			}
+		}
 		expectedFrontierStr := expectedFrontier.String()
+
+		var actualFrontierStr atomic.Value
+		knobs.AfterCoordinatorFrontierRestore = func(frontier *resolvedspan.CoordinatorFrontier) {
+			require.NotNil(t, frontier)
+			actualFrontierStr.Store(frontier.String())
+		}
+
+		// Resume job.
+		require.NoError(t, jobFeed.Resume())
 		testutils.SucceedsSoon(t, func() error {
 			if s := actualFrontierStr.Load(); s != nil {
 				require.Equal(t, expectedFrontierStr, s)
@@ -9605,17 +9644,12 @@ WITH resolved='100ms', min_checkpoint_frequency='1ns'`)
 
 		// Wait for the high water mark to be non-zero.
 		testutils.SucceedsSoon(t, func() error {
-			prog := loadProgress()
-			if p := prog.GetHighWater(); p != nil && !p.IsEmpty() {
+			progress = loadProgress()
+			if p := progress.GetHighWater(); p != nil && !p.IsEmpty() {
 				return nil
 			}
 			return errors.New("waiting for highwater")
 		})
-
-		// At this point, highwater mark should be set, and previous checkpoint should be gone.
-		progress = loadProgress()
-		require.NotNil(t, progress.GetChangefeed())
-		require.Nil(t, loadCheckpoint(t, progress))
 
 		// Verify that none of the resolved spans after resume were checkpointed.
 		for _, sp := range resolved {

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -11,7 +11,6 @@ import (
 	gosql "database/sql"
 	gojson "encoding/json"
 	"fmt"
-	"maps"
 	"math"
 	"math/rand"
 	"net/url"
@@ -35,6 +34,7 @@ import (
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/multiregionccl" // allow locality-related mutations
 	"github.com/cockroachdb/cockroach/pkg/ccl/multiregionccl/multiregionccltestutils"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobfrontier"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -45,6 +45,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -1068,13 +1069,15 @@ var jobRecordRetryOpts = retry.Options{
 	MaxRetries:     10,
 }
 
-// waitForCheckpoint waits for the specified job to have a non-empty checkpoint
-func waitForCheckpoint(t *testing.T, jf cdctest.EnterpriseTestFeed, jr *jobs.Registry) {
+// waitForCheckpoint waits for the persisted frontier to contain spans above
+// the minimum timestamp, indicating that some spans have advanced ahead of
+// others (i.e. a checkpoint exists).
+func waitForCheckpoint(t *testing.T, jf cdctest.EnterpriseTestFeed, idb isql.DB) {
 	for r := retry.Start(jobRecordRetryOpts); ; {
 		t.Log("waiting for checkpoint")
-		progress := loadProgress(t, jf, jr)
-		if p := progress.GetChangefeed(); p != nil && !p.SpanLevelCheckpoint.IsEmpty() {
-			t.Logf("read checkpoint: %#v", p.SpanLevelCheckpoint)
+		spans := loadCheckpointSpans(t, jf.JobID(), idb)
+		if len(spans) > 0 {
+			t.Logf("read checkpoint: %v", spans)
 			return
 		}
 		if !r.Next() {
@@ -1111,30 +1114,66 @@ func loadProgress(
 	return job.Progress()
 }
 
-// loadCheckpoint loads the span-level checkpoint from the job progress.
-func loadCheckpoint(t *testing.T, progress jobspb.Progress) *jobspb.TimestampSpansMap {
+// loadFrontierSpans loads the frontier checkpoint from the job_info table.
+func loadFrontierSpans(t *testing.T, jobID jobspb.JobID, idb isql.DB) []jobspb.ResolvedSpan {
 	t.Helper()
-	changefeedProgress := progress.GetChangefeed()
-	if changefeedProgress == nil {
+	ctx := context.Background()
+	var spans []jobspb.ResolvedSpan
+	require.NoError(t, idb.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+		var found bool
+		var err error
+		spans, found, err = jobfrontier.GetResolvedSpans(ctx, txn, jobID, coordinatorFrontierName)
+		if err != nil {
+			return err
+		}
+		if !found {
+			spans = nil
+		}
 		return nil
+	}))
+	if len(spans) > 0 {
+		t.Logf("found frontier checkpoint: %v", spans)
 	}
-	spanLevelCheckpoint := changefeedProgress.SpanLevelCheckpoint
-	if spanLevelCheckpoint.IsEmpty() {
-		return nil
-	}
-	t.Logf("found checkpoint: %v", maps.Collect(spanLevelCheckpoint.All()))
-	return spanLevelCheckpoint
+	return spans
 }
 
-// makeSpanGroupFromCheckpoint makes a span group containing all the spans
-// contained in a span-level checkpoint.
-func makeSpanGroupFromCheckpoint(
-	t *testing.T, checkpoint *jobspb.TimestampSpansMap,
-) roachpb.SpanGroup {
+// loadCheckpointSpans loads frontier spans that represent checkpoint progress
+// above the effective highwater (the minimum frontier timestamp). This is
+// analogous to the old span-level checkpoint, which only contained spans
+// ahead of the highwater.
+func loadCheckpointSpans(t *testing.T, jobID jobspb.JobID, idb isql.DB) []jobspb.ResolvedSpan {
+	t.Helper()
+	allSpans := loadFrontierSpans(t, jobID, idb)
+	if len(allSpans) == 0 {
+		return nil
+	}
+	// Find the minimum timestamp across all spans (the effective highwater).
+	minTS := allSpans[0].Timestamp
+	for _, rs := range allSpans[1:] {
+		if rs.Timestamp.Less(minTS) {
+			minTS = rs.Timestamp
+		}
+	}
+	// Return only spans strictly above the minimum.
+	var result []jobspb.ResolvedSpan
+	for _, rs := range allSpans {
+		if minTS.Less(rs.Timestamp) {
+			result = append(result, rs)
+		}
+	}
+	if len(result) > 0 {
+		t.Logf("found checkpoint spans (above min %s): %v", minTS, result)
+	}
+	return result
+}
+
+// makeSpanGroupFromFrontierSpans makes a span group containing all the spans
+// contained in a frontier checkpoint.
+func makeSpanGroupFromFrontierSpans(t *testing.T, spans []jobspb.ResolvedSpan) roachpb.SpanGroup {
 	t.Helper()
 	var spanGroup roachpb.SpanGroup
-	for _, sp := range checkpoint.All() {
-		spanGroup.Add(sp...)
+	for _, rs := range spans {
+		spanGroup.Add(rs.Span)
 	}
 	return spanGroup
 }

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -1318,9 +1318,8 @@ message ChangefeedProgress {
   // than the overall resolved timestamp and thus allow us to do less work.
   // This is especially useful during backfills or if some spans are lagging.
   //
-  // Invariant: At most one of Checkpoint and SpanLevelCheckpoint should be
-  // non-nil at any time.
-  TimestampSpansMap span_level_checkpoint = 5;
+  // TODO(#163256): Remove (and reserve) this field once MinSupported = 26.2.
+  TimestampSpansMap span_level_checkpoint = 5 [deprecated = true];
 }
 
 // CreateStatsDetails are used for the CreateStats job, which is triggered


### PR DESCRIPTION
ALTER CHANGEFEED will now modify the persisted frontier when adding or
dropping targets. With this change, frontier persistence is now used
everywhere that legacy span-level checkpoints are (with the exception
of shutdown checkpointing), bringing us one step closer to being able
to fully deprecate the latter.

Fixes #164597

Release note: None