### PR TITLE
sql/inspect: fix TestRowCountCheck flake by adding short job intervals knob

### DIFF
--- a/pkg/sql/inspect/row_count_check_test.go
+++ b/pkg/sql/inspect/row_count_check_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -27,7 +28,11 @@ func TestRowCountCheck(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, db, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	s, db, kvDB := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+		},
+	})
 	defer s.Stopper().Stop(ctx)
 
 	codec := s.ApplicationLayer().Codec()


### PR DESCRIPTION
The test uses TriggerJob + AwaitCompletion which depends on the job adoption loop. Without short intervals, each of the 14 subtests can waste up to 30s waiting for adoption, causing binary timeout.

Fixes: #165114
Release note: None
Epic: None