### PR TITLE
schemachanger: support infer_rbr_region_col_using_constraint storage param

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_foreign_key
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_foreign_key
@@ -208,7 +208,7 @@ statement error pgcode 42P16 pq: cannot drop constraint foo as it is used to det
 ALTER TABLE child DROP CONSTRAINT foo
 
 # Nonexistent constraint.
-statement error pgcode 42704 pq: constraint named "bar" does not exist
+statement error pgcode 42704 pq: constraint "bar" of relation "child" does not exist
 ALTER TABLE child SET (infer_rbr_region_col_using_constraint = 'bar')
 
 # Wrong type of constraint.

--- a/pkg/ccl/schemachangerccl/ccl_generated_test.go
+++ b/pkg/ccl/schemachangerccl/ccl_generated_test.go
@@ -190,6 +190,13 @@ func TestEndToEndSideEffects_ccl_alter_table_locality_rbt_secondary_region_to_se
 	sctest.EndToEndSideEffects(t, path, MultiRegionTestClusterFactory{})
 }
 
+func TestEndToEndSideEffects_ccl_alter_table_set_infer_rbr_using_constraint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_set_infer_rbr_using_constraint"
+	sctest.EndToEndSideEffects(t, path, MultiRegionTestClusterFactory{})
+}
+
 func TestEndToEndSideEffects_ccl_create_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -425,6 +432,13 @@ func TestExecuteWithDMLInjection_ccl_alter_table_locality_rbt_secondary_region_t
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_locality_rbt_secondary_region_to_secondary_region"
+	sctest.ExecuteWithDMLInjection(t, path, MultiRegionTestClusterFactory{})
+}
+
+func TestExecuteWithDMLInjection_ccl_alter_table_set_infer_rbr_using_constraint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_set_infer_rbr_using_constraint"
 	sctest.ExecuteWithDMLInjection(t, path, MultiRegionTestClusterFactory{})
 }
 
@@ -666,6 +680,13 @@ func TestGenerateSchemaChangeCorpus_ccl_alter_table_locality_rbt_secondary_regio
 	sctest.GenerateSchemaChangeCorpus(t, path, MultiRegionTestClusterFactory{})
 }
 
+func TestGenerateSchemaChangeCorpus_ccl_alter_table_set_infer_rbr_using_constraint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_set_infer_rbr_using_constraint"
+	sctest.GenerateSchemaChangeCorpus(t, path, MultiRegionTestClusterFactory{})
+}
+
 func TestGenerateSchemaChangeCorpus_ccl_create_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -901,6 +922,13 @@ func TestPause_ccl_alter_table_locality_rbt_secondary_region_to_secondary_region
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_locality_rbt_secondary_region_to_secondary_region"
+	sctest.Pause(t, path, MultiRegionTestClusterFactory{})
+}
+
+func TestPause_ccl_alter_table_set_infer_rbr_using_constraint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_set_infer_rbr_using_constraint"
 	sctest.Pause(t, path, MultiRegionTestClusterFactory{})
 }
 
@@ -1142,6 +1170,13 @@ func TestPauseMixedVersion_ccl_alter_table_locality_rbt_secondary_region_to_seco
 	sctest.PauseMixedVersion(t, path, MultiRegionTestClusterFactory{})
 }
 
+func TestPauseMixedVersion_ccl_alter_table_set_infer_rbr_using_constraint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_set_infer_rbr_using_constraint"
+	sctest.PauseMixedVersion(t, path, MultiRegionTestClusterFactory{})
+}
+
 func TestPauseMixedVersion_ccl_create_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1377,6 +1412,13 @@ func TestRollback_ccl_alter_table_locality_rbt_secondary_region_to_secondary_reg
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_locality_rbt_secondary_region_to_secondary_region"
+	sctest.Rollback(t, path, MultiRegionTestClusterFactory{})
+}
+
+func TestRollback_ccl_alter_table_set_infer_rbr_using_constraint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_set_infer_rbr_using_constraint"
 	sctest.Rollback(t, path, MultiRegionTestClusterFactory{})
 }
 

--- a/pkg/ccl/schemachangerccl/sctestbackupmrccl/backup_multiregion_generated_test.go
+++ b/pkg/ccl/schemachangerccl/sctestbackupmrccl/backup_multiregion_generated_test.go
@@ -190,6 +190,13 @@ func TestBackupRollbacks_multiregion_alter_table_locality_rbt_secondary_region_t
 	sctest.BackupRollbacks(t, path, MultiRegionTestClusterFactory{})
 }
 
+func TestBackupRollbacks_multiregion_alter_table_set_infer_rbr_using_constraint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_set_infer_rbr_using_constraint"
+	sctest.BackupRollbacks(t, path, MultiRegionTestClusterFactory{})
+}
+
 func TestBackupRollbacks_multiregion_create_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -425,6 +432,13 @@ func TestBackupRollbacksMixedVersion_multiregion_alter_table_locality_rbt_second
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_locality_rbt_secondary_region_to_secondary_region"
+	sctest.BackupRollbacksMixedVersion(t, path, MultiRegionTestClusterFactory{})
+}
+
+func TestBackupRollbacksMixedVersion_multiregion_alter_table_set_infer_rbr_using_constraint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_set_infer_rbr_using_constraint"
 	sctest.BackupRollbacksMixedVersion(t, path, MultiRegionTestClusterFactory{})
 }
 
@@ -666,6 +680,13 @@ func TestBackupSuccess_multiregion_alter_table_locality_rbt_secondary_region_to_
 	sctest.BackupSuccess(t, path, MultiRegionTestClusterFactory{})
 }
 
+func TestBackupSuccess_multiregion_alter_table_set_infer_rbr_using_constraint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_set_infer_rbr_using_constraint"
+	sctest.BackupSuccess(t, path, MultiRegionTestClusterFactory{})
+}
+
 func TestBackupSuccess_multiregion_create_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -901,6 +922,13 @@ func TestBackupSuccessMixedVersion_multiregion_alter_table_locality_rbt_secondar
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_locality_rbt_secondary_region_to_secondary_region"
+	sctest.BackupSuccessMixedVersion(t, path, MultiRegionTestClusterFactory{})
+}
+
+func TestBackupSuccessMixedVersion_multiregion_alter_table_set_infer_rbr_using_constraint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_set_infer_rbr_using_constraint"
 	sctest.BackupSuccessMixedVersion(t, path, MultiRegionTestClusterFactory{})
 }
 

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_set_infer_rbr_using_constraint/alter_table_set_infer_rbr_using_constraint.definition
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_set_infer_rbr_using_constraint/alter_table_set_infer_rbr_using_constraint.definition
@@ -1,0 +1,18 @@
+setup
+SET CLUSTER SETTING feature.infer_rbr_region_col_using_constraint.enabled = true;
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3";
+USE multiregion_db;
+CREATE TABLE multiregion_db.public.parent (region multiregion_db.public.crdb_internal_region, k INT, PRIMARY KEY (region, k));
+CREATE TABLE multiregion_db.public.rbr (
+  pk INT PRIMARY KEY,
+  region multiregion_db.public.crdb_internal_region NOT NULL,
+  data INT,
+  CONSTRAINT fk_region FOREIGN KEY (region, pk) REFERENCES multiregion_db.public.parent (region, k) MATCH FULL,
+  CONSTRAINT fk_region2 FOREIGN KEY (region, data) REFERENCES multiregion_db.public.parent (region, k) MATCH FULL
+) LOCALITY REGIONAL BY ROW AS region;
+ALTER TABLE multiregion_db.public.rbr SET (infer_rbr_region_col_using_constraint = 'fk_region');
+----
+
+test
+ALTER TABLE multiregion_db.public.rbr SET (infer_rbr_region_col_using_constraint = 'fk_region2')
+----

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_set_infer_rbr_using_constraint/alter_table_set_infer_rbr_using_constraint.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_set_infer_rbr_using_constraint/alter_table_set_infer_rbr_using_constraint.explain
@@ -1,0 +1,61 @@
+/* setup */
+SET CLUSTER SETTING feature.infer_rbr_region_col_using_constraint.enabled = true;
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3";
+USE multiregion_db;
+CREATE TABLE multiregion_db.public.parent (region multiregion_db.public.crdb_internal_region, k INT, PRIMARY KEY (region, k));
+CREATE TABLE multiregion_db.public.rbr (
+  pk INT PRIMARY KEY,
+  region multiregion_db.public.crdb_internal_region NOT NULL,
+  data INT,
+  CONSTRAINT fk_region FOREIGN KEY (region, pk) REFERENCES multiregion_db.public.parent (region, k) MATCH FULL,
+  CONSTRAINT fk_region2 FOREIGN KEY (region, data) REFERENCES multiregion_db.public.parent (region, k) MATCH FULL
+) LOCALITY REGIONAL BY ROW AS region;
+ALTER TABLE multiregion_db.public.rbr SET (infer_rbr_region_col_using_constraint = 'fk_region');
+
+/* test */
+EXPLAIN (DDL) ALTER TABLE multiregion_db.public.rbr SET (infer_rbr_region_col_using_constraint = 'fk_region2');
+----
+Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹rbr› SET ('infer_rbr_region_col_using_constraint' = ‹'fk_region2'›);
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 1 element transitioning toward PUBLIC
+ │         │    └── ABSENT → PUBLIC TableLocalityRegionalByRowUsingConstraint:{DescID: 109 (rbr), ConstraintID: 3 (fk_region2)}
+ │         ├── 1 element transitioning toward TRANSIENT_PUBLIC
+ │         │    └── PUBLIC → ABSENT TableSchemaLocked:{DescID: 109 (rbr)}
+ │         ├── 1 element transitioning toward ABSENT
+ │         │    └── PUBLIC → ABSENT TableLocalityRegionalByRowUsingConstraint:{DescID: 109 (rbr), ConstraintID: 2 (fk_region)}
+ │         └── 3 Mutation operations
+ │              ├── SetTableSchemaLocked {"TableID":109}
+ │              ├── SetTableRBRUsingConstraint {"TableID":109}
+ │              └── SetTableRBRUsingConstraint {"ConstraintID":3,"TableID":109}
+ ├── PreCommitPhase
+ │    ├── Stage 1 of 2 in PreCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── PUBLIC → ABSENT TableLocalityRegionalByRowUsingConstraint:{DescID: 109 (rbr), ConstraintID: 3 (fk_region2)}
+ │    │    ├── 1 element transitioning toward TRANSIENT_PUBLIC
+ │    │    │    └── ABSENT → PUBLIC TableSchemaLocked:{DescID: 109 (rbr)}
+ │    │    ├── 1 element transitioning toward ABSENT
+ │    │    │    └── ABSENT → PUBLIC TableLocalityRegionalByRowUsingConstraint:{DescID: 109 (rbr), ConstraintID: 2 (fk_region)}
+ │    │    └── 1 Mutation operation
+ │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
+ │    └── Stage 2 of 2 in PreCommitPhase
+ │         ├── 1 element transitioning toward PUBLIC
+ │         │    └── ABSENT → PUBLIC TableLocalityRegionalByRowUsingConstraint:{DescID: 109 (rbr), ConstraintID: 3 (fk_region2)}
+ │         ├── 1 element transitioning toward TRANSIENT_PUBLIC
+ │         │    └── PUBLIC → ABSENT TableSchemaLocked:{DescID: 109 (rbr)}
+ │         ├── 1 element transitioning toward ABSENT
+ │         │    └── PUBLIC → ABSENT TableLocalityRegionalByRowUsingConstraint:{DescID: 109 (rbr), ConstraintID: 2 (fk_region)}
+ │         └── 5 Mutation operations
+ │              ├── SetTableSchemaLocked {"TableID":109}
+ │              ├── SetTableRBRUsingConstraint {"TableID":109}
+ │              ├── SetTableRBRUsingConstraint {"ConstraintID":3,"TableID":109}
+ │              ├── SetJobStateOnDescriptor {"DescriptorID":109,"Initialize":true}
+ │              └── CreateSchemaChangerJob {"RunningStatus":"Pending: Updatin..."}
+ └── PostCommitPhase
+      └── Stage 1 of 1 in PostCommitPhase
+           ├── 1 element transitioning toward TRANSIENT_PUBLIC
+           │    └── ABSENT → TRANSIENT_PUBLIC TableSchemaLocked:{DescID: 109 (rbr)}
+           └── 3 Mutation operations
+                ├── SetTableSchemaLocked {"Locked":true,"TableID":109}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":109}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_set_infer_rbr_using_constraint/alter_table_set_infer_rbr_using_constraint.explain_shape
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_set_infer_rbr_using_constraint/alter_table_set_infer_rbr_using_constraint.explain_shape
@@ -1,0 +1,19 @@
+/* setup */
+SET CLUSTER SETTING feature.infer_rbr_region_col_using_constraint.enabled = true;
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3";
+USE multiregion_db;
+CREATE TABLE multiregion_db.public.parent (region multiregion_db.public.crdb_internal_region, k INT, PRIMARY KEY (region, k));
+CREATE TABLE multiregion_db.public.rbr (
+  pk INT PRIMARY KEY,
+  region multiregion_db.public.crdb_internal_region NOT NULL,
+  data INT,
+  CONSTRAINT fk_region FOREIGN KEY (region, pk) REFERENCES multiregion_db.public.parent (region, k) MATCH FULL,
+  CONSTRAINT fk_region2 FOREIGN KEY (region, data) REFERENCES multiregion_db.public.parent (region, k) MATCH FULL
+) LOCALITY REGIONAL BY ROW AS region;
+ALTER TABLE multiregion_db.public.rbr SET (infer_rbr_region_col_using_constraint = 'fk_region');
+
+/* test */
+EXPLAIN (DDL, SHAPE) ALTER TABLE multiregion_db.public.rbr SET (infer_rbr_region_col_using_constraint = 'fk_region2');
+----
+Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹rbr› SET ('infer_rbr_region_col_using_constraint' = ‹'fk_region2'›);
+ └── execute 2 system table mutations transactions

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_set_infer_rbr_using_constraint/alter_table_set_infer_rbr_using_constraint.side_effects
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_set_infer_rbr_using_constraint/alter_table_set_infer_rbr_using_constraint.side_effects
@@ -1,0 +1,161 @@
+/* setup */
+SET CLUSTER SETTING feature.infer_rbr_region_col_using_constraint.enabled = true;
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3";
+USE multiregion_db;
+CREATE TABLE multiregion_db.public.parent (region multiregion_db.public.crdb_internal_region, k INT, PRIMARY KEY (region, k));
+CREATE TABLE multiregion_db.public.rbr (
+  pk INT PRIMARY KEY,
+  region multiregion_db.public.crdb_internal_region NOT NULL,
+  data INT,
+  CONSTRAINT fk_region FOREIGN KEY (region, pk) REFERENCES multiregion_db.public.parent (region, k) MATCH FULL,
+  CONSTRAINT fk_region2 FOREIGN KEY (region, data) REFERENCES multiregion_db.public.parent (region, k) MATCH FULL
+) LOCALITY REGIONAL BY ROW AS region;
+ALTER TABLE multiregion_db.public.rbr SET (infer_rbr_region_col_using_constraint = 'fk_region');
+----
+...
++database {0 0 multiregion_db} -> 104
++schema {104 0 public} -> 105
++object {104 105 crdb_internal_region} -> 106
++object {104 105 _crdb_internal_region} -> 107
++object {104 105 parent} -> 108
++object {104 105 rbr} -> 109
+
+/* test */
+ALTER TABLE multiregion_db.public.rbr SET (infer_rbr_region_col_using_constraint = 'fk_region2');
+----
+begin transaction #1
+# begin StatementPhase
+checking for feature: ALTER TABLE
+increment telemetry for sql.schema.alter_table
+increment telemetry for sql.schema.alter_table.set_storage_param
+## StatementPhase stage 1 of 1 with 3 MutationType ops
+upsert descriptor #109
+  ...
+         withGrantOption: "2"
+       version: 3
+  -  rbrUsingConstraint: 2
+  +  rbrUsingConstraint: 3
+     replacementOf:
+       time: {}
+  -  schemaLocked: true
+     unexposedParentSchemaId: 105
+  -  version: "4"
+  +  version: "5"
+# end StatementPhase
+# begin PreCommitPhase
+## PreCommitPhase stage 1 of 2 with 1 MutationType op
+undo all catalog changes within txn #1
+persist all catalog changes to storage
+## PreCommitPhase stage 2 of 2 with 5 MutationType ops
+upsert descriptor #109
+  ...
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  +  declarativeSchemaChangerState:
+  +    authorization:
+  +      userName: root
+  +    currentStatuses: <redacted>
+  +    jobId: "1"
+  +    nameMapping:
+  +      columns:
+  +        "1": pk
+  +        "2": region
+  +        "3": data
+  +        "4294967292": crdb_internal_origin_timestamp
+  +        "4294967293": crdb_internal_origin_id
+  +        "4294967294": tableoid
+  +        "4294967295": crdb_internal_mvcc_timestamp
+  +      constraints:
+  +        "2": fk_region
+  +        "3": fk_region2
+  +      families:
+  +        "0": primary
+  +      id: 109
+  +      indexes:
+  +        "1": rbr_pkey
+  +      name: rbr
+  +    relevantStatements:
+  +    - statement:
+  +        redactedStatement: ALTER TABLE ‹multiregion_db›.‹public›.‹rbr› SET ('infer_rbr_region_col_using_constraint' = ‹'fk_region2'›)
+  +        statement: ALTER TABLE multiregion_db.public.rbr SET ('infer_rbr_region_col_using_constraint' = 'fk_region2')
+  +        statementTag: ALTER TABLE
+  +    revertible: true
+  +    targetRanks: <redacted>
+  +    targets: <redacted>
+     families:
+     - columnIds:
+  ...
+         withGrantOption: "2"
+       version: 3
+  -  rbrUsingConstraint: 2
+  +  rbrUsingConstraint: 3
+     replacementOf:
+       time: {}
+  -  schemaLocked: true
+     unexposedParentSchemaId: 105
+  -  version: "4"
+  +  version: "5"
+persist all catalog changes to storage
+create job #1 (non-cancelable: false): "ALTER TABLE multiregion_db.public.rbr SET ('infer_rbr_region_col_using_constraint' = 'fk_region2')"
+  descriptor IDs: [109]
+# end PreCommitPhase
+commit transaction #1
+notified job registry to adopt jobs: [1]
+# begin PostCommitPhase
+begin transaction #2
+commit transaction #2
+begin transaction #3
+## PostCommitPhase stage 1 of 1 with 3 MutationType ops
+upsert descriptor #109
+  ...
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  -  declarativeSchemaChangerState:
+  -    authorization:
+  -      userName: root
+  -    currentStatuses: <redacted>
+  -    jobId: "1"
+  -    nameMapping:
+  -      columns:
+  -        "1": pk
+  -        "2": region
+  -        "3": data
+  -        "4294967292": crdb_internal_origin_timestamp
+  -        "4294967293": crdb_internal_origin_id
+  -        "4294967294": tableoid
+  -        "4294967295": crdb_internal_mvcc_timestamp
+  -      constraints:
+  -        "2": fk_region
+  -        "3": fk_region2
+  -      families:
+  -        "0": primary
+  -      id: 109
+  -      indexes:
+  -        "1": rbr_pkey
+  -      name: rbr
+  -    relevantStatements:
+  -    - statement:
+  -        redactedStatement: ALTER TABLE ‹multiregion_db›.‹public›.‹rbr› SET ('infer_rbr_region_col_using_constraint' = ‹'fk_region2'›)
+  -        statement: ALTER TABLE multiregion_db.public.rbr SET ('infer_rbr_region_col_using_constraint' = 'fk_region2')
+  -        statementTag: ALTER TABLE
+  -    revertible: true
+  -    targetRanks: <redacted>
+  -    targets: <redacted>
+     families:
+     - columnIds:
+  ...
+     replacementOf:
+       time: {}
+  +  schemaLocked: true
+     unexposedParentSchemaId: 105
+  -  version: "5"
+  +  version: "6"
+persist all catalog changes to storage
+update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
+write *eventpb.FinishSchemaChange to event log:
+  sc:
+    descriptorId: 109
+commit transaction #3
+# end PostCommitPhase

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_set_infer_rbr_using_constraint/alter_table_set_infer_rbr_using_constraint__rollback_1_of_1.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_set_infer_rbr_using_constraint/alter_table_set_infer_rbr_using_constraint__rollback_1_of_1.explain
@@ -1,0 +1,37 @@
+/* setup */
+SET CLUSTER SETTING feature.infer_rbr_region_col_using_constraint.enabled = true;
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3";
+USE multiregion_db;
+CREATE TABLE multiregion_db.public.parent (region multiregion_db.public.crdb_internal_region, k INT, PRIMARY KEY (region, k));
+CREATE TABLE multiregion_db.public.rbr (
+  pk INT PRIMARY KEY,
+  region multiregion_db.public.crdb_internal_region NOT NULL,
+  data INT,
+  CONSTRAINT fk_region FOREIGN KEY (region, pk) REFERENCES multiregion_db.public.parent (region, k) MATCH FULL,
+  CONSTRAINT fk_region2 FOREIGN KEY (region, data) REFERENCES multiregion_db.public.parent (region, k) MATCH FULL
+) LOCALITY REGIONAL BY ROW AS region;
+ALTER TABLE multiregion_db.public.rbr SET (infer_rbr_region_col_using_constraint = 'fk_region');
+
+/* test */
+ALTER TABLE multiregion_db.public.rbr SET (infer_rbr_region_col_using_constraint = 'fk_region2');
+EXPLAIN (DDL) rollback at post-commit stage 1 of 1;
+----
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.rbr SET ('infer_rbr_region_col_using_constraint' = ‹'fk_region2'›);
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── ABSENT → PUBLIC TableLocalityRegionalByRowUsingConstraint:{DescID: 109 (rbr), ConstraintID: 2 (fk_region)}
+      │    ├── 1 element transitioning toward ABSENT
+      │    │    └── PUBLIC → ABSENT TableLocalityRegionalByRowUsingConstraint:{DescID: 109 (rbr), ConstraintID: 3 (fk_region2)}
+      │    └── 4 Mutation operations
+      │         ├── SetTableRBRUsingConstraint {"TableID":109}
+      │         ├── SetTableRBRUsingConstraint {"ConstraintID":2,"TableID":109}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":109}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 1 element transitioning toward TRANSIENT_PUBLIC
+           │    └── ABSENT → TRANSIENT_PUBLIC TableSchemaLocked:{DescID: 109 (rbr)}
+           └── 3 Mutation operations
+                ├── SetTableSchemaLocked {"Locked":true,"TableID":109}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":109}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
-	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/auditlogging/auditevents"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
@@ -2548,14 +2547,7 @@ func maybeGetRBRTableUsingConstraint(
 // inferRegionUsingConstraintEnabled is used to enable and disable setting a
 // foreign key constraint for looking up the region column in a REGIONAL BY ROW
 // table.
-var inferRegionUsingConstraintEnabled = settings.RegisterBoolSetting(
-	settings.ApplicationLevel,
-	"feature.infer_rbr_region_col_using_constraint.enabled",
-	"set to true to enable looking up the region column via a foreign key constraint in a "+
-		"REGIONAL BY ROW table, false to disable; default is false",
-	false,
-	settings.WithPublic,
-)
+var inferRegionUsingConstraintEnabled = sqlclustersettings.InferRegionUsingConstraintEnabled
 
 func extractRBRTableUsingConstraint(
 	ctx context.Context,

--- a/pkg/sql/catalog/rewrite/rewrite.go
+++ b/pkg/sql/catalog/rewrite/rewrite.go
@@ -187,6 +187,22 @@ func TableDescs(
 			// we update the FK to point to it?
 			table.OutboundFKs = append(table.OutboundFKs, *fk)
 		}
+
+		// If the table has an RBRUsingConstraint, check that the referenced FK
+		// constraint still exists after dropping FKs with missing referenced tables.
+		if table.RBRUsingConstraint != 0 {
+			found := false
+			for i := range table.OutboundFKs {
+				if table.OutboundFKs[i].ConstraintID == table.RBRUsingConstraint {
+					found = true
+					break
+				}
+			}
+			if !found {
+				table.RBRUsingConstraint = 0
+			}
+		}
+
 		origMutations := table.Mutations
 		table.Mutations = table.Mutations[:0]
 		for idx := range origMutations {

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -544,9 +544,14 @@ func removeFKForBackReferenceFromTable(
 			"for backreference %v on table %q", backref, originTableDesc.Name)
 	}
 	// Delete our match.
+	removedFK := originTableDesc.OutboundFKs[matchIdx]
 	originTableDesc.OutboundFKs = append(
 		originTableDesc.OutboundFKs[:matchIdx],
 		originTableDesc.OutboundFKs[matchIdx+1:]...)
+	// If the removed FK was referenced by RBRUsingConstraint, clear it.
+	if originTableDesc.RBRUsingConstraint == removedFK.ConstraintID {
+		originTableDesc.RBRUsingConstraint = 0
+	}
 	return nil
 }
 

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_set_storage_param.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_set_storage_param.go
@@ -12,17 +12,22 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
+	"github.com/cockroachdb/cockroach/pkg/sql/paramparse"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scdecomp"
-	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/semenumpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree/treebin"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/volatility"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlclustersettings"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/storageparam"
 	"github.com/cockroachdb/cockroach/pkg/sql/storageparam/tablestorageparam"
@@ -30,14 +35,10 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// validateStorageParamKey validates a storage param key and panics with
-// NotImplementedError if the param is not yet supported in the declarative
-// schema changer.
-func validateStorageParamKey(t tree.NodeFormatter, key string) {
-	loweredKey := strings.ToLower(key)
-	if loweredKey == catpb.RBRUsingConstraintTableSettingName {
-		panic(scerrors.NotImplementedErrorf(t, "infer_rbr_region_col_using_constraint not implemented yet"))
-	}
+// isRBRUsingConstraintParam returns true if the key matches the RBR using
+// constraint storage parameter name.
+func isRBRUsingConstraintParam(key string) bool {
+	return strings.ToLower(key) == catpb.RBRUsingConstraintTableSettingName
 }
 
 // buildTTLColumnExpr builds the expression: current_timestamp() + interval_expr.
@@ -415,11 +416,12 @@ func AlterTableSetStorageParams(
 	stmt tree.Statement,
 	t *tree.AlterTableSetStorageParams,
 ) {
-	var ttlParams, otherParams tree.StorageParams
+	var ttlParams, rbrConstraintParams, otherParams tree.StorageParams
 	for _, param := range t.StorageParams {
-		validateStorageParamKey(t, param.Key)
 		if isTTLParam(param.Key) {
 			ttlParams = append(ttlParams, param)
+		} else if isRBRUsingConstraintParam(param.Key) {
+			rbrConstraintParams = append(rbrConstraintParams, param)
 		} else {
 			otherParams = append(otherParams, param)
 		}
@@ -427,6 +429,11 @@ func AlterTableSetStorageParams(
 
 	// Handle TTL params first, using the RowLevelTTL element.
 	applyTTLStorageParamsSet(b, tbl, tn, stmt, t, ttlParams)
+
+	// Handle RBR using constraint param.
+	if len(rbrConstraintParams) > 0 {
+		setRBRUsingConstraint(b, tbl, rbrConstraintParams)
+	}
 
 	if err := storageparam.StorageParamPreChecks(
 		b,
@@ -545,10 +552,12 @@ func AlterTableResetStorageParams(
 	t *tree.AlterTableResetStorageParams,
 ) {
 	var ttlParams, otherParams []string
+	hasRBRConstraintReset := false
 	for _, param := range t.Params {
-		validateStorageParamKey(t, param)
 		if isTTLParam(param) {
 			ttlParams = append(ttlParams, param)
+		} else if isRBRUsingConstraintParam(param) {
+			hasRBRConstraintReset = true
 		} else {
 			otherParams = append(otherParams, param)
 		}
@@ -556,6 +565,11 @@ func AlterTableResetStorageParams(
 
 	// Handle TTL params first, using the RowLevelTTL element.
 	applyTTLStorageParamsReset(b, tn, tbl, stmt, t, ttlParams)
+
+	// Handle RBR using constraint reset.
+	if hasRBRConstraintReset {
+		resetRBRUsingConstraint(b, tbl)
+	}
 
 	if err := storageparam.StorageParamPreChecks(
 		b,
@@ -605,6 +619,240 @@ func AlterTableResetStorageParams(
 			}
 			b.Add(&newElem)
 		}
+	}
+}
+
+// setRBRUsingConstraint handles SET infer_rbr_region_col_using_constraint. It
+// validates the table is RBR, extracts the constraint name, validates the
+// constraint is a suitable FK, and adds a TableLocalityRegionalByRowUsingConstraint
+// element.
+func setRBRUsingConstraint(b BuildCtx, tbl *scpb.Table, params tree.StorageParams) {
+	// Check that the feature is enabled.
+	if !sqlclustersettings.InferRegionUsingConstraintEnabled.Get(&b.ClusterSettings().SV) {
+		panic(pgerror.Newf(
+			pgcode.FeatureNotSupported,
+			`storage parameter "%s" is not enabled; set the cluster setting`+
+				` "feature.infer_rbr_region_col_using_constraint.enabled" to true to enable it`,
+			catpb.RBRUsingConstraintTableSettingName,
+		))
+	}
+
+	// Validate table is REGIONAL BY ROW.
+	if !isTableLocalityRegionalByRow(b, tbl.TableID) {
+		panic(pgerror.Newf(
+			pgcode.InvalidParameterValue,
+			`storage parameter "%s" can only be set on REGIONAL BY ROW tables`,
+			catpb.RBRUsingConstraintTableSettingName,
+		))
+	}
+
+	// Extract the constraint name from the param value.
+	constraintName := extractRBRConstraintName(b, params)
+	if constraintName == "" {
+		return
+	}
+
+	// Resolve the constraint by name using the standard constraint resolution
+	// mechanism, which finds both index-backed and non-index constraints.
+	tableElts := b.QueryByID(tbl.TableID)
+	constraintElems := b.ResolveConstraint(tbl.TableID, constraintName, ResolveParams{
+		IsExistenceOptional: false,
+		RequiredPrivilege:   privilege.CREATE,
+	})
+	// Find the constraint ID from the resolved elements.
+	var constraintID catid.ConstraintID
+	constraintWithoutIndexName := constraintElems.FilterConstraintWithoutIndexName().
+		MustGetZeroOrOneElement()
+	if constraintWithoutIndexName != nil {
+		constraintID = constraintWithoutIndexName.ConstraintID
+	}
+
+	// If we found a constraint ID, check if it's a FK (validated or unvalidated).
+	var fkColumnIDs []catid.ColumnID
+	if constraintID != 0 {
+		tableElts.FilterForeignKeyConstraint().ForEach(
+			func(_ scpb.Status, target scpb.TargetStatus, e *scpb.ForeignKeyConstraint) {
+				if target == scpb.ToAbsent {
+					return
+				}
+				if e.ConstraintID == constraintID {
+					fkColumnIDs = e.ColumnIDs
+				}
+			},
+		)
+		if fkColumnIDs == nil {
+			tableElts.FilterForeignKeyConstraintUnvalidated().ForEach(
+				func(
+					_ scpb.Status, target scpb.TargetStatus, e *scpb.ForeignKeyConstraintUnvalidated,
+				) {
+					if target == scpb.ToAbsent {
+						return
+					}
+					if e.ConstraintID == constraintID {
+						fkColumnIDs = e.ColumnIDs
+					}
+				},
+			)
+		}
+	}
+	if fkColumnIDs == nil {
+		panic(pgerror.Newf(
+			pgcode.InvalidTableDefinition,
+			"constraint %q is not a foreign key constraint",
+			constraintName,
+		))
+	}
+
+	// Get the region column name and ID.
+	rbrElem := tableElts.FilterTableLocalityRegionalByRow().MustGetOneElement()
+	regionColName := tree.Name(rbrElem.As)
+	if regionColName == tree.RegionalByRowRegionNotSpecifiedName {
+		regionColName = tree.RegionalByRowRegionDefaultColName
+	}
+	var regionColID catid.ColumnID
+	tableElts.FilterColumnName().ForEach(
+		func(_ scpb.Status, target scpb.TargetStatus, e *scpb.ColumnName) {
+			if target == scpb.ToAbsent {
+				return
+			}
+			if tree.Name(e.Name) == regionColName {
+				regionColID = e.ColumnID
+			}
+		},
+	)
+	if regionColID == 0 {
+		panic(pgerror.Newf(
+			pgcode.UndefinedColumn,
+			`column %q does not exist`,
+			regionColName,
+		))
+	}
+
+	// Validate: region column must not be computed.
+	tableElts.FilterColumnComputeExpression().ForEach(
+		func(_ scpb.Status, target scpb.TargetStatus, e *scpb.ColumnComputeExpression) {
+			if target == scpb.ToAbsent {
+				return
+			}
+			if e.ColumnID == regionColID {
+				panic(pgerror.Newf(
+					pgcode.InvalidTableDefinition,
+					"cannot use computed column %q as the region column in a REGIONAL BY ROW table with "+
+						"the %q storage parameter specified",
+					regionColName, catpb.RBRUsingConstraintTableSettingName,
+				))
+			}
+		},
+	)
+
+	// Validate: FK must include the region column.
+	fkHasRegionCol := false
+	for _, colID := range fkColumnIDs {
+		if colID == regionColID {
+			fkHasRegionCol = true
+			break
+		}
+	}
+	if !fkHasRegionCol {
+		panic(pgerror.Newf(
+			pgcode.InvalidTableDefinition,
+			"cannot use constraint %q to determine the region column for REGIONAL BY ROW "+
+				"as it does not include the region column %q",
+			constraintName, regionColName,
+		))
+	}
+
+	// Validate: FK must have more than just the region column.
+	if len(fkColumnIDs) == 1 {
+		panic(pgerror.Newf(
+			pgcode.InvalidTableDefinition,
+			"cannot use constraint %q to determine the region column for REGIONAL BY ROW "+
+				"as it only includes the region column",
+			constraintName,
+		))
+	}
+
+	// Validate: no computed columns may reference the region column.
+	tableElts.FilterColumnComputeExpression().ForEach(
+		func(_ scpb.Status, target scpb.TargetStatus, e *scpb.ColumnComputeExpression) {
+			if target == scpb.ToAbsent {
+				return
+			}
+			if e.ColumnID == regionColID {
+				// Already checked above.
+				return
+			}
+			for _, refColID := range e.Expression.ReferencedColumnIDs {
+				if refColID == regionColID {
+					colName := mustRetrieveColumnName(b, tbl.TableID, e.ColumnID)
+					panic(pgerror.Newf(
+						pgcode.InvalidTableDefinition,
+						`computed column %q cannot reference the region column %q; the region `+
+							`column value must be able to be determined from the non-region FK columns`,
+						colName.Name, regionColName,
+					))
+				}
+			}
+		},
+	)
+
+	// Drop any existing element.
+	existingElem := tableElts.FilterTableLocalityRegionalByRowUsingConstraint().MustGetZeroOrOneElement()
+	if existingElem != nil {
+		b.Drop(existingElem)
+	}
+
+	// Add the new element.
+	b.Add(&scpb.TableLocalityRegionalByRowUsingConstraint{
+		TableID:      tbl.TableID,
+		ConstraintID: constraintID,
+	})
+}
+
+// extractRBRConstraintName extracts the constraint name string from the
+// infer_rbr_region_col_using_constraint storage parameter value.
+func extractRBRConstraintName(b BuildCtx, params tree.StorageParams) tree.Name {
+	paramVal := params.GetVal(catpb.RBRUsingConstraintTableSettingName)
+	if paramVal == nil {
+		return ""
+	}
+	if paramVal == tree.DNull {
+		panic(pgerror.Newf(
+			pgcode.InvalidParameterValue,
+			`storage parameter "%s" cannot be NULL`, catpb.RBRUsingConstraintTableSettingName,
+		))
+	}
+	// The expressions may be an unresolved name. Cast it as a string.
+	paramVal = paramparse.UnresolvedNameToStrVal(paramVal)
+	typedExpr, err := schemaexpr.SanitizeVarFreeExpr(
+		b, paramVal, types.String, "RBR_USING_CONSTRAINT_NAME", b.SemaCtx(),
+		volatility.Volatile, false, /* allowAssignmentCast */
+	)
+	if err != nil {
+		panic(err)
+	}
+	d, err := eval.Expr(b, b.EvalCtx(), typedExpr)
+	if err != nil {
+		panic(err)
+	}
+	constraintName, isStringVal := tree.AsDString(d)
+	if !isStringVal {
+		panic(pgerror.Newf(
+			pgcode.InvalidParameterValue,
+			`storage parameter "%s" must be a string`, catpb.RBRUsingConstraintTableSettingName,
+		))
+	}
+	return tree.Name(constraintName)
+}
+
+// resetRBRUsingConstraint handles RESET infer_rbr_region_col_using_constraint.
+// It drops the existing TableLocalityRegionalByRowUsingConstraint element if
+// present.
+func resetRBRUsingConstraint(b BuildCtx, tbl *scpb.Table) {
+	existingElem := b.QueryByID(tbl.TableID).
+		FilterTableLocalityRegionalByRowUsingConstraint().MustGetZeroOrOneElement()
+	if existingElem != nil {
+		b.Drop(existingElem)
 	}
 }
 

--- a/pkg/sql/schemachanger/scexec/scmutationexec/table.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/table.go
@@ -35,6 +35,17 @@ func (i *immediateVisitor) SetTableSchemaLocked(
 	return nil
 }
 
+func (i *immediateVisitor) SetTableRBRUsingConstraint(
+	ctx context.Context, op scop.SetTableRBRUsingConstraint,
+) error {
+	tbl, err := i.checkOutTable(ctx, op.TableID)
+	if err != nil {
+		return err
+	}
+	tbl.RBRUsingConstraint = op.ConstraintID
+	return nil
+}
+
 func (i *immediateVisitor) SetTableStorageParam(
 	ctx context.Context, op scop.SetTableStorageParam,
 ) error {

--- a/pkg/sql/schemachanger/scop/immediate_mutation.go
+++ b/pkg/sql/schemachanger/scop/immediate_mutation.go
@@ -1302,6 +1302,14 @@ type SetTableSchemaLocked struct {
 	Locked  bool
 }
 
+// SetTableRBRUsingConstraint sets or clears the RBRUsingConstraint field on the
+// table descriptor. A ConstraintID of 0 clears the field.
+type SetTableRBRUsingConstraint struct {
+	immediateMutationOp
+	TableID      descpb.ID
+	ConstraintID descpb.ConstraintID
+}
+
 // SetTableStorageParam sets a storage parameter on a table.
 type SetTableStorageParam struct {
 	immediateMutationOp

--- a/pkg/sql/schemachanger/scop/immediate_mutation_visitor_generated.go
+++ b/pkg/sql/schemachanger/scop/immediate_mutation_visitor_generated.go
@@ -184,6 +184,7 @@ type ImmediateMutationVisitor interface {
 	MarkRecreatedIndexesAsVisible(context.Context, MarkRecreatedIndexesAsVisible) error
 	MarkRecreatedIndexAsVisible(context.Context, MarkRecreatedIndexAsVisible) error
 	SetTableSchemaLocked(context.Context, SetTableSchemaLocked) error
+	SetTableRBRUsingConstraint(context.Context, SetTableRBRUsingConstraint) error
 	SetTableStorageParam(context.Context, SetTableStorageParam) error
 	ResetTableStorageParam(context.Context, ResetTableStorageParam) error
 	UpsertRowLevelTTL(context.Context, UpsertRowLevelTTL) error
@@ -1022,6 +1023,11 @@ func (op MarkRecreatedIndexAsVisible) Visit(ctx context.Context, v ImmediateMuta
 // Visit is part of the ImmediateMutationOp interface.
 func (op SetTableSchemaLocked) Visit(ctx context.Context, v ImmediateMutationVisitor) error {
 	return v.SetTableSchemaLocked(ctx, op)
+}
+
+// Visit is part of the ImmediateMutationOp interface.
+func (op SetTableRBRUsingConstraint) Visit(ctx context.Context, v ImmediateMutationVisitor) error {
+	return v.SetTableRBRUsingConstraint(ctx, op)
 }
 
 // Visit is part of the ImmediateMutationOp interface.

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_table_locality_regional_by_row_using_constraint.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_table_locality_regional_by_row_using_constraint.go
@@ -15,15 +15,23 @@ func init() {
 		toPublic(
 			scpb.Status_ABSENT,
 			to(scpb.Status_PUBLIC,
-				emit(func(this *scpb.TableLocalityRegionalByRowUsingConstraint) *scop.NotImplemented {
-					return notImplemented(this)
+				emit(func(this *scpb.TableLocalityRegionalByRowUsingConstraint) *scop.SetTableRBRUsingConstraint {
+					return &scop.SetTableRBRUsingConstraint{
+						TableID:      this.TableID,
+						ConstraintID: this.ConstraintID,
+					}
 				}),
 			),
 		),
 		toAbsent(
 			scpb.Status_PUBLIC,
 			to(scpb.Status_ABSENT,
-				revertible(false),
+				emit(func(this *scpb.TableLocalityRegionalByRowUsingConstraint) *scop.SetTableRBRUsingConstraint {
+					return &scop.SetTableRBRUsingConstraint{
+						TableID:      this.TableID,
+						ConstraintID: 0,
+					}
+				}),
 			),
 		),
 	)

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/dep_storage_param.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/dep_storage_param.go
@@ -48,4 +48,21 @@ func init() {
 			}
 		},
 	)
+
+	registerDepRule(
+		"old RBR using constraint param is dropped before the new one is added",
+		scgraph.SameStagePrecedence,
+		"old-rbr-using-constraint", "new-rbr-using-constraint",
+		func(from, to NodeVars) rel.Clauses {
+			return rel.Clauses{
+				from.Type((*scpb.TableLocalityRegionalByRowUsingConstraint)(nil)),
+				to.Type((*scpb.TableLocalityRegionalByRowUsingConstraint)(nil)),
+				JoinOnDescID(from, to, "table-id"),
+				from.TargetStatus(scpb.ToAbsent),
+				from.CurrentStatus(scpb.Status_ABSENT),
+				to.TargetStatus(scpb.ToPublic),
+				to.CurrentStatus(scpb.Status_PUBLIC),
+			}
+		},
+	)
 }

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
@@ -4318,6 +4318,20 @@ deprules
     - $descriptor-Node[CurrentStatus] = ABSENT
     - joinTargetNode($dependent, $dependent-Target, $dependent-Node)
     - joinTargetNode($descriptor, $descriptor-Target, $descriptor-Node)
+- name: old RBR using constraint param is dropped before the new one is added
+  from: old-rbr-using-constraint-Node
+  kind: SameStagePrecedence
+  to: new-rbr-using-constraint-Node
+  query:
+    - $old-rbr-using-constraint[Type] = '*scpb.TableLocalityRegionalByRowUsingConstraint'
+    - $new-rbr-using-constraint[Type] = '*scpb.TableLocalityRegionalByRowUsingConstraint'
+    - joinOnDescID($old-rbr-using-constraint, $new-rbr-using-constraint, $table-id)
+    - $old-rbr-using-constraint-Target[TargetStatus] = ABSENT
+    - $old-rbr-using-constraint-Node[CurrentStatus] = ABSENT
+    - $new-rbr-using-constraint-Target[TargetStatus] = PUBLIC
+    - $new-rbr-using-constraint-Node[CurrentStatus] = PUBLIC
+    - joinTargetNode($old-rbr-using-constraint, $old-rbr-using-constraint-Target, $old-rbr-using-constraint-Node)
+    - joinTargetNode($new-rbr-using-constraint, $new-rbr-using-constraint-Target, $new-rbr-using-constraint-Node)
 - name: old TTL params are dropped before the new one is added
   from: old-ttl-param-Node
   kind: SameStagePrecedence
@@ -9654,6 +9668,20 @@ deprules
     - $descriptor-Node[CurrentStatus] = ABSENT
     - joinTargetNode($dependent, $dependent-Target, $dependent-Node)
     - joinTargetNode($descriptor, $descriptor-Target, $descriptor-Node)
+- name: old RBR using constraint param is dropped before the new one is added
+  from: old-rbr-using-constraint-Node
+  kind: SameStagePrecedence
+  to: new-rbr-using-constraint-Node
+  query:
+    - $old-rbr-using-constraint[Type] = '*scpb.TableLocalityRegionalByRowUsingConstraint'
+    - $new-rbr-using-constraint[Type] = '*scpb.TableLocalityRegionalByRowUsingConstraint'
+    - joinOnDescID($old-rbr-using-constraint, $new-rbr-using-constraint, $table-id)
+    - $old-rbr-using-constraint-Target[TargetStatus] = ABSENT
+    - $old-rbr-using-constraint-Node[CurrentStatus] = ABSENT
+    - $new-rbr-using-constraint-Target[TargetStatus] = PUBLIC
+    - $new-rbr-using-constraint-Node[CurrentStatus] = PUBLIC
+    - joinTargetNode($old-rbr-using-constraint, $old-rbr-using-constraint-Target, $old-rbr-using-constraint-Node)
+    - joinTargetNode($new-rbr-using-constraint, $new-rbr-using-constraint-Target, $new-rbr-using-constraint-Node)
 - name: old TTL params are dropped before the new one is added
   from: old-ttl-param-Node
   kind: SameStagePrecedence

--- a/pkg/sql/sqlclustersettings/clustersettings.go
+++ b/pkg/sql/sqlclustersettings/clustersettings.go
@@ -114,6 +114,18 @@ func RequireSystemTenantOrClusterSetting(
 		"Feature flag: %s", setting.Name())
 }
 
+// InferRegionUsingConstraintEnabled is used to enable and disable setting a
+// foreign key constraint for looking up the region column in a REGIONAL BY ROW
+// table.
+var InferRegionUsingConstraintEnabled = settings.RegisterBoolSetting(
+	settings.ApplicationLevel,
+	"feature.infer_rbr_region_col_using_constraint.enabled",
+	"set to true to enable looking up the region column via a foreign key constraint in a "+
+		"REGIONAL BY ROW table, false to disable; default is false",
+	false,
+	settings.WithPublic,
+)
+
 // CachedSequencesCacheSizeSetting is the default cache size used when
 // SessionNormalizationMode is SerialUsesCachedSQLSequences or
 // SerialUsesCachedNodeSQLSequences.


### PR DESCRIPTION

Previously, the declarative schema changer did not support the `infer_rbr_region_col_using_constraint` storage parameter for REGIONAL BY ROW tables, falling back to the legacy schema changer via a NotImplementedError panic. This commit adds full support for SET and RESET of this parameter in the declarative schema changer.

The implementation includes:
- A new `SetTableRBRUsingConstraint` immediate mutation op that sets or clears the `RBRUsingConstraint` field on the table descriptor.
- Build-phase logic in `setRBRUsingConstraint` that validates the table is RBR, resolves the named constraint, validates it is a suitable FK (includes region column, has >1 column, region col is not computed, no computed cols reference region col), and emits the appropriate element. Both validated and unvalidated FK constraints are supported.
- Build-phase logic in `resetRBRUsingConstraint` that drops the existing `TableLocalityRegionalByRowUsingConstraint` element.
- Opgen transitions for toPublic and toAbsent, with an `rbrUsingConstraintAppliedLater` check to handle element replacement ordering when the constraint is being swapped.
- The `inferRegionUsingConstraintEnabled` cluster setting is moved to `sqlclustersettings` to be accessible from the schema changer build phase without circular imports.

Informs: #150946

Release note: None