### PR TITLE
besteffort: add besteffort.Cleanup

### DIFF
--- a/pkg/backup/backupinfo/backup_index.go
+++ b/pkg/backup/backupinfo/backup_index.go
@@ -943,7 +943,7 @@ func readIndexFile(
 	if err != nil {
 		return backuppb.BackupIndexMetadata{}, errors.Wrapf(err, "reading index file %s", indexFilePath)
 	}
-	defer besteffort.Error(ctx, "cleanup-index-reader", func(ctx context.Context) error {
+	defer besteffort.Cleanup(ctx, "cleanup-index-reader", func() error {
 		return reader.Close(ctx)
 	})
 

--- a/pkg/backup/show.go
+++ b/pkg/backup/show.go
@@ -259,9 +259,7 @@ func collectBackupInfo(
 	if err != nil {
 		return backupInfo{}, 0, errors.Wrapf(err, "make storage")
 	}
-	defer besteffort.Error(ctx, "close-root-store", func(_ context.Context) error {
-		return defaultRootStore.Close()
-	})
+	defer besteffort.Cleanup(ctx, "close-root-store", defaultRootStore.Close)
 
 	var backupIdx backuppb.BackupIndexMetadata
 	var backupID string
@@ -292,9 +290,7 @@ func collectBackupInfo(
 	if err != nil {
 		return backupInfo{}, 0, err
 	}
-	defer besteffort.Error(ctx, "close-enc-store", func(_ context.Context) error {
-		return encStore.Close()
-	})
+	defer besteffort.Cleanup(ctx, "close-enc-store", encStore.Close)
 	encryption, err := backupencryption.ResolveEncryptionOptionsFromExpr(
 		ctx, p, p.ExprEvaluator("SHOW BACKUP"), encStore,
 		stmt.Options.EncryptionPassphrase, tree.Exprs(stmt.Options.DecryptionKMSURI),
@@ -311,9 +307,7 @@ func collectBackupInfo(
 	if err != nil {
 		return backupInfo{}, 0, err
 	}
-	defer besteffort.Error(ctx, "close-backup-store", func(_ context.Context) error {
-		return backupStore.Close()
-	})
+	defer besteffort.Cleanup(ctx, "close-backup-store", backupStore.Close)
 	manifest, memReserved, err := backupinfo.ReadBackupManifestFromStore(
 		ctx, mem, backupStore, mainBackupURI, encryption, kmsEnv,
 	)
@@ -333,9 +327,7 @@ func collectBackupInfo(
 	if err != nil {
 		return backupInfo{}, 0, err
 	}
-	defer besteffort.Error(ctx, "close-root-stores", func(_ context.Context) error {
-		return cleanupStores()
-	})
+	defer besteffort.Cleanup(ctx, "close-root-stores", cleanupStores)
 	localityInfo, err := backupinfo.GetLocalityInfo(
 		ctx, rootStores, collectionURIs, manifest, encryption, kmsEnv, backupIdx.Path,
 	)
@@ -413,9 +405,7 @@ func legacyCollectBackupInfo(
 	if err != nil {
 		return backupInfo{}, 0, err
 	}
-	defer besteffort.Error(ctx, "cleanup-backup-stores", func(_ context.Context) error {
-		return cleanup()
-	})
+	defer besteffort.Cleanup(ctx, "cleanup-backup-stores", cleanup)
 
 	encryption, err := backupencryption.ResolveEncryptionOptionsFromExpr(
 		ctx, p, exprEval, baseStores[0],
@@ -1467,9 +1457,7 @@ func showBackupsInCollectionPlanHook(
 		if err != nil {
 			return errors.Wrapf(err, "connect to external storage")
 		}
-		defer besteffort.Error(ctx, "show-backups-close-store", func(_ context.Context) error {
-			return store.Close()
-		})
+		defer besteffort.Cleanup(ctx, "show-backups-close-store", store.Close)
 
 		if useIDs {
 			newerThan, olderThan, maxCount, err := getTimeRangeOrDefaults(ctx, p, showStmt.TimeRange)

--- a/pkg/util/besteffort/besteffort.go
+++ b/pkg/util/besteffort/besteffort.go
@@ -62,3 +62,24 @@ func Error(ctx context.Context, name string, do func(ctx context.Context) error)
 		log.Dev.Errorf(ctx, "best effort operation '%s' failed: %+v", name, err)
 	}
 }
+
+// Cleanup executes a cleanup operation that must always run.
+//
+// Unlike Warning and Error, Cleanup never skips execution in test builds.
+// This is appropriate for resource cleanup (closing files, release locks,
+// etc.), where skipping would cause resource leaks. In production ubilds,
+// errors are logged as warnings. In test builds, errors panic by default to
+// catch regressions.
+//
+// Example usage:
+//
+//	defer besteffort.Cleanup(ctx, "close-store", store.Close)
+func Cleanup(ctx context.Context, name string, do func() error) {
+	err := do()
+	if err != nil {
+		if !isAllowedFailure(name) {
+			panic(err)
+		}
+		log.Dev.Warningf(ctx, "cleanup operation '%s' failed: %+v", name, err)
+	}
+}

--- a/pkg/util/besteffort/besteffort_test.go
+++ b/pkg/util/besteffort/besteffort_test.go
@@ -97,3 +97,42 @@ func TestWarningAndError(t *testing.T) {
 		})
 	}
 }
+
+func TestCleanup(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	const opName = "cleanup"
+	failingCleanup := func() error {
+		return errors.New("test error")
+	}
+
+	t.Run("cleanup never skips", func(t *testing.T) {
+		// We don't expose provide a way to force a skip, so we just run this enough
+		// times to probabilistically ensure that it shouldn't skip.
+		for range 10 {
+			require.Panics(t, func() {
+				Cleanup(ctx, opName, failingCleanup)
+			})
+		}
+	})
+
+	t.Run("TestAllowFailure prevents panic", func(t *testing.T) {
+		defer TestAllowFailure(opName)()
+		require.NotPanics(t, func() {
+			Cleanup(ctx, opName, failingCleanup)
+		})
+	})
+
+	t.Run("TestAllowFailure cleanup restores panic", func(t *testing.T) {
+		forbidFailures := TestAllowFailure(opName)
+		require.NotPanics(t, func() {
+			Cleanup(ctx, opName, failingCleanup)
+		})
+
+		forbidFailures()
+		require.Panics(t, func() {
+			Cleanup(ctx, opName, failingCleanup)
+		})
+	})
+}


### PR DESCRIPTION
This adds the `Cleanup` function to the `besteffort` API. Unlike `Warning` or `Error`, `Cleanup` is never skipped in test builds. This is intended for resource cleanups, where skipping a cleanup would lead to a leak that would fail our tests.

Fixes: #165131

Release note: None