### PR TITLE
opt: fix outer column error in PL/pgSQL with SELECT INTO and RETURN QUERY

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_srf
+++ b/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_srf
@@ -625,3 +625,71 @@ statement ok
 DROP FUNCTION f145414;
 
 subtest end
+
+# Regression test for #130400. When a PL/pgSQL variable name matches a column
+# name from a SQL statement used with SELECT INTO, the variable should resolve
+# correctly in continuation arguments. Previously, the name-based lookup could
+# resolve to the SQL output column instead of the PL/pgSQL variable, causing an
+# "outer columns" internal error.
+subtest regression_130400
+
+statement ok
+CREATE TABLE t_dept (dept_id INT PRIMARY KEY, dept_name TEXT);
+INSERT INTO t_dept VALUES (1, 'Engineering');
+
+statement ok
+CREATE OR REPLACE FUNCTION get_dept_report(p_dept_id INT)
+RETURNS TABLE(dept_name TEXT, report_status TEXT) AS $$
+  DECLARE
+    v_name TEXT;
+  BEGIN
+    SELECT d.dept_name INTO v_name FROM t_dept d WHERE d.dept_id = p_dept_id;
+    IF v_name IS NOT NULL THEN
+      RETURN QUERY SELECT v_name, 'active'::TEXT;
+    ELSE
+      RETURN QUERY SELECT 'unknown'::TEXT, 'inactive'::TEXT;
+    END IF;
+  END;
+$$ LANGUAGE PLpgSQL;
+
+query TT
+SELECT * FROM get_dept_report(1);
+----
+Engineering  active
+
+query TT
+SELECT * FROM get_dept_report(999);
+----
+unknown  inactive
+
+# Also test the case where the RETURNS TABLE column name directly matches the
+# table column name used in SELECT INTO.
+statement ok
+CREATE OR REPLACE FUNCTION get_dept_direct(p_dept_id INT)
+RETURNS TABLE(dept_name TEXT) AS $$
+  BEGIN
+    SELECT d.dept_name INTO dept_name FROM t_dept d WHERE d.dept_id = p_dept_id;
+    IF dept_name IS NOT NULL THEN
+      RETURN QUERY SELECT dept_name::TEXT;
+    ELSE
+      RETURN QUERY SELECT 'unknown'::TEXT;
+    END IF;
+  END;
+$$ LANGUAGE PLpgSQL;
+
+query T
+SELECT * FROM get_dept_direct(1);
+----
+Engineering
+
+query T
+SELECT * FROM get_dept_direct(999);
+----
+unknown
+
+statement ok
+DROP FUNCTION get_dept_report;
+DROP FUNCTION get_dept_direct;
+DROP TABLE t_dept;
+
+subtest end

--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -1524,8 +1524,10 @@ func (b *plpgsqlBuilder) buildCursorNameGen(nameCon *continuation, nameVar ast.V
 			Overload:   &overloads[0],
 		},
 	)
+	_, ord := b.resolveVariableForAssign(nameVar)
 	nameScope := nameCon.s.push()
-	b.ob.synthesizeColumn(nameScope, scopeColName(nameVar), types.RefCursor, nil /* expr */, nameCall)
+	col := b.ob.synthesizeColumn(nameScope, scopeColName(nameVar), types.RefCursor, nil /* expr */, nameCall)
+	col.setParamOrd(ord)
 	b.ob.constructProjectForScope(nameCon.s, nameScope)
 	return nameScope
 }
@@ -2370,7 +2372,20 @@ func (b *plpgsqlBuilder) makeContinuationArgs(con *continuation, s *scope) memo.
 			if err != nil {
 				panic(err)
 			}
-			args = append(args, b.ob.factory.ConstructVariable(source.(*scopeColumn).id))
+			col := source.(*scopeColumn)
+			if col.paramOrd == 0 {
+				// The name-based lookup resolved to a column without a param ordinal,
+				// which means it's a SQL statement output column rather than a PL/pgSQL
+				// variable. Fall back to ordinal-based lookup to find the correct
+				// PL/pgSQL variable column. This can happen when a SQL statement (e.g.
+				// SELECT INTO) has an output column with the same name as a PL/pgSQL
+				// variable.
+				col = s.findFuncArgCol(len(args))
+				if col == nil {
+					panic(errors.AssertionFailedf("variable %s not found", name))
+				}
+			}
+			args = append(args, b.ob.factory.ConstructVariable(col.id))
 		}
 		for _, name := range block.hiddenVars {
 			col := s.findFuncArgCol(len(args))


### PR DESCRIPTION
Previously, when a PL/pgSQL function used SELECT INTO with a column name
that matched a PL/pgSQL variable (e.g. a RETURNS TABLE column), the
`makeContinuationArgs` function could incorrectly resolve the variable to
the SQL statement's output column instead of the PL/pgSQL variable. This
happened because the name-based lookup (`FindSourceProvidingColumn`) walks
the scope chain and returns the first match, which could be a table scan
column from the SELECT INTO statement rather than the PL/pgSQL variable in
an outer scope. This caused an "outer columns" internal error when the
optimizer detected unresolved column references in the top-level expression.

The fix adds a check after name-based lookup: if the resolved column lacks
a param ordinal (meaning it's a SQL output column, not a PL/pgSQL
variable), fall back to ordinal-based lookup (`findFuncArgCol`) which
correctly skips non-parameter columns.

Additionally, `buildCursorNameGen` now sets the param ordinal on the
synthesized cursor name column, consistent with how `addPLpgSQLAssign`
and `buildInto` handle variable projections.

Fixes: #130400
Epic: none

Release note (bug fix): Fixed an internal error with the message
"top-level relational expression cannot have outer columns" that could
occur when a PL/pgSQL routine used SELECT INTO with a column name matching
a RETURNS TABLE column, followed by an IF statement and RETURN QUERY.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>