### PR TITLE
sql/opt: block DML mutations on read-only tables in the optimizer

### DIFF
--- a/pkg/sql/catalog/replication/reader_catalog_test.go
+++ b/pkg/sql/catalog/replication/reader_catalog_test.go
@@ -309,6 +309,12 @@ INSERT INTO t3(n) VALUES (3);
 	r.destRunner.ExpectErr(t, "schema changes are not allowed on a reader catalog", "ALTER SEQUENCE sq1 RENAME TO sq4")
 	r.destRunner.ExpectErr(t, "schema changes are not allowed on a reader catalog", "ALTER TYPE status ADD VALUE 'newval' ")
 
+	// Validate that DML mutations are blocked on external row data tables, even
+	// when the bypass_pcr_reader_catalog_aost session variable is set.
+	r.destRunner.Exec(t, "SET bypass_pcr_reader_catalog_aost = true")
+	r.destRunner.ExpectErr(t, "cannot mutate read-only table", "INSERT INTO t1(val) VALUES('open')")
+	r.destRunner.Exec(t, "SET bypass_pcr_reader_catalog_aost = false")
+
 	// As a final test intentionally drop dependencies between descriptors. If we
 	// don't batch descriptor updates this will cause a validation error, since
 	// the sequence and table depend on each other.

--- a/pkg/sql/opt/cat/table.go
+++ b/pkg/sql/opt/cat/table.go
@@ -46,6 +46,11 @@ type Table interface {
 	// that they cannot be mutated.
 	IsMaterializedView() bool
 
+	// IsReadOnly returns true if this table cannot be mutated. This is the
+	// case for materialized views and tables with external row data (e.g.,
+	// tables on a PCR reader catalog).
+	IsReadOnly() bool
+
 	// LookupColumnOrdinal returns the ordinal of the column with the given ID.
 	LookupColumnOrdinal(colID descpb.ColumnID) (int, error)
 

--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -519,6 +519,10 @@ func (u *unknownTable) IsMaterializedView() bool {
 	return false
 }
 
+func (u *unknownTable) IsReadOnly() bool {
+	return false
+}
+
 func (u *unknownTable) LookupColumnOrdinal(descpb.ColumnID) (int, error) {
 	panic(errors.AssertionFailedf("not implemented"))
 }

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -616,9 +616,15 @@ func (b *Builder) resolveTableForMutation(
 		alias = *outerAlias
 	}
 
-	// We can't mutate materialized views.
-	if tab.IsMaterializedView() {
-		panic(pgerror.Newf(pgcode.WrongObjectType, "cannot mutate materialized view %q", tab.Name()))
+	// We can't mutate read-only tables (materialized views, tables with
+	// external row data on a PCR reader catalog, etc.).
+	if tab.IsReadOnly() {
+		if tab.IsMaterializedView() {
+			panic(pgerror.Newf(pgcode.WrongObjectType,
+				"cannot mutate materialized view %q", tab.Name()))
+		}
+		panic(pgerror.Newf(pgcode.ReadOnlySQLTransaction,
+			"cannot mutate read-only table %q", tab.Name()))
 	}
 
 	return tab, depName, alias, columns

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -988,6 +988,11 @@ func (tt *Table) IsMaterializedView() bool {
 	return false
 }
 
+// IsReadOnly is part of the cat.Table interface.
+func (tt *Table) IsReadOnly() bool {
+	return false
+}
+
 // ColumnCount is part of the cat.Table interface.
 func (tt *Table) ColumnCount() int {
 	return len(tt.Columns)

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -1451,6 +1451,11 @@ func (ot *optTable) IsMaterializedView() bool {
 	return ot.desc.MaterializedView()
 }
 
+// IsReadOnly implements the cat.Table interface.
+func (ot *optTable) IsReadOnly() bool {
+	return ot.desc.IsReadOnly()
+}
+
 // ColumnCount is part of the cat.Table interface.
 func (ot *optTable) ColumnCount() int {
 	return len(ot.columns)
@@ -2635,6 +2640,11 @@ func (ot *optVirtualTable) IsSystemTable() bool {
 
 // IsMaterializedView implements the cat.Table interface.
 func (ot *optVirtualTable) IsMaterializedView() bool {
+	return false
+}
+
+// IsReadOnly implements the cat.Table interface.
+func (ot *optVirtualTable) IsReadOnly() bool {
 	return false
 }
 


### PR DESCRIPTION
The optimizer only blocked mutations on materialized views, not on tables with external row data. This meant DML could bypass the transaction-level read-only guard when the undocumented bypass_pcr_reader_catalog_aost session variable was set. Note that by default, DML is disallowed during reader tenant queries since the conn executor sets an AOST on all queries via GetPCRReaderTimestamp.

Release note: None
Epic: None