### PR TITLE
kvserver: use kvstorage.Batch in the raft application stack

### DIFF
--- a/pkg/kv/kvserver/kvstorage/BUILD.bazel
+++ b/pkg/kv/kvserver/kvstorage/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/keys",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver/kvserverpb",
+        "//pkg/kv/kvserver/kvstorage/wag",
         "//pkg/kv/kvserver/logstore",
         "//pkg/kv/kvserver/rditer",
         "//pkg/kv/kvserver/spanset",

--- a/pkg/kv/kvserver/kvstorage/storage.go
+++ b/pkg/kv/kvserver/kvstorage/storage.go
@@ -361,12 +361,14 @@ func (b *Batch[B]) Raft() RaftWO {
 	return b.raft
 }
 
-// CommitAndSync commits and syncs the batch to storage. When engines are
-// separated, only the LogEngine batch is synced, and the StateEngine part is
-// expected to be replayable from the LogEngine batch.
-func (b *Batch[B]) CommitAndSync() error {
+// Commit commits the batch to storage.
+//
+// The sync flag is one-way. If true, the sync is guaranteed. If false, syncing
+// might still happen, specifically when engines are separated and this is a
+// cross-engine write.
+func (b *Batch[B]) Commit(sync bool) error {
 	if !b.separated() {
-		return b.state.Commit(true /* sync */)
+		return b.state.Commit(sync)
 	}
 	if b.raft != nil {
 		if err := b.raft.Commit(true /* sync */); err != nil {

--- a/pkg/kv/kvserver/kvstorage/storage.go
+++ b/pkg/kv/kvserver/kvstorage/storage.go
@@ -276,15 +276,14 @@ func (e *Engines) Sync() error {
 	return storage.WriteSyncNoop(e.LogEngine())
 }
 
-// NewWriteBatch creates a new write batch to storage. If engines are separated,
-// it consists of two batches, one per engine.
-// TODO(sep-raft-log): generalize this so that the LogEngine batch is lazy.
+// NewWriteBatch creates a new write batch to storage. When engines are
+// separated, the raft engine batch is lazily initialized on first access via
+// Raft().
 func (e *Engines) NewWriteBatch() Batch[storage.WriteBatch] {
 	if e.Separated() {
 		return Batch[storage.WriteBatch]{
 			state:     e.StateEngine().NewWriteBatch(),
-			raft:      e.LogEngine().NewWriteBatch(),
-			separated: true,
+			logEngine: e.LogEngine(),
 		}
 	}
 	// With a single engine, create one batch, and reference it by both pointers.
@@ -307,8 +306,7 @@ func (e *Engines) NewBatch() Batch[storage.Batch] {
 	if e.Separated() {
 		return Batch[storage.Batch]{
 			state:     e.StateEngine().NewBatch(),
-			raft:      e.LogEngine().NewWriteBatch(),
-			separated: true,
+			logEngine: e.LogEngine(),
 		}
 	}
 	// With a single engine, create one batch, and reference it by both pointers.
@@ -328,10 +326,24 @@ func (e *Engines) NewBatch() Batch[storage.Batch] {
 // Batch is a write batch to storage which is aware whether the log and state
 // machine engines are separated. It supports any wrapper around
 // storage.WriteBatch, in particular a read-write storage.Batch.
+//
+// When engines are separated, the raft engine batch is lazily initialized on
+// the first call to Raft(). This avoids creating a raft batch for operations
+// that only touch the state engine.
 type Batch[B storage.WriteBatch] struct {
-	state     B
-	raft      storage.WriteBatch
-	separated bool
+	state B
+	// raft is the LogEngine batch. When engines are not separated, it points to
+	// the same underlying batch as state. When separated, it is lazily
+	// initialized on the first call to Raft().
+	raft storage.WriteBatch
+	// logEngine is a reference to the LogEngine, used for lazy raft batch
+	// creation. Only set when engines are separated.
+	logEngine storage.Engine
+}
+
+// separated returns true if the log and state machine engines are separated.
+func (b *Batch[B]) separated() bool {
+	return b.logEngine != nil
 }
 
 // State returns the StateEngine batch.
@@ -339,8 +351,13 @@ func (b *Batch[B]) State() B {
 	return b.state
 }
 
-// Raft returns the LogEngine writer.
+// Raft returns the LogEngine writer. When engines are separated, the raft
+// batch is lazily created on first access.
 func (b *Batch[B]) Raft() RaftWO {
+	if b.raft == nil {
+		assertTrue(b.separated(), "raft batch unexpectedly nil with non-separated engines")
+		b.raft = b.logEngine.NewWriteBatch()
+	}
 	return b.raft
 }
 
@@ -348,19 +365,21 @@ func (b *Batch[B]) Raft() RaftWO {
 // separated, only the LogEngine batch is synced, and the StateEngine part is
 // expected to be replayable from the LogEngine batch.
 func (b *Batch[B]) CommitAndSync() error {
-	if !b.separated {
+	if !b.separated() {
 		return b.state.Commit(true /* sync */)
 	}
-	if err := b.raft.Commit(true /* sync */); err != nil {
-		return err
+	if b.raft != nil {
+		if err := b.raft.Commit(true /* sync */); err != nil {
+			return err
+		}
 	}
-	return b.state.Commit(false /* false */)
+	return b.state.Commit(false /* sync */)
 }
 
 // Close closes the batch.
 func (b *Batch[B]) Close() {
 	b.state.Close()
-	if b.separated {
+	if b.separated() && b.raft != nil {
 		b.raft.Close()
 	}
 }
@@ -503,4 +522,10 @@ func disableAccessAssertions(eng storage.Engine) storage.Engine {
 		return eng
 	}
 	return eng.(interface{ UnderlyingEngine() storage.Engine }).UnderlyingEngine()
+}
+
+func assertTrue(cond bool, msg string) {
+	if buildutil.CrdbTestBuild && !cond {
+		panic(msg)
+	}
 }

--- a/pkg/kv/kvserver/kvstorage/storage.go
+++ b/pkg/kv/kvserver/kvstorage/storage.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -339,6 +340,9 @@ type Batch[B storage.WriteBatch] struct {
 	// logEngine is a reference to the LogEngine, used for lazy raft batch
 	// creation. Only set when engines are separated.
 	logEngine storage.Engine
+	// w is the WAG writer for staging lifecycle events. Initialized eagerly
+	// when engines are separated; zero-value (no-op) otherwise.
+	w wag.Writer
 }
 
 // separated returns true if the log and state machine engines are separated.
@@ -361,14 +365,30 @@ func (b *Batch[B]) Raft() RaftWO {
 	return b.raft
 }
 
+// WagWriter returns a pointer to the batch's WAG writer. When engines are
+// not separated, the writer is a zero-value no-op.
+func (b *Batch[B]) WagWriter() *wag.Writer {
+	return &b.w
+}
+
 // Commit commits the batch to storage.
 //
 // The sync flag is one-way. If true, the sync is guaranteed. If false, syncing
 // might still happen, specifically when engines are separated and this is a
 // cross-engine write.
+//
+// When engines are separated, any staged WAG events are flushed to the raft
+// batch before committing.
 func (b *Batch[B]) Commit(sync bool) error {
 	if !b.separated() {
 		return b.state.Commit(sync)
+	}
+	// Avoid eagerly creating a raft batch and computing Repr() when no WAG
+	// events were staged.
+	if !b.w.Empty() {
+		if err := b.w.Flush(b.Raft(), b.state.Repr()); err != nil {
+			return err
+		}
 	}
 	if b.raft != nil {
 		if err := b.raft.Commit(true /* sync */); err != nil {

--- a/pkg/kv/kvserver/kvstorage/storage.go
+++ b/pkg/kv/kvserver/kvstorage/storage.go
@@ -277,10 +277,10 @@ func (e *Engines) Sync() error {
 	return storage.WriteSyncNoop(e.LogEngine())
 }
 
-// NewWriteBatch creates a new write batch to storage. When engines are
+// newWriteBatch creates a new write batch to storage. When engines are
 // separated, the raft engine batch is lazily initialized on first access via
-// Raft().
-func (e *Engines) NewWriteBatch() Batch[storage.WriteBatch] {
+// Raft(). Callers outside this package should use BatchFactory.
+func (e *Engines) newWriteBatch() Batch[storage.WriteBatch] {
 	if e.Separated() {
 		return Batch[storage.WriteBatch]{
 			state:     e.StateEngine().NewWriteBatch(),
@@ -301,9 +301,10 @@ func (e *Engines) NewWriteBatch() Batch[storage.WriteBatch] {
 	}
 }
 
-// NewBatch is like NewWriteBatch, but the StateEngine batch is a read-write
-// storage.Batch rather than a write-only storage.WriteBatch.
-func (e *Engines) NewBatch() Batch[storage.Batch] {
+// newBatch is like newWriteBatch, but the StateEngine batch is a read-write
+// storage.Batch rather than a write-only storage.WriteBatch. Callers outside
+// this package should use BatchFactory.
+func (e *Engines) newBatch() Batch[storage.Batch] {
 	if e.Separated() {
 		return Batch[storage.Batch]{
 			state:     e.StateEngine().NewBatch(),
@@ -322,6 +323,38 @@ func (e *Engines) NewBatch() Batch[storage.Batch] {
 		state: e.StateEngine().(batchWrapper).WrapBatch(b),
 		raft:  e.LogEngine().(batchWrapper).WrapWriteBatch(b),
 	}
+}
+
+// BatchFactory is used to create engine separation aware and WAG aware batches.
+type BatchFactory struct {
+	eng *Engines
+	seq *wag.Seq
+}
+
+// MakeBatchFactory creates a BatchFactory for the given engines and WAG
+// sequencer.
+func MakeBatchFactory(eng *Engines, seq *wag.Seq) BatchFactory {
+	return BatchFactory{eng: eng, seq: seq}
+}
+
+// NewWriteBatch creates a new write-only batch. The batch is aware of engine
+// separation and handles WAG writing transparently.
+func (f *BatchFactory) NewWriteBatch() Batch[storage.WriteBatch] {
+	b := f.eng.newWriteBatch()
+	if b.separated() {
+		b.w = wag.MakeWriter(f.seq)
+	}
+	return b
+}
+
+// NewBatch creates a new read-write batch. The batch is aware of engine
+// separation and handles WAG writing transparently.
+func (f *BatchFactory) NewBatch() Batch[storage.Batch] {
+	b := f.eng.newBatch()
+	if b.separated() {
+		b.w = wag.MakeWriter(f.seq)
+	}
+	return b
 }
 
 // Batch is a write batch to storage which is aware whether the log and state

--- a/pkg/kv/kvserver/kvstorage/storage.go
+++ b/pkg/kv/kvserver/kvstorage/storage.go
@@ -378,12 +378,18 @@ func (b *Batch[B]) Commit(sync bool) error {
 	return b.state.Commit(false /* sync */)
 }
 
-// Close closes the batch.
+// Close closes the batch. It is idempotent, but the batch must not be used
+// after the first call to Close.
 func (b *Batch[B]) Close() {
+	if any(b.state) == nil {
+		return
+	}
 	b.state.Close()
 	if b.separated() && b.raft != nil {
 		b.raft.Close()
 	}
+	var zero B
+	b.state = zero
 }
 
 // validateIsStateEngineSpan asserts that the provided span only overlaps with

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -43,15 +42,9 @@ type replicaAppBatch struct {
 	r          *Replica
 	applyStats *applyCommittedEntriesStats
 
-	// batch accumulates writes implied by the raft entries in this batch. If
-	// engines are separated, only contains the StateEngine writes.
-	batch storage.Batch
-	// raftBatch accumulates writes to the raft log engine. It is lazily
-	// initialized when RaftBatch() is called.
-	//
-	// NB: This is currently only non-nil in tests, as that's the only scenario
-	// where we run with separated engines.
-	raftBatch storage.WriteBatch
+	// batch accumulates writes implied by the raft entries in this batch, across
+	// both the state and raft engines. It is engine separation aware.
+	batch kvstorage.Batch[storage.Batch]
 	// state is this batch's view of the replica's state. It is copied from
 	// under the Replica.mu when the batch is initialized and is updated in
 	// stageTrivialReplicatedEvalResult.
@@ -80,11 +73,6 @@ type replicaAppBatch struct {
 
 	start                   time.Time // time at NewBatch()
 	followerStoreWriteBytes kvadmission.FollowerStoreWriteBytes
-
-	// wagWriter stages WAG nodes for this batch. Lifecycle triggers (splits,
-	// merges, etc.) populate it during command processing, and it's flushed to
-	// the raft engine before the command is applied to the state machine.
-	wagWriter wag.Writer
 
 	// Reused by addAppliedStateToBatch to avoid heap allocations.
 	asAlloc kvserverpb.RangeAppliedState
@@ -155,7 +143,7 @@ func (b *replicaAppBatch) Stage(
 	}
 
 	// Stage the command's write batch in the application batch.
-	if err := b.ab.addWriteBatch(ctx, b.batch, cmd); err != nil {
+	if err := b.ab.addWriteBatch(ctx, b.batch.State(), cmd); err != nil {
 		return nil, err
 	}
 
@@ -197,7 +185,7 @@ func (b *replicaAppBatch) Stage(
 
 func (b *replicaAppBatch) ReadWriter() kvstorage.ReadWriter {
 	return kvstorage.ReadWriter{
-		State: kvstorage.WrapState(b.batch),
+		State: kvstorage.WrapState(b.batch.State()),
 		Raft:  b.RaftRW(),
 	}
 }
@@ -226,7 +214,7 @@ func (b *replicaAppBatch) runPreAddTriggersReplicaOnly(
 		// application there are no listening rangefeeds. So we do this only
 		// in Replica application.
 		if p, filter := b.r.getRangefeedProcessorAndFilter(); p != nil {
-			if err := populatePrevValsInLogicalOpLog(ctx, filter, ops, b.batch); err != nil {
+			if err := populatePrevValsInLogicalOpLog(ctx, filter, ops, b.batch.State()); err != nil {
 				b.r.disconnectRangefeedWithErr(p, kvpb.NewError(err))
 			}
 		}
@@ -351,7 +339,10 @@ func (b *replicaAppBatch) runPostAddTriggersReplicaOnly(
 			log.KvExec.Fatalf(ctx, "unable to validate split: %s", err)
 		}
 
-		splitPreApply(ctx, kvstorage.StateRW(b.batch), b.RaftRW(), &b.wagWriter, in)
+		// TODO(arul): consider passing in a kvstorage.Batch to splitPreApply
+		// instead. That way, we don't need to get the WagWriter out of the batch
+		// here, and can instead just have an AddEvent method on the type instead.
+		splitPreApply(ctx, kvstorage.StateRW(b.batch.State()), b.RaftRW(), b.batch.WagWriter(), in)
 
 		// The rangefeed processor will no longer be provided logical ops for
 		// its entire range, so it needs to be shut down and all registrations
@@ -495,7 +486,7 @@ func (b *replicaAppBatch) runPostAddTriggersReplicaOnly(
 	// shutdown of the rangefeed in that situation, so we don't pass anything to
 	// the rangefeed. If no rangefeed is running at all, this call will be a noop.
 	if ops := cmd.Cmd.LogicalOpLog; cmd.Cmd.WriteBatch != nil {
-		b.r.handleLogicalOpLogRaftMuLocked(ctx, ops, b.batch)
+		b.r.handleLogicalOpLogRaftMuLocked(ctx, ops, b.batch.State())
 	} else if ops != nil {
 		log.KvExec.Fatalf(ctx, "non-nil logical op log with nil write batch: %v", cmd.Cmd)
 	}
@@ -540,7 +531,7 @@ func (b *replicaAppBatch) stageTruncation(
 	// for now only to enable experimental testing.
 	if err := handleTruncatedStateBelowRaftPreApply(
 		ctx, b.truncState, *truncatedState,
-		b.r.raftMu.stateLoader.StateLoader, b.RaftBatch(),
+		b.r.raftMu.stateLoader.StateLoader, b.batch.Raft(),
 	); err != nil {
 		return errors.Wrap(err, "unable to handle truncated state")
 	}
@@ -633,31 +624,14 @@ func (b *replicaAppBatch) ApplyToStateMachine(ctx context.Context) error {
 		}
 	}
 
-	// Flush any staged WAG nodes to the raft batch. This must happen after the
-	// state batch is fully prepared (so Repr() captures everything) but before
-	// the raft batch is committed. The Empty() guard avoids eagerly creating a
-	// raft batch and computing Repr() when no WAG nodes were staged.
-	if !b.wagWriter.Empty() {
-		if err := b.wagWriter.Flush(b.RaftBatch(), b.batch.Repr()); err != nil {
-			return err
-		}
-	}
-
-	// Commit the Raft batch to Pebble, if it exists. Note that unlike batches
-	// to the State engine, we always sync writes to the Raft engine.
-	if b.raftBatch != nil {
-		if err := b.raftBatch.Commit(true /* sync */); err != nil {
-			return errors.Wrapf(err, "unable to commit Raft entry batch to raft engine")
-		}
-		b.raftBatch.Close()
-		b.raftBatch = nil
-	}
-
-	// Apply the write batch to Pebble. Entry application is done without syncing
-	// to disk. The atomicity guarantees of the batch, and the fact that the
-	// applied state is stored in this batch, ensure that if the batch ends up not
-	// being durably committed then the entries in this batch will be applied
-	// again upon startup. However, there are a couple of exceptions.
+	// Commit the batch to Pebble. When engines are separated, this also flushes
+	// any staged WAG nodes and commits the raft batch.
+	//
+	// Entry application is done without syncing the state engine to disk. The
+	// atomicity guarantees of the batch, and the fact that the applied state is
+	// stored in this batch, ensure that if the batch ends up not being durably
+	// committed then the entries in this batch will be applied again upon
+	// startup. However, there are a couple of exceptions.
 	//
 	// If we're removing the replica's data then we sync this batch as it is not
 	// safe to call postDestroyRaftMuLocked before ensuring that the replica's
@@ -684,7 +658,6 @@ func (b *replicaAppBatch) ApplyToStateMachine(ctx context.Context) error {
 		return errors.Wrapf(err, "unable to commit Raft entry batch")
 	}
 	b.batch.Close()
-	b.batch = nil
 
 	// Update the replica's applied indexes, mvcc stats and closed timestamp.
 	r := b.r
@@ -769,14 +742,14 @@ func (b *replicaAppBatch) addAppliedStateToBatch(ctx context.Context) error {
 	if b.state.ForceFlushIndex != b.r.shMu.state.ForceFlushIndex {
 		// NB: this branch goes first, so that MVCC stats are accurate below.
 		if err := b.r.raftMu.stateLoader.SetForceFlushIndex(
-			ctx, b.batch, b.state.Stats, &b.state.ForceFlushIndex); err != nil {
+			ctx, b.batch.State(), b.state.Stats, &b.state.ForceFlushIndex); err != nil {
 			return err
 		}
 	}
 	// Set the range applied state, which includes the last applied raft and lease
 	// index along with the MVCC stats, all in one key.
 	b.asAlloc = b.state.ToRangeAppliedState()
-	return b.r.raftMu.stateLoader.SetRangeAppliedState(ctx, b.batch, &b.asAlloc)
+	return b.r.raftMu.stateLoader.SetRangeAppliedState(ctx, b.batch.State(), &b.asAlloc)
 }
 
 func (b *replicaAppBatch) recordStatsOnCommit() {
@@ -863,34 +836,16 @@ func (b *replicaAppBatch) verifySysBytes(ctx context.Context) error {
 
 // Close implements the apply.Batch interface.
 func (b *replicaAppBatch) Close() {
-	if b.batch != nil {
-		b.batch.Close()
-	}
-	if b.raftBatch != nil {
-		b.raftBatch.Close()
-	}
+	b.batch.Close()
 	*b = replicaAppBatch{}
 }
 
-// RaftBatch returns a batch from the Raft engine.
-func (b *replicaAppBatch) RaftBatch() storage.WriteBatch {
-	if !b.r.store.internalEngines.Separated() {
-		// We're not running with separated engines; simply return the batch
-		// that was created for the one and only engine.
-		return b.batch
-	}
-	if b.raftBatch == nil {
-		b.raftBatch = b.r.store.LogEngine().NewWriteBatch()
-	}
-	return b.raftBatch
-}
-
 // RaftRW returns a read/write accessor to the LogEngine. Reads from the engine,
-// writes to the RaftBatch.
+// writes to the batch's raft writer.
 func (b *replicaAppBatch) RaftRW() kvstorage.Raft {
 	return kvstorage.Raft{
 		RO: b.r.LogEngine(),
-		WO: b.RaftBatch(),
+		WO: b.batch.Raft(),
 	}
 }
 

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvadmission"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag"
 	"github.com/cockroachdb/cockroach/pkg/raft"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
@@ -150,14 +149,7 @@ func (sm *replicaStateMachine) NewBatch() apply.Batch {
 	// TODO(#144627): most commands do not need to read. Use NewWriteBatch because
 	// it is more efficient. If there are exceptions, sparingly use NewReader or
 	// NewBatch (if it needs to read its own writes, which is unlikely).
-	//
-	// TODO(sep-raft-log): wrap this to something like kvstorage.Batch, with
-	// appropriate engine access assertions.
-	if s := r.store; s.internalEngines.Separated() {
-		b.batch = s.internalEngines.StateEngine().NewBatch()
-	} else {
-		b.batch = s.internalEngines.Engine().NewBatch()
-	}
+	b.batch = r.store.batchFactory.NewBatch()
 
 	r.mu.RLock()
 	b.state = r.shMu.state
@@ -166,9 +158,6 @@ func (sm *replicaStateMachine) NewBatch() apply.Batch {
 	*b.state.Stats = *r.shMu.state.Stats
 	b.closedTimestampSetter = r.mu.closedTimestampSetter
 	r.mu.RUnlock()
-	if r.store.EnginesSeparated() {
-		b.wagWriter = wag.MakeWriter(&r.store.wagSeq)
-	}
 	b.start = timeutil.Now()
 	return b
 }

--- a/pkg/kv/kvserver/replica_destroy.go
+++ b/pkg/kv/kvserver/replica_destroy.go
@@ -106,7 +106,7 @@ func (r *Replica) destroyRaftMuLocked(ctx context.Context, nextReplicaID roachpb
 	// a synchronous batch first and then delete the data alternatively, but
 	// then need to handle the case in which there is both the tombstone and
 	// leftover replica data.
-	if err := batch.CommitAndSync(); err != nil {
+	if err := batch.Commit(true /* sync */); err != nil {
 		return err
 	}
 	commitTime := timeutil.Now()

--- a/pkg/kv/kvserver/replica_destroy.go
+++ b/pkg/kv/kvserver/replica_destroy.go
@@ -86,7 +86,7 @@ func (r *Replica) destroyRaftMuLocked(ctx context.Context, nextReplicaID roachpb
 	startTime := timeutil.Now()
 
 	ms := r.GetMVCCStats()
-	batch := r.store.internalEngines.NewWriteBatch()
+	batch := r.store.batchFactory.NewWriteBatch()
 	defer batch.Close()
 
 	stateWO, raftWO := kvstorage.StateWO(batch.State()), batch.Raft()

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -881,6 +881,7 @@ type Store struct {
 	cfg                  StoreConfig
 	internalEngines      kvstorage.Engines
 	wagSeq               wag.Seq
+	batchFactory         kvstorage.BatchFactory
 	db                   *kv.DB
 	tsCache              tscache.Cache           // Most recent timestamps for keys / key ranges
 	allocator            allocatorimpl.Allocator // Makes allocation decisions
@@ -1497,6 +1498,7 @@ func NewStore(
 		ioThresholds:                      &iot,
 		rangeFeedSlowClosedTimestampNudge: singleflight.NewGroup("rangfeed-ct-nudge", "range"),
 	}
+	s.batchFactory = kvstorage.MakeBatchFactory(&s.internalEngines, &s.wagSeq)
 	s.ioThreshold.t = &admissionpb.IOThreshold{}
 	// Track the maxScore over the last 5 minutes, in one minute windows.
 	now := cfg.Clock.Now().GoTime()

--- a/pkg/kv/kvserver/store_init.go
+++ b/pkg/kv/kvserver/store_init.go
@@ -267,7 +267,7 @@ func WriteInitialClusterData(
 				return err
 			}
 
-			return batch.CommitAndSync()
+			return batch.Commit(true /* sync */)
 		}()
 		if err != nil {
 			return err

--- a/pkg/kv/kvserver/store_init.go
+++ b/pkg/kv/kvserver/store_init.go
@@ -156,8 +156,13 @@ func WriteInitialClusterData(
 		// TODO(#97616): the ranges are written one by one, so it is possible to end
 		// up with a partially initialized store if there is a crash in the middle.
 		// Write through a single batch, or find another way to make this atomic.
+
+		// TODO(sep-raft-log): this code path initializes replicas when bootstrapping
+		// the cluster and will need to write through WAG.
+		factory := kvstorage.MakeBatchFactory(&eng, nil /* seq */)
+
 		err := func() error {
-			batch := eng.NewBatch()
+			batch := factory.NewBatch()
 			defer batch.Close()
 
 			now := hlc.Timestamp{


### PR DESCRIPTION
The goal of this PR is to replace the three separate fields on
`replicaAppBatch` (`batch`, `raftBatch`, `wagWriter`) with a single
`kvstorage.Batch[storage.Batch]`. All engine separation awareness and
WAG writing now lives behind the `kvstorage.Batch` abstraction -- the
apply stack no longer needs to know about any of it.

The first few commits build up `kvstorage.Batch` with the capabilities
it needs (lazy raft batch init, flexible commit sync, idempotent close,
WAG writer embedding), then introduce a `BatchFactory` as the single
entry point for batch creation, and the final commit wires it all into
the raft application stack.

Individual commits:

1. **kvstorage: lazily initialize raft batch in Batch** — avoid eagerly creating a raft batch when only the state engine is touched.
2. **kvstorage: replace CommitAndSync with Commit on Batch** — give callers control over state engine sync behavior.
3. **kvstorage: make Batch.Close idempotent** — support the double-close pattern in `ApplyToStateMachine` + `replicaAppBatch.Close`.
4. **kvstorage: embed WAG writer in Batch** — stage lifecycle events and flush them in `Commit()`.
5. **kvstorage: introduce BatchFactory** — wraps `*Engines` and `*wag.Seq`; eagerly initializes the WAG writer when engines are separated.
6. **kvserver: use kvstorage.Batch in the raft application stack** — the payoff commit.

Epic: CRDB-49113
Release note: None