### PR TITLE
ui: migrate ScheduleDetails from Redux to SWR

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/schedules/scheduleDetailsPage/scheduleDetails.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/schedules/scheduleDetailsPage/scheduleDetails.spec.tsx
@@ -4,31 +4,23 @@
 // included in the /LICENSE file.
 
 import { render } from "@testing-library/react";
-import * as H from "history";
 import React from "react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Route } from "react-router-dom";
 
 import * as utils from "src/util/hooks";
 
 import { activeScheduleFixture } from "../schedulesPage/schedulesPage.fixture";
 
-import { ScheduleDetails, ScheduleDetailsProps } from "./scheduleDetails";
+import { ScheduleDetails } from "./scheduleDetails";
 
-const getMockScheduleDetailsProps = (
-  scheduleID = "123",
-): ScheduleDetailsProps => {
-  const history = H.createHashHistory();
-  return {
-    location: history.location,
-    history,
-    match: {
-      url: "",
-      path: history.location.pathname,
-      isExact: false,
-      params: { id: scheduleID },
-    },
-  };
-};
+const renderWithRoute = (scheduleID = "123") =>
+  render(
+    <MemoryRouter initialEntries={[`/schedules/${scheduleID}`]}>
+      <Route path="/schedules/:id">
+        <ScheduleDetails />
+      </Route>
+    </MemoryRouter>,
+  );
 
 describe("ScheduleDetails", () => {
   let spy: jest.MockInstance<any, any>;
@@ -44,11 +36,7 @@ describe("ScheduleDetails", () => {
       mutate: null,
       isValidating: false,
     });
-    const { getByText } = render(
-      <MemoryRouter>
-        <ScheduleDetails {...getMockScheduleDetailsProps()} />
-      </MemoryRouter>,
-    );
+    const { getByText } = renderWithRoute();
     getByText("Label");
     getByText("Status");
     getByText("State");
@@ -68,11 +56,7 @@ describe("ScheduleDetails", () => {
       isValidating: false,
     });
 
-    const { getByText } = render(
-      <MemoryRouter>
-        <ScheduleDetails {...getMockScheduleDetailsProps()} />
-      </MemoryRouter>,
-    );
+    const { getByText } = renderWithRoute();
     getByText("Error retrieving data");
   });
 
@@ -85,11 +69,7 @@ describe("ScheduleDetails", () => {
       isValidating: false,
     });
 
-    const { getByTestId } = render(
-      <MemoryRouter>
-        <ScheduleDetails {...getMockScheduleDetailsProps()} />
-      </MemoryRouter>,
-    );
+    const { getByTestId } = renderWithRoute();
     getByTestId("loading-spinner");
   });
 
@@ -102,11 +82,7 @@ describe("ScheduleDetails", () => {
       isValidating: false,
     });
 
-    const { getByText } = render(
-      <MemoryRouter>
-        <ScheduleDetails {...getMockScheduleDetailsProps("456")} />
-      </MemoryRouter>,
-    );
+    const { getByText } = renderWithRoute("456");
     getByText("Schedule ID: 456");
   });
 });

--- a/pkg/ui/workspaces/cluster-ui/src/schedules/scheduleDetailsPage/scheduleDetails.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/schedules/scheduleDetailsPage/scheduleDetails.spec.tsx
@@ -1,0 +1,112 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import { render } from "@testing-library/react";
+import * as H from "history";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+
+import * as utils from "src/util/hooks";
+
+import { activeScheduleFixture } from "../schedulesPage/schedulesPage.fixture";
+
+import { ScheduleDetails, ScheduleDetailsProps } from "./scheduleDetails";
+
+const getMockScheduleDetailsProps = (
+  scheduleID = "123",
+): ScheduleDetailsProps => {
+  const history = H.createHashHistory();
+  return {
+    location: history.location,
+    history,
+    match: {
+      url: "",
+      path: history.location.pathname,
+      isExact: false,
+      params: { id: scheduleID },
+    },
+  };
+};
+
+describe("ScheduleDetails", () => {
+  let spy: jest.MockInstance<any, any>;
+  afterEach(() => {
+    spy.mockClear();
+  });
+
+  it("renders schedule details when data is loaded", () => {
+    spy = jest.spyOn(utils, "useSwrWithClusterId").mockReturnValue({
+      data: activeScheduleFixture,
+      isLoading: false,
+      error: null,
+      mutate: null,
+      isValidating: false,
+    });
+    const { getByText } = render(
+      <MemoryRouter>
+        <ScheduleDetails {...getMockScheduleDetailsProps()} />
+      </MemoryRouter>,
+    );
+    getByText("Label");
+    getByText("Status");
+    getByText("State");
+    getByText("Creation Time");
+    getByText("Next Execution Time");
+    getByText("Recurrence");
+    getByText("Jobs Running");
+    getByText("Owner");
+  });
+
+  it("renders an error message when there is an error retrieving data", () => {
+    spy = jest.spyOn(utils, "useSwrWithClusterId").mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: new Error("Error retrieving data"),
+      mutate: null,
+      isValidating: false,
+    });
+
+    const { getByText } = render(
+      <MemoryRouter>
+        <ScheduleDetails {...getMockScheduleDetailsProps()} />
+      </MemoryRouter>,
+    );
+    getByText("Error retrieving data");
+  });
+
+  it("renders a loading spinner when data is still loading", () => {
+    spy = jest.spyOn(utils, "useSwrWithClusterId").mockReturnValue({
+      data: null,
+      isLoading: true,
+      error: null,
+      mutate: null,
+      isValidating: false,
+    });
+
+    const { getByTestId } = render(
+      <MemoryRouter>
+        <ScheduleDetails {...getMockScheduleDetailsProps()} />
+      </MemoryRouter>,
+    );
+    getByTestId("loading-spinner");
+  });
+
+  it("renders the schedule ID in the header", () => {
+    spy = jest.spyOn(utils, "useSwrWithClusterId").mockReturnValue({
+      data: activeScheduleFixture,
+      isLoading: false,
+      error: null,
+      mutate: null,
+      isValidating: false,
+    });
+
+    const { getByText } = render(
+      <MemoryRouter>
+        <ScheduleDetails {...getMockScheduleDetailsProps("456")} />
+      </MemoryRouter>,
+    );
+    getByText("Schedule ID: 456");
+  });
+});

--- a/pkg/ui/workspaces/cluster-ui/src/schedules/scheduleDetailsPage/scheduleDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/schedules/scheduleDetailsPage/scheduleDetails.tsx
@@ -8,7 +8,7 @@ import classNames from "classnames/bind";
 import Long from "long";
 import React from "react";
 import Helmet from "react-helmet";
-import { RouteComponentProps } from "react-router-dom";
+import { useHistory, useParams } from "react-router-dom";
 
 import { getSchedule } from "src/api/schedulesApi";
 import { Button } from "src/button";
@@ -18,22 +18,16 @@ import scheduleStyles from "src/schedules/schedules.module.scss";
 import { SqlBox, SqlBoxSize } from "src/sql";
 import { SummaryCard, SummaryCardItem } from "src/summaryCard";
 import summaryCardStyles from "src/summaryCard/summaryCard.module.scss";
-import {
-  DATE_FORMAT_24_TZ,
-  idAttr,
-  getMatchParamByName,
-  useSwrWithClusterId,
-} from "src/util";
+import { DATE_FORMAT_24_TZ, useSwrWithClusterId } from "src/util";
 
 import { Timestamp } from "../../timestamp";
 
 const cardCx = classNames.bind(summaryCardStyles);
 const scheduleCx = classNames.bind(scheduleStyles);
 
-export type ScheduleDetailsProps = RouteComponentProps;
-
-export const ScheduleDetails: React.FC<ScheduleDetailsProps> = props => {
-  const idStr = getMatchParamByName(props.match, idAttr);
+export const ScheduleDetails: React.FC = () => {
+  const { id: idStr } = useParams<{ id: string }>();
+  const history = useHistory();
 
   const {
     data: schedule,
@@ -43,7 +37,7 @@ export const ScheduleDetails: React.FC<ScheduleDetailsProps> = props => {
     getSchedule(Long.fromString(idStr)),
   );
 
-  const prevPage = (): void => props.history.goBack();
+  const prevPage = (): void => history.goBack();
 
   const renderContent = (): React.ReactElement => {
     return (

--- a/pkg/ui/workspaces/cluster-ui/src/schedules/scheduleDetailsPage/scheduleDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/schedules/scheduleDetailsPage/scheduleDetails.tsx
@@ -6,11 +6,11 @@ import { ArrowLeft } from "@cockroachlabs/icons";
 import { Col, Row } from "antd";
 import classNames from "classnames/bind";
 import Long from "long";
-import React, { useEffect } from "react";
+import React from "react";
 import Helmet from "react-helmet";
 import { RouteComponentProps } from "react-router-dom";
 
-import { Schedule } from "src/api/schedulesApi";
+import { getSchedule } from "src/api/schedulesApi";
 import { Button } from "src/button";
 import { commonStyles } from "src/common";
 import { Loading } from "src/loading";
@@ -18,38 +18,34 @@ import scheduleStyles from "src/schedules/schedules.module.scss";
 import { SqlBox, SqlBoxSize } from "src/sql";
 import { SummaryCard, SummaryCardItem } from "src/summaryCard";
 import summaryCardStyles from "src/summaryCard/summaryCard.module.scss";
-import { DATE_FORMAT_24_TZ, idAttr, getMatchParamByName } from "src/util";
+import {
+  DATE_FORMAT_24_TZ,
+  idAttr,
+  getMatchParamByName,
+  useSwrWithClusterId,
+} from "src/util";
 
 import { Timestamp } from "../../timestamp";
 
 const cardCx = classNames.bind(summaryCardStyles);
 const scheduleCx = classNames.bind(scheduleStyles);
 
-export interface ScheduleDetailsStateProps {
-  schedule: Schedule;
-  scheduleError: Error | null;
-  scheduleLoading: boolean;
-}
-
-export interface ScheduleDetailsDispatchProps {
-  refreshSchedule: (id: Long) => void;
-}
-
-export type ScheduleDetailsProps = ScheduleDetailsStateProps &
-  ScheduleDetailsDispatchProps &
-  RouteComponentProps;
+export type ScheduleDetailsProps = RouteComponentProps;
 
 export const ScheduleDetails: React.FC<ScheduleDetailsProps> = props => {
   const idStr = getMatchParamByName(props.match, idAttr);
-  const { refreshSchedule } = props;
-  useEffect(() => {
-    refreshSchedule(Long.fromString(idStr));
-  }, [idStr, refreshSchedule]);
+
+  const {
+    data: schedule,
+    error,
+    isLoading,
+  } = useSwrWithClusterId({ name: "schedule", id: idStr }, () =>
+    getSchedule(Long.fromString(idStr)),
+  );
 
   const prevPage = (): void => props.history.goBack();
 
   const renderContent = (): React.ReactElement => {
-    const schedule = props.schedule;
     return (
       <>
         <Row gutter={24}>
@@ -126,9 +122,9 @@ export const ScheduleDetails: React.FC<ScheduleDetailsProps> = props => {
       </div>
       <section className={scheduleCx("section section--container")}>
         <Loading
-          loading={!props.schedule || props.scheduleLoading}
+          loading={!schedule || isLoading}
           page={"schedule details"}
-          error={props.scheduleError}
+          error={error}
           render={renderContent}
         />
       </section>

--- a/pkg/ui/workspaces/db-console/src/app.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.spec.tsx
@@ -13,6 +13,7 @@ stubComponentInModule(
   "@cockroachlabs/cluster-ui",
   "DatabasesPageV2",
   "DatabaseDetailsPageV2",
+  "ScheduleDetails",
 );
 stubComponentInModule("src/views/cluster/containers/nodeGraphs", "default");
 stubComponentInModule("src/views/cluster/containers/events", "EventPage");
@@ -43,7 +44,6 @@ stubComponentInModule(
 );
 stubComponentInModule("src/views/insights/schemaInsightsPage", "default");
 stubComponentInModule("src/views/schedules/schedulesPage", "default");
-stubComponentInModule("src/views/schedules/scheduleDetails", "default");
 stubComponentInModule("src/views/tracez_v2/snapshotPage", "default");
 stubComponentInModule(
   "src/views/app/components/tenantDropdown/tenantDropdown",
@@ -264,7 +264,7 @@ describe("Routing to", () => {
   describe("'/schedules/:id' path", () => {
     test("routes to <ScheduleDetails> component", () => {
       navigateToPath("/schedules/12345");
-      screen.getByTestId("scheduleDetails");
+      screen.getByTestId("ScheduleDetails");
     });
   });
 

--- a/pkg/ui/workspaces/db-console/src/app.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.tsx
@@ -10,6 +10,7 @@ import {
   DatabasesPageV2,
   DatabaseDetailsPageV2,
   TableDetailsPageV2,
+  ScheduleDetails,
 } from "@cockroachlabs/cluster-ui";
 import { ConfigProvider } from "antd";
 import { ConnectedRouter } from "connected-react-router";
@@ -77,7 +78,6 @@ import Range from "src/views/reports/containers/range";
 import ReduxDebug from "src/views/reports/containers/redux";
 import Settings from "src/views/reports/containers/settings";
 import Stores from "src/views/reports/containers/stores";
-import ScheduleDetails from "src/views/schedules/scheduleDetails";
 import SchedulesPage from "src/views/schedules/schedulesPage";
 import SessionDetails from "src/views/sessions/sessionDetails";
 import SQLActivityPage from "src/views/sqlActivity/sqlActivityPage";

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -468,16 +468,6 @@ const schemaInsightsReducerObj = new CachedDataReducer(
 );
 export const refreshSchemaInsights = schemaInsightsReducerObj.refresh;
 
-export const scheduleKey = (scheduleID: Long): string => scheduleID.toString();
-
-const scheduleReducerObj = new KeyedCachedDataReducer(
-  clusterUiApi.getSchedule,
-  "schedule",
-  scheduleKey,
-  moment.duration(10, "s"),
-);
-export const refreshSchedule = scheduleReducerObj.refresh;
-
 const snapshotsReducerObj = new KeyedCachedDataReducer(
   clusterUiApi.listTracingSnapshots,
   "snapshots",
@@ -580,7 +570,6 @@ export interface APIReducersState {
   statementFingerprintInsights: KeyedCachedDataReducerState<
     clusterUiApi.SqlApiResponse<StmtInsightEvent[]>
   >;
-  schedule: KeyedCachedDataReducerState<clusterUiApi.Schedule>;
   snapshots: KeyedCachedDataReducerState<clusterUiApi.ListTracingSnapshotsResponse>;
   snapshot: KeyedCachedDataReducerState<clusterUiApi.GetTracingSnapshotResponse>;
   rawTrace: KeyedCachedDataReducerState<clusterUiApi.GetTraceResponse>;
@@ -631,7 +620,6 @@ export const apiReducersReducer = combineReducers<APIReducersState>({
     txnInsightDetailsReducerObj.reducer,
   [stmtInsightsReducerObj.actionNamespace]: stmtInsightsReducerObj.reducer,
   [schemaInsightsReducerObj.actionNamespace]: schemaInsightsReducerObj.reducer,
-  [scheduleReducerObj.actionNamespace]: scheduleReducerObj.reducer,
   [snapshotsReducerObj.actionNamespace]: snapshotsReducerObj.reducer,
   [snapshotReducerObj.actionNamespace]: snapshotReducerObj.reducer,
   [rawTraceReducerObj.actionNamespace]: rawTraceReducerObj.reducer,

--- a/pkg/ui/workspaces/db-console/src/views/schedules/scheduleDetails.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/schedules/scheduleDetails.tsx
@@ -1,8 +1,0 @@
-// Copyright 2022 The Cockroach Authors.
-//
-// Use of this software is governed by the CockroachDB Software License
-// included in the /LICENSE file.
-import { ScheduleDetails } from "@cockroachlabs/cluster-ui";
-import { withRouter } from "react-router-dom";
-
-export default withRouter(ScheduleDetails);

--- a/pkg/ui/workspaces/db-console/src/views/schedules/scheduleDetails.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/schedules/scheduleDetails.tsx
@@ -2,48 +2,7 @@
 //
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
-import {
-  api,
-  ScheduleDetails,
-  ScheduleDetailsStateProps,
-  selectID,
-} from "@cockroachlabs/cluster-ui";
-import { connect } from "react-redux";
-import { RouteComponentProps, withRouter } from "react-router-dom";
-import { createSelector } from "reselect";
+import { ScheduleDetails } from "@cockroachlabs/cluster-ui";
+import { withRouter } from "react-router-dom";
 
-import { CachedDataReducerState, refreshSchedule } from "src/redux/apiReducers";
-import { AdminUIState } from "src/redux/state";
-
-const selectScheduleState = createSelector(
-  [(state: AdminUIState) => state.cachedData.schedule, selectID],
-  (schedule, scheduleID): CachedDataReducerState<api.Schedule> => {
-    if (!schedule) {
-      return null;
-    }
-    return schedule[scheduleID];
-  },
-);
-
-const mapStateToProps = (
-  state: AdminUIState,
-  props: RouteComponentProps,
-): ScheduleDetailsStateProps => {
-  const scheduleState = selectScheduleState(state, props);
-  const schedule = scheduleState ? scheduleState.data : null;
-  const scheduleLoading = scheduleState ? scheduleState.inFlight : false;
-  const scheduleError = scheduleState ? scheduleState.lastError : null;
-  return {
-    schedule,
-    scheduleLoading,
-    scheduleError,
-  };
-};
-
-const mapDispatchToProps = {
-  refreshSchedule,
-};
-
-export default withRouter(
-  connect(mapStateToProps, mapDispatchToProps)(ScheduleDetails),
-);
+export default withRouter(ScheduleDetails);


### PR DESCRIPTION
Replace the Redux+Saga data fetching in the ScheduleDetails page with the useSwrWithClusterId hook, matching the pattern already used by the SchedulesPage (list view).

In cluster-ui, remove the ScheduleDetailsStateProps and ScheduleDetailsDispatchProps interfaces and the refreshSchedule/useEffect pattern, replacing them with a direct useSwrWithClusterId call to getSchedule.

In db-console, simplify the wrapper to a plain withRouter(ScheduleDetails) since Redux connection is no longer needed. Remove the schedule reducer, refresh action, and state from apiReducers.

Resolves: CRDB-61198
Epic: CRDB-58145
Release note: None