### PR TITLE
sql: block explicit AOST queries on PCR reader tenants

### DIFF
--- a/pkg/sql/catalog/replication/reader_catalog_test.go
+++ b/pkg/sql/catalog/replication/reader_catalog_test.go
@@ -309,6 +309,26 @@ INSERT INTO t3(n) VALUES (3);
 	r.destRunner.ExpectErr(t, "schema changes are not allowed on a reader catalog", "ALTER SEQUENCE sq1 RENAME TO sq4")
 	r.destRunner.ExpectErr(t, "schema changes are not allowed on a reader catalog", "ALTER TYPE status ADD VALUE 'newval' ")
 
+	// Validate that DML mutations are blocked on external row data tables,
+	// with and without the bypass session variable.
+	r.destRunner.ExpectErr(t, "cannot mutate materialized view", "INSERT INTO t1(val) VALUES('open')")
+	r.destRunner.Exec(t, "SET bypass_pcr_reader_catalog_aost = 'true'")
+	r.destRunner.ExpectErr(t, "cannot mutate materialized view", "INSERT INTO t1(val) VALUES('open')")
+	r.destRunner.Exec(t, "SET bypass_pcr_reader_catalog_aost = 'false'")
+
+	// Validate that explicit AOST is blocked on reader tenants.
+	r.destRunner.ExpectErr(t,
+		"explicit AS OF SYSTEM TIME is not allowed on a physical cluster replication reader virtual cluster",
+		"SELECT * FROM t1 AS OF SYSTEM TIME '-1s'")
+	r.destRunner.ExpectErr(t,
+		"explicit AS OF SYSTEM TIME is not allowed on a physical cluster replication reader virtual cluster",
+		"BEGIN AS OF SYSTEM TIME '-1s'")
+
+	// Validate that the bypass session variable allows explicit AOST.
+	r.destRunner.Exec(t, "SET bypass_pcr_reader_catalog_aost = 'true'")
+	r.destRunner.Exec(t, "SELECT * FROM t1 AS OF SYSTEM TIME '-1s'")
+	r.destRunner.Exec(t, "SET bypass_pcr_reader_catalog_aost = 'false'")
+
 	// As a final test intentionally drop dependencies between descriptors. If we
 	// don't batch descriptor updates this will cause a validation error, since
 	// the sequence and table depend on each other.

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -2288,6 +2288,18 @@ func (ex *connExecutor) handleAOST(ctx context.Context, stmt tree.Statement) err
 		return nil
 	}
 
+	// On a PCR reader tenant, explicit AOST is not allowed unless the session
+	// variable bypass_pcr_reader_catalog_aost is set.
+	if ex.isPCRReaderCatalog && !ex.sessionData().BypassPCRReaderCatalogAOST {
+		return errors.WithHint(
+			pgerror.Newf(
+				pgcode.FeatureNotSupported,
+				"explicit AS OF SYSTEM TIME is not allowed on a physical cluster replication reader virtual cluster",
+			),
+			"use SET bypass_pcr_reader_catalog_aost = true to override, after reaching out to support for guidance",
+		)
+	}
+
 	// Implicit transactions can have multiple statements, so we need to check
 	// if one has already been executed.
 	if ex.implicitTxn() && !ex.extraTxnState.firstStmtExecuted {
@@ -3707,6 +3719,17 @@ func (ex *connExecutor) beginTransactionTimestampsAndReadMode(
 			}
 		}
 		return rwMode, now, nil, nil
+	}
+	// On a PCR reader tenant, explicit AOST is not allowed unless the session
+	// variable bypass_pcr_reader_catalog_aost is set.
+	if ex.isPCRReaderCatalog && !ex.sessionData().BypassPCRReaderCatalogAOST {
+		return 0, time.Time{}, nil, errors.WithHint(
+			pgerror.Newf(
+				pgcode.FeatureNotSupported,
+				"explicit AS OF SYSTEM TIME is not allowed on a physical cluster replication reader virtual cluster",
+			),
+			"use SET bypass_pcr_reader_catalog_aost = true to override, after reaching out to support for guidance",
+		)
 	}
 	ex.statsCollector.Reset(ex.applicationStats, ex.phaseTimes)
 	asOf, err := p.EvalAsOfTimestamp(ctx, asOfClause)


### PR DESCRIPTION
On a PCR reader tenant, queries are automatically pinned to the safe replication timestamp. Allowing explicit AS OF SYSTEM TIME leads to a weird UX where the AOST used in the query is actually some time further in the past. The user AOST reads the replicated descriptors at that system time, which then contains the external data reader time to run the query on.

This patch teaches connExecutor to return an error for explicit AOST at both
the statement level and transaction level. The bypass_pcr_reader_catalog_aost
session variable can be used to override this guardrail.

Epic: none

Release note (ops change): users cannot run AOST queries on the reader tenant,
unless they set bypass_pcr_reader_catalog_aost session variable. This session
variable should not be used by default in the reader workload. It should only
be used during investigation or for changing reader tenant specific cluster
settings.