### PR TITLE
importer: fix output type mismatch in distmerge flow planning

### DIFF
--- a/pkg/sql/importer/import_processor_planning.go
+++ b/pkg/sql/importer/import_processor_planning.go
@@ -32,7 +32,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -141,20 +140,16 @@ func distImport(
 			corePlacement[i].SQLInstanceID = sqlInstanceIDs[i%len(sqlInstanceIDs)]
 			corePlacement[i].Core.ReadImport = inputSpecs[i]
 		}
-		outputTypes := []*types.T{types.Bytes, types.Bytes}
-		if useDistributedMerge {
-			outputTypes = []*types.T{types.Bytes, types.Bytes, types.Bytes}
-		}
 		p.AddNoInputStage(
 			corePlacement,
 			execinfrapb.PostProcessSpec{},
 			// The direct-ingest readers will emit a binary encoded BulkOpSummary.
-			outputTypes,
+			importProcessorOutputTypes,
 			execinfrapb.Ordering{},
 			nil, /* finalizeLastStageCb */
 		)
 		// Map the output directly back.
-		colMap := make([]int, len(outputTypes))
+		colMap := make([]int, len(importProcessorOutputTypes))
 		for i := range colMap {
 			colMap[i] = i
 		}


### PR DESCRIPTION
PR #164536 moved SST metadata from the import processor's third output
column to the progress metadata channel. PR #164977 updated the
processor's own output type declaration (`importProcessorOutputTypes`)
from 3 to 2 columns, but missed the separate output type declaration
in `import_processor_planning.go` used to build the physical plan.

This caused the receiver (gateway node) to set up a `StreamDecoder`
expecting 3 columns via `InputSyncSpec.ColumnTypes`, while the producer
sent 2-column rows. When the gateway decoded the row, it panicked with
`index out of range [2] with length 2` in `StreamDecoder.GetRow`,
crashing the node.

Fix by using `importProcessorOutputTypes` (the single source of truth)
in the flow plan instead of a separate local variable.

Fixes: #165147
Epic: CRDB-48845

Release note: None