### PR TITLE
release-25.3: allocatorimpl: improve diagnostic context in lease preference check

### DIFF
--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
@@ -2281,8 +2281,11 @@ func (a *Allocator) LeaseholderShouldMoveDueToPreferences(
 	allExistingReplicas []roachpb.ReplicaDescriptor,
 	exclReplsInNeedOfSnapshots bool,
 ) bool {
-	// Defensive check to ensure that this is never called with a replica set that
-	// does not contain the leaseholder.
+	// Callers pass VoterDescriptors(), which excludes demoting voters,
+	// non-voters, and learners - none of which can hold a lease. The
+	// leaseholder should always be present, but the descriptor and lease are
+	// not loaded under a consistent lock, so they may drift. As defense in
+	// depth, we verify that the leaseholder is in the provided replica set.
 	var leaseholderInExisting bool
 	for _, repl := range allExistingReplicas {
 		if repl.StoreID == leaseRepl.StoreID() {
@@ -2290,12 +2293,10 @@ func (a *Allocator) LeaseholderShouldMoveDueToPreferences(
 			break
 		}
 	}
-	// If the leaseholder is not in the descriptor, then we should not move the
-	// lease since we don't know who the leaseholder is. This normally doesn't
-	// happen, but can occasionally since the loading of the leaseholder and of
-	// the existing replicas aren't always under a consistent lock.
 	if !leaseholderInExisting {
-		log.KvDistribution.Info(ctx, "expected leaseholder store to be in the slice of existing replicas")
+		log.KvDistribution.Infof(ctx,
+			"expected leaseholder s%d to be in the slice of existing replicas %s",
+			leaseRepl.StoreID(), roachpb.MakeReplicaSet(allExistingReplicas))
 		return false
 	}
 

--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
@@ -2294,7 +2294,7 @@ func (a *Allocator) LeaseholderShouldMoveDueToPreferences(
 		}
 	}
 	if !leaseholderInExisting {
-		log.KvDistribution.Infof(ctx,
+		log.KvDistribution.VEventf(ctx, 2,
 			"expected leaseholder s%d to be in the slice of existing replicas %s",
 			leaseRepl.StoreID(), roachpb.MakeReplicaSet(allExistingReplicas))
 		return false


### PR DESCRIPTION
Backport 2/3 commits from #163413.

/cc @cockroachdb/release

---

Non-voting replicas can slip through the lease queue's
`replicaCanBeProcessed` filter when their lease status evaluates as
ERROR (rather than VALID with a different owner). This happens routinely
with leader leases: once `MinExpiration` passes, a follower evaluating a
remote leader lease gets `LeaseState_ERROR`, which the `needsLease`
filter does not reject. The non-voter then reaches
`LeaseholderShouldMoveDueToPreferences`, which cannot find it in
`VoterDescriptors()` and logs a diagnostic message — every scanner
cycle, indefinitely.

This PR:

1. **Improves the diagnostic log** in `LeaseholderShouldMoveDueToPreferences`:
   includes the leaseholder StoreID and replica set, and updates the
   comment to clarify that callers pass `VoterDescriptors()` (which
   excludes replicas that cannot hold a lease).

2. **Downgrades the log to `VEventf` verbosity 2**, since the condition
   is expected during normal operations and does not warrant `Info`-level
   output on every scanner cycle.

3. **Adds an early `shouldQueue` check** that skips replicas where
   `!IsVoterNewConfig()` (non-voters, learners, demoting voters), which
   is the actual fix.

Fixes #107691.

Release justification: low risk obs changes
