### PR TITLE
copy: use 'large' engflow machine for tests

### DIFF
--- a/pkg/sql/copy/BUILD.bazel
+++ b/pkg/sql/copy/BUILD.bazel
@@ -10,6 +10,9 @@ go_test(
         "main_test.go",
     ],
     data = glob(["testdata/**"]),
+    exec_properties = {
+        "test.Pool": "large",
+    },
     shard_count = 4,
     deps = [
         "//pkg/base",


### PR DESCRIPTION
We've seen a couple of test failures on `TestLargeCopy` under the external process mode when ALTER PRIMARY KEY is executed, where there appears to be an overload of the VM, which in turns causes COPY and ALTER to retry a few times. The overload can also lead to an OOM in the EngFlow worker (seen at least once), so this commit requests usage of the large VM by EngFlow for the package.

Fixes: #164723.
Fixes: #165167.
Release note: None