### PR TITLE
allocatorimpl: fix domain store list in bestStoreToMinimizeLoadDelta

### DIFF
--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator_scorer.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator_scorer.go
@@ -1529,7 +1529,11 @@ func bestStoreToMinimizeLoadDelta(
 	// load delta.
 	domain := append(candidates, existing)
 	storeDescs := make([]roachpb.StoreDescriptor, 0, len(domain))
-	for _, desc := range storeDescMap {
+	for _, store := range domain {
+		desc, ok := storeDescMap[store]
+		if !ok {
+			continue
+		}
 		storeDescs = append(storeDescs, *desc)
 	}
 	domainStoreList := storepool.MakeStoreList(storeDescs)

--- a/pkg/kv/kvserver/asim/tests/testdata/non_rand/mma/skewed_cpu_even_ranges_mma.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/non_rand/mma/skewed_cpu_even_ranges_mma.txt
@@ -45,19 +45,19 @@ setting split_queue_enabled=false
 eval duration=22m samples=1 seed=42 cfgs=(sma-count,mma-only,mma-count) metrics=(cpu,cpu_util,leases,replicas,write_bytes_per_second)
 ----
 sma-count:
-cpu#1: last:  [s1=563639640, s2=579095747, s3=561019502, s4=561591114, s5=560289458, s6=563986913, s7=561058911, s8=559174716, s9=561248205] (stddev=5708749.39, mean=563456022.89, sum=5071104206)
-cpu#1: thrash_pct: [s1=61%, s2=93%, s3=85%, s4=33%, s5=25%, s6=31%, s7=26%, s8=31%, s9=38%]  (sum=423%)
-cpu_util#1: last:  [s1=0.11, s2=0.12, s3=0.11, s4=0.11, s5=0.11, s6=0.11, s7=0.11, s8=0.11, s9=0.11] (stddev=0.00, mean=0.11, sum=1)
-cpu_util#1: thrash_pct: [s1=61%, s2=93%, s3=85%, s4=33%, s5=25%, s6=31%, s7=26%, s8=31%, s9=38%]  (sum=423%)
+cpu#1: last:  [s1=562004632, s2=565234905, s3=566360167, s4=560421623, s5=562801549, s6=557821651, s7=566721639, s8=558037579, s9=572463430] (stddev=4424421.63, mean=563540797.22, sum=5071867175)
+cpu#1: thrash_pct: [s1=31%, s2=93%, s3=126%, s4=54%, s5=34%, s6=30%, s7=74%, s8=32%, s9=69%]  (sum=543%)
+cpu_util#1: last:  [s1=0.11, s2=0.11, s3=0.11, s4=0.11, s5=0.11, s6=0.11, s7=0.11, s8=0.11, s9=0.11] (stddev=0.00, mean=0.11, sum=1)
+cpu_util#1: thrash_pct: [s1=31%, s2=93%, s3=126%, s4=54%, s5=34%, s6=30%, s7=74%, s8=32%, s9=69%]  (sum=543%)
 leases#1: first: [s1=36, s2=0, s3=0, s4=36, s5=0, s6=0, s7=36, s8=0, s9=0] (stddev=16.97, mean=12.00, sum=108)
-leases#1: last:  [s1=8, s2=12, s3=10, s4=17, s5=11, s6=15, s7=15, s8=12, s9=8] (stddev=2.98, mean=12.00, sum=108)
-leases#1: thrash_pct: [s1=90%, s2=91%, s3=78%, s4=64%, s5=44%, s6=33%, s7=40%, s8=38%, s9=66%]  (sum=544%)
+leases#1: last:  [s1=13, s2=11, s3=12, s4=15, s5=8, s6=11, s7=14, s8=13, s9=11] (stddev=1.94, mean=12.00, sum=108)
+leases#1: thrash_pct: [s1=83%, s2=73%, s3=148%, s4=88%, s5=66%, s6=56%, s7=152%, s8=38%, s9=79%]  (sum=783%)
 replicas#1: first: [s1=36, s2=36, s3=36, s4=36, s5=36, s6=36, s7=36, s8=36, s9=36] (stddev=0.00, mean=36.00, sum=324)
-replicas#1: last:  [s1=36, s2=38, s3=34, s4=36, s5=34, s6=36, s7=36, s8=38, s9=36] (stddev=1.33, mean=36.00, sum=324)
-replicas#1: thrash_pct: [s1=814%, s2=660%, s3=474%, s4=343%, s5=288%, s6=271%, s7=229%, s8=146%, s9=486%]  (sum=3711%)
-write_bytes_per_second#1: last:  [s1=5732, s2=6066, s3=5520, s4=6053, s5=5656, s6=5984, s7=6012, s8=6348, s9=5994] (stddev=236.75, mean=5929.44, sum=53365)
-write_bytes_per_second#1: thrash_pct: [s1=1071%, s2=1051%, s3=901%, s4=774%, s5=695%, s6=717%, s7=684%, s8=692%, s9=916%]  (sum=7501%)
-hash: 9f6f3c953198a939
+replicas#1: last:  [s1=36, s2=36, s3=38, s4=37, s5=34, s6=36, s7=37, s8=36, s9=34] (stddev=1.25, mean=36.00, sum=324)
+replicas#1: thrash_pct: [s1=389%, s2=311%, s3=1147%, s4=412%, s5=347%, s6=200%, s7=1001%, s8=122%, s9=258%]  (sum=4187%)
+write_bytes_per_second#1: last:  [s1=6000, s2=5756, s3=6107, s4=6127, s5=5551, s6=5943, s7=6050, s8=6103, s9=5791] (stddev=186.31, mean=5936.44, sum=53428)
+write_bytes_per_second#1: thrash_pct: [s1=888%, s2=1064%, s3=1683%, s4=1037%, s5=920%, s6=789%, s7=1532%, s8=819%, s9=1041%]  (sum=9773%)
+hash: 493932fb4e8e9d4
 ==========================
 mma-only:
 cpu#1: last:  [s1=569562730, s2=572002191, s3=578085131, s4=557945087, s5=554889308, s6=555817692, s7=569231042, s8=555128356, s9=558243133] (stddev=8275220.45, mean=563433852.22, sum=5070904670)

--- a/pkg/kv/kvserver/asim/tests/testdata/non_rand/mma/skewed_cpu_skewed_write.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/non_rand/mma/skewed_cpu_skewed_write.txt
@@ -72,17 +72,17 @@ setting split_queue_enabled=false
 eval duration=25m samples=1 seed=42 cfgs=(sma-count,mma-only,mma-count) metrics=(cpu_util,write_bytes_per_second,replicas,leases)
 ----
 sma-count:
-cpu_util#1: last:  [s1=0.17, s2=0.17, s3=0.19, s4=0.17, s5=0.17, s6=0.14] (stddev=0.02, mean=0.17, sum=1)
-cpu_util#1: thrash_pct: [s1=317%, s2=139%, s3=420%, s4=230%, s5=181%, s6=204%]  (sum=1490%)
+cpu_util#1: last:  [s1=0.17, s2=0.17, s3=0.17, s4=0.17, s5=0.17, s6=0.17] (stddev=0.00, mean=0.17, sum=1)
+cpu_util#1: thrash_pct: [s1=184%, s2=118%, s3=267%, s4=242%, s5=83%, s6=89%]  (sum=983%)
 leases#1: first: [s1=136, s2=0, s3=0, s4=136, s5=0, s6=0] (stddev=64.11, mean=45.33, sum=272)
-leases#1: last:  [s1=42, s2=44, s3=41, s4=51, s5=48, s6=46] (stddev=3.45, mean=45.33, sum=272)
-leases#1: thrash_pct: [s1=86%, s2=49%, s3=103%, s4=68%, s5=46%, s6=49%]  (sum=401%)
+leases#1: last:  [s1=43, s2=42, s3=42, s4=51, s5=48, s6=46] (stddev=3.35, mean=45.33, sum=272)
+leases#1: thrash_pct: [s1=42%, s2=29%, s3=61%, s4=68%, s5=20%, s6=23%]  (sum=242%)
 replicas#1: first: [s1=136, s2=136, s3=136, s4=136, s5=136, s6=136] (stddev=0.00, mean=136.00, sum=816)
-replicas#1: last:  [s1=135, s2=129, s3=135, s4=138, s5=139, s6=140] (stddev=3.65, mean=136.00, sum=816)
-replicas#1: thrash_pct: [s1=0%, s2=245%, s3=13%, s4=115%, s5=103%, s6=66%]  (sum=543%)
-write_bytes_per_second#1: last:  [s1=0, s2=2772297, s3=0, s4=18336933, s5=20000880, s6=18892529] (stddev=9136363.37, mean=10000439.83, sum=60002639)
-write_bytes_per_second#1: thrash_pct: [s1=0%, s2=2%, s3=0%, s4=89%, s5=100%, s6=101%]  (sum=292%)
-hash: bbe8bd0a4c78e7a1
+replicas#1: last:  [s1=134, s2=132, s3=131, s4=140, s5=140, s6=139] (stddev=3.79, mean=136.00, sum=816)
+replicas#1: thrash_pct: [s1=0%, s2=73%, s3=64%, s4=73%, s5=43%, s6=52%]  (sum=306%)
+write_bytes_per_second#1: last:  [s1=0, s2=0, s3=1107261, s4=18891348, s5=18891855, s6=19445232] (stddev=9362627.10, mean=9722616.00, sum=58335696)
+write_bytes_per_second#1: thrash_pct: [s1=0%, s2=0%, s3=13%, s4=95%, s5=94%, s6=100%]  (sum=302%)
+hash: b675d1f910d5192
 ==========================
 mma-only:
 cpu_util#1: last:  [s1=0.17, s2=0.17, s3=0.17, s4=0.17, s5=0.17, s6=0.17] (stddev=0.00, mean=0.17, sum=1)

--- a/pkg/kv/kvserver/asim/tests/testdata/non_rand/sma/gateway_overload.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/non_rand/sma/gateway_overload.txt
@@ -41,25 +41,25 @@ asserting: |leases(t)/mean_{T}(leases) - 1| ≤ 0.15 ∀ t∈T and each store (T
 eval duration=10m samples=1 seed=42 cfgs=(sma-count,mma-count) metrics=(cpu,cpu_util,leases,lease_moves,replica_moves)
 ----
 sma-count:
-cpu#1: last:  [s1=1031735064, s2=528633298, s3=778685297, s4=778189140, s5=2025375171, s6=0, s7=0, s8=0] (stddev=647320358.34, mean=642827246.25, sum=5142617970)
-cpu#1: thrash_pct: [s1=362%, s2=312%, s3=403%, s4=489%, s5=258%, s6=0%, s7=0%, s8=1%]  (sum=1826%)
-cpu_util#1: last:  [s1=0.13, s2=0.07, s3=0.10, s4=0.10, s5=0.25, s6=0.00, s7=0.00, s8=0.00] (stddev=0.08, mean=0.08, sum=1)
-cpu_util#1: thrash_pct: [s1=362%, s2=312%, s3=403%, s4=489%, s5=258%, s6=0%, s7=0%, s8=1%]  (sum=1826%)
-lease_moves#1: last:  [s1=10, s2=6, s3=13, s4=13, s5=5, s6=0, s7=0, s8=0] (stddev=5.28, mean=5.88, sum=47)
+cpu#1: last:  [s1=1021125911, s2=1032023266, s3=1276387237, s4=1037438154, s5=779305821, s6=0, s7=0, s8=0] (stddev=513566546.59, mean=643285048.62, sum=5146280389)
+cpu#1: thrash_pct: [s1=471%, s2=362%, s3=319%, s4=434%, s5=339%, s6=0%, s7=0%, s8=1%]  (sum=1926%)
+cpu_util#1: last:  [s1=0.13, s2=0.13, s3=0.16, s4=0.13, s5=0.10, s6=0.00, s7=0.00, s8=0.00] (stddev=0.06, mean=0.08, sum=1)
+cpu_util#1: thrash_pct: [s1=471%, s2=362%, s3=319%, s4=434%, s5=339%, s6=0%, s7=0%, s8=1%]  (sum=1926%)
+lease_moves#1: last:  [s1=15, s2=4, s3=4, s4=11, s5=8, s6=0, s7=0, s8=0] (stddev=5.26, mean=5.25, sum=42)
 lease_moves#1: thrash_pct: [s1=0%, s2=0%, s3=0%, s4=0%, s5=0%, s6=0%, s7=0%, s8=0%]  (sum=0%)
 leases#1: first: [s1=3, s2=2, s3=2, s4=3, s5=2, s6=2, s7=3, s8=4] (stddev=0.70, mean=2.62, sum=21)
-leases#1: last:  [s1=4, s2=2, s3=3, s4=3, s5=8, s6=0, s7=0, s8=1] (stddev=2.45, mean=2.62, sum=21)
-leases#1: thrash_pct: [s1=302%, s2=260%, s3=322%, s4=460%, s5=210%, s6=0%, s7=0%, s8=0%]  (sum=1554%)
-replica_moves#1: last:  [s1=14, s2=13, s3=13, s4=22, s5=14, s6=2, s7=3, s8=5] (stddev=6.40, mean=10.75, sum=86)
+leases#1: last:  [s1=4, s2=4, s3=5, s4=4, s5=3, s6=0, s7=0, s8=1] (stddev=1.87, mean=2.62, sum=21)
+leases#1: thrash_pct: [s1=442%, s2=304%, s3=225%, s4=342%, s5=262%, s6=0%, s7=0%, s8=0%]  (sum=1575%)
+replica_moves#1: last:  [s1=16, s2=17, s3=19, s4=21, s5=16, s6=2, s7=3, s8=5] (stddev=7.21, mean=12.38, sum=99)
 replica_moves#1: thrash_pct: [s1=0%, s2=0%, s3=0%, s4=0%, s5=0%, s6=0%, s7=0%, s8=0%]  (sum=0%)
-hash: 3b6ebc370a99142f
+hash: 63e91911e65572c3
 failed assertion sample 1
   steady state stat=leases threshold=(≤0.15) ticks=100
-	store=1 min/mean=0.23 max/mean=0.54
-	store=2 min/mean=0.11 max/mean=0.33
-	store=3 min/mean=0.08 max/mean=0.84
-	store=4 min/mean=0.05 max/mean=0.59
-	store=5 min/mean=0.87 max/mean=0.08
+	store=1 min/mean=0.29 max/mean=0.42
+	store=2 min/mean=0.22 max/mean=0.04
+	store=3 min/mean=0.38 max/mean=0.04
+	store=4 min/mean=0.25 max/mean=0.25
+	store=5 min/mean=0.04 max/mean=0.61
 ==========================
 mma-count:
 cpu#1: last:  [s1=1030717382, s2=1034178068, s3=1028156073, s4=1028552503, s5=1027707110, s6=0, s7=0, s8=0] (stddev=498583495.61, mean=643663892.00, sum=5149311136)


### PR DESCRIPTION
bestStoreToMinimizeLoadDelta` computes an overfull threshold based on
the mean load across a domain of stores (the candidate stores plus the
existing store). This threshold acts as a dampening gate: if the
existing store's load does not exceed the threshold, the transfer is
declined to prevent unnecessary churn.

The `storeDescMap` passed to this function contains descriptors for all
stores in the cluster, not just the stores in the domain. The code that
constructs `domainStoreList` iterated over `storeDescMap` rather than
over the domain slice, causing the mean load — and thus the overfull
threshold — to be computed over the wrong set of stores. In clusters
with many lightly loaded stores, this pulls the mean down and weakens
the overfull gate.

Note that the practical impact is limited. The bug only affects the
overfull gate — target selection (`getCandidateWithMinLoad`), the
`deltaNotSignificant` check, and the delta-reduction check all operate
on the correct domain. For the bug to cause an unwanted transfer, the
imbalance between domain stores would need to exceed
`MinCPUDifferenceForTransfers` (100ms) to pass the `deltaNotSignificant`
check, and at that point the transfer is arguably reasonable since it
moves load from the hotter store to the colder one within the domain.

This change fixes the iteration to walk the domain slice and look up
each store in the map, so that `domainStoreList` reflects only the
stores that participate in the rebalancing decision.

Epic: none 
Release note: none 