### PR TITLE
release-26.1: sql: add lookup fallback in internalLookupCtx

### DIFF
--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -1676,6 +1676,25 @@ func (tc *Collection) LockDescriptorWithLease(
 	return uint64(desc.GetVersion()), err
 }
 
+// GetLookupContextFallbackFn returns a fallback function if leased descriptors
+// are being used for GetAll.*
+func (tc *Collection) GetLookupContextFallbackFn(
+	ctx context.Context, txn *kv.Txn,
+) func(id descpb.ID) (catalog.Descriptor, error) {
+	// Without leased descriptors everything should be fully resolved
+	// within a look up context.
+	if !getAllowLeasedDescriptorsInCatalogViews(ctx, tc.settings) {
+		return nil
+	}
+	// If we are in a concurrent drop scenario, then GetAll will miss
+	// entiries that don't currently have a namespace entry. The locked
+	// descriptor leasing could pick an earlier timestamp, so we still
+	// need some type of look up
+	return func(id descpb.ID) (catalog.Descriptor, error) {
+		return tc.ByIDWithLeased(txn).Get().Desc(ctx, id)
+	}
+}
+
 // MakeTestCollection makes a Collection that can be used for tests.
 func MakeTestCollection(
 	ctx context.Context, codec keys.SQLCodec, leaseManager LeaseManager,

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -4374,3 +4374,88 @@ func TestLeaseManagerMemoryCloser(t *testing.T) {
 	require.Equal(t, int64(0), monitor.AllocBytes())
 	require.Equal(t, lm.TestingGetBoundAccount().Used(), int64(0))
 }
+
+// TestLeaseInternalLookupCtxWithLocked validates that the internal lookup context
+// will look up leased descriptors that are missing for crdb_internal functions.
+// This specifically focuses on the case where a foreign key reference table is
+// dropped, where the namespace entry and descriptor can be marked as dropped together.
+func TestLeaseInternalLookupCtxWithLocked(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	var targetIDs [2]atomic.Int64
+	waitCh := make(chan struct{})
+	allowCh := make(chan struct{})
+	var hookEnabled atomic.Bool
+	st := cluster.MakeTestingClusterSettings()
+	// Locked leasing is required for this test.
+	lease.LockedLeaseTimestamp.Override(ctx, &st.SV, true)
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Settings: st,
+		Knobs: base.TestingKnobs{
+			SQLLeaseManager: &lease.ManagerTestingKnobs{
+				TestingDescriptorUpdateEvent: func(descriptor *descpb.Descriptor) error {
+					if !hookEnabled.Load() {
+						return nil
+					}
+					id, _, _, _, err := descpb.GetDescriptorMetadata(descriptor)
+					if err != nil {
+						return err
+					}
+					if targetIDs[0].Load() != int64(id) && targetIDs[1].Load() != int64(id) {
+						return nil
+					}
+					// Indicate that the descriptor has been updated.
+					<-waitCh
+					// Block the update from being processing.
+					<-allowCh
+					return nil
+				},
+			},
+		},
+	})
+	defer s.Stopper().Stop(ctx)
+
+	r := sqlutils.MakeSQLRunner(db)
+	r.Exec(t, "SET CLUSTER SETTING sql.catalog.virtual_tables.use_index_lookup_for_descriptors_in_database.enabled = true")
+	r.Exec(t, "SET CLUSTER SETTING sql.catalog.allow_leased_descriptors.enabled = true")
+	r.Exec(t, "CREATE TABLE fk_src(n int primary key) WITH (schema_locked=false)")
+	r.Exec(t, "CREATE TABLE fk_dst(n int primary key, j int not null) WITH (schema_locked=false)")
+	r.Exec(t, "ALTER TABLE fk_dst ADD CONSTRAINT fk_name FOREIGN KEY (j) REFERENCES fk_src (n) NOT VALID;")
+	var descID int64
+	r.QueryRow(t, "SELECT 'fk_dst'::regclass::oid").Scan(&descID)
+	targetIDs[0].Store(descID)
+	r.QueryRow(t, "SELECT 'fk_src'::regclass::oid").Scan(&descID)
+	targetIDs[1].Store(descID)
+	r.Exec(t, "SELECT * FROM crdb_internal.create_statements WHERE descriptor_name SIMILAR TO 'fk_+%'\n  AND descriptor_type='table'")
+
+	hookEnabled.Store(true)
+	defer hookEnabled.Store(false)
+	channelsClosed := false
+	closeChannels := func() {
+		if !channelsClosed {
+			close(waitCh)
+			close(allowCh)
+			channelsClosed = true
+		}
+	}
+	defer closeChannels()
+	grp := ctxgroup.WithContext(ctx)
+	// Execute a drop that will clean up the foreign key source.
+	grp.GoCtx(func(ctx context.Context) error {
+		_, err := db.Exec("DROP TABLE fk_src CASCADE")
+		return err
+	})
+	// Wait for the descriptor drop to be visible.
+	waitCh <- struct{}{}
+	// Validate our definition shows the foreign key, since the leasing timestamp is behind.
+	str := r.QueryStr(t, "SELECT create_statement FROM crdb_internal.create_statements WHERE descriptor_name SIMILAR TO 'fk_+%'\n  AND descriptor_type='table'")
+	require.Equal(t, [][]string{{"CREATE TABLE public.fk_dst (\n\tn INT8 NOT NULL,\n\tj INT8 NOT NULL,\n\tCONSTRAINT fk_dst_pkey PRIMARY KEY (n ASC),\n\tCONSTRAINT fk_name FOREIGN KEY (j) REFERENCES public.fk_src(n) NOT VALID\n)"}}, str)
+	allowCh <- struct{}{}
+	// Close the channels and confirm the schema change completes
+	// successfully.
+	closeChannels()
+	require.NoError(t, grp.Wait())
+
+}

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -6211,7 +6211,7 @@ CREATE TABLE crdb_internal.invalid_objects (
 
 		// Validate database & schema descriptors, and namespace entries.
 		{
-			lCtx := newInternalLookupCtx(c.OrderedDescriptors(), dbContext)
+			lCtx := newInternalLookupCtx(c.OrderedDescriptors(), dbContext, p.Descriptors().GetLookupContextFallbackFn(ctx, p.Txn()))
 
 			if err := c.ForEachDescriptor(func(desc catalog.Descriptor) error {
 				switch d := desc.(type) {

--- a/pkg/sql/database.go
+++ b/pkg/sql/database.go
@@ -112,7 +112,7 @@ func (p *planner) forEachMutableTableInDatabase(
 	}
 
 	// TODO(ajwerner): Rewrite this to not use the internalLookupCtx.
-	lCtx := newInternalLookupCtx(all.OrderedDescriptors(), dbDesc)
+	lCtx := newInternalLookupCtx(all.OrderedDescriptors(), dbDesc, p.Descriptors().GetLookupContextFallbackFn(ctx, p.Txn()))
 	var droppedRemoved []descpb.ID
 	for _, tbID := range lCtx.tbIDs {
 		desc := lCtx.tbDescs[tbID]

--- a/pkg/sql/drop_role.go
+++ b/pkg/sql/drop_role.go
@@ -172,7 +172,7 @@ func (n *DropRoleNode) startExec(params runParams) error {
 		return err
 	}
 
-	lCtx := newInternalLookupCtx(all.OrderedDescriptors(), nil /*prefix - we want all descriptors */)
+	lCtx := newInternalLookupCtx(all.OrderedDescriptors(), nil /*prefix - we want all descriptors */, nil /* fallbackFn */)
 	// privileges are added.
 	for _, tbID := range lCtx.tbIDs {
 		tableDescriptor := lCtx.tbDescs[tbID]

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -2685,7 +2685,7 @@ func forEachTypeDesc(
 	if err != nil {
 		return err
 	}
-	lCtx := newInternalLookupCtx(all.OrderedDescriptors(), dbContext)
+	lCtx := newInternalLookupCtx(all.OrderedDescriptors(), dbContext, p.Descriptors().GetLookupContextFallbackFn(ctx, p.Txn()))
 	for _, id := range lCtx.typIDs {
 		typ := lCtx.typDescs[id]
 		dbDesc, err := lCtx.getDatabaseByID(typ.GetParentID())
@@ -2779,7 +2779,7 @@ func forEachTableDescFromDescriptors(
 	opts forEachTableDescOptions,
 	fn func(context.Context, tableDescContext) error,
 ) error {
-	lCtx := newInternalLookupCtx(c.OrderedDescriptors(), dbContext)
+	lCtx := newInternalLookupCtx(c.OrderedDescriptors(), dbContext, p.Descriptors().GetLookupContextFallbackFn(ctx, p.Txn()))
 
 	vOpts := opts.virtualOpts
 	if vOpts == virtualMany || vOpts == virtualCurrentDB {
@@ -2883,7 +2883,7 @@ func forEachTypeDescWithTableLookupInternalFromDescriptors(
 	c nstree.Catalog,
 	fn func(context.Context, catalog.DatabaseDescriptor, catalog.SchemaDescriptor, catalog.TypeDescriptor, tableLookupFn) error,
 ) error {
-	lCtx := newInternalLookupCtx(c.OrderedDescriptors(), dbContext)
+	lCtx := newInternalLookupCtx(c.OrderedDescriptors(), dbContext, p.Descriptors().GetLookupContextFallbackFn(ctx, p.Txn()))
 
 	for _, typID := range lCtx.typIDs {
 		typDesc := lCtx.typDescs[typID]

--- a/pkg/sql/reassign_owned_by.go
+++ b/pkg/sql/reassign_owned_by.go
@@ -115,7 +115,7 @@ func (n *reassignOwnedByNode) startExec(params runParams) error {
 		return err
 	}
 
-	lCtx := newInternalLookupCtx(all.OrderedDescriptors(), currentDbDesc.ImmutableCopy().(catalog.DatabaseDescriptor))
+	lCtx := newInternalLookupCtx(all.OrderedDescriptors(), currentDbDesc.ImmutableCopy().(catalog.DatabaseDescriptor), nil /* fallbackFn */)
 
 	// Iterate through each object, check for ownership by an old role.
 	for _, oldRole := range n.normalizedOldRoles {

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -809,6 +809,10 @@ func (r *fkSelfResolver) LookupObject(
 	return r.SchemaResolver.LookupObject(ctx, flags, dbName, scName, obName)
 }
 
+// internalLookupCtxFallbackFn fallback function if something
+// is not cached.
+type internalLookupCtxFallbackFn = func(id descpb.ID) (catalog.Descriptor, error)
+
 // internalLookupCtx can be used in contexts where all descriptors
 // have been recently read, to accelerate the lookup of
 // inter-descriptor relationships.
@@ -833,6 +837,8 @@ type internalLookupCtx struct {
 	typIDs      []descpb.ID
 	fnDescs     map[descpb.ID]catalog.FunctionDescriptor
 	fnIDs       []descpb.ID
+	// Optionally, a fallback look up function can be provided.
+	fallbackFn internalLookupCtxFallbackFn
 }
 
 // GetSchemaName looks up a schema with the given id in the LookupContext.
@@ -860,6 +866,14 @@ func (l *internalLookupCtx) GetSchemaName(
 	}
 
 	schemaName, found := l.schemaNames[id]
+	// Attempt a fallback lookup if we don't have this schema for some reason.
+	if !found && l.fallbackFn != nil {
+		desc, err := l.fallbackFn(id)
+		if err == nil && !desc.Dropped() {
+			schemaName = desc.GetName()
+			found = true
+		}
+	}
 	return schemaName, found, nil
 }
 
@@ -883,9 +897,12 @@ var useIndexLookupForDescriptorsInDatabase = settings.RegisterBoolSetting(
 type tableLookupFn = *internalLookupCtx
 
 // newInternalLookupCtx provides cached access to a set of descriptors for use
-// in virtual tables.
+// in virtual tables. Optionally, if fallbackFn missing descriptors are
+// looked up, which is required if a leased descriptors were used for population.
 func newInternalLookupCtx(
-	descs []catalog.Descriptor, prefix catalog.DatabaseDescriptor,
+	descs []catalog.Descriptor,
+	prefix catalog.DatabaseDescriptor,
+	fallbackFn internalLookupCtxFallbackFn,
 ) *internalLookupCtx {
 	dbNames := make(map[descpb.ID]string)
 	dbDescs := make(map[descpb.ID]catalog.DatabaseDescriptor)
@@ -948,12 +965,23 @@ func newInternalLookupCtx(
 		dbIDs:       dbIDs,
 		typIDs:      typIDs,
 		fnIDs:       fnIDs,
+		fallbackFn:  fallbackFn,
 	}
 }
 
 func (l *internalLookupCtx) getDatabaseByID(id descpb.ID) (catalog.DatabaseDescriptor, error) {
 	db, ok := l.dbDescs[id]
-	if !ok {
+	if ok {
+		return db, nil
+	}
+	if l.fallbackFn != nil {
+		desc, err := l.fallbackFn(id)
+		if err != nil {
+			return nil, err
+		}
+		db, _ = desc.(catalog.DatabaseDescriptor)
+	}
+	if db == nil {
 		return nil, sqlerrors.NewUndefinedDatabaseError(fmt.Sprintf("[%d]", id))
 	}
 	return db, nil
@@ -961,7 +989,17 @@ func (l *internalLookupCtx) getDatabaseByID(id descpb.ID) (catalog.DatabaseDescr
 
 func (l *internalLookupCtx) getTableByID(id descpb.ID) (catalog.TableDescriptor, error) {
 	tb, ok := l.tbDescs[id]
-	if !ok {
+	if ok {
+		return tb, nil
+	}
+	if l.fallbackFn != nil {
+		desc, err := l.fallbackFn(id)
+		if err != nil {
+			return nil, err
+		}
+		tb, _ = desc.(catalog.TableDescriptor)
+	}
+	if tb == nil {
 		return nil, sqlerrors.NewUndefinedRelationError(
 			tree.NewUnqualifiedTableName(tree.Name(fmt.Sprintf("[%d]", id))))
 	}
@@ -970,7 +1008,17 @@ func (l *internalLookupCtx) getTableByID(id descpb.ID) (catalog.TableDescriptor,
 
 func (l *internalLookupCtx) getTypeByID(id descpb.ID) (catalog.TypeDescriptor, error) {
 	typ, ok := l.typDescs[id]
-	if !ok {
+	if ok {
+		return typ, nil
+	}
+	if l.fallbackFn != nil {
+		desc, err := l.fallbackFn(id)
+		if err != nil {
+			return nil, err
+		}
+		typ, _ = desc.(catalog.TypeDescriptor)
+	}
+	if typ == nil {
 		return nil, sqlerrors.NewUndefinedTypeError(
 			tree.NewUnqualifiedTypeName(fmt.Sprintf("[%d]", id)))
 	}
@@ -983,13 +1031,26 @@ func (l *internalLookupCtx) hasSchemaWithID(id descpb.ID) bool {
 	if id == keys.SystemPublicSchemaID {
 		return true
 	}
-	_, ok := l.schemaDescs[id]
-	return ok
+	sc, err := l.getSchemaByID(id)
+	if err != nil {
+		return false
+	}
+	return sc != nil
 }
 
 func (l *internalLookupCtx) getSchemaByID(id descpb.ID) (catalog.SchemaDescriptor, error) {
 	sc, ok := l.schemaDescs[id]
-	if !ok {
+	if ok {
+		return sc, nil
+	}
+	if l.fallbackFn != nil {
+		desc, err := l.fallbackFn(id)
+		if err != nil {
+			return nil, err
+		}
+		sc, _ = desc.(catalog.SchemaDescriptor)
+	}
+	if sc == nil {
 		if id == keys.SystemPublicSchemaID {
 			return schemadesc.GetPublicSchema(), nil
 		}
@@ -1013,27 +1074,43 @@ func (l *internalLookupCtx) getSchemaNameByID(id descpb.ID) (string, error) {
 }
 
 func (l *internalLookupCtx) getDatabaseName(table catalog.Descriptor) string {
-	parentName := l.dbNames[table.GetParentID()]
-	if parentName == "" {
-		// The parent database was deleted. This is possible e.g. when
-		// a database is dropped with CASCADE, and someone queries
-		// this table before the dropped table descriptors are
-		// effectively deleted.
-		parentName = fmt.Sprintf("[%d]", table.GetParentID())
+	parentName, exists := l.dbNames[table.GetParentID()]
+	if parentName != "" {
+		return parentName
 	}
-	return parentName
+	// Attempt to resolve the parent name from the lookup function.
+	if !exists && l.fallbackFn != nil {
+		desc, err := l.fallbackFn(table.GetParentID())
+		// If we are able to receive the descriptor, and it
+		// is not dropped, then return the name. Otherwise,
+		// no namespace entry exists.
+		if err == nil && !desc.Dropped() {
+			return desc.GetName()
+		}
+	}
+	// The parent database was deleted. This is possible e.g. when
+	// a database is dropped with CASCADE, and someone queries
+	// this table before the dropped table descriptors are
+	// effectively deleted.
+	return fmt.Sprintf("[%d]", table.GetParentID())
 }
 
 func (l *internalLookupCtx) getSchemaName(table catalog.TableDescriptor) string {
-	schemaName := l.schemaNames[table.GetParentSchemaID()]
-	if schemaName == "" {
-		// The parent schema was deleted. This is possible e.g. when
-		// a schema is dropped with CASCADE, and someone queries
-		// this table before the dropped table descriptors are
-		// effectively deleted.
-		schemaName = fmt.Sprintf("[%d]", table.GetParentSchemaID())
+	schemaName, exists := l.schemaNames[table.GetParentSchemaID()]
+	if schemaName != "" {
+		return schemaName
 	}
-	return schemaName
+	// Attempt to resolve the parent name from the lookup function.
+	if !exists && l.fallbackFn != nil {
+		desc, err := l.fallbackFn(table.GetParentSchemaID())
+		// If we are able to receive the descriptor, and it
+		// is not dropped, then return the name. Otherwise,
+		// no namespace entry exists.
+		if err == nil && !desc.Dropped() {
+			return desc.GetName()
+		}
+	}
+	return fmt.Sprintf("[%d]", table.GetParentSchemaID())
 }
 
 // getTableNameFromTableDescriptor returns a TableName object for a given

--- a/pkg/sql/show_create.go
+++ b/pkg/sql/show_create.go
@@ -390,7 +390,7 @@ func (p *planner) ShowCreate(
 	if desc.IsSequence() {
 		return ShowCreateSequence(ctx, &tn, desc)
 	}
-	lCtx := newInternalLookupCtx(allHydratedDescs, nil /* prefix */)
+	lCtx := newInternalLookupCtx(allHydratedDescs, nil /* prefix */, nil /*fallbackFn*/)
 	// Overwrite desc with hydrated descriptor.
 	var err error
 	desc, err = lCtx.getTableByID(desc.GetID())


### PR DESCRIPTION
Backport 1/1 commits from #164942 on behalf of @fqazi.

----

Previously, when internalLookupCtx was used by crdb_internal or pg_catalog functions, it was assumed that reading system.namespace would cache all references in a database. While this worked when fetching descriptors from KV, this assumption can break when using leased descriptors.

This occurs because system.namespace may be newer than the leased descriptor timestamp. For example, if a table referenced by a foreign key is being dropped, the referencing table may still contain the entry. When the lookup context attempts to resolve that referenced table, the entry will be missing.

To address this, this patch allows internalLookupCtx to use a fallback, enabling it to query missing objects using the descriptor collection.

Fixes: #164430
Fixes: #164648

Release note (bug fix): Fixed a rare race condition where SHOW CREATE TABLE could fail with a "relation does not exist" error if a table referenced by a foreign key was being concurrently dropped.

----

Release justification: low risk change that prevents errors with leased descriptors for crdb_internal / pg_catalog and concurrent drops