### PR TITLE
loqrecovery: deflake TestFindUpdateRaft

### DIFF
--- a/pkg/kv/kvserver/loqrecovery/collect_raft_log_test.go
+++ b/pkg/kv/kvserver/loqrecovery/collect_raft_log_test.go
@@ -179,7 +179,8 @@ func checkRaftLog(
 			Settings: st,
 			Knobs: base.TestingKnobs{
 				Store: &kvserver.StoreTestingKnobs{
-					DisableGCQueue: true,
+					DisableGCQueue:      true,
+					DisableRaftLogQueue: true,
 				},
 			},
 			StoreSpecs: []base.StoreSpec{{InMemory: true}},
@@ -193,6 +194,7 @@ func checkRaftLog(
 					Store: &kvserver.StoreTestingKnobs{
 						TestingPostApplyFilter: raftFilter,
 						DisableGCQueue:         true,
+						DisableRaftLogQueue:    true,
 					},
 				},
 				StoreSpecs: []base.StoreSpec{{InMemory: true}},
@@ -219,8 +221,8 @@ func checkRaftLog(
 		tc.Server(0).DB().Put(ctx, testutils.MakeKey(skey, []byte("second")), "some data"),
 		"failed to put test value")
 	reader := <-snapshots
-	assertRaftLog(t, ctx, reader)
 	defer reader.Close()
+	assertRaftLog(t, ctx, reader)
 }
 
 func requireContainsDescriptor(


### PR DESCRIPTION
This test could fail with an error such as

    error during engine close: leaked snapshots: 1 open snapshots on
    DB 0xc00310a608

This was hiding the real error:

    collect_raft_log_test.go:133: descriptor change sequence []
    doesn't contain {ReplicaChange r82:/{Table/Max-Max} [(n1,s1):1,
    next=3, gen=6, sticky=9223372036.854775807,2147483647] <nil>}

This appears to be the result of the raft log truncation queue truncating the log before the test could read the expected values.

Here, we fix this by disabling the raft truncation queue during the test. We also defer the pebble close immediately so that a test failure doesn't result in a leaked snapshot.

Fixes #164951
Release note: None