### PR TITLE
kvserver/mmaprototype: add BenchmarkRebalanceStores

### DIFF
--- a/pkg/kv/kvserver/allocator/mmaprototype/BUILD.bazel
+++ b/pkg/kv/kvserver/allocator/mmaprototype/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "store_set.go",
         "store_status.go",
         "top_k_replicas.go",
+        "util_pool.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/mmaprototype",
     visibility = ["//visibility:public"],

--- a/pkg/kv/kvserver/allocator/mmaprototype/BUILD.bazel
+++ b/pkg/kv/kvserver/allocator/mmaprototype/BUILD.bazel
@@ -44,6 +44,7 @@ go_test(
     name = "mmaprototype_test",
     srcs = [
         "allocator_state_test.go",
+        "cluster_state_rebalance_stores_bench_test.go",
         "cluster_state_rebalance_stores_test.go",
         "cluster_state_test.go",
         "constraint_matcher_test.go",

--- a/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
@@ -511,6 +511,7 @@ func sortTargetCandidateSetAndPick(
 	maxFractionPendingThreshold float64,
 	failLogger func(shedResult),
 ) roachpb.StoreID {
+	// TODO(tbg): allocates 382x/op (candidate slice filtering and logging).
 	var buf redact.StringBuilder
 	var formatCandidatesLog = func(candidates []candidateInfo) redact.RedactableString {
 		buf.Reset()

--- a/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
@@ -501,6 +501,7 @@ func (i ignoreLevel) String() string {
 // caller should set loadThreshold to overloadSlow and ignoreLevel to
 // ignoreHigherThanLoadThreshold, to maximize the probability of finding a
 // candidate.
+
 func sortTargetCandidateSetAndPick(
 	ctx context.Context,
 	cands candidateSet,
@@ -511,23 +512,6 @@ func sortTargetCandidateSetAndPick(
 	maxFractionPendingThreshold float64,
 	failLogger func(shedResult),
 ) roachpb.StoreID {
-	// TODO(tbg): allocates 382x/op (candidate slice filtering and logging).
-	var buf redact.StringBuilder
-	var formatCandidatesLog = func(candidates []candidateInfo) redact.RedactableString {
-		buf.Reset()
-		for _, c := range candidates {
-			if overloadedDim != NumLoadDimensions {
-				buf.Printf(" s%v(SLS:%v, overloadedDimLoadSummary:%v)", c.StoreID, c.sls, c.dimSummary[overloadedDim])
-			} else {
-				buf.Printf(" s%v(SLS:%v)", c.StoreID, c.storeLoadSummary)
-			}
-		}
-		if len(candidates) > 0 {
-			buf.Printf(", overloadedDim:%v", overloadedDim)
-		}
-		return buf.RedactableString()
-	}
-
 	if loadThreshold <= loadNoChange {
 		panic("loadThreshold must be > loadNoChange")
 	}
@@ -567,7 +551,7 @@ func sortTargetCandidateSetAndPick(
 	for i, cand := range cands.candidates {
 		if !diversityScoresAlmostEqual(bestDiversity, cand.diversityScore) {
 			// Have a set of candidates with the best diversity.
-			if s := formatCandidatesLog(cands.candidates[i:]); s != "" {
+			if s := formatCandidatesLog(ctx, cands.candidates[i:], overloadedDim); s != "" {
 				log.KvDistribution.VEventf(ctx, 3, "discarding candidates due to lower diversity score: %s", s)
 			}
 			break
@@ -599,7 +583,7 @@ func sortTargetCandidateSetAndPick(
 				// Never go to the next set if we have discarded candidates that have
 				// pending changes. We will wait for those to have no pending changes
 				// before we consider later sets.
-				if s := formatCandidatesLog(cands.candidates[i:]); s != "" {
+				if s := formatCandidatesLog(ctx, cands.candidates[i:], overloadedDim); s != "" {
 					log.KvDistribution.VEventf(ctx, 3,
 						"candidate with pending changes was discarded, discarding remaining candidates with higher load: %s", s)
 				}
@@ -613,7 +597,7 @@ func sortTargetCandidateSetAndPick(
 				lowestLoadSet = cand.sls
 			} else if ignoreLevel < ignoreHigherThanLoadThreshold || overloadedDim == NumLoadDimensions {
 				// Past the lowestLoad set. We don't care about these.
-				if s := formatCandidatesLog(cands.candidates[i:]); s != "" {
+				if s := formatCandidatesLog(ctx, cands.candidates[i:], overloadedDim); s != "" {
 					log.KvDistribution.VEventf(ctx, 3,
 						"discarding candidates with higher load than lowestLoadSet(%v): %s", lowestLoadSet, s)
 				}
@@ -624,7 +608,7 @@ func sortTargetCandidateSetAndPick(
 			// cand.sls <= loadThreshold.
 		}
 		if cand.sls > loadThreshold {
-			if s := formatCandidatesLog(cands.candidates[i:]); s != "" {
+			if s := formatCandidatesLog(ctx, cands.candidates[i:], overloadedDim); s != "" {
 				log.KvDistribution.VEventf(ctx, 3,
 					"discarding candidates with higher load than loadThreshold(%v): %s", loadThreshold, s)
 			}
@@ -640,9 +624,11 @@ func sortTargetCandidateSetAndPick(
 			if cand.maxFractionPendingIncrease > epsilon && discardedCandsHadNoPendingChanges {
 				discardedCandsHadNoPendingChanges = false
 			}
-			log.KvDistribution.VEventf(ctx, 3,
-				"candidate store %v was discarded due to (nls=%t overloadDim=%t pending_thresh=%t): sls=%v", cand.StoreID,
-				candDiscardedByNLS, candDiscardedByOverloadDim, candDiscardedByPendingThreshold, cand.storeLoadSummary)
+			if log.ExpensiveLogEnabled(ctx, 3) {
+				log.KvDistribution.VEventf(ctx, 3,
+					"candidate store %v was discarded due to (nls=%t overloadDim=%t pending_thresh=%t): sls=%v", cand.StoreID,
+					candDiscardedByNLS, candDiscardedByOverloadDim, candDiscardedByPendingThreshold, cand.storeLoadSummary)
+			}
 			continue
 		}
 		cands.candidates[j] = cand
@@ -773,14 +759,15 @@ func sortTargetCandidateSetAndPick(
 			}
 			j++
 		}
-		if s := formatCandidatesLog(cands.candidates[j:]); s != "" {
+		if s := formatCandidatesLog(ctx, cands.candidates[j:], overloadedDim); s != "" {
 			log.KvDistribution.VEventf(ctx, 3, "discarding candidates due to overloadedDim: %s", s)
 		}
 		cands.candidates = cands.candidates[:j]
 	}
-	s := formatCandidatesLog(cands.candidates)
 	j = rng.Intn(j)
-	log.KvDistribution.VEventf(ctx, 3, "sortTargetCandidateSetAndPick: candidates:%s, picked s%v", s, cands.candidates[j].StoreID)
+	if s := formatCandidatesLog(ctx, cands.candidates, overloadedDim); s != "" {
+		log.KvDistribution.VEventf(ctx, 3, "sortTargetCandidateSetAndPick: candidates:%s, picked s%v", s, cands.candidates[j].StoreID)
+	}
 	if ignoreLevel == ignoreLoadNoChangeAndHigher && cands.candidates[j].sls >= loadNoChange ||
 		ignoreLevel == ignoreLoadThresholdAndHigher && cands.candidates[j].sls >= loadThreshold ||
 		ignoreLevel == ignoreHigherThanLoadThreshold && cands.candidates[j].sls > loadThreshold {
@@ -788,6 +775,32 @@ func sortTargetCandidateSetAndPick(
 			cands.candidates[j].sls, ignoreLevel))
 	}
 	return cands.candidates[j].StoreID
+}
+
+// formatCandidatesLog builds a redactable log string summarizing the given
+// candidates. Returns "" when verbose logging at level 3 is not enabled,
+// allowing callers to skip the log call entirely.
+func formatCandidatesLog(
+	ctx context.Context, candidates []candidateInfo, overloadedDim LoadDimension,
+) redact.RedactableString {
+	if !log.ExpensiveLogEnabled(ctx, 3) {
+		return ""
+	}
+	var buf redact.StringBuilder
+	for _, c := range candidates {
+		if overloadedDim != NumLoadDimensions {
+			buf.Printf(
+				" s%v(SLS:%v, overloadedDimLoadSummary:%v)",
+				c.StoreID, c.sls, c.dimSummary[overloadedDim],
+			)
+		} else {
+			buf.Printf(" s%v(SLS:%v)", c.StoreID, c.storeLoadSummary)
+		}
+	}
+	if len(candidates) > 0 {
+		buf.Printf(", overloadedDim:%v", overloadedDim)
+	}
+	return buf.RedactableString()
 }
 
 // ensureAnalyzedConstraints ensures that the constraints field of rangeState is

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
@@ -32,6 +32,13 @@ func rangeSkippedDueToFailedConstraintsShouldLog() bool {
 	return buildutil.CrdbTestBuild || rangeSkippedDueToFailedConstraintsLogEvery.ShouldLog()
 }
 
+var storeAndLeasePreferencePool = newSlicePool[storeAndLeasePreference](8)
+var storeIDPool = newSlicePool[roachpb.StoreID](10)
+var candidateInfoPool = newSlicePool[candidateInfo](8)
+
+var nodeLoadMapPool = newMapPool[roachpb.NodeID, *NodeLoad](8)
+var storeIDStructMapPool = newMapPool[roachpb.StoreID, struct{}](8)
+
 // rebalanceEnv tracks the state and outcomes of a rebalanceStores invocation.
 // Recall that such an invocation is on behalf of a local store, but will
 // iterate over a slice of shedding stores - these are not necessarily local
@@ -74,15 +81,6 @@ type rebalanceEnv struct {
 	// passObs is used to collect gauge metrics and logging for this rebalancing
 	// pass. Can be nil.
 	passObs *rebalancingPassMetricsAndLogger
-	// Scratch variables reused across iterations.
-	// TODO(tbg): these are a potential source of errors (imagine two nested
-	// calls using the same scratch variable). Just make a global variable
-	// that wraps a bunch of sync.Pools for the types we need.
-	scratch struct {
-		postMeansExclusions storeSet
-		nodes               map[roachpb.NodeID]*NodeLoad
-		stores              map[roachpb.StoreID]struct{}
-	}
 }
 
 // passObv can be nil.
@@ -127,8 +125,6 @@ func newRebalanceEnv(
 		fractionPendingIncreaseOrDecreaseThreshold: fractionPendingIncreaseOrDecreaseThreshold,
 		lastFailedChangeDelayDuration:              lastFailedChangeDelayDuration,
 	}
-	re.scratch.nodes = map[roachpb.NodeID]*NodeLoad{}
-	re.scratch.stores = map[roachpb.StoreID]struct{}{}
 	return re
 }
 
@@ -459,6 +455,12 @@ func (re *rebalanceEnv) rebalanceReplicas(
 	topKRanges := ss.adjusted.topKRanges[localStoreID]
 	n := topKRanges.len()
 	loadDim := topKRanges.dim
+	pPostMeansExcl := storeIDPool.get()
+	pExistingReplicas := storeIDPool.get()
+	defer func() {
+		storeIDPool.put(pPostMeansExcl)
+		storeIDPool.put(pExistingReplicas)
+	}()
 	for i := 0; i < n; i++ {
 		if re.rangeMoveCount >= re.maxRangeMoveCount {
 			log.KvDistribution.VEventf(ctx, 2,
@@ -534,21 +536,21 @@ func (re *rebalanceEnv) rebalanceReplicas(
 		// NB: to prevent placing replicas on multiple CRDB nodes sharing a
 		// host, we'd need to make changes here.
 		// See: https://github.com/cockroachdb/cockroach/issues/153863
-		re.scratch.postMeansExclusions = re.scratch.postMeansExclusions[:0]
-		existingReplicas := storeSet{} // TODO(tbg): avoid allocation
+		postMeansExclusions := storeSet((*pPostMeansExcl)[:0])
+		existingReplicas := storeSet((*pExistingReplicas)[:0])
 		for _, replica := range rstate.replicas {
 			storeID := replica.StoreID
 			existingReplicas.insert(storeID)
 			if storeID == store.StoreID {
 				// Exclude the shedding store (we're moving away from it), but not
 				// other stores on its node (within-node rebalance is allowed).
-				re.scratch.postMeansExclusions.insert(storeID)
+				postMeansExclusions.insert(storeID)
 				continue
 			}
 			// Exclude all stores on nodes with other existing replicas.
 			nodeID := re.stores[storeID].NodeID
 			for _, storeID := range re.nodes[nodeID].stores {
-				re.scratch.postMeansExclusions.insert(storeID)
+				postMeansExclusions.insert(storeID)
 			}
 		}
 
@@ -556,9 +558,9 @@ func (re *rebalanceEnv) rebalanceReplicas(
 		// that we'll actually be happy to transfer the range to.
 		// Note that existingReplicas is a subset of postMeansExclusions, so they'll
 		// be included in the mean, but are never considered as candidates.
-		//
-		// TODO(sumeer): eliminate cands allocations by passing a scratch slice.
-		cands, ssSLS := re.computeCandidatesForReplicaTransfer(ctx, conj, existingReplicas, re.scratch.postMeansExclusions, store.StoreID, re.passObs)
+		*pPostMeansExcl = []roachpb.StoreID(postMeansExclusions)
+		*pExistingReplicas = []roachpb.StoreID(existingReplicas)
+		cands, ssSLS := re.computeCandidatesForReplicaTransfer(ctx, conj, existingReplicas, postMeansExclusions, store.StoreID, re.passObs)
 		log.KvDistribution.VEventf(ctx, 3, "considering replica-transfer r%v from s%v: store load %v",
 			rangeID, store.StoreID, ss.adjusted.load)
 		if log.ExpensiveLogEnabled(ctx, 3) {
@@ -664,6 +666,18 @@ func (re *rebalanceEnv) rebalanceLeasesFromLocalStoreID(
 	topKRanges := ss.adjusted.topKRanges[localStoreID]
 	var leaseTransferCount int
 	n := topKRanges.len()
+	pLeasePrefs := storeAndLeasePreferencePool.get()
+	pCandsPL := storeIDPool.get()
+	pCandInfos := candidateInfoPool.get()
+	scratchNodes := nodeLoadMapPool.get()
+	scratchStores := storeIDStructMapPool.get()
+	defer func() {
+		storeAndLeasePreferencePool.put(pLeasePrefs)
+		storeIDPool.put(pCandsPL)
+		candidateInfoPool.put(pCandInfos)
+		nodeLoadMapPool.put(scratchNodes)
+		storeIDStructMapPool.put(scratchStores)
+	}()
 	for i := 0; i < n; i++ {
 		if leaseTransferCount >= re.maxLeaseTransferCount {
 			log.KvDistribution.VEventf(ctx, 2, "reached max lease transfer count %d, returning", re.maxLeaseTransferCount)
@@ -744,11 +758,12 @@ func (re *rebalanceEnv) rebalanceLeasesFromLocalStoreID(
 		//
 		// In effect, we interpret each replica whose store is worse than the current
 		// leaseholder as ill-disposed for the lease and (pre-means) filter then out.
-		cands, _ := rstate.constraints.candidatesToMoveLease()
+		cands, _ := rstate.constraints.candidatesToMoveLease(*pLeasePrefs)
+		*pLeasePrefs = cands
 		// candsPL is the set of stores to consider the mean. This should
 		// include the current leaseholder, so we add it in, but only in a
 		// little while.
-		var candsPL storeSet // TODO(tbg): avoid allocation
+		candsPL := storeSet((*pCandsPL)[:0])
 		for _, cand := range cands {
 			candsPL.insert(cand.storeID)
 		}
@@ -773,6 +788,8 @@ func (re *rebalanceEnv) rebalanceLeasesFromLocalStoreID(
 		// leaseholder is always going to include itself in the mean, even if it
 		// is ill-disposed towards leases.
 		candsPL = retainReadyLeaseTargetStoresOnly(ctx, candsPL, re.stores, rangeID, store.StoreID)
+		// Save back to pool slice so capacity is preserved across iterations.
+		*pCandsPL = []roachpb.StoreID(candsPL)
 
 		// INVARIANT: candsPL - {store.StoreID} \subset cands
 		if len(candsPL) == 0 || (len(candsPL) == 1 && candsPL[0] == store.StoreID) {
@@ -785,10 +802,9 @@ func (re *rebalanceEnv) rebalanceLeasesFromLocalStoreID(
 		// INVARIANT: candsPL has at least one candidate other than store.StoreID,
 		// which is also in cands.
 
-		clear(re.scratch.nodes)
 		// NB: candsPL is not empty - it includes at least the current leaseholder
 		// and one additional candidate.
-		means := computeMeansForStoreSet(re, candsPL, re.scratch.nodes, re.scratch.stores)
+		means := computeMeansForStoreSet(re, candsPL, scratchNodes, scratchStores)
 		sls := re.computeLoadSummary(ctx, store.StoreID, &means.storeLoad, &means.nodeLoad)
 		if sls.dimSummary[CPURate] < overloadSlow {
 			// This store is not cpu overloaded relative to these candidates for
@@ -797,7 +813,7 @@ func (re *rebalanceEnv) rebalanceLeasesFromLocalStoreID(
 			re.passObs.leaseShed(notOverloaded)
 			continue
 		}
-		var candsSet candidateSet
+		candsSet := candidateSet{candidates: (*pCandInfos)[:0]}
 		for _, cand := range cands {
 			if cand.storeID == store.StoreID {
 				panic(errors.AssertionFailedf("current leaseholder can't be a candidate: %v", cand))
@@ -808,7 +824,6 @@ func (re *rebalanceEnv) rebalanceLeasesFromLocalStoreID(
 				continue
 			}
 			candSls := re.computeLoadSummary(ctx, cand.storeID, &means.storeLoad, &means.nodeLoad)
-			// TODO(tbg): allocates 87x/op (candidateInfo slice growth).
 			candsSet.candidates = append(candsSet.candidates, candidateInfo{
 				StoreID:              cand.storeID,
 				storeLoadSummary:     candSls,
@@ -816,6 +831,8 @@ func (re *rebalanceEnv) rebalanceLeasesFromLocalStoreID(
 				leasePreferenceIndex: cand.leasePreferenceIndex,
 			})
 		}
+		// Save back to pool slice so capacity is preserved across iterations.
+		*pCandInfos = candsSet.candidates
 		// Have candidates. We set ignoreLevel to
 		// ignoreHigherThanLoadThreshold since this is the only allocator that
 		// can shed leases for this store, and lease shedding is cheap, and it

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
@@ -346,24 +346,25 @@ func (re *rebalanceEnv) rebalanceStore(
 	topKRanges := ss.adjusted.topKRanges[localStoreID]
 	n := topKRanges.len()
 	// Debug logging.
-	if n > 0 {
-		var buf redact.StringBuilder
-		buf.Printf("top-K[%d] ranges for s%d with lease on local s%d:", topKRanges.dim,
-			store.StoreID, localStoreID)
-		for i := 0; i < n; i++ {
-			rangeID := topKRanges.index(i)
-			rstate := re.ranges[rangeID]
-			load := rstate.load.Load
-			if !ss.adjusted.replicas[rangeID].IsLeaseholder {
-				load[CPURate] = rstate.load.RaftCPU
+	if log.ExpensiveLogEnabled(ctx, 2) {
+		if n > 0 {
+			var buf redact.StringBuilder
+			buf.Printf("top-K[%d] ranges for s%d with lease on local s%d:", topKRanges.dim,
+				store.StoreID, localStoreID)
+			for i := 0; i < n; i++ {
+				rangeID := topKRanges.index(i)
+				rstate := re.ranges[rangeID]
+				load := rstate.load.Load
+				if !ss.adjusted.replicas[rangeID].IsLeaseholder {
+					load[CPURate] = rstate.load.RaftCPU
+				}
+				buf.Printf(" r%d:%v", rangeID, load)
 			}
-			// TODO(tbg): allocates 22x/op (top-K logging).
-			buf.Printf(" r%d:%v", rangeID, load)
+			log.KvDistribution.VEventf(ctx, 2, "%s", buf.RedactableString())
+		} else {
+			log.KvDistribution.VEventf(ctx, 2, "no top-K[%s] ranges found for s%d with lease on local s%d",
+				topKRanges.dim, store.StoreID, localStoreID)
 		}
-		log.KvDistribution.VEventf(ctx, 2, "%s", buf.RedactableString())
-	} else {
-		log.KvDistribution.VEventf(ctx, 2, "no top-K[%s] ranges found for s%d with lease on local s%d",
-			topKRanges.dim, store.StoreID, localStoreID)
 	}
 	if n == 0 {
 		return

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
@@ -357,6 +357,7 @@ func (re *rebalanceEnv) rebalanceStore(
 			if !ss.adjusted.replicas[rangeID].IsLeaseholder {
 				load[CPURate] = rstate.load.RaftCPU
 			}
+			// TODO(tbg): allocates 22x/op (top-K logging).
 			buf.Printf(" r%d:%v", rangeID, load)
 		}
 		log.KvDistribution.VEventf(ctx, 2, "%s", buf.RedactableString())
@@ -759,6 +760,7 @@ func (re *rebalanceEnv) rebalanceLeasesFromLocalStoreID(
 		}
 		// NB: intentionally log before re-adding the current leaseholder so
 		// we don't list it as a candidate.
+		// TODO(tbg): allocates 207x/op (logging and candidate building).
 		log.KvDistribution.VEventf(ctx, 3, "considering lease-transfer r%v from s%v: candidates are %v", rangeID, store.StoreID, candsPL)
 		// Now candsPL is ready for computing the means.
 		candsPL.insert(store.StoreID)
@@ -803,6 +805,7 @@ func (re *rebalanceEnv) rebalanceLeasesFromLocalStoreID(
 				continue
 			}
 			candSls := re.computeLoadSummary(ctx, cand.storeID, &means.storeLoad, &means.nodeLoad)
+			// TODO(tbg): allocates 87x/op (candidateInfo slice growth).
 			candsSet.candidates = append(candsSet.candidates, candidateInfo{
 				StoreID:              cand.storeID,
 				storeLoadSummary:     candSls,

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
@@ -762,7 +762,9 @@ func (re *rebalanceEnv) rebalanceLeasesFromLocalStoreID(
 		// NB: intentionally log before re-adding the current leaseholder so
 		// we don't list it as a candidate.
 		// TODO(tbg): allocates 207x/op (logging and candidate building).
-		log.KvDistribution.VEventf(ctx, 3, "considering lease-transfer r%v from s%v: candidates are %v", rangeID, store.StoreID, candsPL)
+		if log.ExpensiveLogEnabled(ctx, 3) {
+			log.KvDistribution.VEventf(ctx, 3, "considering lease-transfer r%v from s%v: candidates are %v", rangeID, store.StoreID, candsPL)
+		}
 		// Now candsPL is ready for computing the means.
 		candsPL.insert(store.StoreID)
 

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores_bench_test.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores_bench_test.go
@@ -1,0 +1,226 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package mmaprototype
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+// setupBenchCluster builds a clusterState with 4 stores on 4 nodes (3
+// regions, round-robin), 1000 ranges with 3 replicas each leased on store 1.
+// 100 ranges are hot (CPU=250 each, totaling 25000) and 900 are cold (CPU=0).
+// Store 1 reports the total hot-range load; stores 2-4 report low load. This
+// makes store 1 overloaded and triggers load-based lease shedding.
+func setupBenchCluster(ts *timeutil.ManualTime) *clusterState {
+	cs := newClusterState(ts, newStringInterner())
+	cs.diskUtilRefuseThreshold = 0.9
+	cs.diskUtilShedThreshold = 0.9
+
+	ctx := context.Background()
+
+	type storeInfo struct {
+		region string
+		zone   string
+	}
+	stores := []storeInfo{
+		{"us-west-1", "us-west-1a"},
+		{"us-east-1", "us-east-1a"},
+		{"us-central-1", "us-central-1a"},
+		{"us-west-1", "us-west-1b"},
+	}
+
+	// Register stores. setStore is the prerequisite for processStoreLoadMsg
+	// (which panics if the store doesn't exist). The external equivalent is
+	// allocatorState.SetStore.
+	storeStatuses := make(map[roachpb.StoreID]Status, len(stores))
+	for i, si := range stores {
+		storeID := roachpb.StoreID(i + 1)
+		sal := StoreAttributesAndLocality{
+			StoreID: storeID,
+			NodeID:  roachpb.NodeID(i + 1),
+			NodeLocality: roachpb.Locality{
+				Tiers: []roachpb.Tier{
+					{Key: "region", Value: si.region},
+					{Key: "zone", Value: si.zone},
+				},
+			},
+		}
+		cs.setStore(sal.withNodeTier())
+		storeStatuses[storeID] = Status{Health: HealthOK}
+	}
+
+	// 100 hot ranges at CPU=250 each => store 1 total CPU = 25000.
+	const (
+		numRanges    = 1000
+		numHotRanges = 100
+		hotCPU       = LoadValue(250)
+		hotRaftCPU   = LoadValue(20)
+	)
+	totalCPU := hotCPU * numHotRanges // 25000
+
+	// Send store load messages. Store 1 carries all the hot-range load;
+	// stores 2-4 are lightly loaded.
+	for i := range stores {
+		storeID := roachpb.StoreID(i + 1)
+		cpuLoad := totalCPU / 10
+		if storeID == 1 {
+			cpuLoad = totalCPU
+		}
+		msg := &StoreLoadMsg{
+			NodeID:          roachpb.NodeID(i + 1),
+			StoreID:         storeID,
+			Load:            LoadVector{cpuLoad, 0, 0},
+			Capacity:        LoadVector{totalCPU, 1000, 1000},
+			NodeCPULoad:     cpuLoad,
+			NodeCPUCapacity: totalCPU,
+		}
+		cs.processStoreLoadMsg(ctx, msg, nil)
+	}
+
+	// Update store statuses after load messages so that disk capacity is
+	// populated and updateStoreStatuses doesn't warn about unknown capacity.
+	cs.updateStoreStatuses(ctx, storeStatuses)
+
+	// Build 1000 ranges: first 100 are hot, rest are cold. All leased on
+	// store 1 with replicas on stores 2 and 3.
+	ranges := make([]RangeMsg, numRanges)
+	for r := 0; r < numRanges; r++ {
+		rangeID := roachpb.RangeID(r + 1)
+		load := LoadVector{0, 0, 0}
+		raftCPU := LoadValue(0)
+		if r < numHotRanges {
+			load[CPURate] = hotCPU
+			raftCPU = hotRaftCPU
+		}
+		// Replicas on stores 1 (leaseholder), 2, 3.
+		ranges[r] = RangeMsg{
+			RangeID: rangeID,
+			RangeLoad: RangeLoad{
+				Load:    load,
+				RaftCPU: raftCPU,
+			},
+			MaybeSpanConfIsPopulated: true,
+			MaybeSpanConf:            roachpb.SpanConfig{NumReplicas: 3},
+			Replicas: []StoreIDAndReplicaState{
+				{
+					StoreID: 1,
+					ReplicaState: ReplicaState{
+						ReplicaIDAndType: ReplicaIDAndType{
+							ReplicaID:   roachpb.ReplicaID(1),
+							ReplicaType: ReplicaType{ReplicaType: roachpb.VOTER_FULL, IsLeaseholder: true},
+						},
+					},
+				},
+				{
+					StoreID: 2,
+					ReplicaState: ReplicaState{
+						ReplicaIDAndType: ReplicaIDAndType{
+							ReplicaID:   roachpb.ReplicaID(2),
+							ReplicaType: ReplicaType{ReplicaType: roachpb.VOTER_FULL},
+						},
+					},
+				},
+				{
+					StoreID: 3,
+					ReplicaState: ReplicaState{
+						ReplicaIDAndType: ReplicaIDAndType{
+							ReplicaID:   roachpb.ReplicaID(3),
+							ReplicaType: ReplicaType{ReplicaType: roachpb.VOTER_FULL},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	cs.processStoreLeaseholderMsg(ctx, &StoreLeaseholderMsg{
+		StoreID: 1,
+		Ranges:  ranges,
+	}, nil)
+
+	return cs
+}
+
+// undoAllPendingChanges reverses all pending changes in the cluster state
+// and resets leaked fields so the state is ready for another benchmark
+// iteration.
+func undoAllPendingChanges(ctx context.Context, cs *clusterState) {
+	// Collect change IDs and affected range IDs before mutating the map.
+	type pending struct {
+		cid     changeID
+		rangeID roachpb.RangeID
+	}
+	var toUndo []pending
+	for cid, pc := range cs.pendingChanges {
+		toUndo = append(toUndo, pending{cid: cid, rangeID: pc.rangeID})
+	}
+
+	for _, p := range toUndo {
+		cs.undoPendingChange(ctx, p.cid)
+		// Reset lastFailedChange on affected ranges (undoPendingChange sets it
+		// to now, which causes a 60s backoff in rebalanceStores).
+		if rs, ok := cs.ranges[p.rangeID]; ok {
+			rs.lastFailedChange = time.Time{}
+		}
+	}
+
+	// Clear the means memo since loadSeqNum changes during undo invalidate
+	// cached entries.
+	cs.meansMemo.clear()
+}
+
+func BenchmarkRebalanceStores(b *testing.B) {
+	defer log.ScopeWithoutShowLogs(b).Close(b)
+	ts := timeutil.NewManualTime(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	cs := setupBenchCluster(ts)
+	ctx := context.Background()
+
+	// Save overload times for all stores so we can restore them after
+	// each iteration.
+	type overloadTimes struct {
+		start time.Time
+		end   time.Time
+	}
+	savedOverload := make(map[roachpb.StoreID]overloadTimes, len(cs.stores))
+	for sid, ss := range cs.stores {
+		savedOverload[sid] = overloadTimes{
+			start: ss.overloadStartTime,
+			end:   ss.overloadEndTime,
+		}
+	}
+
+	dsm := newDiversityScoringMemo()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		re := newRebalanceEnv(
+			cs,
+			rand.New(rand.NewSource(0)),
+			dsm,
+			ts.Now(),
+			nil, /* passObs */
+		)
+		changes := re.rebalanceStores(ctx, 1 /* localStoreID */)
+		if len(changes) == 0 {
+			b.Fatal("rebalanceStores emitted no changes")
+		}
+
+		b.StopTimer()
+		undoAllPendingChanges(ctx, cs)
+		// Restore overload times.
+		for sid, ot := range savedOverload {
+			cs.stores[sid].overloadStartTime = ot.start
+			cs.stores[sid].overloadEndTime = ot.end
+		}
+		b.StartTimer()
+	}
+}

--- a/pkg/kv/kvserver/allocator/mmaprototype/constraint.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/constraint.go
@@ -1768,6 +1768,7 @@ func (rac *rangeAnalyzedConstraints) finishInit(
 		}
 	}
 
+	// TODO(tbg): allocates 21x/op (locality tier slices).
 	var replicaLocalityTiers, voterLocalityTiers []localityTiers
 	for i := range rac.replicas[voterIndex] {
 		replicaLocalityTiers = append(replicaLocalityTiers, rac.replicas[voterIndex][i].localityTiers)
@@ -2107,6 +2108,7 @@ func (rac *rangeAnalyzedConstraints) candidatesToMoveLease() (
 	for i := range rac.leasePreferenceIndices {
 		if rac.leasePreferenceIndices[i] <= curLeasePreferenceIndex &&
 			rac.replicas[voterIndex][i].StoreID != rac.leaseholderID {
+			// TODO(tbg): allocates 197x/op.
 			cands = append(cands, storeAndLeasePreference{
 				leasePreferenceIndex: rac.leasePreferenceIndices[i],
 				storeID:              rac.replicas[voterIndex][i].StoreID,

--- a/pkg/kv/kvserver/allocator/mmaprototype/constraint.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/constraint.go
@@ -1768,7 +1768,8 @@ func (rac *rangeAnalyzedConstraints) finishInit(
 		}
 	}
 
-	// TODO(tbg): allocates 21x/op (locality tier slices).
+	// NB: these slices are captured by makeReplicasLocalityTiers and thus
+	// cannot be pooled.
 	var replicaLocalityTiers, voterLocalityTiers []localityTiers
 	for i := range rac.replicas[voterIndex] {
 		replicaLocalityTiers = append(replicaLocalityTiers, rac.replicas[voterIndex][i].localityTiers)
@@ -2100,15 +2101,15 @@ type storeAndLeasePreference struct {
 //
 // This would require restructuring to pass a health-filtered store set into
 // this function.
-func (rac *rangeAnalyzedConstraints) candidatesToMoveLease() (
-	cands []storeAndLeasePreference,
-	curLeasePreferenceIndex int32,
-) {
+// buf, if non-nil, is reused for the returned slice to avoid allocation.
+func (rac *rangeAnalyzedConstraints) candidatesToMoveLease(
+	buf []storeAndLeasePreference,
+) (cands []storeAndLeasePreference, curLeasePreferenceIndex int32) {
+	cands = buf[:0]
 	curLeasePreferenceIndex = rac.leaseholderPreferenceIndex
 	for i := range rac.leasePreferenceIndices {
 		if rac.leasePreferenceIndices[i] <= curLeasePreferenceIndex &&
 			rac.replicas[voterIndex][i].StoreID != rac.leaseholderID {
-			// TODO(tbg): allocates 197x/op.
 			cands = append(cands, storeAndLeasePreference{
 				leasePreferenceIndex: rac.leasePreferenceIndices[i],
 				storeID:              rac.replicas[voterIndex][i].StoreID,

--- a/pkg/kv/kvserver/allocator/mmaprototype/constraint_test.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/constraint_test.go
@@ -523,7 +523,7 @@ func TestRangeAnalyzedConstraints(t *testing.T) {
 						}
 					}
 				}
-				cands, leaseholderPrefIndex := rac.candidatesToMoveLease()
+				cands, leaseholderPrefIndex := rac.candidatesToMoveLease(nil)
 				fmt.Fprintf(&buf, "toMoveLease\n")
 				fmt.Fprintf(&buf, "  leaseholder-pref-index: %s cands:",
 					leasePrefIndexStr(leaseholderPrefIndex))

--- a/pkg/kv/kvserver/allocator/mmaprototype/load.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/load.go
@@ -102,7 +102,6 @@ func (lv LoadVector) SafeFormat(w redact.SafePrinter, _ rune) {
 			panic(fmt.Sprintf("unknown LoadDimension: %d", dim))
 		}
 	}
-	// TODO(tbg): allocates 513x/op via formatVal closures and redact printing.
 	w.Printf(
 		"[cpu:%s/s, write-bandwidth:%s/s, byte-size:%s]",
 		formatVal(CPURate),

--- a/pkg/kv/kvserver/allocator/mmaprototype/load.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/load.go
@@ -102,6 +102,7 @@ func (lv LoadVector) SafeFormat(w redact.SafePrinter, _ rune) {
 			panic(fmt.Sprintf("unknown LoadDimension: %d", dim))
 		}
 	}
+	// TODO(tbg): allocates 513x/op via formatVal closures and redact printing.
 	w.Printf(
 		"[cpu:%s/s, write-bandwidth:%s/s, byte-size:%s]",
 		formatVal(CPURate),

--- a/pkg/kv/kvserver/allocator/mmaprototype/store_set.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/store_set.go
@@ -122,7 +122,8 @@ func (s *storeSet) insert(storeID roachpb.StoreID) bool {
 		if m < minLength {
 			m = minLength
 		}
-		// TODO(tbg): allocates 109x/op.
+		// NB: this allocates when the slice outgrows its pooled capacity,
+		// but that is rare enough to not matter in practice.
 		b = make([]roachpb.StoreID, n+1, m)
 		// Insert at pos, so pos-1 is the last element before the insertion.
 		if pos > 0 {

--- a/pkg/kv/kvserver/allocator/mmaprototype/store_set.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/store_set.go
@@ -122,6 +122,7 @@ func (s *storeSet) insert(storeID roachpb.StoreID) bool {
 		if m < minLength {
 			m = minLength
 		}
+		// TODO(tbg): allocates 109x/op.
 		b = make([]roachpb.StoreID, n+1, m)
 		// Insert at pos, so pos-1 is the last element before the insertion.
 		if pos > 0 {

--- a/pkg/kv/kvserver/allocator/mmaprototype/util_pool.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/util_pool.go
@@ -1,0 +1,71 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package mmaprototype
+
+import "sync"
+
+// slicePool pools reusable slices of T. Callers receive a *[]T from get; the
+// pointer indirection lets the pool retain capacity even when the caller grows
+// the slice. put clears the elements and resets the length to zero before
+// returning it to the pool, so that stale pointers don't prevent GC.
+//
+// A slicePool must not be copied after first use.
+type slicePool[T any] struct {
+	p sync.Pool
+}
+
+func newSlicePool[T any](initCap int) *slicePool[T] {
+	return &slicePool[T]{
+		p: sync.Pool{
+			New: func() any {
+				s := make([]T, 0, initCap)
+				return &s
+			},
+		},
+	}
+}
+
+// get returns a pointer to a zero-length slice backed by a pooled array.
+func (sp *slicePool[T]) get() *[]T {
+	return sp.p.Get().(*[]T)
+}
+
+// put clears the slice elements, resets the length to zero, and returns it to
+// the pool.
+func (sp *slicePool[T]) put(s *[]T) {
+	clear(*s)
+	*s = (*s)[:0]
+	sp.p.Put(s)
+}
+
+// mapPool pools reusable maps of K→V. put clears all entries before returning
+// the map to the pool.
+//
+// A mapPool must not be copied after first use.
+type mapPool[K comparable, V any] struct {
+	p sync.Pool
+}
+
+func newMapPool[K comparable, V any](initCap int) *mapPool[K, V] {
+	return &mapPool[K, V]{
+		p: sync.Pool{
+			New: func() any {
+				return make(map[K]V, initCap)
+			},
+		},
+	}
+}
+
+// get returns a cleared map from the pool.
+func (mp *mapPool[K, V]) get() map[K]V {
+	return mp.p.Get().(map[K]V)
+}
+
+// put clears the map and returns it to the pool.
+func (mp *mapPool[K, V]) put(m map[K]V) {
+	clear(m)
+	mp.p.Put(m)
+}


### PR DESCRIPTION
## Summary

Reduce per-iteration allocations in the MMA rebalance loop from ~2000 to ~160
allocs/op, primarily by guarding expensive logging and pooling hot slices/maps.

```
name                old time/op    new time/op    delta
RebalanceStores-10     246µs ± 3%     104µs ± 2%  -57.87%  (p=0.000 n=10+10)

name                old alloc/op   new alloc/op   delta
RebalanceStores-10     101kB ± 0%      19kB ± 0%  -81.17%  (p=0.000 n=9+8)

name                old allocs/op  new allocs/op  delta
RebalanceStores-10     1.99k ± 0%     0.16k ± 0%  -91.75%  (p=0.000 n=10+10)
```

### Commit arc

1. **Add BenchmarkRebalanceStores** — microbenchmark for the rebalance loop
   (4 stores, 1000 ranges, 100 hot). Uses `undoPendingChange` to restore state
   between iterations. Baseline: 2013 allocs/op.

2. **Annotate top allocation sites** — TODO comments at each site found via
   memory profiling, guiding the subsequent commits.

3. **Guard logging in sortTargetCandidateSetAndPick** — extract
   `formatCandidatesLog` to a package-level function with an internal
   `ExpensiveLogEnabled` check, removing redundant guards at all 6 call sites.
   2013 → 1689 allocs/op.

4. **Guard top-K debug logging** — wrap the `redact.StringBuilder` +
   `LoadVector` formatting block with `ExpensiveLogEnabled`.
   1689 → 778 allocs/op.

5. **Guard lease-transfer candidate logging** — prevent boxing `candsPL` into
   `interface{}` when verbose logging is off. 778 → 678 allocs/op.

6. **Pool slice and map allocations in rebalance loop** — introduce generic
   `slicePool[T]` and `mapPool[K, V]` wrappers around `sync.Pool`, replacing
   manual pool boilerplate and the `rebalanceEnv.scratch` struct (which had
   aliasing hazards). Five pools cover slices (`storeAndLeasePreference`,
   `StoreID`, `candidateInfo`) and maps (`NodeID→*NodeLoad`,
   `StoreID→struct{}`). `candidatesToMoveLease` accepts a reusable buffer.
   678 → 160 allocs/op.

Epic: CRDB-55052