### PR TITLE
backup: add COCKROACH_SKIP_DOWNLOAD env var for online restore

### DIFF
--- a/pkg/backup/restore_online.go
+++ b/pkg/backup/restore_online.go
@@ -633,6 +633,7 @@ func (r *restoreResumer) sendDownloadWorker(
 }
 
 var useCopy = envutil.EnvOrDefaultBool("COCKROACH_DOWNLOAD_COPY", true)
+var skipDownload = envutil.EnvOrDefaultBool("COCKROACH_SKIP_DOWNLOAD", false)
 
 func sendDownloadSpan(ctx context.Context, execCtx sql.JobExecContext, spans roachpb.Spans) error {
 	ctx, sp := tracing.ChildSpan(ctx, "backup.sendDownloadSpan")
@@ -880,6 +881,11 @@ func (r *restoreResumer) doDownloadFiles(ctx context.Context, execCtx sql.JobExe
 
 	if err := execCtx.ExecCfg().JobRegistry.CheckPausepoint("restore.before_download"); err != nil {
 		return err
+	}
+
+	if skipDownload {
+		log.Infof(ctx, "skipping download phase due to COCKROACH_SKIP_DOWNLOAD env var")
+		return r.cleanupAfterDownload(ctx, details)
 	}
 
 	grp := ctxgroup.WithContext(ctx)


### PR DESCRIPTION
Add `COCKROACH_SKIP_DOWNLOAD` env var that causes the online restore
download job to skip the actual file download while still running
post-download cleanup (re-enabling auto-stats, unsplitting spans).

This is useful for testing the linked-but-not-downloaded state without
needing to use pausepoints.

Epic: none
Release note: None