### PR TITLE
ui: remove unnecessary polling from useUserSQLRoles hook

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/userApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/userApi.ts
@@ -24,8 +24,7 @@ export function getUserSQLRoles(): Promise<UserSQLRolesResponseMessage> {
 
 export function useUserSQLRoles() {
   return useSwrWithClusterId("userSQLRoles", () => getUserSQLRoles(), {
-    // Only call every 5 minutes
-    dedupingInterval: 4_999,
-    refreshInterval: 5_000,
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false,
   });
 }


### PR DESCRIPTION
## Summary

- The `useUserSQLRoles` SWR hook was configured with `refreshInterval: 5_000` (5 seconds), causing `_status/sqlroles` to be polled every 5 seconds. The comment said "Only call every 5 minutes" but the value was 5 seconds, not 5 minutes.
- The previous Redux/saga approach only re-fetched after a 5-minute cache invalidation period, and only on demand.
- SQL roles for the current user do not change during a session, so periodic polling is unnecessary. This removes the `refreshInterval` and `dedupingInterval` and disables `revalidateOnFocus`/`revalidateOnReconnect` so the data is fetched once and cached.

Epic: none
Release note: None