### PR TITLE
release-25.4: kvserver: use span config reader in entireSpanExcludedFromBackup

### DIFF
--- a/pkg/config/system.go
+++ b/pkg/config/system.go
@@ -697,6 +697,16 @@ func (s *SystemConfig) tenantBoundarySplitKey(
 	return roachpb.RKey(keys.MakeTenantPrefix(splitTenID))
 }
 
+// ForEachOverlappingSpanConfig implements spanconfig.StoreReader.
+// SystemConfig is only used as a StoreReader in the legacy fallback
+// path (when span configs are disabled); no callers invoke
+// ForEachOverlappingSpanConfig through that path.
+func (s *SystemConfig) ForEachOverlappingSpanConfig(
+	context.Context, roachpb.Span, func(roachpb.Span, roachpb.SpanConfig) error,
+) error {
+	panic("not implemented")
+}
+
 // NeedsSplit returns whether the range [startKey, endKey) needs a split due
 // to zone configs.
 func (s *SystemConfig) NeedsSplit(

--- a/pkg/kv/kvserver/asim/state/impl.go
+++ b/pkg/kv/kvserver/asim/state/impl.go
@@ -1315,6 +1315,14 @@ func (s *state) ComputeSplitKey(
 	panic("not implemented")
 }
 
+// ForEachOverlappingSpanConfig is part of the spanconfig.StoreReader interface.
+func (s *state) ForEachOverlappingSpanConfig(
+	context.Context, roachpb.Span, func(roachpb.Span, roachpb.SpanConfig) error,
+) error {
+	// We don't need to implement this method for conformance reports.
+	panic("not implemented")
+}
+
 // GetSpanConfigForKey is added for the spanconfig.StoreReader interface, required for
 // SpanConfigConformanceReport.
 func (s *state) GetSpanConfigForKey(

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -45,6 +45,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -1455,41 +1456,56 @@ func (r *Replica) GetGCHint() roachpb.GCHint {
 func (r *Replica) ExcludeDataFromBackup(ctx context.Context, sp roachpb.Span) (bool, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return entireSpanExcludedFromBackup(ctx, sp, r.mu.conf.ExcludeDataFromBackup, r.mu.confSpan)
+	return entireSpanExcludedFromBackup(
+		ctx, sp, r.mu.conf.ExcludeDataFromBackup, r.store.cfg.SpanConfigSubscriber,
+	)
 }
 
 func excludeReplicaFromBackup(
-	ctx context.Context, rspan roachpb.RSpan, excludeDataFromBackup bool, confSpan roachpb.Span,
+	ctx context.Context,
+	rspan roachpb.RSpan,
+	excludeDataFromBackup bool,
+	confReader spanconfig.StoreReader,
 ) bool {
 	// We ignore the error here to avoid failing requests that
 	// don't need to fail.
-	excluded, _ := entireSpanExcludedFromBackup(ctx, rspan.AsRawSpanWithNoLocals(),
-		excludeDataFromBackup, confSpan)
+	excluded, _ := entireSpanExcludedFromBackup(
+		ctx, rspan.AsRawSpanWithNoLocals(), excludeDataFromBackup, confReader,
+	)
 	return excluded
 }
 
-// entireSpanExcludedFromBackup returns true if this replica
-// has ExcludeDataFromBackup set in its span configuration and that
-// span configuration covers the entire given span.
+// entireSpanExcludedFromBackup returns true if all span configurations
+// covering the given span have ExcludeDataFromBackup set. The
+// excludeDataFromBackup parameter is used as a fast path: if the
+// replica's cached config does not have ExcludeDataFromBackup, we can
+// skip the iteration entirely. When span config coalescing is enabled,
+// a single range may cover multiple span config entries, so we must
+// check all of them rather than relying on a single cached confSpan.
 func entireSpanExcludedFromBackup(
-	ctx context.Context, sp roachpb.Span, excludeDataFromBackup bool, confSpan roachpb.Span,
+	ctx context.Context,
+	sp roachpb.Span,
+	excludeDataFromBackup bool,
+	confReader spanconfig.StoreReader,
 ) (bool, error) {
-	if excludeDataFromBackup {
-		// If ExcludeDataFromBackup is set, we also want to ensure that
-		// we only elide data if the span configuration we currently
-		// have actually contains the requested span.
-		if confSpan.Equal(roachpb.Span{}) {
-			return false, errors.Newf("replica's span configuration bounds not set")
-		}
-		if !confSpan.Contains(sp) {
-			log.KvExec.Warningf(ctx, "ExcludeDataFromBackup set but span %q not containd by span config bounds %q",
-				sp,
-				confSpan)
-
-			return false, nil
-		}
+	if !excludeDataFromBackup {
+		return false, nil
 	}
-	return excludeDataFromBackup, nil
+	if confReader == nil {
+		return false, errors.New("span config reader not available")
+	}
+	excluded := true
+	if err := confReader.ForEachOverlappingSpanConfig(ctx, sp,
+		func(_ roachpb.Span, conf roachpb.SpanConfig) error {
+			if !conf.ExcludeDataFromBackup {
+				excluded = false
+			}
+			return nil
+		},
+	); err != nil {
+		return false, errors.Wrap(err, "looking up span config for backup exclusion")
+	}
+	return excluded, nil
 }
 
 // Version returns the replica version.
@@ -2168,7 +2184,6 @@ func (r *Replica) checkExecutionCanProceedAfterStorageSnapshot(
 	cachedProtectedTS := r.mu.cachedProtectedTS
 	confTTL := r.mu.conf.TTL()
 	desc := r.descRLocked()
-	confSpan := r.mu.confSpan
 	excludeDataFromBackup := r.mu.conf.ExcludeDataFromBackup
 	r.mu.RUnlock()
 
@@ -2198,7 +2213,7 @@ func (r *Replica) checkExecutionCanProceedAfterStorageSnapshot(
 	// https://github.com/cockroachdb/cockroach/issues/55293.
 	return r.checkTSAboveGCThreshold(ctx, ba.EarliestActiveTimestamp(), st, ba.IsAdmin(), rSpan,
 		spanConfExplicitlySet, ignoreStrictEnforcement, gcThreshold, cachedProtectedTS, confTTL,
-		desc, confSpan, excludeDataFromBackup)
+		desc, excludeDataFromBackup)
 }
 
 // checkExecutionCanProceedRWOrAdmin returns an error if a batch request going
@@ -2294,7 +2309,7 @@ func (r *Replica) checkExecutionCanProceedForRangeFeed(
 	} else if err := r.checkTSAboveGCThreshold(ctx, ts, status, false /* isAdmin */, rSpan,
 		r.mu.spanConfigExplicitlySet, r.mu.conf.GCPolicy.IgnoreStrictEnforcement,
 		*r.shMu.state.GCThreshold, r.mu.cachedProtectedTS, r.mu.conf.TTL(), r.descRLocked(),
-		r.mu.confSpan, r.mu.conf.ExcludeDataFromBackup); err != nil {
+		r.mu.conf.ExcludeDataFromBackup); err != nil {
 		return err
 	}
 	return nil
@@ -2332,7 +2347,6 @@ func (r *Replica) checkTSAboveGCThreshold(
 	cachedProtectedTS cachedProtectedTimestampState,
 	confTTL time.Duration,
 	desc *roachpb.RangeDescriptor,
-	confSpan roachpb.Span,
 	excludeDataFromBackup bool,
 ) error {
 	threshold := r.getImpliedGCThreshold(st, isAdmin, spanConfigExplicitlySet,
@@ -2341,12 +2355,14 @@ func (r *Replica) checkTSAboveGCThreshold(
 		return nil
 	}
 	return &kvpb.BatchTimestampBeforeGCError{
-		Timestamp:              ts,
-		Threshold:              threshold,
-		DataExcludedFromBackup: excludeReplicaFromBackup(ctx, rspan, excludeDataFromBackup, confSpan),
-		RangeID:                desc.RangeID,
-		StartKey:               desc.StartKey.AsRawKey(),
-		EndKey:                 desc.EndKey.AsRawKey(),
+		Timestamp: ts,
+		Threshold: threshold,
+		DataExcludedFromBackup: excludeReplicaFromBackup(
+			ctx, rspan, excludeDataFromBackup, r.store.cfg.SpanConfigSubscriber,
+		),
+		RangeID:  desc.RangeID,
+		StartKey: desc.StartKey.AsRawKey(),
+		EndKey:   desc.EndKey.AsRawKey(),
 	}
 }
 

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -56,6 +56,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -15220,5 +15221,164 @@ func TestLeaderlessWatcherInit(t *testing.T) {
 		// Channel is closed, which is expected
 	default:
 		t.Fatalf("expected LeaderlessWatcher channel to be closed")
+	}
+}
+
+// backupExclusionStoreReader is a minimal spanconfig.StoreReader for testing
+// entireSpanExcludedFromBackup. It maps contiguous span config entries to their
+// configs. ForEachOverlappingSpanConfig iterates entries that overlap the given
+// span, invoking the callback for each.
+type backupExclusionStoreReader struct {
+	entries []struct {
+		span roachpb.Span
+		conf roachpb.SpanConfig
+	}
+}
+
+var _ spanconfig.StoreReader = &backupExclusionStoreReader{}
+
+func (r *backupExclusionStoreReader) NeedsSplit(
+	context.Context, roachpb.RKey, roachpb.RKey,
+) (bool, error) {
+	panic("unimplemented")
+}
+
+func (r *backupExclusionStoreReader) ComputeSplitKey(
+	context.Context, roachpb.RKey, roachpb.RKey,
+) (roachpb.RKey, error) {
+	panic("unimplemented")
+}
+
+func (r *backupExclusionStoreReader) GetSpanConfigForKey(
+	context.Context, roachpb.RKey,
+) (roachpb.SpanConfig, roachpb.Span, error) {
+	panic("unimplemented")
+}
+
+func (r *backupExclusionStoreReader) ForEachOverlappingSpanConfig(
+	_ context.Context, span roachpb.Span, f func(roachpb.Span, roachpb.SpanConfig) error,
+) error {
+	for _, e := range r.entries {
+		if e.span.Overlaps(span) {
+			if err := f(e.span, e.conf); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func TestEntireSpanExcludedFromBackup(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	excluded := roachpb.SpanConfig{ExcludeDataFromBackup: true}
+	notExcluded := roachpb.SpanConfig{ExcludeDataFromBackup: false}
+
+	mkSpan := func(start, end string) roachpb.Span {
+		return roachpb.Span{Key: roachpb.Key(start), EndKey: roachpb.Key(end)}
+	}
+
+	for _, tc := range []struct {
+		name     string
+		sp       roachpb.Span
+		excluded bool // cached ExcludeDataFromBackup from replica config
+		reader   spanconfig.StoreReader
+		want     bool
+		wantErr  string
+	}{
+		{
+			name:     "fast path: cached config not excluded",
+			sp:       mkSpan("a", "z"),
+			excluded: false,
+			reader:   nil,
+			want:     false,
+		},
+		{
+			name:     "nil reader",
+			sp:       mkSpan("a", "z"),
+			excluded: true,
+			reader:   nil,
+			want:     false,
+			wantErr:  "span config reader not available",
+		},
+		{
+			name:     "single span config covers entire request",
+			sp:       mkSpan("b", "d"),
+			excluded: true,
+			reader: &backupExclusionStoreReader{entries: []struct {
+				span roachpb.Span
+				conf roachpb.SpanConfig
+			}{
+				{span: mkSpan("a", "z"), conf: excluded},
+			}},
+			want: true,
+		},
+		{
+			name:     "multiple span configs all excluded",
+			sp:       mkSpan("a", "d"),
+			excluded: true,
+			reader: &backupExclusionStoreReader{entries: []struct {
+				span roachpb.Span
+				conf roachpb.SpanConfig
+			}{
+				{span: mkSpan("a", "b"), conf: excluded},
+				{span: mkSpan("b", "c"), conf: excluded},
+				{span: mkSpan("c", "d"), conf: excluded},
+			}},
+			want: true,
+		},
+		{
+			name:     "multiple span configs one not excluded",
+			sp:       mkSpan("a", "d"),
+			excluded: true,
+			reader: &backupExclusionStoreReader{entries: []struct {
+				span roachpb.Span
+				conf roachpb.SpanConfig
+			}{
+				{span: mkSpan("a", "b"), conf: excluded},
+				{span: mkSpan("b", "c"), conf: notExcluded},
+				{span: mkSpan("c", "d"), conf: excluded},
+			}},
+			want: false,
+		},
+		{
+			name:     "request span subset of multiple configs all excluded",
+			sp:       mkSpan("b", "e"),
+			excluded: true,
+			reader: &backupExclusionStoreReader{entries: []struct {
+				span roachpb.Span
+				conf roachpb.SpanConfig
+			}{
+				{span: mkSpan("a", "c"), conf: excluded},
+				{span: mkSpan("c", "f"), conf: excluded},
+			}},
+			want: true,
+		},
+		{
+			name:     "last config not excluded",
+			sp:       mkSpan("b", "e"),
+			excluded: true,
+			reader: &backupExclusionStoreReader{entries: []struct {
+				span roachpb.Span
+				conf roachpb.SpanConfig
+			}{
+				{span: mkSpan("a", "c"), conf: excluded},
+				{span: mkSpan("c", "f"), conf: notExcluded},
+			}},
+			want: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := entireSpanExcludedFromBackup(ctx, tc.sp, tc.excluded, tc.reader)
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tc.want, got)
+		})
 	}
 }

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -3527,6 +3527,12 @@ func (m *mockSpanConfigReader) GetSpanConfigForKey(
 	return m.GetSpanConfigForKey(ctx, key)
 }
 
+func (m *mockSpanConfigReader) ForEachOverlappingSpanConfig(
+	context.Context, roachpb.Span, func(roachpb.Span, roachpb.SpanConfig) error,
+) error {
+	panic("unimplemented")
+}
+
 var _ spanconfig.StoreReader = &mockSpanConfigReader{}
 
 // TestAllocatorCheckRangeUnconfigured tests evaluating the allocation decisions

--- a/pkg/spanconfig/spanconfig.go
+++ b/pkg/spanconfig/spanconfig.go
@@ -225,18 +225,6 @@ type Reconciler interface {
 type Store interface {
 	StoreWriter
 	StoreReader
-	// ForEachOverlappingSpanConfig invokes the supplied callback on each span
-	// config that overlaps with the supplied span. The config is combined with
-	// all the system span configs that also apply to this span. In addition to
-	// the SpanConfig, the span it applies over is passed into the callback as
-	// well.
-	//
-	// If there are no overlapping configs for the supplied span, the supplied
-	// callback is invoked on the fallback config combined with any applicable
-	// system span configs
-	ForEachOverlappingSpanConfig(
-		context.Context, roachpb.Span, func(roachpb.Span, roachpb.SpanConfig) error,
-	) error
 }
 
 // StoreWriter is the write-only portion of the Store interface.
@@ -284,6 +272,18 @@ type StoreReader interface {
 	// applies to. Callers can use the returned span to check if a
 	// request is completely contained by the returned config.
 	GetSpanConfigForKey(ctx context.Context, key roachpb.RKey) (roachpb.SpanConfig, roachpb.Span, error)
+	// ForEachOverlappingSpanConfig invokes the supplied callback on each span
+	// config that overlaps with the supplied span. The config is combined with
+	// all the system span configs that also apply to this span. In addition to
+	// the SpanConfig, the span it applies over is passed into the callback as
+	// well.
+	//
+	// If there are no overlapping configs for the supplied span, the supplied
+	// callback is invoked on the fallback config combined with any applicable
+	// system span configs.
+	ForEachOverlappingSpanConfig(
+		context.Context, roachpb.Span, func(roachpb.Span, roachpb.SpanConfig) error,
+	) error
 }
 
 // Limiter is used to limit the number of span configs installed by secondary

--- a/pkg/spanconfig/spanconfigkvsubscriber/dummy.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/dummy.go
@@ -56,6 +56,14 @@ func (n *noopKVSubscriber) GetSpanConfigForKey(
 	return roachpb.SpanConfig{}, roachpb.Span{}, nil
 }
 
+// ForEachOverlappingSpanConfig is part of the spanconfig.KVSubscriber
+// interface.
+func (n *noopKVSubscriber) ForEachOverlappingSpanConfig(
+	context.Context, roachpb.Span, func(roachpb.Span, roachpb.SpanConfig) error,
+) error {
+	return nil
+}
+
 // GetProtectionTimestamps is part of the spanconfig.KVSubscriber interface.
 func (n *noopKVSubscriber) GetProtectionTimestamps(
 	context.Context, roachpb.Span,

--- a/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber.go
@@ -357,6 +357,17 @@ func (s *KVSubscriber) GetSpanConfigForKey(
 	return s.mu.internal.GetSpanConfigForKey(ctx, key)
 }
 
+// ForEachOverlappingSpanConfig is part of the spanconfig.KVSubscriber
+// interface.
+func (s *KVSubscriber) ForEachOverlappingSpanConfig(
+	ctx context.Context, span roachpb.Span, f func(roachpb.Span, roachpb.SpanConfig) error,
+) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.mu.internal.ForEachOverlappingSpanConfig(ctx, span, f)
+}
+
 // GetProtectionTimestamps is part of the spanconfig.KVSubscriber interface.
 func (s *KVSubscriber) GetProtectionTimestamps(
 	ctx context.Context, sp roachpb.Span,

--- a/pkg/spanconfig/spanconfigptsreader/adapter_test.go
+++ b/pkg/spanconfig/spanconfigptsreader/adapter_test.go
@@ -130,6 +130,12 @@ func (m *manualSubscriber) GetSpanConfigForKey(
 	panic("unimplemented")
 }
 
+func (m *manualSubscriber) ForEachOverlappingSpanConfig(
+	context.Context, roachpb.Span, func(roachpb.Span, roachpb.SpanConfig) error,
+) error {
+	panic("unimplemented")
+}
+
 func (m *manualSubscriber) LastUpdated() hlc.Timestamp {
 	return m.updatedTS
 }

--- a/pkg/spanconfig/spanconfigreporter/datadriven_test.go
+++ b/pkg/spanconfig/spanconfigreporter/datadriven_test.go
@@ -280,6 +280,13 @@ func (s *mockCluster) GetSpanConfigForKey(
 	return s.store.GetSpanConfigForKey(ctx, key)
 }
 
+// ForEachOverlappingSpanConfig implements spanconfig.StoreReader.
+func (s *mockCluster) ForEachOverlappingSpanConfig(
+	ctx context.Context, span roachpb.Span, f func(roachpb.Span, roachpb.SpanConfig) error,
+) error {
+	return s.store.ForEachOverlappingSpanConfig(ctx, span, f)
+}
+
 func (s *mockCluster) addNode(desc roachpb.NodeDescriptor) {
 	_, found := s.nodes[desc.NodeID]
 	require.Falsef(s.t, found, "attempting to re-add n%d", desc.NodeID)

--- a/pkg/spanconfig/spanconfigtestutils/utils.go
+++ b/pkg/spanconfig/spanconfigtestutils/utils.go
@@ -825,4 +825,11 @@ func (w *WrappedKVSubscriber) NeedsSplit(
 	return w.wrapped.NeedsSplit(ctx, start, end)
 }
 
+// ForEachOverlappingSpanConfig implements spanconfig.StoreReader.
+func (w *WrappedKVSubscriber) ForEachOverlappingSpanConfig(
+	ctx context.Context, span roachpb.Span, f func(roachpb.Span, roachpb.SpanConfig) error,
+) error {
+	return w.wrapped.ForEachOverlappingSpanConfig(ctx, span, f)
+}
+
 var _ spanconfig.KVSubscriber = &WrappedKVSubscriber{}


### PR DESCRIPTION
Backport 2/2 commits from #164841.

/cc @cockroachdb/release

---

Previously, `entireSpanExcludedFromBackup` used the replica's cached span config to determine whether the entire span of an `ExportRequest` can be excluded from backup. This is a problem for ranges with multiple span configs because only the first one is cached at the replica. In these cases, `entireSpanExcludedFromBackup` returned false becasue the span of the `ExportRequest` is not fully contained in the replica's cached span sonfig.

This commit replaces the cached span config with a config reader; `entireSpanExcludedFromBackup` now iterates over all span configs that overlap with the `ExportRequest`'s span.

Fixes: #131993

Release note: None

---

Release justification: Fix of a bug that potentially prevents backups on cloud host clusters from succeeding.
