### PR TITLE
security: enable DRPC for TestTLSCipherRestrict

### DIFF
--- a/pkg/security/tls_test.go
+++ b/pkg/security/tls_test.go
@@ -162,9 +162,7 @@ func TestTLSCipherRestrict(t *testing.T) {
 			})()
 			ctx := context.Background()
 
-			s := serverutils.StartServerOnly(t, base.TestServerArgs{
-				DefaultDRPCOption: base.TestDRPCDisabled,
-			})
+			s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 			defer s.Stopper().Stop(ctx)
 
 			// set the custom test ciphers


### PR DESCRIPTION
Previously, TestTLSCipherRestrict explicitly disabled DRPC via DefaultDRPCOption. This commit reenables the test.

Fixes: #161581
Epic: CRDB-55382
Release note: None