### PR TITLE
roachtest: add chaos test for backup

### DIFF
--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -343,6 +343,7 @@ go_library(
         "@com_github_aws_smithy_go//logging",
         "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_cockroach_go_v2//crdb",
+        "@com_github_cockroachdb_crlib//crtime",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_cockroachdb_ttycolor//:ttycolor",

--- a/pkg/cmd/roachtest/tests/backup_restore_driver.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_driver.go
@@ -41,7 +41,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/version"
@@ -95,14 +94,6 @@ var (
 		"settings":     "SHOW CLUSTER SETTINGS",
 		"users":        "SHOW USERS",
 		"zones":        "SHOW ZONE CONFIGURATIONS",
-	}
-
-	// retry options while waiting for a backup to complete
-	backupCompletionRetryOptions = retry.Options{
-		InitialBackoff: 10 * time.Second,
-		MaxBackoff:     1 * time.Minute,
-		Multiplier:     1.5,
-		MaxRetries:     80,
 	}
 
 	possibleNumIncrementalBackups = []int{

--- a/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
@@ -21,12 +21,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/task"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/failureinjection/failures"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -109,6 +111,23 @@ func registerBackupRestoreRoundTrip(r registry.Registry) {
 			},
 		})
 	}
+
+	r.Add(registry.TestSpec{
+		Name:                      "backup-restore/chaos",
+		Monitor:                   true,
+		Timeout:                   4 * time.Hour,
+		Owner:                     registry.OwnerDisasterRecovery,
+		Cluster:                   r.MakeClusterSpec(4, spec.WorkloadNode()),
+		EncryptionSupport:         registry.EncryptionMetamorphic,
+		NativeLibs:                registry.LibGEOS,
+		CompatibleClouds:          registry.Clouds(spec.GCE, spec.AWS, spec.Azure, spec.Local),
+		Suites:                    registry.Suites(registry.Nightly),
+		TestSelectionOptOutSuites: registry.Suites(registry.Nightly),
+		Randomized:                true,
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			backupRestoreChaos(ctx, t, c)
+		},
+	})
 }
 
 // backup-restore/round-trip tests that a round trip of creating a backup and
@@ -230,6 +249,192 @@ func backupRestoreRoundTrip(
 	})
 
 	m.Wait()
+}
+
+func backupRestoreChaos(ctx context.Context, t test.Test, c cluster.Cluster) {
+	testRNG, seed := randutil.NewLockedPseudoRand()
+	t.L().Printf("random seed: %d", seed)
+
+	workloadSeed := testRNG.Int63()
+	t.L().Printf("workload seed: %d", workloadSeed)
+
+	startOpts := roachtestutil.MaybeUseMemoryBudget(t, 50)
+	startOpts.RoachprodOpts.ExtraArgs = []string{"--vmodule=split_queue=3,cloud_logging_transport=1"}
+	c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(), c.CRDBNodes())
+
+	const numToKill = 1
+	failureNodes := c.CRDBNodes()[:numToKill]
+	liveNodes := c.CRDBNodes()[numToKill:] // The set of nodes that will not be failure injected
+	isGraceful := testRNG.Intn(2) == 0
+	t.Monitor().ExpectProcessDead(failureNodes)
+	t.L().Printf("process kill failure isGraceful: %t", isGraceful)
+	// To clarify, the grace period refers to the amount of time we wait when
+	// draining gracefully before sending a SIGKILL and is unrelated to the wait
+	// in injectAndRecoverFailure.
+	failer, args, err := roachtestutil.MakeProcessKillFailer(
+		t.L(), c, failureNodes, isGraceful, 5*time.Minute, /* gracePeriod */
+	)
+	require.NoError(t, err)
+	require.NoError(t, failer.Setup(ctx, t.L(), args))
+	defer func() {
+		if err := failer.Cleanup(ctx, t.L()); err != nil {
+			t.L().Printf("failed to clean up failure: %v", err)
+		}
+	}()
+
+	doOnlineRestore := testRNG.Intn(2) == 0
+	// TODO (kev-cao): Running this test with withMock(true) causes the
+	// backups to complete too quickly, but the default workload sizes also take
+	// quite a while to backup. Considering the goal of this test, it'd be good
+	// to add some options to provide the caller with more flexibility over the
+	// workload.
+	testUtils, err := setupBackupRestoreTestUtils(
+		ctx, t, c, testRNG,
+		withCompaction(true), withOnlineRestore(doOnlineRestore),
+	)
+	require.NoError(t, err)
+	defer testUtils.CloseConnections()
+
+	dbs := []string{"bank", "tpcc"}
+	// TODO (kev-cao): The schemachange workload currently run without tolerating
+	// errors so that we can catch schemachange errors, which means it is not
+	// resilient to node failures. We could update our helpers to give us more
+	// granular control over error tolerance, but for now we skip it.
+	excludedWorkloads := []string{"schemachange"}
+	d, runWorkloads, _, err := createDriversForBackupRestore(
+		ctx, t, c, testRNG, workloadSeed, testUtils, dbs, excludedWorkloads,
+	)
+	require.NoError(t, err)
+	stopWorkloads, err := runWorkloads()
+	require.NoError(t, err)
+	defer stopWorkloads()
+
+	bspec := backupSpec{
+		// We query for job progress via plannodes, so we don't want to use nodes
+		// subject to failure injection in the Plan spec.
+		Plan:    labeledNodes{Nodes: liveNodes, Version: clusterupgrade.CurrentVersion().String()},
+		Execute: labeledNodes{Nodes: c.CRDBNodes(), Version: clusterupgrade.CurrentVersion().String()},
+	}
+	builder := d.NewCollectionBuilder(
+		t.L(), t, testRNG, "backup-restore-chaos", bspec, bspec, true /* internalSystemsJobs */, false, /* isMultitenant */
+		WithClusterScope(),
+	)
+	jobID, err := builder.TakeFull(ctx)
+	require.NoError(t, err)
+	injectAndRecoverFailure(
+		ctx, t, t.L(), testUtils, testUtils.RandomNode(testRNG, liveNodes), jobID, failer, args,
+		randFloatBetween(testRNG, 0.15, 0.65),
+		// We use a number greater than 1.0 so that there is a chance of a node
+		// failing until the backup is complete.
+		min(randFloatBetween(testRNG, 0.65, 1.1), 1),
+	)
+	require.NoError(t, builder.WaitForLastJob(ctx))
+
+	for i := 0; i < 3; i++ {
+		jobID, err = builder.TakeInc(ctx)
+		require.NoError(t, err)
+		injectAndRecoverFailure(
+			ctx, t, t.L(), testUtils, testUtils.RandomNode(testRNG, liveNodes), jobID, failer, args,
+			randFloatBetween(testRNG, 0.15, 0.65),
+			min(randFloatBetween(testRNG, 0.65, 1.1), 1),
+		)
+		require.NoError(t, builder.WaitForLastJob(ctx))
+	}
+
+	jobID, err = builder.TakeCompacted(ctx, 1, 3)
+	require.NoError(t, err)
+	injectAndRecoverFailure(
+		ctx, t, t.L(), testUtils, testUtils.RandomNode(testRNG, liveNodes), jobID, failer, args,
+		randFloatBetween(testRNG, 0.15, 0.65),
+		min(randFloatBetween(testRNG, 0.65, 1.1), 1),
+	)
+	require.NoError(t, builder.WaitForLastJob(ctx))
+	collection, err := builder.Finalize(ctx)
+	require.NoError(t, err)
+
+	stopWorkloads()
+	testUtils.takeDebugZip(ctx, t.L())
+	err = testUtils.resetCluster(ctx, t.L(), clusterupgrade.CurrentVersion(), nil, nil)
+	require.NoError(t, err)
+
+	// TODO (kev-cao): Perform failure injection in restore path as well.
+	err = d.verifyBackupCollection(
+		ctx, t.L(), testRNG, collection,
+		true /* checkFiles */, true /* internalSystemJobs */, nil, /* mvHelper */
+	)
+	require.NoError(t, err)
+}
+
+// injectAndRecoverFailure waits for the job to progress past
+// failFractionCompleted, then injects the specified failure, waits for the
+// failure to propagate, waits for the job to progress past
+// recoverFractionCompleted, and then recovers from the failure. It
+// synchronously waits until the job succeeds before returning.
+// queryNode is the node used to poll for job status and should not be the
+// node that is subject to failure injection.
+func injectAndRecoverFailure(
+	ctx context.Context,
+	t test.Test,
+	l *logger.Logger,
+	testUtils *CommonTestUtils,
+	queryNode int,
+	jobID int,
+	failer *failures.Failer,
+	args failures.FailureArgs,
+	failFractionCompleted float64,
+	recoverFractionCompleted float64,
+) {
+	require.LessOrEqual(t, failFractionCompleted, 1.0, "failFractionCompleted should be <= 1.0")
+	require.LessOrEqual(t, recoverFractionCompleted, 1.0, "recoverFractionCompleted should be <= 1.0")
+
+	grp := t.NewErrorGroup(task.WithContext(ctx))
+	cancelFailer := grp.GoWithCancel(func(ctx context.Context, l *logger.Logger) error {
+		l.Printf(
+			"waiting for job %d to progress past %.2f%% before injecting failure",
+			jobID, failFractionCompleted*100,
+		)
+		if err := testUtils.waitForJobFractionCompletedWithNode(
+			ctx, l, queryNode, jobID, failFractionCompleted,
+		); err != nil {
+			return err
+		}
+		l.Printf("injecting failure")
+		if err := failer.Inject(ctx, l, args); err != nil {
+			return err
+		}
+		if err := failer.WaitForFailureToPropagate(ctx, l); err != nil {
+			return err
+		}
+		l.Printf(
+			"failure propagated, waiting for job %d to progress past %.2f%% before recovering",
+			jobID, recoverFractionCompleted*100,
+		)
+		if err := testUtils.waitForJobFractionCompletedWithNode(
+			ctx, l, queryNode, jobID, recoverFractionCompleted,
+		); err != nil {
+			return err
+		}
+		l.Printf("job %d progressed past %.2f%%, recovering from failure", jobID, recoverFractionCompleted*100)
+
+		if err := failer.Recover(ctx, l); err != nil {
+			return err
+		}
+		return failer.WaitForFailureToRecover(ctx, l)
+	}, task.Name(fmt.Sprintf("inject-failure-and-recovery-job-%d", jobID)))
+
+	grp.Go(func(ctx context.Context, l *logger.Logger) error {
+		l.Printf("waiting for job %d to succeed", jobID)
+		if err := testUtils.waitForJobSuccessWithNode(
+			ctx, l, queryNode, jobID, true, /* internalSystemJobs */
+		); err != nil {
+			// If the job fails, the test fails, so no need to attempt to recover.
+			cancelFailer()
+			return err
+		}
+		return nil
+	}, task.Name(fmt.Sprintf("wait-for-job-%d-success", jobID)))
+
+	require.NoError(t, grp.WaitE())
 }
 
 // initBackgroundWorkloads returns a function that starts a TPCC, bank, and a

--- a/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
@@ -145,7 +145,7 @@ func backupRestoreRoundTrip(
 
 		dbs := []string{"bank", "tpcc", schemaChangeDB}
 		d, runBackgroundWorkload, _, err := createDriversForBackupRestore(
-			ctx, t, c, testRNG, workloadSeed, testUtils, dbs,
+			ctx, t, c, testRNG, workloadSeed, testUtils, dbs, nil, /* excludedWorkloads */
 		)
 		if err != nil {
 			return err
@@ -233,7 +233,8 @@ func backupRestoreRoundTrip(
 }
 
 // initBackgroundWorkloads returns a function that starts a TPCC, bank, and a
-// system table workload in the background.
+// system table workload in the background. Workloads in excludedWorkloads will
+// not be started.
 func initBackgroundWorkloads(
 	ctx context.Context,
 	t test.Test,
@@ -244,6 +245,7 @@ func initBackgroundWorkloads(
 	roachNodes, workloadNode option.NodeListOption,
 	testUtils *CommonTestUtils,
 	dbs []string,
+	excludedWorkloads []string,
 ) (func() (func(), error), error) {
 	// numWarehouses is picked as a number that provides enough work
 	// for the cluster used in this test without overloading it,
@@ -252,28 +254,39 @@ func initBackgroundWorkloads(
 	if testUtils.mock {
 		numWarehouses = 10
 	}
+	excluded := make(map[string]bool, len(excludedWorkloads))
+	for _, w := range excludedWorkloads {
+		excluded[w] = true
+	}
+
 	tpccInit, tpccRun := tpccWorkloadCmd(l, testRNG, seed, numWarehouses, roachNodes)
 	bankInit, bankRun := bankWorkloadCmd(l, testRNG, seed, roachNodes, testUtils.mock)
 	scInit, scRun := schemaChangeWorkloadCmd(l, testRNG, seed, roachNodes, testUtils.mock)
 
 	initGroup := t.NewErrorGroup(task.WithContext(ctx))
-	initGroup.Go(func(ctx context.Context, l *logger.Logger) error {
-		return c.RunE(ctx, option.WithNodes(workloadNode), bankInit.String())
-	}, task.Name("init-bank"))
-	initGroup.Go(func(ctx context.Context, l *logger.Logger) error {
-		return c.RunE(ctx, option.WithNodes(workloadNode), tpccInit.String())
-	}, task.Name("init-tpcc"))
-	initGroup.Go(func(ctx context.Context, l *logger.Logger) (err error) {
-		defer func() {
-			if err != nil {
-				err = handleSchemaChangeWorkloadError(err)
+	if !excluded["bank"] {
+		initGroup.Go(func(ctx context.Context, l *logger.Logger) error {
+			return c.RunE(ctx, option.WithNodes(workloadNode), bankInit.String())
+		}, task.Name("init-bank"))
+	}
+	if !excluded["tpcc"] {
+		initGroup.Go(func(ctx context.Context, l *logger.Logger) error {
+			return c.RunE(ctx, option.WithNodes(workloadNode), tpccInit.String())
+		}, task.Name("init-tpcc"))
+	}
+	if !excluded["schemachange"] {
+		initGroup.Go(func(ctx context.Context, l *logger.Logger) (err error) {
+			defer func() {
+				if err != nil {
+					err = handleSchemaChangeWorkloadError(err)
+				}
+			}()
+			if err := prepSchemaChangeWorkload(ctx, workloadNode, testUtils, testRNG); err != nil {
+				return err
 			}
-		}()
-		if err := prepSchemaChangeWorkload(ctx, workloadNode, testUtils, testRNG); err != nil {
-			return err
-		}
-		return c.RunE(ctx, option.WithNodes(workloadNode), scInit.String())
-	}, task.Name("init-schemachange"))
+			return c.RunE(ctx, option.WithNodes(workloadNode), scInit.String())
+		}, task.Name("init-schemachange"))
+	}
 	if err := initGroup.WaitE(); err != nil {
 		return nil, err
 	}
@@ -285,25 +298,33 @@ func initBackgroundWorkloads(
 		}
 
 		runGroup := t.NewGroup()
-		runGroup.Go(func(ctx context.Context, l *logger.Logger) error {
-			return c.RunE(ctx, option.WithNodes(workloadNode), bankRun.String())
-		}, task.Name("run-bank"))
-		runGroup.Go(func(ctx context.Context, l *logger.Logger) error {
-			return c.RunE(ctx, option.WithNodes(workloadNode), tpccRun.String())
-		}, task.Name("run-tpcc"))
-		runGroup.Go(func(ctx context.Context, l *logger.Logger) error {
-			return handleSchemaChangeWorkloadError(
-				c.RunE(ctx, option.WithNodes(workloadNode), scRun.String()),
-			)
-		}, task.Name("run-schemachange"))
-		runGroup.Go(func(ctx context.Context, l *logger.Logger) error {
-			// We use a separate RNG for the system table writer to avoid
-			// non-determinism of the RNG usage due to the time-based nature of
-			// the system writer workload. See
-			// https://github.com/cockroachdb/cockroach/blob/master/pkg/cmd/roachtest/roachtestutil/mixedversion/README.md#note-non-deterministic-use-of-the-randrand-instance
-			systemTableRNG := rand.New(rand.NewSource(testRNG.Int63()))
-			return testUtils.systemTableWriter(ctx, l, systemTableRNG, dbs, tables)
-		}, task.Name("run-system-table-writer"))
+		if !excluded["bank"] {
+			runGroup.Go(func(ctx context.Context, l *logger.Logger) error {
+				return c.RunE(ctx, option.WithNodes(workloadNode), bankRun.String())
+			}, task.Name("run-bank"))
+		}
+		if !excluded["tpcc"] {
+			runGroup.Go(func(ctx context.Context, l *logger.Logger) error {
+				return c.RunE(ctx, option.WithNodes(workloadNode), tpccRun.String())
+			}, task.Name("run-tpcc"))
+		}
+		if !excluded["schemachange"] {
+			runGroup.Go(func(ctx context.Context, l *logger.Logger) error {
+				return handleSchemaChangeWorkloadError(
+					c.RunE(ctx, option.WithNodes(workloadNode), scRun.String()),
+				)
+			}, task.Name("run-schemachange"))
+		}
+		if !excluded["systemTableWriter"] {
+			runGroup.Go(func(ctx context.Context, l *logger.Logger) error {
+				// We use a separate RNG for the system table writer to avoid
+				// non-determinism of the RNG usage due to the time-based nature of
+				// the system writer workload. See
+				// https://github.com/cockroachdb/cockroach/blob/master/pkg/cmd/roachtest/roachtestutil/mixedversion/README.md#note-non-deterministic-use-of-the-randrand-instance
+				systemTableRNG := rand.New(rand.NewSource(testRNG.Int63()))
+				return testUtils.systemTableWriter(ctx, l, systemTableRNG, dbs, tables)
+			}, task.Name("run-system-table-writer"))
+		}
 
 		return runGroup.Cancel, nil
 	}
@@ -399,9 +420,11 @@ func createDriversForBackupRestore(
 	workloadSeed int64,
 	testUtils *CommonTestUtils,
 	dbs []string,
+	excludedWorkloads []string,
 ) (*BackupRestoreTestDriver, func() (func(), error), [][]string, error) {
 	runBackgroundWorkload, err := initBackgroundWorkloads(
 		ctx, t, t.L(), c, rng, workloadSeed, c.CRDBNodes(), c.WorkloadNode(), testUtils, dbs,
+		excludedWorkloads,
 	)
 	if err != nil {
 		return nil, nil, nil, err

--- a/pkg/cmd/roachtest/tests/backup_restore_utils.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_utils.go
@@ -30,12 +30,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/crlib/crtime"
 	"github.com/cockroachdb/errors"
 )
 
@@ -439,9 +441,18 @@ func (u *CommonTestUtils) setClusterSettings(
 // error if the job doesn't succeed within the attempted retries.
 func (u *CommonTestUtils) waitForJobSuccess(
 	ctx context.Context, l *logger.Logger, rng *rand.Rand, jobID int, internalSystemJobs bool,
+) error {
+	return u.waitForJobSuccessWithNode(
+		ctx, l, u.RandomNode(rng, u.roachNodes), jobID, internalSystemJobs,
+	)
+}
+
+// waitForJobSuccessWithNode waits for the given job with the given ID to
+// succeed (according to `backupCompletionRetryOptions`) via the provided node.
+// Returns an error if the job doesn't succeed within the attempted retries.
+func (u *CommonTestUtils) waitForJobSuccessWithNode(
+	ctx context.Context, l *logger.Logger, node int, jobID int, internalSystemJobs bool,
 ) (resErr error) {
-	var lastErr error
-	node := u.RandomNode(rng, u.roachNodes)
 	l.Printf("querying job status through node %d", node)
 
 	db, err := u.cluster.ConnE(ctx, l, node, option.DBName("system"))
@@ -458,7 +469,11 @@ func (u *CommonTestUtils) waitForJobSuccess(
 	if internalSystemJobs {
 		jobsQuery = fmt.Sprintf("(%s)", jobutils.InternalSystemJobsBaseQuery)
 	}
-	r := retry.StartWithCtx(ctx, backupCompletionRetryOptions)
+	r := retry.StartWithCtx(ctx, retry.Options{
+		InitialBackoff: time.Second,
+		MaxBackoff:     time.Second,
+		MaxDuration:    80 * time.Minute,
+	})
 	for r.Next() {
 		var status string
 		var payloadBytes []byte
@@ -466,26 +481,21 @@ func (u *CommonTestUtils) waitForJobSuccess(
 			fmt.Sprintf(`SELECT status, payload FROM %s`, jobsQuery), jobID,
 		).Scan(&status, &payloadBytes)
 		if err != nil {
-			lastErr = fmt.Errorf("error reading (status, payload) for job %d: %w", jobID, err)
-			l.Printf("%v", lastErr)
+			l.Printf("error reading (status, payload) for job %d: %v", jobID, err)
 			continue
 		}
 
 		if jobs.State(status) == jobs.StateFailed {
 			payload := &jobspb.Payload{}
 			if err := protoutil.Unmarshal(payloadBytes, payload); err == nil {
-				lastErr = fmt.Errorf("job %d failed with error: %s", jobID, payload.Error)
+				return fmt.Errorf("job %d failed with error: %s", jobID, payload.Error)
 			} else {
-				lastErr = fmt.Errorf("job %d failed, and could not unmarshal payload: %w", jobID, err)
+				return fmt.Errorf("job %d failed, and could not unmarshal payload: %w", jobID, err)
 			}
-
-			l.Printf("%v", lastErr)
-			break
 		}
 
 		if expected, actual := jobs.StateSucceeded, jobs.State(status); expected != actual {
-			lastErr = fmt.Errorf("job %d: current status %q, waiting for %q", jobID, actual, expected)
-			l.Printf("%v", lastErr)
+			l.Printf("job %d: current status %q, waiting for %q", jobID, actual, expected)
 			continue
 		}
 
@@ -493,11 +503,83 @@ func (u *CommonTestUtils) waitForJobSuccess(
 		return nil
 	}
 
-	if r.CurrentAttempt() >= backupCompletionRetryOptions.MaxRetries {
-		return fmt.Errorf("exhausted all %d retries waiting for job %d to finish, last err: %w", backupCompletionRetryOptions.MaxRetries, jobID, lastErr)
+	if err := ctx.Err(); err != nil {
+		return errors.Wrapf(err, "error waiting for job %d to finish", jobID)
 	}
 
-	return fmt.Errorf("error waiting for job to finish: %w", lastErr)
+	return errors.Newf("retries exhausted waiting for job %d to finish", jobID)
+}
+
+// waitForJobFractionCompletedWithNode waits for the given job to reach at the
+// least the provided progress fraction, querying through the provided node.
+func (u *CommonTestUtils) waitForJobFractionCompletedWithNode(
+	ctx context.Context, l *logger.Logger, node int, jobID int, fraction float64,
+) (resErr error) {
+	l.Printf("querying job progress through node %d", node)
+
+	db, err := u.cluster.ConnE(ctx, l, node, option.DBName("system"))
+	if err != nil {
+		l.Printf("error connecting to node %d: %v", node, err)
+		return err
+	}
+	defer func() {
+		err := db.Close()
+		resErr = errors.CombineErrors(resErr, err)
+	}()
+
+	logThrottler := util.EveryMono(30 * time.Second)
+	const progQuery = `SELECT coordinator_id, fraction_completed, status FROM crdb_internal.jobs WHERE job_id = $1`
+	var claimInstanceID gosql.NullInt64
+	var fractionCompleted gosql.NullFloat64
+	var status string
+	for r := retry.StartWithCtx(ctx, retry.Options{
+		InitialBackoff: time.Second,
+		MaxBackoff:     time.Second,
+		MaxDuration:    60 * time.Minute,
+	}); r.Next(); {
+		unclaimed := !claimInstanceID.Valid
+		err := db.QueryRowContext(ctx, progQuery, jobID).Scan(
+			&claimInstanceID, &fractionCompleted, &status,
+		)
+		if err != nil {
+			l.Printf("error querying progress for job %d: %v", jobID, err)
+			continue
+		}
+		if unclaimed && claimInstanceID.Valid {
+			l.Printf("job %d claimed by instance %d", jobID, claimInstanceID.Int64)
+		}
+
+		if fractionCompleted.Valid {
+			if fractionCompleted.Float64 >= fraction {
+				l.Printf(
+					"job %d passed %.2f%% progress (current progress: %.2f%%)",
+					jobID, fraction*100, fractionCompleted.Float64*100,
+				)
+				return nil
+			}
+			if logThrottler.ShouldProcess(crtime.NowMono()) {
+				l.Printf(
+					"waiting for job %d to pass %.2f%% (current progress: %.2f%%)",
+					jobID, fraction*100, fractionCompleted.Float64*100,
+				)
+			}
+		}
+
+		jobStatus := jobs.State(status)
+		if jobStatus != jobs.StateSucceeded && jobStatus != jobs.StateRunning {
+			return errors.Newf("job %d unexpectedly in state %s while tracking progress", jobID, jobStatus)
+		}
+	}
+
+	if err := ctx.Err(); err != nil {
+		return errors.Wrapf(
+			err, "error waiting for job %d to pass %.2f%% progress", jobID, fraction*100,
+		)
+	}
+
+	return errors.Newf(
+		"retries exhausted waiting for job %d to pass %.2f%% progress", jobID, fraction*100,
+	)
 }
 
 // runJobOnOneOf disables job adoption on cockroach nodes that are not
@@ -665,6 +747,16 @@ func (u *CommonTestUtils) collectFailureArtifacts(
 	return fmt.Errorf("%w (artifacts collected in %s)", restoreErr, dirName), nil
 }
 
+// takeDebugZip fetches a debug.zip from the cluster and saves it with the
+// current timestamp in the test artifacts.
+func (u *CommonTestUtils) takeDebugZip(ctx context.Context, l *logger.Logger) {
+	zipPath := fmt.Sprintf("debug-%d.zip", timeutil.Now().Unix())
+	err := u.cluster.FetchDebugZip(ctx, l, zipPath)
+	if err != nil {
+		l.Printf("failed to fetch debug zip: %v", err)
+	}
+}
+
 // resetCluster wipes the entire cluster and starts it again with the
 // specified version binary. This is done before we attempt restoring a
 // full cluster backup.
@@ -676,7 +768,11 @@ func (u *CommonTestUtils) resetCluster(
 	settings []install.ClusterSettingOption,
 ) error {
 	l.Printf("resetting cluster using version %q", version.String())
-	expectDeathsFn(len(u.roachNodes))
+	// TODO (kev-cao): Once we've migrated off of the deprecated cluster Monitor,
+	// we can remove expectDeathsFn entirely.
+	if expectDeathsFn != nil {
+		expectDeathsFn(len(u.roachNodes))
+	}
 	if err := u.cluster.WipeE(ctx, l, u.roachNodes); err != nil {
 		return fmt.Errorf("failed to wipe cluster: %w", err)
 	}
@@ -732,6 +828,10 @@ func hasInternalSystemJobs(
 
 func randIntBetween(rng *rand.Rand, min, max int) int {
 	return rng.Intn(max-min) + min
+}
+
+func randFloatBetween(rng *rand.Rand, min, max float64) float64 {
+	return rng.Float64()*(max-min) + min
 }
 
 func randString(rng *rand.Rand, strLen int) string {

--- a/pkg/cmd/roachtest/tests/online_restore.go
+++ b/pkg/cmd/roachtest/tests/online_restore.go
@@ -874,7 +874,7 @@ func testOnlineRestoreRecovery(ctx context.Context, t test.Test, c cluster.Clust
 
 		dbs := []string{"bank", "tpcc", schemaChangeDB}
 		d, runBackgroundWorkload, _, err := createDriversForBackupRestore(
-			ctx, t, c, testRNG, workloadSeed, testUtils, dbs,
+			ctx, t, c, testRNG, workloadSeed, testUtils, dbs, nil, /* excludedWorkloads */
 		)
 		if err != nil {
 			return err


### PR DESCRIPTION
This commit adds a test using the new chaos testing framework for backups.

Informs: #163231

Release note: None