### PR TITLE
dev: make `bench` command respect benchdoc parameters

### DIFF
--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=121
+DEV_VERSION=122
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/BUILD.bazel
+++ b/pkg/cmd/dev/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//pkg/build/util",
         "//pkg/cmd/dev/io/exec",
         "//pkg/cmd/dev/io/os",
+        "//pkg/testutils/benchdoc",
         "//pkg/util/buildutil",
         "@com_github_alessio_shellescape//:shellescape",
         "@com_github_google_shlex//:shlex",
@@ -69,6 +70,7 @@ disallowed_imports_test(
     "dev_lib",
     allowlist = [
         "//pkg/build/util",
+        "//pkg/testutils/benchdoc",
         "//pkg/util/buildutil",
         "//pkg/cmd/dev/io/exec",
         "//pkg/cmd/dev/io/os",

--- a/pkg/cmd/dev/bench.go
+++ b/pkg/cmd/dev/bench.go
@@ -6,11 +6,18 @@
 package main
 
 import (
+	"context"
 	"fmt"
+	"go/parser"
+	"go/token"
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/testutils/benchdoc"
 	"github.com/spf13/cobra"
 )
 
@@ -55,6 +62,14 @@ This behavior can be overridden with --test-args='-test.cpu N'`,
 	return benchCmd
 }
 
+// benchRun groups benchmarks that share the same RunArgs so they can be
+// executed in a single bazel invocation.
+type benchRun struct {
+	filter  string
+	names   []string // benchmark names in this group, for display purposes
+	runArgs benchdoc.RunArgs
+}
+
 func (d *dev) bench(cmd *cobra.Command, commandLine []string) error {
 	pkgs, additionalBazelArgs := splitArgsAtDash(cmd, commandLine)
 	ctx := cmd.Context()
@@ -83,13 +98,6 @@ func (d *dev) bench(cmd *cobra.Command, commandLine []string) error {
 		pkgs = append(pkgs, "pkg/...")
 	}
 
-	var args []string
-	args = append(args, "test")
-	addCommonBazelArguments(&args)
-	if timeout > 0 {
-		args = append(args, fmt.Sprintf("--test_timeout=%d", int(timeout.Seconds())))
-	}
-
 	var testTargets []string
 	for _, pkg := range pkgs {
 		labels, err := d.getTestTargets(ctx, pkg)
@@ -103,56 +111,340 @@ func (d *dev) bench(cmd *cobra.Command, commandLine []string) error {
 		testTargets = append(testTargets, labels...)
 	}
 
-	args = append(args, testTargets...)
-	if ignoreCache {
+	// When a filter is provided, look up benchdoc annotations in the source
+	// files for the specified packages. Benchmarks are grouped by their
+	// effective RunArgs so that benchmarks needing different parameters get
+	// separate bazel invocations.
+	var runs []benchRun
+	if filter != "" {
+		workspace, err := d.getWorkspace(ctx)
+		if err != nil {
+			return err
+		}
+		runs, err = d.groupBenchmarksByRunArgs(workspace, pkgs, filter)
+		if err != nil {
+			// Non-fatal: fall back to running with CLI args only.
+			log.Printf("WARNING: could not read benchdoc annotations: %v", err)
+			runs = nil
+		}
+	}
+
+	// Apply CLI flag overrides to benchdoc RunArgs. CLI flags take
+	// precedence when explicitly set by the user.
+	countChanged := cmd.Flags().Changed(countFlag)
+	timeoutChanged := cmd.Flags().Changed(timeoutFlag)
+	for i := range runs {
+		if countChanged {
+			runs[i].runArgs.Count = count
+		}
+		if benchTime != "" {
+			runs[i].runArgs.BenchTime = benchTime
+		}
+		if timeoutChanged {
+			runs[i].runArgs.Timeout = timeout
+		}
+	}
+
+	// If we have no benchdoc-driven groups (no filter, or parsing failed),
+	// fall back to a single run with CLI flags.
+	if len(runs) == 0 {
+		ra := benchdoc.NewRunArgs()
+		ra.Count = count
+		ra.BenchTime = benchTime
+		ra.Timeout = timeout
+		runs = []benchRun{{filter: filter, runArgs: ra}}
+	}
+
+	// Deduplicate runs that ended up with identical RunArgs after overrides.
+	runs = deduplicateRuns(runs)
+
+	for i, run := range runs {
+		if len(runs) > 1 {
+			log.Printf("=== benchmark invocation %d/%d: %s ===",
+				i+1, len(runs), strings.Join(run.names, ", "))
+		}
+		if err := d.runBench(ctx, runBenchOpts{
+			run:                 run,
+			testTargets:         testTargets,
+			ignoreCache:         ignoreCache,
+			short:               short,
+			showLogs:            showLogs,
+			verbose:             verbose,
+			benchMem:            benchMem,
+			streamOutput:        streamOutput,
+			testArgs:            testArgs,
+			runSepProcessTenant: runSepProcessTenant,
+			additionalBazelArgs: additionalBazelArgs,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type runBenchOpts struct {
+	run                 benchRun
+	testTargets         []string
+	ignoreCache         bool
+	short               bool
+	showLogs            bool
+	verbose             bool
+	benchMem            bool
+	streamOutput        bool
+	testArgs            string
+	runSepProcessTenant bool
+	additionalBazelArgs []string
+}
+
+// runBench executes a single bazel test invocation for a group of benchmarks
+// that share the same RunArgs.
+func (d *dev) runBench(ctx context.Context, opts runBenchOpts) error {
+	run := opts.run
+	var args []string
+	args = append(args, "test")
+	addCommonBazelArguments(&args)
+	if run.runArgs.Timeout > 0 {
+		args = append(args, fmt.Sprintf("--test_timeout=%d",
+			int(run.runArgs.Timeout.Seconds())))
+	}
+
+	args = append(args, opts.testTargets...)
+	if opts.ignoreCache {
 		args = append(args, "--nocache_test_results")
 	}
 
 	args = append(args, "--test_arg", "-test.run=-")
-	if filter == "" {
+	if run.filter == "" {
 		args = append(args, "--test_arg", "-test.bench=.")
 	} else {
-		args = append(args, "--test_arg", fmt.Sprintf("-test.bench=%s", filter))
+		args = append(args, "--test_arg",
+			fmt.Sprintf("-test.bench=%s", run.filter))
 	}
 	args = append(args, "--test_sharding_strategy=disabled")
 	args = append(args, "--test_arg", "-test.cpu", "--test_arg", "1")
-	if short {
+	if opts.short {
 		args = append(args, "--test_arg", "-test.short")
 	}
-	if verbose {
+	if opts.verbose {
 		args = append(args, "--test_arg", "-test.v")
 	}
-	if showLogs {
+	if opts.showLogs {
 		args = append(args, "--test_arg", "-show-logs")
 	}
-	if count != 1 {
-		args = append(args, "--test_arg", fmt.Sprintf("-test.count=%d", count))
+	if run.runArgs.Count > 1 {
+		args = append(args, "--test_arg",
+			fmt.Sprintf("-test.count=%d", run.runArgs.Count))
 	}
-	if benchTime != "" {
-		args = append(args, "--test_arg", fmt.Sprintf("-test.benchtime=%s", benchTime))
+	if run.runArgs.BenchTime != "" {
+		args = append(args, "--test_arg",
+			fmt.Sprintf("-test.benchtime=%s", run.runArgs.BenchTime))
 	}
-	if benchMem {
+	if opts.benchMem {
 		args = append(args, "--test_arg", "-test.benchmem")
 	}
-	if runSepProcessTenant {
+	if opts.runSepProcessTenant {
 		args = append(args, "--test_arg", "-run-sep-process-tenant")
 	}
-	// The `crdb_test` flag enables metamorphic variables and various "extra" debug
-	// checking code paths that can interfere with performance testing, hence
-	// it should disabled for benchmarks.
+	// The `crdb_test` flag enables metamorphic variables and various "extra"
+	// debug checking code paths that can interfere with performance testing,
+	// hence it should be disabled for benchmarks.
 	args = append(args, "--crdb_test_off", "--crdb_bench")
-	if testArgs != "" {
-		goTestArgs, err := d.getGoTestArgs(ctx, testArgs)
+	if opts.testArgs != "" {
+		goTestArgs, err := d.getGoTestArgs(ctx, opts.testArgs)
 		if err != nil {
 			return err
 		}
 		args = append(args, goTestArgs...)
 	}
 	args = append(args, d.getGoTestEnvArgs()...)
-	args = append(args, d.getTestOutputArgs(verbose, showLogs, streamOutput)...)
-	args = append(args, additionalBazelArgs...)
+	args = append(args, d.getTestOutputArgs(
+		opts.verbose, opts.showLogs, opts.streamOutput)...)
+	args = append(args, opts.additionalBazelArgs...)
 	logCommand("bazel", args...)
 	return d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...)
+}
+
+// groupBenchmarksByRunArgs scans _test.go files in the given packages for
+// benchdoc annotations, filters benchmarks by the provided regex, and groups
+// them by their RunArgs. Benchmarks with no benchdoc annotation use defaults.
+func (d *dev) groupBenchmarksByRunArgs(
+	workspace string, pkgs []string, filter string,
+) ([]benchRun, error) {
+	filterRe, err := regexp.Compile(filter)
+	if err != nil {
+		return nil, fmt.Errorf("invalid filter regex: %w", err)
+	}
+
+	// Collect all benchmark infos from the specified packages.
+	var allInfos []benchdoc.BenchmarkInfo
+	for _, pkg := range pkgs {
+		// Skip wildcard packages — we can't enumerate source files for
+		// pkg/... without walking the entire tree.
+		if strings.HasSuffix(pkg, "/...") {
+			continue
+		}
+		pkg = normalizePackage(pkg)
+		// Strip any Bazel target suffix (e.g., ":foo_test").
+		if idx := strings.IndexByte(pkg, ':'); idx >= 0 {
+			pkg = pkg[:idx]
+		}
+
+		pkgDir := filepath.Join(workspace, pkg)
+		infos, parseErr := parseBenchmarkInfos(pkgDir, pkg)
+		if parseErr != nil {
+			return nil, parseErr
+		}
+		allInfos = append(allInfos, infos...)
+	}
+
+	if len(allInfos) == 0 {
+		return nil, nil
+	}
+
+	// Filter benchmarks by the regex and group by RunArgs.
+	type runArgsKey struct {
+		Count     int
+		BenchTime string
+		Timeout   time.Duration
+	}
+	groups := make(map[runArgsKey][]string) // key → list of benchmark names
+	argsMap := make(map[runArgsKey]benchdoc.RunArgs)
+
+	for _, info := range allInfos {
+		if !filterRe.MatchString(info.Name) {
+			continue
+		}
+		key := runArgsKey{
+			Count:     info.RunArgs.Count,
+			BenchTime: info.RunArgs.BenchTime,
+			Timeout:   info.RunArgs.Timeout,
+		}
+		groups[key] = append(groups[key], info.Name)
+		argsMap[key] = info.RunArgs
+	}
+
+	if len(groups) == 0 {
+		return nil, nil
+	}
+
+	// If all matched benchmarks have the same RunArgs, keep the original
+	// filter to allow sub-benchmark matching (e.g., "BenchmarkFoo/case1").
+	if len(groups) == 1 {
+		for key, names := range groups {
+			ra := argsMap[key]
+			if !hasCustomRunArgs(ra) {
+				// All defaults — nothing to override.
+				return nil, nil
+			}
+			logBenchdocArgs(names, ra)
+			return []benchRun{{filter: filter, names: names, runArgs: ra}}, nil
+		}
+	}
+
+	// Multiple groups: build a precise filter for each group.
+	var runs []benchRun
+	for key, names := range groups {
+		ra := argsMap[key]
+		// Build an exact-match filter: ^(BenchmarkA|BenchmarkB)$
+		benchFilter := "^(" + strings.Join(names, "|") + ")$"
+		if hasCustomRunArgs(ra) {
+			logBenchdocArgs(names, ra)
+		}
+		runs = append(runs, benchRun{
+			filter: benchFilter, names: names, runArgs: ra,
+		})
+	}
+	return runs, nil
+}
+
+// parseBenchmarkInfos parses all _test.go files in pkgDir and returns
+// benchmark info for each benchmark function found.
+func parseBenchmarkInfos(pkgDir string, pkg string) ([]benchdoc.BenchmarkInfo, error) {
+	entries, err := os.ReadDir(pkgDir)
+	if err != nil {
+		return nil, fmt.Errorf("reading package directory %s: %w", pkgDir, err)
+	}
+
+	var infos []benchdoc.BenchmarkInfo
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+		path := filepath.Join(pkgDir, entry.Name())
+		fset := token.NewFileSet()
+		f, parseErr := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		if parseErr != nil {
+			// Skip files that fail to parse.
+			continue
+		}
+		packageResolver := func() (string, error) { return pkg, nil }
+		teamResolver := func() (string, error) { return "", nil }
+		bi, analyzeErr := benchdoc.AnalyzeBenchmarkDocs(
+			f, packageResolver, teamResolver,
+			true /* lenient */, nil /* reportFailure */)
+		if analyzeErr != nil {
+			return nil, analyzeErr
+		}
+		infos = append(infos, bi...)
+	}
+	return infos, nil
+}
+
+// deduplicateRuns merges runs that have identical RunArgs into a single run
+// with a combined filter.
+func deduplicateRuns(runs []benchRun) []benchRun {
+	if len(runs) <= 1 {
+		return runs
+	}
+	type key struct {
+		Count     int
+		BenchTime string
+		Timeout   time.Duration
+	}
+	seen := make(map[key]int) // key → index in result
+	var result []benchRun
+	for _, r := range runs {
+		k := key{
+			Count:     r.runArgs.Count,
+			BenchTime: r.runArgs.BenchTime,
+			Timeout:   r.runArgs.Timeout,
+		}
+		if idx, ok := seen[k]; ok {
+			// Merge filters and names.
+			existing := result[idx].filter
+			if existing != "" && r.filter != "" {
+				result[idx].filter = existing + "|" + r.filter
+			}
+			result[idx].names = append(result[idx].names, r.names...)
+		} else {
+			seen[k] = len(result)
+			result = append(result, r)
+		}
+	}
+	return result
+}
+
+func hasCustomRunArgs(ra benchdoc.RunArgs) bool {
+	return ra.Count > 0 || ra.BenchTime != "" || ra.Timeout > 0
+}
+
+func logBenchdocArgs(names []string, ra benchdoc.RunArgs) {
+	log.Printf("benchdoc: %s: %s",
+		strings.Join(names, ", "), formatRunArgs(ra))
+}
+
+func formatRunArgs(ra benchdoc.RunArgs) string {
+	var parts []string
+	if ra.Count > 0 {
+		parts = append(parts, fmt.Sprintf("count=%d", ra.Count))
+	}
+	if ra.BenchTime != "" {
+		parts = append(parts, fmt.Sprintf("benchtime=%s", ra.BenchTime))
+	}
+	if ra.Timeout > 0 {
+		parts = append(parts, fmt.Sprintf("timeout=%s", ra.Timeout))
+	}
+	return strings.Join(parts, ", ")
 }
 
 func (d *dev) getGoTestEnvArgs() []string {

--- a/pkg/cmd/dev/util.go
+++ b/pkg/cmd/dev/util.go
@@ -211,6 +211,16 @@ func logCommand(cmd string, args ...string) {
 	log.Printf("$ %s", shellescape.QuoteCommand(fullArgs))
 }
 
+// normalizePackage strips Bazel-style prefixes ("//", "./") and trailing
+// slashes from a package path, returning a clean relative path like
+// "pkg/sql/parser".
+func normalizePackage(pkg string) string {
+	pkg = strings.TrimPrefix(pkg, "//")
+	pkg = strings.TrimPrefix(pkg, "./")
+	pkg = strings.TrimRight(pkg, "/")
+	return pkg
+}
+
 func sendBepDataToBeaverHubIfNeeded(bepFilepath string) error {
 	// Check if a BEP file exists.
 	if _, err := os.Stat(bepFilepath); err != nil {

--- a/pkg/testutils/benchdoc/BUILD.bazel
+++ b/pkg/testutils/benchdoc/BUILD.bazel
@@ -8,7 +8,6 @@ go_library(
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/testutils/benchdoc",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_cockroachdb_errors//:errors"],
 )
 
 go_test(

--- a/pkg/testutils/benchdoc/benchdoc.go
+++ b/pkg/testutils/benchdoc/benchdoc.go
@@ -12,8 +12,6 @@ import (
 	"go/token"
 	"strings"
 	"time"
-
-	"github.com/cockroachdb/errors"
 )
 
 type (
@@ -179,7 +177,7 @@ func analyzeBenchmarkArgs(fn *ast.FuncDecl) (RunArgs, CompareArgs, error) {
 			kv := strings.SplitN(part, "=", 2)
 			if len(kv) != 2 {
 				return RunArgs{}, CompareArgs{},
-					errors.Newf("malformed key-value pair in %s: %q", fn.Name.Name, part)
+					fmt.Errorf("malformed key-value pair in %s: %q", fn.Name.Name, part)
 			}
 			key := strings.TrimSpace(kv[0])
 			val := strings.TrimSpace(kv[1])
@@ -188,7 +186,7 @@ func analyzeBenchmarkArgs(fn *ast.FuncDecl) (RunArgs, CompareArgs, error) {
 				var count int
 				if n, err := fmt.Sscanf(val, "%d", &count); err != nil || n != 1 {
 					return RunArgs{}, CompareArgs{},
-						errors.Newf("invalid count value in %s: %q", fn.Name.Name, val)
+						fmt.Errorf("invalid count value in %s: %q", fn.Name.Name, val)
 				}
 				runArgs.Count = count
 			case "benchtime":
@@ -197,7 +195,7 @@ func analyzeBenchmarkArgs(fn *ast.FuncDecl) (RunArgs, CompareArgs, error) {
 				d, err := time.ParseDuration(val)
 				if err != nil {
 					return RunArgs{}, CompareArgs{},
-						errors.Wrapf(err, "invalid timeout value in %s", fn.Name.Name)
+						fmt.Errorf("invalid timeout value in %s: %w", fn.Name.Name, err)
 				}
 				runArgs.Timeout = d
 			case "suite":
@@ -208,7 +206,7 @@ func analyzeBenchmarkArgs(fn *ast.FuncDecl) (RunArgs, CompareArgs, error) {
 					runArgs.Suite = SuiteManual
 				default:
 					return RunArgs{}, CompareArgs{},
-						errors.Newf("invalid suite value in %s: %q", fn.Name.Name, val)
+						fmt.Errorf("invalid suite value in %s: %q", fn.Name.Name, val)
 				}
 			case "post":
 				switch val {
@@ -220,22 +218,22 @@ func analyzeBenchmarkArgs(fn *ast.FuncDecl) (RunArgs, CompareArgs, error) {
 					compareArgs.PostIssue = PostIssueBlocker
 				default:
 					return RunArgs{}, CompareArgs{},
-						errors.Newf("invalid post issue value in %s: %q", fn.Name.Name, val)
+						fmt.Errorf("invalid post issue value in %s: %q", fn.Name.Name, val)
 				}
 			case "threshold":
 				var threshold float64
 				if n, err := fmt.Sscanf(val, "%f", &threshold); err != nil || n != 1 {
 					return RunArgs{}, CompareArgs{},
-						errors.Newf("invalid threshold value in %s: %q", fn.Name.Name, val)
+						fmt.Errorf("invalid threshold value in %s: %q", fn.Name.Name, val)
 				}
 				if threshold < 0 || threshold > 1.0 {
 					return RunArgs{}, CompareArgs{},
-						errors.Newf("threshold must be in range [0.0, 1.0] in %s: %f", fn.Name.Name, threshold)
+						fmt.Errorf("threshold must be in range [0.0, 1.0] in %s: %f", fn.Name.Name, threshold)
 				}
 				compareArgs.Threshold = threshold
 			default:
 				return RunArgs{}, CompareArgs{},
-					errors.Newf("unknown benchmark config key in %s: %q", fn.Name.Name, key)
+					fmt.Errorf("unknown benchmark config key in %s: %q", fn.Name.Name, key)
 			}
 		}
 	}


### PR DESCRIPTION
Previously, the `./dev bench` command did not take benchdoc parameters on
microbenchmarks into account.

This PR makes `./dev bench` apply `benchmark-ci:` annotation parameters
when running benchmarks with a `--filter`.

The first commit drops the `cockroachdb/errors` dependency from the
`benchdoc` package (replacing it with stdlib `fmt.Errorf`) so that the
`dev` tool can import it without violating its strict import allowlist.

The second commit adds the integration: when `--filter` is provided,
`dev bench` scans `_test.go` files in the specified packages for
`benchmark-ci:` annotations and applies the configured `count`,
`benchtime`, and `timeout` parameters. Benchmarks with different
`RunArgs` are grouped into separate bazel invocations. CLI flags
override benchdoc values when explicitly set. When no filter is provided
or no annotations are found, behavior is unchanged.

Release note: None
Epic: None