### PR TITLE
build: sync fork before pushing PGO profile update branch

### DIFF
--- a/build/teamcity/internal/release/pgo_profile_update.sh
+++ b/build/teamcity/internal/release/pgo_profile_update.sh
@@ -13,7 +13,7 @@ source "$dir/teamcity-support.sh"  # For $root
 source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 
 cleanup() {
-    rm -f ~/.config/gcloud/application_default_credentials.json
+    rm -f ~agent/.config/gcloud/application_default_credentials.json
 }
 trap cleanup EXIT
 
@@ -197,6 +197,11 @@ Release note: none"
 
 git commit -m "$commit_message"
 set +x
+# Sync the fork with upstream before pushing. Without this, pushing a branch
+# based on current upstream master to a stale fork can trigger GitHub's workflow
+# scope requirement for any .github/workflows/ files that diverged since the
+# fork was last synced.
+gh repo sync "$gh_username/cockroach" --source cockroachdb/cockroach --force
 git push "https://$gh_username:$GH_TOKEN@github.com/$gh_username/cockroach.git" "$branch_name"
 set -x
 


### PR DESCRIPTION
Sync the cockroach-teamcity fork with upstream before pushing the PGO profile update branch. When the fork is stale, GitHub detects workflow file changes relative to the fork's state and rejects the push because the PAT lacks the `workflow` scope. Using `gh repo sync` via the API avoids this issue.

Epic: none
Release note: none