### PR TITLE
obs: instrument Prometheus scrape volume with meta-metrics

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -15666,6 +15666,30 @@ layers:
       unit: CONST
       aggregation: AVG
       derivative: NONE
+    - name: obs.metric_export.child.count
+      exported_name: obs_metric_export_child_count
+      description: 'Exported-line-weighted child count per parent metric: histogram children count their expanded Prometheus lines, others count 1'
+      y_axis_label: Child Instances
+      type: GAUGE
+      unit: COUNT
+      aggregation: AVG
+      derivative: NONE
+    - name: obs.metric_export.line.count
+      exported_name: obs_metric_export_line_count
+      description: Total individual time series (all label combinations) in the most recent Prometheus scrape
+      y_axis_label: Time Series
+      type: GAUGE
+      unit: COUNT
+      aggregation: AVG
+      derivative: NONE
+    - name: obs.metric_export.name.count
+      exported_name: obs_metric_export_name_count
+      description: Number of metric families (unique metric names) in the most recent Prometheus scrape
+      y_axis_label: Metric Names
+      type: GAUGE
+      unit: COUNT
+      aggregation: AVG
+      derivative: NONE
     - name: queue.consistency.pending
       exported_name: queue_consistency_pending
       description: Number of pending replicas in the consistency checker queue

--- a/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
+++ b/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
@@ -1790,6 +1790,9 @@ obs_clustermetrics_flush_count: obs.clustermetrics.flush.count
 obs_clustermetrics_flush_errors: obs.clustermetrics.flush.errors
 obs_clustermetrics_flush_latency: obs.clustermetrics.flush.latency
 obs_clustermetrics_flush_metrics_written: obs.clustermetrics.flush.metrics_written
+obs_metric_export_child_count: obs.metric_export.child.count
+obs_metric_export_line_count: obs.metric_export.line.count
+obs_metric_export_name_count: obs.metric_export.name.count
 obs_tablemetadata_update_job_duration: obs.tablemetadata.update_job.duration
 obs_tablemetadata_update_job_duration_bucket: obs.tablemetadata.update_job.duration.bucket
 obs_tablemetadata_update_job_duration_count: obs.tablemetadata.update_job.duration.count

--- a/pkg/server/status/recorder.go
+++ b/pkg/server/status/recorder.go
@@ -124,6 +124,40 @@ var ChildMetricsStorageEnabled = settings.RegisterBoolSetting(
 	false,
 	settings.WithVisibility(settings.Reserved))
 
+// ScrapeMetrics holds meta-metrics that describe the volume of a Prometheus
+// scrape. They are updated at the end of each /_status/vars scrape cycle and
+// therefore report values from the most recent (or, on first scrape, zero)
+// scrape. Because the metrics themselves live in the node registry, they are
+// self-referentially included in the output.
+type ScrapeMetrics struct {
+	NameCount  *metric.Gauge
+	LineCount  *metric.Gauge
+	ChildCount *metric.GaugeVec
+}
+
+func newScrapeMetrics() *ScrapeMetrics {
+	return &ScrapeMetrics{
+		NameCount: metric.NewGauge(metric.Metadata{
+			Name:        "obs.metric_export.name.count",
+			Help:        "Number of metric families (unique metric names) in the most recent Prometheus scrape",
+			Measurement: "Metric Names",
+			Unit:        metric.Unit_COUNT,
+		}),
+		LineCount: metric.NewGauge(metric.Metadata{
+			Name:        "obs.metric_export.line.count",
+			Help:        "Total individual time series (all label combinations) in the most recent Prometheus scrape",
+			Measurement: "Time Series",
+			Unit:        metric.Unit_COUNT,
+		}),
+		ChildCount: metric.NewExportedGaugeVec(metric.Metadata{
+			Name:        "obs.metric_export.child.count",
+			Help:        "Exported-line-weighted child count per parent metric: histogram children count their expanded Prometheus lines, others count 1",
+			Measurement: "Child Instances",
+			Unit:        metric.Unit_COUNT,
+		}, []string{"metric_name"}),
+	}
+}
+
 // MetricsRecorder is used to periodically record the information in a number of
 // metric registries.
 //
@@ -155,6 +189,10 @@ type MetricsRecorder struct {
 	// prometheus text format. It has a ScrapeAndPrintAsText method for thread safe
 	// scrape and print so there is no need to have additional lock here.
 	prometheusExporter metric.PrometheusExporter
+
+	// scrapeMetrics holds meta-metrics that describe the volume of the most
+	// recent /_status/vars Prometheus scrape.
+	scrapeMetrics *ScrapeMetrics
 
 	// mu synchronizes the reading of node/store registries against the adding of
 	// nodes/stores. Consequently, almost all uses of it only need to take an
@@ -228,6 +266,7 @@ func NewMetricsRecorder(
 		tenantID:            tenantID,
 		tenantNameContainer: tenantNameContainer,
 		prometheusExporter:  metric.MakePrometheusExporter(),
+		scrapeMetrics:       newScrapeMetrics(),
 	}
 	mr.mu.storeRegistries = make(map[roachpb.StoreID]*metric.Registry)
 	mr.mu.stores = make(map[roachpb.StoreID]storeMetrics)
@@ -340,6 +379,7 @@ func (mr *MetricsRecorder) AddNode(
 	nodeIDGauge := metric.NewGauge(metadata)
 	nodeIDGauge.Update(int64(desc.NodeID))
 	nodeReg.AddMetric(nodeIDGauge)
+	nodeReg.AddMetricStruct(mr.scrapeMetrics)
 
 	if !disableNodeAndTenantLabels {
 		nodeIDInt := int(desc.NodeID)
@@ -462,11 +502,58 @@ func (mr *MetricsRecorder) PrintAsText(
 	w io.Writer, contentType expfmt.Format, useStaticLabels bool,
 ) error {
 	var buf bytes.Buffer
-	if err := mr.prometheusExporter.ScrapeAndPrintAsText(&buf, contentType, mr.ScrapeIntoPrometheusWithStaticLabels(useStaticLabels)); err != nil {
+	scrapeFunc := mr.ScrapeIntoPrometheusWithStaticLabels(useStaticLabels)
+	// For /_status/vars (useStaticLabels=false), update scrape meta-metrics
+	// after scraping. Values appear in the next scrape (first reports zeros).
+	if !useStaticLabels {
+		inner := scrapeFunc
+		scrapeFunc = func(pm *metric.PrometheusExporter) {
+			inner(pm)
+			mr.updateScrapeMetrics(pm)
+		}
+	}
+	if err := mr.prometheusExporter.ScrapeAndPrintAsText(
+		&buf, contentType, scrapeFunc,
+	); err != nil {
 		return err
+	}
+	// Count actual output lines from the encoded buffer. This must happen
+	// after encoding because histograms expand a single Metric object into
+	// multiple lines (per-bucket + _count + _sum), and Gather() doesn't
+	// reflect that.
+	if !useStaticLabels {
+		mr.scrapeMetrics.LineCount.Update(countTimeSeriesLines(buf.Bytes()))
 	}
 	_, err := buf.WriteTo(w)
 	return err
+}
+
+// countTimeSeriesLines counts data lines in prometheus text format output.
+// Each non-empty, non-comment line corresponds to one time series.
+func countTimeSeriesLines(data []byte) int64 {
+	var count int64
+	for _, line := range bytes.Split(data, []byte("\n")) {
+		if len(line) > 0 && line[0] != '#' {
+			count++
+		}
+	}
+	return count
+}
+
+// updateScrapeMetrics updates the name count and child count meta-metrics
+// from the current exporter state. Called inside ScrapeAndPrintAsText's
+// lock, after all registries have been scraped but before clearMetrics.
+// Line count is set separately from the encoded output buffer.
+func (mr *MetricsRecorder) updateScrapeMetrics(pm *metric.PrometheusExporter) {
+	families, _ := pm.Gather()
+	mr.scrapeMetrics.NameCount.Update(int64(len(families)))
+
+	mr.scrapeMetrics.ChildCount.Clear()
+	for metricName, count := range pm.ChildCounts() {
+		mr.scrapeMetrics.ChildCount.Update(
+			map[string]string{"metric_name": metricName}, count,
+		)
+	}
 }
 
 // ExportToGraphite sends the current metric values to a Graphite server.

--- a/pkg/server/status/recorder_test.go
+++ b/pkg/server/status/recorder_test.go
@@ -218,6 +218,28 @@ func TestMetricsRecorderLabels(t *testing.T) {
 				},
 			},
 		},
+		// The scrape meta-metrics are updated by the PrintAsText calls above.
+		// The system recorder sees 6 metric families and 10 time series.
+		{
+			Name:   "cr.node.obs.metric_export.name.count",
+			Source: "7",
+			Datapoints: []tspb.TimeSeriesDatapoint{
+				{
+					TimestampNanos: manual.Now().UnixNano(),
+					Value:          6,
+				},
+			},
+		},
+		{
+			Name:   "cr.node.obs.metric_export.line.count",
+			Source: "7",
+			Datapoints: []tspb.TimeSeriesDatapoint{
+				{
+					TimestampNanos: manual.Now().UnixNano(),
+					Value:          10,
+				},
+			},
+		},
 		{
 			Name:   "cr.node.some_metric",
 			Source: "7",
@@ -246,6 +268,27 @@ func TestMetricsRecorderLabels(t *testing.T) {
 				{
 					TimestampNanos: manual.Now().UnixNano(),
 					Value:          float64(nodeDesc.NodeID),
+				},
+			},
+		},
+		// The tenant recorder sees 6 metric families and 6 time series.
+		{
+			Name:   "cr.node.obs.metric_export.name.count",
+			Source: "7-123",
+			Datapoints: []tspb.TimeSeriesDatapoint{
+				{
+					TimestampNanos: manual.Now().UnixNano(),
+					Value:          6,
+				},
+			},
+		},
+		{
+			Name:   "cr.node.obs.metric_export.line.count",
+			Source: "7-123",
+			Datapoints: []tspb.TimeSeriesDatapoint{
+				{
+					TimestampNanos: manual.Now().UnixNano(),
+					Value:          6,
 				},
 			},
 		},
@@ -847,6 +890,12 @@ func TestMetricsRecorder(t *testing.T) {
 	g.Update(int64(nodeDesc.NodeID))
 	addExpected("", "node-id", 1, 100, g.Value(), true)
 
+	// The scrape meta-metrics (obs.metric_export.name.count and
+	// obs.metric_export.line.count) are registered in the node registry
+	// via AddNode and start at zero.
+	addExpected("", "obs.metric_export.name.count", 1, 100, 0, true)
+	addExpected("", "obs.metric_export.line.count", 1, 100, 0, true)
+
 	for _, reg := range regList {
 		for _, data := range metricNames {
 			switch data.typ {
@@ -1345,4 +1394,144 @@ func BenchmarkRecordChangefeedChildMetrics(b *testing.B) {
 			}
 		})
 	}
+}
+
+// TestScrapeMetrics verifies that the scrape meta-metrics (name.count,
+// line.count, child.count) report correct values and follow the expected
+// chicken-and-egg lifecycle: first scrape exports zeros, second scrape
+// exports the counts from the first.
+func TestScrapeMetrics(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	st := cluster.MakeTestingClusterSettings()
+	ChildMetricsEnabled.Override(context.Background(), &st.SV, true)
+	manual := timeutil.NewManualTime(timeutil.Unix(0, 100))
+
+	recorder := NewMetricsRecorder(
+		roachpb.SystemTenantID,
+		roachpb.NewTenantNameContainer(""),
+		nil, nil, manual, st,
+	)
+	nodeReg := metric.NewRegistry()
+	appReg := metric.NewRegistry()
+	logReg := metric.NewRegistry()
+	sysReg := metric.NewRegistry()
+	clusterReg := metric.NewRegistry()
+	recorder.AddNode(
+		nodeReg, appReg, logReg, sysReg, clusterReg,
+		roachpb.NodeDescriptor{NodeID: 1}, 50,
+		"foo:26257", "foo:26258", "foo:5432",
+	)
+
+	// Add a plain gauge, an agg-metric with children, and a histogram.
+	g := metric.NewGauge(metric.Metadata{Name: "test_gauge"})
+	nodeReg.AddMetric(g)
+	g.Update(42)
+
+	ac := aggmetric.NewCounter(metric.Metadata{Name: "test_agg"}, "label")
+	nodeReg.AddMetric(ac)
+	ac.AddChild("a").Inc(1)
+	ac.AddChild("b").Inc(2)
+	ac.AddChild("c").Inc(3)
+
+	ah := aggmetric.NewHistogram(metric.HistogramOptions{
+		Metadata: metric.Metadata{Name: "test_agg_histo"},
+		Duration: time.Second,
+		Buckets:  []float64{1.0, 10.0, 100.0},
+		Mode:     metric.HistogramModePrometheus,
+	}, "label")
+	nodeReg.AddMetric(ah)
+	ah.AddChild("x").RecordValue(5)
+	ah.AddChild("y").RecordValue(50)
+
+	// Histogram with 4 explicit buckets. The text encoder expands this into
+	// bucket lines + _count + _sum, so line.count must reflect the actual
+	// output volume, not just len(family.Metric).
+	h := metric.NewHistogram(metric.HistogramOptions{
+		Metadata: metric.Metadata{Name: "test_histo"},
+		Duration: time.Second,
+		Buckets:  []float64{1.0, 10.0, 100.0, 1000.0},
+		Mode:     metric.HistogramModePrometheus,
+	})
+	nodeReg.AddMetric(h)
+	h.RecordValue(5)
+
+	// First scrape: meta-metrics should be zero in the output because the
+	// gauges haven't been updated yet.
+	var buf bytes.Buffer
+	require.NoError(t, recorder.PrintAsText(&buf, expfmt.FmtText, false))
+	firstOutput := buf.String()
+
+	require.Contains(t, firstOutput, "obs_metric_export_name_count")
+	require.Contains(t, firstOutput, "obs_metric_export_line_count")
+	// The gauges were zero before this scrape, so the output shows 0.
+	// Labels are present on the metric line, so match the suffix.
+	require.Contains(t, firstOutput, `obs_metric_export_name_count{node_id="1",tenant=""} 0`)
+	require.Contains(t, firstOutput, `obs_metric_export_line_count{node_id="1",tenant=""} 0`)
+
+	// After the first scrape, the gauges have been updated internally.
+	// Verify the gauge values are nonzero now.
+	require.Greater(t, recorder.scrapeMetrics.NameCount.Value(), int64(0))
+	require.Greater(t, recorder.scrapeMetrics.LineCount.Value(), int64(0))
+
+	nameCount := recorder.scrapeMetrics.NameCount.Value()
+	lineCount := recorder.scrapeMetrics.LineCount.Value()
+
+	// Verify line count includes expanded histogram buckets, not just 1
+	// per histogram Metric object. The histogram has 4 explicit buckets
+	// plus +Inf, _count, _sum = 7 lines. A naive Gather()-based count
+	// would report 1.
+	histoLines := int64(strings.Count(firstOutput, "test_histo"))
+	require.Greater(t, histoLines, int64(1),
+		"histogram should expand to multiple output lines")
+	require.Equal(t, lineCount, countTimeSeriesLines([]byte(firstOutput)),
+		"line count should match actual output lines")
+
+	// Second scrape: the output should now contain the counts from the
+	// first scrape. This proves values survive across cycles and are not
+	// prematurely cleared.
+	buf.Reset()
+	require.NoError(t, recorder.PrintAsText(&buf, expfmt.FmtText, false))
+	secondOutput := buf.String()
+
+	require.Contains(t, secondOutput,
+		fmt.Sprintf(`obs_metric_export_name_count{node_id="1",tenant=""} %d`, nameCount))
+	require.Contains(t, secondOutput,
+		fmt.Sprintf(`obs_metric_export_line_count{node_id="1",tenant=""} %d`, lineCount))
+
+	// Child count: the agg-metric has 3 children. With child metrics
+	// enabled, the child.count GaugeVec should report this. The GaugeVec
+	// carries its own labels plus the registry labels.
+	require.Contains(t, secondOutput, `metric_name="test_agg"`)
+	require.Contains(t, secondOutput, `obs_metric_export_child_count`)
+	// Verify the count value is 3.
+	require.Regexp(t, `obs_metric_export_child_count\{[^}]*metric_name="test_agg"[^}]*\} 3`,
+		secondOutput)
+
+	// Histogram children are weighted by exported Prometheus lines: each
+	// histogram child expands to len(Bucket)+3 lines (+Inf, _count, _sum).
+	// The test histogram has 3 explicit buckets, so each child = 6 lines.
+	expectedHistoWeight := 2 * (3 + 3) // 2 children * (3 buckets + Inf + count + sum)
+	require.Regexp(t,
+		fmt.Sprintf(
+			`obs_metric_export_child_count\{[^}]*metric_name="test_agg_histo"[^}]*\} %d`,
+			expectedHistoWeight,
+		),
+		secondOutput)
+
+	// Third scrape after adding a child: the output still shows the
+	// previous cycle's count (3) because of the chicken-and-egg delay.
+	// The fourth scrape should show the updated count (4).
+	ac.AddChild("d").Inc(4)
+	buf.Reset()
+	require.NoError(t, recorder.PrintAsText(&buf, expfmt.FmtText, false))
+	thirdOutput := buf.String()
+	require.Regexp(t, `obs_metric_export_child_count\{[^}]*metric_name="test_agg"[^}]*\} 3`,
+		thirdOutput)
+
+	buf.Reset()
+	require.NoError(t, recorder.PrintAsText(&buf, expfmt.FmtText, false))
+	fourthOutput := buf.String()
+	require.Regexp(t, `obs_metric_export_child_count\{[^}]*metric_name="test_agg"[^}]*\} 4`,
+		fourthOutput)
 }

--- a/pkg/util/metric/prometheus_exporter.go
+++ b/pkg/util/metric/prometheus_exporter.go
@@ -38,18 +38,30 @@ type PrometheusExporter struct {
 	muScrapeAndPrint syncutil.Mutex
 	families         map[string]*prometheusgo.MetricFamily
 	selection        map[string]struct{}
+
+	// childCounts tracks the number of child instances produced by each
+	// PrometheusIterable parent metric during the current scrape cycle.
+	// Accumulated across ScrapeRegistry calls and cleared in clearMetrics.
+	childCounts map[string]int64
 }
 
 // MakePrometheusExporter returns an initialized prometheus exporter.
 func MakePrometheusExporter() PrometheusExporter {
-	return PrometheusExporter{families: map[string]*prometheusgo.MetricFamily{}}
+	return PrometheusExporter{
+		families:    map[string]*prometheusgo.MetricFamily{},
+		childCounts: map[string]int64{},
+	}
 }
 
 // MakePrometheusExporterForSelectedMetrics returns an initialized prometheus
 // exporter. It would only consider selected metrics when scraping. The caller
 // should not modify the map after the call.
 func MakePrometheusExporterForSelectedMetrics(selection map[string]struct{}) PrometheusExporter {
-	return PrometheusExporter{families: map[string]*prometheusgo.MetricFamily{}, selection: selection}
+	return PrometheusExporter{
+		families:    map[string]*prometheusgo.MetricFamily{},
+		selection:   selection,
+		childCounts: map[string]int64{},
+	}
 }
 
 // find the family for the passed-in metric, or create and return it if not found.
@@ -159,11 +171,23 @@ func (pm *PrometheusExporter) ScrapeRegistry(registry RegistryReader, options ..
 
 				promIter, ok := v.(PrometheusIterable)
 				numChildren := 0
+				childWeight := int64(0)
 				if ok && o.includeChildMetrics {
 					promIter.Each(m.Label, func(metric *prometheusgo.Metric) {
 						family.Metric = append(family.Metric, metric)
-						numChildren += 1
+						numChildren++
+						if metric.Histogram != nil {
+							// +Inf bucket, _count, _sum = 3 lines beyond explicit buckets.
+							childWeight += int64(len(metric.Histogram.Bucket)) + 3
+						} else {
+							childWeight++
+						}
 					})
+				}
+
+				if numChildren > 0 {
+					metricName := prom.GetName(o.useStaticLabels)
+					pm.childCounts[metricName] += childWeight
 				}
 
 				// PrometheusReinitialisable metrics (like SQLMetric) dynamically
@@ -187,9 +211,22 @@ func (pm *PrometheusExporter) ScrapeRegistry(registry RegistryReader, options ..
 				if o.includeAggregateMetrics {
 					family.Metric = append(family.Metric, m)
 				}
+				numChildren := 0
+				childWeight := int64(0)
 				promIter.Each(m.Label, func(metric *prometheusgo.Metric) {
 					family.Metric = append(family.Metric, metric)
+					numChildren++
+					if metric.Histogram != nil {
+						// +Inf bucket, _count, _sum = 3 lines beyond explicit buckets.
+						childWeight += int64(len(metric.Histogram.Bucket)) + 3
+					} else {
+						childWeight++
+					}
 				})
+				if numChildren > 0 {
+					metricName := prom.GetName(o.useStaticLabels)
+					pm.childCounts[metricName] += childWeight
+				}
 				return
 			}
 
@@ -207,6 +244,12 @@ func (pm *PrometheusExporter) ScrapeRegistry(registry RegistryReader, options ..
 	} else {
 		registry.Select(pm.selection, f)
 	}
+}
+
+// ChildCounts returns the per-metric child instance counts accumulated
+// during the current scrape cycle. The caller must not modify the map.
+func (pm *PrometheusExporter) ChildCounts() map[string]int64 {
+	return pm.childCounts
 }
 
 // printAsText writes all metrics in the families map to the io.Writer in
@@ -262,5 +305,8 @@ func (pm *PrometheusExporter) clearMetrics() {
 	for _, family := range pm.families {
 		// Set to nil to avoid allocation if the family never gets any metrics.
 		family.Metric = nil
+	}
+	for k := range pm.childCounts {
+		delete(pm.childCounts, k)
 	}
 }


### PR DESCRIPTION
Add three new metrics that describe the volume of each `/_status/vars` Prometheus scrape:

- `obs.metric_export.name.count` (Gauge): number of metric families
- `obs.metric_export.line.count` (Gauge): total individual time series
- `obs.metric_export.child.count` (GaugeVec, labeled `metric_name`): per-parent child instance counts for PrometheusIterable metrics

These are updated at the end of each scrape cycle, so values reflect the previous scrape (first scrape reports zeros). The child counting piggybacks on the existing `Each()` iteration in `ScrapeRegistry`—no extra traversal.

The two Gauge metrics are persisted to TSDB; the GaugeVec is Prometheus-only by design. Only the `/_status/vars` endpoint (useStaticLabels=false) updates these metrics.