### PR TITLE
sql: add @primary hints to avoid expensive virtual table lookup joins

### DIFF
--- a/pkg/bench/bench_test.go
+++ b/pkg/bench/bench_test.go
@@ -1593,3 +1593,32 @@ func BenchmarkFuncExprTypeCheck(b *testing.B) {
 		})
 	}
 }
+
+// BenchmarkShowIndexes measures SHOW INDEXES performance as the number of
+// tables in the database increases. Before the fix for #164443, pg_class had
+// an incomplete virtual index that caused each index OID lookup to fall back
+// to a full table scan, making SHOW INDEXES scale quadratically with the
+// number of objects.
+func BenchmarkShowIndexes(b *testing.B) {
+	skip.UnderShort(b)
+	defer log.Scope(b).Close(b)
+	benchmarkCockroach(b, func(b *testing.B, db *sqlutils.SQLRunner) {
+		numCreated := 0
+		for _, numTables := range []int{10, 50, 100} {
+			b.Run(fmt.Sprintf("tables=%d", numTables), func(b *testing.B) {
+				for i := numCreated; i < numTables; i++ {
+					db.Exec(b, fmt.Sprintf(
+						"CREATE TABLE t%d (a INT PRIMARY KEY, b INT, INDEX idx_%d(b))", i, i,
+					))
+				}
+				numCreated = numTables
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					rows := db.Query(b, "SHOW INDEXES FROM t0")
+					rows.Close()
+				}
+				b.StopTimer()
+			})
+		}
+	})
+}

--- a/pkg/cli/clisqlshell/describe.go
+++ b/pkg/cli/clisqlshell/describe.go
@@ -412,8 +412,16 @@ func listTables(tabTypes string, hasPattern bool, verbose, showSystem bool) (str
           COALESCE(pg_catalog.obj_description(c.oid, 'pg_class'),'') as "Description"`)
 	}
 
+	if showIndexes {
+		// Use an index hint to avoid an incomplete virtual index lookup join that
+		// degrades to a full scan.
+		buf.WriteString(`
+     FROM pg_catalog.pg_class@primary c`)
+	} else {
+		buf.WriteString(`
+     FROM pg_catalog.pg_class c`)
+	}
 	buf.WriteString(`
-     FROM pg_catalog.pg_class c
 LEFT JOIN pg_catalog.pg_namespace n on n.oid = c.relnamespace`)
 
 	if showTables || showMatViews || showIndexes {

--- a/pkg/cli/clisqlshell/testdata/describe
+++ b/pkg/cli/clisqlshell/testdata/describe
@@ -744,7 +744,7 @@ List of relations:
           END as "Type",
           pg_catalog.pg_get_userbyid(c.relowner) as "Owner",
           c2.relname AS "Table"
-     FROM pg_catalog.pg_class c
+     FROM pg_catalog.pg_class@primary c
 LEFT JOIN pg_catalog.pg_namespace n on n.oid = c.relnamespace
 LEFT JOIN pg_catalog.pg_am am ON am.oid = c.relam
 LEFT JOIN pg_catalog.pg_index i ON i.indexrelid = c.oid
@@ -790,7 +790,7 @@ List of relations:
           WHEN 'u' THEN 'unlogged' END AS "Persistence",
           am.amname AS "Access Method",
           COALESCE(pg_catalog.obj_description(c.oid, 'pg_class'),'') as "Description"
-     FROM pg_catalog.pg_class c
+     FROM pg_catalog.pg_class@primary c
 LEFT JOIN pg_catalog.pg_namespace n on n.oid = c.relnamespace
 LEFT JOIN pg_catalog.pg_am am ON am.oid = c.relam
 LEFT JOIN pg_catalog.pg_index i ON i.indexrelid = c.oid
@@ -830,7 +830,7 @@ List of relations:
           END as "Type",
           pg_catalog.pg_get_userbyid(c.relowner) as "Owner",
           c2.relname AS "Table"
-     FROM pg_catalog.pg_class c
+     FROM pg_catalog.pg_class@primary c
 LEFT JOIN pg_catalog.pg_namespace n on n.oid = c.relnamespace
 LEFT JOIN pg_catalog.pg_am am ON am.oid = c.relam
 LEFT JOIN pg_catalog.pg_index i ON i.indexrelid = c.oid
@@ -868,7 +868,7 @@ List of relations:
           WHEN 'u' THEN 'unlogged' END AS "Persistence",
           am.amname AS "Access Method",
           COALESCE(pg_catalog.obj_description(c.oid, 'pg_class'),'') as "Description"
-     FROM pg_catalog.pg_class c
+     FROM pg_catalog.pg_class@primary c
 LEFT JOIN pg_catalog.pg_namespace n on n.oid = c.relnamespace
 LEFT JOIN pg_catalog.pg_am am ON am.oid = c.relam
 LEFT JOIN pg_catalog.pg_index i ON i.indexrelid = c.oid

--- a/pkg/sql/delegate/show_database_indexes.go
+++ b/pkg/sql/delegate/show_database_indexes.go
@@ -53,7 +53,9 @@ SELECT
 	getAllIndexesQuery += `
 FROM
     %[1]s.information_schema.statistics AS s
-    JOIN %[1]s.pg_catalog.pg_class c ON c.relname = s.index_name
+    -- Use an index hint to avoid an incomplete virtual index lookup join that
+    -- degrades to a full scan.
+    JOIN %[1]s.pg_catalog.pg_class@primary AS c ON c.relname = s.index_name
     JOIN %[1]s.pg_catalog.pg_class c_table ON c_table.relname = s.table_name
     JOIN %[1]s.pg_catalog.pg_namespace n ON c.relnamespace = n.oid AND c_table.relnamespace = n.oid AND n.nspname = s.index_schema
     JOIN %[1]s.pg_catalog.pg_index i ON i.indexrelid = c.oid AND i.indrelid = c_table.oid

--- a/pkg/sql/delegate/show_table.go
+++ b/pkg/sql/delegate/show_table.go
@@ -168,7 +168,9 @@ SELECT
 	getIndexesQuery += `
 FROM
     %[4]s.information_schema.statistics AS s
-    JOIN %[4]s.pg_catalog.pg_class c ON c.relname = s.index_name
+    -- Use an index hint to avoid an incomplete virtual index lookup join that
+    -- degrades to a full scan.
+    JOIN %[4]s.pg_catalog.pg_class@primary AS c ON c.relname = s.index_name
     JOIN %[4]s.pg_catalog.pg_class c_table ON c_table.relname = s.table_name
     JOIN %[4]s.pg_catalog.pg_namespace n ON c.relnamespace = n.oid AND c_table.relnamespace = n.oid AND n.nspname = s.index_schema
     JOIN %[4]s.pg_catalog.pg_index i ON i.indexrelid = c.oid AND i.indrelid = c_table.oid

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -656,13 +656,15 @@ distribution: local
 └── • render
     │
     └── • virtual table lookup join
-        │ table: pg_class@pg_class_oid_idx
-        │ equality: (indexrelid) = (oid)
-        │ pred: (relname = index_name) AND (relnamespace = relnamespace)
+        │ table: pg_index@pg_index_indrelid_idx
+        │ equality: (oid) = (indrelid)
+        │ pred: indexrelid = oid
         │
-        └── • virtual table lookup join
-            │ table: pg_index@pg_index_indrelid_idx
-            │ equality: (oid) = (indrelid)
+        └── • hash join
+            │ equality: (relname, relnamespace) = (index_name, relnamespace)
+            │
+            ├── • virtual table
+            │     table: pg_class@primary
             │
             └── • hash join
                 │ equality: (relname, nspname) = (table_name, index_schema)
@@ -687,6 +689,126 @@ distribution: local
                     │
                     └── • virtual table
                           table: statistics@primary
+
+# Verify that SHOW INDEX FROM DATABASE also avoids virtual table lookup join
+# on pg_class for the index-OID alias (c), using a hash join instead.
+query T
+EXPLAIN SHOW INDEX FROM DATABASE test
+----
+distribution: local
+·
+• sort
+│ order: +table_name,+index_name,+non_unique
+│
+└── • render
+    │
+    └── • hash join
+        │ equality: (oid, nspname) = (relnamespace, index_schema)
+        │
+        ├── • virtual table
+        │     table: pg_namespace@primary
+        │
+        └── • hash join
+            │ equality: (index_name, table_name) = (relname, relname)
+            │
+            ├── • virtual table
+            │     table: statistics@primary
+            │
+            └── • hash join
+                │ equality: (relnamespace, indexrelid) = (relnamespace, oid)
+                │
+                ├── • merge join
+                │   │ equality: (oid) = (indrelid)
+                │   │
+                │   ├── • virtual table
+                │   │     table: pg_class@pg_class_oid_idx
+                │   │
+                │   └── • virtual table
+                │         table: pg_index@pg_index_indrelid_idx
+                │
+                └── • virtual table
+                      table: pg_class@primary
+
+# Verify that pg_get_indexdef (3-arg) avoids virtual table lookup join on
+# pg_attribute for the index-OID join (a.attrelid = i.indexrelid).
+query T
+EXPLAIN SELECT pg_get_indexdef(oid, 1, true) FROM pg_class WHERE relkind = 'i' LIMIT 1
+----
+distribution: local
+·
+• render
+│
+└── • limit
+    │ count: 1
+    │
+    └── • filter
+        │ filter: relkind = 'i'
+        │
+        └── • virtual table
+              table: pg_class@primary
+
+# Verify that the Smither's extractIndexes query avoids a virtual table lookup
+# join on pg_class for the index-OID alias (c). This query previously caused
+# timeouts when the database had many objects.
+statement ok
+CREATE TABLE table_2 (a INT PRIMARY KEY, b INT, INDEX idx_b(b))
+
+query T
+EXPLAIN SELECT si.index_name, column_name, storing, direction = 'ASC', is_inverted
+FROM [SHOW INDEXES FROM test.public.table_2] AS si
+JOIN "".crdb_internal.table_indexes AS ti
+  ON (si.table_name = ti.descriptor_name) AND (si.index_name = ti.index_name)
+WHERE column_name != 'rowid'
+----
+distribution: local
+·
+• render
+│
+└── • hash join
+    │ equality: (descriptor_name, index_name) = (table_name, index_name)
+    │
+    ├── • virtual table
+    │     table: table_indexes@primary
+    │
+    └── • filter
+        │ filter: column_name != 'rowid'
+        │
+        └── • render
+            │
+            └── • virtual table lookup join
+                │ table: pg_index@pg_index_indrelid_idx
+                │ equality: (oid) = (indrelid)
+                │ pred: indexrelid = oid
+                │
+                └── • hash join
+                    │ equality: (relname, relnamespace) = (index_name, relnamespace)
+                    │
+                    ├── • virtual table
+                    │     table: pg_class@primary
+                    │
+                    └── • hash join
+                        │ equality: (nspname, oid) = (index_schema, relnamespace)
+                        │
+                        ├── • virtual table
+                        │     table: pg_namespace@primary
+                        │
+                        └── • merge join
+                            │ equality: (relname) = (table_name)
+                            │
+                            ├── • filter
+                            │   │ filter: relname = 'table_2'
+                            │   │
+                            │   └── • virtual table
+                            │         table: pg_class@primary
+                            │
+                            └── • filter
+                                │ filter: ((table_name = 'table_2') AND (table_catalog = 'test')) AND (table_schema = 'public')
+                                │
+                                └── • virtual table
+                                      table: statistics@primary
+
+statement ok
+DROP TABLE table_2
 
 query T
 EXPLAIN SHOW CONSTRAINTS FROM foo

--- a/pkg/sql/opt/exec/execbuilder/testdata/virtual
+++ b/pkg/sql/opt/exec/execbuilder/testdata/virtual
@@ -9,6 +9,21 @@ distribution: local
   table: pg_class@pg_class_oid_idx
   spans: [/50 - /50]
 
+# The @primary hint forces a full scan, preventing the optimizer from using
+# the virtual index. This is useful when the virtual index is incomplete and
+# lookups with certain OIDs (e.g. hashed index OIDs) fall back to a full
+# scan anyway, making the optimizer's O(1) cost estimate incorrect.
+query T
+EXPLAIN SELECT * FROM pg_catalog.pg_class@primary WHERE oid = 50
+----
+distribution: local
+·
+• filter
+│ filter: oid = 50
+│
+└── • virtual table
+      table: pg_class@primary
+
 query T
 EXPLAIN SELECT * FROM pg_catalog.pg_class WHERE relname = 'blah'
 ----

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -626,14 +626,36 @@ func (b *Builder) buildScan(
 	}
 	if tab.IsVirtualTable() {
 		if indexFlags != nil {
-			panic(pgerror.Newf(pgcode.Syntax,
-				"index flags not allowed with virtual tables"))
+			// Only the primary index hint is allowed for virtual tables. It forces
+			// a full scan instead of a virtual table lookup join, which is important
+			// for tables like pg_class and pg_attribute whose virtual indexes are
+			// incomplete.
+			if !indexFlags.IndexOnlyHint() {
+				panic(pgerror.Newf(pgcode.Syntax,
+					"%q hint not allowed with virtual tables, only hinting primary index is allowed",
+					tree.ErrString(indexFlags),
+				))
+			}
+			primaryIdxName := tab.Index(cat.PrimaryIndex).Name()
+			isPrimary := indexFlags.Index == tabledesc.LegacyPrimaryKeyIndexName ||
+				tree.Name(indexFlags.Index) == primaryIdxName
+			if !isPrimary {
+				panic(pgerror.Newf(pgcode.Syntax,
+					"%q hint not allowed with virtual tables, only hinting primary index is allowed",
+					tree.ErrString(indexFlags),
+				))
+			}
 		}
 		if locking.isSet() {
 			panic(pgerror.Newf(pgcode.Syntax,
 				"%s not allowed with virtual tables", locking.get().Strength))
 		}
 		private := memo.ScanPrivate{Table: tabID, Cols: scanColIDs}
+		if indexFlags != nil {
+			// Force primary index to prevent virtual index lookup joins.
+			private.Flags.ForceIndex = true
+			private.Flags.Index = cat.PrimaryIndex
+		}
 		outScope.expr = b.factory.ConstructScan(&private)
 
 		// Add the partial indexes after constructing the scan so we can use the

--- a/pkg/sql/opt/optbuilder/testdata/virtual-scan
+++ b/pkg/sql/opt/optbuilder/testdata/virtual-scan
@@ -30,9 +30,30 @@ project
  └── scan columns [as=c]
       └── columns: crdb_internal_vtable_pk:1!null table_catalog:2!null table_schema:3!null table_name:4!null column_name:5!null column_comment:6 ordinal_position:7!null column_default:8 is_nullable:9!null data_type:10!null character_maximum_length:11 character_octet_length:12 numeric_precision:13 numeric_precision_radix:14 numeric_scale:15 datetime_precision:16 interval_type:17 interval_precision:18 character_set_catalog:19 character_set_schema:20 character_set_name:21 collation_catalog:22 collation_schema:23 collation_name:24 domain_catalog:25 domain_schema:26 domain_name:27 udt_catalog:28 udt_schema:29 udt_name:30 scope_catalog:31 scope_schema:32 scope_name:33 maximum_cardinality:34 dtd_identifier:35 is_self_referencing:36 is_identity:37 identity_generation:38 identity_start:39 identity_increment:40 identity_maximum:41 identity_minimum:42 identity_cycle:43 is_generated:44 generation_expression:45 is_updatable:46 is_hidden:47!null crdb_sql_type:48!null column_on_update:49
 
-# Virtual tables can't have index hints.
+# Virtual tables allow @primary to force a full scan (preventing virtual index
+# lookup joins), but reject all other index hints.
 
 build
 SELECT * FROM information_schema.tables@primary
 ----
-error (42601): index flags not allowed with virtual tables
+project
+ ├── columns: table_catalog:2!null table_schema:3!null table_name:4!null table_type:5!null is_insertable_into:6!null version:7
+ └── scan tables
+      ├── columns: crdb_internal_vtable_pk:1!null table_catalog:2!null table_schema:3!null table_name:4!null table_type:5!null is_insertable_into:6!null version:7
+      └── flags: force-index=tables_pkey
+
+# The actual primary key name also works.
+build
+SELECT * FROM information_schema.tables@tables_pkey
+----
+project
+ ├── columns: table_catalog:2!null table_schema:3!null table_name:4!null table_type:5!null is_insertable_into:6!null version:7
+ └── scan tables
+      ├── columns: crdb_internal_vtable_pk:1!null table_catalog:2!null table_schema:3!null table_name:4!null table_type:5!null is_insertable_into:6!null version:7
+      └── flags: force-index=tables_pkey
+
+# Non-primary index hints are rejected.
+build
+SELECT * FROM information_schema.tables@{NO_FULL_SCAN}
+----
+error (42601): "@{NO_FULL_SCAN}" hint not allowed with virtual tables, only hinting primary index is allowed

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -1237,8 +1237,15 @@ func (c *coster) computeIndexLookupJoinCost(
 		perLookupCost.C += 4 * randIOCostFactor
 	}
 	if c.mem.Metadata().Table(table).IsVirtualTable() {
-		// It's expensive to perform a lookup join into a virtual table because
-		// we need to fetch the table descriptors on each lookup.
+		// It's expensive to perform a lookup join into a virtual table because we
+		// need to fetch the table descriptors on each lookup. Note that virtual
+		// tables with incomplete indexes (e.g. pg_class, pg_attribute) may fall
+		// back to a full table scan when the lookup key is not found. The actual
+		// cost can match a full table scan, which is much higher than modeled
+		// here. For now, we rely on @primary index hints in known-problematic
+		// queries to avoid this.
+		// TODO(michae2): differentiate cost for complete vs incomplete virtual
+		// index lookups, so the optimizer naturally avoids the degenerate case.
 		perLookupCost.C += virtualScanTableDescriptorFetchCost
 	}
 	cost := memo.Cost{C: lookupCount * perLookupCost.C}

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -398,6 +398,12 @@ https://www.postgresql.org/docs/9.5/catalog-pg-attrdef.html`,
 	},
 	nil)
 
+// pg_attribute has an incomplete virtual index on attrelid. Lookups using table
+// descriptor OIDs resolve directly, but hashed index OIDs (e.g.  from
+// pg_index.indexrelid) miss the index and fall back to a full table scan.
+// Queries joining pg_attribute on a potentially hashed OID should use
+// pg_attribute@primary to force a hash join rather than an expensive lookup
+// join that silently degrades to a full scan.
 var pgCatalogAttributeTable = makeAllRelationsVirtualTableWithDescriptorIDIndex(
 	`table columns (incomplete - see also information_schema.columns)
 https://www.postgresql.org/docs/12/catalog-pg-attribute.html`,
@@ -785,6 +791,12 @@ var (
 	relPersistenceTemporary = tree.NewDString("t")
 )
 
+// pg_class has an incomplete virtual index on oid. Lookups using table
+// descriptor OIDs resolve directly, but hashed index OIDs (e.g. from
+// pg_index.indexrelid) miss the index and fall back to a full table scan.
+// Queries joining pg_class on a potentially hashed OID should use
+// pg_class@primary to force a hash join rather than an expensive lookup join
+// that silently degrades to a full scan.
 var pgCatalogClassTable = makeAllRelationsVirtualTableWithDescriptorIDIndex(
 	`tables and relation-like objects (incomplete - see also information_schema.tables/sequences/views)
 https://www.postgresql.org/docs/9.5/catalog-pg-class.html`,

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -899,7 +899,9 @@ FROM defaults_parsed
 						ELSE a.attname
 					END as pg_get_indexdef
 					FROM pg_catalog.pg_index i
-					LEFT JOIN pg_catalog.pg_attribute a ON (a.attrelid = i.indexrelid AND a.attnum = $2)
+					-- Use an index hint to avoid an incomplete virtual index lookup join
+					-- that degrades to a full scan.
+					LEFT JOIN pg_catalog.pg_attribute@primary AS a ON (a.attrelid = i.indexrelid AND a.attnum = $2)
 					LEFT JOIN pg_catalog.pg_indexes defs ON ($2 = 0 AND defs.crdb_oid = i.indexrelid)
 					WHERE i.indexrelid = $1`,
 			Info:       "Gets the CREATE INDEX command for index, or definition of just one index column when given a non-zero column number",

--- a/pkg/sql/sem/tree/select.go
+++ b/pkg/sql/sem/tree/select.go
@@ -517,7 +517,7 @@ func TestingEnableFamilyIndexHint() func() {
 // Format implements the NodeFormatter interface.
 func (ih *IndexFlags) Format(ctx *FmtCtx) {
 	ctx.WriteByte('@')
-	if ih.indexOnlyHint() {
+	if ih.IndexOnlyHint() {
 		if ih.Index != "" {
 			ctx.FormatNode(&ih.Index)
 		} else {
@@ -608,7 +608,7 @@ func (ih *IndexFlags) Format(ctx *FmtCtx) {
 	}
 }
 
-func (ih *IndexFlags) indexOnlyHint() bool {
+func (ih *IndexFlags) IndexOnlyHint() bool {
 	return !ih.NoIndexJoin && !ih.NoZigzagJoin && !ih.NoFullScan && !ih.AvoidFullScan &&
 		!ih.IgnoreForeignKeys && !ih.IgnoreUniqueWithoutIndexKeys && ih.Direction == 0 &&
 		!ih.ForceInvertedIndex && !ih.zigzagForced() && ih.FamilyID == nil


### PR DESCRIPTION
### bench: add wall-clock benchmark for SHOW INDEXES scaling

Add BenchmarkShowIndexes which measures SHOW INDEXES execution time as
the number of tables in the database increases (10, 50, 100 tables).
This benchmark verifies that the fix for #164443 keeps execution time
roughly constant regardless of database size, rather than scaling
quadratically due to repeated full virtual table scans.

Informs: #164443

Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

---

### optbuilder: allow primary index hints on virtual tables

Previously, all index hints were rejected for virtual tables. However,
hinting the primary index is safe and useful: it forces a full scan (the
default for virtual tables) while preventing the optimizer from
generating virtual index lookup joins.

This is important for virtual tables like pg_class and pg_attribute that
have incomplete virtual indexes. Incomplete virtual indexes sometimes
silently fall back to full table scans, making the optimizer's O(1) cost
estimate incorrect. Hinting the primary index forces a hash join
instead, which is more predictable in some cases.

Both @primary (the legacy name) and the actual primary key name (e.g.
@pg_class_pkey) are accepted. All other index hints remain rejected.

Informs: #164443

Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

---

### sql: document incomplete virtual indexes on pg_class and pg_attribute

Add comments to pgCatalogClassTable and pgCatalogAttributeTable
explaining that their virtual indexes on oid/attrelid are incomplete:
lookups using table descriptor OIDs resolve directly, but hashed index
OIDs miss the index and fall back to a full table scan. Queries joining
on potentially hashed OIDs should use @primary to force a hash join.

Also add a comment and TODO to the optimizer coster noting that the
cost model doesn't distinguish between complete and incomplete virtual
index lookups, so the actual cost can be much higher than modeled.

Informs: #164443

Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

---

### sql: add @primary hints to avoid expensive virtual table lookup joins

PR #162095 introduced a new index which caused a plan change for SHOW
INDEXES, leading to statement timeouts for Smither-based roachtests.

SHOW INDEXES, pg_get_indexdef, and listTables (with showIndexes) join
pg_class/pg_attribute on hashed index OIDs. The virtual indexes on these
tables are incomplete, meaning they can resolve table descriptor OIDs
but not hashed index OIDs. With a hashed index OID they silently fall
back to a full table scan on each lookup. The optimizer doesn't know
about this fallback and costs the lookup as O(1), leading to
O(N)-per-index performance that makes SHOW INDEXES scale quadratically
with the number of objects in the database.

Add @primary index hints to force hash joins instead of virtual table
lookup joins in:
- delegateShowIndexes (pg_class c joined via index OIDs)
- delegateShowDatabaseIndexes (same)
- listTables (with showIndexes) CLI command (same)
- pg_get_indexdef 3-arg overload (pg_attribute a joined via index OIDs)

Add EXPLAIN tests for SHOW INDEX FROM DATABASE, pg_get_indexdef, and the
Smither's extractIndexes query.

Fixes: #163484
Fixes: #163923
Fixes: #164443

Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>