### PR TITLE
roachtest/operations: add consistency checker operation

### DIFF
--- a/pkg/cmd/roachtest/operations/BUILD.bazel
+++ b/pkg/cmd/roachtest/operations/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "backup_restore.go",
         "cancel_job.go",
         "cluster_settings.go",
+        "consistency_checks.go",
         "debug_zip.go",
         "disk_stall.go",
         "grant_revoke_all.go",

--- a/pkg/cmd/roachtest/operations/consistency_checks.go
+++ b/pkg/cmd/roachtest/operations/consistency_checks.go
@@ -1,0 +1,121 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package operations
+
+import (
+	"context"
+	gosql "database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/operation"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestflags"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+// runConsistencyChecks connects to a random cluster node and verifies
+// schema consistency by querying crdb_internal.invalid_objects.
+func runConsistencyChecks(
+	ctx context.Context, o operation.Operation, c cluster.Cluster,
+) registry.OperationCleanup {
+	rng, _ := randutil.NewPseudoRand()
+	nodes := c.All()
+	nid := nodes[rng.Intn(len(nodes))]
+
+	conn := c.Conn(ctx, o.L(), nid, option.VirtualClusterName(roachtestflags.VirtualCluster))
+	defer conn.Close()
+
+	o.Status("starting SQL consistency checks")
+	checkInvalidObjects(ctx, o, conn)
+	o.Status("SQL consistency checks complete")
+
+	return nil
+}
+
+// checkInvalidObjects queries crdb_internal.invalid_objects for broken
+// schema references such as dangling foreign keys, missing types, or
+// orphaned descriptors.
+func checkInvalidObjects(ctx context.Context, o operation.Operation, conn *gosql.DB) {
+	o.Status("checking for invalid objects")
+	invalids, err := queryInvalidObjects(ctx, conn)
+	if err != nil {
+		o.Fatal(err)
+	}
+	if len(invalids) == 0 {
+		o.Status("no invalid objects found")
+		return
+	}
+
+	// Re-check after a delay to filter transient inconsistencies caused
+	// by concurrent DDL operations.
+	o.Status(fmt.Sprintf(
+		"found %d invalid object(s), rechecking after delay to filter transient states",
+		len(invalids),
+	))
+	recheckTimer := time.NewTimer(2 * time.Minute)
+	defer recheckTimer.Stop()
+	select {
+	case <-recheckTimer.C:
+	case <-ctx.Done():
+		o.Fatalf("context canceled while waiting for recheck: %v", ctx.Err())
+	}
+
+	invalids, err = queryInvalidObjects(ctx, conn)
+	if err != nil {
+		o.Fatal(err)
+	}
+	if len(invalids) == 0 {
+		o.Status("no invalid objects found on recheck")
+		return
+	}
+	o.Fatalf("found %d persistent invalid object(s):\n%s",
+		len(invalids), strings.Join(invalids, "\n"))
+}
+
+// queryInvalidObjects runs a single query against
+// crdb_internal.invalid_objects and returns the results as formatted
+// strings.
+func queryInvalidObjects(ctx context.Context, conn *gosql.DB) ([]string, error) {
+	checkCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	rows, err := conn.QueryContext(checkCtx,
+		`SELECT database_name, schema_name, obj_name, error FROM "".crdb_internal.invalid_objects`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var invalids []string
+	for rows.Next() {
+		var dbName, schemaName, objName, objError string
+		if err := rows.Scan(&dbName, &schemaName, &objName, &objError); err != nil {
+			return nil, err
+		}
+		invalids = append(invalids, fmt.Sprintf("%s.%s.%s: %s", dbName, schemaName, objName, objError))
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return invalids, nil
+}
+
+func registerConsistencyCheck(r registry.Registry) {
+	r.AddOperation(registry.OperationSpec{
+		Name:                    "consistency-check",
+		Owner:                   registry.OwnerKV,
+		Timeout:                 1 * time.Hour,
+		CompatibleClouds:        registry.AllClouds,
+		CanRunConcurrently:      registry.OperationCannotRunConcurrentlyWithItself,
+		Dependencies:            []registry.OperationDependency{registry.OperationRequiresPopulatedDatabase},
+		WaitBeforeNextExecution: 12 * time.Hour,
+		Run:                     runConsistencyChecks,
+	})
+}

--- a/pkg/cmd/roachtest/operations/register.go
+++ b/pkg/cmd/roachtest/operations/register.go
@@ -35,4 +35,5 @@ func RegisterOperations(r registry.Registry) {
 	registerDebugZip(r)
 	changefeeds.RegisterChangefeeds(r)
 	registerInspect(r)
+	registerConsistencyCheck(r)
 }

--- a/pkg/cmd/roachtest/registry/operation_spec.go
+++ b/pkg/cmd/roachtest/registry/operation_spec.go
@@ -90,6 +90,11 @@ type OperationSpec struct {
 	// --wait-before-cleanup.
 	WaitBeforeCleanup time.Duration
 
+	// WaitBeforeNextExecution specifies the minimum duration between
+	// consecutive runs of this operation. This overrides the global
+	// --wait-before-next-execution flag. If zero, the global value is used.
+	WaitBeforeNextExecution time.Duration
+
 	// Run is the operation function. It returns an OperationCleanup if this
 	// operation requires additional cleanup steps afterwards (eg. dropping an
 	// extra column that was created). A nil return value indicates no cleanup

--- a/pkg/cmd/roachtest/run_operation.go
+++ b/pkg/cmd/roachtest/run_operation.go
@@ -230,9 +230,14 @@ func (r *opsRunner) selectOperationToRun(
 	}
 
 	// If the time since the last run of the operation has not exceeded its
-	// cadence, choose another operation.
+	// cadence, choose another operation. Per-operation WaitBeforeNextExecution
+	// overrides the global default when set.
 	if lastRun, ok := r.status.lastRun[opSpec.NamePrefix()]; ok {
-		nextRunTime := lastRun.Add(r.waitBeforeNextExecution)
+		interval := r.waitBeforeNextExecution
+		if opSpec.WaitBeforeNextExecution != 0 {
+			interval = opSpec.WaitBeforeNextExecution
+		}
+		nextRunTime := lastRun.Add(interval)
 		if timeutil.Now().Before(nextRunTime) {
 			return nil
 		}
@@ -240,12 +245,24 @@ func (r *opsRunner) selectOperationToRun(
 
 	if opSpec.CanRunConcurrently == registry.OperationCannotRunConcurrently {
 		r.status.lockOperationSelection = true
-		// selected operation cannot run concurrently with other operations —
-		// wait for other running operation completion.
+		// Selected operation cannot run concurrently with other operations.
+		// Wait for other running operations to complete, with a timeout to
+		// prevent indefinite blocking when long-running operations (e.g.,
+		// multi-day backup-restore) are in flight.
 		workerLabel := strconv.Itoa(workerID)
-		for {
-			if len(r.status.running) == 0 {
-				break
+		drainDeadline := timeutil.Now().Add(30 * time.Minute)
+		for len(r.status.running) > 0 {
+			if ctx.Err() != nil {
+				r.status.lockOperationSelection = false
+				return nil
+			}
+			if timeutil.Now().After(drainDeadline) {
+				r.logger.Printf(
+					"[%d] drain timed out waiting for %d operation(s) to complete, skipping exclusive op %s",
+					workerID, len(r.status.running), opSpec.Name,
+				)
+				r.status.lockOperationSelection = false
+				return nil
 			}
 			r.setWorkerState(workerLabel, workerOperationIdle, workerStateIdle, opSpec.NamePrefix(), workerStateWaitingLock)
 			r.logger.Printf("[%d] operation: %s waiting for other operation to complete", workerID, opSpec.Name)


### PR DESCRIPTION
## Summary

- Add a new roachtest operation (`consistency-check`) that queries `crdb_internal.invalid_objects` to detect broken schema references, with a 2-minute recheck delay to filter transient inconsistencies from concurrent DDL.
- Introduce per-operation `WaitBeforeNextExecution` on `OperationSpec` so individual operations can override the global execution cadence (consistency checker uses 12h).
- Add a 30-minute drain timeout to the exclusive-operation wait loop to prevent indefinite blocking when long-running operations are in flight.

Epic: none
Release note: None
Fixes: #163589 