### PR TITLE
workload/schemachange: skip virtual computed check for PK cols in STORING

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -1082,14 +1082,22 @@ func (og *operationGenerator) createIndex(ctx context.Context, tx pgx.Tx) (*opSt
 				regionColStored = true
 			}
 
-			// Virtual computed columns are not allowed to be indexed
+			// Virtual computed columns are not allowed to be indexed, but
+			// PK columns are silently dropped from STORING by the DSC
+			// before the virtual column check, so skip the check for PK cols.
 			if columnNames[i].generated && !isStoringVirtualComputed {
-				isVirtualComputed, err := og.columnIsVirtualComputed(ctx, tx, tableName, columnNames[i].name)
+				colIsPK, err := og.colIsPrimaryKey(ctx, tx, tableName, columnNames[i].name)
 				if err != nil {
 					return nil, err
 				}
-				if isVirtualComputed {
-					isStoringVirtualComputed = true
+				if !colIsPK {
+					isVirtualComputed, err := og.columnIsVirtualComputed(ctx, tx, tableName, columnNames[i].name)
+					if err != nil {
+						return nil, err
+					}
+					if isVirtualComputed {
+						isStoringVirtualComputed = true
+					}
 				}
 			}
 		}


### PR DESCRIPTION

The DSC silently drops PK columns from STORING before checking if a column is virtual computed. The schemachange workload was still predicting a FeatureNotSupported error for virtual computed PK columns in STORING, causing TestWorkload failures.

Skip the `isStoringVirtualComputed` check when the STORING column is a PK column, since the DSC will silently drop it and succeed.

Fixes: #165146

Release note: None