### PR TITLE
workload: add security_invoker view option to schemachange workload 

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -1662,8 +1662,12 @@ func (og *operationGenerator) createView(ctx context.Context, tx pgx.Tx) (*opStm
 	})
 	// Descriptor ID generator may be temporarily unavailable, so
 	// allow uncategorized errors temporarily.
-	opStmt.sql = fmt.Sprintf(`CREATE VIEW %s AS %s`,
-		destViewName, selectStatement.String())
+	securityInvokerClause, err := og.randSecurityInvokerClause(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+	opStmt.sql = fmt.Sprintf(`CREATE VIEW %s%s AS %s`,
+		destViewName, securityInvokerClause, selectStatement.String())
 	return opStmt, nil
 }
 
@@ -2499,6 +2503,66 @@ func (og *operationGenerator) renameView(ctx context.Context, tx pgx.Tx) (*opStm
 	})
 
 	stmt.sql = fmt.Sprintf(`ALTER VIEW %s RENAME TO %s`, srcViewName, destViewName)
+	return stmt, nil
+}
+
+func (og *operationGenerator) alterViewSetViewOption(
+	ctx context.Context, tx pgx.Tx,
+) (*opStmt, error) {
+	viewName, err := og.randView(ctx, tx, og.pctExisting(true), "")
+	if err != nil {
+		return nil, err
+	}
+	viewExists, err := og.viewExists(ctx, tx, viewName)
+	if err != nil {
+		return nil, err
+	}
+	notSupported, err := isClusterVersionLessThan(
+		ctx, tx, clusterversion.V26_2.Version(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	stmt := makeOpStmt(OpStmtDDL)
+	stmt.expectedExecErrors.addAll(codesWithConditions{
+		{code: pgcode.UndefinedTable, condition: !viewExists},
+		{code: pgcode.Syntax, condition: notSupported},
+		{code: pgcode.FeatureNotSupported, condition: notSupported},
+	})
+	value := "true"
+	if og.params.rng.Intn(2) == 0 {
+		value = "false"
+	}
+	stmt.sql = fmt.Sprintf(`ALTER VIEW %s SET (security_invoker = %s)`, viewName, value)
+	return stmt, nil
+}
+
+func (og *operationGenerator) alterViewResetViewOption(
+	ctx context.Context, tx pgx.Tx,
+) (*opStmt, error) {
+	viewName, err := og.randView(ctx, tx, og.pctExisting(true), "")
+	if err != nil {
+		return nil, err
+	}
+	viewExists, err := og.viewExists(ctx, tx, viewName)
+	if err != nil {
+		return nil, err
+	}
+	notSupported, err := isClusterVersionLessThan(
+		ctx, tx, clusterversion.V26_2.Version(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	stmt := makeOpStmt(OpStmtDDL)
+	stmt.expectedExecErrors.addAll(codesWithConditions{
+		{code: pgcode.UndefinedTable, condition: !viewExists},
+		{code: pgcode.Syntax, condition: notSupported},
+		{code: pgcode.FeatureNotSupported, condition: notSupported},
+	})
+	stmt.sql = fmt.Sprintf(`ALTER VIEW %s RESET (security_invoker)`, viewName)
 	return stmt, nil
 }
 
@@ -3792,6 +3856,35 @@ func (og *operationGenerator) randReferenceActions(
 		acts.Update = tree.NoAction
 	}
 	return acts
+}
+
+// randSecurityInvokerClause randomly returns a WITH (security_invoker) clause
+// for use in CREATE VIEW statements. It returns one of:
+// - " WITH (security_invoker = true)"
+// - " WITH (security_invoker = false)"
+// - "" (no clause)
+// The security_invoker option is only available in v26.2+, so an empty string
+// is always returned on older versions.
+func (og *operationGenerator) randSecurityInvokerClause(
+	ctx context.Context, tx pgx.Tx,
+) (string, error) {
+	notSupported, err := isClusterVersionLessThan(
+		ctx, tx, clusterversion.V26_2.Version(),
+	)
+	if err != nil {
+		return "", err
+	}
+	if notSupported {
+		return "", nil
+	}
+	switch og.params.rng.Intn(3) {
+	case 0:
+		return " WITH (security_invoker = true)", nil
+	case 1:
+		return " WITH (security_invoker = false)", nil
+	default:
+		return "", nil
+	}
 }
 
 // randParentColumnForFkRelation fetches a column and table to use as the parent in a single-column foreign key relation.

--- a/pkg/workload/schemachange/optype.go
+++ b/pkg/workload/schemachange/optype.go
@@ -113,6 +113,11 @@ const (
 	alterTableSetStorageParams        // ALTER TABLE <table> SET (<storage_param>=<val>)
 	alterTableResetStorageParams      // ALTER TABLE <table> RESET <storage_param>
 
+	// ALTER VIEW ...
+
+	alterViewSetViewOption   // ALTER VIEW <view> SET (security_invoker = <bool>)
+	alterViewResetViewOption // ALTER VIEW <view> RESET (security_invoker)
+
 	// ALTER TYPE ...
 
 	alterTypeDropValue // ALTER TYPE <type> DROP VALUE <value>
@@ -246,6 +251,8 @@ var opFuncs = []func(*operationGenerator, context.Context, pgx.Tx) (*opStmt, err
 	alterTableSetColumnNotNull:        (*operationGenerator).setColumnNotNull,
 	alterTableSetStorageParams:        (*operationGenerator).setTableStorageParam,
 	alterTableResetStorageParams:      (*operationGenerator).resetTableStorageParam,
+	alterViewSetViewOption:            (*operationGenerator).alterViewSetViewOption,
+	alterViewResetViewOption:          (*operationGenerator).alterViewResetViewOption,
 	alterTypeDropValue:                (*operationGenerator).alterTypeDropValue,
 	commentOn:                         (*operationGenerator).commentOn,
 	createFunction:                    (*operationGenerator).createFunction,
@@ -307,6 +314,8 @@ var opWeights = []int{
 	alterTableSetColumnNotNull:        1,
 	alterTableSetStorageParams:        1,
 	alterTableResetStorageParams:      1,
+	alterViewSetViewOption:            1,
+	alterViewResetViewOption:          1,
 	alterTypeDropValue:                1,
 	commentOn:                         1,
 	createFunction:                    1,

--- a/pkg/workload/schemachange/optype_string.go
+++ b/pkg/workload/schemachange/optype_string.go
@@ -46,29 +46,31 @@ func _() {
 	_ = x[alterTableSetColumnNotNull-30]
 	_ = x[alterTableSetStorageParams-31]
 	_ = x[alterTableResetStorageParams-32]
-	_ = x[alterTypeDropValue-33]
-	_ = x[createTypeEnum-34]
-	_ = x[createTypeComposite-35]
-	_ = x[createIndex-36]
-	_ = x[createPolicy-37]
-	_ = x[createSchema-38]
-	_ = x[createSequence-39]
-	_ = x[createTable-40]
-	_ = x[createTableAs-41]
-	_ = x[createView-42]
-	_ = x[createFunction-43]
-	_ = x[createTrigger-44]
-	_ = x[commentOn-45]
-	_ = x[dropFunction-46]
-	_ = x[dropIndex-47]
-	_ = x[dropPolicy-48]
-	_ = x[dropSchema-49]
-	_ = x[dropSequence-50]
-	_ = x[dropTable-51]
-	_ = x[dropTrigger-52]
-	_ = x[dropView-53]
-	_ = x[truncateTable-54]
-	_ = x[inspect-55]
+	_ = x[alterViewSetViewOption-33]
+	_ = x[alterViewResetViewOption-34]
+	_ = x[alterTypeDropValue-35]
+	_ = x[createTypeEnum-36]
+	_ = x[createTypeComposite-37]
+	_ = x[createIndex-38]
+	_ = x[createPolicy-39]
+	_ = x[createSchema-40]
+	_ = x[createSequence-41]
+	_ = x[createTable-42]
+	_ = x[createTableAs-43]
+	_ = x[createView-44]
+	_ = x[createFunction-45]
+	_ = x[createTrigger-46]
+	_ = x[commentOn-47]
+	_ = x[dropFunction-48]
+	_ = x[dropIndex-49]
+	_ = x[dropPolicy-50]
+	_ = x[dropSchema-51]
+	_ = x[dropSequence-52]
+	_ = x[dropTable-53]
+	_ = x[dropTrigger-54]
+	_ = x[dropView-55]
+	_ = x[truncateTable-56]
+	_ = x[inspect-57]
 }
 
 func (i opType) String() string {
@@ -139,6 +141,10 @@ func (i opType) String() string {
 		return "alterTableSetStorageParams"
 	case alterTableResetStorageParams:
 		return "alterTableResetStorageParams"
+	case alterViewSetViewOption:
+		return "alterViewSetViewOption"
+	case alterViewResetViewOption:
+		return "alterViewResetViewOption"
 	case alterTypeDropValue:
 		return "alterTypeDropValue"
 	case createTypeEnum:


### PR DESCRIPTION
Stacked PR. Only review the top commit.

The security_invoker option is added to CRDB views in 26.2. This
change enables testing it with the random schema worklaod.
The test will create views with security_invoker unset (default),
false, and true. It also tests `ALTER VIEW SET/RESET (security_invoker)`.

Fixes: #165253

Release note: None
