### PR TITLE
roachtest: add cdc-prs ownership for cdc roachtest files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -512,6 +512,7 @@
 #!/pkg/cmd/roachtest/tests     @cockroachdb/test-eng-noreview
 /pkg/cmd/roachtest/tests/activerecord.go  @cockroachdb/sql-foundations @cockroachdb/docs-infra-prs
 /pkg/cmd/roachtest/tests/asyncpg.go       @cockroachdb/sql-foundations @cockroachdb/docs-infra-prs
+/pkg/cmd/roachtest/tests/cdc*.go          @cockroachdb/cdc-prs
 /pkg/cmd/roachtest/tests/django.go        @cockroachdb/sql-foundations @cockroachdb/docs-infra-prs
 /pkg/cmd/roachtest/tests/gopg.go	        @cockroachdb/sql-foundations @cockroachdb/docs-infra-prs
 /pkg/cmd/roachtest/tests/gorm.go	        @cockroachdb/sql-foundations @cockroachdb/docs-infra-prs


### PR DESCRIPTION
Currently, `pkg/cmd/roachtest/tests/cdc*.go` falls through to the catch-all `#!/pkg/cmd/roachtest/tests @cockroachdb/test-eng-noreview` rule, which is intentionally hidden from GitHub. This means no one from `cdc-prs` gets auto-assigned to review PRs that touch CDC roachtests.

This follows the established pattern used by other teams (e.g. `sql-foundations` for ORM test files) and adds an explicit override so that `@cockroachdb/cdc-prs` is auto-requested for review on changes to CDC roachtest files.

Informs: #165295