### PR TITLE
ttljob: enable DRPC for tests in ttljob package

### DIFF
--- a/pkg/sql/ttl/ttljob/ttljob_test.go
+++ b/pkg/sql/ttl/ttljob/ttljob_test.go
@@ -130,8 +130,6 @@ func newRowLevelTTLTestJobTestHelper(
 			Settings:          makeSettings(),
 			Knobs:             baseTestingKnobs,
 			InsecureWebAccess: true,
-			// TODO(server): re-enable DRPC once flakiness is addressed, see #158387.
-			DefaultDRPCOption: base.TestDRPCDisabled,
 		},
 	})
 	th.testCluster = testCluster


### PR DESCRIPTION
Previously, tests in ttljob package were disabled for DRPC. This commit reenables the tests.

Fixes: #161598
Fixes: #158387
Epic: CRDB-55382
Release note: None