### PR TITLE
github: specify project when accessing EngFlow secrets

### DIFF
--- a/build/github/get-engflow-keys.sh
+++ b/build/github/get-engflow-keys.sh
@@ -8,5 +8,5 @@
 
 set -euxo pipefail
 
-gcloud secrets versions access 2 --secret=engflow-mesolite-key > /home/agent/engflow.key
-gcloud secrets versions access 2 --secret=engflow-mesolite-crt > /home/agent/engflow.crt
+gcloud secrets versions access 2 --secret=engflow-mesolite-key --project=crl-github-actions > /home/agent/engflow.key
+gcloud secrets versions access 2 --secret=engflow-mesolite-crt --project=crl-github-actions > /home/agent/engflow.crt


### PR DESCRIPTION
Part of: DEVINF-1656
Release note: none