### PR TITLE
kvserver: use StateEngine for rangefeeds

### DIFF
--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -514,7 +514,7 @@ func (r *Replica) registerWithRangefeedRaftMuLocked(
 		// synchronizes with the rangefeed Processor calling this function by
 		// waiting for the Register call below to return.
 		r.raftMu.AssertHeld()
-		return rangefeed.NewSeparatedIntentScanner(streamCtx, r.store.TODOEngine(), desc.RSpan())
+		return rangefeed.NewSeparatedIntentScanner(streamCtx, r.store.StateEngine(), desc.RSpan())
 	}
 
 	// NB: This only errors if the stopper is stopping, and we have to return here


### PR DESCRIPTION
Rangefeeds are sourced from a range's state machine MVCC space.

Part of #97627