### PR TITLE
roachtest/task: fix WaitE/NewGroup deadlock

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/task/manager.go
+++ b/pkg/cmd/roachtest/roachtestutil/task/manager.go
@@ -286,11 +286,19 @@ func (t *group) Wait() {
 
 // WaitE implements the ErrorGroup interface.
 func (t *group) WaitE() error {
-	var err error
-	t.groupMu.Lock()
-	defer t.groupMu.Unlock()
-	err = t.ctxGroup.Wait()
-	for _, g := range t.groupMu.groups {
+	// Wait for all tasks in this group's ctxGroup first, without holding
+	// groupMu. Holding the lock across ctxGroup.Wait() would deadlock if a
+	// running task calls NewGroup (which also needs groupMu).
+	err := t.ctxGroup.Wait()
+
+	// Take a snapshot of subgroups under the lock, then wait on each without
+	// the lock held.
+	subgroups := func() []*group {
+		t.groupMu.Lock()
+		defer t.groupMu.Unlock()
+		return append([]*group(nil), t.groupMu.groups...)
+	}()
+	for _, g := range subgroups {
 		err = errors.CombineErrors(g.WaitE(), err)
 	}
 	return err

--- a/pkg/cmd/roachtest/roachtestutil/task/manager_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/task/manager_test.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -256,6 +257,111 @@ func TestErrorGroups(t *testing.T) {
 	}
 
 	m.Terminate(nilLogger())
+}
+
+// TestDeadlockTerminateNewGroup_PostCancel verifies that no deadlock
+// occurs when a task calls NewGroup on the manager after its context
+// has been canceled by Terminate.
+func TestDeadlockTerminateNewGroup_PostCancel(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	m := NewManager(ctx, nilLogger())
+
+	ready := make(chan struct{})
+	m.Go(func(ctx context.Context, l *logger.Logger) error {
+		close(ready)
+		<-ctx.Done()
+		// After Terminate cancels this task's context, attempt to create
+		// a subgroup. This routes through m.group.newGroupInternal which
+		// tries to lock m.group.groupMu — the same lock WaitE holds.
+		m.NewGroup()
+		return nil
+	})
+
+	// Drain events so they don't block the task goroutine. Cancel the
+	// parent context after Terminate completes to unblock the drain
+	// goroutine.
+	go func() {
+		for {
+			select {
+			case <-m.CompletedEvents():
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	<-ready
+
+	done := make(chan struct{})
+	go func() {
+		m.Terminate(nilLogger())
+		cancel()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// No deadlock.
+	case <-time.After(5 * time.Second):
+		t.Fatal("DEADLOCK: Terminate did not complete within 5 seconds")
+	}
+}
+
+// TestDeadlockTerminateNewGroup_DuringWork verifies that no deadlock
+// occurs when Terminate races with a task that calls NewGroup as part
+// of its normal work.
+func TestDeadlockTerminateNewGroup_DuringWork(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	m := NewManager(ctx, nilLogger())
+
+	ready := make(chan struct{})
+	proceed := make(chan struct{})
+	m.Go(func(ctx context.Context, l *logger.Logger) error {
+		close(ready)
+		// Block until Terminate has acquired groupMu.
+		<-proceed
+		// This call needs m.group.groupMu, which WaitE already holds.
+		m.NewGroup()
+		return nil
+	})
+
+	// Drain events so they don't block the task goroutine. Cancel the
+	// parent context after Terminate completes to unblock the drain
+	// goroutine.
+	go func() {
+		for {
+			select {
+			case <-m.CompletedEvents():
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	<-ready
+
+	done := make(chan struct{})
+	go func() {
+		m.Terminate(nilLogger())
+		cancel()
+		close(done)
+	}()
+
+	// Give Terminate time to cancel tasks and enter WaitE.
+	time.Sleep(50 * time.Millisecond)
+	// Let the task proceed to call NewGroup while WaitE is waiting.
+	close(proceed)
+
+	select {
+	case <-done:
+		// No deadlock.
+	case <-time.After(5 * time.Second):
+		t.Fatal("DEADLOCK: Terminate did not complete within 5 seconds")
+	}
 }
 
 func nilLogger() *logger.Logger {


### PR DESCRIPTION
- Fix a deadlock in the roachtest task manager where `WaitE` and `NewGroup` contend on `groupMu`
- `WaitE` held `groupMu` for the entire duration of `ctxGroup.Wait()`, so if any running task called `NewGroup` (which also needs `groupMu`), both goroutines would deadlock
- Fix by calling `ctxGroup.Wait()` without the lock, then snapshotting subgroups under the lock to wait on them individually

The first commit adds two tests that demonstrate the deadlock, the second commit fixes it.

Release note: None
Epic: None