### PR TITLE
obs: canary statement times and plan gist distribution chart

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -4725,6 +4725,8 @@ StatementDetailsRequest requests the details of a Statement, based on its keys.
 | aggregated_ts | [google.protobuf.Timestamp](#cockroach.server.serverpb.StatementDetailsResponse-google.protobuf.Timestamp) |  |  | [reserved](#support-status) |
 | plan_hash | [uint64](#cockroach.server.serverpb.StatementDetailsResponse-uint64) |  |  | [reserved](#support-status) |
 | plan_gist | [string](#cockroach.server.serverpb.StatementDetailsResponse-string) |  |  | [reserved](#support-status) |
+| canary_execution_count | [int64](#cockroach.server.serverpb.StatementDetailsResponse-int64) |  | canary_execution_count is the number of executions that used canary (newest) table statistics during the canary experiment. | [reserved](#support-status) |
+| stable_execution_count | [int64](#cockroach.server.serverpb.StatementDetailsResponse-int64) |  | stable_execution_count is the number of executions that used stable (second-newest) table statistics while the canary experiment was active. This is tracked explicitly rather than derived from execution_count - canary_execution_count, because executions where the canary experiment is off should not count as stable. | [reserved](#support-status) |
 
 
 

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -1880,6 +1880,15 @@ message StatementDetailsResponse {
     google.protobuf.Timestamp aggregated_ts = 2 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
     uint64 plan_hash = 3;
     string plan_gist = 4;
+    // canary_execution_count is the number of executions that used canary
+    // (newest) table statistics during the canary experiment.
+    int64 canary_execution_count = 5;
+    // stable_execution_count is the number of executions that used stable
+    // (second-newest) table statistics while the canary experiment was
+    // active. This is tracked explicitly rather than derived from
+    // execution_count - canary_execution_count, because executions where
+    // the canary experiment is off should not count as stable.
+    int64 stable_execution_count = 6;
   }
 
   // statement returns the total statistics for the statement.

--- a/pkg/server/statement_details.go
+++ b/pkg/server/statement_details.go
@@ -665,13 +665,15 @@ LIMIT $%d`, rb.mergeAggStmtMetadataColExpr, rb.whereClause, len(args)), args...)
 func (rb *statementDetailsRespBuilder) getStatementDetailsPerAggregatedTsAndPlanHash(
 	ctx context.Context,
 ) ([]serverpb.StatementDetailsResponse_StatementPlanDistribution, error) {
-	const expectedNumDatums = 4
+	const expectedNumDatums = 6
 	const queryFormat = `
 SELECT
     COALESCE(sum((statistics -> 'statistics' ->> 'cnt')::INT8), 0)::INT8 AS execution_count,
     aggregated_ts,
     plan_hash,
-    (statistics -> 'statistics' -> 'planGists' ->> 0) AS plan_gist
+    (statistics -> 'statistics' -> 'planGists' ->> 0) AS plan_gist,
+    COALESCE(sum((statistics -> 'statistics' -> 'canaryStats' ->> 'count')::INT8), 0)::INT8 AS canary_execution_count,
+    COALESCE(sum((statistics -> 'statistics' -> 'stableStats' ->> 'count')::INT8), 0)::INT8 AS stable_execution_count
 FROM %s %s
 GROUP BY
     aggregated_ts,
@@ -752,11 +754,16 @@ LIMIT $%d`
 			planGist = string(tree.MustBeDString(row[3]))
 		}
 
+		canaryExecutionCount := int64(tree.MustBeDInt(row[4]))
+		stableExecutionCount := int64(tree.MustBeDInt(row[5]))
+
 		stmt := serverpb.StatementDetailsResponse_StatementPlanDistribution{
-			ExecutionCount: executionCount,
-			AggregatedTs:   aggregatedTs,
-			PlanHash:       planHash,
-			PlanGist:       planGist,
+			ExecutionCount:       executionCount,
+			AggregatedTs:         aggregatedTs,
+			PlanHash:             planHash,
+			PlanGist:             planGist,
+			CanaryExecutionCount: canaryExecutionCount,
+			StableExecutionCount: stableExecutionCount,
 		}
 
 		statements = append(statements, stmt)

--- a/pkg/sql/appstatspb/app_stats.go
+++ b/pkg/sql/appstatspb/app_stats.go
@@ -228,6 +228,9 @@ func (s *StatementStatistics) Add(other *StatementStatistics) {
 	s.FailureCount += other.FailureCount
 	s.GenericCount += other.GenericCount
 	s.StmtHintsCount += other.StmtHintsCount
+
+	s.CanaryStats.Add(other.CanaryStats)
+	s.StableStats.Add(other.StableStats)
 }
 
 // AlmostEqual compares two StatementStatistics and their contained NumericStats
@@ -246,10 +249,30 @@ func (s *StatementStatistics) AlmostEqual(other *StatementStatistics, eps float6
 		s.SensitiveInfo.Equal(other.SensitiveInfo) &&
 		s.BytesRead.AlmostEqual(other.BytesRead, eps) &&
 		s.RowsRead.AlmostEqual(other.RowsRead, eps) &&
-		s.RowsWritten.AlmostEqual(other.RowsWritten, eps)
+		s.RowsWritten.AlmostEqual(other.RowsWritten, eps) &&
+		s.CanaryStats.AlmostEqual(other.CanaryStats, eps) &&
+		s.StableStats.AlmostEqual(other.StableStats, eps)
 	// s.ExecStats are deliberately ignored since they are subject to sampling
 	// probability and are not fully deterministic (e.g. the number of network
 	// messages depends on the range cache state).
+}
+
+// Add combines other into this ExperimentStatsInfo.
+func (e *ExperimentStatsInfo) Add(other ExperimentStatsInfo) {
+	statsCount := e.Count
+	if statsCount == 0 && other.Count == 0 {
+		statsCount = 1
+	}
+	e.RunLat.Add(other.RunLat, statsCount, other.Count)
+	e.PlanLat.Add(other.PlanLat, statsCount, other.Count)
+	e.Count += other.Count
+}
+
+// AlmostEqual compares two ExperimentStatsInfo within a window of size eps.
+func (e *ExperimentStatsInfo) AlmostEqual(other ExperimentStatsInfo, eps float64) bool {
+	return e.Count == other.Count &&
+		e.RunLat.AlmostEqual(other.RunLat, eps) &&
+		e.PlanLat.AlmostEqual(other.PlanLat, eps)
 }
 
 // Add combines other into this ExecStats.

--- a/pkg/sql/appstatspb/app_stats.proto
+++ b/pkg/sql/appstatspb/app_stats.proto
@@ -147,9 +147,22 @@ message StatementStatistics {
   // (ex/ not replication related work).
   optional NumericStat kv_cpu_time_nanos = 38 [(gogoproto.nullable) = false, (gogoproto.customname) = "KVCPUTimeNanos"];
 
+  // canary_stats tracks execution statistics for the subset of executions
+  // that used canary (newest) table statistics for planning. This is used
+  // to compare performance between canary and stable statistics rollout
+  // paths.
+  optional ExperimentStatsInfo canary_stats = 39 [(gogoproto.nullable) = false];
+
+  // stable_stats tracks execution statistics for the subset of executions
+  // that used stable (second-newest) table statistics while the canary
+  // experiment was active (i.e. sql.stats.canary_fraction > 0). Executions
+  // where the canary experiment is off are neither canary nor stable — they
+  // are unclassified and not counted here.
+  optional ExperimentStatsInfo stable_stats = 40 [(gogoproto.nullable) = false];
+
   // Note: be sure to update `sql/app_stats.go` when adding/removing fields here!
 
-  reserved 13, 14, 17, 18, 19, 20;
+  reserved 13, 14, 17, 18, 19, 20, 41, 42, 43, 44;
 }
 
 message TransactionStatistics {
@@ -200,6 +213,15 @@ message TransactionStatistics {
   optional NumericStat kv_cpu_time_nanos = 12 [(gogoproto.nullable) = false, (gogoproto.customname) = "KVCPUTimeNanos"];
 }
 
+
+// ExperimentStatsInfo groups the count and latency statistics for a single
+// bucket of the canary-vs-stable table statistics experiment. Two instances
+// are embedded in StatementStatistics: one for canary and one for stable.
+message ExperimentStatsInfo {
+  optional int64 count = 1 [(gogoproto.nullable) = false];
+  optional NumericStat run_lat = 2 [(gogoproto.nullable) = false];
+  optional NumericStat plan_lat = 3 [(gogoproto.nullable) = false];
+}
 
 message SensitiveInfo {
   option (gogoproto.equal) = true;

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -168,10 +168,7 @@ func canaryRollDice(evalCtx *eval.Context, rng *rand.Rand) eval.StatsRolloutSele
 	threshold := stats.CanaryFraction.Get(&evalCtx.Settings.SV)
 	switch m := evalCtx.SessionData().CanaryStatsMode; m {
 	case sessiondatapb.CanaryStatsModeOff:
-		if threshold > 0 {
-			return eval.StatsRolloutStable
-		}
-		return eval.StatsRolloutDefault
+		return eval.StatsRolloutStable
 	case sessiondatapb.CanaryStatsModeOn:
 		return eval.StatsRolloutCanary
 	case sessiondatapb.CanaryStatsModeAuto:

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -4027,6 +4027,7 @@ func (ex *connExecutor) resetEvalCtx(evalCtx *extendedEvalContext, txn *kv.Txn, 
 	evalCtx.SchemaChangerState = ex.extraTxnState.schemaChangerState
 	evalCtx.DescIDGenerator = ex.getDescIDGenerator()
 	evalCtx.UseCanaryStats = false
+	evalCtx.CanaryAndStableStatsDiffer = false
 
 	// See resetPlanner for more context on setting the maximum timestamp for
 	// AOST read retries.

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -156,35 +156,37 @@ var detailedLatencyMetrics = settings.RegisterBoolSetting(
 	settings.WithPublic,
 )
 
-// canaryRollDice performs the probabilistic check to determine if a query
-// should use the "canary path" for statistics.
-// This selection is atomic per query, meaning that if a query is chosen to use
-// canary stats, all the tables involved in this query will use canary stats for
-// planning, if applicable.
-// This canary stats decision is made only for non-internal queries.
-func canaryRollDice(evalCtx *eval.Context, rng *rand.Rand) bool {
+// canaryRollDice determines the stats rollout selection for a query.
+// The result is one of:
+//   - StatsRolloutDefault: experiment not active, use default stats.
+//   - StatsRolloutCanary:  experiment active, dice selected canary (newest) stats.
+//   - StatsRolloutStable:  experiment active, dice selected stable (second-newest) stats.
+//
+// The selection is atomic per query — all tables in the query use the same
+// rollout path. Only called for non-internal queries.
+func canaryRollDice(evalCtx *eval.Context, rng *rand.Rand) eval.StatsRolloutSelection {
+	threshold := stats.CanaryFraction.Get(&evalCtx.Settings.SV)
 	switch m := evalCtx.SessionData().CanaryStatsMode; m {
-	case sessiondatapb.CanaryStatsModeAuto:
-		threshold := stats.CanaryFraction.Get(&evalCtx.Settings.SV)
-		// If the fraction is 0, never use canary stats.
-		if threshold == 0 {
-			return false
-		}
-		// If the fraction is 1, always use canary stats.
-		if threshold == 1 {
-			return true
-		}
-
-		actual := rng.Float64()
-		return actual < threshold
 	case sessiondatapb.CanaryStatsModeOff:
-		return false
+		if threshold > 0 {
+			return eval.StatsRolloutStable
+		}
+		return eval.StatsRolloutDefault
 	case sessiondatapb.CanaryStatsModeOn:
-		return true
+		return eval.StatsRolloutCanary
+	case sessiondatapb.CanaryStatsModeAuto:
+		if threshold == 0 {
+			return eval.StatsRolloutDefault
+		}
+		if threshold == 1 {
+			return eval.StatsRolloutCanary
+		}
+		if rng.Float64() < threshold {
+			return eval.StatsRolloutCanary
+		}
+		return eval.StatsRolloutStable
 	}
-	// This should not happen but just in case of an unknown mode, we
-	// default to not using canary stats.
-	return false
+	return eval.StatsRolloutDefault
 }
 
 // The metric label name we'll use to facet latency metrics by statement fingerprint.
@@ -4026,7 +4028,7 @@ func (ex *connExecutor) resetEvalCtx(evalCtx *extendedEvalContext, txn *kv.Txn, 
 	evalCtx.SkipNormalize = false
 	evalCtx.SchemaChangerState = ex.extraTxnState.schemaChangerState
 	evalCtx.DescIDGenerator = ex.getDescIDGenerator()
-	evalCtx.UseCanaryStats = false
+	evalCtx.StatsRollout = eval.StatsRolloutDefault
 	evalCtx.CanaryAndStableStatsDiffer = false
 
 	// See resetPlanner for more context on setting the maximum timestamp for

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -3488,10 +3488,14 @@ func (ex *connExecutor) makeExecPlan(
 		return ctx, err
 	}
 
-	// For each non-internal query, we roll the dice to decide to use
-	// canary stats or stable stats for planning.
+	// For each non-internal query, roll the dice to determine the canary
+	// stats rollout path. The result is one of three states:
+	//   - StatsRolloutDefault: experiment off, use default stats
+	//   - StatsRolloutCanary:  experiment on, use canary (newest) stats
+	//   - StatsRolloutStable:  experiment on, use stable (second-newest) stats
 	if !planner.SessionData().Internal {
-		planner.EvalContext().UseCanaryStats = canaryRollDice(planner.EvalContext(), ex.rng.internal)
+		planner.EvalContext().StatsRollout =
+			canaryRollDice(planner.EvalContext(), ex.rng.internal)
 	}
 
 	if err := planner.makeOptimizerPlan(ctx); err != nil {

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/contentionpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/idxrecommendations"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -231,6 +232,15 @@ func (ex *connExecutor) recordStatementSummary(
 
 		if len(stmt.Hints) > 0 {
 			b.AppliedStatementHints()
+		}
+
+		if planner.EvalContext().CanaryAndStableStatsDiffer {
+			switch planner.EvalContext().StatsRollout {
+			case eval.StatsRolloutCanary:
+				b.CanaryStats()
+			case eval.StatsRolloutStable:
+				b.StableStats()
+			}
 		}
 
 		ex.statsCollector.RecordStatement(ctx, b.Build())

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -701,7 +701,17 @@ func (oc *optCatalog) dataSourceForTable(
 			statsCanaryWindow = desc.TableDesc().StatsCanaryWindow
 			statsAsOf = oc.planner.EvalContext().SessionData().StatsAsOf
 		}
-		tableStats, err = oc.planner.execCfg.TableStatsCache.GetTableStatsMaybeStable(ctx, desc, typeResolver, stable, statsCanaryWindow, statsAsOf)
+		var statsDiffer bool
+		tableStats, statsDiffer, err = oc.planner.execCfg.TableStatsCache.GetTableStatsMaybeStable(ctx, desc, typeResolver, stable, statsCanaryWindow, statsAsOf)
+		// "OR" the per-table divergence flag into the query-wide flag. This
+		// is called once per table during optbuilder.Build(), which walks
+		// the AST sequentially on a single goroutine (the planner is not
+		// safe for concurrent use — see planner.go). The flag is
+		// write-only here and read-only later in metric recording, so no
+		// synchronization is needed.
+		if statsDiffer {
+			oc.planner.EvalContext().CanaryAndStableStatsDiffer = true
+		}
 		if err != nil {
 			// Ignore any error. We still want to be able to run queries even if we lose
 			// access to the statistics table.

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -697,7 +697,8 @@ func (oc *optCatalog) dataSourceForTable(
 		var statsCanaryWindow time.Duration
 		var statsAsOf hlc.Timestamp
 		if desc.TableDesc() != nil && oc.planner != nil && oc.planner.EvalContext() != nil {
-			stable = desc.TableDesc().StatsCanaryWindow > 0 && !oc.planner.EvalContext().UseCanaryStats
+			stable = desc.TableDesc().StatsCanaryWindow > 0 &&
+				oc.planner.EvalContext().StatsRollout == eval.StatsRolloutStable
 			statsCanaryWindow = desc.TableDesc().StatsCanaryWindow
 			statsAsOf = oc.planner.EvalContext().SessionData().StatsAsOf
 		}

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -496,7 +496,8 @@ func (opc *optPlanningCtx) reset(ctx context.Context) {
 		// potential reuse of versions. To avoid these issues, we prevent saving a
 		// memo (for prepare) or reusing a saved memo (for execute).
 		// We only allow reusing memo if this plan is not going to use canary stats.
-		opc.allowMemoReuse = !p.Descriptors().HasUncommittedTables() && !p.EvalContext().UseCanaryStats
+		opc.allowMemoReuse = !p.Descriptors().HasUncommittedTables() &&
+			p.EvalContext().StatsRollout != eval.StatsRolloutCanary
 		opc.useCache = opc.allowMemoReuse && queryCacheEnabled.Get(&p.execCfg.Settings.SV)
 
 		if _, isCanned := p.stmt.AST.(*tree.CannedOptPlan); isCanned {

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -361,6 +361,21 @@ type Context struct {
 	// are always for stable stats.
 	UseCanaryStats bool
 
+	// CanaryAndStableStatsDiffer is set to true during planning if at least
+	// one table referenced by the query has genuinely different canary
+	// (newest) vs. stable (second-newest) statistics within its canary
+	// window.
+	//
+	// This flag gates experiment metric recording only. When false, the
+	// execution is not recorded in canary/stable experiment buckets even if
+	// UseCanaryStats is set, because both paths used the same statistics
+	// and recording would only add noise.
+	//
+	// This flag is independent of UseCanaryStats: UseCanaryStats is decided
+	// by the dice roll (canaryRollDice) before planning; this flag is
+	// determined during planning by inspecting each table's cache entry.
+	CanaryAndStableStatsDiffer bool
+
 	// WorkloadID for ASH sampling.
 	WorkloadID uint64
 

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -51,6 +51,22 @@ import (
 
 var ErrNilTxnInClusterContext = errors.New("nil txn in cluster context")
 
+// StatsRolloutSelection describes the role of a query execution in the
+// canary stats rollout experiment.
+type StatsRolloutSelection int
+
+const (
+	// StatsRolloutDefault means the canary experiment is not active for
+	// this execution. The optimizer uses default stats.
+	StatsRolloutDefault StatsRolloutSelection = iota
+	// StatsRolloutCanary means this execution uses canary (newest) table
+	// statistics as part of the canary experiment.
+	StatsRolloutCanary
+	// StatsRolloutStable means this execution uses stable (second-newest)
+	// table statistics while the canary experiment is active.
+	StatsRolloutStable
+)
+
 // Context defines the context in which to evaluate an expression, allowing
 // the retrieval of state such as the node ID or statement start time.
 //
@@ -326,40 +342,36 @@ type Context struct {
 	// ExecutedStatementCounters contains metrics for successfully executed
 	// statements defined within the body of a UDF/SP.
 	ExecutedRoutineStatementCounters RoutineStatementCounters
-	// UseCanaryStats indicates whether this query participates in the canary
-	// statistics rollout feature. When set to true, the optimizer attempts to use
-	// "canary statistics" for all tables referenced by the query.
+	// StatsRollout records the outcome of the canary stats rollout dice
+	// roll for this query execution. It has three possible values:
 	//
-	// This flag is determined probabilistically during query planning based on the
-	// sql.stats.canary_fraction cluster setting. The selection is atomic per query:
-	// either all tables use canary stats (when available) or all use stable stats.
+	//   - StatsRolloutDefault: the canary experiment is not active
+	//     (sql.stats.canary_fraction = 0 or mode is off). The optimizer
+	//     uses whatever stats are available (default behavior). The
+	//     execution is not classified as canary or stable.
 	//
-	// Canary statistics are newly collected table statistics that are still within
-	// their configured "canary window" (sql_stats_canary_window storage parameter).
-	// These stats provide a controlled way to gradually roll out new statistics
-	// before promoting them to stable, allowing for manual intervention if
-	// performance regressions are detected.
+	//   - StatsRolloutCanary: the canary experiment is active and this
+	//     execution was selected to use canary (newest) table statistics.
+	//     The optimizer attempts to use canary stats for all tables
+	//     referenced by the query. If a table lacks distinct canary stats
+	//     (e.g., only one version exists or canary stats have expired),
+	//     the optimizer falls back to stable stats for that table.
 	//
-	// Stable statistics are the previously established statistics that have either
-	// been promoted from canary status or were collected before canary mode was
-	// enabled for the table.
+	//   - StatsRolloutStable: the canary experiment is active but this
+	//     execution was not selected for canary — it uses stable
+	//     (second-newest) table statistics.
 	//
-	// Fallback behavior: If a table lacks distinct canary statistics (e.g., only
-	// one statistics version exists, or canary stats have expired), the optimizer
-	// will use the available stable statistics even when this flag is true.
+	// The selection is determined probabilistically during query planning
+	// based on the sql.stats.canary_fraction cluster setting. It is
+	// atomic per query: all tables use the same rollout path.
 	//
-	// UseCanaryStats should only be set True for non-internal and when creating
-	// a not-prepared stmt. In other words, internal queries and prepared statements
-	// will always use stable statistics.
+	// Only set for non-internal, non-prepared queries. Internal queries
+	// and prepared statements always use StatsRolloutDefault.
 	//
-	// When UseCanaryStats is true, the optimizer will bypass query cache or
-	// the cached memo within a prepared stmt, but rather build a one-off memo
-	// only for this query execution. This is because we roll the dice for
-	// query execution to decide whether to use canary stats or not, and
-	// we'd like to avoid frequently invalidating cached plans. The rule of
-	// thumb is: the cached memo, either in query cache or prepared stmt,
-	// are always for stable stats.
-	UseCanaryStats bool
+	// When StatsRolloutCanary, the optimizer bypasses the query cache and
+	// the cached memo within a prepared stmt, building a one-off memo for
+	// this execution. Cached memos are always built with stable stats.
+	StatsRollout StatsRolloutSelection
 
 	// CanaryAndStableStatsDiffer is set to true during planning if at least
 	// one table referenced by the query has genuinely different canary
@@ -368,11 +380,11 @@ type Context struct {
 	//
 	// This flag gates experiment metric recording only. When false, the
 	// execution is not recorded in canary/stable experiment buckets even if
-	// UseCanaryStats is set, because both paths used the same statistics
-	// and recording would only add noise.
+	// StatsRollout is Canary or Stable, because both paths used the same
+	// statistics and recording would only add noise.
 	//
-	// This flag is independent of UseCanaryStats: UseCanaryStats is decided
-	// by the dice roll (canaryRollDice) before planning; this flag is
+	// This flag is independent of StatsRollout: StatsRollout is decided by
+	// the dice roll (canaryRollDice) before planning; this flag is
 	// determined during planning by inspecting each table's cache entry.
 	CanaryAndStableStatsDiffer bool
 

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
@@ -112,7 +112,16 @@ func TestSQLStatsJsonEncoding(t *testing.T) {
            "max": {{.Float}}
          },
          "lastErrorCode": "{{.String}}",
-				 "sqlType": "{{.String}}" 
+				 "sqlType": "{{.String}}",
+				 "canaryCount": {{.Int64}},
+				 "canaryRunLat": {
+				   "mean": {{.Float}},
+				   "sqDiff": {{.Float}}
+				 },
+				 "canaryPlanLat": {
+				   "mean": {{.Float}},
+				   "sqDiff": {{.Float}}
+				 }
        },
        "execution_statistics": {
          "cnt": {{.Int64}},

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
@@ -286,6 +286,47 @@ func TestSQLStatsJsonEncoding(t *testing.T) {
 		require.Equal(t, appstatspb.ExperimentStatsInfo{}, decoded.StableStats)
 	})
 
+	// Verify that when CanaryStats and StableStats have non-zero counts, the
+	// fields are present in the encoded JSON and survive a roundtrip.
+	t.Run("statement_statistics non-zero canary and stable roundtrip", func(t *testing.T) {
+		input := appstatspb.StatementStatistics{
+			Count:             10,
+			FirstAttemptCount: 8,
+			CanaryStats: appstatspb.ExperimentStatsInfo{
+				Count:   3,
+				RunLat:  appstatspb.NumericStat{Mean: 0.05, SquaredDiffs: 0.001},
+				PlanLat: appstatspb.NumericStat{Mean: 0.02, SquaredDiffs: 0.0005},
+			},
+			StableStats: appstatspb.ExperimentStatsInfo{
+				Count:   7,
+				RunLat:  appstatspb.NumericStat{Mean: 0.08, SquaredDiffs: 0.003},
+				PlanLat: appstatspb.NumericStat{Mean: 0.03, SquaredDiffs: 0.001},
+			},
+		}
+
+		statsJSON, err := BuildStmtStatisticsJSON(&input)
+		require.NoError(t, err)
+
+		// Verify canary and stable fields are present in the encoded JSON.
+		statsField, err := statsJSON.FetchValKey("statistics")
+		require.NoError(t, err)
+		canaryStats, err := statsField.FetchValKey("canaryStats")
+		require.NoError(t, err)
+		require.NotNil(t, canaryStats, "canaryStats should be present when non-zero")
+		stableStats, err := statsField.FetchValKey("stableStats")
+		require.NoError(t, err)
+		require.NotNil(t, stableStats, "stableStats should be present when non-zero")
+
+		// Decode and verify roundtrip.
+		var decoded appstatspb.StatementStatistics
+		err = DecodeStmtStatsStatisticsJSON(statsJSON, &decoded)
+		require.NoError(t, err)
+		require.Equal(t, input.CanaryStats.Count, decoded.CanaryStats.Count)
+		require.Equal(t, input.StableStats.Count, decoded.StableStats.Count)
+		require.InEpsilon(t, input.CanaryStats.RunLat.Mean, decoded.CanaryStats.RunLat.Mean, 0.0000001)
+		require.InEpsilon(t, input.StableStats.RunLat.Mean, decoded.StableStats.RunLat.Mean, 0.0000001)
+	})
+
 	// When a new statistic is added to a statement payload, older versions won't have the
 	// new parameter, so this test is to confirm that all other parameters will be set and
 	// the new one will be empty, without breaking the decoding process.

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
@@ -113,14 +113,27 @@ func TestSQLStatsJsonEncoding(t *testing.T) {
          },
          "lastErrorCode": "{{.String}}",
 				 "sqlType": "{{.String}}",
-				 "canaryCount": {{.Int64}},
-				 "canaryRunLat": {
-				   "mean": {{.Float}},
-				   "sqDiff": {{.Float}}
+				 "canaryStats": {
+				   "count": {{.Int64}},
+				   "runLat": {
+				     "mean": {{.Float}},
+				     "sqDiff": {{.Float}}
+				   },
+				   "planLat": {
+				     "mean": {{.Float}},
+				     "sqDiff": {{.Float}}
+				   }
 				 },
-				 "canaryPlanLat": {
-				   "mean": {{.Float}},
-				   "sqDiff": {{.Float}}
+				 "stableStats": {
+				   "count": {{.Int64}},
+				   "runLat": {
+				     "mean": {{.Float}},
+				     "sqDiff": {{.Float}}
+				   },
+				   "planLat": {
+				     "mean": {{.Float}},
+				     "sqDiff": {{.Float}}
+				   }
 				 }
        },
        "execution_statistics": {
@@ -240,6 +253,37 @@ func TestSQLStatsJsonEncoding(t *testing.T) {
 		err = DecodeStmtStatsStatisticsJSON(actualStatisticsJSON, &actualJSONUnmarshalled.Stats)
 		require.NoError(t, err)
 		require.Equal(t, input, actualJSONUnmarshalled)
+	})
+
+	// Verify that when CanaryCount and StableCount are zero, the canary/stable
+	// fields are omitted from the JSON encoding to save storage, and that
+	// decoding such JSON back produces the correct zero-valued fields.
+	t.Run("statement_statistics zero canary and stable roundtrip", func(t *testing.T) {
+		input := appstatspb.StatementStatistics{
+			Count:             5,
+			FirstAttemptCount: 3,
+			// CanaryCount and StableCount are zero — fields should be omitted.
+		}
+
+		statsJSON, err := BuildStmtStatisticsJSON(&input)
+		require.NoError(t, err)
+
+		// Verify canary and stable fields are absent from the encoded JSON.
+		statsField, err := statsJSON.FetchValKey("statistics")
+		require.NoError(t, err)
+		canaryStats, err := statsField.FetchValKey("canaryStats")
+		require.NoError(t, err)
+		require.Nil(t, canaryStats, "canaryStats should be omitted when zero")
+		stableStats, err := statsField.FetchValKey("stableStats")
+		require.NoError(t, err)
+		require.Nil(t, stableStats, "stableStats should be omitted when zero")
+
+		// Decode and verify roundtrip produces zero values.
+		var decoded appstatspb.StatementStatistics
+		err = DecodeStmtStatsStatisticsJSON(statsJSON, &decoded)
+		require.NoError(t, err)
+		require.Equal(t, appstatspb.ExperimentStatsInfo{}, decoded.CanaryStats)
+		require.Equal(t, appstatspb.ExperimentStatsInfo{}, decoded.StableStats)
 	})
 
 	// When a new statistic is added to a statement payload, older versions won't have the

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
@@ -349,6 +349,9 @@ func (s *innerStmtStats) jsonFields() jsonFields {
 		{"genericCount", (*jsonInt)(&s.GenericCount)},
 		{"stmtHintsCount", (*jsonInt)(&s.StmtHintsCount)},
 		{"sqlType", (*jsonString)(&s.SQLType)},
+		{"canaryCount", (*jsonInt)(&s.CanaryCount)},
+		{"canaryRunLat", (*numericStats)(&s.CanaryRunLat)},
+		{"canaryPlanLat", (*numericStats)(&s.CanaryPlanLat)},
 	}
 }
 

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
@@ -47,6 +47,7 @@ var (
 	_ jsonMarshaler = (*int64Array)(nil)
 	_ jsonMarshaler = (*int32Array)(nil)
 	_ jsonMarshaler = &latencyInfo{}
+	_ jsonMarshaler = &experimentStatsInfo{}
 )
 
 type txnStats appstatspb.TransactionStatistics
@@ -349,18 +350,54 @@ func (s *innerStmtStats) jsonFields() jsonFields {
 		{"genericCount", (*jsonInt)(&s.GenericCount)},
 		{"stmtHintsCount", (*jsonInt)(&s.StmtHintsCount)},
 		{"sqlType", (*jsonString)(&s.SQLType)},
-		{"canaryCount", (*jsonInt)(&s.CanaryCount)},
-		{"canaryRunLat", (*numericStats)(&s.CanaryRunLat)},
-		{"canaryPlanLat", (*numericStats)(&s.CanaryPlanLat)},
+	}
+}
+
+// canaryJsonFields returns the JSON fields for canary stats tracking.
+// These are separated from jsonFields() so they can be conditionally
+// encoded only when canary/stable data is present, avoiding storage
+// overhead per row in system.statement_statistics for the common case
+// where the canary experiment is not active.
+func (s *innerStmtStats) canaryJsonFields() jsonFields {
+	return jsonFields{
+		{"canaryStats", (*experimentStatsInfo)(&s.CanaryStats)},
+	}
+}
+
+// stableJsonFields returns the JSON fields for stable stats tracking.
+// Like canaryJsonFields, these are conditionally encoded.
+func (s *innerStmtStats) stableJsonFields() jsonFields {
+	return jsonFields{
+		{"stableStats", (*experimentStatsInfo)(&s.StableStats)},
 	}
 }
 
 func (s *innerStmtStats) decodeJSON(js json.JSON) error {
-	return s.jsonFields().decodeJSON(js)
+	if err := s.jsonFields().decodeJSON(js); err != nil {
+		return err
+	}
+	// Canary and stable fields are optional in the JSON — they are only
+	// present when the canary experiment was active. Decode them if present;
+	// missing fields are left at their zero values by decodeJSON.
+	if err := s.canaryJsonFields().decodeJSON(js); err != nil {
+		return err
+	}
+	return s.stableJsonFields().decodeJSON(js)
 }
 
 func (s *innerStmtStats) encodeJSON() (json.JSON, error) {
-	return s.jsonFields().encodeJSON()
+	fields := s.jsonFields()
+	// Only include canary/stable fields when the respective stats were
+	// actually collected. This avoids adding zero-valued JSON to every
+	// row in system.statement_statistics when the canary experiment is
+	// not in use.
+	if s.CanaryStats.Count > 0 {
+		fields = append(fields, s.canaryJsonFields()...)
+	}
+	if s.StableStats.Count > 0 {
+		fields = append(fields, s.stableJsonFields()...)
+	}
+	return fields.encodeJSON()
 }
 
 type execStats appstatspb.ExecStats
@@ -447,6 +484,24 @@ func (l *latencyInfo) decodeJSON(js json.JSON) error {
 
 func (l *latencyInfo) encodeJSON() (json.JSON, error) {
 	return l.jsonFields().encodeJSON()
+}
+
+type experimentStatsInfo appstatspb.ExperimentStatsInfo
+
+func (e *experimentStatsInfo) jsonFields() jsonFields {
+	return jsonFields{
+		{"count", (*jsonInt)(&e.Count)},
+		{"runLat", (*numericStats)(&e.RunLat)},
+		{"planLat", (*numericStats)(&e.PlanLat)},
+	}
+}
+
+func (e *experimentStatsInfo) decodeJSON(js json.JSON) error {
+	return e.jsonFields().decodeJSON(js)
+}
+
+func (e *experimentStatsInfo) encodeJSON() (json.JSON, error) {
+	return e.jsonFields().encodeJSON()
 }
 
 type jsonFields []jsonField

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
@@ -83,6 +83,20 @@ func (s *Container) RecordStatement(ctx context.Context, value *sqlstats.Recorde
 	if value.AppliedStmtHints {
 		stats.mu.data.StmtHintsCount++
 	}
+	// Track canary and stable stats separately: these latencies use their own
+	// counts (not the overall Count) for Welford's running average, since they
+	// represent only the subsets of executions that participated in the canary
+	// experiment. Executions where the experiment is off (canary_fraction = 0)
+	// are counted in neither bucket.
+	if value.UsedCanaryStats {
+		stats.mu.data.CanaryStats.Count++
+		stats.mu.data.CanaryStats.RunLat.Record(stats.mu.data.CanaryStats.Count, value.RunLatencySec)
+		stats.mu.data.CanaryStats.PlanLat.Record(stats.mu.data.CanaryStats.Count, value.PlanLatencySec)
+	} else if value.UsedStableStats {
+		stats.mu.data.StableStats.Count++
+		stats.mu.data.StableStats.RunLat.Record(stats.mu.data.StableStats.Count, value.RunLatencySec)
+		stats.mu.data.StableStats.PlanLat.Record(stats.mu.data.StableStats.Count, value.PlanLatencySec)
+	}
 	if value.AutoRetryCount == 0 {
 		stats.mu.data.FirstAttemptCount++
 	} else if int64(value.AutoRetryCount) > stats.mu.data.MaxRetries {

--- a/pkg/sql/sqlstats/ssprovider.go
+++ b/pkg/sql/sqlstats/ssprovider.go
@@ -101,6 +101,8 @@ type RecordedStmtStats struct {
 	Indexes                  []string
 	QueryTags                []sqlcommenter.QueryTag
 	UnderOuterTxn            bool
+	UsedCanaryStats          bool
+	UsedStableStats          bool
 }
 
 var recordedStmtStatsSize = int64(unsafe.Sizeof(RecordedStmtStats{}))
@@ -410,6 +412,22 @@ func (b *RecordedStatementStatsBuilder) AppliedStatementHints() *RecordedStateme
 		return b
 	}
 	b.stmtStats.AppliedStmtHints = true
+	return b
+}
+
+func (b *RecordedStatementStatsBuilder) CanaryStats() *RecordedStatementStatsBuilder {
+	if b == nil {
+		return b
+	}
+	b.stmtStats.UsedCanaryStats = true
+	return b
+}
+
+func (b *RecordedStatementStatsBuilder) StableStats() *RecordedStatementStatsBuilder {
+	if b == nil {
+		return b
+	}
+	b.stmtStats.UsedStableStats = true
 	return b
 }
 

--- a/pkg/sql/stats/automatic_stats.go
+++ b/pkg/sql/stats/automatic_stats.go
@@ -910,7 +910,7 @@ func (r *Refresher) EstimateStaleness(
 	// NB: we pass nil boolean as 'forecast' argument in order to not invalidate
 	// the stats cache entry since we don't care whether there is a forecast or
 	// not in the stats.
-	tableStats, err := r.cache.getTableStatsFromCache(ctx, tableDesc.GetID(), forecast, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
+	tableStats, _, err := r.cache.getTableStatsFromCache(ctx, tableDesc.GetID(), forecast, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
 	if err != nil {
 		return 0, err
 	}
@@ -964,7 +964,7 @@ func (r *Refresher) maybeRefreshStats(
 	// the stats cache entry since we don't care whether there is a forecast or
 	// not in the stats.
 	var forecast *bool
-	tableStats, err := r.cache.getTableStatsFromCache(ctx, tableID, forecast, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
+	tableStats, _, err := r.cache.getTableStatsFromCache(ctx, tableID, forecast, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
 	if err != nil {
 		log.Dev.Errorf(ctx, "failed to get table statistics: %v", err)
 		return

--- a/pkg/sql/stats/delete_stats_test.go
+++ b/pkg/sql/stats/delete_stats_test.go
@@ -261,7 +261,7 @@ func TestDeleteOldStatsForColumns(t *testing.T) {
 		}
 
 		return testutils.SucceedsSoonError(func() error {
-			tableStats, err := cache.getTableStatsFromCache(ctx, tableID, nil /* forecast */, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
+			tableStats, _, err := cache.getTableStatsFromCache(ctx, tableID, nil /* forecast */, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
 			if err != nil {
 				return err
 			}
@@ -269,7 +269,7 @@ func TestDeleteOldStatsForColumns(t *testing.T) {
 			for i := range testData {
 				stat := &testData[i]
 				if stat.TableID != tableID {
-					stats, err := cache.getTableStatsFromCache(ctx, stat.TableID, nil /* forecast */, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
+					stats, _, err := cache.getTableStatsFromCache(ctx, stat.TableID, nil /* forecast */, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
 					if err != nil {
 						return err
 					}
@@ -555,7 +555,7 @@ func TestDeleteOldStatsForOtherColumns(t *testing.T) {
 		}
 
 		return testutils.SucceedsSoonError(func() error {
-			tableStats, err := cache.getTableStatsFromCache(ctx, tableID, nil /* forecast */, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
+			tableStats, _, err := cache.getTableStatsFromCache(ctx, tableID, nil /* forecast */, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
 			if err != nil {
 				return err
 			}
@@ -563,7 +563,7 @@ func TestDeleteOldStatsForOtherColumns(t *testing.T) {
 			for i := range testData {
 				stat := &testData[i]
 				if stat.TableID != tableID {
-					stats, err := cache.getTableStatsFromCache(ctx, stat.TableID, nil /* forecast */, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
+					stats, _, err := cache.getTableStatsFromCache(ctx, stat.TableID, nil /* forecast */, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
 					if err != nil {
 						return err
 					}

--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -530,7 +530,7 @@ func (e *cacheEntry) getStableStatsLocked(
 // "canary" or "stable" would only add noise to the "canary vs stable" metrics.
 //
 // Note: this does NOT affect which stats the optimizer uses — that is
-// controlled by canaryStatsRollout (the dice roll) and getStableStatsLocked.
+// controlled by canaryRollDice (the dice roll) and getStableStatsLocked.
 func (e *cacheEntry) canaryAndStableStatsDiffer(
 	canaryWindowSize time.Duration, asOf hlc.Timestamp,
 ) bool {

--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -288,13 +288,21 @@ func (sc *TableStatisticsCache) GetFreshTableStats(
 		return nil, nil
 	}
 	forecast := forecastAllowed(table, sc.settings)
-	return sc.getTableStatsFromCache(ctx, table.GetID(), &forecast, table.UserDefinedTypeColumns(), typeResolver, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
+	stats, _, err = sc.getTableStatsFromCache(ctx, table.GetID(), &forecast, table.UserDefinedTypeColumns(), typeResolver, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
+	return stats, err
 }
 
-// GetTableStatsMaybeStable is similar to GetFreshTableStats, but maybe return
-// the stable stats cache opposed to the freshest "canary" table statistics.
-// It only differs with GetFreshTableStats if the table has the canary window size
-// set.
+// GetTableStatsMaybeStable is similar to GetFreshTableStats, but may return
+// the stable stats cache instead of the freshest "canary" table statistics.
+// It only differs from GetFreshTableStats when the table has a non-zero canary
+// window size.
+//
+// The returned statsDiffer flag indicates whether the canary (newest)
+// and stable (second-newest) statistics for this table are genuinely
+// different. The flag is not affected by which stats the optimizer
+// uses; it only determines whether this execution is worth recording
+// for canary vs. stable experiment metrics (when false, both paths use
+// identical stats, so recording would add noise).
 func (sc *TableStatisticsCache) GetTableStatsMaybeStable(
 	ctx context.Context,
 	table catalog.TableDescriptor,
@@ -302,9 +310,9 @@ func (sc *TableStatisticsCache) GetTableStatsMaybeStable(
 	stable bool,
 	canaryWindowSize time.Duration,
 	statsAsOf hlc.Timestamp,
-) (stats []*TableStatistic, err error) {
+) (stats []*TableStatistic, statsDiffer bool, err error) {
 	if !sc.statsUsageAllowed(table) {
-		return nil, nil
+		return nil, false, nil
 	}
 	forecast := forecastAllowed(table, sc.settings)
 	return sc.getTableStatsFromCache(ctx, table.GetID(), &forecast, table.UserDefinedTypeColumns(), typeResolver, stable, canaryWindowSize, statsAsOf)
@@ -423,7 +431,7 @@ func (sc *TableStatisticsCache) getTableStatsFromCache(
 	stable bool,
 	canaryWindowSize time.Duration,
 	statsAsOf hlc.Timestamp,
-) ([]*TableStatistic, error) {
+) ([]*TableStatistic, bool, error) {
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
 
@@ -437,10 +445,11 @@ func (sc *TableStatisticsCache) getTableStatsFromCache(
 			// Evict the cache entry and build it again.
 			sc.mu.cache.Del(tableID)
 		} else {
+			statsDiffer := e.canaryAndStableStatsDiffer(canaryWindowSize, asOfTs)
 			if stable {
-				return e.getStableStatsLocked(ctx, canaryWindowSize, asOfTs), e.err
+				return e.getStableStatsLocked(ctx, canaryWindowSize, asOfTs), statsDiffer, e.err
 			}
-			return e.stats, e.err
+			return e.stats, statsDiffer, e.err
 		}
 	}
 
@@ -506,6 +515,37 @@ func (e *cacheEntry) getStableStatsLocked(
 	return e.stats
 }
 
+// canaryAndStableStatsDiffer reports whether this table's canary (newest)
+// and stable (second-newest) statistics are genuinely different under the
+// given canary window. It returns true only when all three conditions hold:
+//
+//  1. The table has a non-zero canary window (canaryWindowSize > 0).
+//  2. We are still within the canary window (the freshest stats have not
+//     yet "ripened" past it).
+//  3. A second generation of stats exists and is older than the first
+//     (i.e., there are actually two distinct stat sets to compare).
+//
+// This is used to gate "canary vs stable" metric recording: when canary and stable
+// stats are identical (this returns false), tagging the execution as
+// "canary" or "stable" would only add noise to the "canary vs stable" metrics.
+//
+// Note: this does NOT affect which stats the optimizer uses — that is
+// controlled by canaryStatsRollout (the dice roll) and getStableStatsLocked.
+func (e *cacheEntry) canaryAndStableStatsDiffer(
+	canaryWindowSize time.Duration, asOf hlc.Timestamp,
+) bool {
+	if canaryWindowSize == 0 || e.latestFullStatsTimestamp.IsEmpty() {
+		return false
+	}
+	if !e.latestFullStatsTimestamp.AddDuration(canaryWindowSize).After(asOf) {
+		return false // Past canary window; fresh stats promoted to all users.
+	}
+	// Within the canary window. Divergence requires a second generation
+	// whose timestamp predates the latest full stats.
+	return !e.latestStableFullStatsTimestamp.IsEmpty() &&
+		e.latestStableFullStatsTimestamp.Less(e.latestFullStatsTimestamp)
+}
+
 // lookupStatsLocked retrieves any existing stats for the given table.
 //
 // If another goroutine is in the process of retrieving the same stats, this
@@ -550,7 +590,7 @@ func (sc *TableStatisticsCache) lookupStatsLocked(
 // addCacheEntryLocked creates a new cache entry and retrieves table statistics
 // from the database. It does this in a way so that the other goroutines that
 // need the same stats can wait on us:
-//   - an cache entry with wait=true is created;
+//   - a cache entry with wait=true is created;
 //   - mutex is unlocked;
 //   - stats are retrieved from database:
 //   - mutex is locked again and the entry is updated.
@@ -567,7 +607,7 @@ func (sc *TableStatisticsCache) addCacheEntryLocked(
 	stable bool,
 	canaryWindowSize time.Duration,
 	asOf hlc.Timestamp,
-) (stats []*TableStatistic, err error) {
+) (stats []*TableStatistic, statsDiffer bool, err error) {
 	defer sc.generation.Add(1)
 	// Add a cache entry that other queries can find and wait on until we have the
 	// stats.
@@ -608,11 +648,13 @@ func (sc *TableStatisticsCache) addCacheEntryLocked(
 		sc.mu.cache.Del(tableID)
 	}
 
+	statsDiffer = e.canaryAndStableStatsDiffer(canaryWindowSize, asOf)
+
 	if err == nil && stable {
-		return e.getStableStatsLocked(ctx, canaryWindowSize, asOf), nil
+		return e.getStableStatsLocked(ctx, canaryWindowSize, asOf), statsDiffer, nil
 	}
 
-	return stats, err
+	return stats, statsDiffer, err
 }
 
 // refreshCacheEntry retrieves table statistics from the database and updates

--- a/pkg/sql/stats/stats_cache_test.go
+++ b/pkg/sql/stats/stats_cache_test.go
@@ -114,7 +114,7 @@ func checkStatsForTable(
 
 	// Perform the lookup and refresh, and confirm the
 	// returned stats match the expected values.
-	statsList, err := sc.getTableStatsFromCache(ctx, tableID, nil /* forecast */, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
+	statsList, _, err := sc.getTableStatsFromCache(ctx, tableID, nil /* forecast */, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
 	if err != nil {
 		t.Fatalf("error retrieving stats: %s", err)
 	}
@@ -412,7 +412,7 @@ func TestCacheWait(t *testing.T) {
 		for n := 0; n < 10; n++ {
 			wg.Add(1)
 			go func() {
-				stats, err := sc.getTableStatsFromCache(ctx, id, nil /* forecast */, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
+				stats, _, err := sc.getTableStatsFromCache(ctx, id, nil /* forecast */, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
 				if err != nil {
 					t.Error(err)
 				} else if !checkStats(stats, expectedStats[id]) {
@@ -840,6 +840,98 @@ func TestDecodeHistogramBucketsEnum(t *testing.T) {
 	}
 }
 
+// TestCanaryAndStableStatsDiffer exercises the cacheEntry.canaryAndStableStatsDiffer
+// method with a table-driven test covering all edge cases.
+func TestCanaryAndStableStatsDiffer(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	now := hlc.Timestamp{WallTime: 1000 * time.Second.Nanoseconds()}
+	latestTS := hlc.Timestamp{WallTime: 999 * time.Second.Nanoseconds()}
+	stableTS := hlc.Timestamp{WallTime: 990 * time.Second.Nanoseconds()}
+	window := 10 * time.Second
+
+	tests := []struct {
+		name                           string
+		canaryWindowSize               time.Duration
+		asOf                           hlc.Timestamp
+		latestFullStatsTimestamp       hlc.Timestamp
+		latestStableFullStatsTimestamp hlc.Timestamp
+		expected                       bool
+	}{
+		{
+			name:             "no canary window",
+			canaryWindowSize: 0,
+			asOf:             now,
+			expected:         false,
+		},
+		{
+			name:                           "within window, two distinct generations",
+			canaryWindowSize:               window,
+			asOf:                           now,
+			latestFullStatsTimestamp:       latestTS,
+			latestStableFullStatsTimestamp: stableTS,
+			expected:                       true,
+		},
+		{
+			name:                           "past canary window",
+			canaryWindowSize:               window,
+			asOf:                           hlc.Timestamp{WallTime: 1100 * time.Second.Nanoseconds()},
+			latestFullStatsTimestamp:       latestTS,
+			latestStableFullStatsTimestamp: stableTS,
+			expected:                       false,
+		},
+		{
+			name:                     "within window, only one generation (stable timestamp empty)",
+			canaryWindowSize:         window,
+			asOf:                     now,
+			latestFullStatsTimestamp: latestTS,
+			expected:                 false,
+		},
+		{
+			name:                           "within window, same timestamp for both generations",
+			canaryWindowSize:               window,
+			asOf:                           now,
+			latestFullStatsTimestamp:       latestTS,
+			latestStableFullStatsTimestamp: latestTS,
+			expected:                       false,
+		},
+		{
+			name:             "empty latestFullStatsTimestamp",
+			canaryWindowSize: window,
+			asOf:             now,
+			expected:         false,
+		},
+		{
+			name:                           "exactly at window boundary (window just expired)",
+			canaryWindowSize:               window,
+			asOf:                           hlc.Timestamp{WallTime: (999*time.Second + window).Nanoseconds()},
+			latestFullStatsTimestamp:       latestTS,
+			latestStableFullStatsTimestamp: stableTS,
+			expected:                       false,
+		},
+		{
+			name:                           "one nanosecond before window expires",
+			canaryWindowSize:               window,
+			asOf:                           hlc.Timestamp{WallTime: (999*time.Second + window).Nanoseconds() - 1},
+			latestFullStatsTimestamp:       latestTS,
+			latestStableFullStatsTimestamp: stableTS,
+			expected:                       true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			e := &cacheEntry{
+				latestFullStatsTimestamp:       tc.latestFullStatsTimestamp,
+				latestStableFullStatsTimestamp: tc.latestStableFullStatsTimestamp,
+			}
+			got := e.canaryAndStableStatsDiffer(tc.canaryWindowSize, tc.asOf)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}
+
 // TestCanaryDualCache tests the dual cache mechanism that maintains
 // separate fresh and stable statistics caches. The stable cache
 // preserves older stats during canary windows to ensure query plan
@@ -893,6 +985,35 @@ func TestCanaryDualCache(t *testing.T) {
 			formatStats("fresh", stats)
 			formatStats("stable", stableStats)
 			return result.String()
+
+		case "stats-differ":
+			tableName := "test"
+			if d.HasArg("table") {
+				d.ScanArgs(t, "table", &tableName)
+			}
+			var canaryWindow time.Duration
+			if d.HasArg("canary-window") {
+				var windowStr string
+				d.ScanArgs(t, "canary-window", &windowStr)
+				var err error
+				canaryWindow, err = time.ParseDuration(windowStr)
+				if err != nil {
+					return fmt.Sprintf("error parsing canary-window: %v", err)
+				}
+			}
+
+			tbl := desctestutils.TestingGetPublicTableDescriptor(kvDB, s.Codec(), "defaultdb", tableName)
+			if !d.HasArg("no-invalidate") {
+				sc.InvalidateTableStats(ctx, tbl.GetID())
+			}
+			_, statsDiffer, err := sc.GetTableStatsMaybeStable(
+				ctx, tbl, nil /* typeResolver */, false /* stable */, canaryWindow, hlc.Timestamp{}, /* statsAsOf */
+			)
+			if err != nil {
+				return fmt.Sprintf("error: %v", err)
+			}
+			return fmt.Sprintf("stats_differ: %t\n", statsDiffer)
+
 		default:
 			return fmt.Sprintf("unknown command: %s", d.Cmd)
 		}

--- a/pkg/sql/stats/testdata/dual_cache
+++ b/pkg/sql/stats/testdata/dual_cache
@@ -614,3 +614,83 @@ created_at=2023-02-01 00:30:00, name="__auto__", row_count=6, distinct_count=3, 
 created_at=2023-02-01 00:00:00, name="__auto__", row_count=3, distinct_count=3, null_count=0, delayed_delete=false
 
 subtest end
+
+subtest stats_differ
+
+# Create a new table with canary window for stats-differ testing.
+exec
+CREATE TABLE differ_test (id INT PRIMARY KEY) WITH (sql_stats_canary_window = '1h')
+----
+
+# No stats yet — stats should not differ.
+stats-differ table=differ_test canary-window=1h
+----
+stats_differ: false
+
+# Inject a single generation of stats.
+exec
+ALTER TABLE differ_test INJECT STATISTICS '[
+  {
+    "columns": ["id"],
+    "created_at": "2025-01-01 10:00:00.000000",
+    "row_count": 100,
+    "distinct_count": 100,
+    "null_count": 0,
+    "avg_size": 8,
+    "name": "__auto__"
+  }
+]'
+----
+
+# Only one generation — no divergence.
+stats-differ table=differ_test canary-window=1h
+----
+stats_differ: false
+
+# Inject two generations of stats. Use a far-future timestamp for the freshest
+# generation so the canary window never expires regardless of when the test runs.
+exec
+ALTER TABLE differ_test INJECT STATISTICS '[
+  {
+    "columns": ["id"],
+    "created_at": "2025-01-01 10:00:00.000000",
+    "row_count": 100,
+    "distinct_count": 100,
+    "null_count": 0,
+    "avg_size": 8,
+    "name": "__auto__"
+  },
+  {
+    "columns": ["id"],
+    "created_at": "2099-01-01 10:00:00.000000",
+    "row_count": 200,
+    "distinct_count": 200,
+    "null_count": 0,
+    "avg_size": 8,
+    "name": "__auto__"
+  }
+]'
+----
+
+# Two distinct generations within the canary window — stats differ.
+stats-differ table=differ_test canary-window=1h
+----
+stats_differ: true
+
+# No canary window — stats should not differ even with two generations.
+stats-differ table=differ_test canary-window=0s
+----
+stats_differ: false
+
+# Test warm-cache path: call stats-differ without invalidating the cache
+# first (no-invalidate). The cache-hit branch in getTableStatsFromCache
+# should return the same statsDiffer value.
+stats-differ table=differ_test canary-window=1h no-invalidate
+----
+stats_differ: true
+
+stats-differ table=differ_test canary-window=0s no-invalidate
+----
+stats_differ: false
+
+subtest end

--- a/pkg/ui/workspaces/cluster-ui/src/graphs/bargraph/bars.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/graphs/bargraph/bars.ts
@@ -134,6 +134,118 @@ export const getStackedBarOpts = (
   return options;
 };
 
+// getGroupedStackedBarOpts creates options for a chart with two groups of
+// stacked bars side by side. The data series are expected in order:
+// [timestamps, group1_bottom, group1_top, group2_bottom, group2_top].
+// group1 bars are left-aligned, group2 bars are right-aligned.
+export const getGroupedStackedBarOpts = (
+  unstackedData: AlignedData,
+  userOptions: Partial<Options>,
+  xAxisDomain: AxisDomain,
+  yAxisDomain: AxisDomain,
+  yAxisUnits: AxisUnits,
+  colourPalette = seriesPalette,
+  timezone: string,
+): { opts: Options; stackedData: AlignedData } => {
+  const { series, ...providedOpts } = userOptions;
+  const leftBars = getBarsBuilder(0.4, 40, 4, -1);
+  const rightBars = getBarsBuilder(0.4, 40, 4, 1);
+
+  const opts: Options = {
+    width: 947,
+    height: 300,
+    ms: 1,
+    legend: {
+      isolate: true,
+      live: false,
+    },
+    scales: {
+      x: {
+        range: () => [xAxisDomain.extent[0], xAxisDomain.extent[1]],
+      },
+      yAxis: {
+        range: () => [yAxisDomain.extent[0], yAxisDomain.extent[1]],
+      },
+    },
+    axes: [
+      {
+        values: (_u, vals) => vals.map(xAxisDomain.tickFormat),
+        splits: () => xAxisDomain.ticks,
+      },
+      {
+        values: (_u, vals) => vals.map(yAxisDomain.tickFormat),
+        splits: () => [
+          yAxisDomain.extent[0],
+          ...yAxisDomain.ticks,
+          yAxisDomain.extent[1],
+        ],
+        scale: "yAxis",
+      },
+    ],
+    series: [
+      {
+        value: (_u, millis) => xAxisDomain.guideFormat(millis),
+      },
+      // Group 1 (canary): left-aligned bars
+      ...series.slice(1, 3).map((s, i) => ({
+        fill: colourPalette[i % colourPalette.length],
+        stroke: colourPalette[i % colourPalette.length],
+        width: 2,
+        paths: leftBars,
+        points: { show: false },
+        scale: "yAxis",
+        ...s,
+      })),
+      // Group 2 (stable): right-aligned bars
+      ...series.slice(3, 5).map((s, i) => ({
+        fill: colourPalette[(i + 2) % colourPalette.length],
+        stroke: colourPalette[(i + 2) % colourPalette.length],
+        width: 2,
+        paths: rightBars,
+        points: { show: false },
+        scale: "yAxis",
+        ...s,
+      })),
+    ],
+    plugins: [barTooltipPlugin(yAxisUnits, timezone)],
+  };
+
+  const combinedOpts = merge(opts, providedOpts);
+  combinedOpts.axes[1].label += ` ${yAxisDomain.label}`;
+
+  // Pre-stack each group independently: series 2 += series 1, series 4 += series 3.
+  const stackedData: AlignedData = [
+    unstackedData[0],
+    unstackedData[1],
+    unstackedData[1].map((v, i) => v + unstackedData[2][i]),
+    unstackedData[3],
+    unstackedData[3].map((v, i) => v + unstackedData[4][i]),
+  ];
+
+  // Bands fill between the top and bottom of each group.
+  combinedOpts.bands = [
+    { series: [2, 1] as Band.Bounds }, // canary: execution on top of planning
+    { series: [4, 3] as Band.Bounds }, // stable: execution on top of planning
+  ];
+
+  // Show unstacked values in tooltip/legend.
+  combinedOpts.series.forEach((s, si) => {
+    s.value = (_u, _v, _si, i) => unstackedData[si]?.[i];
+    s.points = s.points || { show: false };
+    s.points.filter = (_u, seriesIdx, show) => {
+      if (show) {
+        const pts: number[] = [];
+        unstackedData[seriesIdx]?.forEach((v, i) => {
+          v && pts.push(i);
+        });
+        return pts;
+      }
+    };
+  });
+
+  return { opts: combinedOpts, stackedData };
+};
+
 export const getBarChartOpts = (
   userOptions: Partial<Options>,
   xAxisDomain: AxisDomain,

--- a/pkg/ui/workspaces/cluster-ui/src/graphs/bargraph/bars.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/graphs/bargraph/bars.ts
@@ -135,8 +135,9 @@ export const getStackedBarOpts = (
 };
 
 // getGroupedStackedBarOpts creates options for a chart with two groups of
-// stacked bars side by side. The data series are expected in order:
-// [timestamps, group1_bottom, group1_top, group2_bottom, group2_top].
+// stacked bars side by side. Data layout:
+//   [timestamps, ...group1_series(N), ...group2_series(N)]
+// where groupSize = N is the number of stacked layers per group.
 // group1 bars are left-aligned, group2 bars are right-aligned.
 export const getGroupedStackedBarOpts = (
   unstackedData: AlignedData,
@@ -146,10 +147,14 @@ export const getGroupedStackedBarOpts = (
   yAxisUnits: AxisUnits,
   colourPalette = seriesPalette,
   timezone: string,
+  groupSize?: number,
 ): { opts: Options; stackedData: AlignedData } => {
   const { series, ...providedOpts } = userOptions;
   const leftBars = getBarsBuilder(0.4, 40, 4, -1);
   const rightBars = getBarsBuilder(0.4, 40, 4, 1);
+
+  // Default: half the data series belong to each group.
+  const n = groupSize ?? Math.floor((unstackedData.length - 1) / 2);
 
   const opts: Options = {
     width: 947,
@@ -186,8 +191,8 @@ export const getGroupedStackedBarOpts = (
       {
         value: (_u, millis) => xAxisDomain.guideFormat(millis),
       },
-      // Group 1 (canary): left-aligned bars
-      ...series.slice(1, 3).map((s, i) => ({
+      // Group 1: left-aligned bars
+      ...series.slice(1, 1 + n).map((s, i) => ({
         fill: colourPalette[i % colourPalette.length],
         stroke: colourPalette[i % colourPalette.length],
         width: 2,
@@ -196,10 +201,10 @@ export const getGroupedStackedBarOpts = (
         scale: "yAxis",
         ...s,
       })),
-      // Group 2 (stable): right-aligned bars
-      ...series.slice(3, 5).map((s, i) => ({
-        fill: colourPalette[(i + 2) % colourPalette.length],
-        stroke: colourPalette[(i + 2) % colourPalette.length],
+      // Group 2: right-aligned bars
+      ...series.slice(1 + n, 1 + 2 * n).map((s, i) => ({
+        fill: colourPalette[i % colourPalette.length],
+        stroke: colourPalette[i % colourPalette.length],
         width: 2,
         paths: rightBars,
         points: { show: false },
@@ -213,20 +218,45 @@ export const getGroupedStackedBarOpts = (
   const combinedOpts = merge(opts, providedOpts);
   combinedOpts.axes[1].label += ` ${yAxisDomain.label}`;
 
-  // Pre-stack each group independently: series 2 += series 1, series 4 += series 3.
-  const stackedData: AlignedData = [
-    unstackedData[0],
-    unstackedData[1],
-    unstackedData[1].map((v, i) => v + unstackedData[2][i]),
-    unstackedData[3],
-    unstackedData[3].map((v, i) => v + unstackedData[4][i]),
-  ];
+  // Pre-stack each group independently by cumulatively summing layers.
+  const stackedData: AlignedData = [unstackedData[0]];
+  // Group 1 (series indices 1..n)
+  for (let i = 0; i < n; i++) {
+    if (i === 0) {
+      stackedData.push([...unstackedData[1]]);
+    } else {
+      stackedData.push(
+        unstackedData[1 + i].map(
+          (v, j) => v + (stackedData[i] as number[])[j],
+        ),
+      );
+    }
+  }
+  // Group 2 (series indices n+1..2n)
+  for (let i = 0; i < n; i++) {
+    if (i === 0) {
+      stackedData.push([...unstackedData[1 + n]]);
+    } else {
+      stackedData.push(
+        unstackedData[1 + n + i].map(
+          (v, j) => v + (stackedData[n + i] as number[])[j],
+        ),
+      );
+    }
+  }
 
-  // Bands fill between the top and bottom of each group.
-  combinedOpts.bands = [
-    { series: [2, 1] as Band.Bounds }, // canary: execution on top of planning
-    { series: [4, 3] as Band.Bounds }, // stable: execution on top of planning
-  ];
+  // Bands fill between adjacent stacked layers within each group.
+  combinedOpts.bands = [];
+  for (let i = 1; i < n; i++) {
+    // Group 1: series i+1 on top of series i (1-indexed in uPlot)
+    combinedOpts.bands.push({ series: [i + 1, i] as Band.Bounds });
+  }
+  for (let i = 1; i < n; i++) {
+    // Group 2: series n+i+1 on top of series n+i
+    combinedOpts.bands.push({
+      series: [n + i + 1, n + i] as Band.Bounds,
+    });
+  }
 
   // Show unstacked values in tooltip/legend.
   combinedOpts.series.forEach((s, si) => {

--- a/pkg/ui/workspaces/cluster-ui/src/graphs/bargraph/bars.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/graphs/bargraph/bars.ts
@@ -8,7 +8,10 @@ import uPlot, { Options, Band, AlignedData } from "uplot";
 
 import { AxisUnits, AxisDomain } from "../utils/domain";
 
-import { barTooltipPlugin } from "./plugins";
+import {
+  barTooltipPlugin,
+  groupedStackedBarTooltipPlugin,
+} from "./plugins";
 
 const seriesPalette = [
   "#003EBD",
@@ -134,11 +137,188 @@ export const getStackedBarOpts = (
   return options;
 };
 
+// Horizontally translate a Path2D by the given offset.
+function offsetPath2D(
+  path: Path2D | null | undefined,
+  transform: DOMMatrix2DInit,
+): Path2D | undefined {
+  if (!path) return undefined;
+  const p = new Path2D();
+  p.addPath(path, transform);
+  return p;
+}
+
+// Wraps a standard bars builder and shifts the resulting paths by
+// offsetCssPx CSS pixels horizontally, creating a visible gap
+// between grouped bar pairs.
+const getOffsetBarsBuilder = (
+  barWidthFactor: number,
+  maxWidth: number,
+  minWidth: number,
+  align: 0 | 1 | -1,
+  offsetCssPx: number,
+): uPlot.Series.PathBuilder => {
+  const baseBars = getBarsBuilder(
+    barWidthFactor,
+    maxWidth,
+    minWidth,
+    align,
+  );
+  if (offsetCssPx === 0) return baseBars;
+
+  return (u, seriesIdx, idx0, idx1) => {
+    const result = baseBars(u, seriesIdx, idx0, idx1);
+    if (!result) return result;
+
+    // Paths are in device-pixel space.
+    const offset =
+      offsetCssPx * (window.devicePixelRatio || 1);
+    const tx: DOMMatrix2DInit = {
+      a: 1, b: 0, c: 0, d: 1, e: offset, f: 0,
+    };
+
+    return {
+      flags: result.flags,
+      fill:
+        result.fill instanceof Path2D
+          ? offsetPath2D(result.fill, tx)
+          : result.fill,
+      stroke:
+        result.stroke instanceof Path2D
+          ? offsetPath2D(result.stroke, tx)
+          : result.stroke,
+      clip:
+        result.clip instanceof Path2D
+          ? offsetPath2D(result.clip, tx)
+          : result.clip,
+      band:
+        result.band instanceof Path2D
+          ? offsetPath2D(result.band, tx)
+          : result.band,
+    };
+  };
+};
+
+// pairGroupingPlugin draws alternating light background bands behind
+// every other timestamp bin so that each {group1 + group2} pair is
+// visually grouped together.
+function pairGroupingPlugin(): uPlot.Plugin {
+  return {
+    hooks: {
+      drawClear: (u: uPlot) => {
+        const ctx = u.ctx;
+        const timestamps = u.data[0] as number[];
+        if (!timestamps || timestamps.length < 2) return;
+
+        const { top, height } = u.bbox;
+
+        // Bin width in canvas-pixel space.
+        const x0 = u.valToPos(timestamps[0], "x", true);
+        const x1 = u.valToPos(timestamps[1], "x", true);
+        const binWidth = Math.abs(x1 - x0);
+        const halfBin = binWidth / 2;
+
+        ctx.save();
+        ctx.fillStyle = "rgba(0, 0, 0, 0.04)";
+
+        for (let i = 1; i < timestamps.length; i += 2) {
+          const cx = u.valToPos(timestamps[i], "x", true);
+          ctx.fillRect(cx - halfBin, top, binWidth, height);
+        }
+
+        ctx.restore();
+      },
+    },
+  };
+}
+
+// groupLabelsPlugin draws text labels (e.g. "Canary", "Stable")
+// above each bar stack so the user can tell the two groups apart
+// without relying on the legend.
+function groupLabelsPlugin(
+  labels: [string, string],
+  labelColors: [string, string],
+  n: number,
+  unstackedData: AlignedData,
+  barWidthFactor: number,
+  gapCssPx: number,
+): uPlot.Plugin {
+  return {
+    hooks: {
+      draw: (u: uPlot) => {
+        const ctx = u.ctx;
+        const timestamps = u.data[0] as number[];
+        if (!timestamps || timestamps.length < 1) return;
+
+        const pxr = window.devicePixelRatio || 1;
+
+        // Approximate bar width in device pixels.
+        const colWid =
+          timestamps.length > 1
+            ? Math.abs(
+                u.valToPos(timestamps[1], "x", true) -
+                  u.valToPos(timestamps[0], "x", true),
+              )
+            : u.bbox.width;
+        const barWid = Math.min(
+          Math.max(colWid * barWidthFactor, 4 * pxr),
+          40 * pxr,
+        );
+        const gap = gapCssPx * pxr;
+
+        ctx.save();
+        ctx.font = `bold ${9 * pxr}px sans-serif`;
+        ctx.textAlign = "center";
+
+        for (let t = 0; t < timestamps.length; t++) {
+          const cx = u.valToPos(timestamps[t], "x", true);
+
+          // Sum unstacked values for each group at this ts.
+          let g1Total = 0;
+          for (let i = 0; i < n; i++) {
+            g1Total += unstackedData[1 + i]?.[t] || 0;
+          }
+          let g2Total = 0;
+          for (let i = 0; i < n; i++) {
+            g2Total += unstackedData[1 + n + i]?.[t] || 0;
+          }
+
+          // Bar centres: align=-1 shifts by -barWid/2,
+          // then the gap offset shifts further out.
+          const leftCX = cx - barWid / 2 - gap;
+          const rightCX = cx + barWid / 2 + gap;
+
+          if (g1Total > 0) {
+            const topY = u.valToPos(g1Total, "yAxis", true);
+            ctx.fillStyle = labelColors[0];
+            ctx.fillText(labels[0], leftCX, topY - 4 * pxr);
+          }
+          if (g2Total > 0) {
+            const topY = u.valToPos(g2Total, "yAxis", true);
+            ctx.fillStyle = labelColors[1];
+            ctx.fillText(labels[1], rightCX, topY - 4 * pxr);
+          }
+        }
+
+        ctx.restore();
+      },
+    },
+  };
+}
+
 // getGroupedStackedBarOpts creates options for a chart with two groups of
 // stacked bars side by side. Data layout:
 //   [timestamps, ...group1_series(N), ...group2_series(N)]
 // where groupSize = N is the number of stacked layers per group.
 // group1 bars are left-aligned, group2 bars are right-aligned.
+//
+// groupStrokeColors optionally provides distinct border colors for each
+// group (e.g. ["#c62828", "#1565c0"]) so the user can tell group1 from
+// group2 at a glance. Fill colors still come from colourPalette.
+//
+// groupLabels optionally provides text labels (e.g. ["Canary","Stable"])
+// drawn above each bar stack. When set, the built-in uPlot legend is
+// hidden (the caller should render its own gist-only legend).
 export const getGroupedStackedBarOpts = (
   unstackedData: AlignedData,
   userOptions: Partial<Options>,
@@ -148,19 +328,33 @@ export const getGroupedStackedBarOpts = (
   colourPalette = seriesPalette,
   timezone: string,
   groupSize?: number,
+  groupStrokeColors?: [string, string],
+  groupLabels?: [string, string],
+  gistLabels?: string[],
 ): { opts: Options; stackedData: AlignedData } => {
   const { series, ...providedOpts } = userOptions;
-  const leftBars = getBarsBuilder(0.4, 40, 4, -1);
-  const rightBars = getBarsBuilder(0.4, 40, 4, 1);
 
   // Default: half the data series belong to each group.
   const n = groupSize ?? Math.floor((unstackedData.length - 1) / 2);
+
+  const barWidthFactor = 0.3;
+  const gapCssPx = 2;
+
+  // Offset bars so each group is shifted away from the centre,
+  // creating a visible gap between the two bars in every pair.
+  const leftBars = getOffsetBarsBuilder(
+    barWidthFactor, 40, 4, -1, -gapCssPx,
+  );
+  const rightBars = getOffsetBarsBuilder(
+    barWidthFactor, 40, 4, 1, gapCssPx,
+  );
 
   const opts: Options = {
     width: 947,
     height: 300,
     ms: 1,
     legend: {
+      show: !groupLabels,
       isolate: true,
       live: false,
     },
@@ -191,28 +385,28 @@ export const getGroupedStackedBarOpts = (
       {
         value: (_u, millis) => xAxisDomain.guideFormat(millis),
       },
-      // Group 1: left-aligned bars
+      // Group 1: left-aligned bars, white stroke for layer division
       ...series.slice(1, 1 + n).map((s, i) => ({
         fill: colourPalette[i % colourPalette.length],
-        stroke: colourPalette[i % colourPalette.length],
-        width: 2,
+        stroke: "#fff",
+        width: 1,
         paths: leftBars,
         points: { show: false },
         scale: "yAxis",
         ...s,
       })),
-      // Group 2: right-aligned bars
+      // Group 2: right-aligned bars, white stroke for layer division
       ...series.slice(1 + n, 1 + 2 * n).map((s, i) => ({
         fill: colourPalette[i % colourPalette.length],
-        stroke: colourPalette[i % colourPalette.length],
-        width: 2,
+        stroke: "#fff",
+        width: 1,
         paths: rightBars,
         points: { show: false },
         scale: "yAxis",
         ...s,
       })),
     ],
-    plugins: [barTooltipPlugin(yAxisUnits, timezone)],
+    plugins: [], // populated below after stackedData is computed
   };
 
   const combinedOpts = merge(opts, providedOpts);
@@ -245,6 +439,39 @@ export const getGroupedStackedBarOpts = (
     }
   }
 
+  // Build plugins now that stackedData is available.
+  const plugins: uPlot.Plugin[] = [];
+  if (gistLabels && groupLabels) {
+    plugins.push(
+      groupedStackedBarTooltipPlugin(
+        yAxisUnits,
+        timezone,
+        unstackedData,
+        stackedData,
+        n,
+        gistLabels,
+        groupLabels,
+        colourPalette,
+      ),
+    );
+  } else {
+    plugins.push(barTooltipPlugin(yAxisUnits, timezone));
+  }
+  plugins.push(pairGroupingPlugin());
+  if (groupLabels && groupStrokeColors) {
+    plugins.push(
+      groupLabelsPlugin(
+        groupLabels,
+        groupStrokeColors,
+        n,
+        unstackedData,
+        barWidthFactor,
+        gapCssPx,
+      ),
+    );
+  }
+  combinedOpts.plugins = plugins;
+
   // Bands fill between adjacent stacked layers within each group.
   combinedOpts.bands = [];
   for (let i = 1; i < n; i++) {
@@ -271,6 +498,65 @@ export const getGroupedStackedBarOpts = (
         return pts;
       }
     };
+  });
+
+  // Restack each group independently when series are toggled via the
+  // legend (click-to-isolate). This mirrors what getStackedBarOpts
+  // does for single-group stacked bars.
+  combinedOpts.hooks = combinedOpts.hooks || {};
+  combinedOpts.hooks.setSeries = combinedOpts.hooks.setSeries || [];
+  combinedOpts.hooks.setSeries.push((u: uPlot) => {
+    const newData: AlignedData = [unstackedData[0]];
+    // Restack group 1 (series 1..n), skipping hidden series.
+    const accum1 = new Array(unstackedData[0].length).fill(0);
+    for (let i = 0; i < n; i++) {
+      if (u.series[1 + i].show) {
+        newData.push(
+          unstackedData[1 + i].map((v, j) => (accum1[j] += v)),
+        );
+      } else {
+        newData.push(unstackedData[1 + i]);
+      }
+    }
+    // Restack group 2 (series n+1..2n), skipping hidden series.
+    const accum2 = new Array(unstackedData[0].length).fill(0);
+    for (let i = 0; i < n; i++) {
+      if (u.series[1 + n + i].show) {
+        newData.push(
+          unstackedData[1 + n + i].map((v, j) => (accum2[j] += v)),
+        );
+      } else {
+        newData.push(unstackedData[1 + n + i]);
+      }
+    }
+
+    // Rebuild bands between consecutive visible series in each group.
+    u.delBand(null);
+    // Group 1: find pairs of adjacent visible series.
+    for (let i = 1; i < n; i++) {
+      if (!u.series[1 + i].show) continue;
+      // Find the nearest visible series below in group 1.
+      for (let j = i - 1; j >= 0; j--) {
+        if (u.series[1 + j].show) {
+          u.addBand({ series: [1 + i, 1 + j] as Band.Bounds });
+          break;
+        }
+      }
+    }
+    // Group 2: same logic.
+    for (let i = 1; i < n; i++) {
+      if (!u.series[1 + n + i].show) continue;
+      for (let j = i - 1; j >= 0; j--) {
+        if (u.series[1 + n + j].show) {
+          u.addBand({
+            series: [1 + n + i, 1 + n + j] as Band.Bounds,
+          });
+          break;
+        }
+      }
+    }
+
+    u.setData(newData as AlignedData);
   });
 
   return { opts: combinedOpts, stackedData };

--- a/pkg/ui/workspaces/cluster-ui/src/graphs/bargraph/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/graphs/bargraph/index.tsx
@@ -118,11 +118,13 @@ export const BarGraphTimeSeries: React.FC<BarGraphTimeSeriesProps> = ({
 };
 
 // GroupedStackedBarGraphTimeSeries renders two groups of stacked bars
-// side by side per timestamp. The data must have 5 series:
-// [timestamps, group1_bottom, group1_top, group2_bottom, group2_top].
+// side by side per timestamp. Data layout:
+//   [timestamps, ...group1_series(N), ...group2_series(N)]
+// groupSize specifies N (layers per group). Defaults to half the data series.
 export type GroupedStackedBarGraphProps = {
   alignedData?: AlignedData;
   colourPalette?: string[];
+  groupSize?: number;
   preCalcGraphSize?: boolean;
   title: string;
   tooltip?: React.ReactNode;
@@ -136,6 +138,7 @@ export const GroupedStackedBarGraphTimeSeries: React.FC<
 > = ({
   alignedData,
   colourPalette,
+  groupSize,
   preCalcGraphSize = true,
   title,
   tooltip,
@@ -164,13 +167,22 @@ export const GroupedStackedBarGraphTimeSeries: React.FC<
       timezone,
     );
 
-    // Pre-compute stacked values for y-axis domain calculation.
-    // Group 1 (series 1+2) and group 2 (series 3+4) stack independently.
-    const preStackedTops = [
-      ...alignedData[1].map((v, i) => v + alignedData[2][i]),
-      ...alignedData[3].map((v, i) => v + alignedData[4][i]),
-    ];
-    const yAxisDomain = calculateYAxisDomain(yAxisUnits, preStackedTops);
+    // Compute y-axis domain from stacked tops of both groups.
+    const n = groupSize ?? Math.floor((alignedData.length - 1) / 2);
+    const group1Top = alignedData[1].map((_, j) => {
+      let sum = 0;
+      for (let i = 0; i < n; i++) sum += alignedData[1 + i][j];
+      return sum;
+    });
+    const group2Top = alignedData[1].map((_, j) => {
+      let sum = 0;
+      for (let i = 0; i < n; i++) sum += alignedData[1 + n + i][j];
+      return sum;
+    });
+    const yAxisDomain = calculateYAxisDomain(yAxisUnits, [
+      ...group1Top,
+      ...group2Top,
+    ]);
 
     const { opts, stackedData } = getGroupedStackedBarOpts(
       alignedData,
@@ -180,6 +192,7 @@ export const GroupedStackedBarGraphTimeSeries: React.FC<
       yAxisUnits,
       colourPalette,
       timezone,
+      groupSize,
     );
 
     // When groupLabels is set but the caller overrides the legend to be
@@ -210,6 +223,7 @@ export const GroupedStackedBarGraphTimeSeries: React.FC<
   }, [
     alignedData,
     colourPalette,
+    groupSize,
     uPlotOptions,
     yAxisUnits,
     samplingIntervalMillis,

--- a/pkg/ui/workspaces/cluster-ui/src/graphs/bargraph/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/graphs/bargraph/index.tsx
@@ -16,7 +16,7 @@ import {
 import { Visualization } from "../visualization";
 
 import styles from "./bargraph.module.scss";
-import { getStackedBarOpts, stack } from "./bars";
+import { getStackedBarOpts, getGroupedStackedBarOpts, stack } from "./bars";
 import { categoricalBarTooltipPlugin, BarMetadata } from "./plugins";
 
 const cx = classNames.bind(styles);
@@ -87,6 +87,120 @@ export const BarGraphTimeSeries: React.FC<BarGraphTimeSeriesProps> = ({
       colourPalette,
       timezone,
     );
+
+    const plot = new uPlot(opts, stackedData, graphRef.current);
+
+    return () => {
+      plot?.destroy();
+    };
+  }, [
+    alignedData,
+    colourPalette,
+    uPlotOptions,
+    yAxisUnits,
+    samplingIntervalMillis,
+    timezone,
+    xScale,
+  ]);
+
+  return (
+    <Visualization
+      title={title}
+      loading={!alignedData}
+      preCalcGraphSize={preCalcGraphSize}
+      tooltip={tooltip}
+    >
+      <div className={cx("bargraph")}>
+        <div ref={graphRef} />
+      </div>
+    </Visualization>
+  );
+};
+
+// GroupedStackedBarGraphTimeSeries renders two groups of stacked bars
+// side by side per timestamp. The data must have 5 series:
+// [timestamps, group1_bottom, group1_top, group2_bottom, group2_top].
+export type GroupedStackedBarGraphProps = {
+  alignedData?: AlignedData;
+  colourPalette?: string[];
+  preCalcGraphSize?: boolean;
+  title: string;
+  tooltip?: React.ReactNode;
+  uPlotOptions: Partial<Options>;
+  yAxisUnits: AxisUnits;
+  xScale?: XScale;
+};
+
+export const GroupedStackedBarGraphTimeSeries: React.FC<
+  GroupedStackedBarGraphProps
+> = ({
+  alignedData,
+  colourPalette,
+  preCalcGraphSize = true,
+  title,
+  tooltip,
+  uPlotOptions,
+  yAxisUnits,
+  xScale,
+}) => {
+  const graphRef = useRef<HTMLDivElement>(null);
+  const samplingIntervalMillis =
+    alignedData[0].length > 1 ? alignedData[0][1] - alignedData[0][0] : 1e3;
+  const timezone = useContext(TimezoneContext);
+
+  useEffect(() => {
+    if (!alignedData) return;
+
+    const start = xScale.graphTsStartMillis
+      ? xScale.graphTsStartMillis
+      : alignedData[0][0];
+    const end = xScale.graphTsEndMillis
+      ? xScale.graphTsEndMillis
+      : alignedData[0][alignedData[0].length - 1];
+    const xAxisDomain = calculateXAxisDomainBarChart(
+      start,
+      end,
+      samplingIntervalMillis,
+      timezone,
+    );
+
+    // Pre-compute stacked values for y-axis domain calculation.
+    // Group 1 (series 1+2) and group 2 (series 3+4) stack independently.
+    const preStackedTops = [
+      ...alignedData[1].map((v, i) => v + alignedData[2][i]),
+      ...alignedData[3].map((v, i) => v + alignedData[4][i]),
+    ];
+    const yAxisDomain = calculateYAxisDomain(yAxisUnits, preStackedTops);
+
+    const { opts, stackedData } = getGroupedStackedBarOpts(
+      alignedData,
+      uPlotOptions,
+      xAxisDomain,
+      yAxisDomain,
+      yAxisUnits,
+      colourPalette,
+      timezone,
+    );
+
+    // When groupLabels is set but the caller overrides the legend to be
+    // visible (e.g. for the Statement Times chart), hide group 2's
+    // duplicate legend entries so only one set of layer labels appears.
+    if (groupLabels && opts.legend?.show) {
+      const nn = groupSize ?? Math.floor((alignedData.length - 1) / 2);
+      opts.plugins.push({
+        hooks: {
+          init: (u: uPlot) => {
+            const rows = u.root.querySelectorAll(".u-legend .u-series");
+            // Legend rows: 0=x-axis, 1..n=group1, n+1..2n=group2
+            for (let i = nn + 1; i <= 2 * nn; i++) {
+              if (rows[i]) {
+                (rows[i] as HTMLElement).style.display = "none";
+              }
+            }
+          },
+        },
+      });
+    }
 
     const plot = new uPlot(opts, stackedData, graphRef.current);
 

--- a/pkg/ui/workspaces/cluster-ui/src/graphs/bargraph/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/graphs/bargraph/index.tsx
@@ -125,6 +125,15 @@ export type GroupedStackedBarGraphProps = {
   alignedData?: AlignedData;
   colourPalette?: string[];
   groupSize?: number;
+  // Text labels drawn above each bar stack (e.g. ["Canary","Stable"]).
+  // When set, the built-in uPlot legend is hidden.
+  groupLabels?: [string, string];
+  // Distinct border colours for group 1 / group 2 bars
+  // (e.g. ["#c62828", "#1565c0"] for canary vs stable).
+  groupStrokeColors?: [string, string];
+  // Layer labels (e.g. plan gist IDs). When provided together with
+  // groupLabels, the tooltip shows only the hovered sub-bar layer.
+  gistLabels?: string[];
   preCalcGraphSize?: boolean;
   title: string;
   tooltip?: React.ReactNode;
@@ -138,7 +147,10 @@ export const GroupedStackedBarGraphTimeSeries: React.FC<
 > = ({
   alignedData,
   colourPalette,
+  gistLabels,
+  groupLabels,
   groupSize,
+  groupStrokeColors,
   preCalcGraphSize = true,
   title,
   tooltip,
@@ -193,23 +205,44 @@ export const GroupedStackedBarGraphTimeSeries: React.FC<
       colourPalette,
       timezone,
       groupSize,
+      groupStrokeColors,
+      groupLabels,
+      gistLabels,
     );
 
     // When groupLabels is set but the caller overrides the legend to be
-    // visible (e.g. for the Statement Times chart), hide group 2's
-    // duplicate legend entries so only one set of layer labels appears.
+    // visible (e.g. for the Statement Times or Plan Distribution chart),
+    // hide group 2's duplicate legend entries so only one set of labels
+    // appears, and sync group 2 visibility with group 1 so that
+    // click-to-isolate toggles both canary and stable bars together.
     if (groupLabels && opts.legend?.show) {
       const nn = groupSize ?? Math.floor((alignedData.length - 1) / 2);
+      let syncing = false;
       opts.plugins.push({
         hooks: {
           init: (u: uPlot) => {
             const rows = u.root.querySelectorAll(".u-legend .u-series");
-            // Legend rows: 0=x-axis, 1..n=group1, n+1..2n=group2
+            // Legend rows: 0=x-axis, 1..nn=group1, nn+1..2*nn=group2
             for (let i = nn + 1; i <= 2 * nn; i++) {
               if (rows[i]) {
                 (rows[i] as HTMLElement).style.display = "none";
               }
             }
+          },
+          setSeries: (u: uPlot) => {
+            if (syncing) return;
+            syncing = true;
+            // Mirror group 1 visibility to group 2 so both canary and
+            // stable bars for a given layer toggle together.
+            queueMicrotask(() => {
+              for (let i = 1; i <= nn; i++) {
+                const g1Show = u.series[i].show;
+                if (u.series[nn + i].show !== g1Show) {
+                  u.setSeries(nn + i, { show: g1Show });
+                }
+              }
+              syncing = false;
+            });
           },
         },
       });
@@ -223,7 +256,10 @@ export const GroupedStackedBarGraphTimeSeries: React.FC<
   }, [
     alignedData,
     colourPalette,
+    gistLabels,
+    groupLabels,
     groupSize,
+    groupStrokeColors,
     uPlotOptions,
     yAxisUnits,
     samplingIntervalMillis,

--- a/pkg/ui/workspaces/cluster-ui/src/graphs/bargraph/plugins.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/graphs/bargraph/plugins.ts
@@ -4,7 +4,7 @@
 // included in the /LICENSE file.
 
 import moment from "moment-timezone";
-import uPlot, { Plugin } from "uplot";
+import uPlot, { AlignedData, Plugin } from "uplot";
 
 import {
   Bytes,
@@ -217,6 +217,157 @@ export function categoricalBarTooltipPlugin(
     tooltip.style.lineHeight = "1.4";
 
     plot?.appendChild(tooltip);
+  }
+
+  return {
+    hooks: {
+      init,
+      ready,
+      setCursor,
+    },
+  };
+}
+
+// Tooltip plugin for grouped stacked bar charts that shows only the
+// specific sub-bar layer being hovered, instead of all series.
+// It determines which group (left/right) via cursor X relative to
+// the bin centre, and which layer via cursor Y against stacked
+// cumulative boundaries.
+export function groupedStackedBarTooltipPlugin(
+  yAxis: AxisUnits,
+  timezone: string,
+  unstackedData: AlignedData,
+  stackedData: AlignedData,
+  n: number,
+  gistLabels: string[],
+  groupLabels: [string, string],
+  colourPalette: string[],
+): Plugin {
+  const tooltipEl = document.createElement("div");
+
+  function setCursor(u: uPlot) {
+    const { left = 0, top = 0 } = u.cursor;
+    const idx = u.posToIdx(left);
+
+    if (idx === null || idx === undefined || idx < 0) {
+      tooltipEl.style.display = "none";
+      return;
+    }
+
+    // Which group? Compare cursor x to the bin centre.
+    const binCenterX = u.valToPos(u.data[0][idx], "x");
+    const groupIdx = left < binCenterX ? 0 : 1;
+
+    // Which layer? Compare cursor y (in data coords) against the
+    // cumulative stacked boundaries for the selected group.
+    const yVal = u.posToVal(top, "yAxis");
+    // In stackedData: group 0 occupies indices 1..n,
+    //                 group 1 occupies indices n+1..2n.
+    const groupOffset = groupIdx === 0 ? 1 : 1 + n;
+
+    let hitLayer = -1;
+    for (let i = 0; i < n; i++) {
+      const layerBottom =
+        i === 0 ? 0 : (stackedData[groupOffset + i - 1][idx] as number);
+      const layerTop = stackedData[groupOffset + i][idx] as number;
+      if (yVal >= layerBottom && yVal <= layerTop) {
+        hitLayer = i;
+        break;
+      }
+    }
+
+    if (hitLayer < 0 || yVal < 0) {
+      tooltipEl.style.display = "none";
+      return;
+    }
+
+    // Get the unstacked (raw) value for this single layer.
+    const rawValue = unstackedData[groupOffset + hitLayer][idx];
+    if (!rawValue || rawValue === 0) {
+      tooltipEl.style.display = "none";
+      return;
+    }
+
+    const gistLabel = gistLabels[hitLayer] || "unknown";
+    const groupLabel = groupLabels[groupIdx];
+    const color =
+      colourPalette[hitLayer % colourPalette.length] || DEFAULT_STROKE;
+
+    // Format timestamp header.
+    const closestDataPointTimeMillis = u.data[0][idx];
+    const timeStr = FormatWithTimezone(
+      moment(closestDataPointTimeMillis as number),
+      DATE_WITH_SECONDS_FORMAT_24_TZ,
+      timezone,
+    );
+
+    tooltipEl.innerHTML = "";
+
+    const header = document.createElement("div");
+    header.style.paddingTop = "12px";
+    header.style.marginBottom = "8px";
+    header.textContent = timeStr;
+    tooltipEl.appendChild(header);
+
+    const groupDiv = document.createElement("div");
+    groupDiv.style.fontWeight = "bold";
+    groupDiv.style.marginBottom = "8px";
+    groupDiv.textContent = groupLabel;
+    tooltipEl.appendChild(groupDiv);
+
+    const container = document.createElement("div");
+    container.style.display = "flex";
+    container.style.alignItems = "center";
+
+    const colorBox = document.createElement("span");
+    colorBox.style.height = "12px";
+    colorBox.style.width = "12px";
+    colorBox.style.background = color;
+    colorBox.style.display = "inline-block";
+    colorBox.style.marginRight = "12px";
+    colorBox.style.borderRadius = "2px";
+
+    const label = document.createElement("span");
+    label.textContent = gistLabel;
+
+    const value = document.createElement("div");
+    value.style.textAlign = "right";
+    value.style.flex = "1";
+    value.style.fontFamily = "'Source Sans Pro', sans-serif";
+    value.style.marginLeft = "16px";
+    value.textContent = getFormattedValue(rawValue, yAxis);
+
+    container.appendChild(colorBox);
+    container.appendChild(label);
+    container.appendChild(value);
+    tooltipEl.appendChild(container);
+
+    // Position tooltip offset from the cursor.
+    tooltipEl.style.left = `${left + 20}px`;
+    tooltipEl.style.top = `${top - 10}px`;
+    tooltipEl.style.display = "";
+  }
+
+  function ready(u: uPlot) {
+    const plot = u.root.querySelector(".u-over");
+    plot?.addEventListener("mouseleave", () => {
+      tooltipEl.style.display = "none";
+    });
+  }
+
+  function init(u: uPlot) {
+    const plot = u.root.querySelector(".u-over");
+    tooltipEl.style.display = "none";
+    tooltipEl.style.pointerEvents = "none";
+    tooltipEl.style.position = "absolute";
+    tooltipEl.style.padding = "0 16px 16px";
+    tooltipEl.style.minWidth = "200px";
+    tooltipEl.style.background = "#fff";
+    tooltipEl.style.borderRadius = "5px";
+    tooltipEl.style.boxShadow = "0px 7px 13px rgba(71, 88, 114, 0.3)";
+    tooltipEl.style.zIndex = "100";
+    tooltipEl.style.whiteSpace = "nowrap";
+    plot?.appendChild(tooltipEl);
   }
 
   return {

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -60,7 +60,11 @@ import {
 import { CockroachCloudContext } from "../contexts";
 import { Delayed } from "../delayed";
 import { AxisUnits } from "../graphs";
-import { BarGraphTimeSeries, XScale } from "../graphs/bargraph";
+import {
+  BarGraphTimeSeries,
+  GroupedStackedBarGraphTimeSeries,
+  XScale,
+} from "../graphs/bargraph";
 import {
   getStmtInsightRecommendations,
   InsightType,
@@ -99,6 +103,7 @@ import {
   generateRowsProcessedTimeseries,
   generateCPUTimeseries,
   generateClientWaitTimeseries,
+  generateCanaryVsStableTimeseries,
   generatePlanDistributionTimeseries,
 } from "./timeseriesUtils";
 
@@ -667,6 +672,22 @@ export function StatementDetails(
       width: cardWidth,
     };
 
+    const canaryVsStableTimeseries: AlignedData =
+      generateCanaryVsStableTimeseries(statsPerAggregatedTs);
+    const canaryVsStableOps: Partial<Options> = {
+      axes: [{}, { label: "Time Spent" }],
+      series: [
+        {},
+        { label: "Execution" },
+        { label: "Planning" },
+        { label: "Execution" },
+        { label: "Planning" },
+      ],
+      legend: { show: true },
+      width: cardWidth,
+    };
+    const hasCanaryData = canaryVsStableTimeseries[0].length > 0;
+
     const insightsColumns = makeInsightsColumns(
       isCockroachCloud,
       hasAdminRole,
@@ -886,6 +907,32 @@ export function StatementDetails(
               />
             </Col>
           </Row>
+          {hasCanaryData && (
+            <Row gutter={24}>
+              <Col className="gutter-row" span={12}>
+                <GroupedStackedBarGraphTimeSeries
+                  title="Canary vs Stable Statement Times"
+                  alignedData={canaryVsStableTimeseries}
+                  uPlotOptions={canaryVsStableOps}
+                  yAxisUnits={AxisUnits.Duration}
+                  xScale={xScale}
+                  gistLabels={["Execution", "Planning"]}
+                  groupLabels={["Canary", "Stable"]}
+                  groupStrokeColors={["#c62828", "#1565c0"]}
+                  tooltip={
+                    <>
+                      Compares execution latency between canary (newest table
+                      statistics) and stable (second-newest table statistics)
+                      paths. Each bar is split into execution (bottom) and
+                      planning (top) time, matching the Statement Times chart
+                      colors. This helps identify performance regressions
+                      caused by newly collected table statistics.
+                    </>
+                  }
+                />
+              </Col>
+            </Row>
+          )}
           <Row gutter={24}>
             <Col className="gutter-row" span={12}>
               <BarGraphTimeSeries

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -1038,12 +1038,40 @@ export function StatementDetails(
       ],
     };
 
+    // Build a map from plan_gist → average run latency (seconds)
+    // for heat map coloring. If multiple plan_hashes share a gist,
+    // use a count-weighted average.
+    const latencyByGist = new Map<string, number>();
+    const countByGist = new Map<string, number>();
+    (statementStatisticsPerPlanHash || []).forEach(plan => {
+      const gist = plan.stats?.plan_gists?.[0] || "unknown";
+      const count = longToInt(plan.stats?.count) || 1;
+      const lat = plan.stats?.run_lat?.mean || 0;
+      latencyByGist.set(
+        gist,
+        (latencyByGist.get(gist) || 0) + count * lat,
+      );
+      countByGist.set(
+        gist,
+        (countByGist.get(gist) || 0) + count,
+      );
+    });
+    latencyByGist.forEach((totalLat, gist) => {
+      latencyByGist.set(
+        gist,
+        totalLat / (countByGist.get(gist) || 1),
+      );
+    });
+
     const {
       alignedData: canaryPlanDistData,
       planGists: canaryPlanGists,
       groupSize: canaryPlanGroupSize,
+      colourPalette: canaryColourPalette,
+      latencyRange: canaryLatencyRange,
     } = generateCanaryVsStablePlanDistributionTimeseries(
       statementStatisticsPerAggregatedTsAndPlanHash || [],
+      latencyByGist,
     );
     const hasCanaryPlanData = canaryPlanDistData[0].length > 0;
     const canaryPlanDistOps: Partial<Options> = {
@@ -1052,13 +1080,14 @@ export function StatementDetails(
         {},
         // Canary group: one series per plan gist
         ...canaryPlanGists.map(gist => ({
-          label: `Canary ${gist}`,
+          label: gist,
         })),
         // Stable group: one series per plan gist
         ...canaryPlanGists.map(gist => ({
-          label: `Stable ${gist}`,
+          label: gist,
         })),
       ],
+      legend: { show: true },
     };
 
     const [chartsStart, chartsEnd] = toRoundedDateRange(timeScale);
@@ -1124,22 +1153,74 @@ export function StatementDetails(
           {hasCanaryPlanData && (
             <Row gutter={24}>
               <Col className="gutter-row" span={24}>
-                <GroupedStackedBarGraphTimeSeries
-                  title="Canary vs Stable Plan Distribution"
-                  tooltip={
-                    <>
-                      Compares plan distribution between canary (newest table
-                      statistics) and stable (second-newest) executions. Left
-                      bars show canary execution counts, right bars show stable.
-                      Each color represents a different plan gist.
-                    </>
-                  }
-                  alignedData={canaryPlanDistData}
-                  uPlotOptions={canaryPlanDistOps}
-                  groupSize={canaryPlanGroupSize}
-                  yAxisUnits={AxisUnits.Count}
-                  xScale={xScale}
-                />
+                <div style={{ display: "inline-flex", alignItems: "stretch" }}>
+                  <div>
+                    <GroupedStackedBarGraphTimeSeries
+                      title="Canary vs Stable Plan Distribution"
+                      tooltip={
+                        <>
+                          Compares plan distribution between canary (newest
+                          table statistics) and stable (second-newest)
+                          executions. Left bars show canary execution counts,
+                          right bars show stable. Color intensity indicates
+                          average execution latency: darker red = higher
+                          latency, lighter red = lower latency.
+                        </>
+                      }
+                      alignedData={canaryPlanDistData}
+                      uPlotOptions={canaryPlanDistOps}
+                      colourPalette={canaryColourPalette}
+                      gistLabels={canaryPlanGists}
+                      groupLabels={["Canary", "Stable"]}
+                      groupStrokeColors={["#c62828", "#1565c0"]}
+                      groupSize={canaryPlanGroupSize}
+                      yAxisUnits={AxisUnits.Count}
+                      xScale={xScale}
+                    />
+                  </div>
+                  {canaryLatencyRange && (
+                    <div
+                      style={{
+                        display: "flex",
+                        flexDirection: "column",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        marginLeft: 12,
+                        paddingTop: 40,
+                        paddingBottom: 24,
+                        fontSize: 11,
+                        color: "#475872",
+                      }}
+                    >
+                      <span>
+                        {Duration(canaryLatencyRange.max * 1e9)}
+                      </span>
+                      <div
+                        style={{
+                          width: 14,
+                          flex: 1,
+                          minHeight: 60,
+                          margin: "4px 0",
+                          borderRadius: 3,
+                          background:
+                            "linear-gradient(to bottom, hsl(270,60%,35%), hsl(270,60%,85%))",
+                        }}
+                      />
+                      <span>
+                        {Duration(canaryLatencyRange.min * 1e9)}
+                      </span>
+                      <span
+                        style={{
+                          marginTop: 4,
+                          fontSize: 10,
+                          color: "#8b96a9",
+                        }}
+                      >
+                        Avg Latency
+                      </span>
+                    </div>
+                  )}
+                </div>
               </Col>
             </Row>
           )}

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -105,6 +105,7 @@ import {
   generateClientWaitTimeseries,
   generateCanaryVsStableTimeseries,
   generatePlanDistributionTimeseries,
+  generateCanaryVsStablePlanDistributionTimeseries,
 } from "./timeseriesUtils";
 
 type StatementDetailsResponse =
@@ -1037,6 +1038,29 @@ export function StatementDetails(
       ],
     };
 
+    const {
+      alignedData: canaryPlanDistData,
+      planGists: canaryPlanGists,
+      groupSize: canaryPlanGroupSize,
+    } = generateCanaryVsStablePlanDistributionTimeseries(
+      statementStatisticsPerAggregatedTsAndPlanHash || [],
+    );
+    const hasCanaryPlanData = canaryPlanDistData[0].length > 0;
+    const canaryPlanDistOps: Partial<Options> = {
+      axes: [{}, { label: "Execution Count" }],
+      series: [
+        {},
+        // Canary group: one series per plan gist
+        ...canaryPlanGists.map(gist => ({
+          label: `Canary ${gist}`,
+        })),
+        // Stable group: one series per plan gist
+        ...canaryPlanGists.map(gist => ({
+          label: `Stable ${gist}`,
+        })),
+      ],
+    };
+
     const [chartsStart, chartsEnd] = toRoundedDateRange(timeScale);
     const xScale = {
       graphTsStartMillis: chartsStart.valueOf(),
@@ -1096,6 +1120,28 @@ export function StatementDetails(
                 </Col>
               </Row>
             </>
+          )}
+          {hasCanaryPlanData && (
+            <Row gutter={24}>
+              <Col className="gutter-row" span={24}>
+                <GroupedStackedBarGraphTimeSeries
+                  title="Canary vs Stable Plan Distribution"
+                  tooltip={
+                    <>
+                      Compares plan distribution between canary (newest table
+                      statistics) and stable (second-newest) executions. Left
+                      bars show canary execution counts, right bars show stable.
+                      Each color represents a different plan gist.
+                    </>
+                  }
+                  alignedData={canaryPlanDistData}
+                  uPlotOptions={canaryPlanDistOps}
+                  groupSize={canaryPlanGroupSize}
+                  yAxisUnits={AxisUnits.Count}
+                  xScale={xScale}
+                />
+              </Col>
+            </Row>
           )}
           <PlanDetails
             statementFingerprintID={statementFingerprintID}

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/timeseriesUtils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/timeseriesUtils.ts
@@ -198,3 +198,75 @@ export function generatePlanDistributionTimeseries(
 
   return { alignedData, planGists };
 }
+
+// generateCanaryVsStablePlanDistributionTimeseries builds a grouped bar
+// chart with two bars per timestamp: canary (left) and stable (right).
+// Each bar is stacked by plan gist, showing execution counts.
+//
+// Returns data as [timestamps, gist1_canary, gist2_canary, ..., gist1_stable, gist2_stable, ...]
+// along with the plan gist list and the number of gists (groupSize).
+export function generateCanaryVsStablePlanDistributionTimeseries(
+  stats: StatementStatisticsPerAggregatedTsAndPlanHash[],
+): { alignedData: AlignedData; planGists: string[]; groupSize: number } {
+  // Two maps: one for canary counts, one for stable counts.
+  const canaryMap = new Map<number, Map<string, number>>();
+  const stableMap = new Map<number, Map<string, number>>();
+  const planGistSet = new Set<string>();
+  let hasCanary = false;
+
+  stats.forEach(stat => {
+    const ts = TimestampToNumber(stat.aggregated_ts) * 1e3;
+    const planGist = stat.plan_gist || "unknown";
+    planGistSet.add(planGist);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const canaryCount = Number((stat as any).canary_execution_count || 0);
+    // Use the explicitly tracked stable count rather than deriving it
+    // from (total - canary), since executions where the canary experiment
+    // is off should not be counted as stable.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const stableCount = Number((stat as any).stable_execution_count || 0);
+
+    if (canaryCount > 0 || stableCount > 0) {
+      hasCanary = true;
+    }
+
+    if (!canaryMap.has(ts)) {
+      canaryMap.set(ts, new Map());
+      stableMap.set(ts, new Map());
+    }
+
+    const existingCanary = canaryMap.get(ts).get(planGist) || 0;
+    canaryMap.get(ts).set(planGist, existingCanary + canaryCount);
+
+    const existingStable = stableMap.get(ts).get(planGist) || 0;
+    stableMap.get(ts).set(planGist, existingStable + stableCount);
+  });
+
+  if (!hasCanary) {
+    return { alignedData: [[]], planGists: [], groupSize: 0 };
+  }
+
+  const timestamps = Array.from(canaryMap.keys()).sort((a, b) => a - b);
+  const planGists = Array.from(planGistSet).sort();
+  const groupSize = planGists.length;
+
+  // Data layout: [timestamps, ...canary_gists, ...stable_gists]
+  const alignedData: AlignedData = [timestamps];
+
+  // Canary series (one per plan gist)
+  planGists.forEach(planGist => {
+    alignedData.push(
+      timestamps.map(ts => canaryMap.get(ts)?.get(planGist) || 0),
+    );
+  });
+
+  // Stable series (one per plan gist)
+  planGists.forEach(planGist => {
+    alignedData.push(
+      timestamps.map(ts => stableMap.get(ts)?.get(planGist) || 0),
+    );
+  });
+
+  return { alignedData, planGists, groupSize };
+}

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/timeseriesUtils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/timeseriesUtils.ts
@@ -199,15 +199,41 @@ export function generatePlanDistributionTimeseries(
   return { alignedData, planGists };
 }
 
+// latencyToColor maps a latency value to a red-tone HSL color.
+// Lower latency → lighter (higher lightness), higher → darker.
+function latencyToColor(
+  lat: number,
+  min: number,
+  max: number,
+): string {
+  const t = max === min ? 0.5 : (lat - min) / (max - min);
+  // Lightness ranges from 85% (light pink) to 35% (dark red).
+  const lightness = 85 - t * 50;
+  return `hsl(270, 60%, ${lightness}%)`;
+}
+
 // generateCanaryVsStablePlanDistributionTimeseries builds a grouped bar
 // chart with two bars per timestamp: canary (left) and stable (right).
 // Each bar is stacked by plan gist, showing execution counts.
+//
+// When latencyByGist is provided, plan gists are sorted by latency
+// ascending (lowest latency at the bottom of the stack) and each gist
+// is assigned a heat-map color (light red = low latency, dark red =
+// high latency). The colour palette and latency range are returned so
+// the caller can render a legend.
 //
 // Returns data as [timestamps, gist1_canary, gist2_canary, ..., gist1_stable, gist2_stable, ...]
 // along with the plan gist list and the number of gists (groupSize).
 export function generateCanaryVsStablePlanDistributionTimeseries(
   stats: StatementStatisticsPerAggregatedTsAndPlanHash[],
-): { alignedData: AlignedData; planGists: string[]; groupSize: number } {
+  latencyByGist?: Map<string, number>,
+): {
+  alignedData: AlignedData;
+  planGists: string[];
+  groupSize: number;
+  colourPalette: string[];
+  latencyRange?: { min: number; max: number };
+} {
   // Two maps: one for canary counts, one for stable counts.
   const canaryMap = new Map<number, Map<string, number>>();
   const stableMap = new Map<number, Map<string, number>>();
@@ -244,11 +270,50 @@ export function generateCanaryVsStablePlanDistributionTimeseries(
   });
 
   if (!hasCanary) {
-    return { alignedData: [[]], planGists: [], groupSize: 0 };
+    return { alignedData: [[]], planGists: [], groupSize: 0, colourPalette: [] };
   }
 
   const timestamps = Array.from(canaryMap.keys()).sort((a, b) => a - b);
-  const planGists = Array.from(planGistSet).sort();
+
+  // Sort plan gists by latency ascending when a latency map is
+  // provided, so lower-latency plans sit at the bottom of the stack
+  // and receive lighter colors. Always generate a red heat-map
+  // palette — if no latency data is available, use evenly-spaced
+  // red shades so the chart never falls back to the default
+  // multi-colour palette.
+  let planGists: string[];
+  let colourPalette: string[];
+  let latencyRange: { min: number; max: number } | undefined;
+
+  // Check whether latencyByGist has entries that actually match gists
+  // in this chart's data.
+  const hasLatencyData =
+    latencyByGist &&
+    latencyByGist.size > 0 &&
+    Array.from(planGistSet).some(g => latencyByGist.has(g));
+
+  if (hasLatencyData) {
+    planGists = Array.from(planGistSet).sort((a, b) => {
+      return (latencyByGist.get(a) || 0) - (latencyByGist.get(b) || 0);
+    });
+    const lats = planGists.map(g => latencyByGist.get(g) || 0);
+    const minLat = Math.min(...lats);
+    const maxLat = Math.max(...lats);
+    colourPalette = planGists.map(g =>
+      latencyToColor(latencyByGist.get(g) || 0, minLat, maxLat),
+    );
+    latencyRange = { min: minLat, max: maxLat };
+  } else {
+    planGists = Array.from(planGistSet).sort();
+    // Evenly-spaced red shades as fallback.
+    const n = planGists.length;
+    colourPalette = planGists.map((_, i) => {
+      const t = n <= 1 ? 0.5 : i / (n - 1);
+      const lightness = 85 - t * 50;
+      return `hsl(270, 60%, ${lightness}%)`;
+    });
+  }
+
   const groupSize = planGists.length;
 
   // Data layout: [timestamps, ...canary_gists, ...stable_gists]
@@ -268,5 +333,5 @@ export function generateCanaryVsStablePlanDistributionTimeseries(
     );
   });
 
-  return { alignedData, planGists, groupSize };
+  return { alignedData, planGists, groupSize, colourPalette, latencyRange };
 }

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/timeseriesUtils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/timeseriesUtils.ts
@@ -118,6 +118,48 @@ export function generateCPUTimeseries(
   return [ts, count];
 }
 
+// generateCanaryVsStableTimeseries builds a time series with four data
+// series for a grouped+stacked bar chart. For each aggregated timestamp,
+// two side-by-side bars are shown: one for canary and one for stable.
+// Each bar is split into execution (bottom) and planning (top) portions,
+// matching the color order of the "Statement Times" chart (execution =
+// blue at index 0, planning = green at index 1).
+//
+// Returns [timestamps, canaryRun, canaryPlan, stableRun, stablePlan].
+// Both canary and stable latencies are tracked explicitly in the backend
+// rather than deriving stable from (total - canary), because executions
+// where the canary experiment is off should not be counted as stable.
+export function generateCanaryVsStableTimeseries(
+  stats: StatementStatisticsPerAggregatedTs[],
+): AlignedData {
+  const ts: Array<number> = [];
+  const canaryRun: Array<number> = [];
+  const canaryPlan: Array<number> = [];
+  const stableRun: Array<number> = [];
+  const stablePlan: Array<number> = [];
+
+  stats.forEach(function (stat: StatementStatisticsPerAggregatedTs) {
+    const canaryStats = stat.stats?.canary_stats;
+    const stableStats = stat.stats?.stable_stats;
+    const canaryCount = longToInt(canaryStats?.count) || 0;
+    const stableCount = longToInt(stableStats?.count) || 0;
+
+    // Skip timestamps where the canary experiment was not active.
+    if (canaryCount === 0 && stableCount === 0) {
+      return;
+    }
+
+    ts.push(TimestampToNumber(stat.aggregated_ts) * 1e3);
+
+    canaryRun.push((canaryStats?.run_lat?.mean || 0) * 1e9);
+    canaryPlan.push((canaryStats?.plan_lat?.mean || 0) * 1e9);
+    stableRun.push((stableStats?.run_lat?.mean || 0) * 1e9);
+    stablePlan.push((stableStats?.plan_lat?.mean || 0) * 1e9);
+  });
+
+  return [ts, canaryRun, canaryPlan, stableRun, stablePlan];
+}
+
 type StatementStatisticsPerAggregatedTsAndPlanHash =
   cockroach.server.serverpb.StatementDetailsResponse.IStatementPlanDistribution;
 export function generatePlanDistributionTimeseries(

--- a/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.ts
@@ -162,6 +162,32 @@ export function addExecStats(a: ExecStats, b: ExecStats): ExecStats {
   };
 }
 
+export function addExperimentStatsInfo(
+  a: cockroach.sql.IExperimentStatsInfo,
+  b: cockroach.sql.IExperimentStatsInfo,
+): cockroach.sql.IExperimentStatsInfo {
+  if (!a && !b) return {};
+  if (!a) return b;
+  if (!b) return a;
+  const countA = FixLong(a.count).toInt();
+  const countB = FixLong(b.count).toInt();
+  return {
+    count: FixLong(a.count).add(FixLong(b.count)),
+    run_lat: aggregateNumericStats(
+      a.run_lat,
+      b.run_lat,
+      countA || 1,
+      countB || 1,
+    ),
+    plan_lat: aggregateNumericStats(
+      a.plan_lat,
+      b.plan_lat,
+      countA || 1,
+      countB || 1,
+    ),
+  };
+}
+
 export function addStatementStats(
   a: StatementStatistics,
   b: StatementStatistics,
@@ -270,6 +296,8 @@ export function addStatementStats(
     indexes: indexes,
     latency_info: aggregateLatencyInfo(a, b),
     last_error_code: "",
+    canary_stats: addExperimentStatsInfo(a.canary_stats, b.canary_stats),
+    stable_stats: addExperimentStatsInfo(a.stable_stats, b.stable_stats),
   };
 }
 


### PR DESCRIPTION
Informs: #156817
Informs: #165255
Informs: #165250

```sql

-- Clean up from previous runs.
DROP TABLE IF EXISTS orders;

-- Step 1: Create table with a secondary index and canary window enabled.
CREATE TABLE orders (
id INT PRIMARY KEY,
status TEXT NOT NULL,
payload TEXT,
INDEX idx_status (status)
) WITH (sql_stats_canary_window = '1h');

-- Step 2: Insert skewed data where status='complete' is RARE (1%).
-- With these stats, the optimizer prefers an INDEX SCAN for
-- WHERE status = 'complete' since it estimates very few matching rows.
INSERT INTO orders
SELECT i,
CASE WHEN i <= 10 THEN 'complete' ELSE 'pending' END,
repeat('x', 100)
FROM generate_series(1, 1000) AS g(i);

ANALYZE orders;
-- Stats v1 (will become "stable"): complete is rare (1%)

-- Step 3: Change data distribution so status='complete' is DOMINANT (99%).
-- With these stats, the optimizer prefers a FULL TABLE SCAN for
-- WHERE status = 'complete' since nearly all rows match.
UPDATE orders SET status = 'complete' WHERE status = 'pending';
UPDATE orders SET status = 'pending' WHERE id <= 10;
-- Now: 990 complete, 10 pending

ANALYZE orders;
-- Stats v2 (becomes "canary"): complete is dominant (99%)
-- Canary = v2 (newest), Stable = v1 (second-newest)

-- Step 4: Run several queries forcing CANARY stats (v2: complete is common -> full table scan).
SET canary_stats_mode = on;
SELECT * FROM orders WHERE status = 'complete';
SELECT * FROM orders WHERE status = 'complete';
SELECT * FROM orders WHERE status = 'complete';

-- Step 5: Run several queries forcing STABLE stats (v1: complete is rare -> index scan).
SET canary_stats_mode = off;
SELECT * FROM orders WHERE status = 'complete';
SELECT * FROM orders WHERE status = 'complete';
SELECT * FROM orders WHERE status = 'complete';
```

