### PR TITLE
jobs: add DeleteChunkedFile, WriteChunkedProto, and ReadChunkedProto helpers

### DIFF
--- a/pkg/jobs/job_info_utils.go
+++ b/pkg/jobs/job_info_utils.go
@@ -23,6 +23,16 @@ import (
 const bundleChunkSize = 1 << 20 // 1 MiB
 const finalChunkSuffix = "#_final"
 
+// DeleteChunkedFile deletes all chunks associated with the given filename from
+// the job_info table. Chunks are stored with info keys in [filename,
+// filename#_final~), and this function removes all of them.
+func DeleteChunkedFile(
+	ctx context.Context, filename string, txn isql.Txn, jobID jobspb.JobID,
+) error {
+	finalChunkName := filename + finalChunkSuffix
+	return InfoStorageForJob(txn, jobID).DeleteRange(ctx, filename, finalChunkName+"~", 0)
+}
+
 // WriteChunkedFileToJobInfo will break up data into chunks of a fixed size, and
 // gzip compress them before writing them to the job_info table. This method
 // clears any existing chunks with the same filename before writing the new
@@ -34,11 +44,8 @@ func WriteChunkedFileToJobInfo(
 	finalChunkName := filename + finalChunkSuffix
 	jobInfo := InfoStorageForJob(txn, jobID)
 
-	// Clear any existing chunks with the same filename before writing new chunks.
-	// We clear all rows that with info keys in [filename, filename#_final~). The
-	// trailing "~" makes the exclusive end-key inclusive of all possible chunks
-	// as "~" sorts after all digit.
-	if err := jobInfo.DeleteRange(ctx, filename, finalChunkName+"~", 0); err != nil {
+	// Clear any existing chunks with the same filename before writing new ones.
+	if err := DeleteChunkedFile(ctx, filename, txn, jobID); err != nil {
 		return err
 	}
 
@@ -148,6 +155,37 @@ func (i InfoStorage) GetProto(
 	data, found, err := i.Get(ctx, "get-proto", infoKey)
 	if err != nil || !found {
 		return found, err
+	}
+	if err := protoutil.Unmarshal(data, msg); err != nil {
+		return false, errors.Wrap(err, "failed to unmarshal proto")
+	}
+	return true, nil
+}
+
+// WriteChunkedProto marshals a protobuf message and writes it as a chunked
+// file to the job_info table.
+func WriteChunkedProto(
+	ctx context.Context, filename string, msg protoutil.Message, txn isql.Txn, jobID jobspb.JobID,
+) error {
+	data, err := protoutil.Marshal(msg)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal proto")
+	}
+	return WriteChunkedFileToJobInfo(ctx, filename, data, txn, jobID)
+}
+
+// ReadChunkedProto reads a chunked file from the job_info table and unmarshals
+// it into the provided protobuf message. Returns true if data was found and
+// unmarshaled successfully.
+func ReadChunkedProto(
+	ctx context.Context, filename string, txn isql.Txn, jobID jobspb.JobID, msg protoutil.Message,
+) (bool, error) {
+	data, err := ReadChunkedFileToJobInfo(ctx, filename, txn, jobID)
+	if err != nil {
+		return false, err
+	}
+	if len(data) == 0 {
+		return false, nil
 	}
 	if err := protoutil.Unmarshal(data, msg); err != nil {
 		return false, errors.Wrap(err, "failed to unmarshal proto")

--- a/pkg/jobs/job_info_utils_test.go
+++ b/pkg/jobs/job_info_utils_test.go
@@ -72,10 +72,61 @@ func TestReadWriteChunkedFileToJobInfo(t *testing.T) {
 					return err
 				}
 				require.Equal(t, tt.data, got)
+
+				// Delete and verify the file is gone.
+				err = DeleteChunkedFile(ctx, tt.name, txn, jobspb.JobID(123))
+				if err != nil {
+					return err
+				}
+				got, err = ReadChunkedFileToJobInfo(ctx, tt.name, txn, jobspb.JobID(123))
+				if err != nil {
+					return err
+				}
+				require.Empty(t, got)
 				return nil
 			}))
 		})
 	}
+}
+
+func TestReadWriteChunkedProto(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	params := base.TestServerArgs{}
+	params.Knobs.JobsTestingKnobs = NewTestingKnobsWithShortIntervals()
+	s := serverutils.StartServerOnly(t, params)
+	defer s.Stopper().Stop(ctx)
+
+	db := s.InternalDB().(isql.DB)
+	jobID := jobspb.JobID(789)
+
+	t.Run("write and read proto", func(t *testing.T) {
+		msg := &jobspb.Payload{Description: "test chunked proto"}
+		require.NoError(t, db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+			return WriteChunkedProto(ctx, "test-proto", msg, txn, jobID)
+		}))
+
+		var got jobspb.Payload
+		require.NoError(t, db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+			found, err := ReadChunkedProto(ctx, "test-proto", txn, jobID, &got)
+			require.NoError(t, err)
+			require.True(t, found)
+			return nil
+		}))
+		require.Equal(t, msg.Description, got.Description)
+	})
+
+	t.Run("read nonexistent proto", func(t *testing.T) {
+		var got jobspb.Payload
+		require.NoError(t, db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+			found, err := ReadChunkedProto(ctx, "nonexistent", txn, jobID, &got)
+			require.NoError(t, err)
+			require.False(t, found)
+			return nil
+		}))
+	})
 }
 
 func TestOverwriteChunkingWithVariableLengths(t *testing.T) {

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -1061,9 +1061,7 @@ func (r *importResumer) cleanupTempStorage(ctx context.Context, execCfg *sql.Exe
 	// Clean up SST manifest job info keys.
 	besteffort.Warning(ctx, "import-manifest-cleanup", func(ctx context.Context) error {
 		return execCfg.InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-			return jobs.InfoStorageForJob(txn, r.job.ID()).DeleteRange(
-				ctx, importSSTManifestsInfoKey, importSSTManifestsInfoKey+"~", 0,
-			)
+			return jobs.DeleteChunkedFile(ctx, importSSTManifestsInfoKey, txn, r.job.ID())
 		})
 	})
 

--- a/pkg/sql/importer/import_processor_planning.go
+++ b/pkg/sql/importer/import_processor_planning.go
@@ -233,12 +233,10 @@ func distImport(
 			// Only write when the buffer has new data to avoid unnecessary I/O.
 			if useDistributedMerge && manifestBuf != nil && manifestBuf.Dirty() {
 				manifests := manifestBuf.SnapshotAndMarkClean()
-				data, err := protoutil.Marshal(&jobspb.BulkSSTManifests{Manifests: manifests})
-				if err != nil {
-					return errors.Wrap(err, "marshaling SST manifests")
-				}
-				if err := jobs.WriteChunkedFileToJobInfo(
-					ctx, importSSTManifestsInfoKey, data, txn, job.ID(),
+				if err := jobs.WriteChunkedProto(
+					ctx, importSSTManifestsInfoKey,
+					&jobspb.BulkSSTManifests{Manifests: manifests},
+					txn, job.ID(),
 				); err != nil {
 					return errors.Wrap(err, "writing SST manifests to job info")
 				}
@@ -270,17 +268,14 @@ func distImport(
 		if err := execCtx.ExecCfg().InternalDB.Txn(ctx, func(
 			ctx context.Context, txn isql.Txn,
 		) error {
-			data, err := jobs.ReadChunkedFileToJobInfo(
-				ctx, importSSTManifestsInfoKey, txn, job.ID(),
+			var stored jobspb.BulkSSTManifests
+			found, err := jobs.ReadChunkedProto(
+				ctx, importSSTManifestsInfoKey, txn, job.ID(), &stored,
 			)
 			if err != nil {
 				return err
 			}
-			if len(data) > 0 {
-				var stored jobspb.BulkSSTManifests
-				if err := protoutil.Unmarshal(data, &stored); err != nil {
-					return errors.Wrap(err, "unmarshaling SST manifests from job info")
-				}
+			if found {
 				resumeManifests = stored.Manifests
 				processorOutput = append(
 					processorOutput, bulksst.ManifestsToSSTFiles(resumeManifests),


### PR DESCRIPTION
jobs: add DeleteChunkedFile, WriteChunkedProto, and ReadChunkedProto helpers
Add convenience helpers to the job info storage chunked file API:

- DeleteChunkedFile: encapsulates the DeleteRange call with the correct
  key range for chunked files, so callers don't need to know the internal
  chunking scheme.
- WriteChunkedProto/ReadChunkedProto: combine proto marshalling with
  chunked file I/O, analogous to the existing WriteProto/GetProto
  helpers on InfoStorage.

Refactor the import job to use these new helpers, replacing inline
proto marshal/unmarshal and manual DeleteRange calls.

Epic: none 

Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>