### PR TITLE
security: enable DRPC for TestListSessionsV2

### DIFF
--- a/pkg/server/api_v2_test.go
+++ b/pkg/server/api_v2_test.go
@@ -40,11 +40,7 @@ func TestListSessionsV2(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	testCluster := serverutils.StartCluster(t, 3, base.TestClusterArgs{
-		ServerArgs: base.TestServerArgs{
-			DefaultDRPCOption: base.TestDRPCDisabled,
-		},
-	})
+	testCluster := serverutils.StartCluster(t, 3, base.TestClusterArgs{})
 	ctx := context.Background()
 	defer testCluster.Stopper().Stop(ctx)
 


### PR DESCRIPTION
Previously, TestListSessionsV2 explicitly disabled DRPC via DefaultDRPCOption. This commit reenables the test.

TestListSessionsV2 is disabled for secondary tenants.

Fixes: #161483
Epic: CRDB-55382
Release note: None