### PR TITLE
roachtest: use exponential backoff in getProfilesWithTimeout

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/profile.go
+++ b/pkg/cmd/roachtest/roachtestutil/profile.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	rperrors "github.com/cockroachdb/cockroach/pkg/roachprod/errors"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/google/pprof/profile"
@@ -323,21 +324,11 @@ func getProfileWithTimeout(
 	logger.Printf("getting profile using URL: %s", url)
 
 	// Set up a timer to limit the time spent trying to get the profile.
-	timer := time.NewTimer(timeout)
-	defer timer.Stop()
-
+	r := retry.StartWithCtx(ctx, retry.Options{
+		MaxDuration: timeout,
+	})
 	var latestError error
-	for {
-		select {
-		case <-ctx.Done():
-			return nil, errors.Wrapf(errors.CombineErrors(latestError, ctx.Err()),
-				"failed to get profile from %s after %s", url, timeout)
-		case <-timer.C:
-			return nil, errors.Wrapf(errors.CombineErrors(latestError, errors.New("timed out")),
-				"failed to get profile from %s after %s", url, timeout)
-		default:
-		}
-
+	for r.Next() {
 		// Request the profile.
 		resp, err := client.Get(ctx, url)
 		if err != nil {
@@ -380,6 +371,8 @@ func getProfileWithTimeout(
 
 		return prof, nil
 	}
+	return nil, errors.Wrapf(errors.CombineErrors(latestError, errors.New("timed out")),
+		"failed to get profile from %s after %s", url, timeout)
 }
 
 // getProfileSingleNode returns the specified profile for a single node. The


### PR DESCRIPTION
Previously, it was possible to push a cluster over its tipping point if profile collection failed during testing. This occurred because the framework would attempt to collect profiles in a tight loop until a timeout was reached. In the `large-schema-benchmark`, this behavior led to a massive spike of `auth-session` calls in a very short span of time.

To address this, this patch modifies `getProfilesWithTimeout` to implement exponential backoff.

Fixes: #164601

Release note: None