### PR TITLE
*: support syncing separated engines

### DIFF
--- a/pkg/kv/kvserver/kvstorage/storage.go
+++ b/pkg/kv/kvserver/kvstorage/storage.go
@@ -245,6 +245,26 @@ func (e *Engines) SetStoreID(ctx context.Context, id roachpb.StoreID) error {
 	return nil
 }
 
+// Sync ensures that everything written to the engine(s) up to this point is
+// durable.
+func (e *Engines) Sync() error {
+	// Flush the state machine engine first. Use the Flush method since
+	// StateEngine does not support WAL / incremental syncs.
+	if e.Separated() {
+		// TODO(sep-raft-log): ensure that StateEngine uses the DisableWAL option,
+		// otherwise we would need to WriteSyncNoop here.
+		if err := e.StateEngine().Flush(); err != nil {
+			return err
+		}
+	}
+	// Sync the LogEngine second, to ensure that the state machine engine
+	// doesn't run in front of it. Latest updates are captured by the LogEngine,
+	// before they are written to the state machine.
+	//
+	// NB: if engines are not separated, this syncs the entire engine.
+	return storage.WriteSyncNoop(e.LogEngine())
+}
+
 // NewWriteBatch creates a new write batch to storage. If engines are separated,
 // it consists of two batches, one per engine.
 // TODO(sep-raft-log): generalize this so that the LogEngine batch is lazy.

--- a/pkg/kv/kvserver/liveness/liveness.go
+++ b/pkg/kv/kvserver/liveness/liveness.go
@@ -1100,6 +1100,7 @@ func (nl *NodeLiveness) updateLiveness(
 // verifyDiskHealth does a sync write to all disks before updating liveness, so
 // that a faulty or stalled disk will cause us to fail liveness and lose our
 // leases. All disks are written concurrently.
+//
 // We do this asynchronously in order to respect the caller's context, and
 // coalesce concurrent writes onto an in-flight one. This is particularly
 // relevant for a stalled disk during a lease acquisition heartbeat, where we
@@ -1116,7 +1117,10 @@ func (nl *NodeLiveness) verifyDiskHealth(ctx context.Context) error {
 				InheritCancelation: false,
 			},
 			func(ctx context.Context) (interface{}, error) {
-				return nil, diskStorage.WriteSyncNoop(eng.TODOEngine())
+				// NB: sync only the LogEngine. It is the engine through which all
+				// writes pass first. Also, the StateEngine does not support timely /
+				// incremental syncs, and forcing its Flush here would be too expensive.
+				return nil, diskStorage.WriteSyncNoop(eng.LogEngine())
 			})
 	}
 	for _, resultC := range resultCs {

--- a/pkg/kv/kvserver/stores_server.go
+++ b/pkg/kv/kvserver/stores_server.go
@@ -9,10 +9,13 @@ import (
 	"context"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag/wagpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/errors"
 )
 
 // Server implements PerReplicaServer.
@@ -90,18 +93,10 @@ func (is Server) WaitForApplication(
 			leaseAppliedIndex := repl.shMu.state.LeaseAppliedIndex
 			repl.mu.RUnlock()
 			if leaseAppliedIndex >= req.LeaseIndex {
-				// For performance reasons, we don't sync to disk when
-				// applying raft commands. This means that if a node restarts
-				// after applying but before the next sync, its
-				// LeaseAppliedIndex could temporarily regress (until it
-				// reapplies its latest raft log entries).
-				//
-				// Merging relies on the monotonicity of the log applied
-				// index, so before returning ensure that rocksdb has synced
-				// everything up to this point to disk.
-				//
+				// Merging relies on the applied index monotonicity, so before returning
+				// ensure that the state machine synced everything up to this point.
 				// https://github.com/cockroachdb/cockroach/issues/33120
-				return storage.WriteSyncNoop(s.TODOEngine())
+				return syncAppliedState(repl)
 			}
 		}
 		if ctx.Err() == nil {
@@ -110,6 +105,41 @@ func (is Server) WaitForApplication(
 		return ctx.Err()
 	})
 	return resp, err
+}
+
+// syncAppliedState syncs the applied state of the given replica, with a
+// guarantee that it will never regress.
+//
+// NB: for performance reasons, we otherwise don't sync the state machine when
+// applying raft commands. This means that if a node restarts after applying but
+// before the next sync, its applied index could temporarily regress (until it
+// reapplies its latest raft log entries).
+func syncAppliedState(r *Replica) error {
+	s := r.store
+	// If engines are not separated, sync the entire engine.
+	if !s.EnginesSeparated() {
+		return storage.WriteSyncNoop(s.internalEngines.Engine())
+	}
+	// With separated engines, durably write a WAG node to the LogEngine
+	// instructing the replay to apply the replica up to its current index.
+	b := s.internalEngines.LogEngine().NewWriteBatch()
+	defer b.Close()
+	r.raftMu.Lock()
+	defer r.raftMu.Unlock()
+	if r.shMu.destroyStatus.Removed() {
+		// Skip the replica if it has already been destroyed. There is already a WAG
+		// node committing to its removal.
+		return nil
+	}
+	if err := wag.Write(b, s.wagSeq.Next(1), wagpb.Node{
+		Events: []wagpb.Event{{
+			Addr: wagpb.MakeAddr(r.ID(), r.shMu.state.RaftAppliedIndex),
+			Type: wagpb.EventApply,
+		}},
+	}); err != nil {
+		return errors.Wrapf(err, "writing WAG node")
+	}
+	return b.Commit(true /* sync */)
 }
 
 // WaitForReplicaInit implements PerReplicaServer.

--- a/pkg/server/migration.go
+++ b/pkg/server/migration.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
@@ -156,32 +155,14 @@ func (m *migrationServer) SyncAllEngines(
 	defer span.Finish()
 	ctx = logtags.AddTag(ctx, opName, nil)
 
-	// TODO(pav-kv): make this a method of kvstorage.Engines.
-	sync := func(eng kvstorage.Engines) error {
-		// Flush the state machine engine first. Use the Flush method since
-		// StateEngine does not support WAL / incremental syncs.
-		if eng.Separated() {
-			if err := eng.StateEngine().Flush(); err != nil {
-				return err
-			}
-		}
-		// Sync the LogEngine second, to ensure that the state machine engine
-		// doesn't run in front of it. Latest updates are captured by the LogEngine,
-		// before they are written to the state machine.
-		//
-		// NB: if engines are not separated, this syncs the entire engine.
-		return storage.WriteSyncNoop(eng.LogEngine())
-	}
-
 	if err := m.server.stopper.RunTaskWithErr(ctx, opName, func(
 		ctx context.Context,
 	) error {
-		// Let's be paranoid here and ensure that all stores have been fully
-		// initialized.
+		// Ensure that all stores have been fully initialized.
 		m.server.node.waitForAdditionalStoreInit()
-
+		// Sync all engines on all stores.
 		for _, eng := range m.server.engines {
-			if err := sync(eng); err != nil {
+			if err := eng.Sync(); err != nil {
 				return err
 			}
 		}

--- a/pkg/server/migration.go
+++ b/pkg/server/migration.go
@@ -156,6 +156,23 @@ func (m *migrationServer) SyncAllEngines(
 	defer span.Finish()
 	ctx = logtags.AddTag(ctx, opName, nil)
 
+	// TODO(pav-kv): make this a method of kvstorage.Engines.
+	sync := func(eng kvstorage.Engines) error {
+		// Flush the state machine engine first. Use the Flush method since
+		// StateEngine does not support WAL / incremental syncs.
+		if eng.Separated() {
+			if err := eng.StateEngine().Flush(); err != nil {
+				return err
+			}
+		}
+		// Sync the LogEngine second, to ensure that the state machine engine
+		// doesn't run in front of it. Latest updates are captured by the LogEngine,
+		// before they are written to the state machine.
+		//
+		// NB: if engines are not separated, this syncs the entire engine.
+		return storage.WriteSyncNoop(eng.LogEngine())
+	}
+
 	if err := m.server.stopper.RunTaskWithErr(ctx, opName, func(
 		ctx context.Context,
 	) error {
@@ -164,9 +181,7 @@ func (m *migrationServer) SyncAllEngines(
 		m.server.node.waitForAdditionalStoreInit()
 
 		for _, eng := range m.server.engines {
-			// TODO(sep-raft-log): figure out whether StateEngine needs a sync, or we
-			// can only sync LogEngine here.
-			if err := storage.WriteSyncNoop(eng.TODOEngine()); err != nil {
+			if err := sync(eng); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
This PR converts all uses of `WriteSyncNoop` to be aware of engine separation. See individual commits for details on each.

Part of #97627
Part of #165186