### PR TITLE
roachtest: deflake schemachange/mixed-versions

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_schemachange.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_schemachange.go
@@ -41,6 +41,10 @@ func registerSchemaChangeMixedVersions(r registry.Registry) {
 			if c.IsLocal() {
 				maxOps = 10
 				concurrency = 2
+			} else if t.RuntimeAssertionsCockroach() != "" {
+				// When runtime assertions are enabled, produce fewer operations
+				// to avoid risk of timeouts.
+				maxOps = maxOps / 4
 			}
 			runSchemaChangeMixedVersions(ctx, t, c, maxOps, concurrency)
 		},


### PR DESCRIPTION
The schema changer workload can be slower when assertions are enabled on the CRDB binaries due to extra validation execute. To reduce the risk of timing out on these builds we will generate 1/4th the number operations.

Fixes: #164643

Release note: None