### PR TITLE
sql/sqlstats: add canary stats tracking to statement statistics

### DIFF
--- a/pkg/sql/appstatspb/app_stats.go
+++ b/pkg/sql/appstatspb/app_stats.go
@@ -202,6 +202,7 @@ func (s *StatementStatistics) Add(other *StatementStatistics) {
 	s.Indexes = util.CombineUnique(s.Indexes, other.Indexes)
 	s.ExecStats.Add(other.ExecStats)
 	s.LatencyInfo.MergeMaxMin(other.LatencyInfo)
+	s.CanaryStatsInfo.Add(other.CanaryStatsInfo)
 
 	if s.SensitiveInfo.MostRecentPlanTimestamp.Before(other.SensitiveInfo.MostRecentPlanTimestamp) {
 		s.SensitiveInfo = other.SensitiveInfo
@@ -294,4 +295,14 @@ func (s *LatencyInfo) MergeMaxMin(other LatencyInfo) {
 	if other.Max > s.Max {
 		s.Max = other.Max
 	}
+}
+
+// Add combines other into this CanaryStatsInfo
+func (c *CanaryStatsInfo) Add(other CanaryStatsInfo) {
+	currentCount := c.Count
+	c.Count += other.Count
+	c.PlanLat.Add(other.PlanLat, currentCount, other.Count)
+	c.ParseLat.Add(other.ParseLat, currentCount, other.Count)
+	c.RunLat.Add(other.RunLat, currentCount, other.Count)
+	c.ServiceLat.Add(other.ServiceLat, currentCount, other.Count)
 }

--- a/pkg/sql/appstatspb/app_stats.proto
+++ b/pkg/sql/appstatspb/app_stats.proto
@@ -147,6 +147,11 @@ message StatementStatistics {
   // (ex/ not replication related work).
   optional NumericStat kv_cpu_time_nanos = 38 [(gogoproto.nullable) = false, (gogoproto.customname) = "KVCPUTimeNanos"];
 
+  // canary_stats_info contains stats for statements executed with canary
+  // stats. Non-canary stats can be derived from the overall stats minus the
+  // canary stats.
+  optional CanaryStatsInfo canary_stats_info = 39 [(gogoproto.nullable) = false];
+
   // Note: be sure to update `sql/app_stats.go` when adding/removing fields here!
 
   reserved 13, 14, 17, 18, 19, 20;
@@ -200,6 +205,23 @@ message TransactionStatistics {
   optional NumericStat kv_cpu_time_nanos = 12 [(gogoproto.nullable) = false, (gogoproto.customname) = "KVCPUTimeNanos"];
 }
 
+// CanaryStatsInfo contains the subset of statistics that are used to differentiate
+// between statements executed with and without canary stats.
+message CanaryStatsInfo {
+  optional int64 count = 1 [(gogoproto.nullable) = false];
+
+  // ParseLat is the time in seconds to transform the SQL string into an AST.
+  optional NumericStat parse_lat = 2 [(gogoproto.nullable) = false];
+
+  // PlanLat is the time spent in seconds to transform the AST into a logical query plan.
+  optional NumericStat plan_lat = 3 [(gogoproto.nullable) = false];
+
+  // RunLat is the time in seconds to run the query and fetch/compute the result rows.
+  optional NumericStat run_lat = 4 [(gogoproto.nullable) = false];
+
+  // ServiceLat is the time in seconds to service the query, from start of parse to end of execute.
+  optional NumericStat service_lat = 5 [(gogoproto.nullable) = false];
+}
 
 message SensitiveInfo {
   option (gogoproto.equal) = true;

--- a/pkg/sql/appstatspb/app_stats_test.go
+++ b/pkg/sql/appstatspb/app_stats_test.go
@@ -79,6 +79,49 @@ func TestAddNumericStats(t *testing.T) {
 	}
 }
 
+func TestAddCanaryStatsInfo(t *testing.T) {
+	numericStatA := NumericStat{Mean: 0.5, SquaredDiffs: 0.1}
+	numericStatB := NumericStat{Mean: 1.5, SquaredDiffs: 0.3}
+
+	a := CanaryStatsInfo{
+		Count:      3,
+		PlanLat:    numericStatA,
+		ParseLat:   numericStatA,
+		RunLat:     numericStatA,
+		ServiceLat: numericStatA,
+	}
+	b := CanaryStatsInfo{
+		Count:      2,
+		PlanLat:    numericStatB,
+		ParseLat:   numericStatB,
+		RunLat:     numericStatB,
+		ServiceLat: numericStatB,
+	}
+
+	expectedPlanLat := AddNumericStats(a.PlanLat, b.PlanLat, a.Count, b.Count)
+	expectedParseLat := AddNumericStats(a.ParseLat, b.ParseLat, a.Count, b.Count)
+	expectedRunLat := AddNumericStats(a.RunLat, b.RunLat, a.Count, b.Count)
+	expectedServiceLat := AddNumericStats(a.ServiceLat, b.ServiceLat, a.Count, b.Count)
+
+	a.Add(b)
+
+	require.Equal(t, int64(5), a.Count)
+	epsilon := 0.00000001
+	require.True(t, expectedPlanLat.AlmostEqual(a.PlanLat, epsilon),
+		"expected PlanLat %+v, but found %+v", expectedPlanLat, a.PlanLat)
+	require.True(t, expectedParseLat.AlmostEqual(a.ParseLat, epsilon),
+		"expected ParseLat %+v, but found %+v", expectedParseLat, a.ParseLat)
+	require.True(t, expectedRunLat.AlmostEqual(a.RunLat, epsilon),
+		"expected RunLat %+v, but found %+v", expectedRunLat, a.RunLat)
+	require.True(t, expectedServiceLat.AlmostEqual(a.ServiceLat, epsilon),
+		"expected ServiceLat %+v, but found %+v", expectedServiceLat, a.ServiceLat)
+
+	// Verify adding zero-count CanaryStatsInfo is a no-op on counts.
+	before := a
+	a.Add(CanaryStatsInfo{})
+	require.Equal(t, before.Count, a.Count)
+}
+
 func TestAddExecStats(t *testing.T) {
 	numericStatA := NumericStat{Mean: 354.123, SquaredDiffs: 34.34123}
 	numericStatB := NumericStat{Mean: 9.34354, SquaredDiffs: 75.321}

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -233,6 +233,10 @@ func (ex *connExecutor) recordStatementSummary(
 			b.AppliedStatementHints()
 		}
 
+		if ex.planner.EvalContext().UseCanaryStats {
+			b.UsedCanaryStats()
+		}
+
 		ex.statsCollector.RecordStatement(ctx, b.Build())
 	}
 

--- a/pkg/sql/routine.go
+++ b/pkg/sql/routine.go
@@ -386,6 +386,9 @@ func (g *routineGenerator) startInternal(ctx context.Context, txn *kv.Txn) (err 
 						log.Dev.Error(ctx, "No stats collector exists on the planner, cannot record statement stats")
 						return
 					}
+					if g.p.ExtendedEvalContext().UseCanaryStats {
+						statsBuilder.UsedCanaryStats()
+					}
 					stmtStats := statsBuilder.
 						SessionID(g.p.ExtendedEvalContext().SessionID).
 						QueryID(g.p.execCfg.GenerateID()).

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
@@ -112,7 +112,26 @@ func TestSQLStatsJsonEncoding(t *testing.T) {
            "max": {{.Float}}
          },
          "lastErrorCode": "{{.String}}",
-				 "sqlType": "{{.String}}" 
+				 "sqlType": "{{.String}}",
+         "canaryStatsInfo": {
+           "count": {{.Int64}},
+           "parseLat": {
+             "mean": {{.Float}},
+             "sqDiff": {{.Float}}
+           },
+           "planLat": {
+             "mean": {{.Float}},
+             "sqDiff": {{.Float}}
+           },
+           "runLat": {
+             "mean": {{.Float}},
+             "sqDiff": {{.Float}}
+           },
+           "svcLat": {
+             "mean": {{.Float}},
+             "sqDiff": {{.Float}}
+           }
+         }
        },
        "execution_statistics": {
          "cnt": {{.Int64}},

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
@@ -47,6 +47,7 @@ var (
 	_ jsonMarshaler = (*int64Array)(nil)
 	_ jsonMarshaler = (*int32Array)(nil)
 	_ jsonMarshaler = &latencyInfo{}
+	_ jsonMarshaler = &canaryStatsInfo{}
 )
 
 type txnStats appstatspb.TransactionStatistics
@@ -349,6 +350,7 @@ func (s *innerStmtStats) jsonFields() jsonFields {
 		{"genericCount", (*jsonInt)(&s.GenericCount)},
 		{"stmtHintsCount", (*jsonInt)(&s.StmtHintsCount)},
 		{"sqlType", (*jsonString)(&s.SQLType)},
+		{"canaryStatsInfo", (*canaryStatsInfo)(&s.CanaryStatsInfo)},
 	}
 }
 
@@ -444,6 +446,24 @@ func (l *latencyInfo) decodeJSON(js json.JSON) error {
 
 func (l *latencyInfo) encodeJSON() (json.JSON, error) {
 	return l.jsonFields().encodeJSON()
+}
+
+type canaryStatsInfo appstatspb.CanaryStatsInfo
+
+func (c *canaryStatsInfo) jsonFields() jsonFields {
+	return jsonFields{
+		{"count", (*jsonInt)(&c.Count)},
+		{"parseLat", (*numericStats)(&c.ParseLat)},
+		{"planLat", (*numericStats)(&c.PlanLat)},
+		{"runLat", (*numericStats)(&c.RunLat)},
+		{"svcLat", (*numericStats)(&c.ServiceLat)},
+	}
+}
+func (c *canaryStatsInfo) decodeJSON(js json.JSON) error {
+	return c.jsonFields().decodeJSON(js)
+}
+func (c *canaryStatsInfo) encodeJSON() (json.JSON, error) {
+	return c.jsonFields().encodeJSON()
 }
 
 type jsonFields []jsonField

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
@@ -119,6 +119,15 @@ func (s *Container) RecordStatement(ctx context.Context, value *sqlstats.Recorde
 	}
 	stats.mu.data.LatencyInfo.MergeMaxMin(latencyInfo)
 
+	if value.UsedCanaryStats {
+		canaryStats := &stats.mu.data.CanaryStatsInfo
+		canaryStats.Count++
+		canaryStats.ServiceLat.Record(canaryStats.Count, value.ServiceLatencySec)
+		canaryStats.ParseLat.Record(canaryStats.Count, value.ParseLatencySec)
+		canaryStats.RunLat.Record(canaryStats.Count, value.RunLatencySec)
+		canaryStats.PlanLat.Record(canaryStats.Count, value.PlanLatencySec)
+	}
+
 	// Note that some fields derived from tracing statements (such as
 	// BytesSentOverNetwork) are not updated here because they are collected
 	// on-demand.

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer_test.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer_test.go
@@ -287,6 +287,71 @@ func verifyTxnStatsReduced(
 	require.InEpsilon(t, float64(txnStats.KVCPUTimeNanos.Nanoseconds())/cnt, destTxnStats.mu.data.KVCPUTimeNanos.Mean, epsilon)
 }
 
+// TestRecordStatementCanaryStats verifies that canary stats are only recorded
+// into CanaryStatsInfo when UsedCanaryStats is true, and that non-canary
+// statements do not affect CanaryStatsInfo.
+func TestRecordStatementCanaryStats(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	settings := cluster.MakeTestingClusterSettings()
+
+	container := New(settings,
+		nil, /* uniqueServerCount */
+		testMonitor(ctx, "test-mon", settings),
+		"test-app",
+		nil,
+	)
+
+	// Record a non-canary statement — should not affect CanaryStatsInfo.
+	require.NoError(t, container.RecordStatement(ctx, &sqlstats.RecordedStmtStats{
+		FingerprintID:     1,
+		Query:             "SELECT 1",
+		ServiceLatencySec: 0.1,
+		ParseLatencySec:   0.01,
+		PlanLatencySec:    0.02,
+		RunLatencySec:     0.03,
+		UsedCanaryStats:   false,
+	}))
+
+	// Record a canary statement with the same fingerprint.
+	require.NoError(t, container.RecordStatement(ctx, &sqlstats.RecordedStmtStats{
+		FingerprintID:     1,
+		Query:             "SELECT 1",
+		ServiceLatencySec: 0.5,
+		ParseLatencySec:   0.05,
+		PlanLatencySec:    0.06,
+		RunLatencySec:     0.07,
+		UsedCanaryStats:   true,
+	}))
+
+	// Record another non-canary statement.
+	require.NoError(t, container.RecordStatement(ctx, &sqlstats.RecordedStmtStats{
+		FingerprintID:     1,
+		Query:             "SELECT 1",
+		ServiceLatencySec: 0.2,
+		ParseLatencySec:   0.02,
+		PlanLatencySec:    0.03,
+		RunLatencySec:     0.04,
+		UsedCanaryStats:   false,
+	}))
+
+	stats := container.getStatsForStmtWithKey(stmtKey{fingerprintID: 1})
+	require.NotNil(t, stats)
+
+	// CanaryStatsInfo should only contain the single canary recording.
+	require.Equal(t, int64(1), stats.mu.data.CanaryStatsInfo.Count)
+	require.InEpsilon(t, 0.5, stats.mu.data.CanaryStatsInfo.ServiceLat.Mean, epsilon)
+	require.InEpsilon(t, 0.05, stats.mu.data.CanaryStatsInfo.ParseLat.Mean, epsilon)
+	require.InEpsilon(t, 0.06, stats.mu.data.CanaryStatsInfo.PlanLat.Mean, epsilon)
+	require.InEpsilon(t, 0.07, stats.mu.data.CanaryStatsInfo.RunLat.Mean, epsilon)
+
+	// The overall stats should reflect all 3 recordings (both canary and
+	// non-canary). Non-canary latencies can be derived from overall minus
+	// canary when needed.
+	require.Equal(t, int64(3), stats.mu.data.Count)
+}
+
 func testMonitor(
 	ctx context.Context, name redact.SafeString, settings *cluster.Settings,
 ) *mon.BytesMonitor {

--- a/pkg/sql/sqlstats/ssprovider.go
+++ b/pkg/sql/sqlstats/ssprovider.go
@@ -101,6 +101,7 @@ type RecordedStmtStats struct {
 	Indexes                  []string
 	QueryTags                []sqlcommenter.QueryTag
 	UnderOuterTxn            bool
+	UsedCanaryStats          bool
 }
 
 var recordedStmtStatsSize = int64(unsafe.Sizeof(RecordedStmtStats{}))
@@ -410,6 +411,14 @@ func (b *RecordedStatementStatsBuilder) AppliedStatementHints() *RecordedStateme
 		return b
 	}
 	b.stmtStats.AppliedStmtHints = true
+	return b
+}
+
+func (b *RecordedStatementStatsBuilder) UsedCanaryStats() *RecordedStatementStatsBuilder {
+	if b == nil {
+		return b
+	}
+	b.stmtStats.UsedCanaryStats = true
 	return b
 }
 

--- a/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.ts
@@ -14,6 +14,7 @@ export type StatementStatistics = cockroach.sql.IStatementStatistics;
 export type ExecStats = cockroach.sql.IExecStats;
 export type CollectedStatementStatistics =
   cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
+export type CanaryStatsInfo = cockroach.sql.ICanaryStatsInfo;
 
 export interface NumericStat {
   mean?: number;
@@ -162,6 +163,32 @@ export function addExecStats(a: ExecStats, b: ExecStats): ExecStats {
   };
 }
 
+export function addCanaryStatsInfo(
+  a: CanaryStatsInfo,
+  b: CanaryStatsInfo,
+): CanaryStatsInfo {
+  let countA = FixLong(a.count).toInt();
+  const countB = FixLong(b.count).toInt();
+  if (countA === 0 && countB === 0) {
+    // If both counts are zero, artificially set the one count to one to avoid
+    // division by zero when calculating the mean in addNumericStats.
+    countA = 1;
+  }
+
+  return {
+    count: a.count.add(b.count),
+    parse_lat: aggregateNumericStats(a.parse_lat, b.parse_lat, countA, countB),
+    plan_lat: aggregateNumericStats(a.plan_lat, b.plan_lat, countA, countB),
+    run_lat: aggregateNumericStats(a.run_lat, b.run_lat, countA, countB),
+    service_lat: aggregateNumericStats(
+      a.service_lat,
+      b.service_lat,
+      countA,
+      countB,
+    ),
+  };
+}
+
 export function addStatementStats(
   a: StatementStatistics,
   b: StatementStatistics,
@@ -270,6 +297,10 @@ export function addStatementStats(
     indexes: indexes,
     latency_info: aggregateLatencyInfo(a, b),
     last_error_code: "",
+    canary_stats_info: addCanaryStatsInfo(
+      a.canary_stats_info,
+      b.canary_stats_info,
+    ),
   };
 }
 


### PR DESCRIPTION
## Summary

- Add `CanaryStatsInfo` and `NonCanaryStatsInfo` fields to `StatementStatistics`
  to separately track latency metrics (parse, plan, run, service) for statements
  executed with vs without canary stats.
- Add protobuf message `CanaryStatsInfo` with count and latency `NumericStat` fields.
- Wire up `UsedCanaryStats` flag through `RecordedStmtStats` builder and recording
  path (`connExecutor`, `routineGenerator`, `ss_mem_writer`).
- Add JSON encoding/decoding support for the new fields.
- Add unit tests for `CanaryStatsInfo.Add()`, JSON round-trip, and mem writer bucketing.

Epic: none
Release note: None