### PR TITLE
release-25.4: backup: tenant backup schedules no longer push primary backup metric

### DIFF
--- a/pkg/backup/schedule_exec.go
+++ b/pkg/backup/schedule_exec.go
@@ -373,14 +373,18 @@ func (e *scheduledBackupExecutor) backupSucceeded(
 	}
 
 	// If this schedule is designated as maintaining the "LastBackup" metric used
-	// for monitoring an RPO SLA, update that metric.
+	// for monitoring an RPO SLA, update that metric. We only update RpoMetric for
+	// non-tenant schedules because a host cluster backing up both itself and its
+	// tenants would have the metric clobbered by multiple schedules otherwise.
+	// See: https://github.com/cockroachdb/cockroach/issues/165125
 	if args.UpdatesLastBackupMetric {
-		e.metrics.RpoMetric.Update(details.(jobspb.BackupDetails).EndTime.GoTime().Unix())
 		if details.(jobspb.BackupDetails).SpecificTenantIds != nil {
 			for _, tenantID := range details.(jobspb.BackupDetails).SpecificTenantIds {
 				e.metrics.RpoTenantMetric.Update(map[string]string{"tenant_id": tenantID.String()},
 					details.(jobspb.BackupDetails).EndTime.GoTime().Unix())
 			}
+		} else {
+			e.metrics.RpoMetric.Update(details.(jobspb.BackupDetails).EndTime.GoTime().Unix())
 		}
 	}
 

--- a/pkg/backup/schedule_exec_test.go
+++ b/pkg/backup/schedule_exec_test.go
@@ -58,6 +58,32 @@ func TestBackupSucceededUpdatesMetrics(t *testing.T) {
 		verifyRPOTenantMetricLabels(t, executor.metrics.RpoTenantMetric, expectedTenantIDs)
 		verifyRPOTenantMetricGaugeValue(t, executor.metrics.RpoTenantMetric, details.EndTime)
 	})
+
+	t.Run("tenant backup does not update RPO metric", func(t *testing.T) {
+		// Use a fresh executor to ensure RpoMetric starts at zero.
+		freshExecutor := &scheduledBackupExecutor{
+			metrics: backupMetrics{
+				RpoMetric:       metric.NewGauge(metric.Metadata{}),
+				RpoTenantMetric: metric.NewExportedGaugeVec(metric.Metadata{}, []string{"tenant_id"}),
+			},
+		}
+		schedule := createSchedule(t, true)
+		tenantIDs := mustMakeTenantIDs(t, 2)
+		endTime := hlc.Timestamp{WallTime: hlc.UnixNano()}
+		details := jobspb.BackupDetails{
+			EndTime:           endTime,
+			SpecificTenantIds: tenantIDs,
+		}
+
+		err := freshExecutor.backupSucceeded(ctx, nil, schedule, details, nil)
+		require.NoError(t, err)
+
+		// RpoMetric should NOT be updated for tenant-specific backups.
+		require.Equal(t, int64(0), freshExecutor.metrics.RpoMetric.Value())
+		// But RpoTenantMetric should be updated.
+		verifyRPOTenantMetricLabels(t, freshExecutor.metrics.RpoTenantMetric, []string{"2"})
+		verifyRPOTenantMetricGaugeValue(t, freshExecutor.metrics.RpoTenantMetric, details.EndTime)
+	})
 }
 
 func TestBackupFailedUpdatesMetrics(t *testing.T) {


### PR DESCRIPTION
Backport 1/1 commits from #165126 on behalf of @kev-cao.

----

This commit teaches tenant backup schedules that have `updates_cluster_last_backup_time_metric` set to not push the primary `schedules.BACKUP.last-completed-time` metric.

Fixes: #165125

Release note: None

----

Release justification: Fix broken alerting on Cockroach Cloud that prevented missing backup alerts from firing for host clusters.