### PR TITLE
sql/schemachanger: add cluster version check type to command registration

### DIFF
--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table.go
@@ -85,7 +85,6 @@ var alterTableSubcommandNames = map[reflect.Type]string{
 }
 
 func init() {
-	boolType := reflect.TypeOf((*bool)(nil)).Elem()
 	// Check function signatures inside the supportedAlterTableStatements map.
 	for statementType, statementEntry := range supportedAlterTableStatements {
 		callBackType := reflect.TypeOf(statementEntry.fn)
@@ -103,19 +102,10 @@ func init() {
 				"does not have a valid signature; got %v", statementType, callBackType))
 		}
 		if statementEntry.checks != nil {
-			checks := reflect.TypeOf(statementEntry.checks)
-			if checks.Kind() != reflect.Func {
-				panic(errors.AssertionFailedf("%v checks for statement is "+
-					"not a function", statementType))
-			}
-			if checks.NumIn() != 3 ||
-				(checks.In(0) != statementType && !statementType.Implements(checks.In(0))) ||
-				checks.In(1) != reflect.TypeOf(sessiondatapb.UseNewSchemaChangerOff) ||
-				checks.In(2) != reflect.TypeOf((*clusterversion.ClusterVersion)(nil)).Elem() ||
-				checks.NumOut() != 1 ||
-				checks.Out(0) != boolType {
-				panic(errors.AssertionFailedf("%v checks does not have a valid signature; got %v",
-					statementType, checks))
+			if _, ok := statementEntry.checks.(isVersionActiveFunc); !ok {
+				panic(errors.AssertionFailedf(
+					"%v checks is not an isVersionActiveFunc; got %T",
+					statementType, statementEntry.checks))
 			}
 		}
 		// Validate that every entry in supportedAlterTableStatements has a

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
@@ -249,14 +249,17 @@ func getDeclarativeSchemaChangerModeForStmt(
 	return ret
 }
 
-var isV254Active = func(_ tree.NodeFormatter, _ sessiondatapb.NewSchemaChangerMode, activeVersion clusterversion.ClusterVersion) bool {
+// isVersionActiveFunc is a function type for checking whether a statement is supported in the current cluster version.
+type isVersionActiveFunc = func(_ tree.NodeFormatter, _ sessiondatapb.NewSchemaChangerMode, activeVersion clusterversion.ClusterVersion) bool
+
+var isV254Active isVersionActiveFunc = func(_ tree.NodeFormatter, _ sessiondatapb.NewSchemaChangerMode, activeVersion clusterversion.ClusterVersion) bool {
 	return activeVersion.IsActive(clusterversion.V25_4)
 }
 
-var isV261Active = func(_ tree.NodeFormatter, _ sessiondatapb.NewSchemaChangerMode, activeVersion clusterversion.ClusterVersion) bool {
+var isV261Active isVersionActiveFunc = func(_ tree.NodeFormatter, _ sessiondatapb.NewSchemaChangerMode, activeVersion clusterversion.ClusterVersion) bool {
 	return activeVersion.IsActive(clusterversion.V26_1)
 }
 
-var isV262Active = func(_ tree.NodeFormatter, _ sessiondatapb.NewSchemaChangerMode, activeVersion clusterversion.ClusterVersion) bool {
+var isV262Active isVersionActiveFunc = func(_ tree.NodeFormatter, _ sessiondatapb.NewSchemaChangerMode, activeVersion clusterversion.ClusterVersion) bool {
 	return activeVersion.IsActive(clusterversion.V26_2)
 }


### PR DESCRIPTION
This change adds a function type for the cluster
version checks that are common to sub-handlers so
that those handlers can tighten the check type
explicitly.

Epic: CRDB-31325
Part of: #164213

Release note: None
