### PR TITLE
concurrency: allow VIR in non-test builds

### DIFF
--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
-	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/debugutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -174,12 +173,6 @@ var VirtualIntentResolution = settings.RegisterBoolSetting(
 	// solved.
 	// metamorphic.ConstantWithTestBool("kv.concurrency.virtual_intent_resolution.enabled",
 	// false),
-	settings.WithValidateBool(func(_ *settings.Values, b bool) error {
-		if b && !buildutil.CrdbTestBuild {
-			return errors.New("kv.concurrency.virtual_intent_resolution.enabled is not supported in production builds")
-		}
-		return nil
-	}),
 )
 
 // PushUsingCachedClockObservation controls whether we allow intents from


### PR DESCRIPTION
This "test builds only" prevents us from enabling the feature reliably in roachtests. Since the feature is a bit further along now, it seems reasonable to remove this. It is still an undocumented setting.

Fixes #164821
Releaes note: None