### PR TITLE
roachtest/task: add Cancel method to Group and ErrorGroup

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/task/group.go
+++ b/pkg/cmd/roachtest/roachtestutil/task/group.go
@@ -10,6 +10,9 @@ package task
 // complete.
 type Group interface {
 	Tasker
+	// Cancel cancels all tasks in the group and its subgroups. Cancel is
+	// idempotent and safe to call multiple times.
+	Cancel()
 	// Wait waits for all tasks in the group to complete. Errors from tasks are
 	// reported to the test framework automatically and will cause the test to
 	// fail, which also cancels the context passed to the group.
@@ -22,6 +25,9 @@ type Group interface {
 // Errors are returned through the WaitE method.
 type ErrorGroup interface {
 	Tasker
+	// Cancel cancels all tasks in the group and its subgroups. Cancel is
+	// idempotent and safe to call multiple times.
+	Cancel()
 	// WaitE waits for all tasks in the group to complete. Any errors from tasks
 	// are returned and will cancel the context passed to the group. If the group
 	// contains multiple subgroups, the errors from the groups will be combined

--- a/pkg/cmd/roachtest/roachtestutil/task/manager.go
+++ b/pkg/cmd/roachtest/roachtestutil/task/manager.go
@@ -279,6 +279,13 @@ func (t *group) cancelAll() {
 	}
 }
 
+// Cancel cancels all tasks in the group and its subgroups. Cancel is idempotent
+// and safe to call multiple times. It marks all tasks as expecting cancellation
+// so that errors from context cancellation are not reported as test failures.
+func (t *group) Cancel() {
+	t.cancelAll()
+}
+
 // Wait implements the Group interface.
 func (t *group) Wait() {
 	_ = t.WaitE()

--- a/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
@@ -284,18 +284,7 @@ func initBackgroundWorkloads(
 			return nil, err
 		}
 
-		groupCtx, cancel := context.WithCancel(ctx)
-		runGroup := t.NewGroup(
-			task.WithContext(groupCtx),
-			task.ErrorHandler(func(_ context.Context, _ string, _ *logger.Logger, err error) error {
-				// We expect the workloads to be canceled via context cancellation,
-				// so we want to ignore those errors.
-				if errors.Is(err, context.Canceled) {
-					return nil
-				}
-				return err
-			}),
-		)
+		runGroup := t.NewGroup()
 		runGroup.Go(func(ctx context.Context, l *logger.Logger) error {
 			return c.RunE(ctx, option.WithNodes(workloadNode), bankRun.String())
 		}, task.Name("run-bank"))
@@ -316,7 +305,7 @@ func initBackgroundWorkloads(
 			return testUtils.systemTableWriter(ctx, l, systemTableRNG, dbs, tables)
 		}, task.Name("run-system-table-writer"))
 
-		return cancel, nil
+		return runGroup.Cancel, nil
 	}
 
 	return runWorkloadTasks, nil

--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -410,17 +410,16 @@ func runFollowerReadsTest(
 
 	l.Printf("starting read load")
 	const loadDuration = 4 * time.Minute
-	timeoutCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	time.AfterFunc(loadDuration, func() {
-		l.Printf("stopping load")
-		cancel()
-	})
-	g = t.NewGroup(task.WithContext(timeoutCtx), task.ErrorHandler(
+	g = t.NewGroup(task.ErrorHandler(
 		func(_ context.Context, name string, l *logger.Logger, err error) error {
 			return errors.Wrapf(err, "error reading data")
 		},
 	))
+	defer g.Cancel()
+	time.AfterFunc(loadDuration, func() {
+		l.Printf("stopping load")
+		g.Cancel()
+	})
 	const concurrency = 32
 	var cur int
 	for i := 0; cur < concurrency; i++ {


### PR DESCRIPTION
Groups previously had no way to cancel their tasks directly.
Callers that needed to cancel a group had to manually create a
cancelable context and thread it through via task.WithContext,
resulting in boilerplate:

```
groupCtx, cancel := context.WithCancel(ctx)
g := t.NewGroup(task.WithContext(groupCtx))
```

Add a Cancel() method to both the Group and ErrorGroup interfaces.
Cancel delegates to the existing cancelAll mechanism, which cancels
each task individually and sets expectedContextCancellation so that
errors from context cancellation are not reported as test failures.
Callers can simply call `group.Cancel()` to cancel the `group`.

Release note: None
Epic: None