### PR TITLE
sql/sqlstats: add vectorized, distsql, fullscan, implicit_txn counters

### DIFF
--- a/pkg/sql/appstatspb/app_stats.go
+++ b/pkg/sql/appstatspb/app_stats.go
@@ -228,6 +228,10 @@ func (s *StatementStatistics) Add(other *StatementStatistics) {
 	s.FailureCount += other.FailureCount
 	s.GenericCount += other.GenericCount
 	s.StmtHintsCount += other.StmtHintsCount
+	s.VectorizedCount += other.VectorizedCount
+	s.FullScanCount += other.FullScanCount
+	s.DistSQLCount += other.DistSQLCount
+	s.ImplicitTxnCount += other.ImplicitTxnCount
 }
 
 // AlmostEqual compares two StatementStatistics and their contained NumericStats

--- a/pkg/sql/appstatspb/app_stats.proto
+++ b/pkg/sql/appstatspb/app_stats.proto
@@ -147,6 +147,18 @@ message StatementStatistics {
   // (ex/ not replication related work).
   optional NumericStat kv_cpu_time_nanos = 38 [(gogoproto.nullable) = false, (gogoproto.customname) = "KVCPUTimeNanos"];
 
+  // vectorized_count is the count of executions that used vectorized execution.
+  optional int64 vectorized_count = 39 [(gogoproto.nullable) = false];
+
+  // full_scan_count is the count of executions that performed a full table or index scan.
+  optional int64 full_scan_count = 40 [(gogoproto.nullable) = false];
+
+  // dist_sql_count is the count of executions that used the distributed SQL engine.
+  optional int64 dist_sql_count = 41 [(gogoproto.nullable) = false, (gogoproto.customname) = "DistSQLCount"];
+
+  // implicit_txn_count is the count of executions that ran in an implicit transaction.
+  optional int64 implicit_txn_count = 42 [(gogoproto.nullable) = false];
+
   // Note: be sure to update `sql/app_stats.go` when adding/removing fields here!
 
   reserved 13, 14, 17, 18, 19, 20;

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding.go
@@ -184,6 +184,10 @@ func BuildStmtMetadataJSON(statistics *appstatspb.CollectedStatementStatistics) 
 //		        "usedFollowerRead":  { "type": "boolean" },
 //		        "indexes":           { "type": "indexes" },
 //		        "lastErrorCode":     { "type": "string" },
+//		        "vectorizedCount":   { "type": "number" },
+//		        "fullScanCount":     { "type": "number" },
+//		        "distSQLCount":      { "type": "number" },
+//		        "implicitTxnCount":  { "type": "number" },
 //		      },
 //		      "required": [
 //		        "firstAttemptCnt",

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
@@ -55,6 +55,10 @@ func TestSQLStatsJsonEncoding(t *testing.T) {
          "failureCount":    {{.Int64}},
          "genericCount":    {{.Int64}},
          "stmtHintsCount":  {{.Int64}},
+         "vectorizedCount": {{.Int64}},
+         "fullScanCount":   {{.Int64}},
+         "distSQLCount":    {{.Int64}},
+         "implicitTxnCount": {{.Int64}},
          "maxRetries":      {{.Int64}},
          "lastExecAt":      "{{stringifyTime .Time}}",
          "numRows": {

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
@@ -348,6 +348,10 @@ func (s *innerStmtStats) jsonFields() jsonFields {
 		{"failureCount", (*jsonInt)(&s.FailureCount)},
 		{"genericCount", (*jsonInt)(&s.GenericCount)},
 		{"stmtHintsCount", (*jsonInt)(&s.StmtHintsCount)},
+		{"vectorizedCount", (*jsonInt)(&s.VectorizedCount)},
+		{"fullScanCount", (*jsonInt)(&s.FullScanCount)},
+		{"distSQLCount", (*jsonInt)(&s.DistSQLCount)},
+		{"implicitTxnCount", (*jsonInt)(&s.ImplicitTxnCount)},
 		{"sqlType", (*jsonString)(&s.SQLType)},
 	}
 }

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
@@ -83,6 +83,18 @@ func (s *Container) RecordStatement(ctx context.Context, value *sqlstats.Recorde
 	if value.AppliedStmtHints {
 		stats.mu.data.StmtHintsCount++
 	}
+	if value.Vec {
+		stats.mu.data.VectorizedCount++
+	}
+	if value.DistSQL {
+		stats.mu.data.DistSQLCount++
+	}
+	if value.FullScan {
+		stats.mu.data.FullScanCount++
+	}
+	if value.ImplicitTxn {
+		stats.mu.data.ImplicitTxnCount++
+	}
 	if value.AutoRetryCount == 0 {
 		stats.mu.data.FirstAttemptCount++
 	} else if int64(value.AutoRetryCount) > stats.mu.data.MaxRetries {

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer_test.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer_test.go
@@ -121,6 +121,10 @@ func TestContainer_Add(t *testing.T) {
 			Failed:             true,
 			Generic:            true,
 			AppliedStmtHints:   true,
+			Vec:                true,
+			DistSQL:            true,
+			FullScan:           true,
+			ImplicitTxn:        true,
 			StatementError:     errors.New("test error"),
 		}
 		require.NoError(t, src.RecordStatement(ctx, stmtStats))
@@ -166,6 +170,10 @@ func TestContainer_Add(t *testing.T) {
 			Failed:             true,
 			Generic:            true,
 			AppliedStmtHints:   true,
+			Vec:                true,
+			DistSQL:            true,
+			FullScan:           true,
+			ImplicitTxn:        true,
 			StatementError:     errors.New("test error"),
 		}
 		reducedTxnFingerprintID := appstatspb.TransactionFingerprintID(321)
@@ -215,6 +223,10 @@ func verifyStmtStatsMultiple(
 	require.Equal(t, destStmtStats.mu.data.FailureCount, int64(count))
 	require.Equal(t, destStmtStats.mu.data.GenericCount, int64(count))
 	require.Equal(t, destStmtStats.mu.data.StmtHintsCount, int64(count))
+	require.Equal(t, destStmtStats.mu.data.VectorizedCount, int64(count))
+	require.Equal(t, destStmtStats.mu.data.FullScanCount, int64(count))
+	require.Equal(t, destStmtStats.mu.data.DistSQLCount, int64(count))
+	require.Equal(t, destStmtStats.mu.data.ImplicitTxnCount, int64(count))
 	require.InEpsilon(t, float64(stmtStats.RowsAffected), destStmtStats.mu.data.NumRows.Mean, epsilon)
 	require.InEpsilon(t, float64(stmtStats.RowsAffected), destStmtStats.mu.data.NumRows.Mean, epsilon)
 	require.InEpsilon(t, stmtStats.IdleLatencySec, destStmtStats.mu.data.IdleLat.Mean, epsilon)
@@ -237,6 +249,10 @@ func verifyStmtStatsReduced(
 	require.NotNil(t, destStmtStats)
 	require.Equal(t, destStmtStats.mu.data.Count, int64(count))
 	require.Equal(t, destStmtStats.mu.data.FailureCount, int64(1))
+	require.Equal(t, destStmtStats.mu.data.VectorizedCount, int64(1))
+	require.Equal(t, destStmtStats.mu.data.FullScanCount, int64(1))
+	require.Equal(t, destStmtStats.mu.data.DistSQLCount, int64(1))
+	require.Equal(t, destStmtStats.mu.data.ImplicitTxnCount, int64(1))
 	require.InEpsilon(t, float64(stmtStats.RowsAffected)/cnt, destStmtStats.mu.data.NumRows.Mean, epsilon)
 	require.InEpsilon(t, stmtStats.IdleLatencySec/cnt, destStmtStats.mu.data.IdleLat.Mean, epsilon)
 	require.InEpsilon(t, stmtStats.ParseLatencySec/cnt, destStmtStats.mu.data.ParseLat.Mean, epsilon)

--- a/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.ts
@@ -270,6 +270,10 @@ export function addStatementStats(
     indexes: indexes,
     latency_info: aggregateLatencyInfo(a, b),
     last_error_code: "",
+    vectorized_count: a.vectorized_count.add(b.vectorized_count),
+    full_scan_count: a.full_scan_count.add(b.full_scan_count),
+    dist_sql_count: a.dist_sql_count.add(b.dist_sql_count),
+    implicit_txn_count: a.implicit_txn_count.add(b.implicit_txn_count),
   };
 }
 

--- a/pkg/ui/workspaces/db-console/src/views/statements/statements.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statements.spec.tsx
@@ -299,6 +299,10 @@ function makeStats(): Required<StatementStatistics> {
     generic_count: Long.fromNumber(0),
     stmt_hints_count: Long.fromNumber(0),
     kv_cpu_time_nanos: makeStat(),
+    vectorized_count: Long.fromNumber(0),
+    full_scan_count: Long.fromNumber(0),
+    dist_sql_count: Long.fromNumber(0),
+    implicit_txn_count: Long.fromNumber(0),
   };
 }
 


### PR DESCRIPTION
Plan metadata flags (`vectorized`, `distsql`, `fullscan`, `implicitTxn`) are
currently recorded as booleans on `StatementStatisticsKey`, used for
bucketing. When stats are aggregated across buckets (e.g., on the
Statement Details page), booleans lose information because they only
reflect the key's bucket rather than accumulated counts.

Add four new `int64` counters to `StatementStatistics`:
- `vectorized_count`
- `full_scan_count`
- `dist_sql_count`
- `implicit_txn_count`

These counters are incremented in `RecordStatement()` based on the
existing boolean flags, aggregated in `StatementStatistics.Add()`, and
serialized/deserialized via the existing JSON encoding infrastructure.
This follows the same pattern as `generic_count` and `stmt_hints_count`.

The existing boolean flags on `StatementStatisticsKey` are not removed;
that will be a follow-up change.

Resolves: #165230

Release note: None