### PR TITLE
*: introduce TODOBothEngines

### DIFF
--- a/pkg/kv/kvserver/kvstorage/storage.go
+++ b/pkg/kv/kvserver/kvstorage/storage.go
@@ -202,6 +202,17 @@ func (e *Engines) TODOEngine() storage.Engine {
 	return e.todoEngine
 }
 
+// TODOBothEngines returns the StateEngine, and indicates that the caller must
+// support a certain operation over both engines. For example, introspection and
+// metrics should eventually be per-engine, or combined from information
+// returned by both.
+//
+// TODO(sep-raft-log): the callers must migrate off as part of separated engines
+// productionization.
+func (e *Engines) TODOBothEngines() storage.Engine {
+	return e.stateEngine
+}
+
 // Separated returns true iff the engines are logically or physically separated.
 // Can return true only in tests, until separated engines are supported.
 func (e *Engines) Separated() bool {

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -2799,14 +2799,14 @@ func (r *Replica) GetResponseMemoryAccount() *mon.BoundAccount {
 // GetEngineCapacity returns the store's underlying engine capacity; other
 // StoreCapacity fields not related to engine capacity are not populated.
 func (r *Replica) GetEngineCapacity() (roachpb.StoreCapacity, error) {
-	// TODO(sep-raft-log): need to expose log engine capacity.
-	return r.store.TODOEngine().Capacity()
+	return r.store.TODOBothEngines().Capacity()
 }
 
 // GetApproximateDiskBytes returns an approximate measure of bytes in the store
 // in the specified key range.
 func (r *Replica) GetApproximateDiskBytes(from, to roachpb.Key) (uint64, error) {
-	bytes, _, _, err := r.store.TODOEngine().ApproximateDiskBytes(from, to)
+	// TODO(sep-raft-log): this one probably only needs StateEngine.
+	bytes, _, _, err := r.store.TODOBothEngines().ApproximateDiskBytes(from, to)
 	return bytes, err
 }
 

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3091,6 +3091,12 @@ func (s *Store) TODOEngine() storage.Engine {
 	return s.internalEngines.TODOEngine()
 }
 
+// TODOBothEngines is a placeholder for cases in which the caller needs to be
+// updated because it likely needs to handle both engines.
+func (s *Store) TODOBothEngines() storage.Engine {
+	return s.internalEngines.TODOBothEngines()
+}
+
 // LogEngine returns the raft/log engine.
 func (s *Store) LogEngine() storage.Engine {
 	return s.internalEngines.LogEngine()
@@ -3127,8 +3133,7 @@ func (s *Store) Attrs() roachpb.Attributes {
 
 // Properties returns the properties of the underlying store.
 func (s *Store) Properties() roachpb.StoreProperties {
-	// TODO(sep-raft-log): see if this needs to exist for the logEngine too.
-	return s.TODOEngine().Properties()
+	return s.TODOBothEngines().Properties()
 }
 
 // Capacity returns the capacity of the underlying storage engine. Note that
@@ -3143,7 +3148,7 @@ func (s *Store) Capacity(ctx context.Context, useCached bool) (roachpb.StoreCapa
 		}
 	}
 
-	capacity, err := s.TODOEngine().Capacity()
+	capacity, err := s.TODOBothEngines().Capacity()
 	if err != nil {
 		return roachpb.StoreCapacity{}, err
 	}
@@ -3718,19 +3723,19 @@ func (s *Store) computeMetricsLocked(ctx context.Context) (m storage.Metrics, er
 	}
 
 	// Get the latest engine metrics.
-	m = s.TODOEngine().GetMetrics()
-	_ = s.TODOEngine() // TODO(sep-raft-log): log engine should also have metrics
+	eng := s.TODOBothEngines()
+	m = eng.GetMetrics()
 	s.metrics.updateEngineMetrics(m)
 
 	// Get engine Env stats.
-	envStats, err := s.TODOEngine().GetEnvStats()
+	envStats, err := eng.GetEnvStats()
 	if err != nil {
 		return m, err
 	}
 	s.metrics.updateEnvStats(*envStats)
 
 	{
-		dirs, err := s.TODOEngine().Env().List(s.checkpointsDir())
+		dirs, err := eng.Env().List(s.checkpointsDir())
 		if err != nil { // skip NotFound or any other error
 			dirs = nil
 		}

--- a/pkg/kv/kvserver/stores_server.go
+++ b/pkg/kv/kvserver/stores_server.go
@@ -158,7 +158,7 @@ func (is Server) GetTableMetrics(
 	resp := &GetTableMetricsResponse{}
 	err := is.execStoreCommand(ctx, req.StoreRequestHeader,
 		func(ctx context.Context, s *Store) error {
-			metricsInfo, err := s.TODOEngine().GetTableMetrics(req.Span.Key, req.Span.EndKey)
+			metricsInfo, err := s.TODOBothEngines().GetTableMetrics(req.Span.Key, req.Span.EndKey)
 
 			if err != nil {
 				return err
@@ -176,7 +176,7 @@ func (is Server) ScanStorageInternalKeys(
 	resp := &ScanStorageInternalKeysResponse{}
 	err := is.execStoreCommand(ctx, req.StoreRequestHeader,
 		func(ctx context.Context, s *Store) error {
-			metrics, err := s.TODOEngine().ScanStorageInternalKeys(req.Span.Key, req.Span.EndKey, req.MegabytesPerSecond)
+			metrics, err := s.TODOBothEngines().ScanStorageInternalKeys(req.Span.Key, req.Span.EndKey, req.MegabytesPerSecond)
 
 			if err != nil {
 				return err
@@ -200,12 +200,12 @@ func (is Server) SetCompactionConcurrency(
 	resp := &CompactionConcurrencyResponse{}
 	err := is.execStoreCommand(ctx, req.StoreRequestHeader,
 		func(ctx context.Context, s *Store) error {
-			s.TODOEngine().SetCompactionConcurrency(req.CompactionConcurrency)
+			s.TODOBothEngines().SetCompactionConcurrency(req.CompactionConcurrency)
 
 			// Wait for cancellation, and once cancelled, reset the compaction
 			// concurrency.
 			<-ctx.Done()
-			s.TODOEngine().SetCompactionConcurrency(0)
+			s.TODOBothEngines().SetCompactionConcurrency(0)
 			return nil
 		})
 	return resp, err

--- a/pkg/server/debug/replay/replay.go
+++ b/pkg/server/debug/replay/replay.go
@@ -57,7 +57,7 @@ func (h *HTTPHandler) HandleRequest(w http.ResponseWriter, req *http.Request) {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		getter, ok := s.TODOEngine().(workloadCollectorGetter)
+		getter, ok := s.TODOBothEngines().(workloadCollectorGetter)
 		if !ok {
 			http.Error(
 				w,
@@ -80,7 +80,7 @@ func (h *HTTPHandler) HandleRequest(w http.ResponseWriter, req *http.Request) {
 				}
 				if !wc.IsRunning() {
 					wc.Start(captureFS, actionJSON.CaptureDirectory)
-					err = s.TODOEngine().CreateCheckpoint(captureFS.PathJoin(actionJSON.CaptureDirectory, "checkpoint"), nil)
+					err = s.TODOBothEngines().CreateCheckpoint(captureFS.PathJoin(actionJSON.CaptureDirectory, "checkpoint"), nil)
 				}
 				if err != nil {
 					return err
@@ -103,7 +103,7 @@ func (h *HTTPHandler) HandleRequest(w http.ResponseWriter, req *http.Request) {
 	case "GET":
 		var response []WorkloadCollectorStatus
 		err := h.Stores.VisitStores(func(s *kvserver.Store) error {
-			getter, ok := s.TODOEngine().(workloadCollectorGetter)
+			getter, ok := s.TODOBothEngines().(workloadCollectorGetter)
 			if !ok {
 				return errors.Newf("Failed to retrieve workload collector for store with id: %d", s.StoreID())
 			}

--- a/pkg/server/debug/server.go
+++ b/pkg/server/debug/server.go
@@ -233,11 +233,11 @@ func (ds *Server) RegisterWorkloadCollector(stores *kvserver.Stores) error {
 func GetLSMStats(engines []kvstorage.Engines) (map[roachpb.StoreID]string, error) {
 	stats := make(map[roachpb.StoreID]string, len(engines))
 	for _, eng := range engines {
-		storeID, err := eng.TODOEngine().GetStoreID()
+		storeID, err := eng.TODOBothEngines().GetStoreID()
 		if err != nil {
 			return nil, err
 		}
-		stats[roachpb.StoreID(storeID)] = eng.TODOEngine().GetMetrics().String()
+		stats[roachpb.StoreID(storeID)] = eng.TODOBothEngines().GetMetrics().String()
 	}
 	return stats, nil
 }
@@ -261,14 +261,15 @@ func (ds *Server) RegisterEngines(engines []kvstorage.Engines) error {
 		fmt.Fprint(w, FormatLSMStats(stats))
 	})
 
-	for _, eng := range engines {
-		dir := eng.TODOEngine().Env().Dir
+	for _, e := range engines {
+		eng := e.TODOBothEngines()
+		dir := eng.Env().Dir
 		if dir == "" {
 			// TODO(yevgeniy): Add plumbing to support LSM visualization for in memory engines.
 			continue
 		}
 
-		storeID, err := eng.TODOEngine().GetStoreID()
+		storeID, err := eng.GetStoreID()
 		if err != nil {
 			return err
 		}
@@ -293,7 +294,7 @@ func (ds *Server) RegisterEngines(engines []kvstorage.Engines) error {
 				ctx := req.Context()
 				ctx, cancel := context.WithTimeout(ctx, dur)
 				defer cancel()
-				profile, err := eng.TODOEngine().ProfileSeparatedValueRetrievals(ctx)
+				profile, err := eng.ProfileSeparatedValueRetrievals(ctx)
 				if err != nil {
 					http.Error(w, "error profiling separated value retrievals", http.StatusInternalServerError)
 					return

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1426,7 +1426,7 @@ func (pmp *nodePebbleMetricsProvider) GetPebbleMetrics() []admission.StoreMetric
 	}
 	var metrics []admission.StoreMetrics
 	_ = pmp.n.stores.VisitStores(func(store *kvserver.Store) error {
-		eng := store.TODOEngine()
+		eng := store.TODOBothEngines()
 		m := eng.GetMetrics()
 		opts := eng.GetPebbleOptions()
 		memTableSizeForStopWrites := opts.MemTableSize * uint64(opts.MemTableStopWritesThreshold)

--- a/pkg/server/span_stats_server.go
+++ b/pkg/server/span_stats_server.go
@@ -265,7 +265,8 @@ func (s *systemStatusServer) statsForSpan(
 
 	// First, get the approximate disk bytes from each store.
 	err = s.stores.VisitStores(func(store *kvserver.Store) error {
-		approxDiskBytes, remoteBytes, externalBytes, err := store.TODOEngine().ApproximateDiskBytes(rSpan.Key.AsRawKey(), rSpan.EndKey.AsRawKey())
+		approxDiskBytes, remoteBytes, externalBytes, err := store.TODOBothEngines().
+			ApproximateDiskBytes(rSpan.Key.AsRawKey(), rSpan.EndKey.AsRawKey())
 		if err != nil {
 			return err
 		}
@@ -349,7 +350,7 @@ func (s *systemStatusServer) statsForSpan(
 			err = s.stores.VisitStores(func(s *kvserver.Store) error {
 				stats, err := storage.ComputeStats(
 					ctx,
-					s.TODOEngine(),
+					s.TODOBothEngines(),
 					fs.UnknownReadCategory,
 					scanStart.AsRawKey(),
 					scanEnd.AsRawKey(),

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -4211,7 +4211,7 @@ func (s *systemStatusServer) Stores(
 
 	resp := &serverpb.StoresResponse{}
 	err = s.stores.VisitStores(func(store *kvserver.Store) error {
-		eng := store.TODOEngine()
+		eng := store.TODOBothEngines()
 		envStats, err := eng.GetEnvStats()
 		if err != nil {
 			return err


### PR DESCRIPTION
Introduce a new TODO method for cases when it is clear that the existing functionality can't be attributed only to `LogEngine` or `StateEngine`. This covers cases like metrics reporting and various introspection into the engine. These will be resolved as part of separated engines productionization work.

Part of #97627