### PR TITLE
testcluster,kvserver: enable DRPC for TestReportUnreachableRemoveRace

### DIFF
--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -2928,10 +2928,6 @@ func TestReportUnreachableRemoveRace(t *testing.T) {
 	ctx := context.Background()
 	tc := testcluster.StartTestCluster(t, 3,
 		base.TestClusterArgs{
-			ServerArgs: base.TestServerArgs{
-				// TODO(server): enabled DRPC once serverutils adds support for DRPC.
-				DefaultDRPCOption: base.TestDRPCDisabled,
-			},
 			ReplicationMode: base.ReplicationManual,
 		})
 	defer tc.Stopper().Stop(ctx)

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -560,17 +560,25 @@ func (tc *TestCluster) Start(t serverutils.TestFataler) {
 	testutils.SucceedsSoon(t, func() error {
 		var err error
 		for _, ssrv := range tc.Servers {
+			rpcCtx := ssrv.SystemLayer().RPCContext()
 			for _, dsrv := range tc.Servers {
 				stl := dsrv.StorageLayer()
+				addr := dsrv.SystemLayer().AdvRPCAddr()
+				nodeID := stl.NodeID()
+
 				// Note: we avoid using .RPCClientConn() here to avoid accumulating
 				// stopper closures in RAM during the SucceedsSoon iterations.
-				_, e := ssrv.SystemLayer().RPCContext().GRPCDialNode(
-					dsrv.SystemLayer().AdvRPCAddr(),
-					stl.NodeID(),
-					roachpb.Locality{},
-					rpcbase.DefaultClass,
-				).Connect(context.TODO())
-				err = errors.CombineErrors(err, e)
+				if !rpcCtx.UseDRPC {
+					_, e := rpcCtx.GRPCDialNode(
+						addr, nodeID, roachpb.Locality{}, rpcbase.DefaultClass,
+					).Connect(context.TODO())
+					err = errors.CombineErrors(err, e)
+				} else {
+					_, e := rpcCtx.DRPCDialNode(
+						addr, nodeID, roachpb.Locality{}, rpcbase.DefaultClass,
+					).Connect(context.TODO())
+					err = errors.CombineErrors(err, e)
+				}
 			}
 		}
 		return err
@@ -1794,16 +1802,37 @@ func (tc *TestCluster) WaitForNodeStatuses(t serverutils.TestFataler) {
 		// Note: we avoid using .RPCClientConn() here to avoid accumulating
 		// stopper closures in RAM during the SucceedsSoon iterations.
 		srv := tc.Server(0).SystemLayer()
-		conn, err := srv.RPCContext().GRPCDialNode(
-			srv.AdvRPCAddr(),
-			tc.Server(0).StorageLayer().NodeID(),
-			roachpb.Locality{},
-			rpcbase.DefaultClass,
-		).Connect(context.TODO())
+		rpcCtx := srv.RPCContext()
+
+		client, err := func() (serverpb.RPCStatusClient, error) {
+			if !rpcCtx.UseDRPC {
+				cc, err := rpcCtx.GRPCDialNode(
+					srv.AdvRPCAddr(),
+					tc.Server(0).StorageLayer().NodeID(),
+					roachpb.Locality{},
+					rpcbase.DefaultClass,
+				).Connect(context.TODO())
+				if err != nil {
+					return nil, err
+				}
+				return serverpb.NewGRPCStatusClientAdapter(cc), nil
+			}
+
+			dc, err := rpcCtx.DRPCDialNode(
+				srv.AdvRPCAddr(),
+				tc.Server(0).StorageLayer().NodeID(),
+				roachpb.Locality{},
+				rpcbase.DefaultClass,
+			).Connect(context.TODO())
+			if err != nil {
+				return nil, err
+			}
+			return serverpb.NewDRPCStatusClientAdapter(dc), nil
+		}()
 		if err != nil {
 			return err
 		}
-		client := serverpb.NewGRPCStatusClientAdapter(conn)
+
 		response, err := client.Nodes(context.Background(), &serverpb.NodesRequest{})
 		if err != nil {
 			return err


### PR DESCRIPTION
TestCluster.Start warms up DefaultClass connections between all node pairs via GRPCDialNode so that GetCircuitBreaker(nodeID, DefaultClass) returns ok=true for every pair. In DRPC mode, GetBreakerForAddr dispatches to drpcGetBreakerForAddr, which looks only in rpcCtx.drpcPeers; those entries are never created by GRPCDialNode, so GetCircuitBreaker returned ok=false for nodes that had not yet sent a DefaultClass DRPC message.

TestReportUnreachableRemoveRace calls GetCircuitBreaker(DefaultClass) on server 1 and requires ok=true, but with DRPC enabled server 1 had no DefaultClass DRPC peer entry for the partitioned node, causing the test to fail.

Fix: when rpcCtx.UseDRPC is true, also call DRPCDialNode(DefaultClass) for every node pair in the warmup loop, creating the DRPC peer entries that mirror the existing gRPC ones.

Epic: CRDB-55382
Fixes: #161571
Release note: None