### PR TITLE
ui: migrate Network page from Redux to SWR hooks

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/connectivityApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/connectivityApi.ts
@@ -1,0 +1,39 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+
+import { fetchData } from "src/api";
+
+import { useSwrWithClusterId } from "../util";
+
+const CONNECTIVITY_PATH = "_status/connectivity";
+
+export const CONNECTIVITY_SWR_KEY = "connectivity";
+
+export const getConnectivity =
+  (): Promise<cockroach.server.serverpb.NetworkConnectivityResponse> => {
+    return fetchData(
+      cockroach.server.serverpb.NetworkConnectivityResponse,
+      CONNECTIVITY_PATH,
+    );
+  };
+
+export const useConnectivity = () => {
+  const { data, isLoading, error } = useSwrWithClusterId(
+    CONNECTIVITY_SWR_KEY,
+    getConnectivity,
+    {
+      revalidateOnFocus: false,
+      dedupingInterval: 10000, // 10 seconds.
+    },
+  );
+
+  return {
+    isLoading,
+    error,
+    connections: data?.connections ?? {},
+  };
+};

--- a/pkg/ui/workspaces/cluster-ui/src/api/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/index.ts
@@ -24,3 +24,4 @@ export * from "./eventsApi";
 export * from "./types";
 export * from "./jobProfilerApi";
 export * from "./txnInsightDetailsApi";
+export * from "./connectivityApi";

--- a/pkg/ui/workspaces/cluster-ui/src/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/index.ts
@@ -45,6 +45,7 @@ export { util, api };
 export { useNodes } from "./api/nodesApi";
 export { useNodesSummary } from "./api/nodesSummaryApi";
 export type { NodesSummary } from "./api/nodesSummaryApi";
+export { useConnectivity } from "./api/connectivityApi";
 export * from "./sessions";
 export * from "./timeScaleDropdown";
 export * from "./activeExecutions";

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -518,15 +518,6 @@ const tenantsListObj = new CachedDataReducer(
 
 export const refreshTenantsList = tenantsListObj.refresh;
 
-const connectivityObj = new CachedDataReducer(
-  api.getNetworkConnectivity,
-  "connectivity",
-  moment.duration(30, "s"),
-  moment.duration(1, "minute"),
-);
-
-export const refreshConnectivity = connectivityObj.refresh;
-
 export interface APIReducersState {
   cluster: CachedDataReducerState<api.ClusterResponseMessage>;
   events: CachedDataReducerState<
@@ -585,7 +576,6 @@ export interface APIReducersState {
   snapshot: KeyedCachedDataReducerState<clusterUiApi.GetTracingSnapshotResponse>;
   rawTrace: KeyedCachedDataReducerState<clusterUiApi.GetTraceResponse>;
   tenants: CachedDataReducerState<api.ListTenantsResponseMessage>;
-  connectivity: CachedDataReducerState<api.NetworkConnectivityResponse>;
 }
 
 export const apiReducersReducer = combineReducers<APIReducersState>({
@@ -638,7 +628,6 @@ export const apiReducersReducer = combineReducers<APIReducersState>({
   [statementFingerprintInsightsReducerObj.actionNamespace]:
     statementFingerprintInsightsReducerObj.reducer,
   [tenantsListObj.actionNamespace]: tenantsListObj.reducer,
-  [connectivityObj.actionNamespace]: connectivityObj.reducer,
 });
 
 export { CachedDataReducerState, KeyedCachedDataReducerState };

--- a/pkg/ui/workspaces/db-console/src/redux/connectivity.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/connectivity.ts
@@ -1,9 +1,0 @@
-// Copyright 2023 The Cockroach Authors.
-//
-// Use of this software is governed by the CockroachDB Software License
-// included in the /LICENSE file.
-
-import { AdminUIState } from "src/redux/state";
-
-export const connectivitySelector = (state: AdminUIState) =>
-  state.cachedData.connectivity;

--- a/pkg/ui/workspaces/db-console/src/util/api.ts
+++ b/pkg/ui/workspaces/db-console/src/util/api.ts
@@ -201,11 +201,6 @@ export type ListTenantsRequestMessage =
 export type ListTenantsResponseMessage =
   protos.cockroach.server.serverpb.ListTenantsResponse;
 
-export type NetworkConnectivityRequest =
-  protos.cockroach.server.serverpb.NetworkConnectivityRequest;
-export type NetworkConnectivityResponse =
-  protos.cockroach.server.serverpb.NetworkConnectivityResponse;
-
 export type GetThrottlingMetadataRequest =
   protos.cockroach.server.serverpb.GetThrottlingMetadataRequest;
 export type GetThrottlingMetadataResponse =
@@ -847,18 +842,6 @@ export function getTenants(
   return timeoutFetch(
     serverpb.ListTenantsResponse,
     `${API_PREFIX}/tenants`,
-    req as any,
-    timeout,
-  );
-}
-
-export function getNetworkConnectivity(
-  req: NetworkConnectivityRequest,
-  timeout?: moment.Duration,
-): Promise<NetworkConnectivityResponse> {
-  return timeoutFetch(
-    serverpb.NetworkConnectivityResponse,
-    `${STATUS_PREFIX}/connectivity`,
     req as any,
     timeout,
   );

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/network/index.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/network/index.spec.tsx
@@ -3,158 +3,153 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
+import { useNodesSummary, useConnectivity } from "@cockroachlabs/cluster-ui";
 import * as protos from "@cockroachlabs/crdb-protobuf-client";
 import { render, screen } from "@testing-library/react";
-import { Location } from "history";
 import Long from "long";
 import React from "react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Route } from "react-router-dom";
 
-import { Network } from "./index";
+import Network from "./index";
+
+jest.mock("@cockroachlabs/cluster-ui", () => {
+  const actual = jest.requireActual("@cockroachlabs/cluster-ui");
+  return {
+    ...actual,
+    useNodesSummary: jest.fn(),
+    useConnectivity: jest.fn(),
+  };
+});
+
+const mockUseNodesSummary = useNodesSummary as jest.Mock;
+const mockUseConnectivity = useConnectivity as jest.Mock;
 
 describe("Network", () => {
-  const defaultProps = {
-    nodesSummary: {
-      nodeStatuses: [
-        {
-          desc: {
-            node_id: 1,
-            address: { address_field: "localhost:26257" },
-            locality: {
-              tiers: [
-                { key: "region", value: "us-east-1" },
-                { key: "zone", value: "a" },
-              ],
-            },
+  const defaultNodesSummary = {
+    nodeStatuses: [
+      {
+        desc: {
+          node_id: 1,
+          address: { address_field: "localhost:26257" },
+          locality: {
+            tiers: [
+              { key: "region", value: "us-east-1" },
+              { key: "zone", value: "a" },
+            ],
           },
-          updated_at: Long.fromNumber(1000),
         },
-        {
-          desc: {
-            node_id: 2,
-            address: { address_field: "localhost:26258" },
-            locality: {
-              tiers: [
-                { key: "region", value: "us-east-1" },
-                { key: "zone", value: "b" },
-              ],
-            },
+        updated_at: Long.fromNumber(1000),
+      },
+      {
+        desc: {
+          node_id: 2,
+          address: { address_field: "localhost:26258" },
+          locality: {
+            tiers: [
+              { key: "region", value: "us-east-1" },
+              { key: "zone", value: "b" },
+            ],
           },
-          updated_at: Long.fromNumber(1000),
         },
-      ] as any[],
-      nodeStatusByID: {
-        "1": {
-          desc: {
-            node_id: 1,
-            address: { address_field: "localhost:26257" },
-            locality: {
-              tiers: [
-                { key: "region", value: "us-east-1" },
-                { key: "zone", value: "a" },
-              ],
-            },
+        updated_at: Long.fromNumber(1000),
+      },
+    ] as any[],
+    nodeStatusByID: {
+      "1": {
+        desc: {
+          node_id: 1,
+          address: { address_field: "localhost:26257" },
+          locality: {
+            tiers: [
+              { key: "region", value: "us-east-1" },
+              { key: "zone", value: "a" },
+            ],
           },
-          updated_at: Long.fromNumber(1000),
         },
-        "2": {
-          desc: {
-            node_id: 2,
-            address: { address_field: "localhost:26258" },
-            locality: {
-              tiers: [
-                { key: "region", value: "us-east-1" },
-                { key: "zone", value: "b" },
-              ],
-            },
+        updated_at: Long.fromNumber(1000),
+      },
+      "2": {
+        desc: {
+          node_id: 2,
+          address: { address_field: "localhost:26258" },
+          locality: {
+            tiers: [
+              { key: "region", value: "us-east-1" },
+              { key: "zone", value: "b" },
+            ],
           },
-          updated_at: Long.fromNumber(1000),
         },
-      },
-      nodeIDs: ["1", "2"],
-      nodeDisplayNameByID: {
-        "1": "node-1",
-        "2": "node-2",
-      },
-      storeIDsByNodeID: {
-        "1": ["1"],
-        "2": ["2"],
-      },
-      nodeLastError: null as Error | null,
-      livenessByNodeID: {
-        "1": {
-          nodeId: 1,
-          epoch: Long.fromNumber(1),
-          expiration: Long.fromNumber(1000),
-          draining: false,
-          membership:
-            protos.cockroach.kv.kvserver.liveness.livenesspb.MembershipStatus
-              .ACTIVE,
-        } as protos.cockroach.kv.kvserver.liveness.livenesspb.ILiveness,
-        "2": {
-          nodeId: 2,
-          epoch: Long.fromNumber(1),
-          expiration: Long.fromNumber(1000),
-          draining: false,
-          membership:
-            protos.cockroach.kv.kvserver.liveness.livenesspb.MembershipStatus
-              .ACTIVE,
-        } as protos.cockroach.kv.kvserver.liveness.livenesspb.ILiveness,
-      },
-      livenessStatusByNodeID: {
-        "1": protos.cockroach.kv.kvserver.liveness.livenesspb.NodeLivenessStatus
-          .NODE_STATUS_LIVE,
-        "2": protos.cockroach.kv.kvserver.liveness.livenesspb.NodeLivenessStatus
-          .NODE_STATUS_LIVE,
+        updated_at: Long.fromNumber(1000),
       },
     },
-    nodeSummaryErrors: [] as Error[],
-    connectivity: {
-      data: {
-        connections: {
-          "1": {
-            peers: {
-              "2": { latency: { nanos: 1000000 } }, // 1ms
-            },
-          },
-          "2": {
-            peers: {
-              "1": { latency: { nanos: 1000000 } }, // 1ms
-            },
-          },
-        },
-        errors_by_node_id: {},
+    nodeIDs: ["1", "2"],
+    nodeDisplayNameByID: {
+      "1": "node-1",
+      "2": "node-2",
+    },
+    storeIDsByNodeID: {
+      "1": ["1"],
+      "2": ["2"],
+    },
+    livenessByNodeID: {
+      "1": {
+        nodeId: 1,
+        epoch: Long.fromNumber(1),
+        expiration: Long.fromNumber(1000),
+        draining: false,
+        membership:
+          protos.cockroach.kv.kvserver.liveness.livenesspb.MembershipStatus
+            .ACTIVE,
+      } as protos.cockroach.kv.kvserver.liveness.livenesspb.ILiveness,
+      "2": {
+        nodeId: 2,
+        epoch: Long.fromNumber(1),
+        expiration: Long.fromNumber(1000),
+        draining: false,
+        membership:
+          protos.cockroach.kv.kvserver.liveness.livenesspb.MembershipStatus
+            .ACTIVE,
+      } as protos.cockroach.kv.kvserver.liveness.livenesspb.ILiveness,
+    },
+    livenessStatusByNodeID: {
+      "1": protos.cockroach.kv.kvserver.liveness.livenesspb.NodeLivenessStatus
+        .NODE_STATUS_LIVE,
+      "2": protos.cockroach.kv.kvserver.liveness.livenesspb.NodeLivenessStatus
+        .NODE_STATUS_LIVE,
+    },
+    isLoading: false,
+    error: undefined as Error | undefined,
+  };
+
+  const defaultConnections = {
+    "1": {
+      peers: {
+        "2": { latency: { nanos: 1000000 } }, // 1ms
       },
-      inFlight: false,
-      valid: true,
-      unauthorized: false,
     },
-    refreshNodes: jest.fn(),
-    refreshLiveness: jest.fn(),
-    refreshConnectivity: jest.fn(),
-    match: {
-      params: {},
-      isExact: true,
-      path: "/network",
-      url: "/network",
+    "2": {
+      peers: {
+        "1": { latency: { nanos: 1000000 } }, // 1ms
+      },
     },
-    location: {
-      pathname: "/network",
-      search: "",
-      state: null,
-      hash: "",
-    } as Location,
-    history: {} as any,
   };
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseNodesSummary.mockReturnValue(defaultNodesSummary);
+    mockUseConnectivity.mockReturnValue({
+      connections: defaultConnections,
+      isLoading: false,
+      error: undefined,
+    });
   });
 
   it("renders network page with latency table", () => {
     render(
-      <MemoryRouter>
-        <Network {...defaultProps} />
+      <MemoryRouter initialEntries={["/network"]}>
+        <Route path="/network">
+          <Network />
+        </Route>
       </MemoryRouter>,
     );
 
@@ -162,64 +157,40 @@ describe("Network", () => {
     expect(screen.getByRole("table")).toBeTruthy();
   });
 
-  it("calls refresh functions on mount", () => {
-    render(
-      <MemoryRouter>
-        <Network {...defaultProps} />
-      </MemoryRouter>,
-    );
-
-    expect(defaultProps.refreshNodes).toHaveBeenCalled();
-    expect(defaultProps.refreshLiveness).toHaveBeenCalled();
-    expect(defaultProps.refreshConnectivity).toHaveBeenCalled();
-  });
-
   it("displays message for single node cluster", () => {
-    const propsWithSingleNode = {
-      ...defaultProps,
-      nodesSummary: {
-        nodeStatuses: [defaultProps.nodesSummary.nodeStatuses[0]],
-        nodeStatusByID: {
-          "1": defaultProps.nodesSummary.nodeStatusByID["1"],
-        },
-        nodeIDs: ["1"],
-        nodeDisplayNameByID: {
-          "1": "node-1",
-        },
-        storeIDsByNodeID: {
-          "1": ["1"],
-        },
-        nodeLastError: null as Error | null,
-        livenessByNodeID: {
-          "1": {
-            nodeId: 1,
-            epoch: Long.fromNumber(1),
-            expiration: Long.fromNumber(1000),
-            draining: false,
-            membership:
-              protos.cockroach.kv.kvserver.liveness.livenesspb.MembershipStatus
-                .ACTIVE,
-          } as protos.cockroach.kv.kvserver.liveness.livenesspb.ILiveness,
-        },
-        livenessStatusByNodeID: {
-          "1": protos.cockroach.kv.kvserver.liveness.livenesspb
-            .NodeLivenessStatus.NODE_STATUS_LIVE,
-        },
+    mockUseNodesSummary.mockReturnValue({
+      nodeStatuses: [defaultNodesSummary.nodeStatuses[0]],
+      nodeStatusByID: {
+        "1": defaultNodesSummary.nodeStatusByID["1"],
       },
-      connectivity: {
-        data: {
-          connections: {},
-          errors_by_node_id: {},
-        },
-        inFlight: false,
-        valid: true,
-        unauthorized: false,
+      nodeIDs: ["1"],
+      nodeDisplayNameByID: {
+        "1": "node-1",
       },
-    };
+      storeIDsByNodeID: {
+        "1": ["1"],
+      },
+      livenessByNodeID: {
+        "1": defaultNodesSummary.livenessByNodeID["1"],
+      },
+      livenessStatusByNodeID: {
+        "1": protos.cockroach.kv.kvserver.liveness.livenesspb.NodeLivenessStatus
+          .NODE_STATUS_LIVE,
+      },
+      isLoading: false,
+      error: undefined,
+    });
+    mockUseConnectivity.mockReturnValue({
+      connections: {},
+      isLoading: false,
+      error: undefined,
+    });
 
     render(
-      <MemoryRouter>
-        <Network {...propsWithSingleNode} />
+      <MemoryRouter initialEntries={["/network"]}>
+        <Route path="/network">
+          <Network />
+        </Route>
       </MemoryRouter>,
     );
 
@@ -231,62 +202,48 @@ describe("Network", () => {
   });
 
   it("handles peers with null latency", () => {
-    const propsWithNullLatency = {
-      ...defaultProps,
-      connectivity: {
-        ...defaultProps.connectivity,
-        data: {
-          connections: {
-            "1": {
-              peers: {
-                "2": {
-                  latency: {
-                    nanos: 1000000,
-                  } as protos.cockroach.server.serverpb.NetworkConnectivityResponse.IPeer["latency"],
-                }, // 1ms
-                "3": {
-                  latency:
-                    null as protos.cockroach.server.serverpb.NetworkConnectivityResponse.IPeer["latency"],
-                }, // null latency
-              },
-            },
+    mockUseConnectivity.mockReturnValue({
+      connections: {
+        "1": {
+          peers: {
             "2": {
-              peers: {
-                "1": {
-                  latency: {
-                    nanos: 1000000,
-                  } as protos.cockroach.server.serverpb.NetworkConnectivityResponse.IPeer["latency"],
-                }, // 1ms
-                "3": {
-                  latency:
-                    null as protos.cockroach.server.serverpb.NetworkConnectivityResponse.IPeer["latency"],
-                }, // null latency
-              },
+              latency: { nanos: 1000000 },
             },
             "3": {
-              peers: {
-                "1": {
-                  latency:
-                    null as protos.cockroach.server.serverpb.NetworkConnectivityResponse.IPeer["latency"],
-                }, // null latency
-                "2": {
-                  latency:
-                    null as protos.cockroach.server.serverpb.NetworkConnectivityResponse.IPeer["latency"],
-                }, // null latency
-              },
+              latency: null,
             },
           },
-          errors_by_node_id: {},
         },
-        inFlight: false,
-        valid: true,
-        unauthorized: false,
+        "2": {
+          peers: {
+            "1": {
+              latency: { nanos: 1000000 },
+            },
+            "3": {
+              latency: null,
+            },
+          },
+        },
+        "3": {
+          peers: {
+            "1": {
+              latency: null,
+            },
+            "2": {
+              latency: null,
+            },
+          },
+        },
       },
-    };
+      isLoading: false,
+      error: undefined,
+    });
 
     render(
-      <MemoryRouter>
-        <Network {...propsWithNullLatency} />
+      <MemoryRouter initialEntries={["/network"]}>
+        <Route path="/network">
+          <Network />
+        </Route>
       </MemoryRouter>,
     );
 

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/network/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/network/index.tsx
@@ -3,7 +3,13 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
-import { util, Loading } from "@cockroachlabs/cluster-ui";
+import {
+  util,
+  Loading,
+  useNodesSummary,
+  useConnectivity,
+  NodesSummary,
+} from "@cockroachlabs/cluster-ui";
 import * as protos from "@cockroachlabs/crdb-protobuf-client";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { deviation as d3Deviation, mean as d3Mean } from "d3-array";
@@ -20,30 +26,13 @@ import union from "lodash/union";
 import values from "lodash/values";
 import moment from "moment-timezone";
 import { common } from "protobufjs";
-import React, { Fragment, useEffect, useState } from "react";
+import React, { Fragment, useState } from "react";
 import { Helmet } from "react-helmet";
-import { connect } from "react-redux";
-import { withRouter, RouteComponentProps } from "react-router-dom";
-import { createSelector } from "reselect";
+import { useParams, useLocation } from "react-router-dom";
 
 import { InlineAlert } from "src/components";
-import {
-  CachedDataReducerState,
-  refreshConnectivity,
-  refreshLiveness,
-  refreshNodes,
-} from "src/redux/apiReducers";
-import { connectivitySelector } from "src/redux/connectivity";
-import {
-  NodesSummary,
-  nodesSummarySelector,
-  selectLivenessRequestStatus,
-  selectNodeRequestStatus,
-} from "src/redux/nodes";
-import { AdminUIState } from "src/redux/state";
 import { trackFilter, trackCollapseNodes } from "src/util/analytics";
 import { getDataFromServer } from "src/util/dataFromServer";
-import { getMatchParamByName } from "src/util/query";
 import {
   getFilters,
   localityToString,
@@ -61,15 +50,6 @@ import IConnectivity = cockroach.server.serverpb.NetworkConnectivityResponse.ICo
 import IPeer = cockroach.server.serverpb.NetworkConnectivityResponse.IPeer;
 import IDuration = common.IDuration;
 
-interface NetworkOwnProps {
-  nodesSummary: NodesSummary;
-  nodeSummaryErrors: Error[];
-  connectivity: CachedDataReducerState<cockroach.server.serverpb.NetworkConnectivityResponse>;
-  refreshNodes: typeof refreshNodes;
-  refreshLiveness: typeof refreshLiveness;
-  refreshConnectivity: typeof refreshConnectivity;
-}
-
 export type Identity = {
   nodeID: number;
   address: string;
@@ -83,8 +63,6 @@ export interface NoConnection {
   from: Identity;
   to: Identity;
 }
-
-type NetworkProps = NetworkOwnProps & RouteComponentProps;
 
 export interface NetworkFilter {
   [key: string]: Array<string>;
@@ -146,26 +124,24 @@ export function getValueFromString(
 /**
  * Renders the Network Report page.
  */
-export function Network({
-  nodesSummary,
-  nodeSummaryErrors,
-  connectivity,
-  refreshNodes: refreshNodesAction,
-  refreshLiveness: refreshLivenessAction,
-  refreshConnectivity: refreshConnectivityAction,
-  match,
-  location,
-}: NetworkProps): React.ReactElement {
+export default function Network(): React.ReactElement {
+  const { node_id: nodeIdParam } = useParams<{ node_id: string }>();
+  const location = useLocation();
+  const {
+    isLoading: nodesSummaryLoading,
+    error: nodesSummaryError,
+    ...nodesSummary
+  } = useNodesSummary();
+  const {
+    connections,
+    isLoading: connectivityLoading,
+    error: connectivityError,
+  } = useConnectivity();
+
   const [collapsed, setCollapsed] = useState(false);
   const [networkFilter, setNetworkFilter] = useState<NetworkFilter | null>(
     null,
   );
-
-  useEffect(() => {
-    refreshLivenessAction();
-    refreshNodesAction();
-    refreshConnectivityAction();
-  });
 
   const onChangeCollapse = (newCollapsed: boolean) => {
     trackCollapseNodes(newCollapsed);
@@ -295,15 +271,14 @@ export function Network({
   const getDisplayIdentities = (
     identityByID: Map<number, Identity>,
   ): Identity[] => {
-    const nodeId = getMatchParamByName(match, "node_id");
     const identityContent = sortBy(
       Array.from(identityByID.values()),
       identity => identity.nodeID,
     );
     const sort = getSortParams(identityContent);
-    if (sort.some(x => x.id === nodeId)) {
+    if (sort.some(x => x.id === nodeIdParam)) {
       return sortBy(identityContent, identity =>
-        getValueFromString(nodeId, identity.locality, true),
+        getValueFromString(nodeIdParam, identity.locality, true),
       );
     }
     return identityContent;
@@ -313,7 +288,6 @@ export function Network({
     latencies: number[],
     displayIdentities: Identity[],
   ) => {
-    const nodeId = getMatchParamByName(match, "node_id");
     const mean = d3Mean(latencies);
     const sortParams = getSortParams(displayIdentities);
     let stddev = d3Deviation(latencies);
@@ -329,8 +303,8 @@ export function Network({
     const latencyTable = (
       <Latency
         displayIdentities={filteredDisplayIdentities(displayIdentities)}
-        multipleHeader={nodeId !== "cluster"}
-        node_id={nodeId}
+        multipleHeader={nodeIdParam !== "cluster"}
+        node_id={nodeIdParam}
         collapsed={collapsed}
         std={{
           stddev,
@@ -374,7 +348,7 @@ export function Network({
   const renderContent = (
     summary: NodesSummary,
     filters: NodeFilterListProps,
-    connections: protos.cockroach.server.serverpb.NetworkConnectivityResponse["connections"],
+    conns: protos.cockroach.server.serverpb.NetworkConnectivityResponse["connections"],
   ) => {
     if (!contentAvailable(summary)) {
       return null;
@@ -387,7 +361,7 @@ export function Network({
     // Nodes api to make sure we show all known nodes.
     const knownNodeIds = union(
       Object.keys(summary.livenessByNodeID),
-      Object.keys(connections),
+      Object.keys(conns),
     );
 
     // List of node identities.
@@ -405,7 +379,7 @@ export function Network({
           summary.livenessStatusByNodeID[nodeId] ||
           protos.cockroach.kv.kvserver.liveness.livenesspb.NodeLivenessStatus
             .NODE_STATUS_UNKNOWN,
-        connectivity: connections[nodeId],
+        connectivity: conns[nodeId],
       });
     });
 
@@ -429,7 +403,7 @@ export function Network({
       (vals: IPeer[]) => flatMap(vals, v => v.latency),
       (vals: IDuration[]) => filter(vals, v => v && v.nanos),
       (vals: IDuration[]) => map(vals, v => util.NanoToMilli(v.nanos)),
-    ])(connections);
+    ])(conns);
 
     if (isEmpty(identityByID)) {
       return <h2 className="base-heading">No nodes match the filters</h2>;
@@ -447,6 +421,7 @@ export function Network({
   const filters = getFilters(location);
   const canShowPage =
     !getDataFromServer().FeatureFlags.disable_kv_level_advanced_debug;
+  const errors = [nodesSummaryError, connectivityError].filter(Boolean);
 
   return (
     <Fragment>
@@ -463,10 +438,12 @@ export function Network({
       {canShowPage && (
         <Loading
           loading={
-            !contentAvailable(nodesSummary) || !connectivity?.data?.connections
+            nodesSummaryLoading ||
+            !contentAvailable(nodesSummary) ||
+            (connectivityLoading && isEmpty(connections))
           }
           page={"network"}
-          error={nodeSummaryErrors}
+          error={errors}
           className="loading-image loading-image__spinner-left loading-image__spinner-left__padded"
           render={() => (
             <div>
@@ -474,11 +451,7 @@ export function Network({
                 nodeIDs={filters.nodeIDs}
                 localityRegex={filters.localityRegex}
               />
-              {renderContent(
-                nodesSummary,
-                filters,
-                connectivity?.data?.connections,
-              )}
+              {renderContent(nodesSummary, filters, connections)}
             </div>
           )}
         />
@@ -486,25 +459,3 @@ export function Network({
     </Fragment>
   );
 }
-
-const nodeSummaryErrors = createSelector(
-  selectNodeRequestStatus,
-  selectLivenessRequestStatus,
-  (nodes, liveness) => [nodes.lastError, liveness.lastError],
-);
-
-const mapStateToProps = (state: AdminUIState) => ({
-  nodesSummary: nodesSummarySelector(state),
-  nodeSummaryErrors: nodeSummaryErrors(state),
-  connectivity: connectivitySelector(state),
-});
-
-const mapDispatchToProps = {
-  refreshNodes,
-  refreshLiveness,
-  refreshConnectivity,
-};
-
-export default withRouter(
-  connect(mapStateToProps, mapDispatchToProps)(Network),
-);


### PR DESCRIPTION
Refactor the Network diagnostics page to use SWR hooks instead of Redux for data fetching. This replaces the `connect`/`mapStateToProps`/ `mapDispatchToProps` pattern with the `useNodesSummary` and a new `useConnectivity` SWR hook.

Changes:
- Add `connectivityApi.ts` in cluster-ui with a `useConnectivity` hook that wraps the `_status/connectivity` endpoint via SWR with a 10s deduplication interval.
- Convert the Network component from a connected Redux component to a plain function component using `useParams`/`useLocation` from react-router and the new SWR hooks.
- Remove the now-dead Redux connectivity plumbing: `connectivityObj` reducer, `refreshConnectivity` action, `connectivitySelector`, `getNetworkConnectivity` API function, and associated type aliases.
- Update tests to mock SWR hooks directly instead of passing Redux props.

Resolves: CRDB-61196
Epic: CRDB-58145

Release note: None