### PR TITLE
sql/lease: add tracing spans to descriptor version wait functions

### DIFF
--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -151,6 +151,8 @@ func (m *Manager) WaitForNoVersion(
 	regions regionliveness.CachedDatabaseRegions,
 	retryOpts retry.Options,
 ) error {
+	ctx, span := tracing.ChildSpan(ctx, "wait-for-no-version")
+	defer span.Finish()
 	versions := []IDVersion{
 		{
 			Name:    fmt.Sprintf("[%d]", id),
@@ -566,6 +568,8 @@ func (m *Manager) WaitForOneVersion(
 	regions regionliveness.CachedDatabaseRegions,
 	retryOpts retry.Options,
 ) (catalog.Descriptor, error) {
+	ctx, span := tracing.ChildSpan(ctx, "wait-for-one-version")
+	defer span.Finish()
 	// Increment the long wait gauge for wait for one version, if this function
 	// takes longer than the lease duration.
 	decAfterWait := m.IncGaugeAfterLeaseDuration(GaugeWaitForOneVersion)
@@ -613,6 +617,8 @@ func (m *Manager) WaitForNewVersion(
 	regions regionliveness.CachedDatabaseRegions,
 	retryOpts retry.Options,
 ) (catalog.Descriptor, error) {
+	ctx, span := tracing.ChildSpan(ctx, "wait-for-new-version")
+	defer span.Finish()
 	if retryOpts.MaxRetries != 0 {
 		return nil, errors.New("The MaxRetries option shouldn't be set in WaitForNewVersion")
 	}

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -44,6 +44,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/startup"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/crlib/crtime"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
@@ -1987,6 +1989,11 @@ func (ief *InternalDB) txn(
 		if len(modifiedDescriptors) == 0 && deletedDescs.Len() == 0 {
 			return nil
 		}
+		ctx, span := tracing.ChildSpan(ctx, "wait-for-descriptors")
+		defer span.Finish()
+		start := timeutil.Now()
+		log.Dev.Infof(ctx, "waiting for %d modified and %d deleted descriptors",
+			len(modifiedDescriptors), deletedDescs.Len())
 		retryOpts := retry.Options{
 			InitialBackoff: time.Millisecond,
 			Multiplier:     1.5,
@@ -2015,6 +2022,7 @@ func (ief *InternalDB) txn(
 				return err
 			}
 		}
+		log.Dev.Infof(ctx, "waiting for descriptors done, took %v", timeutil.Since(start))
 		return nil
 	}
 


### PR DESCRIPTION
Add named child spans to WaitForOneVersion, WaitForNoVersion, and WaitForNewVersion so they appear as distinct labeled spans in statement bundle traces. Previously, time spent waiting for lease drains was opaque in traces, making it difficult to diagnose slow schema changes (e.g. #118240).

Also add a wrapping span and log messages to the waitForDescriptors closure in internal.go, which is the path used by the declarative schema changer. This gives visibility into the lease drain phase for operations like CREATE VIEW.

resolves #118240
Release note: None