### PR TITLE
rpc,kvserver: fix DRPC knobs to pass actual connection class

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -593,6 +593,8 @@ go_test(
         "@com_github_raduberinde_btreemap//:btreemap",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@io_storj_drpc//:drpc",
+        "@io_storj_drpc//drpcclient",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//metadata",
         "@org_golang_x_exp//maps",

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -73,6 +73,8 @@ import (
 	"github.com/cockroachdb/redact"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"storj.io/drpc"
+	"storj.io/drpc/drpcclient"
 )
 
 // mustGetInt decodes an int64 value from the bytes field of the receiver
@@ -4997,6 +4999,38 @@ func (cs *disablingClientStream) SendMsg(m interface{}) error {
 	return cs.ClientStream.SendMsg(m)
 }
 
+// disablingDRPCClientStream is the DRPC equivalent of disablingClientStream.
+// It wraps a drpc.Stream and delays MsgSend calls when the disabled function
+// returns true, buffering messages and flushing them when re-enabled.
+type disablingDRPCClientStream struct {
+	drpc.Stream
+	wasDisabled bool
+	buffer      []struct {
+		msg drpc.Message
+		enc drpc.Encoding
+	}
+	disabled func() bool
+}
+
+func (cs *disablingDRPCClientStream) MsgSend(msg drpc.Message, enc drpc.Encoding) error {
+	if cs.disabled() {
+		cs.buffer = append(cs.buffer, struct {
+			msg drpc.Message
+			enc drpc.Encoding
+		}{msg, enc})
+		cs.wasDisabled = true
+		return nil
+	}
+	if cs.wasDisabled {
+		for _, buf := range cs.buffer {
+			_ = cs.Stream.MsgSend(buf.msg, buf.enc)
+		}
+		cs.buffer = nil
+		cs.wasDisabled = false
+	}
+	return cs.Stream.MsgSend(msg, enc)
+}
+
 // TestDefaultConnectionDisruptionDoesNotInterfereWithSystemTraffic tests that
 // disconnection on connections of the rpc.DefaultClass do not interfere with
 // traffic on the SystemClass connection.
@@ -5038,6 +5072,27 @@ func TestDefaultConnectionDisruptionDoesNotInterfereWithSystemTraffic(t *testing
 				}, nil
 			}
 		},
+		StreamClientInterceptorDRPC: func(target string, class rpcbase.ConnectionClass) drpcclient.StreamClientInterceptor {
+			disabledFunc := func() bool {
+				if class == rpcbase.SystemClass {
+					return disabledSystem.Load().(bool)
+				}
+				return disabled.Load().(bool)
+			}
+			return func(
+				ctx context.Context, rpc string, enc drpc.Encoding, cc *drpcclient.ClientConn,
+				streamer drpcclient.Streamer,
+			) (drpc.Stream, error) {
+				s, err := streamer(ctx, rpc, enc, cc)
+				if err != nil {
+					return nil, err
+				}
+				return &disablingDRPCClientStream{
+					disabled: disabledFunc,
+					Stream:   s,
+				}, nil
+			}
+		},
 	}
 
 	// This test relies on epoch leases being invalidated when a node restart,
@@ -5070,10 +5125,7 @@ func TestDefaultConnectionDisruptionDoesNotInterfereWithSystemTraffic(t *testing
 		base.TestClusterArgs{
 			ReplicationMode:     base.ReplicationManual,
 			ReusableListenerReg: lisReg,
-			ServerArgs: base.TestServerArgs{
-				DefaultDRPCOption: base.TestDRPCDisabled,
-			},
-			ServerArgsPerNode: stickyServerArgs,
+			ServerArgsPerNode:   stickyServerArgs,
 		})
 	defer tc.Stopper().Stop(ctx)
 	// Make a key that's in the user data space.

--- a/pkg/rpc/drpc.go
+++ b/pkg/rpc/drpc.go
@@ -120,7 +120,7 @@ func (rpcCtx *Context) drpcDialOptsCommon(
 
 	unaryInterceptors := rpcCtx.clientUnaryInterceptorsDRPC
 	if rpcCtx.Knobs.UnaryClientInterceptorDRPC != nil {
-		interceptor := rpcCtx.Knobs.UnaryClientInterceptorDRPC(target, rpcbase.DefaultClass)
+		interceptor := rpcCtx.Knobs.UnaryClientInterceptorDRPC(target, class)
 		if interceptor != nil {
 			unaryInterceptors = append(unaryInterceptors, interceptor)
 		}
@@ -129,7 +129,7 @@ func (rpcCtx *Context) drpcDialOptsCommon(
 
 	streamInterceptors := rpcCtx.clientStreamInterceptorsDRPC
 	if rpcCtx.Knobs.StreamClientInterceptorDRPC != nil {
-		interceptor := rpcCtx.Knobs.StreamClientInterceptorDRPC(target, rpcbase.DefaultClass)
+		interceptor := rpcCtx.Knobs.StreamClientInterceptorDRPC(target, class)
 		if interceptor != nil {
 			streamInterceptors = append(streamInterceptors, interceptor)
 		}


### PR DESCRIPTION
drpcDialOptsCommon was invoking the testing knob factories with rpcbase.DefaultClass hardcoded, ignoring the class parameter passed to the function. The gRPC equivalent (dialOptsCommon) correctly forwarded the class.

This caused TestDefaultConnectionDisruptionDoesNotInterfereWithSystem Traffic to fail under DRPC. The test's interceptor uses the connection class to decide whether to block traffic, but all DRPC connections (including SystemClass liveness) appeared as DefaultClass. When disabled=true, liveness writes timed out instead of succeeding, breaking the expSucceed("writing to liveness range") assertion.

Fix the bug by passing the actual class argument to both the unary and stream knob factory invocations in drpcDialOptsCommon.

Enable DRPC for
TestDefaultConnectionDisruptionDoesNotInterfereWithSystemTraffic test. On the test side, add a disablingDRPCClientStream (the DRPC analog of the existing disablingClientStream) that buffers MsgSend calls while disabled and flushes them on re-enable. Wire it up via a new StreamClientInterceptorDRPC knob using the same class-based routing logic as the gRPC interceptor.

Epic: CRDB-55382
Fixes: #161566
Release note: None