### PR TITLE
backupinfo: default backup.index.read.enabled to true

### DIFF
--- a/pkg/backup/backupinfo/backup_index.go
+++ b/pkg/backup/backupinfo/backup_index.go
@@ -43,7 +43,7 @@ var (
 		settings.ApplicationLevel,
 		"backup.index.read.enabled",
 		"if true, the backup index will be read when reading from a backup collection",
-		metamorphic.ConstantWithTestBool("backup.index.read.enabled", false),
+		metamorphic.ConstantWithTestBool("backup.index.read.enabled", true),
 	)
 )
 


### PR DESCRIPTION
Epic: none

Release note: none