### PR TITLE
sql/schemachanger: add `ALTER TYPE` statements as stub handlers

### DIFF
--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "alter_table_set_storage_param.go",
         "alter_table_set_trigger.go",
         "alter_table_validate_constraint.go",
+        "alter_type.go",
         "comment_on.go",
         "configure_zone.go",
         "create_database.go",

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_type.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_type.go
@@ -1,0 +1,139 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package scbuildstmt
+
+import (
+	"reflect"
+
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scerrors"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
+	"github.com/cockroachdb/errors"
+)
+
+type supportedAlterTypeCommand = supportedStatement
+
+// supportedAlterTypeStatements tracks alter type operations fully supported by
+// the declarative schema changer. Operations marked as non-fully supported can
+// only be used with the use_declarative_schema_changer session variable.
+var supportedAlterTypeStatements = map[reflect.Type]supportedAlterTypeCommand{
+	reflect.TypeOf((*tree.AlterTypeAddValue)(nil)):    {fn: alterTypeAddValue, on: false, checks: nil},
+	reflect.TypeOf((*tree.AlterTypeRenameValue)(nil)): {fn: alterTypeRenameValue, on: false, checks: nil},
+	reflect.TypeOf((*tree.AlterTypeRename)(nil)):      {fn: alterTypeRename, on: false, checks: nil},
+	reflect.TypeOf((*tree.AlterTypeSetSchema)(nil)):   {fn: alterTypeSetSchema, on: false, checks: nil},
+	reflect.TypeOf((*tree.AlterTypeOwner)(nil)):       {fn: alterTypeOwner, on: false, checks: nil},
+	reflect.TypeOf((*tree.AlterTypeDropValue)(nil)):   {fn: alterTypeDropValue, on: false, checks: nil},
+}
+
+func init() {
+	// Check function signatures inside the supportedAlterTypeStatements map.
+	for statementType, statementEntry := range supportedAlterTypeStatements {
+		callBackType := reflect.TypeOf(statementEntry.fn)
+		if callBackType.Kind() != reflect.Func {
+			panic(errors.AssertionFailedf("%v entry for statement is "+
+				"not a function", statementType))
+		}
+		if callBackType.NumIn() != 4 ||
+			!callBackType.In(0).Implements(reflect.TypeOf((*BuildCtx)(nil)).Elem()) ||
+			callBackType.In(1) != reflect.TypeOf((*tree.TypeName)(nil)) ||
+			callBackType.In(2) != reflect.TypeOf((*scpb.EnumType)(nil)) ||
+			callBackType.In(3) != statementType {
+			panic(errors.AssertionFailedf("%v entry for alter type statement "+
+				"does not have a valid signature; got %v", statementType, callBackType))
+		}
+		if statementEntry.checks != nil {
+			if _, ok := statementEntry.checks.(isVersionActiveFunc); !ok {
+				panic(errors.AssertionFailedf(
+					"%v checks is not an isVersionActiveFunc; got %T",
+					statementType, statementEntry.checks))
+			}
+		}
+	}
+}
+
+// alterTypeChecks determines if the alter type command is supported.
+func alterTypeChecks(
+	n *tree.AlterType,
+	mode sessiondatapb.NewSchemaChangerMode,
+	activeVersion clusterversion.ClusterVersion,
+) bool {
+	return isFullySupportedWithFalsePositiveInternal(
+		supportedAlterTypeStatements,
+		reflect.TypeOf(n.Cmd), reflect.ValueOf(n.Cmd), mode, activeVersion,
+	)
+}
+
+// AlterType implements ALTER TYPE.
+func AlterType(b BuildCtx, n *tree.AlterType) {
+	elts := b.ResolveUserDefinedTypeType(n.Type, ResolveParams{})
+
+	if !elts.FilterCompositeType().IsEmpty() {
+		panic(pgerror.Newf(pgcode.WrongObjectType, "cannot modify composite type"))
+	}
+
+	enumTypeElts := elts.FilterEnumType()
+	_, target, enumType := enumTypeElts.Get(0)
+	if target != scpb.ToPublic {
+		panic(pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
+			"type %q is being dropped, try again later", n.Type.Object()))
+	}
+
+	tn := n.Type.ToTypeName()
+	tn.ObjectNamePrefix = b.NamePrefix(enumType)
+	b.SetUnresolvedNameAnnotation(n.Type, &tn)
+	b.IncrementSchemaChangeAlterCounter("type", n.Cmd.TelemetryName())
+	b.IncrementEnumCounter(sqltelemetry.EnumAlter)
+
+	info := supportedAlterTypeStatements[reflect.TypeOf(n.Cmd)]
+	fn := reflect.ValueOf(info.fn)
+	fn.Call([]reflect.Value{
+		reflect.ValueOf(b),
+		reflect.ValueOf(&tn),
+		reflect.ValueOf(enumType),
+		reflect.ValueOf(n.Cmd),
+	})
+}
+
+func alterTypeAddValue(
+	b BuildCtx, tn *tree.TypeName, enumType *scpb.EnumType, t *tree.AlterTypeAddValue,
+) {
+	panic(scerrors.NotImplementedErrorf(t, "ALTER TYPE ADD VALUE is not supported"))
+}
+
+func alterTypeRenameValue(
+	b BuildCtx, tn *tree.TypeName, enumType *scpb.EnumType, t *tree.AlterTypeRenameValue,
+) {
+	panic(scerrors.NotImplementedErrorf(t, "ALTER TYPE RENAME VALUE is not supported"))
+}
+
+func alterTypeRename(
+	b BuildCtx, tn *tree.TypeName, enumType *scpb.EnumType, t *tree.AlterTypeRename,
+) {
+	panic(scerrors.NotImplementedErrorf(t, "ALTER TYPE RENAME is not supported"))
+}
+
+func alterTypeSetSchema(
+	b BuildCtx, tn *tree.TypeName, enumType *scpb.EnumType, t *tree.AlterTypeSetSchema,
+) {
+	panic(scerrors.NotImplementedErrorf(t, "ALTER TYPE SET SCHEMA is not supported"))
+}
+
+func alterTypeOwner(
+	b BuildCtx, tn *tree.TypeName, enumType *scpb.EnumType, t *tree.AlterTypeOwner,
+) {
+	panic(scerrors.NotImplementedErrorf(t, "ALTER TYPE OWNER TO is not supported"))
+}
+
+func alterTypeDropValue(
+	b BuildCtx, tn *tree.TypeName, enumType *scpb.EnumType, t *tree.AlterTypeDropValue,
+) {
+	panic(scerrors.NotImplementedErrorf(t, "ALTER TYPE DROP VALUE is not supported"))
+}

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
@@ -44,6 +44,7 @@ var supportedStatements = map[reflect.Type]supportedStatement{
 	// supportedAlterTableStatements list, so we will consider it fully supported
 	// here.
 	reflect.TypeOf((*tree.AlterTable)(nil)):          {fn: AlterTable, statementTags: []string{tree.AlterTableTag}, on: true, checks: alterTableChecks},
+	reflect.TypeOf((*tree.AlterType)(nil)):           {fn: AlterType, statementTags: []string{tree.AlterTypeTag}, on: false, checks: alterTypeChecks},
 	reflect.TypeOf((*tree.AlterTableLocality)(nil)):  {fn: AlterTableLocality, statementTags: []string{tree.AlterTableTag}, on: true, checks: isV262Active},
 	reflect.TypeOf((*tree.AlterTableSetSchema)(nil)): {fn: AlterTableSetSchema, statementTags: []string{tree.AlterTableTag}, on: true, checks: isV261Active},
 	reflect.TypeOf((*tree.AlterPolicy)(nil)):         {fn: AlterPolicy, statementTags: []string{tree.AlterPolicyTag}, on: true, checks: nil},

--- a/pkg/sql/schemachanger/scbuild/testdata/alter_type
+++ b/pkg/sql/schemachanger/scbuild/testdata/alter_type
@@ -1,0 +1,3 @@
+setup
+CREATE TYPE defaultdb.climes AS ENUM ('tropical', 'arctic', 'mediterranean');
+----

--- a/pkg/sql/schemachanger/scbuild/testdata/unimplemented_alter_type
+++ b/pkg/sql/schemachanger/scbuild/testdata/unimplemented_alter_type
@@ -1,0 +1,27 @@
+setup
+CREATE TYPE defaultdb.climes AS ENUM ('tropical', 'arctic', 'mediterranean');
+----
+
+unimplemented
+ALTER TYPE defaultdb.climes ADD VALUE 'desert'
+----
+
+unimplemented
+ALTER TYPE defaultdb.climes RENAME VALUE 'tropical' TO 'equatorial'
+----
+
+unimplemented
+ALTER TYPE defaultdb.climes DROP VALUE 'arctic'
+----
+
+unimplemented
+ALTER TYPE defaultdb.climes RENAME TO environs
+----
+
+unimplemented
+ALTER TYPE defaultdb.climes SET SCHEMA public
+----
+
+unimplemented
+ALTER TYPE defaultdb.climes OWNER TO weatherman
+----

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -90,6 +90,7 @@ const (
 const (
 	AlterSequenceTag       = "ALTER SEQUENCE"
 	AlterTableTag          = "ALTER TABLE"
+	AlterTypeTag           = "ALTER TYPE"
 	AlterPolicyTag         = "ALTER POLICY"
 	BackupTag              = "BACKUP"
 	CreateIndexTag         = "CREATE INDEX"


### PR DESCRIPTION
The `ALTER TYPE` statements are handled by the
legacy schema changer. This change adds disabled
stub handlers for those statements.

Epic: CRDB-31325
Closes: #164213

Release note: None

**Part of a stack with #165261.**
