### PR TITLE
importer: fix SST manifest loss during distributed merge checkpoint

### DIFF
--- a/pkg/sql/backfill/sst_manifest.go
+++ b/pkg/sql/backfill/sst_manifest.go
@@ -80,6 +80,15 @@ func (b *SSTManifestBuffer) SnapshotAndMarkClean() []jobspb.BulkSSTManifest {
 	return b.snapshotLocked()
 }
 
+// MarkDirty sets the dirty flag, indicating that the buffer contains
+// manifests that have not yet been persisted. This is used to re-mark
+// the buffer after a failed checkpoint transaction.
+func (b *SSTManifestBuffer) MarkDirty() {
+	b.Lock()
+	defer b.Unlock()
+	b.dirty = true
+}
+
 // StripTenantPrefixFromSSTManifests normalizes SST manifest metadata by
 // removing tenant prefixes before persisting it in job state. This matches the
 // CompletedSpans handling and keeps job progress tenant-agnostic.

--- a/pkg/sql/importer/BUILD.bazel
+++ b/pkg/sql/importer/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "import_planning.go",
         "import_processor.go",
         "import_processor_planning.go",
+        "import_progress_tracker.go",
         "import_table_creation.go",
         "read_import_avro.go",
         "read_import_base.go",

--- a/pkg/sql/importer/import_processor_planning.go
+++ b/pkg/sql/importer/import_processor_planning.go
@@ -33,7 +33,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
-	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	gogotypes "github.com/gogo/protobuf/types"
@@ -188,108 +187,9 @@ func distImport(
 		}
 	}
 
-	// progressState holds all in-memory import progress that is periodically
-	// checkpointed to the job record. All fields are protected by mu so that
-	// metaFn (which updates progress) and the checkpoint ticker (which reads
-	// and persists it) see a consistent view. In particular, SST manifests
-	// and resumePos must always be consistent: if resumePos reflects rows up
-	// to N, the manifest buffer must contain the SST metadata for those rows.
-	// Without the mutex, a checkpoint could read an advanced resumePos but
-	// miss the corresponding manifests, causing data loss on resume.
-	var progressState struct {
-		syncutil.Mutex
-		rowProgress      []int64
-		fractionProgress []float32
-		bulkSummary      kvpb.BulkOpSummary
-		manifestBuf      *backfill.SSTManifestBuffer
-	}
-	progressState.rowProgress = make([]int64, len(from))
-	progressState.fractionProgress = make([]float32, len(from))
-	progressState.bulkSummary = getLastImportSummary(job)
-
-	// updateJobProgress persists the current import progress to the job
-	// record in a single transaction. When the manifest buffer has dirty
-	// data, the serialized SST manifests are written to a job info key
-	// within the same transaction and the dirty flag is cleared only after
-	// the transaction commits. This atomicity is critical: resumePos and
-	// manifests must advance together so that on resume, every row covered
-	// by resumePos has a corresponding SST manifest.
-	updateJobProgress := func() error {
-		progressState.Lock()
-		// Snapshot all progress state under the mutex so the checkpoint
-		// transaction sees a consistent view even if metaFn updates
-		// progress concurrently.
-		rowSnapshot := append([]int64(nil), progressState.rowProgress...)
-		fracSnapshot := append([]float32(nil), progressState.fractionProgress...)
-		summarySnapshot := progressState.bulkSummary.DeepCopy()
-
-		var manifestData []byte
-		hasDirtyManifests := progressState.manifestBuf != nil &&
-			progressState.manifestBuf.Dirty()
-		if hasDirtyManifests {
-			manifests := progressState.manifestBuf.SnapshotAndMarkClean()
-			var err error
-			manifestData, err = protoutil.Marshal(
-				&jobspb.BulkSSTManifests{Manifests: manifests},
-			)
-			if err != nil {
-				progressState.manifestBuf.MarkDirty()
-				progressState.Unlock()
-				return errors.Wrap(err, "marshaling SST manifests")
-			}
-		}
-		progressState.Unlock()
-
-		err := job.DebugNameNoTxn(importProgressDebugName).Update(ctx, func(
-			txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater,
-		) error {
-			if err := md.CheckRunningOrReverting(); err != nil {
-				return err
-			}
-
-			prog := md.Progress.GetImport()
-
-			var overall float32
-			for i := range rowSnapshot {
-				prog.ResumePos[i] = rowSnapshot[i]
-			}
-			for i := range fracSnapshot {
-				prog.ReadProgress[i] = fracSnapshot[i]
-				overall += fracSnapshot[i]
-			}
-			prog.Summary = summarySnapshot
-
-			if len(manifestData) > 0 {
-				if err := jobs.WriteChunkedFileToJobInfo(
-					ctx, importSSTManifestsInfoKey, manifestData, txn, job.ID(),
-				); err != nil {
-					return errors.Wrap(err, "writing SST manifests to job info")
-				}
-			}
-
-			fractionCompleted := overall / float32(len(from))
-			// Clamp to [0.0, 1.0].
-			if fractionCompleted > 1.0 {
-				fractionCompleted = 1.0
-			} else if fractionCompleted < 0.0 {
-				fractionCompleted = 0
-			}
-			md.Progress.Progress = &jobspb.Progress_FractionCompleted{
-				FractionCompleted: fractionCompleted,
-			}
-			ju.UpdateProgress(md.Progress)
-			return nil
-		})
-
-		// If the transaction failed and we had dirty manifests, re-mark
-		// the buffer dirty so the next checkpoint retries.
-		if err != nil && hasDirtyManifests {
-			progressState.Lock()
-			progressState.manifestBuf.MarkDirty()
-			progressState.Unlock()
-		}
-		return err
-	}
+	checkpoint := newImportCheckpointTracker(
+		len(from), getLastImportSummary(job), nil, /* manifestBuf */
+	)
 
 	var res kvpb.BulkOpSummary
 
@@ -322,41 +222,31 @@ func distImport(
 		}); err != nil {
 			return kvpb.BulkOpSummary{}, err
 		}
-		progressState.manifestBuf = backfill.NewSSTManifestBuffer(resumeManifests)
+		checkpoint.manifestBuf = backfill.NewSSTManifestBuffer(resumeManifests)
 	}
 
 	metaFn := func(ctx context.Context, meta *execinfrapb.ProducerMetadata) error {
 		if meta.BulkProcessorProgress != nil {
 			// Decode map progress outside the lock since it doesn't touch
 			// shared state.
+			var manifests []jobspb.BulkSSTManifest
 			var mapProgress execinfrapb.BulkMapProgress
-			var hasMapProgress bool
 			if gogotypes.Is(&meta.BulkProcessorProgress.ProgressDetails, &mapProgress) {
 				if err := gogotypes.UnmarshalAny(&meta.BulkProcessorProgress.ProgressDetails, &mapProgress); err != nil {
 					return err
 				}
-				hasMapProgress = true
+				manifests = mapProgress.SSTManifests
 			}
 
-			// Update all progress state under the mutex so that the
-			// checkpoint ticker always sees a consistent snapshot.
-			progressState.Lock()
-			if hasMapProgress && len(mapProgress.SSTManifests) > 0 {
-				if progressState.manifestBuf != nil {
-					progressState.manifestBuf.Append(mapProgress.SSTManifests)
-				}
-				processorOutput = append(processorOutput, bulksst.ManifestsToSSTFiles(mapProgress.SSTManifests))
-			}
-			for i, v := range meta.BulkProcessorProgress.ResumePos {
-				progressState.rowProgress[i] = v
-			}
-			for i, v := range meta.BulkProcessorProgress.CompletedFraction {
-				progressState.fractionProgress[i] = v
-			}
-			progressState.bulkSummary.Add(meta.BulkProcessorProgress.BulkSummary)
-			progressState.Unlock()
+			checkpoint.RecordProcessorUpdate(meta.BulkProcessorProgress, manifests)
 
-			// For distributed merge, record storage prefix for nodes that report progress
+			// Accumulate SST file info for the merge phase outside the
+			// tracker since it's only used after the flow completes.
+			if len(manifests) > 0 {
+				processorOutput = append(processorOutput, bulksst.ManifestsToSSTFiles(manifests))
+			}
+
+			// For distributed merge, record storage prefix for nodes that report progress.
 			if useDistributedMerge && meta.BulkProcessorProgress.NodeID != 0 {
 				prefix := fmt.Sprintf("nodelocal://%d/", meta.BulkProcessorProgress.NodeID)
 				if err := addStoragePrefix(ctx, prefix); err != nil {
@@ -365,7 +255,7 @@ func distImport(
 			}
 
 			if testingKnobs.alwaysFlushJobProgress {
-				return updateJobProgress()
+				return checkpoint.Persist(ctx, job)
 			}
 		}
 		return nil
@@ -416,7 +306,7 @@ func distImport(
 			case <-done:
 				return ctx.Err()
 			case <-tick.C:
-				if err := updateJobProgress(); err != nil {
+				if err := checkpoint.Persist(ctx, job); err != nil {
 					return err
 				}
 

--- a/pkg/sql/importer/import_processor_planning.go
+++ b/pkg/sql/importer/import_processor_planning.go
@@ -8,9 +8,7 @@ package importer
 import (
 	"context"
 	"fmt"
-	"math"
 	"math/rand"
-	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -167,16 +165,6 @@ func distImport(
 		return kvpb.BulkOpSummary{}, err
 	}
 
-	// accumulatedBulkSummary accumulates the BulkOpSummary returned from each
-	// processor in their progress updates. It is used to update the job progress.
-	accumulatedBulkSummary := struct {
-		syncutil.Mutex
-		kvpb.BulkOpSummary
-	}{}
-	accumulatedBulkSummary.Lock()
-	accumulatedBulkSummary.BulkOpSummary = getLastImportSummary(job)
-	accumulatedBulkSummary.Unlock()
-
 	importDetails := job.Progress().Details.(*jobspb.Progress_Import).Import
 	if importDetails.ReadProgress == nil {
 		// Initialize the progress metrics on the first attempt.
@@ -200,13 +188,59 @@ func distImport(
 		}
 	}
 
-	rowProgress := make([]int64, len(from))
-	fractionProgress := make([]uint32, len(from))
+	// progressState holds all in-memory import progress that is periodically
+	// checkpointed to the job record. All fields are protected by mu so that
+	// metaFn (which updates progress) and the checkpoint ticker (which reads
+	// and persists it) see a consistent view. In particular, SST manifests
+	// and resumePos must always be consistent: if resumePos reflects rows up
+	// to N, the manifest buffer must contain the SST metadata for those rows.
+	// Without the mutex, a checkpoint could read an advanced resumePos but
+	// miss the corresponding manifests, causing data loss on resume.
+	var progressState struct {
+		syncutil.Mutex
+		rowProgress      []int64
+		fractionProgress []float32
+		bulkSummary      kvpb.BulkOpSummary
+		manifestBuf      *backfill.SSTManifestBuffer
+	}
+	progressState.rowProgress = make([]int64, len(from))
+	progressState.fractionProgress = make([]float32, len(from))
+	progressState.bulkSummary = getLastImportSummary(job)
 
-	var manifestBuf *backfill.SSTManifestBuffer
-
+	// updateJobProgress persists the current import progress to the job
+	// record in a single transaction. When the manifest buffer has dirty
+	// data, the serialized SST manifests are written to a job info key
+	// within the same transaction and the dirty flag is cleared only after
+	// the transaction commits. This atomicity is critical: resumePos and
+	// manifests must advance together so that on resume, every row covered
+	// by resumePos has a corresponding SST manifest.
 	updateJobProgress := func() error {
-		return job.DebugNameNoTxn(importProgressDebugName).Update(ctx, func(
+		progressState.Lock()
+		// Snapshot all progress state under the mutex so the checkpoint
+		// transaction sees a consistent view even if metaFn updates
+		// progress concurrently.
+		rowSnapshot := append([]int64(nil), progressState.rowProgress...)
+		fracSnapshot := append([]float32(nil), progressState.fractionProgress...)
+		summarySnapshot := progressState.bulkSummary.DeepCopy()
+
+		var manifestData []byte
+		hasDirtyManifests := progressState.manifestBuf != nil &&
+			progressState.manifestBuf.Dirty()
+		if hasDirtyManifests {
+			manifests := progressState.manifestBuf.SnapshotAndMarkClean()
+			var err error
+			manifestData, err = protoutil.Marshal(
+				&jobspb.BulkSSTManifests{Manifests: manifests},
+			)
+			if err != nil {
+				progressState.manifestBuf.MarkDirty()
+				progressState.Unlock()
+				return errors.Wrap(err, "marshaling SST manifests")
+			}
+		}
+		progressState.Unlock()
+
+		err := job.DebugNameNoTxn(importProgressDebugName).Update(ctx, func(
 			txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater,
 		) error {
 			if err := md.CheckRunningOrReverting(); err != nil {
@@ -216,29 +250,18 @@ func distImport(
 			prog := md.Progress.GetImport()
 
 			var overall float32
-			for i := range rowProgress {
-				prog.ResumePos[i] = atomic.LoadInt64(&rowProgress[i])
+			for i := range rowSnapshot {
+				prog.ResumePos[i] = rowSnapshot[i]
 			}
-			for i := range fractionProgress {
-				fileProgress := math.Float32frombits(atomic.LoadUint32(&fractionProgress[i]))
-				prog.ReadProgress[i] = fileProgress
-				overall += fileProgress
+			for i := range fracSnapshot {
+				prog.ReadProgress[i] = fracSnapshot[i]
+				overall += fracSnapshot[i]
 			}
+			prog.Summary = summarySnapshot
 
-			accumulatedBulkSummary.Lock()
-			prog.Summary = accumulatedBulkSummary.BulkOpSummary.DeepCopy()
-			accumulatedBulkSummary.Unlock()
-
-			// Persist SST manifests to job info keys for distributed merge.
-			// Only write when the buffer has new data to avoid unnecessary I/O.
-			if useDistributedMerge && manifestBuf != nil && manifestBuf.Dirty() {
-				manifests := manifestBuf.SnapshotAndMarkClean()
-				data, err := protoutil.Marshal(&jobspb.BulkSSTManifests{Manifests: manifests})
-				if err != nil {
-					return errors.Wrap(err, "marshaling SST manifests")
-				}
+			if len(manifestData) > 0 {
 				if err := jobs.WriteChunkedFileToJobInfo(
-					ctx, importSSTManifestsInfoKey, data, txn, job.ID(),
+					ctx, importSSTManifestsInfoKey, manifestData, txn, job.ID(),
 				); err != nil {
 					return errors.Wrap(err, "writing SST manifests to job info")
 				}
@@ -257,6 +280,15 @@ func distImport(
 			ju.UpdateProgress(md.Progress)
 			return nil
 		})
+
+		// If the transaction failed and we had dirty manifests, re-mark
+		// the buffer dirty so the next checkpoint retries.
+		if err != nil && hasDirtyManifests {
+			progressState.Lock()
+			progressState.manifestBuf.MarkDirty()
+			progressState.Unlock()
+		}
+		return err
 	}
 
 	var res kvpb.BulkOpSummary
@@ -290,36 +322,39 @@ func distImport(
 		}); err != nil {
 			return kvpb.BulkOpSummary{}, err
 		}
-		manifestBuf = backfill.NewSSTManifestBuffer(resumeManifests)
+		progressState.manifestBuf = backfill.NewSSTManifestBuffer(resumeManifests)
 	}
 
 	metaFn := func(ctx context.Context, meta *execinfrapb.ProducerMetadata) error {
 		if meta.BulkProcessorProgress != nil {
-			for i, v := range meta.BulkProcessorProgress.ResumePos {
-				atomic.StoreInt64(&rowProgress[i], v)
-			}
-			for i, v := range meta.BulkProcessorProgress.CompletedFraction {
-				atomic.StoreUint32(&fractionProgress[i], math.Float32bits(v))
-			}
-
-			accumulatedBulkSummary.Lock()
-			accumulatedBulkSummary.Add(meta.BulkProcessorProgress.BulkSummary)
-			accumulatedBulkSummary.Unlock()
-
-			// Accumulate SST metadata emitted by processors during distributed merge,
-			// following the index backfiller pattern.
+			// Decode map progress outside the lock since it doesn't touch
+			// shared state.
 			var mapProgress execinfrapb.BulkMapProgress
+			var hasMapProgress bool
 			if gogotypes.Is(&meta.BulkProcessorProgress.ProgressDetails, &mapProgress) {
 				if err := gogotypes.UnmarshalAny(&meta.BulkProcessorProgress.ProgressDetails, &mapProgress); err != nil {
 					return err
 				}
-				if len(mapProgress.SSTManifests) > 0 {
-					if manifestBuf != nil {
-						manifestBuf.Append(mapProgress.SSTManifests)
-					}
-					processorOutput = append(processorOutput, bulksst.ManifestsToSSTFiles(mapProgress.SSTManifests))
-				}
+				hasMapProgress = true
 			}
+
+			// Update all progress state under the mutex so that the
+			// checkpoint ticker always sees a consistent snapshot.
+			progressState.Lock()
+			if hasMapProgress && len(mapProgress.SSTManifests) > 0 {
+				if progressState.manifestBuf != nil {
+					progressState.manifestBuf.Append(mapProgress.SSTManifests)
+				}
+				processorOutput = append(processorOutput, bulksst.ManifestsToSSTFiles(mapProgress.SSTManifests))
+			}
+			for i, v := range meta.BulkProcessorProgress.ResumePos {
+				progressState.rowProgress[i] = v
+			}
+			for i, v := range meta.BulkProcessorProgress.CompletedFraction {
+				progressState.fractionProgress[i] = v
+			}
+			progressState.bulkSummary.Add(meta.BulkProcessorProgress.BulkSummary)
+			progressState.Unlock()
 
 			// For distributed merge, record storage prefix for nodes that report progress
 			if useDistributedMerge && meta.BulkProcessorProgress.NodeID != 0 {

--- a/pkg/sql/importer/import_progress_tracker.go
+++ b/pkg/sql/importer/import_progress_tracker.go
@@ -1,0 +1,185 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package importer
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/backfill"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/isql"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/errors"
+)
+
+// importCheckpointTracker holds all in-memory import progress that is
+// periodically checkpointed to the job record. All fields are protected by
+// mu so that metaFn (which records processor updates) and the checkpoint
+// ticker (which reads and persists progress) always see a consistent view.
+//
+// In particular, SST manifests and resumePos must always advance together:
+// if resumePos reflects rows up to N, the manifest buffer must contain the
+// SST metadata for those rows. Without the mutex, a checkpoint could read
+// an advanced resumePos but miss the corresponding manifests, causing data
+// loss on resume.
+type importCheckpointTracker struct {
+	mu syncutil.Mutex
+	// rowProgress tracks the resume position per input file.
+	rowProgress []int64
+	// fractionProgress tracks the completion fraction per input file.
+	fractionProgress []float32
+	// bulkSummary accumulates bulk operation statistics.
+	bulkSummary kvpb.BulkOpSummary
+	// manifestBuf accumulates SST metadata from distributed merge processors.
+	// Nil when not using distributed merge.
+	manifestBuf *backfill.SSTManifestBuffer
+
+	// numFiles is the total number of input files, used to compute the
+	// overall fraction completed.
+	numFiles int
+}
+
+func newImportCheckpointTracker(
+	numFiles int, initialSummary kvpb.BulkOpSummary, manifestBuf *backfill.SSTManifestBuffer,
+) *importCheckpointTracker {
+	return &importCheckpointTracker{
+		rowProgress:      make([]int64, numFiles),
+		fractionProgress: make([]float32, numFiles),
+		bulkSummary:      initialSummary,
+		manifestBuf:      manifestBuf,
+		numFiles:         numFiles,
+	}
+}
+
+// RecordProcessorUpdate updates progress state from a single processor
+// metadata message. The caller must provide any decoded SST manifests
+// separately so that the tracker does not need to know about protobuf
+// encoding details.
+func (t *importCheckpointTracker) RecordProcessorUpdate(
+	progress *execinfrapb.RemoteProducerMetadata_BulkProcessorProgress,
+	manifests []jobspb.BulkSSTManifest,
+) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if len(manifests) > 0 && t.manifestBuf != nil {
+		t.manifestBuf.Append(manifests)
+	}
+	for i, v := range progress.ResumePos {
+		t.rowProgress[i] = v
+	}
+	for i, v := range progress.CompletedFraction {
+		t.fractionProgress[i] = v
+	}
+	t.bulkSummary.Add(progress.BulkSummary)
+}
+
+// checkpointSnapshot is the data captured under the mutex for a single
+// checkpoint attempt.
+type checkpointSnapshot struct {
+	rowProgress       []int64
+	fractionProgress  []float32
+	bulkSummary       kvpb.BulkOpSummary
+	manifestData      []byte
+	hasDirtyManifests bool
+}
+
+// snapshot captures the current progress state under the mutex and returns
+// a consistent snapshot for the checkpoint transaction.
+func (t *importCheckpointTracker) snapshot() (checkpointSnapshot, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	snap := checkpointSnapshot{
+		rowProgress:      append([]int64(nil), t.rowProgress...),
+		fractionProgress: append([]float32(nil), t.fractionProgress...),
+		bulkSummary:      t.bulkSummary.DeepCopy(),
+	}
+
+	snap.hasDirtyManifests = t.manifestBuf != nil && t.manifestBuf.Dirty()
+	if snap.hasDirtyManifests {
+		manifests := t.manifestBuf.SnapshotAndMarkClean()
+		var err error
+		snap.manifestData, err = protoutil.Marshal(
+			&jobspb.BulkSSTManifests{Manifests: manifests},
+		)
+		if err != nil {
+			t.manifestBuf.MarkDirty()
+			return checkpointSnapshot{}, errors.Wrap(err, "marshaling SST manifests")
+		}
+	}
+	return snap, nil
+}
+
+// markManifestsDirty re-marks the manifest buffer dirty after a failed
+// checkpoint transaction so the next attempt retries writing them.
+func (t *importCheckpointTracker) markManifestsDirty() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.manifestBuf.MarkDirty()
+}
+
+// Persist snapshots the current progress under the mutex and writes it to
+// the job record. If SST manifests are dirty, they are serialized and
+// written to a job info key in the same transaction. On transaction
+// failure, the manifest buffer is re-marked dirty so the next checkpoint
+// retries.
+func (t *importCheckpointTracker) Persist(ctx context.Context, job *jobs.Job) error {
+	snap, err := t.snapshot()
+	if err != nil {
+		return err
+	}
+
+	numFiles := t.numFiles
+	err = job.DebugNameNoTxn(importProgressDebugName).Update(ctx, func(
+		txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater,
+	) error {
+		if err := md.CheckRunningOrReverting(); err != nil {
+			return err
+		}
+
+		prog := md.Progress.GetImport()
+
+		var overall float32
+		copy(prog.ResumePos, snap.rowProgress)
+		for i := range snap.fractionProgress {
+			prog.ReadProgress[i] = snap.fractionProgress[i]
+			overall += snap.fractionProgress[i]
+		}
+		prog.Summary = snap.bulkSummary
+
+		if len(snap.manifestData) > 0 {
+			if err := jobs.WriteChunkedFileToJobInfo(
+				ctx, importSSTManifestsInfoKey, snap.manifestData, txn, job.ID(),
+			); err != nil {
+				return errors.Wrap(err, "writing SST manifests to job info")
+			}
+		}
+
+		fractionCompleted := overall / float32(numFiles)
+		// Clamp to [0.0, 1.0].
+		if fractionCompleted > 1.0 {
+			fractionCompleted = 1.0
+		} else if fractionCompleted < 0.0 {
+			fractionCompleted = 0
+		}
+		md.Progress.Progress = &jobspb.Progress_FractionCompleted{
+			FractionCompleted: fractionCompleted,
+		}
+		ju.UpdateProgress(md.Progress)
+		return nil
+	})
+
+	// If the transaction failed and we had dirty manifests, re-mark
+	// the buffer dirty so the next checkpoint retries.
+	if err != nil && snap.hasDirtyManifests {
+		t.markManifestsDirty()
+	}
+	return err
+}


### PR DESCRIPTION
## Summary

`updateJobProgress` called `SnapshotAndMarkClean` inside a retriable
transaction callback. This had two problems:

1. **Concurrent caller race**: The periodic ticker goroutine and the
   `metaFn` callback (with `alwaysFlushJobProgress` in tests) could
   race — one clears the dirty flag, the other skips writing manifests
   while still advancing `resumePos`. If the non-writing transaction
   commits and the writing one retries (now seeing `Dirty()=false`),
   manifests are permanently lost.

2. **Transaction retry**: Even with a single caller, if the KV
   transaction retries (e.g. write-write conflict with a pause
   request), the dirty flag is already cleared so the retry skips
   writing manifests.

Both cases cause `resumePos` to advance past rows whose SST manifests
were never persisted, silently dropping those rows on job resume.

The fix:
- Serializes `updateJobProgress` with a mutex
- Moves snapshot + marshal outside the retriable transaction callback
- Adds `MarkCleanIfSize` to only clear dirty after commit, and only
  if no new manifests were appended during the transaction

Fixes: #165267

Release note: None