### PR TITLE
sql/schemachanger: clarify resolver's use of owner

### DIFF
--- a/pkg/sql/schemachanger/scbuild/builder_state.go
+++ b/pkg/sql/schemachanger/scbuild/builder_state.go
@@ -1190,6 +1190,7 @@ func (b *builderState) checkOwnershipOrPrivilegesOnSchemaDesc(
 }
 
 // ResolveUserDefinedTypeType implements the scbuildstmt.NameResolver interface.
+// The type must be owned to be resolved.
 func (b *builderState) ResolveUserDefinedTypeType(
 	name *tree.UnresolvedObjectName, p scbuildstmt.ResolveParams,
 ) scbuildstmt.ElementResultSet {
@@ -1214,10 +1215,8 @@ func (b *builderState) ResolveUserDefinedTypeType(
 			"try ALTER DATABASE %s DROP REGION %s", prefix.Database.GetName(), typ.GetName()))
 	case descpb.TypeDescriptor_ENUM:
 		b.ensureDescriptor(typ.GetID())
-		b.mustOwn(typ.GetID())
 	case descpb.TypeDescriptor_COMPOSITE:
 		b.ensureDescriptor(typ.GetID())
-		b.mustOwn(typ.GetID())
 	case descpb.TypeDescriptor_TABLE_IMPLICIT_RECORD_TYPE:
 		// Implicit record types are not directly modifiable.
 		panic(pgerror.Newf(pgcode.DependentObjectsStillExist,
@@ -1225,9 +1224,7 @@ func (b *builderState) ResolveUserDefinedTypeType(
 	default:
 		panic(errors.AssertionFailedf("unknown type kind %s", typ.GetKind()))
 	}
-	if p.RequireOwnership {
-		b.mustOwn(typ.GetID())
-	}
+	b.mustOwn(typ.GetID())
 	return b.QueryByID(typ.GetID())
 }
 

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_type.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_type.go
@@ -9,7 +9,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
-	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
@@ -27,7 +26,6 @@ func DropType(b BuildCtx, n *tree.DropType) {
 	for _, name := range n.Names {
 		elts := b.ResolveUserDefinedTypeType(name, ResolveParams{
 			IsExistenceOptional: n.IfExists,
-			RequiredPrivilege:   privilege.DROP,
 		})
 		var typ scpb.Element
 		var typeID, arrayTypeID catid.DescID


### PR DESCRIPTION
The `p.RequireOwnership` check isn't used by the
resolver because the ownership is already
enforced. This change clarifies that the resolver
has stricter requirements.

Epic: CRDB-31325
Part of: #164213

Release note: None
