### PR TITLE
tabledesc: remove redundant TestRemoveDefaultExprFromComputedColumn

### DIFF
--- a/pkg/sql/catalog/tabledesc/structured_test.go
+++ b/pkg/sql/catalog/tabledesc/structured_test.go
@@ -952,25 +952,6 @@ func TestStrippedDanglingSelfBackReferences(t *testing.T) {
 	require.True(t, desc.GetPostDeserializationChanges().Contains(catalog.StrippedDanglingSelfBackReferences))
 }
 
-// TestRemoveDefaultExprFromComputedColumn tests that default expressions are
-// correctly removed from descriptors of computed columns as part of the
-// RunPostDeserializationChanges suite.
-func TestRemoveDefaultExprFromComputedColumn(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer srv.Stopper().Stop(context.Background())
-	tdb := sqlutils.MakeSQLRunner(sqlDB)
-
-	const expectedErrRE = `.*: computed column \"b\" cannot also have a DEFAULT or ON UPDATE expression`
-	// Create a table with a computed column.
-	tdb.Exec(t, `CREATE DATABASE t`)
-	tdb.Exec(t, `CREATE TABLE t.tbl (a INT PRIMARY KEY, b INT AS (1) STORED)`)
-	// Setting a default value on the computed column should fail.
-	tdb.ExpectErr(t, expectedErrRE, `ALTER TABLE t.tbl ALTER COLUMN b SET DEFAULT 2`)
-}
-
 func TestLogicalColumnID(t *testing.T) {
 	tests := []struct {
 		desc     descpb.TableDescriptor


### PR DESCRIPTION
This unit test spins up a full test server just to verify that `ALTER TABLE ... SET DEFAULT` is rejected on computed columns. Despite its comment claiming it tests RunPostDeserializationChanges, the test body does not exercise that code path at all.

The same scenario is already covered more thoroughly by logic tests in `pkg/sql/logictest/testdata/logic_test/computed`:
- Regression test for #72881 (line 1339): SET DEFAULT on computed column
- Regression test for #127522 (line 1388, `computed_column_with_default` subtest): covers SET DEFAULT, SET ON UPDATE, SET DEFAULT NULL, and DROP DEFAULT on computed columns

Remove the redundant unit test to fix.

Fixes: #164905
Epic: None
Release note: None