### PR TITLE
opt: inline placeholder equalities in InlineConstVar

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -1214,41 +1214,54 @@ regions: <hidden>
     └── • limit
         │ count: 1
         │
-        └── • lookup join
+        └── • cross join
             │ sql nodes: <hidden>
             │ regions: <hidden>
-            │ KV time: 0µs
-            │ KV rows decoded: 0
             │ execution time: 0µs
             │ actual row count: 0
             │ estimated row count: 10
-            │ table: t137352@t137352_pkey
-            │ equality: (k) = (k)
-            │ equality cols are key
             │
-            └── • lookup join
-                │ sql nodes: <hidden>
-                │ kv nodes: <hidden>
-                │ regions: <hidden>
-                │ KV time: 0µs
-                │ KV rows decoded: 0
-                │ execution time: 0µs
-                │ actual row count: 0
-                │ estimated row count: 10
-                │ table: t137352@t137352_a_idx
-                │ equality: (k) = (a)
-                │ pred: a = 1
-                │
-                └── • scan
-                      sql nodes: <hidden>
-                      kv nodes: <hidden>
-                      regions: <hidden>
-                      KV time: 0µs
-                      KV rows decoded: 1
-                      actual row count: 1
-                      estimated row count: 1
-                      table: t137352@t137352_pkey
-                      spans: [/1 - /1]
+            ├── • lookup join
+            │   │ sql nodes: <hidden>
+            │   │ regions: <hidden>
+            │   │ KV time: 0µs
+            │   │ KV rows decoded: 0
+            │   │ execution time: 0µs
+            │   │ actual row count: 0
+            │   │ estimated row count: 10
+            │   │ table: t137352@t137352_pkey
+            │   │ equality: (k) = (k)
+            │   │ equality cols are key
+            │   │
+            │   └── • lookup join
+            │       │ sql nodes: <hidden>
+            │       │ kv nodes: <hidden>
+            │       │ regions: <hidden>
+            │       │ KV time: 0µs
+            │       │ KV rows decoded: 0
+            │       │ execution time: 0µs
+            │       │ actual row count: 0
+            │       │ estimated row count: 10
+            │       │ table: t137352@t137352_a_idx
+            │       │ equality: ($1) = (a)
+            │       │
+            │       └── • values
+            │             sql nodes: <hidden>
+            │             regions: <hidden>
+            │             execution time: 0µs
+            │             actual row count: 1
+            │             size: 1 column, 1 row
+            │
+            └── • scan
+                  sql nodes: <hidden>
+                  kv nodes: <hidden>
+                  regions: <hidden>
+                  KV time: 0µs
+                  KV rows decoded: 1
+                  actual row count: 1
+                  estimated row count: 1
+                  table: t137352@t137352_pkey
+                  spans: [/1 - /1]
 
 statement count 1
 DELETE FROM t137352 WHERE true;

--- a/pkg/sql/opt/norm/inline_funcs.go
+++ b/pkg/sql/opt/norm/inline_funcs.go
@@ -291,13 +291,18 @@ func (c *CustomFuncs) inlineProjections(e opt.Expr, projections memo.Projections
 	return replace(e)
 }
 
+// extractVarEqualsConst extracts a (variable = const) or (variable =
+// placeholder) equality from a filter condition. Placeholder expressions
+// are treated like constants because they are bound to a single value at
+// execution time.
 func (c *CustomFuncs) extractVarEqualsConst(
 	e opt.Expr,
-) (ok bool, left *memo.VariableExpr, right *memo.ConstExpr) {
+) (ok bool, left *memo.VariableExpr, right opt.ScalarExpr) {
 	if eq, ok := e.(*memo.EqExpr); ok {
 		if l, ok := eq.Left.(*memo.VariableExpr); ok {
-			if r, ok := eq.Right.(*memo.ConstExpr); ok {
-				return true, l, r
+			switch eq.Right.(type) {
+			case *memo.ConstExpr, *memo.PlaceholderExpr:
+				return true, l, eq.Right
 			}
 		}
 	}
@@ -327,7 +332,7 @@ func (c *CustomFuncs) CanInlineConstVar(f memo.FiltersExpr) bool {
 				// to composite-ness.
 				continue
 			}
-			if !e.Typ.Equivalent(colType) {
+			if !e.DataType().Equivalent(colType) {
 				continue
 			}
 			if !fixedCols.Contains(l.Col) {
@@ -364,7 +369,7 @@ func (c *CustomFuncs) InlineConstVar(f memo.FiltersExpr) memo.FiltersExpr {
 			if colinfo.CanHaveCompositeKeyEncoding(colType) {
 				continue
 			}
-			if !e.Typ.Equivalent(colType) {
+			if !e.DataType().Equivalent(colType) {
 				continue
 			}
 			if _, ok := vals[v.Col]; !ok {

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -177,6 +177,55 @@ inner-join (cross)
  │         └── y:9 = 10 [outer=(9), constraints=(/9: [/10 - /10]; tight), fd=()-->(9)]
  └── filters (true)
 
+# Regression test for #164666. A placeholder equality like i = $1 should
+# propagate into correlated subqueries referencing the same column.
+norm expect=InlineConstVar
+SELECT k FROM a WHERE i = $1 AND EXISTS(SELECT 1 FROM xy WHERE y = a.i)
+----
+project
+ ├── columns: k:1!null
+ ├── has-placeholder
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null i:2!null
+      ├── has-placeholder
+      ├── key: (1)
+      ├── fd: ()-->(2)
+      ├── scan a
+      │    ├── columns: k:1!null i:2
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2)
+      └── filters
+           ├── i:2 = $1 [outer=(2), constraints=(/2: (/NULL - ]), fd=()-->(2)]
+           └── coalesce [subquery]
+                ├── subquery
+                │    └── project
+                │         ├── columns: column14:14!null
+                │         ├── cardinality: [0 - 1]
+                │         ├── has-placeholder
+                │         ├── key: ()
+                │         ├── fd: ()-->(14)
+                │         ├── limit
+                │         │    ├── columns: y:9!null
+                │         │    ├── cardinality: [0 - 1]
+                │         │    ├── has-placeholder
+                │         │    ├── key: ()
+                │         │    ├── fd: ()-->(9)
+                │         │    ├── select
+                │         │    │    ├── columns: y:9!null
+                │         │    │    ├── has-placeholder
+                │         │    │    ├── fd: ()-->(9)
+                │         │    │    ├── limit hint: 1.00
+                │         │    │    ├── scan xy
+                │         │    │    │    ├── columns: y:9
+                │         │    │    │    └── limit hint: 100.00
+                │         │    │    └── filters
+                │         │    │         └── y:9 = $1 [outer=(9), constraints=(/9: (/NULL - ]), fd=()-->(9)]
+                │         │    └── 1
+                │         └── projections
+                │              └── true [as=column14:14]
+                └── false
+
 # --------------------------------------------------
 # InlineProjectConstants
 # --------------------------------------------------

--- a/pkg/sql/opt/norm/testdata/rules/mutation
+++ b/pkg/sql/opt/norm/testdata/rules/mutation
@@ -807,17 +807,18 @@ update (swap) abc
       ├── key: ()
       ├── fd: ()-->(11-13)
       ├── values
-      │    ├── columns: a:11 b:12 c:13!null
+      │    ├── columns: a:11 b:12 c:13
       │    ├── cardinality: [1 - 1]
       │    ├── has-placeholder
       │    ├── key: ()
       │    ├── fd: ()-->(11-13)
-      │    └── ($1, $2, true)
+      │    └── ($1, $2, $3)
       └── filters
            ├── a:11 IS NOT NULL [outer=(11), constraints=(/11: (/NULL - ]; tight)]
            ├── b:12 IS NOT NULL [outer=(12), constraints=(/12: (/NULL - ]; tight)]
            ├── $3
-           └── a:11 < b:12 [outer=(11,12), constraints=(/11: (/NULL - ]; /12: (/NULL - ])]
+           ├── c:13 IS NOT NULL [outer=(13), constraints=(/13: (/NULL - ]; tight)]
+           └── $1 < $2
 
 # Test that we do use swap mutations with RETURNING.
 
@@ -851,7 +852,7 @@ update (swap) abc
       └── filters
            ├── a:11 IS NOT NULL [outer=(11), constraints=(/11: (/NULL - ]; tight)]
            ├── b:12 IS NOT NULL [outer=(12), constraints=(/12: (/NULL - ]; tight)]
-           └── a:11 < b:12 [outer=(11,12), constraints=(/11: (/NULL - ]; /12: (/NULL - ])]
+           └── $1 < $2
 
 norm set=use_swap_mutations=true expect=UseSwapMutation
 UPDATE abc SET a = b WHERE a = $1 AND b = $2 + 1 AND c RETURNING a + b
@@ -1246,8 +1247,8 @@ update (swap) mnop
       │    │    │    ├── fd: ()-->(17,18)
       │    │    │    └── ($3, $4)
       │    │    └── filters
-      │    │         ├── (m:17 + n:18) = $5 [outer=(17,18), immutable]
-      │    │         ├── m:17 >= n:18 [outer=(17,18), constraints=(/17: (/NULL - ]; /18: (/NULL - ])]
+      │    │         ├── (n:18 + $3) = $5 [outer=(18), immutable]
+      │    │         ├── n:18 <= $3 [outer=(18), constraints=(/18: (/NULL - ])]
       │    │         └── m:17 IS NOT NULL [outer=(17), constraints=(/17: (/NULL - ]; tight)]
       │    └── projections
       │         ├── $1 [as=m_new:13]
@@ -2226,13 +2227,13 @@ update (swap) hij
       ├── cardinality: [0 - 1]
       ├── immutable, has-placeholder
       ├── key: ()
-      ├── fd: ()-->(11-14), (13)==(14), (14)==(13)
+      ├── fd: ()-->(11-14)
       ├── select
       │    ├── columns: h:12!null i:13!null j:14!null
       │    ├── cardinality: [0 - 1]
       │    ├── has-placeholder
       │    ├── key: ()
-      │    ├── fd: ()-->(12-14), (13)==(14), (14)==(13)
+      │    ├── fd: ()-->(12-14)
       │    ├── values
       │    │    ├── columns: h:12 i:13 j:14
       │    │    ├── cardinality: [1 - 1]
@@ -2244,7 +2245,7 @@ update (swap) hij
       │         ├── h:12 IS NOT NULL [outer=(12), constraints=(/12: (/NULL - ]; tight)]
       │         ├── i:13 IS NOT NULL [outer=(13), constraints=(/13: (/NULL - ]; tight)]
       │         ├── j:14 IS NOT NULL [outer=(14), constraints=(/14: (/NULL - ]; tight)]
-      │         └── i:13 = j:14 [outer=(13,14), constraints=(/13: (/NULL - ]; /14: (/NULL - ]), fd=(13)==(14), (14)==(13)]
+      │         └── $2 = $3
       └── projections
            └── i:13 + 1 [as=i_new:11, outer=(13), immutable]
 
@@ -2278,7 +2279,7 @@ update hij
       │    └── filters
       │         ├── h:6 = $1 [outer=(6), constraints=(/6: (/NULL - ]), fd=()-->(6)]
       │         ├── i:7 = (j:8 + 1) [outer=(7,8), immutable, constraints=(/7: (/NULL - ]), fd=(8)-->(7)]
-      │         └── j:8 = (h:6 * 2) [outer=(6,8), immutable, constraints=(/8: (/NULL - ]), fd=(6)-->(8)]
+      │         └── j:8 = ($1 * 2) [outer=(8), immutable, constraints=(/8: (/NULL - ]), fd=()-->(8)]
       └── projections
            └── i:7 + 1 [as=i_new:11, outer=(7), immutable]
 

--- a/pkg/sql/opt/xform/testdata/external/nova
+++ b/pkg/sql/opt/xform/testdata/external/nova
@@ -552,7 +552,7 @@ sort
            │    │    │         │    │    │    └── ordering: +20
            │    │    │         │    │    └── filters
            │    │    │         │    │         ├── instance_type_projects.deleted:22 = $2 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
-           │    │    │         │    │         ├── instance_type_projects.deleted:22 = $3 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
+           │    │    │         │    │         ├── $2 = $3
            │    │    │         │    │         └── project_id:21 = $4 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
            │    │    │         │    └── filters (true)
            │    │    │         └── filters
@@ -872,93 +872,84 @@ from (select instance_types.created_at as instance_types_created_at,
      on instance_type_extra_specs_1.instance_type_id = anon_1.instance_types_id
         and instance_type_extra_specs_1.deleted = $7
 ----
-project
- ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7 anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:38 instance_type_extra_specs_1_updated_at:39 instance_type_extra_specs_1_deleted_at:37 instance_type_extra_specs_1_deleted:36 instance_type_extra_specs_1_id:32 instance_type_extra_specs_1_key:33 instance_type_extra_specs_1_value:34 instance_type_extra_specs_1_instance_type_id:35
+left-join (lookup instance_type_extra_specs [as=instance_type_extra_specs_1])
+ ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7 anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:37 instance_type_extra_specs_1_updated_at:38 instance_type_extra_specs_1_deleted_at:36 instance_type_extra_specs_1_deleted:35 instance_type_extra_specs_1_id:31 instance_type_extra_specs_1_key:32 instance_type_extra_specs_1_value:33 instance_type_extra_specs_1_instance_type_id:34
+ ├── key columns: [31] = [31]
+ ├── lookup columns are key
  ├── immutable, has-placeholder
- ├── key: (32)
- ├── fd: ()-->(1-16,35), (32)-->(33,34,36-39), (33,35,36)~~>(32,34,37-39)
- └── left-join (lookup instance_type_extra_specs [as=instance_type_extra_specs_1])
-      ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22 instance_type_extra_specs_1.id:32 key:33 value:34 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
-      ├── key columns: [32] = [32]
-      ├── lookup columns are key
-      ├── immutable, has-placeholder
-      ├── key: (32)
-      ├── fd: ()-->(1-16,20-22,35), (32)-->(33,34,36-39), (33,35,36)~~>(32,34,37-39)
-      ├── left-join (lookup instance_type_extra_specs@instance_type_extra_specs_instance_type_id_key_deleted_key [as=instance_type_extra_specs_1])
-      │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22 instance_type_extra_specs_1.id:32 key:33 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36
-      │    ├── key columns: [1] = [35]
-      │    ├── immutable, has-placeholder
-      │    ├── key: (32)
-      │    ├── fd: ()-->(1-16,20-22,35,36), (32)-->(33), (33,35,36)~~>(32)
-      │    ├── limit
-      │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
-      │    │    ├── cardinality: [0 - 1]
-      │    │    ├── immutable, has-placeholder
-      │    │    ├── key: ()
-      │    │    ├── fd: ()-->(1-16,20-22)
-      │    │    ├── offset
-      │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
-      │    │    │    ├── cardinality: [0 - 1]
-      │    │    │    ├── has-placeholder
-      │    │    │    ├── key: ()
-      │    │    │    ├── fd: ()-->(1-16,20-22)
-      │    │    │    ├── select
-      │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
-      │    │    │    │    ├── cardinality: [0 - 1]
-      │    │    │    │    ├── has-placeholder
-      │    │    │    │    ├── key: ()
-      │    │    │    │    ├── fd: ()-->(1-16,20-22)
-      │    │    │    │    ├── left-join (merge)
-      │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
-      │    │    │    │    │    ├── left ordering: +1
-      │    │    │    │    │    ├── right ordering: +20
-      │    │    │    │    │    ├── cardinality: [0 - 1]
-      │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    ├── fd: ()-->(1-16,20-22)
-      │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
-      │    │    │    │    │    │    ├── cardinality: [0 - 1]
-      │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    ├── fd: ()-->(1-16)
-      │    │    │    │    │    │    └── inner-join (lookup instance_types)
-      │    │    │    │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 "$4":42!null "$1":43!null
-      │    │    │    │    │    │         ├── flags: disallow merge join
-      │    │    │    │    │    │         ├── key columns: [42] = [1]
-      │    │    │    │    │    │         ├── lookup columns are key
-      │    │    │    │    │    │         ├── cardinality: [0 - 1]
-      │    │    │    │    │    │         ├── parameterized columns: (42,43)
-      │    │    │    │    │    │         ├── has-placeholder
-      │    │    │    │    │    │         ├── key: ()
-      │    │    │    │    │    │         ├── fd: ()-->(1-16,42,43), (1)==(42), (42)==(1), (13)==(43), (43)==(13)
-      │    │    │    │    │    │         ├── values
-      │    │    │    │    │    │         │    ├── columns: "$4":42 "$1":43
-      │    │    │    │    │    │         │    ├── cardinality: [1 - 1]
-      │    │    │    │    │    │         │    ├── has-placeholder
-      │    │    │    │    │    │         │    ├── key: ()
-      │    │    │    │    │    │         │    ├── fd: ()-->(42,43)
-      │    │    │    │    │    │         │    └── ($4, $1)
-      │    │    │    │    │    │         └── filters
-      │    │    │    │    │    │              └── instance_types.deleted:13 = "$1":43 [outer=(13,43), constraints=(/13: (/NULL - ]; /43: (/NULL - ]), fd=(13)==(43), (43)==(13)]
-      │    │    │    │    │    ├── placeholder-scan instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key
-      │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:20!null project_id:21!null instance_type_projects.deleted:22!null
-      │    │    │    │    │    │    ├── cardinality: [0 - 1]
-      │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    ├── fd: ()-->(20-22)
-      │    │    │    │    │    │    └── span
-      │    │    │    │    │    │         ├── $4
-      │    │    │    │    │    │         ├── $3
-      │    │    │    │    │    │         └── $2
-      │    │    │    │    │    └── filters (true)
-      │    │    │    │    └── filters
-      │    │    │    │         └── is_public:12 OR (instance_type_projects.instance_type_id:20 IS NOT NULL) [outer=(12,20)]
-      │    │    │    └── $5
-      │    │    └── $6
-      │    └── filters
-      │         └── instance_type_extra_specs_1.deleted:36 = $7 [outer=(36), constraints=(/36: (/NULL - ]), fd=()-->(36)]
-      └── filters (true)
+ ├── key: (31)
+ ├── fd: ()-->(1-16,34), (31)-->(32,33,35-38), (32,34,35)~~>(31,33,36-38)
+ ├── left-join (lookup instance_type_extra_specs@instance_type_extra_specs_instance_type_id_key_deleted_key [as=instance_type_extra_specs_1])
+ │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_extra_specs_1.id:31 key:32 instance_type_extra_specs_1.instance_type_id:34 instance_type_extra_specs_1.deleted:35
+ │    ├── key columns: [1] = [34]
+ │    ├── immutable, has-placeholder
+ │    ├── key: (31)
+ │    ├── fd: ()-->(1-16,34,35), (31)-->(32), (32,34,35)~~>(31)
+ │    ├── limit
+ │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── immutable, has-placeholder
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1-16)
+ │    │    ├── offset
+ │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
+ │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    ├── has-placeholder
+ │    │    │    ├── key: ()
+ │    │    │    ├── fd: ()-->(1-16)
+ │    │    │    ├── project
+ │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
+ │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    ├── has-placeholder
+ │    │    │    │    ├── key: ()
+ │    │    │    │    ├── fd: ()-->(1-16)
+ │    │    │    │    └── inner-join (lookup instance_types)
+ │    │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 "$1":44!null "$4":45!null
+ │    │    │    │         ├── flags: disallow merge join
+ │    │    │    │         ├── key columns: [45] = [1]
+ │    │    │    │         ├── lookup columns are key
+ │    │    │    │         ├── cardinality: [0 - 1]
+ │    │    │    │         ├── parameterized columns: (44,45)
+ │    │    │    │         ├── has-placeholder
+ │    │    │    │         ├── key: ()
+ │    │    │    │         ├── fd: ()-->(1-16,44,45), (13)==(44), (44)==(13), (1)==(45), (45)==(1)
+ │    │    │    │         ├── values
+ │    │    │    │         │    ├── columns: "$1":44 "$4":45
+ │    │    │    │         │    ├── cardinality: [1 - 1]
+ │    │    │    │         │    ├── has-placeholder
+ │    │    │    │         │    ├── key: ()
+ │    │    │    │         │    ├── fd: ()-->(44,45)
+ │    │    │    │         │    └── ($1, $4)
+ │    │    │    │         └── filters
+ │    │    │    │              ├── instance_types.deleted:13 = "$1":44 [outer=(13,44), constraints=(/13: (/NULL - ]; /44: (/NULL - ]), fd=(13)==(44), (44)==(13)]
+ │    │    │    │              └── or [outer=(12), subquery]
+ │    │    │    │                   ├── is_public:12
+ │    │    │    │                   └── coalesce
+ │    │    │    │                        ├── subquery
+ │    │    │    │                        │    └── project
+ │    │    │    │                        │         ├── columns: column30:30!null
+ │    │    │    │                        │         ├── cardinality: [0 - 1]
+ │    │    │    │                        │         ├── has-placeholder
+ │    │    │    │                        │         ├── key: ()
+ │    │    │    │                        │         ├── fd: ()-->(30)
+ │    │    │    │                        │         ├── placeholder-scan instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key
+ │    │    │    │                        │         │    ├── columns: instance_type_projects.instance_type_id:20!null project_id:21!null instance_type_projects.deleted:22!null
+ │    │    │    │                        │         │    ├── cardinality: [0 - 1]
+ │    │    │    │                        │         │    ├── has-placeholder
+ │    │    │    │                        │         │    ├── key: ()
+ │    │    │    │                        │         │    ├── fd: ()-->(20-22)
+ │    │    │    │                        │         │    └── span
+ │    │    │    │                        │         │         ├── $4
+ │    │    │    │                        │         │         ├── $3
+ │    │    │    │                        │         │         └── $2
+ │    │    │    │                        │         └── projections
+ │    │    │    │                        │              └── true [as=column30:30]
+ │    │    │    │                        └── false
+ │    │    │    └── $5
+ │    │    └── $6
+ │    └── filters
+ │         └── instance_type_extra_specs_1.deleted:35 = $7 [outer=(35), constraints=(/35: (/NULL - ]), fd=()-->(35)]
+ └── filters (true)
 
 opt
 select anon_1.flavors_created_at as anon_1_flavors_created_at,
@@ -2204,7 +2195,7 @@ sort
            │    │    │         │    │    │    └── ordering: +30
            │    │    │         │    │    └── filters
            │    │    │         │    │         ├── instance_type_projects.deleted:32 = $4 [outer=(32), constraints=(/32: (/NULL - ]), fd=()-->(32)]
-           │    │    │         │    │         ├── instance_type_projects.deleted:32 = $5 [outer=(32), constraints=(/32: (/NULL - ]), fd=()-->(32)]
+           │    │    │         │    │         ├── $4 = $5
            │    │    │         │    │         └── project_id:31 = $6 [outer=(31), constraints=(/31: (/NULL - ]), fd=()-->(31)]
            │    │    │         │    └── filters (true)
            │    │    │         └── filters
@@ -2409,74 +2400,81 @@ from (select flavors.created_at as flavors_created_at,
      left join flavor_extra_specs as flavor_extra_specs_1
      on flavor_extra_specs_1.flavor_id = anon_1.flavors_id
 ----
-project
- ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:33 flavor_extra_specs_1_updated_at:34 flavor_extra_specs_1_id:29 flavor_extra_specs_1_key:30 flavor_extra_specs_1_value:31 flavor_extra_specs_1_flavor_id:32
+left-join (lookup flavor_extra_specs [as=flavor_extra_specs_1])
+ ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:32 flavor_extra_specs_1_updated_at:33 flavor_extra_specs_1_id:28 flavor_extra_specs_1_key:29 flavor_extra_specs_1_value:30 flavor_extra_specs_1_flavor_id:31
+ ├── key columns: [28] = [28]
+ ├── lookup columns are key
  ├── immutable, has-placeholder
- ├── key: (29)
- ├── fd: ()-->(1-12,14,15,32), (29)-->(30,31,33,34), (30)-->(29,31,33,34)
- └── left-join (lookup flavor_extra_specs [as=flavor_extra_specs_1])
-      ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20 flavor_extra_specs_1.id:29 key:30 value:31 flavor_extra_specs_1.flavor_id:32 flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
-      ├── key columns: [29] = [29]
-      ├── lookup columns are key
-      ├── immutable, has-placeholder
-      ├── key: (29)
-      ├── fd: ()-->(1-12,14,15,19,20,32), (29)-->(30,31,33,34), (30)-->(29,31,33,34)
-      ├── left-join (lookup flavor_extra_specs@flavor_extra_specs_flavor_id_key_idx [as=flavor_extra_specs_1])
-      │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20 flavor_extra_specs_1.id:29 key:30 flavor_extra_specs_1.flavor_id:32
-      │    ├── key columns: [1] = [32]
-      │    ├── immutable, has-placeholder
-      │    ├── key: (29)
-      │    ├── fd: ()-->(1-12,14,15,19,20,32), (29)-->(30), (30)-->(29)
-      │    ├── limit
-      │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
-      │    │    ├── cardinality: [0 - 1]
-      │    │    ├── immutable, has-placeholder
-      │    │    ├── key: ()
-      │    │    ├── fd: ()-->(1-12,14,15,19,20)
-      │    │    ├── offset
-      │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
-      │    │    │    ├── cardinality: [0 - 1]
-      │    │    │    ├── has-placeholder
-      │    │    │    ├── key: ()
-      │    │    │    ├── fd: ()-->(1-12,14,15,19,20)
-      │    │    │    ├── select
-      │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
-      │    │    │    │    ├── cardinality: [0 - 1]
-      │    │    │    │    ├── has-placeholder
-      │    │    │    │    ├── key: ()
-      │    │    │    │    ├── fd: ()-->(1-12,14,15,19,20)
-      │    │    │    │    ├── left-join (merge)
-      │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
-      │    │    │    │    │    ├── left ordering: +1
-      │    │    │    │    │    ├── right ordering: +19
-      │    │    │    │    │    ├── cardinality: [0 - 1]
-      │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,20)
-      │    │    │    │    │    ├── placeholder-scan flavors
-      │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
-      │    │    │    │    │    │    ├── cardinality: [0 - 1]
-      │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15)
-      │    │    │    │    │    │    └── span
-      │    │    │    │    │    │         └── $2
-      │    │    │    │    │    ├── placeholder-scan flavor_projects@flavor_projects_flavor_id_project_id_key
-      │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:19!null project_id:20!null
-      │    │    │    │    │    │    ├── cardinality: [0 - 1]
-      │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    ├── fd: ()-->(19,20)
-      │    │    │    │    │    │    └── span
-      │    │    │    │    │    │         ├── $2
-      │    │    │    │    │    │         └── $1
-      │    │    │    │    │    └── filters (true)
-      │    │    │    │    └── filters
-      │    │    │    │         └── is_public:12 OR (flavor_projects.flavor_id:19 IS NOT NULL) [outer=(12,19)]
-      │    │    │    └── $3
-      │    │    └── $4
-      │    └── filters (true)
-      └── filters (true)
+ ├── key: (28)
+ ├── fd: ()-->(1-12,14,15,31), (28)-->(29,30,32,33), (29)-->(28,30,32,33)
+ ├── left-join (lookup flavor_extra_specs@flavor_extra_specs_flavor_id_key_idx [as=flavor_extra_specs_1])
+ │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_extra_specs_1.id:28 key:29 flavor_extra_specs_1.flavor_id:31
+ │    ├── key columns: [1] = [31]
+ │    ├── immutable, has-placeholder
+ │    ├── key: (28)
+ │    ├── fd: ()-->(1-12,14,15,31), (28)-->(29), (29)-->(28)
+ │    ├── limit
+ │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── immutable, has-placeholder
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1-12,14,15)
+ │    │    ├── offset
+ │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
+ │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    ├── has-placeholder
+ │    │    │    ├── key: ()
+ │    │    │    ├── fd: ()-->(1-12,14,15)
+ │    │    │    ├── project
+ │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
+ │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    ├── has-placeholder
+ │    │    │    │    ├── key: ()
+ │    │    │    │    ├── fd: ()-->(1-12,14,15)
+ │    │    │    │    └── inner-join (lookup flavors)
+ │    │    │    │         ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 "$2":38!null
+ │    │    │    │         ├── flags: disallow merge join
+ │    │    │    │         ├── key columns: [38] = [1]
+ │    │    │    │         ├── lookup columns are key
+ │    │    │    │         ├── cardinality: [0 - 1]
+ │    │    │    │         ├── parameterized columns: (38)
+ │    │    │    │         ├── has-placeholder
+ │    │    │    │         ├── key: ()
+ │    │    │    │         ├── fd: ()-->(1-12,14,15,38), (1)==(38), (38)==(1)
+ │    │    │    │         ├── values
+ │    │    │    │         │    ├── columns: "$2":38
+ │    │    │    │         │    ├── cardinality: [1 - 1]
+ │    │    │    │         │    ├── has-placeholder
+ │    │    │    │         │    ├── key: ()
+ │    │    │    │         │    ├── fd: ()-->(38)
+ │    │    │    │         │    └── ($2,)
+ │    │    │    │         └── filters
+ │    │    │    │              └── or [outer=(12), subquery]
+ │    │    │    │                   ├── is_public:12
+ │    │    │    │                   └── coalesce
+ │    │    │    │                        ├── subquery
+ │    │    │    │                        │    └── project
+ │    │    │    │                        │         ├── columns: column27:27!null
+ │    │    │    │                        │         ├── cardinality: [0 - 1]
+ │    │    │    │                        │         ├── has-placeholder
+ │    │    │    │                        │         ├── key: ()
+ │    │    │    │                        │         ├── fd: ()-->(27)
+ │    │    │    │                        │         ├── placeholder-scan flavor_projects@flavor_projects_flavor_id_project_id_key
+ │    │    │    │                        │         │    ├── columns: flavor_projects.flavor_id:19!null project_id:20!null
+ │    │    │    │                        │         │    ├── cardinality: [0 - 1]
+ │    │    │    │                        │         │    ├── has-placeholder
+ │    │    │    │                        │         │    ├── key: ()
+ │    │    │    │                        │         │    ├── fd: ()-->(19,20)
+ │    │    │    │                        │         │    └── span
+ │    │    │    │                        │         │         ├── $2
+ │    │    │    │                        │         │         └── $1
+ │    │    │    │                        │         └── projections
+ │    │    │    │                        │              └── true [as=column27:27]
+ │    │    │    │                        └── false
+ │    │    │    └── $3
+ │    │    └── $4
+ │    └── filters (true)
+ └── filters (true)
 
 opt
 select anon_1.flavors_created_at as anon_1_flavors_created_at,

--- a/pkg/sql/opt/xform/testdata/rules/generic
+++ b/pkg/sql/opt/xform/testdata/rules/generic
@@ -1111,3 +1111,130 @@ project
       │    ├── fd: ()-->(1)
       │    └── ($1,)
       └── filters (true)
+
+# Regression test for #164666. The EXISTS subquery references t1.k2 via
+# correlation; after InlineConstVar propagates the placeholder from
+# t1.k2 = $1, the subquery filter becomes t3.k2 = $1, enabling an index
+# scan on t3 instead of a full scan.
+exec-ddl
+CREATE TABLE t164666_t1 (
+  k1 INT8 NOT NULL,
+  k2 INT8 NOT NULL,
+  a1 STRING NULL,
+  fk1 INT8 NULL,
+  CONSTRAINT pk_t164666_t1 PRIMARY KEY (k1 ASC),
+  INDEX ix_t164666_t1_k2 (k2 ASC)
+)
+----
+
+exec-ddl
+CREATE TABLE t164666_t3 (
+  k4 INT8 NOT NULL,
+  fk2 STRING NOT NULL DEFAULT '',
+  k2 INT8 NULL,
+  k1 INT8 NULL,
+  b1 BOOL NULL,
+  CONSTRAINT pk_t164666_t3 PRIMARY KEY (k4 ASC),
+  INDEX ix_t164666_t3_k2 (k2 ASC)
+)
+----
+
+opt
+SELECT t164666_t1.k1
+FROM t164666_t1
+WHERE t164666_t1.k2 = $1
+AND (
+  t164666_t1.a1 IS NOT NULL
+  OR EXISTS(
+    SELECT 1
+    FROM t164666_t3
+    WHERE t164666_t3.k1 = t164666_t1.k1
+    AND t164666_t3.k2 = t164666_t1.k2
+  )
+)
+----
+project
+ ├── columns: k1:1!null
+ ├── has-placeholder
+ ├── key: (1)
+ └── select
+      ├── columns: t164666_t1.k1:1!null a1:3 canary_agg:16
+      ├── has-placeholder
+      ├── key: (1)
+      ├── fd: (1)-->(3,16)
+      ├── group-by (hash)
+      │    ├── columns: t164666_t1.k1:1!null a1:3 canary_agg:16
+      │    ├── grouping columns: t164666_t1.k1:1!null
+      │    ├── has-placeholder
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(3,16)
+      │    ├── left-join (hash)
+      │    │    ├── columns: t164666_t1.k1:1!null t164666_t1.k2:2!null a1:3 t164666_t3.k2:9 t164666_t3.k1:10
+      │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
+      │    │    ├── has-placeholder
+      │    │    ├── fd: ()-->(2), (1)-->(3)
+      │    │    ├── project
+      │    │    │    ├── columns: t164666_t1.k1:1!null t164666_t1.k2:2!null a1:3
+      │    │    │    ├── has-placeholder
+      │    │    │    ├── key: (1)
+      │    │    │    ├── fd: ()-->(2), (1)-->(3)
+      │    │    │    └── inner-join (lookup t164666_t1)
+      │    │    │         ├── columns: t164666_t1.k1:1!null t164666_t1.k2:2!null a1:3 "$1":18!null
+      │    │    │         ├── key columns: [1] = [1]
+      │    │    │         ├── lookup columns are key
+      │    │    │         ├── has-placeholder
+      │    │    │         ├── key: (1)
+      │    │    │         ├── fd: ()-->(2,18), (1)-->(3), (2)==(18), (18)==(2)
+      │    │    │         ├── inner-join (lookup t164666_t1@ix_t164666_t1_k2)
+      │    │    │         │    ├── columns: t164666_t1.k1:1!null t164666_t1.k2:2!null "$1":18!null
+      │    │    │         │    ├── flags: disallow merge join
+      │    │    │         │    ├── key columns: [18] = [2]
+      │    │    │         │    ├── parameterized columns: (18)
+      │    │    │         │    ├── has-placeholder
+      │    │    │         │    ├── key: (1)
+      │    │    │         │    ├── fd: ()-->(2,18), (2)==(18), (18)==(2)
+      │    │    │         │    ├── values
+      │    │    │         │    │    ├── columns: "$1":18
+      │    │    │         │    │    ├── cardinality: [1 - 1]
+      │    │    │         │    │    ├── has-placeholder
+      │    │    │         │    │    ├── key: ()
+      │    │    │         │    │    ├── fd: ()-->(18)
+      │    │    │         │    │    └── ($1,)
+      │    │    │         │    └── filters (true)
+      │    │    │         └── filters (true)
+      │    │    ├── project
+      │    │    │    ├── columns: t164666_t3.k2:9!null t164666_t3.k1:10
+      │    │    │    ├── has-placeholder
+      │    │    │    ├── fd: ()-->(9)
+      │    │    │    └── inner-join (lookup t164666_t3)
+      │    │    │         ├── columns: t164666_t3.k2:9!null t164666_t3.k1:10 "$1":19!null
+      │    │    │         ├── key columns: [7] = [7]
+      │    │    │         ├── lookup columns are key
+      │    │    │         ├── has-placeholder
+      │    │    │         ├── fd: ()-->(9,19), (9)==(19), (19)==(9)
+      │    │    │         ├── inner-join (lookup t164666_t3@ix_t164666_t3_k2)
+      │    │    │         │    ├── columns: k4:7!null t164666_t3.k2:9!null "$1":19!null
+      │    │    │         │    ├── flags: disallow merge join
+      │    │    │         │    ├── key columns: [19] = [9]
+      │    │    │         │    ├── parameterized columns: (19)
+      │    │    │         │    ├── has-placeholder
+      │    │    │         │    ├── key: (7)
+      │    │    │         │    ├── fd: ()-->(9,19), (9)==(19), (19)==(9)
+      │    │    │         │    ├── values
+      │    │    │         │    │    ├── columns: "$1":19
+      │    │    │         │    │    ├── cardinality: [1 - 1]
+      │    │    │         │    │    ├── has-placeholder
+      │    │    │         │    │    ├── key: ()
+      │    │    │         │    │    ├── fd: ()-->(19)
+      │    │    │         │    │    └── ($1,)
+      │    │    │         │    └── filters (true)
+      │    │    │         └── filters (true)
+      │    │    └── filters
+      │    │         └── t164666_t3.k1:10 = t164666_t1.k1:1 [outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
+      │    └── aggregations
+      │         ├── const-not-null-agg [as=canary_agg:16, outer=(9)]
+      │         │    └── t164666_t3.k2:9
+      │         └── const-agg [as=a1:3, outer=(3)]
+      │              └── a1:3
+      └── filters
+           └── (a1:3 IS NOT NULL) OR (canary_agg:16 IS NOT NULL) [outer=(3,16)]


### PR DESCRIPTION
Fixes: https://github.com/cockroachdb/cockroach/issues/164666

Release note (performance improvement): We now inline placeholder
equalities into other references of the same column, such as correlated
subqueries. This allows constrained index scans in prepared statements
where previously a full scan was required.