### PR TITLE
build: remove stale references to pgcryptoccl

### DIFF
--- a/build/oss-fuzz/build.sh
+++ b/build/oss-fuzz/build.sh
@@ -38,9 +38,9 @@ compile_native_go_fuzzer ./pkg/util/span FuzzBtreeFrontier fuzzBtreeFrontier
 
 compile_native_go_fuzzer ./pkg/util/span FuzzLLRBFrontier fuzzLLRBFrontier
 
-compile_native_go_fuzzer ./pkg/ccl/pgcryptoccl/pgcryptocipherccl FuzzEncryptDecryptAES fuzzEncryptDecryptAES
+compile_native_go_fuzzer ./pkg/sql/pgcrypto/pgcryptocipher FuzzEncryptDecryptAES fuzzEncryptDecryptAES
 
-compile_native_go_fuzzer ./pkg/ccl/pgcryptoccl/pgcryptocipherccl FuzzNoPaddingEncryptDecryptAES fuzzNoPaddingEncryptDecryptAES
+compile_native_go_fuzzer ./pkg/sql/pgcrypto/pgcryptocipher FuzzNoPaddingEncryptDecryptAES fuzzNoPaddingEncryptDecryptAES
 
 compile_native_go_fuzzer ./pkg/storage FuzzEngineKeysInvariants fuzzEngineKeysInvariants
 


### PR DESCRIPTION
We missed these two references when moving pgcryptoccl into pkg/sql.

Epic: none
Release note: None