### PR TITLE
roachtest: apply crdb_skip to psycopg test suite

### DIFF
--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -221,6 +221,7 @@ go_library(
         "ycsb.go",
     ],
     embedsrcs = [
+        "psycopg_crdb_skip.py",
         "ruby_pg_helpers.rb",
         "knexfile.js",
         "create-msk-topic/main.go.txt",

--- a/pkg/cmd/roachtest/tests/psycopg.go
+++ b/pkg/cmd/roachtest/tests/psycopg.go
@@ -7,6 +7,7 @@ package tests
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
 	"regexp"
 
@@ -20,6 +21,12 @@ import (
 
 var psycopgReleaseTagRegex = regexp.MustCompile(`^(?P<major>\d+)(?:\.(?P<minor>\d+)(?:\.(?P<point>\d+)(?:\.(?P<subpoint>\d+))?)?)?$`)
 var supportedPsycopgTag = "3.2.8"
+
+// psycopgCrdbSkipPlugin is a pytest plugin that skips tests marked with
+// @pytest.mark.crdb_skip("reason") when running the psycopg suite against CockroachDB.
+//
+//go:embed psycopg_crdb_skip.py
+var psycopgCrdbSkipPlugin string
 
 // This test runs psycopg full test suite against a single cockroach node.
 func registerPsycopg(r registry.Registry) {
@@ -149,13 +156,18 @@ func registerPsycopg(r registry.Registry) {
 
 		t.Status("running psycopg test suite")
 
+		if err := c.PutString(ctx, psycopgCrdbSkipPlugin, "/mnt/data1/psycopg/psycopg_crdb_skip.py", 0644, node); err != nil {
+			t.Fatal(err)
+		}
+
 		const testResultsXML = "/mnt/data1/psycopg/test_results.xml"
 		result, err := c.RunWithDetailsSingleNode(ctx, t.L(), option.WithNodes(node), fmt.Sprintf(
 			`source venv/bin/activate &&
 			cd /mnt/data1/psycopg/ &&
+			export PYTHONPATH=/mnt/data1/psycopg &&
 			export PSYCOPG_TEST_DSN="host=localhost port={pgport:1} user=%[1]s password=%[2]s dbname=defaultdb" &&
 			export PGPASSWORD=%[2]s
-			pytest -vv -m "not timing" --junit-xml=%[3]s`,
+			pytest -vv -m "not timing" -p psycopg_crdb_skip --junit-xml=%[3]s`,
 			install.DefaultUser, install.DefaultPassword, testResultsXML))
 
 		// Fatal for a roachprod or transient error. A roachprod error is when result.Err==nil.

--- a/pkg/cmd/roachtest/tests/psycopg_crdb_skip.py
+++ b/pkg/cmd/roachtest/tests/psycopg_crdb_skip.py
@@ -1,0 +1,17 @@
+# Pytest plugin used by CockroachDB's psycopg roachtest to skip tests marked
+# with @pytest.mark.crdb_skip("reason"). Load with: pytest -p psycopg_crdb_skip
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "crdb_skip(reason): mark test to skip when running against CockroachDB",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    import pytest
+    for item in items:
+        for mark in item.iter_markers("crdb_skip"):
+            reason = mark.args[0] if mark.args else "CockroachDB"
+            item.add_marker(pytest.mark.skip(reason=f"crdb_skip: {reason}"))
+            break


### PR DESCRIPTION
Previously, we would apply our own skip to the psycopg tests. We can instead automatically skip tests that are marked as unsupported in their repository, which reduce overhead of maintaining this test. If in the future some functionality is supported, we can white list it to test by modifying: psycopg_crdb_skip.py.

Fixes: #164635

Release note: None