### PR TITLE
sql/lease: check IsMissingRegionEnumErr unconditionally in handleRegionLivenessErrors

### DIFF
--- a/pkg/sql/catalog/lease/count.go
+++ b/pkg/sql/catalog/lease/count.go
@@ -239,24 +239,24 @@ func getCountLeaseColumns() string {
 func handleRegionLivenessErrors(
 	ctx context.Context, prober regionliveness.Prober, region string, err error,
 ) (bool, error) {
-	// If regionliveness is not enabled, then return the error directly.
-	if hasRegionLiveness, _ := prober.GetProbeTimeout(); hasRegionLiveness && err != nil {
+	// Missing region enum errors should always skip the region,
+	// regardless of whether region liveness is enabled. Since the
+	// database regions are cached, they may be stale and have
+	// regions that are not yet public or have been dropped.
+	if regionliveness.IsMissingRegionEnumErr(err) {
+		log.Dev.Infof(ctx, "count-lease skipping region %s due to error: %v", region, err)
+		return true, nil
+	}
+	// Only attempt liveness probing if region liveness is enabled.
+	if hasRegionLiveness, _ := prober.GetProbeTimeout(); hasRegionLiveness {
 		if regionliveness.IsQueryTimeoutErr(err) {
 			// Probe and mark the region potentially.
 			probeErr := prober.ProbeLiveness(ctx, region)
 			if probeErr != nil {
-				err = errors.WithSecondaryError(err, probeErr)
-				return false, err
+				return false, errors.WithSecondaryError(err, probeErr)
 			}
 			return false, errors.Wrapf(err, "count-lease timed out reading from a region")
-		} else if regionliveness.IsMissingRegionEnumErr(err) {
-			// Skip this region because we were unable to find region in
-			// type descriptor. Since the database regions are cached, they
-			// may be stale and have dropped regions.
-			log.Dev.Infof(ctx, "count-lease skipping region %s due to error: %v", region, err)
-			return true, nil
 		}
-		return false, err
 	}
 	return false, err
 }


### PR DESCRIPTION
Commit dc1501c850 re-gated all error handling in handleRegionLivenessErrors behind the sql.region_liveness.enabled cluster setting (disabled by default) to fix a nil pointer dereference in ProbeLiveness. This inadvertently caused IsMissingRegionEnumErr to never be checked, so regions with enum values in ADDING state (not yet public) would surface an error instead of being skipped.

Move the IsMissingRegionEnumErr check before the region liveness gate so it applies unconditionally. The ProbeLiveness call path remains gated.

Fixes: #165205
Release note: None