### PR TITLE
roachtest: restrict inspect scale test to GCE

### DIFF
--- a/pkg/cmd/roachtest/tests/inspect_throughput.go
+++ b/pkg/cmd/roachtest/tests/inspect_throughput.go
@@ -96,7 +96,7 @@ func makeInspectThroughputTest(
 		Owner:               registry.OwnerSQLFoundations,
 		Benchmark:           true,
 		Cluster:             r.MakeClusterSpec(numNodes, spec.WorkloadNode(), spec.CPU(numCPUs)),
-		CompatibleClouds:    registry.AllExceptAWS,
+		CompatibleClouds:    registry.OnlyGCE,
 		Suites:              registry.Suites(registry.Nightly),
 		Leases:              registry.LeaderLeases,
 		Timeout:             length,


### PR DESCRIPTION
Azure tends to experience more infrastructure flakes and appears more susceptible to tests that drive high machine utilization. The inspect scale test is resource intensive. We are restricting that tests so it only runs on GCE.

Epic: None
Release note: none

Closes #165005