### PR TITLE
kvserver: store Attributes in LogEngine

### DIFF
--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3122,7 +3122,7 @@ func (s *Store) AllocateRangeID(ctx context.Context) (roachpb.RangeID, error) {
 
 // Attrs returns the attributes of the underlying store.
 func (s *Store) Attrs() roachpb.Attributes {
-	return s.TODOEngine().Attrs()
+	return s.LogEngine().Attrs()
 }
 
 // Properties returns the properties of the underlying store.

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -805,6 +805,8 @@ func (cfg *Config) CreateEngines(ctx context.Context) (Engines, error) {
 	for i, spec := range cfg.Stores.Specs {
 		log.Eventf(ctx, "initializing %+v", spec)
 
+		// TODO(sep-raft-log): store Attributes only in the LogEngine or the
+		// overarching kvstorage.Engines.
 		storageConfigOpts := []storage.ConfigOption{
 			walFailoverConfig,
 			storage.Attributes(roachpb.Attributes{Attrs: spec.Attributes}),


### PR DESCRIPTION
These attributes are not used by storage/Pebble, and only stored in the `Engine` for plumbing convenience. Use `LogEngine`, since this is a primary local engine.

Part of #97627