### PR TITLE
release-25.2: roachtest: deflake activerecord

### DIFF
--- a/pkg/cmd/roachtest/tests/activerecord_blocklist.go
+++ b/pkg/cmd/roachtest/tests/activerecord_blocklist.go
@@ -25,6 +25,7 @@ var activeRecordIgnoreList = blocklist{
 	`ActiveRecord::AdapterTestWithoutTransaction#test_create_with_query_cache`:                                                                                 "affected by autocommit_before_ddl",
 	`ActiveRecord::CockroachDBStructureDumpTest#test_schema_dump_with_dump_schemas_all`:                                                                        "flaky",
 	`ActiveRecord::CockroachDBStructureDumpTest#test_structure_dump`:                                                                                           "flaky",
+	`ActiveRecord::ConnectionAdapters::ConnectionPoolFiberTest#test_idle_through_keepalive`:                                                                    "flaky",
 	`ActiveRecord::ConnectionAdapters::ConnectionPoolThreadTest#test_checkout_fairness`:                                                                        "flaky",
 	`ActiveRecord::ConnectionAdapters::ConnectionPoolThreadTest#test_checkout_fairness_by_group`:                                                               "flaky",
 	`ActiveRecord::ConnectionAdapters::ConnectionPoolThreadTest#test_disconnect_and_clear_reloadable_connections_are_able_to_preempt_other_waiting_threads`:    "flaky",


### PR DESCRIPTION
Backport 1/1 commits from #165337 on behalf of @fqazi.

----

Previously, the active record flake on the
`ConnectionPoolFiberTest#test_idle_through_keepalive` test. This patch marks the test as flaky.

Fixes: #164486

Release note: None

----

Release justification: