### PR TITLE
release-25.2: acceptance: set `DOCKER_API_VERSION=1.44` in ARM CI

### DIFF
--- a/build/teamcity/cockroach/ci/tests-aws-linux-arm64/acceptance.sh
+++ b/build/teamcity/cockroach/ci/tests-aws-linux-arm64/acceptance.sh
@@ -41,6 +41,7 @@ $BAZCI --artifacts_dir=$PWD/artifacts -- \
   --test_arg=-b=$PWD/artifacts/cockroach \
   --test_env=COCKROACH_DEV_LICENSE  \
   --test_env=COCKROACH_RUN_ACCEPTANCE=true \
+  --test_env=DOCKER_API_VERSION=1.44 \
   --test_env=TZ=America/New_York \
   --profile=$PWD/artifacts/profile.gz \
   --test_timeout=1800 || status=$?


### PR DESCRIPTION
Backport 1/1 commits from #165364.

/cc @cockroachdb/release

---

Release justification: Non-production code changes
Release note: none
Epic: none
